### PR TITLE
Add imported secrets with encrypted storage and REST key wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Changelog
 
+## 0.3.0 — 2026-03-31
+
+### Imported Secrets
+
+- **Import external private keys** — New `POST /keys/import` endpoint
+  and `pnm keys import` command allow importing externally-created
+  private keys (Ed25519, X25519, P-256) into the VTA. Imported keys
+  are stored encrypted at rest and participate in signing, secret
+  export, backup/restore, and revocation alongside BIP-32-derived keys.
+- **Ephemeral wrapping keys (REST)** — REST key import uses
+  ECDH-ES + AES-256-GCM key wrapping via ephemeral X25519 keypairs
+  (`GET /keys/import/wrapping-key`). Each wrapping key is single-use
+  with a 60-second TTL. DIDComm transport sends keys directly inside
+  the end-to-end encrypted envelope.
+- **Encrypted storage layer** — Imported secrets are encrypted with
+  AES-256-GCM using a KEK derived from the BIP-32 master seed via
+  HKDF-SHA256 with a random 32-byte salt. Each ciphertext is bound
+  to its `key_id:key_type` via authenticated associated data (AAD),
+  preventing blob-swap attacks.
+- **Secure deletion on revoke** — Revoking an imported key overwrites
+  the encrypted blob with zeros and deletes it from the keyspace.
+  The `KeyRecord` is retained for audit trail.
+- **Seed rotation re-encryption** — When the BIP-32 seed is rotated,
+  all imported secrets are automatically re-encrypted with the new
+  seed-derived KEK.
+- **Backup & restore** — Imported secrets are included in the
+  encrypted backup payload (plaintext inside the Argon2id+AES-256-GCM
+  envelope) and restored on import. The KEK salt is also backed up
+  for deterministic KEK reconstruction.
+
+### Data Model
+
+- **`KeyOrigin` enum** — New `origin` field on `KeyRecord`:
+  `derived` (default, BIP-32) or `imported` (external). Backward
+  compatible via `#[serde(default)]`.
+- **`ImportedSecretBackup`** — New type in `BackupPayload` for
+  portable imported secret backup.
+- **`imported_secret_count`** — Added to `ImportResult` for
+  visibility during backup preview/import.
+
+### Security
+
+- **Zeroize** — All private key buffers are zeroized after use
+  via the `zeroize` crate (import, signing, backup export/import,
+  seed rotation re-encryption).
+- **AAD binding** — AES-GCM encryption of imported secrets includes
+  `key_id:key_type` as additional authenticated data, preventing
+  ciphertext swapping between key entries.
+- **Independent KEK salt** — A random 32-byte salt is generated
+  per VTA instance and stored alongside the keyspace, ensuring
+  two VTAs with the same seed produce different KEKs.
+- **Admin-only import** — The import endpoint requires Admin role
+  (stricter than key creation which allows Initiator).
+
+### CLI
+
+- **`pnm keys import`** — Import a private key from multibase
+  string (`--private-key`) or file (`--private-key-file`).
+  Supports `--key-type ed25519|x25519|p256`, `--label`, and
+  `--context-id`. Prints a secure-deletion warning on success.
+
+### Testing
+
+- **6 new unit tests** — Imported secret encrypt/decrypt roundtrip,
+  wrong-AAD rejection, secure deletion, seed rotation re-encryption,
+  ephemeral wrapping key generation + unwrap, single-use enforcement.
+- **Total: 234 tests** (up from 228).
+
+### Breaking Changes
+
+- **Operation signatures** — `get_key_secret()`, `sign_payload()`,
+  `revoke_key()`, `rotate_seed()`, `export_backup()`, and
+  `apply_import()` now accept an `imported_ks` parameter.
+- **`AppState`** — Added `imported_ks: KeyspaceHandle` and
+  `wrapping_cache: WrappingKeyCache` fields.
+- **`VtaState` (DIDComm)** — Added `imported_ks: KeyspaceHandle`.
+- **Workspace version bumped to 0.3.0** — All crates updated.
+
+### Dependency Updates
+
+- `hkdf` 0.12 (new — KEK derivation for imported secrets)
+
+---
+
 ## 0.2.1 — 2026-03-30
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "cnm-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -5049,7 +5049,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnm-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "chrono",
@@ -7697,18 +7697,24 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
+ "hkdf",
+ "multibase",
  "ratatui",
  "serde_json",
+ "sha2 0.10.9",
  "vta-sdk",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "vta-enclave"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7723,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7743,7 +7749,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7774,6 +7780,7 @@ dependencies = [
  "google-cloud-auth",
  "google-cloud-secretmanager-v1",
  "hex",
+ "hkdf",
  "hmac",
  "http-body-util",
  "jsonwebtoken",
@@ -7810,7 +7817,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7854,7 +7861,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "affinidi-tdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "3"
 
 [workspace.package]
 description = "Verifiable Trust Infrastructure (VTI) — VTA, VTC, and supporting crates"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 publish = true
 authors = ["Glenn Gore <glenn@affinidi.com>"]

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.2.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 clap = { workspace = true, features = ["env"] }
 dialoguer = "0.12"

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 tokio = { workspace = true }

--- a/docs/didcomm_protocol.md
+++ b/docs/didcomm_protocol.md
@@ -100,6 +100,8 @@ All protocol URIs are under `https://firstperson.network/protocols/`.
 | `.../revoke-key` | `.../revoke-key-result` | Admin | Revoke a key |
 | `.../get-key-secret` | `.../get-key-secret-result` | Admin | Export secret key material |
 | `.../sign-request` | `.../sign-result` | Auth + context | Sign payload (signing oracle) |
+| `.../import-key` | `.../import-key-result` | Admin | Import an external private key |
+| `.../get-wrapping-key` | `.../get-wrapping-key-result` | Admin | Get ephemeral wrapping key (REST only) |
 
 #### create-key
 
@@ -710,6 +712,10 @@ https://firstperson.network/protocols/key-management/1.0/get-key-secret
 https://firstperson.network/protocols/key-management/1.0/get-key-secret-result
 https://firstperson.network/protocols/key-management/1.0/sign-request
 https://firstperson.network/protocols/key-management/1.0/sign-result
+https://firstperson.network/protocols/key-management/1.0/import-key
+https://firstperson.network/protocols/key-management/1.0/import-key-result
+https://firstperson.network/protocols/key-management/1.0/get-wrapping-key
+https://firstperson.network/protocols/key-management/1.0/get-wrapping-key-result
 
 # Seed Management
 https://firstperson.network/protocols/seed-management/1.0/list-seeds

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -127,6 +127,27 @@ graph LR
    │ → Mark old seed generation as "retired"  │
    │ → New keys derived from new seed         │
    │ → Old keys remain readable (old seed)    │
+   │ → Re-encrypt imported secrets with new   │
+   │   seed-derived KEK                       │
+   └─────────────────────────────────────────┘
+
+5. Imported Key (external, non-BIP-32):
+   ┌─────────────────────────────────────────┐
+   │ Receive private key via REST (JWE-      │
+   │   wrapped with ephemeral ECDH-ES) or    │
+   │   DIDComm (E2E encrypted)               │
+   │ → Validate key type + length            │
+   │ → Derive public key, verify consistency │
+   │ → HKDF(seed, salt) → KEK               │
+   │ → AES-256-GCM(KEK, nonce, key,         │
+   │     AAD=key_id:key_type)                │
+   │ → Store ciphertext in imported_secrets  │
+   │ → KeyRecord with origin=imported        │
+   │                                          │
+   │ On revoke: overwrite blob → delete       │
+   │ On seed rotation: re-encrypt all         │
+   │ On backup: plaintext inside encrypted    │
+   │   envelope (Argon2id + AES-256-GCM)      │
    └─────────────────────────────────────────┘
 ```
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.2.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/pnm-cli/README.md
+++ b/pnm-cli/README.md
@@ -185,13 +185,16 @@ url = "http://localhost:3000"
 | Command                                                                    | Description     |
 | -------------------------------------------------------------------------- | --------------- |
 | `keys list [--status active\|revoked] [--limit N] [--offset N]`            | List keys       |
-| `keys create --key-type ed25519\|x25519 [--context-id ID] [--label LABEL]` | Create a key    |
+| `keys create --key-type ed25519\|x25519 [--context-id ID] [--label LABEL]` | Create a key (BIP-32 derived) |
+| `keys import --key-type TYPE --private-key KEY [--label L] [--context-id ID]` | Import an external private key |
 | `keys get <key_id>`                                                        | Get a key by ID |
 | `keys revoke <key_id>`                                                     | Revoke a key               |
 | `keys rename <key_id> <new_key_id>`                                        | Rename a key               |
 | `keys secrets [key_ids...] [--context ID]`                                 | Export secret key material |
 | `keys seeds`                                                               | List seed generations      |
 | `keys rotate-seed [--mnemonic PHRASE]`                                     | Rotate to a new seed       |
+
+The `keys import` command accepts `--private-key <multibase>` or `--private-key-file <path>` and supports key types `ed25519`, `x25519`, and `p256`. The private key is wrapped with ECDH-ES+AES-256-GCM before transmission over REST.
 
 ### Contexts
 

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -493,6 +493,24 @@ enum KeyCommands {
         #[arg(long)]
         context_id: Option<String>,
     },
+    /// Import an externally-created private key
+    Import {
+        /// Key type: ed25519, x25519, or p256
+        #[arg(long)]
+        key_type: String,
+        /// Multibase-encoded private key
+        #[arg(long)]
+        private_key: Option<String>,
+        /// Path to private key file
+        #[arg(long)]
+        private_key_file: Option<std::path::PathBuf>,
+        /// Human-readable label
+        #[arg(long)]
+        label: Option<String>,
+        /// Application context ID
+        #[arg(long)]
+        context_id: Option<String>,
+    },
     /// Get a key by ID
     Get {
         /// Key ID
@@ -991,6 +1009,18 @@ async fn main() {
                     mnemonic,
                     label,
                     context_id,
+                )
+                .await
+            }
+            KeyCommands::Import {
+                key_type,
+                private_key,
+                private_key_file,
+                label,
+                context_id,
+            } => {
+                keys::cmd_key_import(
+                    &client, &key_type, private_key, private_key_file, label, context_id,
                 )
                 .await
             }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -11,8 +11,14 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = ["client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["client"] }
 chrono = "0.4"
 ed25519-dalek = "2"
 ratatui = { workspace = true }
 serde_json = { workspace = true }
+multibase = { workspace = true }
+x25519-dalek = { workspace = true }
+sha2 = { workspace = true }
+hkdf = "0.12"
+aes-gcm = "0.10"
+base64 = { workspace = true }

--- a/vta-cli-common/src/commands/keys.rs
+++ b/vta-cli-common/src/commands/keys.rs
@@ -4,7 +4,7 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Cell, Row, Table},
 };
-use vta_sdk::client::{CreateKeyRequest, VtaClient};
+use vta_sdk::client::{CreateKeyRequest, ImportKeyRequest, VtaClient};
 use vta_sdk::did_secrets::{DidSecretsBundle, SecretEntry};
 use vta_sdk::keys::KeyType;
 
@@ -45,6 +45,134 @@ pub async fn cmd_key_create(
     }
     println!("  Created At:      {}", resp.created_at);
     Ok(())
+}
+
+pub async fn cmd_key_import(
+    client: &VtaClient,
+    key_type: &str,
+    private_key: Option<String>,
+    private_key_file: Option<std::path::PathBuf>,
+    label: Option<String>,
+    context_id: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let key_type = match key_type {
+        "ed25519" => KeyType::Ed25519,
+        "x25519" => KeyType::X25519,
+        "p256" => KeyType::P256,
+        other => {
+            return Err(format!("unknown key type '{other}', expected ed25519, x25519, or p256").into());
+        }
+    };
+
+    // Read private key bytes
+    let private_key_multibase = if let Some(key_str) = private_key {
+        key_str
+    } else if let Some(path) = private_key_file {
+        let bytes = std::fs::read(&path)
+            .map_err(|e| format!("failed to read key file '{}': {e}", path.display()))?;
+        // If file is text (multibase), use as-is; otherwise encode as multibase
+        match String::from_utf8(bytes.clone()) {
+            Ok(s) if s.starts_with('z') || s.starts_with('f') || s.starts_with('u') => {
+                s.trim().to_string()
+            }
+            _ => multibase::encode(multibase::Base::Base58Btc, &bytes),
+        }
+    } else {
+        return Err("either --private-key or --private-key-file is required".into());
+    };
+
+    // For REST transport, fetch wrapping key and create JWE
+    // For DIDComm, send multibase directly
+    let (jwe, multibase) = match client.get_wrapping_key().await {
+        Ok(wrapping_key) => {
+            // REST path: wrap with ECDH-ES
+            let jwe = wrap_private_key(&wrapping_key.kid, &wrapping_key.x, &private_key_multibase)?;
+            (Some(jwe), None)
+        }
+        Err(_) => {
+            // DIDComm path (or wrapping key not available): send multibase
+            (None, Some(private_key_multibase))
+        }
+    };
+
+    let req = ImportKeyRequest {
+        key_type,
+        private_key_jwe: jwe,
+        private_key_multibase: multibase,
+        label,
+        context_id,
+    };
+    let resp = client.import_key(req).await?;
+
+    println!("Key imported successfully:");
+    println!("  Key ID:     {}", resp.key_id);
+    println!("  Key Type:   {}", resp.key_type);
+    println!("  Public Key: {}", resp.public_key);
+    println!("  Status:     {}", resp.status);
+    println!("  Origin:     imported");
+    if let Some(label) = &resp.label {
+        println!("  Label:      {label}");
+    }
+    println!("  Created At: {}", resp.created_at);
+    eprintln!();
+    eprintln!("\x1b[1;33mWarning: securely delete the source key material \u{2014} the VTA now holds this secret.\x1b[0m");
+
+    Ok(())
+}
+
+/// Wrap a multibase-encoded private key with ECDH-ES+AES-256-GCM for REST transport.
+fn wrap_private_key(
+    kid: &str,
+    vta_pub_b64: &str,
+    private_key_multibase: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+
+    // Decode the VTA's wrapping public key
+    let vta_pub_bytes: [u8; 32] = BASE64
+        .decode(vta_pub_b64)?
+        .try_into()
+        .map_err(|_| "wrapping public key must be 32 bytes")?;
+
+    // Decode the private key from multibase
+    let (_, key_bytes) = multibase::decode(private_key_multibase)?;
+
+    // Generate ephemeral X25519 keypair for client side
+    let client_secret = x25519_dalek::StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+    let client_pub = x25519_dalek::PublicKey::from(&client_secret);
+
+    // ECDH
+    let vta_pub = x25519_dalek::PublicKey::from(vta_pub_bytes);
+    let shared = client_secret.diffie_hellman(&vta_pub);
+
+    // HKDF to derive AES key
+    use sha2::Sha256;
+    let hkdf = hkdf::Hkdf::<Sha256>::new(None, shared.as_bytes());
+    let mut aes_key = [0u8; 32];
+    hkdf.expand(b"vta-key-import-wrapping", &mut aes_key)
+        .map_err(|e| format!("hkdf: {e}"))?;
+
+    // AES-256-GCM encrypt
+    use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+    use aes_gcm::aead::Aead;
+    use aes_gcm::aead::rand_core::RngCore;
+
+    let cipher = Aes256Gcm::new_from_slice(&aes_key)?;
+    let mut nonce_bytes = [0u8; 12];
+    aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let ciphertext = cipher.encrypt(nonce, key_bytes.as_ref())
+        .map_err(|e| format!("encrypt: {e}"))?;
+
+    // Format: kid.ephemeral_pub.nonce.ciphertext
+    Ok(format!(
+        "{}.{}.{}.{}",
+        kid,
+        BASE64.encode(client_pub.as_bytes()),
+        BASE64.encode(nonce_bytes),
+        BASE64.encode(ciphertext),
+    ))
 }
 
 pub async fn cmd_key_get(

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -23,8 +23,8 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.2.0", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.2.0", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.3.0", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -73,6 +73,42 @@ pub struct CreateKeyRequest {
     pub context_id: Option<String>,
 }
 
+// ── Import key types ───────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct ImportKeyRequest {
+    pub key_type: KeyType,
+    /// JWE compact serialization of the private key (REST transport).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key_jwe: Option<String>,
+    /// Multibase-encoded private key (DIDComm transport).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key_multibase: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ImportKeyResponse {
+    pub key_id: String,
+    pub key_type: KeyType,
+    pub public_key: String,
+    pub status: KeyStatus,
+    pub label: Option<String>,
+    pub origin: crate::keys::KeyOrigin,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WrappingKeyResponse {
+    pub kid: String,
+    pub kty: String,
+    pub crv: String,
+    pub x: String,
+}
+
 // ── Context types ───────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -734,6 +770,42 @@ impl VtaClient {
                         key_id: new_key_id.to_string(),
                     })
             },
+        )
+        .await
+    }
+
+    // ── Import key methods ──────────────────────────────────────────
+
+    /// Fetch an ephemeral wrapping key for REST key import.
+    pub async fn get_wrapping_key(&self) -> Result<WrappingKeyResponse, Box<dyn std::error::Error>> {
+        match &self.transport {
+            Transport::Rest {
+                client,
+                base_url,
+                token,
+            } => {
+                let req = client.get(format!("{base_url}/keys/import/wrapping-key"));
+                let resp = Self::with_auth(req, token).send().await?;
+                Self::handle_response(resp).await
+            }
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => {
+                Err("wrapping key not needed for DIDComm transport".into())
+            }
+        }
+    }
+
+    /// Import an externally-created private key into the VTA.
+    pub async fn import_key(
+        &self,
+        req: ImportKeyRequest,
+    ) -> Result<ImportKeyResponse, Box<dyn std::error::Error>> {
+        self.rpc(
+            key_management::IMPORT_KEY,
+            serde_json::to_value(&req)?,
+            key_management::IMPORT_KEY_RESULT,
+            30,
+            |c, url| c.post(format!("{url}/keys/import")).json(&req),
         )
         .await
     }

--- a/vta-sdk/src/keys/mod.rs
+++ b/vta-sdk/src/keys/mod.rs
@@ -17,6 +17,18 @@ pub enum KeyStatus {
     Revoked,
 }
 
+/// Whether a key was derived from the BIP-32 seed or imported externally.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum KeyOrigin {
+    Derived,
+    Imported,
+}
+
+fn default_derived() -> KeyOrigin {
+    KeyOrigin::Derived
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyRecord {
     pub key_id: String,
@@ -29,6 +41,8 @@ pub struct KeyRecord {
     pub context_id: Option<String>,
     #[serde(default)]
     pub seed_id: Option<u32>,
+    #[serde(default = "default_derived")]
+    pub origin: KeyOrigin,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/vta-sdk/src/protocols/backup_management/types.rs
+++ b/vta-sdk/src/protocols/backup_management/types.rs
@@ -79,6 +79,20 @@ pub struct BackupPayload {
     /// Audit logs (optional, may be empty).
     #[serde(default)]
     pub audit_logs: Vec<AuditLogEntry>,
+    /// Imported (non-derived) secrets. Plaintext inside the encrypted envelope.
+    #[serde(default)]
+    pub imported_secrets: Vec<ImportedSecretBackup>,
+    /// Hex-encoded KEK salt for imported secret encryption.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imported_kek_salt: Option<String>,
+}
+
+/// An imported secret included in the backup payload.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportedSecretBackup {
+    pub key_id: String,
+    /// Hex-encoded raw private key bytes.
+    pub private_key_hex: String,
 }
 
 /// Seed record for backup (mirrors SeedRecord from vta-service).
@@ -166,6 +180,8 @@ pub struct ImportResult {
     pub acl_count: usize,
     pub context_count: usize,
     pub audit_count: usize,
+    #[serde(default)]
+    pub imported_secret_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }

--- a/vta-sdk/src/protocols/key_management/create.rs
+++ b/vta-sdk/src/protocols/key_management/create.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::keys::{KeyStatus, KeyType};
+use crate::keys::{KeyOrigin, KeyStatus, KeyType};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateKeyBody {
@@ -20,5 +20,11 @@ pub struct CreateKeyResultBody {
     pub public_key: String,
     pub status: KeyStatus,
     pub label: Option<String>,
+    #[serde(default = "default_derived")]
+    pub origin: KeyOrigin,
     pub created_at: DateTime<Utc>,
+}
+
+fn default_derived() -> KeyOrigin {
+    KeyOrigin::Derived
 }

--- a/vta-sdk/src/protocols/key_management/mod.rs
+++ b/vta-sdk/src/protocols/key_management/mod.rs
@@ -37,3 +37,13 @@ pub const SIGN_REQUEST: &str =
     "https://firstperson.network/protocols/key-management/1.0/sign-request";
 pub const SIGN_RESULT: &str =
     "https://firstperson.network/protocols/key-management/1.0/sign-result";
+
+pub const IMPORT_KEY: &str =
+    "https://firstperson.network/protocols/key-management/1.0/import-key";
+pub const IMPORT_KEY_RESULT: &str =
+    "https://firstperson.network/protocols/key-management/1.0/import-key-result";
+
+pub const GET_WRAPPING_KEY: &str =
+    "https://firstperson.network/protocols/key-management/1.0/get-wrapping-key";
+pub const GET_WRAPPING_KEY_RESULT: &str =
+    "https://firstperson.network/protocols/key-management/1.0/get-wrapping-key-result";

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -45,8 +45,9 @@ name = "vta"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.2.1", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.2.1", features = ["didcomm"] }
+vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
+hkdf = "0.12"
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.13"
 affinidi-messaging-didcomm-service = { workspace = true }

--- a/vta-service/src/keys/imported.rs
+++ b/vta-service/src/keys/imported.rs
@@ -1,0 +1,351 @@
+//! Encrypted storage for imported (non-BIP32-derived) secrets.
+//!
+//! Imported secrets are encrypted at rest using AES-256-GCM with a KEK
+//! derived from the BIP-32 master seed via HKDF-SHA256 with a random salt.
+//! Each secret's ciphertext is bound to its `key_id:key_type` via AAD.
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use hkdf::Hkdf;
+use sha2::Sha256;
+use zeroize::Zeroize;
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+const KEK_SALT_KEY: &str = "imported_kek_salt";
+const SECRET_PREFIX: &str = "secret:";
+const NONCE_LEN: usize = 12;
+
+/// Derive the KEK for imported secret encryption from the master seed and salt.
+fn derive_kek(seed: &[u8], salt: &[u8]) -> [u8; 32] {
+    let hkdf = Hkdf::<Sha256>::new(Some(salt), seed);
+    let mut kek = [0u8; 32];
+    hkdf.expand(b"vta-imported-secret-encryption", &mut kek)
+        .expect("32-byte output is valid for HKDF-SHA256");
+    kek
+}
+
+/// Build the AAD string for a given key_id and key_type.
+fn build_aad(key_id: &str, key_type: &str) -> Vec<u8> {
+    format!("{key_id}:{key_type}").into_bytes()
+}
+
+/// Get or create the KEK salt. Returns the 32-byte salt.
+pub async fn get_or_create_salt(keys_ks: &KeyspaceHandle) -> Result<Vec<u8>, AppError> {
+    if let Some(existing) = keys_ks.get_raw(KEK_SALT_KEY).await? {
+        return Ok(existing);
+    }
+    // Generate a new random salt
+    use aes_gcm::aead::rand_core::RngCore;
+    let mut salt = vec![0u8; 32];
+    aes_gcm::aead::OsRng.fill_bytes(&mut salt);
+    keys_ks.insert_raw(KEK_SALT_KEY, salt.clone()).await?;
+    Ok(salt)
+}
+
+/// Store the KEK salt (used during backup restore).
+pub async fn set_salt(keys_ks: &KeyspaceHandle, salt: &[u8]) -> Result<(), AppError> {
+    keys_ks.insert_raw(KEK_SALT_KEY, salt.to_vec()).await?;
+    Ok(())
+}
+
+/// Get the KEK salt if it exists (for backup export).
+pub async fn get_salt(keys_ks: &KeyspaceHandle) -> Result<Option<Vec<u8>>, AppError> {
+    Ok(keys_ks.get_raw(KEK_SALT_KEY).await?)
+}
+
+/// Encrypt and store an imported secret.
+pub async fn store_secret(
+    imported_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
+    seed: &[u8],
+    key_id: &str,
+    key_type: &str,
+    secret_bytes: &[u8],
+) -> Result<(), AppError> {
+    let salt = get_or_create_salt(keys_ks).await?;
+    let mut kek = derive_kek(seed, &salt);
+
+    let cipher = Aes256Gcm::new_from_slice(&kek)
+        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+
+    // Random nonce
+    use aes_gcm::aead::rand_core::RngCore;
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let aad = build_aad(key_id, key_type);
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            aes_gcm::aead::Payload {
+                msg: secret_bytes,
+                aad: &aad,
+            },
+        )
+        .map_err(|e| AppError::Internal(format!("encrypt imported secret: {e}")))?;
+
+    // Store as nonce || ciphertext
+    let mut blob = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    blob.extend_from_slice(&nonce_bytes);
+    blob.extend_from_slice(&ciphertext);
+
+    imported_ks
+        .insert_raw(format!("{SECRET_PREFIX}{key_id}"), blob)
+        .await?;
+
+    kek.zeroize();
+    Ok(())
+}
+
+/// Load and decrypt an imported secret.
+pub async fn load_secret(
+    imported_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
+    seed: &[u8],
+    key_id: &str,
+    key_type: &str,
+) -> Result<Vec<u8>, AppError> {
+    let blob = imported_ks
+        .get_raw(format!("{SECRET_PREFIX}{key_id}"))
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("imported secret not found: {key_id}")))?;
+
+    if blob.len() < NONCE_LEN + 1 {
+        return Err(AppError::Internal("imported secret blob too short".into()));
+    }
+
+    let salt = get_or_create_salt(keys_ks).await?;
+    let mut kek = derive_kek(seed, &salt);
+
+    let cipher = Aes256Gcm::new_from_slice(&kek)
+        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+
+    let nonce = Nonce::from_slice(&blob[..NONCE_LEN]);
+    let aad = build_aad(key_id, key_type);
+    let mut plaintext = cipher
+        .decrypt(
+            nonce,
+            aes_gcm::aead::Payload {
+                msg: &blob[NONCE_LEN..],
+                aad: &aad,
+            },
+        )
+        .map_err(|_| AppError::Internal("imported secret decryption failed (AAD mismatch or corruption)".into()))?;
+
+    kek.zeroize();
+
+    // Return plaintext; caller is responsible for zeroizing
+    Ok(std::mem::take(&mut plaintext))
+}
+
+/// Securely delete an imported secret (overwrite then remove).
+pub async fn delete_secret(
+    imported_ks: &KeyspaceHandle,
+    key_id: &str,
+) -> Result<(), AppError> {
+    let store_key = format!("{SECRET_PREFIX}{key_id}");
+    // Overwrite with zeros before deletion
+    if let Some(blob) = imported_ks.get_raw(store_key.clone()).await? {
+        let zeros = vec![0u8; blob.len()];
+        imported_ks.insert_raw(store_key.clone(), zeros).await?;
+    }
+    imported_ks.remove(store_key).await?;
+    Ok(())
+}
+
+/// Re-encrypt all imported secrets with a new KEK (used during seed rotation).
+pub async fn reencrypt_all(
+    imported_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
+    old_seed: &[u8],
+    new_seed: &[u8],
+    key_records: &[(String, String)], // (key_id, key_type) for AAD
+) -> Result<u32, AppError> {
+    let salt = get_or_create_salt(keys_ks).await?;
+    let mut old_kek = derive_kek(old_seed, &salt);
+    let mut new_kek = derive_kek(new_seed, &salt);
+
+    let old_cipher = Aes256Gcm::new_from_slice(&old_kek)
+        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+    let new_cipher = Aes256Gcm::new_from_slice(&new_kek)
+        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+
+    let mut count = 0u32;
+
+    for (key_id, key_type) in key_records {
+        let store_key = format!("{SECRET_PREFIX}{key_id}");
+        let Some(blob) = imported_ks.get_raw(store_key.clone()).await? else {
+            continue;
+        };
+
+        if blob.len() < NONCE_LEN + 1 {
+            continue;
+        }
+
+        let old_nonce = Nonce::from_slice(&blob[..NONCE_LEN]);
+        let aad = build_aad(key_id, key_type);
+
+        // Decrypt with old KEK
+        let mut plaintext = old_cipher
+            .decrypt(
+                old_nonce,
+                aes_gcm::aead::Payload {
+                    msg: &blob[NONCE_LEN..],
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| {
+                AppError::Internal(format!(
+                    "failed to decrypt imported secret {key_id} during re-encryption"
+                ))
+            })?;
+
+        // Re-encrypt with new KEK
+        use aes_gcm::aead::rand_core::RngCore;
+        let mut new_nonce_bytes = [0u8; NONCE_LEN];
+        aes_gcm::aead::OsRng.fill_bytes(&mut new_nonce_bytes);
+        let new_nonce = Nonce::from_slice(&new_nonce_bytes);
+
+        let new_ciphertext = new_cipher
+            .encrypt(
+                new_nonce,
+                aes_gcm::aead::Payload {
+                    msg: plaintext.as_ref(),
+                    aad: &aad,
+                },
+            )
+            .map_err(|e| AppError::Internal(format!("re-encrypt: {e}")))?;
+
+        plaintext.zeroize();
+
+        let mut new_blob = Vec::with_capacity(NONCE_LEN + new_ciphertext.len());
+        new_blob.extend_from_slice(&new_nonce_bytes);
+        new_blob.extend_from_slice(&new_ciphertext);
+
+        imported_ks.insert_raw(store_key, new_blob).await?;
+        count += 1;
+    }
+
+    old_kek.zeroize();
+    new_kek.zeroize();
+
+    Ok(count)
+}
+
+/// List all imported secret key IDs (for backup export).
+pub async fn list_secret_ids(
+    imported_ks: &KeyspaceHandle,
+) -> Result<Vec<String>, AppError> {
+    let raw = imported_ks.prefix_iter_raw(SECRET_PREFIX).await?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|(k, _)| {
+            String::from_utf8(k)
+                .ok()?
+                .strip_prefix(SECRET_PREFIX)
+                .map(String::from)
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use vti_common::config::StoreConfig;
+
+    fn temp_store() -> (Store, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&config).unwrap();
+        (store, dir)
+    }
+
+    #[tokio::test]
+    async fn test_store_and_load_secret() {
+        let (store, _dir) = temp_store();
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
+        let seed = [42u8; 32];
+        let secret = b"my-secret-key-bytes-32-chars!!!!";
+
+        store_secret(&imported_ks, &keys_ks, &seed, "test-key", "ed25519", secret)
+            .await
+            .unwrap();
+
+        let loaded = load_secret(&imported_ks, &keys_ks, &seed, "test-key", "ed25519")
+            .await
+            .unwrap();
+
+        assert_eq!(loaded, secret);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_aad_fails() {
+        let (store, _dir) = temp_store();
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
+        let seed = [42u8; 32];
+        let secret = b"my-secret-key-bytes-32-chars!!!!";
+
+        store_secret(&imported_ks, &keys_ks, &seed, "test-key", "ed25519", secret)
+            .await
+            .unwrap();
+
+        // Try to load with wrong key_type (wrong AAD)
+        let result = load_secret(&imported_ks, &keys_ks, &seed, "test-key", "x25519").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_secure_delete() {
+        let (store, _dir) = temp_store();
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
+        let seed = [42u8; 32];
+
+        store_secret(&imported_ks, &keys_ks, &seed, "del-key", "ed25519", b"secret")
+            .await
+            .unwrap();
+
+        delete_secret(&imported_ks, "del-key").await.unwrap();
+
+        let result = load_secret(&imported_ks, &keys_ks, &seed, "del-key", "ed25519").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_reencrypt_all() {
+        let (store, _dir) = temp_store();
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
+        let old_seed = [42u8; 32];
+        let new_seed = [99u8; 32];
+        let secret = b"my-secret-key-bytes-32-chars!!!!";
+
+        store_secret(&imported_ks, &keys_ks, &old_seed, "rk-1", "ed25519", secret)
+            .await
+            .unwrap();
+
+        let key_records = vec![("rk-1".to_string(), "ed25519".to_string())];
+        let count = reencrypt_all(&imported_ks, &keys_ks, &old_seed, &new_seed, &key_records)
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+
+        // Old seed can no longer decrypt
+        let result = load_secret(&imported_ks, &keys_ks, &old_seed, "rk-1", "ed25519").await;
+        assert!(result.is_err());
+
+        // New seed can decrypt
+        let loaded = load_secret(&imported_ks, &keys_ks, &new_seed, "rk-1", "ed25519")
+            .await
+            .unwrap();
+        assert_eq!(loaded, secret);
+    }
+}

--- a/vta-service/src/keys/mod.rs
+++ b/vta-service/src/keys/mod.rs
@@ -1,7 +1,9 @@
 pub mod derivation;
+pub mod imported;
 pub mod paths;
 pub mod seed_store;
 pub mod seeds;
+pub mod wrapping;
 
 use affinidi_tdk::secrets_resolver::secrets::Secret;
 use chrono::Utc;
@@ -11,7 +13,7 @@ use multibase::Base;
 
 use crate::store::KeyspaceHandle;
 
-pub use vta_sdk::keys::{KeyRecord, KeyStatus, KeyType};
+pub use vta_sdk::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
 
 pub fn store_key(key_id: &str) -> String {
     format!("key:{key_id}")
@@ -41,6 +43,7 @@ pub async fn save_key_record(
         label: Some(label.to_string()),
         context_id: context_id.map(String::from),
         seed_id,
+        origin: KeyOrigin::Derived,
         created_at: now,
         updated_at: now,
     };

--- a/vta-service/src/keys/wrapping.rs
+++ b/vta-service/src/keys/wrapping.rs
@@ -1,0 +1,226 @@
+//! Ephemeral X25519 wrapping key for REST key import.
+//!
+//! Each wrapping key is single-use with a 60-second TTL. The VTA generates
+//! an ephemeral X25519 keypair and returns the public key as a JWK. The
+//! PNM client performs ECDH-ES key agreement and wraps the imported private
+//! key with AES-256-GCM before sending it over REST.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use hkdf::Hkdf;
+use sha2::Sha256;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::Zeroize;
+
+use crate::error::AppError;
+
+const TTL: Duration = Duration::from_secs(60);
+const NONCE_LEN: usize = 12;
+
+struct WrappingEntry {
+    private_key: StaticSecret,
+    #[allow(dead_code)]
+    public_key: PublicKey,
+    created_at: Instant,
+    used: bool,
+}
+
+/// In-memory cache of ephemeral wrapping keys.
+#[derive(Clone)]
+pub struct WrappingKeyCache {
+    entries: Arc<Mutex<HashMap<String, WrappingEntry>>>,
+}
+
+impl WrappingKeyCache {
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Generate a new ephemeral wrapping keypair and return (kid, public_key_base64url).
+    pub async fn generate(&self) -> (String, String) {
+        let kid = Uuid::new_v4().to_string();
+        // Use StaticSecret so we can store it (EphemeralSecret is consumed on DH)
+        let secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+        let public = PublicKey::from(&secret);
+
+        let public_b64 = BASE64.encode(public.as_bytes());
+
+        let entry = WrappingEntry {
+            private_key: secret,
+            public_key: public,
+            created_at: Instant::now(),
+            used: false,
+        };
+
+        self.entries.lock().await.insert(kid.clone(), entry);
+
+        (kid, public_b64)
+    }
+
+    /// Consume a wrapping key and decrypt a JWE-like payload.
+    ///
+    /// Expected format: `{kid}.{ephemeral_pub_b64}.{nonce_b64}.{ciphertext_b64}`
+    /// where ciphertext was encrypted with AES-256-GCM using a key derived from
+    /// ECDH(ephemeral_client_secret, vta_wrapping_pub) via HKDF.
+    pub async fn unwrap_jwe(&self, jwe: &str) -> Result<Vec<u8>, AppError> {
+        let parts: Vec<&str> = jwe.split('.').collect();
+        if parts.len() != 4 {
+            return Err(AppError::Validation(
+                "invalid JWE format: expected kid.ephemeral_pub.nonce.ciphertext".into(),
+            ));
+        }
+
+        let kid = parts[0];
+        let ephemeral_pub_bytes = BASE64
+            .decode(parts[1])
+            .map_err(|e| AppError::Validation(format!("invalid ephemeral public key: {e}")))?;
+        let nonce_bytes = BASE64
+            .decode(parts[2])
+            .map_err(|e| AppError::Validation(format!("invalid nonce: {e}")))?;
+        let ciphertext = BASE64
+            .decode(parts[3])
+            .map_err(|e| AppError::Validation(format!("invalid ciphertext: {e}")))?;
+
+        if ephemeral_pub_bytes.len() != 32 {
+            return Err(AppError::Validation("ephemeral public key must be 32 bytes".into()));
+        }
+        if nonce_bytes.len() != NONCE_LEN {
+            return Err(AppError::Validation(format!("nonce must be {NONCE_LEN} bytes")));
+        }
+
+        // Look up and consume the wrapping key
+        let mut entries = self.entries.lock().await;
+        let entry = entries
+            .get_mut(kid)
+            .ok_or_else(|| AppError::NotFound("wrapping key not found or expired".into()))?;
+
+        if entry.used {
+            entries.remove(kid);
+            return Err(AppError::Validation("wrapping key already used".into()));
+        }
+        if entry.created_at.elapsed() > TTL {
+            entries.remove(kid);
+            return Err(AppError::Validation("wrapping key expired".into()));
+        }
+
+        // Perform ECDH
+        let ephemeral_pub: [u8; 32] = ephemeral_pub_bytes
+            .try_into()
+            .map_err(|_| AppError::Internal("public key conversion failed".into()))?;
+        let ephemeral_pub = PublicKey::from(ephemeral_pub);
+        let shared_secret = entry.private_key.diffie_hellman(&ephemeral_pub);
+
+        // Mark as used and remove
+        entry.used = true;
+        entries.remove(kid);
+        drop(entries);
+
+        // Derive AES key from shared secret via HKDF
+        let hkdf = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
+        let mut aes_key = [0u8; 32];
+        hkdf.expand(b"vta-key-import-wrapping", &mut aes_key)
+            .map_err(|e| AppError::Internal(format!("hkdf expand: {e}")))?;
+
+        // Decrypt
+        let cipher = Aes256Gcm::new_from_slice(&aes_key)
+            .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let mut plaintext = cipher
+            .decrypt(nonce, ciphertext.as_ref())
+            .map_err(|_| AppError::Authentication("failed to unwrap key (ECDH mismatch or tampering)".into()))?;
+
+        aes_key.zeroize();
+
+        Ok(std::mem::take(&mut plaintext))
+    }
+
+    /// Remove expired entries. Call periodically.
+    pub async fn reap_expired(&self) {
+        let mut entries = self.entries.lock().await;
+        entries.retain(|_, entry| entry.created_at.elapsed() < TTL && !entry.used);
+    }
+
+    /// Spawn a background task that reaps expired wrapping keys every 30 seconds.
+    pub fn spawn_reaper(self) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                self.reap_expired().await;
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Client-side wrapping helper for tests.
+    fn wrap_for_test(
+        vta_pub_bytes: &[u8; 32],
+        kid: &str,
+        plaintext: &[u8],
+    ) -> String {
+        let vta_pub = PublicKey::from(*vta_pub_bytes);
+        let client_secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+        let client_pub = PublicKey::from(&client_secret);
+
+        let shared = client_secret.diffie_hellman(&vta_pub);
+        let hkdf = Hkdf::<Sha256>::new(None, shared.as_bytes());
+        let mut aes_key = [0u8; 32];
+        hkdf.expand(b"vta-key-import-wrapping", &mut aes_key).unwrap();
+
+        let cipher = Aes256Gcm::new_from_slice(&aes_key).unwrap();
+        use aes_gcm::aead::rand_core::RngCore;
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let ciphertext = cipher.encrypt(nonce, plaintext).unwrap();
+
+        format!(
+            "{}.{}.{}.{}",
+            kid,
+            BASE64.encode(client_pub.as_bytes()),
+            BASE64.encode(nonce_bytes),
+            BASE64.encode(ciphertext),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_generate_and_unwrap() {
+        let cache = WrappingKeyCache::new();
+        let (kid, pub_b64) = cache.generate().await;
+
+        let pub_bytes: [u8; 32] = BASE64.decode(&pub_b64).unwrap().try_into().unwrap();
+
+        let secret = b"test-private-key-32-bytes!!!!!!";
+        let jwe = wrap_for_test(&pub_bytes, &kid, secret);
+
+        let unwrapped = cache.unwrap_jwe(&jwe).await.unwrap();
+        assert_eq!(unwrapped, secret);
+    }
+
+    #[tokio::test]
+    async fn test_single_use() {
+        let cache = WrappingKeyCache::new();
+        let (kid, pub_b64) = cache.generate().await;
+        let pub_bytes: [u8; 32] = BASE64.decode(&pub_b64).unwrap().try_into().unwrap();
+
+        let jwe = wrap_for_test(&pub_bytes, &kid, b"secret");
+        cache.unwrap_jwe(&jwe).await.unwrap();
+
+        // Second use should fail
+        let jwe2 = wrap_for_test(&pub_bytes, &kid, b"secret2");
+        assert!(cache.unwrap_jwe(&jwe2).await.is_err());
+    }
+}

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -130,7 +130,7 @@ pub async fn handle_revoke_key(
     let body: vta_sdk::protocols::key_management::revoke::RevokeKeyBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::revoke_key(
-        &state.keys_ks, &state.audit_ks, &auth, &body.key_id, "didcomm",
+        &state.keys_ks, &state.imported_ks, &state.audit_ks, &auth, &body.key_id, "didcomm",
     ).await.map_err(handler_err)?;
     response(key_management::REVOKE_KEY_RESULT, &result)
 }
@@ -145,7 +145,7 @@ pub async fn handle_get_key_secret(
     let body: vta_sdk::protocols::key_management::secret::GetKeySecretBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::get_key_secret(
-        &state.keys_ks, &state.seed_store, &state.audit_ks, &auth, &body.key_id, "didcomm",
+        &state.keys_ks, &state.imported_ks, &state.seed_store, &state.audit_ks, &auth, &body.key_id, "didcomm",
     ).await.map_err(handler_err)?;
     response(key_management::GET_KEY_SECRET_RESULT, &result)
 }
@@ -164,7 +164,7 @@ pub async fn handle_sign_request(
         .map_err(|e| handler_err(format!("invalid base64url payload: {e}")))?;
 
     let result = operations::keys::sign_payload(
-        &state.keys_ks, &state.seed_store, &auth,
+        &state.keys_ks, &state.imported_ks, &state.seed_store, &auth,
         &body.key_id, &payload, &body.algorithm, "didcomm",
     ).await.map_err(handler_err)?;
     response(key_management::SIGN_RESULT, &result)
@@ -196,7 +196,7 @@ pub async fn handle_rotate_seed(
     let body: vta_sdk::protocols::seed_management::rotate::RotateSeedBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::seeds::rotate_seed(
-        &state.keys_ks, &state.seed_store, &state.audit_ks, &auth.did,
+        &state.keys_ks, &state.imported_ks, &state.seed_store, &state.audit_ks, &auth.did,
         body.mnemonic.as_deref(), "didcomm",
     ).await.map_err(handler_err)?;
     response(seed_management::ROTATE_SEED_RESULT, &result)
@@ -699,7 +699,7 @@ pub async fn handle_backup_export(
         serde_json::from_value(message.body).map_err(handler_err)?;
     let config = state.config.read().await;
     let envelope = operations::backup::export_backup(
-        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks,
+        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks, &state.imported_ks,
         #[cfg(feature = "webvh")]
         &state.webvh_ks,
         &*state.seed_store, &config, &auth, &body.password, body.include_audit,
@@ -737,7 +737,7 @@ pub async fn handle_backup_import(
 
     let result = operations::backup::apply_import(
         &payload,
-        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks,
+        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks, &state.imported_ks,
         #[cfg(feature = "webvh")]
         &state.webvh_ks,
         &state.seed_store, &state.config,

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -36,6 +36,7 @@ pub struct VtaState {
     pub acl_ks: KeyspaceHandle,
     pub contexts_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
+    pub imported_ks: KeyspaceHandle,
     #[cfg(feature = "webvh")]
     pub webvh_ks: KeyspaceHandle,
     pub seed_store: Arc<dyn SeedStore>,

--- a/vta-service/src/operations/backup.rs
+++ b/vta-service/src/operations/backup.rs
@@ -18,8 +18,10 @@ use tracing::info;
 
 use crate::auth::AuthClaims;
 use crate::error::AppError;
+use crate::keys::imported;
 use crate::keys::seeds::{SeedRecord, get_active_seed_id, save_seed_record, set_active_seed_id};
 use crate::keys::seed_store::SeedStore;
+use crate::keys::KeyOrigin;
 use crate::seal::{SealRecord, get_seal};
 use crate::store::KeyspaceHandle;
 
@@ -41,6 +43,7 @@ pub async fn export_backup(
     acl_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
     config: &crate::config::AppConfig,
@@ -193,6 +196,27 @@ pub async fn export_backup(
     // 10. JWT signing key
     let jwt_signing_key = config.auth.jwt_signing_key.clone();
 
+    // 11. Collect imported secrets
+    let imported_kek_salt = imported::get_salt(keys_ks).await?.map(hex::encode);
+    let imported_secrets = {
+        let mut secrets = Vec::new();
+        for kr in &key_records {
+            if kr.origin == KeyOrigin::Imported && kr.status == vta_sdk::keys::KeyStatus::Active {
+                if let Ok(mut plaintext) = imported::load_secret(
+                    imported_ks, keys_ks, &seed_bytes, &kr.key_id, &kr.key_type.to_string(),
+                ).await {
+                    secrets.push(ImportedSecretBackup {
+                        key_id: kr.key_id.clone(),
+                        private_key_hex: hex::encode(&plaintext),
+                    });
+                    use zeroize::Zeroize;
+                    plaintext.zeroize();
+                }
+            }
+        }
+        secrets
+    };
+
     // Assemble payload
     let payload = BackupPayload {
         active_seed_hex,
@@ -209,6 +233,8 @@ pub async fn export_backup(
         webvh_logs,
         config: backup_config,
         audit_logs,
+        imported_secrets,
+        imported_kek_salt,
     };
 
     // Encrypt
@@ -241,6 +267,7 @@ pub async fn preview_import(
         acl_count: payload.acl_entries.len(),
         context_count: payload.context_records.len(),
         audit_count: payload.audit_logs.len(),
+        imported_secret_count: payload.imported_secrets.len(),
         message: Some("Preview only — no changes applied. Set confirm=true to import.".into()),
     };
 
@@ -259,6 +286,7 @@ pub async fn apply_import(
     acl_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     config: &tokio::sync::RwLock<crate::config::AppConfig>,
@@ -269,6 +297,7 @@ pub async fn apply_import(
     clear_keyspace(acl_ks, &["acl:", "vta:"]).await?;
     clear_keyspace(contexts_ks, &["ctx:"]).await?;
     clear_keyspace(audit_ks, &["log:"]).await?;
+    clear_keyspace(imported_ks, &["secret:"]).await?;
     #[cfg(feature = "webvh")]
     clear_keyspace(webvh_ks, &["server:", "did:", "log:"]).await?;
 
@@ -366,7 +395,32 @@ pub async fn apply_import(
             .await?;
     }
 
-    // 11. Update config
+    // 11. Restore imported secrets
+    if !payload.imported_secrets.is_empty() {
+        // Restore the KEK salt (or create a new one)
+        if let Some(ref salt_hex) = payload.imported_kek_salt {
+            let salt = hex::decode(salt_hex)
+                .map_err(|e| AppError::Internal(format!("invalid imported KEK salt hex: {e}")))?;
+            imported::set_salt(keys_ks, &salt).await?;
+        }
+
+        for secret_backup in &payload.imported_secrets {
+            let private_bytes = hex::decode(&secret_backup.private_key_hex)
+                .map_err(|e| AppError::Internal(format!("invalid imported secret hex: {e}")))?;
+
+            // Find the matching key record for AAD
+            let key_type_str = payload.key_records.iter()
+                .find(|kr| kr.key_id == secret_backup.key_id)
+                .map(|kr| kr.key_type.to_string())
+                .unwrap_or_else(|| "ed25519".to_string());
+
+            imported::store_secret(
+                imported_ks, keys_ks, &seed_bytes, &secret_backup.key_id, &key_type_str, &private_bytes,
+            ).await?;
+        }
+    }
+
+    // 12. Update config
     {
         let mut cfg = config.write().await;
         if let Some(ref did) = payload.config.vta_did {
@@ -433,6 +487,7 @@ pub async fn apply_import(
         acl_count: payload.acl_entries.len(),
         context_count: payload.context_records.len(),
         audit_count: payload.audit_logs.len(),
+        imported_secret_count: payload.imported_secrets.len(),
         message: Some("Import complete. VTA will restart with new identity.".into()),
     })
 }
@@ -600,6 +655,8 @@ mod tests {
                 mediator_did: None,
             },
             audit_logs: vec![],
+            imported_secrets: vec![],
+            imported_kek_salt: None,
         }
     }
 

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 use multibase::Base;
 use p256::elliptic_curve::sec1::ToEncodedPoint;
 use tracing::info;
+use zeroize::Zeroize;
 
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody, list::ListKeysResultBody, rename::RenameKeyResultBody,
@@ -17,10 +18,11 @@ use crate::auth::AuthClaims;
 use crate::contexts::get_context;
 use crate::error::{AppError, key_derivation_error};
 use crate::keys::derivation::Bip32Extension;
+use crate::keys::imported;
 use crate::keys::paths::allocate_path;
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
-use crate::keys::{self, KeyRecord, KeyStatus, KeyType};
+use crate::keys::{self, KeyOrigin, KeyRecord, KeyStatus, KeyType};
 use crate::store::KeyspaceHandle;
 
 pub struct CreateKeyParams {
@@ -122,6 +124,7 @@ pub async fn create_key(
         label: params.label.clone(),
         context_id: context_id.clone(),
         seed_id: Some(active_id),
+        origin: keys::KeyOrigin::Derived,
         created_at: now,
         updated_at: now,
     };
@@ -139,6 +142,131 @@ pub async fn create_key(
         public_key,
         status: KeyStatus::Active,
         label: params.label,
+        origin: keys::KeyOrigin::Derived,
+        created_at: now,
+    })
+}
+
+// ── Import key ─────────────────────────────────────────────────────
+
+pub struct ImportKeyParams {
+    pub key_type: KeyType,
+    pub private_key_bytes: Vec<u8>,
+    pub label: Option<String>,
+    pub context_id: Option<String>,
+}
+
+pub async fn import_key(
+    keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
+    seed_store: &Arc<dyn SeedStore>,
+    audit_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    params: ImportKeyParams,
+    channel: &str,
+) -> Result<CreateKeyResultBody, AppError> {
+    // Require admin role (stricter than create_key which allows initiator)
+    auth.require_admin()?;
+
+    // Resolve context
+    let context_id = if let Some(ref ctx) = params.context_id {
+        auth.require_context(ctx)?;
+        Some(ctx.clone())
+    } else if auth.is_super_admin() {
+        None
+    } else if let Some(ctx) = auth.default_context() {
+        Some(ctx.to_string())
+    } else {
+        return Err(AppError::Forbidden(
+            "context_id required: admin has access to multiple contexts".into(),
+        ));
+    };
+
+    // Validate key bytes and derive public key
+    let mut private_bytes = params.private_key_bytes;
+    let (public_key, key_type_str) = match params.key_type {
+        KeyType::Ed25519 => {
+            if private_bytes.len() != 32 {
+                return Err(AppError::Validation(
+                    format!("Ed25519 private key must be 32 bytes, got {}", private_bytes.len()),
+                ));
+            }
+            let signing_key = ed25519_dalek::SigningKey::from_bytes(
+                private_bytes.as_slice().try_into().unwrap(),
+            );
+            let pub_bytes = signing_key.verifying_key().to_bytes();
+            let pub_multibase = keys::ed25519_multibase_pubkey(&pub_bytes);
+            (pub_multibase, "ed25519")
+        }
+        KeyType::X25519 => {
+            if private_bytes.len() != 32 {
+                return Err(AppError::Validation(
+                    format!("X25519 private key must be 32 bytes, got {}", private_bytes.len()),
+                ));
+            }
+            let secret_bytes: [u8; 32] = private_bytes.as_slice().try_into().unwrap();
+            let secret = x25519_dalek::StaticSecret::from(secret_bytes);
+            let public = x25519_dalek::PublicKey::from(&secret);
+            let pub_multibase = multibase::encode(Base::Base58Btc, public.as_bytes());
+            (pub_multibase, "x25519")
+        }
+        KeyType::P256 => {
+            let secret_key = p256::SecretKey::from_slice(&private_bytes)
+                .map_err(|e| AppError::Validation(format!("invalid P-256 private key: {e}")))?;
+            let public = secret_key.public_key();
+            let encoded = public.to_encoded_point(true);
+            let pub_multibase = multibase::encode(Base::Base58Btc, encoded.as_bytes());
+            (pub_multibase, "p256")
+        }
+    };
+
+    let now = Utc::now();
+    let key_id = params.label.clone().unwrap_or_else(|| {
+        format!("imported-{}-{}", key_type_str, now.format("%Y%m%d%H%M%S"))
+    });
+
+    // Encrypt and store the secret
+    let active_id = get_active_seed_id(keys_ks)
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    let seed = load_seed_bytes(keys_ks, &**seed_store, Some(active_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+    imported::store_secret(imported_ks, keys_ks, &seed, &key_id, key_type_str, &private_bytes)
+        .await?;
+
+    // Zeroize private key material
+    private_bytes.zeroize();
+
+    // Create key record
+    let record = KeyRecord {
+        key_id: key_id.clone(),
+        derivation_path: String::new(),
+        key_type: params.key_type.clone(),
+        status: KeyStatus::Active,
+        public_key: public_key.clone(),
+        label: params.label.clone(),
+        context_id: context_id.clone(),
+        seed_id: None,
+        origin: KeyOrigin::Imported,
+        created_at: now,
+        updated_at: now,
+    };
+    keys_ks.insert(keys::store_key(&key_id), &record).await?;
+
+    info!(channel, key_id = %key_id, key_type = ?params.key_type, "key imported");
+    audit!("key.import", actor = &auth.did, resource = &key_id, outcome = "success");
+    let _ = audit::record(audit_ks, "key.import", &auth.did, Some(&key_id), "success", Some(channel), context_id.as_deref()).await;
+
+    Ok(CreateKeyResultBody {
+        key_id,
+        key_type: params.key_type,
+        derivation_path: String::new(),
+        public_key,
+        status: KeyStatus::Active,
+        label: params.label,
+        origin: KeyOrigin::Imported,
         created_at: now,
     })
 }
@@ -261,6 +389,7 @@ pub async fn rename_key(
 
 pub async fn revoke_key(
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     key_id: &str,
@@ -287,6 +416,11 @@ pub async fn revoke_key(
         )));
     }
 
+    // Secure deletion for imported keys: destroy the encrypted secret
+    if record.origin == KeyOrigin::Imported {
+        imported::delete_secret(imported_ks, key_id).await?;
+    }
+
     record.status = KeyStatus::Revoked;
     record.updated_at = Utc::now();
 
@@ -305,6 +439,7 @@ pub async fn revoke_key(
 
 pub async fn get_key_secret(
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
@@ -324,34 +459,50 @@ pub async fn get_key_secret(
         ));
     }
 
-    let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
-        .await
-        .map_err(|e| AppError::Internal(format!("{e}")))?;
-    let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
-        .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+    let (public_key_multibase, private_key_multibase) = match record.origin {
+        KeyOrigin::Imported => {
+            // Decrypt from imported_secrets keyspace
+            let seed = load_seed_bytes(keys_ks, &**seed_store, None)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let mut secret_bytes = imported::load_secret(
+                imported_ks, keys_ks, &seed, key_id, &record.key_type.to_string(),
+            ).await?;
+            let priv_mb = multibase::encode(Base::Base58Btc, &secret_bytes);
+            secret_bytes.zeroize();
+            (record.public_key.clone(), priv_mb)
+        }
+        KeyOrigin::Derived => {
+            let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
+                .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
 
-    let (public_key_multibase, private_key_multibase) = match record.key_type {
-        KeyType::Ed25519 => {
-            let secret = bip32.derive_ed25519(&record.derivation_path)?;
-            (
-                secret.get_public_keymultibase()?,
-                secret.get_private_keymultibase()?,
-            )
-        }
-        KeyType::X25519 => {
-            let secret = bip32.derive_x25519(&record.derivation_path)?;
-            (
-                secret.get_public_keymultibase()?,
-                secret.get_private_keymultibase()?,
-            )
-        }
-        KeyType::P256 => {
-            let p256_secret = bip32.derive_p256(&record.derivation_path)?;
-            let public_key = p256_secret.secret_key.public_key();
-            let encoded = public_key.to_encoded_point(true);
-            let pub_mb = multibase::encode(Base::Base58Btc, encoded.as_bytes());
-            let priv_mb = multibase::encode(Base::Base58Btc, p256_secret.secret_key.to_bytes());
-            (pub_mb, priv_mb)
+            match record.key_type {
+                KeyType::Ed25519 => {
+                    let secret = bip32.derive_ed25519(&record.derivation_path)?;
+                    (
+                        secret.get_public_keymultibase()?,
+                        secret.get_private_keymultibase()?,
+                    )
+                }
+                KeyType::X25519 => {
+                    let secret = bip32.derive_x25519(&record.derivation_path)?;
+                    (
+                        secret.get_public_keymultibase()?,
+                        secret.get_private_keymultibase()?,
+                    )
+                }
+                KeyType::P256 => {
+                    let p256_secret = bip32.derive_p256(&record.derivation_path)?;
+                    let public_key = p256_secret.secret_key.public_key();
+                    let encoded = public_key.to_encoded_point(true);
+                    let pub_mb = multibase::encode(Base::Base58Btc, encoded.as_bytes());
+                    let priv_mb = multibase::encode(Base::Base58Btc, p256_secret.secret_key.to_bytes());
+                    (pub_mb, priv_mb)
+                }
+            }
         }
     };
 
@@ -369,10 +520,12 @@ pub async fn get_key_secret(
 
 /// Sign a payload using a VTA-managed key.
 ///
-/// Derives the key from the BIP-32 seed, signs in memory, and returns
-/// the base64url-encoded signature. Key material is dropped after signing.
+/// For derived keys, re-derives from BIP-32 seed. For imported keys,
+/// decrypts from the imported_secrets keyspace. Key material is zeroized
+/// after signing.
 pub async fn sign_payload(
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     auth: &AuthClaims,
     key_id: &str,
@@ -399,39 +552,80 @@ pub async fn sign_payload(
         ));
     }
 
-    let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
-        .await
-        .map_err(|e| AppError::Internal(format!("{e}")))?;
-    let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
-        .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+    let signature_bytes = match record.origin {
+        KeyOrigin::Imported => {
+            // Decrypt imported secret and sign
+            let seed = load_seed_bytes(keys_ks, &**seed_store, None)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let mut secret_bytes = imported::load_secret(
+                imported_ks, keys_ks, &seed, key_id, &record.key_type.to_string(),
+            ).await?;
 
-    let signature_bytes = match (algorithm, &record.key_type) {
-        (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
-            let derivation_path: ed25519_dalek_bip32::DerivationPath = record
-                .derivation_path
-                .parse()
-                .map_err(|e| key_derivation_error(format!("invalid derivation path: {e}")))?;
-            let derived = bip32
-                .derive(&derivation_path)
-                .map_err(|e| key_derivation_error(format!("derivation failed: {e}")))?;
-            let signing_key =
-                ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes());
-            use ed25519_dalek::Signer;
-            let sig = signing_key.sign(payload);
-            sig.to_bytes().to_vec()
+            let sig = match (algorithm, &record.key_type) {
+                (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
+                    let signing_key = ed25519_dalek::SigningKey::from_bytes(
+                        secret_bytes.as_slice().try_into().map_err(|_| {
+                            AppError::Internal("invalid Ed25519 key length".into())
+                        })?,
+                    );
+                    use ed25519_dalek::Signer;
+                    signing_key.sign(payload).to_bytes().to_vec()
+                }
+                (SignAlgorithm::ES256, KeyType::P256) => {
+                    let secret_key = p256::SecretKey::from_slice(&secret_bytes)
+                        .map_err(|e| AppError::Internal(format!("invalid P-256 key: {e}")))?;
+                    let signing_key = p256::ecdsa::SigningKey::from(&secret_key);
+                    use p256::ecdsa::signature::Signer;
+                    let sig: p256::ecdsa::Signature = signing_key.sign(payload);
+                    sig.to_bytes().to_vec()
+                }
+                _ => {
+                    secret_bytes.zeroize();
+                    return Err(AppError::Validation(format!(
+                        "algorithm {} incompatible with key type {}",
+                        algorithm, record.key_type
+                    )));
+                }
+            };
+            secret_bytes.zeroize();
+            sig
         }
-        (SignAlgorithm::ES256, KeyType::P256) => {
-            let p256_secret = bip32.derive_p256(&record.derivation_path)?;
-            let signing_key = p256::ecdsa::SigningKey::from(&p256_secret.secret_key);
-            use p256::ecdsa::signature::Signer;
-            let sig: p256::ecdsa::Signature = signing_key.sign(payload);
-            sig.to_bytes().to_vec()
-        }
-        _ => {
-            return Err(AppError::Validation(format!(
-                "algorithm {} incompatible with key type {}",
-                algorithm, record.key_type
-            )));
+        KeyOrigin::Derived => {
+            let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
+                .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+
+            match (algorithm, &record.key_type) {
+                (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
+                    let derivation_path: ed25519_dalek_bip32::DerivationPath = record
+                        .derivation_path
+                        .parse()
+                        .map_err(|e| key_derivation_error(format!("invalid derivation path: {e}")))?;
+                    let derived = bip32
+                        .derive(&derivation_path)
+                        .map_err(|e| key_derivation_error(format!("derivation failed: {e}")))?;
+                    let signing_key =
+                        ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes());
+                    use ed25519_dalek::Signer;
+                    signing_key.sign(payload).to_bytes().to_vec()
+                }
+                (SignAlgorithm::ES256, KeyType::P256) => {
+                    let p256_secret = bip32.derive_p256(&record.derivation_path)?;
+                    let signing_key = p256::ecdsa::SigningKey::from(&p256_secret.secret_key);
+                    use p256::ecdsa::signature::Signer;
+                    let sig: p256::ecdsa::Signature = signing_key.sign(payload);
+                    sig.to_bytes().to_vec()
+                }
+                _ => {
+                    return Err(AppError::Validation(format!(
+                        "algorithm {} incompatible with key type {}",
+                        algorithm, record.key_type
+                    )));
+                }
+            }
         }
     };
 

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -3,14 +3,17 @@ use std::sync::Arc;
 use tracing::info;
 
 use crate::audit::{self, audit};
+use vta_sdk::keys::KeyOrigin;
 use vta_sdk::protocols::seed_management::{
     list::{ListSeedsResultBody, SeedInfo},
     rotate::RotateSeedResultBody,
 };
 
 use crate::error::AppError;
+use crate::keys::imported;
 use crate::keys::seed_store::SeedStore;
-use crate::keys::seeds::{self as seeds, get_active_seed_id};
+use crate::keys::seeds::{self as seeds, get_active_seed_id, load_seed_bytes};
+use crate::keys::KeyRecord;
 use crate::store::KeyspaceHandle;
 
 pub async fn list_seeds(
@@ -48,6 +51,7 @@ pub async fn list_seeds(
 
 pub async fn rotate_seed(
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     audit_ks: &KeyspaceHandle,
     actor: &str,
@@ -58,9 +62,33 @@ pub async fn rotate_seed(
         .await
         .map_err(|e| AppError::Internal(format!("{e}")))?;
 
+    // Load old seed for re-encryption of imported secrets
+    let old_seed = load_seed_bytes(keys_ks, &**seed_store, Some(previous_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+
     let new_id = seeds::rotate_seed(keys_ks, &**seed_store, mnemonic)
         .await
         .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+    // Re-encrypt imported secrets with the new seed
+    let new_seed = load_seed_bytes(keys_ks, &**seed_store, Some(new_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+    // Collect imported key records for AAD
+    let raw = keys_ks.prefix_iter_raw("key:").await?;
+    let imported_keys: Vec<(String, String)> = raw
+        .into_iter()
+        .filter_map(|(_, v)| serde_json::from_slice::<KeyRecord>(&v).ok())
+        .filter(|r| r.origin == KeyOrigin::Imported && r.status == vta_sdk::keys::KeyStatus::Active)
+        .map(|r| (r.key_id, r.key_type.to_string()))
+        .collect();
+
+    if !imported_keys.is_empty() {
+        let count = imported::reencrypt_all(imported_ks, keys_ks, &old_seed, &new_seed, &imported_keys).await?;
+        info!(channel, count, "re-encrypted imported secrets after seed rotation");
+    }
 
     info!(channel, previous_id, new_id, "seed rotated");
     audit!("seed.rotate", actor = actor, resource = "seed", outcome = "success");

--- a/vta-service/src/routes/backup.rs
+++ b/vta-service/src/routes/backup.rs
@@ -22,6 +22,7 @@ pub async fn export(
         &state.acl_ks,
         &state.contexts_ks,
         &state.audit_ks,
+        &state.imported_ks,
         #[cfg(feature = "webvh")]
         &state.webvh_ks,
         &*state.seed_store,
@@ -70,6 +71,7 @@ pub async fn import(
         &state.acl_ks,
         &state.contexts_ks,
         &state.audit_ks,
+        &state.imported_ks,
         #[cfg(feature = "webvh")]
         &state.webvh_ks,
         &state.seed_store,

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -1,7 +1,7 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody, list::ListKeysResultBody, rename::RenameKeyResultBody,
@@ -64,6 +64,7 @@ pub async fn get_key_secret(
 ) -> Result<Json<GetKeySecretResultBody>, AppError> {
     let result = operations::keys::get_key_secret(
         &state.keys_ks,
+        &state.imported_ks,
         &state.seed_store,
         &state.audit_ks,
         &auth.0,
@@ -90,7 +91,7 @@ pub async fn invalidate_key(
     State(state): State<AppState>,
     Path(key_id): Path<String>,
 ) -> Result<Json<RevokeKeyResultBody>, AppError> {
-    let result = operations::keys::revoke_key(&state.keys_ks, &state.audit_ks, &auth.0, &key_id, "rest").await?;
+    let result = operations::keys::revoke_key(&state.keys_ks, &state.imported_ks, &state.audit_ks, &auth.0, &key_id, "rest").await?;
     Ok(Json(result))
 }
 
@@ -164,6 +165,7 @@ pub async fn rotate_seed(
 ) -> Result<Json<RotateSeedResultBody>, AppError> {
     let result = operations::seeds::rotate_seed(
         &state.keys_ks,
+        &state.imported_ks,
         &state.seed_store,
         &state.audit_ks,
         &_auth.0.did,
@@ -196,6 +198,7 @@ pub async fn sign_with_key(
 
     let result = operations::keys::sign_payload(
         &state.keys_ks,
+        &state.imported_ks,
         &state.seed_store,
         &auth,
         &key_id,
@@ -205,4 +208,76 @@ pub async fn sign_with_key(
     )
     .await?;
     Ok(Json(result))
+}
+
+// ── Import key endpoints ─────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct WrappingKeyResponse {
+    pub kid: String,
+    pub kty: String,
+    pub crv: String,
+    pub x: String,
+}
+
+/// GET /keys/import/wrapping-key — get an ephemeral X25519 public key for REST key wrapping.
+pub async fn get_wrapping_key(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<WrappingKeyResponse>, AppError> {
+    let (kid, x) = state.wrapping_cache.generate().await;
+    Ok(Json(WrappingKeyResponse {
+        kid,
+        kty: "OKP".into(),
+        crv: "X25519".into(),
+        x,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ImportKeyRestRequest {
+    pub key_type: KeyType,
+    /// JWE compact serialization of the private key (REST transport).
+    pub private_key_jwe: Option<String>,
+    /// Multibase-encoded private key (DIDComm transport — should not be used via REST).
+    pub private_key_multibase: Option<String>,
+    pub label: Option<String>,
+    pub context_id: Option<String>,
+}
+
+/// POST /keys/import — import an externally-created private key. Auth: Admin only.
+pub async fn import_key(
+    auth: AdminAuth,
+    State(state): State<AppState>,
+    Json(req): Json<ImportKeyRestRequest>,
+) -> Result<(StatusCode, Json<CreateKeyResultBody>), AppError> {
+    // Unwrap the private key based on transport
+    let private_key_bytes = if let Some(jwe) = req.private_key_jwe {
+        state.wrapping_cache.unwrap_jwe(&jwe).await?
+    } else if let Some(ref mb) = req.private_key_multibase {
+        let (_, bytes) = multibase::decode(mb)
+            .map_err(|e| AppError::Validation(format!("invalid multibase private key: {e}")))?;
+        bytes
+    } else {
+        return Err(AppError::Validation(
+            "either private_key_jwe or private_key_multibase is required".into(),
+        ));
+    };
+
+    let result = operations::keys::import_key(
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.seed_store,
+        &state.audit_ks,
+        &auth.0,
+        operations::keys::ImportKeyParams {
+            key_type: req.key_type,
+            private_key_bytes,
+            label: req.label,
+            context_id: req.context_id,
+        },
+        "rest",
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(result)))
 }

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -54,6 +54,8 @@ pub fn router() -> Router<AppState> {
         )
         .route("/keys/{key_id}/secret", get(keys::get_key_secret))
         .route("/keys/{key_id}/sign", post(keys::sign_with_key))
+        .route("/keys/import/wrapping-key", get(keys::get_wrapping_key))
+        .route("/keys/import", post(keys::import_key))
         .route("/keys/seeds", get(keys::list_seeds))
         .route("/keys/seeds/rotate", post(keys::rotate_seed))
         // Context routes

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -78,9 +78,11 @@ pub struct AppState {
     pub acl_ks: KeyspaceHandle,
     pub contexts_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
+    pub imported_ks: KeyspaceHandle,
     pub cache_ks: KeyspaceHandle,
     #[cfg(feature = "webvh")]
     pub webvh_ks: KeyspaceHandle,
+    pub wrapping_cache: crate::keys::wrapping::WrappingKeyCache,
     pub config: Arc<RwLock<AppConfig>>,
     pub seed_store: Arc<dyn SeedStore>,
     pub did_resolver: Option<DIDCacheClient>,
@@ -132,6 +134,7 @@ pub async fn build_app_state(
     let acl_ks = apply_encryption(store.keyspace("acl")?);
     let contexts_ks = apply_encryption(store.keyspace("contexts")?);
     let audit_ks = apply_encryption(store.keyspace("audit")?);
+    let imported_ks = apply_encryption(store.keyspace("imported_secrets")?);
     let cache_ks = store.keyspace("cache")?;
     #[cfg(feature = "webvh")]
     let webvh_ks = apply_encryption(store.keyspace("webvh")?);
@@ -145,9 +148,11 @@ pub async fn build_app_state(
         acl_ks,
         contexts_ks,
         audit_ks,
+        imported_ks,
         cache_ks,
         #[cfg(feature = "webvh")]
         webvh_ks,
+        wrapping_cache: crate::keys::wrapping::WrappingKeyCache::new(),
         config: Arc::new(RwLock::new(config)),
         seed_store,
         did_resolver,
@@ -215,6 +220,7 @@ pub async fn run(
         let acl_ks = apply_encryption(store.keyspace("acl")?);
         let contexts_ks = apply_encryption(store.keyspace("contexts")?);
         let audit_ks = apply_encryption(store.keyspace("audit")?);
+        let imported_ks = apply_encryption(store.keyspace("imported_secrets")?);
         let cache_ks = store.keyspace("cache")?;
         #[cfg(feature = "webvh")]
         let webvh_ks = apply_encryption(store.keyspace("webvh")?);
@@ -273,6 +279,7 @@ pub async fn run(
                 acl_ks: acl_ks.clone(),
                 contexts_ks: contexts_ks.clone(),
                 audit_ks: audit_ks.clone(),
+                imported_ks: imported_ks.clone(),
                 #[cfg(feature = "webvh")]
                 webvh_ks: webvh_ks.clone(),
                 seed_store: seed_store.clone(),
@@ -290,15 +297,20 @@ pub async fn run(
         #[cfg(feature = "rest")]
         let rest_handle = if let Some(ref listener_ref) = std_listener {
             let listener = listener_ref.try_clone().map_err(AppError::Io)?;
+            let wrapping_cache = crate::keys::wrapping::WrappingKeyCache::new();
+            wrapping_cache.clone().spawn_reaper();
+
             let state = AppState {
                 keys_ks,
                 sessions_ks,
                 acl_ks,
                 contexts_ks,
                 audit_ks,
+                imported_ks,
                 cache_ks,
                 #[cfg(feature = "webvh")]
                 webvh_ks,
+                wrapping_cache,
                 config: Arc::new(RwLock::new(config.clone())),
                 seed_store: seed_store.clone(),
                 did_resolver,

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -75,15 +75,18 @@ impl TestApp {
 
         let (restart_tx, _rx) = watch::channel(false);
 
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
         let state = AppState {
             keys_ks: keys_ks.clone(),
             sessions_ks: sessions_ks.clone(),
             acl_ks: acl_ks.clone(),
             contexts_ks,
             audit_ks: audit_ks.clone(),
+            imported_ks,
             cache_ks,
             #[cfg(feature = "webvh")]
             webvh_ks,
+            wrapping_cache: vta_service::keys::wrapping::WrappingKeyCache::new(),
             config: Arc::new(RwLock::new(config)),
             seed_store,
             did_resolver: None,

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -28,8 +28,8 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.2.0" }
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = [
+vti-common = { path = "../vti-common", version = "0.3.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = [
   "didcomm",
   "session",
   "config-session",


### PR DESCRIPTION
## Summary

- Allow users to import externally-created private keys (Ed25519, X25519, P-256) into the VTA via `POST /keys/import` and `pnm keys import`
- Imported keys are encrypted at rest with AES-256-GCM (seed-derived KEK via HKDF-SHA256), participate in signing/secret export alongside BIP-32 derived keys, and are included in backup/restore
- REST transport wraps keys with ephemeral ECDH-ES+AES-256-GCM (`GET /keys/import/wrapping-key`); DIDComm sends directly inside the E2E encrypted envelope

### Security hardening
- Zeroize all private key buffers after use
- AAD binding (`key_id:key_type`) prevents ciphertext blob-swap attacks
- Secure deletion on revoke (overwrite with zeros then delete)
- Automatic re-encryption of imported secrets on seed rotation
- Independent random KEK salt per VTA instance
- Admin-only import endpoint (stricter than key creation)
- Ephemeral wrapping keys: single-use, 60s TTL, background reaper

### Changes across crates
- **vta-sdk**: `KeyOrigin` enum, `origin` field on `KeyRecord`, `ImportKeyRequest`/`WrappingKeyResponse` types, `import_key()`/`get_wrapping_key()` client methods, `imported_secrets` in `BackupPayload`
- **vta-service**: `imported.rs` (encrypted storage layer), `wrapping.rs` (ephemeral ECDH-ES cache), updated `import_key`/`get_key_secret`/`sign_payload`/`revoke_key`/`rotate_seed`/`export_backup`/`apply_import` operations, new REST routes
- **vta-cli-common**: `cmd_key_import()` with client-side ECDH-ES+AES-256-GCM wrapping
- **pnm-cli**: `keys import` subcommand
- **All crates**: version bump to 0.3.0

### Docs updated
- CHANGELOG.md, PNM CLI README, DIDComm protocol reference, security architecture

## Test plan
- [x] 6 new unit tests: encrypt/decrypt roundtrip, wrong-AAD rejection, secure deletion, seed rotation re-encryption, wrapping key generate+unwrap, single-use enforcement
- [x] All 234 existing + new tests pass (`cargo test --workspace`)
- [x] Full workspace builds clean (`cargo build --workspace`)
- [ ] Manual test: `pnm keys import --key-type ed25519 --private-key <multibase> --label test`
- [ ] Manual test: backup export → import with imported secrets
- [ ] Manual test: seed rotation preserves imported secret access