### PR TITLE
Fix vta-sdk API methods missing client feature gate

### DIFF
--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -348,7 +348,7 @@ impl VtaClient {
 
 // ── Client implementation ───────────────────────────────────────────
 
-#[cfg(feature = "session")]
+#[cfg(feature = "client")]
 use crate::protocols::{
     acl_management, context_management, credential_management, did_management, key_management,
     seed_management, vta_management,
@@ -507,7 +507,10 @@ impl VtaClient {
             },
         }
     }
+}
 
+#[cfg(feature = "client")]
+impl VtaClient {
     // ── VTA Management ──────────────────────────────────────────────
 
     /// Trigger a soft restart of the VTA.


### PR DESCRIPTION
## Summary

- Gate vta-sdk protocol imports behind `#[cfg(feature = "client")]` instead of `#[cfg(feature = "session")]`
- Split the `impl VtaClient` block so API methods (restart, backup, config, keys, ACL, contexts, seeds, DIDs, audit) are behind `#[cfg(feature = "client")]`
- Fixes compilation error when `vta-sdk` is used without the `session` feature (e.g. as a published crate with just `client`)

## Test plan

- [x] `cargo check -p vta-sdk --no-default-features` passes
- [x] `cargo check -p vta-sdk --no-default-features --features client` passes
- [x] Full workspace `cargo check` passes