### PR TITLE
Migrate DIDComm to affinidi-messaging-didcomm-service + unify audit logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7639,6 +7639,7 @@ dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
  "affinidi-tdk",
+ "affinidi-tdk-common",
  "aws-config",
  "aws-sdk-kms",
  "aws-sdk-secretsmanager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-messaging-didcomm-service"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba2422a25edc8a21d807af3b6dcf94061855695956faff49c9b77e0fa66a30f"
+dependencies = [
+ "affinidi-messaging-didcomm",
+ "affinidi-messaging-sdk",
+ "affinidi-secrets-resolver",
+ "affinidi-tdk-common",
+ "async-trait",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha256",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "affinidi-messaging-sdk"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7010,6 +7033,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -7612,6 +7636,8 @@ dependencies = [
  "aes",
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm-service",
  "affinidi-tdk",
  "aws-config",
  "aws-sdk-kms",
@@ -7649,6 +7675,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml",
  "tower 0.5.3",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ repository = "https://github.com/FirstPersonNetwork/vtc-vta-rs"
 
 # Affinidi Trust Development Kit
 affinidi-tdk = "0.6"
+affinidi-messaging-didcomm-service = "0.1"
 
 # Decentralized Trust Graph Credentials
 # NOTE: When this is published, switch from git to crates.io

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -1,35 +1,33 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use affinidi_tdk::common::TDKSharedState;
+use affinidi_tdk::didcomm::Message;
 use affinidi_tdk::messaging::ATM;
 use affinidi_tdk::messaging::config::ATMConfig;
 use affinidi_tdk::messaging::profiles::ATMProfile;
-use affinidi_tdk::messaging::transports::websockets::WebSocketResponses;
+use affinidi_tdk::messaging::transports::SendMessageResponse;
 use affinidi_tdk::secrets_resolver::SecretsResolver;
-use tokio::sync::broadcast;
-use tokio::task::JoinHandle;
-use tracing::{debug, warn};
+use tracing::debug;
 
-use crate::didcomm_transport::{PendingMap, send_and_wait_raw};
 use crate::protocols::PROBLEM_REPORT_TYPE;
 
 /// Client-side DIDComm session for request-response messaging via ATM.
 ///
-/// Mirrors the server's `DIDCommBridge` pattern but from the client side.
-/// Maintains a persistent ATM connection with a spawned inbound routing task
-/// that matches responses to pending requests by thread ID.
+/// Uses REST-based message send/receive through the mediator (no WebSocket).
+/// Designed for short-lived CLI tools that send a request and wait for a reply.
 pub struct DIDCommSession {
     atm: Arc<ATM>,
     profile: Arc<ATMProfile>,
     pub(crate) client_did: String,
     pub(crate) vta_did: String,
-    pending: PendingMap,
-    _inbound_task: JoinHandle<()>,
 }
 
 impl DIDCommSession {
     /// Connect to a VTA via DIDComm through a mediator.
+    ///
+    /// Sets up the ATM and profile for REST-based messaging. Does NOT open a
+    /// WebSocket — all communication goes through the mediator's REST API,
+    /// avoiding connection storms when the CLI is invoked repeatedly.
     pub async fn connect(
         client_did: &str,
         private_key_multibase: &str,
@@ -45,10 +43,8 @@ impl DIDCommSession {
         tdk.secrets_resolver.insert(secrets.signing).await;
         tdk.secrets_resolver.insert(secrets.key_agreement).await;
 
-        // Build ATM with inbound message channel
-        let atm_config = ATMConfig::builder()
-            .with_inbound_message_channel(100)
-            .build()?;
+        // Build ATM (no inbound channel needed — we use REST polling)
+        let atm_config = ATMConfig::builder().build()?;
         let atm = ATM::new(atm_config, Arc::new(tdk)).await?;
 
         // Create profile with mediator
@@ -61,39 +57,23 @@ impl DIDCommSession {
         .await?;
         let profile = Arc::new(profile);
 
-        // Enable WebSocket (starts live streaming from mediator)
-        atm.profile_enable_websocket(&profile).await?;
-
+        // No WebSocket — REST-only transport for CLI use
         let atm = Arc::new(atm);
-        let pending: PendingMap = Arc::new(std::sync::Mutex::new(HashMap::new()));
 
-        // Spawn inbound routing task
-        let inbound_rx = atm
-            .get_inbound_channel()
-            .ok_or("no inbound channel available")?;
-        let task_atm = atm.clone();
-        let task_profile = profile.clone();
-        let task_pending = pending.clone();
-        let inbound_task = tokio::spawn(async move {
-            run_inbound_loop(inbound_rx, &task_atm, &task_profile, &task_pending).await;
-        });
-
-        debug!("DIDComm session connected via mediator {mediator_did}");
+        debug!("DIDComm session connected via mediator {mediator_did} (REST mode)");
 
         Ok(Self {
             atm,
             profile,
             client_did: client_did.to_string(),
             vta_did: vta_did.to_string(),
-            pending,
-            _inbound_task: inbound_task,
         })
     }
 
     /// Send a DIDComm message and wait for a matching response.
     ///
-    /// Builds an encrypted message, sends it via ATM, waits for a response
-    /// matching the thread ID, then deserializes the response body.
+    /// Packs the message, sends it via the mediator's REST API, and polls
+    /// for the response. No WebSocket needed.
     pub async fn send_and_wait<T: serde::de::DeserializeOwned>(
         &self,
         msg_type: &str,
@@ -101,85 +81,65 @@ impl DIDCommSession {
         expected_result_type: &str,
         timeout_secs: u64,
     ) -> Result<T, Box<dyn std::error::Error>> {
-        let response = send_and_wait_raw(
-            &self.atm,
-            &self.profile,
-            &self.pending,
-            &self.client_did,
-            &self.vta_did,
-            msg_type,
-            body,
-            expected_result_type,
-            PROBLEM_REPORT_TYPE,
-            timeout_secs,
+        let msg_id = uuid::Uuid::new_v4().to_string();
+        let msg = Message::build(msg_id.clone(), msg_type.to_string(), body)
+            .from(self.client_did.clone())
+            .to(self.vta_did.clone())
+            .finalize();
+
+        // Pack encrypted (signed + encrypted to recipient)
+        let (packed, _) = self
+            .atm
+            .pack_encrypted(
+                &msg,
+                &self.vta_did,
+                Some(&self.client_did),
+                Some(&self.client_did),
+            )
+            .await
+            .map_err(|e| format!("failed to pack message: {e}"))?;
+
+        debug!(msg_type, msg_id, "sending via DIDComm REST");
+
+        // Send and wait for response via REST (mediator holds the response
+        // until it arrives, then returns it in the same HTTP response)
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            self.atm.send_message(&self.profile, &packed, &msg_id, true, true),
         )
         .await
-        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        .map_err(|_| "timeout waiting for DIDComm response")?
+        .map_err(|e| format!("failed to send/receive message: {e}"))?;
 
-        // Delete message from mediator (best-effort)
-        if let Err(e) = self
-            .atm
-            .delete_message_background(&self.profile, &response.id)
-            .await
-        {
-            warn!("failed to delete message from mediator: {e}");
+        let response_msg = match response {
+            SendMessageResponse::Message(msg) => *msg,
+            _ => return Err("no response message received from mediator".into()),
+        };
+
+        debug!(response_type = %response_msg.typ, "received DIDComm response");
+
+        // Check for problem report
+        if response_msg.typ == PROBLEM_REPORT_TYPE || response_msg.typ.contains("problem-report") {
+            let code = response_msg.body.get("code").and_then(|v| v.as_str()).unwrap_or("unknown");
+            let comment = response_msg.body.get("comment").and_then(|v| v.as_str()).unwrap_or("");
+            return Err(format!("{code}: {comment}").into());
+        }
+
+        // Verify expected type
+        if response_msg.typ != expected_result_type {
+            return Err(format!(
+                "unexpected response type: expected {expected_result_type}, got {}",
+                response_msg.typ
+            ).into());
         }
 
         // Deserialize response body
-        serde_json::from_value(response.body)
+        serde_json::from_value(response_msg.body)
             .map_err(|e| format!("failed to deserialize DIDComm response: {e}").into())
     }
 
     /// Gracefully shut down the DIDComm session.
     pub async fn shutdown(&self) {
         self.atm.graceful_shutdown().await;
-        self._inbound_task.abort();
-    }
-}
-
-/// Inbound message routing loop.
-///
-/// Receives messages from the ATM broadcast channel and routes them to
-/// pending requests by matching thread ID.
-async fn run_inbound_loop(
-    mut rx: broadcast::Receiver<WebSocketResponses>,
-    atm: &ATM,
-    profile: &Arc<ATMProfile>,
-    pending: &PendingMap,
-) {
-    loop {
-        let msg = match rx.recv().await {
-            Ok(WebSocketResponses::MessageReceived(msg, _metadata)) => *msg,
-            Ok(WebSocketResponses::PackedMessageReceived(packed)) => {
-                match atm.unpack(&packed).await {
-                    Ok((msg, _metadata)) => msg,
-                    Err(e) => {
-                        warn!("failed to unpack inbound message: {e}");
-                        continue;
-                    }
-                }
-            }
-            Err(broadcast::error::RecvError::Lagged(n)) => {
-                warn!("inbound channel lagged, missed {n} messages");
-                continue;
-            }
-            Err(broadcast::error::RecvError::Closed) => {
-                debug!("inbound channel closed");
-                break;
-            }
-        };
-
-        // Try to complete a pending request by thread ID
-        if let Some(thid) = &msg.thid {
-            if let Some(tx) = pending.lock().unwrap().remove(thid) {
-                let _ = tx.send(msg);
-                continue;
-            }
-        }
-
-        // Unexpected inbound message — delete from mediator
-        if let Err(e) = atm.delete_message_background(profile, &msg.id).await {
-            warn!("failed to delete unexpected message from mediator: {e}");
-        }
     }
 }

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -7,7 +7,7 @@ use affinidi_tdk::messaging::config::ATMConfig;
 use affinidi_tdk::messaging::profiles::ATMProfile;
 use affinidi_tdk::messaging::transports::SendMessageResponse;
 use affinidi_tdk::secrets_resolver::SecretsResolver;
-use tracing::debug;
+use tracing::{debug, info, warn};
 
 use crate::protocols::PROBLEM_REPORT_TYPE;
 
@@ -59,6 +59,32 @@ impl DIDCommSession {
 
         // No WebSocket — REST-only transport for CLI use
         let atm = Arc::new(atm);
+
+        // Flush stale messages from the inbox (accumulated between CLI runs)
+        {
+            use affinidi_tdk::messaging::messages::Folder;
+            match atm.list_messages(&profile, Folder::Inbox).await {
+                Ok(messages) if !messages.is_empty() => {
+                    let ids: Vec<String> = messages.iter().map(|m| m.msg_id.clone()).collect();
+                    info!(count = ids.len(), "flushing stale queued messages from inbox");
+                    let delete_req = affinidi_tdk::messaging::messages::DeleteMessageRequest {
+                        message_ids: ids,
+                    };
+                    match atm.delete_messages_direct(&profile, &delete_req).await {
+                        Ok(resp) => {
+                            debug!(
+                                deleted = resp.success.len(),
+                                errors = resp.errors.len(),
+                                "inbox flushed"
+                            );
+                        }
+                        Err(e) => warn!("failed to flush stale messages (non-fatal): {e}"),
+                    }
+                }
+                Ok(_) => {} // Empty inbox
+                Err(e) => warn!("could not list inbox (non-fatal): {e}"),
+            }
+        }
 
         debug!("DIDComm session connected via mediator {mediator_did} (REST mode)");
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -51,6 +51,7 @@ vta-sdk = { path = "../vta-sdk", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.13"
 affinidi-messaging-didcomm-service = { workspace = true }
+affinidi-tdk-common = "0.5"
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 base64 = { workspace = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -49,7 +49,10 @@ path = "src/main.rs"
 vti-common = { path = "../vti-common", features = ["encryption"] }
 vta-sdk = { path = "../vta-sdk", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
+affinidi-messaging-didcomm = "0.13"
+affinidi-messaging-didcomm-service = { workspace = true }
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 base64 = { workspace = true }
 axum = "0.8"
 axum-extra = { workspace = true }

--- a/vta-service/src/messaging/handlers/acl.rs
+++ b/vta-service/src/messaging/handlers/acl.rs
@@ -26,6 +26,7 @@ pub async fn handle_create_acl(
 
     let result = operations::acl::create_acl(
         &state.acl_ks,
+        &state.audit_ks,
         &auth,
         &body.did,
         role,
@@ -77,6 +78,7 @@ pub async fn handle_update_acl(
 
     let result = operations::acl::update_acl(
         &state.acl_ks,
+        &state.audit_ks,
         &auth,
         &body.did,
         operations::acl::UpdateAclParams {
@@ -101,6 +103,6 @@ didcomm_handler!(handle_delete_acl,
     body: vta_sdk::protocols::acl_management::delete::DeleteAclBody,
     result: acl_management::DELETE_ACL_RESULT,
     |state, auth, body| operations::acl::delete_acl(
-        &state.acl_ks, &auth, &body.did, "didcomm",
+        &state.acl_ks, &state.audit_ks, &auth, &body.did, "didcomm",
     )
 );

--- a/vta-service/src/messaging/handlers/audit.rs
+++ b/vta-service/src/messaging/handlers/audit.rs
@@ -31,6 +31,6 @@ didcomm_handler!(handle_update_retention,
     auth: admin,
     result: audit_management::UPDATE_RETENTION_RESULT,
     |state, auth, body| operations::audit::update_retention(
-        &state.config, &auth, body.retention_days, "didcomm"
+        &state.config, &state.audit_ks, &auth, body.retention_days, "didcomm"
     )
 );

--- a/vta-service/src/messaging/handlers/keys.rs
+++ b/vta-service/src/messaging/handlers/keys.rs
@@ -17,6 +17,7 @@ didcomm_handler!(handle_create_key,
         &state.keys_ks,
         &state.contexts_ks,
         &state.seed_store,
+        &state.audit_ks,
         &auth,
         operations::keys::CreateKeyParams {
             key_type: body.key_type,
@@ -63,7 +64,7 @@ didcomm_handler!(handle_rename_key,
     auth: admin,
     result: key_management::RENAME_KEY_RESULT,
     |state, auth, body| operations::keys::rename_key(
-        &state.keys_ks, &auth, &body.key_id, &body.new_key_id, "didcomm",
+        &state.keys_ks, &state.audit_ks, &auth, &body.key_id, &body.new_key_id, "didcomm",
     )
 );
 
@@ -72,7 +73,7 @@ didcomm_handler!(handle_revoke_key,
     auth: admin,
     result: key_management::REVOKE_KEY_RESULT,
     |state, auth, body| operations::keys::revoke_key(
-        &state.keys_ks, &auth, &body.key_id, "didcomm",
+        &state.keys_ks, &state.audit_ks, &auth, &body.key_id, "didcomm",
     )
 );
 
@@ -81,6 +82,6 @@ didcomm_handler!(handle_get_key_secret,
     auth: admin,
     result: key_management::GET_KEY_SECRET_RESULT,
     |state, auth, body| operations::keys::get_key_secret(
-        &state.keys_ks, &state.seed_store, &auth, &body.key_id, "didcomm",
+        &state.keys_ks, &state.seed_store, &state.audit_ks, &auth, &body.key_id, "didcomm",
     )
 );

--- a/vta-service/src/messaging/handlers/seeds.rs
+++ b/vta-service/src/messaging/handlers/seeds.rs
@@ -22,6 +22,8 @@ didcomm_handler!(handle_rotate_seed,
     |state, auth, body| operations::seeds::rotate_seed(
         &state.keys_ks,
         &state.seed_store,
+        &state.audit_ks,
+        &auth.did,
         body.mnemonic.as_deref(),
         "didcomm",
     )

--- a/vta-service/src/messaging/mod.rs
+++ b/vta-service/src/messaging/mod.rs
@@ -1,6 +1,8 @@
 pub mod auth;
 pub mod handlers;
 pub mod response;
+pub mod router;
+pub mod service_handlers;
 
 use std::sync::Arc;
 

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -1,0 +1,123 @@
+//! DIDComm message router built on `affinidi-messaging-didcomm-service`.
+//!
+//! Replaces the manual `dispatch_message()` match statement with a typed
+//! Router that maps message types to handler functions. Shared state is
+//! injected via `Extension<Arc<VtaState>>`.
+
+use std::sync::Arc;
+
+use affinidi_messaging_didcomm_service::{
+    DIDCommServiceError, MessagePolicy, RequestLogging, Router,
+    handler_fn, ignore_handler, trust_ping_handler, TRUST_PING_TYPE, MESSAGE_PICKUP_STATUS_TYPE,
+};
+use tokio::sync::RwLock;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+
+use crate::config::AppConfig;
+use crate::keys::seed_store::SeedStore;
+use crate::store::KeyspaceHandle;
+
+use super::service_handlers;
+
+#[cfg(feature = "tee")]
+use vta_sdk::protocols::attestation_management;
+#[cfg(feature = "webvh")]
+use vta_sdk::protocols::did_management;
+use vta_sdk::protocols::{
+    self, acl_management, audit_management, context_management, credential_management,
+    key_management, seed_management, vta_management,
+};
+
+/// Shared state injected into all DIDComm handlers via `Extension<Arc<VtaState>>`.
+#[derive(Clone)]
+pub struct VtaState {
+    pub keys_ks: KeyspaceHandle,
+    pub acl_ks: KeyspaceHandle,
+    pub contexts_ks: KeyspaceHandle,
+    pub audit_ks: KeyspaceHandle,
+    #[cfg(feature = "webvh")]
+    pub webvh_ks: KeyspaceHandle,
+    pub seed_store: Arc<dyn SeedStore>,
+    pub config: Arc<RwLock<AppConfig>>,
+    pub did_resolver: Option<DIDCacheClient>,
+    #[cfg(feature = "tee")]
+    pub tee_state: Option<crate::tee::TeeState>,
+}
+
+/// Build the DIDComm message router with all VTA protocol handlers.
+pub fn build_router(state: Arc<VtaState>) -> Result<Router, DIDCommServiceError> {
+    let mut router = Router::new()
+        .extension(state)
+        // Built-in protocol handlers
+        .route(TRUST_PING_TYPE, handler_fn(trust_ping_handler))?
+        .route(MESSAGE_PICKUP_STATUS_TYPE, handler_fn(ignore_handler))?
+        // Key management
+        .route(key_management::CREATE_KEY, handler_fn(service_handlers::handle_create_key))?
+        .route(key_management::GET_KEY, handler_fn(service_handlers::handle_get_key))?
+        .route(key_management::LIST_KEYS, handler_fn(service_handlers::handle_list_keys))?
+        .route(key_management::RENAME_KEY, handler_fn(service_handlers::handle_rename_key))?
+        .route(key_management::REVOKE_KEY, handler_fn(service_handlers::handle_revoke_key))?
+        .route(key_management::GET_KEY_SECRET, handler_fn(service_handlers::handle_get_key_secret))?
+        // Seed management
+        .route(seed_management::LIST_SEEDS, handler_fn(service_handlers::handle_list_seeds))?
+        .route(seed_management::ROTATE_SEED, handler_fn(service_handlers::handle_rotate_seed))?
+        // Context management
+        .route(context_management::CREATE_CONTEXT, handler_fn(service_handlers::handle_create_context))?
+        .route(context_management::GET_CONTEXT, handler_fn(service_handlers::handle_get_context))?
+        .route(context_management::LIST_CONTEXTS, handler_fn(service_handlers::handle_list_contexts))?
+        .route(context_management::UPDATE_CONTEXT, handler_fn(service_handlers::handle_update_context))?
+        .route(context_management::PREVIEW_DELETE_CONTEXT, handler_fn(service_handlers::handle_preview_delete_context))?
+        .route(context_management::DELETE_CONTEXT, handler_fn(service_handlers::handle_delete_context))?
+        // ACL management
+        .route(acl_management::CREATE_ACL, handler_fn(service_handlers::handle_create_acl))?
+        .route(acl_management::GET_ACL, handler_fn(service_handlers::handle_get_acl))?
+        .route(acl_management::LIST_ACL, handler_fn(service_handlers::handle_list_acl))?
+        .route(acl_management::UPDATE_ACL, handler_fn(service_handlers::handle_update_acl))?
+        .route(acl_management::DELETE_ACL, handler_fn(service_handlers::handle_delete_acl))?
+        // Audit management
+        .route(audit_management::LIST_LOGS, handler_fn(service_handlers::handle_list_logs))?
+        .route(audit_management::GET_RETENTION, handler_fn(service_handlers::handle_get_retention))?
+        .route(audit_management::UPDATE_RETENTION, handler_fn(service_handlers::handle_update_retention))?
+        // VTA management
+        .route(vta_management::GET_CONFIG, handler_fn(service_handlers::handle_get_config))?
+        .route(vta_management::UPDATE_CONFIG, handler_fn(service_handlers::handle_update_config))?
+        // Credential management
+        .route(credential_management::GENERATE_CREDENTIALS, handler_fn(service_handlers::handle_generate_credentials))?
+        // Problem reports
+        .route(protocols::PROBLEM_REPORT_TYPE, handler_fn(service_handlers::handle_problem_report))?;
+
+    // WebVH handlers (feature-gated)
+    #[cfg(feature = "webvh")]
+    {
+        router = router
+            .route(did_management::CREATE_DID_WEBVH, handler_fn(service_handlers::handle_create_did_webvh))?
+            .route(did_management::GET_DID_WEBVH, handler_fn(service_handlers::handle_get_did_webvh))?
+            .route(did_management::GET_DID_WEBVH_LOG, handler_fn(service_handlers::handle_get_did_webvh_log))?
+            .route(did_management::LIST_DIDS_WEBVH, handler_fn(service_handlers::handle_list_dids_webvh))?
+            .route(did_management::DELETE_DID_WEBVH, handler_fn(service_handlers::handle_delete_did_webvh))?
+            .route(did_management::ADD_WEBVH_SERVER, handler_fn(service_handlers::handle_add_webvh_server))?
+            .route(did_management::LIST_WEBVH_SERVERS, handler_fn(service_handlers::handle_list_webvh_servers))?
+            .route(did_management::UPDATE_WEBVH_SERVER, handler_fn(service_handlers::handle_update_webvh_server))?
+            .route(did_management::REMOVE_WEBVH_SERVER, handler_fn(service_handlers::handle_remove_webvh_server))?;
+    }
+
+    // TEE attestation handlers (feature-gated)
+    #[cfg(feature = "tee")]
+    {
+        router = router
+            .route(attestation_management::GET_TEE_STATUS, handler_fn(service_handlers::handle_tee_status))?
+            .route(attestation_management::REQUEST_ATTESTATION, handler_fn(service_handlers::handle_request_attestation))?;
+    }
+
+    // Fallback, middleware, error handling
+    router = router
+        .fallback(handler_fn(service_handlers::handle_unknown))
+        .layer(MessagePolicy::new()
+            .require_encrypted(true)
+            .require_authenticated(true)
+            .allow_anonymous_sender(false))
+        .layer(RequestLogging);
+
+    Ok(router)
+}

--- a/vta-service/src/messaging/service_handlers.rs
+++ b/vta-service/src/messaging/service_handlers.rs
@@ -1,0 +1,670 @@
+//! DIDComm handler functions for `affinidi-messaging-didcomm-service` Router.
+//!
+//! Each handler follows the `handler_fn()` pattern:
+//!   - Extracts `HandlerContext`, `Message`, and `Extension<Arc<VtaState>>`
+//!   - Performs auth via `auth_from_message()`
+//!   - Calls the shared operation
+//!   - Returns `Ok(Some(DIDCommResponse))` or `Ok(None)`
+
+use std::sync::Arc;
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_didcomm_service::{
+    DIDCommResponse, DIDCommServiceError, Extension, HandlerContext, ProblemReport,
+    ServiceProblemReport,
+};
+use tracing::warn;
+
+use crate::acl::Role;
+use crate::messaging::auth::auth_from_message;
+use crate::operations;
+
+use super::router::VtaState;
+
+use vta_sdk::protocols::{
+    acl_management, audit_management, context_management, credential_management,
+    key_management, seed_management, vta_management,
+};
+
+type HandlerResult = Result<Option<DIDCommResponse>, DIDCommServiceError>;
+
+/// Helper to convert AppError/Box<dyn Error> into DIDCommServiceError.
+fn handler_err(e: impl std::fmt::Display) -> DIDCommServiceError {
+    DIDCommServiceError::Handler(e.to_string())
+}
+
+/// Helper to build a typed response from a serializable result.
+fn response<T: serde::Serialize>(
+    msg_type: &str,
+    result: &T,
+) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let body = serde_json::to_value(result).map_err(handler_err)?;
+    Ok(Some(DIDCommResponse::new(msg_type, body)))
+}
+
+// ---------------------------------------------------------------------------
+// Key management
+// ---------------------------------------------------------------------------
+
+pub async fn handle_create_key(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
+    let body: vta_sdk::protocols::key_management::create::CreateKeyBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::keys::create_key(
+        &state.keys_ks, &state.contexts_ks, &state.seed_store, &state.audit_ks,
+        &auth,
+        operations::keys::CreateKeyParams {
+            key_type: body.key_type,
+            derivation_path: if body.derivation_path.is_empty() { None } else { Some(body.derivation_path) },
+            key_id: None,
+            mnemonic: body.mnemonic,
+            label: body.label,
+            context_id: body.context_id,
+        },
+        "didcomm",
+    ).await.map_err(handler_err)?;
+    response(key_management::CREATE_KEY_RESULT, &result)
+}
+
+pub async fn handle_get_key(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::key_management::get::GetKeyBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::keys::get_key(&state.keys_ks, &auth, &body.key_id, "didcomm")
+        .await.map_err(handler_err)?;
+    response(key_management::GET_KEY_RESULT, &result)
+}
+
+pub async fn handle_list_keys(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::key_management::list::ListKeysBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::keys::list_keys(
+        &state.keys_ks, &auth,
+        operations::keys::ListKeysParams {
+            offset: body.offset, limit: body.limit,
+            status: body.status, context_id: body.context_id,
+        },
+        "didcomm",
+    ).await.map_err(handler_err)?;
+    response(key_management::LIST_KEYS_RESULT, &result)
+}
+
+pub async fn handle_rename_key(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
+    let body: vta_sdk::protocols::key_management::rename::RenameKeyBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::keys::rename_key(
+        &state.keys_ks, &state.audit_ks, &auth, &body.key_id, &body.new_key_id, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(key_management::RENAME_KEY_RESULT, &result)
+}
+
+pub async fn handle_revoke_key(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
+    let body: vta_sdk::protocols::key_management::revoke::RevokeKeyBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::keys::revoke_key(
+        &state.keys_ks, &state.audit_ks, &auth, &body.key_id, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(key_management::REVOKE_KEY_RESULT, &result)
+}
+
+pub async fn handle_get_key_secret(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
+    let body: vta_sdk::protocols::key_management::secret::GetKeySecretBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::keys::get_key_secret(
+        &state.keys_ks, &state.seed_store, &state.audit_ks, &auth, &body.key_id, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(key_management::GET_KEY_SECRET_RESULT, &result)
+}
+
+// ---------------------------------------------------------------------------
+// Seed management
+// ---------------------------------------------------------------------------
+
+pub async fn handle_list_seeds(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
+    let result = operations::seeds::list_seeds(&state.keys_ks, "didcomm")
+        .await.map_err(handler_err)?;
+    response(seed_management::LIST_SEEDS_RESULT, &result)
+}
+
+pub async fn handle_rotate_seed(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
+    let body: vta_sdk::protocols::seed_management::rotate::RotateSeedBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::seeds::rotate_seed(
+        &state.keys_ks, &state.seed_store, &state.audit_ks, &auth.did,
+        body.mnemonic.as_deref(), "didcomm",
+    ).await.map_err(handler_err)?;
+    response(seed_management::ROTATE_SEED_RESULT, &result)
+}
+
+// ---------------------------------------------------------------------------
+// Context management
+// ---------------------------------------------------------------------------
+
+pub async fn handle_create_context(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::context_management::create::CreateContextBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::contexts::create_context(
+        &state.contexts_ks, &auth, &body.id, body.name, body.description, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(context_management::CREATE_CONTEXT_RESULT, &result)
+}
+
+pub async fn handle_get_context(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::context_management::get::GetContextBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::contexts::get_context_op(
+        &state.contexts_ks, &auth, &body.id, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(context_management::GET_CONTEXT_RESULT, &result)
+}
+
+pub async fn handle_list_contexts(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let result = operations::contexts::list_contexts(
+        &state.contexts_ks, &auth, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(context_management::LIST_CONTEXTS_RESULT, &result)
+}
+
+pub async fn handle_update_context(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::context_management::update::UpdateContextBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::contexts::update_context(
+        &state.contexts_ks, &auth, &body.id,
+        operations::contexts::UpdateContextParams {
+            name: body.name, did: body.did, description: body.description,
+        },
+        "didcomm",
+    ).await.map_err(handler_err)?;
+    response(context_management::UPDATE_CONTEXT_RESULT, &result)
+}
+
+pub async fn handle_preview_delete_context(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::context_management::delete::DeleteContextPreviewBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::contexts::preview_delete_context(
+        &state.contexts_ks, &state.keys_ks, &state.acl_ks,
+        #[cfg(feature = "webvh")]
+        &state.webvh_ks,
+        &auth, &body.id, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(context_management::PREVIEW_DELETE_CONTEXT_RESULT, &result)
+}
+
+pub async fn handle_delete_context(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::context_management::delete::DeleteContextBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::contexts::delete_context(
+        &state.contexts_ks, &state.keys_ks, &state.acl_ks,
+        #[cfg(feature = "webvh")]
+        &state.webvh_ks,
+        &auth, &body.id, body.force, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(context_management::DELETE_CONTEXT_RESULT, &result)
+}
+
+// ---------------------------------------------------------------------------
+// ACL management
+// ---------------------------------------------------------------------------
+
+pub async fn handle_create_acl(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::acl_management::create::CreateAclBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let role = Role::from_str(&body.role).map_err(handler_err)?;
+    let result = operations::acl::create_acl(
+        &state.acl_ks, &state.audit_ks, &auth, &body.did, role, body.label, body.allowed_contexts, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(acl_management::CREATE_ACL_RESULT, &result)
+}
+
+pub async fn handle_get_acl(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::acl_management::get::GetAclBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::acl::get_acl(&state.acl_ks, &auth, &body.did, "didcomm")
+        .await.map_err(handler_err)?;
+    response(acl_management::GET_ACL_RESULT, &result)
+}
+
+pub async fn handle_list_acl(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::acl_management::list::ListAclBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::acl::list_acl(&state.acl_ks, &auth, body.context.as_deref(), "didcomm")
+        .await.map_err(handler_err)?;
+    response(acl_management::LIST_ACL_RESULT, &result)
+}
+
+pub async fn handle_update_acl(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::acl_management::update::UpdateAclBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let role = match body.role {
+        Some(r) => Some(Role::from_str(&r).map_err(handler_err)?),
+        None => None,
+    };
+    let result = operations::acl::update_acl(
+        &state.acl_ks, &state.audit_ks, &auth, &body.did,
+        operations::acl::UpdateAclParams { role, label: body.label, allowed_contexts: body.allowed_contexts },
+        "didcomm",
+    ).await.map_err(handler_err)?;
+    response(acl_management::UPDATE_ACL_RESULT, &result)
+}
+
+pub async fn handle_delete_acl(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::acl_management::delete::DeleteAclBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::acl::delete_acl(
+        &state.acl_ks, &state.audit_ks, &auth, &body.did, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(acl_management::DELETE_ACL_RESULT, &result)
+}
+
+// ---------------------------------------------------------------------------
+// Audit management
+// ---------------------------------------------------------------------------
+
+pub async fn handle_list_logs(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::audit_management::list::ListAuditLogsBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::audit::list_audit_logs(&state.audit_ks, &auth, &body, "didcomm")
+        .await.map_err(handler_err)?;
+    response(audit_management::LIST_LOGS_RESULT, &result)
+}
+
+pub async fn handle_get_retention(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let result = operations::audit::get_retention(&state.config, &auth, "didcomm")
+        .await.map_err(handler_err)?;
+    response(audit_management::GET_RETENTION_RESULT, &result)
+}
+
+pub async fn handle_update_retention(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
+    let body: vta_sdk::protocols::audit_management::retention::UpdateRetentionBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::audit::update_retention(
+        &state.config, &state.audit_ks, &auth, body.retention_days, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(audit_management::UPDATE_RETENTION_RESULT, &result)
+}
+
+// ---------------------------------------------------------------------------
+// VTA management
+// ---------------------------------------------------------------------------
+
+pub async fn handle_get_config(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let result = operations::config::get_config(&state.config, &auth, "didcomm")
+        .await.map_err(handler_err)?;
+    response(vta_management::GET_CONFIG_RESULT, &result)
+}
+
+pub async fn handle_update_config(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::config::update_config(
+        &state.config, &auth,
+        operations::config::UpdateConfigParams {
+            vta_did: body.vta_did, vta_name: body.vta_name, public_url: body.public_url,
+        },
+        "didcomm",
+    ).await.map_err(handler_err)?;
+    response(vta_management::UPDATE_CONFIG_RESULT, &result)
+}
+
+// ---------------------------------------------------------------------------
+// Credential management
+// ---------------------------------------------------------------------------
+
+pub async fn handle_generate_credentials(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::credential_management::generate::GenerateCredentialsBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let role = Role::from_str(&body.role).map_err(handler_err)?;
+    let result = operations::credentials::generate_credentials(
+        &state.acl_ks, &state.config, &auth, role, body.label, body.allowed_contexts, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(credential_management::GENERATE_CREDENTIALS_RESULT, &result)
+}
+
+// ---------------------------------------------------------------------------
+// DID WebVH management (feature-gated)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "webvh")]
+pub async fn handle_create_did_webvh(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::did_management::create::CreateDidWebvhBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let config = state.config.read().await;
+    let did_resolver = state.did_resolver.as_ref()
+        .ok_or_else(|| handler_err("DID resolver not available"))?;
+
+    // NOTE: The DIDComm bridge for WebVH server communication is not yet
+    // available in the new service handler path. This will be wired in PR 3
+    // when DIDCommService replaces the manual thread. For now, pass a dummy
+    // empty bridge that will use REST fallback if available.
+    let bridge = std::sync::Arc::new(tokio::sync::RwLock::new(None));
+
+    let result = operations::did_webvh::create_did_webvh(
+        &state.keys_ks, &state.contexts_ks, &state.webvh_ks, &*state.seed_store,
+        &config, &auth,
+        operations::did_webvh::CreateDidWebvhParams {
+            context_id: body.context_id, server_id: body.server_id,
+            url: body.url, path: body.path, label: body.label,
+            portable: body.portable.unwrap_or(true),
+            add_mediator_service: body.add_mediator_service.unwrap_or(false),
+            additional_services: body.additional_services,
+            pre_rotation_count: body.pre_rotation_count.unwrap_or(0),
+        },
+        did_resolver, &bridge, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(vta_sdk::protocols::did_management::CREATE_DID_WEBVH_RESULT, &result)
+}
+
+#[cfg(feature = "webvh")]
+pub async fn handle_get_did_webvh(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::did_management::get::GetDidWebvhBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::did_webvh::get_did_webvh(&state.webvh_ks, &auth, &body.did, "didcomm")
+        .await.map_err(handler_err)?;
+    response(vta_sdk::protocols::did_management::GET_DID_WEBVH_RESULT, &result)
+}
+
+#[cfg(feature = "webvh")]
+pub async fn handle_get_did_webvh_log(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::did_management::get::GetDidWebvhBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::did_webvh::get_did_webvh_log(&state.webvh_ks, &auth, &body.did, "didcomm")
+        .await.map_err(handler_err)?;
+    response(vta_sdk::protocols::did_management::GET_DID_WEBVH_LOG_RESULT, &result)
+}
+
+#[cfg(feature = "webvh")]
+pub async fn handle_list_dids_webvh(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::did_management::list::ListDidsWebvhBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::did_webvh::list_dids_webvh(
+        &state.webvh_ks, &auth, body.context_id.as_deref(), body.server_id.as_deref(), "didcomm",
+    ).await.map_err(handler_err)?;
+    response(vta_sdk::protocols::did_management::LIST_DIDS_WEBVH_RESULT, &result)
+}
+
+#[cfg(feature = "webvh")]
+pub async fn handle_delete_did_webvh(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::did_management::delete::DeleteDidWebvhBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let config = state.config.read().await;
+    let did_resolver = state.did_resolver.as_ref()
+        .ok_or_else(|| handler_err("DID resolver not available"))?;
+    // NOTE: Bridge not yet wired — see handle_create_did_webvh comment
+    let bridge = std::sync::Arc::new(tokio::sync::RwLock::new(None));
+    let result = operations::did_webvh::delete_did_webvh(
+        &state.webvh_ks, &state.keys_ks, &*state.seed_store, &config, &auth,
+        &body.did, did_resolver, &bridge, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(vta_sdk::protocols::did_management::DELETE_DID_WEBVH_RESULT, &result)
+}
+
+#[cfg(feature = "webvh")]
+pub async fn handle_add_webvh_server(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::did_management::servers::AddWebvhServerBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let did_resolver = state.did_resolver.as_ref()
+        .ok_or_else(|| handler_err("DID resolver not available"))?;
+    let result = operations::did_webvh::add_webvh_server(
+        &state.webvh_ks, &auth, &body.id, &body.did, body.label, did_resolver, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(vta_sdk::protocols::did_management::ADD_WEBVH_SERVER_RESULT, &result)
+}
+
+#[cfg(feature = "webvh")]
+pub async fn handle_list_webvh_servers(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let result = operations::did_webvh::list_webvh_servers(&state.webvh_ks, &auth, "didcomm")
+        .await.map_err(handler_err)?;
+    response(vta_sdk::protocols::did_management::LIST_WEBVH_SERVERS_RESULT, &result)
+}
+
+#[cfg(feature = "webvh")]
+pub async fn handle_update_webvh_server(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::did_management::servers::UpdateWebvhServerBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::did_webvh::update_webvh_server(
+        &state.webvh_ks, &auth, &body.id, body.label, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(vta_sdk::protocols::did_management::UPDATE_WEBVH_SERVER_RESULT, &result)
+}
+
+#[cfg(feature = "webvh")]
+pub async fn handle_remove_webvh_server(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::did_management::servers::RemoveWebvhServerBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::did_webvh::remove_webvh_server(&state.webvh_ks, &auth, &body.id, "didcomm")
+        .await.map_err(handler_err)?;
+    response(vta_sdk::protocols::did_management::REMOVE_WEBVH_SERVER_RESULT, &result)
+}
+
+// ---------------------------------------------------------------------------
+// TEE Attestation (feature-gated, unauthenticated)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "tee")]
+pub async fn handle_tee_status(
+    _ctx: HandlerContext,
+    _message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let tee_state = state.tee_state.as_ref()
+        .ok_or_else(|| handler_err("TEE attestation is not enabled on this VTA"))?;
+    let status = operations::attestation::get_tee_status(tee_state);
+    response(vta_sdk::protocols::attestation_management::GET_TEE_STATUS_RESULT, &status)
+}
+
+#[cfg(feature = "tee")]
+pub async fn handle_request_attestation(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let tee_state = state.tee_state.as_ref()
+        .ok_or_else(|| handler_err("TEE attestation is not enabled on this VTA"))?;
+    let body: crate::tee::types::AttestationRequest =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::attestation::generate_attestation_report(
+        tee_state, &state.config, &body.nonce,
+    ).await.map_err(handler_err)?;
+    response(vta_sdk::protocols::attestation_management::ATTESTATION_RESULT, &result)
+}
+
+// ---------------------------------------------------------------------------
+// Problem report & fallback
+// ---------------------------------------------------------------------------
+
+pub async fn handle_problem_report(
+    _ctx: HandlerContext,
+    message: Message,
+) -> HandlerResult {
+    let code = message.body.get("code").and_then(|v| v.as_str()).unwrap_or("unknown");
+    let comment = message.body.get("comment").and_then(|v| v.as_str()).unwrap_or("");
+    let from = message.from.as_deref().unwrap_or("unknown");
+    let thid = message.thid.as_deref().unwrap_or("none");
+    warn!(from, code, comment, thid, "received problem-report");
+    Ok(None)
+}
+
+pub async fn handle_unknown(
+    _ctx: HandlerContext,
+    message: Message,
+) -> HandlerResult {
+    warn!(msg_type = %message.typ, "unknown message type — ignoring");
+    Ok(Some(DIDCommResponse::problem_report(
+        ProblemReport::bad_request(format!("unsupported message type: {}", message.typ)),
+    )))
+}

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -1,5 +1,6 @@
 use tracing::info;
 
+use crate::audit::{self, audit};
 use vta_sdk::protocols::acl_management::{
     create::CreateAclResultBody, delete::DeleteAclResultBody, list::ListAclResultBody,
 };
@@ -32,6 +33,7 @@ fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
 
 pub async fn create_acl(
     acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     did: &str,
     role: Role,
@@ -61,6 +63,8 @@ pub async fn create_acl(
     store_acl_entry(acl_ks, &entry).await?;
 
     info!(channel, caller = %auth.did, did = %entry.did, role = %entry.role, "ACL entry created");
+    audit!("acl.create", actor = &auth.did, resource = did, outcome = "success");
+    let _ = audit::record(audit_ks, "acl.create", &auth.did, Some(did), "success", Some(channel), None).await;
     Ok(to_result_body(&entry))
 }
 
@@ -108,6 +112,7 @@ pub async fn list_acl(
 
 pub async fn update_acl(
     acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     did: &str,
     params: UpdateAclParams,
@@ -140,11 +145,14 @@ pub async fn update_acl(
     store_acl_entry(acl_ks, &entry).await?;
 
     info!(channel, did = %did, "ACL entry updated");
+    audit!("acl.update", actor = &auth.did, resource = did, outcome = "success");
+    let _ = audit::record(audit_ks, "acl.update", &auth.did, Some(did), "success", Some(channel), None).await;
     Ok(to_result_body(&entry))
 }
 
 pub async fn delete_acl(
     acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     did: &str,
     channel: &str,
@@ -169,6 +177,8 @@ pub async fn delete_acl(
     delete_acl_entry(acl_ks, did).await?;
 
     info!(channel, caller = %auth.did, did = %did, "ACL entry deleted");
+    audit!("acl.delete", actor = &auth.did, resource = did, outcome = "success");
+    let _ = audit::record(audit_ks, "acl.delete", &auth.did, Some(did), "success", Some(channel), None).await;
     Ok(DeleteAclResultBody {
         did: did.to_string(),
         deleted: true,

--- a/vta-service/src/operations/audit.rs
+++ b/vta-service/src/operations/audit.rs
@@ -5,6 +5,7 @@ use vta_sdk::protocols::audit_management::list::{
 };
 use vta_sdk::protocols::audit_management::retention::RetentionResultBody;
 
+use crate::audit::{self, audit};
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::error::AppError;
@@ -95,6 +96,7 @@ pub async fn get_retention(
 /// Update the audit retention period (super-admin only).
 pub async fn update_retention(
     config: &Arc<RwLock<AppConfig>>,
+    audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     retention_days: u32,
     channel: &str,
@@ -119,5 +121,7 @@ pub async fn update_retention(
 
     std::fs::write(&path, contents).map_err(AppError::Io)?;
     tracing::info!(channel, retention_days, "audit retention updated");
+    audit!("audit.retention_update", actor = &auth.did, resource = retention_days, outcome = "success");
+    let _ = audit::record(audit_ks, "audit.retention_update", &auth.did, Some(&retention_days.to_string()), "success", Some(channel), None).await;
     Ok(result)
 }

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -8,6 +8,7 @@ use vta_sdk::protocols::key_management::{
     revoke::RevokeKeyResultBody, secret::GetKeySecretResultBody,
 };
 
+use crate::audit::{self, audit};
 use crate::auth::AuthClaims;
 use crate::contexts::get_context;
 use crate::error::{AppError, key_derivation_error};
@@ -38,6 +39,7 @@ pub async fn create_key(
     keys_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
+    audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     params: CreateKeyParams,
     channel: &str,
@@ -112,6 +114,8 @@ pub async fn create_key(
     keys_ks.insert(keys::store_key(&key_id), &record).await?;
 
     info!(channel, key_id = %key_id, key_type = ?params.key_type, path = %derivation_path, "key created");
+    audit!("key.create", actor = &auth.did, resource = &key_id, outcome = "success");
+    let _ = audit::record(audit_ks, "key.create", &auth.did, Some(&key_id), "success", Some(channel), context_id.as_deref()).await;
 
     Ok(CreateKeyResultBody {
         key_id,
@@ -199,6 +203,7 @@ pub async fn list_keys(
 
 pub async fn rename_key(
     keys_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     key_id: &str,
     new_key_id: &str,
@@ -230,6 +235,8 @@ pub async fn rename_key(
     }
 
     info!(channel, old_id = %key_id, new_id = %new_key_id, "key renamed");
+    audit!("key.rename", actor = &auth.did, resource = new_key_id, outcome = "success");
+    let _ = audit::record(audit_ks, "key.rename", &auth.did, Some(new_key_id), "success", Some(channel), record.context_id.as_deref()).await;
 
     Ok(RenameKeyResultBody {
         key_id: new_key_id.to_string(),
@@ -239,6 +246,7 @@ pub async fn rename_key(
 
 pub async fn revoke_key(
     keys_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     key_id: &str,
     channel: &str,
@@ -270,6 +278,8 @@ pub async fn revoke_key(
     keys_ks.insert(store_key, &record).await?;
 
     info!(channel, key_id = %key_id, "key revoked");
+    audit!("key.revoke", actor = &auth.did, resource = key_id, outcome = "success");
+    let _ = audit::record(audit_ks, "key.revoke", &auth.did, Some(key_id), "success", Some(channel), record.context_id.as_deref()).await;
 
     Ok(RevokeKeyResultBody {
         key_id: key_id.to_string(),
@@ -281,6 +291,7 @@ pub async fn revoke_key(
 pub async fn get_key_secret(
     keys_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
+    audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     key_id: &str,
     channel: &str,
@@ -310,6 +321,8 @@ pub async fn get_key_secret(
     };
 
     info!(channel, key_id = %key_id, "key secret retrieved");
+    audit!("key.secret_export", actor = &auth.did, resource = key_id, outcome = "success");
+    let _ = audit::record(audit_ks, "key.secret_export", &auth.did, Some(key_id), "success", Some(channel), record.context_id.as_deref()).await;
 
     Ok(GetKeySecretResultBody {
         key_id: record.key_id,

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use tracing::info;
 
+use crate::audit::{self, audit};
 use vta_sdk::protocols::seed_management::{
     list::{ListSeedsResultBody, SeedInfo},
     rotate::RotateSeedResultBody,
@@ -48,6 +49,8 @@ pub async fn list_seeds(
 pub async fn rotate_seed(
     keys_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
+    audit_ks: &KeyspaceHandle,
+    actor: &str,
     mnemonic: Option<&str>,
     channel: &str,
 ) -> Result<RotateSeedResultBody, AppError> {
@@ -60,6 +63,8 @@ pub async fn rotate_seed(
         .map_err(|e| AppError::Internal(format!("{e}")))?;
 
     info!(channel, previous_id, new_id, "seed rotated");
+    audit!("seed.rotate", actor = actor, resource = "seed", outcome = "success");
+    let _ = audit::record(audit_ks, "seed.rotate", actor, Some("seed"), "success", Some(channel), None).await;
 
     Ok(RotateSeedResultBody {
         previous_seed_id: previous_id,

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -6,7 +6,6 @@ use serde::Deserialize;
 use vta_sdk::protocols::acl_management::{create::CreateAclResultBody, list::ListAclResultBody};
 
 use crate::acl::Role;
-use crate::audit::audit;
 use crate::auth::ManageAuth;
 use crate::error::AppError;
 use crate::operations;
@@ -43,6 +42,7 @@ pub async fn create_acl(
 ) -> Result<(StatusCode, Json<CreateAclResultBody>), AppError> {
     let result = operations::acl::create_acl(
         &state.acl_ks,
+        &state.audit_ks,
         &auth.0,
         &req.did,
         req.role,
@@ -51,7 +51,6 @@ pub async fn create_acl(
         "rest",
     )
     .await?;
-    audit!("acl.create", actor = &auth.0.did, resource =&req.did, outcome = "success");
     Ok((StatusCode::CREATED, Json(result)))
 }
 
@@ -79,6 +78,7 @@ pub async fn update_acl(
 ) -> Result<Json<CreateAclResultBody>, AppError> {
     let result = operations::acl::update_acl(
         &state.acl_ks,
+        &state.audit_ks,
         &auth.0,
         &did,
         operations::acl::UpdateAclParams {
@@ -89,7 +89,6 @@ pub async fn update_acl(
         "rest",
     )
     .await?;
-    audit!("acl.update", actor = &auth.0.did, resource =&did, outcome = "success");
     Ok(Json(result))
 }
 
@@ -98,7 +97,6 @@ pub async fn delete_acl(
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<StatusCode, AppError> {
-    operations::acl::delete_acl(&state.acl_ks, &auth.0, &did, "rest").await?;
-    audit!("acl.delete", actor = &auth.0.did, resource =&did, outcome = "success");
+    operations::acl::delete_acl(&state.acl_ks, &state.audit_ks, &auth.0, &did, "rest").await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/vta-service/src/routes/audit.rs
+++ b/vta-service/src/routes/audit.rs
@@ -4,7 +4,6 @@ use axum::extract::{Query, State};
 use vta_sdk::protocols::audit_management::list::{ListAuditLogsBody, ListAuditLogsResultBody};
 use vta_sdk::protocols::audit_management::retention::{RetentionResultBody, UpdateRetentionBody};
 
-use crate::audit::audit;
 use crate::auth::{AdminAuth, SuperAdminAuth};
 use crate::error::AppError;
 use crate::operations;
@@ -43,8 +42,7 @@ pub async fn update_retention(
     Json(body): Json<UpdateRetentionBody>,
 ) -> Result<Json<RetentionResultBody>, AppError> {
     let result = operations::audit::update_retention(
-        &state.config, &auth.0, body.retention_days, "rest",
+        &state.config, &state.audit_ks, &auth.0, body.retention_days, "rest",
     ).await?;
-    audit!("audit.retention_update", actor = &auth.0.did, resource = body.retention_days, outcome = "success");
     Ok(Json(result))
 }

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -11,7 +11,6 @@ use vta_sdk::protocols::seed_management::{
     list::ListSeedsResultBody, rotate::RotateSeedResultBody,
 };
 
-use crate::audit::audit;
 use crate::auth::{AdminAuth, AuthClaims};
 use crate::error::AppError;
 use crate::keys::KeyRecord;
@@ -39,6 +38,7 @@ pub async fn create_key(
         &state.keys_ks,
         &state.contexts_ks,
         &state.seed_store,
+        &state.audit_ks,
         &auth.0,
         operations::keys::CreateKeyParams {
             key_type: req.key_type,
@@ -51,7 +51,6 @@ pub async fn create_key(
         "rest",
     )
     .await?;
-    audit!("key.create", actor = &auth.0.did, resource =&result.key_id, outcome = "success");
     Ok((StatusCode::CREATED, Json(result)))
 }
 
@@ -63,12 +62,12 @@ pub async fn get_key_secret(
     let result = operations::keys::get_key_secret(
         &state.keys_ks,
         &state.seed_store,
+        &state.audit_ks,
         &auth.0,
         &key_id,
         "rest",
     )
     .await?;
-    audit!("key.secret_export", actor = &auth.0.did, resource =&key_id, outcome = "success");
     Ok(Json(result))
 }
 
@@ -86,8 +85,7 @@ pub async fn invalidate_key(
     State(state): State<AppState>,
     Path(key_id): Path<String>,
 ) -> Result<Json<RevokeKeyResultBody>, AppError> {
-    let result = operations::keys::revoke_key(&state.keys_ks, &auth.0, &key_id, "rest").await?;
-    audit!("key.revoke", actor = &auth.0.did, resource =&key_id, outcome = "success");
+    let result = operations::keys::revoke_key(&state.keys_ks, &state.audit_ks, &auth.0, &key_id, "rest").await?;
     Ok(Json(result))
 }
 
@@ -103,7 +101,7 @@ pub async fn rename_key(
     Json(req): Json<RenameKeyRequest>,
 ) -> Result<Json<RenameKeyResultBody>, AppError> {
     let result =
-        operations::keys::rename_key(&state.keys_ks, &auth.0, &key_id, &req.key_id, "rest").await?;
+        operations::keys::rename_key(&state.keys_ks, &state.audit_ks, &auth.0, &key_id, &req.key_id, "rest").await?;
     Ok(Json(result))
 }
 
@@ -158,10 +156,11 @@ pub async fn rotate_seed(
     let result = operations::seeds::rotate_seed(
         &state.keys_ks,
         &state.seed_store,
+        &state.audit_ks,
+        &_auth.0.did,
         req.mnemonic.as_deref(),
         "rest",
     )
     .await?;
-    audit!("seed.rotate", actor = &_auth.0.did, resource ="seed", outcome = "success");
     Ok(Json(result))
 }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -368,9 +368,11 @@ pub async fn run(
         })
         .map_err(|e| AppError::Internal(format!("failed to spawn storage thread: {e}")))?;
 
-    // Join service threads
+    // Wait for shutdown signal (blocks until SIGINT/SIGTERM or a service thread exits)
     let mut any_panic = false;
 
+    // If REST is running, wait for it to stop (it blocks on its own shutdown_rx).
+    // If REST is not running, wait directly for the shutdown signal.
     if let Some(handle) = rest_handle {
         match tokio::task::spawn_blocking(move || handle.join()).await {
             Ok(Ok(())) => info!("REST thread stopped"),
@@ -383,9 +385,14 @@ pub async fn run(
                 any_panic = true;
             }
         }
+    } else {
+        // No REST thread — wait for the shutdown signal directly so the DIDComm
+        // service stays alive until SIGINT/SIGTERM.
+        let mut wait_rx = shutdown_rx.clone();
+        let _ = wait_rx.changed().await;
     }
 
-    // Shutdown DIDComm service
+    // Signal DIDComm service to stop and wait for graceful shutdown
     #[cfg(feature = "didcomm")]
     if let Some(service) = didcomm_service {
         didcomm_shutdown.cancel();

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -34,6 +34,15 @@ use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, Tr
 use tracing::Level;
 use tracing::{debug, error, info, warn};
 
+#[cfg(feature = "didcomm")]
+use affinidi_messaging_didcomm_service::{
+    DIDCommService, DIDCommServiceConfig, ListenerConfig, RestartPolicy, RetryConfig,
+};
+#[cfg(feature = "didcomm")]
+use affinidi_tdk_common::profiles::TDKProfile;
+#[cfg(feature = "didcomm")]
+use tokio_util::sync::CancellationToken;
+
 /// TEE context passed by the caller (main.rs or vta-enclave).
 /// None when running outside a TEE.
 ///
@@ -200,11 +209,17 @@ pub async fn run(
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
     // Spawn signal handler on the main tokio runtime
+    #[cfg(feature = "didcomm")]
+    let didcomm_shutdown = CancellationToken::new();
     tokio::spawn({
         let shutdown_tx = shutdown_tx.clone();
+        #[cfg(feature = "didcomm")]
+        let didcomm_shutdown = didcomm_shutdown.clone();
         async move {
             shutdown_signal().await;
             let _ = shutdown_tx.send(true);
+            #[cfg(feature = "didcomm")]
+            didcomm_shutdown.cancel();
         }
     });
 
@@ -215,14 +230,14 @@ pub async fn run(
     let storage_auth_config = config.auth.clone();
     let has_auth = jwt_keys.is_some();
 
-    // Shared DIDComm bridge (set by the DIDComm thread once ATM is ready)
+    // Shared DIDComm bridge (still used by REST handlers for WebVH request-response)
     #[cfg(feature = "didcomm")]
     let didcomm_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> = Arc::new(tokio::sync::RwLock::new(None));
 
-    // Clone handles for DIDComm before REST takes ownership
+    // Build VtaState for the DIDComm service router
     #[cfg(feature = "didcomm")]
-    let didcomm_state = if config.services.didcomm {
-        Some(messaging::DidcommState {
+    let vta_state = if config.services.didcomm {
+        Some(Arc::new(messaging::router::VtaState {
             keys_ks: keys_ks.clone(),
             acl_ks: acl_ks.clone(),
             contexts_ks: contexts_ks.clone(),
@@ -232,10 +247,9 @@ pub async fn run(
             seed_store: seed_store.clone(),
             config: Arc::new(RwLock::new(config.clone())),
             did_resolver: did_resolver.clone(),
-            didcomm_bridge: didcomm_bridge.clone(),
             #[cfg(feature = "tee")]
-            tee_state: tee_context.as_ref().and_then(|tc| Some(tc.state.clone())),
-        })
+            tee_state: tee_context.as_ref().map(|tc| tc.state.clone()),
+        }))
     } else {
         None
     };
@@ -275,32 +289,67 @@ pub async fn run(
     #[cfg(not(feature = "rest"))]
     let rest_handle: Option<std::thread::JoinHandle<()>> = None;
 
-    // Spawn DIDComm thread (conditional)
+    // Start DIDComm service (conditional)
     #[cfg(feature = "didcomm")]
-    let didcomm_handle = if let Some(didcomm_state) = didcomm_state {
-        let didcomm_secrets = secrets_resolver;
-        let didcomm_vta_did = config.vta_did.clone();
-        let mut didcomm_shutdown_rx = shutdown_rx.clone();
-        let didcomm_bridge_lock = didcomm_bridge;
-        Some(
-            std::thread::Builder::new()
-                .name("vta-didcomm".into())
-                .spawn(move || {
-                    run_didcomm_thread(
-                        didcomm_secrets,
-                        didcomm_vta_did,
-                        didcomm_state,
-                        &mut didcomm_shutdown_rx,
-                        didcomm_bridge_lock,
-                    )
-                })
-                .map_err(|e| AppError::Internal(format!("failed to spawn DIDComm thread: {e}")))?,
-        )
+    let didcomm_service: Option<DIDCommService> = if let Some(ref vta_state) = vta_state {
+        match (&secrets_resolver, &config.vta_did, &config.messaging) {
+            (Some(sr), Some(vta_did), Some(messaging_config)) => {
+                // Collect secrets from the resolver for the TDKProfile
+                let mut secrets = Vec::new();
+                let signing_id = format!("{vta_did}#key-0");
+                let ka_id = format!("{vta_did}#key-1");
+                if let Some(s) = sr.get_secret(&signing_id).await {
+                    secrets.push(s);
+                }
+                if let Some(s) = sr.get_secret(&ka_id).await {
+                    secrets.push(s);
+                }
+
+                let profile = TDKProfile::new(
+                    "VTA",
+                    vta_did,
+                    Some(&messaging_config.mediator_did),
+                    secrets,
+                );
+
+                let service_config = DIDCommServiceConfig {
+                    listeners: vec![ListenerConfig {
+                        id: "vta-main".into(),
+                        profile,
+                        restart_policy: RestartPolicy::Always {
+                            backoff: RetryConfig {
+                                initial_delay_secs: 5,
+                                max_delay_secs: 60,
+                            },
+                        },
+                        ..Default::default()
+                    }],
+                };
+
+                let router = messaging::router::build_router(Arc::clone(vta_state))
+                    .map_err(|e| AppError::Internal(format!("failed to build DIDComm router: {e}")))?;
+
+                match DIDCommService::start(service_config, router, didcomm_shutdown.clone()).await {
+                    Ok(service) => {
+                        info!("DIDComm service started");
+                        Some(service)
+                    }
+                    Err(e) => {
+                        warn!("failed to start DIDComm service: {e}");
+                        None
+                    }
+                }
+            }
+            _ => {
+                info!("DIDComm not configured — service not started");
+                None
+            }
+        }
     } else {
         None
     };
     #[cfg(not(feature = "didcomm"))]
-    let didcomm_handle: Option<std::thread::JoinHandle<()>> = None;
+    let didcomm_service: Option<()> = None;
 
     // Storage thread always runs
     let mut storage_shutdown_rx = shutdown_rx.clone();
@@ -336,19 +385,15 @@ pub async fn run(
         }
     }
 
-    if let Some(handle) = didcomm_handle {
-        match tokio::task::spawn_blocking(move || handle.join()).await {
-            Ok(Ok(())) => info!("DIDComm thread stopped"),
-            Ok(Err(_panic)) => {
-                error!("DIDComm thread panicked");
-                any_panic = true;
-            }
-            Err(e) => {
-                error!("failed to join DIDComm thread: {e}");
-                any_panic = true;
-            }
-        }
+    // Shutdown DIDComm service
+    #[cfg(feature = "didcomm")]
+    if let Some(service) = didcomm_service {
+        didcomm_shutdown.cancel();
+        service.shutdown().await;
+        info!("DIDComm service stopped");
     }
+    #[cfg(not(feature = "didcomm"))]
+    drop(didcomm_service);
 
     if any_panic {
         let _ = shutdown_tx.send(true);
@@ -467,12 +512,10 @@ fn run_rest_thread(
     });
 }
 
-/// DIDComm thread: connects to the mediator and processes inbound messages.
-///
-/// Retries with exponential backoff (5 s -> 60 s cap) when the mediator
-/// connection fails or drops. The bridge is cleared while reconnecting so
-/// REST handlers can report the correct status.
+/// Legacy DIDComm thread — replaced by DIDCommService in the new architecture.
+/// Kept temporarily for reference; will be removed in cleanup PR.
 #[cfg(feature = "didcomm")]
+#[allow(dead_code)]
 fn run_didcomm_thread(
     secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
     vta_did: Option<String>,


### PR DESCRIPTION
## Summary

- **Audit consolidation**: Moves audit logging from REST route handlers into the operations layer so DIDComm operations are audited identically to REST (key create/revoke/export, ACL CRUD, seed rotation, retention update)
- **DIDComm service migration**: Replaces the manual DIDComm thread (ATM lifecycle, exponential backoff, WebSocket management, 140-line dispatch_message match) with `affinidi-messaging-didcomm-service` crate's `DIDCommService` + `Router` + `handler_fn()` pattern
- **New router infrastructure**: All ~35 VTA protocol handlers registered via typed Router with `MessagePolicy` middleware (require encrypted + authenticated), `RequestLogging`, and built-in `trust_ping_handler`/`ignore_handler`

The old `run_didcomm_thread()` and macro-based handlers are kept (dead code) for reference until verified in production.

## Test plan

- [ ] `cargo test` passes (all 47 tests)
- [ ] `cargo check --package vta-enclave` compiles
- [ ] Deploy to TEE enclave — verify auth + WebSocket + live streaming + trust-ping
- [ ] Run `didcomm-test` against mediator to verify connectivity
- [ ] Verify audit events appear for DIDComm operations (RUST_LOG=audit=info)
- [ ] Test reconnection: stop mediator, verify VTA reconnects with backoff
- [ ] Test graceful shutdown (SIGTERM)