### PR TITLE
Fix context_id not passed through DIDComm create-key path

### DIFF
--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -528,6 +528,7 @@ impl VtaClient {
                 "derivation_path": req.derivation_path.as_deref().unwrap_or_default(),
                 "mnemonic": req.mnemonic.as_deref(),
                 "label": req.label.as_deref(),
+                "context_id": req.context_id.as_deref(),
             }),
             key_management::CREATE_KEY_RESULT,
             30,

--- a/vta-sdk/src/protocols/key_management/create.rs
+++ b/vta-sdk/src/protocols/key_management/create.rs
@@ -9,6 +9,7 @@ pub struct CreateKeyBody {
     pub derivation_path: String,
     pub mnemonic: Option<String>,
     pub label: Option<String>,
+    pub context_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/vta-service/src/messaging/handlers/keys.rs
+++ b/vta-service/src/messaging/handlers/keys.rs
@@ -28,7 +28,7 @@ didcomm_handler!(handle_create_key,
             key_id: None,
             mnemonic: body.mnemonic,
             label: body.label,
-            context_id: None,
+            context_id: body.context_id,
         },
         "didcomm",
     )


### PR DESCRIPTION
## Summary
- The DIDComm RPC path for `create_key` was dropping `context_id`, causing validation errors ("derivation_path is required when context_id is not provided") even when `--context-id` was supplied
- Added `context_id` to `CreateKeyBody` protocol struct, the SDK client RPC JSON payload, and the DIDComm handler
- The REST path was unaffected since it serialized the full request struct

## Test plan
- [ ] `pnm keys create --key-type ed25519 --label "Webvh Server Admin" --context-id webvh-services` succeeds without requiring `--derivation-path`
- [x] `cargo build` compiles without errors
- [x] `cargo clippy` — no new warnings