### PR TITLE
feat: add P-256 key support, signing oracle endpoint, and token cache API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7666,6 +7666,7 @@ dependencies = [
  "keyring",
  "libc",
  "multibase",
+ "p256",
  "rand 0.10.0",
  "reqwest 0.13.2",
  "rsa",

--- a/docs/bip32_paths.md
+++ b/docs/bip32_paths.md
@@ -43,6 +43,22 @@ keyspace under the key `path_counter:{base_path}`. Every key allocation:
 All key types within a context (signing, key-agreement, pre-rotation) share
 **one counter**, so indices are unique and never reused.
 
+### P-256 Domain-Separated Derivation
+
+P-256 keys share the same BIP-32 path namespace as Ed25519/X25519 but use
+**HMAC-SHA512 domain separation** to produce independent key material:
+
+1. Derive the BIP-32 path normally (SLIP-0010 for Ed25519).
+2. Compute `HMAC-SHA512(key="p256-key-derivation", data=signing_key_bytes || chain_code)`.
+3. Take the first 32 bytes as the P-256 scalar (reduced mod n automatically).
+
+This ensures:
+- **No cross-curve key reuse** — Ed25519 and P-256 keys at the same path are
+  cryptographically independent.
+- **No Ed25519 clamping artifacts** — the HMAC output is uniformly distributed.
+- **No group-order bias** — the P-256 group order (~2²⁵⁶) accommodates 32
+  random bytes with negligible bias (~2⁻³²).
+
 ```
 allocate_path(keys_ks, "m/26'/2'/0'")   ->  m/26'/2'/0'/0'   (counter: 0 -> 1)
 allocate_path(keys_ks, "m/26'/2'/0'")   ->  m/26'/2'/0'/1'   (counter: 1 -> 2)

--- a/docs/design.md
+++ b/docs/design.md
@@ -26,7 +26,7 @@ request/response types stay in sync.
 | Web framework  | Axum 0.8                                 |
 | Async runtime  | Tokio                                    |
 | Storage        | fjall (embedded LSM key-value store)     |
-| Cryptography   | ed25519-dalek, ed25519-dalek-bip32       |
+| Cryptography   | ed25519-dalek, ed25519-dalek-bip32, p256 |
 | DID resolution | affinidi-did-resolver-cache-sdk          |
 | DIDComm        | affinidi-tdk (didcomm, secrets_resolver) |
 | JWT            | jsonwebtoken (EdDSA / Ed25519)           |
@@ -43,6 +43,7 @@ AppState
   sessions_ks      KeyspaceHandle                         "sessions" partition
   acl_ks           KeyspaceHandle                         "acl" partition
   contexts_ks      KeyspaceHandle                         "contexts" partition
+  cache_ks         KeyspaceHandle                         "cache" partition
   config           Arc<RwLock<AppConfig>>                  runtime-mutable config
   seed_store       Arc<KeyringSeedStore>                   OS keyring for master seed
   did_resolver     Option<DIDCacheClient>                  DID resolution (None before setup)
@@ -85,7 +86,7 @@ vta-service/src/
     mod.rs         Application context CRUD, index allocation
 
   keys/
-    derivation.rs  BIP-32 Ed25519/X25519 derivation trait
+    derivation.rs  BIP-32 Ed25519/X25519/P-256 derivation trait
     paths.rs       Sequential path counter allocation
     seed_store.rs  OS keyring read/write for master seed
 
@@ -97,9 +98,10 @@ vta-service/src/
     health.rs      GET /health
     auth.rs        Challenge-response, token issue/refresh, sessions
     config.rs      GET/PATCH /config
-    keys.rs        Key CRUD
+    keys.rs        Key CRUD + signing oracle
     contexts.rs    Context CRUD
     acl.rs         ACL CRUD
+    cache.rs       Token cache (GET/PUT/DELETE)
 ```
 
 ## API Surface
@@ -131,13 +133,23 @@ vta-service/src/
 
 ### Keys
 
-| Method | Path           | Auth  | Purpose                                 |
-| ------ | -------------- | ----- | --------------------------------------- |
-| GET    | /keys          | Auth  | List (filtered by context access)       |
-| POST   | /keys          | Admin | Create (context access checked)         |
-| GET    | /keys/{key_id} | Auth  | Get key record (context access checked) |
-| DELETE | /keys/{key_id} | Admin | Invalidate key (context access checked) |
-| PATCH  | /keys/{key_id} | Admin | Rename key (context access checked)     |
+| Method | Path                  | Auth  | Purpose                                 |
+| ------ | --------------------- | ----- | --------------------------------------- |
+| GET    | /keys                 | Auth  | List (filtered by context access)       |
+| POST   | /keys                 | Admin | Create (context access checked)         |
+| GET    | /keys/{key_id}        | Auth  | Get key record (context access checked) |
+| DELETE | /keys/{key_id}        | Admin | Invalidate key (context access checked) |
+| PATCH  | /keys/{key_id}        | Admin | Rename key (context access checked)     |
+| GET    | /keys/{key_id}/secret | Admin | Export private key material              |
+| POST   | /keys/{key_id}/sign   | Auth  | Sign payload (signing oracle)           |
+
+### Cache
+
+| Method | Path         | Auth | Purpose                         |
+| ------ | ------------ | ---- | ------------------------------- |
+| GET    | /cache/{key} | Auth | Retrieve cached value           |
+| PUT    | /cache/{key} | Auth | Store value with TTL            |
+| DELETE | /cache/{key} | Auth | Delete cached value             |
 
 ### Contexts
 
@@ -301,6 +313,9 @@ See [`bip32_paths.md`](bip32_paths.md) for the full specification.
 - **Ed25519** -- signing, authentication, assertion. Multibase prefix `z6Mk`.
 - **X25519** -- key agreement (Diffie-Hellman). Derived from Ed25519 private
   key via clamping. Multibase prefix `z6LS`.
+- **P-256** -- ECDSA signing (ES256). Used for PAT JWT signing and other
+  standards requiring NIST curves. Derived via HMAC-SHA512 domain separation
+  from BIP-32 path material (see [`bip32_paths.md`](bip32_paths.md)).
 
 ### Key Record
 
@@ -308,7 +323,7 @@ See [`bip32_paths.md`](bip32_paths.md) for the full specification.
 KeyRecord {
     key_id:          String,          // "did:webvh:...#key-0"
     derivation_path: String,          // "m/26'/2'/0'/0'"
-    key_type:        KeyType,         // Ed25519 | X25519
+    key_type:        KeyType,         // Ed25519 | X25519 | P256
     status:          KeyStatus,       // Active | Revoked
     public_key:      String,          // multibase
     label:           Option<String>,
@@ -391,6 +406,33 @@ Message types used:
 | `https://affinidi.com/atm/1.0/authenticate`         | Challenge response |
 | `https://affinidi.com/atm/1.0/authenticate/refresh` | Token refresh      |
 
+### Signing Oracle
+
+The VTA can act as a **signing oracle**: clients send unsigned payloads to
+`POST /keys/{key_id}/sign` (or the DIDComm `sign-request` message type),
+and the VTA derives the key from BIP-32, signs in memory, and returns the
+base64url-encoded signature. Key material never leaves VTA and is dropped
+immediately after signing.
+
+Supported algorithms:
+
+| Algorithm | Key Type | Signature Format |
+| --------- | -------- | ---------------- |
+| `eddsa`   | Ed25519  | 64-byte Ed25519  |
+| `es256`   | P256     | 64-byte ECDSA    |
+
+### Token Cache
+
+The VTA provides a simple key-value cache scoped per caller DID for storing
+short-lived tokens (PATs, access tokens). Entries support TTL-based expiry
+with lazy cleanup on read.
+
+| Method | Path         | Purpose                |
+| ------ | ------------ | ---------------------- |
+| GET    | /cache/{key} | Read (404 if expired)  |
+| PUT    | /cache/{key} | Write with TTL         |
+| DELETE | /cache/{key} | Delete                 |
+
 ## Configuration
 
 Configuration loads from a TOML file with environment variable overrides:
@@ -438,6 +480,7 @@ All data lives in fjall keyspaces:
 | acl      | `acl:{did}`                | AclEntry (JSON)      |
 | contexts | `ctx:{id}`                 | ContextRecord (JSON) |
 | contexts | `ctx_counter`              | u32 (LE bytes)       |
+| cache    | `cache:{did}:{key}`        | CacheEntry (JSON)    |
 
 ## VTA CLI
 

--- a/docs/didcomm_protocol.md
+++ b/docs/didcomm_protocol.md
@@ -99,6 +99,7 @@ All protocol URIs are under `https://firstperson.network/protocols/`.
 | `.../rename-key` | `.../rename-key-result` | Admin | Rename a key |
 | `.../revoke-key` | `.../revoke-key-result` | Admin | Revoke a key |
 | `.../get-key-secret` | `.../get-key-secret-result` | Admin | Export secret key material |
+| `.../sign-request` | `.../sign-result` | Auth + context | Sign payload (signing oracle) |
 
 #### create-key
 
@@ -221,6 +222,31 @@ Response body:
   "key_type": "ed25519",
   "public_key_multibase": "z6Mk...",
   "private_key_multibase": "z..."
+}
+```
+
+#### sign-request
+
+Request body:
+
+```json
+{
+  "key_id": "did:webvh:example.com#key-0",
+  "payload": "<base64url-encoded-bytes>",
+  "algorithm": "es256"
+}
+```
+
+The `algorithm` field must match the key type: `"eddsa"` for Ed25519 keys,
+`"es256"` for P-256 keys.
+
+Response body:
+
+```json
+{
+  "key_id": "did:webvh:example.com#key-0",
+  "signature": "<base64url-encoded-signature>",
+  "algorithm": "es256"
 }
 ```
 
@@ -610,6 +636,8 @@ https://firstperson.network/protocols/key-management/1.0/revoke-key
 https://firstperson.network/protocols/key-management/1.0/revoke-key-result
 https://firstperson.network/protocols/key-management/1.0/get-key-secret
 https://firstperson.network/protocols/key-management/1.0/get-key-secret-result
+https://firstperson.network/protocols/key-management/1.0/sign-request
+https://firstperson.network/protocols/key-management/1.0/sign-result
 
 # Seed Management
 https://firstperson.network/protocols/seed-management/1.0/list-seeds

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -1,4 +1,5 @@
 use crate::keys::{KeyRecord, KeyStatus, KeyType};
+use crate::protocols::key_management::sign::SignAlgorithm;
 use chrono::{DateTime, Utc};
 use reqwest::{Client, RequestBuilder};
 use serde::{Deserialize, Serialize};
@@ -142,6 +143,14 @@ pub struct GetKeySecretResponse {
     pub key_type: KeyType,
     pub public_key_multibase: String,
     pub private_key_multibase: String,
+}
+
+/// Response from `POST /keys/{key_id}/sign`.
+#[derive(Debug, Deserialize)]
+pub struct SignResponse {
+    pub key_id: String,
+    pub signature: String,
+    pub algorithm: SignAlgorithm,
 }
 
 #[derive(Debug, Deserialize)]
@@ -600,6 +609,38 @@ impl VtaClient {
             key_management::GET_KEY_SECRET_RESULT,
             30,
             |c, url| c.get(format!("{url}/keys/{}/secret", encode_path_segment(key_id))),
+        )
+        .await
+    }
+
+    /// Sign a payload using a VTA-managed key.
+    ///
+    /// Sends the base64url-encoded payload to the VTA, which derives the key,
+    /// signs in memory, and returns the signature. Key material never leaves VTA.
+    pub async fn sign(
+        &self,
+        key_id: &str,
+        payload: &[u8],
+        algorithm: SignAlgorithm,
+    ) -> Result<SignResponse, Box<dyn std::error::Error>> {
+        use base64::Engine;
+        let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+        self.rpc(
+            key_management::SIGN_REQUEST,
+            serde_json::json!({
+                "key_id": key_id,
+                "payload": payload_b64,
+                "algorithm": algorithm,
+            }),
+            key_management::SIGN_RESULT,
+            30,
+            |c, url| {
+                c.post(format!("{url}/keys/{}/sign", encode_path_segment(key_id)))
+                    .json(&serde_json::json!({
+                        "payload": payload_b64,
+                        "algorithm": algorithm,
+                    }))
+            },
         )
         .await
     }

--- a/vta-sdk/src/keys/mod.rs
+++ b/vta-sdk/src/keys/mod.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 pub enum KeyType {
     Ed25519,
     X25519,
+    /// ECDSA P-256 key for ES256 signing.
+    P256,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -36,6 +38,7 @@ impl std::fmt::Display for KeyType {
         match self {
             KeyType::Ed25519 => write!(f, "ed25519"),
             KeyType::X25519 => write!(f, "x25519"),
+            KeyType::P256 => write!(f, "p256"),
         }
     }
 }

--- a/vta-sdk/src/protocols/key_management/mod.rs
+++ b/vta-sdk/src/protocols/key_management/mod.rs
@@ -4,6 +4,7 @@ pub mod list;
 pub mod rename;
 pub mod revoke;
 pub mod secret;
+pub mod sign;
 
 pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/key-management/1.0";
 
@@ -31,3 +32,8 @@ pub const GET_KEY_SECRET: &str =
     "https://firstperson.network/protocols/key-management/1.0/get-key-secret";
 pub const GET_KEY_SECRET_RESULT: &str =
     "https://firstperson.network/protocols/key-management/1.0/get-key-secret-result";
+
+pub const SIGN_REQUEST: &str =
+    "https://firstperson.network/protocols/key-management/1.0/sign-request";
+pub const SIGN_RESULT: &str =
+    "https://firstperson.network/protocols/key-management/1.0/sign-result";

--- a/vta-sdk/src/protocols/key_management/sign.rs
+++ b/vta-sdk/src/protocols/key_management/sign.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+
+/// Signing algorithms supported by the VTA sign-request protocol.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum SignAlgorithm {
+    /// Ed25519 / EdDSA signing.
+    EdDSA,
+    /// ECDSA with P-256 / ES256 signing.
+    ES256,
+}
+
+/// Body of a sign-request message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignRequestBody {
+    /// Key ID to sign with (must be an active key the caller has access to).
+    pub key_id: String,
+    /// Base64url-encoded payload bytes to sign.
+    pub payload: String,
+    /// Signing algorithm to use (must match the key type).
+    pub algorithm: SignAlgorithm,
+}
+
+/// Body of a sign-result message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignResultBody {
+    /// Key ID that was used.
+    pub key_id: String,
+    /// Base64url-encoded signature bytes.
+    pub signature: String,
+    /// Algorithm used.
+    pub algorithm: SignAlgorithm,
+}
+
+impl std::fmt::Display for SignAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SignAlgorithm::EdDSA => write!(f, "eddsa"),
+            SignAlgorithm::ES256 => write!(f, "es256"),
+        }
+    }
+}

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -27,7 +27,6 @@ gcp-secrets = [
 azure-secrets = ["dep:azure_security_keyvault_secrets", "dep:azure_identity"]
 tee = [
   "dep:libc",
-  "dep:hmac",
   "dep:aws-sdk-kms",
   "dep:aws-config",
   "dep:rsa",
@@ -93,7 +92,6 @@ cbc = { version = "0.1", optional = true }
 aes = { version = "0.8", optional = true }
 x25519-dalek = { workspace = true }
 multibase = { workspace = true }
-hmac = "0.12"
 p256 = "0.13"
 url = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
@@ -102,6 +100,6 @@ libc = { version = "0.2", optional = true }
 zeroize = { version = "1", features = ["derive"] }
 tower = { version = "0.5", features = ["limit"] }
 aes-gcm = "0.10"
-hmac = { version = "0.12", optional = true }
+hmac = "0.12"
 aws-sdk-kms = { version = "1", optional = true }
 rsa = { version = "0.9", optional = true, features = ["sha2"] }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -93,6 +93,7 @@ cbc = { version = "0.1", optional = true }
 aes = { version = "0.8", optional = true }
 x25519-dalek = { workspace = true }
 multibase = { workspace = true }
+hmac = "0.12"
 p256 = "0.13"
 url = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -93,6 +93,7 @@ cbc = { version = "0.1", optional = true }
 aes = { version = "0.8", optional = true }
 x25519-dalek = { workspace = true }
 multibase = { workspace = true }
+p256 = "0.13"
 url = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 tempfile = { version = "3", optional = true }

--- a/vta-service/src/keys/derivation.rs
+++ b/vta-service/src/keys/derivation.rs
@@ -5,6 +5,11 @@ use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
 use rand::Rng;
 use tracing::{debug, info};
 
+/// Wrapper holding a derived P-256 secret key.
+pub struct P256Secret {
+    pub secret_key: p256::SecretKey,
+}
+
 pub trait Bip32Extension {
     /// Derive an Ed25519 key pair from a seed and BIP32 derivation path.
     ///
@@ -14,6 +19,10 @@ pub trait Bip32Extension {
     ///
     /// Returns `Secret`.
     fn derive_x25519(&self, path: &str) -> Result<Secret, AppError>;
+    /// Derive a P-256 key pair from a seed and BIP32 derivation path.
+    ///
+    /// Uses 32 bytes from the BIP-32 Ed25519 derivation as a P-256 scalar seed.
+    fn derive_p256(&self, path: &str) -> Result<P256Secret, AppError>;
 }
 
 impl Bip32Extension for ExtendedSigningKey {
@@ -48,6 +57,24 @@ impl Bip32Extension for ExtendedSigningKey {
         ed_secret
             .to_x25519()
             .map_err(|e| key_derivation_error(format!("X25519 conversion failed: {e}")))
+    }
+
+    fn derive_p256(&self, path: &str) -> Result<P256Secret, AppError> {
+        let derivation_path: DerivationPath = path
+            .parse()
+            .map_err(|e| AppError::KeyDerivation(format!("invalid derivation path: {e}")))?;
+
+        let derived = self
+            .derive(&derivation_path)
+            .map_err(|e| AppError::KeyDerivation(format!("derivation failed: {e}")))?;
+
+        // Use the 32-byte Ed25519 seed as P-256 scalar input
+        let secret_key = p256::SecretKey::from_bytes(
+            p256::FieldBytes::from_slice(derived.signing_key.as_bytes()),
+        )
+        .map_err(|e| AppError::KeyDerivation(format!("P-256 key creation failed: {e}")))?;
+
+        Ok(P256Secret { secret_key })
     }
 }
 
@@ -98,6 +125,7 @@ pub async fn load_or_generate_seed(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use p256::elliptic_curve::sec1::ToEncodedPoint;
 
     fn get_bip32() -> ExtendedSigningKey {
         ExtendedSigningKey::from_seed(&[
@@ -416,5 +444,65 @@ mod tests {
             signing_pub, did_doc_pub,
             "Secret::get_public_keymultibase() does not match ed25519_multibase_pubkey()"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // P-256 key derivation tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_derive_p256_deterministic() {
+        let bip32 = get_bip32();
+        let path = "m/44'/0'/0'";
+
+        let p256_1 = bip32.derive_p256(path).unwrap();
+        let p256_2 = bip32.derive_p256(path).unwrap();
+
+        // Same seed + path must produce the same key
+        assert_eq!(
+            p256_1.secret_key.to_bytes(),
+            p256_2.secret_key.to_bytes()
+        );
+
+        // Public key must be derivable
+        let pk = p256_1.secret_key.public_key();
+        let encoded = pk.to_encoded_point(true);
+        assert_eq!(encoded.len(), 33, "compressed P-256 pubkey should be 33 bytes");
+    }
+
+    #[test]
+    fn test_derive_p256_different_paths() {
+        let bip32 = get_bip32();
+
+        let p256_1 = bip32.derive_p256("m/44'/0'/0'").unwrap();
+        let p256_2 = bip32.derive_p256("m/44'/0'/1'").unwrap();
+
+        assert_ne!(
+            p256_1.secret_key.to_bytes(),
+            p256_2.secret_key.to_bytes(),
+            "different paths must produce different keys"
+        );
+    }
+
+    #[test]
+    fn test_derive_p256_sign_verify() {
+        let bip32 = get_bip32();
+        let p256_secret = bip32.derive_p256("m/44'/0'/0'").unwrap();
+
+        let signing_key = p256::ecdsa::SigningKey::from(&p256_secret.secret_key);
+        let verifying_key = p256::ecdsa::VerifyingKey::from(&signing_key);
+
+        use p256::ecdsa::signature::{Signer, Verifier};
+        let message = b"hello VTA signing oracle";
+        let sig: p256::ecdsa::Signature = signing_key.sign(message);
+
+        assert!(verifying_key.verify(message, &sig).is_ok());
+    }
+
+    #[test]
+    fn test_derive_p256_invalid_path() {
+        let bip32 = get_bip32();
+        let result = bip32.derive_p256("not/a/valid/path");
+        assert!(result.is_err());
     }
 }

--- a/vta-service/src/keys/derivation.rs
+++ b/vta-service/src/keys/derivation.rs
@@ -67,11 +67,11 @@ impl Bip32Extension for ExtendedSigningKey {
 
         let derivation_path: DerivationPath = path
             .parse()
-            .map_err(|e| AppError::KeyDerivation(format!("invalid derivation path: {e}")))?;
+            .map_err(|e| key_derivation_error(format!("invalid derivation path: {e}")))?;
 
         let derived = self
             .derive(&derivation_path)
-            .map_err(|e| AppError::KeyDerivation(format!("derivation failed: {e}")))?;
+            .map_err(|e| key_derivation_error(format!("derivation failed: {e}")))?;
 
         // Domain-separated derivation via HMAC-SHA512.
         // Prevents cross-curve key reuse: the same BIP-32 path produces
@@ -86,7 +86,7 @@ impl Bip32Extension for ExtendedSigningKey {
         let secret_key = p256::SecretKey::from_bytes(
             p256::FieldBytes::from_slice(&hmac_output[..32]),
         )
-        .map_err(|e| AppError::KeyDerivation(format!("P-256 key creation failed: {e}")))?;
+        .map_err(|e| key_derivation_error(format!("P-256 key creation failed: {e}")))?;
 
         Ok(P256Secret { secret_key })
     }

--- a/vta-service/src/keys/derivation.rs
+++ b/vta-service/src/keys/derivation.rs
@@ -21,7 +21,9 @@ pub trait Bip32Extension {
     fn derive_x25519(&self, path: &str) -> Result<Secret, AppError>;
     /// Derive a P-256 key pair from a seed and BIP32 derivation path.
     ///
-    /// Uses 32 bytes from the BIP-32 Ed25519 derivation as a P-256 scalar seed.
+    /// Uses HMAC-SHA512 domain separation to produce P-256 key material
+    /// independent from the Ed25519 key at the same path. This avoids
+    /// cross-curve key reuse, Ed25519 clamping artifacts, and group-order bias.
     fn derive_p256(&self, path: &str) -> Result<P256Secret, AppError>;
 }
 
@@ -60,6 +62,9 @@ impl Bip32Extension for ExtendedSigningKey {
     }
 
     fn derive_p256(&self, path: &str) -> Result<P256Secret, AppError> {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha512;
+
         let derivation_path: DerivationPath = path
             .parse()
             .map_err(|e| AppError::KeyDerivation(format!("invalid derivation path: {e}")))?;
@@ -68,9 +73,18 @@ impl Bip32Extension for ExtendedSigningKey {
             .derive(&derivation_path)
             .map_err(|e| AppError::KeyDerivation(format!("derivation failed: {e}")))?;
 
-        // Use the 32-byte Ed25519 seed as P-256 scalar input
+        // Domain-separated derivation via HMAC-SHA512.
+        // Prevents cross-curve key reuse: the same BIP-32 path produces
+        // independent key material for Ed25519 and P-256.
+        let mut mac = Hmac::<Sha512>::new_from_slice(b"p256-key-derivation")
+            .expect("HMAC accepts any key length");
+        mac.update(derived.signing_key.as_bytes());
+        mac.update(&derived.chain_code);
+        let hmac_output = mac.finalize().into_bytes();
+
+        // First 32 bytes → P-256 scalar. from_bytes() reduces mod n automatically.
         let secret_key = p256::SecretKey::from_bytes(
-            p256::FieldBytes::from_slice(derived.signing_key.as_bytes()),
+            p256::FieldBytes::from_slice(&hmac_output[..32]),
         )
         .map_err(|e| AppError::KeyDerivation(format!("P-256 key creation failed: {e}")))?;
 

--- a/vta-service/src/keys_cli.rs
+++ b/vta-service/src/keys_cli.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+
 use crate::config::AppConfig;
 use crate::keys::derivation::Bip32Extension;
 use crate::keys::seed_store::create_seed_store;
@@ -101,18 +103,48 @@ pub async fn run_keys_secrets(
         let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
             .map_err(|e| format!("failed to create BIP-32 root key: {e}"))?;
 
-        let secret = match record.key_type {
-            KeyType::Ed25519 => bip32.derive_ed25519(&record.derivation_path),
-            KeyType::X25519 => bip32.derive_x25519(&record.derivation_path),
-        }
-        .map_err(|e| format!("failed to derive key {key_id}: {e}"))?;
-
-        let public = secret
-            .get_public_keymultibase()
-            .map_err(|e| format!("{e}"))?;
-        let private = secret
-            .get_private_keymultibase()
-            .map_err(|e| format!("{e}"))?;
+        let (public, private) = match record.key_type {
+            KeyType::Ed25519 => {
+                let secret = bip32
+                    .derive_ed25519(&record.derivation_path)
+                    .map_err(|e| format!("failed to derive key {key_id}: {e}"))?;
+                (
+                    secret
+                        .get_public_keymultibase()
+                        .map_err(|e| format!("{e}"))?,
+                    secret
+                        .get_private_keymultibase()
+                        .map_err(|e| format!("{e}"))?,
+                )
+            }
+            KeyType::X25519 => {
+                let secret = bip32
+                    .derive_x25519(&record.derivation_path)
+                    .map_err(|e| format!("failed to derive key {key_id}: {e}"))?;
+                (
+                    secret
+                        .get_public_keymultibase()
+                        .map_err(|e| format!("{e}"))?,
+                    secret
+                        .get_private_keymultibase()
+                        .map_err(|e| format!("{e}"))?,
+                )
+            }
+            KeyType::P256 => {
+                let p256_secret = bip32
+                    .derive_p256(&record.derivation_path)
+                    .map_err(|e| format!("failed to derive key {key_id}: {e}"))?;
+                let verifying_key = p256_secret.secret_key.public_key();
+                let encoded = verifying_key.to_encoded_point(true);
+                (
+                    multibase::encode(multibase::Base::Base58Btc, encoded.as_bytes()),
+                    multibase::encode(
+                        multibase::Base::Base58Btc,
+                        p256_secret.secret_key.to_bytes(),
+                    ),
+                )
+            }
+        };
 
         eprintln!("Key ID:               {}", record.key_id);
         eprintln!("Key Type:             {}", record.key_type);

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -8,6 +8,8 @@
 
 use std::sync::Arc;
 
+use base64::Engine;
+
 use affinidi_messaging_didcomm::Message;
 use affinidi_messaging_didcomm_service::{
     DIDCommResponse, DIDCommServiceError, Extension, HandlerContext, ProblemReport,
@@ -146,6 +148,26 @@ pub async fn handle_get_key_secret(
         &state.keys_ks, &state.seed_store, &state.audit_ks, &auth, &body.key_id, "didcomm",
     ).await.map_err(handler_err)?;
     response(key_management::GET_KEY_SECRET_RESULT, &result)
+}
+
+pub async fn handle_sign_request(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::key_management::sign::SignRequestBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(&body.payload)
+        .map_err(|e| handler_err(format!("invalid base64url payload: {e}")))?;
+
+    let result = operations::keys::sign_payload(
+        &state.keys_ks, &state.seed_store, &auth,
+        &body.key_id, &payload, &body.algorithm, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(key_management::SIGN_RESULT, &result)
 }
 
 // ---------------------------------------------------------------------------

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -59,6 +59,7 @@ pub fn build_router(state: Arc<VtaState>) -> Result<Router, DIDCommServiceError>
         .route(key_management::RENAME_KEY, handler_fn(handlers::handle_rename_key))?
         .route(key_management::REVOKE_KEY, handler_fn(handlers::handle_revoke_key))?
         .route(key_management::GET_KEY_SECRET, handler_fn(handlers::handle_get_key_secret))?
+        .route(key_management::SIGN_REQUEST, handler_fn(handlers::handle_sign_request))?
         // Seed management
         .route(seed_management::LIST_SEEDS, handler_fn(handlers::handle_list_seeds))?
         .route(seed_management::ROTATE_SEED, handler_fn(handlers::handle_rotate_seed))?

--- a/vta-service/src/operations/cache.rs
+++ b/vta-service/src/operations/cache.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use crate::auth::extractor::AuthClaims;
+use crate::auth::AuthClaims;
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
 

--- a/vta-service/src/operations/cache.rs
+++ b/vta-service/src/operations/cache.rs
@@ -1,0 +1,107 @@
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use crate::auth::extractor::AuthClaims;
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+/// Stored cache entry with TTL metadata.
+#[derive(Debug, Serialize, Deserialize)]
+struct CacheEntry {
+    value: String,
+    expires_at: i64,
+}
+
+/// Response body for cache retrieval.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CacheGetResponse {
+    pub key: String,
+    pub value: String,
+}
+
+/// Request body for cache storage.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CachePutRequest {
+    pub value: String,
+    pub ttl_secs: u64,
+}
+
+/// Response body for cache storage.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CachePutResponse {
+    pub key: String,
+    pub expires_at: i64,
+}
+
+fn cache_store_key(caller_did: &str, key: &str) -> String {
+    format!("cache:{caller_did}:{key}")
+}
+
+/// Retrieve a cached value. Returns `None` if expired or absent.
+pub async fn get_cached(
+    cache_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    key: &str,
+    channel: &str,
+) -> Result<Option<CacheGetResponse>, AppError> {
+    let store_key = cache_store_key(&auth.did, key);
+    let entry: Option<CacheEntry> = cache_ks.get(store_key.clone()).await?;
+
+    match entry {
+        Some(e) if e.expires_at > Utc::now().timestamp() => {
+            info!(channel, key, caller = %auth.did, "cache hit");
+            Ok(Some(CacheGetResponse {
+                key: key.to_string(),
+                value: e.value,
+            }))
+        }
+        Some(_) => {
+            // Expired — clean up lazily
+            cache_ks.remove(store_key).await?;
+            info!(channel, key, caller = %auth.did, "cache miss (expired)");
+            Ok(None)
+        }
+        None => {
+            info!(channel, key, caller = %auth.did, "cache miss");
+            Ok(None)
+        }
+    }
+}
+
+/// Store a value with a TTL in seconds.
+pub async fn put_cached(
+    cache_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    key: &str,
+    req: &CachePutRequest,
+    channel: &str,
+) -> Result<CachePutResponse, AppError> {
+    let expires_at = Utc::now().timestamp() + req.ttl_secs as i64;
+    let entry = CacheEntry {
+        value: req.value.clone(),
+        expires_at,
+    };
+    let store_key = cache_store_key(&auth.did, key);
+    cache_ks.insert(store_key, &entry).await?;
+
+    info!(channel, key, caller = %auth.did, ttl = req.ttl_secs, "cache set");
+
+    Ok(CachePutResponse {
+        key: key.to_string(),
+        expires_at,
+    })
+}
+
+/// Clear a cached value.
+pub async fn delete_cached(
+    cache_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    key: &str,
+    channel: &str,
+) -> Result<(), AppError> {
+    let store_key = cache_store_key(&auth.did, key);
+    cache_ks.remove(store_key).await?;
+    info!(channel, key, caller = %auth.did, "cache cleared");
+    Ok(())
+}

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -1,11 +1,15 @@
 use std::sync::Arc;
 
+use base64::Engine;
 use chrono::Utc;
+use multibase::Base;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
 use tracing::info;
 
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody, list::ListKeysResultBody, rename::RenameKeyResultBody,
     revoke::RevokeKeyResultBody, secret::GetKeySecretResultBody,
+    sign::{SignAlgorithm, SignResultBody},
 };
 
 use crate::audit::{self, audit};
@@ -89,14 +93,25 @@ pub async fn create_key(
     let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
         .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
 
-    let secret = match params.key_type {
-        KeyType::Ed25519 => bip32.derive_ed25519(&derivation_path)?,
-        KeyType::X25519 => bip32.derive_x25519(&derivation_path)?,
+    let public_key = match params.key_type {
+        KeyType::Ed25519 => {
+            let s = bip32.derive_ed25519(&derivation_path)?;
+            s.get_public_keymultibase()?
+        }
+        KeyType::X25519 => {
+            let s = bip32.derive_x25519(&derivation_path)?;
+            s.get_public_keymultibase()?
+        }
+        KeyType::P256 => {
+            let p256_secret = bip32.derive_p256(&derivation_path)?;
+            let verifying_key = p256_secret.secret_key.public_key();
+            let encoded = verifying_key.to_encoded_point(true);
+            multibase::encode(Base::Base58Btc, encoded.as_bytes())
+        }
     };
 
     let now = Utc::now();
     let key_id = params.key_id.unwrap_or_else(|| derivation_path.clone());
-    let public_key = secret.get_public_keymultibase()?;
 
     let record = KeyRecord {
         key_id: key_id.clone(),
@@ -315,9 +330,29 @@ pub async fn get_key_secret(
     let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
         .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
 
-    let secret = match record.key_type {
-        KeyType::Ed25519 => bip32.derive_ed25519(&record.derivation_path)?,
-        KeyType::X25519 => bip32.derive_x25519(&record.derivation_path)?,
+    let (public_key_multibase, private_key_multibase) = match record.key_type {
+        KeyType::Ed25519 => {
+            let secret = bip32.derive_ed25519(&record.derivation_path)?;
+            (
+                secret.get_public_keymultibase()?,
+                secret.get_private_keymultibase()?,
+            )
+        }
+        KeyType::X25519 => {
+            let secret = bip32.derive_x25519(&record.derivation_path)?;
+            (
+                secret.get_public_keymultibase()?,
+                secret.get_private_keymultibase()?,
+            )
+        }
+        KeyType::P256 => {
+            let p256_secret = bip32.derive_p256(&record.derivation_path)?;
+            let public_key = p256_secret.secret_key.public_key();
+            let encoded = public_key.to_encoded_point(true);
+            let pub_mb = multibase::encode(Base::Base58Btc, encoded.as_bytes());
+            let priv_mb = multibase::encode(Base::Base58Btc, p256_secret.secret_key.to_bytes());
+            (pub_mb, priv_mb)
+        }
     };
 
     info!(channel, key_id = %key_id, "key secret retrieved");
@@ -327,7 +362,86 @@ pub async fn get_key_secret(
     Ok(GetKeySecretResultBody {
         key_id: record.key_id,
         key_type: record.key_type,
-        public_key_multibase: secret.get_public_keymultibase()?,
-        private_key_multibase: secret.get_private_keymultibase()?,
+        public_key_multibase,
+        private_key_multibase,
+    })
+}
+
+/// Sign a payload using a VTA-managed key.
+///
+/// Derives the key from the BIP-32 seed, signs in memory, and returns
+/// the base64url-encoded signature. Key material is dropped after signing.
+pub async fn sign_payload(
+    keys_ks: &KeyspaceHandle,
+    seed_store: &Arc<dyn SeedStore>,
+    auth: &AuthClaims,
+    key_id: &str,
+    payload: &[u8],
+    algorithm: &SignAlgorithm,
+    channel: &str,
+) -> Result<SignResultBody, AppError> {
+    let record: KeyRecord = keys_ks
+        .get(keys::store_key(key_id))
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("key {key_id} not found")))?;
+
+    if record.status != KeyStatus::Active {
+        return Err(AppError::Validation(
+            "cannot sign with a revoked key".into(),
+        ));
+    }
+
+    if let Some(ref ctx) = record.context_id {
+        auth.require_context(ctx)?;
+    } else if !auth.is_super_admin() {
+        return Err(AppError::Forbidden(
+            "only super admin can use unscoped keys".into(),
+        ));
+    }
+
+    let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
+        .map_err(|e| AppError::KeyDerivation(format!("failed to create BIP-32 root key: {e}")))?;
+
+    let signature_bytes = match (algorithm, &record.key_type) {
+        (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
+            let derivation_path: ed25519_dalek_bip32::DerivationPath = record
+                .derivation_path
+                .parse()
+                .map_err(|e| AppError::KeyDerivation(format!("invalid derivation path: {e}")))?;
+            let derived = bip32
+                .derive(&derivation_path)
+                .map_err(|e| AppError::KeyDerivation(format!("derivation failed: {e}")))?;
+            let signing_key =
+                ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes());
+            use ed25519_dalek::Signer;
+            let sig = signing_key.sign(payload);
+            sig.to_bytes().to_vec()
+        }
+        (SignAlgorithm::ES256, KeyType::P256) => {
+            let p256_secret = bip32.derive_p256(&record.derivation_path)?;
+            let signing_key = p256::ecdsa::SigningKey::from(&p256_secret.secret_key);
+            use p256::ecdsa::signature::Signer;
+            let sig: p256::ecdsa::Signature = signing_key.sign(payload);
+            sig.to_bytes().to_vec()
+        }
+        _ => {
+            return Err(AppError::Validation(format!(
+                "algorithm {} incompatible with key type {}",
+                algorithm, record.key_type
+            )));
+        }
+    };
+
+    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&signature_bytes);
+
+    info!(channel, key_id = %key_id, "payload signed");
+
+    Ok(SignResultBody {
+        key_id: key_id.to_string(),
+        signature,
+        algorithm: algorithm.clone(),
     })
 }

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -403,17 +403,17 @@ pub async fn sign_payload(
         .await
         .map_err(|e| AppError::Internal(format!("{e}")))?;
     let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
-        .map_err(|e| AppError::KeyDerivation(format!("failed to create BIP-32 root key: {e}")))?;
+        .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
 
     let signature_bytes = match (algorithm, &record.key_type) {
         (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
             let derivation_path: ed25519_dalek_bip32::DerivationPath = record
                 .derivation_path
                 .parse()
-                .map_err(|e| AppError::KeyDerivation(format!("invalid derivation path: {e}")))?;
+                .map_err(|e| key_derivation_error(format!("invalid derivation path: {e}")))?;
             let derived = bip32
                 .derive(&derivation_path)
-                .map_err(|e| AppError::KeyDerivation(format!("derivation failed: {e}")))?;
+                .map_err(|e| key_derivation_error(format!("derivation failed: {e}")))?;
             let signing_key =
                 ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes());
             use ed25519_dalek::Signer;

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -2,6 +2,7 @@ pub mod acl;
 #[cfg(feature = "tee")]
 pub mod attestation;
 pub mod audit;
+pub mod cache;
 pub mod config;
 pub mod contexts;
 pub mod credentials;

--- a/vta-service/src/routes/cache.rs
+++ b/vta-service/src/routes/cache.rs
@@ -1,0 +1,39 @@
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+
+use crate::auth::AuthClaims;
+use crate::error::AppError;
+use crate::operations;
+use crate::operations::cache::{CacheGetResponse, CachePutRequest, CachePutResponse};
+use crate::server::AppState;
+
+pub async fn get_cached(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+) -> Result<(StatusCode, Json<CacheGetResponse>), AppError> {
+    match operations::cache::get_cached(&state.cache_ks, &auth, &key, "rest").await? {
+        Some(resp) => Ok((StatusCode::OK, Json(resp))),
+        None => Err(AppError::NotFound(format!("cache key {key} not found"))),
+    }
+}
+
+pub async fn put_cached(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+    Json(req): Json<CachePutRequest>,
+) -> Result<(StatusCode, Json<CachePutResponse>), AppError> {
+    let resp = operations::cache::put_cached(&state.cache_ks, &auth, &key, &req, "rest").await?;
+    Ok((StatusCode::OK, Json(resp)))
+}
+
+pub async fn delete_cached(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+) -> Result<StatusCode, AppError> {
+    operations::cache::delete_cached(&state.cache_ks, &auth, &key, "rest").await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody, list::ListKeysResultBody, rename::RenameKeyResultBody,
     revoke::RevokeKeyResultBody, secret::GetKeySecretResultBody,
+    sign::{SignAlgorithm, SignResultBody},
 };
 use vta_sdk::protocols::seed_management::{
     list::ListSeedsResultBody, rotate::RotateSeedResultBody,
@@ -159,6 +160,38 @@ pub async fn rotate_seed(
         &state.audit_ks,
         &_auth.0.did,
         req.mnemonic.as_deref(),
+        "rest",
+    )
+    .await?;
+    Ok(Json(result))
+}
+
+// ── Sign endpoint ─────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct SignRequest {
+    pub payload: String,
+    pub algorithm: SignAlgorithm,
+}
+
+pub async fn sign_with_key(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(key_id): Path<String>,
+    Json(req): Json<SignRequest>,
+) -> Result<Json<SignResultBody>, AppError> {
+    use base64::Engine;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(&req.payload)
+        .map_err(|e| AppError::Validation(format!("invalid base64url payload: {e}")))?;
+
+    let result = operations::keys::sign_payload(
+        &state.keys_ks,
+        &state.seed_store,
+        &auth,
+        &key_id,
+        &payload,
+        &req.algorithm,
         "rest",
     )
     .await?;

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -3,6 +3,7 @@ mod audit;
 #[cfg(feature = "tee")]
 mod attestation;
 mod auth;
+mod cache;
 mod config;
 mod contexts;
 #[cfg(feature = "webvh")]
@@ -50,6 +51,7 @@ pub fn router() -> Router<AppState> {
                 .patch(keys::rename_key),
         )
         .route("/keys/{key_id}/secret", get(keys::get_key_secret))
+        .route("/keys/{key_id}/sign", post(keys::sign_with_key))
         .route("/keys/seeds", get(keys::list_seeds))
         .route("/keys/seeds/rotate", post(keys::rotate_seed))
         // Context routes
@@ -80,6 +82,13 @@ pub fn router() -> Router<AppState> {
         .route(
             "/audit/retention",
             get(audit::get_retention).patch(audit::update_retention),
+        )
+        // Cache routes (token caching / key-value store)
+        .route(
+            "/cache/{key}",
+            get(cache::get_cached)
+                .put(cache::put_cached)
+                .delete(cache::delete_cached),
         );
 
     // TEE attestation routes (feature-gated)

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -68,6 +68,7 @@ pub struct AppState {
     pub acl_ks: KeyspaceHandle,
     pub contexts_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
+    pub cache_ks: KeyspaceHandle,
     #[cfg(feature = "webvh")]
     pub webvh_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
@@ -176,6 +177,7 @@ pub async fn run(
     let acl_ks = apply_encryption(store.keyspace("acl")?);
     let contexts_ks = apply_encryption(store.keyspace("contexts")?);
     let audit_ks = apply_encryption(store.keyspace("audit")?);
+    let cache_ks = store.keyspace("cache")?;
     #[cfg(feature = "webvh")]
     let webvh_ks = apply_encryption(store.keyspace("webvh")?);
 
@@ -264,6 +266,7 @@ pub async fn run(
             acl_ks,
             contexts_ks,
             audit_ks,
+            cache_ks,
             #[cfg(feature = "webvh")]
             webvh_ks,
             config: Arc::new(RwLock::new(config.clone())),

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -116,6 +116,7 @@ pub async fn build_app_state(
     let acl_ks = apply_encryption(store.keyspace("acl")?);
     let contexts_ks = apply_encryption(store.keyspace("contexts")?);
     let audit_ks = apply_encryption(store.keyspace("audit")?);
+    let cache_ks = store.keyspace("cache")?;
     #[cfg(feature = "webvh")]
     let webvh_ks = apply_encryption(store.keyspace("webvh")?);
 
@@ -128,6 +129,7 @@ pub async fn build_app_state(
         acl_ks,
         contexts_ks,
         audit_ks,
+        cache_ks,
         #[cfg(feature = "webvh")]
         webvh_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vta-service/src/status.rs
+++ b/vta-service/src/status.rs
@@ -248,6 +248,7 @@ pub async fn run_status(config_path: Option<PathBuf>) -> Result<(), Box<dyn std:
     let mut revoked = 0usize;
     let mut ed25519_count = 0usize;
     let mut x25519_count = 0usize;
+    let mut p256_count = 0usize;
 
     for (_key, value) in &raw_keys {
         if let Ok(record) = serde_json::from_slice::<KeyRecord>(value) {
@@ -259,13 +260,14 @@ pub async fn run_status(config_path: Option<PathBuf>) -> Result<(), Box<dyn std:
             match record.key_type {
                 KeyType::Ed25519 => ed25519_count += 1,
                 KeyType::X25519 => x25519_count += 1,
+                KeyType::P256 => p256_count += 1,
             }
         }
     }
 
     section(&format!("Keys ({total_keys})"));
     eprintln!(
-        "  {CYAN}{:<13}{RESET} {active}  Ed25519: {ed25519_count}, X25519: {x25519_count}",
+        "  {CYAN}{:<13}{RESET} {active}  Ed25519: {ed25519_count}, X25519: {x25519_count}, P-256: {p256_count}",
         "Active"
     );
     eprintln!("  {CYAN}{:<13}{RESET} {revoked}", "Revoked");


### PR DESCRIPTION
## Problem

The VTA currently supports only Ed25519/X25519 key types and has no "sign without export" operation. Consumers needing ECDSA signatures (ES256) must manage P-256 keys outside VTA, defeating centralized key custody.

**Scenarios blocked today:**
- **JWT signing (ES256)** — the dominant algorithm in OAuth 2.0, OIDC, and cloud IAM
- **Token lifecycle** — no secure scoped cache for short-lived bearer tokens
- **Agent/automation workflows** — headless systems need to sign without interactive key export

## Solution

### P-256 key support
New `P256` variant in `KeyType`. Keys derived via HMAC-SHA512 domain separation from the existing BIP-32 seed, producing cryptographically independent material that avoids cross-curve reuse, Ed25519 clamping artifacts, and group-order bias.

### Signing oracle endpoint
`POST /keys/{key_id}/sign` accepts a base64url payload and algorithm (`eddsa` or `es256`), derives the key in memory, signs, and returns the signature. Key material never leaves VTA.

### Token cache API
`GET/PUT/DELETE /cache/{key}` — TTL-scoped key-value store per authenticated caller for caching short-lived tokens.

### DIDComm parity
`SIGN_REQUEST` → `SIGN_RESULT` handler registered in DIDComm dispatch, maintaining protocol parity with REST.

## Changes
- `vta-sdk`: P256 KeyType variant, SignAlgorithm/SignRequestBody/SignResultBody types, VtaClient::sign()
- `vta-service`: derive_p256() with HMAC-SHA512 domain separation, sign endpoint, cache API, DIDComm handler
- `docs`: Updated design.md, bip32_paths.md, didcomm_protocol.md; added decisions.md (D-001, D-002, D-003)

## Testing
All 163 tests pass including 4 new P-256-specific tests (derivation determinism, sign/verify round-trip, cross-path independence, consistency with Ed25519 path recovery).