### PR TITLE
Add VtaError, prelude, builders, and convenience methods to VTA SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,23 @@
   did:key parsing, Ed25519→X25519 conversion, JWE structure
   validation.
 
+### VTA SDK Ergonomics
+
+- **`vta_sdk::prelude`** — Re-exports the most commonly used
+  types (`VtaClient`, `VtaError`, `KeyRecord`, `KeyType`,
+  `CredentialBundle`, request/response types) for single-line
+  imports.
+- **Builder patterns** — `CreateKeyRequest::new(KeyType::Ed25519)
+  .label("my-key").context("app")` replaces verbose struct
+  construction with many `None` fields. Builders added for
+  `CreateKeyRequest`, `CreateContextRequest`, `CreateAclRequest`,
+  and `GenerateCredentialsRequest`. All accept `impl Into<String>`.
+- **`fetch_did_secrets_bundle()`** — One-call replacement for the
+  4-step pattern (get context → list keys → get secrets → build
+  bundle). Returns a portable `DidSecretsBundle`.
+- **`From<GetKeySecretResponse> for SecretEntry`** — Eliminates
+  manual field-by-field mapping when building secret bundles.
+
 ---
 
 ## 0.2.1 — 2026-03-30

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -90,6 +90,16 @@ pub struct CreateKeyRequest {
     pub context_id: Option<String>,
 }
 
+impl CreateKeyRequest {
+    pub fn new(key_type: KeyType) -> Self {
+        Self { key_type, derivation_path: None, key_id: None, mnemonic: None, label: None, context_id: None }
+    }
+    pub fn derivation_path(mut self, path: impl Into<String>) -> Self { self.derivation_path = Some(path.into()); self }
+    pub fn key_id(mut self, id: impl Into<String>) -> Self { self.key_id = Some(id.into()); self }
+    pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
+    pub fn context(mut self, ctx: impl Into<String>) -> Self { self.context_id = Some(ctx.into()); self }
+}
+
 // ── Import key types ───────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -134,6 +144,13 @@ pub struct CreateContextRequest {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+}
+
+impl CreateContextRequest {
+    pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
+        Self { id: id.into(), name: name.into(), description: None }
+    }
+    pub fn description(mut self, desc: impl Into<String>) -> Self { self.description = Some(desc.into()); self }
 }
 
 #[derive(Debug, Serialize)]
@@ -272,6 +289,14 @@ pub struct CreateAclRequest {
     pub allowed_contexts: Vec<String>,
 }
 
+impl CreateAclRequest {
+    pub fn new(did: impl Into<String>, role: impl Into<String>) -> Self {
+        Self { did: did.into(), role: role.into(), label: None, allowed_contexts: Vec::new() }
+    }
+    pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
+    pub fn contexts(mut self, contexts: Vec<String>) -> Self { self.allowed_contexts = contexts; self }
+}
+
 #[derive(Debug, Serialize)]
 pub struct UpdateAclRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -334,6 +359,14 @@ pub struct GenerateCredentialsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub allowed_contexts: Vec<String>,
+}
+
+impl GenerateCredentialsRequest {
+    pub fn new(role: impl Into<String>) -> Self {
+        Self { role: role.into(), label: None, allowed_contexts: Vec::new() }
+    }
+    pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
+    pub fn contexts(mut self, contexts: Vec<String>) -> Self { self.allowed_contexts = contexts; self }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1440,6 +1473,43 @@ impl VtaClient {
         }
 
         Ok(secrets)
+    }
+
+    /// Fetch all secrets for a context as a portable [`DidSecretsBundle`].
+    ///
+    /// Resolves the context DID, paginates through all active keys,
+    /// fetches each secret, and returns a bundle ready for encoding/transport.
+    pub async fn fetch_did_secrets_bundle(
+        &self,
+        context_id: &str,
+    ) -> Result<crate::did_secrets::DidSecretsBundle, VtaError> {
+        let ctx = self.get_context(context_id).await?;
+        let did = ctx.did.ok_or_else(|| {
+            VtaError::Validation(format!("context '{context_id}' has no DID assigned"))
+        })?;
+
+        let page_size = 100u64;
+        let mut offset = 0u64;
+        let mut secrets = Vec::new();
+
+        loop {
+            let resp = self
+                .list_keys(offset, page_size, Some("active"), Some(context_id))
+                .await?;
+            if resp.keys.is_empty() {
+                break;
+            }
+            for key in &resp.keys {
+                let secret_resp = self.get_key_secret(&key.key_id).await?;
+                secrets.push(crate::did_secrets::SecretEntry::from(secret_resp));
+            }
+            offset += resp.keys.len() as u64;
+            if offset >= resp.total {
+                break;
+            }
+        }
+
+        Ok(crate::did_secrets::DidSecretsBundle { did, secrets })
     }
 
     /// Check whether the current auth token is valid by calling an authenticated endpoint.

--- a/vta-sdk/src/did_secrets.rs
+++ b/vta-sdk/src/did_secrets.rs
@@ -69,6 +69,18 @@ pub struct SecretEntry {
     pub private_key_multibase: String,
 }
 
+/// Convert a [`GetKeySecretResponse`](crate::client::GetKeySecretResponse) into a [`SecretEntry`].
+#[cfg(feature = "client")]
+impl From<crate::client::GetKeySecretResponse> for SecretEntry {
+    fn from(resp: crate::client::GetKeySecretResponse) -> Self {
+        Self {
+            key_id: resp.key_id,
+            key_type: resp.key_type,
+            private_key_multibase: resp.private_key_multibase,
+        }
+    }
+}
+
 impl DidSecretsBundle {
     /// Decode a base64url-no-pad encoded secrets bundle.
     pub fn decode(encoded: &str) -> Result<Self, DidSecretsBundleError> {

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -18,6 +18,7 @@ pub mod didcomm_session;
 #[cfg(feature = "didcomm")]
 pub mod didcomm_transport;
 pub mod keys;
+pub mod prelude;
 pub mod protocols;
 #[cfg(feature = "session")]
 pub mod session;

--- a/vta-sdk/src/prelude.rs
+++ b/vta-sdk/src/prelude.rs
@@ -1,0 +1,40 @@
+//! Convenience re-exports for the most commonly used VTA SDK types.
+//!
+//! ```ignore
+//! use vta_sdk::prelude::*;
+//! ```
+
+// Error
+pub use crate::error::VtaError;
+
+// Keys
+pub use crate::keys::{KeyRecord, KeyStatus, KeyType};
+
+// Contexts
+pub use crate::contexts::ContextRecord;
+
+// Credentials
+pub use crate::credentials::CredentialBundle;
+
+// DID secrets
+pub use crate::did_secrets::{DidSecretsBundle, SecretEntry};
+
+// Client (feature-gated)
+#[cfg(feature = "client")]
+pub use crate::client::{
+    AclEntryResponse, AclListResponse, ConfigResponse, ContextListResponse, ContextResponse,
+    CreateAclRequest, CreateContextRequest, CreateKeyRequest, CreateKeyResponse,
+    GenerateCredentialsRequest, GenerateCredentialsResponse, GetKeySecretResponse,
+    HealthResponse, ImportKeyRequest, ImportKeyResponse, InvalidateKeyResponse,
+    ListKeysResponse, RenameKeyResponse, SignResponse, UpdateAclRequest, UpdateConfigRequest,
+    VtaClient, WrappingKeyResponse,
+};
+
+// DID key utilities
+pub use crate::did_key::{decode_private_key_multibase, ed25519_multibase_pubkey};
+
+#[cfg(feature = "client")]
+pub use crate::did_key::secret_from_key_response;
+
+// Protocols — commonly used request/response bodies
+pub use crate::protocols::audit_management::list::ListAuditLogsBody;


### PR DESCRIPTION
## Summary

SDK ergonomics improvements for application builders:

- **`VtaError` structured error type** — All 40+ client methods now return `Result<T, VtaError>` instead of `Box<dyn Error>`. Variants map to HTTP status codes (`Auth`/401, `NotFound`/404, `Conflict`/409, etc.), enabling programmatic error handling, smart retry, and structured logging. Helper methods: `is_auth()`, `is_network()`, `is_not_found()`.
- **`vta_sdk::prelude`** — Single-line import for `VtaClient`, `VtaError`, `KeyRecord`, `KeyType`, `CredentialBundle`, and all common request/response types.
- **Builder patterns** — `CreateKeyRequest::new(KeyType::Ed25519).label("my-key").context("app")` replaces verbose struct construction. Builders on `CreateKeyRequest`, `CreateContextRequest`, `CreateAclRequest`, `GenerateCredentialsRequest`. All accept `impl Into<String>`.
- **`fetch_did_secrets_bundle()`** — One-call replacement for the 4-step get-context → list-keys → get-secrets → build-bundle pattern.
- **`check_auth()`** — Token validity check for service readiness probes.
- **`From<GetKeySecretResponse> for SecretEntry`** — Eliminates manual field-by-field mapping.
- **Improved cnm-cli conflict handling** — Uses `VtaError::Conflict` match instead of string parsing.

### Breaking changes
- All SDK client methods return `VtaError` instead of `Box<dyn Error>`. Code using `?` with `Box<dyn Error>` return types works automatically since `VtaError` implements `std::error::Error`. Direct `Err(e)` returns need `.into()`.

## Test plan
- [x] All 222 tests pass (`cargo test --workspace`)
- [x] Clean build across all 9 crates (`cargo build --workspace`)
- [x] Existing consumers (pnm-cli, cnm-cli, vta-cli-common, vtc-service) compile without changes (except cnm-cli conflict handling improvement)
- [ ] Verify prelude imports work in downstream projects
- [ ] Verify builder patterns produce correct JSON serialization