### PR TITLE
Fix health check deserialization and audit log levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.2.1 — 2026-03-30
+
+### Bug Fixes
+
+- **Health check deserialization** — Made `version` field optional
+  in `vta-sdk::HealthResponse` so the unauthenticated `GET /health`
+  endpoint (which returns only `{"status": "ok"}`) deserializes
+  correctly. Previously `pnm health` and `cnm health` reported
+  "error decoding response body".
+
+### Improvements
+
+- **Audit log levels** — Audit events now use `INFO` for successful
+  outcomes and `ERROR` for failures (e.g. `denied:*`). Previously
+  all audit events were emitted at `ERROR` level regardless of
+  outcome.
+
 ## 0.2.0 — 2026-03-29
 
 ### Observability

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "cnm-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -5049,7 +5049,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnm-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "chrono",
@@ -7697,7 +7697,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -7708,7 +7708,7 @@ dependencies = [
 
 [[package]]
 name = "vta-enclave"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7723,7 +7723,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7743,7 +7743,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7810,7 +7810,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7854,7 +7854,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "affinidi-tdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "3"
 
 [workspace.package]
 description = "Verifiable Trust Infrastructure (VTI) — VTA, VTC, and supporting crates"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 publish = true
 authors = ["Glenn Gore <glenn@affinidi.com>"]

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -772,9 +772,14 @@ async fn cmd_health(
 
     match client.health().await {
         Ok(resp) => {
+            let ver = resp
+                .version
+                .as_deref()
+                .map(|v| format!(" (v{v})"))
+                .unwrap_or_default();
             println!(
-                "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok (v{})",
-                "Service", resp.version
+                "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok{ver}",
+                "Service"
             );
         }
         Err(e) => {
@@ -864,9 +869,14 @@ async fn print_personal_vta_section(
     let personal_client = VtaClient::new(&personal.url);
     match personal_client.health().await {
         Ok(resp) => {
+            let ver = resp
+                .version
+                .as_deref()
+                .map(|v| format!(" (v{v})"))
+                .unwrap_or_default();
             println!(
-                "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok (v{})",
-                "Service", resp.version
+                "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok{ver}",
+                "Service"
             );
         }
         Err(e) => {

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -1038,7 +1038,8 @@ async fn cmd_restart(client: &VtaClient) -> Result<(), Box<dyn std::error::Error
     for attempt in 1..=5 {
         match client.health().await {
             Ok(resp) => {
-                println!("{GREEN}✓{RESET} VTA is back (v{})", resp.version);
+                let ver = resp.version.as_deref().unwrap_or("?");
+                println!("{GREEN}✓{RESET} VTA is back (v{ver})");
                 return Ok(());
             }
             Err(_) if attempt < 5 => {
@@ -1187,9 +1188,14 @@ async fn cmd_health(client: &VtaClient, keyring_key: &str) -> Result<(), Box<dyn
 
         match client.health().await {
             Ok(resp) => {
+                let ver = resp
+                    .version
+                    .as_deref()
+                    .map(|v| format!(" (v{v})"))
+                    .unwrap_or_default();
                 println!(
-                    "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok (v{})",
-                    "Service", resp.version
+                    "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok{ver}",
+                    "Service"
                 );
             }
             Err(e) => {

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -31,7 +31,8 @@ pub struct VtaClient {
 #[allow(dead_code)]
 pub struct HealthResponse {
     pub status: String,
-    pub version: String,
+    #[serde(default)]
+    pub version: Option<String>,
     #[serde(default)]
     pub mediator_url: Option<String>,
     #[serde(default)]
@@ -1329,7 +1330,15 @@ mod tests {
         let json = r#"{"status":"ok","version":"0.1.0"}"#;
         let resp: HealthResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.status, "ok");
-        assert_eq!(resp.version, "0.1.0");
+        assert_eq!(resp.version.as_deref(), Some("0.1.0"));
+    }
+
+    #[test]
+    fn test_health_response_minimal() {
+        let json = r#"{"status":"ok"}"#;
+        let resp: HealthResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "ok");
+        assert_eq!(resp.version, None);
     }
 
     #[test]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -45,8 +45,8 @@ name = "vta"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.2.0", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = ["didcomm"] }
+vti-common = { path = "../vti-common", version = "0.2.1", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.2.1", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.13"
 affinidi-messaging-didcomm-service = { workspace = true }

--- a/vta-service/src/audit.rs
+++ b/vta-service/src/audit.rs
@@ -14,25 +14,48 @@ use crate::error::AppError;
 use crate::store::KeyspaceHandle;
 
 /// Emit a structured audit event to the tracing subsystem.
+///
+/// Uses `INFO` for successful outcomes and `ERROR` for failures (e.g. `denied:*`).
 macro_rules! audit {
     ($action:expr, actor = $actor:expr, resource = $resource:expr, outcome = $outcome:expr) => {
-        ::tracing::event!(
-            target: "audit",
-            ::tracing::Level::ERROR,
-            action = $action,
-            actor = %$actor,
-            resource = %$resource,
-            outcome = $outcome,
-        );
+        if $outcome.starts_with("success") {
+            ::tracing::event!(
+                target: "audit",
+                ::tracing::Level::INFO,
+                action = $action,
+                actor = %$actor,
+                resource = %$resource,
+                outcome = $outcome,
+            );
+        } else {
+            ::tracing::event!(
+                target: "audit",
+                ::tracing::Level::ERROR,
+                action = $action,
+                actor = %$actor,
+                resource = %$resource,
+                outcome = $outcome,
+            );
+        }
     };
     ($action:expr, actor = $actor:expr, outcome = $outcome:expr) => {
-        ::tracing::event!(
-            target: "audit",
-            ::tracing::Level::ERROR,
-            action = $action,
-            actor = %$actor,
-            outcome = $outcome,
-        );
+        if $outcome.starts_with("success") {
+            ::tracing::event!(
+                target: "audit",
+                ::tracing::Level::INFO,
+                action = $action,
+                actor = %$actor,
+                outcome = $outcome,
+            );
+        } else {
+            ::tracing::event!(
+                target: "audit",
+                ::tracing::Level::ERROR,
+                action = $action,
+                actor = %$actor,
+                outcome = $outcome,
+            );
+        }
     };
 }
 


### PR DESCRIPTION
## Summary

- **Health check fix** — Made `version` optional in `vta-sdk::HealthResponse` so the unauthenticated `GET /health` endpoint (returns `{"status":"ok"}` without `version`) deserializes correctly. Previously `pnm health` and `cnm health` reported "error decoding response body".
- **Audit log levels** — Audit events now emit at `INFO` for successful outcomes and `ERROR` for failures (e.g. `denied:*`). Previously all audit events used `ERROR` regardless of outcome.
- Bumps workspace version to 0.2.1.

## Affected crates

- `vta-sdk` — `HealthResponse.version` changed to `Option<String>`
- `vta-service` — `audit!` macro now varies log level by outcome
- `pnm-cli` — Updated health display for optional version
- `cnm-cli` — Updated health display for optional version

## Test plan

- [x] `cargo check` passes
- [x] `test_health_response_deserialization` — full response with version
- [x] `test_health_response_minimal` — minimal response without version (new test)
- [ ] Run `pnm health` against a non-TEE VTA and confirm `Service ✓ ok` displays correctly