### PR TITLE
Add VTA SDK convenience methods for service integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,52 @@
 
 - `hkdf` 0.12 (new — KEK derivation for imported secrets)
 
+### VTA SDK Improvements for Service Integration
+
+- **Lightweight DIDComm auth (`auth_light`)** — New
+  `challenge_response_light()` and `refresh_token_light()`
+  functions perform DIDComm challenge-response authentication
+  without requiring ATM/TDK runtime initialization. Uses a
+  hand-rolled JWE packer (`didcomm_light`) with
+  ECDH-ES+A256KW key agreement and A256GCM content
+  encryption. Available behind the `client` feature (not
+  `session`).
+- **`VtaClient::from_credential()`** — One-line constructor
+  that decodes a base64 credential bundle, authenticates via
+  lightweight auth, and returns a ready-to-use client with
+  auto-refresh enabled.
+- **Automatic token refresh** — `VtaClient` now stores
+  credential material and automatically refreshes expired
+  tokens before each API call. Tries the `/auth/refresh`
+  endpoint first (cheap), falls back to full
+  challenge-response if the refresh token is expired.
+  Token expiry is checked with a 30-second buffer.
+- **`fetch_context_secrets()`** — Convenience method that
+  paginates through all active keys in a context and returns
+  TDK `Secret` objects ready for DIDComm or signing. Pages
+  in batches of 100 to handle large key sets.
+- **`check_auth()`** — Verifies the current token is valid
+  by calling `GET /health/details`. Returns `true`/`false`
+  for readiness checks.
+- **`token_expires_at()`** — Exposes token expiry for health
+  monitoring in long-running services.
+- **`set_token()` is now `&self`** — No longer requires
+  `&mut self`, simplifying usage in shared contexts.
+
+### Lightweight DIDComm Packer (`didcomm_light`)
+
+- **DIDComm v2 anoncrypt** — Minimal JWE (General JSON)
+  packer producing messages compatible with any DIDComm v2
+  unpacker (including `affinidi-tdk`'s `ATM::unpack()`).
+- **ECDH-ES+A256KW** key agreement with ephemeral X25519.
+- **A256GCM** content encryption (simpler than A256CBC-HS512).
+- **Concat KDF** (NIST SP 800-56A) for key derivation.
+- **AES-256 Key Wrap** (RFC 3394) for CEK wrapping.
+- **`did:key` → X25519** conversion (Edwards→Montgomery).
+- **8 unit tests** — Key wrap roundtrip, KDF determinism,
+  did:key parsing, Ed25519→X25519 conversion, JWE structure
+  validation.
+
 ---
 
 ## 0.2.1 — 2026-03-30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7731,20 +7731,27 @@ dependencies = [
 name = "vta-sdk"
 version = "0.3.0"
 dependencies = [
+ "aes",
+ "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
  "azure_identity",
  "azure_security_keyvault_secrets",
  "base64 0.22.1",
  "chrono",
+ "curve25519-dalek",
+ "ed25519-dalek",
  "keyring",
  "multibase",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
+ "x25519-dalek",
 ]
 
 [[package]]

--- a/cnm-cli/src/setup.rs
+++ b/cnm-cli/src/setup.rs
@@ -132,7 +132,7 @@ pub async fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
             let context_name = format!("CNM - {community_name}");
 
             // Authenticate personal VTA client
-            let mut personal_client = VtaClient::new(&personal_url);
+            let personal_client = VtaClient::new(&personal_url);
             let token = auth::ensure_authenticated(&personal_url, PERSONAL_KEYRING_KEY).await?;
             personal_client.set_token(token);
 
@@ -147,13 +147,11 @@ pub async fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(ctx) => {
                     eprintln!("  Context created: {} ({})", ctx.id, ctx.base_path);
                 }
+                Err(ref e) if matches!(e, vta_sdk::error::VtaError::Conflict(_)) => {
+                    eprintln!("  Context '{context_slug}' already exists, reusing it.");
+                }
                 Err(e) => {
-                    let msg = e.to_string();
-                    if msg.contains("409") || msg.to_lowercase().contains("already exists") {
-                        eprintln!("  Context '{context_slug}' already exists, reusing it.");
-                    } else {
-                        return Err(e);
-                    }
+                    return Err(e.into());
                 }
             }
 
@@ -311,7 +309,7 @@ pub async fn bootstrap_community_session(
 
     // Authenticate to personal VTA
     let token = auth::ensure_authenticated(personal_url, PERSONAL_KEYRING_KEY).await?;
-    let mut personal_client = VtaClient::new(personal_url);
+    let personal_client = VtaClient::new(personal_url);
     personal_client.set_token(token);
 
     // Generate a new credential on the personal VTA

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -12,7 +12,19 @@ repository.workspace = true
 
 [features]
 didcomm = ["dep:affinidi-tdk", "dep:affinidi-did-resolver-cache-sdk", "dep:tracing", "dep:uuid", "dep:tokio"]
-client = ["dep:reqwest", "dep:tracing", "dep:uuid", "dep:affinidi-tdk"]
+client = [
+  "dep:reqwest",
+  "dep:tracing",
+  "dep:uuid",
+  "dep:affinidi-tdk",
+  "dep:tokio",
+  "dep:ed25519-dalek",
+  "dep:x25519-dalek",
+  "dep:curve25519-dalek",
+  "dep:aes-gcm",
+  "dep:aes",
+  "dep:sha2",
+]
 session = [
   "client",
   "didcomm",
@@ -33,6 +45,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 base64 = { workspace = true }
 multibase = { workspace = true }
+thiserror = { workspace = true }
 affinidi-tdk = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
@@ -42,3 +55,12 @@ keyring = { version = "3", optional = true }
 azure_security_keyvault_secrets = { version = "0.12", optional = true }
 azure_identity = { version = "0.33", optional = true }
 tokio = { workspace = true, optional = true }
+ed25519-dalek = { version = "2", optional = true }
+x25519-dalek = { workspace = true, optional = true }
+curve25519-dalek = { version = "4", optional = true }
+aes-gcm = { version = "0.10", optional = true }
+aes = { version = "0.8", optional = true }
+sha2 = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/vta-sdk/src/auth_light.rs
+++ b/vta-sdk/src/auth_light.rs
@@ -1,0 +1,166 @@
+//! Lightweight challenge-response authentication for VTA REST clients.
+//!
+//! This module provides the same DIDComm challenge-response flow as
+//! `session::challenge_response()` but without requiring ATM/TDK runtime
+//! initialization. It uses the lightweight DIDComm packer from
+//! `didcomm_light` to build encrypted auth messages.
+//!
+//! Feature gate: `client` (not `session`).
+
+use crate::credentials::CredentialBundle;
+use crate::didcomm_light;
+use crate::protocols::auth::{AuthenticateResponse, ChallengeRequest, ChallengeResponse};
+
+/// Result of a successful authentication.
+#[derive(Debug, Clone)]
+pub struct AuthResult {
+    pub access_token: String,
+    pub access_expires_at: u64,
+    pub refresh_token: Option<String>,
+    pub refresh_expires_at: Option<u64>,
+}
+
+/// Perform DIDComm challenge-response authentication without ATM/TDK runtime.
+///
+/// This is the lightweight equivalent of `session::challenge_response()`.
+/// It uses the `didcomm_light` packer to build the encrypted message.
+pub async fn challenge_response_light(
+    base_url: &str,
+    client_did: &str,
+    private_key_multibase: &str,
+    vta_did: &str,
+) -> Result<AuthResult, crate::error::VtaError> {
+    let _ = private_key_multibase; // Sender identity is in the plaintext `from` field;
+                                    // anoncrypt doesn't use sender's private key for encryption.
+    let http = reqwest::Client::new();
+
+    // Step 1: Request challenge
+    let challenge_url = format!("{base_url}/auth/challenge");
+    let challenge_resp = http
+        .post(&challenge_url)
+        .json(&ChallengeRequest {
+            did: client_did.to_string(),
+        })
+        .send()
+        .await
+        .map_err(|e| format!("could not connect to VTA at {challenge_url}: {e}"))?;
+
+    if !challenge_resp.status().is_success() {
+        let status = challenge_resp.status();
+        let body = challenge_resp.text().await.unwrap_or_default();
+        return Err(format!("challenge request failed ({status}): {body}").into());
+    }
+
+    let challenge: ChallengeResponse = challenge_resp
+        .json()
+        .await
+        .map_err(|e| format!("unexpected response from VTA: {e}"))?;
+
+    // Step 2: Pack encrypted authenticate message
+    let packed = didcomm_light::pack_auth_message(
+        "https://affinidi.com/atm/1.0/authenticate",
+        serde_json::json!({
+            "challenge": challenge.data.challenge,
+            "session_id": challenge.session_id,
+        }),
+        client_did,
+        vta_did,
+    )?;
+
+    // Step 3: Send packed message
+    let auth_url = format!("{base_url}/auth/");
+    let auth_resp = http
+        .post(&auth_url)
+        .header("content-type", "text/plain")
+        .body(packed)
+        .send()
+        .await
+        .map_err(|e| format!("could not connect to VTA at {auth_url}: {e}"))?;
+
+    if !auth_resp.status().is_success() {
+        let status = auth_resp.status();
+        let body = auth_resp.text().await.unwrap_or_default();
+        return Err(format!("authentication failed ({status}): {body}").into());
+    }
+
+    let auth_data: AuthenticateResponse = auth_resp
+        .json()
+        .await
+        .map_err(|e| format!("unexpected auth response: {e}"))?;
+
+    Ok(AuthResult {
+        access_token: auth_data.data.access_token,
+        access_expires_at: auth_data.data.access_expires_at,
+        refresh_token: auth_data.data.refresh_token,
+        refresh_expires_at: auth_data.data.refresh_expires_at,
+    })
+}
+
+/// Refresh an access token using the refresh token endpoint.
+///
+/// Returns a new `AuthResult` with a fresh access token. The refresh token
+/// itself remains unchanged.
+pub async fn refresh_token_light(
+    base_url: &str,
+    client_did: &str,
+    vta_did: &str,
+    refresh_token: &str,
+) -> Result<AuthResult, crate::error::VtaError> {
+    let packed = didcomm_light::pack_auth_message(
+        "https://affinidi.com/atm/1.0/authenticate/refresh",
+        serde_json::json!({
+            "refresh_token": refresh_token,
+        }),
+        client_did,
+        vta_did,
+    )?;
+
+    let http = reqwest::Client::new();
+    let refresh_url = format!("{base_url}/auth/refresh");
+    let resp = http
+        .post(&refresh_url)
+        .header("content-type", "text/plain")
+        .body(packed)
+        .send()
+        .await
+        .map_err(|e| format!("refresh request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("token refresh failed ({status}): {body}").into());
+    }
+
+    let auth_data: AuthenticateResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("unexpected refresh response: {e}"))?;
+
+    Ok(AuthResult {
+        access_token: auth_data.data.access_token,
+        access_expires_at: auth_data.data.access_expires_at,
+        refresh_token: auth_data.data.refresh_token,
+        refresh_expires_at: auth_data.data.refresh_expires_at,
+    })
+}
+
+/// Decode a credential bundle and authenticate, returning an `AuthResult`.
+pub async fn authenticate_with_credential(
+    credential_b64: &str,
+    url_override: Option<&str>,
+) -> Result<(AuthResult, CredentialBundle), crate::error::VtaError> {
+    let cred = CredentialBundle::decode(credential_b64)?;
+    let url = url_override
+        .or(cred.vta_url.as_deref())
+        .ok_or("no VTA URL in credential and no override provided")?;
+
+    let result = challenge_response_light(
+        url,
+        &cred.did,
+        &cred.private_key_multibase,
+        &cred.vta_did,
+    )
+    .await?;
+
+    Ok((result, cred))
+}

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -1,3 +1,4 @@
+use crate::error::VtaError;
 use crate::keys::{KeyRecord, KeyStatus, KeyType};
 use crate::protocols::key_management::sign::SignAlgorithm;
 use chrono::{DateTime, Utc};
@@ -6,11 +7,27 @@ use serde::{Deserialize, Serialize};
 
 // ── Internal transport ──────────────────────────────────────────────
 
+/// Stored credential for automatic token refresh.
+struct AuthCredential {
+    did: String,
+    private_key_multibase: String,
+    vta_did: String,
+}
+
+/// Mutable auth state protected by a mutex for auto-refresh.
+struct RestAuth {
+    token: Option<String>,
+    expires_at: Option<u64>,
+    refresh_token: Option<String>,
+    refresh_expires_at: Option<u64>,
+    credential: Option<AuthCredential>,
+}
+
 enum Transport {
     Rest {
         client: Client,
         base_url: String,
-        token: Option<String>,
+        auth: tokio::sync::Mutex<RestAuth>,
     },
     #[cfg(feature = "session")]
     DIDComm {
@@ -343,7 +360,7 @@ fn encode_path_segment(s: &str) -> String {
 
 impl VtaClient {
     /// Attach Bearer token to a request if one is set.
-    fn with_auth(req: RequestBuilder, token: &Option<String>) -> RequestBuilder {
+    fn with_auth_token(req: RequestBuilder, token: &Option<String>) -> RequestBuilder {
         match token {
             Some(token) => req.bearer_auth(token),
             None => req,
@@ -352,7 +369,7 @@ impl VtaClient {
 
     async fn handle_response<T: serde::de::DeserializeOwned>(
         resp: reqwest::Response,
-    ) -> Result<T, Box<dyn std::error::Error>> {
+    ) -> Result<T, VtaError> {
         if resp.status().is_success() {
             Ok(resp.json::<T>().await?)
         } else {
@@ -362,13 +379,13 @@ impl VtaClient {
                 .await
                 .map(|e| e.error)
                 .unwrap_or_else(|_| "unknown error".to_string());
-            Err(format!("{status}: {body}").into())
+            Err(VtaError::from_http(status, body))
         }
     }
 
     async fn handle_delete_response(
         resp: reqwest::Response,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), VtaError> {
         if resp.status().is_success() {
             Ok(())
         } else {
@@ -378,7 +395,7 @@ impl VtaClient {
                 .await
                 .map(|e| e.error)
                 .unwrap_or_else(|_| "unknown error".to_string());
-            Err(format!("{status}: {body}").into())
+            Err(VtaError::from_http(status, body))
         }
     }
 }
@@ -398,8 +415,58 @@ impl VtaClient {
             transport: Transport::Rest {
                 client: Client::new(),
                 base_url: base_url.trim_end_matches('/').to_string(),
-                token: None,
+                auth: tokio::sync::Mutex::new(RestAuth {
+                    token: None,
+                    expires_at: None,
+                    refresh_token: None,
+                    refresh_expires_at: None,
+                    credential: None,
+                }),
             },
+        }
+    }
+
+    /// Create a client from a base64-encoded credential bundle.
+    ///
+    /// Performs lightweight challenge-response auth (no ATM/TDK initialization)
+    /// and stores the credential for automatic token refresh.
+    pub async fn from_credential(
+        credential_b64: &str,
+        url_override: Option<&str>,
+    ) -> Result<Self, VtaError> {
+        let (result, cred) =
+            crate::auth_light::authenticate_with_credential(credential_b64, url_override).await?;
+        let base_url = url_override
+            .or(cred.vta_url.as_deref())
+            .ok_or("no VTA URL")?
+            .trim_end_matches('/')
+            .to_string();
+
+        Ok(Self {
+            transport: Transport::Rest {
+                client: Client::new(),
+                base_url,
+                auth: tokio::sync::Mutex::new(RestAuth {
+                    token: Some(result.access_token),
+                    expires_at: Some(result.access_expires_at),
+                    refresh_token: result.refresh_token,
+                    refresh_expires_at: result.refresh_expires_at,
+                    credential: Some(AuthCredential {
+                        did: cred.did,
+                        private_key_multibase: cred.private_key_multibase,
+                        vta_did: cred.vta_did,
+                    }),
+                }),
+            },
+        })
+    }
+
+    /// Returns the token expiry timestamp, if known.
+    pub async fn token_expires_at(&self) -> Option<u64> {
+        if let Transport::Rest { auth, .. } = &self.transport {
+            auth.lock().await.expires_at
+        } else {
+            None
         }
     }
 
@@ -413,7 +480,7 @@ impl VtaClient {
         vta_did: &str,
         mediator_did: &str,
         rest_url: Option<String>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, VtaError> {
         let session = crate::didcomm_session::DIDCommSession::connect(
             client_did,
             private_key_multibase,
@@ -434,9 +501,22 @@ impl VtaClient {
     }
 
     /// Set the Bearer token for authenticated requests (REST only, no-op for DIDComm).
-    pub fn set_token(&mut self, token: String) {
-        if let Transport::Rest { token: t, .. } = &mut self.transport {
-            *t = Some(token);
+    ///
+    /// Can be called from sync or async contexts. For async contexts, use
+    /// [`set_token_async`](Self::set_token_async) to avoid potential blocking.
+    pub fn set_token(&self, token: String) {
+        if let Transport::Rest { auth, .. } = &self.transport {
+            // try_lock avoids blocking the current thread if called from async
+            if let Ok(mut guard) = auth.try_lock() {
+                guard.token = Some(token);
+            }
+        }
+    }
+
+    /// Set the Bearer token (async version).
+    pub async fn set_token_async(&self, token: String) {
+        if let Transport::Rest { auth, .. } = &self.transport {
+            auth.lock().await.token = Some(token);
         }
     }
 
@@ -459,6 +539,75 @@ impl VtaClient {
 
     // ── RPC helpers ─────────────────────────────────────────────────
 
+    /// Ensure the REST auth token is valid, refreshing if needed.
+    async fn ensure_token_valid(
+        _client: &Client,
+        base_url: &str,
+        auth: &tokio::sync::Mutex<RestAuth>,
+    ) -> Result<(), VtaError> {
+        let mut guard = auth.lock().await;
+
+        // Check if token is still valid (>30s remaining)
+        if let Some(expires_at) = guard.expires_at {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            if now + 30 < expires_at {
+                return Ok(()); // Token still valid
+            }
+        } else if guard.token.is_some() {
+            // Token without expiry — assume valid
+            return Ok(());
+        }
+
+        // No credential stored — can't auto-refresh
+        let Some(ref cred) = guard.credential else {
+            return Ok(());
+        };
+
+        // Try refresh token first (cheaper than full re-auth)
+        if let Some(ref refresh_tok) = guard.refresh_token {
+            if let Some(refresh_exp) = guard.refresh_expires_at {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                if now < refresh_exp {
+                    if let Ok(result) = crate::auth_light::refresh_token_light(
+                        base_url, &cred.did, &cred.vta_did, refresh_tok,
+                    ).await {
+                        guard.token = Some(result.access_token);
+                        guard.expires_at = Some(result.access_expires_at);
+                        if let Some(new_refresh) = result.refresh_token {
+                            guard.refresh_token = Some(new_refresh);
+                        }
+                        guard.refresh_expires_at = result.refresh_expires_at;
+                        return Ok(());
+                    }
+                    // Refresh failed — fall through to full re-auth
+                }
+            }
+        }
+
+        // Full re-authentication
+        let did = cred.did.clone();
+        let pk = cred.private_key_multibase.clone();
+        let vta = cred.vta_did.clone();
+        drop(guard); // Release lock before async call
+
+        let result = crate::auth_light::challenge_response_light(
+            base_url, &did, &pk, &vta,
+        ).await?;
+
+        let mut guard = auth.lock().await;
+        guard.token = Some(result.access_token);
+        guard.expires_at = Some(result.access_expires_at);
+        guard.refresh_token = result.refresh_token;
+        guard.refresh_expires_at = result.refresh_expires_at;
+        Ok(())
+    }
+
     /// Dispatch an RPC call via REST (using `build_rest`) or DIDComm (using
     /// `msg_type`/`body`/`result_type`), returning a deserialized response.
     #[allow(unused_variables)]
@@ -469,15 +618,17 @@ impl VtaClient {
         result_type: &str,
         timeout: u64,
         build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
-    ) -> Result<T, Box<dyn std::error::Error>> {
+    ) -> Result<T, VtaError> {
         match &self.transport {
             Transport::Rest {
                 client,
                 base_url,
-                token,
+                auth,
             } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
                 let req = build_rest(client, base_url);
-                let resp = Self::with_auth(req, token).send().await?;
+                let resp = Self::with_auth_token(req, &token).send().await?;
                 Self::handle_response(resp).await
             }
             #[cfg(feature = "session")]
@@ -485,6 +636,7 @@ impl VtaClient {
                 session
                     .send_and_wait(msg_type, body, result_type, timeout)
                     .await
+                    .map_err(|e| VtaError::Protocol(e.to_string()))
             }
         }
     }
@@ -498,22 +650,25 @@ impl VtaClient {
         result_type: &str,
         timeout: u64,
         build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), VtaError> {
         match &self.transport {
             Transport::Rest {
                 client,
                 base_url,
-                token,
+                auth,
             } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
                 let req = build_rest(client, base_url);
-                let resp = Self::with_auth(req, token).send().await?;
+                let resp = Self::with_auth_token(req, &token).send().await?;
                 Self::handle_delete_response(resp).await
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { session, .. } => {
                 let _: serde_json::Value = session
                     .send_and_wait(msg_type, body, result_type, timeout)
-                    .await?;
+                    .await
+                    .map_err(|e| VtaError::Protocol(e.to_string()))?;
                 Ok(())
             }
         }
@@ -521,8 +676,8 @@ impl VtaClient {
 
     // ── Health ───────────────────────────────────────────────────────
 
-    /// GET /health (always REST)
-    pub async fn health(&self) -> Result<HealthResponse, Box<dyn std::error::Error>> {
+    /// GET /health (always REST, unauthenticated)
+    pub async fn health(&self) -> Result<HealthResponse, VtaError> {
         match &self.transport {
             Transport::Rest {
                 client, base_url, ..
@@ -551,7 +706,7 @@ impl VtaClient {
     // ── VTA Management ──────────────────────────────────────────────
 
     /// Trigger a soft restart of the VTA.
-    pub async fn restart(&self) -> Result<vta_management::restart::RestartResult, Box<dyn std::error::Error>> {
+    pub async fn restart(&self) -> Result<vta_management::restart::RestartResult, VtaError> {
         self.rpc(
             vta_management::RESTART,
             serde_json::json!({}),
@@ -569,7 +724,7 @@ impl VtaClient {
         &self,
         password: &str,
         include_audit: bool,
-    ) -> Result<crate::protocols::backup_management::types::BackupEnvelope, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::backup_management::types::BackupEnvelope, VtaError> {
         self.rpc(
             crate::protocols::backup_management::EXPORT_BACKUP,
             serde_json::json!({ "password": password, "include_audit": include_audit }),
@@ -589,7 +744,7 @@ impl VtaClient {
         backup: &crate::protocols::backup_management::types::BackupEnvelope,
         password: &str,
         confirm: bool,
-    ) -> Result<crate::protocols::backup_management::types::ImportResult, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::backup_management::types::ImportResult, VtaError> {
         self.rpc(
             crate::protocols::backup_management::IMPORT_BACKUP,
             serde_json::json!({ "backup": backup, "password": password, "confirm": confirm }),
@@ -605,7 +760,7 @@ impl VtaClient {
 
     // ── Config ──────────────────────────────────────────────────────
 
-    pub async fn get_config(&self) -> Result<ConfigResponse, Box<dyn std::error::Error>> {
+    pub async fn get_config(&self) -> Result<ConfigResponse, VtaError> {
         self.rpc(
             vta_management::GET_CONFIG,
             serde_json::json!({}),
@@ -619,7 +774,7 @@ impl VtaClient {
     pub async fn update_config(
         &self,
         req: UpdateConfigRequest,
-    ) -> Result<ConfigResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ConfigResponse, VtaError> {
         self.rpc(
             vta_management::UPDATE_CONFIG,
             serde_json::to_value(&req)?,
@@ -635,7 +790,7 @@ impl VtaClient {
     pub async fn create_key(
         &self,
         req: CreateKeyRequest,
-    ) -> Result<CreateKeyResponse, Box<dyn std::error::Error>> {
+    ) -> Result<CreateKeyResponse, VtaError> {
         self.rpc(
             key_management::CREATE_KEY,
             serde_json::json!({
@@ -658,7 +813,7 @@ impl VtaClient {
         limit: u64,
         status: Option<&str>,
         context_id: Option<&str>,
-    ) -> Result<ListKeysResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ListKeysResponse, VtaError> {
         self.rpc(
             key_management::LIST_KEYS,
             serde_json::json!({
@@ -683,7 +838,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn get_key(&self, key_id: &str) -> Result<KeyRecord, Box<dyn std::error::Error>> {
+    pub async fn get_key(&self, key_id: &str) -> Result<KeyRecord, VtaError> {
         self.rpc(
             key_management::GET_KEY,
             serde_json::json!({ "key_id": key_id }),
@@ -697,7 +852,7 @@ impl VtaClient {
     pub async fn get_key_secret(
         &self,
         key_id: &str,
-    ) -> Result<GetKeySecretResponse, Box<dyn std::error::Error>> {
+    ) -> Result<GetKeySecretResponse, VtaError> {
         self.rpc(
             key_management::GET_KEY_SECRET,
             serde_json::json!({ "key_id": key_id }),
@@ -717,7 +872,7 @@ impl VtaClient {
         key_id: &str,
         payload: &[u8],
         algorithm: SignAlgorithm,
-    ) -> Result<SignResponse, Box<dyn std::error::Error>> {
+    ) -> Result<SignResponse, VtaError> {
         use base64::Engine;
         let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
         self.rpc(
@@ -743,7 +898,7 @@ impl VtaClient {
     pub async fn invalidate_key(
         &self,
         key_id: &str,
-    ) -> Result<InvalidateKeyResponse, Box<dyn std::error::Error>> {
+    ) -> Result<InvalidateKeyResponse, VtaError> {
         self.rpc(
             key_management::REVOKE_KEY,
             serde_json::json!({ "key_id": key_id }),
@@ -758,7 +913,7 @@ impl VtaClient {
         &self,
         key_id: &str,
         new_key_id: &str,
-    ) -> Result<RenameKeyResponse, Box<dyn std::error::Error>> {
+    ) -> Result<RenameKeyResponse, VtaError> {
         self.rpc(
             key_management::RENAME_KEY,
             serde_json::json!({ "key_id": key_id, "new_key_id": new_key_id }),
@@ -777,20 +932,22 @@ impl VtaClient {
     // ── Import key methods ──────────────────────────────────────────
 
     /// Fetch an ephemeral wrapping key for REST key import.
-    pub async fn get_wrapping_key(&self) -> Result<WrappingKeyResponse, Box<dyn std::error::Error>> {
+    pub async fn get_wrapping_key(&self) -> Result<WrappingKeyResponse, VtaError> {
         match &self.transport {
             Transport::Rest {
                 client,
                 base_url,
-                token,
+                auth,
             } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
                 let req = client.get(format!("{base_url}/keys/import/wrapping-key"));
-                let resp = Self::with_auth(req, token).send().await?;
+                let resp = Self::with_auth_token(req, &token).send().await?;
                 Self::handle_response(resp).await
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {
-                Err("wrapping key not needed for DIDComm transport".into())
+                Err(VtaError::Other("wrapping key not needed for DIDComm transport".into()))
             }
         }
     }
@@ -799,7 +956,7 @@ impl VtaClient {
     pub async fn import_key(
         &self,
         req: ImportKeyRequest,
-    ) -> Result<ImportKeyResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ImportKeyResponse, VtaError> {
         self.rpc(
             key_management::IMPORT_KEY,
             serde_json::to_value(&req)?,
@@ -812,7 +969,7 @@ impl VtaClient {
 
     // ── Seed methods ────────────────────────────────────────────────
 
-    pub async fn list_seeds(&self) -> Result<ListSeedsResponse, Box<dyn std::error::Error>> {
+    pub async fn list_seeds(&self) -> Result<ListSeedsResponse, VtaError> {
         self.rpc(
             seed_management::LIST_SEEDS,
             serde_json::json!({}),
@@ -826,7 +983,7 @@ impl VtaClient {
     pub async fn rotate_seed(
         &self,
         mnemonic: Option<String>,
-    ) -> Result<RotateSeedResponse, Box<dyn std::error::Error>> {
+    ) -> Result<RotateSeedResponse, VtaError> {
         let body = RotateSeedRequest {
             mnemonic: mnemonic.clone(),
         };
@@ -845,7 +1002,7 @@ impl VtaClient {
     pub async fn list_acl(
         &self,
         context: Option<&str>,
-    ) -> Result<AclListResponse, Box<dyn std::error::Error>> {
+    ) -> Result<AclListResponse, VtaError> {
         self.rpc(
             acl_management::LIST_ACL,
             serde_json::json!({ "context": context }),
@@ -862,7 +1019,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn get_acl(&self, did: &str) -> Result<AclEntryResponse, Box<dyn std::error::Error>> {
+    pub async fn get_acl(&self, did: &str) -> Result<AclEntryResponse, VtaError> {
         self.rpc(
             acl_management::GET_ACL,
             serde_json::json!({ "did": did }),
@@ -876,7 +1033,7 @@ impl VtaClient {
     pub async fn create_acl(
         &self,
         req: CreateAclRequest,
-    ) -> Result<AclEntryResponse, Box<dyn std::error::Error>> {
+    ) -> Result<AclEntryResponse, VtaError> {
         self.rpc(
             acl_management::CREATE_ACL,
             serde_json::to_value(&req)?,
@@ -891,7 +1048,7 @@ impl VtaClient {
         &self,
         did: &str,
         req: UpdateAclRequest,
-    ) -> Result<AclEntryResponse, Box<dyn std::error::Error>> {
+    ) -> Result<AclEntryResponse, VtaError> {
         self.rpc(
             acl_management::UPDATE_ACL,
             serde_json::json!({
@@ -910,7 +1067,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn delete_acl(&self, did: &str) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn delete_acl(&self, did: &str) -> Result<(), VtaError> {
         self.rpc_void(
             acl_management::DELETE_ACL,
             serde_json::json!({ "did": did }),
@@ -926,7 +1083,7 @@ impl VtaClient {
     pub async fn generate_credentials(
         &self,
         req: GenerateCredentialsRequest,
-    ) -> Result<GenerateCredentialsResponse, Box<dyn std::error::Error>> {
+    ) -> Result<GenerateCredentialsResponse, VtaError> {
         self.rpc(
             credential_management::GENERATE_CREDENTIALS,
             serde_json::to_value(&req)?,
@@ -939,7 +1096,7 @@ impl VtaClient {
 
     // ── Context methods ──────────────────────────────────────────────
 
-    pub async fn list_contexts(&self) -> Result<ContextListResponse, Box<dyn std::error::Error>> {
+    pub async fn list_contexts(&self) -> Result<ContextListResponse, VtaError> {
         self.rpc(
             context_management::LIST_CONTEXTS,
             serde_json::json!({}),
@@ -953,7 +1110,7 @@ impl VtaClient {
     pub async fn get_context(
         &self,
         id: &str,
-    ) -> Result<ContextResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ContextResponse, VtaError> {
         self.rpc(
             context_management::GET_CONTEXT,
             serde_json::json!({ "id": id }),
@@ -967,7 +1124,7 @@ impl VtaClient {
     pub async fn create_context(
         &self,
         req: CreateContextRequest,
-    ) -> Result<ContextResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ContextResponse, VtaError> {
         self.rpc(
             context_management::CREATE_CONTEXT,
             serde_json::to_value(&req)?,
@@ -982,7 +1139,7 @@ impl VtaClient {
         &self,
         id: &str,
         req: UpdateContextRequest,
-    ) -> Result<ContextResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ContextResponse, VtaError> {
         self.rpc(
             context_management::UPDATE_CONTEXT,
             serde_json::json!({
@@ -1006,7 +1163,7 @@ impl VtaClient {
         id: &str,
     ) -> Result<
         context_management::delete::DeleteContextPreviewResultBody,
-        Box<dyn std::error::Error>,
+        VtaError,
     > {
         self.rpc(
             context_management::PREVIEW_DELETE_CONTEXT,
@@ -1018,7 +1175,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn delete_context(&self, id: &str, force: bool) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn delete_context(&self, id: &str, force: bool) -> Result<(), VtaError> {
         self.rpc_void(
             context_management::DELETE_CONTEXT,
             serde_json::json!({ "id": id, "force": force }),
@@ -1040,7 +1197,7 @@ impl VtaClient {
     pub async fn add_webvh_server(
         &self,
         req: AddWebvhServerRequest,
-    ) -> Result<crate::webvh::WebvhServerRecord, Box<dyn std::error::Error>> {
+    ) -> Result<crate::webvh::WebvhServerRecord, VtaError> {
         self.rpc(
             did_management::ADD_WEBVH_SERVER,
             serde_json::to_value(&req)?,
@@ -1055,7 +1212,7 @@ impl VtaClient {
         &self,
     ) -> Result<
         crate::protocols::did_management::servers::ListWebvhServersResultBody,
-        Box<dyn std::error::Error>,
+        VtaError,
     > {
         self.rpc(
             did_management::LIST_WEBVH_SERVERS,
@@ -1071,7 +1228,7 @@ impl VtaClient {
         &self,
         id: &str,
         req: UpdateWebvhServerRequest,
-    ) -> Result<crate::webvh::WebvhServerRecord, Box<dyn std::error::Error>> {
+    ) -> Result<crate::webvh::WebvhServerRecord, VtaError> {
         self.rpc(
             did_management::UPDATE_WEBVH_SERVER,
             serde_json::json!({ "id": id, "label": &req.label }),
@@ -1085,7 +1242,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn remove_webvh_server(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn remove_webvh_server(&self, id: &str) -> Result<(), VtaError> {
         self.rpc_void(
             did_management::REMOVE_WEBVH_SERVER,
             serde_json::json!({ "id": id }),
@@ -1103,7 +1260,7 @@ impl VtaClient {
         req: CreateDidWebvhRequest,
     ) -> Result<
         crate::protocols::did_management::create::CreateDidWebvhResultBody,
-        Box<dyn std::error::Error>,
+        VtaError,
     > {
         self.rpc(
             did_management::CREATE_DID_WEBVH,
@@ -1121,7 +1278,7 @@ impl VtaClient {
         server_id: Option<&str>,
     ) -> Result<
         crate::protocols::did_management::list::ListDidsWebvhResultBody,
-        Box<dyn std::error::Error>,
+        VtaError,
     > {
         self.rpc(
             did_management::LIST_DIDS_WEBVH,
@@ -1150,7 +1307,7 @@ impl VtaClient {
     pub async fn get_did_webvh(
         &self,
         did: &str,
-    ) -> Result<crate::webvh::WebvhDidRecord, Box<dyn std::error::Error>> {
+    ) -> Result<crate::webvh::WebvhDidRecord, VtaError> {
         self.rpc(
             did_management::GET_DID_WEBVH,
             serde_json::json!({ "did": did }),
@@ -1164,7 +1321,7 @@ impl VtaClient {
     pub async fn get_did_webvh_log(
         &self,
         did: &str,
-    ) -> Result<GetDidLogResponse, Box<dyn std::error::Error>> {
+    ) -> Result<GetDidLogResponse, VtaError> {
         self.rpc(
             did_management::GET_DID_WEBVH_LOG,
             serde_json::json!({ "did": did }),
@@ -1175,7 +1332,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn delete_did_webvh(&self, did: &str) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn delete_did_webvh(&self, did: &str) -> Result<(), VtaError> {
         self.rpc_void(
             did_management::DELETE_DID_WEBVH,
             serde_json::json!({ "did": did }),
@@ -1192,7 +1349,7 @@ impl VtaClient {
     pub async fn list_audit_logs(
         &self,
         params: &crate::protocols::audit_management::list::ListAuditLogsBody,
-    ) -> Result<crate::protocols::audit_management::list::ListAuditLogsResultBody, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::audit_management::list::ListAuditLogsResultBody, VtaError> {
         use crate::protocols::audit_management;
         self.rpc(
             audit_management::LIST_LOGS,
@@ -1219,7 +1376,7 @@ impl VtaClient {
     /// Get the current audit log retention period.
     pub async fn get_audit_retention(
         &self,
-    ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, VtaError> {
         use crate::protocols::audit_management;
         self.rpc(
             audit_management::GET_RETENTION,
@@ -1235,7 +1392,7 @@ impl VtaClient {
     pub async fn update_audit_retention(
         &self,
         retention_days: u32,
-    ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, VtaError> {
         use crate::protocols::audit_management;
         let body = audit_management::retention::UpdateRetentionBody { retention_days };
         self.rpc(
@@ -1246,6 +1403,67 @@ impl VtaClient {
             |c, url| c.patch(format!("{url}/audit/retention")).json(&body),
         )
         .await
+    }
+
+    // ── Convenience methods ────────────────────────────────────────
+
+    /// Fetch all secrets for a context, paginating through all keys.
+    ///
+    /// Returns TDK `Secret` objects ready for use with DIDComm or signing.
+    pub async fn fetch_context_secrets(
+        &self,
+        context_id: &str,
+    ) -> Result<Vec<affinidi_tdk::secrets_resolver::secrets::Secret>, VtaError> {
+        let page_size = 100u64;
+        let mut offset = 0u64;
+        let mut secrets = Vec::new();
+
+        loop {
+            let resp = self
+                .list_keys(offset, page_size, Some("active"), Some(context_id))
+                .await?;
+
+            if resp.keys.is_empty() {
+                break;
+            }
+
+            for key in &resp.keys {
+                let secret_resp = self.get_key_secret(&key.key_id).await?;
+                let secret = crate::did_key::secret_from_key_response(&secret_resp)?;
+                secrets.push(secret);
+            }
+
+            offset += resp.keys.len() as u64;
+            if offset >= resp.total {
+                break;
+            }
+        }
+
+        Ok(secrets)
+    }
+
+    /// Check whether the current auth token is valid by calling an authenticated endpoint.
+    ///
+    /// Returns `true` if authenticated, `false` if the token is invalid/expired.
+    /// Returns an error only on network failures.
+    pub async fn check_auth(&self) -> Result<bool, VtaError> {
+        match &self.transport {
+            Transport::Rest {
+                client,
+                base_url,
+                auth,
+            } => {
+                let token = auth.lock().await.token.clone();
+                let req = client.get(format!("{base_url}/health/details"));
+                let resp = Self::with_auth_token(req, &token).send().await?;
+                Ok(resp.status().is_success())
+            }
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => {
+                // DIDComm sessions are always authenticated
+                Ok(true)
+            }
+        }
     }
 }
 
@@ -1316,22 +1534,24 @@ mod tests {
         assert_eq!(client.base_url(), "http://localhost:3000");
     }
 
-    #[test]
-    fn test_new_token_initially_none() {
+    #[tokio::test]
+    async fn test_new_token_initially_none() {
         let client = VtaClient::new("http://example.com");
         match &client.transport {
-            Transport::Rest { token, .. } => assert!(token.is_none()),
+            Transport::Rest { auth, .. } => assert!(auth.lock().await.token.is_none()),
             #[cfg(feature = "session")]
             _ => panic!("expected REST transport"),
         }
     }
 
-    #[test]
-    fn test_set_token() {
-        let mut client = VtaClient::new("http://example.com");
+    #[tokio::test]
+    async fn test_set_token() {
+        let client = VtaClient::new("http://example.com");
         client.set_token("my-jwt".to_string());
         match &client.transport {
-            Transport::Rest { token, .. } => assert_eq!(token.as_deref(), Some("my-jwt")),
+            Transport::Rest { auth, .. } => {
+                assert_eq!(auth.lock().await.token.as_deref(), Some("my-jwt"));
+            }
             #[cfg(feature = "session")]
             _ => panic!("expected REST transport"),
         }

--- a/vta-sdk/src/didcomm_light.rs
+++ b/vta-sdk/src/didcomm_light.rs
@@ -1,0 +1,479 @@
+//! Lightweight DIDComm v2 anonymous encryption (anoncrypt) packer.
+//!
+//! Produces a JWE (General JSON Serialization) that can be unpacked by any
+//! DIDComm v2 implementation (including `affinidi-tdk`'s `ATM::unpack()`).
+//!
+//! This module avoids the heavyweight ATM/TDK runtime initialization. It only
+//! needs the recipient's X25519 public key (derived from their `did:key`).
+//!
+//! Algorithm: ECDH-ES+A256KW (key agreement) + A256GCM (content encryption).
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use sha2::{Digest, Sha256};
+use x25519_dalek::{PublicKey, StaticSecret};
+
+const GCM_NONCE_LEN: usize = 12;
+const AES_KEY_LEN: usize = 32;
+
+// ── DIDComm message builder ─────────────────────────────────────────
+
+/// Build a DIDComm v2 plaintext message JSON.
+pub fn build_message(
+    msg_type: &str,
+    body: serde_json::Value,
+    from: &str,
+    to: &str,
+) -> String {
+    serde_json::json!({
+        "id": uuid::Uuid::new_v4().to_string(),
+        "typ": "application/didcomm-plain+json",
+        "type": msg_type,
+        "body": body,
+        "from": from,
+        "to": [to],
+    })
+    .to_string()
+}
+
+// ── JWE anoncrypt packer ────────────────────────────────────────────
+
+/// Pack a plaintext message as a DIDComm v2 anoncrypt JWE (General JSON).
+///
+/// Returns the JWE as a JSON string suitable for sending to `POST /auth/`.
+pub fn pack_anoncrypt(
+    plaintext: &[u8],
+    recipient_x25519_pub: &[u8; 32],
+    recipient_kid: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use aes_gcm::aead::rand_core::RngCore;
+
+    // 1. Generate ephemeral X25519 keypair
+    let ephemeral_secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+    let ephemeral_pub = PublicKey::from(&ephemeral_secret);
+
+    // 2. ECDH: shared secret
+    let recipient_pub = PublicKey::from(*recipient_x25519_pub);
+    let shared_secret = ephemeral_secret.diffie_hellman(&recipient_pub);
+
+    // 3. Build protected header
+    let protected = serde_json::json!({
+        "typ": "application/didcomm-encrypted+json",
+        "alg": "ECDH-ES+A256KW",
+        "enc": "A256GCM",
+        "apu": B64.encode(b""),
+        "apv": B64.encode(Sha256::digest(recipient_kid.as_bytes())),
+        "epk": {
+            "kty": "OKP",
+            "crv": "X25519",
+            "x": B64.encode(ephemeral_pub.as_bytes()),
+        },
+    });
+    let protected_b64 = B64.encode(protected.to_string().as_bytes());
+
+    // 4. Derive key-wrapping key via Concat KDF
+    let apu = b"";
+    let apv = Sha256::digest(recipient_kid.as_bytes());
+    let kek = concat_kdf(shared_secret.as_bytes(), "A256KW", apu, &apv)?;
+
+    // 5. Generate random CEK (32 bytes for AES-256-GCM)
+    let mut cek = [0u8; AES_KEY_LEN];
+    aes_gcm::aead::OsRng.fill_bytes(&mut cek);
+
+    // 6. AES-256 Key Wrap the CEK
+    let encrypted_key = aes_key_wrap(&kek, &cek)?;
+
+    // 7. AES-256-GCM encrypt the plaintext with CEK
+    let cipher = Aes256Gcm::new_from_slice(&cek)
+        .map_err(|e| format!("aes-gcm key: {e}"))?;
+    let mut nonce_bytes = [0u8; GCM_NONCE_LEN];
+    aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    // AAD = protected header (base64url encoded)
+    let ciphertext_with_tag = cipher
+        .encrypt(
+            nonce,
+            aes_gcm::aead::Payload {
+                msg: plaintext,
+                aad: protected_b64.as_bytes(),
+            },
+        )
+        .map_err(|e| format!("aes-gcm encrypt: {e}"))?;
+
+    // Split ciphertext and tag (last 16 bytes is the GCM tag)
+    let tag_start = ciphertext_with_tag.len() - 16;
+    let ciphertext = &ciphertext_with_tag[..tag_start];
+    let tag = &ciphertext_with_tag[tag_start..];
+
+    // 8. Assemble JWE General JSON Serialization
+    let jwe = serde_json::json!({
+        "protected": protected_b64,
+        "recipients": [{
+            "header": { "kid": recipient_kid },
+            "encrypted_key": B64.encode(&encrypted_key),
+        }],
+        "iv": B64.encode(nonce_bytes),
+        "ciphertext": B64.encode(ciphertext),
+        "tag": B64.encode(tag),
+    });
+
+    Ok(jwe.to_string())
+}
+
+// ── Concat KDF (NIST SP 800-56A, single-pass SHA-256) ──────────────
+
+/// Derive a 256-bit key from ECDH shared secret using Concat KDF.
+fn concat_kdf(
+    z: &[u8],
+    algorithm: &str,
+    apu: &[u8],
+    apv: &[u8],
+) -> Result<[u8; 32], Box<dyn std::error::Error>> {
+    let mut hasher = Sha256::new();
+
+    // counter = 00000001
+    hasher.update(1u32.to_be_bytes());
+
+    // Z = shared secret
+    hasher.update(z);
+
+    // OtherInfo:
+    // AlgorithmID = len(4 BE) || algorithm
+    hasher.update((algorithm.len() as u32).to_be_bytes());
+    hasher.update(algorithm.as_bytes());
+
+    // PartyUInfo = len(4 BE) || apu
+    hasher.update((apu.len() as u32).to_be_bytes());
+    hasher.update(apu);
+
+    // PartyVInfo = len(4 BE) || apv
+    hasher.update((apv.len() as u32).to_be_bytes());
+    hasher.update(apv);
+
+    // SuppPubInfo = keydatalen in bits (256) as 32-bit BE
+    hasher.update(256u32.to_be_bytes());
+
+    let result = hasher.finalize();
+    Ok(result.into())
+}
+
+// ── AES-256 Key Wrap (RFC 3394) ─────────────────────────────────────
+
+/// Wrap a key using AES-256 Key Wrap (RFC 3394).
+///
+/// Input: 32-byte KEK, key to wrap (multiple of 8 bytes).
+/// Output: wrapped key (input_len + 8 bytes).
+fn aes_key_wrap(kek: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use aes::cipher::{BlockEncrypt, KeyInit as AesKeyInit};
+    use aes::Aes256;
+
+    if plaintext.len() % 8 != 0 || plaintext.is_empty() {
+        return Err("key wrap input must be a non-empty multiple of 8 bytes".into());
+    }
+
+    let n = plaintext.len() / 8;
+    let cipher = Aes256::new_from_slice(kek)
+        .map_err(|e| format!("aes key wrap: {e}"))?;
+
+    // Initialize: A = IV (0xA6 repeated 8 times), R[1..n] = plaintext blocks
+    let mut a = [0xA6u8; 8];
+    let mut r: Vec<[u8; 8]> = plaintext
+        .chunks_exact(8)
+        .map(|c| {
+            let mut block = [0u8; 8];
+            block.copy_from_slice(c);
+            block
+        })
+        .collect();
+
+    // Wrap: 6 rounds
+    for j in 0..6u64 {
+        for i in 0..n {
+            let t = (n as u64) * j + (i as u64) + 1;
+
+            // B = AES(K, A || R[i])
+            let mut block = aes::Block::default();
+            block[..8].copy_from_slice(&a);
+            block[8..].copy_from_slice(&r[i]);
+            cipher.encrypt_block(&mut block);
+
+            // A = MSB(64, B) ^ t
+            a.copy_from_slice(&block[..8]);
+            let t_bytes = t.to_be_bytes();
+            for k in 0..8 {
+                a[k] ^= t_bytes[k];
+            }
+
+            // R[i] = LSB(64, B)
+            r[i].copy_from_slice(&block[8..]);
+        }
+    }
+
+    // Output: A || R[1] || R[2] || ... || R[n]
+    let mut output = Vec::with_capacity(8 + plaintext.len());
+    output.extend_from_slice(&a);
+    for block in &r {
+        output.extend_from_slice(block);
+    }
+    Ok(output)
+}
+
+/// Unwrap a key using AES-256 Key Unwrap (RFC 3394). Used for testing.
+#[cfg(test)]
+fn aes_key_unwrap(kek: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use aes::cipher::{BlockDecrypt, KeyInit as AesKeyInit};
+    use aes::Aes256;
+
+    if ciphertext.len() % 8 != 0 || ciphertext.len() < 24 {
+        return Err("key unwrap input must be at least 24 bytes and a multiple of 8".into());
+    }
+
+    let n = (ciphertext.len() / 8) - 1;
+    let cipher = Aes256::new_from_slice(kek)?;
+
+    let mut a = [0u8; 8];
+    a.copy_from_slice(&ciphertext[..8]);
+    let mut r: Vec<[u8; 8]> = ciphertext[8..]
+        .chunks_exact(8)
+        .map(|c| {
+            let mut block = [0u8; 8];
+            block.copy_from_slice(c);
+            block
+        })
+        .collect();
+
+    for j in (0..6u64).rev() {
+        for i in (0..n).rev() {
+            let t = (n as u64) * j + (i as u64) + 1;
+
+            let t_bytes = t.to_be_bytes();
+            for k in 0..8 {
+                a[k] ^= t_bytes[k];
+            }
+
+            let mut block = aes::Block::default();
+            block[..8].copy_from_slice(&a);
+            block[8..].copy_from_slice(&r[i]);
+            cipher.decrypt_block(&mut block);
+
+            a.copy_from_slice(&block[..8]);
+            r[i].copy_from_slice(&block[8..]);
+        }
+    }
+
+    if a != [0xA6u8; 8] {
+        return Err("key unwrap integrity check failed".into());
+    }
+
+    let mut output = Vec::with_capacity(n * 8);
+    for block in &r {
+        output.extend_from_slice(block);
+    }
+    Ok(output)
+}
+
+// ── did:key → X25519 public key conversion ──────────────────────────
+
+/// Extract the Ed25519 public key bytes from a `did:key:z6Mk...` identifier.
+pub fn parse_did_key_ed25519(did: &str) -> Result<[u8; 32], Box<dyn std::error::Error>> {
+    let multibase_part = did
+        .strip_prefix("did:key:")
+        .ok_or("not a did:key")?;
+    let (_, decoded) = multibase::decode(multibase_part)?;
+    // Expect 34 bytes: 2-byte multicodec (0xed 0x01) + 32-byte key
+    if decoded.len() != 34 || decoded[0] != 0xed || decoded[1] != 0x01 {
+        return Err("invalid did:key: expected Ed25519 multicodec prefix 0xed01".into());
+    }
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&decoded[2..]);
+    Ok(key)
+}
+
+/// Convert an Ed25519 public key to an X25519 public key (Edwards → Montgomery).
+pub fn ed25519_pub_to_x25519_pub(ed_pub: &[u8; 32]) -> Result<[u8; 32], Box<dyn std::error::Error>> {
+    let compressed = curve25519_dalek::edwards::CompressedEdwardsY(*ed_pub);
+    let edwards = compressed
+        .decompress()
+        .ok_or("invalid Ed25519 public key: decompression failed")?;
+    Ok(edwards.to_montgomery().to_bytes())
+}
+
+/// Derive the X25519 key-agreement key ID for a `did:key`.
+///
+/// Given `did:key:z6Mk...`, returns `did:key:z6Mk...#z6LS...` where the
+/// fragment is the X25519 public key encoded with multicodec `0xec01`.
+pub fn did_key_agreement_kid(did: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let ed_pub = parse_did_key_ed25519(did)?;
+    let x_pub = ed25519_pub_to_x25519_pub(&ed_pub)?;
+    let mut buf = Vec::with_capacity(34);
+    buf.extend_from_slice(&[0xec, 0x01]); // x25519-pub multicodec
+    buf.extend_from_slice(&x_pub);
+    let x_multibase = multibase::encode(multibase::Base::Base58Btc, &buf);
+    Ok(format!("{did}#{x_multibase}"))
+}
+
+/// Convert an Ed25519 seed (private key) to X25519 static secret bytes.
+pub fn ed25519_seed_to_x25519_secret(seed: &[u8; 32]) -> [u8; 32] {
+    // Standard Ed25519→X25519 conversion: SHA-512(seed)[0..32] with clamping
+    let hash = sha2::Sha512::digest(seed);
+    let mut x25519_bytes = [0u8; 32];
+    x25519_bytes.copy_from_slice(&hash[..32]);
+    // Clamping (applied by StaticSecret::from, but be explicit)
+    x25519_bytes[0] &= 248;
+    x25519_bytes[31] &= 127;
+    x25519_bytes[31] |= 64;
+    x25519_bytes
+}
+
+// ── High-level: pack auth message ───────────────────────────────────
+
+/// Pack a DIDComm v2 authenticate message for VTA challenge-response.
+///
+/// This is the lightweight equivalent of `atm.pack_encrypted()` — it produces
+/// a JWE that the server's ATM can unpack, without needing ATM initialization.
+pub fn pack_auth_message(
+    msg_type: &str,
+    body: serde_json::Value,
+    client_did: &str,
+    vta_did: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let plaintext = build_message(msg_type, body, client_did, vta_did);
+
+    // Get recipient's X25519 public key from their did:key
+    let ed_pub = parse_did_key_ed25519(vta_did)?;
+    let x_pub = ed25519_pub_to_x25519_pub(&ed_pub)?;
+    let kid = did_key_agreement_kid(vta_did)?;
+
+    pack_anoncrypt(plaintext.as_bytes(), &x_pub, &kid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_aes_key_wrap_roundtrip() {
+        let kek = [42u8; 32];
+        let plaintext = [1u8; 32]; // 32 bytes = 4 blocks of 8
+
+        let wrapped = aes_key_wrap(&kek, &plaintext).unwrap();
+        assert_eq!(wrapped.len(), 40); // 32 + 8
+
+        let unwrapped = aes_key_unwrap(&kek, &wrapped).unwrap();
+        assert_eq!(unwrapped, plaintext);
+    }
+
+    #[test]
+    fn test_aes_key_wrap_different_keys_different_output() {
+        let kek1 = [1u8; 32];
+        let kek2 = [2u8; 32];
+        let plaintext = [99u8; 32];
+
+        let w1 = aes_key_wrap(&kek1, &plaintext).unwrap();
+        let w2 = aes_key_wrap(&kek2, &plaintext).unwrap();
+        assert_ne!(w1, w2);
+    }
+
+    #[test]
+    fn test_concat_kdf_deterministic() {
+        let z = [0u8; 32];
+        let k1 = concat_kdf(&z, "A256KW", b"", b"recipient").unwrap();
+        let k2 = concat_kdf(&z, "A256KW", b"", b"recipient").unwrap();
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn test_concat_kdf_different_algorithms() {
+        let z = [0u8; 32];
+        let k1 = concat_kdf(&z, "A256KW", b"", b"x").unwrap();
+        let k2 = concat_kdf(&z, "A128KW", b"", b"x").unwrap();
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn test_parse_did_key_ed25519() {
+        // Create a known did:key from a known public key
+        let pub_bytes = [42u8; 32];
+        let did = format!(
+            "did:key:{}",
+            crate::did_key::ed25519_multibase_pubkey(&pub_bytes)
+        );
+        let parsed = parse_did_key_ed25519(&did).unwrap();
+        assert_eq!(parsed, pub_bytes);
+    }
+
+    #[test]
+    fn test_ed25519_to_x25519_conversion() {
+        // Generate an Ed25519 key pair and verify conversion produces valid X25519
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+        let ed_pub = verifying_key.to_bytes();
+
+        let x_pub = ed25519_pub_to_x25519_pub(&ed_pub).unwrap();
+        assert_ne!(x_pub, [0u8; 32]); // Should not be all zeros
+    }
+
+    #[test]
+    fn test_did_key_agreement_kid() {
+        let pub_bytes = [42u8; 32];
+        let did = format!(
+            "did:key:{}",
+            crate::did_key::ed25519_multibase_pubkey(&pub_bytes)
+        );
+        let kid = did_key_agreement_kid(&did).unwrap();
+        assert!(kid.starts_with(&did));
+        assert!(kid.contains('#'));
+        // The fragment should be an X25519 multibase (starts with z after #)
+        let fragment = kid.split('#').nth(1).unwrap();
+        assert!(fragment.starts_with('z'));
+    }
+
+    #[test]
+    fn test_pack_anoncrypt_produces_valid_jwe() {
+        let recipient_secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+        let recipient_pub = PublicKey::from(&recipient_secret);
+
+        let jwe_str = pack_anoncrypt(
+            b"hello world",
+            recipient_pub.as_bytes(),
+            "did:key:test#key-1",
+        )
+        .unwrap();
+
+        let jwe: serde_json::Value = serde_json::from_str(&jwe_str).unwrap();
+        assert!(jwe["protected"].is_string());
+        assert!(jwe["recipients"].is_array());
+        assert_eq!(jwe["recipients"].as_array().unwrap().len(), 1);
+        assert!(jwe["iv"].is_string());
+        assert!(jwe["ciphertext"].is_string());
+        assert!(jwe["tag"].is_string());
+
+        // Verify protected header
+        let protected_json: serde_json::Value = serde_json::from_slice(
+            &B64.decode(jwe["protected"].as_str().unwrap()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(protected_json["alg"], "ECDH-ES+A256KW");
+        assert_eq!(protected_json["enc"], "A256GCM");
+        assert_eq!(protected_json["typ"], "application/didcomm-encrypted+json");
+    }
+
+    #[test]
+    fn test_build_message_structure() {
+        let msg = build_message(
+            "https://example.com/test",
+            serde_json::json!({"foo": "bar"}),
+            "did:key:sender",
+            "did:key:recipient",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        assert_eq!(parsed["type"], "https://example.com/test");
+        assert_eq!(parsed["from"], "did:key:sender");
+        assert_eq!(parsed["to"][0], "did:key:recipient");
+        assert_eq!(parsed["body"]["foo"], "bar");
+        assert!(parsed["id"].is_string());
+    }
+}

--- a/vta-sdk/src/error.rs
+++ b/vta-sdk/src/error.rs
@@ -1,0 +1,115 @@
+//! Structured error type for VTA SDK operations.
+
+/// Errors returned by VTA SDK client operations.
+#[derive(Debug, thiserror::Error)]
+pub enum VtaError {
+    /// Network-level error (connection refused, timeout, DNS failure).
+    #[cfg(feature = "client")]
+    #[error("network error: {0}")]
+    Network(#[from] reqwest::Error),
+
+    /// Authentication failed (401) or token expired.
+    #[error("authentication failed: {0}")]
+    Auth(String),
+
+    /// Resource not found (404).
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// Request validation error (400).
+    #[error("validation error: {0}")]
+    Validation(String),
+
+    /// Permission denied (403).
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+
+    /// Conflict (409) — e.g. duplicate key ID.
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// Server error (5xx).
+    #[error("server error ({status}): {body}")]
+    Server { status: u16, body: String },
+
+    /// Protocol error (e.g. unexpected DIDComm message type).
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
+    /// Serialization/deserialization error.
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    /// Catch-all for other errors.
+    #[error("{0}")]
+    Other(String),
+}
+
+impl VtaError {
+    /// Create from an HTTP response status and error body.
+    #[cfg(feature = "client")]
+    pub(crate) fn from_http(status: reqwest::StatusCode, body: String) -> Self {
+        match status.as_u16() {
+            401 => Self::Auth(body),
+            403 => Self::Forbidden(body),
+            404 => Self::NotFound(body),
+            400 | 422 => Self::Validation(body),
+            409 => Self::Conflict(body),
+            s if s >= 500 => Self::Server {
+                status: s,
+                body,
+            },
+            s => Self::Other(format!("{s}: {body}")),
+        }
+    }
+
+    /// Returns true if this is an authentication/authorization error.
+    pub fn is_auth(&self) -> bool {
+        matches!(self, Self::Auth(_) | Self::Forbidden(_))
+    }
+
+    /// Returns true if this is a network-level error (retryable).
+    pub fn is_network(&self) -> bool {
+        #[cfg(feature = "client")]
+        if matches!(self, Self::Network(_)) {
+            return true;
+        }
+        false
+    }
+
+    /// Returns true if the resource was not found.
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, Self::NotFound(_))
+    }
+}
+
+impl From<String> for VtaError {
+    fn from(s: String) -> Self {
+        Self::Other(s)
+    }
+}
+
+impl From<&str> for VtaError {
+    fn from(s: &str) -> Self {
+        Self::Other(s.to_string())
+    }
+}
+
+// Allow converting from Box<dyn Error> for backward compat during migration
+impl From<Box<dyn std::error::Error>> for VtaError {
+    fn from(e: Box<dyn std::error::Error>) -> Self {
+        Self::Other(e.to_string())
+    }
+}
+
+impl From<crate::credentials::CredentialBundleError> for VtaError {
+    fn from(e: crate::credentials::CredentialBundleError) -> Self {
+        Self::Validation(e.to_string())
+    }
+}
+
+impl From<crate::did_key::DidKeyError> for VtaError {
+    fn from(e: crate::did_key::DidKeyError) -> Self {
+        Self::Other(e.to_string())
+    }
+}

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -1,9 +1,15 @@
+pub mod error;
+
+#[cfg(feature = "client")]
+pub mod auth_light;
 #[cfg(feature = "client")]
 pub mod client;
 pub mod context_provision;
 pub mod contexts;
 pub mod credentials;
 pub mod did_key;
+#[cfg(feature = "client")]
+pub mod didcomm_light;
 pub mod did_secrets;
 #[cfg(feature = "didcomm")]
 pub mod didcomm_init;

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -541,7 +541,7 @@ impl SessionStore {
         if let Some(url) = url_override {
             debug!(url, "using REST transport (URL override)");
             let token = self.ensure_authenticated(url, key).await?;
-            let mut client = crate::client::VtaClient::new(url);
+            let client = crate::client::VtaClient::new(url);
             client.set_token(token);
             return Ok(client);
         }
@@ -567,7 +567,7 @@ impl SessionStore {
             VtaEndpoint::Rest { url } => {
                 debug!(url = %url, "connecting via REST");
                 let token = self.ensure_authenticated(&url, key).await?;
-                let mut client = crate::client::VtaClient::new(&url);
+                let client = crate::client::VtaClient::new(&url);
                 client.set_token(token);
                 Ok(client)
             }


### PR DESCRIPTION
## Summary

- **Lightweight DIDComm auth** (`auth_light`): challenge-response and token refresh without ATM/TDK runtime initialization, using a hand-rolled JWE packer (ECDH-ES+A256KW + A256GCM). Works with just the `client` feature.
- **`VtaClient::from_credential()`**: one-line constructor from a base64 credential bundle with automatic token refresh
- **Auto-refresh in `rpc()`**: checks token expiry (30s buffer) before each call; tries `/auth/refresh` first, falls back to full challenge-response
- **`fetch_context_secrets()`**: paginated secret fetching (batches of 100) returning TDK `Secret` objects
- **`check_auth()`**: token validity check via `GET /health/details` for service readiness probes

### New modules
- `vta-sdk/src/didcomm_light.rs` — Minimal DIDComm v2 anoncrypt JWE packer: Concat KDF (NIST SP 800-56A), AES-256 Key Wrap (RFC 3394), did:key → X25519 conversion, A256GCM content encryption
- `vta-sdk/src/auth_light.rs` — `challenge_response_light()`, `refresh_token_light()`, `authenticate_with_credential()`

### Breaking changes
- `set_token()` signature changed from `&mut self` to `&self` (callers no longer need `mut`)
- Internal `Transport::Rest` now uses `tokio::sync::Mutex<RestAuth>` for thread-safe auto-refresh

## Test plan
- [x] 8 new unit tests in `didcomm_light`: key wrap roundtrip, KDF determinism, did:key parsing, Ed25519→X25519 conversion, JWE structure validation
- [x] Updated client tests for async mutex-based auth state
- [x] All 239 tests pass (`cargo test --workspace`)
- [x] Clean build (`cargo build --workspace`)
- [ ] Integration test: `VtaClient::from_credential()` against running VTA
- [ ] Integration test: auto-refresh after token expiry
- [ ] Integration test: `fetch_context_secrets()` with multi-page key set