### PR TITLE
Add context provisioning, serverless DIDs, and didwebvh-rs 0.3 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,46 @@
 # Changelog
 
-## 0.1.1 — 2026-03-16
+## 2026-03-16
 
-### New Features
+### vta-sdk `0.1.1`
 
-- **Application context provisioning (`pnm context provision`)** — Single command that creates a context, generates admin credentials, and optionally creates a WebVH DID (server-managed or self-hosted). Outputs a portable base64-encoded bundle containing everything an application needs to connect, authenticate, and self-administer its context.
+- **Context provision bundle** — New `ContextProvisionBundle` type for encoding/decoding portable application onboarding bundles (context credentials, VTA config, and optional DID material).
+- **Pluggable session storage (`SessionBackend` trait)** — `SessionStore` now uses a `SessionBackend` trait instead of compile-time feature flags. Consumers can provide their own storage implementation via `SessionStore::with_backend()`. Built-in backends (keyring, file, Azure) remain available as trait implementations.
+- **DID log retrieval** — New `get_did_webvh_log()` client method and `GET_DID_WEBVH_LOG` protocol constant for retrieving stored DID logs.
+- **Context deletion preview** — New `preview_delete_context()` and `delete_context()` client methods with cascading resource cleanup.
+- **Serverless DID creation** — `CreateDidWebvhRequest` now supports an optional `url` field for serverless DID creation. Response includes `did_document` and `log_entry` for self-hosting.
 
-- **Context reprovisioning (`pnm context reprovision`)** — Regenerate a provision bundle for an existing context. Select an existing VTA-stored key interactively or specify one via `--key`, or create a new admin key. The bundle includes full DID material (document, log entry, and key secrets) matching the format produced by `provision`.
+### vta-service `0.1.2`
 
-- **Serverless WebVH DID creation (`--did-url`)** — Create a DID document and log entry locally without a pre-registered WebVH server. When `--did-url` is provided instead of `--server`, keys are derived and stored but the DID document and log entry are returned for self-hosting. Available in both `pnm webvh create-did` and `pnm context provision`.
+- **Serverless WebVH DID creation (`--did-url`)** — Create a DID document and log entry locally without a pre-registered WebVH server. Keys are derived and stored, and the DID document and log entry are returned for self-hosting.
+- **Cascading context deletion** — Deleting a context removes all associated keys, WebVH DIDs (and logs), and cleans up ACL entries. A preview endpoint lets callers inspect what will be removed before committing.
+- **DID log retrieval API** — New `GET /webvh/dids/{did}/log` endpoint (REST and DIDComm) to retrieve the stored DID log for a given WebVH DID.
+- **Serverless DIDs now persist data** — Serverless DID creation stores the `WebvhDidRecord`, DID log, and updates the context DID field, matching server-managed behavior.
+- **Upgraded to didwebvh-rs 0.3 `create_did()` API** — Replaced manual `DIDWebVHState` + `create_log_entry` + SCID/DID extraction with the high-level `CreateDIDConfig` builder and `create_did()`. DID documents now use `{DID}` placeholders.
 
-- **Cascading context deletion** — Deleting a context now removes all associated keys, WebVH DIDs (and logs), and cleans up ACL entries. A preview shows what will be removed before committing. The CLI prompts for confirmation unless `--force` is passed.
+### vta-cli-common `0.1.1`
 
-- **DID log retrieval API** — New `GET /webvh/dids/{did}/log` endpoint (REST and DIDComm) to retrieve the stored DID log for a given WebVH DID. Used by reprovisioning and external tools that need the original log entry.
+- **`cmd_context_provision`** — Creates a context, generates admin credentials, and optionally creates a WebVH DID. Outputs a portable base64 bundle for application onboarding.
+- **`cmd_context_reprovision`** — Regenerates a provision bundle for an existing context. Supports selecting an existing VTA-stored key interactively or via `--key`, or creating a new admin key. Includes full DID material (document, log entry, secrets).
+- **`cmd_context_delete`** — Cascading delete with preview and interactive confirmation.
+- **Serverless DID support** in `cmd_webvh_did_create` via `--did-url`.
 
-- **Pluggable session storage (`SessionBackend` trait)** — `SessionStore` now uses a `SessionBackend` trait instead of compile-time feature flags. Consumers can provide their own storage implementation via `SessionStore::with_backend()`. Built-in backends (keyring, file, Azure) are available as trait implementations.
+### pnm-cli `0.1.1`
 
-### Improvements
+- **`pnm context provision`** — Single command for application onboarding with optional DID creation.
+- **`pnm context reprovision`** — Regenerate provision bundles for existing contexts.
+- **`pnm context delete`** — Cascading delete with preview and `--force` flag.
+- **`pnm webvh create-did --did-url`** — Serverless DID creation.
 
-- **Upgraded to didwebvh-rs 0.3 `create_did()` API** — Replaced the manual `DIDWebVHState` + `create_log_entry` + SCID/DID extraction pattern with the high-level `CreateDIDConfig` builder and `create_did()` convenience function. DID documents now use `{DID}` placeholders instead of pre-computed strings.
+### cnm-cli `0.1.1`
 
-- **Serverless DIDs now persist data** — Serverless DID creation stores the `WebvhDidRecord`, DID log, and updates the context DID field, matching server-managed behavior. This enables reprovisioning and log retrieval for self-hosted DIDs.
+- **`cnm context delete`** — Cascading delete with preview and `--force` flag.
 
-### Dependency Updates
+### vtc-service `0.1.1`
+
+- **Upgraded to didwebvh-rs 0.3 `create_did()` API** — Same refactoring as vta-service for DID creation flows.
+
+### Dependency Updates (all crates)
 
 - `didwebvh-rs` 0.2 → 0.3
 - `affinidi-tdk` 0.5 → 0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## 0.1.1 — 2026-03-16
+
+### New Features
+
+- **Application context provisioning (`pnm context provision`)** — Single command that creates a context, generates admin credentials, and optionally creates a WebVH DID (server-managed or self-hosted). Outputs a portable base64-encoded bundle containing everything an application needs to connect, authenticate, and self-administer its context.
+
+- **Context reprovisioning (`pnm context reprovision`)** — Regenerate a provision bundle for an existing context. Select an existing VTA-stored key interactively or specify one via `--key`, or create a new admin key. The bundle includes full DID material (document, log entry, and key secrets) matching the format produced by `provision`.
+
+- **Serverless WebVH DID creation (`--did-url`)** — Create a DID document and log entry locally without a pre-registered WebVH server. When `--did-url` is provided instead of `--server`, keys are derived and stored but the DID document and log entry are returned for self-hosting. Available in both `pnm webvh create-did` and `pnm context provision`.
+
+- **Cascading context deletion** — Deleting a context now removes all associated keys, WebVH DIDs (and logs), and cleans up ACL entries. A preview shows what will be removed before committing. The CLI prompts for confirmation unless `--force` is passed.
+
+- **DID log retrieval API** — New `GET /webvh/dids/{did}/log` endpoint (REST and DIDComm) to retrieve the stored DID log for a given WebVH DID. Used by reprovisioning and external tools that need the original log entry.
+
+- **Pluggable session storage (`SessionBackend` trait)** — `SessionStore` now uses a `SessionBackend` trait instead of compile-time feature flags. Consumers can provide their own storage implementation via `SessionStore::with_backend()`. Built-in backends (keyring, file, Azure) are available as trait implementations.
+
+### Improvements
+
+- **Upgraded to didwebvh-rs 0.3 `create_did()` API** — Replaced the manual `DIDWebVHState` + `create_log_entry` + SCID/DID extraction pattern with the high-level `CreateDIDConfig` builder and `create_did()` convenience function. DID documents now use `{DID}` placeholders instead of pre-computed strings.
+
+- **Serverless DIDs now persist data** — Serverless DID creation stores the `WebvhDidRecord`, DID log, and updates the context DID field, matching server-managed behavior. This enables reprovisioning and log retrieval for self-hosted DIDs.
+
+### Dependency Updates
+
+- `didwebvh-rs` 0.2 → 0.3
+- `affinidi-tdk` 0.5 → 0.6
+- `azure_security_keyvault_secrets` 0.11 → 0.12
+- `azure_identity` 0.32 → 0.33
+- All compatible transitive dependencies updated to latest versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,41 +4,94 @@
 
 ### vta-sdk `0.1.1`
 
-- **Context provision bundle** — New `ContextProvisionBundle` type for encoding/decoding portable application onboarding bundles (context credentials, VTA config, and optional DID material).
-- **Pluggable session storage (`SessionBackend` trait)** — `SessionStore` now uses a `SessionBackend` trait instead of compile-time feature flags. Consumers can provide their own storage implementation via `SessionStore::with_backend()`. Built-in backends (keyring, file, Azure) remain available as trait implementations.
-- **DID log retrieval** — New `get_did_webvh_log()` client method and `GET_DID_WEBVH_LOG` protocol constant for retrieving stored DID logs.
-- **Context deletion preview** — New `preview_delete_context()` and `delete_context()` client methods with cascading resource cleanup.
-- **Serverless DID creation** — `CreateDidWebvhRequest` now supports an optional `url` field for serverless DID creation. Response includes `did_document` and `log_entry` for self-hosting.
+- **Context provision bundle** — New
+  `ContextProvisionBundle` type for encoding/decoding
+  portable application onboarding bundles (context
+  credentials, VTA config, and optional DID material).
+- **Pluggable session storage (`SessionBackend` trait)**
+  — `SessionStore` now uses a `SessionBackend` trait
+  instead of compile-time feature flags. Consumers can
+  provide their own storage implementation via
+  `SessionStore::with_backend()`. Built-in backends
+  (keyring, file, Azure) remain available as trait
+  implementations.
+- **DID log retrieval** — New `get_did_webvh_log()`
+  client method and `GET_DID_WEBVH_LOG` protocol
+  constant for retrieving stored DID logs.
+- **Context deletion preview** — New
+  `preview_delete_context()` and `delete_context()`
+  client methods with cascading resource cleanup.
+- **Serverless DID creation** —
+  `CreateDidWebvhRequest` now supports an optional
+  `url` field for serverless DID creation. Response
+  includes `did_document` and `log_entry` for
+  self-hosting.
 
 ### vta-service `0.1.2`
 
-- **Serverless WebVH DID creation (`--did-url`)** — Create a DID document and log entry locally without a pre-registered WebVH server. Keys are derived and stored, and the DID document and log entry are returned for self-hosting.
-- **Cascading context deletion** — Deleting a context removes all associated keys, WebVH DIDs (and logs), and cleans up ACL entries. A preview endpoint lets callers inspect what will be removed before committing.
-- **DID log retrieval API** — New `GET /webvh/dids/{did}/log` endpoint (REST and DIDComm) to retrieve the stored DID log for a given WebVH DID.
-- **Serverless DIDs now persist data** — Serverless DID creation stores the `WebvhDidRecord`, DID log, and updates the context DID field, matching server-managed behavior.
-- **Upgraded to didwebvh-rs 0.3 `create_did()` API** — Replaced manual `DIDWebVHState` + `create_log_entry` + SCID/DID extraction with the high-level `CreateDIDConfig` builder and `create_did()`. DID documents now use `{DID}` placeholders.
+- **Serverless WebVH DID creation (`--did-url`)** —
+  Create a DID document and log entry locally without
+  a pre-registered WebVH server. Keys are derived and
+  stored, and the DID document and log entry are
+  returned for self-hosting.
+- **Cascading context deletion** — Deleting a context
+  removes all associated keys, WebVH DIDs (and logs),
+  and cleans up ACL entries. A preview endpoint lets
+  callers inspect what will be removed before
+  committing.
+- **DID log retrieval API** — New
+  `GET /webvh/dids/{did}/log` endpoint (REST and
+  DIDComm) to retrieve the stored DID log for a given
+  WebVH DID.
+- **Serverless DIDs now persist data** — Serverless
+  DID creation stores the `WebvhDidRecord`, DID log,
+  and updates the context DID field, matching
+  server-managed behavior.
+- **Upgraded to didwebvh-rs 0.3 `create_did()` API**
+  — Replaced manual `DIDWebVHState` +
+  `create_log_entry` + SCID/DID extraction with the
+  high-level `CreateDIDConfig` builder and
+  `create_did()`. DID documents now use `{DID}`
+  placeholders.
 
 ### vta-cli-common `0.1.1`
 
-- **`cmd_context_provision`** — Creates a context, generates admin credentials, and optionally creates a WebVH DID. Outputs a portable base64 bundle for application onboarding.
-- **`cmd_context_reprovision`** — Regenerates a provision bundle for an existing context. Supports selecting an existing VTA-stored key interactively or via `--key`, or creating a new admin key. Includes full DID material (document, log entry, secrets).
-- **`cmd_context_delete`** — Cascading delete with preview and interactive confirmation.
-- **Serverless DID support** in `cmd_webvh_did_create` via `--did-url`.
+- **`cmd_context_provision`** — Creates a context,
+  generates admin credentials, and optionally creates
+  a WebVH DID. Outputs a portable base64 bundle for
+  application onboarding.
+- **`cmd_context_reprovision`** — Regenerates a
+  provision bundle for an existing context. Supports
+  selecting an existing VTA-stored key interactively
+  or via `--key`, or creating a new admin key.
+  Includes full DID material (document, log entry,
+  secrets).
+- **`cmd_context_delete`** — Cascading delete with
+  preview and interactive confirmation.
+- **Serverless DID support** in
+  `cmd_webvh_did_create` via `--did-url`.
 
 ### pnm-cli `0.1.1`
 
-- **`pnm context provision`** — Single command for application onboarding with optional DID creation.
-- **`pnm context reprovision`** — Regenerate provision bundles for existing contexts.
-- **`pnm context delete`** — Cascading delete with preview and `--force` flag.
-- **`pnm webvh create-did --did-url`** — Serverless DID creation.
+- **`pnm context provision`** — Single command for
+  application onboarding with optional DID creation.
+- **`pnm context reprovision`** — Regenerate provision
+  bundles for existing contexts.
+- **`pnm context delete`** — Cascading delete with
+  preview and `--force` flag.
+- **`pnm webvh create-did --did-url`** — Serverless
+  DID creation.
 
 ### cnm-cli `0.1.1`
 
-- **`cnm context delete`** — Cascading delete with preview and `--force` flag.
+- **`cnm context delete`** — Cascading delete with
+  preview and `--force` flag.
 
 ### vtc-service `0.1.1`
 
-- **Upgraded to didwebvh-rs 0.3 `create_did()` API** — Same refactoring as vta-service for DID creation flows.
+- **Upgraded to didwebvh-rs 0.3 `create_did()` API**
+  — Same refactoring as vta-service for DID creation
+  flows.
 
 ### Dependency Updates (all crates)
 
@@ -46,4 +99,5 @@
 - `affinidi-tdk` 0.5 → 0.6
 - `azure_security_keyvault_secrets` 0.11 → 0.12
 - `azure_identity` 0.32 → 0.33
-- All compatible transitive dependencies updated to latest versions
+- All compatible transitive dependencies updated to
+  latest versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 
 [workspace.package]
 description = "Verifiable Trust Communities - Verifiable Trust Agent SDK and Services"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 publish = false
 authors = ["Glenn Gore <glenn@affinidi.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/FirstPersonNetwork/vtc-vta-rs"
 [workspace.dependencies]
 
 # Affinidi Trust Development Kit
-affinidi-tdk = "0.5"
+affinidi-tdk = "0.6"
 
 # Decentralized Trust Graph Credentials
 # NOTE: When this is published, switch from git to crates.io
@@ -65,7 +65,7 @@ chrono = { version = "0.4", features = ["serde"] }
 rand = "0.10"
 
 # DID Web with Verifiable History
-didwebvh-rs = "0.2"
+didwebvh-rs = "0.3"
 
 # URL parsing
 url = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ chrono = { version = "0.4", features = ["serde"] }
 rand = "0.10"
 
 # DID Web with Verifiable History
-didwebvh-rs = "0.1"
+didwebvh-rs = "0.2"
 
 # URL parsing
 url = "2"

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -23,7 +23,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 [dependencies]
 vta-sdk = { path = "../vta-sdk", features = ["session"] }
 vta-cli-common = { path = "../vta-cli-common" }
-affinidi-did-resolver-cache-sdk = "0.7"
+affinidi-did-resolver-cache-sdk = "0.8"
 clap = { workspace = true, features = ["env"] }
 dialoguer = "0.12"
 dirs = "6"

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -167,10 +167,13 @@ enum ContextCommands {
         #[arg(long)]
         description: Option<String>,
     },
-    /// Delete an application context
+    /// Delete an application context and all associated resources
     Delete {
         /// Context ID
         id: String,
+        /// Skip confirmation and delete immediately
+        #[arg(long, short)]
+        force: bool,
     },
     /// Create a context and generate credentials for its first admin
     Bootstrap {
@@ -520,7 +523,9 @@ async fn main() {
                 did,
                 description,
             } => contexts::cmd_context_update(&client, &id, name, did, description).await,
-            ContextCommands::Delete { id } => contexts::cmd_context_delete(&client, &id).await,
+            ContextCommands::Delete { id, force } => {
+                contexts::cmd_context_delete(&client, &id, force).await
+            }
             ContextCommands::Bootstrap {
                 id,
                 name,

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -23,7 +23,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 [dependencies]
 vta-sdk = { path = "../vta-sdk", features = ["session"] }
 vta-cli-common = { path = "../vta-cli-common" }
-affinidi-did-resolver-cache-sdk = "0.7"
+affinidi-did-resolver-cache-sdk = "0.8"
 clap = { workspace = true, features = ["env"] }
 dirs = "6"
 serde = { workspace = true }

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -115,9 +115,12 @@ enum WebvhCommands {
         /// Application context ID
         #[arg(long)]
         context: String,
-        /// WebVH server ID
+        /// WebVH server ID (mutually exclusive with --did-url)
         #[arg(long)]
-        server: String,
+        server: Option<String>,
+        /// DID URL for serverless creation (mutually exclusive with --server)
+        #[arg(long)]
+        did_url: Option<String>,
         /// Optional path on the WebVH server
         #[arg(long)]
         path: Option<String>,
@@ -569,31 +572,41 @@ async fn main() {
             WebvhCommands::CreateDid {
                 context,
                 server,
+                did_url,
                 path,
                 label,
                 portable,
                 mediator_service,
                 services,
                 pre_rotation,
-            } => match services
-                .map(|s| serde_json::from_str::<Vec<serde_json::Value>>(&s))
-                .transpose()
-            {
-                Err(e) => Err(format!("invalid --services JSON: {e}").into()),
-                Ok(additional_services) => {
-                    let req = vta_sdk::client::CreateDidWebvhRequest {
-                        context_id: context,
-                        server_id: server,
-                        path,
-                        label,
-                        portable,
-                        add_mediator_service: mediator_service,
-                        additional_services,
-                        pre_rotation_count: pre_rotation,
-                    };
-                    webvh::cmd_webvh_did_create(&client, req).await
+            } => {
+                if server.is_none() && did_url.is_none() {
+                    Err("either --server or --did-url is required".into())
+                } else if server.is_some() && did_url.is_some() {
+                    Err("--server and --did-url are mutually exclusive".into())
+                } else {
+                    match services
+                        .map(|s| serde_json::from_str::<Vec<serde_json::Value>>(&s))
+                        .transpose()
+                    {
+                        Err(e) => Err(format!("invalid --services JSON: {e}").into()),
+                        Ok(additional_services) => {
+                            let req = vta_sdk::client::CreateDidWebvhRequest {
+                                context_id: context,
+                                server_id: server,
+                                url: did_url,
+                                path,
+                                label,
+                                portable,
+                                add_mediator_service: mediator_service,
+                                additional_services,
+                                pre_rotation_count: pre_rotation,
+                            };
+                            webvh::cmd_webvh_did_create(&client, req).await
+                        }
+                    }
                 }
-            },
+            }
             WebvhCommands::ListDids { context, server } => {
                 webvh::cmd_webvh_did_list(&client, context.as_deref(), server.as_deref()).await
             }

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -250,6 +250,41 @@ enum ContextCommands {
         #[arg(long)]
         admin_label: Option<String>,
     },
+    /// Provision a new application context with a portable config bundle
+    ///
+    /// Creates a context, generates admin credentials, and optionally creates a
+    /// WebVH DID. Outputs a single base64-encoded bundle that contains
+    /// everything an application needs to connect, authenticate, and
+    /// self-administer its context.
+    Provision {
+        /// Context slug (lowercase alphanumeric + hyphens)
+        #[arg(long)]
+        id: String,
+        /// Human-readable name
+        #[arg(long)]
+        name: String,
+        /// Optional description
+        #[arg(long)]
+        description: Option<String>,
+        /// Admin label
+        #[arg(long)]
+        admin_label: Option<String>,
+        /// Create a DID using this WebVH server (mutually exclusive with --did-url)
+        #[arg(long)]
+        server: Option<String>,
+        /// Create a DID at this URL for self-hosting (mutually exclusive with --server)
+        #[arg(long)]
+        did_url: Option<String>,
+        /// Make the DID portable (default: true)
+        #[arg(long, default_value = "true")]
+        portable: bool,
+        /// Add a mediator service endpoint to the DID
+        #[arg(long)]
+        mediator_service: bool,
+        /// Number of pre-rotation keys to generate
+        #[arg(long, default_value = "0")]
+        pre_rotation: u32,
+    },
 }
 
 #[derive(Subcommand)]
@@ -537,6 +572,41 @@ async fn main() {
                 admin_label,
             } => {
                 contexts::cmd_context_bootstrap(&client, &id, &name, description, admin_label).await
+            }
+            ContextCommands::Provision {
+                id,
+                name,
+                description,
+                admin_label,
+                server,
+                did_url,
+                portable,
+                mediator_service,
+                pre_rotation,
+            } => {
+                if server.is_some() && did_url.is_some() {
+                    Err("--server and --did-url are mutually exclusive".into())
+                } else {
+                    let did_opts = match (&server, &did_url) {
+                        (None, None) => None,
+                        _ => Some(contexts::ProvisionDidOptions {
+                            server_id: server,
+                            did_url,
+                            portable,
+                            add_mediator_service: mediator_service,
+                            pre_rotation_count: pre_rotation,
+                        }),
+                    };
+                    contexts::cmd_context_provision(
+                        &client,
+                        &id,
+                        &name,
+                        description,
+                        admin_label,
+                        did_opts,
+                    )
+                    .await
+                }
             }
         },
         Commands::Acl { command } => match command {

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -285,6 +285,25 @@ enum ContextCommands {
         #[arg(long, default_value = "0")]
         pre_rotation: u32,
     },
+    /// Regenerate a provision bundle for an existing context
+    ///
+    /// Fetches context metadata and builds a new provision bundle.
+    /// By default generates a new admin credential; pass --credential
+    /// to reuse an existing one instead.
+    Reprovision {
+        /// Context ID to reprovision
+        #[arg(long)]
+        id: String,
+        /// Reuse this existing credential (base64url-encoded) instead of generating a new one
+        #[arg(long)]
+        credential: Option<String>,
+        /// Label for the new admin credential (ignored when --credential is provided)
+        #[arg(long)]
+        admin_label: Option<String>,
+        /// Include DID key secrets in the bundle
+        #[arg(long)]
+        include_did: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -607,6 +626,17 @@ async fn main() {
                     )
                     .await
                 }
+            }
+            ContextCommands::Reprovision {
+                id,
+                credential,
+                admin_label,
+                include_did,
+            } => {
+                contexts::cmd_context_reprovision(
+                    &client, &id, credential, admin_label, include_did,
+                )
+                .await
             }
         },
         Commands::Acl { command } => match command {

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -227,10 +227,13 @@ enum ContextCommands {
         #[arg(long)]
         description: Option<String>,
     },
-    /// Delete an application context
+    /// Delete an application context and all associated resources
     Delete {
         /// Context ID
         id: String,
+        /// Skip confirmation and delete immediately
+        #[arg(long, short)]
+        force: bool,
     },
     /// Create a context and generate credentials for its first admin
     Bootstrap {
@@ -524,7 +527,9 @@ async fn main() {
                 did,
                 description,
             } => contexts::cmd_context_update(&client, &id, name, did, description).await,
-            ContextCommands::Delete { id } => contexts::cmd_context_delete(&client, &id).await,
+            ContextCommands::Delete { id, force } => {
+                contexts::cmd_context_delete(&client, &id, force).await
+            }
             ContextCommands::Bootstrap {
                 id,
                 name,

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -287,22 +287,19 @@ enum ContextCommands {
     },
     /// Regenerate a provision bundle for an existing context
     ///
-    /// Fetches context metadata and builds a new provision bundle.
-    /// By default generates a new admin credential; pass --credential
-    /// to reuse an existing one instead.
+    /// Builds a new provision bundle using a VTA-stored key as the admin
+    /// credential. Pass --key to specify a key ID directly, or omit it
+    /// to interactively select from existing keys or create a new one.
     Reprovision {
         /// Context ID to reprovision
         #[arg(long)]
         id: String,
-        /// Reuse this existing credential (base64url-encoded) instead of generating a new one
+        /// Key ID of an existing VTA-stored Ed25519 key to use as admin credential
         #[arg(long)]
-        credential: Option<String>,
-        /// Label for the new admin credential (ignored when --credential is provided)
+        key: Option<String>,
+        /// Label for a newly created admin key (used when no --key is provided)
         #[arg(long)]
         admin_label: Option<String>,
-        /// Include DID key secrets in the bundle
-        #[arg(long)]
-        include_did: bool,
     },
 }
 
@@ -629,14 +626,11 @@ async fn main() {
             }
             ContextCommands::Reprovision {
                 id,
-                credential,
+                key,
                 admin_label,
-                include_did,
             } => {
-                contexts::cmd_context_reprovision(
-                    &client, &id, credential, admin_label, include_did,
-                )
-                .await
+                contexts::cmd_context_reprovision(&client, &id, key, admin_label)
+                    .await
             }
         },
         Commands::Acl { command } => match command {

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -12,3 +12,4 @@ repository.workspace = true
 [dependencies]
 vta-sdk = { path = "../vta-sdk", features = ["client"] }
 ratatui = { workspace = true }
+serde_json = { workspace = true }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -11,5 +11,6 @@ repository.workspace = true
 
 [dependencies]
 vta-sdk = { path = "../vta-sdk", features = ["client"] }
+ed25519-dalek = "2"
 ratatui = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -1,3 +1,5 @@
+use std::io::{self, Write};
+
 use ratatui::{
     layout::Constraint,
     style::{Color, Modifier, Style},
@@ -173,8 +175,68 @@ pub async fn cmd_context_update(
 pub async fn cmd_context_delete(
     client: &VtaClient,
     id: &str,
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    client.delete_context(id).await?;
+    // Fetch a preview of what will be removed
+    let preview = client.preview_delete_context(id).await?;
+
+    let has_resources = !preview.keys.is_empty()
+        || !preview.webvh_dids.is_empty()
+        || !preview.acl_entries_removed.is_empty()
+        || !preview.acl_entries_updated.is_empty();
+
+    if has_resources {
+        println!("Deleting context '{}' will remove the following resources:\n", id);
+
+        if !preview.keys.is_empty() {
+            println!("  Keys ({}):", preview.keys.len());
+            for key in &preview.keys {
+                println!("    - {key}");
+            }
+        }
+
+        if !preview.webvh_dids.is_empty() {
+            println!("  WebVH DIDs ({}):", preview.webvh_dids.len());
+            for did in &preview.webvh_dids {
+                println!("    - {did}");
+            }
+        }
+
+        if !preview.acl_entries_removed.is_empty() {
+            println!("  ACL entries removed ({}):", preview.acl_entries_removed.len());
+            for did in &preview.acl_entries_removed {
+                println!("    - {did}");
+            }
+        }
+
+        if !preview.acl_entries_updated.is_empty() {
+            println!(
+                "  ACL entries updated (context removed from access list) ({}):",
+                preview.acl_entries_updated.len()
+            );
+            for did in &preview.acl_entries_updated {
+                println!("    - {did}");
+            }
+        }
+
+        println!();
+
+        if !force {
+            print!("Proceed with deletion? [y/N] ");
+            io::stdout().flush()?;
+
+            let mut input = String::new();
+            io::stdin().read_line(&mut input)?;
+            let input = input.trim().to_lowercase();
+
+            if input != "y" && input != "yes" {
+                println!("Aborted.");
+                return Ok(());
+            }
+        }
+    }
+
+    client.delete_context(id, true).await?;
     println!("Context deleted: {id}");
     Ok(())
 }

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -10,6 +10,7 @@ use vta_sdk::client::{
     VtaClient,
 };
 use vta_sdk::context_provision::{ContextProvisionBundle, ProvisionedDid};
+use vta_sdk::credentials::CredentialBundle;
 use vta_sdk::did_secrets::SecretEntry;
 
 use crate::render::print_widget;
@@ -361,6 +362,105 @@ pub async fn cmd_context_provision(
         if did.log_entry.is_some() {
             eprintln!("             (includes log entry for self-hosting)");
         }
+    }
+    eprintln!();
+    println!("{encoded}");
+    eprintln!();
+
+    Ok(())
+}
+
+pub async fn cmd_context_reprovision(
+    client: &VtaClient,
+    id: &str,
+    credential: Option<String>,
+    admin_label: Option<String>,
+    include_did: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Fetch the existing context
+    eprintln!("Fetching context '{id}'...");
+    let ctx = client.get_context(id).await?;
+
+    // 2. Resolve admin credential: reuse existing or generate new
+    let (admin_credential, admin_did, is_new_credential) = if let Some(ref cred) = credential {
+        let decoded = CredentialBundle::decode(cred)
+            .map_err(|e| format!("Invalid credential: {e}"))?;
+        eprintln!("Reusing existing admin credential...");
+        (cred.clone(), decoded.did, false)
+    } else {
+        eprintln!("Generating new admin credentials...");
+        let cred_req = GenerateCredentialsRequest {
+            role: "admin".to_string(),
+            label: admin_label,
+            allowed_contexts: vec![id.to_string()],
+        };
+        let cred_resp = client.generate_credentials(cred_req).await?;
+        (cred_resp.credential, cred_resp.did, true)
+    };
+
+    // 3. Fetch VTA config for URL/DID
+    let config = client.get_config().await?;
+
+    // 4. Optionally collect DID key secrets
+    let provisioned_did = if include_did {
+        if let Some(ref did_id) = ctx.did {
+            eprintln!("Fetching DID key secrets...");
+            let keys_resp = client
+                .list_keys(0, 10000, Some("active"), Some(id))
+                .await?;
+            let mut secrets = Vec::new();
+            for key in &keys_resp.keys {
+                let secret = client.get_key_secret(&key.key_id).await?;
+                secrets.push(SecretEntry {
+                    key_id: secret.key_id,
+                    key_type: secret.key_type,
+                    private_key_multibase: secret.private_key_multibase,
+                });
+            }
+            Some(ProvisionedDid {
+                id: did_id.clone(),
+                did_document: None,
+                log_entry: None,
+                secrets,
+            })
+        } else {
+            eprintln!("Warning: context has no DID assigned, skipping DID material");
+            None
+        }
+    } else {
+        None
+    };
+
+    // 5. Build the provision bundle
+    let bundle = ContextProvisionBundle {
+        context_id: id.to_string(),
+        context_name: ctx.name.clone(),
+        vta_url: config.public_url,
+        vta_did: config.community_vta_did,
+        credential: admin_credential,
+        admin_did,
+        did: provisioned_did,
+    };
+
+    let encoded = bundle.encode().map_err(|e| format!("{e}"))?;
+
+    // 6. Output
+    eprintln!();
+    eprintln!("\x1b[1;33m╔══════════════════════════════════════════════════════════════╗");
+    eprintln!("║  Context provision bundle (contains secrets — save securely) ║");
+    eprintln!("╚══════════════════════════════════════════════════════════════╝\x1b[0m");
+    eprintln!();
+    eprintln!("  Context:   {} ({})", id, ctx.name);
+    eprintln!("  Admin DID: {}", bundle.admin_did);
+    if let Some(ref did) = bundle.did {
+        eprintln!("  DID:       {}", did.id);
+    }
+    eprintln!();
+    if is_new_credential {
+        eprintln!("  Note: This is a NEW admin credential. Previous credentials");
+        eprintln!("        remain valid — revoke them separately if needed.");
+    } else {
+        eprintln!("  Note: Using existing admin credential.");
     }
     eprintln!();
     println!("{encoded}");

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -6,10 +6,21 @@ use ratatui::{
     widgets::{Block, Cell, Row, Table},
 };
 use vta_sdk::client::{
-    CreateContextRequest, GenerateCredentialsRequest, UpdateContextRequest, VtaClient,
+    CreateContextRequest, CreateDidWebvhRequest, GenerateCredentialsRequest, UpdateContextRequest,
+    VtaClient,
 };
+use vta_sdk::context_provision::{ContextProvisionBundle, ProvisionedDid};
+use vta_sdk::did_secrets::SecretEntry;
 
 use crate::render::print_widget;
+
+pub struct ProvisionDidOptions {
+    pub server_id: Option<String>,
+    pub did_url: Option<String>,
+    pub portable: bool,
+    pub add_mediator_service: bool,
+    pub pre_rotation_count: u32,
+}
 
 pub async fn cmd_context_bootstrap(
     client: &VtaClient,
@@ -238,5 +249,122 @@ pub async fn cmd_context_delete(
 
     client.delete_context(id, true).await?;
     println!("Context deleted: {id}");
+    Ok(())
+}
+
+pub async fn cmd_context_provision(
+    client: &VtaClient,
+    id: &str,
+    name: &str,
+    description: Option<String>,
+    admin_label: Option<String>,
+    did_opts: Option<ProvisionDidOptions>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Create the context
+    eprintln!("Creating context '{id}'...");
+    let ctx_req = CreateContextRequest {
+        id: id.to_string(),
+        name: name.to_string(),
+        description,
+    };
+    client.create_context(ctx_req).await?;
+
+    // 2. Generate admin credentials scoped to this context
+    eprintln!("Generating admin credentials...");
+    let cred_req = GenerateCredentialsRequest {
+        role: "admin".to_string(),
+        label: admin_label,
+        allowed_contexts: vec![id.to_string()],
+    };
+    let cred_resp = client.generate_credentials(cred_req).await?;
+
+    // 3. Fetch VTA config for URL/DID
+    let config = client.get_config().await?;
+
+    // 4. Optionally create a DID and collect its secrets
+    let provisioned_did = if let Some(opts) = did_opts {
+        eprintln!("Creating WebVH DID...");
+        let req = CreateDidWebvhRequest {
+            context_id: id.to_string(),
+            server_id: opts.server_id,
+            url: opts.did_url,
+            path: None,
+            label: Some(id.to_string()),
+            portable: opts.portable,
+            add_mediator_service: opts.add_mediator_service,
+            additional_services: None,
+            pre_rotation_count: opts.pre_rotation_count,
+        };
+        let did_result = client.create_did_webvh(req).await?;
+
+        // Collect secrets for the DID keys
+        eprintln!("Fetching DID key secrets...");
+        let mut secrets = Vec::new();
+        // Signing key
+        let signing = client.get_key_secret(&did_result.signing_key_id).await?;
+        secrets.push(SecretEntry {
+            key_id: signing.key_id,
+            key_type: signing.key_type,
+            private_key_multibase: signing.private_key_multibase,
+        });
+        // Key-agreement key
+        let ka = client.get_key_secret(&did_result.ka_key_id).await?;
+        secrets.push(SecretEntry {
+            key_id: ka.key_id,
+            key_type: ka.key_type,
+            private_key_multibase: ka.private_key_multibase,
+        });
+        // Pre-rotation keys
+        for i in 0..did_result.pre_rotation_key_count {
+            let pre_rot_id = format!("{}#pre-rotation-{i}", did_result.did);
+            let pre_rot = client.get_key_secret(&pre_rot_id).await?;
+            secrets.push(SecretEntry {
+                key_id: pre_rot.key_id,
+                key_type: pre_rot.key_type,
+                private_key_multibase: pre_rot.private_key_multibase,
+            });
+        }
+
+        Some(ProvisionedDid {
+            id: did_result.did,
+            did_document: did_result.did_document,
+            log_entry: did_result.log_entry,
+            secrets,
+        })
+    } else {
+        None
+    };
+
+    // 5. Build the provision bundle
+    let bundle = ContextProvisionBundle {
+        context_id: id.to_string(),
+        context_name: name.to_string(),
+        vta_url: config.public_url,
+        vta_did: config.community_vta_did,
+        credential: cred_resp.credential,
+        admin_did: cred_resp.did,
+        did: provisioned_did,
+    };
+
+    let encoded = bundle.encode().map_err(|e| format!("{e}"))?;
+
+    // 6. Output
+    eprintln!();
+    eprintln!("\x1b[1;33m╔══════════════════════════════════════════════════════════════╗");
+    eprintln!("║  Context provision bundle (contains secrets — save securely) ║");
+    eprintln!("╚══════════════════════════════════════════════════════════════╝\x1b[0m");
+    eprintln!();
+    eprintln!("  Context:   {} ({})", id, name);
+    eprintln!("  Admin DID: {}", bundle.admin_did);
+    if let Some(ref did) = bundle.did {
+        eprintln!("  DID:       {}", did.id);
+        if did.log_entry.is_some() {
+            eprintln!("             (includes log entry for self-hosting)");
+        }
+    }
+    eprintln!();
+    println!("{encoded}");
+    eprintln!();
+
     Ok(())
 }

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -6,12 +6,14 @@ use ratatui::{
     widgets::{Block, Cell, Row, Table},
 };
 use vta_sdk::client::{
-    CreateContextRequest, CreateDidWebvhRequest, GenerateCredentialsRequest, UpdateContextRequest,
-    VtaClient,
+    CreateContextRequest, CreateDidWebvhRequest, CreateKeyRequest, GenerateCredentialsRequest,
+    UpdateContextRequest, VtaClient,
 };
 use vta_sdk::context_provision::{ContextProvisionBundle, ProvisionedDid};
 use vta_sdk::credentials::CredentialBundle;
+use vta_sdk::did_key::{decode_private_key_multibase, ed25519_multibase_pubkey};
 use vta_sdk::did_secrets::SecretEntry;
+use vta_sdk::keys::KeyType;
 
 use crate::render::print_widget;
 
@@ -370,68 +372,182 @@ pub async fn cmd_context_provision(
     Ok(())
 }
 
+/// Build a `CredentialBundle` from a VTA-stored key, deriving its `did:key`.
+async fn credential_from_key(
+    client: &VtaClient,
+    key_id: &str,
+    vta_did: &str,
+    vta_url: Option<&str>,
+) -> Result<(String, String), Box<dyn std::error::Error>> {
+    let secret = client.get_key_secret(key_id).await?;
+    let seed = decode_private_key_multibase(&secret.private_key_multibase)
+        .map_err(|e| format!("Cannot decode key secret: {e}"))?;
+    let public_key = ed25519_dalek::SigningKey::from_bytes(&seed)
+        .verifying_key()
+        .to_bytes();
+    let did = format!("did:key:{}", ed25519_multibase_pubkey(&public_key));
+
+    let bundle = CredentialBundle {
+        did: did.clone(),
+        private_key_multibase: secret.private_key_multibase,
+        vta_did: vta_did.to_string(),
+        vta_url: vta_url.map(String::from),
+    };
+    let encoded = bundle.encode().map_err(|e| format!("{e}"))?;
+    Ok((encoded, did))
+}
+
 pub async fn cmd_context_reprovision(
     client: &VtaClient,
     id: &str,
-    credential: Option<String>,
+    key_id: Option<String>,
     admin_label: Option<String>,
-    include_did: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // 1. Fetch the existing context
     eprintln!("Fetching context '{id}'...");
     let ctx = client.get_context(id).await?;
 
-    // 2. Resolve admin credential: reuse existing or generate new
-    let (admin_credential, admin_did, is_new_credential) = if let Some(ref cred) = credential {
-        let decoded = CredentialBundle::decode(cred)
-            .map_err(|e| format!("Invalid credential: {e}"))?;
-        eprintln!("Reusing existing admin credential...");
-        (cred.clone(), decoded.did, false)
+    // 2. Fetch VTA config for URL/DID
+    let config = client.get_config().await?;
+    let vta_did = config
+        .community_vta_did
+        .as_deref()
+        .ok_or("VTA DID not configured")?;
+
+    // 3. Resolve admin credential
+    let (admin_credential, admin_did) = if let Some(ref kid) = key_id {
+        // Direct key ID specified
+        eprintln!("Using key '{kid}'...");
+        credential_from_key(client, kid, vta_did, config.public_url.as_deref()).await?
     } else {
-        eprintln!("Generating new admin credentials...");
-        let cred_req = GenerateCredentialsRequest {
-            role: "admin".to_string(),
-            label: admin_label,
-            allowed_contexts: vec![id.to_string()],
+        // Interactive: list existing Ed25519 keys and let user choose
+        let keys_resp = client
+            .list_keys(0, 10000, Some("active"), Some(id))
+            .await?;
+        let ed25519_keys: Vec<_> = keys_resp
+            .keys
+            .iter()
+            .filter(|k| k.key_type == KeyType::Ed25519)
+            .collect();
+
+        eprintln!();
+        eprintln!("Select an admin credential key for context '{id}':");
+        eprintln!();
+        for (i, key) in ed25519_keys.iter().enumerate() {
+            let label = key
+                .label
+                .as_deref()
+                .map(|l| format!(" ({l})"))
+                .unwrap_or_default();
+            eprintln!("  [{}] {}{}", i + 1, key.key_id, label);
+        }
+        let new_option = ed25519_keys.len() + 1;
+        eprintln!("  [{}] Create a new admin key", new_option);
+        eprintln!();
+        eprint!("Choice [{}]: ", new_option);
+        io::stderr().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let input = input.trim();
+
+        // Default to creating a new key if empty
+        let choice: usize = if input.is_empty() {
+            new_option
+        } else {
+            input
+                .parse()
+                .map_err(|_| format!("Invalid choice: {input}"))?
         };
-        let cred_resp = client.generate_credentials(cred_req).await?;
-        (cred_resp.credential, cred_resp.did, true)
+
+        if choice == new_option {
+            // Create a new Ed25519 key in VTA scoped to this context
+            eprintln!("Creating new admin key...");
+            let key_resp = client
+                .create_key(CreateKeyRequest {
+                    key_type: KeyType::Ed25519,
+                    derivation_path: None,
+                    key_id: None,
+                    mnemonic: None,
+                    label: admin_label.or_else(|| Some("admin".to_string())),
+                    context_id: Some(id.to_string()),
+                })
+                .await?;
+            credential_from_key(
+                client,
+                &key_resp.key_id,
+                vta_did,
+                config.public_url.as_deref(),
+            )
+            .await?
+        } else if choice >= 1 && choice <= ed25519_keys.len() {
+            let selected = &ed25519_keys[choice - 1];
+            eprintln!("Using key '{}'...", selected.key_id);
+            credential_from_key(
+                client,
+                &selected.key_id,
+                vta_did,
+                config.public_url.as_deref(),
+            )
+            .await?
+        } else {
+            return Err(format!("Invalid choice: {choice}").into());
+        }
     };
 
-    // 3. Fetch VTA config for URL/DID
-    let config = client.get_config().await?;
-
-    // 4. Optionally collect DID key secrets
-    let provisioned_did = if include_did {
-        if let Some(ref did_id) = ctx.did {
-            eprintln!("Fetching DID key secrets...");
-            let keys_resp = client
-                .list_keys(0, 10000, Some("active"), Some(id))
-                .await?;
-            let mut secrets = Vec::new();
-            for key in &keys_resp.keys {
-                let secret = client.get_key_secret(&key.key_id).await?;
-                secrets.push(SecretEntry {
-                    key_id: secret.key_id,
-                    key_type: secret.key_type,
-                    private_key_multibase: secret.private_key_multibase,
-                });
-            }
-            Some(ProvisionedDid {
-                id: did_id.clone(),
-                did_document: None,
-                log_entry: None,
-                secrets,
+    // 4. Ensure an ACL entry exists for this admin DID
+    if client.get_acl(&admin_did).await.is_err() {
+        eprintln!("Creating ACL entry for {admin_did}...");
+        client
+            .create_acl(vta_sdk::client::CreateAclRequest {
+                did: admin_did.clone(),
+                role: "admin".to_string(),
+                label: None,
+                allowed_contexts: vec![id.to_string()],
             })
+            .await?;
+    }
+
+    // 5. Collect DID material (document, log, secrets) when the context has a DID
+    let provisioned_did = if let Some(ref did_id) = ctx.did {
+        eprintln!("Fetching DID material...");
+
+        // Fetch the DID log and extract the DID document from it
+        let log_resp = client.get_did_webvh_log(did_id).await?;
+        let (did_document, log_entry) = if let Some(ref log_str) = log_resp.log {
+            let parsed: serde_json::Value = serde_json::from_str(log_str)
+                .map_err(|e| format!("failed to parse DID log: {e}"))?;
+            let doc = parsed.get("state").cloned();
+            (doc, Some(log_str.clone()))
         } else {
-            eprintln!("Warning: context has no DID assigned, skipping DID material");
-            None
+            (None, None)
+        };
+
+        // Fetch all active key secrets for this context
+        let keys_resp = client
+            .list_keys(0, 10000, Some("active"), Some(id))
+            .await?;
+        let mut secrets = Vec::new();
+        for key in &keys_resp.keys {
+            let secret = client.get_key_secret(&key.key_id).await?;
+            secrets.push(SecretEntry {
+                key_id: secret.key_id,
+                key_type: secret.key_type,
+                private_key_multibase: secret.private_key_multibase,
+            });
         }
+
+        Some(ProvisionedDid {
+            id: did_id.clone(),
+            did_document,
+            log_entry,
+            secrets,
+        })
     } else {
         None
     };
 
-    // 5. Build the provision bundle
+    // 6. Build the provision bundle
     let bundle = ContextProvisionBundle {
         context_id: id.to_string(),
         context_name: ctx.name.clone(),
@@ -444,7 +560,7 @@ pub async fn cmd_context_reprovision(
 
     let encoded = bundle.encode().map_err(|e| format!("{e}"))?;
 
-    // 6. Output
+    // 7. Output
     eprintln!();
     eprintln!("\x1b[1;33m╔══════════════════════════════════════════════════════════════╗");
     eprintln!("║  Context provision bundle (contains secrets — save securely) ║");
@@ -454,13 +570,6 @@ pub async fn cmd_context_reprovision(
     eprintln!("  Admin DID: {}", bundle.admin_did);
     if let Some(ref did) = bundle.did {
         eprintln!("  DID:       {}", did.id);
-    }
-    eprintln!();
-    if is_new_credential {
-        eprintln!("  Note: This is a NEW admin credential. Previous credentials");
-        eprintln!("        remain valid — revoke them separately if needed.");
-    } else {
-        eprintln!("  Note: Using existing admin credential.");
     }
     eprintln!();
     println!("{encoded}");

--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -117,13 +117,35 @@ pub async fn cmd_webvh_did_create(
     println!("WebVH DID created:");
     println!("  DID:              {}", result.did);
     println!("  Context:          {}", result.context_id);
-    println!("  Server:           {}", result.server_id);
-    println!("  Mnemonic:         {}", result.mnemonic);
+    if let Some(ref server_id) = result.server_id {
+        println!("  Server:           {}", server_id);
+    }
+    if let Some(ref mnemonic) = result.mnemonic {
+        println!("  Mnemonic:         {}", mnemonic);
+    }
     println!("  SCID:             {}", result.scid);
     println!("  Portable:         {}", result.portable);
     println!("  Signing key:      {}", result.signing_key_id);
     println!("  KA key:           {}", result.ka_key_id);
     println!("  Pre-rotation keys: {}", result.pre_rotation_key_count);
+
+    if let Some(ref did_document) = result.did_document {
+        println!();
+        println!("DID Document:");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(did_document).unwrap_or_else(|_| format!("{did_document}"))
+        );
+    }
+    if let Some(ref log_entry) = result.log_entry {
+        println!();
+        println!("Log Entry (did.jsonl):");
+        println!("{}", log_entry);
+        println!();
+        println!("To self-host this DID, place the log entry in a file named `did.jsonl`");
+        println!("at the URL path corresponding to your DID URL.");
+    }
+
     Ok(())
 }
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -39,6 +39,6 @@ tracing = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 affinidi-did-resolver-cache-sdk = { version = "0.8", optional = true }
 keyring = { version = "3", optional = true }
-azure_security_keyvault_secrets = { version = "0.11", optional = true }
-azure_identity = { version = "0.32", optional = true }
+azure_security_keyvault_secrets = { version = "0.12", optional = true }
+azure_identity = { version = "0.33", optional = true }
 tokio = { workspace = true, optional = true }

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -255,6 +255,14 @@ pub struct CreateDidWebvhRequest {
     pub pre_rotation_count: u32,
 }
 
+// ── WebVH DID log types ──────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct GetDidLogResponse {
+    pub did: String,
+    pub log: Option<String>,
+}
+
 // ── Credential types ────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -977,6 +985,20 @@ impl VtaClient {
             did_management::GET_DID_WEBVH_RESULT,
             30,
             |c, url| c.get(format!("{url}/webvh/dids/{}", encode_path_segment(did))),
+        )
+        .await
+    }
+
+    pub async fn get_did_webvh_log(
+        &self,
+        did: &str,
+    ) -> Result<GetDidLogResponse, Box<dyn std::error::Error>> {
+        self.rpc(
+            did_management::GET_DID_WEBVH_LOG,
+            serde_json::json!({ "did": did }),
+            did_management::GET_DID_WEBVH_LOG_RESULT,
+            30,
+            |c, url| c.get(format!("{url}/webvh/dids/{}/log", encode_path_segment(did))),
         )
         .await
     }

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -821,13 +821,36 @@ impl VtaClient {
         .await
     }
 
-    pub async fn delete_context(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn preview_delete_context(
+        &self,
+        id: &str,
+    ) -> Result<
+        context_management::delete::DeleteContextPreviewResultBody,
+        Box<dyn std::error::Error>,
+    > {
+        self.rpc(
+            context_management::PREVIEW_DELETE_CONTEXT,
+            serde_json::json!({ "id": id }),
+            context_management::PREVIEW_DELETE_CONTEXT_RESULT,
+            30,
+            |c, url| c.get(format!("{url}/contexts/{}/delete-preview", encode_path_segment(id))),
+        )
+        .await
+    }
+
+    pub async fn delete_context(&self, id: &str, force: bool) -> Result<(), Box<dyn std::error::Error>> {
         self.rpc_void(
             context_management::DELETE_CONTEXT,
-            serde_json::json!({ "id": id }),
+            serde_json::json!({ "id": id, "force": force }),
             context_management::DELETE_CONTEXT_RESULT,
             30,
-            |c, url| c.delete(format!("{url}/contexts/{}", encode_path_segment(id))),
+            |c, url| {
+                let mut url = format!("{url}/contexts/{}", encode_path_segment(id));
+                if force {
+                    url.push_str("?force=true");
+                }
+                c.delete(url)
+            },
         )
         .await
     }

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -240,7 +240,10 @@ pub struct UpdateWebvhServerRequest {
 #[derive(Debug, Serialize)]
 pub struct CreateDidWebvhRequest {
     pub context_id: String,
-    pub server_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/vta-sdk/src/context_provision.rs
+++ b/vta-sdk/src/context_provision.rs
@@ -1,0 +1,146 @@
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use serde::{Deserialize, Serialize};
+
+use crate::did_secrets::SecretEntry;
+
+/// A self-contained bundle for provisioning an application context.
+///
+/// Contains everything an independent application needs to connect to the VTA,
+/// authenticate, and self-administer its context. Optionally includes DID
+/// material (document, log entry, keys) when a DID was created during
+/// provisioning.
+///
+/// Encodes as JSON, then base64url-no-pad for safe transport.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextProvisionBundle {
+    /// Context identifier.
+    pub context_id: String,
+    /// Human-readable context name.
+    pub context_name: String,
+    /// VTA service public URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vta_url: Option<String>,
+    /// VTA service DID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vta_did: Option<String>,
+    /// Base64url-encoded admin credential bundle (existing `CredentialBundle` format).
+    pub credential: String,
+    /// DID of the admin identity created for this context.
+    pub admin_did: String,
+    /// DID material, present when a DID was created during provisioning.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub did: Option<ProvisionedDid>,
+}
+
+/// DID material included when a DID is created during context provisioning.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProvisionedDid {
+    /// The DID identifier (e.g. `did:webvh:...`).
+    pub id: String,
+    /// DID document (JSON).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub did_document: Option<serde_json::Value>,
+    /// Serialized DID log entry for `did.jsonl`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_entry: Option<String>,
+    /// Private keys associated with the DID.
+    pub secrets: Vec<SecretEntry>,
+}
+
+impl ContextProvisionBundle {
+    /// Decode a base64url-no-pad encoded provision bundle.
+    pub fn decode(encoded: &str) -> Result<Self, ContextProvisionBundleError> {
+        let json_bytes = BASE64
+            .decode(encoded)
+            .map_err(|e| ContextProvisionBundleError::Base64(e.to_string()))?;
+        serde_json::from_slice(&json_bytes)
+            .map_err(|e| ContextProvisionBundleError::Json(e.to_string()))
+    }
+
+    /// Encode this bundle as a base64url-no-pad string.
+    pub fn encode(&self) -> Result<String, ContextProvisionBundleError> {
+        let json = serde_json::to_vec(self)
+            .map_err(|e| ContextProvisionBundleError::Json(e.to_string()))?;
+        Ok(BASE64.encode(&json))
+    }
+}
+
+/// Errors when decoding or encoding a [`ContextProvisionBundle`].
+#[derive(Debug)]
+pub enum ContextProvisionBundleError {
+    Base64(String),
+    Json(String),
+}
+
+impl std::fmt::Display for ContextProvisionBundleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Base64(e) => write!(f, "base64 decode error: {e}"),
+            Self::Json(e) => write!(f, "JSON error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ContextProvisionBundleError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_decode_roundtrip_without_did() {
+        let bundle = ContextProvisionBundle {
+            context_id: "my-app".to_string(),
+            context_name: "My Application".to_string(),
+            vta_url: Some("https://vta.example.com".to_string()),
+            vta_did: Some("did:webvh:abc:example.com".to_string()),
+            credential: "eyJ0ZXN0IjogdHJ1ZX0".to_string(),
+            admin_did: "did:key:z6Mk123".to_string(),
+            did: None,
+        };
+        let encoded = bundle.encode().unwrap();
+        let decoded = ContextProvisionBundle::decode(&encoded).unwrap();
+        assert_eq!(decoded.context_id, "my-app");
+        assert_eq!(decoded.context_name, "My Application");
+        assert_eq!(decoded.admin_did, "did:key:z6Mk123");
+        assert!(decoded.did.is_none());
+    }
+
+    #[test]
+    fn test_encode_decode_roundtrip_with_did() {
+        let bundle = ContextProvisionBundle {
+            context_id: "my-app".to_string(),
+            context_name: "My Application".to_string(),
+            vta_url: None,
+            vta_did: None,
+            credential: "eyJ0ZXN0IjogdHJ1ZX0".to_string(),
+            admin_did: "did:key:z6Mk123".to_string(),
+            did: Some(ProvisionedDid {
+                id: "did:webvh:abc:example.com".to_string(),
+                did_document: Some(serde_json::json!({"id": "did:webvh:abc:example.com"})),
+                log_entry: Some("{\"log\": \"entry\"}".to_string()),
+                secrets: vec![SecretEntry {
+                    key_id: "did:webvh:abc:example.com#key-0".to_string(),
+                    key_type: crate::keys::KeyType::Ed25519,
+                    private_key_multibase: "z6Mk...signing".to_string(),
+                }],
+            }),
+        };
+        let encoded = bundle.encode().unwrap();
+        let decoded = ContextProvisionBundle::decode(&encoded).unwrap();
+        assert_eq!(decoded.context_id, "my-app");
+        let did = decoded.did.unwrap();
+        assert_eq!(did.id, "did:webvh:abc:example.com");
+        assert!(did.did_document.is_some());
+        assert!(did.log_entry.is_some());
+        assert_eq!(did.secrets.len(), 1);
+    }
+
+    #[test]
+    fn test_decode_invalid_base64() {
+        let result = ContextProvisionBundle::decode("!!!not-base64!!!");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("base64"));
+    }
+}

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "client")]
 pub mod client;
+pub mod context_provision;
 pub mod contexts;
 pub mod credentials;
 pub mod did_key;

--- a/vta-sdk/src/protocols/context_management/delete.rs
+++ b/vta-sdk/src/protocols/context_management/delete.rs
@@ -3,10 +3,29 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteContextBody {
     pub id: String,
+    #[serde(default)]
+    pub force: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteContextResultBody {
     pub id: String,
     pub deleted: bool,
+}
+
+/// Summary of resources that will be removed when deleting a context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteContextPreviewBody {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DeleteContextPreviewResultBody {
+    pub id: String,
+    pub keys: Vec<String>,
+    pub webvh_dids: Vec<String>,
+    /// ACL entries that will be deleted (only have this context).
+    pub acl_entries_removed: Vec<String>,
+    /// ACL entries that will have this context removed from their allowed list.
+    pub acl_entries_updated: Vec<String>,
 }

--- a/vta-sdk/src/protocols/context_management/mod.rs
+++ b/vta-sdk/src/protocols/context_management/mod.rs
@@ -30,3 +30,8 @@ pub const DELETE_CONTEXT: &str =
     "https://firstperson.network/protocols/context-management/1.0/delete-context";
 pub const DELETE_CONTEXT_RESULT: &str =
     "https://firstperson.network/protocols/context-management/1.0/delete-context-result";
+
+pub const PREVIEW_DELETE_CONTEXT: &str =
+    "https://firstperson.network/protocols/context-management/1.0/preview-delete-context";
+pub const PREVIEW_DELETE_CONTEXT_RESULT: &str =
+    "https://firstperson.network/protocols/context-management/1.0/preview-delete-context-result";

--- a/vta-sdk/src/protocols/did_management/create.rs
+++ b/vta-sdk/src/protocols/did_management/create.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateDidWebvhBody {
     pub context_id: String,
-    pub server_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -23,12 +26,18 @@ pub struct CreateDidWebvhBody {
 pub struct CreateDidWebvhResultBody {
     pub did: String,
     pub context_id: String,
-    pub server_id: String,
-    pub mnemonic: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mnemonic: Option<String>,
     pub scid: String,
     pub portable: bool,
     pub signing_key_id: String,
     pub ka_key_id: String,
     pub pre_rotation_key_count: u32,
     pub created_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub did_document: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_entry: Option<String>,
 }

--- a/vta-sdk/src/protocols/did_management/mod.rs
+++ b/vta-sdk/src/protocols/did_management/mod.rs
@@ -21,6 +21,11 @@ pub const LIST_DIDS_WEBVH: &str =
 pub const LIST_DIDS_WEBVH_RESULT: &str =
     "https://firstperson.network/protocols/did-management/1.0/list-dids-webvh-result";
 
+pub const GET_DID_WEBVH_LOG: &str =
+    "https://firstperson.network/protocols/did-management/1.0/get-did-webvh-log";
+pub const GET_DID_WEBVH_LOG_RESULT: &str =
+    "https://firstperson.network/protocols/did-management/1.0/get-did-webvh-log-result";
+
 pub const DELETE_DID_WEBVH: &str =
     "https://firstperson.network/protocols/did-management/1.0/delete-did-webvh";
 pub const DELETE_DID_WEBVH_RESULT: &str =

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -60,114 +60,76 @@ pub struct TokenResult {
     pub access_expires_at: u64,
 }
 
-// ── SessionStore ────────────────────────────────────────────────────
+// ── SessionBackend trait ────────────────────────────────────────────
 
-/// Reusable session storage for VTA authentication.
+/// Pluggable storage backend for VTA session credentials.
 ///
-/// Stores sessions in either the OS keyring or a local JSON file,
-/// depending on which feature is enabled.
-pub struct SessionStore {
-    #[cfg(feature = "keyring")]
-    service_name: String,
-    #[cfg(all(
-        feature = "config-session",
-        not(feature = "keyring"),
-        not(feature = "azure-secrets")
-    ))]
-    sessions_dir: PathBuf,
-    #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
-    azure_vault_url: String,
-    #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
-    azure_secret_prefix: String,
-    #[cfg(not(any(
-        feature = "keyring",
-        feature = "config-session",
-        feature = "azure-secrets"
-    )))]
-    sessions_dir: PathBuf,
+/// Implement this trait to store VTA sessions in a custom backend
+/// (e.g., the same secrets store your application already uses).
+///
+/// The `key` parameter identifies the session (e.g., "default", "setup").
+/// The `value` is a JSON-serialized session blob containing credentials
+/// and cached tokens.
+pub trait SessionBackend: Send + Sync {
+    /// Load a session by key. Returns `None` if not found.
+    fn load(&self, key: &str) -> Option<String>;
+    /// Store a session. The value is JSON-serialized session data.
+    fn save(&self, key: &str, value: &str) -> Result<(), Box<dyn std::error::Error>>;
+    /// Remove a session by key.
+    fn clear(&self, key: &str);
 }
 
-impl SessionStore {
-    /// Create a new session store.
-    ///
-    /// - `service_name`: keyring service name (used with `keyring` feature)
-    /// - `sessions_dir`: directory for `sessions.json` (used with `config-session` feature)
-    pub fn new(service_name: &str, sessions_dir: PathBuf) -> Self {
-        // Suppress unused-variable warnings based on active feature
-        let _ = &sessions_dir;
-        let _ = service_name;
+// ── Built-in backends ───────────────────────────────────────────────
 
-        Self {
-            #[cfg(feature = "keyring")]
-            service_name: service_name.to_string(),
-            #[cfg(all(
-                feature = "config-session",
-                not(feature = "keyring"),
-                not(feature = "azure-secrets")
-            ))]
-            sessions_dir,
-            #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
-            azure_vault_url: std::env::var("AZURE_KEYVAULT_URL").unwrap_or_default(),
-            #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
-            azure_secret_prefix: service_name.to_string(),
-            #[cfg(not(any(
-                feature = "keyring",
-                feature = "config-session",
-                feature = "azure-secrets"
-            )))]
-            sessions_dir,
+/// OS keyring backend (requires `keyring` feature).
+#[cfg(feature = "keyring")]
+struct KeyringBackend {
+    service_name: String,
+}
+
+#[cfg(feature = "keyring")]
+impl SessionBackend for KeyringBackend {
+    fn load(&self, key: &str) -> Option<String> {
+        let entry = keyring::Entry::new(&self.service_name, key).ok()?;
+        match entry.get_password() {
+            Ok(v) => Some(v),
+            Err(keyring::Error::NoEntry) => None,
+            Err(e) => {
+                eprintln!("Warning: keyring read error: {e}");
+                None
+            }
         }
     }
 
-    // ── Storage backends ────────────────────────────────────────────
-
-    #[cfg(feature = "keyring")]
-    fn load(&self, key: &str) -> Option<Session> {
-        let entry = keyring::Entry::new(&self.service_name, key).ok()?;
-        let json = match entry.get_password() {
-            Ok(v) => v,
-            Err(keyring::Error::NoEntry) => return None,
-            Err(e) => {
-                eprintln!("Warning: keyring read error: {e}");
-                return None;
-            }
-        };
-        serde_json::from_str(&json).ok()
-    }
-
-    #[cfg(feature = "keyring")]
-    fn save(&self, key: &str, session: &Session) -> Result<(), Box<dyn std::error::Error>> {
+    fn save(&self, key: &str, value: &str) -> Result<(), Box<dyn std::error::Error>> {
         let entry = keyring::Entry::new(&self.service_name, key)
             .map_err(|e| format!("keyring entry error: {e}"))?;
-        let json = serde_json::to_string(session)?;
         entry
-            .set_password(&json)
+            .set_password(value)
             .map_err(|e| format!("failed to store session in keyring: {e}"))?;
         Ok(())
     }
 
-    #[cfg(feature = "keyring")]
     fn clear(&self, key: &str) {
         if let Ok(entry) = keyring::Entry::new(&self.service_name, key) {
             let _ = entry.delete_credential();
         }
     }
+}
 
-    #[cfg(all(
-        feature = "config-session",
-        not(feature = "keyring"),
-        not(feature = "azure-secrets")
-    ))]
+/// Local JSON file backend (requires `config-session` feature, or used
+/// as plaintext fallback when no secure backend is compiled in).
+struct FileBackend {
+    sessions_dir: PathBuf,
+    warn: bool,
+}
+
+impl FileBackend {
     fn sessions_path(&self) -> PathBuf {
         self.sessions_dir.join("sessions.json")
     }
 
-    #[cfg(all(
-        feature = "config-session",
-        not(feature = "keyring"),
-        not(feature = "azure-secrets")
-    ))]
-    fn load_sessions_map(&self) -> std::collections::HashMap<String, Session> {
+    fn load_map(&self) -> std::collections::HashMap<String, serde_json::Value> {
         let path = self.sessions_path();
         let data = match std::fs::read_to_string(&path) {
             Ok(d) => d,
@@ -176,67 +138,70 @@ impl SessionStore {
         serde_json::from_str(&data).unwrap_or_default()
     }
 
-    #[cfg(all(
-        feature = "config-session",
-        not(feature = "keyring"),
-        not(feature = "azure-secrets")
-    ))]
-    fn save_sessions_map(
+    fn save_map(
         &self,
-        map: &std::collections::HashMap<String, Session>,
+        map: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let path = self.sessions_path();
         let json = serde_json::to_string_pretty(map)?;
         std::fs::write(&path, json)?;
         Ok(())
     }
+}
 
-    #[cfg(all(
-        feature = "config-session",
-        not(feature = "keyring"),
-        not(feature = "azure-secrets")
-    ))]
-    fn load(&self, key: &str) -> Option<Session> {
-        self.load_sessions_map().get(key).cloned()
+impl SessionBackend for FileBackend {
+    fn load(&self, key: &str) -> Option<String> {
+        if self.warn {
+            eprintln!("WARNING: No secure session store — using plaintext file storage");
+        }
+        let map = self.load_map();
+        map.get(key).map(|v| v.to_string())
     }
 
-    #[cfg(all(
-        feature = "config-session",
-        not(feature = "keyring"),
-        not(feature = "azure-secrets")
-    ))]
-    fn save(&self, key: &str, session: &Session) -> Result<(), Box<dyn std::error::Error>> {
-        let mut map = self.load_sessions_map();
-        map.insert(key.to_string(), session.clone());
-        self.save_sessions_map(&map)
+    fn save(&self, key: &str, value: &str) -> Result<(), Box<dyn std::error::Error>> {
+        if self.warn {
+            eprintln!("WARNING: No secure session store — using plaintext file storage");
+        }
+        if let Some(parent) = self.sessions_dir.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::create_dir_all(&self.sessions_dir).ok();
+        let mut map = self.load_map();
+        let parsed: serde_json::Value = serde_json::from_str(value)?;
+        map.insert(key.to_string(), parsed);
+        self.save_map(&map)
     }
 
-    #[cfg(all(
-        feature = "config-session",
-        not(feature = "keyring"),
-        not(feature = "azure-secrets")
-    ))]
     fn clear(&self, key: &str) {
-        let mut map = self.load_sessions_map();
+        let mut map = self.load_map();
         map.remove(key);
-        let _ = self.save_sessions_map(&map);
+        let _ = self.save_map(&map);
     }
+}
 
-    // ── Azure Key Vault backend ─────────────────────────────────────
+/// Azure Key Vault backend (requires `azure-secrets` feature).
+#[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
+struct AzureBackend {
+    vault_url: String,
+    secret_prefix: String,
+}
 
-    #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
-    fn azure_secret_name(&self, key: &str) -> String {
-        format!("{}-{}", self.azure_secret_prefix, key)
+#[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
+impl AzureBackend {
+    fn secret_name(&self, key: &str) -> String {
+        format!("{}-{}", self.secret_prefix, key)
     }
+}
 
-    #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
-    fn load(&self, key: &str) -> Option<Session> {
+#[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
+impl SessionBackend for AzureBackend {
+    fn load(&self, key: &str) -> Option<String> {
         use azure_identity::DeveloperToolsCredential;
         use azure_security_keyvault_secrets::SecretClient;
 
         let credential = DeveloperToolsCredential::new(None).ok()?;
-        let client = SecretClient::new(&self.azure_vault_url, credential, None).ok()?;
-        let secret_name = self.azure_secret_name(key);
+        let client = SecretClient::new(&self.vault_url, credential, None).ok()?;
+        let secret_name = self.secret_name(key);
 
         let result = tokio::runtime::Handle::current()
             .block_on(async { client.get_secret(&secret_name, None).await });
@@ -244,27 +209,24 @@ impl SessionStore {
         match result {
             Ok(response) => {
                 let model = response.into_model().ok()?;
-                let json = model.value?;
-                serde_json::from_str(&json).ok()
+                model.value
             }
             Err(_) => None,
         }
     }
 
-    #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
-    fn save(&self, key: &str, session: &Session) -> Result<(), Box<dyn std::error::Error>> {
+    fn save(&self, key: &str, value: &str) -> Result<(), Box<dyn std::error::Error>> {
         use azure_identity::DeveloperToolsCredential;
         use azure_security_keyvault_secrets::SecretClient;
 
         let credential = DeveloperToolsCredential::new(None)
             .map_err(|e| format!("Azure credential error: {e}"))?;
-        let client = SecretClient::new(&self.azure_vault_url, credential, None)
+        let client = SecretClient::new(&self.vault_url, credential, None)
             .map_err(|e| format!("Azure client error: {e}"))?;
-        let secret_name = self.azure_secret_name(key);
-        let json = serde_json::to_string(session)?;
+        let secret_name = self.secret_name(key);
 
         let params = azure_security_keyvault_secrets::models::SetSecretParameters {
-            value: Some(json),
+            value: Some(value.to_string()),
             ..Default::default()
         };
 
@@ -281,7 +243,6 @@ impl SessionStore {
         Ok(())
     }
 
-    #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
     fn clear(&self, key: &str) {
         use azure_identity::DeveloperToolsCredential;
         use azure_security_keyvault_secrets::SecretClient;
@@ -289,97 +250,116 @@ impl SessionStore {
         let Ok(credential) = DeveloperToolsCredential::new(None) else {
             return;
         };
-        let Ok(client) = SecretClient::new(&self.azure_vault_url, credential, None) else {
+        let Ok(client) = SecretClient::new(&self.vault_url, credential, None) else {
             return;
         };
-        let secret_name = self.azure_secret_name(key);
+        let secret_name = self.secret_name(key);
 
         let _ = tokio::runtime::Handle::current()
             .block_on(async { client.delete_secret(&secret_name, None).await });
     }
+}
 
-    // ── Plaintext fallback backend ──────────────────────────────────
+/// Create the default session backend based on compiled features.
+///
+/// Priority: keyring → azure-secrets → config-session → plaintext fallback.
+fn default_backend(service_name: &str, sessions_dir: PathBuf) -> Box<dyn SessionBackend> {
+    let _ = service_name;
+    let _ = &sessions_dir;
 
-    #[cfg(not(any(
-        feature = "keyring",
-        feature = "config-session",
-        feature = "azure-secrets"
-    )))]
-    fn sessions_path(&self) -> PathBuf {
-        self.sessions_dir.join("sessions.json")
+    #[cfg(feature = "keyring")]
+    {
+        return Box::new(KeyringBackend {
+            service_name: service_name.to_string(),
+        });
     }
 
-    #[cfg(not(any(
-        feature = "keyring",
-        feature = "config-session",
-        feature = "azure-secrets"
-    )))]
-    fn load_sessions_map(&self) -> std::collections::HashMap<String, Session> {
-        let path = self.sessions_path();
-        let data = match std::fs::read_to_string(&path) {
-            Ok(d) => d,
-            Err(_) => return std::collections::HashMap::new(),
-        };
-        serde_json::from_str(&data).unwrap_or_default()
+    #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
+    {
+        return Box::new(AzureBackend {
+            vault_url: std::env::var("AZURE_KEYVAULT_URL").unwrap_or_default(),
+            secret_prefix: service_name.to_string(),
+        });
     }
 
-    #[cfg(not(any(
-        feature = "keyring",
+    #[cfg(all(
         feature = "config-session",
-        feature = "azure-secrets"
-    )))]
-    fn save_sessions_map(
-        &self,
-        map: &std::collections::HashMap<String, Session>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let path = self.sessions_path();
-        let json = serde_json::to_string_pretty(map)?;
-        std::fs::write(&path, json)?;
-        Ok(())
+        not(feature = "keyring"),
+        not(feature = "azure-secrets")
+    ))]
+    {
+        return Box::new(FileBackend {
+            sessions_dir,
+            warn: false,
+        });
     }
 
-    #[cfg(not(any(
-        feature = "keyring",
-        feature = "config-session",
-        feature = "azure-secrets"
-    )))]
-    fn load(&self, key: &str) -> Option<Session> {
-        eprintln!("WARNING: No secure session store — using plaintext file storage");
-        self.load_sessions_map().get(key).cloned()
-    }
+    #[allow(unreachable_code)]
+    Box::new(FileBackend {
+        sessions_dir,
+        warn: true,
+    })
+}
 
-    #[cfg(not(any(
-        feature = "keyring",
-        feature = "config-session",
-        feature = "azure-secrets"
-    )))]
-    fn save(&self, key: &str, session: &Session) -> Result<(), Box<dyn std::error::Error>> {
-        eprintln!("WARNING: No secure session store — using plaintext file storage");
-        if let Some(parent) = self.sessions_dir.parent() {
-            std::fs::create_dir_all(parent).ok();
+// ── SessionStore ────────────────────────────────────────────────────
+
+/// Reusable session storage for VTA authentication.
+///
+/// Uses a pluggable [`SessionBackend`] for credential persistence.
+/// By default, the backend is selected based on compiled features
+/// (keyring → azure → config-file → plaintext). Consumers can
+/// provide their own backend via [`SessionStore::with_backend`].
+pub struct SessionStore {
+    backend: Box<dyn SessionBackend>,
+}
+
+impl SessionStore {
+    /// Create a new session store with the default backend.
+    ///
+    /// The backend is selected based on compiled features:
+    /// - `keyring` → OS keyring (uses `service_name`)
+    /// - `azure-secrets` → Azure Key Vault (uses `service_name` as prefix)
+    /// - `config-session` → local JSON file (uses `sessions_dir`)
+    /// - fallback → plaintext JSON file with warning
+    pub fn new(service_name: &str, sessions_dir: PathBuf) -> Self {
+        Self {
+            backend: default_backend(service_name, sessions_dir),
         }
-        std::fs::create_dir_all(&self.sessions_dir).ok();
-        let mut map = self.load_sessions_map();
-        map.insert(key.to_string(), session.clone());
-        self.save_sessions_map(&map)
     }
 
-    #[cfg(not(any(
-        feature = "keyring",
-        feature = "config-session",
-        feature = "azure-secrets"
-    )))]
-    fn clear(&self, key: &str) {
-        let mut map = self.load_sessions_map();
-        map.remove(key);
-        let _ = self.save_sessions_map(&map);
+    /// Create a session store with a custom backend.
+    ///
+    /// Use this to integrate with your application's existing secrets
+    /// storage (e.g., AWS Secrets Manager, GCP Secret Manager, etc.).
+    pub fn with_backend(backend: Box<dyn SessionBackend>) -> Self {
+        Self { backend }
+    }
+
+    // ── Internal session serialization ───────────────────────────────
+
+    fn load_session(&self, key: &str) -> Option<Session> {
+        let json = self.backend.load(key)?;
+        serde_json::from_str(&json).ok()
+    }
+
+    fn save_session(
+        &self,
+        key: &str,
+        session: &Session,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let json = serde_json::to_string(session)?;
+        self.backend.save(key, &json)
+    }
+
+    fn clear_session(&self, key: &str) {
+        self.backend.clear(key);
     }
 
     // ── Public API ──────────────────────────────────────────────────
 
     /// Returns true if a session exists for the given key.
     pub fn has_session(&self, key: &str) -> bool {
-        self.load(key).is_some()
+        self.load_session(key).is_some()
     }
 
     /// Import a base64-encoded credential and authenticate.
@@ -410,7 +390,7 @@ impl SessionStore {
             access_token: None,
             access_expires_at: None,
         };
-        self.save(key, &session)?;
+        self.save_session(key, &session)?;
         debug!(keyring_key = key, "session saved");
 
         // Perform authentication
@@ -424,7 +404,7 @@ impl SessionStore {
 
         session.access_token = Some(token.access_token);
         session.access_expires_at = Some(token.access_expires_at);
-        self.save(key, &session)?;
+        self.save_session(key, &session)?;
 
         Ok(LoginResult {
             client_did: bundle.did,
@@ -450,17 +430,17 @@ impl SessionStore {
             access_token: None,
             access_expires_at: None,
         };
-        self.save(key, &session)
+        self.save_session(key, &session)
     }
 
     /// Clear stored credentials and cached tokens.
     pub fn logout(&self, key: &str) {
-        self.clear(key);
+        self.clear_session(key);
     }
 
     /// Load the stored session for diagnostics (DID resolution, etc.).
     pub fn loaded_session(&self, key: &str) -> Option<SessionInfo> {
-        self.load(key).map(|s| SessionInfo {
+        self.load_session(key).map(|s| SessionInfo {
             client_did: s.client_did,
             vta_did: s.vta_did,
             private_key_multibase: s.private_key,
@@ -469,7 +449,7 @@ impl SessionStore {
 
     /// Get the status of a stored session.
     pub fn session_status(&self, key: &str) -> Option<SessionStatus> {
-        let session = self.load(key)?;
+        let session = self.load_session(key)?;
         let token_status = match (session.access_token, session.access_expires_at) {
             (Some(_), Some(exp)) => {
                 let now = now_epoch();
@@ -503,7 +483,7 @@ impl SessionStore {
     ) -> Result<String, Box<dyn std::error::Error>> {
         debug!(base_url, keyring_key = key, "ensuring authentication");
 
-        let mut session = self.load(key).ok_or(
+        let mut session = self.load_session(key).ok_or(
             "Not authenticated.\n\nTo authenticate, import a credential:\n  <cli> auth login <credential-string>",
         )?;
 
@@ -535,7 +515,7 @@ impl SessionStore {
         let token = result.access_token.clone();
         session.access_token = Some(result.access_token);
         session.access_expires_at = Some(result.access_expires_at);
-        self.save(key, &session)?;
+        self.save_session(key, &session)?;
         debug!("new token cached");
 
         Ok(token)
@@ -553,7 +533,7 @@ impl SessionStore {
         key: &str,
         url_override: Option<&str>,
     ) -> Result<crate::client::VtaClient, Box<dyn std::error::Error>> {
-        let session = self.load(key).ok_or(
+        let session = self.load_session(key).ok_or(
             "Not authenticated.\n\nTo authenticate, import a credential:\n  <cli> auth login <credential-string>",
         )?;
 
@@ -1029,5 +1009,45 @@ mod tests {
     #[test]
     fn test_url_from_did_key_returns_none() {
         assert_eq!(url_from_did("did:key:z6MkTest"), None);
+    }
+
+    #[test]
+    fn test_in_memory_backend() {
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+
+        struct InMemoryBackend {
+            data: Mutex<HashMap<String, String>>,
+        }
+
+        impl SessionBackend for InMemoryBackend {
+            fn load(&self, key: &str) -> Option<String> {
+                self.data.lock().unwrap().get(key).cloned()
+            }
+            fn save(&self, key: &str, value: &str) -> Result<(), Box<dyn std::error::Error>> {
+                self.data.lock().unwrap().insert(key.to_string(), value.to_string());
+                Ok(())
+            }
+            fn clear(&self, key: &str) {
+                self.data.lock().unwrap().remove(key);
+            }
+        }
+
+        let backend = InMemoryBackend {
+            data: Mutex::new(HashMap::new()),
+        };
+        let store = SessionStore::with_backend(Box::new(backend));
+
+        assert!(!store.has_session("test"));
+
+        store.store_direct("test", "did:key:z6Mk1", "zSeed", "did:key:zVTA", "https://vta.example.com").unwrap();
+        assert!(store.has_session("test"));
+
+        let info = store.loaded_session("test").unwrap();
+        assert_eq!(info.client_did, "did:key:z6Mk1");
+        assert_eq!(info.vta_did, "did:key:zVTA");
+
+        store.logout("test");
+        assert!(!store.has_session("test"));
     }
 }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -65,8 +65,8 @@ clap = { workspace = true }
 didwebvh-rs = { workspace = true, optional = true }
 rand = { workspace = true }
 dialoguer = "0.12"
-azure_security_keyvault_secrets = { version = "0.11", optional = true }
-azure_identity = { version = "0.32", optional = true }
+azure_security_keyvault_secrets = { version = "0.12", optional = true }
+azure_identity = { version = "0.33", optional = true }
 sha2 = { workspace = true }
 x25519-dalek = { workspace = true }
 multibase = { workspace = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -136,12 +136,12 @@ pub async fn run_create_did_webvh(
 
     // Build parameters
     let parameters = WebVHParameters {
-        update_keys: Some(Arc::new(vec![derived.signing_pub.clone()])),
+        update_keys: Some(Arc::new(vec![derived.signing_pub.clone().into()])),
         portable: Some(portable),
         next_key_hashes: if next_key_hashes.is_empty() {
             None
         } else {
-            Some(Arc::new(next_key_hashes))
+            Some(Arc::new(next_key_hashes.into_iter().map(Into::into).collect()))
         },
         ..Default::default()
     };
@@ -150,18 +150,21 @@ pub async fn run_create_did_webvh(
     let mut did_state = DIDWebVHState::default();
     did_state
         .create_log_entry(None, &did_document, &parameters, &derived.signing_secret)
+        .await
         .map_err(|e| format!("Failed to create DID log entry: {e}"))?;
 
-    let scid = did_state.scid.clone();
-    let log_entry_state = did_state.log_entries.last().unwrap();
+    let scid = did_state.scid().to_string();
+    let log_entry_state = did_state.log_entries().last().unwrap();
 
     let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
     let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => doc
-            .get("id")
-            .and_then(|id| id.as_str())
-            .map(String::from)
-            .unwrap_or(fallback_did),
+        Ok(doc) => {
+            let doc: serde_json::Value = doc;
+            doc.get("id")
+                .and_then(|id: &serde_json::Value| id.as_str())
+                .map(String::from)
+                .unwrap_or(fallback_did)
+        }
         Err(_) => fallback_did,
     };
 

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use dialoguer::{Confirm, Input, Select};
-use didwebvh_rs::DIDWebVHState;
-use didwebvh_rs::log_entry::LogEntryMethods;
+use didwebvh_rs::create::{CreateDIDConfig, create_did};
 use didwebvh_rs::parameters::Parameters as WebVHParameters;
 use serde_json::json;
 
@@ -67,7 +66,6 @@ pub async fn run_create_did_webvh(
 
     // Prompt for URL and convert to WebVHURL
     let webvh_url = setup::prompt_webvh_url(label)?;
-    let did_id = webvh_url.to_string();
 
     // Convert the Signing Key ID to did:key format (required by didwebvh-rs)
     derived.signing_secret.id = [
@@ -79,7 +77,7 @@ pub async fn run_create_did_webvh(
     .concat();
 
     // Build base DID document using shared helper (without services)
-    let mut did_document = ops::build_did_document(&did_id, &derived, &config, false, &None);
+    let mut did_document = ops::build_did_document(&derived, &config, false, &None);
 
     // Interactive service endpoint selection
     if let Some(ref msg) = config.messaging {
@@ -97,7 +95,7 @@ pub async fn run_create_did_webvh(
             // Reference the mediator DID for routing
             did_document["service"] = json!([
                 {
-                    "id": format!("{did_id}#vta-didcomm"),
+                    "id": "{DID}#vta-didcomm",
                     "type": "DIDCommMessaging",
                     "serviceEndpoint": [{
                         "accept": ["didcomm/v2"],
@@ -146,27 +144,20 @@ pub async fn run_create_did_webvh(
         ..Default::default()
     };
 
-    // Create the log entry
-    let mut did_state = DIDWebVHState::default();
-    did_state
-        .create_log_entry(None, &did_document, &parameters, &derived.signing_secret)
-        .await
-        .map_err(|e| format!("Failed to create DID log entry: {e}"))?;
+    // Create the DID
+    let url_str = webvh_url.get_http_url(None).map_err(|e| format!("{e}"))?.to_string();
+    let create_config = CreateDIDConfig::builder()
+        .address(url_str)
+        .authorization_key(derived.signing_secret.clone())
+        .did_document(did_document)
+        .parameters(parameters)
+        .build()
+        .map_err(|e| format!("failed to build DID config: {e}"))?;
 
-    let scid = did_state.scid().to_string();
-    let log_entry_state = did_state.log_entries().last().unwrap();
+    let result = create_did(create_config).await
+        .map_err(|e| format!("failed to create DID: {e}"))?;
 
-    let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
-    let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => {
-            let doc: serde_json::Value = doc;
-            doc.get("id")
-                .and_then(|id: &serde_json::Value| id.as_str())
-                .map(String::from)
-                .unwrap_or(fallback_did)
-        }
-        Err(_) => fallback_did,
-    };
+    let final_did = result.did().to_string();
 
     eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");
 
@@ -212,8 +203,8 @@ pub async fn run_create_did_webvh(
         .default(default_file)
         .interact_text()?;
 
-    log_entry_state
-        .log_entry
+    result
+        .log_entry()
         .save_to_file(&did_file)
         .map_err(|e| format!("Failed to save DID log file: {e}"))?;
 

--- a/vta-service/src/messaging/handlers/contexts.rs
+++ b/vta-service/src/messaging/handlers/contexts.rs
@@ -48,10 +48,33 @@ didcomm_handler!(handle_update_context,
     )
 );
 
+didcomm_handler!(handle_preview_delete_context,
+    body: vta_sdk::protocols::context_management::delete::DeleteContextPreviewBody,
+    result: context_management::PREVIEW_DELETE_CONTEXT_RESULT,
+    |state, auth, body| operations::contexts::preview_delete_context(
+        &state.contexts_ks,
+        &state.keys_ks,
+        &state.acl_ks,
+        #[cfg(feature = "webvh")]
+        &state.webvh_ks,
+        &auth,
+        &body.id,
+        "didcomm",
+    )
+);
+
 didcomm_handler!(handle_delete_context,
     body: vta_sdk::protocols::context_management::delete::DeleteContextBody,
     result: context_management::DELETE_CONTEXT_RESULT,
     |state, auth, body| operations::contexts::delete_context(
-        &state.contexts_ks, &auth, &body.id, "didcomm",
+        &state.contexts_ks,
+        &state.keys_ks,
+        &state.acl_ks,
+        #[cfg(feature = "webvh")]
+        &state.webvh_ks,
+        &auth,
+        &body.id,
+        body.force,
+        "didcomm",
     )
 );

--- a/vta-service/src/messaging/handlers/did_webvh.rs
+++ b/vta-service/src/messaging/handlers/did_webvh.rs
@@ -23,6 +23,7 @@ pub async fn handle_create_did_webvh(
     let params = operations::did_webvh::CreateDidWebvhParams {
         context_id: body.context_id,
         server_id: body.server_id,
+        url: body.url,
         path: body.path,
         label: body.label,
         portable: body.portable.unwrap_or(true),

--- a/vta-service/src/messaging/handlers/did_webvh.rs
+++ b/vta-service/src/messaging/handlers/did_webvh.rs
@@ -66,6 +66,14 @@ didcomm_handler!(handle_get_did_webvh,
     )
 );
 
+didcomm_handler!(handle_get_did_webvh_log,
+    body: vta_sdk::protocols::did_management::get::GetDidWebvhBody,
+    result: did_management::GET_DID_WEBVH_LOG_RESULT,
+    |state, auth, body| operations::did_webvh::get_did_webvh_log(
+        &state.webvh_ks, &auth, &body.did, "didcomm",
+    )
+);
+
 didcomm_handler!(handle_list_dids_webvh,
     body: vta_sdk::protocols::did_management::list::ListDidsWebvhBody,
     result: did_management::LIST_DIDS_WEBVH_RESULT,

--- a/vta-service/src/messaging/mod.rs
+++ b/vta-service/src/messaging/mod.rs
@@ -220,6 +220,10 @@ async fn dispatch_message(
             handlers::did_webvh::handle_get_did_webvh(state, &ctx, msg).await
         }
         #[cfg(feature = "webvh")]
+        did_management::GET_DID_WEBVH_LOG => {
+            handlers::did_webvh::handle_get_did_webvh_log(state, &ctx, msg).await
+        }
+        #[cfg(feature = "webvh")]
         did_management::LIST_DIDS_WEBVH => {
             handlers::did_webvh::handle_list_dids_webvh(state, &ctx, msg).await
         }

--- a/vta-service/src/messaging/mod.rs
+++ b/vta-service/src/messaging/mod.rs
@@ -185,6 +185,9 @@ async fn dispatch_message(
         context_management::UPDATE_CONTEXT => {
             handlers::contexts::handle_update_context(state, &ctx, msg).await
         }
+        context_management::PREVIEW_DELETE_CONTEXT => {
+            handlers::contexts::handle_preview_delete_context(state, &ctx, msg).await
+        }
         context_management::DELETE_CONTEXT => {
             handlers::contexts::handle_delete_context(state, &ctx, msg).await
         }

--- a/vta-service/src/operations/contexts.rs
+++ b/vta-service/src/operations/contexts.rs
@@ -2,7 +2,9 @@ use chrono::Utc;
 use tracing::info;
 
 use vta_sdk::protocols::context_management::{
-    create::CreateContextResultBody, delete::DeleteContextResultBody, list::ListContextsResultBody,
+    create::CreateContextResultBody,
+    delete::{DeleteContextPreviewResultBody, DeleteContextResultBody},
+    list::ListContextsResultBody,
 };
 
 use crate::auth::extractor::AuthClaims;
@@ -150,10 +152,43 @@ pub async fn update_context(
     Ok(to_result_body(&record))
 }
 
-pub async fn delete_context(
+/// Collect a preview of all resources associated with a context.
+pub async fn preview_delete_context(
     contexts_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
+    acl_ks: &KeyspaceHandle,
+    #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     id: &str,
+    channel: &str,
+) -> Result<DeleteContextPreviewResultBody, AppError> {
+    auth.require_super_admin()?;
+
+    get_context(contexts_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("context not found: {id}")))?;
+
+    let preview = collect_context_resources(
+        keys_ks,
+        acl_ks,
+        #[cfg(feature = "webvh")]
+        webvh_ks,
+        id,
+    )
+    .await?;
+
+    info!(channel, id = %id, keys = preview.keys.len(), dids = preview.webvh_dids.len(), "context delete preview");
+    Ok(preview)
+}
+
+pub async fn delete_context(
+    contexts_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
+    acl_ks: &KeyspaceHandle,
+    #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    id: &str,
+    force: bool,
     channel: &str,
 ) -> Result<DeleteContextResultBody, AppError> {
     auth.require_super_admin()?;
@@ -162,11 +197,120 @@ pub async fn delete_context(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("context not found: {id}")))?;
 
+    let preview = collect_context_resources(
+        keys_ks,
+        acl_ks,
+        #[cfg(feature = "webvh")]
+        webvh_ks,
+        id,
+    )
+    .await?;
+
+    let has_resources = !preview.keys.is_empty()
+        || !preview.webvh_dids.is_empty()
+        || !preview.acl_entries_removed.is_empty()
+        || !preview.acl_entries_updated.is_empty();
+
+    if has_resources && !force {
+        return Err(AppError::Validation(
+            "context has associated resources; use force=true to delete, or preview first".into(),
+        ));
+    }
+
+    // Delete keys
+    for key_id in &preview.keys {
+        keys_ks
+            .remove(crate::keys::store_key(key_id))
+            .await?;
+    }
+
+    // Delete WebVH DIDs and their logs
+    #[cfg(feature = "webvh")]
+    for did in &preview.webvh_dids {
+        crate::webvh_store::delete_did(webvh_ks, did).await?;
+        // Remove the log entry (best-effort, may not exist for serverless DIDs)
+        let _ = webvh_ks.remove(format!("log:{did}")).await;
+    }
+
+    // Remove or update ACL entries
+    for did in &preview.acl_entries_removed {
+        crate::acl::delete_acl_entry(acl_ks, did).await?;
+    }
+    for did in &preview.acl_entries_updated {
+        if let Some(mut entry) = crate::acl::get_acl_entry(acl_ks, did).await? {
+            entry.allowed_contexts.retain(|c| c != id);
+            crate::acl::store_acl_entry(acl_ks, &entry).await?;
+        }
+    }
+
+    // Delete the context record itself
     delete_context_store(contexts_ks, id).await?;
 
-    info!(channel, id = %id, "context deleted");
+    info!(
+        channel,
+        id = %id,
+        keys_removed = preview.keys.len(),
+        dids_removed = preview.webvh_dids.len(),
+        acl_removed = preview.acl_entries_removed.len(),
+        acl_updated = preview.acl_entries_updated.len(),
+        "context deleted with cascade"
+    );
     Ok(DeleteContextResultBody {
         id: id.to_string(),
         deleted: true,
     })
+}
+
+/// Scan all keyspaces and collect resources associated with a context.
+async fn collect_context_resources(
+    keys_ks: &KeyspaceHandle,
+    acl_ks: &KeyspaceHandle,
+    #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
+    context_id: &str,
+) -> Result<DeleteContextPreviewResultBody, AppError> {
+    use crate::keys::KeyRecord;
+
+    let mut preview = DeleteContextPreviewResultBody {
+        id: context_id.to_string(),
+        ..Default::default()
+    };
+
+    // Keys
+    let raw_keys = keys_ks.prefix_iter_raw("key:").await?;
+    for (_key, value) in raw_keys {
+        let record: KeyRecord = serde_json::from_slice(&value)?;
+        if record.context_id.as_deref() == Some(context_id) {
+            preview.keys.push(record.key_id);
+        }
+    }
+
+    // WebVH DIDs
+    #[cfg(feature = "webvh")]
+    {
+        use vta_sdk::webvh::WebvhDidRecord;
+        let raw_dids = webvh_ks.prefix_iter_raw("did:").await?;
+        for (_key, value) in raw_dids {
+            let record: WebvhDidRecord = serde_json::from_slice(&value)?;
+            if record.context_id == context_id {
+                preview.webvh_dids.push(record.did);
+            }
+        }
+    }
+
+    // ACL entries
+    let raw_acl = acl_ks.prefix_iter_raw("acl:").await?;
+    for (_key, value) in raw_acl {
+        let entry: crate::acl::AclEntry = serde_json::from_slice(&value)?;
+        if entry.allowed_contexts.contains(&context_id.to_string()) {
+            if entry.allowed_contexts.len() == 1 {
+                // This entry only has this context — it will be deleted entirely
+                preview.acl_entries_removed.push(entry.did);
+            } else {
+                // This entry has other contexts — just remove this one from the list
+                preview.acl_entries_updated.push(entry.did);
+            }
+        }
+    }
+
+    Ok(preview)
 }

--- a/vta-service/src/operations/did_webvh.rs
+++ b/vta-service/src/operations/did_webvh.rs
@@ -372,13 +372,23 @@ pub async fn get_did_webvh_log(
     auth: &AuthClaims,
     did: &str,
     channel: &str,
-) -> Result<Option<String>, AppError> {
+) -> Result<GetDidWebvhLogResult, AppError> {
     let record = webvh_store::get_did(webvh_ks, did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("webvh DID not found: {did}")))?;
     auth.require_context(&record.context_id)?;
+    let log = webvh_store::get_did_log(webvh_ks, did).await?;
     info!(channel, did = %did, "webvh DID log retrieved");
-    webvh_store::get_did_log(webvh_ks, did).await
+    Ok(GetDidWebvhLogResult {
+        did: did.to_string(),
+        log,
+    })
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct GetDidWebvhLogResult {
+    pub did: String,
+    pub log: Option<String>,
 }
 
 pub async fn list_dids_webvh(

--- a/vta-service/src/operations/did_webvh.rs
+++ b/vta-service/src/operations/did_webvh.rs
@@ -41,7 +41,8 @@ use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
 
 pub struct CreateDidWebvhParams {
     pub context_id: String,
-    pub server_id: String,
+    pub server_id: Option<String>,
+    pub url: Option<String>,
     pub path: Option<String>,
     pub label: Option<String>,
     pub portable: bool,
@@ -66,17 +67,26 @@ pub async fn create_did_webvh(
     auth.require_admin()?;
     auth.require_context(&params.context_id)?;
 
+    // Validate exactly one of server_id / url is provided
+    let serverless = match (&params.server_id, &params.url) {
+        (Some(_), Some(_)) => {
+            return Err(AppError::Validation(
+                "server_id and url are mutually exclusive".into(),
+            ));
+        }
+        (None, None) => {
+            return Err(AppError::Validation(
+                "either server_id or url is required".into(),
+            ));
+        }
+        (None, Some(_)) => true,
+        (Some(_), None) => false,
+    };
+
     // Resolve context
     let mut ctx = crate::contexts::get_context(contexts_ks, &params.context_id)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("context not found: {}", params.context_id)))?;
-
-    // Resolve server
-    let server = webvh_store::get_server(webvh_ks, &params.server_id)
-        .await?
-        .ok_or_else(|| {
-            AppError::NotFound(format!("webvh server not found: {}", params.server_id))
-        })?;
 
     // Load seed
     let active_seed_id = get_active_seed_id(keys_ks)
@@ -99,19 +109,33 @@ pub async fn create_did_webvh(
     .await
     .map_err(|e| AppError::Internal(format!("{e}")))?;
 
-    // Resolve server transport (REST or DIDComm)
-    let transport =
-        WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, config).await?;
+    // Resolve URL: serverless uses user-provided URL, server-managed requests from server
+    let (webvh_url, mnemonic) = if serverless {
+        let url_str = params.url.as_ref().unwrap();
+        let parsed_url = Url::parse(url_str)
+            .map_err(|e| AppError::Validation(format!("invalid url: {e}")))?;
+        let wurl = WebVHURL::parse_url(&parsed_url)
+            .map_err(|e| AppError::Validation(format!("failed to parse WebVH URL: {e}")))?;
+        (wurl, None)
+    } else {
+        let server_id = params.server_id.as_ref().unwrap();
+        let server = webvh_store::get_server(webvh_ks, server_id)
+            .await?
+            .ok_or_else(|| {
+                AppError::NotFound(format!("webvh server not found: {server_id}"))
+            })?;
 
-    // Request URI from server
-    let uri_response = transport.request_uri(params.path.as_deref()).await?;
-    let mnemonic = uri_response.mnemonic;
+        let transport =
+            WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, config).await?;
+        let uri_response = transport.request_uri(params.path.as_deref()).await?;
 
-    // Parse the did_url into a WebVHURL
-    let parsed_url = Url::parse(&uri_response.did_url)
-        .map_err(|e| AppError::Internal(format!("invalid did_url from server: {e}")))?;
-    let webvh_url = WebVHURL::parse_url(&parsed_url)
-        .map_err(|e| AppError::Internal(format!("failed to parse WebVH URL: {e}")))?;
+        let parsed_url = Url::parse(&uri_response.did_url)
+            .map_err(|e| AppError::Internal(format!("invalid did_url from server: {e}")))?;
+        let wurl = WebVHURL::parse_url(&parsed_url)
+            .map_err(|e| AppError::Internal(format!("failed to parse WebVH URL: {e}")))?;
+        (wurl, Some(uri_response.mnemonic))
+    };
+
     let did_id = webvh_url.to_string();
 
     // Convert signing key ID to did:key format (required by didwebvh-rs)
@@ -179,14 +203,11 @@ pub async fn create_did_webvh(
         Err(_) => fallback_did,
     };
 
-    // Serialize log entry for publishing
+    // Serialize log entry
     let log_content = serde_json::to_string(&log_entry_state.log_entry)
         .map_err(|e| AppError::Internal(format!("failed to serialize DID log: {e}")))?;
 
-    // Publish to webvh-server
-    transport.publish_did(&mnemonic, &log_content).await?;
-
-    // Save key records
+    // Save key records (common to both paths)
     keys::save_entity_key_records(
         &final_did,
         &derived,
@@ -213,49 +234,98 @@ pub async fn create_did_webvh(
         .map_err(|e| AppError::Internal(format!("{e}")))?;
     }
 
-    // Update context with the new DID
-    ctx.did = Some(final_did.clone());
-    ctx.updated_at = Utc::now();
-    crate::contexts::store_context(contexts_ks, &ctx)
-        .await
-        .map_err(|e| AppError::Internal(format!("{e}")))?;
-
-    // Store DID record and log in fjall
     let now = Utc::now();
-    let did_record = WebvhDidRecord {
-        did: final_did.clone(),
-        server_id: params.server_id.clone(),
-        mnemonic: mnemonic.clone(),
-        scid: scid.clone(),
-        context_id: params.context_id.clone(),
-        portable: params.portable,
-        log_entry_count: 1,
-        created_at: now,
-        updated_at: now,
-    };
-    webvh_store::store_did(webvh_ks, &did_record).await?;
-    webvh_store::store_did_log(webvh_ks, &final_did, &log_content).await?;
 
-    info!(
-        channel,
-        did = %final_did,
-        context = %params.context_id,
-        server = %params.server_id,
-        "did:webvh created and published"
-    );
+    if serverless {
+        // Serverless: extract final DID document from log entry, return it + log entry.
+        // Skip publish, context DID update, and WebvhDidRecord/log storage.
+        let final_did_document = log_entry_state
+            .log_entry
+            .get_did_document()
+            .ok()
+            .unwrap_or(did_document);
 
-    Ok(CreateDidWebvhResultBody {
-        did: final_did.clone(),
-        context_id: params.context_id,
-        server_id: params.server_id,
-        mnemonic,
-        scid,
-        portable: params.portable,
-        signing_key_id: format!("{final_did}#key-0"),
-        ka_key_id: format!("{final_did}#key-1"),
-        pre_rotation_key_count: pre_rotation_keys.len() as u32,
-        created_at: now,
-    })
+        info!(
+            channel,
+            did = %final_did,
+            context = %params.context_id,
+            "did:webvh created (serverless)"
+        );
+
+        Ok(CreateDidWebvhResultBody {
+            did: final_did.clone(),
+            context_id: params.context_id,
+            server_id: None,
+            mnemonic: None,
+            scid,
+            portable: params.portable,
+            signing_key_id: format!("{final_did}#key-0"),
+            ka_key_id: format!("{final_did}#key-1"),
+            pre_rotation_key_count: pre_rotation_keys.len() as u32,
+            created_at: now,
+            did_document: Some(final_did_document),
+            log_entry: Some(log_content),
+        })
+    } else {
+        // Server-managed: publish, update context, store records
+        let server_id = params.server_id.as_ref().unwrap();
+        let mnemonic = mnemonic.as_ref().unwrap();
+
+        let server = webvh_store::get_server(webvh_ks, server_id)
+            .await?
+            .ok_or_else(|| {
+                AppError::NotFound(format!("webvh server not found: {server_id}"))
+            })?;
+
+        let transport =
+            WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, config).await?;
+        transport.publish_did(mnemonic, &log_content).await?;
+
+        // Update context with the new DID
+        ctx.did = Some(final_did.clone());
+        ctx.updated_at = Utc::now();
+        crate::contexts::store_context(contexts_ks, &ctx)
+            .await
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+        // Store DID record and log
+        let did_record = WebvhDidRecord {
+            did: final_did.clone(),
+            server_id: server_id.clone(),
+            mnemonic: mnemonic.clone(),
+            scid: scid.clone(),
+            context_id: params.context_id.clone(),
+            portable: params.portable,
+            log_entry_count: 1,
+            created_at: now,
+            updated_at: now,
+        };
+        webvh_store::store_did(webvh_ks, &did_record).await?;
+        webvh_store::store_did_log(webvh_ks, &final_did, &log_content).await?;
+
+        info!(
+            channel,
+            did = %final_did,
+            context = %params.context_id,
+            server = %server_id,
+            "did:webvh created and published"
+        );
+
+        Ok(CreateDidWebvhResultBody {
+            did: final_did.clone(),
+            context_id: params.context_id,
+            server_id: Some(server_id.clone()),
+            mnemonic: Some(mnemonic.clone()),
+            scid,
+            portable: params.portable,
+            signing_key_id: format!("{final_did}#key-0"),
+            ka_key_id: format!("{final_did}#key-1"),
+            pre_rotation_key_count: pre_rotation_keys.len() as u32,
+            created_at: now,
+            did_document: None,
+            log_entry: None,
+        })
+    }
 }
 
 pub async fn get_did_webvh(

--- a/vta-service/src/operations/did_webvh.rs
+++ b/vta-service/src/operations/did_webvh.rs
@@ -174,12 +174,12 @@ pub async fn create_did_webvh(
 
     // Build parameters
     let parameters = WebVHParameters {
-        update_keys: Some(Arc::new(vec![derived.signing_pub.clone()])),
+        update_keys: Some(Arc::new(vec![derived.signing_pub.clone().into()])),
         portable: Some(params.portable),
         next_key_hashes: if next_key_hashes.is_empty() {
             None
         } else {
-            Some(Arc::new(next_key_hashes))
+            Some(Arc::new(next_key_hashes.into_iter().map(Into::into).collect()))
         },
         ..Default::default()
     };
@@ -188,18 +188,21 @@ pub async fn create_did_webvh(
     let mut did_state = DIDWebVHState::default();
     did_state
         .create_log_entry(None, &did_document, &parameters, &derived.signing_secret)
+        .await
         .map_err(|e| AppError::Internal(format!("failed to create DID log entry: {e}")))?;
 
-    let scid = did_state.scid.clone();
-    let log_entry_state = did_state.log_entries.last().unwrap();
+    let scid = did_state.scid().to_string();
+    let log_entry_state = did_state.log_entries().last().unwrap();
 
     let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
     let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => doc
-            .get("id")
-            .and_then(|id| id.as_str())
-            .map(String::from)
-            .unwrap_or(fallback_did),
+        Ok(doc) => {
+            let doc: serde_json::Value = doc;
+            doc.get("id")
+                .and_then(|id: &serde_json::Value| id.as_str())
+                .map(String::from)
+                .unwrap_or(fallback_did)
+        }
         Err(_) => fallback_did,
     };
 

--- a/vta-service/src/operations/did_webvh.rs
+++ b/vta-service/src/operations/did_webvh.rs
@@ -241,12 +241,34 @@ pub async fn create_did_webvh(
 
     if serverless {
         // Serverless: extract final DID document from log entry, return it + log entry.
-        // Skip publish, context DID update, and WebvhDidRecord/log storage.
+        // Skip publish but DO store the DID record and log locally.
         let final_did_document = log_entry_state
             .log_entry
             .get_did_document()
             .ok()
             .unwrap_or(did_document);
+
+        // Update context with the new DID
+        ctx.did = Some(final_did.clone());
+        ctx.updated_at = Utc::now();
+        crate::contexts::store_context(contexts_ks, &ctx)
+            .await
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+        // Store DID record and log
+        let did_record = WebvhDidRecord {
+            did: final_did.clone(),
+            server_id: "serverless".to_string(),
+            mnemonic: String::new(),
+            scid: scid.clone(),
+            context_id: params.context_id.clone(),
+            portable: params.portable,
+            log_entry_count: 1,
+            created_at: now,
+            updated_at: now,
+        };
+        webvh_store::store_did(webvh_ks, &did_record).await?;
+        webvh_store::store_did_log(webvh_ks, &final_did, &log_content).await?;
 
         info!(
             channel,
@@ -343,6 +365,20 @@ pub async fn get_did_webvh(
     auth.require_context(&record.context_id)?;
     info!(channel, did = %did, "webvh DID retrieved");
     Ok(record)
+}
+
+pub async fn get_did_webvh_log(
+    webvh_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    did: &str,
+    channel: &str,
+) -> Result<Option<String>, AppError> {
+    let record = webvh_store::get_did(webvh_ks, did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("webvh DID not found: {did}")))?;
+    auth.require_context(&record.context_id)?;
+    info!(channel, did = %did, "webvh DID log retrieved");
+    webvh_store::get_did_log(webvh_ks, did).await
 }
 
 pub async fn list_dids_webvh(

--- a/vta-service/src/operations/did_webvh.rs
+++ b/vta-service/src/operations/did_webvh.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, OnceLock};
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use chrono::Utc;
-use didwebvh_rs::DIDWebVHState;
+use didwebvh_rs::create::{CreateDIDConfig, create_did};
 use didwebvh_rs::log_entry::LogEntryMethods;
 use didwebvh_rs::parameters::Parameters as WebVHParameters;
 use didwebvh_rs::url::WebVHURL;
@@ -110,13 +110,14 @@ pub async fn create_did_webvh(
     .map_err(|e| AppError::Internal(format!("{e}")))?;
 
     // Resolve URL: serverless uses user-provided URL, server-managed requests from server
-    let (webvh_url, mnemonic) = if serverless {
-        let url_str = params.url.as_ref().unwrap();
-        let parsed_url = Url::parse(url_str)
+    let (url_str, mnemonic) = if serverless {
+        let url_str = params.url.as_ref().unwrap().clone();
+        // Validate the URL
+        let parsed_url = Url::parse(&url_str)
             .map_err(|e| AppError::Validation(format!("invalid url: {e}")))?;
-        let wurl = WebVHURL::parse_url(&parsed_url)
+        WebVHURL::parse_url(&parsed_url)
             .map_err(|e| AppError::Validation(format!("failed to parse WebVH URL: {e}")))?;
-        (wurl, None)
+        (url_str, None)
     } else {
         let server_id = params.server_id.as_ref().unwrap();
         let server = webvh_store::get_server(webvh_ks, server_id)
@@ -129,14 +130,13 @@ pub async fn create_did_webvh(
             WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, config).await?;
         let uri_response = transport.request_uri(params.path.as_deref()).await?;
 
+        // Validate the URL
         let parsed_url = Url::parse(&uri_response.did_url)
             .map_err(|e| AppError::Internal(format!("invalid did_url from server: {e}")))?;
-        let wurl = WebVHURL::parse_url(&parsed_url)
+        WebVHURL::parse_url(&parsed_url)
             .map_err(|e| AppError::Internal(format!("failed to parse WebVH URL: {e}")))?;
-        (wurl, Some(uri_response.mnemonic))
+        (uri_response.did_url, Some(uri_response.mnemonic))
     };
-
-    let did_id = webvh_url.to_string();
 
     // Convert signing key ID to did:key format (required by didwebvh-rs)
     derived.signing_secret.id = [
@@ -155,7 +155,6 @@ pub async fn create_did_webvh(
 
     // Build DID document
     let did_document = build_did_document(
-        &did_id,
         &derived,
         config,
         params.add_mediator_service,
@@ -184,30 +183,22 @@ pub async fn create_did_webvh(
         ..Default::default()
     };
 
-    // Create the log entry
-    let mut did_state = DIDWebVHState::default();
-    did_state
-        .create_log_entry(None, &did_document, &parameters, &derived.signing_secret)
-        .await
-        .map_err(|e| AppError::Internal(format!("failed to create DID log entry: {e}")))?;
+    // Create the DID
+    let create_config = CreateDIDConfig::builder()
+        .address(&url_str)
+        .authorization_key(derived.signing_secret.clone())
+        .did_document(did_document.clone())
+        .parameters(parameters)
+        .build()
+        .map_err(|e| AppError::Internal(format!("failed to build DID config: {e}")))?;
 
-    let scid = did_state.scid().to_string();
-    let log_entry_state = did_state.log_entries().last().unwrap();
+    let result = create_did(create_config).await
+        .map_err(|e| AppError::Internal(format!("failed to create DID: {e}")))?;
 
-    let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
-    let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => {
-            let doc: serde_json::Value = doc;
-            doc.get("id")
-                .and_then(|id: &serde_json::Value| id.as_str())
-                .map(String::from)
-                .unwrap_or(fallback_did)
-        }
-        Err(_) => fallback_did,
-    };
-
-    // Serialize log entry
-    let log_content = serde_json::to_string(&log_entry_state.log_entry)
+    let final_did = result.did().to_string();
+    let scid = result.log_entry().get_scid()
+        .unwrap_or_default().to_string();
+    let log_content = serde_json::to_string(result.log_entry())
         .map_err(|e| AppError::Internal(format!("failed to serialize DID log: {e}")))?;
 
     // Save key records (common to both paths)
@@ -242,8 +233,8 @@ pub async fn create_did_webvh(
     if serverless {
         // Serverless: extract final DID document from log entry, return it + log entry.
         // Skip publish but DO store the DID record and log locally.
-        let final_did_document = log_entry_state
-            .log_entry
+        let final_did_document = result
+            .log_entry()
             .get_did_document()
             .ok()
             .unwrap_or(did_document);
@@ -692,7 +683,6 @@ async fn validate_server_did(
 // ---------------------------------------------------------------------------
 
 pub(crate) fn build_did_document(
-    did_id: &str,
     derived: &keys::DerivedEntityKeys,
     config: &AppConfig,
     add_mediator_service: bool,
@@ -703,24 +693,24 @@ pub(crate) fn build_did_document(
             "https://www.w3.org/ns/did/v1",
             "https://www.w3.org/ns/cid/v1"
         ],
-        "id": did_id,
+        "id": "{DID}",
         "verificationMethod": [
             {
-                "id": format!("{did_id}#key-0"),
+                "id": "{DID}#key-0",
                 "type": "Multikey",
-                "controller": did_id,
+                "controller": "{DID}",
                 "publicKeyMultibase": &derived.signing_pub
             },
             {
-                "id": format!("{did_id}#key-1"),
+                "id": "{DID}#key-1",
                 "type": "Multikey",
-                "controller": did_id,
+                "controller": "{DID}",
                 "publicKeyMultibase": &derived.ka_pub
             }
         ],
-        "authentication": [format!("{did_id}#key-0")],
-        "assertionMethod": [format!("{did_id}#key-0")],
-        "keyAgreement": [format!("{did_id}#key-1")]
+        "authentication": ["{DID}#key-0"],
+        "assertionMethod": ["{DID}#key-0"],
+        "keyAgreement": ["{DID}#key-1"]
     });
 
     // Optionally add mediator DIDComm service
@@ -731,7 +721,7 @@ pub(crate) fn build_did_document(
             .entry("service")
             .or_insert_with(|| json!([]));
         services.as_array_mut().unwrap().push(json!({
-            "id": format!("{did_id}#vta-didcomm"),
+            "id": "{DID}#vta-didcomm",
             "type": "DIDCommMessaging",
             "serviceEndpoint": [{
                 "accept": ["didcomm/v2"],

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -1,10 +1,12 @@
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use serde::Deserialize;
 
 use vta_sdk::protocols::context_management::{
-    create::CreateContextResultBody, list::ListContextsResultBody,
+    create::CreateContextResultBody,
+    delete::DeleteContextPreviewResultBody,
+    list::ListContextsResultBody,
 };
 
 use crate::auth::{AuthClaims, SuperAdminAuth};
@@ -24,6 +26,12 @@ pub struct UpdateContextRequest {
     pub name: Option<String>,
     pub did: Option<String>,
     pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DeleteContextQuery {
+    #[serde(default)]
+    pub force: bool,
 }
 
 pub async fn list_contexts_handler(
@@ -82,11 +90,42 @@ pub async fn update_context_handler(
     Ok(Json(result))
 }
 
+pub async fn preview_delete_context_handler(
+    auth: SuperAdminAuth,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<DeleteContextPreviewResultBody>, AppError> {
+    let result = operations::contexts::preview_delete_context(
+        &state.contexts_ks,
+        &state.keys_ks,
+        &state.acl_ks,
+        #[cfg(feature = "webvh")]
+        &state.webvh_ks,
+        &auth.0,
+        &id,
+        "rest",
+    )
+    .await?;
+    Ok(Json(result))
+}
+
 pub async fn delete_context_handler(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
     Path(id): Path<String>,
+    Query(query): Query<DeleteContextQuery>,
 ) -> Result<StatusCode, AppError> {
-    operations::contexts::delete_context(&state.contexts_ks, &auth.0, &id, "rest").await?;
+    operations::contexts::delete_context(
+        &state.contexts_ks,
+        &state.keys_ks,
+        &state.acl_ks,
+        #[cfg(feature = "webvh")]
+        &state.webvh_ks,
+        &auth.0,
+        &id,
+        query.force,
+        "rest",
+    )
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -175,20 +175,14 @@ pub async fn get_did_handler(
     Ok(Json(result))
 }
 
-#[derive(Debug, serde::Serialize)]
-pub struct GetDidLogResponse {
-    pub did: String,
-    pub log: Option<String>,
-}
-
 pub async fn get_did_log_handler(
     auth: AuthClaims,
     State(state): State<AppState>,
     Path(did): Path<String>,
-) -> Result<Json<GetDidLogResponse>, AppError> {
-    let log =
+) -> Result<Json<operations::did_webvh::GetDidWebvhLogResult>, AppError> {
+    let result =
         operations::did_webvh::get_did_webvh_log(&state.webvh_ks, &auth, &did, "rest").await?;
-    Ok(Json(GetDidLogResponse { did, log }))
+    Ok(Json(result))
 }
 
 pub async fn delete_did_handler(

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -25,7 +25,8 @@ pub struct AddServerRequest {
 #[derive(Debug, Deserialize)]
 pub struct CreateDidRequest {
     pub context_id: String,
-    pub server_id: String,
+    pub server_id: Option<String>,
+    pub url: Option<String>,
     pub path: Option<String>,
     pub label: Option<String>,
     #[serde(default = "default_true")]
@@ -121,6 +122,7 @@ pub async fn create_did_handler(
     let params = operations::did_webvh::CreateDidWebvhParams {
         context_id: req.context_id,
         server_id: req.server_id,
+        url: req.url,
         path: req.path,
         label: req.label,
         portable: req.portable,

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -175,6 +175,22 @@ pub async fn get_did_handler(
     Ok(Json(result))
 }
 
+#[derive(Debug, serde::Serialize)]
+pub struct GetDidLogResponse {
+    pub did: String,
+    pub log: Option<String>,
+}
+
+pub async fn get_did_log_handler(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(did): Path<String>,
+) -> Result<Json<GetDidLogResponse>, AppError> {
+    let log =
+        operations::did_webvh::get_did_webvh_log(&state.webvh_ks, &auth, &did, "rest").await?;
+    Ok(Json(GetDidLogResponse { did, log }))
+}
+
 pub async fn delete_did_handler(
     auth: AdminAuth,
     State(state): State<AppState>,

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -54,6 +54,10 @@ pub fn router() -> Router<AppState> {
                 .patch(contexts::update_context_handler)
                 .delete(contexts::delete_context_handler),
         )
+        .route(
+            "/contexts/{id}/delete-preview",
+            get(contexts::preview_delete_context_handler),
+        )
         // ACL routes (flattened for consistency)
         .route("/acl", get(acl::list_acl).post(acl::create_acl))
         .route(

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -86,6 +86,10 @@ pub fn router() -> Router<AppState> {
         .route(
             "/webvh/dids/{did}",
             get(did_webvh::get_did_handler).delete(did_webvh::delete_did_handler),
+        )
+        .route(
+            "/webvh/dids/{did}/log",
+            get(did_webvh::get_did_log_handler),
         );
 
     router

--- a/vta-service/src/setup.rs
+++ b/vta-service/src/setup.rs
@@ -7,8 +7,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use bip39::Mnemonic;
 use chrono::Utc;
 use dialoguer::{Confirm, Input, MultiSelect, Select};
-use didwebvh_rs::DIDWebVHState;
-use didwebvh_rs::log_entry::LogEntryMethods;
+use didwebvh_rs::create::{CreateDIDConfig, create_did};
 use didwebvh_rs::parameters::Parameters as WebVHParameters;
 use didwebvh_rs::url::WebVHURL;
 use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
@@ -1150,7 +1149,6 @@ async fn create_webvh_did(
 ) -> Result<String, Box<dyn std::error::Error>> {
     // Prompt for URL and convert to WebVHURL
     let webvh_url = prompt_webvh_url(label)?;
-    let did_id = webvh_url.to_string(); // e.g. did:webvh:{SCID}:example.com
 
     // Convert the Signing Key ID to be correct
     derived.signing_secret.id = [
@@ -1167,17 +1165,17 @@ async fn create_webvh_did(
             "https://www.w3.org/ns/did/v1",
             "https://www.w3.org/ns/cid/v1"
         ],
-        "id": &did_id,
+        "id": "{DID}",
         "verificationMethod": [
             {
-                "id": format!("{did_id}#key-0"),
+                "id": "{DID}#key-0",
                 "type": "Multikey",
-                "controller": &did_id,
+                "controller": "{DID}",
                 "publicKeyMultibase": &derived.signing_pub
             }
         ],
-        "authentication": [format!("{did_id}#key-0")],
-        "assertionMethod": [format!("{did_id}#key-0")]
+        "authentication": ["{DID}#key-0"],
+        "assertionMethod": ["{DID}#key-0"]
     });
 
     // Add X25519 key agreement method
@@ -1185,12 +1183,12 @@ async fn create_webvh_did(
         .as_array_mut()
         .unwrap()
         .push(json!({
-            "id": format!("{did_id}#key-1"),
+            "id": "{DID}#key-1",
             "type": "Multikey",
-            "controller": &did_id,
+            "controller": "{DID}",
             "publicKeyMultibase": &derived.ka_pub
         }));
-    did_document["keyAgreement"] = json!([format!("{did_id}#key-1")]);
+    did_document["keyAgreement"] = json!(["{DID}#key-1"]);
 
     // Add service endpoints
     let mut services = Vec::new();
@@ -1201,7 +1199,7 @@ async fn create_webvh_did(
             .replace("https://", "wss://")
             .replace("http://", "ws://");
         services.push(json!({
-            "id": format!("{did_id}#didcomm"),
+            "id": "{DID}#didcomm",
             "type": "DIDCommMessaging",
             "serviceEndpoint": [
                 {
@@ -1215,14 +1213,14 @@ async fn create_webvh_did(
             ]
         }));
         services.push(json!({
-            "id": format!("{did_id}#auth"),
+            "id": "{DID}#auth",
             "type": "Authentication",
             "serviceEndpoint": format!("{url}/authenticate")
         }));
     } else if let Some(msg) = messaging {
         // VTA DID: add #vta-didcomm referencing the mediator DID
         services.push(json!({
-            "id": format!("{did_id}#vta-didcomm"),
+            "id": "{DID}#vta-didcomm",
             "type": "DIDCommMessaging",
             "serviceEndpoint": [{
                 "accept": ["didcomm/v2"],
@@ -1234,7 +1232,7 @@ async fn create_webvh_did(
     // Add #vta-rest service endpoint if a public URL is configured
     if let Some(url) = vta_public_url {
         services.push(json!({
-            "id": format!("{did_id}#vta-rest"),
+            "id": "{DID}#vta-rest",
             "type": "VTARest",
             "serviceEndpoint": url
         }));
@@ -1273,27 +1271,20 @@ async fn create_webvh_did(
         ..Default::default()
     };
 
-    // Create the log entry
-    let mut did_state = DIDWebVHState::default();
-    did_state
-        .create_log_entry(None, &did_document, &parameters, &derived.signing_secret)
-        .await
-        .map_err(|e| format!("Failed to create DID log entry: {e}"))?;
+    // Create the DID
+    let url_str = webvh_url.get_http_url(None).map_err(|e| format!("{e}"))?.to_string();
+    let create_config = CreateDIDConfig::builder()
+        .address(url_str)
+        .authorization_key(derived.signing_secret.clone())
+        .did_document(did_document)
+        .parameters(parameters)
+        .build()
+        .map_err(|e| format!("failed to build DID config: {e}"))?;
 
-    let scid = did_state.scid().to_string();
-    let log_entry_state = did_state.log_entries().last().unwrap();
+    let result = create_did(create_config).await
+        .map_err(|e| format!("failed to create DID: {e}"))?;
 
-    let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
-    let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => {
-            let doc: serde_json::Value = doc;
-            doc.get("id")
-                .and_then(|id: &serde_json::Value| id.as_str())
-                .map(String::from)
-                .unwrap_or(fallback_did)
-        }
-        Err(_) => fallback_did,
-    };
+    let final_did = result.did().to_string();
 
     eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");
 
@@ -1322,8 +1313,8 @@ async fn create_webvh_did(
         .default(default_file)
         .interact_text()?;
 
-    log_entry_state
-        .log_entry
+    result
+        .log_entry()
         .save_to_file(&did_file)
         .map_err(|e| format!("Failed to save DID log file: {e}"))?;
 

--- a/vta-service/src/setup.rs
+++ b/vta-service/src/setup.rs
@@ -1263,12 +1263,12 @@ async fn create_webvh_did(
 
     // Build parameters
     let parameters = WebVHParameters {
-        update_keys: Some(Arc::new(vec![derived.signing_pub.clone()])),
+        update_keys: Some(Arc::new(vec![derived.signing_pub.clone().into()])),
         portable: Some(portable),
         next_key_hashes: if next_key_hashes.is_empty() {
             None
         } else {
-            Some(Arc::new(next_key_hashes))
+            Some(Arc::new(next_key_hashes.into_iter().map(Into::into).collect()))
         },
         ..Default::default()
     };
@@ -1277,18 +1277,21 @@ async fn create_webvh_did(
     let mut did_state = DIDWebVHState::default();
     did_state
         .create_log_entry(None, &did_document, &parameters, &derived.signing_secret)
+        .await
         .map_err(|e| format!("Failed to create DID log entry: {e}"))?;
 
-    let scid = did_state.scid.clone();
-    let log_entry_state = did_state.log_entries.last().unwrap();
+    let scid = did_state.scid().to_string();
+    let log_entry_state = did_state.log_entries().last().unwrap();
 
     let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
     let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => doc
-            .get("id")
-            .and_then(|id| id.as_str())
-            .map(String::from)
-            .unwrap_or(fallback_did),
+        Ok(doc) => {
+            let doc: serde_json::Value = doc;
+            doc.get("id")
+                .and_then(|id: &serde_json::Value| id.as_str())
+                .map(String::from)
+                .unwrap_or(fallback_did)
+        }
         Err(_) => fallback_did,
     };
 

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -151,7 +151,8 @@ pub async fn run_create_did(
     let auth = cli_super_admin();
     let params = operations::did_webvh::CreateDidWebvhParams {
         context_id: context_id.clone(),
-        server_id,
+        server_id: Some(server_id),
+        url: None,
         path,
         label,
         portable,
@@ -179,9 +180,13 @@ pub async fn run_create_did(
 
     eprintln!("\x1b[1;32mCreated DID:\x1b[0m {}", result.did);
     eprintln!("  Context:    {}", result.context_id);
-    eprintln!("  Server:     {}", result.server_id);
+    if let Some(ref server_id) = result.server_id {
+        eprintln!("  Server:     {}", server_id);
+    }
     eprintln!("  SCID:       {}", result.scid);
-    eprintln!("  Mnemonic:   {}", result.mnemonic);
+    if let Some(ref mnemonic) = result.mnemonic {
+        eprintln!("  Mnemonic:   {}", mnemonic);
+    }
     eprintln!("  Portable:   {}", result.portable);
     eprintln!("  Signing:    {}", result.signing_key_id);
     eprintln!("  KA:         {}", result.ka_key_id);

--- a/vta-service/src/webvh_store.rs
+++ b/vta-service/src/webvh_store.rs
@@ -62,6 +62,11 @@ pub async fn list_dids(ks: &KeyspaceHandle) -> Result<Vec<WebvhDidRecord>, AppEr
     Ok(dids)
 }
 
+pub async fn get_did_log(ks: &KeyspaceHandle, did: &str) -> Result<Option<String>, AppError> {
+    let bytes = ks.get_raw(log_key(did)).await?;
+    Ok(bytes.map(|b| String::from_utf8_lossy(&b).into_owned()))
+}
+
 pub async fn store_did_log(
     ks: &KeyspaceHandle,
     did: &str,

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -64,8 +64,8 @@ clap = { workspace = true }
 didwebvh-rs = { workspace = true, optional = true }
 rand = { workspace = true }
 dialoguer = { version = "0.12", optional = true }
-azure_security_keyvault_secrets = { version = "0.11", optional = true }
-azure_identity = { version = "0.32", optional = true }
+azure_security_keyvault_secrets = { version = "0.12", optional = true }
+azure_identity = { version = "0.33", optional = true }
 sha2 = { workspace = true }
 x25519-dalek = { workspace = true }
 multibase = { workspace = true }

--- a/vtc-service/src/did_webvh.rs
+++ b/vtc-service/src/did_webvh.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 
 use affinidi_tdk::secrets_resolver::secrets::Secret;
 use dialoguer::{Confirm, Input, Select};
-use didwebvh_rs::DIDWebVHState;
-use didwebvh_rs::log_entry::LogEntryMethods;
+use didwebvh_rs::create::{CreateDIDConfig, create_did};
 use didwebvh_rs::parameters::Parameters as WebVHParameters;
 use serde_json::json;
 
@@ -67,7 +66,6 @@ pub async fn run_create_did_webvh(
 
     // Prompt for URL and convert to WebVHURL
     let webvh_url = setup::prompt_webvh_url(label)?;
-    let did_id = webvh_url.to_string();
 
     // Convert the Signing Key ID to did:key format (required by didwebvh-rs)
     signing_secret.id = [
@@ -84,17 +82,17 @@ pub async fn run_create_did_webvh(
             "https://www.w3.org/ns/did/v1",
             "https://www.w3.org/ns/cid/v1"
         ],
-        "id": &did_id,
+        "id": "{DID}",
         "verificationMethod": [
             {
-                "id": format!("{did_id}#key-0"),
+                "id": "{DID}#key-0",
                 "type": "Multikey",
-                "controller": &did_id,
+                "controller": "{DID}",
                 "publicKeyMultibase": &signing_pub
             }
         ],
-        "authentication": [format!("{did_id}#key-0")],
-        "assertionMethod": [format!("{did_id}#key-0")]
+        "authentication": ["{DID}#key-0"],
+        "assertionMethod": ["{DID}#key-0"]
     });
 
     // Add X25519 key agreement method
@@ -102,12 +100,12 @@ pub async fn run_create_did_webvh(
         .as_array_mut()
         .unwrap()
         .push(json!({
-            "id": format!("{did_id}#key-1"),
+            "id": "{DID}#key-1",
             "type": "Multikey",
-            "controller": &did_id,
+            "controller": "{DID}",
             "publicKeyMultibase": &ka_pub
         }));
-    did_document["keyAgreement"] = json!([format!("{did_id}#key-1")]);
+    did_document["keyAgreement"] = json!(["{DID}#key-1"]);
 
     // Optionally add service endpoints
     if let Some(ref msg) = config.messaging {
@@ -124,7 +122,7 @@ pub async fn run_create_did_webvh(
         if service_choice == 0 {
             did_document["service"] = json!([
                 {
-                    "id": format!("{did_id}#didcomm"),
+                    "id": "{DID}#didcomm",
                     "type": "DIDCommMessaging",
                     "serviceEndpoint": [{
                         "accept": ["didcomm/v2"],
@@ -141,7 +139,7 @@ pub async fn run_create_did_webvh(
             .get_mut("service")
             .and_then(|s| s.as_array_mut());
         let vtc_service = json!({
-            "id": format!("{did_id}#vtc"),
+            "id": "{DID}#vtc",
             "type": "VerifiableTrustCommunity",
             "serviceEndpoint": url
         });
@@ -173,27 +171,20 @@ pub async fn run_create_did_webvh(
         ..Default::default()
     };
 
-    // Create the log entry
-    let mut did_state = DIDWebVHState::default();
-    did_state
-        .create_log_entry(None, &did_document, &parameters, &signing_secret)
-        .await
-        .map_err(|e| format!("Failed to create DID log entry: {e}"))?;
+    // Create the DID
+    let url_str = webvh_url.get_http_url(None).map_err(|e| format!("{e}"))?.to_string();
+    let create_config = CreateDIDConfig::builder()
+        .address(url_str)
+        .authorization_key(signing_secret.clone())
+        .did_document(did_document)
+        .parameters(parameters)
+        .build()
+        .map_err(|e| format!("failed to build DID config: {e}"))?;
 
-    let scid = did_state.scid().to_string();
-    let log_entry_state = did_state.log_entries().last().unwrap();
+    let result = create_did(create_config).await
+        .map_err(|e| format!("failed to create DID: {e}"))?;
 
-    let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
-    let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => {
-            let doc: serde_json::Value = doc;
-            doc.get("id")
-                .and_then(|id: &serde_json::Value| id.as_str())
-                .map(String::from)
-                .unwrap_or(fallback_did)
-        }
-        Err(_) => fallback_did,
-    };
+    let final_did = result.did().to_string();
 
     eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");
 
@@ -207,8 +198,8 @@ pub async fn run_create_did_webvh(
         .default(default_file)
         .interact_text()?;
 
-    log_entry_state
-        .log_entry
+    result
+        .log_entry()
         .save_to_file(&did_file)
         .map_err(|e| format!("Failed to save DID log file: {e}"))?;
 

--- a/vtc-service/src/did_webvh.rs
+++ b/vtc-service/src/did_webvh.rs
@@ -168,7 +168,7 @@ pub async fn run_create_did_webvh(
 
     // Build parameters
     let parameters = WebVHParameters {
-        update_keys: Some(Arc::new(vec![signing_pub.clone()])),
+        update_keys: Some(Arc::new(vec![signing_pub.clone().into()])),
         portable: Some(portable),
         ..Default::default()
     };
@@ -177,18 +177,21 @@ pub async fn run_create_did_webvh(
     let mut did_state = DIDWebVHState::default();
     did_state
         .create_log_entry(None, &did_document, &parameters, &signing_secret)
+        .await
         .map_err(|e| format!("Failed to create DID log entry: {e}"))?;
 
-    let scid = did_state.scid.clone();
-    let log_entry_state = did_state.log_entries.last().unwrap();
+    let scid = did_state.scid().to_string();
+    let log_entry_state = did_state.log_entries().last().unwrap();
 
     let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
     let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => doc
-            .get("id")
-            .and_then(|id| id.as_str())
-            .map(String::from)
-            .unwrap_or(fallback_did),
+        Ok(doc) => {
+            let doc: serde_json::Value = doc;
+            doc.get("id")
+                .and_then(|id: &serde_json::Value| id.as_str())
+                .map(String::from)
+                .unwrap_or(fallback_did)
+        }
         Err(_) => fallback_did,
     };
 

--- a/vtc-service/src/setup.rs
+++ b/vtc-service/src/setup.rs
@@ -7,8 +7,7 @@ use affinidi_tdk::{
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use dialoguer::{Confirm, Input, Select};
-use didwebvh_rs::DIDWebVHState;
-use didwebvh_rs::log_entry::LogEntryMethods;
+use didwebvh_rs::create::{CreateDIDConfig, create_did};
 use didwebvh_rs::parameters::Parameters as WebVHParameters;
 use rand::Rng;
 use serde_json::json;
@@ -764,7 +763,6 @@ async fn create_webvh_did(
 ) -> Result<String, Box<dyn std::error::Error>> {
     // Prompt for URL and convert to WebVHURL
     let webvh_url = prompt_webvh_url(label)?;
-    let did_id = webvh_url.to_string();
 
     // Convert the Signing Key ID to did:key format (required by didwebvh-rs)
     signing_secret.id = [
@@ -781,17 +779,17 @@ async fn create_webvh_did(
             "https://www.w3.org/ns/did/v1",
             "https://www.w3.org/ns/cid/v1"
         ],
-        "id": &did_id,
+        "id": "{DID}",
         "verificationMethod": [
             {
-                "id": format!("{did_id}#key-0"),
+                "id": "{DID}#key-0",
                 "type": "Multikey",
-                "controller": &did_id,
+                "controller": "{DID}",
                 "publicKeyMultibase": signing_pub
             }
         ],
-        "authentication": [format!("{did_id}#key-0")],
-        "assertionMethod": [format!("{did_id}#key-0")]
+        "authentication": ["{DID}#key-0"],
+        "assertionMethod": ["{DID}#key-0"]
     });
 
     // Add X25519 key agreement method
@@ -799,12 +797,12 @@ async fn create_webvh_did(
         .as_array_mut()
         .unwrap()
         .push(json!({
-            "id": format!("{did_id}#key-1"),
+            "id": "{DID}#key-1",
             "type": "Multikey",
-            "controller": &did_id,
+            "controller": "{DID}",
             "publicKeyMultibase": ka_pub
         }));
-    did_document["keyAgreement"] = json!([format!("{did_id}#key-1")]);
+    did_document["keyAgreement"] = json!(["{DID}#key-1"]);
 
     // Add service endpoints
     let mut services = Vec::new();
@@ -812,7 +810,7 @@ async fn create_webvh_did(
     if let Some(msg) = messaging {
         // VTC DID: add #didcomm referencing the mediator DID
         services.push(json!({
-            "id": format!("{did_id}#didcomm"),
+            "id": "{DID}#didcomm",
             "type": "DIDCommMessaging",
             "serviceEndpoint": [{
                 "accept": ["didcomm/v2"],
@@ -824,7 +822,7 @@ async fn create_webvh_did(
     // Add #vtc service endpoint if a public URL is configured
     if let Some(url) = vtc_public_url {
         services.push(json!({
-            "id": format!("{did_id}#vtc"),
+            "id": "{DID}#vtc",
             "type": "VerifiableTrustCommunity",
             "serviceEndpoint": url
         }));
@@ -854,27 +852,20 @@ async fn create_webvh_did(
         ..Default::default()
     };
 
-    // Create the log entry
-    let mut did_state = DIDWebVHState::default();
-    did_state
-        .create_log_entry(None, &did_document, &parameters, signing_secret)
-        .await
-        .map_err(|e| format!("Failed to create DID log entry: {e}"))?;
+    // Create the DID
+    let url_str = webvh_url.get_http_url(None).map_err(|e| format!("{e}"))?.to_string();
+    let create_config = CreateDIDConfig::builder()
+        .address(url_str)
+        .authorization_key(signing_secret.clone())
+        .did_document(did_document)
+        .parameters(parameters)
+        .build()
+        .map_err(|e| format!("failed to build DID config: {e}"))?;
 
-    let scid = did_state.scid().to_string();
-    let log_entry_state = did_state.log_entries().last().unwrap();
+    let result = create_did(create_config).await
+        .map_err(|e| format!("failed to create DID: {e}"))?;
 
-    let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
-    let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => {
-            let doc: serde_json::Value = doc;
-            doc.get("id")
-                .and_then(|id: &serde_json::Value| id.as_str())
-                .map(String::from)
-                .unwrap_or(fallback_did)
-        }
-        Err(_) => fallback_did,
-    };
+    let final_did = result.did().to_string();
 
     eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");
 
@@ -885,8 +876,8 @@ async fn create_webvh_did(
         .default(default_file)
         .interact_text()?;
 
-    log_entry_state
-        .log_entry
+    result
+        .log_entry()
         .save_to_file(&did_file)
         .map_err(|e| format!("Failed to save DID log file: {e}"))?;
 

--- a/vtc-service/src/setup.rs
+++ b/vtc-service/src/setup.rs
@@ -849,7 +849,7 @@ async fn create_webvh_did(
 
     // Build parameters
     let parameters = WebVHParameters {
-        update_keys: Some(Arc::new(vec![signing_pub.to_string()])),
+        update_keys: Some(Arc::new(vec![signing_pub.to_string().into()])),
         portable: Some(portable),
         ..Default::default()
     };
@@ -858,18 +858,21 @@ async fn create_webvh_did(
     let mut did_state = DIDWebVHState::default();
     did_state
         .create_log_entry(None, &did_document, &parameters, signing_secret)
+        .await
         .map_err(|e| format!("Failed to create DID log entry: {e}"))?;
 
-    let scid = did_state.scid.clone();
-    let log_entry_state = did_state.log_entries.last().unwrap();
+    let scid = did_state.scid().to_string();
+    let log_entry_state = did_state.log_entries().last().unwrap();
 
     let fallback_did = format!("did:webvh:{scid}:{}", webvh_url.domain);
     let final_did = match log_entry_state.log_entry.get_did_document() {
-        Ok(doc) => doc
-            .get("id")
-            .and_then(|id| id.as_str())
-            .map(String::from)
-            .unwrap_or(fallback_did),
+        Ok(doc) => {
+            let doc: serde_json::Value = doc;
+            doc.get("id")
+                .and_then(|id: &serde_json::Value| id.as_str())
+                .map(String::from)
+                .unwrap_or(fallback_did)
+        }
         Err(_) => fallback_did,
     };
 


### PR DESCRIPTION
## Summary

- **Context provisioning & reprovisioning** — `pnm context provision` creates a context + admin credentials + optional WebVH DID in a single command, outputting a portable base64 bundle. `pnm context reprovision` regenerates the bundle for existing contexts using VTA-stored keys.
- **Serverless WebVH DID creation** — `--did-url` flag creates DIDs locally without a pre-registered server, returning the document and log entry for self-hosting.
- **Cascading context deletion** — Deleting a context removes all associated keys, DIDs, logs, and ACL entries with preview and confirmation.
- **DID log retrieval API** — `GET /webvh/dids/{did}/log` (REST + DIDComm) for retrieving stored DID logs.
- **Pluggable session storage** — `SessionBackend` trait replaces compile-time feature flags for session storage.
- **didwebvh-rs 0.3 upgrade** — Migrated to the high-level `create_did()` API with `{DID}` placeholders, replacing manual state management.
- **All dependencies updated** to latest versions.

See [CHANGELOG.md](CHANGELOG.md) for full details.

## Test plan

- [ ] All 114 unit tests pass (`cargo test`)
- [ ] `pnm context provision` creates context + credentials + DID and outputs valid bundle
- [ ] `pnm context reprovision` regenerates a bundle with full DID material matching provision format
- [ ] Serverless DID creation via `--did-url` produces valid DID document and log entry
- [ ] Context deletion cascades to keys, DIDs, and ACL entries
- [ ] DID log retrieval works over both REST and DIDComm
- [ ] Provision bundle imports correctly in webvh-services