### PR TITLE
Release 0.3.0: Integration module, SDK ergonomics, and workspace cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  push:
+    branches: [main, nightly]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-check-
+            ${{ runner.os }}-cargo-
+
+      - run: cargo check --workspace
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
+
+      - run: cargo test --workspace
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-
+            ${{ runner.os }}-cargo-
+
+      - run: cargo clippy --workspace -- -D warnings
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: actions/cache@v4
@@ -37,6 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: actions/cache@v4
@@ -57,6 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.0 — 2026-04-01
+## 0.3.0 — 2026-04-01
 
 ### Reader Role & Action Classification
 
@@ -43,15 +43,7 @@ Super Admin  (Admin + unrestricted)
 
 ### Version Bumps
 
-| Crate          | Old   | New   |
-| -------------- | ----- | ----- |
-| vti-common     | 0.3.0 | 0.4.0 |
-| vta-service    | 0.4.0 | 0.5.0 |
-| vta-cli-common | 0.4.0 | 0.5.0 |
-| pnm-cli        | 0.4.0 | 0.5.0 |
-| cnm-cli        | 0.4.0 | 0.5.0 |
-| vta-enclave    | 0.2.2 | 0.2.3 |
-| vtc-service    | 0.2.2 | 0.2.3 |
+All crates bumped from 0.2.1 to **0.3.0**.
 
 ### Testing
 
@@ -60,10 +52,6 @@ Super Admin  (Admin + unrestricted)
   roles, Initiator/Admin can create Reader), integration tests (Reader
   can list keys, cannot sign, cannot create keys).
 - **Total: 263 tests** (up from 245).
-
----
-
-## 0.4.0 — 2026-04-01
 
 ### VTA SDK Integration Module
 
@@ -112,16 +100,6 @@ Super Admin  (Admin + unrestricted)
 - **`WebvhClient` refactor** — Extracted `send()` and `with_auth()`
   helpers to eliminate repeated request/error-handling boilerplate
   across 4 methods.
-
-### Version Bumps
-
-| Crate          | Old   | New   |
-| -------------- | ----- | ----- |
-| vta-sdk        | 0.3.0 | 0.4.0 |
-| vta-service    | 0.3.0 | 0.4.0 |
-| vta-cli-common | 0.3.0 | 0.4.0 |
-| pnm-cli        | 0.3.0 | 0.4.0 |
-| cnm-cli        | 0.3.0 | 0.4.0 |
 
 ### Code Quality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,23 @@
   did:key parsing, Ed25519→X25519 conversion, JWE structure
   validation.
 
+### VTA SDK Ergonomics
+
+- **`vta_sdk::prelude`** — Re-exports the most commonly used
+  types (`VtaClient`, `VtaError`, `KeyRecord`, `KeyType`,
+  `CredentialBundle`, request/response types) for single-line
+  imports.
+- **Builder patterns** — `CreateKeyRequest::new(KeyType::Ed25519)
+  .label("my-key").context("app")` replaces verbose struct
+  construction with many `None` fields. Builders added for
+  `CreateKeyRequest`, `CreateContextRequest`, `CreateAclRequest`,
+  and `GenerateCredentialsRequest`. All accept `impl Into<String>`.
+- **`fetch_did_secrets_bundle()`** — One-call replacement for the
+  4-step pattern (get context → list keys → get secrets → build
+  bundle). Returns a portable `DidSecretsBundle`.
+- **`From<GetKeySecretResponse> for SecretEntry`** — Eliminates
+  manual field-by-field mapping when building secret bundles.
+
 ---
 
 ## 0.2.1 — 2026-03-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,13 +52,13 @@
 
 ### Version Bumps
 
-| Crate | Old | New |
-|-------|-----|-----|
-| vta-sdk | 0.3.0 | 0.4.0 |
-| vta-service | 0.3.0 | 0.4.0 |
+| Crate          | Old   | New   |
+| -------------- | ----- | ----- |
+| vta-sdk        | 0.3.0 | 0.4.0 |
+| vta-service    | 0.3.0 | 0.4.0 |
 | vta-cli-common | 0.3.0 | 0.4.0 |
-| pnm-cli | 0.3.0 | 0.4.0 |
-| cnm-cli | 0.3.0 | 0.4.0 |
+| pnm-cli        | 0.3.0 | 0.4.0 |
+| cnm-cli        | 0.3.0 | 0.4.0 |
 
 ### Documentation
 
@@ -205,7 +205,7 @@
   `CredentialBundle`, request/response types) for single-line
   imports.
 - **Builder patterns** — `CreateKeyRequest::new(KeyType::Ed25519)
-  .label("my-key").context("app")` replaces verbose struct
+.label("my-key").context("app")` replaces verbose struct
   construction with many `None` fields. Builders added for
   `CreateKeyRequest`, `CreateContextRequest`, `CreateAclRequest`,
   and `GenerateCredentialsRequest`. All accept `impl Into<String>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,51 @@
 | pnm-cli        | 0.3.0 | 0.4.0 |
 | cnm-cli        | 0.3.0 | 0.4.0 |
 
+### Code Quality
+
+- **Zero clippy warnings** — Resolved all clippy warnings across the
+  workspace: collapsible ifs, `.is_multiple_of()`, needless `Ok(?)`,
+  `Default` impl for `WrappingKeyCache`, type alias for complex KMS
+  return type.
+- **`Keyspaces` struct** — New `operations::Keyspaces` bundles keyspace
+  handles with `from_app_state()` and `from_vta_state()` constructors.
+  Reduces argument counts for `export_backup` (11→6), `apply_import`
+  (10→5), `delete_context` (8→5).
+- **`DIDCommSendParams`** — New params struct for `send_and_wait_raw`,
+  replacing 10 positional arguments.
+- **`cargo fmt`** — Full workspace formatting pass.
+
+### Security
+
+- **VTC key material zeroization** — Added `zeroize` dependency to
+  `vtc-service`. Replaced `.unwrap()` on key material slices with
+  proper error propagation. Secrets bundle now written to file
+  instead of stdout (preventing key leakage to logs).
+- **Session error visibility** — Replaced `.ok()?` chains in keyring,
+  file, and Azure session backends with explicit error logging via
+  `tracing::warn`. Users can now diagnose auth failures from logs.
+
+### Architecture
+
+- **Shared `SeedStore` trait** — Extracted seed/secret store trait
+  from `vta-service` into `vti-common/src/seed_store.rs`. Both VTA
+  (`SeedStore`) and VTC (`SecretStore`) now implement the shared
+  interface. Cloud backend implementations remain in each service crate.
+
+### Testing
+
+- **Operation-level unit tests** — New tests for `create_key` (Ed25519,
+  P256), `sign_payload` (EdDSA roundtrip), and `rotate_seed` (archive
+  + generation increment). Uses mock `SeedStore` and temp fjall stores.
+- **Total: 245 tests** (up from 241).
+
+### CI/CD
+
+- **GitHub Actions pipeline** (`.github/workflows/ci.yml`) — Four
+  parallel jobs: `cargo check`, `cargo test`, `cargo clippy -D warnings`,
+  `cargo fmt --check`. Triggers on push to main/nightly and PRs to main.
+  Cargo registry and target caching via `actions/cache`.
+
 ### Documentation
 
 - **Integration Guide** (`docs/integration-guide.md`) — Comprehensive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Changelog
 
+## 0.3.0 — 2026-03-31
+
+### Imported Secrets
+
+- **Import external private keys** — New `POST /keys/import` endpoint
+  and `pnm keys import` command allow importing externally-created
+  private keys (Ed25519, X25519, P-256) into the VTA. Imported keys
+  are stored encrypted at rest and participate in signing, secret
+  export, backup/restore, and revocation alongside BIP-32-derived keys.
+- **Ephemeral wrapping keys (REST)** — REST key import uses
+  ECDH-ES + AES-256-GCM key wrapping via ephemeral X25519 keypairs
+  (`GET /keys/import/wrapping-key`). Each wrapping key is single-use
+  with a 60-second TTL. DIDComm transport sends keys directly inside
+  the end-to-end encrypted envelope.
+- **Encrypted storage layer** — Imported secrets are encrypted with
+  AES-256-GCM using a KEK derived from the BIP-32 master seed via
+  HKDF-SHA256 with a random 32-byte salt. Each ciphertext is bound
+  to its `key_id:key_type` via authenticated associated data (AAD),
+  preventing blob-swap attacks.
+- **Secure deletion on revoke** — Revoking an imported key overwrites
+  the encrypted blob with zeros and deletes it from the keyspace.
+  The `KeyRecord` is retained for audit trail.
+- **Seed rotation re-encryption** — When the BIP-32 seed is rotated,
+  all imported secrets are automatically re-encrypted with the new
+  seed-derived KEK.
+- **Backup & restore** — Imported secrets are included in the
+  encrypted backup payload (plaintext inside the Argon2id+AES-256-GCM
+  envelope) and restored on import. The KEK salt is also backed up
+  for deterministic KEK reconstruction.
+
+### Data Model
+
+- **`KeyOrigin` enum** — New `origin` field on `KeyRecord`:
+  `derived` (default, BIP-32) or `imported` (external). Backward
+  compatible via `#[serde(default)]`.
+- **`ImportedSecretBackup`** — New type in `BackupPayload` for
+  portable imported secret backup.
+- **`imported_secret_count`** — Added to `ImportResult` for
+  visibility during backup preview/import.
+
+### Security
+
+- **Zeroize** — All private key buffers are zeroized after use
+  via the `zeroize` crate (import, signing, backup export/import,
+  seed rotation re-encryption).
+- **AAD binding** — AES-GCM encryption of imported secrets includes
+  `key_id:key_type` as additional authenticated data, preventing
+  ciphertext swapping between key entries.
+- **Independent KEK salt** — A random 32-byte salt is generated
+  per VTA instance and stored alongside the keyspace, ensuring
+  two VTAs with the same seed produce different KEKs.
+- **Admin-only import** — The import endpoint requires Admin role
+  (stricter than key creation which allows Initiator).
+
+### CLI
+
+- **`pnm keys import`** — Import a private key from multibase
+  string (`--private-key`) or file (`--private-key-file`).
+  Supports `--key-type ed25519|x25519|p256`, `--label`, and
+  `--context-id`. Prints a secure-deletion warning on success.
+
+### Testing
+
+- **6 new unit tests** — Imported secret encrypt/decrypt roundtrip,
+  wrong-AAD rejection, secure deletion, seed rotation re-encryption,
+  ephemeral wrapping key generation + unwrap, single-use enforcement.
+- **Total: 234 tests** (up from 228).
+
+### Breaking Changes
+
+- **Operation signatures** — `get_key_secret()`, `sign_payload()`,
+  `revoke_key()`, `rotate_seed()`, `export_backup()`, and
+  `apply_import()` now accept an `imported_ks` parameter.
+- **`AppState`** — Added `imported_ks: KeyspaceHandle` and
+  `wrapping_cache: WrappingKeyCache` fields.
+- **`VtaState` (DIDComm)** — Added `imported_ks: KeyspaceHandle`.
+- **Workspace version bumped to 0.3.0** — All crates updated.
+
+### Dependency Updates
+
+- `hkdf` 0.12 (new — KEK derivation for imported secrets)
+
+---
+
 ## 0.2.1 — 2026-03-30
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## 0.5.0 — 2026-04-01
+
+### Reader Role & Action Classification
+
+- **New `Reader` role** — Context-scoped read-only access to keys,
+  contexts, DIDs, and configuration. Sits between Application and
+  Monitor in the hierarchy. Readers can observe all business data
+  within their allowed contexts but cannot sign, write to cache,
+  create keys, or perform any mutating operation.
+- **Action classification** — Every endpoint is now classified as
+  read, write, or manage:
+  - **Read** (Reader+): list/get keys, contexts, DIDs, config, cache
+  - **Write** (Application+): sign, cache write/delete
+  - **Admin**: key create/delete/import, seeds, audit, DID management
+  - **Manage** (Initiator+): ACL operations, credential generation
+  - **Super Admin**: config update, context CRUD, backup, restart
+- **`require_read()` / `require_write()`** — New methods on
+  `AuthClaims` for action-level authorization checks.
+- **`WriteAuth` extractor** — Route-level extractor requiring at
+  least Application role. Applied to sign and cache write endpoints.
+- **Tightened auth on sign and cache** — `POST /keys/{id}/sign`,
+  `PUT /cache/{key}`, and `DELETE /cache/{key}` now require
+  Application role or higher (previously any authenticated user).
+- **Backup export route** — Changed from `AuthClaims` to
+  `SuperAdminAuth` extractor, matching the operations layer.
+- **DIDComm handler auth fixes** — 17 handlers now have explicit
+  role checks matching their REST counterparts (defense-in-depth).
+  Fixed `handle_update_retention` from `require_admin()` to
+  `require_super_admin()` to match REST.
+
+### Role Hierarchy (updated)
+
+```
+Super Admin  (Admin + unrestricted)
+  Admin      — key mgmt, DID ops, audit, seeds
+    Initiator  — ACL management, credential generation
+      Application — sign, cache write, standard API
+        Reader     — read-only business data access
+          Monitor  — metrics and health only
+```
+
+### Version Bumps
+
+| Crate          | Old   | New   |
+| -------------- | ----- | ----- |
+| vti-common     | 0.3.0 | 0.4.0 |
+| vta-service    | 0.4.0 | 0.5.0 |
+| vta-cli-common | 0.4.0 | 0.5.0 |
+| pnm-cli        | 0.4.0 | 0.5.0 |
+| cnm-cli        | 0.4.0 | 0.5.0 |
+| vta-enclave    | 0.2.2 | 0.2.3 |
+| vtc-service    | 0.2.2 | 0.2.3 |
+
+### Testing
+
+- **18 new tests** — Reader role parsing, `require_read`/`require_write`
+  enforcement across all roles, ACL validation (Reader cannot assign
+  roles, Initiator/Admin can create Reader), integration tests (Reader
+  can list keys, cannot sign, cannot create keys).
+- **Total: 263 tests** (up from 245).
+
+---
+
 ## 0.4.0 — 2026-04-01
 
 ### VTA SDK Integration Module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## 0.4.0 — 2026-04-01
+
+### VTA SDK Integration Module
+
+- **`vta_sdk::integration::startup()`** — Unified startup pattern for
+  any service that manages its DID and secrets through a VTA. Handles
+  authentication, secret fetching, local caching, and offline fallback
+  in a single call. Returns a `StartupResult` with the service DID,
+  secrets bundle, source indicator, and an optional `VtaClient` for
+  follow-up calls.
+- **`SecretCache` trait** — Pluggable local cache for VTA secrets.
+  Services implement `store()` and `load()` using their preferred
+  backend (keyring, AWS Secrets Manager, filesystem, etc.) to enable
+  offline resilience.
+- **`authenticate()`** — Two-tier authentication strategy: lightweight
+  REST auth first (`VtaClient::from_credential`), with session-based
+  DIDComm fallback for non-`did:key` VTAs. Network errors propagate
+  immediately without fallback.
+- **`integration` feature flag** — New opt-in feature on `vta-sdk`
+  (implies `client` + `session`) that enables the integration module.
+
+### Key Labels as Verification Method IDs
+
+- **`fetch_did_secrets_bundle()`** — When a key has a label, it is now
+  used as the verification method fragment (e.g., `did:example#my-label`)
+  instead of the raw key ID. This produces cleaner, human-readable DID
+  documents for services that use labeled keys.
+
+### Workspace Dependency Consolidation
+
+- **`ed25519-dalek`** — Moved to `workspace.dependencies`, updated 6
+  crates to use `workspace = true`.
+- **`dialoguer`** — Moved to `workspace.dependencies`, updated 4
+  crates to use `workspace = true`.
+- **`chrono` in `vta-cli-common`** — Now uses workspace definition
+  (gains `serde` feature that was previously missing).
+
+### HTTP Client Improvements
+
+- **`auth_light` client reuse** — `challenge_response_light()` and
+  `refresh_token_light()` now accept a `&reqwest::Client` parameter
+  instead of creating a new client per call, enabling connection
+  pooling across authentication flows.
+- **`authenticate_with_credential()`** — Returns the HTTP client
+  alongside the auth result, which `VtaClient::from_credential()`
+  now reuses directly (eliminating a redundant client allocation).
+- **`WebvhClient` refactor** — Extracted `send()` and `with_auth()`
+  helpers to eliminate repeated request/error-handling boilerplate
+  across 4 methods.
+
+### Version Bumps
+
+| Crate | Old | New |
+|-------|-----|-----|
+| vta-sdk | 0.3.0 | 0.4.0 |
+| vta-service | 0.3.0 | 0.4.0 |
+| vta-cli-common | 0.3.0 | 0.4.0 |
+| pnm-cli | 0.3.0 | 0.4.0 |
+| cnm-cli | 0.3.0 | 0.4.0 |
+
+### Documentation
+
+- **Integration Guide** (`docs/integration-guide.md`) — Comprehensive
+  guide for 3rd-party developers integrating applications and services
+  with the VTA. Covers credential provisioning, authentication patterns,
+  key management, the SDK integration module, offline resilience, and
+  security best practices.
+
+---
+
 ## 0.3.0 — 2026-03-31
 
 ### Imported Secrets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,52 @@
 
 - `hkdf` 0.12 (new — KEK derivation for imported secrets)
 
+### VTA SDK Improvements for Service Integration
+
+- **Lightweight DIDComm auth (`auth_light`)** — New
+  `challenge_response_light()` and `refresh_token_light()`
+  functions perform DIDComm challenge-response authentication
+  without requiring ATM/TDK runtime initialization. Uses a
+  hand-rolled JWE packer (`didcomm_light`) with
+  ECDH-ES+A256KW key agreement and A256GCM content
+  encryption. Available behind the `client` feature (not
+  `session`).
+- **`VtaClient::from_credential()`** — One-line constructor
+  that decodes a base64 credential bundle, authenticates via
+  lightweight auth, and returns a ready-to-use client with
+  auto-refresh enabled.
+- **Automatic token refresh** — `VtaClient` now stores
+  credential material and automatically refreshes expired
+  tokens before each API call. Tries the `/auth/refresh`
+  endpoint first (cheap), falls back to full
+  challenge-response if the refresh token is expired.
+  Token expiry is checked with a 30-second buffer.
+- **`fetch_context_secrets()`** — Convenience method that
+  paginates through all active keys in a context and returns
+  TDK `Secret` objects ready for DIDComm or signing. Pages
+  in batches of 100 to handle large key sets.
+- **`check_auth()`** — Verifies the current token is valid
+  by calling `GET /health/details`. Returns `true`/`false`
+  for readiness checks.
+- **`token_expires_at()`** — Exposes token expiry for health
+  monitoring in long-running services.
+- **`set_token()` is now `&self`** — No longer requires
+  `&mut self`, simplifying usage in shared contexts.
+
+### Lightweight DIDComm Packer (`didcomm_light`)
+
+- **DIDComm v2 anoncrypt** — Minimal JWE (General JSON)
+  packer producing messages compatible with any DIDComm v2
+  unpacker (including `affinidi-tdk`'s `ATM::unpack()`).
+- **ECDH-ES+A256KW** key agreement with ephemeral X25519.
+- **A256GCM** content encryption (simpler than A256CBC-HS512).
+- **Concat KDF** (NIST SP 800-56A) for key derivation.
+- **AES-256 Key Wrap** (RFC 3394) for CEK wrapping.
+- **`did:key` → X25519** conversion (Edwards→Montgomery).
+- **8 unit tests** — Key wrap roundtrip, KDF determinism,
+  did:key parsing, Ed25519→X25519 conversion, JWE structure
+  validation.
+
 ---
 
 ## 0.2.1 — 2026-03-30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7731,20 +7731,27 @@ dependencies = [
 name = "vta-sdk"
 version = "0.3.0"
 dependencies = [
+ "aes",
+ "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
  "azure_identity",
  "azure_security_keyvault_secrets",
  "base64 0.22.1",
  "chrono",
+ "curve25519-dalek",
+ "ed25519-dalek",
  "keyring",
  "multibase",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
+ "x25519-dalek",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "cnm-cli"
-version = "0.5.0"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -5023,7 +5023,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnm-cli"
-version = "0.5.0"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "chrono",
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.5.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -7688,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "vta-enclave"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7703,7 +7703,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.4.0"
+version = "0.3.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.5.0"
+version = "0.3.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7798,7 +7798,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7843,7 +7843,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.4.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "affinidi-tdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7688,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "vta-enclave"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7798,7 +7798,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7843,7 +7843,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "affinidi-tdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,7 @@ version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
- "dialoguer 0.12.0",
+ "dialoguer",
  "dirs",
  "serde",
  "tokio",
@@ -1662,19 +1662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2114,24 +2101,11 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
-dependencies = [
- "console 0.15.11",
- "shell-words",
- "tempfile",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.16.3",
+ "console",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -4375,27 +4349,27 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "metrics",
  "quanta",
  "rand 0.9.2",
@@ -5054,7 +5028,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "chrono",
  "clap",
- "dialoguer 0.11.0",
+ "dialoguer",
  "dirs",
  "ed25519-dalek",
  "multibase",
@@ -7779,7 +7753,7 @@ dependencies = [
  "cbc",
  "chrono",
  "clap",
- "dialoguer 0.12.0",
+ "dialoguer",
  "didwebvh-rs",
  "ed25519-dalek",
  "ed25519-dalek-bip32",
@@ -7838,7 +7812,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "dialoguer 0.12.0",
+ "dialoguer",
  "didwebvh-rs",
  "ed25519-dalek",
  "fjall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "cnm-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -5049,7 +5049,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnm-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "chrono",
@@ -7697,18 +7697,24 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
+ "hkdf",
+ "multibase",
  "ratatui",
  "serde_json",
+ "sha2 0.10.9",
  "vta-sdk",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "vta-enclave"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7723,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7743,7 +7749,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7774,6 +7780,7 @@ dependencies = [
  "google-cloud-auth",
  "google-cloud-secretmanager-v1",
  "hex",
+ "hkdf",
  "hmac",
  "http-body-util",
  "jsonwebtoken",
@@ -7810,7 +7817,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7854,7 +7861,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "affinidi-tdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.3.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "vta-enclave"
-version = "0.3.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7824,7 +7824,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.3.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7868,7 +7868,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.3.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "affinidi-tdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "cnm-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -5023,7 +5023,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnm-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "chrono",
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -7688,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "vta-enclave"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7798,7 +7798,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -7843,7 +7843,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "affinidi-tdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7838,6 +7838,7 @@ dependencies = [
  "vta-sdk",
  "vti-common",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "cnm-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -5023,7 +5023,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnm-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "chrono",
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -7703,7 +7703,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ resolver = "3"
 
 [workspace.package]
 description = "Verifiable Trust Infrastructure (VTI) — VTA, VTC, and supporting crates"
-version = "0.3.0"
 edition = "2024"
 publish = true
 authors = ["Glenn Gore <glenn@affinidi.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "3"
 
 [workspace.package]
 description = "Verifiable Trust Infrastructure (VTI) — VTA, VTC, and supporting crates"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 publish = true
 authors = ["Glenn Gore <glenn@affinidi.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ didwebvh-rs = "0.4"
 url = "2"
 
 # Cryptography
+ed25519-dalek = "2"
 sha2 = "0.10"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 multibase = "0.9"
@@ -89,6 +90,9 @@ base64 = "0.22"
 
 # HTTP client
 reqwest = { version = "0.13", features = ["json"] }
+
+# Interactive prompts
+dialoguer = "0.12"
 
 # CLI argument parsing
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ See [PNM CLI](pnm-cli/README.md) and [CNM CLI](cnm-cli/README.md) for command re
 
 ## Additional Resources
 
+- [Integration Guide](docs/integration-guide.md) -- how to integrate a 3rd-party application with the VTA
 - [First Person Project White Paper](https://www.firstperson.network/white-paper)
 - [Design Document](docs/design.md)
 - [BIP-32 Path Specification](docs/bip32_paths.md)
+- [Security Architecture](docs/security-architecture.md)

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.5.0"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.5.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.2.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 clap = { workspace = true, features = ["env"] }
 dialoguer = "0.12"

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -25,7 +25,7 @@ vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 clap = { workspace = true, features = ["env"] }
-dialoguer = "0.12"
+dialoguer = { workspace = true }
 dirs = "6"
 serde = { workspace = true }
 toml = "1.0"

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.4.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -22,7 +22,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
 vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.4.0" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.5.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -167,6 +167,13 @@ enum ContextCommands {
         #[arg(long)]
         description: Option<String>,
     },
+    /// Update the DID for a context (context admin or super admin)
+    UpdateDid {
+        /// Context ID
+        id: String,
+        /// The new DID to assign
+        did: String,
+    },
     /// Delete an application context and all associated resources
     Delete {
         /// Context ID
@@ -523,6 +530,9 @@ async fn main() {
                 did,
                 description,
             } => contexts::cmd_context_update(&client, &id, name, did, description).await,
+            ContextCommands::UpdateDid { id, did } => {
+                contexts::cmd_context_update_did(&client, &id, &did).await
+            }
             ContextCommands::Delete { id, force } => {
                 contexts::cmd_context_delete(&client, &id, force).await
             }

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -787,10 +787,7 @@ async fn cmd_health(
                 .as_deref()
                 .map(|v| format!(" (v{v})"))
                 .unwrap_or_default();
-            println!(
-                "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok{ver}",
-                "Service"
-            );
+            println!("  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok{ver}", "Service");
         }
         Err(e) => {
             println!(
@@ -884,10 +881,7 @@ async fn print_personal_vta_section(
                 .as_deref()
                 .map(|v| format!(" (v{v})"))
                 .unwrap_or_default();
-            println!(
-                "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok{ver}",
-                "Service"
-            );
+            println!("  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok{ver}", "Service");
         }
         Err(e) => {
             println!(

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -217,7 +217,7 @@ enum AclCommands {
         /// DID to grant access to
         #[arg(long)]
         did: String,
-        /// Role: admin, initiator, or application
+        /// Role: admin, initiator, application, or reader
         #[arg(long)]
         role: String,
         /// Human-readable label
@@ -252,7 +252,7 @@ enum AclCommands {
 enum AuthCredentialCommands {
     /// Generate a new auth credential (did:key + ACL entry) for a service or application
     Create {
-        /// Role: admin, initiator, or application
+        /// Role: admin, initiator, application, or reader
         #[arg(long)]
         role: String,
         /// Human-readable label

--- a/cnm-cli/src/setup.rs
+++ b/cnm-cli/src/setup.rs
@@ -5,7 +5,7 @@ use crate::config::{
     CommunityConfig, PERSONAL_KEYRING_KEY, PersonalVtaConfig, community_keyring_key, load_config,
     save_config,
 };
-use vta_sdk::client::{CreateContextRequest, GenerateCredentialsRequest, VtaClient};
+use vta_sdk::prelude::*;
 
 /// Derive a URL-safe slug from a community name.
 ///
@@ -138,11 +138,8 @@ pub async fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
 
             // Create context in personal VTA
             eprintln!("\nCreating context '{context_name}' in personal VTA...");
-            let ctx_req = CreateContextRequest {
-                id: context_slug.clone(),
-                name: context_name,
-                description: Some(format!("Community admin identity for {}", community_name)),
-            };
+            let ctx_req = CreateContextRequest::new(&context_slug, &context_name)
+                .description(format!("Community admin identity for {}", community_name));
             match personal_client.create_context(ctx_req).await {
                 Ok(ctx) => {
                     eprintln!("  Context created: {} ({})", ctx.id, ctx.base_path);
@@ -157,11 +154,9 @@ pub async fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
 
             // Generate credential in personal VTA
             eprintln!("Generating community admin credential...");
-            let cred_req = GenerateCredentialsRequest {
-                role: "admin".into(),
-                label: Some(format!("CNM community admin — {community_slug}")),
-                allowed_contexts: vec![context_slug.clone()],
-            };
+            let cred_req = GenerateCredentialsRequest::new("admin")
+                .label(format!("CNM community admin — {community_slug}"))
+                .contexts(vec![context_slug.clone()]);
             let resp = personal_client.generate_credentials(cred_req).await?;
 
             // Decode credential to extract the private key

--- a/cnm-cli/src/setup.rs
+++ b/cnm-cli/src/setup.rs
@@ -132,7 +132,7 @@ pub async fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
             let context_name = format!("CNM - {community_name}");
 
             // Authenticate personal VTA client
-            let mut personal_client = VtaClient::new(&personal_url);
+            let personal_client = VtaClient::new(&personal_url);
             let token = auth::ensure_authenticated(&personal_url, PERSONAL_KEYRING_KEY).await?;
             personal_client.set_token(token);
 
@@ -147,13 +147,11 @@ pub async fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(ctx) => {
                     eprintln!("  Context created: {} ({})", ctx.id, ctx.base_path);
                 }
+                Err(ref e) if matches!(e, vta_sdk::error::VtaError::Conflict(_)) => {
+                    eprintln!("  Context '{context_slug}' already exists, reusing it.");
+                }
                 Err(e) => {
-                    let msg = e.to_string();
-                    if msg.contains("409") || msg.to_lowercase().contains("already exists") {
-                        eprintln!("  Context '{context_slug}' already exists, reusing it.");
-                    } else {
-                        return Err(e);
-                    }
+                    return Err(e.into());
                 }
             }
 
@@ -311,7 +309,7 @@ pub async fn bootstrap_community_session(
 
     // Authenticate to personal VTA
     let token = auth::ensure_authenticated(personal_url, PERSONAL_KEYRING_KEY).await?;
-    let mut personal_client = VtaClient::new(personal_url);
+    let personal_client = VtaClient::new(personal_url);
     personal_client.set_token(token);
 
     // Generate a new credential on the personal VTA

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 tokio = { workspace = true }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 tokio = { workspace = true }
@@ -23,5 +23,5 @@ rand = { workspace = true }
 clap = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 multibase = { workspace = true }
-ed25519-dalek = "2"
+ed25519-dalek = { workspace = true }
 hex = "0.4"

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version = "0.2.2"
+version = "0.3.0"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 tokio = { workspace = true }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version.workspace = true
+version = "0.2.1"
 edition.workspace = true
 publish = false
 rust-version.workspace = true

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 publish = false
 rust-version.workspace = true

--- a/didcomm-test/src/main.rs
+++ b/didcomm-test/src/main.rs
@@ -196,16 +196,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 4. Send a trust-ping
     // ---------------------------------------------------------------
     info!("sending trust-ping to mediator...");
-    let ping = TrustPing::default()
-        .generate_ping_message(Some(&did), &args.mediator_did, true)?;
+    let ping = TrustPing::default().generate_ping_message(Some(&did), &args.mediator_did, true)?;
 
     let (packed, _) = atm
-        .pack_encrypted(
-            &ping,
-            &args.mediator_did,
-            Some(&did),
-            Some(&did),
-        )
+        .pack_encrypted(&ping, &args.mediator_did, Some(&did), Some(&did))
         .await
         .map_err(|e| format!("pack_encrypted failed: {e}"))?;
 
@@ -218,9 +212,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ---------------------------------------------------------------
     // 5. Listen for inbound messages
     // ---------------------------------------------------------------
-    let mut rx = atm
-        .get_inbound_channel()
-        .ok_or("no inbound channel")?;
+    let mut rx = atm.get_inbound_channel().ok_or("no inbound channel")?;
 
     info!(
         listen_secs = args.listen_secs,

--- a/docs/didcomm_protocol.md
+++ b/docs/didcomm_protocol.md
@@ -100,6 +100,8 @@ All protocol URIs are under `https://firstperson.network/protocols/`.
 | `.../revoke-key` | `.../revoke-key-result` | Admin | Revoke a key |
 | `.../get-key-secret` | `.../get-key-secret-result` | Admin | Export secret key material |
 | `.../sign-request` | `.../sign-result` | Auth + context | Sign payload (signing oracle) |
+| `.../import-key` | `.../import-key-result` | Admin | Import an external private key |
+| `.../get-wrapping-key` | `.../get-wrapping-key-result` | Admin | Get ephemeral wrapping key (REST only) |
 
 #### create-key
 
@@ -710,6 +712,10 @@ https://firstperson.network/protocols/key-management/1.0/get-key-secret
 https://firstperson.network/protocols/key-management/1.0/get-key-secret-result
 https://firstperson.network/protocols/key-management/1.0/sign-request
 https://firstperson.network/protocols/key-management/1.0/sign-result
+https://firstperson.network/protocols/key-management/1.0/import-key
+https://firstperson.network/protocols/key-management/1.0/import-key-result
+https://firstperson.network/protocols/key-management/1.0/get-wrapping-key
+https://firstperson.network/protocols/key-management/1.0/get-wrapping-key-result
 
 # Seed Management
 https://firstperson.network/protocols/seed-management/1.0/list-seeds

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1,0 +1,305 @@
+# VTA Integration Guide
+
+This guide walks through integrating a 3rd-party application or service with a
+Verifiable Trust Agent (VTA). By the end you will have a service that:
+
+- Authenticates to a VTA using a credential bundle
+- Fetches its DID and private keys for signing or DIDComm
+- Caches secrets locally for offline resilience
+- Refreshes credentials automatically
+
+## Prerequisites
+
+- A running VTA instance (local or remote)
+- A **credential bundle** (base64url string) issued by the VTA admin
+- Rust 1.91.0+ (or use the REST API directly from any language)
+
+## Concepts
+
+| Term | Description |
+|------|-------------|
+| **VTA** | Verifiable Trust Agent — manages keys, DIDs, and access control |
+| **Context** | A logical namespace within the VTA (e.g., `my-app`, `mediator`) |
+| **Credential bundle** | A portable base64url token containing your DID, private key, and VTA endpoint |
+| **`DidSecretsBundle`** | A JSON bundle containing a DID and its associated private keys |
+
+## Step 1: Provision a Context and Credential
+
+The VTA admin creates a context for your application and issues a credential:
+
+```sh
+# Using the PNM CLI (admin)
+pnm context provision \
+  --id my-service \
+  --name "My Service" \
+  --admin-label "Service Admin"
+```
+
+This outputs a base64url credential string. Store it securely — it grants
+access to the `my-service` context.
+
+## Step 2: Add the SDK Dependency
+
+```toml
+[dependencies]
+vta-sdk = { version = "0.4", features = ["integration"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+```
+
+The `integration` feature enables the unified startup module, which
+includes the HTTP client, session management, and offline caching support.
+
+## Step 3: Implement a Secret Cache
+
+The `SecretCache` trait lets your service persist secrets locally so it can
+start even when the VTA is temporarily unreachable. The simplest
+implementation writes to a file:
+
+```rust,ignore
+use std::path::PathBuf;
+use vta_sdk::did_secrets::DidSecretsBundle;
+use vta_sdk::integration::SecretCache;
+
+struct FileCache {
+    path: PathBuf,
+}
+
+impl SecretCache for FileCache {
+    async fn store(
+        &self,
+        bundle: &DidSecretsBundle,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let encoded = bundle.encode()?;
+        tokio::fs::write(&self.path, encoded).await?;
+        Ok(())
+    }
+
+    async fn load(
+        &self,
+    ) -> Result<Option<DidSecretsBundle>, Box<dyn std::error::Error + Send + Sync>> {
+        match tokio::fs::read_to_string(&self.path).await {
+            Ok(data) => Ok(Some(DidSecretsBundle::decode(&data)?)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+```
+
+For production, consider encrypting the cached file or using your platform's
+secret manager (AWS Secrets Manager, GCP Secret Manager, OS keyring, etc.).
+
+## Step 4: Start Up with the Integration Module
+
+```rust,ignore
+use vta_sdk::integration::{startup, VtaServiceConfig, SecretSource};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::init();
+
+    let config = VtaServiceConfig {
+        credential: load_credential()?,   // Load from env, file, or secret manager
+        context: "my-service".into(),
+        url_override: None,               // Use the URL embedded in the credential
+    };
+
+    let cache = FileCache {
+        path: "/var/lib/my-service/vta-secrets.cache".into(),
+    };
+
+    let result = startup(&config, &cache).await?;
+
+    match result.source {
+        SecretSource::Vta => tracing::info!("Started with fresh secrets from VTA"),
+        SecretSource::Cache => tracing::warn!("Started with CACHED secrets (VTA unreachable)"),
+    }
+
+    tracing::info!(did = %result.did, secrets = result.bundle.secrets.len());
+
+    // Use result.bundle.secrets for DIDComm or signing
+    // Use result.client (if Some) for additional VTA API calls
+
+    Ok(())
+}
+```
+
+### What `startup()` Does
+
+1. **Authenticates** to the VTA using the credential bundle (lightweight REST
+   auth with automatic fallback to DIDComm session auth)
+2. **Fetches** the latest `DidSecretsBundle` from the VTA context
+3. **Caches** the bundle locally via your `SecretCache` implementation
+4. **Falls back** to the cached bundle if the VTA is unreachable
+
+On first run (no cache), the VTA must be reachable. On subsequent runs, the
+service can start with cached secrets and refresh them later.
+
+## Step 5: Use Keys for Signing
+
+The `DidSecretsBundle` contains private keys that you can use directly:
+
+```rust,ignore
+use vta_sdk::did_key::secret_from_key_response;
+
+// The bundle contains SecretEntry items with key_id and private_key_multibase
+for entry in &result.bundle.secrets {
+    tracing::info!(
+        key_id = %entry.key_id,
+        key_type = %entry.key_type,
+        "Available key"
+    );
+}
+```
+
+Or use the VTA as a remote signing oracle (keys never leave the VTA):
+
+```rust,ignore
+if let Some(ref client) = result.client {
+    let signature = client.sign("my-key-id", b"payload to sign", "EdDSA").await?;
+    tracing::info!(signature = %signature.signature, "Signed payload");
+}
+```
+
+## Alternative: Direct Client Usage
+
+If you don't need offline resilience, use the client directly:
+
+```rust,ignore
+use vta_sdk::prelude::*;
+
+// One-line auth from a credential bundle
+let client = VtaClient::from_credential(&credential_b64, None).await?;
+
+// Token refresh is automatic — no manual token management needed
+
+// Create keys
+let key = client.create_key(
+    CreateKeyRequest::new(KeyType::Ed25519)
+        .label("signing-key")
+        .context("my-app")
+).await?;
+
+// List keys
+let keys = client.list_keys(None, None, None, None, None).await?;
+
+// Get a key's private material (for local signing)
+let secret = client.get_key_secret(&key.key_id).await?;
+
+// Server-side signing (key never leaves VTA)
+let sig = client.sign(&key.key_id, b"hello", "EdDSA").await?;
+
+// Fetch all secrets for a context as a portable bundle
+let bundle = client.fetch_did_secrets_bundle("my-app").await?;
+```
+
+## Alternative: REST API (Any Language)
+
+The VTA exposes a standard REST API. Any HTTP client can integrate:
+
+### Authentication
+
+```
+POST /auth/challenge
+Content-Type: application/json
+{"did": "did:key:z6Mk..."}
+
+→ {"session_id": "...", "data": {"challenge": "..."}}
+
+POST /auth/
+Content-Type: text/plain
+<DIDComm-packed authenticate message>
+
+→ {"data": {"access_token": "...", "refresh_token": "..."}}
+```
+
+### Key Operations
+
+```
+# List keys
+GET /keys?context_id=my-app&status=active
+Authorization: Bearer <token>
+
+# Create a key
+POST /keys
+Authorization: Bearer <token>
+{"key_type": "Ed25519", "label": "my-key", "context_id": "my-app"}
+
+# Sign a payload
+POST /keys/<key_id>/sign
+Authorization: Bearer <token>
+{"payload": "<base64url>", "algorithm": "EdDSA"}
+
+# Get private key material
+GET /keys/<key_id>/secret
+Authorization: Bearer <token>
+```
+
+### Context Operations
+
+```
+# List contexts
+GET /contexts
+Authorization: Bearer <token>
+
+# Create a context
+POST /contexts
+Authorization: Bearer <token>
+{"id": "my-app", "name": "My Application"}
+```
+
+See [docs/VTA_Service_Overview.md](VTA_Service_Overview.md) for the
+complete API reference.
+
+## Security Best Practices
+
+1. **Store credentials securely** — Use your platform's secret manager
+   (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, or OS keyring).
+   Never commit credentials to source control.
+
+2. **Encrypt cached secrets** — The `SecretCache` file contains private keys.
+   Encrypt it at rest or use a secret manager backend.
+
+3. **Use context scoping** — Each application should have its own VTA context
+   with the minimum required role (typically `application`). Avoid sharing
+   admin credentials across services.
+
+4. **Prefer server-side signing** — Use `POST /keys/{id}/sign` instead of
+   exporting private keys when possible. This keeps keys inside the VTA's
+   security boundary.
+
+5. **Monitor token expiry** — `VtaClient` handles refresh automatically, but
+   long-running services should monitor `client.token_expires_at()` for
+   health checks.
+
+6. **Handle offline gracefully** — The integration module's cache fallback
+   ensures your service can start during VTA outages, but cached keys may be
+   stale (e.g., after a key rotation). Log the `SecretSource::Cache` state
+   prominently and refresh as soon as the VTA is reachable.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────┐
+│          Your Application           │
+│                                     │
+│  ┌───────────┐  ┌───────────────┐   │
+│  │ vta-sdk   │  │ SecretCache   │   │
+│  │ integration│  │ (your impl)  │   │
+│  └─────┬─────┘  └──────┬────────┘   │
+│        │               │            │
+└────────┼───────────────┼────────────┘
+         │               │
+         ▼               ▼
+    ┌─────────┐   ┌────────────┐
+    │   VTA   │   │ Local disk │
+    │ Service │   │ / keyring  │
+    └─────────┘   └────────────┘
+```
+
+1. On startup, `vta_sdk::integration::startup()` authenticates and fetches secrets.
+2. Fresh secrets are cached locally via your `SecretCache` implementation.
+3. If the VTA is unreachable, cached secrets are loaded instead.
+4. Your application uses the DID and keys for signing, DIDComm, or other operations.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -262,9 +262,12 @@ complete API reference.
 2. **Encrypt cached secrets** — The `SecretCache` file contains private keys.
    Encrypt it at rest or use a secret manager backend.
 
-3. **Use context scoping** — Each application should have its own VTA context
-   with the minimum required role (typically `application`). Avoid sharing
-   admin credentials across services.
+3. **Use context scoping and least-privilege roles** — Each application
+   should have its own VTA context with the minimum required role:
+   - **Reader** — for services that only need to read keys and config
+   - **Application** — for services that need to sign or write to cache
+   - **Admin** — only for services that manage keys and DIDs
+   Avoid sharing admin credentials across services.
 
 4. **Prefer server-side signing** — Use `POST /keys/{id}/sign` instead of
    exporting private keys when possible. This keeps keys inside the VTA's

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -34,7 +34,13 @@ The VTA implements a defense-in-depth security model with eight layers of protec
 
 ### Layer 5: Identity & Access Control
 - DID-based authentication via challenge-response (Ed25519 signatures)
-- Role hierarchy: super-admin > admin > initiator > application
+- Role hierarchy: super-admin > admin > initiator > application > reader > monitor
+- Action classification: every endpoint is classified as read, write, or manage
+  - **Reader**: read-only access to business data (keys, contexts, DIDs) within allowed contexts
+  - **Application**: can sign and write to cache (write actions)
+  - **Initiator**: can manage ACL entries and credentials (manage actions)
+  - **Admin**: full key/DID/audit management within contexts
+  - **Monitor**: infrastructure-only (metrics, health)
 - Context scoping restricts access to assigned application contexts
 - DID method whitelist blocks unsafe `did:web` in TEE mode
 - Session state machine prevents challenge replay

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -127,6 +127,27 @@ graph LR
    │ → Mark old seed generation as "retired"  │
    │ → New keys derived from new seed         │
    │ → Old keys remain readable (old seed)    │
+   │ → Re-encrypt imported secrets with new   │
+   │   seed-derived KEK                       │
+   └─────────────────────────────────────────┘
+
+5. Imported Key (external, non-BIP-32):
+   ┌─────────────────────────────────────────┐
+   │ Receive private key via REST (JWE-      │
+   │   wrapped with ephemeral ECDH-ES) or    │
+   │   DIDComm (E2E encrypted)               │
+   │ → Validate key type + length            │
+   │ → Derive public key, verify consistency │
+   │ → HKDF(seed, salt) → KEK               │
+   │ → AES-256-GCM(KEK, nonce, key,         │
+   │     AAD=key_id:key_type)                │
+   │ → Store ciphertext in imported_secrets  │
+   │ → KeyRecord with origin=imported        │
+   │                                          │
+   │ On revoke: overwrite blob → delete       │
+   │ On seed rotation: re-encrypt all         │
+   │ On backup: plaintext inside encrypted    │
+   │   envelope (Argon2id + AES-256-GCM)      │
    └─────────────────────────────────────────┘
 ```
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -26,7 +26,7 @@ vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
-dialoguer = "0.11"
+dialoguer = "0.12"
 dirs = "6"
 ed25519-dalek = "2"
 multibase = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.5.0"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.5.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -26,9 +26,9 @@ vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
-dialoguer = "0.12"
+dialoguer = { workspace = true }
 dirs = "6"
-ed25519-dalek = "2"
+ed25519-dalek = { workspace = true }
 multibase = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.2.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -22,7 +22,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
 vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.4.0" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.5.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.4.0" }
 affinidi-did-resolver-cache-sdk = "0.8"
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/pnm-cli/README.md
+++ b/pnm-cli/README.md
@@ -185,13 +185,16 @@ url = "http://localhost:3000"
 | Command                                                                    | Description     |
 | -------------------------------------------------------------------------- | --------------- |
 | `keys list [--status active\|revoked] [--limit N] [--offset N]`            | List keys       |
-| `keys create --key-type ed25519\|x25519 [--context-id ID] [--label LABEL]` | Create a key    |
+| `keys create --key-type ed25519\|x25519 [--context-id ID] [--label LABEL]` | Create a key (BIP-32 derived) |
+| `keys import --key-type TYPE --private-key KEY [--label L] [--context-id ID]` | Import an external private key |
 | `keys get <key_id>`                                                        | Get a key by ID |
 | `keys revoke <key_id>`                                                     | Revoke a key               |
 | `keys rename <key_id> <new_key_id>`                                        | Rename a key               |
 | `keys secrets [key_ids...] [--context ID]`                                 | Export secret key material |
 | `keys seeds`                                                               | List seed generations      |
 | `keys rotate-seed [--mnemonic PHRASE]`                                     | Rotate to a new seed       |
+
+The `keys import` command accepts `--private-key <multibase>` or `--private-key-file <path>` and supports key types `ed25519`, `x25519`, and `p256`. The private key is wrapped with ECDH-ES+AES-256-GCM before transmission over REST.
 
 ### Contexts
 

--- a/pnm-cli/src/config.rs
+++ b/pnm-cli/src/config.rs
@@ -54,20 +54,21 @@ pub fn load_config() -> Result<PnmConfig, Box<dyn std::error::Error>> {
 
     // Migrate legacy single-URL config
     if config.vtas.is_empty()
-        && let Some(url) = config.url.take() {
-            eprintln!("\x1b[33mMigrating legacy config to multi-VTA format...\x1b[0m");
-            config.vtas.insert(
-                "default".to_string(),
-                VtaConfig {
-                    name: "Default VTA".to_string(),
-                    url: Some(url),
-                    vta_did: None,
-                },
-            );
-            config.default_vta = Some("default".to_string());
-            save_config(&config)?;
-            eprintln!("  Migrated to VTA slug: \x1b[36mdefault\x1b[0m");
-        }
+        && let Some(url) = config.url.take()
+    {
+        eprintln!("\x1b[33mMigrating legacy config to multi-VTA format...\x1b[0m");
+        config.vtas.insert(
+            "default".to_string(),
+            VtaConfig {
+                name: "Default VTA".to_string(),
+                url: Some(url),
+                vta_did: None,
+            },
+        );
+        config.default_vta = Some("default".to_string());
+        save_config(&config)?;
+        eprintln!("  Migrated to VTA slug: \x1b[36mdefault\x1b[0m");
+    }
 
     Ok(config)
 }

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -493,6 +493,24 @@ enum KeyCommands {
         #[arg(long)]
         context_id: Option<String>,
     },
+    /// Import an externally-created private key
+    Import {
+        /// Key type: ed25519, x25519, or p256
+        #[arg(long)]
+        key_type: String,
+        /// Multibase-encoded private key
+        #[arg(long)]
+        private_key: Option<String>,
+        /// Path to private key file
+        #[arg(long)]
+        private_key_file: Option<std::path::PathBuf>,
+        /// Human-readable label
+        #[arg(long)]
+        label: Option<String>,
+        /// Application context ID
+        #[arg(long)]
+        context_id: Option<String>,
+    },
     /// Get a key by ID
     Get {
         /// Key ID
@@ -991,6 +1009,18 @@ async fn main() {
                     mnemonic,
                     label,
                     context_id,
+                )
+                .await
+            }
+            KeyCommands::Import {
+                key_type,
+                private_key,
+                private_key_file,
+                label,
+                context_id,
+            } => {
+                keys::cmd_key_import(
+                    &client, &key_type, private_key, private_key_file, label, context_id,
                 )
                 .await
             }

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -284,6 +284,13 @@ enum ContextCommands {
         #[arg(long)]
         description: Option<String>,
     },
+    /// Update the DID for a context (context admin or super admin)
+    UpdateDid {
+        /// Context ID
+        id: String,
+        /// The new DID to assign
+        did: String,
+    },
     /// Delete an application context and all associated resources
     Delete {
         /// Context ID
@@ -822,6 +829,9 @@ async fn main() {
                 did,
                 description,
             } => contexts::cmd_context_update(&client, &id, name, did, description).await,
+            ContextCommands::UpdateDid { id, did } => {
+                contexts::cmd_context_update_did(&client, &id, &did).await
+            }
             ContextCommands::Delete { id, force } => {
                 contexts::cmd_context_delete(&client, &id, force).await
             }

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -387,7 +387,7 @@ enum AclCommands {
         /// DID to grant access to
         #[arg(long)]
         did: String,
-        /// Role: admin, initiator, or application
+        /// Role: admin, initiator, application, or reader
         #[arg(long)]
         role: String,
         /// Human-readable label
@@ -422,7 +422,7 @@ enum AclCommands {
 enum AuthCredentialCommands {
     /// Generate a new auth credential (did:key + ACL entry) for a service or application
     Create {
-        /// Role: admin, initiator, or application
+        /// Role: admin, initiator, application, or reader
         #[arg(long)]
         role: String,
         /// Human-readable label

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -5,7 +5,9 @@ mod setup;
 use clap::{Parser, Subcommand};
 use vta_sdk::client::VtaClient;
 
-use vta_cli_common::commands::{acl, audit, config as config_cmd, contexts, credentials, keys, webvh};
+use vta_cli_common::commands::{
+    acl, audit, config as config_cmd, contexts, credentials, keys, webvh,
+};
 use vta_cli_common::render::{CYAN, DIM, GREEN, RED, RESET};
 
 #[derive(Parser)]
@@ -600,15 +602,17 @@ fn print_banner() {
 /// Returns true if this command requires authentication.
 fn requires_auth(cmd: &Commands) -> bool {
     // VTA restart requires auth; other VTA subcommands don't
-    if matches!(cmd, Commands::Vta { command: VtaCommands::Restart }) {
+    if matches!(
+        cmd,
+        Commands::Vta {
+            command: VtaCommands::Restart
+        }
+    ) {
         return true;
     }
     !matches!(
         cmd,
-        Commands::Health
-            | Commands::Auth { .. }
-            | Commands::Setup { .. }
-            | Commands::Vta { .. }
+        Commands::Health | Commands::Auth { .. } | Commands::Setup { .. } | Commands::Vta { .. }
     )
 }
 
@@ -740,7 +744,12 @@ async fn main() {
                 }
             }
             // Restart needs VTA connectivity — don't return early
-            if !matches!(cli.command, Commands::Vta { command: VtaCommands::Restart }) {
+            if !matches!(
+                cli.command,
+                Commands::Vta {
+                    command: VtaCommands::Restart
+                }
+            ) {
                 return;
             }
         }
@@ -774,15 +783,15 @@ async fn main() {
             }
         }
     } else {
-        let url = url_override
-            .or(vta_config.url.clone())
-            .unwrap_or_default();
+        let url = url_override.or(vta_config.url.clone()).unwrap_or_default();
         VtaClient::new(&url)
     };
 
     let result = match cli.command {
         Commands::Setup { .. } => unreachable!(),
-        Commands::Vta { command: VtaCommands::Restart } => cmd_restart(&client).await,
+        Commands::Vta {
+            command: VtaCommands::Restart,
+        } => cmd_restart(&client).await,
         Commands::Vta { .. } => unreachable!(),
         Commands::Health => cmd_health(&client, &keyring_key).await,
         Commands::Auth { command } => match command {
@@ -882,10 +891,7 @@ async fn main() {
                 id,
                 key,
                 admin_label,
-            } => {
-                contexts::cmd_context_reprovision(&client, &id, key, admin_label)
-                    .await
-            }
+            } => contexts::cmd_context_reprovision(&client, &id, key, admin_label).await,
         },
         Commands::Acl { command } => match command {
             AclCommands::List { context } => acl::cmd_acl_list(&client, context.as_deref()).await,
@@ -991,15 +997,14 @@ async fn main() {
             }
             AuditCommands::Retention { command } => match command {
                 RetentionCommands::Get => audit::cmd_get_retention(&client).await,
-                RetentionCommands::Set { days } => {
-                    audit::cmd_update_retention(&client, days).await
-                }
+                RetentionCommands::Set { days } => audit::cmd_update_retention(&client, days).await,
             },
         },
         Commands::Backup { command } => match command {
-            BackupCommands::Export { include_audit, output } => {
-                cmd_backup_export(&client, include_audit, output).await
-            }
+            BackupCommands::Export {
+                include_audit,
+                output,
+            } => cmd_backup_export(&client, include_audit, output).await,
             BackupCommands::Import { file, preview } => {
                 cmd_backup_import(&client, file, preview).await
             }
@@ -1030,7 +1035,12 @@ async fn main() {
                 context_id,
             } => {
                 keys::cmd_key_import(
-                    &client, &key_type, private_key, private_key_file, label, context_id,
+                    &client,
+                    &key_type,
+                    private_key,
+                    private_key_file,
+                    label,
+                    context_id,
                 )
                 .await
             }
@@ -1050,9 +1060,7 @@ async fn main() {
             KeyCommands::Secrets { key_ids, context } => {
                 keys::cmd_key_secrets(&client, key_ids, context).await
             }
-            KeyCommands::Bundle { context } => {
-                keys::cmd_key_bundle(&client, &context).await
-            }
+            KeyCommands::Bundle { context } => keys::cmd_key_bundle(&client, &context).await,
             KeyCommands::Seeds => keys::cmd_seeds_list(&client).await,
             KeyCommands::RotateSeed { mnemonic } => keys::cmd_seeds_rotate(&client, mnemonic).await,
         },
@@ -1126,7 +1134,10 @@ async fn cmd_backup_export(
     std::fs::write(&path, &json)?;
 
     println!("{GREEN}✓{RESET} Backup saved to {}", path.display());
-    println!("  Source DID: {}", envelope.source_did.as_deref().unwrap_or("(none)"));
+    println!(
+        "  Source DID: {}",
+        envelope.source_did.as_deref().unwrap_or("(none)")
+    );
     println!("  Includes audit: {}", envelope.includes_audit);
     println!("  File size: {} bytes", json.len());
     Ok(())
@@ -1142,7 +1153,10 @@ async fn cmd_backup_import(
         serde_json::from_str(&json)?;
 
     println!("Backup file: {}", file.display());
-    println!("  Source DID:  {}", envelope.source_did.as_deref().unwrap_or("(none)"));
+    println!(
+        "  Source DID:  {}",
+        envelope.source_did.as_deref().unwrap_or("(none)")
+    );
     println!("  Created:     {}", envelope.created_at);
     println!("  Version:     {}", envelope.source_version);
     println!("  Audit:       {}", envelope.includes_audit);
@@ -1178,7 +1192,10 @@ async fn cmd_backup_import(
 
     println!("Importing...");
     let result = client.backup_import(&envelope, &password, true).await?;
-    println!("{GREEN}✓{RESET} {}", result.message.as_deref().unwrap_or("Import complete"));
+    println!(
+        "{GREEN}✓{RESET} {}",
+        result.message.as_deref().unwrap_or("Import complete")
+    );
 
     if result.status == "imported" {
         println!("  VTA is restarting with the new identity.");
@@ -1191,7 +1208,10 @@ use vta_cli_common::render::print_section;
 
 // ── Command handlers ────────────────────────────────────────────────
 
-async fn cmd_health(client: &VtaClient, keyring_key: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn cmd_health(
+    client: &VtaClient,
+    keyring_key: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 
     let session = auth::loaded_session(keyring_key);
@@ -1233,10 +1253,7 @@ async fn cmd_health(client: &VtaClient, keyring_key: &str) -> Result<(), Box<dyn
                     .as_deref()
                     .map(|v| format!(" (v{v})"))
                     .unwrap_or_default();
-                println!(
-                    "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok{ver}",
-                    "Service"
-                );
+                println!("  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} ok{ver}", "Service");
             }
             Err(e) => {
                 println!(

--- a/pnm-cli/src/setup.rs
+++ b/pnm-cli/src/setup.rs
@@ -89,9 +89,7 @@ async fn setup_with_credential(
         eprintln!("Resolving VTA DID: {}", bundle.vta_did);
         vta_sdk::session::resolve_vta_url(&bundle.vta_did).await?
     } else {
-        let url: String = Input::new()
-            .with_prompt("VTA URL")
-            .interact_text()?;
+        let url: String = Input::new().with_prompt("VTA URL").interact_text()?;
         url
     };
     let url = url.trim_end_matches('/').to_string();
@@ -181,14 +179,10 @@ async fn setup_tee(config: &mut PnmConfig) -> Result<(), Box<dyn std::error::Err
     eprintln!("The VTA's DID is shown in its boot logs. You can also retrieve");
     eprintln!("it via: GET /attestation/did-log (if REST is enabled).");
     eprintln!();
-    let vta_did: String = Input::new()
-        .with_prompt("VTA DID")
-        .interact_text()?;
+    let vta_did: String = Input::new().with_prompt("VTA DID").interact_text()?;
 
     // 6. Prompt for mediator DID
-    let mediator_did: String = Input::new()
-        .with_prompt("Mediator DID")
-        .interact_text()?;
+    let mediator_did: String = Input::new().with_prompt("Mediator DID").interact_text()?;
 
     // 7. Build credential bundle and store in keyring
     let bundle = CredentialBundle::new(did.clone(), private_key_multibase.clone(), vta_did.clone());

--- a/pnm-cli/src/setup.rs
+++ b/pnm-cli/src/setup.rs
@@ -3,8 +3,7 @@ use std::io::{self, BufRead, Write};
 use dialoguer::{Input, Select};
 use ed25519_dalek::SigningKey;
 use rand::Rng;
-use vta_sdk::credentials::CredentialBundle;
-use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::prelude::*;
 
 use crate::auth;
 use crate::config::{PnmConfig, VtaConfig, save_config, slugify, vta_keyring_key};
@@ -192,12 +191,7 @@ async fn setup_tee(config: &mut PnmConfig) -> Result<(), Box<dyn std::error::Err
         .interact_text()?;
 
     // 7. Build credential bundle and store in keyring
-    let bundle = CredentialBundle {
-        did: did.clone(),
-        private_key_multibase: private_key_multibase.clone(),
-        vta_did: vta_did.clone(),
-        vta_url: None,
-    };
+    let bundle = CredentialBundle::new(did.clone(), private_key_multibase.clone(), vta_did.clone());
     let _credential_b64 = bundle.encode()?;
     let keyring_key = vta_keyring_key(&slug);
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 
 [dependencies]
 vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["client"] }
-chrono = "0.4"
-ed25519-dalek = "2"
+chrono = { workspace = true }
+ed25519-dalek = { workspace = true }
 ratatui = { workspace = true }
 serde_json = { workspace = true }
 multibase = { workspace = true }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -11,8 +11,14 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = ["client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["client"] }
 chrono = "0.4"
 ed25519-dalek = "2"
 ratatui = { workspace = true }
 serde_json = { workspace = true }
+multibase = { workspace = true }
+x25519-dalek = { workspace = true }
+sha2 = { workspace = true }
+hkdf = "0.12"
+aes-gcm = "0.10"
+base64 = { workspace = true }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["client"] }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }
 ratatui = { workspace = true }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.5.0"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["client"] }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }
 ratatui = { workspace = true }

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -3,7 +3,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Block, Cell, Row, Table},
 };
-use vta_sdk::client::{CreateAclRequest, UpdateAclRequest, VtaClient};
+use vta_sdk::prelude::*;
 
 use crate::render::print_widget;
 
@@ -121,12 +121,8 @@ pub async fn cmd_acl_create(
     contexts: Vec<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_role(&role)?;
-    let req = CreateAclRequest {
-        did,
-        role,
-        label,
-        allowed_contexts: contexts,
-    };
+    let mut req = CreateAclRequest::new(did, role).contexts(contexts);
+    if let Some(l) = label { req = req.label(l); }
     let entry = client.create_acl(req).await?;
     println!("ACL entry created:");
     println!("  DID:      {}", entry.did);

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -122,7 +122,9 @@ pub async fn cmd_acl_create(
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_role(&role)?;
     let mut req = CreateAclRequest::new(did, role).contexts(contexts);
-    if let Some(l) = label { req = req.label(l); }
+    if let Some(l) = label {
+        req = req.label(l);
+    }
     let entry = client.create_acl(req).await?;
     println!("ACL entry created:");
     println!("  DID:      {}", entry.did);

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -25,10 +25,11 @@ pub fn format_role(role: &str, contexts: &[String]) -> String {
 
 pub fn validate_role(role: &str) -> Result<(), Box<dyn std::error::Error>> {
     match role {
-        "admin" | "initiator" | "application" => Ok(()),
-        _ => {
-            Err(format!("invalid role '{role}', expected: admin, initiator, or application").into())
-        }
+        "admin" | "initiator" | "application" | "reader" => Ok(()),
+        _ => Err(format!(
+            "invalid role '{role}', expected: admin, initiator, application, or reader"
+        )
+        .into()),
     }
 }
 
@@ -239,6 +240,11 @@ mod tests {
     #[test]
     fn test_validate_role_application_ok() {
         assert!(validate_role("application").is_ok());
+    }
+
+    #[test]
+    fn test_validate_role_reader_ok() {
+        assert!(validate_role("reader").is_ok());
     }
 
     #[test]

--- a/vta-cli-common/src/commands/audit.rs
+++ b/vta-cli-common/src/commands/audit.rs
@@ -2,8 +2,7 @@ use ratatui::layout::Constraint;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 use ratatui::widgets::{Cell, Row, Table};
-use vta_sdk::client::VtaClient;
-use vta_sdk::protocols::audit_management::list::ListAuditLogsBody;
+use vta_sdk::prelude::*;
 
 use crate::render::print_widget;
 

--- a/vta-cli-common/src/commands/audit.rs
+++ b/vta-cli-common/src/commands/audit.rs
@@ -38,9 +38,7 @@ pub async fn cmd_list_audit_logs(
             let outcome_style = if entry.outcome == "success" {
                 Style::default().fg(Color::Green)
             } else if entry.outcome.starts_with("denied") {
-                Style::default()
-                    .fg(Color::Red)
-                    .add_modifier(Modifier::BOLD)
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::Yellow)
             };
@@ -121,7 +119,7 @@ pub async fn cmd_list_audit_logs(
             Constraint::Length(19), // Timestamp
             Constraint::Length(22), // Action
             Constraint::Length(30), // Actor
-            Constraint::Min(16),   // Resource
+            Constraint::Min(16),    // Resource
             Constraint::Length(20), // Outcome
         ],
     )
@@ -143,9 +141,7 @@ pub async fn cmd_list_audit_logs(
 }
 
 /// Display the current audit retention period.
-pub async fn cmd_get_retention(
-    client: &VtaClient,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn cmd_get_retention(client: &VtaClient) -> Result<(), Box<dyn std::error::Error>> {
     let result = client.get_audit_retention().await?;
     println!("\n  \x1b[1mAudit Retention\x1b[0m");
     println!(

--- a/vta-cli-common/src/commands/config.rs
+++ b/vta-cli-common/src/commands/config.rs
@@ -1,4 +1,4 @@
-use vta_sdk::client::{UpdateConfigRequest, VtaClient};
+use vta_sdk::prelude::*;
 
 pub async fn cmd_config_get(
     client: &VtaClient,

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -174,6 +174,22 @@ pub async fn cmd_context_update(
     Ok(())
 }
 
+pub async fn cmd_context_update_did(
+    client: &VtaClient,
+    id: &str,
+    did: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let resp = client.update_context_did(id, did).await?;
+    println!("Context DID updated:");
+    println!("  ID:         {}", resp.id);
+    println!(
+        "  DID:        {}",
+        resp.did.as_deref().unwrap_or("(not set)")
+    );
+    println!("  Updated At: {}", resp.updated_at);
+    Ok(())
+}
+
 pub async fn cmd_context_delete(
     client: &VtaClient,
     id: &str,

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -5,15 +5,9 @@ use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Block, Cell, Row, Table},
 };
-use vta_sdk::client::{
-    CreateContextRequest, CreateDidWebvhRequest, CreateKeyRequest, GenerateCredentialsRequest,
-    UpdateContextRequest, VtaClient,
-};
+use vta_sdk::client::{CreateDidWebvhRequest, UpdateContextRequest};
 use vta_sdk::context_provision::{ContextProvisionBundle, ProvisionedDid};
-use vta_sdk::credentials::CredentialBundle;
-use vta_sdk::did_key::{decode_private_key_multibase, ed25519_multibase_pubkey};
-use vta_sdk::did_secrets::SecretEntry;
-use vta_sdk::keys::KeyType;
+use vta_sdk::prelude::*;
 
 use crate::render::print_widget;
 
@@ -32,22 +26,16 @@ pub async fn cmd_context_bootstrap(
     description: Option<String>,
     admin_label: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let ctx_req = CreateContextRequest {
-        id: id.to_string(),
-        name: name.to_string(),
-        description,
-    };
+    let mut ctx_req = CreateContextRequest::new(id, name);
+    if let Some(desc) = description { ctx_req = ctx_req.description(desc); }
     let ctx = client.create_context(ctx_req).await?;
     println!("Context created:");
     println!("  ID:        {}", ctx.id);
     println!("  Name:      {}", ctx.name);
     println!("  Base Path: {}", ctx.base_path);
 
-    let cred_req = GenerateCredentialsRequest {
-        role: "admin".to_string(),
-        label: admin_label,
-        allowed_contexts: vec![id.to_string()],
-    };
+    let mut cred_req = GenerateCredentialsRequest::new("admin").contexts(vec![id.to_string()]);
+    if let Some(l) = admin_label { cred_req = cred_req.label(l); }
     let resp = client.generate_credentials(cred_req).await?;
     println!();
     println!("Admin credential created:");
@@ -265,20 +253,14 @@ pub async fn cmd_context_provision(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // 1. Create the context
     eprintln!("Creating context '{id}'...");
-    let ctx_req = CreateContextRequest {
-        id: id.to_string(),
-        name: name.to_string(),
-        description,
-    };
+    let mut ctx_req = CreateContextRequest::new(id, name);
+    if let Some(desc) = description { ctx_req = ctx_req.description(desc); }
     client.create_context(ctx_req).await?;
 
     // 2. Generate admin credentials scoped to this context
     eprintln!("Generating admin credentials...");
-    let cred_req = GenerateCredentialsRequest {
-        role: "admin".to_string(),
-        label: admin_label,
-        allowed_contexts: vec![id.to_string()],
-    };
+    let mut cred_req = GenerateCredentialsRequest::new("admin").contexts(vec![id.to_string()]);
+    if let Some(l) = admin_label { cred_req = cred_req.label(l); }
     let cred_resp = client.generate_credentials(cred_req).await?;
 
     // 3. Fetch VTA config for URL/DID
@@ -302,30 +284,15 @@ pub async fn cmd_context_provision(
 
         // Collect secrets for the DID keys
         eprintln!("Fetching DID key secrets...");
-        let mut secrets = Vec::new();
+        let mut secrets: Vec<SecretEntry> = Vec::new();
         // Signing key
-        let signing = client.get_key_secret(&did_result.signing_key_id).await?;
-        secrets.push(SecretEntry {
-            key_id: signing.key_id,
-            key_type: signing.key_type,
-            private_key_multibase: signing.private_key_multibase,
-        });
+        secrets.push(client.get_key_secret(&did_result.signing_key_id).await?.into());
         // Key-agreement key
-        let ka = client.get_key_secret(&did_result.ka_key_id).await?;
-        secrets.push(SecretEntry {
-            key_id: ka.key_id,
-            key_type: ka.key_type,
-            private_key_multibase: ka.private_key_multibase,
-        });
+        secrets.push(client.get_key_secret(&did_result.ka_key_id).await?.into());
         // Pre-rotation keys
         for i in 0..did_result.pre_rotation_key_count {
             let pre_rot_id = format!("{}#pre-rotation-{i}", did_result.did);
-            let pre_rot = client.get_key_secret(&pre_rot_id).await?;
-            secrets.push(SecretEntry {
-                key_id: pre_rot.key_id,
-                key_type: pre_rot.key_type,
-                private_key_multibase: pre_rot.private_key_multibase,
-            });
+            secrets.push(client.get_key_secret(&pre_rot_id).await?.into());
         }
 
         Some(ProvisionedDid {
@@ -499,12 +466,10 @@ pub async fn cmd_context_reprovision(
     if client.get_acl(&admin_did).await.is_err() {
         eprintln!("Creating ACL entry for {admin_did}...");
         client
-            .create_acl(vta_sdk::client::CreateAclRequest {
-                did: admin_did.clone(),
-                role: "admin".to_string(),
-                label: None,
-                allowed_contexts: vec![id.to_string()],
-            })
+            .create_acl(
+                vta_sdk::client::CreateAclRequest::new(&admin_did, "admin")
+                    .contexts(vec![id.to_string()]),
+            )
             .await?;
     }
 
@@ -524,24 +489,13 @@ pub async fn cmd_context_reprovision(
         };
 
         // Fetch all active key secrets for this context
-        let keys_resp = client
-            .list_keys(0, 10000, Some("active"), Some(id))
-            .await?;
-        let mut secrets = Vec::new();
-        for key in &keys_resp.keys {
-            let secret = client.get_key_secret(&key.key_id).await?;
-            secrets.push(SecretEntry {
-                key_id: secret.key_id,
-                key_type: secret.key_type,
-                private_key_multibase: secret.private_key_multibase,
-            });
-        }
+        let secrets_bundle = client.fetch_did_secrets_bundle(id).await?;
 
         Some(ProvisionedDid {
             id: did_id.clone(),
             did_document,
             log_entry,
-            secrets,
+            secrets: secrets_bundle.secrets,
         })
     } else {
         None

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -27,7 +27,9 @@ pub async fn cmd_context_bootstrap(
     admin_label: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut ctx_req = CreateContextRequest::new(id, name);
-    if let Some(desc) = description { ctx_req = ctx_req.description(desc); }
+    if let Some(desc) = description {
+        ctx_req = ctx_req.description(desc);
+    }
     let ctx = client.create_context(ctx_req).await?;
     println!("Context created:");
     println!("  ID:        {}", ctx.id);
@@ -35,7 +37,9 @@ pub async fn cmd_context_bootstrap(
     println!("  Base Path: {}", ctx.base_path);
 
     let mut cred_req = GenerateCredentialsRequest::new("admin").contexts(vec![id.to_string()]);
-    if let Some(l) = admin_label { cred_req = cred_req.label(l); }
+    if let Some(l) = admin_label {
+        cred_req = cred_req.label(l);
+    }
     let resp = client.generate_credentials(cred_req).await?;
     println!();
     println!("Admin credential created:");
@@ -204,7 +208,10 @@ pub async fn cmd_context_delete(
         || !preview.acl_entries_updated.is_empty();
 
     if has_resources {
-        println!("Deleting context '{}' will remove the following resources:\n", id);
+        println!(
+            "Deleting context '{}' will remove the following resources:\n",
+            id
+        );
 
         if !preview.keys.is_empty() {
             println!("  Keys ({}):", preview.keys.len());
@@ -221,7 +228,10 @@ pub async fn cmd_context_delete(
         }
 
         if !preview.acl_entries_removed.is_empty() {
-            println!("  ACL entries removed ({}):", preview.acl_entries_removed.len());
+            println!(
+                "  ACL entries removed ({}):",
+                preview.acl_entries_removed.len()
+            );
             for did in &preview.acl_entries_removed {
                 println!("    - {did}");
             }
@@ -270,13 +280,17 @@ pub async fn cmd_context_provision(
     // 1. Create the context
     eprintln!("Creating context '{id}'...");
     let mut ctx_req = CreateContextRequest::new(id, name);
-    if let Some(desc) = description { ctx_req = ctx_req.description(desc); }
+    if let Some(desc) = description {
+        ctx_req = ctx_req.description(desc);
+    }
     client.create_context(ctx_req).await?;
 
     // 2. Generate admin credentials scoped to this context
     eprintln!("Generating admin credentials...");
     let mut cred_req = GenerateCredentialsRequest::new("admin").contexts(vec![id.to_string()]);
-    if let Some(l) = admin_label { cred_req = cred_req.label(l); }
+    if let Some(l) = admin_label {
+        cred_req = cred_req.label(l);
+    }
     let cred_resp = client.generate_credentials(cred_req).await?;
 
     // 3. Fetch VTA config for URL/DID
@@ -302,7 +316,12 @@ pub async fn cmd_context_provision(
         eprintln!("Fetching DID key secrets...");
         let mut secrets: Vec<SecretEntry> = Vec::new();
         // Signing key
-        secrets.push(client.get_key_secret(&did_result.signing_key_id).await?.into());
+        secrets.push(
+            client
+                .get_key_secret(&did_result.signing_key_id)
+                .await?
+                .into(),
+        );
         // Key-agreement key
         secrets.push(client.get_key_secret(&did_result.ka_key_id).await?.into());
         // Pre-rotation keys
@@ -404,9 +423,7 @@ pub async fn cmd_context_reprovision(
         credential_from_key(client, kid, vta_did, config.public_url.as_deref()).await?
     } else {
         // Interactive: list existing Ed25519 keys and let user choose
-        let keys_resp = client
-            .list_keys(0, 10000, Some("active"), Some(id))
-            .await?;
+        let keys_resp = client.list_keys(0, 10000, Some("active"), Some(id)).await?;
         let ed25519_keys: Vec<_> = keys_resp
             .keys
             .iter()

--- a/vta-cli-common/src/commands/credentials.rs
+++ b/vta-cli-common/src/commands/credentials.rs
@@ -1,4 +1,4 @@
-use vta_sdk::client::{GenerateCredentialsRequest, VtaClient};
+use vta_sdk::prelude::*;
 
 use super::acl::validate_role;
 
@@ -9,11 +9,8 @@ pub async fn cmd_auth_credential_create(
     contexts: Vec<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_role(&role)?;
-    let req = GenerateCredentialsRequest {
-        role,
-        label,
-        allowed_contexts: contexts,
-    };
+    let mut req = GenerateCredentialsRequest::new(role).contexts(contexts);
+    if let Some(l) = label { req = req.label(l); }
     let resp = client.generate_credentials(req).await?;
     println!("Credentials generated:");
     println!("  DID:  {}", resp.did);

--- a/vta-cli-common/src/commands/credentials.rs
+++ b/vta-cli-common/src/commands/credentials.rs
@@ -10,7 +10,9 @@ pub async fn cmd_auth_credential_create(
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_role(&role)?;
     let mut req = GenerateCredentialsRequest::new(role).contexts(contexts);
-    if let Some(l) = label { req = req.label(l); }
+    if let Some(l) = label {
+        req = req.label(l);
+    }
     let resp = client.generate_credentials(req).await?;
     println!("Credentials generated:");
     println!("  DID:  {}", resp.did);

--- a/vta-cli-common/src/commands/keys.rs
+++ b/vta-cli-common/src/commands/keys.rs
@@ -4,9 +4,7 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Cell, Row, Table},
 };
-use vta_sdk::client::{CreateKeyRequest, ImportKeyRequest, VtaClient};
-use vta_sdk::did_secrets::{DidSecretsBundle, SecretEntry};
-use vta_sdk::keys::KeyType;
+use vta_sdk::prelude::*;
 
 use crate::render::print_widget;
 
@@ -25,14 +23,11 @@ pub async fn cmd_key_create(
             return Err(format!("unknown key type '{other}', expected ed25519 or x25519").into());
         }
     };
-    let req = CreateKeyRequest {
-        key_type,
-        derivation_path,
-        key_id: None,
-        mnemonic,
-        label,
-        context_id,
-    };
+    let mut req = CreateKeyRequest::new(key_type);
+    if let Some(p) = derivation_path { req = req.derivation_path(p); }
+    if let Some(m) = mnemonic { req = req.mnemonic(m); }
+    if let Some(l) = label { req = req.label(l); }
+    if let Some(c) = context_id { req = req.context(c); }
     let resp = client.create_key(req).await?;
     println!("Key created:");
     println!("  Key ID:          {}", resp.key_id);
@@ -348,33 +343,8 @@ pub async fn cmd_key_bundle(
     client: &VtaClient,
     context: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // 1. Get the context to find the DID
-    let ctx = client.get_context(context).await?;
-    let did = ctx
-        .did
-        .ok_or(format!("context '{context}' has no DID assigned"))?;
-
-    // 2. List all active keys in the context
-    let resp = client
-        .list_keys(0, 10000, Some("active"), Some(context))
-        .await?;
-    if resp.keys.is_empty() {
-        return Err("no active keys found in this context".into());
-    }
-
-    // 3. Get secrets for each key and build SecretEntry vec
-    let mut secrets = Vec::new();
-    for key in &resp.keys {
-        let secret = client.get_key_secret(&key.key_id).await?;
-        secrets.push(SecretEntry {
-            key_id: secret.key_id,
-            key_type: secret.key_type,
-            private_key_multibase: secret.private_key_multibase,
-        });
-    }
-
-    // 4. Build and encode the bundle
-    let bundle = DidSecretsBundle { did, secrets };
+    // Fetch all secrets for this context as a portable bundle
+    let bundle = client.fetch_did_secrets_bundle(context).await?;
     let encoded = bundle.encode().map_err(|e| format!("{e}"))?;
 
     // 5. Print with security warning

--- a/vta-cli-common/src/commands/keys.rs
+++ b/vta-cli-common/src/commands/keys.rs
@@ -24,10 +24,18 @@ pub async fn cmd_key_create(
         }
     };
     let mut req = CreateKeyRequest::new(key_type);
-    if let Some(p) = derivation_path { req = req.derivation_path(p); }
-    if let Some(m) = mnemonic { req = req.mnemonic(m); }
-    if let Some(l) = label { req = req.label(l); }
-    if let Some(c) = context_id { req = req.context(c); }
+    if let Some(p) = derivation_path {
+        req = req.derivation_path(p);
+    }
+    if let Some(m) = mnemonic {
+        req = req.mnemonic(m);
+    }
+    if let Some(l) = label {
+        req = req.label(l);
+    }
+    if let Some(c) = context_id {
+        req = req.context(c);
+    }
     let resp = client.create_key(req).await?;
     println!("Key created:");
     println!("  Key ID:          {}", resp.key_id);
@@ -55,7 +63,9 @@ pub async fn cmd_key_import(
         "x25519" => KeyType::X25519,
         "p256" => KeyType::P256,
         other => {
-            return Err(format!("unknown key type '{other}', expected ed25519, x25519, or p256").into());
+            return Err(
+                format!("unknown key type '{other}', expected ed25519, x25519, or p256").into(),
+            );
         }
     };
 
@@ -110,7 +120,9 @@ pub async fn cmd_key_import(
     }
     println!("  Created At: {}", resp.created_at);
     eprintln!();
-    eprintln!("\x1b[1;33mWarning: securely delete the source key material \u{2014} the VTA now holds this secret.\x1b[0m");
+    eprintln!(
+        "\x1b[1;33mWarning: securely delete the source key material \u{2014} the VTA now holds this secret.\x1b[0m"
+    );
 
     Ok(())
 }
@@ -149,15 +161,16 @@ fn wrap_private_key(
         .map_err(|e| format!("hkdf: {e}"))?;
 
     // AES-256-GCM encrypt
-    use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
     use aes_gcm::aead::Aead;
     use aes_gcm::aead::rand_core::RngCore;
+    use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 
     let cipher = Aes256Gcm::new_from_slice(&aes_key)?;
     let mut nonce_bytes = [0u8; 12];
     aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
-    let ciphertext = cipher.encrypt(nonce, key_bytes.as_ref())
+    let ciphertext = cipher
+        .encrypt(nonce, key_bytes.as_ref())
         .map_err(|e| format!("encrypt: {e}"))?;
 
     // Format: kid.ephemeral_pub.nonce.ciphertext

--- a/vta-cli-common/src/commands/keys.rs
+++ b/vta-cli-common/src/commands/keys.rs
@@ -4,7 +4,7 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Cell, Row, Table},
 };
-use vta_sdk::client::{CreateKeyRequest, VtaClient};
+use vta_sdk::client::{CreateKeyRequest, ImportKeyRequest, VtaClient};
 use vta_sdk::did_secrets::{DidSecretsBundle, SecretEntry};
 use vta_sdk::keys::KeyType;
 
@@ -45,6 +45,134 @@ pub async fn cmd_key_create(
     }
     println!("  Created At:      {}", resp.created_at);
     Ok(())
+}
+
+pub async fn cmd_key_import(
+    client: &VtaClient,
+    key_type: &str,
+    private_key: Option<String>,
+    private_key_file: Option<std::path::PathBuf>,
+    label: Option<String>,
+    context_id: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let key_type = match key_type {
+        "ed25519" => KeyType::Ed25519,
+        "x25519" => KeyType::X25519,
+        "p256" => KeyType::P256,
+        other => {
+            return Err(format!("unknown key type '{other}', expected ed25519, x25519, or p256").into());
+        }
+    };
+
+    // Read private key bytes
+    let private_key_multibase = if let Some(key_str) = private_key {
+        key_str
+    } else if let Some(path) = private_key_file {
+        let bytes = std::fs::read(&path)
+            .map_err(|e| format!("failed to read key file '{}': {e}", path.display()))?;
+        // If file is text (multibase), use as-is; otherwise encode as multibase
+        match String::from_utf8(bytes.clone()) {
+            Ok(s) if s.starts_with('z') || s.starts_with('f') || s.starts_with('u') => {
+                s.trim().to_string()
+            }
+            _ => multibase::encode(multibase::Base::Base58Btc, &bytes),
+        }
+    } else {
+        return Err("either --private-key or --private-key-file is required".into());
+    };
+
+    // For REST transport, fetch wrapping key and create JWE
+    // For DIDComm, send multibase directly
+    let (jwe, multibase) = match client.get_wrapping_key().await {
+        Ok(wrapping_key) => {
+            // REST path: wrap with ECDH-ES
+            let jwe = wrap_private_key(&wrapping_key.kid, &wrapping_key.x, &private_key_multibase)?;
+            (Some(jwe), None)
+        }
+        Err(_) => {
+            // DIDComm path (or wrapping key not available): send multibase
+            (None, Some(private_key_multibase))
+        }
+    };
+
+    let req = ImportKeyRequest {
+        key_type,
+        private_key_jwe: jwe,
+        private_key_multibase: multibase,
+        label,
+        context_id,
+    };
+    let resp = client.import_key(req).await?;
+
+    println!("Key imported successfully:");
+    println!("  Key ID:     {}", resp.key_id);
+    println!("  Key Type:   {}", resp.key_type);
+    println!("  Public Key: {}", resp.public_key);
+    println!("  Status:     {}", resp.status);
+    println!("  Origin:     imported");
+    if let Some(label) = &resp.label {
+        println!("  Label:      {label}");
+    }
+    println!("  Created At: {}", resp.created_at);
+    eprintln!();
+    eprintln!("\x1b[1;33mWarning: securely delete the source key material \u{2014} the VTA now holds this secret.\x1b[0m");
+
+    Ok(())
+}
+
+/// Wrap a multibase-encoded private key with ECDH-ES+AES-256-GCM for REST transport.
+fn wrap_private_key(
+    kid: &str,
+    vta_pub_b64: &str,
+    private_key_multibase: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+
+    // Decode the VTA's wrapping public key
+    let vta_pub_bytes: [u8; 32] = BASE64
+        .decode(vta_pub_b64)?
+        .try_into()
+        .map_err(|_| "wrapping public key must be 32 bytes")?;
+
+    // Decode the private key from multibase
+    let (_, key_bytes) = multibase::decode(private_key_multibase)?;
+
+    // Generate ephemeral X25519 keypair for client side
+    let client_secret = x25519_dalek::StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+    let client_pub = x25519_dalek::PublicKey::from(&client_secret);
+
+    // ECDH
+    let vta_pub = x25519_dalek::PublicKey::from(vta_pub_bytes);
+    let shared = client_secret.diffie_hellman(&vta_pub);
+
+    // HKDF to derive AES key
+    use sha2::Sha256;
+    let hkdf = hkdf::Hkdf::<Sha256>::new(None, shared.as_bytes());
+    let mut aes_key = [0u8; 32];
+    hkdf.expand(b"vta-key-import-wrapping", &mut aes_key)
+        .map_err(|e| format!("hkdf: {e}"))?;
+
+    // AES-256-GCM encrypt
+    use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+    use aes_gcm::aead::Aead;
+    use aes_gcm::aead::rand_core::RngCore;
+
+    let cipher = Aes256Gcm::new_from_slice(&aes_key)?;
+    let mut nonce_bytes = [0u8; 12];
+    aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let ciphertext = cipher.encrypt(nonce, key_bytes.as_ref())
+        .map_err(|e| format!("encrypt: {e}"))?;
+
+    // Format: kid.ephemeral_pub.nonce.ciphertext
+    Ok(format!(
+        "{}.{}.{}.{}",
+        kid,
+        BASE64.encode(client_pub.as_bytes()),
+        BASE64.encode(nonce_bytes),
+        BASE64.encode(ciphertext),
+    ))
 }
 
 pub async fn cmd_key_get(

--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -133,7 +133,8 @@ pub async fn cmd_webvh_did_create(
         println!("DID Document:");
         println!(
             "{}",
-            serde_json::to_string_pretty(did_document).unwrap_or_else(|_| format!("{did_document}"))
+            serde_json::to_string_pretty(did_document)
+                .unwrap_or_else(|_| format!("{did_document}"))
         );
     }
     if let Some(ref log_entry) = result.log_entry {

--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -3,9 +3,8 @@ use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Block, Cell, Row, Table},
 };
-use vta_sdk::client::{
-    AddWebvhServerRequest, CreateDidWebvhRequest, UpdateWebvhServerRequest, VtaClient,
-};
+use vta_sdk::client::{AddWebvhServerRequest, CreateDidWebvhRequest, UpdateWebvhServerRequest};
+use vta_sdk::prelude::*;
 
 use crate::render::print_widget;
 

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version.workspace = true
+version = "0.2.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -24,7 +24,7 @@ vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
 vta-service = { path = "../vta-service", version = "0.3.0", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.2.1", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -23,7 +23,7 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.3.0", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.4.0", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.2.1", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.2.3"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -23,8 +23,8 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.5.0", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.4.0", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.3.0", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -23,8 +23,8 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.2.0", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.2.0", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.3.0", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -23,8 +23,8 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.4.0", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.5.0", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.4.0", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -24,7 +24,7 @@ vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
 vta-service = { path = "../vta-service", version = "0.4.0", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.2.1", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-enclave/src/main.rs
+++ b/vta-enclave/src/main.rs
@@ -44,12 +44,23 @@ async fn main() {
     let cli = Cli::parse();
 
     // Load config — resolve the path first so we can print diagnostics on failure
-    let config_path = cli.config.clone()
-        .or_else(|| std::env::var("VTA_CONFIG_PATH").ok().map(std::path::PathBuf::from))
+    let config_path = cli
+        .config
+        .clone()
+        .or_else(|| {
+            std::env::var("VTA_CONFIG_PATH")
+                .ok()
+                .map(std::path::PathBuf::from)
+        })
         .unwrap_or_else(|| std::path::PathBuf::from("config.toml"));
     eprintln!("Loading config from: {}", config_path.display());
     if config_path.exists() {
-        eprintln!("Config file exists ({} bytes)", std::fs::metadata(&config_path).map(|m| m.len()).unwrap_or(0));
+        eprintln!(
+            "Config file exists ({} bytes)",
+            std::fs::metadata(&config_path)
+                .map(|m| m.len())
+                .unwrap_or(0)
+        );
     } else {
         eprintln!("Config file NOT FOUND at {}", config_path.display());
     }
@@ -178,11 +189,14 @@ async fn main() {
 
         if let Some(ref bootstrap) = tee_bootstrap {
             if let (Some(entropy), Some(window_secs)) = (bootstrap.entropy, export_window) {
-                Some(Arc::new(
-                    tee::mnemonic_guard::MnemonicExportGuard::new(entropy, window_secs),
-                ))
+                Some(Arc::new(tee::mnemonic_guard::MnemonicExportGuard::new(
+                    entropy,
+                    window_secs,
+                )))
             } else if bootstrap.entropy.is_some() && export_window.is_none() {
-                info!("first boot but VTA_MNEMONIC_EXPORT_WINDOW not set — mnemonic export disabled");
+                info!(
+                    "first boot but VTA_MNEMONIC_EXPORT_WINDOW not set — mnemonic export disabled"
+                );
                 Some(Arc::new(tee::mnemonic_guard::MnemonicExportGuard::empty()))
             } else {
                 Some(Arc::new(tee::mnemonic_guard::MnemonicExportGuard::empty()))

--- a/vta-enclave/src/vsock_log.rs
+++ b/vta-enclave/src/vsock_log.rs
@@ -43,32 +43,28 @@ pub async fn start() -> TeeMakeWriter {
     // so early boot logs aren't lost.
     let addr = VsockAddr::new(PARENT_CID, VSOCK_LOG_PORT);
     eprintln!("[vsock-log] connecting to parent CID {PARENT_CID} port {VSOCK_LOG_PORT}...");
-    let initial_stream = match tokio::time::timeout(
-        CONNECT_TIMEOUT,
-        VsockStream::connect(addr),
-    )
-    .await
-    {
-        Ok(Ok(stream)) => {
-            eprintln!("[vsock-log] connected to parent vsock:{VSOCK_LOG_PORT}");
-            Some(stream)
-        }
-        Ok(Err(e)) => {
-            eprintln!(
-                "[vsock-log] failed to connect to parent vsock:{VSOCK_LOG_PORT}: {e} — \
+    let initial_stream =
+        match tokio::time::timeout(CONNECT_TIMEOUT, VsockStream::connect(addr)).await {
+            Ok(Ok(stream)) => {
+                eprintln!("[vsock-log] connected to parent vsock:{VSOCK_LOG_PORT}");
+                Some(stream)
+            }
+            Ok(Err(e)) => {
+                eprintln!(
+                    "[vsock-log] failed to connect to parent vsock:{VSOCK_LOG_PORT}: {e} — \
                  will retry in background"
-            );
-            None
-        }
-        Err(_) => {
-            eprintln!(
-                "[vsock-log] connection to parent vsock:{VSOCK_LOG_PORT} timed out after {}s — \
+                );
+                None
+            }
+            Err(_) => {
+                eprintln!(
+                    "[vsock-log] connection to parent vsock:{VSOCK_LOG_PORT} timed out after {}s — \
                  will retry in background",
-                CONNECT_TIMEOUT.as_secs()
-            );
-            None
-        }
-    };
+                    CONNECT_TIMEOUT.as_secs()
+                );
+                None
+            }
+        };
 
     tokio::spawn(vsock_drain_task(rx, initial_stream));
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version.workspace = true
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -31,6 +31,7 @@ session = [
   "dep:affinidi-did-resolver-cache-sdk",
   "dep:tokio",
 ]
+integration = ["client", "session"]
 keyring = ["dep:keyring"]
 config-session = []
 azure-secrets = [

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -12,7 +12,19 @@ repository.workspace = true
 
 [features]
 didcomm = ["dep:affinidi-tdk", "dep:affinidi-did-resolver-cache-sdk", "dep:tracing", "dep:uuid", "dep:tokio"]
-client = ["dep:reqwest", "dep:tracing", "dep:uuid", "dep:affinidi-tdk"]
+client = [
+  "dep:reqwest",
+  "dep:tracing",
+  "dep:uuid",
+  "dep:affinidi-tdk",
+  "dep:tokio",
+  "dep:ed25519-dalek",
+  "dep:x25519-dalek",
+  "dep:curve25519-dalek",
+  "dep:aes-gcm",
+  "dep:aes",
+  "dep:sha2",
+]
 session = [
   "client",
   "didcomm",
@@ -33,6 +45,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 base64 = { workspace = true }
 multibase = { workspace = true }
+thiserror = { workspace = true }
 affinidi-tdk = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
@@ -42,3 +55,12 @@ keyring = { version = "3", optional = true }
 azure_security_keyvault_secrets = { version = "0.12", optional = true }
 azure_identity = { version = "0.33", optional = true }
 tokio = { workspace = true, optional = true }
+ed25519-dalek = { version = "2", optional = true }
+x25519-dalek = { workspace = true, optional = true }
+curve25519-dalek = { version = "4", optional = true }
+aes-gcm = { version = "0.10", optional = true }
+aes = { version = "0.8", optional = true }
+sha2 = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -55,7 +55,7 @@ keyring = { version = "3", optional = true }
 azure_security_keyvault_secrets = { version = "0.12", optional = true }
 azure_identity = { version = "0.33", optional = true }
 tokio = { workspace = true, optional = true }
-ed25519-dalek = { version = "2", optional = true }
+ed25519-dalek = { workspace = true, optional = true }
 x25519-dalek = { workspace = true, optional = true }
 curve25519-dalek = { version = "4", optional = true }
 aes-gcm = { version = "0.10", optional = true }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.4.0"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/README.md
+++ b/vta-sdk/README.md
@@ -17,14 +17,17 @@ protocol constants needed to interact with a VTA service:
   (requires `didcomm` feature).
 - **Session management** -- credential import, challenge-response auth, and
   automatic token refresh (requires `session` feature).
+- **Integration module** -- unified startup pattern for services that manage
+  their DID and keys through a VTA (requires `integration` feature).
 
 ## Feature Flags
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `client` | No | VTA HTTP client (`reqwest`-based) |
+| `client` | No | VTA HTTP client (`reqwest`-based) with lightweight auth |
 | `didcomm` | No | DIDComm v2 message support |
 | `session` | No | Full session management (implies `client` + `didcomm`) |
+| `integration` | No | Service startup module with offline resilience (implies `client` + `session`) |
 | `keyring` | No | OS keyring session storage |
 | `config-session` | No | File-based session storage |
 | `azure-secrets` | No | Azure Key Vault secrets resolver |
@@ -36,10 +39,63 @@ Add to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Types only (no network)
-vta-sdk = "0.2"
+vta-sdk = "0.4"
 
 # Full client with session management
-vta-sdk = { version = "0.2", features = ["session", "keyring"] }
+vta-sdk = { version = "0.4", features = ["session", "keyring"] }
+
+# Service integration with offline resilience
+vta-sdk = { version = "0.4", features = ["integration"] }
+```
+
+### Quick Start: Service Integration
+
+The `integration` module provides a one-call startup pattern for services
+that delegate key management to a VTA:
+
+```rust,ignore
+use vta_sdk::integration::{startup, VtaServiceConfig, SecretCache};
+
+// 1. Implement SecretCache for your storage backend
+struct MyCache;
+impl SecretCache for MyCache {
+    async fn store(&self, bundle: &DidSecretsBundle) -> Result<(), Box<dyn Error>> { /* ... */ }
+    async fn load(&self) -> Result<Option<DidSecretsBundle>, Box<dyn Error>> { /* ... */ }
+}
+
+// 2. Configure and start
+let config = VtaServiceConfig {
+    credential: std::fs::read_to_string("credential.b64")?,
+    context: "my-service".into(),
+    url_override: None,
+};
+
+let result = startup(&config, &MyCache).await?;
+// result.did      — your service's DID
+// result.bundle   — private keys for DIDComm/signing
+// result.source   — SecretSource::Vta or SecretSource::Cache
+// result.client   — Some(VtaClient) when VTA is reachable
+```
+
+See the [Integration Guide](../docs/integration-guide.md) for the full walkthrough.
+
+### Quick Start: Direct Client
+
+```rust,ignore
+use vta_sdk::prelude::*;
+
+// Authenticate with a credential bundle
+let client = VtaClient::from_credential(&credential_b64, None).await?;
+
+// Create a key
+let key = client.create_key(
+    CreateKeyRequest::new(KeyType::Ed25519)
+        .label("signing-key")
+        .context("my-app")
+).await?;
+
+// Sign a payload
+let sig = client.sign(&key.key_id, b"hello", "EdDSA").await?;
 ```
 
 ## License

--- a/vta-sdk/src/auth_light.rs
+++ b/vta-sdk/src/auth_light.rs
@@ -10,6 +10,7 @@
 use crate::credentials::CredentialBundle;
 use crate::didcomm_light;
 use crate::protocols::auth::{AuthenticateResponse, ChallengeRequest, ChallengeResponse};
+use reqwest::Client;
 
 /// Result of a successful authentication.
 #[derive(Debug, Clone)]
@@ -25,6 +26,7 @@ pub struct AuthResult {
 /// This is the lightweight equivalent of `session::challenge_response()`.
 /// It uses the `didcomm_light` packer to build the encrypted message.
 pub async fn challenge_response_light(
+    http: &Client,
     base_url: &str,
     client_did: &str,
     private_key_multibase: &str,
@@ -32,7 +34,6 @@ pub async fn challenge_response_light(
 ) -> Result<AuthResult, crate::error::VtaError> {
     let _ = private_key_multibase; // Sender identity is in the plaintext `from` field;
                                     // anoncrypt doesn't use sender's private key for encryption.
-    let http = reqwest::Client::new();
 
     // Step 1: Request challenge
     let challenge_url = format!("{base_url}/auth/challenge");
@@ -101,6 +102,7 @@ pub async fn challenge_response_light(
 /// Returns a new `AuthResult` with a fresh access token. The refresh token
 /// itself remains unchanged.
 pub async fn refresh_token_light(
+    http: &Client,
     base_url: &str,
     client_did: &str,
     vta_did: &str,
@@ -115,7 +117,6 @@ pub async fn refresh_token_light(
         vta_did,
     )?;
 
-    let http = reqwest::Client::new();
     let refresh_url = format!("{base_url}/auth/refresh");
     let resp = http
         .post(&refresh_url)
@@ -148,13 +149,15 @@ pub async fn refresh_token_light(
 pub async fn authenticate_with_credential(
     credential_b64: &str,
     url_override: Option<&str>,
-) -> Result<(AuthResult, CredentialBundle), crate::error::VtaError> {
+) -> Result<(AuthResult, CredentialBundle, Client), crate::error::VtaError> {
     let cred = CredentialBundle::decode(credential_b64)?;
     let url = url_override
         .or(cred.vta_url.as_deref())
         .ok_or("no VTA URL in credential and no override provided")?;
 
+    let http = Client::new();
     let result = challenge_response_light(
+        &http,
         url,
         &cred.did,
         &cred.private_key_multibase,
@@ -162,5 +165,5 @@ pub async fn authenticate_with_credential(
     )
     .await?;
 
-    Ok((result, cred))
+    Ok((result, cred, http))
 }

--- a/vta-sdk/src/auth_light.rs
+++ b/vta-sdk/src/auth_light.rs
@@ -33,7 +33,7 @@ pub async fn challenge_response_light(
     vta_did: &str,
 ) -> Result<AuthResult, crate::error::VtaError> {
     let _ = private_key_multibase; // Sender identity is in the plaintext `from` field;
-                                    // anoncrypt doesn't use sender's private key for encryption.
+    // anoncrypt doesn't use sender's private key for encryption.
 
     // Step 1: Request challenge
     let challenge_url = format!("{base_url}/auth/challenge");

--- a/vta-sdk/src/auth_light.rs
+++ b/vta-sdk/src/auth_light.rs
@@ -1,0 +1,166 @@
+//! Lightweight challenge-response authentication for VTA REST clients.
+//!
+//! This module provides the same DIDComm challenge-response flow as
+//! `session::challenge_response()` but without requiring ATM/TDK runtime
+//! initialization. It uses the lightweight DIDComm packer from
+//! `didcomm_light` to build encrypted auth messages.
+//!
+//! Feature gate: `client` (not `session`).
+
+use crate::credentials::CredentialBundle;
+use crate::didcomm_light;
+use crate::protocols::auth::{AuthenticateResponse, ChallengeRequest, ChallengeResponse};
+
+/// Result of a successful authentication.
+#[derive(Debug, Clone)]
+pub struct AuthResult {
+    pub access_token: String,
+    pub access_expires_at: u64,
+    pub refresh_token: Option<String>,
+    pub refresh_expires_at: Option<u64>,
+}
+
+/// Perform DIDComm challenge-response authentication without ATM/TDK runtime.
+///
+/// This is the lightweight equivalent of `session::challenge_response()`.
+/// It uses the `didcomm_light` packer to build the encrypted message.
+pub async fn challenge_response_light(
+    base_url: &str,
+    client_did: &str,
+    private_key_multibase: &str,
+    vta_did: &str,
+) -> Result<AuthResult, crate::error::VtaError> {
+    let _ = private_key_multibase; // Sender identity is in the plaintext `from` field;
+                                    // anoncrypt doesn't use sender's private key for encryption.
+    let http = reqwest::Client::new();
+
+    // Step 1: Request challenge
+    let challenge_url = format!("{base_url}/auth/challenge");
+    let challenge_resp = http
+        .post(&challenge_url)
+        .json(&ChallengeRequest {
+            did: client_did.to_string(),
+        })
+        .send()
+        .await
+        .map_err(|e| format!("could not connect to VTA at {challenge_url}: {e}"))?;
+
+    if !challenge_resp.status().is_success() {
+        let status = challenge_resp.status();
+        let body = challenge_resp.text().await.unwrap_or_default();
+        return Err(format!("challenge request failed ({status}): {body}").into());
+    }
+
+    let challenge: ChallengeResponse = challenge_resp
+        .json()
+        .await
+        .map_err(|e| format!("unexpected response from VTA: {e}"))?;
+
+    // Step 2: Pack encrypted authenticate message
+    let packed = didcomm_light::pack_auth_message(
+        "https://affinidi.com/atm/1.0/authenticate",
+        serde_json::json!({
+            "challenge": challenge.data.challenge,
+            "session_id": challenge.session_id,
+        }),
+        client_did,
+        vta_did,
+    )?;
+
+    // Step 3: Send packed message
+    let auth_url = format!("{base_url}/auth/");
+    let auth_resp = http
+        .post(&auth_url)
+        .header("content-type", "text/plain")
+        .body(packed)
+        .send()
+        .await
+        .map_err(|e| format!("could not connect to VTA at {auth_url}: {e}"))?;
+
+    if !auth_resp.status().is_success() {
+        let status = auth_resp.status();
+        let body = auth_resp.text().await.unwrap_or_default();
+        return Err(format!("authentication failed ({status}): {body}").into());
+    }
+
+    let auth_data: AuthenticateResponse = auth_resp
+        .json()
+        .await
+        .map_err(|e| format!("unexpected auth response: {e}"))?;
+
+    Ok(AuthResult {
+        access_token: auth_data.data.access_token,
+        access_expires_at: auth_data.data.access_expires_at,
+        refresh_token: auth_data.data.refresh_token,
+        refresh_expires_at: auth_data.data.refresh_expires_at,
+    })
+}
+
+/// Refresh an access token using the refresh token endpoint.
+///
+/// Returns a new `AuthResult` with a fresh access token. The refresh token
+/// itself remains unchanged.
+pub async fn refresh_token_light(
+    base_url: &str,
+    client_did: &str,
+    vta_did: &str,
+    refresh_token: &str,
+) -> Result<AuthResult, crate::error::VtaError> {
+    let packed = didcomm_light::pack_auth_message(
+        "https://affinidi.com/atm/1.0/authenticate/refresh",
+        serde_json::json!({
+            "refresh_token": refresh_token,
+        }),
+        client_did,
+        vta_did,
+    )?;
+
+    let http = reqwest::Client::new();
+    let refresh_url = format!("{base_url}/auth/refresh");
+    let resp = http
+        .post(&refresh_url)
+        .header("content-type", "text/plain")
+        .body(packed)
+        .send()
+        .await
+        .map_err(|e| format!("refresh request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("token refresh failed ({status}): {body}").into());
+    }
+
+    let auth_data: AuthenticateResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("unexpected refresh response: {e}"))?;
+
+    Ok(AuthResult {
+        access_token: auth_data.data.access_token,
+        access_expires_at: auth_data.data.access_expires_at,
+        refresh_token: auth_data.data.refresh_token,
+        refresh_expires_at: auth_data.data.refresh_expires_at,
+    })
+}
+
+/// Decode a credential bundle and authenticate, returning an `AuthResult`.
+pub async fn authenticate_with_credential(
+    credential_b64: &str,
+    url_override: Option<&str>,
+) -> Result<(AuthResult, CredentialBundle), crate::error::VtaError> {
+    let cred = CredentialBundle::decode(credential_b64)?;
+    let url = url_override
+        .or(cred.vta_url.as_deref())
+        .ok_or("no VTA URL in credential and no override provided")?;
+
+    let result = challenge_response_light(
+        url,
+        &cred.did,
+        &cred.private_key_multibase,
+        &cred.vta_did,
+    )
+    .await?;
+
+    Ok((result, cred))
+}

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -73,6 +73,42 @@ pub struct CreateKeyRequest {
     pub context_id: Option<String>,
 }
 
+// ── Import key types ───────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct ImportKeyRequest {
+    pub key_type: KeyType,
+    /// JWE compact serialization of the private key (REST transport).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key_jwe: Option<String>,
+    /// Multibase-encoded private key (DIDComm transport).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key_multibase: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ImportKeyResponse {
+    pub key_id: String,
+    pub key_type: KeyType,
+    pub public_key: String,
+    pub status: KeyStatus,
+    pub label: Option<String>,
+    pub origin: crate::keys::KeyOrigin,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WrappingKeyResponse {
+    pub kid: String,
+    pub kty: String,
+    pub crv: String,
+    pub x: String,
+}
+
 // ── Context types ───────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -734,6 +770,42 @@ impl VtaClient {
                         key_id: new_key_id.to_string(),
                     })
             },
+        )
+        .await
+    }
+
+    // ── Import key methods ──────────────────────────────────────────
+
+    /// Fetch an ephemeral wrapping key for REST key import.
+    pub async fn get_wrapping_key(&self) -> Result<WrappingKeyResponse, Box<dyn std::error::Error>> {
+        match &self.transport {
+            Transport::Rest {
+                client,
+                base_url,
+                token,
+            } => {
+                let req = client.get(format!("{base_url}/keys/import/wrapping-key"));
+                let resp = Self::with_auth(req, token).send().await?;
+                Self::handle_response(resp).await
+            }
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => {
+                Err("wrapping key not needed for DIDComm transport".into())
+            }
+        }
+    }
+
+    /// Import an externally-created private key into the VTA.
+    pub async fn import_key(
+        &self,
+        req: ImportKeyRequest,
+    ) -> Result<ImportKeyResponse, Box<dyn std::error::Error>> {
+        self.rpc(
+            key_management::IMPORT_KEY,
+            serde_json::to_value(&req)?,
+            key_management::IMPORT_KEY_RESULT,
+            30,
+            |c, url| c.post(format!("{url}/keys/import")).json(&req),
         )
         .await
     }

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -96,6 +96,7 @@ impl CreateKeyRequest {
     }
     pub fn derivation_path(mut self, path: impl Into<String>) -> Self { self.derivation_path = Some(path.into()); self }
     pub fn key_id(mut self, id: impl Into<String>) -> Self { self.key_id = Some(id.into()); self }
+    pub fn mnemonic(mut self, m: impl Into<String>) -> Self { self.mnemonic = Some(m.into()); self }
     pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
     pub fn context(mut self, ctx: impl Into<String>) -> Self { self.context_id = Some(ctx.into()); self }
 }

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -92,13 +92,35 @@ pub struct CreateKeyRequest {
 
 impl CreateKeyRequest {
     pub fn new(key_type: KeyType) -> Self {
-        Self { key_type, derivation_path: None, key_id: None, mnemonic: None, label: None, context_id: None }
+        Self {
+            key_type,
+            derivation_path: None,
+            key_id: None,
+            mnemonic: None,
+            label: None,
+            context_id: None,
+        }
     }
-    pub fn derivation_path(mut self, path: impl Into<String>) -> Self { self.derivation_path = Some(path.into()); self }
-    pub fn key_id(mut self, id: impl Into<String>) -> Self { self.key_id = Some(id.into()); self }
-    pub fn mnemonic(mut self, m: impl Into<String>) -> Self { self.mnemonic = Some(m.into()); self }
-    pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
-    pub fn context(mut self, ctx: impl Into<String>) -> Self { self.context_id = Some(ctx.into()); self }
+    pub fn derivation_path(mut self, path: impl Into<String>) -> Self {
+        self.derivation_path = Some(path.into());
+        self
+    }
+    pub fn key_id(mut self, id: impl Into<String>) -> Self {
+        self.key_id = Some(id.into());
+        self
+    }
+    pub fn mnemonic(mut self, m: impl Into<String>) -> Self {
+        self.mnemonic = Some(m.into());
+        self
+    }
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+    pub fn context(mut self, ctx: impl Into<String>) -> Self {
+        self.context_id = Some(ctx.into());
+        self
+    }
 }
 
 // ── Import key types ───────────────────────────────────────────────
@@ -149,9 +171,16 @@ pub struct CreateContextRequest {
 
 impl CreateContextRequest {
     pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
-        Self { id: id.into(), name: name.into(), description: None }
+        Self {
+            id: id.into(),
+            name: name.into(),
+            description: None,
+        }
     }
-    pub fn description(mut self, desc: impl Into<String>) -> Self { self.description = Some(desc.into()); self }
+    pub fn description(mut self, desc: impl Into<String>) -> Self {
+        self.description = Some(desc.into());
+        self
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -297,10 +326,21 @@ pub struct CreateAclRequest {
 
 impl CreateAclRequest {
     pub fn new(did: impl Into<String>, role: impl Into<String>) -> Self {
-        Self { did: did.into(), role: role.into(), label: None, allowed_contexts: Vec::new() }
+        Self {
+            did: did.into(),
+            role: role.into(),
+            label: None,
+            allowed_contexts: Vec::new(),
+        }
     }
-    pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
-    pub fn contexts(mut self, contexts: Vec<String>) -> Self { self.allowed_contexts = contexts; self }
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+    pub fn contexts(mut self, contexts: Vec<String>) -> Self {
+        self.allowed_contexts = contexts;
+        self
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -369,10 +409,20 @@ pub struct GenerateCredentialsRequest {
 
 impl GenerateCredentialsRequest {
     pub fn new(role: impl Into<String>) -> Self {
-        Self { role: role.into(), label: None, allowed_contexts: Vec::new() }
+        Self {
+            role: role.into(),
+            label: None,
+            allowed_contexts: Vec::new(),
+        }
     }
-    pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
-    pub fn contexts(mut self, contexts: Vec<String>) -> Self { self.allowed_contexts = contexts; self }
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+    pub fn contexts(mut self, contexts: Vec<String>) -> Self {
+        self.allowed_contexts = contexts;
+        self
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -422,9 +472,7 @@ impl VtaClient {
         }
     }
 
-    async fn handle_delete_response(
-        resp: reqwest::Response,
-    ) -> Result<(), VtaError> {
+    async fn handle_delete_response(resp: reqwest::Response) -> Result<(), VtaError> {
         if resp.status().is_success() {
             Ok(())
         } else {
@@ -606,27 +654,32 @@ impl VtaClient {
         };
 
         // Try refresh token first (cheaper than full re-auth)
-        if let Some(ref refresh_tok) = guard.refresh_token {
-            if let Some(refresh_exp) = guard.refresh_expires_at {
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-                if now < refresh_exp {
-                    if let Ok(result) = crate::auth_light::refresh_token_light(
-                        client, base_url, &cred.did, &cred.vta_did, refresh_tok,
-                    ).await {
-                        guard.token = Some(result.access_token);
-                        guard.expires_at = Some(result.access_expires_at);
-                        if let Some(new_refresh) = result.refresh_token {
-                            guard.refresh_token = Some(new_refresh);
-                        }
-                        guard.refresh_expires_at = result.refresh_expires_at;
-                        return Ok(());
-                    }
-                    // Refresh failed — fall through to full re-auth
+        if let Some(ref refresh_tok) = guard.refresh_token
+            && let Some(refresh_exp) = guard.refresh_expires_at
+        {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            if now < refresh_exp
+                && let Ok(result) = crate::auth_light::refresh_token_light(
+                    client,
+                    base_url,
+                    &cred.did,
+                    &cred.vta_did,
+                    refresh_tok,
+                )
+                .await
+            {
+                guard.token = Some(result.access_token);
+                guard.expires_at = Some(result.access_expires_at);
+                if let Some(new_refresh) = result.refresh_token {
+                    guard.refresh_token = Some(new_refresh);
                 }
+                guard.refresh_expires_at = result.refresh_expires_at;
+                return Ok(());
             }
+            // Refresh failed or expired — fall through to full re-auth
         }
 
         // Full re-authentication
@@ -635,9 +688,8 @@ impl VtaClient {
         let vta = cred.vta_did.clone();
         drop(guard); // Release lock before async call
 
-        let result = crate::auth_light::challenge_response_light(
-            client, base_url, &did, &pk, &vta,
-        ).await?;
+        let result =
+            crate::auth_light::challenge_response_light(client, base_url, &did, &pk, &vta).await?;
 
         let mut guard = auth.lock().await;
         guard.token = Some(result.access_token);
@@ -671,12 +723,10 @@ impl VtaClient {
                 Self::handle_response(resp).await
             }
             #[cfg(feature = "session")]
-            Transport::DIDComm { session, .. } => {
-                session
-                    .send_and_wait(msg_type, body, result_type, timeout)
-                    .await
-                    .map_err(|e| VtaError::Protocol(e.to_string()))
-            }
+            Transport::DIDComm { session, .. } => session
+                .send_and_wait(msg_type, body, result_type, timeout)
+                .await
+                .map_err(|e| VtaError::Protocol(e.to_string())),
         }
     }
 
@@ -751,7 +801,10 @@ impl VtaClient {
             serde_json::json!({}),
             vta_management::RESTART_RESULT,
             30,
-            |c, url| c.post(format!("{url}/vta/restart")).json(&serde_json::json!({})),
+            |c, url| {
+                c.post(format!("{url}/vta/restart"))
+                    .json(&serde_json::json!({}))
+            },
         )
         .await
     }
@@ -770,8 +823,9 @@ impl VtaClient {
             crate::protocols::backup_management::EXPORT_BACKUP_RESULT,
             120, // backup can take longer
             |c, url| {
-                c.post(format!("{url}/backup/export"))
-                    .json(&serde_json::json!({ "password": password, "include_audit": include_audit }))
+                c.post(format!("{url}/backup/export")).json(
+                    &serde_json::json!({ "password": password, "include_audit": include_audit }),
+                )
             },
         )
         .await
@@ -826,10 +880,7 @@ impl VtaClient {
 
     // ── Key methods ─────────────────────────────────────────────────
 
-    pub async fn create_key(
-        &self,
-        req: CreateKeyRequest,
-    ) -> Result<CreateKeyResponse, VtaError> {
+    pub async fn create_key(&self, req: CreateKeyRequest) -> Result<CreateKeyResponse, VtaError> {
         self.rpc(
             key_management::CREATE_KEY,
             serde_json::json!({
@@ -888,10 +939,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn get_key_secret(
-        &self,
-        key_id: &str,
-    ) -> Result<GetKeySecretResponse, VtaError> {
+    pub async fn get_key_secret(&self, key_id: &str) -> Result<GetKeySecretResponse, VtaError> {
         self.rpc(
             key_management::GET_KEY_SECRET,
             serde_json::json!({ "key_id": key_id }),
@@ -934,10 +982,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn invalidate_key(
-        &self,
-        key_id: &str,
-    ) -> Result<InvalidateKeyResponse, VtaError> {
+    pub async fn invalidate_key(&self, key_id: &str) -> Result<InvalidateKeyResponse, VtaError> {
         self.rpc(
             key_management::REVOKE_KEY,
             serde_json::json!({ "key_id": key_id }),
@@ -985,17 +1030,14 @@ impl VtaClient {
                 Self::handle_response(resp).await
             }
             #[cfg(feature = "session")]
-            Transport::DIDComm { .. } => {
-                Err(VtaError::Other("wrapping key not needed for DIDComm transport".into()))
-            }
+            Transport::DIDComm { .. } => Err(VtaError::Other(
+                "wrapping key not needed for DIDComm transport".into(),
+            )),
         }
     }
 
     /// Import an externally-created private key into the VTA.
-    pub async fn import_key(
-        &self,
-        req: ImportKeyRequest,
-    ) -> Result<ImportKeyResponse, VtaError> {
+    pub async fn import_key(&self, req: ImportKeyRequest) -> Result<ImportKeyResponse, VtaError> {
         self.rpc(
             key_management::IMPORT_KEY,
             serde_json::to_value(&req)?,
@@ -1038,10 +1080,7 @@ impl VtaClient {
 
     // ── ACL methods ─────────────────────────────────────────────────
 
-    pub async fn list_acl(
-        &self,
-        context: Option<&str>,
-    ) -> Result<AclListResponse, VtaError> {
+    pub async fn list_acl(&self, context: Option<&str>) -> Result<AclListResponse, VtaError> {
         self.rpc(
             acl_management::LIST_ACL,
             serde_json::json!({ "context": context }),
@@ -1069,10 +1108,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn create_acl(
-        &self,
-        req: CreateAclRequest,
-    ) -> Result<AclEntryResponse, VtaError> {
+    pub async fn create_acl(&self, req: CreateAclRequest) -> Result<AclEntryResponse, VtaError> {
         self.rpc(
             acl_management::CREATE_ACL,
             serde_json::to_value(&req)?,
@@ -1146,10 +1182,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn get_context(
-        &self,
-        id: &str,
-    ) -> Result<ContextResponse, VtaError> {
+    pub async fn get_context(&self, id: &str) -> Result<ContextResponse, VtaError> {
         self.rpc(
             context_management::GET_CONTEXT,
             serde_json::json!({ "id": id }),
@@ -1220,16 +1253,18 @@ impl VtaClient {
     pub async fn preview_delete_context(
         &self,
         id: &str,
-    ) -> Result<
-        context_management::delete::DeleteContextPreviewResultBody,
-        VtaError,
-    > {
+    ) -> Result<context_management::delete::DeleteContextPreviewResultBody, VtaError> {
         self.rpc(
             context_management::PREVIEW_DELETE_CONTEXT,
             serde_json::json!({ "id": id }),
             context_management::PREVIEW_DELETE_CONTEXT_RESULT,
             30,
-            |c, url| c.get(format!("{url}/contexts/{}/delete-preview", encode_path_segment(id))),
+            |c, url| {
+                c.get(format!(
+                    "{url}/contexts/{}/delete-preview",
+                    encode_path_segment(id)
+                ))
+            },
         )
         .await
     }
@@ -1269,10 +1304,8 @@ impl VtaClient {
 
     pub async fn list_webvh_servers(
         &self,
-    ) -> Result<
-        crate::protocols::did_management::servers::ListWebvhServersResultBody,
-        VtaError,
-    > {
+    ) -> Result<crate::protocols::did_management::servers::ListWebvhServersResultBody, VtaError>
+    {
         self.rpc(
             did_management::LIST_WEBVH_SERVERS,
             serde_json::json!({}),
@@ -1317,10 +1350,7 @@ impl VtaClient {
     pub async fn create_did_webvh(
         &self,
         req: CreateDidWebvhRequest,
-    ) -> Result<
-        crate::protocols::did_management::create::CreateDidWebvhResultBody,
-        VtaError,
-    > {
+    ) -> Result<crate::protocols::did_management::create::CreateDidWebvhResultBody, VtaError> {
         self.rpc(
             did_management::CREATE_DID_WEBVH,
             serde_json::to_value(&req)?,
@@ -1335,10 +1365,7 @@ impl VtaClient {
         &self,
         context_id: Option<&str>,
         server_id: Option<&str>,
-    ) -> Result<
-        crate::protocols::did_management::list::ListDidsWebvhResultBody,
-        VtaError,
-    > {
+    ) -> Result<crate::protocols::did_management::list::ListDidsWebvhResultBody, VtaError> {
         self.rpc(
             did_management::LIST_DIDS_WEBVH,
             serde_json::json!({
@@ -1363,10 +1390,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn get_did_webvh(
-        &self,
-        did: &str,
-    ) -> Result<crate::webvh::WebvhDidRecord, VtaError> {
+    pub async fn get_did_webvh(&self, did: &str) -> Result<crate::webvh::WebvhDidRecord, VtaError> {
         self.rpc(
             did_management::GET_DID_WEBVH,
             serde_json::json!({ "did": did }),
@@ -1377,10 +1401,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn get_did_webvh_log(
-        &self,
-        did: &str,
-    ) -> Result<GetDidLogResponse, VtaError> {
+    pub async fn get_did_webvh_log(&self, did: &str) -> Result<GetDidLogResponse, VtaError> {
         self.rpc(
             did_management::GET_DID_WEBVH_LOG,
             serde_json::json!({ "did": did }),
@@ -1420,12 +1441,24 @@ impl VtaClient {
                     format!("page={}", params.page),
                     format!("page_size={}", params.page_size),
                 ];
-                if let Some(from) = params.from { qs.push(format!("from={from}")); }
-                if let Some(to) = params.to { qs.push(format!("to={to}")); }
-                if let Some(ref action) = params.action { qs.push(format!("action={action}")); }
-                if let Some(ref actor) = params.actor { qs.push(format!("actor={actor}")); }
-                if let Some(ref outcome) = params.outcome { qs.push(format!("outcome={outcome}")); }
-                if let Some(ref ctx) = params.context_id { qs.push(format!("context_id={ctx}")); }
+                if let Some(from) = params.from {
+                    qs.push(format!("from={from}"));
+                }
+                if let Some(to) = params.to {
+                    qs.push(format!("to={to}"));
+                }
+                if let Some(ref action) = params.action {
+                    qs.push(format!("action={action}"));
+                }
+                if let Some(ref actor) = params.actor {
+                    qs.push(format!("actor={actor}"));
+                }
+                if let Some(ref outcome) = params.outcome {
+                    qs.push(format!("outcome={outcome}"));
+                }
+                if let Some(ref ctx) = params.context_id {
+                    qs.push(format!("context_id={ctx}"));
+                }
                 c.get(format!("{url}/audit/logs?{}", qs.join("&")))
             },
         )
@@ -1532,10 +1565,10 @@ impl VtaClient {
                 // verification method ID (e.g., "did:webvh:...#key-0"). The setup
                 // wizard and provisioning flows set labels to match the DID document,
                 // so this lets consumers use the bundle directly without remapping.
-                if let Some(label) = key.label.as_deref() {
-                    if label.contains('#') || label.starts_with("did:") {
-                        entry.key_id = label.to_string();
-                    }
+                if let Some(label) = key.label.as_deref()
+                    && (label.contains('#') || label.starts_with("did:"))
+                {
+                    entry.key_id = label.to_string();
                 }
                 secrets.push(entry);
             }

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -90,6 +90,16 @@ pub struct CreateKeyRequest {
     pub context_id: Option<String>,
 }
 
+impl CreateKeyRequest {
+    pub fn new(key_type: KeyType) -> Self {
+        Self { key_type, derivation_path: None, key_id: None, mnemonic: None, label: None, context_id: None }
+    }
+    pub fn derivation_path(mut self, path: impl Into<String>) -> Self { self.derivation_path = Some(path.into()); self }
+    pub fn key_id(mut self, id: impl Into<String>) -> Self { self.key_id = Some(id.into()); self }
+    pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
+    pub fn context(mut self, ctx: impl Into<String>) -> Self { self.context_id = Some(ctx.into()); self }
+}
+
 // ── Import key types ───────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -134,6 +144,13 @@ pub struct CreateContextRequest {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+}
+
+impl CreateContextRequest {
+    pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
+        Self { id: id.into(), name: name.into(), description: None }
+    }
+    pub fn description(mut self, desc: impl Into<String>) -> Self { self.description = Some(desc.into()); self }
 }
 
 #[derive(Debug, Serialize)]
@@ -272,6 +289,14 @@ pub struct CreateAclRequest {
     pub allowed_contexts: Vec<String>,
 }
 
+impl CreateAclRequest {
+    pub fn new(did: impl Into<String>, role: impl Into<String>) -> Self {
+        Self { did: did.into(), role: role.into(), label: None, allowed_contexts: Vec::new() }
+    }
+    pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
+    pub fn contexts(mut self, contexts: Vec<String>) -> Self { self.allowed_contexts = contexts; self }
+}
+
 #[derive(Debug, Serialize)]
 pub struct UpdateAclRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -334,6 +359,14 @@ pub struct GenerateCredentialsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub allowed_contexts: Vec<String>,
+}
+
+impl GenerateCredentialsRequest {
+    pub fn new(role: impl Into<String>) -> Self {
+        Self { role: role.into(), label: None, allowed_contexts: Vec::new() }
+    }
+    pub fn label(mut self, label: impl Into<String>) -> Self { self.label = Some(label.into()); self }
+    pub fn contexts(mut self, contexts: Vec<String>) -> Self { self.allowed_contexts = contexts; self }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1440,6 +1473,43 @@ impl VtaClient {
         }
 
         Ok(secrets)
+    }
+
+    /// Fetch all secrets for a context as a portable [`DidSecretsBundle`].
+    ///
+    /// Resolves the context DID, paginates through all active keys,
+    /// fetches each secret, and returns a bundle ready for encoding/transport.
+    pub async fn fetch_did_secrets_bundle(
+        &self,
+        context_id: &str,
+    ) -> Result<crate::did_secrets::DidSecretsBundle, VtaError> {
+        let ctx = self.get_context(context_id).await?;
+        let did = ctx.did.ok_or_else(|| {
+            VtaError::Validation(format!("context '{context_id}' has no DID assigned"))
+        })?;
+
+        let page_size = 100u64;
+        let mut offset = 0u64;
+        let mut secrets = Vec::new();
+
+        loop {
+            let resp = self
+                .list_keys(offset, page_size, Some("active"), Some(context_id))
+                .await?;
+            if resp.keys.is_empty() {
+                break;
+            }
+            for key in &resp.keys {
+                let secret_resp = self.get_key_secret(&key.key_id).await?;
+                secrets.push(crate::did_secrets::SecretEntry::from(secret_resp));
+            }
+            offset += resp.keys.len() as u64;
+            if offset >= resp.total {
+                break;
+            }
+        }
+
+        Ok(crate::did_secrets::DidSecretsBundle { did, secrets })
     }
 
     /// Check whether the current auth token is valid by calling an authenticated endpoint.

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -1,3 +1,4 @@
+use crate::error::VtaError;
 use crate::keys::{KeyRecord, KeyStatus, KeyType};
 use crate::protocols::key_management::sign::SignAlgorithm;
 use chrono::{DateTime, Utc};
@@ -6,11 +7,27 @@ use serde::{Deserialize, Serialize};
 
 // ── Internal transport ──────────────────────────────────────────────
 
+/// Stored credential for automatic token refresh.
+struct AuthCredential {
+    did: String,
+    private_key_multibase: String,
+    vta_did: String,
+}
+
+/// Mutable auth state protected by a mutex for auto-refresh.
+struct RestAuth {
+    token: Option<String>,
+    expires_at: Option<u64>,
+    refresh_token: Option<String>,
+    refresh_expires_at: Option<u64>,
+    credential: Option<AuthCredential>,
+}
+
 enum Transport {
     Rest {
         client: Client,
         base_url: String,
-        token: Option<String>,
+        auth: tokio::sync::Mutex<RestAuth>,
     },
     #[cfg(feature = "session")]
     DIDComm {
@@ -343,7 +360,7 @@ fn encode_path_segment(s: &str) -> String {
 
 impl VtaClient {
     /// Attach Bearer token to a request if one is set.
-    fn with_auth(req: RequestBuilder, token: &Option<String>) -> RequestBuilder {
+    fn with_auth_token(req: RequestBuilder, token: &Option<String>) -> RequestBuilder {
         match token {
             Some(token) => req.bearer_auth(token),
             None => req,
@@ -352,7 +369,7 @@ impl VtaClient {
 
     async fn handle_response<T: serde::de::DeserializeOwned>(
         resp: reqwest::Response,
-    ) -> Result<T, Box<dyn std::error::Error>> {
+    ) -> Result<T, VtaError> {
         if resp.status().is_success() {
             Ok(resp.json::<T>().await?)
         } else {
@@ -362,13 +379,13 @@ impl VtaClient {
                 .await
                 .map(|e| e.error)
                 .unwrap_or_else(|_| "unknown error".to_string());
-            Err(format!("{status}: {body}").into())
+            Err(VtaError::from_http(status, body))
         }
     }
 
     async fn handle_delete_response(
         resp: reqwest::Response,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), VtaError> {
         if resp.status().is_success() {
             Ok(())
         } else {
@@ -378,7 +395,7 @@ impl VtaClient {
                 .await
                 .map(|e| e.error)
                 .unwrap_or_else(|_| "unknown error".to_string());
-            Err(format!("{status}: {body}").into())
+            Err(VtaError::from_http(status, body))
         }
     }
 }
@@ -398,8 +415,58 @@ impl VtaClient {
             transport: Transport::Rest {
                 client: Client::new(),
                 base_url: base_url.trim_end_matches('/').to_string(),
-                token: None,
+                auth: tokio::sync::Mutex::new(RestAuth {
+                    token: None,
+                    expires_at: None,
+                    refresh_token: None,
+                    refresh_expires_at: None,
+                    credential: None,
+                }),
             },
+        }
+    }
+
+    /// Create a client from a base64-encoded credential bundle.
+    ///
+    /// Performs lightweight challenge-response auth (no ATM/TDK initialization)
+    /// and stores the credential for automatic token refresh.
+    pub async fn from_credential(
+        credential_b64: &str,
+        url_override: Option<&str>,
+    ) -> Result<Self, VtaError> {
+        let (result, cred) =
+            crate::auth_light::authenticate_with_credential(credential_b64, url_override).await?;
+        let base_url = url_override
+            .or(cred.vta_url.as_deref())
+            .ok_or("no VTA URL")?
+            .trim_end_matches('/')
+            .to_string();
+
+        Ok(Self {
+            transport: Transport::Rest {
+                client: Client::new(),
+                base_url,
+                auth: tokio::sync::Mutex::new(RestAuth {
+                    token: Some(result.access_token),
+                    expires_at: Some(result.access_expires_at),
+                    refresh_token: result.refresh_token,
+                    refresh_expires_at: result.refresh_expires_at,
+                    credential: Some(AuthCredential {
+                        did: cred.did,
+                        private_key_multibase: cred.private_key_multibase,
+                        vta_did: cred.vta_did,
+                    }),
+                }),
+            },
+        })
+    }
+
+    /// Returns the token expiry timestamp, if known.
+    pub async fn token_expires_at(&self) -> Option<u64> {
+        if let Transport::Rest { auth, .. } = &self.transport {
+            auth.lock().await.expires_at
+        } else {
+            None
         }
     }
 
@@ -413,7 +480,7 @@ impl VtaClient {
         vta_did: &str,
         mediator_did: &str,
         rest_url: Option<String>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, VtaError> {
         let session = crate::didcomm_session::DIDCommSession::connect(
             client_did,
             private_key_multibase,
@@ -434,9 +501,22 @@ impl VtaClient {
     }
 
     /// Set the Bearer token for authenticated requests (REST only, no-op for DIDComm).
-    pub fn set_token(&mut self, token: String) {
-        if let Transport::Rest { token: t, .. } = &mut self.transport {
-            *t = Some(token);
+    ///
+    /// Can be called from sync or async contexts. For async contexts, use
+    /// [`set_token_async`](Self::set_token_async) to avoid potential blocking.
+    pub fn set_token(&self, token: String) {
+        if let Transport::Rest { auth, .. } = &self.transport {
+            // try_lock avoids blocking the current thread if called from async
+            if let Ok(mut guard) = auth.try_lock() {
+                guard.token = Some(token);
+            }
+        }
+    }
+
+    /// Set the Bearer token (async version).
+    pub async fn set_token_async(&self, token: String) {
+        if let Transport::Rest { auth, .. } = &self.transport {
+            auth.lock().await.token = Some(token);
         }
     }
 
@@ -459,6 +539,75 @@ impl VtaClient {
 
     // ── RPC helpers ─────────────────────────────────────────────────
 
+    /// Ensure the REST auth token is valid, refreshing if needed.
+    async fn ensure_token_valid(
+        _client: &Client,
+        base_url: &str,
+        auth: &tokio::sync::Mutex<RestAuth>,
+    ) -> Result<(), VtaError> {
+        let mut guard = auth.lock().await;
+
+        // Check if token is still valid (>30s remaining)
+        if let Some(expires_at) = guard.expires_at {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            if now + 30 < expires_at {
+                return Ok(()); // Token still valid
+            }
+        } else if guard.token.is_some() {
+            // Token without expiry — assume valid
+            return Ok(());
+        }
+
+        // No credential stored — can't auto-refresh
+        let Some(ref cred) = guard.credential else {
+            return Ok(());
+        };
+
+        // Try refresh token first (cheaper than full re-auth)
+        if let Some(ref refresh_tok) = guard.refresh_token {
+            if let Some(refresh_exp) = guard.refresh_expires_at {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                if now < refresh_exp {
+                    if let Ok(result) = crate::auth_light::refresh_token_light(
+                        base_url, &cred.did, &cred.vta_did, refresh_tok,
+                    ).await {
+                        guard.token = Some(result.access_token);
+                        guard.expires_at = Some(result.access_expires_at);
+                        if let Some(new_refresh) = result.refresh_token {
+                            guard.refresh_token = Some(new_refresh);
+                        }
+                        guard.refresh_expires_at = result.refresh_expires_at;
+                        return Ok(());
+                    }
+                    // Refresh failed — fall through to full re-auth
+                }
+            }
+        }
+
+        // Full re-authentication
+        let did = cred.did.clone();
+        let pk = cred.private_key_multibase.clone();
+        let vta = cred.vta_did.clone();
+        drop(guard); // Release lock before async call
+
+        let result = crate::auth_light::challenge_response_light(
+            base_url, &did, &pk, &vta,
+        ).await?;
+
+        let mut guard = auth.lock().await;
+        guard.token = Some(result.access_token);
+        guard.expires_at = Some(result.access_expires_at);
+        guard.refresh_token = result.refresh_token;
+        guard.refresh_expires_at = result.refresh_expires_at;
+        Ok(())
+    }
+
     /// Dispatch an RPC call via REST (using `build_rest`) or DIDComm (using
     /// `msg_type`/`body`/`result_type`), returning a deserialized response.
     #[allow(unused_variables)]
@@ -469,15 +618,17 @@ impl VtaClient {
         result_type: &str,
         timeout: u64,
         build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
-    ) -> Result<T, Box<dyn std::error::Error>> {
+    ) -> Result<T, VtaError> {
         match &self.transport {
             Transport::Rest {
                 client,
                 base_url,
-                token,
+                auth,
             } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
                 let req = build_rest(client, base_url);
-                let resp = Self::with_auth(req, token).send().await?;
+                let resp = Self::with_auth_token(req, &token).send().await?;
                 Self::handle_response(resp).await
             }
             #[cfg(feature = "session")]
@@ -485,6 +636,7 @@ impl VtaClient {
                 session
                     .send_and_wait(msg_type, body, result_type, timeout)
                     .await
+                    .map_err(|e| VtaError::Protocol(e.to_string()))
             }
         }
     }
@@ -498,22 +650,25 @@ impl VtaClient {
         result_type: &str,
         timeout: u64,
         build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), VtaError> {
         match &self.transport {
             Transport::Rest {
                 client,
                 base_url,
-                token,
+                auth,
             } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
                 let req = build_rest(client, base_url);
-                let resp = Self::with_auth(req, token).send().await?;
+                let resp = Self::with_auth_token(req, &token).send().await?;
                 Self::handle_delete_response(resp).await
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { session, .. } => {
                 let _: serde_json::Value = session
                     .send_and_wait(msg_type, body, result_type, timeout)
-                    .await?;
+                    .await
+                    .map_err(|e| VtaError::Protocol(e.to_string()))?;
                 Ok(())
             }
         }
@@ -521,8 +676,8 @@ impl VtaClient {
 
     // ── Health ───────────────────────────────────────────────────────
 
-    /// GET /health (always REST)
-    pub async fn health(&self) -> Result<HealthResponse, Box<dyn std::error::Error>> {
+    /// GET /health (always REST, unauthenticated)
+    pub async fn health(&self) -> Result<HealthResponse, VtaError> {
         match &self.transport {
             Transport::Rest {
                 client, base_url, ..
@@ -551,7 +706,7 @@ impl VtaClient {
     // ── VTA Management ──────────────────────────────────────────────
 
     /// Trigger a soft restart of the VTA.
-    pub async fn restart(&self) -> Result<vta_management::restart::RestartResult, Box<dyn std::error::Error>> {
+    pub async fn restart(&self) -> Result<vta_management::restart::RestartResult, VtaError> {
         self.rpc(
             vta_management::RESTART,
             serde_json::json!({}),
@@ -569,7 +724,7 @@ impl VtaClient {
         &self,
         password: &str,
         include_audit: bool,
-    ) -> Result<crate::protocols::backup_management::types::BackupEnvelope, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::backup_management::types::BackupEnvelope, VtaError> {
         self.rpc(
             crate::protocols::backup_management::EXPORT_BACKUP,
             serde_json::json!({ "password": password, "include_audit": include_audit }),
@@ -589,7 +744,7 @@ impl VtaClient {
         backup: &crate::protocols::backup_management::types::BackupEnvelope,
         password: &str,
         confirm: bool,
-    ) -> Result<crate::protocols::backup_management::types::ImportResult, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::backup_management::types::ImportResult, VtaError> {
         self.rpc(
             crate::protocols::backup_management::IMPORT_BACKUP,
             serde_json::json!({ "backup": backup, "password": password, "confirm": confirm }),
@@ -605,7 +760,7 @@ impl VtaClient {
 
     // ── Config ──────────────────────────────────────────────────────
 
-    pub async fn get_config(&self) -> Result<ConfigResponse, Box<dyn std::error::Error>> {
+    pub async fn get_config(&self) -> Result<ConfigResponse, VtaError> {
         self.rpc(
             vta_management::GET_CONFIG,
             serde_json::json!({}),
@@ -619,7 +774,7 @@ impl VtaClient {
     pub async fn update_config(
         &self,
         req: UpdateConfigRequest,
-    ) -> Result<ConfigResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ConfigResponse, VtaError> {
         self.rpc(
             vta_management::UPDATE_CONFIG,
             serde_json::to_value(&req)?,
@@ -635,7 +790,7 @@ impl VtaClient {
     pub async fn create_key(
         &self,
         req: CreateKeyRequest,
-    ) -> Result<CreateKeyResponse, Box<dyn std::error::Error>> {
+    ) -> Result<CreateKeyResponse, VtaError> {
         self.rpc(
             key_management::CREATE_KEY,
             serde_json::json!({
@@ -658,7 +813,7 @@ impl VtaClient {
         limit: u64,
         status: Option<&str>,
         context_id: Option<&str>,
-    ) -> Result<ListKeysResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ListKeysResponse, VtaError> {
         self.rpc(
             key_management::LIST_KEYS,
             serde_json::json!({
@@ -683,7 +838,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn get_key(&self, key_id: &str) -> Result<KeyRecord, Box<dyn std::error::Error>> {
+    pub async fn get_key(&self, key_id: &str) -> Result<KeyRecord, VtaError> {
         self.rpc(
             key_management::GET_KEY,
             serde_json::json!({ "key_id": key_id }),
@@ -697,7 +852,7 @@ impl VtaClient {
     pub async fn get_key_secret(
         &self,
         key_id: &str,
-    ) -> Result<GetKeySecretResponse, Box<dyn std::error::Error>> {
+    ) -> Result<GetKeySecretResponse, VtaError> {
         self.rpc(
             key_management::GET_KEY_SECRET,
             serde_json::json!({ "key_id": key_id }),
@@ -717,7 +872,7 @@ impl VtaClient {
         key_id: &str,
         payload: &[u8],
         algorithm: SignAlgorithm,
-    ) -> Result<SignResponse, Box<dyn std::error::Error>> {
+    ) -> Result<SignResponse, VtaError> {
         use base64::Engine;
         let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
         self.rpc(
@@ -743,7 +898,7 @@ impl VtaClient {
     pub async fn invalidate_key(
         &self,
         key_id: &str,
-    ) -> Result<InvalidateKeyResponse, Box<dyn std::error::Error>> {
+    ) -> Result<InvalidateKeyResponse, VtaError> {
         self.rpc(
             key_management::REVOKE_KEY,
             serde_json::json!({ "key_id": key_id }),
@@ -758,7 +913,7 @@ impl VtaClient {
         &self,
         key_id: &str,
         new_key_id: &str,
-    ) -> Result<RenameKeyResponse, Box<dyn std::error::Error>> {
+    ) -> Result<RenameKeyResponse, VtaError> {
         self.rpc(
             key_management::RENAME_KEY,
             serde_json::json!({ "key_id": key_id, "new_key_id": new_key_id }),
@@ -777,20 +932,22 @@ impl VtaClient {
     // ── Import key methods ──────────────────────────────────────────
 
     /// Fetch an ephemeral wrapping key for REST key import.
-    pub async fn get_wrapping_key(&self) -> Result<WrappingKeyResponse, Box<dyn std::error::Error>> {
+    pub async fn get_wrapping_key(&self) -> Result<WrappingKeyResponse, VtaError> {
         match &self.transport {
             Transport::Rest {
                 client,
                 base_url,
-                token,
+                auth,
             } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
                 let req = client.get(format!("{base_url}/keys/import/wrapping-key"));
-                let resp = Self::with_auth(req, token).send().await?;
+                let resp = Self::with_auth_token(req, &token).send().await?;
                 Self::handle_response(resp).await
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {
-                Err("wrapping key not needed for DIDComm transport".into())
+                Err(VtaError::Other("wrapping key not needed for DIDComm transport".into()))
             }
         }
     }
@@ -799,7 +956,7 @@ impl VtaClient {
     pub async fn import_key(
         &self,
         req: ImportKeyRequest,
-    ) -> Result<ImportKeyResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ImportKeyResponse, VtaError> {
         self.rpc(
             key_management::IMPORT_KEY,
             serde_json::to_value(&req)?,
@@ -812,7 +969,7 @@ impl VtaClient {
 
     // ── Seed methods ────────────────────────────────────────────────
 
-    pub async fn list_seeds(&self) -> Result<ListSeedsResponse, Box<dyn std::error::Error>> {
+    pub async fn list_seeds(&self) -> Result<ListSeedsResponse, VtaError> {
         self.rpc(
             seed_management::LIST_SEEDS,
             serde_json::json!({}),
@@ -826,7 +983,7 @@ impl VtaClient {
     pub async fn rotate_seed(
         &self,
         mnemonic: Option<String>,
-    ) -> Result<RotateSeedResponse, Box<dyn std::error::Error>> {
+    ) -> Result<RotateSeedResponse, VtaError> {
         let body = RotateSeedRequest {
             mnemonic: mnemonic.clone(),
         };
@@ -845,7 +1002,7 @@ impl VtaClient {
     pub async fn list_acl(
         &self,
         context: Option<&str>,
-    ) -> Result<AclListResponse, Box<dyn std::error::Error>> {
+    ) -> Result<AclListResponse, VtaError> {
         self.rpc(
             acl_management::LIST_ACL,
             serde_json::json!({ "context": context }),
@@ -862,7 +1019,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn get_acl(&self, did: &str) -> Result<AclEntryResponse, Box<dyn std::error::Error>> {
+    pub async fn get_acl(&self, did: &str) -> Result<AclEntryResponse, VtaError> {
         self.rpc(
             acl_management::GET_ACL,
             serde_json::json!({ "did": did }),
@@ -876,7 +1033,7 @@ impl VtaClient {
     pub async fn create_acl(
         &self,
         req: CreateAclRequest,
-    ) -> Result<AclEntryResponse, Box<dyn std::error::Error>> {
+    ) -> Result<AclEntryResponse, VtaError> {
         self.rpc(
             acl_management::CREATE_ACL,
             serde_json::to_value(&req)?,
@@ -891,7 +1048,7 @@ impl VtaClient {
         &self,
         did: &str,
         req: UpdateAclRequest,
-    ) -> Result<AclEntryResponse, Box<dyn std::error::Error>> {
+    ) -> Result<AclEntryResponse, VtaError> {
         self.rpc(
             acl_management::UPDATE_ACL,
             serde_json::json!({
@@ -910,7 +1067,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn delete_acl(&self, did: &str) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn delete_acl(&self, did: &str) -> Result<(), VtaError> {
         self.rpc_void(
             acl_management::DELETE_ACL,
             serde_json::json!({ "did": did }),
@@ -926,7 +1083,7 @@ impl VtaClient {
     pub async fn generate_credentials(
         &self,
         req: GenerateCredentialsRequest,
-    ) -> Result<GenerateCredentialsResponse, Box<dyn std::error::Error>> {
+    ) -> Result<GenerateCredentialsResponse, VtaError> {
         self.rpc(
             credential_management::GENERATE_CREDENTIALS,
             serde_json::to_value(&req)?,
@@ -939,7 +1096,7 @@ impl VtaClient {
 
     // ── Context methods ──────────────────────────────────────────────
 
-    pub async fn list_contexts(&self) -> Result<ContextListResponse, Box<dyn std::error::Error>> {
+    pub async fn list_contexts(&self) -> Result<ContextListResponse, VtaError> {
         self.rpc(
             context_management::LIST_CONTEXTS,
             serde_json::json!({}),
@@ -953,7 +1110,7 @@ impl VtaClient {
     pub async fn get_context(
         &self,
         id: &str,
-    ) -> Result<ContextResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ContextResponse, VtaError> {
         self.rpc(
             context_management::GET_CONTEXT,
             serde_json::json!({ "id": id }),
@@ -967,7 +1124,7 @@ impl VtaClient {
     pub async fn create_context(
         &self,
         req: CreateContextRequest,
-    ) -> Result<ContextResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ContextResponse, VtaError> {
         self.rpc(
             context_management::CREATE_CONTEXT,
             serde_json::to_value(&req)?,
@@ -982,7 +1139,7 @@ impl VtaClient {
         &self,
         id: &str,
         req: UpdateContextRequest,
-    ) -> Result<ContextResponse, Box<dyn std::error::Error>> {
+    ) -> Result<ContextResponse, VtaError> {
         self.rpc(
             context_management::UPDATE_CONTEXT,
             serde_json::json!({
@@ -1006,7 +1163,7 @@ impl VtaClient {
         id: &str,
     ) -> Result<
         context_management::delete::DeleteContextPreviewResultBody,
-        Box<dyn std::error::Error>,
+        VtaError,
     > {
         self.rpc(
             context_management::PREVIEW_DELETE_CONTEXT,
@@ -1018,7 +1175,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn delete_context(&self, id: &str, force: bool) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn delete_context(&self, id: &str, force: bool) -> Result<(), VtaError> {
         self.rpc_void(
             context_management::DELETE_CONTEXT,
             serde_json::json!({ "id": id, "force": force }),
@@ -1040,7 +1197,7 @@ impl VtaClient {
     pub async fn add_webvh_server(
         &self,
         req: AddWebvhServerRequest,
-    ) -> Result<crate::webvh::WebvhServerRecord, Box<dyn std::error::Error>> {
+    ) -> Result<crate::webvh::WebvhServerRecord, VtaError> {
         self.rpc(
             did_management::ADD_WEBVH_SERVER,
             serde_json::to_value(&req)?,
@@ -1055,7 +1212,7 @@ impl VtaClient {
         &self,
     ) -> Result<
         crate::protocols::did_management::servers::ListWebvhServersResultBody,
-        Box<dyn std::error::Error>,
+        VtaError,
     > {
         self.rpc(
             did_management::LIST_WEBVH_SERVERS,
@@ -1071,7 +1228,7 @@ impl VtaClient {
         &self,
         id: &str,
         req: UpdateWebvhServerRequest,
-    ) -> Result<crate::webvh::WebvhServerRecord, Box<dyn std::error::Error>> {
+    ) -> Result<crate::webvh::WebvhServerRecord, VtaError> {
         self.rpc(
             did_management::UPDATE_WEBVH_SERVER,
             serde_json::json!({ "id": id, "label": &req.label }),
@@ -1085,7 +1242,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn remove_webvh_server(&self, id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn remove_webvh_server(&self, id: &str) -> Result<(), VtaError> {
         self.rpc_void(
             did_management::REMOVE_WEBVH_SERVER,
             serde_json::json!({ "id": id }),
@@ -1103,7 +1260,7 @@ impl VtaClient {
         req: CreateDidWebvhRequest,
     ) -> Result<
         crate::protocols::did_management::create::CreateDidWebvhResultBody,
-        Box<dyn std::error::Error>,
+        VtaError,
     > {
         self.rpc(
             did_management::CREATE_DID_WEBVH,
@@ -1121,7 +1278,7 @@ impl VtaClient {
         server_id: Option<&str>,
     ) -> Result<
         crate::protocols::did_management::list::ListDidsWebvhResultBody,
-        Box<dyn std::error::Error>,
+        VtaError,
     > {
         self.rpc(
             did_management::LIST_DIDS_WEBVH,
@@ -1150,7 +1307,7 @@ impl VtaClient {
     pub async fn get_did_webvh(
         &self,
         did: &str,
-    ) -> Result<crate::webvh::WebvhDidRecord, Box<dyn std::error::Error>> {
+    ) -> Result<crate::webvh::WebvhDidRecord, VtaError> {
         self.rpc(
             did_management::GET_DID_WEBVH,
             serde_json::json!({ "did": did }),
@@ -1164,7 +1321,7 @@ impl VtaClient {
     pub async fn get_did_webvh_log(
         &self,
         did: &str,
-    ) -> Result<GetDidLogResponse, Box<dyn std::error::Error>> {
+    ) -> Result<GetDidLogResponse, VtaError> {
         self.rpc(
             did_management::GET_DID_WEBVH_LOG,
             serde_json::json!({ "did": did }),
@@ -1175,7 +1332,7 @@ impl VtaClient {
         .await
     }
 
-    pub async fn delete_did_webvh(&self, did: &str) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn delete_did_webvh(&self, did: &str) -> Result<(), VtaError> {
         self.rpc_void(
             did_management::DELETE_DID_WEBVH,
             serde_json::json!({ "did": did }),
@@ -1192,7 +1349,7 @@ impl VtaClient {
     pub async fn list_audit_logs(
         &self,
         params: &crate::protocols::audit_management::list::ListAuditLogsBody,
-    ) -> Result<crate::protocols::audit_management::list::ListAuditLogsResultBody, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::audit_management::list::ListAuditLogsResultBody, VtaError> {
         use crate::protocols::audit_management;
         self.rpc(
             audit_management::LIST_LOGS,
@@ -1219,7 +1376,7 @@ impl VtaClient {
     /// Get the current audit log retention period.
     pub async fn get_audit_retention(
         &self,
-    ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, VtaError> {
         use crate::protocols::audit_management;
         self.rpc(
             audit_management::GET_RETENTION,
@@ -1235,7 +1392,7 @@ impl VtaClient {
     pub async fn update_audit_retention(
         &self,
         retention_days: u32,
-    ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, Box<dyn std::error::Error>> {
+    ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, VtaError> {
         use crate::protocols::audit_management;
         let body = audit_management::retention::UpdateRetentionBody { retention_days };
         self.rpc(
@@ -1246,6 +1403,67 @@ impl VtaClient {
             |c, url| c.patch(format!("{url}/audit/retention")).json(&body),
         )
         .await
+    }
+
+    // ── Convenience methods ────────────────────────────────────────
+
+    /// Fetch all secrets for a context, paginating through all keys.
+    ///
+    /// Returns TDK `Secret` objects ready for use with DIDComm or signing.
+    pub async fn fetch_context_secrets(
+        &self,
+        context_id: &str,
+    ) -> Result<Vec<affinidi_tdk::secrets_resolver::secrets::Secret>, VtaError> {
+        let page_size = 100u64;
+        let mut offset = 0u64;
+        let mut secrets = Vec::new();
+
+        loop {
+            let resp = self
+                .list_keys(offset, page_size, Some("active"), Some(context_id))
+                .await?;
+
+            if resp.keys.is_empty() {
+                break;
+            }
+
+            for key in &resp.keys {
+                let secret_resp = self.get_key_secret(&key.key_id).await?;
+                let secret = crate::did_key::secret_from_key_response(&secret_resp)?;
+                secrets.push(secret);
+            }
+
+            offset += resp.keys.len() as u64;
+            if offset >= resp.total {
+                break;
+            }
+        }
+
+        Ok(secrets)
+    }
+
+    /// Check whether the current auth token is valid by calling an authenticated endpoint.
+    ///
+    /// Returns `true` if authenticated, `false` if the token is invalid/expired.
+    /// Returns an error only on network failures.
+    pub async fn check_auth(&self) -> Result<bool, VtaError> {
+        match &self.transport {
+            Transport::Rest {
+                client,
+                base_url,
+                auth,
+            } => {
+                let token = auth.lock().await.token.clone();
+                let req = client.get(format!("{base_url}/health/details"));
+                let resp = Self::with_auth_token(req, &token).send().await?;
+                Ok(resp.status().is_success())
+            }
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => {
+                // DIDComm sessions are always authenticated
+                Ok(true)
+            }
+        }
     }
 }
 
@@ -1316,22 +1534,24 @@ mod tests {
         assert_eq!(client.base_url(), "http://localhost:3000");
     }
 
-    #[test]
-    fn test_new_token_initially_none() {
+    #[tokio::test]
+    async fn test_new_token_initially_none() {
         let client = VtaClient::new("http://example.com");
         match &client.transport {
-            Transport::Rest { token, .. } => assert!(token.is_none()),
+            Transport::Rest { auth, .. } => assert!(auth.lock().await.token.is_none()),
             #[cfg(feature = "session")]
             _ => panic!("expected REST transport"),
         }
     }
 
-    #[test]
-    fn test_set_token() {
-        let mut client = VtaClient::new("http://example.com");
+    #[tokio::test]
+    async fn test_set_token() {
+        let client = VtaClient::new("http://example.com");
         client.set_token("my-jwt".to_string());
         match &client.transport {
-            Transport::Rest { token, .. } => assert_eq!(token.as_deref(), Some("my-jwt")),
+            Transport::Rest { auth, .. } => {
+                assert_eq!(auth.lock().await.token.as_deref(), Some("my-jwt"));
+            }
             #[cfg(feature = "session")]
             _ => panic!("expected REST transport"),
         }

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -1527,7 +1527,17 @@ impl VtaClient {
             }
             for key in &resp.keys {
                 let secret_resp = self.get_key_secret(&key.key_id).await?;
-                secrets.push(crate::did_secrets::SecretEntry::from(secret_resp));
+                let mut entry = crate::did_secrets::SecretEntry::from(secret_resp);
+                // Use the key's label as the secret ID when it looks like a DID
+                // verification method ID (e.g., "did:webvh:...#key-0"). The setup
+                // wizard and provisioning flows set labels to match the DID document,
+                // so this lets consumers use the bundle directly without remapping.
+                if let Some(label) = key.label.as_deref() {
+                    if label.contains('#') || label.starts_with("did:") {
+                        entry.key_id = label.to_string();
+                    }
+                }
+                secrets.push(entry);
             }
             offset += resp.keys.len() as u64;
             if offset >= resp.total {

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -473,7 +473,7 @@ impl VtaClient {
         credential_b64: &str,
         url_override: Option<&str>,
     ) -> Result<Self, VtaError> {
-        let (result, cred) =
+        let (result, cred, http) =
             crate::auth_light::authenticate_with_credential(credential_b64, url_override).await?;
         let base_url = url_override
             .or(cred.vta_url.as_deref())
@@ -483,7 +483,7 @@ impl VtaClient {
 
         Ok(Self {
             transport: Transport::Rest {
-                client: Client::new(),
+                client: http,
                 base_url,
                 auth: tokio::sync::Mutex::new(RestAuth {
                     token: Some(result.access_token),
@@ -580,7 +580,7 @@ impl VtaClient {
 
     /// Ensure the REST auth token is valid, refreshing if needed.
     async fn ensure_token_valid(
-        _client: &Client,
+        client: &Client,
         base_url: &str,
         auth: &tokio::sync::Mutex<RestAuth>,
     ) -> Result<(), VtaError> {
@@ -614,7 +614,7 @@ impl VtaClient {
                     .as_secs();
                 if now < refresh_exp {
                     if let Ok(result) = crate::auth_light::refresh_token_light(
-                        base_url, &cred.did, &cred.vta_did, refresh_tok,
+                        client, base_url, &cred.did, &cred.vta_did, refresh_tok,
                     ).await {
                         guard.token = Some(result.access_token);
                         guard.expires_at = Some(result.access_expires_at);
@@ -636,7 +636,7 @@ impl VtaClient {
         drop(guard); // Release lock before async call
 
         let result = crate::auth_light::challenge_response_light(
-            base_url, &did, &pk, &vta,
+            client, base_url, &did, &pk, &vta,
         ).await?;
 
         let mut guard = auth.lock().await;

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -164,6 +164,11 @@ pub struct UpdateContextRequest {
     pub description: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct UpdateContextDidRequest {
+    pub did: String,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ContextResponse {
     pub id: String,
@@ -1187,6 +1192,26 @@ impl VtaClient {
             |c, url| {
                 c.patch(format!("{url}/contexts/{}", encode_path_segment(id)))
                     .json(&req)
+            },
+        )
+        .await
+    }
+
+    /// Update the DID for a context. Requires Admin role with access to the context.
+    pub async fn update_context_did(
+        &self,
+        id: &str,
+        did: impl Into<String>,
+    ) -> Result<ContextResponse, VtaError> {
+        let did = did.into();
+        self.rpc(
+            context_management::UPDATE_CONTEXT_DID,
+            serde_json::json!({ "id": id, "did": &did }),
+            context_management::UPDATE_CONTEXT_DID_RESULT,
+            30,
+            |c, url| {
+                c.put(format!("{url}/contexts/{}/did", encode_path_segment(id)))
+                    .json(&UpdateContextDidRequest { did: did.clone() })
             },
         )
         .await

--- a/vta-sdk/src/credentials.rs
+++ b/vta-sdk/src/credentials.rs
@@ -17,6 +17,26 @@ pub struct CredentialBundle {
 }
 
 impl CredentialBundle {
+    /// Create a new credential bundle.
+    pub fn new(
+        did: impl Into<String>,
+        private_key_multibase: impl Into<String>,
+        vta_did: impl Into<String>,
+    ) -> Self {
+        Self {
+            did: did.into(),
+            private_key_multibase: private_key_multibase.into(),
+            vta_did: vta_did.into(),
+            vta_url: None,
+        }
+    }
+
+    /// Set the VTA URL on this bundle.
+    pub fn vta_url(mut self, url: impl Into<String>) -> Self {
+        self.vta_url = Some(url.into());
+        self
+    }
+
     /// Decode a base64url-no-pad encoded credential bundle.
     pub fn decode(encoded: &str) -> Result<Self, CredentialBundleError> {
         let json_bytes = BASE64

--- a/vta-sdk/src/did_key.rs
+++ b/vta-sdk/src/did_key.rs
@@ -8,8 +8,8 @@ pub fn ed25519_multibase_pubkey(public_key_bytes: &[u8; 32]) -> String {
 
 /// Known 2-byte multicodec varint prefixes for private keys.
 const ED25519_PRIV_CODEC: [u8; 2] = [0x80, 0x26]; // 0x1300
-const X25519_PRIV_CODEC: [u8; 2] = [0x82, 0x26];  // 0x1302
-const P256_PRIV_CODEC: [u8; 2] = [0x86, 0x26];    // 0x1306
+const X25519_PRIV_CODEC: [u8; 2] = [0x82, 0x26]; // 0x1302
+const P256_PRIV_CODEC: [u8; 2] = [0x86, 0x26]; // 0x1306
 
 /// Decode a multibase-encoded private key to raw bytes.
 ///

--- a/vta-sdk/src/did_key.rs
+++ b/vta-sdk/src/did_key.rs
@@ -6,22 +6,30 @@ pub fn ed25519_multibase_pubkey(public_key_bytes: &[u8; 32]) -> String {
     multibase::encode(multibase::Base::Base58Btc, &buf)
 }
 
-/// Ed25519 private key multicodec prefix (`0x8026`).
-const ED25519_PRIV_CODEC: [u8; 2] = [0x80, 0x26];
+/// Known 2-byte multicodec varint prefixes for private keys.
+const ED25519_PRIV_CODEC: [u8; 2] = [0x80, 0x26]; // 0x1300
+const X25519_PRIV_CODEC: [u8; 2] = [0x82, 0x26];  // 0x1302
+const P256_PRIV_CODEC: [u8; 2] = [0x86, 0x26];    // 0x1306
 
-/// Decode a multibase-encoded private key seed to 32 bytes.
+/// Decode a multibase-encoded private key to raw bytes.
 ///
-/// Accepts both raw 32-byte encodings and 34-byte encodings that include
-/// the `0x8026` ed25519-priv multicodec prefix (as produced by
-/// `Secret::get_private_keymultibase()`).
+/// Accepts both:
+/// - Multicodec-prefixed: 2-byte prefix + raw key bytes (standard format)
+/// - Raw: just the key bytes (legacy/backwards-compatible)
+///
+/// Strips known private-key multicodec prefixes (Ed25519, X25519, P256)
+/// before returning the raw key bytes.
 pub fn decode_private_key_multibase(mb: &str) -> Result<[u8; 32], DidKeyError> {
     let (_, raw) = multibase::decode(mb).map_err(|e| DidKeyError::Multibase(e.to_string()))?;
-    let seed_bytes = if raw.len() == 34 && raw[..2] == ED25519_PRIV_CODEC {
-        &raw[2..]
+    let key_bytes = if raw.len() >= 2 {
+        match [raw[0], raw[1]] {
+            ED25519_PRIV_CODEC | X25519_PRIV_CODEC | P256_PRIV_CODEC => &raw[2..],
+            _ => &raw[..],
+        }
     } else {
         &raw[..]
     };
-    seed_bytes
+    key_bytes
         .try_into()
         .map_err(|_| DidKeyError::InvalidSeedLength)
 }

--- a/vta-sdk/src/did_secrets.rs
+++ b/vta-sdk/src/did_secrets.rs
@@ -61,11 +61,15 @@ pub struct SecretEntry {
     pub key_id: String,
     /// Key type — determines how to reconstruct the secret.
     pub key_type: KeyType,
-    /// Multibase-encoded (Base58BTC) private key seed bytes.
+    /// Multibase-encoded (Base58BTC) private key with multicodec prefix.
     ///
-    /// For **Ed25519** keys, these are the 32-byte Ed25519 seed.
-    /// For **X25519** keys, these are the 32-byte Ed25519 seed that was
-    /// used to derive the X25519 key via scalar conversion.
+    /// The multicodec prefix identifies the key type:
+    /// - Ed25519 private: `0x1300` — 32-byte Ed25519 seed
+    /// - X25519 private: `0x1302` — 32-byte X25519 scalar (from `get_key_secret`)
+    ///   or Ed25519 seed for conversion (from provisioning)
+    /// - P256 private: `0x1306` — 32-byte P-256 scalar
+    ///
+    /// Compatible with `Secret::from_multibase()` for direct use in DIDComm.
     pub private_key_multibase: String,
 }
 

--- a/vta-sdk/src/did_secrets.rs
+++ b/vta-sdk/src/did_secrets.rs
@@ -21,29 +21,19 @@ use crate::keys::KeyType;
 /// # Example — constructing secrets for DIDComm
 ///
 /// Applications using `affinidi_tdk` can reconstruct `Secret` objects from the
-/// entries in this bundle:
+/// entries in this bundle using `Secret::from_multibase()`, which handles all
+/// key types (Ed25519, X25519, P-256) via their multicodec prefix:
 ///
 /// ```ignore
 /// use affinidi_tdk::secrets_resolver::secrets::Secret;
 ///
-/// let bundle = DidSecretsBundle::decode(&base64_string)?;
+/// let bundle = client.fetch_did_secrets_bundle("my-context").await?;
 /// for entry in &bundle.secrets {
-///     let seed_bytes: [u8; 32] = /* decode entry.private_key_multibase */;
-///     match entry.key_type {
-///         KeyType::Ed25519 => {
-///             let secret = Secret::generate_ed25519(
-///                 Some(&entry.key_id), Some(&seed_bytes),
-///             );
-///             resolver.insert(secret);
-///         }
-///         KeyType::X25519 => {
-///             let secret = Secret::generate_ed25519(None, Some(&seed_bytes))
-///                 .to_x25519()?;
-///             // Set the key ID after conversion
-///             secret.id = entry.key_id.clone();
-///             resolver.insert(secret);
-///         }
-///     }
+///     let secret = Secret::from_multibase(
+///         &entry.private_key_multibase,
+///         Some(&entry.key_id),
+///     )?;
+///     resolver.insert(secret);
 /// }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/vta-sdk/src/did_secrets.rs
+++ b/vta-sdk/src/did_secrets.rs
@@ -69,6 +69,18 @@ pub struct SecretEntry {
     pub private_key_multibase: String,
 }
 
+/// Convert a [`GetKeySecretResponse`](crate::client::GetKeySecretResponse) into a [`SecretEntry`].
+#[cfg(feature = "client")]
+impl From<crate::client::GetKeySecretResponse> for SecretEntry {
+    fn from(resp: crate::client::GetKeySecretResponse) -> Self {
+        Self {
+            key_id: resp.key_id,
+            key_type: resp.key_type,
+            private_key_multibase: resp.private_key_multibase,
+        }
+    }
+}
+
 impl DidSecretsBundle {
     /// Decode a base64url-no-pad encoded secrets bundle.
     pub fn decode(encoded: &str) -> Result<Self, DidSecretsBundleError> {

--- a/vta-sdk/src/didcomm_init.rs
+++ b/vta-sdk/src/didcomm_init.rs
@@ -119,10 +119,12 @@ pub async fn init_didcomm_connection(
         match atm.list_messages(&profile, Folder::Inbox).await {
             Ok(messages) if !messages.is_empty() => {
                 let ids: Vec<String> = messages.iter().map(|m| m.msg_id.clone()).collect();
-                info!(count = ids.len(), "flushing stale queued messages from mediator inbox");
-                let delete_req = affinidi_tdk::messaging::messages::DeleteMessageRequest {
-                    message_ids: ids,
-                };
+                info!(
+                    count = ids.len(),
+                    "flushing stale queued messages from mediator inbox"
+                );
+                let delete_req =
+                    affinidi_tdk::messaging::messages::DeleteMessageRequest { message_ids: ids };
                 match atm.delete_messages_direct(&profile, &delete_req).await {
                     Ok(resp) => {
                         info!(
@@ -174,12 +176,7 @@ pub async fn handle_trust_ping(
     let pong = TrustPing::default().generate_pong_message(ping, Some(service_did))?;
 
     let (packed, _) = atm
-        .pack_encrypted(
-            &pong,
-            sender_did,
-            Some(service_did),
-            Some(service_did),
-        )
+        .pack_encrypted(&pong, sender_did, Some(service_did), Some(service_did))
         .await?;
 
     atm.send_message(profile, &packed, &pong.id, false, false)

--- a/vta-sdk/src/didcomm_light.rs
+++ b/vta-sdk/src/didcomm_light.rs
@@ -21,12 +21,7 @@ const AES_KEY_LEN: usize = 32;
 // ── DIDComm message builder ─────────────────────────────────────────
 
 /// Build a DIDComm v2 plaintext message JSON.
-pub fn build_message(
-    msg_type: &str,
-    body: serde_json::Value,
-    from: &str,
-    to: &str,
-) -> String {
+pub fn build_message(msg_type: &str, body: serde_json::Value, from: &str, to: &str) -> String {
     serde_json::json!({
         "id": uuid::Uuid::new_v4().to_string(),
         "typ": "application/didcomm-plain+json",
@@ -86,8 +81,7 @@ pub fn pack_anoncrypt(
     let encrypted_key = aes_key_wrap(&kek, &cek)?;
 
     // 7. AES-256-GCM encrypt the plaintext with CEK
-    let cipher = Aes256Gcm::new_from_slice(&cek)
-        .map_err(|e| format!("aes-gcm key: {e}"))?;
+    let cipher = Aes256Gcm::new_from_slice(&cek).map_err(|e| format!("aes-gcm key: {e}"))?;
     let mut nonce_bytes = [0u8; GCM_NONCE_LEN];
     aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
@@ -167,16 +161,15 @@ fn concat_kdf(
 /// Input: 32-byte KEK, key to wrap (multiple of 8 bytes).
 /// Output: wrapped key (input_len + 8 bytes).
 fn aes_key_wrap(kek: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    use aes::cipher::{BlockEncrypt, KeyInit as AesKeyInit};
     use aes::Aes256;
+    use aes::cipher::{BlockEncrypt, KeyInit as AesKeyInit};
 
-    if plaintext.len() % 8 != 0 || plaintext.is_empty() {
+    if !plaintext.len().is_multiple_of(8) || plaintext.is_empty() {
         return Err("key wrap input must be a non-empty multiple of 8 bytes".into());
     }
 
     let n = plaintext.len() / 8;
-    let cipher = Aes256::new_from_slice(kek)
-        .map_err(|e| format!("aes key wrap: {e}"))?;
+    let cipher = Aes256::new_from_slice(kek).map_err(|e| format!("aes key wrap: {e}"))?;
 
     // Initialize: A = IV (0xA6 repeated 8 times), R[1..n] = plaintext blocks
     let mut a = [0xA6u8; 8];
@@ -191,13 +184,13 @@ fn aes_key_wrap(kek: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, Box<dyn std
 
     // Wrap: 6 rounds
     for j in 0..6u64 {
-        for i in 0..n {
+        for (i, ri) in r.iter_mut().enumerate().take(n) {
             let t = (n as u64) * j + (i as u64) + 1;
 
             // B = AES(K, A || R[i])
             let mut block = aes::Block::default();
             block[..8].copy_from_slice(&a);
-            block[8..].copy_from_slice(&r[i]);
+            block[8..].copy_from_slice(ri);
             cipher.encrypt_block(&mut block);
 
             // A = MSB(64, B) ^ t
@@ -208,7 +201,7 @@ fn aes_key_wrap(kek: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, Box<dyn std
             }
 
             // R[i] = LSB(64, B)
-            r[i].copy_from_slice(&block[8..]);
+            ri.copy_from_slice(&block[8..]);
         }
     }
 
@@ -223,9 +216,12 @@ fn aes_key_wrap(kek: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, Box<dyn std
 
 /// Unwrap a key using AES-256 Key Unwrap (RFC 3394). Used for testing.
 #[cfg(test)]
-fn aes_key_unwrap(kek: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    use aes::cipher::{BlockDecrypt, KeyInit as AesKeyInit};
+fn aes_key_unwrap(
+    kek: &[u8; 32],
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     use aes::Aes256;
+    use aes::cipher::{BlockDecrypt, KeyInit as AesKeyInit};
 
     if ciphertext.len() % 8 != 0 || ciphertext.len() < 24 {
         return Err("key unwrap input must be at least 24 bytes and a multiple of 8".into());
@@ -279,9 +275,7 @@ fn aes_key_unwrap(kek: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, Box<dyn 
 
 /// Extract the Ed25519 public key bytes from a `did:key:z6Mk...` identifier.
 pub fn parse_did_key_ed25519(did: &str) -> Result<[u8; 32], Box<dyn std::error::Error>> {
-    let multibase_part = did
-        .strip_prefix("did:key:")
-        .ok_or("not a did:key")?;
+    let multibase_part = did.strip_prefix("did:key:").ok_or("not a did:key")?;
     let (_, decoded) = multibase::decode(multibase_part)?;
     // Expect 34 bytes: 2-byte multicodec (0xed 0x01) + 32-byte key
     if decoded.len() != 34 || decoded[0] != 0xed || decoded[1] != 0x01 {
@@ -293,7 +287,9 @@ pub fn parse_did_key_ed25519(did: &str) -> Result<[u8; 32], Box<dyn std::error::
 }
 
 /// Convert an Ed25519 public key to an X25519 public key (Edwards → Montgomery).
-pub fn ed25519_pub_to_x25519_pub(ed_pub: &[u8; 32]) -> Result<[u8; 32], Box<dyn std::error::Error>> {
+pub fn ed25519_pub_to_x25519_pub(
+    ed_pub: &[u8; 32],
+) -> Result<[u8; 32], Box<dyn std::error::Error>> {
     let compressed = curve25519_dalek::edwards::CompressedEdwardsY(*ed_pub);
     let edwards = compressed
         .decompress()
@@ -452,10 +448,9 @@ mod tests {
         assert!(jwe["tag"].is_string());
 
         // Verify protected header
-        let protected_json: serde_json::Value = serde_json::from_slice(
-            &B64.decode(jwe["protected"].as_str().unwrap()).unwrap(),
-        )
-        .unwrap();
+        let protected_json: serde_json::Value =
+            serde_json::from_slice(&B64.decode(jwe["protected"].as_str().unwrap()).unwrap())
+                .unwrap();
         assert_eq!(protected_json["alg"], "ECDH-ES+A256KW");
         assert_eq!(protected_json["enc"], "A256GCM");
         assert_eq!(protected_json["typ"], "application/didcomm-encrypted+json");

--- a/vta-sdk/src/didcomm_light.rs
+++ b/vta-sdk/src/didcomm_light.rs
@@ -1,0 +1,479 @@
+//! Lightweight DIDComm v2 anonymous encryption (anoncrypt) packer.
+//!
+//! Produces a JWE (General JSON Serialization) that can be unpacked by any
+//! DIDComm v2 implementation (including `affinidi-tdk`'s `ATM::unpack()`).
+//!
+//! This module avoids the heavyweight ATM/TDK runtime initialization. It only
+//! needs the recipient's X25519 public key (derived from their `did:key`).
+//!
+//! Algorithm: ECDH-ES+A256KW (key agreement) + A256GCM (content encryption).
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use sha2::{Digest, Sha256};
+use x25519_dalek::{PublicKey, StaticSecret};
+
+const GCM_NONCE_LEN: usize = 12;
+const AES_KEY_LEN: usize = 32;
+
+// ── DIDComm message builder ─────────────────────────────────────────
+
+/// Build a DIDComm v2 plaintext message JSON.
+pub fn build_message(
+    msg_type: &str,
+    body: serde_json::Value,
+    from: &str,
+    to: &str,
+) -> String {
+    serde_json::json!({
+        "id": uuid::Uuid::new_v4().to_string(),
+        "typ": "application/didcomm-plain+json",
+        "type": msg_type,
+        "body": body,
+        "from": from,
+        "to": [to],
+    })
+    .to_string()
+}
+
+// ── JWE anoncrypt packer ────────────────────────────────────────────
+
+/// Pack a plaintext message as a DIDComm v2 anoncrypt JWE (General JSON).
+///
+/// Returns the JWE as a JSON string suitable for sending to `POST /auth/`.
+pub fn pack_anoncrypt(
+    plaintext: &[u8],
+    recipient_x25519_pub: &[u8; 32],
+    recipient_kid: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use aes_gcm::aead::rand_core::RngCore;
+
+    // 1. Generate ephemeral X25519 keypair
+    let ephemeral_secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+    let ephemeral_pub = PublicKey::from(&ephemeral_secret);
+
+    // 2. ECDH: shared secret
+    let recipient_pub = PublicKey::from(*recipient_x25519_pub);
+    let shared_secret = ephemeral_secret.diffie_hellman(&recipient_pub);
+
+    // 3. Build protected header
+    let protected = serde_json::json!({
+        "typ": "application/didcomm-encrypted+json",
+        "alg": "ECDH-ES+A256KW",
+        "enc": "A256GCM",
+        "apu": B64.encode(b""),
+        "apv": B64.encode(Sha256::digest(recipient_kid.as_bytes())),
+        "epk": {
+            "kty": "OKP",
+            "crv": "X25519",
+            "x": B64.encode(ephemeral_pub.as_bytes()),
+        },
+    });
+    let protected_b64 = B64.encode(protected.to_string().as_bytes());
+
+    // 4. Derive key-wrapping key via Concat KDF
+    let apu = b"";
+    let apv = Sha256::digest(recipient_kid.as_bytes());
+    let kek = concat_kdf(shared_secret.as_bytes(), "A256KW", apu, &apv)?;
+
+    // 5. Generate random CEK (32 bytes for AES-256-GCM)
+    let mut cek = [0u8; AES_KEY_LEN];
+    aes_gcm::aead::OsRng.fill_bytes(&mut cek);
+
+    // 6. AES-256 Key Wrap the CEK
+    let encrypted_key = aes_key_wrap(&kek, &cek)?;
+
+    // 7. AES-256-GCM encrypt the plaintext with CEK
+    let cipher = Aes256Gcm::new_from_slice(&cek)
+        .map_err(|e| format!("aes-gcm key: {e}"))?;
+    let mut nonce_bytes = [0u8; GCM_NONCE_LEN];
+    aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    // AAD = protected header (base64url encoded)
+    let ciphertext_with_tag = cipher
+        .encrypt(
+            nonce,
+            aes_gcm::aead::Payload {
+                msg: plaintext,
+                aad: protected_b64.as_bytes(),
+            },
+        )
+        .map_err(|e| format!("aes-gcm encrypt: {e}"))?;
+
+    // Split ciphertext and tag (last 16 bytes is the GCM tag)
+    let tag_start = ciphertext_with_tag.len() - 16;
+    let ciphertext = &ciphertext_with_tag[..tag_start];
+    let tag = &ciphertext_with_tag[tag_start..];
+
+    // 8. Assemble JWE General JSON Serialization
+    let jwe = serde_json::json!({
+        "protected": protected_b64,
+        "recipients": [{
+            "header": { "kid": recipient_kid },
+            "encrypted_key": B64.encode(&encrypted_key),
+        }],
+        "iv": B64.encode(nonce_bytes),
+        "ciphertext": B64.encode(ciphertext),
+        "tag": B64.encode(tag),
+    });
+
+    Ok(jwe.to_string())
+}
+
+// ── Concat KDF (NIST SP 800-56A, single-pass SHA-256) ──────────────
+
+/// Derive a 256-bit key from ECDH shared secret using Concat KDF.
+fn concat_kdf(
+    z: &[u8],
+    algorithm: &str,
+    apu: &[u8],
+    apv: &[u8],
+) -> Result<[u8; 32], Box<dyn std::error::Error>> {
+    let mut hasher = Sha256::new();
+
+    // counter = 00000001
+    hasher.update(1u32.to_be_bytes());
+
+    // Z = shared secret
+    hasher.update(z);
+
+    // OtherInfo:
+    // AlgorithmID = len(4 BE) || algorithm
+    hasher.update((algorithm.len() as u32).to_be_bytes());
+    hasher.update(algorithm.as_bytes());
+
+    // PartyUInfo = len(4 BE) || apu
+    hasher.update((apu.len() as u32).to_be_bytes());
+    hasher.update(apu);
+
+    // PartyVInfo = len(4 BE) || apv
+    hasher.update((apv.len() as u32).to_be_bytes());
+    hasher.update(apv);
+
+    // SuppPubInfo = keydatalen in bits (256) as 32-bit BE
+    hasher.update(256u32.to_be_bytes());
+
+    let result = hasher.finalize();
+    Ok(result.into())
+}
+
+// ── AES-256 Key Wrap (RFC 3394) ─────────────────────────────────────
+
+/// Wrap a key using AES-256 Key Wrap (RFC 3394).
+///
+/// Input: 32-byte KEK, key to wrap (multiple of 8 bytes).
+/// Output: wrapped key (input_len + 8 bytes).
+fn aes_key_wrap(kek: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use aes::cipher::{BlockEncrypt, KeyInit as AesKeyInit};
+    use aes::Aes256;
+
+    if plaintext.len() % 8 != 0 || plaintext.is_empty() {
+        return Err("key wrap input must be a non-empty multiple of 8 bytes".into());
+    }
+
+    let n = plaintext.len() / 8;
+    let cipher = Aes256::new_from_slice(kek)
+        .map_err(|e| format!("aes key wrap: {e}"))?;
+
+    // Initialize: A = IV (0xA6 repeated 8 times), R[1..n] = plaintext blocks
+    let mut a = [0xA6u8; 8];
+    let mut r: Vec<[u8; 8]> = plaintext
+        .chunks_exact(8)
+        .map(|c| {
+            let mut block = [0u8; 8];
+            block.copy_from_slice(c);
+            block
+        })
+        .collect();
+
+    // Wrap: 6 rounds
+    for j in 0..6u64 {
+        for i in 0..n {
+            let t = (n as u64) * j + (i as u64) + 1;
+
+            // B = AES(K, A || R[i])
+            let mut block = aes::Block::default();
+            block[..8].copy_from_slice(&a);
+            block[8..].copy_from_slice(&r[i]);
+            cipher.encrypt_block(&mut block);
+
+            // A = MSB(64, B) ^ t
+            a.copy_from_slice(&block[..8]);
+            let t_bytes = t.to_be_bytes();
+            for k in 0..8 {
+                a[k] ^= t_bytes[k];
+            }
+
+            // R[i] = LSB(64, B)
+            r[i].copy_from_slice(&block[8..]);
+        }
+    }
+
+    // Output: A || R[1] || R[2] || ... || R[n]
+    let mut output = Vec::with_capacity(8 + plaintext.len());
+    output.extend_from_slice(&a);
+    for block in &r {
+        output.extend_from_slice(block);
+    }
+    Ok(output)
+}
+
+/// Unwrap a key using AES-256 Key Unwrap (RFC 3394). Used for testing.
+#[cfg(test)]
+fn aes_key_unwrap(kek: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use aes::cipher::{BlockDecrypt, KeyInit as AesKeyInit};
+    use aes::Aes256;
+
+    if ciphertext.len() % 8 != 0 || ciphertext.len() < 24 {
+        return Err("key unwrap input must be at least 24 bytes and a multiple of 8".into());
+    }
+
+    let n = (ciphertext.len() / 8) - 1;
+    let cipher = Aes256::new_from_slice(kek)?;
+
+    let mut a = [0u8; 8];
+    a.copy_from_slice(&ciphertext[..8]);
+    let mut r: Vec<[u8; 8]> = ciphertext[8..]
+        .chunks_exact(8)
+        .map(|c| {
+            let mut block = [0u8; 8];
+            block.copy_from_slice(c);
+            block
+        })
+        .collect();
+
+    for j in (0..6u64).rev() {
+        for i in (0..n).rev() {
+            let t = (n as u64) * j + (i as u64) + 1;
+
+            let t_bytes = t.to_be_bytes();
+            for k in 0..8 {
+                a[k] ^= t_bytes[k];
+            }
+
+            let mut block = aes::Block::default();
+            block[..8].copy_from_slice(&a);
+            block[8..].copy_from_slice(&r[i]);
+            cipher.decrypt_block(&mut block);
+
+            a.copy_from_slice(&block[..8]);
+            r[i].copy_from_slice(&block[8..]);
+        }
+    }
+
+    if a != [0xA6u8; 8] {
+        return Err("key unwrap integrity check failed".into());
+    }
+
+    let mut output = Vec::with_capacity(n * 8);
+    for block in &r {
+        output.extend_from_slice(block);
+    }
+    Ok(output)
+}
+
+// ── did:key → X25519 public key conversion ──────────────────────────
+
+/// Extract the Ed25519 public key bytes from a `did:key:z6Mk...` identifier.
+pub fn parse_did_key_ed25519(did: &str) -> Result<[u8; 32], Box<dyn std::error::Error>> {
+    let multibase_part = did
+        .strip_prefix("did:key:")
+        .ok_or("not a did:key")?;
+    let (_, decoded) = multibase::decode(multibase_part)?;
+    // Expect 34 bytes: 2-byte multicodec (0xed 0x01) + 32-byte key
+    if decoded.len() != 34 || decoded[0] != 0xed || decoded[1] != 0x01 {
+        return Err("invalid did:key: expected Ed25519 multicodec prefix 0xed01".into());
+    }
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&decoded[2..]);
+    Ok(key)
+}
+
+/// Convert an Ed25519 public key to an X25519 public key (Edwards → Montgomery).
+pub fn ed25519_pub_to_x25519_pub(ed_pub: &[u8; 32]) -> Result<[u8; 32], Box<dyn std::error::Error>> {
+    let compressed = curve25519_dalek::edwards::CompressedEdwardsY(*ed_pub);
+    let edwards = compressed
+        .decompress()
+        .ok_or("invalid Ed25519 public key: decompression failed")?;
+    Ok(edwards.to_montgomery().to_bytes())
+}
+
+/// Derive the X25519 key-agreement key ID for a `did:key`.
+///
+/// Given `did:key:z6Mk...`, returns `did:key:z6Mk...#z6LS...` where the
+/// fragment is the X25519 public key encoded with multicodec `0xec01`.
+pub fn did_key_agreement_kid(did: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let ed_pub = parse_did_key_ed25519(did)?;
+    let x_pub = ed25519_pub_to_x25519_pub(&ed_pub)?;
+    let mut buf = Vec::with_capacity(34);
+    buf.extend_from_slice(&[0xec, 0x01]); // x25519-pub multicodec
+    buf.extend_from_slice(&x_pub);
+    let x_multibase = multibase::encode(multibase::Base::Base58Btc, &buf);
+    Ok(format!("{did}#{x_multibase}"))
+}
+
+/// Convert an Ed25519 seed (private key) to X25519 static secret bytes.
+pub fn ed25519_seed_to_x25519_secret(seed: &[u8; 32]) -> [u8; 32] {
+    // Standard Ed25519→X25519 conversion: SHA-512(seed)[0..32] with clamping
+    let hash = sha2::Sha512::digest(seed);
+    let mut x25519_bytes = [0u8; 32];
+    x25519_bytes.copy_from_slice(&hash[..32]);
+    // Clamping (applied by StaticSecret::from, but be explicit)
+    x25519_bytes[0] &= 248;
+    x25519_bytes[31] &= 127;
+    x25519_bytes[31] |= 64;
+    x25519_bytes
+}
+
+// ── High-level: pack auth message ───────────────────────────────────
+
+/// Pack a DIDComm v2 authenticate message for VTA challenge-response.
+///
+/// This is the lightweight equivalent of `atm.pack_encrypted()` — it produces
+/// a JWE that the server's ATM can unpack, without needing ATM initialization.
+pub fn pack_auth_message(
+    msg_type: &str,
+    body: serde_json::Value,
+    client_did: &str,
+    vta_did: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let plaintext = build_message(msg_type, body, client_did, vta_did);
+
+    // Get recipient's X25519 public key from their did:key
+    let ed_pub = parse_did_key_ed25519(vta_did)?;
+    let x_pub = ed25519_pub_to_x25519_pub(&ed_pub)?;
+    let kid = did_key_agreement_kid(vta_did)?;
+
+    pack_anoncrypt(plaintext.as_bytes(), &x_pub, &kid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_aes_key_wrap_roundtrip() {
+        let kek = [42u8; 32];
+        let plaintext = [1u8; 32]; // 32 bytes = 4 blocks of 8
+
+        let wrapped = aes_key_wrap(&kek, &plaintext).unwrap();
+        assert_eq!(wrapped.len(), 40); // 32 + 8
+
+        let unwrapped = aes_key_unwrap(&kek, &wrapped).unwrap();
+        assert_eq!(unwrapped, plaintext);
+    }
+
+    #[test]
+    fn test_aes_key_wrap_different_keys_different_output() {
+        let kek1 = [1u8; 32];
+        let kek2 = [2u8; 32];
+        let plaintext = [99u8; 32];
+
+        let w1 = aes_key_wrap(&kek1, &plaintext).unwrap();
+        let w2 = aes_key_wrap(&kek2, &plaintext).unwrap();
+        assert_ne!(w1, w2);
+    }
+
+    #[test]
+    fn test_concat_kdf_deterministic() {
+        let z = [0u8; 32];
+        let k1 = concat_kdf(&z, "A256KW", b"", b"recipient").unwrap();
+        let k2 = concat_kdf(&z, "A256KW", b"", b"recipient").unwrap();
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn test_concat_kdf_different_algorithms() {
+        let z = [0u8; 32];
+        let k1 = concat_kdf(&z, "A256KW", b"", b"x").unwrap();
+        let k2 = concat_kdf(&z, "A128KW", b"", b"x").unwrap();
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn test_parse_did_key_ed25519() {
+        // Create a known did:key from a known public key
+        let pub_bytes = [42u8; 32];
+        let did = format!(
+            "did:key:{}",
+            crate::did_key::ed25519_multibase_pubkey(&pub_bytes)
+        );
+        let parsed = parse_did_key_ed25519(&did).unwrap();
+        assert_eq!(parsed, pub_bytes);
+    }
+
+    #[test]
+    fn test_ed25519_to_x25519_conversion() {
+        // Generate an Ed25519 key pair and verify conversion produces valid X25519
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+        let ed_pub = verifying_key.to_bytes();
+
+        let x_pub = ed25519_pub_to_x25519_pub(&ed_pub).unwrap();
+        assert_ne!(x_pub, [0u8; 32]); // Should not be all zeros
+    }
+
+    #[test]
+    fn test_did_key_agreement_kid() {
+        let pub_bytes = [42u8; 32];
+        let did = format!(
+            "did:key:{}",
+            crate::did_key::ed25519_multibase_pubkey(&pub_bytes)
+        );
+        let kid = did_key_agreement_kid(&did).unwrap();
+        assert!(kid.starts_with(&did));
+        assert!(kid.contains('#'));
+        // The fragment should be an X25519 multibase (starts with z after #)
+        let fragment = kid.split('#').nth(1).unwrap();
+        assert!(fragment.starts_with('z'));
+    }
+
+    #[test]
+    fn test_pack_anoncrypt_produces_valid_jwe() {
+        let recipient_secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+        let recipient_pub = PublicKey::from(&recipient_secret);
+
+        let jwe_str = pack_anoncrypt(
+            b"hello world",
+            recipient_pub.as_bytes(),
+            "did:key:test#key-1",
+        )
+        .unwrap();
+
+        let jwe: serde_json::Value = serde_json::from_str(&jwe_str).unwrap();
+        assert!(jwe["protected"].is_string());
+        assert!(jwe["recipients"].is_array());
+        assert_eq!(jwe["recipients"].as_array().unwrap().len(), 1);
+        assert!(jwe["iv"].is_string());
+        assert!(jwe["ciphertext"].is_string());
+        assert!(jwe["tag"].is_string());
+
+        // Verify protected header
+        let protected_json: serde_json::Value = serde_json::from_slice(
+            &B64.decode(jwe["protected"].as_str().unwrap()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(protected_json["alg"], "ECDH-ES+A256KW");
+        assert_eq!(protected_json["enc"], "A256GCM");
+        assert_eq!(protected_json["typ"], "application/didcomm-encrypted+json");
+    }
+
+    #[test]
+    fn test_build_message_structure() {
+        let msg = build_message(
+            "https://example.com/test",
+            serde_json::json!({"foo": "bar"}),
+            "did:key:sender",
+            "did:key:recipient",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        assert_eq!(parsed["type"], "https://example.com/test");
+        assert_eq!(parsed["from"], "did:key:sender");
+        assert_eq!(parsed["to"][0], "did:key:recipient");
+        assert_eq!(parsed["body"]["foo"], "bar");
+        assert!(parsed["id"].is_string());
+    }
+}

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -64,7 +64,10 @@ impl DIDCommSession {
             match atm.list_messages(&profile, Folder::Inbox).await {
                 Ok(messages) if !messages.is_empty() => {
                     let ids: Vec<String> = messages.iter().map(|m| m.msg_id.clone()).collect();
-                    info!(count = ids.len(), "flushing stale queued messages from inbox");
+                    info!(
+                        count = ids.len(),
+                        "flushing stale queued messages from inbox"
+                    );
                     let delete_req = affinidi_tdk::messaging::messages::DeleteMessageRequest {
                         message_ids: ids,
                     };

--- a/vta-sdk/src/didcomm_transport.rs
+++ b/vta-sdk/src/didcomm_transport.rs
@@ -13,23 +13,38 @@ use crate::protocols::{PROBLEM_REPORT_TYPE, extract_problem_report};
 /// Map of pending request IDs to oneshot senders for response routing.
 pub type PendingMap = Arc<std::sync::Mutex<HashMap<String, oneshot::Sender<Message>>>>;
 
+/// Parameters for sending a DIDComm message and waiting for a response.
+pub struct DIDCommSendParams<'a> {
+    pub atm: &'a ATM,
+    pub profile: &'a Arc<ATMProfile>,
+    pub pending: &'a PendingMap,
+    pub from_did: &'a str,
+    pub to_did: &'a str,
+    pub msg_type: &'a str,
+    pub body: serde_json::Value,
+    pub expected_type: &'a str,
+    pub problem_report_type: &'a str,
+    pub timeout_secs: u64,
+}
+
 /// Core send-and-wait logic shared by DIDCommSession (SDK) and DIDCommBridge (service).
 ///
 /// Builds a message, registers a pending oneshot, packs/sends via ATM, and waits
 /// for a response matching the thread ID. Returns `Err(String)` on failure —
 /// callers map the error into their own type.
-pub async fn send_and_wait_raw(
-    atm: &ATM,
-    profile: &Arc<ATMProfile>,
-    pending: &PendingMap,
-    from_did: &str,
-    to_did: &str,
-    msg_type: &str,
-    body: serde_json::Value,
-    expected_type: &str,
-    problem_report_type: &str,
-    timeout_secs: u64,
-) -> Result<Message, String> {
+pub async fn send_and_wait_raw(params: DIDCommSendParams<'_>) -> Result<Message, String> {
+    let DIDCommSendParams {
+        atm,
+        profile,
+        pending,
+        from_did,
+        to_did,
+        msg_type,
+        body,
+        expected_type,
+        problem_report_type,
+        timeout_secs,
+    } = params;
     let msg_id = uuid::Uuid::new_v4().to_string();
     let msg = Message::build(msg_id.clone(), msg_type.to_string(), body)
         .from(from_did.to_string())

--- a/vta-sdk/src/error.rs
+++ b/vta-sdk/src/error.rs
@@ -1,0 +1,115 @@
+//! Structured error type for VTA SDK operations.
+
+/// Errors returned by VTA SDK client operations.
+#[derive(Debug, thiserror::Error)]
+pub enum VtaError {
+    /// Network-level error (connection refused, timeout, DNS failure).
+    #[cfg(feature = "client")]
+    #[error("network error: {0}")]
+    Network(#[from] reqwest::Error),
+
+    /// Authentication failed (401) or token expired.
+    #[error("authentication failed: {0}")]
+    Auth(String),
+
+    /// Resource not found (404).
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// Request validation error (400).
+    #[error("validation error: {0}")]
+    Validation(String),
+
+    /// Permission denied (403).
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+
+    /// Conflict (409) — e.g. duplicate key ID.
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// Server error (5xx).
+    #[error("server error ({status}): {body}")]
+    Server { status: u16, body: String },
+
+    /// Protocol error (e.g. unexpected DIDComm message type).
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
+    /// Serialization/deserialization error.
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    /// Catch-all for other errors.
+    #[error("{0}")]
+    Other(String),
+}
+
+impl VtaError {
+    /// Create from an HTTP response status and error body.
+    #[cfg(feature = "client")]
+    pub(crate) fn from_http(status: reqwest::StatusCode, body: String) -> Self {
+        match status.as_u16() {
+            401 => Self::Auth(body),
+            403 => Self::Forbidden(body),
+            404 => Self::NotFound(body),
+            400 | 422 => Self::Validation(body),
+            409 => Self::Conflict(body),
+            s if s >= 500 => Self::Server {
+                status: s,
+                body,
+            },
+            s => Self::Other(format!("{s}: {body}")),
+        }
+    }
+
+    /// Returns true if this is an authentication/authorization error.
+    pub fn is_auth(&self) -> bool {
+        matches!(self, Self::Auth(_) | Self::Forbidden(_))
+    }
+
+    /// Returns true if this is a network-level error (retryable).
+    pub fn is_network(&self) -> bool {
+        #[cfg(feature = "client")]
+        if matches!(self, Self::Network(_)) {
+            return true;
+        }
+        false
+    }
+
+    /// Returns true if the resource was not found.
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, Self::NotFound(_))
+    }
+}
+
+impl From<String> for VtaError {
+    fn from(s: String) -> Self {
+        Self::Other(s)
+    }
+}
+
+impl From<&str> for VtaError {
+    fn from(s: &str) -> Self {
+        Self::Other(s.to_string())
+    }
+}
+
+// Allow converting from Box<dyn Error> for backward compat during migration
+impl From<Box<dyn std::error::Error>> for VtaError {
+    fn from(e: Box<dyn std::error::Error>) -> Self {
+        Self::Other(e.to_string())
+    }
+}
+
+impl From<crate::credentials::CredentialBundleError> for VtaError {
+    fn from(e: crate::credentials::CredentialBundleError) -> Self {
+        Self::Validation(e.to_string())
+    }
+}
+
+impl From<crate::did_key::DidKeyError> for VtaError {
+    fn from(e: crate::did_key::DidKeyError) -> Self {
+        Self::Other(e.to_string())
+    }
+}

--- a/vta-sdk/src/error.rs
+++ b/vta-sdk/src/error.rs
@@ -55,10 +55,7 @@ impl VtaError {
             404 => Self::NotFound(body),
             400 | 422 => Self::Validation(body),
             409 => Self::Conflict(body),
-            s if s >= 500 => Self::Server {
-                status: s,
-                body,
-            },
+            s if s >= 500 => Self::Server { status: s, body },
             s => Self::Other(format!("{s}: {body}")),
         }
     }

--- a/vta-sdk/src/integration/auth.rs
+++ b/vta-sdk/src/integration/auth.rs
@@ -33,9 +33,7 @@ pub async fn authenticate(config: &VtaServiceConfig) -> Result<VtaClient, VtaErr
             let vta_url = url_override
                 .or(credential.vta_url.as_deref())
                 .ok_or_else(|| {
-                    VtaError::Validation(
-                        "VTA URL not found in credential or url_override".into(),
-                    )
+                    VtaError::Validation("VTA URL not found in credential or url_override".into())
                 })?;
 
             let token_result = crate::session::challenge_response(

--- a/vta-sdk/src/integration/auth.rs
+++ b/vta-sdk/src/integration/auth.rs
@@ -45,7 +45,7 @@ pub async fn authenticate(config: &VtaServiceConfig) -> Result<VtaClient, VtaErr
             .await?;
 
             let client = VtaClient::new(vta_url);
-            client.set_token(token_result.access_token);
+            client.set_token_async(token_result.access_token).await;
 
             tracing::info!("Authenticated to VTA at '{vta_url}' (REST, session auth)");
             Ok(client)

--- a/vta-sdk/src/integration/auth.rs
+++ b/vta-sdk/src/integration/auth.rs
@@ -1,0 +1,56 @@
+use crate::client::VtaClient;
+use crate::credentials::CredentialBundle;
+use crate::error::VtaError;
+
+use super::VtaServiceConfig;
+
+/// Authenticate to VTA using a two-tier strategy:
+///
+/// 1. **Lightweight REST auth** via [`VtaClient::from_credential`] — works when the
+///    VTA DID is `did:key`. Enables automatic token refresh.
+/// 2. **Session-based challenge-response** via [`crate::session::challenge_response`] —
+///    fallback for VTAs using `did:web`, `did:webvh`, or other non-`did:key` methods.
+///
+/// Network errors are returned immediately (no fallback attempt) since the VTA
+/// is genuinely unreachable.
+pub async fn authenticate(config: &VtaServiceConfig) -> Result<VtaClient, VtaError> {
+    let url_override = config.url_override.as_deref();
+
+    match VtaClient::from_credential(&config.credential, url_override).await {
+        Ok(client) => {
+            tracing::info!(
+                "Authenticated to VTA at '{}' (REST, auto-refresh enabled)",
+                client.base_url()
+            );
+            Ok(client)
+        }
+        Err(e) if e.is_network() => Err(e),
+        Err(e) => {
+            tracing::debug!("Lightweight VTA auth failed ({e}), trying session auth");
+
+            let credential = CredentialBundle::decode(&config.credential)?;
+
+            let vta_url = url_override
+                .or(credential.vta_url.as_deref())
+                .ok_or_else(|| {
+                    VtaError::Validation(
+                        "VTA URL not found in credential or url_override".into(),
+                    )
+                })?;
+
+            let token_result = crate::session::challenge_response(
+                vta_url,
+                &credential.did,
+                &credential.private_key_multibase,
+                &credential.vta_did,
+            )
+            .await?;
+
+            let client = VtaClient::new(vta_url);
+            client.set_token(token_result.access_token);
+
+            tracing::info!("Authenticated to VTA at '{vta_url}' (REST, session auth)");
+            Ok(client)
+        }
+    }
+}

--- a/vta-sdk/src/integration/cache.rs
+++ b/vta-sdk/src/integration/cache.rs
@@ -1,0 +1,27 @@
+use crate::did_secrets::DidSecretsBundle;
+
+/// Local cache for VTA secrets, enabling offline startup when VTA is unreachable.
+///
+/// Services implement this trait to persist [`DidSecretsBundle`] using their
+/// preferred storage backend (keyring, AWS Secrets Manager, GCP Secret Manager, etc.).
+///
+/// The bundle's [`encode()`](DidSecretsBundle::encode) and
+/// [`decode()`](DidSecretsBundle::decode) methods produce/consume a base64url
+/// JSON string — most backends only need to store and retrieve that single string.
+pub trait SecretCache: Send + Sync {
+    /// Persist a secrets bundle for offline recovery.
+    fn store(
+        &self,
+        bundle: &DidSecretsBundle,
+    ) -> impl Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send;
+
+    /// Load the last cached secrets bundle, if any.
+    ///
+    /// Returns `Ok(None)` when no cached data exists (first run before VTA contact).
+    fn load(
+        &self,
+    ) -> impl Future<Output = Result<Option<DidSecretsBundle>, Box<dyn std::error::Error + Send + Sync>>>
+           + Send;
+}
+
+use std::future::Future;

--- a/vta-sdk/src/integration/cache.rs
+++ b/vta-sdk/src/integration/cache.rs
@@ -20,8 +20,9 @@ pub trait SecretCache: Send + Sync {
     /// Returns `Ok(None)` when no cached data exists (first run before VTA contact).
     fn load(
         &self,
-    ) -> impl Future<Output = Result<Option<DidSecretsBundle>, Box<dyn std::error::Error + Send + Sync>>>
-           + Send;
+    ) -> impl Future<
+        Output = Result<Option<DidSecretsBundle>, Box<dyn std::error::Error + Send + Sync>>,
+    > + Send;
 }
 
 use std::future::Future;

--- a/vta-sdk/src/integration/mod.rs
+++ b/vta-sdk/src/integration/mod.rs
@@ -65,7 +65,6 @@ pub enum SecretSource {
 }
 
 /// Successful result from [`startup`].
-#[derive(Debug, Clone)]
 pub struct StartupResult {
     /// The service's DID, as recorded in the VTA context.
     pub did: String,
@@ -73,6 +72,10 @@ pub struct StartupResult {
     pub bundle: DidSecretsBundle,
     /// Where the secrets came from.
     pub source: SecretSource,
+    /// The authenticated VTA client, if secrets were fetched live.
+    /// `None` when secrets came from the local cache.
+    /// Services can use this for additional VTA calls (e.g., health checks).
+    pub client: Option<crate::client::VtaClient>,
 }
 
 /// Errors from the VTA integration startup flow.
@@ -136,6 +139,7 @@ pub async fn startup(
                         did: bundle.did.clone(),
                         bundle,
                         source: SecretSource::Vta,
+                        client: Some(client),
                     })
                 }
                 Err(e) => {
@@ -166,6 +170,7 @@ async fn load_from_cache(
                 did: bundle.did.clone(),
                 bundle,
                 source: SecretSource::Cache,
+                client: None,
             })
         }
         Ok(None) => Err(VtaIntegrationError::NoCachedSecrets),

--- a/vta-sdk/src/integration/mod.rs
+++ b/vta-sdk/src/integration/mod.rs
@@ -38,6 +38,10 @@ pub use cache::SecretCache;
 
 use crate::did_secrets::DidSecretsBundle;
 use crate::error::VtaError;
+use std::time::Duration;
+
+/// Default timeout for the entire VTA startup flow (auth + secret fetch).
+const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Configuration for connecting a service to its VTA context.
 ///
@@ -53,6 +57,9 @@ pub struct VtaServiceConfig {
     /// Optional REST URL override. When set, bypasses the URL embedded in the
     /// credential (useful for VTARest service discovery or dev/testing).
     pub url_override: Option<String>,
+    /// Timeout for the VTA startup flow (auth + secret fetch).
+    /// Defaults to 30 seconds if `None`.
+    pub timeout: Option<Duration>,
 }
 
 /// Whether secrets were loaded live from the VTA or from the local cache.
@@ -84,6 +91,9 @@ pub enum VtaIntegrationError {
     /// VTA is unreachable and no locally cached secrets exist.
     /// This typically means the service has never successfully contacted the VTA.
     NoCachedSecrets,
+    /// The VTA context returned zero secrets. This is a configuration error —
+    /// the context must have at least one key (signing or key agreement) provisioned.
+    EmptySecretsBundle(String),
     /// The local secret cache could not be read or written.
     CacheError(String),
     /// An error from the VTA SDK (authentication or secret fetch).
@@ -97,6 +107,11 @@ impl std::fmt::Display for VtaIntegrationError {
                 f,
                 "VTA is unreachable and no cached secrets exist. \
                  Run the setup wizard or ensure the VTA is accessible for the first startup."
+            ),
+            Self::EmptySecretsBundle(ctx) => write!(
+                f,
+                "VTA context '{ctx}' returned zero secrets. \
+                 Provision keys via the setup wizard or VTA admin tools."
             ),
             Self::CacheError(e) => write!(f, "secret cache error: {e}"),
             Self::Vta(e) => write!(f, "VTA error: {e}"),
@@ -123,31 +138,49 @@ pub async fn startup(
     config: &VtaServiceConfig,
     cache: &(impl SecretCache + ?Sized),
 ) -> Result<StartupResult, VtaIntegrationError> {
-    match authenticate(config).await {
-        Ok(client) => match client.fetch_did_secrets_bundle(&config.context).await {
-            Ok(bundle) => {
-                if let Err(e) = cache.store(&bundle).await {
-                    tracing::warn!("Failed to cache VTA secrets locally: {e}");
-                }
-                tracing::info!(
-                    context = config.context,
-                    secrets = bundle.secrets.len(),
-                    "Loaded fresh secrets from VTA",
-                );
-                Ok(StartupResult {
-                    did: bundle.did.clone(),
-                    bundle,
-                    source: SecretSource::Vta,
-                    client: Some(client),
-                })
+    let timeout = config.timeout.unwrap_or(DEFAULT_STARTUP_TIMEOUT);
+
+    let vta_result = tokio::time::timeout(timeout, async {
+        let client = authenticate(config).await?;
+        let bundle = client
+            .fetch_did_secrets_bundle(&config.context)
+            .await
+            .map_err(VtaIntegrationError::from)?;
+        Ok::<_, VtaIntegrationError>((client, bundle))
+    })
+    .await;
+
+    match vta_result {
+        Ok(Ok((client, bundle))) => {
+            if bundle.secrets.is_empty() {
+                return Err(VtaIntegrationError::EmptySecretsBundle(
+                    config.context.clone(),
+                ));
             }
-            Err(e) => {
-                tracing::warn!("VTA reachable but secret fetch failed: {e}");
-                load_from_cache(cache, &config.context).await
+            if let Err(e) = cache.store(&bundle).await {
+                tracing::warn!("Failed to cache VTA secrets locally: {e}");
             }
-        },
-        Err(e) => {
-            tracing::warn!("VTA unreachable ({e}), falling back to cached secrets");
+            tracing::info!(
+                context = config.context,
+                secrets = bundle.secrets.len(),
+                "Loaded fresh secrets from VTA",
+            );
+            Ok(StartupResult {
+                did: bundle.did.clone(),
+                bundle,
+                source: SecretSource::Vta,
+                client: Some(client),
+            })
+        }
+        Ok(Err(e)) => {
+            tracing::warn!("VTA startup failed: {e}");
+            load_from_cache(cache, &config.context).await
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                "VTA startup timed out after {}s, falling back to cached secrets",
+                timeout.as_secs()
+            );
             load_from_cache(cache, &config.context).await
         }
     }
@@ -159,6 +192,11 @@ async fn load_from_cache(
 ) -> Result<StartupResult, VtaIntegrationError> {
     match cache.load().await {
         Ok(Some(bundle)) => {
+            if bundle.secrets.is_empty() {
+                return Err(VtaIntegrationError::EmptySecretsBundle(
+                    context.to_string(),
+                ));
+            }
             tracing::warn!(
                 context = context,
                 secrets = bundle.secrets.len(),

--- a/vta-sdk/src/integration/mod.rs
+++ b/vta-sdk/src/integration/mod.rs
@@ -1,0 +1,174 @@
+//! Unified VTA integration for service startup.
+//!
+//! Provides a single startup pattern for any service that manages its DID and
+//! secrets through a VTA:
+//!
+//! 1. Authenticate to the VTA (lightweight REST, with session-based fallback).
+//! 2. Fetch the latest [`DidSecretsBundle`] from the VTA context.
+//! 3. Cache the bundle locally for offline resilience.
+//! 4. If the VTA is unreachable, load the last cached bundle.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use vta_sdk::integration::{startup, VtaServiceConfig, SecretCache};
+//!
+//! // Implement SecretCache for your storage backend (keyring, AWS, etc.)
+//! struct MyCache { /* ... */ }
+//! impl SecretCache for MyCache { /* ... */ }
+//!
+//! let config = VtaServiceConfig {
+//!     credential: loaded_credential_string,
+//!     context: "my-service".into(),
+//!     url_override: None,
+//! };
+//! let cache = MyCache::new();
+//!
+//! let result = startup(&config, &cache).await?;
+//! // result.did — the service's DID
+//! // result.bundle.secrets — Vec<SecretEntry> for DIDComm/signing
+//! // result.source — whether secrets came from VTA or cache
+//! ```
+
+pub mod auth;
+pub mod cache;
+
+pub use auth::authenticate;
+pub use cache::SecretCache;
+
+use crate::did_secrets::DidSecretsBundle;
+use crate::error::VtaError;
+
+/// Configuration for connecting a service to its VTA context.
+///
+/// The `credential` field should contain the already-loaded base64url credential
+/// string. How the credential is loaded (from a config file, AWS Secrets Manager,
+/// OS keyring, etc.) is left to the calling service.
+#[derive(Clone, Debug)]
+pub struct VtaServiceConfig {
+    /// Base64url-encoded VTA credential bundle.
+    pub credential: String,
+    /// VTA context ID that holds this service's DID and keys.
+    pub context: String,
+    /// Optional REST URL override. When set, bypasses the URL embedded in the
+    /// credential (useful for VTARest service discovery or dev/testing).
+    pub url_override: Option<String>,
+}
+
+/// Whether secrets were loaded live from the VTA or from the local cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecretSource {
+    /// Fresh secrets fetched from the VTA.
+    Vta,
+    /// Stale secrets loaded from the local cache (VTA was unreachable).
+    Cache,
+}
+
+/// Successful result from [`startup`].
+#[derive(Debug, Clone)]
+pub struct StartupResult {
+    /// The service's DID, as recorded in the VTA context.
+    pub did: String,
+    /// The full secrets bundle (DID + all private keys).
+    pub bundle: DidSecretsBundle,
+    /// Where the secrets came from.
+    pub source: SecretSource,
+}
+
+/// Errors from the VTA integration startup flow.
+#[derive(Debug)]
+pub enum VtaIntegrationError {
+    /// VTA is unreachable and no locally cached secrets exist.
+    /// This typically means the service has never successfully contacted the VTA.
+    NoCachedSecrets,
+    /// The local secret cache could not be read or written.
+    CacheError(String),
+    /// An error from the VTA SDK (authentication or secret fetch).
+    Vta(VtaError),
+}
+
+impl std::fmt::Display for VtaIntegrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoCachedSecrets => write!(
+                f,
+                "VTA is unreachable and no cached secrets exist. \
+                 Run the setup wizard or ensure the VTA is accessible for the first startup."
+            ),
+            Self::CacheError(e) => write!(f, "secret cache error: {e}"),
+            Self::Vta(e) => write!(f, "VTA error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for VtaIntegrationError {}
+
+impl From<VtaError> for VtaIntegrationError {
+    fn from(e: VtaError) -> Self {
+        Self::Vta(e)
+    }
+}
+
+/// Main entry point for VTA-integrated service startup.
+///
+/// Attempts to fetch fresh secrets from the VTA and cache them locally.
+/// If the VTA is unreachable, falls back to the last cached bundle.
+///
+/// Returns a [`StartupResult`] containing the service DID, secrets bundle,
+/// and whether the secrets are fresh or cached.
+pub async fn startup(
+    config: &VtaServiceConfig,
+    cache: &(impl SecretCache + ?Sized),
+) -> Result<StartupResult, VtaIntegrationError> {
+    match authenticate(config).await {
+        Ok(client) => {
+            match client.fetch_did_secrets_bundle(&config.context).await {
+                Ok(bundle) => {
+                    if let Err(e) = cache.store(&bundle).await {
+                        tracing::warn!("Failed to cache VTA secrets locally: {e}");
+                    }
+                    tracing::info!(
+                        context = config.context,
+                        secrets = bundle.secrets.len(),
+                        "Loaded fresh secrets from VTA",
+                    );
+                    Ok(StartupResult {
+                        did: bundle.did.clone(),
+                        bundle,
+                        source: SecretSource::Vta,
+                    })
+                }
+                Err(e) => {
+                    tracing::warn!("VTA reachable but secret fetch failed: {e}");
+                    load_from_cache(cache, &config.context).await
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("VTA unreachable ({e}), falling back to cached secrets");
+            load_from_cache(cache, &config.context).await
+        }
+    }
+}
+
+async fn load_from_cache(
+    cache: &(impl SecretCache + ?Sized),
+    context: &str,
+) -> Result<StartupResult, VtaIntegrationError> {
+    match cache.load().await {
+        Ok(Some(bundle)) => {
+            tracing::warn!(
+                context = context,
+                secrets = bundle.secrets.len(),
+                "Using CACHED secrets — keys may be stale",
+            );
+            Ok(StartupResult {
+                did: bundle.did.clone(),
+                bundle,
+                source: SecretSource::Cache,
+            })
+        }
+        Ok(None) => Err(VtaIntegrationError::NoCachedSecrets),
+        Err(e) => Err(VtaIntegrationError::CacheError(e.to_string())),
+    }
+}

--- a/vta-sdk/src/integration/mod.rs
+++ b/vta-sdk/src/integration/mod.rs
@@ -124,30 +124,28 @@ pub async fn startup(
     cache: &(impl SecretCache + ?Sized),
 ) -> Result<StartupResult, VtaIntegrationError> {
     match authenticate(config).await {
-        Ok(client) => {
-            match client.fetch_did_secrets_bundle(&config.context).await {
-                Ok(bundle) => {
-                    if let Err(e) = cache.store(&bundle).await {
-                        tracing::warn!("Failed to cache VTA secrets locally: {e}");
-                    }
-                    tracing::info!(
-                        context = config.context,
-                        secrets = bundle.secrets.len(),
-                        "Loaded fresh secrets from VTA",
-                    );
-                    Ok(StartupResult {
-                        did: bundle.did.clone(),
-                        bundle,
-                        source: SecretSource::Vta,
-                        client: Some(client),
-                    })
+        Ok(client) => match client.fetch_did_secrets_bundle(&config.context).await {
+            Ok(bundle) => {
+                if let Err(e) = cache.store(&bundle).await {
+                    tracing::warn!("Failed to cache VTA secrets locally: {e}");
                 }
-                Err(e) => {
-                    tracing::warn!("VTA reachable but secret fetch failed: {e}");
-                    load_from_cache(cache, &config.context).await
-                }
+                tracing::info!(
+                    context = config.context,
+                    secrets = bundle.secrets.len(),
+                    "Loaded fresh secrets from VTA",
+                );
+                Ok(StartupResult {
+                    did: bundle.did.clone(),
+                    bundle,
+                    source: SecretSource::Vta,
+                    client: Some(client),
+                })
             }
-        }
+            Err(e) => {
+                tracing::warn!("VTA reachable but secret fetch failed: {e}");
+                load_from_cache(cache, &config.context).await
+            }
+        },
         Err(e) => {
             tracing::warn!("VTA unreachable ({e}), falling back to cached secrets");
             load_from_cache(cache, &config.context).await

--- a/vta-sdk/src/integration/mod.rs
+++ b/vta-sdk/src/integration/mod.rs
@@ -193,9 +193,7 @@ async fn load_from_cache(
     match cache.load().await {
         Ok(Some(bundle)) => {
             if bundle.secrets.is_empty() {
-                return Err(VtaIntegrationError::EmptySecretsBundle(
-                    context.to_string(),
-                ));
+                return Err(VtaIntegrationError::EmptySecretsBundle(context.to_string()));
             }
             tracing::warn!(
                 context = context,

--- a/vta-sdk/src/keys/mod.rs
+++ b/vta-sdk/src/keys/mod.rs
@@ -17,6 +17,18 @@ pub enum KeyStatus {
     Revoked,
 }
 
+/// Whether a key was derived from the BIP-32 seed or imported externally.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum KeyOrigin {
+    Derived,
+    Imported,
+}
+
+fn default_derived() -> KeyOrigin {
+    KeyOrigin::Derived
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyRecord {
     pub key_id: String,
@@ -29,6 +41,8 @@ pub struct KeyRecord {
     pub context_id: Option<String>,
     #[serde(default)]
     pub seed_id: Option<u32>,
+    #[serde(default = "default_derived")]
+    pub origin: KeyOrigin,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -23,3 +23,6 @@ pub mod protocols;
 #[cfg(feature = "session")]
 pub mod session;
 pub mod webvh;
+
+#[cfg(feature = "integration")]
+pub mod integration;

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -8,11 +8,11 @@ pub mod context_provision;
 pub mod contexts;
 pub mod credentials;
 pub mod did_key;
-#[cfg(feature = "client")]
-pub mod didcomm_light;
 pub mod did_secrets;
 #[cfg(feature = "didcomm")]
 pub mod didcomm_init;
+#[cfg(feature = "client")]
+pub mod didcomm_light;
 #[cfg(feature = "session")]
 pub mod didcomm_session;
 #[cfg(feature = "didcomm")]

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -1,9 +1,15 @@
+pub mod error;
+
+#[cfg(feature = "client")]
+pub mod auth_light;
 #[cfg(feature = "client")]
 pub mod client;
 pub mod context_provision;
 pub mod contexts;
 pub mod credentials;
 pub mod did_key;
+#[cfg(feature = "client")]
+pub mod didcomm_light;
 pub mod did_secrets;
 #[cfg(feature = "didcomm")]
 pub mod didcomm_init;

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -18,6 +18,7 @@ pub mod didcomm_session;
 #[cfg(feature = "didcomm")]
 pub mod didcomm_transport;
 pub mod keys;
+pub mod prelude;
 pub mod protocols;
 #[cfg(feature = "session")]
 pub mod session;

--- a/vta-sdk/src/prelude.rs
+++ b/vta-sdk/src/prelude.rs
@@ -36,5 +36,12 @@ pub use crate::did_key::{decode_private_key_multibase, ed25519_multibase_pubkey}
 #[cfg(feature = "client")]
 pub use crate::did_key::secret_from_key_response;
 
+// Integration (feature-gated)
+#[cfg(feature = "integration")]
+pub use crate::integration::{
+    SecretCache, SecretSource, StartupResult, VtaIntegrationError, VtaServiceConfig,
+    authenticate, startup,
+};
+
 // Protocols — commonly used request/response bodies
 pub use crate::protocols::audit_management::list::ListAuditLogsBody;

--- a/vta-sdk/src/prelude.rs
+++ b/vta-sdk/src/prelude.rs
@@ -24,9 +24,9 @@ pub use crate::did_secrets::{DidSecretsBundle, SecretEntry};
 pub use crate::client::{
     AclEntryResponse, AclListResponse, ConfigResponse, ContextListResponse, ContextResponse,
     CreateAclRequest, CreateContextRequest, CreateKeyRequest, CreateKeyResponse,
-    GenerateCredentialsRequest, GenerateCredentialsResponse, GetKeySecretResponse,
-    HealthResponse, ImportKeyRequest, ImportKeyResponse, InvalidateKeyResponse,
-    ListKeysResponse, RenameKeyResponse, SignResponse, UpdateAclRequest, UpdateConfigRequest,
+    GenerateCredentialsRequest, GenerateCredentialsResponse, GetKeySecretResponse, HealthResponse,
+    ImportKeyRequest, ImportKeyResponse, InvalidateKeyResponse, ListKeysResponse,
+    RenameKeyResponse, SignResponse, UpdateAclRequest, UpdateConfigRequest,
     UpdateContextDidRequest, VtaClient, WrappingKeyResponse,
 };
 
@@ -39,8 +39,8 @@ pub use crate::did_key::secret_from_key_response;
 // Integration (feature-gated)
 #[cfg(feature = "integration")]
 pub use crate::integration::{
-    SecretCache, SecretSource, StartupResult, VtaIntegrationError, VtaServiceConfig,
-    authenticate, startup,
+    SecretCache, SecretSource, StartupResult, VtaIntegrationError, VtaServiceConfig, authenticate,
+    startup,
 };
 
 // Protocols — commonly used request/response bodies

--- a/vta-sdk/src/prelude.rs
+++ b/vta-sdk/src/prelude.rs
@@ -27,7 +27,7 @@ pub use crate::client::{
     GenerateCredentialsRequest, GenerateCredentialsResponse, GetKeySecretResponse,
     HealthResponse, ImportKeyRequest, ImportKeyResponse, InvalidateKeyResponse,
     ListKeysResponse, RenameKeyResponse, SignResponse, UpdateAclRequest, UpdateConfigRequest,
-    VtaClient, WrappingKeyResponse,
+    UpdateContextDidRequest, VtaClient, WrappingKeyResponse,
 };
 
 // DID key utilities

--- a/vta-sdk/src/prelude.rs
+++ b/vta-sdk/src/prelude.rs
@@ -1,0 +1,40 @@
+//! Convenience re-exports for the most commonly used VTA SDK types.
+//!
+//! ```ignore
+//! use vta_sdk::prelude::*;
+//! ```
+
+// Error
+pub use crate::error::VtaError;
+
+// Keys
+pub use crate::keys::{KeyRecord, KeyStatus, KeyType};
+
+// Contexts
+pub use crate::contexts::ContextRecord;
+
+// Credentials
+pub use crate::credentials::CredentialBundle;
+
+// DID secrets
+pub use crate::did_secrets::{DidSecretsBundle, SecretEntry};
+
+// Client (feature-gated)
+#[cfg(feature = "client")]
+pub use crate::client::{
+    AclEntryResponse, AclListResponse, ConfigResponse, ContextListResponse, ContextResponse,
+    CreateAclRequest, CreateContextRequest, CreateKeyRequest, CreateKeyResponse,
+    GenerateCredentialsRequest, GenerateCredentialsResponse, GetKeySecretResponse,
+    HealthResponse, ImportKeyRequest, ImportKeyResponse, InvalidateKeyResponse,
+    ListKeysResponse, RenameKeyResponse, SignResponse, UpdateAclRequest, UpdateConfigRequest,
+    VtaClient, WrappingKeyResponse,
+};
+
+// DID key utilities
+pub use crate::did_key::{decode_private_key_multibase, ed25519_multibase_pubkey};
+
+#[cfg(feature = "client")]
+pub use crate::did_key::secret_from_key_response;
+
+// Protocols — commonly used request/response bodies
+pub use crate::protocols::audit_management::list::ListAuditLogsBody;

--- a/vta-sdk/src/protocols/attestation_management.rs
+++ b/vta-sdk/src/protocols/attestation_management.rs
@@ -1,15 +1,12 @@
 //! DIDComm protocol types for TEE attestation management.
 
 /// Request TEE detection status.
-pub const GET_TEE_STATUS: &str =
-    "https://firstperson.network/vta/1.0/attestation/status";
+pub const GET_TEE_STATUS: &str = "https://firstperson.network/vta/1.0/attestation/status";
 /// Response with TEE detection status.
 pub const GET_TEE_STATUS_RESULT: &str =
     "https://firstperson.network/vta/1.0/attestation/status-result";
 
 /// Request a fresh attestation report (body includes nonce).
-pub const REQUEST_ATTESTATION: &str =
-    "https://firstperson.network/vta/1.0/attestation/request";
+pub const REQUEST_ATTESTATION: &str = "https://firstperson.network/vta/1.0/attestation/request";
 /// Response with attestation report.
-pub const ATTESTATION_RESULT: &str =
-    "https://firstperson.network/vta/1.0/attestation/result";
+pub const ATTESTATION_RESULT: &str = "https://firstperson.network/vta/1.0/attestation/result";

--- a/vta-sdk/src/protocols/audit_management/list.rs
+++ b/vta-sdk/src/protocols/audit_management/list.rs
@@ -45,8 +45,12 @@ pub struct ListAuditLogsBody {
     pub page_size: u64,
 }
 
-fn default_page() -> u64 { 1 }
-fn default_page_size() -> u64 { 50 }
+fn default_page() -> u64 {
+    1
+}
+fn default_page_size() -> u64 {
+    50
+}
 
 /// Response body for listing audit logs.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/vta-sdk/src/protocols/audit_management/mod.rs
+++ b/vta-sdk/src/protocols/audit_management/mod.rs
@@ -4,10 +4,15 @@ pub mod retention;
 pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/audit-management/1.0";
 
 pub const LIST_LOGS: &str = "https://firstperson.network/protocols/audit-management/1.0/list-logs";
-pub const LIST_LOGS_RESULT: &str = "https://firstperson.network/protocols/audit-management/1.0/list-logs-result";
+pub const LIST_LOGS_RESULT: &str =
+    "https://firstperson.network/protocols/audit-management/1.0/list-logs-result";
 
-pub const GET_RETENTION: &str = "https://firstperson.network/protocols/audit-management/1.0/get-retention";
-pub const GET_RETENTION_RESULT: &str = "https://firstperson.network/protocols/audit-management/1.0/get-retention-result";
+pub const GET_RETENTION: &str =
+    "https://firstperson.network/protocols/audit-management/1.0/get-retention";
+pub const GET_RETENTION_RESULT: &str =
+    "https://firstperson.network/protocols/audit-management/1.0/get-retention-result";
 
-pub const UPDATE_RETENTION: &str = "https://firstperson.network/protocols/audit-management/1.0/update-retention";
-pub const UPDATE_RETENTION_RESULT: &str = "https://firstperson.network/protocols/audit-management/1.0/update-retention-result";
+pub const UPDATE_RETENTION: &str =
+    "https://firstperson.network/protocols/audit-management/1.0/update-retention";
+pub const UPDATE_RETENTION_RESULT: &str =
+    "https://firstperson.network/protocols/audit-management/1.0/update-retention-result";

--- a/vta-sdk/src/protocols/backup_management/types.rs
+++ b/vta-sdk/src/protocols/backup_management/types.rs
@@ -79,6 +79,20 @@ pub struct BackupPayload {
     /// Audit logs (optional, may be empty).
     #[serde(default)]
     pub audit_logs: Vec<AuditLogEntry>,
+    /// Imported (non-derived) secrets. Plaintext inside the encrypted envelope.
+    #[serde(default)]
+    pub imported_secrets: Vec<ImportedSecretBackup>,
+    /// Hex-encoded KEK salt for imported secret encryption.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imported_kek_salt: Option<String>,
+}
+
+/// An imported secret included in the backup payload.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportedSecretBackup {
+    pub key_id: String,
+    /// Hex-encoded raw private key bytes.
+    pub private_key_hex: String,
 }
 
 /// Seed record for backup (mirrors SeedRecord from vta-service).
@@ -166,6 +180,8 @@ pub struct ImportResult {
     pub acl_count: usize,
     pub context_count: usize,
     pub audit_count: usize,
+    #[serde(default)]
+    pub imported_secret_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }

--- a/vta-sdk/src/protocols/context_management/mod.rs
+++ b/vta-sdk/src/protocols/context_management/mod.rs
@@ -3,6 +3,7 @@ pub mod delete;
 pub mod get;
 pub mod list;
 pub mod update;
+pub mod update_did;
 
 pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/context-management/1.0";
 
@@ -25,6 +26,11 @@ pub const UPDATE_CONTEXT: &str =
     "https://firstperson.network/protocols/context-management/1.0/update-context";
 pub const UPDATE_CONTEXT_RESULT: &str =
     "https://firstperson.network/protocols/context-management/1.0/update-context-result";
+
+pub const UPDATE_CONTEXT_DID: &str =
+    "https://firstperson.network/protocols/context-management/1.0/update-context-did";
+pub const UPDATE_CONTEXT_DID_RESULT: &str =
+    "https://firstperson.network/protocols/context-management/1.0/update-context-did-result";
 
 pub const DELETE_CONTEXT: &str =
     "https://firstperson.network/protocols/context-management/1.0/delete-context";

--- a/vta-sdk/src/protocols/context_management/update_did.rs
+++ b/vta-sdk/src/protocols/context_management/update_did.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+use super::create::CreateContextResultBody;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateContextDidBody {
+    pub id: String,
+    pub did: String,
+}
+
+pub type UpdateContextDidResultBody = CreateContextResultBody;

--- a/vta-sdk/src/protocols/key_management/create.rs
+++ b/vta-sdk/src/protocols/key_management/create.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::keys::{KeyStatus, KeyType};
+use crate::keys::{KeyOrigin, KeyStatus, KeyType};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateKeyBody {
@@ -20,5 +20,11 @@ pub struct CreateKeyResultBody {
     pub public_key: String,
     pub status: KeyStatus,
     pub label: Option<String>,
+    #[serde(default = "default_derived")]
+    pub origin: KeyOrigin,
     pub created_at: DateTime<Utc>,
+}
+
+fn default_derived() -> KeyOrigin {
+    KeyOrigin::Derived
 }

--- a/vta-sdk/src/protocols/key_management/mod.rs
+++ b/vta-sdk/src/protocols/key_management/mod.rs
@@ -37,3 +37,13 @@ pub const SIGN_REQUEST: &str =
     "https://firstperson.network/protocols/key-management/1.0/sign-request";
 pub const SIGN_RESULT: &str =
     "https://firstperson.network/protocols/key-management/1.0/sign-result";
+
+pub const IMPORT_KEY: &str =
+    "https://firstperson.network/protocols/key-management/1.0/import-key";
+pub const IMPORT_KEY_RESULT: &str =
+    "https://firstperson.network/protocols/key-management/1.0/import-key-result";
+
+pub const GET_WRAPPING_KEY: &str =
+    "https://firstperson.network/protocols/key-management/1.0/get-wrapping-key";
+pub const GET_WRAPPING_KEY_RESULT: &str =
+    "https://firstperson.network/protocols/key-management/1.0/get-wrapping-key-result";

--- a/vta-sdk/src/protocols/key_management/mod.rs
+++ b/vta-sdk/src/protocols/key_management/mod.rs
@@ -38,8 +38,7 @@ pub const SIGN_REQUEST: &str =
 pub const SIGN_RESULT: &str =
     "https://firstperson.network/protocols/key-management/1.0/sign-result";
 
-pub const IMPORT_KEY: &str =
-    "https://firstperson.network/protocols/key-management/1.0/import-key";
+pub const IMPORT_KEY: &str = "https://firstperson.network/protocols/key-management/1.0/import-key";
 pub const IMPORT_KEY_RESULT: &str =
     "https://firstperson.network/protocols/key-management/1.0/import-key-result";
 

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -1,8 +1,8 @@
 pub mod acl_management;
 pub mod attestation_management;
 pub mod audit_management;
-pub mod backup_management;
 pub mod auth;
+pub mod backup_management;
 pub mod context_management;
 pub mod credential_management;
 pub mod did_management;

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -342,11 +342,7 @@ impl SessionStore {
         serde_json::from_str(&json).ok()
     }
 
-    fn save_session(
-        &self,
-        key: &str,
-        session: &Session,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    fn save_session(&self, key: &str, session: &Session) -> Result<(), Box<dyn std::error::Error>> {
         let json = serde_json::to_string(session)?;
         self.backend.save(key, &json)
     }
@@ -624,16 +620,19 @@ pub async fn challenge_response(
     // Step 2: Build DIDComm message
     debug!("initializing DID resolver and ATM for message packing");
 
-    use std::sync::Arc;
     use affinidi_tdk::common::TDKSharedState;
     use affinidi_tdk::common::config::TDKConfig;
     use affinidi_tdk::messaging::ATM;
     use affinidi_tdk::messaging::config::ATMConfig;
+    use std::sync::Arc;
 
-    let tdk = TDKSharedState::new(TDKConfig::builder().build()
-        .map_err(|e| format!("TDK config build failed: {e}"))?)
-        .await
-        .map_err(|e| format!("TDK init failed: {e}"))?;
+    let tdk = TDKSharedState::new(
+        TDKConfig::builder()
+            .build()
+            .map_err(|e| format!("TDK config build failed: {e}"))?,
+    )
+    .await
+    .map_err(|e| format!("TDK init failed: {e}"))?;
 
     // Build DIDComm secrets from the private key
     let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
@@ -642,10 +641,13 @@ pub async fn challenge_response(
     tdk.secrets_resolver.insert(secrets.signing).await;
     tdk.secrets_resolver.insert(secrets.key_agreement).await;
 
-    let atm = ATM::new(ATMConfig::builder().build()
-        .map_err(|e| format!("ATM config build failed: {e}"))?,
+    let atm = ATM::new(
+        ATMConfig::builder()
+            .build()
+            .map_err(|e| format!("ATM config build failed: {e}"))?,
         Arc::new(tdk),
-    ).await
+    )
+    .await
     .map_err(|e| format!("ATM init failed: {e}"))?;
 
     // Build the authenticate message
@@ -801,11 +803,12 @@ pub async fn resolve_vta_url(vta_did: &str) -> Result<String, Box<dyn std::error
     match did_resolver.resolve(vta_did).await {
         Ok(resolved) => {
             if let Some(svc) = resolved.doc.find_service("vta-rest")
-                && let Some(url) = svc.service_endpoint.get_uri() {
-                    let url = url.trim_matches('"').trim_end_matches('/').to_string();
-                    debug!(url = %url, "found VTA URL from #vta-rest service endpoint");
-                    return Ok(url);
-                }
+                && let Some(url) = svc.service_endpoint.get_uri()
+            {
+                let url = url.trim_matches('"').trim_end_matches('/').to_string();
+                debug!(url = %url, "found VTA URL from #vta-rest service endpoint");
+                return Ok(url);
+            }
             debug!("no #vta-rest service found in DID document, falling back to DID parsing");
         }
         Err(e) => {
@@ -917,9 +920,9 @@ pub async fn resolve_mediator_did_with_resolver(
                 .into_iter()
                 .map(|u| u.trim_matches('"').to_string())
                 .find(|u| u.starts_with("did:"))
-            {
-                return Ok(Some(did));
-            }
+        {
+            return Ok(Some(did));
+        }
     }
 
     Ok(None)
@@ -943,11 +946,11 @@ impl TrustPingSession {
         private_key_multibase: &str,
         mediator_did: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        use std::sync::Arc;
         use affinidi_tdk::common::TDKSharedState;
         use affinidi_tdk::messaging::ATM;
         use affinidi_tdk::messaging::config::ATMConfig;
         use affinidi_tdk::messaging::profiles::ATMProfile;
+        use std::sync::Arc;
 
         let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
         let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
@@ -978,12 +981,9 @@ impl TrustPingSession {
 
     /// Send a trust-ping to a target (or the mediator if `target_did` is None).
     /// Returns latency in milliseconds.
-    pub async fn ping(
-        &self,
-        target_did: Option<&str>,
-    ) -> Result<u128, Box<dyn std::error::Error>> {
-        use std::time::Instant;
+    pub async fn ping(&self, target_did: Option<&str>) -> Result<u128, Box<dyn std::error::Error>> {
         use affinidi_tdk::messaging::protocols::trust_ping::TrustPing;
+        use std::time::Instant;
 
         let target = target_did.unwrap_or(&self.mediator_did);
         let start = Instant::now();
@@ -1101,7 +1101,10 @@ mod tests {
                 self.data.lock().unwrap().get(key).cloned()
             }
             fn save(&self, key: &str, value: &str) -> Result<(), Box<dyn std::error::Error>> {
-                self.data.lock().unwrap().insert(key.to_string(), value.to_string());
+                self.data
+                    .lock()
+                    .unwrap()
+                    .insert(key.to_string(), value.to_string());
                 Ok(())
             }
             fn clear(&self, key: &str) {
@@ -1116,7 +1119,15 @@ mod tests {
 
         assert!(!store.has_session("test"));
 
-        store.store_direct("test", "did:key:z6Mk1", "zSeed", "did:key:zVTA", "https://vta.example.com").unwrap();
+        store
+            .store_direct(
+                "test",
+                "did:key:z6Mk1",
+                "zSeed",
+                "did:key:zVTA",
+                "https://vta.example.com",
+            )
+            .unwrap();
         assert!(store.has_session("test"));
 
         let info = store.loaded_session("test").unwrap();

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -90,12 +90,18 @@ struct KeyringBackend {
 #[cfg(feature = "keyring")]
 impl SessionBackend for KeyringBackend {
     fn load(&self, key: &str) -> Option<String> {
-        let entry = keyring::Entry::new(&self.service_name, key).ok()?;
+        let entry = match keyring::Entry::new(&self.service_name, key) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!("keyring entry creation failed for '{key}': {e}");
+                return None;
+            }
+        };
         match entry.get_password() {
             Ok(v) => Some(v),
             Err(keyring::Error::NoEntry) => None,
             Err(e) => {
-                eprintln!("Warning: keyring read error: {e}");
+                tracing::warn!("keyring read error for '{key}': {e}");
                 None
             }
         }
@@ -111,8 +117,15 @@ impl SessionBackend for KeyringBackend {
     }
 
     fn clear(&self, key: &str) {
-        if let Ok(entry) = keyring::Entry::new(&self.service_name, key) {
-            let _ = entry.delete_credential();
+        match keyring::Entry::new(&self.service_name, key) {
+            Ok(entry) => {
+                if let Err(e) = entry.delete_credential() {
+                    tracing::debug!("keyring clear for '{key}': {e}");
+                }
+            }
+            Err(e) => {
+                tracing::debug!("keyring entry creation failed during clear for '{key}': {e}")
+            }
         }
     }
 }
@@ -133,9 +146,21 @@ impl FileBackend {
         let path = self.sessions_path();
         let data = match std::fs::read_to_string(&path) {
             Ok(d) => d,
-            Err(_) => return std::collections::HashMap::new(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return std::collections::HashMap::new();
+            }
+            Err(e) => {
+                tracing::warn!("failed to read sessions file {}: {e}", path.display());
+                return std::collections::HashMap::new();
+            }
         };
-        serde_json::from_str(&data).unwrap_or_default()
+        match serde_json::from_str(&data) {
+            Ok(map) => map,
+            Err(e) => {
+                tracing::warn!("failed to parse sessions file {}: {e}", path.display());
+                std::collections::HashMap::new()
+            }
+        }
     }
 
     fn save_map(
@@ -162,10 +187,14 @@ impl SessionBackend for FileBackend {
         if self.warn {
             eprintln!("WARNING: No secure session store — using plaintext file storage");
         }
-        if let Some(parent) = self.sessions_dir.parent() {
-            std::fs::create_dir_all(parent).ok();
+        if let Some(parent) = self.sessions_dir.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            tracing::warn!("failed to create sessions parent dir: {e}");
         }
-        std::fs::create_dir_all(&self.sessions_dir).ok();
+        if let Err(e) = std::fs::create_dir_all(&self.sessions_dir) {
+            tracing::warn!("failed to create sessions dir: {e}");
+        }
         let mut map = self.load_map();
         let parsed: serde_json::Value = serde_json::from_str(value)?;
         map.insert(key.to_string(), parsed);
@@ -199,19 +228,37 @@ impl SessionBackend for AzureBackend {
         use azure_identity::DeveloperToolsCredential;
         use azure_security_keyvault_secrets::SecretClient;
 
-        let credential = DeveloperToolsCredential::new(None).ok()?;
-        let client = SecretClient::new(&self.vault_url, credential, None).ok()?;
+        let credential = match DeveloperToolsCredential::new(None) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Azure credential creation failed: {e}");
+                return None;
+            }
+        };
+        let client = match SecretClient::new(&self.vault_url, credential, None) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Azure Key Vault client creation failed: {e}");
+                return None;
+            }
+        };
         let secret_name = self.secret_name(key);
 
         let result = tokio::runtime::Handle::current()
             .block_on(async { client.get_secret(&secret_name, None).await });
 
         match result {
-            Ok(response) => {
-                let model = response.into_model().ok()?;
-                model.value
+            Ok(response) => match response.into_model() {
+                Ok(model) => model.value,
+                Err(e) => {
+                    tracing::warn!("Azure Key Vault response parsing failed: {e}");
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::debug!("Azure Key Vault secret '{secret_name}' not found: {e}");
+                None
             }
-            Err(_) => None,
         }
     }
 

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -541,7 +541,7 @@ impl SessionStore {
         if let Some(url) = url_override {
             debug!(url, "using REST transport (URL override)");
             let token = self.ensure_authenticated(url, key).await?;
-            let mut client = crate::client::VtaClient::new(url);
+            let client = crate::client::VtaClient::new(url);
             client.set_token(token);
             return Ok(client);
         }
@@ -567,7 +567,7 @@ impl SessionStore {
             VtaEndpoint::Rest { url } => {
                 debug!(url = %url, "connecting via REST");
                 let token = self.ensure_authenticated(&url, key).await?;
-                let mut client = crate::client::VtaClient::new(&url);
+                let client = crate::client::VtaClient::new(&url);
                 client.set_token(token);
                 Ok(client)
             }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.5.0"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -45,8 +45,8 @@ name = "vta"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.4.0", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["didcomm"] }
+vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
 hkdf = "0.12"
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.13"

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -68,7 +68,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 bip39 = "2"
-ed25519-dalek = "2"
+ed25519-dalek = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 hex = "0.4"
 keyring = { version = "3", optional = true }
@@ -84,7 +84,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 didwebvh-rs = { workspace = true, optional = true }
 rand = { workspace = true }
-dialoguer = "0.12"
+dialoguer = { workspace = true }
 azure_security_keyvault_secrets = { version = "0.12", optional = true }
 azure_identity = { version = "0.33", optional = true }
 sha1 = "0.10"

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -45,8 +45,9 @@ name = "vta"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.2.1", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.2.1", features = ["didcomm"] }
+vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
+hkdf = "0.12"
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.13"
 affinidi-messaging-didcomm-service = { workspace = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -45,7 +45,7 @@ name = "vta"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.2.1", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
 vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["didcomm"] }
 hkdf = "0.12"
 affinidi-tdk = { workspace = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -45,7 +45,7 @@ name = "vta"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.4.0", features = ["encryption"] }
 vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["didcomm"] }
 hkdf = "0.12"
 affinidi-tdk = { workspace = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -101,7 +101,7 @@ libc = { version = "0.2", optional = true }
 zeroize = { version = "1", features = ["derive"] }
 tower = { version = "0.5", features = ["limit"] }
 metrics = "0.24"
-metrics-exporter-prometheus = { version = "0.16", default-features = false }
+metrics-exporter-prometheus = { version = "0.18", default-features = false }
 aes-gcm = "0.10"
 argon2 = "0.5"
 hmac = "0.12"

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -45,7 +45,7 @@ name = "vta"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.2.1", features = ["encryption"] }
 vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
 hkdf = "0.12"
 affinidi-tdk = { workspace = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -46,7 +46,7 @@ path = "src/main.rs"
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.2.1", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = ["didcomm"] }
 hkdf = "0.12"
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.13"

--- a/vta-service/src/auth/mod.rs
+++ b/vta-service/src/auth/mod.rs
@@ -1,5 +1,7 @@
 pub mod credentials;
 
-pub use vti_common::auth::extractor::{AdminAuth, AuthClaims, AuthState, ManageAuth, SuperAdminAuth};
+pub use vti_common::auth::extractor::{
+    AdminAuth, AuthClaims, AuthState, ManageAuth, SuperAdminAuth,
+};
 pub use vti_common::auth::jwt;
 pub use vti_common::auth::session;

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -307,17 +307,29 @@ impl AppConfig {
 
             // Log warnings for any env vars that would have been applied
             let blocked_vars = [
-                "VTA_DID", "VTA_SERVER_HOST", "VTA_SERVER_PORT",
-                "VTA_PUBLIC_URL", "VTA_STORE_DATA_DIR",
-                "VTA_MESSAGING_MEDIATOR_URL", "VTA_MESSAGING_MEDIATOR_DID",
-                "VTA_SECRETS_SEED", "VTA_SECRETS_AWS_SECRET_NAME",
-                "VTA_SECRETS_AWS_REGION", "VTA_SECRETS_GCP_PROJECT",
-                "VTA_SECRETS_GCP_SECRET_NAME", "VTA_SECRETS_AZURE_VAULT_URL",
-                "VTA_SECRETS_AZURE_SECRET_NAME", "VTA_SECRETS_KEYRING_SERVICE",
-                "VTA_AUTH_ACCESS_EXPIRY", "VTA_AUTH_REFRESH_EXPIRY",
-                "VTA_AUTH_CHALLENGE_TTL", "VTA_AUTH_SESSION_CLEANUP_INTERVAL",
-                "VTA_AUTH_JWT_SIGNING_KEY", "VTA_TEE_MODE",
-                "VTA_TEE_EMBED_IN_DID", "VTA_TEE_ATTESTATION_CACHE_TTL",
+                "VTA_DID",
+                "VTA_SERVER_HOST",
+                "VTA_SERVER_PORT",
+                "VTA_PUBLIC_URL",
+                "VTA_STORE_DATA_DIR",
+                "VTA_MESSAGING_MEDIATOR_URL",
+                "VTA_MESSAGING_MEDIATOR_DID",
+                "VTA_SECRETS_SEED",
+                "VTA_SECRETS_AWS_SECRET_NAME",
+                "VTA_SECRETS_AWS_REGION",
+                "VTA_SECRETS_GCP_PROJECT",
+                "VTA_SECRETS_GCP_SECRET_NAME",
+                "VTA_SECRETS_AZURE_VAULT_URL",
+                "VTA_SECRETS_AZURE_SECRET_NAME",
+                "VTA_SECRETS_KEYRING_SERVICE",
+                "VTA_AUTH_ACCESS_EXPIRY",
+                "VTA_AUTH_REFRESH_EXPIRY",
+                "VTA_AUTH_CHALLENGE_TTL",
+                "VTA_AUTH_SESSION_CLEANUP_INTERVAL",
+                "VTA_AUTH_JWT_SIGNING_KEY",
+                "VTA_TEE_MODE",
+                "VTA_TEE_EMBED_IN_DID",
+                "VTA_TEE_ATTESTATION_CACHE_TTL",
             ];
             for var in &blocked_vars {
                 if std::env::var(var).is_ok() {
@@ -455,9 +467,10 @@ impl AppConfig {
 
         // Audit
         if let Ok(val) = std::env::var("VTA_AUDIT_RETENTION_DAYS")
-            && let Ok(days) = val.parse::<u32>() {
-                config.audit.retention_days = days;
-            }
+            && let Ok(days) = val.parse::<u32>()
+        {
+            config.audit.retention_days = days;
+        }
 
         // TEE (non-KMS mode — all overrides allowed)
         #[cfg(feature = "tee")]
@@ -468,7 +481,9 @@ impl AppConfig {
                     "optional" => TeeMode::Optional,
                     "simulated" => TeeMode::Simulated,
                     "disabled" => {
-                        tracing::warn!("VTA_TEE_MODE=disabled is deprecated — use 'optional' instead");
+                        tracing::warn!(
+                            "VTA_TEE_MODE=disabled is deprecated — use 'optional' instead"
+                        );
                         TeeMode::Optional
                     }
                     other => {
@@ -479,9 +494,9 @@ impl AppConfig {
                 };
             }
             if let Ok(val) = std::env::var("VTA_TEE_EMBED_IN_DID") {
-                config.tee.embed_in_did = val.parse().map_err(|e| {
-                    AppError::Config(format!("invalid VTA_TEE_EMBED_IN_DID: {e}"))
-                })?;
+                config.tee.embed_in_did = val
+                    .parse()
+                    .map_err(|e| AppError::Config(format!("invalid VTA_TEE_EMBED_IN_DID: {e}")))?;
             }
             if let Ok(val) = std::env::var("VTA_TEE_ATTESTATION_CACHE_TTL") {
                 config.tee.attestation_cache_ttl = val.parse().map_err(|e| {

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -139,13 +139,18 @@ pub async fn run_create_did_webvh(
         next_key_hashes: if next_key_hashes.is_empty() {
             None
         } else {
-            Some(Arc::new(next_key_hashes.into_iter().map(Into::into).collect()))
+            Some(Arc::new(
+                next_key_hashes.into_iter().map(Into::into).collect(),
+            ))
         },
         ..Default::default()
     };
 
     // Create the DID
-    let url_str = webvh_url.get_http_url(None).map_err(|e| format!("{e}"))?.to_string();
+    let url_str = webvh_url
+        .get_http_url(None)
+        .map_err(|e| format!("{e}"))?
+        .to_string();
     let create_config = CreateDIDConfig::builder()
         .address(url_str)
         .authorization_key(derived.signing_secret.clone())
@@ -154,7 +159,8 @@ pub async fn run_create_did_webvh(
         .build()
         .map_err(|e| format!("failed to build DID config: {e}"))?;
 
-    let result = create_did(create_config).await
+    let result = create_did(create_config)
+        .await
         .map_err(|e| format!("failed to create DID: {e}"))?;
 
     let final_did = result.did().to_string();

--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use affinidi_tdk::didcomm::Message;
 use affinidi_tdk::messaging::ATM;
 use affinidi_tdk::messaging::profiles::ATMProfile;
-use vta_sdk::didcomm_transport::{PendingMap, send_and_wait_raw};
+use vta_sdk::didcomm_transport::{DIDCommSendParams, PendingMap, send_and_wait_raw};
 
 use crate::error::{AppError, bad_gateway_error};
 
@@ -51,18 +51,18 @@ impl DIDCommBridge {
         problem_report_type: &str,
         timeout_secs: u64,
     ) -> Result<Message, AppError> {
-        send_and_wait_raw(
-            &self.atm,
-            &self.profile,
-            &self.pending,
-            vta_did,
-            server_did,
+        send_and_wait_raw(DIDCommSendParams {
+            atm: &self.atm,
+            profile: &self.profile,
+            pending: &self.pending,
+            from_did: vta_did,
+            to_did: server_did,
             msg_type,
             body,
             expected_type,
             problem_report_type,
             timeout_secs,
-        )
+        })
         .await
         .map_err(bad_gateway_error)
     }

--- a/vta-service/src/import_did.rs
+++ b/vta-service/src/import_did.rs
@@ -28,7 +28,7 @@ pub async fn run_import_did(args: ImportDidArgs) -> Result<(), Box<dyn std::erro
     let role = match args.role {
         Some(r) => Role::parse(&r)?,
         None => {
-            let roles = ["admin", "initiator", "application"];
+            let roles = ["admin", "initiator", "application", "reader"];
             let selection = Select::new()
                 .with_prompt("Select role for this DID")
                 .items(roles)

--- a/vta-service/src/keys/derivation.rs
+++ b/vta-service/src/keys/derivation.rs
@@ -83,10 +83,9 @@ impl Bip32Extension for ExtendedSigningKey {
         let hmac_output = mac.finalize().into_bytes();
 
         // First 32 bytes → P-256 scalar. from_bytes() reduces mod n automatically.
-        let secret_key = p256::SecretKey::from_bytes(
-            p256::FieldBytes::from_slice(&hmac_output[..32]),
-        )
-        .map_err(|e| key_derivation_error(format!("P-256 key creation failed: {e}")))?;
+        let secret_key =
+            p256::SecretKey::from_bytes(p256::FieldBytes::from_slice(&hmac_output[..32]))
+                .map_err(|e| key_derivation_error(format!("P-256 key creation failed: {e}")))?;
 
         Ok(P256Secret { secret_key })
     }
@@ -289,8 +288,8 @@ mod tests {
     #[test]
     fn test_ed25519_creation_matches_recovery() {
         let seed = &[
-            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182,
-            73, 89, 196, 246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
+            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182, 73, 89, 196,
+            246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
         ];
         for path in ["m/44'/0'/0'", "m/44'/0'/1'", "m/44'/0'/99'"] {
             let created = creation_path_ed25519(seed, path);
@@ -312,8 +311,8 @@ mod tests {
     #[test]
     fn test_x25519_creation_matches_recovery() {
         let seed = &[
-            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182,
-            73, 89, 196, 246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
+            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182, 73, 89, 196,
+            246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
         ];
         for path in ["m/44'/0'/0'", "m/44'/0'/1'", "m/44'/0'/99'"] {
             let created = creation_path_x25519(seed, path);
@@ -338,8 +337,8 @@ mod tests {
     #[test]
     fn test_multiple_restarts_produce_identical_keys() {
         let seed = &[
-            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182,
-            73, 89, 196, 246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
+            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182, 73, 89, 196,
+            246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
         ];
         let sign_path = "m/44'/0'/0'";
         let ka_path = "m/44'/0'/1'";
@@ -398,8 +397,8 @@ mod tests {
     #[test]
     fn test_ka_priv_reconstructs_x25519() {
         let seed = &[
-            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182,
-            73, 89, 196, 246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
+            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182, 73, 89, 196,
+            246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
         ];
         let ka_path = "m/44'/0'/1'";
 
@@ -407,10 +406,7 @@ mod tests {
         let root = ExtendedSigningKey::from_seed(seed).unwrap();
         let dp: DerivationPath = ka_path.parse().unwrap();
         let derived = root.derive(&dp).unwrap();
-        let ka_priv = multibase::encode(
-            multibase::Base::Base58Btc,
-            derived.signing_key.as_bytes(),
-        );
+        let ka_priv = multibase::encode(multibase::Base::Base58Btc, derived.signing_key.as_bytes());
 
         // Original X25519 key (as would be in DID document)
         let original = creation_path_x25519(seed, ka_path);
@@ -434,8 +430,8 @@ mod tests {
     #[test]
     fn test_signing_pub_matches_did_document_format() {
         let seed = &[
-            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182,
-            73, 89, 196, 246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
+            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182, 73, 89, 196,
+            246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
         ];
         let path = "m/44'/0'/0'";
 
@@ -447,11 +443,9 @@ mod tests {
         let root = ExtendedSigningKey::from_seed(seed).unwrap();
         let dp: DerivationPath = path.parse().unwrap();
         let derived = root.derive(&dp).unwrap();
-        let raw_pub = ed25519_dalek::SigningKey::from_bytes(
-            derived.signing_key.as_bytes(),
-        )
-        .verifying_key()
-        .to_bytes();
+        let raw_pub = ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes())
+            .verifying_key()
+            .to_bytes();
         let did_doc_pub = vta_sdk::did_key::ed25519_multibase_pubkey(&raw_pub);
 
         assert_eq!(
@@ -473,15 +467,16 @@ mod tests {
         let p256_2 = bip32.derive_p256(path).unwrap();
 
         // Same seed + path must produce the same key
-        assert_eq!(
-            p256_1.secret_key.to_bytes(),
-            p256_2.secret_key.to_bytes()
-        );
+        assert_eq!(p256_1.secret_key.to_bytes(), p256_2.secret_key.to_bytes());
 
         // Public key must be derivable
         let pk = p256_1.secret_key.public_key();
         let encoded = pk.to_encoded_point(true);
-        assert_eq!(encoded.len(), 33, "compressed P-256 pubkey should be 33 bytes");
+        assert_eq!(
+            encoded.len(),
+            33,
+            "compressed P-256 pubkey should be 33 bytes"
+        );
     }
 
     #[test]

--- a/vta-service/src/keys/imported.rs
+++ b/vta-service/src/keys/imported.rs
@@ -1,0 +1,351 @@
+//! Encrypted storage for imported (non-BIP32-derived) secrets.
+//!
+//! Imported secrets are encrypted at rest using AES-256-GCM with a KEK
+//! derived from the BIP-32 master seed via HKDF-SHA256 with a random salt.
+//! Each secret's ciphertext is bound to its `key_id:key_type` via AAD.
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use hkdf::Hkdf;
+use sha2::Sha256;
+use zeroize::Zeroize;
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+const KEK_SALT_KEY: &str = "imported_kek_salt";
+const SECRET_PREFIX: &str = "secret:";
+const NONCE_LEN: usize = 12;
+
+/// Derive the KEK for imported secret encryption from the master seed and salt.
+fn derive_kek(seed: &[u8], salt: &[u8]) -> [u8; 32] {
+    let hkdf = Hkdf::<Sha256>::new(Some(salt), seed);
+    let mut kek = [0u8; 32];
+    hkdf.expand(b"vta-imported-secret-encryption", &mut kek)
+        .expect("32-byte output is valid for HKDF-SHA256");
+    kek
+}
+
+/// Build the AAD string for a given key_id and key_type.
+fn build_aad(key_id: &str, key_type: &str) -> Vec<u8> {
+    format!("{key_id}:{key_type}").into_bytes()
+}
+
+/// Get or create the KEK salt. Returns the 32-byte salt.
+pub async fn get_or_create_salt(keys_ks: &KeyspaceHandle) -> Result<Vec<u8>, AppError> {
+    if let Some(existing) = keys_ks.get_raw(KEK_SALT_KEY).await? {
+        return Ok(existing);
+    }
+    // Generate a new random salt
+    use aes_gcm::aead::rand_core::RngCore;
+    let mut salt = vec![0u8; 32];
+    aes_gcm::aead::OsRng.fill_bytes(&mut salt);
+    keys_ks.insert_raw(KEK_SALT_KEY, salt.clone()).await?;
+    Ok(salt)
+}
+
+/// Store the KEK salt (used during backup restore).
+pub async fn set_salt(keys_ks: &KeyspaceHandle, salt: &[u8]) -> Result<(), AppError> {
+    keys_ks.insert_raw(KEK_SALT_KEY, salt.to_vec()).await?;
+    Ok(())
+}
+
+/// Get the KEK salt if it exists (for backup export).
+pub async fn get_salt(keys_ks: &KeyspaceHandle) -> Result<Option<Vec<u8>>, AppError> {
+    Ok(keys_ks.get_raw(KEK_SALT_KEY).await?)
+}
+
+/// Encrypt and store an imported secret.
+pub async fn store_secret(
+    imported_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
+    seed: &[u8],
+    key_id: &str,
+    key_type: &str,
+    secret_bytes: &[u8],
+) -> Result<(), AppError> {
+    let salt = get_or_create_salt(keys_ks).await?;
+    let mut kek = derive_kek(seed, &salt);
+
+    let cipher = Aes256Gcm::new_from_slice(&kek)
+        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+
+    // Random nonce
+    use aes_gcm::aead::rand_core::RngCore;
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let aad = build_aad(key_id, key_type);
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            aes_gcm::aead::Payload {
+                msg: secret_bytes,
+                aad: &aad,
+            },
+        )
+        .map_err(|e| AppError::Internal(format!("encrypt imported secret: {e}")))?;
+
+    // Store as nonce || ciphertext
+    let mut blob = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    blob.extend_from_slice(&nonce_bytes);
+    blob.extend_from_slice(&ciphertext);
+
+    imported_ks
+        .insert_raw(format!("{SECRET_PREFIX}{key_id}"), blob)
+        .await?;
+
+    kek.zeroize();
+    Ok(())
+}
+
+/// Load and decrypt an imported secret.
+pub async fn load_secret(
+    imported_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
+    seed: &[u8],
+    key_id: &str,
+    key_type: &str,
+) -> Result<Vec<u8>, AppError> {
+    let blob = imported_ks
+        .get_raw(format!("{SECRET_PREFIX}{key_id}"))
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("imported secret not found: {key_id}")))?;
+
+    if blob.len() < NONCE_LEN + 1 {
+        return Err(AppError::Internal("imported secret blob too short".into()));
+    }
+
+    let salt = get_or_create_salt(keys_ks).await?;
+    let mut kek = derive_kek(seed, &salt);
+
+    let cipher = Aes256Gcm::new_from_slice(&kek)
+        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+
+    let nonce = Nonce::from_slice(&blob[..NONCE_LEN]);
+    let aad = build_aad(key_id, key_type);
+    let mut plaintext = cipher
+        .decrypt(
+            nonce,
+            aes_gcm::aead::Payload {
+                msg: &blob[NONCE_LEN..],
+                aad: &aad,
+            },
+        )
+        .map_err(|_| AppError::Internal("imported secret decryption failed (AAD mismatch or corruption)".into()))?;
+
+    kek.zeroize();
+
+    // Return plaintext; caller is responsible for zeroizing
+    Ok(std::mem::take(&mut plaintext))
+}
+
+/// Securely delete an imported secret (overwrite then remove).
+pub async fn delete_secret(
+    imported_ks: &KeyspaceHandle,
+    key_id: &str,
+) -> Result<(), AppError> {
+    let store_key = format!("{SECRET_PREFIX}{key_id}");
+    // Overwrite with zeros before deletion
+    if let Some(blob) = imported_ks.get_raw(store_key.clone()).await? {
+        let zeros = vec![0u8; blob.len()];
+        imported_ks.insert_raw(store_key.clone(), zeros).await?;
+    }
+    imported_ks.remove(store_key).await?;
+    Ok(())
+}
+
+/// Re-encrypt all imported secrets with a new KEK (used during seed rotation).
+pub async fn reencrypt_all(
+    imported_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
+    old_seed: &[u8],
+    new_seed: &[u8],
+    key_records: &[(String, String)], // (key_id, key_type) for AAD
+) -> Result<u32, AppError> {
+    let salt = get_or_create_salt(keys_ks).await?;
+    let mut old_kek = derive_kek(old_seed, &salt);
+    let mut new_kek = derive_kek(new_seed, &salt);
+
+    let old_cipher = Aes256Gcm::new_from_slice(&old_kek)
+        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+    let new_cipher = Aes256Gcm::new_from_slice(&new_kek)
+        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+
+    let mut count = 0u32;
+
+    for (key_id, key_type) in key_records {
+        let store_key = format!("{SECRET_PREFIX}{key_id}");
+        let Some(blob) = imported_ks.get_raw(store_key.clone()).await? else {
+            continue;
+        };
+
+        if blob.len() < NONCE_LEN + 1 {
+            continue;
+        }
+
+        let old_nonce = Nonce::from_slice(&blob[..NONCE_LEN]);
+        let aad = build_aad(key_id, key_type);
+
+        // Decrypt with old KEK
+        let mut plaintext = old_cipher
+            .decrypt(
+                old_nonce,
+                aes_gcm::aead::Payload {
+                    msg: &blob[NONCE_LEN..],
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| {
+                AppError::Internal(format!(
+                    "failed to decrypt imported secret {key_id} during re-encryption"
+                ))
+            })?;
+
+        // Re-encrypt with new KEK
+        use aes_gcm::aead::rand_core::RngCore;
+        let mut new_nonce_bytes = [0u8; NONCE_LEN];
+        aes_gcm::aead::OsRng.fill_bytes(&mut new_nonce_bytes);
+        let new_nonce = Nonce::from_slice(&new_nonce_bytes);
+
+        let new_ciphertext = new_cipher
+            .encrypt(
+                new_nonce,
+                aes_gcm::aead::Payload {
+                    msg: plaintext.as_ref(),
+                    aad: &aad,
+                },
+            )
+            .map_err(|e| AppError::Internal(format!("re-encrypt: {e}")))?;
+
+        plaintext.zeroize();
+
+        let mut new_blob = Vec::with_capacity(NONCE_LEN + new_ciphertext.len());
+        new_blob.extend_from_slice(&new_nonce_bytes);
+        new_blob.extend_from_slice(&new_ciphertext);
+
+        imported_ks.insert_raw(store_key, new_blob).await?;
+        count += 1;
+    }
+
+    old_kek.zeroize();
+    new_kek.zeroize();
+
+    Ok(count)
+}
+
+/// List all imported secret key IDs (for backup export).
+pub async fn list_secret_ids(
+    imported_ks: &KeyspaceHandle,
+) -> Result<Vec<String>, AppError> {
+    let raw = imported_ks.prefix_iter_raw(SECRET_PREFIX).await?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|(k, _)| {
+            String::from_utf8(k)
+                .ok()?
+                .strip_prefix(SECRET_PREFIX)
+                .map(String::from)
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use vti_common::config::StoreConfig;
+
+    fn temp_store() -> (Store, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&config).unwrap();
+        (store, dir)
+    }
+
+    #[tokio::test]
+    async fn test_store_and_load_secret() {
+        let (store, _dir) = temp_store();
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
+        let seed = [42u8; 32];
+        let secret = b"my-secret-key-bytes-32-chars!!!!";
+
+        store_secret(&imported_ks, &keys_ks, &seed, "test-key", "ed25519", secret)
+            .await
+            .unwrap();
+
+        let loaded = load_secret(&imported_ks, &keys_ks, &seed, "test-key", "ed25519")
+            .await
+            .unwrap();
+
+        assert_eq!(loaded, secret);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_aad_fails() {
+        let (store, _dir) = temp_store();
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
+        let seed = [42u8; 32];
+        let secret = b"my-secret-key-bytes-32-chars!!!!";
+
+        store_secret(&imported_ks, &keys_ks, &seed, "test-key", "ed25519", secret)
+            .await
+            .unwrap();
+
+        // Try to load with wrong key_type (wrong AAD)
+        let result = load_secret(&imported_ks, &keys_ks, &seed, "test-key", "x25519").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_secure_delete() {
+        let (store, _dir) = temp_store();
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
+        let seed = [42u8; 32];
+
+        store_secret(&imported_ks, &keys_ks, &seed, "del-key", "ed25519", b"secret")
+            .await
+            .unwrap();
+
+        delete_secret(&imported_ks, "del-key").await.unwrap();
+
+        let result = load_secret(&imported_ks, &keys_ks, &seed, "del-key", "ed25519").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_reencrypt_all() {
+        let (store, _dir) = temp_store();
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
+        let old_seed = [42u8; 32];
+        let new_seed = [99u8; 32];
+        let secret = b"my-secret-key-bytes-32-chars!!!!";
+
+        store_secret(&imported_ks, &keys_ks, &old_seed, "rk-1", "ed25519", secret)
+            .await
+            .unwrap();
+
+        let key_records = vec![("rk-1".to_string(), "ed25519".to_string())];
+        let count = reencrypt_all(&imported_ks, &keys_ks, &old_seed, &new_seed, &key_records)
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+
+        // Old seed can no longer decrypt
+        let result = load_secret(&imported_ks, &keys_ks, &old_seed, "rk-1", "ed25519").await;
+        assert!(result.is_err());
+
+        // New seed can decrypt
+        let loaded = load_secret(&imported_ks, &keys_ks, &new_seed, "rk-1", "ed25519")
+            .await
+            .unwrap();
+        assert_eq!(loaded, secret);
+    }
+}

--- a/vta-service/src/keys/imported.rs
+++ b/vta-service/src/keys/imported.rs
@@ -52,7 +52,7 @@ pub async fn set_salt(keys_ks: &KeyspaceHandle, salt: &[u8]) -> Result<(), AppEr
 
 /// Get the KEK salt if it exists (for backup export).
 pub async fn get_salt(keys_ks: &KeyspaceHandle) -> Result<Option<Vec<u8>>, AppError> {
-    Ok(keys_ks.get_raw(KEK_SALT_KEY).await?)
+    keys_ks.get_raw(KEK_SALT_KEY).await
 }
 
 /// Encrypt and store an imported secret.
@@ -67,8 +67,8 @@ pub async fn store_secret(
     let salt = get_or_create_salt(keys_ks).await?;
     let mut kek = derive_kek(seed, &salt);
 
-    let cipher = Aes256Gcm::new_from_slice(&kek)
-        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&kek).map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
 
     // Random nonce
     use aes_gcm::aead::rand_core::RngCore;
@@ -120,8 +120,8 @@ pub async fn load_secret(
     let salt = get_or_create_salt(keys_ks).await?;
     let mut kek = derive_kek(seed, &salt);
 
-    let cipher = Aes256Gcm::new_from_slice(&kek)
-        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&kek).map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
 
     let nonce = Nonce::from_slice(&blob[..NONCE_LEN]);
     let aad = build_aad(key_id, key_type);
@@ -133,7 +133,11 @@ pub async fn load_secret(
                 aad: &aad,
             },
         )
-        .map_err(|_| AppError::Internal("imported secret decryption failed (AAD mismatch or corruption)".into()))?;
+        .map_err(|_| {
+            AppError::Internal(
+                "imported secret decryption failed (AAD mismatch or corruption)".into(),
+            )
+        })?;
 
     kek.zeroize();
 
@@ -142,10 +146,7 @@ pub async fn load_secret(
 }
 
 /// Securely delete an imported secret (overwrite then remove).
-pub async fn delete_secret(
-    imported_ks: &KeyspaceHandle,
-    key_id: &str,
-) -> Result<(), AppError> {
+pub async fn delete_secret(imported_ks: &KeyspaceHandle, key_id: &str) -> Result<(), AppError> {
     let store_key = format!("{SECRET_PREFIX}{key_id}");
     // Overwrite with zeros before deletion
     if let Some(blob) = imported_ks.get_raw(store_key.clone()).await? {
@@ -236,9 +237,7 @@ pub async fn reencrypt_all(
 }
 
 /// List all imported secret key IDs (for backup export).
-pub async fn list_secret_ids(
-    imported_ks: &KeyspaceHandle,
-) -> Result<Vec<String>, AppError> {
+pub async fn list_secret_ids(imported_ks: &KeyspaceHandle) -> Result<Vec<String>, AppError> {
     let raw = imported_ks.prefix_iter_raw(SECRET_PREFIX).await?;
     Ok(raw
         .into_iter()
@@ -309,9 +308,16 @@ mod tests {
         let keys_ks = store.keyspace("keys").unwrap();
         let seed = [42u8; 32];
 
-        store_secret(&imported_ks, &keys_ks, &seed, "del-key", "ed25519", b"secret")
-            .await
-            .unwrap();
+        store_secret(
+            &imported_ks,
+            &keys_ks,
+            &seed,
+            "del-key",
+            "ed25519",
+            b"secret",
+        )
+        .await
+        .unwrap();
 
         delete_secret(&imported_ks, "del-key").await.unwrap();
 

--- a/vta-service/src/keys/mod.rs
+++ b/vta-service/src/keys/mod.rs
@@ -15,6 +15,34 @@ use crate::store::KeyspaceHandle;
 
 pub use vta_sdk::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
 
+/// Encode raw private key bytes as multibase (Base58BTC) with multicodec prefix.
+/// This makes private key material self-describing and compatible with
+/// `Secret::from_multibase()` in the SSI ecosystem.
+pub(crate) fn encode_private_multibase(key_type: &KeyType, raw_bytes: &[u8]) -> String {
+    let codec: &[u8] = match key_type {
+        KeyType::Ed25519 => &[0x80, 0x26], // ed25519-priv (0x1300)
+        KeyType::X25519 => &[0x82, 0x26],  // x25519-priv (0x1302)
+        KeyType::P256 => &[0x86, 0x26],    // p256-priv (0x1306)
+    };
+    let mut buf = Vec::with_capacity(codec.len() + raw_bytes.len());
+    buf.extend_from_slice(codec);
+    buf.extend_from_slice(raw_bytes);
+    multibase::encode(Base::Base58Btc, &buf)
+}
+
+/// Encode raw public key bytes as multibase (Base58BTC) with multicodec prefix.
+pub(crate) fn encode_public_multibase(key_type: &KeyType, raw_bytes: &[u8]) -> String {
+    let codec: &[u8] = match key_type {
+        KeyType::Ed25519 => &[0xed, 0x01], // ed25519-pub
+        KeyType::X25519 => &[0xec, 0x01],  // x25519-pub
+        KeyType::P256 => &[0x80, 0x24],    // p256-pub (0x1200)
+    };
+    let mut buf = Vec::with_capacity(codec.len() + raw_bytes.len());
+    buf.extend_from_slice(codec);
+    buf.extend_from_slice(raw_bytes);
+    multibase::encode(Base::Base58Btc, &buf)
+}
+
 pub fn store_key(key_id: &str) -> String {
     format!("key:{key_id}")
 }
@@ -83,7 +111,7 @@ pub async fn derive_and_store_did_key(
     let did = format!("did:key:{multibase_pubkey}");
     let key_id = format!("{did}#{multibase_pubkey}");
     let private_key_multibase =
-        multibase::encode(Base::Base58Btc, dk_derived.signing_key.as_bytes());
+        encode_private_multibase(&KeyType::Ed25519, dk_derived.signing_key.as_bytes());
 
     save_key_record(
         keys_ks,
@@ -152,7 +180,7 @@ pub async fn derive_entity_keys(
                 .map_err(|e| format!("Invalid derivation path: {e}"))?,
         )
         .map_err(|e| format!("Key derivation failed: {e}"))?;
-    let signing_priv = multibase::encode(Base::Base58Btc, signing_derived.signing_key.as_bytes());
+    let signing_priv = encode_private_multibase(&KeyType::Ed25519, signing_derived.signing_key.as_bytes());
     let signing_secret =
         Secret::generate_ed25519(None, Some(signing_derived.signing_key.as_bytes()));
     let signing_pub = signing_secret
@@ -167,7 +195,8 @@ pub async fn derive_entity_keys(
                 .map_err(|e| format!("Invalid derivation path: {e}"))?,
         )
         .map_err(|e| format!("Key derivation failed: {e}"))?;
-    let ka_priv = multibase::encode(Base::Base58Btc, ka_derived.signing_key.as_bytes());
+    // Encode as Ed25519 seed — consumers derive X25519 via Secret::to_x25519()
+    let ka_priv = encode_private_multibase(&KeyType::Ed25519, ka_derived.signing_key.as_bytes());
     let ka_secret = Secret::generate_ed25519(None, Some(ka_derived.signing_key.as_bytes()));
     let ka_secret = ka_secret
         .to_x25519()

--- a/vta-service/src/keys/mod.rs
+++ b/vta-service/src/keys/mod.rs
@@ -1,7 +1,9 @@
 pub mod derivation;
+pub mod imported;
 pub mod paths;
 pub mod seed_store;
 pub mod seeds;
+pub mod wrapping;
 
 use affinidi_tdk::secrets_resolver::secrets::Secret;
 use chrono::Utc;
@@ -11,7 +13,7 @@ use multibase::Base;
 
 use crate::store::KeyspaceHandle;
 
-pub use vta_sdk::keys::{KeyRecord, KeyStatus, KeyType};
+pub use vta_sdk::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
 
 pub fn store_key(key_id: &str) -> String {
     format!("key:{key_id}")
@@ -41,6 +43,7 @@ pub async fn save_key_record(
         label: Some(label.to_string()),
         context_id: context_id.map(String::from),
         seed_id,
+        origin: KeyOrigin::Derived,
         created_at: now,
         updated_at: now,
     };

--- a/vta-service/src/keys/mod.rs
+++ b/vta-service/src/keys/mod.rs
@@ -180,7 +180,8 @@ pub async fn derive_entity_keys(
                 .map_err(|e| format!("Invalid derivation path: {e}"))?,
         )
         .map_err(|e| format!("Key derivation failed: {e}"))?;
-    let signing_priv = encode_private_multibase(&KeyType::Ed25519, signing_derived.signing_key.as_bytes());
+    let signing_priv =
+        encode_private_multibase(&KeyType::Ed25519, signing_derived.signing_key.as_bytes());
     let signing_secret =
         Secret::generate_ed25519(None, Some(signing_derived.signing_key.as_bytes()));
     let signing_pub = signing_secret
@@ -267,8 +268,8 @@ mod tests {
 
     fn test_seed() -> Vec<u8> {
         vec![
-            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182,
-            73, 89, 196, 246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
+            7, 26, 142, 230, 65, 85, 188, 182, 29, 129, 52, 229, 217, 159, 243, 182, 73, 89, 196,
+            246, 58, 28, 100, 144, 187, 21, 157, 39, 4, 188, 154, 180,
         ]
     }
 
@@ -293,11 +294,9 @@ mod tests {
         let did = "did:webvh:abc123:example.com:vta";
 
         // === CREATION (first boot — derive_entity_keys + save) ===
-        let derived = derive_entity_keys(
-            &seed, "m/44'/0'", "signing", "key-agreement", &keys_ks,
-        )
-        .await
-        .unwrap();
+        let derived = derive_entity_keys(&seed, "m/44'/0'", "signing", "key-agreement", &keys_ks)
+            .await
+            .unwrap();
 
         save_entity_key_records(did, &derived, &keys_ks, Some("vta"), Some(0))
             .await
@@ -326,7 +325,9 @@ mod tests {
 
         let root = ExtendedSigningKey::from_seed(&seed).unwrap();
 
-        let recovered_signing = root.derive_ed25519(&signing_record.derivation_path).unwrap();
+        let recovered_signing = root
+            .derive_ed25519(&signing_record.derivation_path)
+            .unwrap();
         let recovered_ka = root.derive_x25519(&ka_record.derivation_path).unwrap();
 
         let recovered_signing_pub = recovered_signing.get_public_keymultibase().unwrap();
@@ -367,15 +368,15 @@ mod tests {
 
         // Create and save
         {
-            let config = StoreConfig { data_dir: dir.path().to_path_buf() };
+            let config = StoreConfig {
+                data_dir: dir.path().to_path_buf(),
+            };
             let store = Store::open(&config).unwrap();
             let keys_ks = store.keyspace("keys").unwrap();
 
-            let derived = derive_entity_keys(
-                &seed, "m/44'/0'", "signing", "ka", &keys_ks,
-            )
-            .await
-            .unwrap();
+            let derived = derive_entity_keys(&seed, "m/44'/0'", "signing", "ka", &keys_ks)
+                .await
+                .unwrap();
 
             save_entity_key_records(did, &derived, &keys_ks, Some("vta"), Some(0))
                 .await
@@ -386,7 +387,9 @@ mod tests {
 
         // Reopen and verify
         {
-            let config = StoreConfig { data_dir: dir.path().to_path_buf() };
+            let config = StoreConfig {
+                data_dir: dir.path().to_path_buf(),
+            };
             let store = Store::open(&config).unwrap();
             let keys_ks = store.keyspace("keys").unwrap();
 

--- a/vta-service/src/keys/seed_store/kms_tee.rs
+++ b/vta-service/src/keys/seed_store/kms_tee.rs
@@ -34,9 +34,10 @@ impl KmsTeeSeedStore {
 impl SeedStore for KmsTeeSeedStore {
     fn get(&self) -> BoxFuture<'_, Result<Option<Vec<u8>>, AppError>> {
         Box::pin(async {
-            let guard = self.seed.lock().map_err(|e| {
-                AppError::SecretStore(format!("seed lock poisoned: {e}"))
-            })?;
+            let guard = self
+                .seed
+                .lock()
+                .map_err(|e| AppError::SecretStore(format!("seed lock poisoned: {e}")))?;
             Ok(guard.clone())
         })
     }
@@ -50,9 +51,10 @@ impl SeedStore for KmsTeeSeedStore {
                 "seed updated in memory — restart the enclave to re-encrypt \
                  and persist the new seed via KMS bootstrap"
             );
-            let mut guard = self.seed.lock().map_err(|e| {
-                AppError::SecretStore(format!("seed lock poisoned: {e}"))
-            })?;
+            let mut guard = self
+                .seed
+                .lock()
+                .map_err(|e| AppError::SecretStore(format!("seed lock poisoned: {e}")))?;
             *guard = Some(seed);
             Ok(())
         })

--- a/vta-service/src/keys/seed_store/mod.rs
+++ b/vta-service/src/keys/seed_store/mod.rs
@@ -32,12 +32,9 @@ use std::pin::Pin;
 use crate::config::AppConfig;
 use crate::error::AppError;
 
-type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+pub use vti_common::seed_store::SeedStore;
 
-pub trait SeedStore: Send + Sync {
-    fn get(&self) -> BoxFuture<'_, Result<Option<Vec<u8>>, AppError>>;
-    fn set(&self, seed: &[u8]) -> BoxFuture<'_, Result<(), AppError>>;
-}
+pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Create a seed store backend based on compiled features and configuration.
 ///

--- a/vta-service/src/keys/wrapping.rs
+++ b/vta-service/src/keys/wrapping.rs
@@ -39,6 +39,14 @@ pub struct WrappingKeyCache {
     entries: Arc<Mutex<HashMap<String, WrappingEntry>>>,
 }
 
+impl Default for WrappingKeyCache {
+    fn default() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
 impl WrappingKeyCache {
     pub fn new() -> Self {
         Self {
@@ -92,10 +100,14 @@ impl WrappingKeyCache {
             .map_err(|e| AppError::Validation(format!("invalid ciphertext: {e}")))?;
 
         if ephemeral_pub_bytes.len() != 32 {
-            return Err(AppError::Validation("ephemeral public key must be 32 bytes".into()));
+            return Err(AppError::Validation(
+                "ephemeral public key must be 32 bytes".into(),
+            ));
         }
         if nonce_bytes.len() != NONCE_LEN {
-            return Err(AppError::Validation(format!("nonce must be {NONCE_LEN} bytes")));
+            return Err(AppError::Validation(format!(
+                "nonce must be {NONCE_LEN} bytes"
+            )));
         }
 
         // Look up and consume the wrapping key
@@ -135,9 +147,9 @@ impl WrappingKeyCache {
         let cipher = Aes256Gcm::new_from_slice(&aes_key)
             .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let mut plaintext = cipher
-            .decrypt(nonce, ciphertext.as_ref())
-            .map_err(|_| AppError::Authentication("failed to unwrap key (ECDH mismatch or tampering)".into()))?;
+        let mut plaintext = cipher.decrypt(nonce, ciphertext.as_ref()).map_err(|_| {
+            AppError::Authentication("failed to unwrap key (ECDH mismatch or tampering)".into())
+        })?;
 
         aes_key.zeroize();
 
@@ -166,11 +178,7 @@ mod tests {
     use super::*;
 
     /// Client-side wrapping helper for tests.
-    fn wrap_for_test(
-        vta_pub_bytes: &[u8; 32],
-        kid: &str,
-        plaintext: &[u8],
-    ) -> String {
+    fn wrap_for_test(vta_pub_bytes: &[u8; 32], kid: &str, plaintext: &[u8]) -> String {
         let vta_pub = PublicKey::from(*vta_pub_bytes);
         let client_secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
         let client_pub = PublicKey::from(&client_secret);
@@ -178,7 +186,8 @@ mod tests {
         let shared = client_secret.diffie_hellman(&vta_pub);
         let hkdf = Hkdf::<Sha256>::new(None, shared.as_bytes());
         let mut aes_key = [0u8; 32];
-        hkdf.expand(b"vta-key-import-wrapping", &mut aes_key).unwrap();
+        hkdf.expand(b"vta-key-import-wrapping", &mut aes_key)
+            .unwrap();
 
         let cipher = Aes256Gcm::new_from_slice(&aes_key).unwrap();
         use aes_gcm::aead::rand_core::RngCore;

--- a/vta-service/src/keys/wrapping.rs
+++ b/vta-service/src/keys/wrapping.rs
@@ -1,0 +1,226 @@
+//! Ephemeral X25519 wrapping key for REST key import.
+//!
+//! Each wrapping key is single-use with a 60-second TTL. The VTA generates
+//! an ephemeral X25519 keypair and returns the public key as a JWK. The
+//! PNM client performs ECDH-ES key agreement and wraps the imported private
+//! key with AES-256-GCM before sending it over REST.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use hkdf::Hkdf;
+use sha2::Sha256;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::Zeroize;
+
+use crate::error::AppError;
+
+const TTL: Duration = Duration::from_secs(60);
+const NONCE_LEN: usize = 12;
+
+struct WrappingEntry {
+    private_key: StaticSecret,
+    #[allow(dead_code)]
+    public_key: PublicKey,
+    created_at: Instant,
+    used: bool,
+}
+
+/// In-memory cache of ephemeral wrapping keys.
+#[derive(Clone)]
+pub struct WrappingKeyCache {
+    entries: Arc<Mutex<HashMap<String, WrappingEntry>>>,
+}
+
+impl WrappingKeyCache {
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Generate a new ephemeral wrapping keypair and return (kid, public_key_base64url).
+    pub async fn generate(&self) -> (String, String) {
+        let kid = Uuid::new_v4().to_string();
+        // Use StaticSecret so we can store it (EphemeralSecret is consumed on DH)
+        let secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+        let public = PublicKey::from(&secret);
+
+        let public_b64 = BASE64.encode(public.as_bytes());
+
+        let entry = WrappingEntry {
+            private_key: secret,
+            public_key: public,
+            created_at: Instant::now(),
+            used: false,
+        };
+
+        self.entries.lock().await.insert(kid.clone(), entry);
+
+        (kid, public_b64)
+    }
+
+    /// Consume a wrapping key and decrypt a JWE-like payload.
+    ///
+    /// Expected format: `{kid}.{ephemeral_pub_b64}.{nonce_b64}.{ciphertext_b64}`
+    /// where ciphertext was encrypted with AES-256-GCM using a key derived from
+    /// ECDH(ephemeral_client_secret, vta_wrapping_pub) via HKDF.
+    pub async fn unwrap_jwe(&self, jwe: &str) -> Result<Vec<u8>, AppError> {
+        let parts: Vec<&str> = jwe.split('.').collect();
+        if parts.len() != 4 {
+            return Err(AppError::Validation(
+                "invalid JWE format: expected kid.ephemeral_pub.nonce.ciphertext".into(),
+            ));
+        }
+
+        let kid = parts[0];
+        let ephemeral_pub_bytes = BASE64
+            .decode(parts[1])
+            .map_err(|e| AppError::Validation(format!("invalid ephemeral public key: {e}")))?;
+        let nonce_bytes = BASE64
+            .decode(parts[2])
+            .map_err(|e| AppError::Validation(format!("invalid nonce: {e}")))?;
+        let ciphertext = BASE64
+            .decode(parts[3])
+            .map_err(|e| AppError::Validation(format!("invalid ciphertext: {e}")))?;
+
+        if ephemeral_pub_bytes.len() != 32 {
+            return Err(AppError::Validation("ephemeral public key must be 32 bytes".into()));
+        }
+        if nonce_bytes.len() != NONCE_LEN {
+            return Err(AppError::Validation(format!("nonce must be {NONCE_LEN} bytes")));
+        }
+
+        // Look up and consume the wrapping key
+        let mut entries = self.entries.lock().await;
+        let entry = entries
+            .get_mut(kid)
+            .ok_or_else(|| AppError::NotFound("wrapping key not found or expired".into()))?;
+
+        if entry.used {
+            entries.remove(kid);
+            return Err(AppError::Validation("wrapping key already used".into()));
+        }
+        if entry.created_at.elapsed() > TTL {
+            entries.remove(kid);
+            return Err(AppError::Validation("wrapping key expired".into()));
+        }
+
+        // Perform ECDH
+        let ephemeral_pub: [u8; 32] = ephemeral_pub_bytes
+            .try_into()
+            .map_err(|_| AppError::Internal("public key conversion failed".into()))?;
+        let ephemeral_pub = PublicKey::from(ephemeral_pub);
+        let shared_secret = entry.private_key.diffie_hellman(&ephemeral_pub);
+
+        // Mark as used and remove
+        entry.used = true;
+        entries.remove(kid);
+        drop(entries);
+
+        // Derive AES key from shared secret via HKDF
+        let hkdf = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
+        let mut aes_key = [0u8; 32];
+        hkdf.expand(b"vta-key-import-wrapping", &mut aes_key)
+            .map_err(|e| AppError::Internal(format!("hkdf expand: {e}")))?;
+
+        // Decrypt
+        let cipher = Aes256Gcm::new_from_slice(&aes_key)
+            .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let mut plaintext = cipher
+            .decrypt(nonce, ciphertext.as_ref())
+            .map_err(|_| AppError::Authentication("failed to unwrap key (ECDH mismatch or tampering)".into()))?;
+
+        aes_key.zeroize();
+
+        Ok(std::mem::take(&mut plaintext))
+    }
+
+    /// Remove expired entries. Call periodically.
+    pub async fn reap_expired(&self) {
+        let mut entries = self.entries.lock().await;
+        entries.retain(|_, entry| entry.created_at.elapsed() < TTL && !entry.used);
+    }
+
+    /// Spawn a background task that reaps expired wrapping keys every 30 seconds.
+    pub fn spawn_reaper(self) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                self.reap_expired().await;
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Client-side wrapping helper for tests.
+    fn wrap_for_test(
+        vta_pub_bytes: &[u8; 32],
+        kid: &str,
+        plaintext: &[u8],
+    ) -> String {
+        let vta_pub = PublicKey::from(*vta_pub_bytes);
+        let client_secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+        let client_pub = PublicKey::from(&client_secret);
+
+        let shared = client_secret.diffie_hellman(&vta_pub);
+        let hkdf = Hkdf::<Sha256>::new(None, shared.as_bytes());
+        let mut aes_key = [0u8; 32];
+        hkdf.expand(b"vta-key-import-wrapping", &mut aes_key).unwrap();
+
+        let cipher = Aes256Gcm::new_from_slice(&aes_key).unwrap();
+        use aes_gcm::aead::rand_core::RngCore;
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let ciphertext = cipher.encrypt(nonce, plaintext).unwrap();
+
+        format!(
+            "{}.{}.{}.{}",
+            kid,
+            BASE64.encode(client_pub.as_bytes()),
+            BASE64.encode(nonce_bytes),
+            BASE64.encode(ciphertext),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_generate_and_unwrap() {
+        let cache = WrappingKeyCache::new();
+        let (kid, pub_b64) = cache.generate().await;
+
+        let pub_bytes: [u8; 32] = BASE64.decode(&pub_b64).unwrap().try_into().unwrap();
+
+        let secret = b"test-private-key-32-bytes!!!!!!";
+        let jwe = wrap_for_test(&pub_bytes, &kid, secret);
+
+        let unwrapped = cache.unwrap_jwe(&jwe).await.unwrap();
+        assert_eq!(unwrapped, secret);
+    }
+
+    #[tokio::test]
+    async fn test_single_use() {
+        let cache = WrappingKeyCache::new();
+        let (kid, pub_b64) = cache.generate().await;
+        let pub_bytes: [u8; 32] = BASE64.decode(&pub_b64).unwrap().try_into().unwrap();
+
+        let jwe = wrap_for_test(&pub_bytes, &kid, b"secret");
+        cache.unwrap_jwe(&jwe).await.unwrap();
+
+        // Second use should fail
+        let jwe2 = wrap_for_test(&pub_bytes, &kid, b"secret2");
+        assert!(cache.unwrap_jwe(&jwe2).await.is_err());
+    }
+}

--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -11,13 +11,13 @@ pub mod audit;
 pub mod auth;
 pub mod config;
 pub mod contexts;
-#[cfg(feature = "rest")]
-pub mod metrics;
 pub mod didcomm_bridge;
 pub mod error;
 pub mod keys;
 #[cfg(feature = "didcomm")]
 pub mod messaging;
+#[cfg(feature = "rest")]
+pub mod metrics;
 pub mod operations;
 #[cfg(feature = "rest")]
 pub mod routes;
@@ -50,8 +50,8 @@ where
 {
     use tracing_subscriber::EnvFilter;
 
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(&config.log.level));
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&config.log.level));
 
     let subscriber = tracing_subscriber::fmt()
         .with_env_filter(filter)

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -95,7 +95,7 @@ enum Commands {
         /// The DID to import
         #[arg(long)]
         did: String,
-        /// Role to assign (admin, initiator, application)
+        /// Role to assign (admin, initiator, application, reader)
         #[arg(long)]
         role: Option<String>,
         /// Human-readable label for the ACL entry
@@ -232,7 +232,7 @@ enum AclCommands {
         /// Filter by context
         #[arg(long)]
         context: Option<String>,
-        /// Filter by role (admin, initiator, application)
+        /// Filter by role (admin, initiator, application, reader)
         #[arg(long)]
         role: Option<String>,
     },
@@ -245,7 +245,7 @@ enum AclCommands {
     Update {
         /// The DID to update
         did: String,
-        /// New role (admin, initiator, application)
+        /// New role (admin, initiator, application, reader)
         #[arg(long)]
         role: Option<String>,
         /// New label (empty string to clear)

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -511,10 +511,7 @@ async fn main() {
                 Arc::from(create_seed_store(&config).expect("failed to create seed store"));
 
             if let Err(e) = server::run(
-                config,
-                store,
-                seed_store,
-                None, // no storage encryption (non-TEE mode)
+                config, store, seed_store, None, // no storage encryption (non-TEE mode)
                 None, // no TEE context (use vta-enclave for TEE mode)
             )
             .await
@@ -593,9 +590,16 @@ async fn run_bootstrap_admin(
         .collect();
 
     if !existing_super_admins.is_empty() {
-        eprintln!("WARNING: {} existing super admin(s) found:", existing_super_admins.len());
+        eprintln!(
+            "WARNING: {} existing super admin(s) found:",
+            existing_super_admins.len()
+        );
         for admin in &existing_super_admins {
-            eprintln!("  - {} ({})", admin.did, admin.label.as_deref().unwrap_or("no label"));
+            eprintln!(
+                "  - {} ({})",
+                admin.did,
+                admin.label.as_deref().unwrap_or("no label")
+            );
         }
         eprintln!();
         eprintln!("Proceeding will add another super admin and seal the VTA.");
@@ -627,7 +631,10 @@ async fn run_bootstrap_admin(
     eprintln!("=== VTA Bootstrapped and Sealed ===");
     eprintln!();
     eprintln!("  Admin DID: {}", did);
-    eprintln!("  Sealed at: {}", seal_record.sealed_at.format("%Y-%m-%d %H:%M:%S UTC"));
+    eprintln!(
+        "  Sealed at: {}",
+        seal_record.sealed_at.format("%Y-%m-%d %H:%M:%S UTC")
+    );
     eprintln!();
     eprintln!("  The VTA is now sealed. Offline CLI commands that modify state are disabled.");
     eprintln!("  All management must go through the authenticated REST API or DIDComm.");

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -264,6 +264,20 @@ pub async fn handle_update_context(
     response(context_management::UPDATE_CONTEXT_RESULT, &result)
 }
 
+pub async fn handle_update_context_did(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let body: vta_sdk::protocols::context_management::update_did::UpdateContextDidBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let result = operations::contexts::update_context_did(
+        &state.contexts_ks, &auth, &body.id, body.did, "didcomm",
+    ).await.map_err(handler_err)?;
+    response(context_management::UPDATE_CONTEXT_DID_RESULT, &result)
+}
+
 pub async fn handle_preview_delete_context(
     _ctx: HandlerContext,
     message: Message,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -207,6 +207,7 @@ pub async fn handle_sign_request(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_write().map_err(handler_err)?;
     let body: vta_sdk::protocols::key_management::sign::SignRequestBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
 
@@ -285,6 +286,7 @@ pub async fn handle_create_context(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_super_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::create::CreateContextBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::contexts::create_context(
@@ -339,6 +341,7 @@ pub async fn handle_update_context(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_super_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::update::UpdateContextBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::contexts::update_context(
@@ -365,6 +368,7 @@ pub async fn handle_update_context_did(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::update_did::UpdateContextDidBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::contexts::update_context_did(
@@ -387,6 +391,7 @@ pub async fn handle_preview_delete_context(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_super_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::delete::DeleteContextPreviewBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::contexts::preview_delete_context(
@@ -412,6 +417,7 @@ pub async fn handle_delete_context(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_super_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::delete::DeleteContextBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let ks = operations::Keyspaces::from_vta_state(&state);
@@ -433,6 +439,7 @@ pub async fn handle_create_acl(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_manage().map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::create::CreateAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let role = Role::parse(&body.role).map_err(handler_err)?;
@@ -459,6 +466,7 @@ pub async fn handle_get_acl(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_manage().map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::get::GetAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::acl::get_acl(&state.acl_ks, &auth, &body.did, "didcomm")
@@ -475,6 +483,7 @@ pub async fn handle_list_acl(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_manage().map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::list::ListAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result =
@@ -492,6 +501,7 @@ pub async fn handle_update_acl(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_manage().map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::update::UpdateAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let role = match body.role {
@@ -523,6 +533,7 @@ pub async fn handle_delete_acl(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_manage().map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::delete::DeleteAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result =
@@ -544,6 +555,7 @@ pub async fn handle_list_logs(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::audit_management::list::ListAuditLogsBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::audit::list_audit_logs(&state.audit_ks, &auth, &body, "didcomm")
@@ -560,6 +572,7 @@ pub async fn handle_get_retention(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_admin().map_err(handler_err)?;
     let result = operations::audit::get_retention(&state.config, &auth, "didcomm")
         .await
         .map_err(handler_err)?;
@@ -574,7 +587,7 @@ pub async fn handle_update_retention(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
-    auth.require_admin().map_err(handler_err)?;
+    auth.require_super_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::audit_management::retention::UpdateRetentionBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::audit::update_retention(
@@ -615,6 +628,7 @@ pub async fn handle_update_config(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_super_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::config::update_config(
@@ -644,6 +658,7 @@ pub async fn handle_generate_credentials(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_manage().map_err(handler_err)?;
     let body: vta_sdk::protocols::credential_management::generate::GenerateCredentialsBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let role = Role::parse(&body.role).map_err(handler_err)?;
@@ -1006,6 +1021,7 @@ pub async fn handle_backup_export(
     let auth = auth_from_message(&message, &state.acl_ks)
         .await
         .map_err(handler_err)?;
+    auth.require_super_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::backup_management::types::ExportRequest =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let config = state.config.read().await;

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -24,8 +24,8 @@ use crate::operations;
 use super::router::VtaState;
 
 use vta_sdk::protocols::{
-    acl_management, audit_management, context_management, credential_management,
-    key_management, seed_management, vta_management,
+    acl_management, audit_management, context_management, credential_management, key_management,
+    seed_management, vta_management,
 };
 
 type HandlerResult = Result<Option<DIDCommResponse>, DIDCommServiceError>;
@@ -53,23 +53,34 @@ pub async fn handle_create_key(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     auth.require_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::key_management::create::CreateKeyBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::create_key(
-        &state.keys_ks, &state.contexts_ks, &state.seed_store, &state.audit_ks,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.seed_store,
+        &state.audit_ks,
         &auth,
         operations::keys::CreateKeyParams {
             key_type: body.key_type,
-            derivation_path: if body.derivation_path.is_empty() { None } else { Some(body.derivation_path) },
+            derivation_path: if body.derivation_path.is_empty() {
+                None
+            } else {
+                Some(body.derivation_path)
+            },
             key_id: None,
             mnemonic: body.mnemonic,
             label: body.label,
             context_id: body.context_id,
         },
         "didcomm",
-    ).await.map_err(handler_err)?;
+    )
+    .await
+    .map_err(handler_err)?;
     response(key_management::CREATE_KEY_RESULT, &result)
 }
 
@@ -78,11 +89,14 @@ pub async fn handle_get_key(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::key_management::get::GetKeyBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::get_key(&state.keys_ks, &auth, &body.key_id, "didcomm")
-        .await.map_err(handler_err)?;
+        .await
+        .map_err(handler_err)?;
     response(key_management::GET_KEY_RESULT, &result)
 }
 
@@ -91,17 +105,24 @@ pub async fn handle_list_keys(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::key_management::list::ListKeysBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::list_keys(
-        &state.keys_ks, &auth,
+        &state.keys_ks,
+        &auth,
         operations::keys::ListKeysParams {
-            offset: body.offset, limit: body.limit,
-            status: body.status, context_id: body.context_id,
+            offset: body.offset,
+            limit: body.limit,
+            status: body.status,
+            context_id: body.context_id,
         },
         "didcomm",
-    ).await.map_err(handler_err)?;
+    )
+    .await
+    .map_err(handler_err)?;
     response(key_management::LIST_KEYS_RESULT, &result)
 }
 
@@ -110,13 +131,22 @@ pub async fn handle_rename_key(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     auth.require_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::key_management::rename::RenameKeyBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::rename_key(
-        &state.keys_ks, &state.audit_ks, &auth, &body.key_id, &body.new_key_id, "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.keys_ks,
+        &state.audit_ks,
+        &auth,
+        &body.key_id,
+        &body.new_key_id,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(key_management::RENAME_KEY_RESULT, &result)
 }
 
@@ -125,13 +155,22 @@ pub async fn handle_revoke_key(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     auth.require_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::key_management::revoke::RevokeKeyBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::revoke_key(
-        &state.keys_ks, &state.imported_ks, &state.audit_ks, &auth, &body.key_id, "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.audit_ks,
+        &auth,
+        &body.key_id,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(key_management::REVOKE_KEY_RESULT, &result)
 }
 
@@ -140,13 +179,23 @@ pub async fn handle_get_key_secret(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     auth.require_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::key_management::secret::GetKeySecretBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::get_key_secret(
-        &state.keys_ks, &state.imported_ks, &state.seed_store, &state.audit_ks, &auth, &body.key_id, "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.seed_store,
+        &state.audit_ks,
+        &auth,
+        &body.key_id,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(key_management::GET_KEY_SECRET_RESULT, &result)
 }
 
@@ -155,7 +204,9 @@ pub async fn handle_sign_request(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::key_management::sign::SignRequestBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
 
@@ -164,9 +215,17 @@ pub async fn handle_sign_request(
         .map_err(|e| handler_err(format!("invalid base64url payload: {e}")))?;
 
     let result = operations::keys::sign_payload(
-        &state.keys_ks, &state.imported_ks, &state.seed_store, &auth,
-        &body.key_id, &payload, &body.algorithm, "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.seed_store,
+        &auth,
+        &body.key_id,
+        &payload,
+        &body.algorithm,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(key_management::SIGN_RESULT, &result)
 }
 
@@ -179,10 +238,13 @@ pub async fn handle_list_seeds(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     auth.require_admin().map_err(handler_err)?;
     let result = operations::seeds::list_seeds(&state.keys_ks, "didcomm")
-        .await.map_err(handler_err)?;
+        .await
+        .map_err(handler_err)?;
     response(seed_management::LIST_SEEDS_RESULT, &result)
 }
 
@@ -191,14 +253,23 @@ pub async fn handle_rotate_seed(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     auth.require_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::seed_management::rotate::RotateSeedBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::seeds::rotate_seed(
-        &state.keys_ks, &state.imported_ks, &state.seed_store, &state.audit_ks, &auth.did,
-        body.mnemonic.as_deref(), "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.seed_store,
+        &state.audit_ks,
+        &auth.did,
+        body.mnemonic.as_deref(),
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(seed_management::ROTATE_SEED_RESULT, &result)
 }
 
@@ -211,12 +282,21 @@ pub async fn handle_create_context(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::create::CreateContextBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::contexts::create_context(
-        &state.contexts_ks, &auth, &body.id, body.name, body.description, "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.contexts_ks,
+        &auth,
+        &body.id,
+        body.name,
+        body.description,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(context_management::CREATE_CONTEXT_RESULT, &result)
 }
 
@@ -225,12 +305,15 @@ pub async fn handle_get_context(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::get::GetContextBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
-    let result = operations::contexts::get_context_op(
-        &state.contexts_ks, &auth, &body.id, "didcomm",
-    ).await.map_err(handler_err)?;
+    let result =
+        operations::contexts::get_context_op(&state.contexts_ks, &auth, &body.id, "didcomm")
+            .await
+            .map_err(handler_err)?;
     response(context_management::GET_CONTEXT_RESULT, &result)
 }
 
@@ -239,10 +322,12 @@ pub async fn handle_list_contexts(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
-    let result = operations::contexts::list_contexts(
-        &state.contexts_ks, &auth, "didcomm",
-    ).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
+    let result = operations::contexts::list_contexts(&state.contexts_ks, &auth, "didcomm")
+        .await
+        .map_err(handler_err)?;
     response(context_management::LIST_CONTEXTS_RESULT, &result)
 }
 
@@ -251,16 +336,24 @@ pub async fn handle_update_context(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::update::UpdateContextBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::contexts::update_context(
-        &state.contexts_ks, &auth, &body.id,
+        &state.contexts_ks,
+        &auth,
+        &body.id,
         operations::contexts::UpdateContextParams {
-            name: body.name, did: body.did, description: body.description,
+            name: body.name,
+            did: body.did,
+            description: body.description,
         },
         "didcomm",
-    ).await.map_err(handler_err)?;
+    )
+    .await
+    .map_err(handler_err)?;
     response(context_management::UPDATE_CONTEXT_RESULT, &result)
 }
 
@@ -269,12 +362,20 @@ pub async fn handle_update_context_did(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::update_did::UpdateContextDidBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::contexts::update_context_did(
-        &state.contexts_ks, &auth, &body.id, body.did, "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.contexts_ks,
+        &auth,
+        &body.id,
+        body.did,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(context_management::UPDATE_CONTEXT_DID_RESULT, &result)
 }
 
@@ -283,15 +384,23 @@ pub async fn handle_preview_delete_context(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::delete::DeleteContextPreviewBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::contexts::preview_delete_context(
-        &state.contexts_ks, &state.keys_ks, &state.acl_ks,
+        &state.contexts_ks,
+        &state.keys_ks,
+        &state.acl_ks,
         #[cfg(feature = "webvh")]
         &state.webvh_ks,
-        &auth, &body.id, "didcomm",
-    ).await.map_err(handler_err)?;
+        &auth,
+        &body.id,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(context_management::PREVIEW_DELETE_CONTEXT_RESULT, &result)
 }
 
@@ -300,15 +409,15 @@ pub async fn handle_delete_context(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::context_management::delete::DeleteContextBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
-    let result = operations::contexts::delete_context(
-        &state.contexts_ks, &state.keys_ks, &state.acl_ks,
-        #[cfg(feature = "webvh")]
-        &state.webvh_ks,
-        &auth, &body.id, body.force, "didcomm",
-    ).await.map_err(handler_err)?;
+    let ks = operations::Keyspaces::from_vta_state(&state);
+    let result = operations::contexts::delete_context(&ks, &auth, &body.id, body.force, "didcomm")
+        .await
+        .map_err(handler_err)?;
     response(context_management::DELETE_CONTEXT_RESULT, &result)
 }
 
@@ -321,13 +430,24 @@ pub async fn handle_create_acl(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::create::CreateAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let role = Role::parse(&body.role).map_err(handler_err)?;
     let result = operations::acl::create_acl(
-        &state.acl_ks, &state.audit_ks, &auth, &body.did, role, body.label, body.allowed_contexts, "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.acl_ks,
+        &state.audit_ks,
+        &auth,
+        &body.did,
+        role,
+        body.label,
+        body.allowed_contexts,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(acl_management::CREATE_ACL_RESULT, &result)
 }
 
@@ -336,11 +456,14 @@ pub async fn handle_get_acl(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::get::GetAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::acl::get_acl(&state.acl_ks, &auth, &body.did, "didcomm")
-        .await.map_err(handler_err)?;
+        .await
+        .map_err(handler_err)?;
     response(acl_management::GET_ACL_RESULT, &result)
 }
 
@@ -349,11 +472,15 @@ pub async fn handle_list_acl(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::list::ListAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
-    let result = operations::acl::list_acl(&state.acl_ks, &auth, body.context.as_deref(), "didcomm")
-        .await.map_err(handler_err)?;
+    let result =
+        operations::acl::list_acl(&state.acl_ks, &auth, body.context.as_deref(), "didcomm")
+            .await
+            .map_err(handler_err)?;
     response(acl_management::LIST_ACL_RESULT, &result)
 }
 
@@ -362,7 +489,9 @@ pub async fn handle_update_acl(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::update::UpdateAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let role = match body.role {
@@ -370,10 +499,19 @@ pub async fn handle_update_acl(
         None => None,
     };
     let result = operations::acl::update_acl(
-        &state.acl_ks, &state.audit_ks, &auth, &body.did,
-        operations::acl::UpdateAclParams { role, label: body.label, allowed_contexts: body.allowed_contexts },
+        &state.acl_ks,
+        &state.audit_ks,
+        &auth,
+        &body.did,
+        operations::acl::UpdateAclParams {
+            role,
+            label: body.label,
+            allowed_contexts: body.allowed_contexts,
+        },
         "didcomm",
-    ).await.map_err(handler_err)?;
+    )
+    .await
+    .map_err(handler_err)?;
     response(acl_management::UPDATE_ACL_RESULT, &result)
 }
 
@@ -382,12 +520,15 @@ pub async fn handle_delete_acl(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::acl_management::delete::DeleteAclBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
-    let result = operations::acl::delete_acl(
-        &state.acl_ks, &state.audit_ks, &auth, &body.did, "didcomm",
-    ).await.map_err(handler_err)?;
+    let result =
+        operations::acl::delete_acl(&state.acl_ks, &state.audit_ks, &auth, &body.did, "didcomm")
+            .await
+            .map_err(handler_err)?;
     response(acl_management::DELETE_ACL_RESULT, &result)
 }
 
@@ -400,11 +541,14 @@ pub async fn handle_list_logs(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::audit_management::list::ListAuditLogsBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::audit::list_audit_logs(&state.audit_ks, &auth, &body, "didcomm")
-        .await.map_err(handler_err)?;
+        .await
+        .map_err(handler_err)?;
     response(audit_management::LIST_LOGS_RESULT, &result)
 }
 
@@ -413,9 +557,12 @@ pub async fn handle_get_retention(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let result = operations::audit::get_retention(&state.config, &auth, "didcomm")
-        .await.map_err(handler_err)?;
+        .await
+        .map_err(handler_err)?;
     response(audit_management::GET_RETENTION_RESULT, &result)
 }
 
@@ -424,13 +571,21 @@ pub async fn handle_update_retention(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     auth.require_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::audit_management::retention::UpdateRetentionBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::audit::update_retention(
-        &state.config, &state.audit_ks, &auth, body.retention_days, "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.config,
+        &state.audit_ks,
+        &auth,
+        body.retention_days,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(audit_management::UPDATE_RETENTION_RESULT, &result)
 }
 
@@ -443,9 +598,12 @@ pub async fn handle_get_config(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let result = operations::config::get_config(&state.config, &auth, "didcomm")
-        .await.map_err(handler_err)?;
+        .await
+        .map_err(handler_err)?;
     response(vta_management::GET_CONFIG_RESULT, &result)
 }
 
@@ -454,16 +612,23 @@ pub async fn handle_update_config(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::config::update_config(
-        &state.config, &auth,
+        &state.config,
+        &auth,
         operations::config::UpdateConfigParams {
-            vta_did: body.vta_did, vta_name: body.vta_name, public_url: body.public_url,
+            vta_did: body.vta_did,
+            vta_name: body.vta_name,
+            public_url: body.public_url,
         },
         "didcomm",
-    ).await.map_err(handler_err)?;
+    )
+    .await
+    .map_err(handler_err)?;
     response(vta_management::UPDATE_CONFIG_RESULT, &result)
 }
 
@@ -476,13 +641,23 @@ pub async fn handle_generate_credentials(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::credential_management::generate::GenerateCredentialsBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let role = Role::parse(&body.role).map_err(handler_err)?;
     let result = operations::credentials::generate_credentials(
-        &state.acl_ks, &state.config, &auth, role, body.label, body.allowed_contexts, "didcomm",
-    ).await.map_err(handler_err)?;
+        &state.acl_ks,
+        &state.config,
+        &auth,
+        role,
+        body.label,
+        body.allowed_contexts,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
     response(credential_management::GENERATE_CREDENTIALS_RESULT, &result)
 }
 
@@ -496,11 +671,15 @@ pub async fn handle_create_did_webvh(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::did_management::create::CreateDidWebvhBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let config = state.config.read().await;
-    let did_resolver = state.did_resolver.as_ref()
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
         .ok_or_else(|| handler_err("DID resolver not available"))?;
 
     // NOTE: The DIDComm bridge for WebVH server communication is not yet
@@ -510,19 +689,33 @@ pub async fn handle_create_did_webvh(
     let bridge = std::sync::Arc::new(tokio::sync::RwLock::new(None));
 
     let result = operations::did_webvh::create_did_webvh(
-        &state.keys_ks, &state.contexts_ks, &state.webvh_ks, &*state.seed_store,
-        &config, &auth,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &*state.seed_store,
+        &config,
+        &auth,
         operations::did_webvh::CreateDidWebvhParams {
-            context_id: body.context_id, server_id: body.server_id,
-            url: body.url, path: body.path, label: body.label,
+            context_id: body.context_id,
+            server_id: body.server_id,
+            url: body.url,
+            path: body.path,
+            label: body.label,
             portable: body.portable.unwrap_or(true),
             add_mediator_service: body.add_mediator_service.unwrap_or(false),
             additional_services: body.additional_services,
             pre_rotation_count: body.pre_rotation_count.unwrap_or(0),
         },
-        did_resolver, &bridge, "didcomm",
-    ).await.map_err(handler_err)?;
-    response(vta_sdk::protocols::did_management::CREATE_DID_WEBVH_RESULT, &result)
+        did_resolver,
+        &bridge,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::did_management::CREATE_DID_WEBVH_RESULT,
+        &result,
+    )
 }
 
 #[cfg(feature = "webvh")]
@@ -531,12 +724,18 @@ pub async fn handle_get_did_webvh(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::did_management::get::GetDidWebvhBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::did_webvh::get_did_webvh(&state.webvh_ks, &auth, &body.did, "didcomm")
-        .await.map_err(handler_err)?;
-    response(vta_sdk::protocols::did_management::GET_DID_WEBVH_RESULT, &result)
+        .await
+        .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::did_management::GET_DID_WEBVH_RESULT,
+        &result,
+    )
 }
 
 #[cfg(feature = "webvh")]
@@ -545,12 +744,19 @@ pub async fn handle_get_did_webvh_log(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::did_management::get::GetDidWebvhBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
-    let result = operations::did_webvh::get_did_webvh_log(&state.webvh_ks, &auth, &body.did, "didcomm")
-        .await.map_err(handler_err)?;
-    response(vta_sdk::protocols::did_management::GET_DID_WEBVH_LOG_RESULT, &result)
+    let result =
+        operations::did_webvh::get_did_webvh_log(&state.webvh_ks, &auth, &body.did, "didcomm")
+            .await
+            .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::did_management::GET_DID_WEBVH_LOG_RESULT,
+        &result,
+    )
 }
 
 #[cfg(feature = "webvh")]
@@ -559,13 +765,24 @@ pub async fn handle_list_dids_webvh(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::did_management::list::ListDidsWebvhBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::did_webvh::list_dids_webvh(
-        &state.webvh_ks, &auth, body.context_id.as_deref(), body.server_id.as_deref(), "didcomm",
-    ).await.map_err(handler_err)?;
-    response(vta_sdk::protocols::did_management::LIST_DIDS_WEBVH_RESULT, &result)
+        &state.webvh_ks,
+        &auth,
+        body.context_id.as_deref(),
+        body.server_id.as_deref(),
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::did_management::LIST_DIDS_WEBVH_RESULT,
+        &result,
+    )
 }
 
 #[cfg(feature = "webvh")]
@@ -574,19 +791,35 @@ pub async fn handle_delete_did_webvh(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::did_management::delete::DeleteDidWebvhBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let config = state.config.read().await;
-    let did_resolver = state.did_resolver.as_ref()
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
         .ok_or_else(|| handler_err("DID resolver not available"))?;
     // NOTE: Bridge not yet wired — see handle_create_did_webvh comment
     let bridge = std::sync::Arc::new(tokio::sync::RwLock::new(None));
     let result = operations::did_webvh::delete_did_webvh(
-        &state.webvh_ks, &state.keys_ks, &*state.seed_store, &config, &auth,
-        &body.did, did_resolver, &bridge, "didcomm",
-    ).await.map_err(handler_err)?;
-    response(vta_sdk::protocols::did_management::DELETE_DID_WEBVH_RESULT, &result)
+        &state.webvh_ks,
+        &state.keys_ks,
+        &*state.seed_store,
+        &config,
+        &auth,
+        &body.did,
+        did_resolver,
+        &bridge,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::did_management::DELETE_DID_WEBVH_RESULT,
+        &result,
+    )
 }
 
 #[cfg(feature = "webvh")]
@@ -595,15 +828,30 @@ pub async fn handle_add_webvh_server(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::did_management::servers::AddWebvhServerBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
-    let did_resolver = state.did_resolver.as_ref()
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
         .ok_or_else(|| handler_err("DID resolver not available"))?;
     let result = operations::did_webvh::add_webvh_server(
-        &state.webvh_ks, &auth, &body.id, &body.did, body.label, did_resolver, "didcomm",
-    ).await.map_err(handler_err)?;
-    response(vta_sdk::protocols::did_management::ADD_WEBVH_SERVER_RESULT, &result)
+        &state.webvh_ks,
+        &auth,
+        &body.id,
+        &body.did,
+        body.label,
+        did_resolver,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::did_management::ADD_WEBVH_SERVER_RESULT,
+        &result,
+    )
 }
 
 #[cfg(feature = "webvh")]
@@ -612,10 +860,16 @@ pub async fn handle_list_webvh_servers(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let result = operations::did_webvh::list_webvh_servers(&state.webvh_ks, &auth, "didcomm")
-        .await.map_err(handler_err)?;
-    response(vta_sdk::protocols::did_management::LIST_WEBVH_SERVERS_RESULT, &result)
+        .await
+        .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::did_management::LIST_WEBVH_SERVERS_RESULT,
+        &result,
+    )
 }
 
 #[cfg(feature = "webvh")]
@@ -624,13 +878,24 @@ pub async fn handle_update_webvh_server(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::did_management::servers::UpdateWebvhServerBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::did_webvh::update_webvh_server(
-        &state.webvh_ks, &auth, &body.id, body.label, "didcomm",
-    ).await.map_err(handler_err)?;
-    response(vta_sdk::protocols::did_management::UPDATE_WEBVH_SERVER_RESULT, &result)
+        &state.webvh_ks,
+        &auth,
+        &body.id,
+        body.label,
+        "didcomm",
+    )
+    .await
+    .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::did_management::UPDATE_WEBVH_SERVER_RESULT,
+        &result,
+    )
 }
 
 #[cfg(feature = "webvh")]
@@ -639,12 +904,19 @@ pub async fn handle_remove_webvh_server(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::did_management::servers::RemoveWebvhServerBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
-    let result = operations::did_webvh::remove_webvh_server(&state.webvh_ks, &auth, &body.id, "didcomm")
-        .await.map_err(handler_err)?;
-    response(vta_sdk::protocols::did_management::REMOVE_WEBVH_SERVER_RESULT, &result)
+    let result =
+        operations::did_webvh::remove_webvh_server(&state.webvh_ks, &auth, &body.id, "didcomm")
+            .await
+            .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::did_management::REMOVE_WEBVH_SERVER_RESULT,
+        &result,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -657,10 +929,15 @@ pub async fn handle_tee_status(
     _message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let tee_state = state.tee_state.as_ref()
+    let tee_state = state
+        .tee_state
+        .as_ref()
         .ok_or_else(|| handler_err("TEE attestation is not enabled on this VTA"))?;
     let status = operations::attestation::get_tee_status(tee_state);
-    response(vta_sdk::protocols::attestation_management::GET_TEE_STATUS_RESULT, &status)
+    response(
+        vta_sdk::protocols::attestation_management::GET_TEE_STATUS_RESULT,
+        &status,
+    )
 }
 
 #[cfg(feature = "tee")]
@@ -669,14 +946,20 @@ pub async fn handle_request_attestation(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let tee_state = state.tee_state.as_ref()
+    let tee_state = state
+        .tee_state
+        .as_ref()
         .ok_or_else(|| handler_err("TEE attestation is not enabled on this VTA"))?;
     let body: crate::tee::types::AttestationRequest =
         serde_json::from_value(message.body).map_err(handler_err)?;
-    let result = operations::attestation::generate_attestation_report(
-        tee_state, &state.config, &body.nonce,
-    ).await.map_err(handler_err)?;
-    response(vta_sdk::protocols::attestation_management::ATTESTATION_RESULT, &result)
+    let result =
+        operations::attestation::generate_attestation_report(tee_state, &state.config, &body.nonce)
+            .await
+            .map_err(handler_err)?;
+    response(
+        vta_sdk::protocols::attestation_management::ATTESTATION_RESULT,
+        &result,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -688,15 +971,27 @@ pub async fn handle_restart(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     auth.require_super_admin().map_err(handler_err)?;
     let _ = crate::audit::record(
-        &state.audit_ks, "vta.restart", &auth.did, None, "success", Some("didcomm"), None,
-    ).await;
+        &state.audit_ks,
+        "vta.restart",
+        &auth.did,
+        None,
+        "success",
+        Some("didcomm"),
+        None,
+    )
+    .await;
     crate::server::trigger_restart(&state.restart_tx);
-    response(vta_sdk::protocols::vta_management::RESTART_RESULT, &vta_sdk::protocols::vta_management::restart::RestartResult {
-        status: "restarting".into(),
-    })
+    response(
+        vta_sdk::protocols::vta_management::RESTART_RESULT,
+        &vta_sdk::protocols::vta_management::restart::RestartResult {
+            status: "restarting".into(),
+        },
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -708,24 +1003,41 @@ pub async fn handle_backup_export(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     let body: vta_sdk::protocols::backup_management::types::ExportRequest =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let config = state.config.read().await;
+    let ks = operations::Keyspaces::from_vta_state(&state);
     let envelope = operations::backup::export_backup(
-        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks, &state.imported_ks,
-        #[cfg(feature = "webvh")]
-        &state.webvh_ks,
-        &*state.seed_store, &config, &auth, &body.password, body.include_audit,
-    ).await.map_err(handler_err)?;
+        &ks,
+        &*state.seed_store,
+        &config,
+        &auth,
+        &body.password,
+        body.include_audit,
+    )
+    .await
+    .map_err(handler_err)?;
     let _ = crate::audit::record(
-        &state.audit_ks, "backup.export", &auth.did, None, "success", Some("didcomm"), None,
-    ).await;
+        &state.audit_ks,
+        "backup.export",
+        &auth.did,
+        None,
+        "success",
+        Some("didcomm"),
+        None,
+    )
+    .await;
     info!(
         ciphertext_bytes = envelope.ciphertext.len(),
         "backup export DIDComm response size"
     );
-    response(vta_sdk::protocols::backup_management::EXPORT_BACKUP_RESULT, &envelope)
+    response(
+        vta_sdk::protocols::backup_management::EXPORT_BACKUP_RESULT,
+        &envelope,
+    )
 }
 
 pub async fn handle_backup_import(
@@ -733,60 +1045,77 @@ pub async fn handle_backup_import(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
-    let auth = auth_from_message(&message, &state.acl_ks).await.map_err(handler_err)?;
+    let auth = auth_from_message(&message, &state.acl_ks)
+        .await
+        .map_err(handler_err)?;
     auth.require_super_admin().map_err(handler_err)?;
     let body: vta_sdk::protocols::backup_management::types::ImportRequest =
         serde_json::from_value(message.body).map_err(handler_err)?;
 
     if !body.confirm {
-        let (_payload, preview) =
-            operations::backup::preview_import(&body.backup, &body.password)
-                .await.map_err(handler_err)?;
-        return response(vta_sdk::protocols::backup_management::IMPORT_BACKUP_RESULT, &preview);
+        let (_payload, preview) = operations::backup::preview_import(&body.backup, &body.password)
+            .await
+            .map_err(handler_err)?;
+        return response(
+            vta_sdk::protocols::backup_management::IMPORT_BACKUP_RESULT,
+            &preview,
+        );
     }
 
     let payload =
-        operations::backup::decrypt_backup(&body.backup, &body.password)
-            .map_err(handler_err)?;
+        operations::backup::decrypt_backup(&body.backup, &body.password).map_err(handler_err)?;
 
+    let ks = operations::Keyspaces::from_vta_state(&state);
     let result = operations::backup::apply_import(
         &payload,
-        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks, &state.imported_ks,
-        #[cfg(feature = "webvh")]
-        &state.webvh_ks,
-        &state.seed_store, &state.config,
+        &ks,
+        &state.seed_store,
+        &state.config,
         None, // Store for TEE re-encryption (handled on restart)
-    ).await.map_err(handler_err)?;
+    )
+    .await
+    .map_err(handler_err)?;
 
     let _ = crate::audit::record(
-        &state.audit_ks, "backup.import", &auth.did,
-        payload.config.vta_did.as_deref(), "success", Some("didcomm"), None,
-    ).await;
+        &state.audit_ks,
+        "backup.import",
+        &auth.did,
+        payload.config.vta_did.as_deref(),
+        "success",
+        Some("didcomm"),
+        None,
+    )
+    .await;
 
     crate::server::trigger_restart(&state.restart_tx);
-    response(vta_sdk::protocols::backup_management::IMPORT_BACKUP_RESULT, &result)
+    response(
+        vta_sdk::protocols::backup_management::IMPORT_BACKUP_RESULT,
+        &result,
+    )
 }
 
 // ---------------------------------------------------------------------------
 // Problem report & fallback
 // ---------------------------------------------------------------------------
 
-pub async fn handle_problem_report(
-    _ctx: HandlerContext,
-    message: Message,
-) -> HandlerResult {
-    let code = message.body.get("code").and_then(|v| v.as_str()).unwrap_or("unknown");
-    let comment = message.body.get("comment").and_then(|v| v.as_str()).unwrap_or("");
+pub async fn handle_problem_report(_ctx: HandlerContext, message: Message) -> HandlerResult {
+    let code = message
+        .body
+        .get("code")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let comment = message
+        .body
+        .get("comment")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     let from = message.from.as_deref().unwrap_or("unknown");
     let thid = message.thid.as_deref().unwrap_or("none");
     warn!(from, code, comment, thid, "received problem-report");
     Ok(None)
 }
 
-pub async fn handle_unknown(
-    _ctx: HandlerContext,
-    message: Message,
-) -> HandlerResult {
+pub async fn handle_unknown(_ctx: HandlerContext, message: Message) -> HandlerResult {
     warn!(msg_type = %message.typ, "unknown message type — ignoring");
     Ok(Some(DIDCommResponse::problem_report(
         ProblemReport::bad_request(format!("unsupported message type: {}", message.typ)),

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -130,7 +130,7 @@ pub async fn handle_revoke_key(
     let body: vta_sdk::protocols::key_management::revoke::RevokeKeyBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::revoke_key(
-        &state.keys_ks, &state.audit_ks, &auth, &body.key_id, "didcomm",
+        &state.keys_ks, &state.imported_ks, &state.audit_ks, &auth, &body.key_id, "didcomm",
     ).await.map_err(handler_err)?;
     response(key_management::REVOKE_KEY_RESULT, &result)
 }
@@ -145,7 +145,7 @@ pub async fn handle_get_key_secret(
     let body: vta_sdk::protocols::key_management::secret::GetKeySecretBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::keys::get_key_secret(
-        &state.keys_ks, &state.seed_store, &state.audit_ks, &auth, &body.key_id, "didcomm",
+        &state.keys_ks, &state.imported_ks, &state.seed_store, &state.audit_ks, &auth, &body.key_id, "didcomm",
     ).await.map_err(handler_err)?;
     response(key_management::GET_KEY_SECRET_RESULT, &result)
 }
@@ -164,7 +164,7 @@ pub async fn handle_sign_request(
         .map_err(|e| handler_err(format!("invalid base64url payload: {e}")))?;
 
     let result = operations::keys::sign_payload(
-        &state.keys_ks, &state.seed_store, &auth,
+        &state.keys_ks, &state.imported_ks, &state.seed_store, &auth,
         &body.key_id, &payload, &body.algorithm, "didcomm",
     ).await.map_err(handler_err)?;
     response(key_management::SIGN_RESULT, &result)
@@ -196,7 +196,7 @@ pub async fn handle_rotate_seed(
     let body: vta_sdk::protocols::seed_management::rotate::RotateSeedBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = operations::seeds::rotate_seed(
-        &state.keys_ks, &state.seed_store, &state.audit_ks, &auth.did,
+        &state.keys_ks, &state.imported_ks, &state.seed_store, &state.audit_ks, &auth.did,
         body.mnemonic.as_deref(), "didcomm",
     ).await.map_err(handler_err)?;
     response(seed_management::ROTATE_SEED_RESULT, &result)
@@ -699,7 +699,7 @@ pub async fn handle_backup_export(
         serde_json::from_value(message.body).map_err(handler_err)?;
     let config = state.config.read().await;
     let envelope = operations::backup::export_backup(
-        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks,
+        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks, &state.imported_ks,
         #[cfg(feature = "webvh")]
         &state.webvh_ks,
         &*state.seed_store, &config, &auth, &body.password, body.include_audit,
@@ -737,7 +737,7 @@ pub async fn handle_backup_import(
 
     let result = operations::backup::apply_import(
         &payload,
-        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks,
+        &state.keys_ks, &state.acl_ks, &state.contexts_ks, &state.audit_ks, &state.imported_ks,
         #[cfg(feature = "webvh")]
         &state.webvh_ks,
         &state.seed_store, &state.config,

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -71,6 +71,7 @@ pub fn build_router(state: Arc<VtaState>) -> Result<Router, DIDCommServiceError>
         .route(context_management::GET_CONTEXT, handler_fn(handlers::handle_get_context))?
         .route(context_management::LIST_CONTEXTS, handler_fn(handlers::handle_list_contexts))?
         .route(context_management::UPDATE_CONTEXT, handler_fn(handlers::handle_update_context))?
+        .route(context_management::UPDATE_CONTEXT_DID, handler_fn(handlers::handle_update_context_did))?
         .route(context_management::PREVIEW_DELETE_CONTEXT, handler_fn(handlers::handle_preview_delete_context))?
         .route(context_management::DELETE_CONTEXT, handler_fn(handlers::handle_delete_context))?
         // ACL management

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -36,6 +36,7 @@ pub struct VtaState {
     pub acl_ks: KeyspaceHandle,
     pub contexts_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
+    pub imported_ks: KeyspaceHandle,
     #[cfg(feature = "webvh")]
     pub webvh_ks: KeyspaceHandle,
     pub seed_store: Arc<dyn SeedStore>,

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -7,8 +7,8 @@
 use std::sync::Arc;
 
 use affinidi_messaging_didcomm_service::{
-    DIDCommServiceError, MessagePolicy, RequestLogging, Router,
-    handler_fn, ignore_handler, trust_ping_handler, TRUST_PING_TYPE, MESSAGE_PICKUP_STATUS_TYPE,
+    DIDCommServiceError, MESSAGE_PICKUP_STATUS_TYPE, MessagePolicy, RequestLogging, Router,
+    TRUST_PING_TYPE, handler_fn, ignore_handler, trust_ping_handler,
 };
 use tokio::sync::RwLock;
 
@@ -56,77 +56,205 @@ pub fn build_router(state: Arc<VtaState>) -> Result<Router, DIDCommServiceError>
         .route(TRUST_PING_TYPE, handler_fn(trust_ping_handler))?
         .route(MESSAGE_PICKUP_STATUS_TYPE, handler_fn(ignore_handler))?
         // Key management
-        .route(key_management::CREATE_KEY, handler_fn(handlers::handle_create_key))?
-        .route(key_management::GET_KEY, handler_fn(handlers::handle_get_key))?
-        .route(key_management::LIST_KEYS, handler_fn(handlers::handle_list_keys))?
-        .route(key_management::RENAME_KEY, handler_fn(handlers::handle_rename_key))?
-        .route(key_management::REVOKE_KEY, handler_fn(handlers::handle_revoke_key))?
-        .route(key_management::GET_KEY_SECRET, handler_fn(handlers::handle_get_key_secret))?
-        .route(key_management::SIGN_REQUEST, handler_fn(handlers::handle_sign_request))?
+        .route(
+            key_management::CREATE_KEY,
+            handler_fn(handlers::handle_create_key),
+        )?
+        .route(
+            key_management::GET_KEY,
+            handler_fn(handlers::handle_get_key),
+        )?
+        .route(
+            key_management::LIST_KEYS,
+            handler_fn(handlers::handle_list_keys),
+        )?
+        .route(
+            key_management::RENAME_KEY,
+            handler_fn(handlers::handle_rename_key),
+        )?
+        .route(
+            key_management::REVOKE_KEY,
+            handler_fn(handlers::handle_revoke_key),
+        )?
+        .route(
+            key_management::GET_KEY_SECRET,
+            handler_fn(handlers::handle_get_key_secret),
+        )?
+        .route(
+            key_management::SIGN_REQUEST,
+            handler_fn(handlers::handle_sign_request),
+        )?
         // Seed management
-        .route(seed_management::LIST_SEEDS, handler_fn(handlers::handle_list_seeds))?
-        .route(seed_management::ROTATE_SEED, handler_fn(handlers::handle_rotate_seed))?
+        .route(
+            seed_management::LIST_SEEDS,
+            handler_fn(handlers::handle_list_seeds),
+        )?
+        .route(
+            seed_management::ROTATE_SEED,
+            handler_fn(handlers::handle_rotate_seed),
+        )?
         // Context management
-        .route(context_management::CREATE_CONTEXT, handler_fn(handlers::handle_create_context))?
-        .route(context_management::GET_CONTEXT, handler_fn(handlers::handle_get_context))?
-        .route(context_management::LIST_CONTEXTS, handler_fn(handlers::handle_list_contexts))?
-        .route(context_management::UPDATE_CONTEXT, handler_fn(handlers::handle_update_context))?
-        .route(context_management::UPDATE_CONTEXT_DID, handler_fn(handlers::handle_update_context_did))?
-        .route(context_management::PREVIEW_DELETE_CONTEXT, handler_fn(handlers::handle_preview_delete_context))?
-        .route(context_management::DELETE_CONTEXT, handler_fn(handlers::handle_delete_context))?
+        .route(
+            context_management::CREATE_CONTEXT,
+            handler_fn(handlers::handle_create_context),
+        )?
+        .route(
+            context_management::GET_CONTEXT,
+            handler_fn(handlers::handle_get_context),
+        )?
+        .route(
+            context_management::LIST_CONTEXTS,
+            handler_fn(handlers::handle_list_contexts),
+        )?
+        .route(
+            context_management::UPDATE_CONTEXT,
+            handler_fn(handlers::handle_update_context),
+        )?
+        .route(
+            context_management::UPDATE_CONTEXT_DID,
+            handler_fn(handlers::handle_update_context_did),
+        )?
+        .route(
+            context_management::PREVIEW_DELETE_CONTEXT,
+            handler_fn(handlers::handle_preview_delete_context),
+        )?
+        .route(
+            context_management::DELETE_CONTEXT,
+            handler_fn(handlers::handle_delete_context),
+        )?
         // ACL management
-        .route(acl_management::CREATE_ACL, handler_fn(handlers::handle_create_acl))?
-        .route(acl_management::GET_ACL, handler_fn(handlers::handle_get_acl))?
-        .route(acl_management::LIST_ACL, handler_fn(handlers::handle_list_acl))?
-        .route(acl_management::UPDATE_ACL, handler_fn(handlers::handle_update_acl))?
-        .route(acl_management::DELETE_ACL, handler_fn(handlers::handle_delete_acl))?
+        .route(
+            acl_management::CREATE_ACL,
+            handler_fn(handlers::handle_create_acl),
+        )?
+        .route(
+            acl_management::GET_ACL,
+            handler_fn(handlers::handle_get_acl),
+        )?
+        .route(
+            acl_management::LIST_ACL,
+            handler_fn(handlers::handle_list_acl),
+        )?
+        .route(
+            acl_management::UPDATE_ACL,
+            handler_fn(handlers::handle_update_acl),
+        )?
+        .route(
+            acl_management::DELETE_ACL,
+            handler_fn(handlers::handle_delete_acl),
+        )?
         // Audit management
-        .route(audit_management::LIST_LOGS, handler_fn(handlers::handle_list_logs))?
-        .route(audit_management::GET_RETENTION, handler_fn(handlers::handle_get_retention))?
-        .route(audit_management::UPDATE_RETENTION, handler_fn(handlers::handle_update_retention))?
+        .route(
+            audit_management::LIST_LOGS,
+            handler_fn(handlers::handle_list_logs),
+        )?
+        .route(
+            audit_management::GET_RETENTION,
+            handler_fn(handlers::handle_get_retention),
+        )?
+        .route(
+            audit_management::UPDATE_RETENTION,
+            handler_fn(handlers::handle_update_retention),
+        )?
         // VTA management
-        .route(vta_management::GET_CONFIG, handler_fn(handlers::handle_get_config))?
-        .route(vta_management::UPDATE_CONFIG, handler_fn(handlers::handle_update_config))?
+        .route(
+            vta_management::GET_CONFIG,
+            handler_fn(handlers::handle_get_config),
+        )?
+        .route(
+            vta_management::UPDATE_CONFIG,
+            handler_fn(handlers::handle_update_config),
+        )?
         // Credential management
-        .route(credential_management::GENERATE_CREDENTIALS, handler_fn(handlers::handle_generate_credentials))?
+        .route(
+            credential_management::GENERATE_CREDENTIALS,
+            handler_fn(handlers::handle_generate_credentials),
+        )?
         // Problem reports
-        .route(protocols::PROBLEM_REPORT_TYPE, handler_fn(handlers::handle_problem_report))?
+        .route(
+            protocols::PROBLEM_REPORT_TYPE,
+            handler_fn(handlers::handle_problem_report),
+        )?
         // VTA management — restart
-        .route(vta_management::RESTART, handler_fn(handlers::handle_restart))?
+        .route(
+            vta_management::RESTART,
+            handler_fn(handlers::handle_restart),
+        )?
         // Backup management
-        .route(protocols::backup_management::EXPORT_BACKUP, handler_fn(handlers::handle_backup_export))?
-        .route(protocols::backup_management::IMPORT_BACKUP, handler_fn(handlers::handle_backup_import))?;
+        .route(
+            protocols::backup_management::EXPORT_BACKUP,
+            handler_fn(handlers::handle_backup_export),
+        )?
+        .route(
+            protocols::backup_management::IMPORT_BACKUP,
+            handler_fn(handlers::handle_backup_import),
+        )?;
 
     // WebVH handlers (feature-gated)
     #[cfg(feature = "webvh")]
     {
         router = router
-            .route(did_management::CREATE_DID_WEBVH, handler_fn(handlers::handle_create_did_webvh))?
-            .route(did_management::GET_DID_WEBVH, handler_fn(handlers::handle_get_did_webvh))?
-            .route(did_management::GET_DID_WEBVH_LOG, handler_fn(handlers::handle_get_did_webvh_log))?
-            .route(did_management::LIST_DIDS_WEBVH, handler_fn(handlers::handle_list_dids_webvh))?
-            .route(did_management::DELETE_DID_WEBVH, handler_fn(handlers::handle_delete_did_webvh))?
-            .route(did_management::ADD_WEBVH_SERVER, handler_fn(handlers::handle_add_webvh_server))?
-            .route(did_management::LIST_WEBVH_SERVERS, handler_fn(handlers::handle_list_webvh_servers))?
-            .route(did_management::UPDATE_WEBVH_SERVER, handler_fn(handlers::handle_update_webvh_server))?
-            .route(did_management::REMOVE_WEBVH_SERVER, handler_fn(handlers::handle_remove_webvh_server))?;
+            .route(
+                did_management::CREATE_DID_WEBVH,
+                handler_fn(handlers::handle_create_did_webvh),
+            )?
+            .route(
+                did_management::GET_DID_WEBVH,
+                handler_fn(handlers::handle_get_did_webvh),
+            )?
+            .route(
+                did_management::GET_DID_WEBVH_LOG,
+                handler_fn(handlers::handle_get_did_webvh_log),
+            )?
+            .route(
+                did_management::LIST_DIDS_WEBVH,
+                handler_fn(handlers::handle_list_dids_webvh),
+            )?
+            .route(
+                did_management::DELETE_DID_WEBVH,
+                handler_fn(handlers::handle_delete_did_webvh),
+            )?
+            .route(
+                did_management::ADD_WEBVH_SERVER,
+                handler_fn(handlers::handle_add_webvh_server),
+            )?
+            .route(
+                did_management::LIST_WEBVH_SERVERS,
+                handler_fn(handlers::handle_list_webvh_servers),
+            )?
+            .route(
+                did_management::UPDATE_WEBVH_SERVER,
+                handler_fn(handlers::handle_update_webvh_server),
+            )?
+            .route(
+                did_management::REMOVE_WEBVH_SERVER,
+                handler_fn(handlers::handle_remove_webvh_server),
+            )?;
     }
 
     // TEE attestation handlers (feature-gated)
     #[cfg(feature = "tee")]
     {
         router = router
-            .route(attestation_management::GET_TEE_STATUS, handler_fn(handlers::handle_tee_status))?
-            .route(attestation_management::REQUEST_ATTESTATION, handler_fn(handlers::handle_request_attestation))?;
+            .route(
+                attestation_management::GET_TEE_STATUS,
+                handler_fn(handlers::handle_tee_status),
+            )?
+            .route(
+                attestation_management::REQUEST_ATTESTATION,
+                handler_fn(handlers::handle_request_attestation),
+            )?;
     }
 
     // Fallback, middleware, error handling
     router = router
         .fallback(handler_fn(handlers::handle_unknown))
-        .layer(MessagePolicy::new()
-            .require_encrypted(true)
-            .require_authenticated(true)
-            .allow_anonymous_sender(false))
+        .layer(
+            MessagePolicy::new()
+                .require_encrypted(true)
+                .require_authenticated(true)
+                .allow_anonymous_sender(false),
+        )
         .layer(RequestLogging);
 
     Ok(router)

--- a/vta-service/src/metrics.rs
+++ b/vta-service/src/metrics.rs
@@ -41,7 +41,8 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> Response {
     let status = response.status().as_u16().to_string();
 
     let _ = counter!("http_requests_total", "method" => method.clone(), "path" => path.clone(), "status" => status);
-    histogram!("http_request_duration_seconds", "method" => method, "path" => path).record(duration);
+    histogram!("http_request_duration_seconds", "method" => method, "path" => path)
+        .record(duration);
 
     response
 }

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -31,6 +31,7 @@ fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_acl(
     acl_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
@@ -63,8 +64,22 @@ pub async fn create_acl(
     store_acl_entry(acl_ks, &entry).await?;
 
     info!(channel, caller = %auth.did, did = %entry.did, role = %entry.role, "ACL entry created");
-    audit!("acl.create", actor = &auth.did, resource = did, outcome = "success");
-    let _ = audit::record(audit_ks, "acl.create", &auth.did, Some(did), "success", Some(channel), None).await;
+    audit!(
+        "acl.create",
+        actor = &auth.did,
+        resource = did,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "acl.create",
+        &auth.did,
+        Some(did),
+        "success",
+        Some(channel),
+        None,
+    )
+    .await;
     Ok(to_result_body(&entry))
 }
 
@@ -145,8 +160,22 @@ pub async fn update_acl(
     store_acl_entry(acl_ks, &entry).await?;
 
     info!(channel, did = %did, "ACL entry updated");
-    audit!("acl.update", actor = &auth.did, resource = did, outcome = "success");
-    let _ = audit::record(audit_ks, "acl.update", &auth.did, Some(did), "success", Some(channel), None).await;
+    audit!(
+        "acl.update",
+        actor = &auth.did,
+        resource = did,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "acl.update",
+        &auth.did,
+        Some(did),
+        "success",
+        Some(channel),
+        None,
+    )
+    .await;
     Ok(to_result_body(&entry))
 }
 
@@ -177,8 +206,22 @@ pub async fn delete_acl(
     delete_acl_entry(acl_ks, did).await?;
 
     info!(channel, caller = %auth.did, did = %did, "ACL entry deleted");
-    audit!("acl.delete", actor = &auth.did, resource = did, outcome = "success");
-    let _ = audit::record(audit_ks, "acl.delete", &auth.did, Some(did), "success", Some(channel), None).await;
+    audit!(
+        "acl.delete",
+        actor = &auth.did,
+        resource = did,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "acl.delete",
+        &auth.did,
+        Some(did),
+        "success",
+        Some(channel),
+        None,
+    )
+    .await;
     Ok(DeleteAclResultBody {
         did: did.to_string(),
         deleted: true,

--- a/vta-service/src/operations/attestation.rs
+++ b/vta-service/src/operations/attestation.rs
@@ -33,7 +33,10 @@ pub async fn generate_attestation_report(
     let vta_did = config.read().await.vta_did.clone();
     let user_data = vta_did.as_deref().unwrap_or("").as_bytes();
 
-    debug!(nonce_len = nonce_bytes.len(), "generating attestation report");
+    debug!(
+        nonce_len = nonce_bytes.len(),
+        "generating attestation report"
+    );
 
     // Generate the report via the platform provider
     let mut report = tee_state.provider.attest(user_data, &nonce_bytes)?;

--- a/vta-service/src/operations/audit.rs
+++ b/vta-service/src/operations/audit.rs
@@ -36,17 +36,35 @@ pub async fn list_audit_logs(
 
         // Apply filters
         if let Some(from) = params.from
-            && entry.timestamp < from { continue; }
+            && entry.timestamp < from
+        {
+            continue;
+        }
         if let Some(to) = params.to
-            && entry.timestamp > to { continue; }
+            && entry.timestamp > to
+        {
+            continue;
+        }
         if let Some(ref action) = params.action
-            && !entry.action.contains(action.as_str()) { continue; }
+            && !entry.action.contains(action.as_str())
+        {
+            continue;
+        }
         if let Some(ref actor) = params.actor
-            && entry.actor != *actor { continue; }
+            && entry.actor != *actor
+        {
+            continue;
+        }
         if let Some(ref outcome) = params.outcome
-            && !entry.outcome.contains(outcome.as_str()) { continue; }
+            && !entry.outcome.contains(outcome.as_str())
+        {
+            continue;
+        }
         if let Some(ref ctx) = params.context_id
-            && entry.context_id.as_deref() != Some(ctx.as_str()) { continue; }
+            && entry.context_id.as_deref() != Some(ctx.as_str())
+        {
+            continue;
+        }
 
         entries.push(entry);
     }
@@ -115,7 +133,21 @@ pub async fn update_retention(
 
     std::fs::write(&path, contents).map_err(AppError::Io)?;
     tracing::info!(channel, retention_days, "audit retention updated");
-    audit!("audit.retention_update", actor = &auth.did, resource = retention_days, outcome = "success");
-    let _ = audit::record(audit_ks, "audit.retention_update", &auth.did, Some(&retention_days.to_string()), "success", Some(channel), None).await;
+    audit!(
+        "audit.retention_update",
+        actor = &auth.did,
+        resource = retention_days,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "audit.retention_update",
+        &auth.did,
+        Some(&retention_days.to_string()),
+        "success",
+        Some(channel),
+        None,
+    )
+    .await;
     Ok(result)
 }

--- a/vta-service/src/operations/backup.rs
+++ b/vta-service/src/operations/backup.rs
@@ -18,8 +18,10 @@ use tracing::info;
 
 use crate::auth::AuthClaims;
 use crate::error::AppError;
+use crate::keys::imported;
 use crate::keys::seeds::{SeedRecord, get_active_seed_id, save_seed_record, set_active_seed_id};
 use crate::keys::seed_store::SeedStore;
+use crate::keys::KeyOrigin;
 use crate::seal::{SealRecord, get_seal};
 use crate::store::KeyspaceHandle;
 
@@ -41,6 +43,7 @@ pub async fn export_backup(
     acl_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
     config: &crate::config::AppConfig,
@@ -193,6 +196,27 @@ pub async fn export_backup(
     // 10. JWT signing key
     let jwt_signing_key = config.auth.jwt_signing_key.clone();
 
+    // 11. Collect imported secrets
+    let imported_kek_salt = imported::get_salt(keys_ks).await?.map(hex::encode);
+    let imported_secrets = {
+        let mut secrets = Vec::new();
+        for kr in &key_records {
+            if kr.origin == KeyOrigin::Imported && kr.status == vta_sdk::keys::KeyStatus::Active {
+                if let Ok(mut plaintext) = imported::load_secret(
+                    imported_ks, keys_ks, &seed_bytes, &kr.key_id, &kr.key_type.to_string(),
+                ).await {
+                    secrets.push(ImportedSecretBackup {
+                        key_id: kr.key_id.clone(),
+                        private_key_hex: hex::encode(&plaintext),
+                    });
+                    use zeroize::Zeroize;
+                    plaintext.zeroize();
+                }
+            }
+        }
+        secrets
+    };
+
     // Assemble payload
     let payload = BackupPayload {
         active_seed_hex,
@@ -209,6 +233,8 @@ pub async fn export_backup(
         webvh_logs,
         config: backup_config,
         audit_logs,
+        imported_secrets,
+        imported_kek_salt,
     };
 
     // Encrypt
@@ -241,6 +267,7 @@ pub async fn preview_import(
         acl_count: payload.acl_entries.len(),
         context_count: payload.context_records.len(),
         audit_count: payload.audit_logs.len(),
+        imported_secret_count: payload.imported_secrets.len(),
         message: Some("Preview only — no changes applied. Set confirm=true to import.".into()),
     };
 
@@ -259,6 +286,7 @@ pub async fn apply_import(
     acl_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     config: &tokio::sync::RwLock<crate::config::AppConfig>,
@@ -269,6 +297,7 @@ pub async fn apply_import(
     clear_keyspace(acl_ks, &["acl:", "vta:"]).await?;
     clear_keyspace(contexts_ks, &["ctx:"]).await?;
     clear_keyspace(audit_ks, &["log:"]).await?;
+    clear_keyspace(imported_ks, &["secret:"]).await?;
     #[cfg(feature = "webvh")]
     clear_keyspace(webvh_ks, &["server:", "did:", "log:"]).await?;
 
@@ -366,7 +395,32 @@ pub async fn apply_import(
             .await?;
     }
 
-    // 11. Update config
+    // 11. Restore imported secrets
+    if !payload.imported_secrets.is_empty() {
+        // Restore the KEK salt (or create a new one)
+        if let Some(ref salt_hex) = payload.imported_kek_salt {
+            let salt = hex::decode(salt_hex)
+                .map_err(|e| AppError::Internal(format!("invalid imported KEK salt hex: {e}")))?;
+            imported::set_salt(keys_ks, &salt).await?;
+        }
+
+        for secret_backup in &payload.imported_secrets {
+            let private_bytes = hex::decode(&secret_backup.private_key_hex)
+                .map_err(|e| AppError::Internal(format!("invalid imported secret hex: {e}")))?;
+
+            // Find the matching key record for AAD
+            let key_type_str = payload.key_records.iter()
+                .find(|kr| kr.key_id == secret_backup.key_id)
+                .map(|kr| kr.key_type.to_string())
+                .unwrap_or_else(|| "ed25519".to_string());
+
+            imported::store_secret(
+                imported_ks, keys_ks, &seed_bytes, &secret_backup.key_id, &key_type_str, &private_bytes,
+            ).await?;
+        }
+    }
+
+    // 12. Update config
     {
         let mut cfg = config.write().await;
         if let Some(ref did) = payload.config.vta_did {
@@ -433,6 +487,7 @@ pub async fn apply_import(
         acl_count: payload.acl_entries.len(),
         context_count: payload.context_records.len(),
         audit_count: payload.audit_logs.len(),
+        imported_secret_count: payload.imported_secrets.len(),
         message: Some("Import complete. VTA will restart with new identity.".into()),
     })
 }
@@ -600,6 +655,8 @@ mod tests {
                 mediator_did: None,
             },
             audit_logs: vec![],
+            imported_secrets: vec![],
+            imported_kek_salt: None,
         }
     }
 

--- a/vta-service/src/operations/backup.rs
+++ b/vta-service/src/operations/backup.rs
@@ -18,10 +18,10 @@ use tracing::info;
 
 use crate::auth::AuthClaims;
 use crate::error::AppError;
-use crate::keys::imported;
-use crate::keys::seeds::{SeedRecord, get_active_seed_id, save_seed_record, set_active_seed_id};
-use crate::keys::seed_store::SeedStore;
 use crate::keys::KeyOrigin;
+use crate::keys::imported;
+use crate::keys::seed_store::SeedStore;
+use crate::keys::seeds::{SeedRecord, get_active_seed_id, save_seed_record, set_active_seed_id};
 use crate::seal::{SealRecord, get_seal};
 use crate::store::KeyspaceHandle;
 
@@ -39,18 +39,20 @@ const NONCE_LEN: usize = 12;
 
 /// Assemble and encrypt a backup of the entire VTA state.
 pub async fn export_backup(
-    keys_ks: &KeyspaceHandle,
-    acl_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
+    ks: &super::Keyspaces<'_>,
     seed_store: &dyn SeedStore,
     config: &crate::config::AppConfig,
     auth: &AuthClaims,
     password: &str,
     include_audit: bool,
 ) -> Result<BackupEnvelope, AppError> {
+    let keys_ks = ks.keys;
+    let acl_ks = ks.acl;
+    let contexts_ks = ks.contexts;
+    let audit_ks = ks.audit;
+    let imported_ks = ks.imported;
+    #[cfg(feature = "webvh")]
+    let webvh_ks = ks.webvh;
     auth.require_super_admin()?;
 
     if password.len() < 12 {
@@ -128,21 +130,22 @@ pub async fn export_backup(
                             })
                             .unwrap_or_default(),
                         created_at: val["created_at"].as_u64().unwrap_or(0),
-                        created_by: val["created_by"]
-                            .as_str()
-                            .unwrap_or_default()
-                            .to_string(),
+                        created_by: val["created_by"].as_str().unwrap_or_default().to_string(),
                     })
             })
             .collect()
     };
 
     // 6. Collect seal record
-    let seal = get_seal(acl_ks).await.ok().flatten().map(|s| SealRecordBackup {
-        sealed_by: s.sealed_by,
-        sealed_at: s.sealed_at,
-        reason: s.reason,
-    });
+    let seal = get_seal(acl_ks)
+        .await
+        .ok()
+        .flatten()
+        .map(|s| SealRecordBackup {
+            sealed_by: s.sealed_by,
+            sealed_at: s.sealed_at,
+            reason: s.reason,
+        });
 
     // 7. Collect WebVH records
     #[cfg(feature = "webvh")]
@@ -201,17 +204,23 @@ pub async fn export_backup(
     let imported_secrets = {
         let mut secrets = Vec::new();
         for kr in &key_records {
-            if kr.origin == KeyOrigin::Imported && kr.status == vta_sdk::keys::KeyStatus::Active {
-                if let Ok(mut plaintext) = imported::load_secret(
-                    imported_ks, keys_ks, &seed_bytes, &kr.key_id, &kr.key_type.to_string(),
-                ).await {
-                    secrets.push(ImportedSecretBackup {
-                        key_id: kr.key_id.clone(),
-                        private_key_hex: hex::encode(&plaintext),
-                    });
-                    use zeroize::Zeroize;
-                    plaintext.zeroize();
-                }
+            if kr.origin == KeyOrigin::Imported
+                && kr.status == vta_sdk::keys::KeyStatus::Active
+                && let Ok(mut plaintext) = imported::load_secret(
+                    imported_ks,
+                    keys_ks,
+                    &seed_bytes,
+                    &kr.key_id,
+                    &kr.key_type.to_string(),
+                )
+                .await
+            {
+                secrets.push(ImportedSecretBackup {
+                    key_id: kr.key_id.clone(),
+                    private_key_hex: hex::encode(&plaintext),
+                });
+                use zeroize::Zeroize;
+                plaintext.zeroize();
             }
         }
         secrets
@@ -282,16 +291,18 @@ pub async fn preview_import(
 /// The caller is responsible for triggering a soft restart after this returns.
 pub async fn apply_import(
     payload: &BackupPayload,
-    keys_ks: &KeyspaceHandle,
-    acl_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
+    ks: &super::Keyspaces<'_>,
     seed_store: &Arc<dyn SeedStore>,
     config: &tokio::sync::RwLock<crate::config::AppConfig>,
     store: Option<&crate::store::Store>,
 ) -> Result<ImportResult, AppError> {
+    let keys_ks = ks.keys;
+    let acl_ks = ks.acl;
+    let contexts_ks = ks.contexts;
+    let audit_ks = ks.audit;
+    let imported_ks = ks.imported;
+    #[cfg(feature = "webvh")]
+    let webvh_ks = ks.webvh;
     // 1. Clear all keyspaces
     clear_keyspace(keys_ks, &["key:", "seed:"]).await?;
     clear_keyspace(acl_ks, &["acl:", "vta:"]).await?;
@@ -340,9 +351,7 @@ pub async fn apply_import(
 
     // 6. Write context records + counter
     for cr in &payload.context_records {
-        contexts_ks
-            .insert(format!("ctx:{}", cr.id), cr)
-            .await?;
+        contexts_ks.insert(format!("ctx:{}", cr.id), cr).await?;
     }
     contexts_ks
         .insert_raw("ctx_counter", &payload.context_counter.to_le_bytes())
@@ -350,9 +359,7 @@ pub async fn apply_import(
 
     // 7. Write ACL entries
     for entry in &payload.acl_entries {
-        acl_ks
-            .insert(format!("acl:{}", entry.did), entry)
-            .await?;
+        acl_ks.insert(format!("acl:{}", entry.did), entry).await?;
     }
 
     // 8. Write seal record
@@ -388,10 +395,7 @@ pub async fn apply_import(
     // 10. Write audit logs
     for entry in &payload.audit_logs {
         audit_ks
-            .insert(
-                format!("log:{:020}:{}", entry.timestamp, entry.id),
-                entry,
-            )
+            .insert(format!("log:{:020}:{}", entry.timestamp, entry.id), entry)
             .await?;
     }
 
@@ -409,14 +413,22 @@ pub async fn apply_import(
                 .map_err(|e| AppError::Internal(format!("invalid imported secret hex: {e}")))?;
 
             // Find the matching key record for AAD
-            let key_type_str = payload.key_records.iter()
+            let key_type_str = payload
+                .key_records
+                .iter()
                 .find(|kr| kr.key_id == secret_backup.key_id)
                 .map(|kr| kr.key_type.to_string())
                 .unwrap_or_else(|| "ed25519".to_string());
 
             imported::store_secret(
-                imported_ks, keys_ks, &seed_bytes, &secret_backup.key_id, &key_type_str, &private_bytes,
-            ).await?;
+                imported_ks,
+                keys_ks,
+                &seed_bytes,
+                &secret_backup.key_id,
+                &key_type_str,
+                &private_bytes,
+            )
+            .await?;
         }
     }
 
@@ -436,13 +448,13 @@ pub async fn apply_import(
             cfg.auth.jwt_signing_key = Some(jwt.clone());
         }
         if payload.config.mediator_url.is_some() || payload.config.mediator_did.is_some() {
-            let messaging = cfg.messaging.get_or_insert_with(|| {
-                vti_common::config::MessagingConfig {
-                    mediator_url: String::new(),
-                    mediator_did: String::new(),
-                    mediator_host: None,
-                }
-            });
+            let messaging =
+                cfg.messaging
+                    .get_or_insert_with(|| vti_common::config::MessagingConfig {
+                        mediator_url: String::new(),
+                        mediator_did: String::new(),
+                        mediator_host: None,
+                    });
             if let Some(ref url) = payload.config.mediator_url {
                 messaging.mediator_url = url.clone();
             }
@@ -457,19 +469,26 @@ pub async fn apply_import(
     if let Some(store) = store {
         let cfg = config.read().await;
         if let crate::config::TeeMode::Required = cfg.tee.mode
-            && let Some(ref kms_config) = cfg.tee.kms {
-                let jwt_key_bytes: Option<[u8; 32]> = payload.jwt_signing_key.as_ref().and_then(|b64| {
-                    base64::Engine::decode(&BASE64, b64).ok().and_then(|b| b.try_into().ok())
+            && let Some(ref kms_config) = cfg.tee.kms
+        {
+            let jwt_key_bytes: Option<[u8; 32]> =
+                payload.jwt_signing_key.as_ref().and_then(|b64| {
+                    base64::Engine::decode(&BASE64, b64)
+                        .ok()
+                        .and_then(|b| b.try_into().ok())
                 });
-                if let Some(jwt_key) = jwt_key_bytes {
-                    crate::tee::kms_bootstrap::re_encrypt_bootstrap_secrets(
-                        kms_config, store, &seed_bytes, &jwt_key,
-                    )
-                    .await?;
-                } else {
-                    info!("no JWT key in backup — skipping KMS re-encryption");
-                }
+            if let Some(jwt_key) = jwt_key_bytes {
+                crate::tee::kms_bootstrap::re_encrypt_bootstrap_secrets(
+                    kms_config,
+                    store,
+                    &seed_bytes,
+                    &jwt_key,
+                )
+                .await?;
+            } else {
+                info!("no JWT key in backup — skipping KMS re-encryption");
             }
+        }
     }
 
     info!(
@@ -523,8 +542,8 @@ fn encrypt_payload(
         .map_err(|e| AppError::Internal(format!("argon2 hash: {e}")))?;
 
     // Encrypt with AES-256-GCM
-    let cipher = Aes256Gcm::new_from_slice(&key)
-        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&key).map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
     let nonce = Nonce::from_slice(&nonce_bytes);
     let ciphertext = cipher
         .encrypt(nonce, plaintext.as_ref())
@@ -595,8 +614,8 @@ pub fn decrypt_backup(
         .map_err(|e| AppError::Internal(format!("argon2 hash: {e}")))?;
 
     // Decrypt with AES-256-GCM
-    let cipher = Aes256Gcm::new_from_slice(&key)
-        .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&key).map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
     let nonce = Nonce::from_slice(&nonce_bytes);
     let plaintext = cipher
         .decrypt(nonce, ciphertext.as_ref())

--- a/vta-service/src/operations/contexts.rs
+++ b/vta-service/src/operations/contexts.rs
@@ -152,6 +152,31 @@ pub async fn update_context(
     Ok(to_result_body(&record))
 }
 
+/// Update the DID for a context. Requires Admin role with access to the context
+/// (context-scoped admins can update DIDs on their own contexts).
+pub async fn update_context_did(
+    contexts_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    id: &str,
+    did: String,
+    channel: &str,
+) -> Result<CreateContextResultBody, AppError> {
+    auth.require_admin()?;
+    auth.require_context(id)?;
+
+    let mut record = get_context(contexts_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("context not found: {id}")))?;
+
+    record.did = Some(did);
+    record.updated_at = Utc::now();
+
+    store_context(contexts_ks, &record).await?;
+
+    info!(channel, id = %id, did = ?record.did, "context DID updated");
+    Ok(to_result_body(&record))
+}
+
 /// Collect a preview of all resources associated with a context.
 pub async fn preview_delete_context(
     contexts_ks: &KeyspaceHandle,

--- a/vta-service/src/operations/contexts.rs
+++ b/vta-service/src/operations/contexts.rs
@@ -207,15 +207,17 @@ pub async fn preview_delete_context(
 }
 
 pub async fn delete_context(
-    contexts_ks: &KeyspaceHandle,
-    keys_ks: &KeyspaceHandle,
-    acl_ks: &KeyspaceHandle,
-    #[cfg(feature = "webvh")] webvh_ks: &KeyspaceHandle,
+    ks: &super::Keyspaces<'_>,
     auth: &AuthClaims,
     id: &str,
     force: bool,
     channel: &str,
 ) -> Result<DeleteContextResultBody, AppError> {
+    let contexts_ks = ks.contexts;
+    let keys_ks = ks.keys;
+    let acl_ks = ks.acl;
+    #[cfg(feature = "webvh")]
+    let webvh_ks = ks.webvh;
     auth.require_super_admin()?;
 
     get_context(contexts_ks, id)
@@ -244,9 +246,7 @@ pub async fn delete_context(
 
     // Delete keys
     for key_id in &preview.keys {
-        keys_ks
-            .remove(crate::keys::store_key(key_id))
-            .await?;
+        keys_ks.remove(crate::keys::store_key(key_id)).await?;
     }
 
     // Delete WebVH DIDs and their logs

--- a/vta-service/src/operations/credentials.rs
+++ b/vta-service/src/operations/credentials.rs
@@ -7,8 +7,8 @@ use vta_sdk::credentials::CredentialBundle;
 use vta_sdk::protocols::credential_management::generate::GenerateCredentialsResultBody;
 
 use crate::acl::{AclEntry, Role, store_acl_entry, validate_acl_modification};
-use crate::auth::credentials::generate_did_key;
 use crate::auth::AuthClaims;
+use crate::auth::credentials::generate_did_key;
 use crate::auth::session::now_epoch;
 use crate::config::AppConfig;
 use crate::error::AppError;

--- a/vta-service/src/operations/did_webvh.rs
+++ b/vta-service/src/operations/did_webvh.rs
@@ -113,8 +113,8 @@ pub async fn create_did_webvh(
     let (url_str, mnemonic) = if serverless {
         let url_str = params.url.as_ref().unwrap().clone();
         // Validate the URL
-        let parsed_url = Url::parse(&url_str)
-            .map_err(|e| AppError::Validation(format!("invalid url: {e}")))?;
+        let parsed_url =
+            Url::parse(&url_str).map_err(|e| AppError::Validation(format!("invalid url: {e}")))?;
         WebVHURL::parse_url(&parsed_url)
             .map_err(|e| AppError::Validation(format!("failed to parse WebVH URL: {e}")))?;
         (url_str, None)
@@ -122,9 +122,7 @@ pub async fn create_did_webvh(
         let server_id = params.server_id.as_ref().unwrap();
         let server = webvh_store::get_server(webvh_ks, server_id)
             .await?
-            .ok_or_else(|| {
-                AppError::NotFound(format!("webvh server not found: {server_id}"))
-            })?;
+            .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {server_id}")))?;
 
         let transport =
             WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, config).await?;
@@ -178,7 +176,9 @@ pub async fn create_did_webvh(
         next_key_hashes: if next_key_hashes.is_empty() {
             None
         } else {
-            Some(Arc::new(next_key_hashes.into_iter().map(Into::into).collect()))
+            Some(Arc::new(
+                next_key_hashes.into_iter().map(Into::into).collect(),
+            ))
         },
         ..Default::default()
     };
@@ -192,12 +192,16 @@ pub async fn create_did_webvh(
         .build()
         .map_err(|e| AppError::Internal(format!("failed to build DID config: {e}")))?;
 
-    let result = create_did(create_config).await
+    let result = create_did(create_config)
+        .await
         .map_err(|e| AppError::Internal(format!("failed to create DID: {e}")))?;
 
     let final_did = result.did().to_string();
-    let scid = result.log_entry().get_scid()
-        .unwrap_or_default().to_string();
+    let scid = result
+        .log_entry()
+        .get_scid()
+        .unwrap_or_default()
+        .to_string();
     let log_content = serde_json::to_string(result.log_entry())
         .map_err(|e| AppError::Internal(format!("failed to serialize DID log: {e}")))?;
 
@@ -289,9 +293,7 @@ pub async fn create_did_webvh(
 
         let server = webvh_store::get_server(webvh_ks, server_id)
             .await?
-            .ok_or_else(|| {
-                AppError::NotFound(format!("webvh server not found: {server_id}"))
-            })?;
+            .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {server_id}")))?;
 
         let transport =
             WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, config).await?;
@@ -619,7 +621,9 @@ impl<'a> WebvhTransport<'a> {
     }
 
     /// Acquire the DIDComm bridge and return an error if the connection is down.
-    async fn acquire_bridge(&self) -> Result<tokio::sync::RwLockReadGuard<'_, Option<DIDCommBridge>>, AppError> {
+    async fn acquire_bridge(
+        &self,
+    ) -> Result<tokio::sync::RwLockReadGuard<'_, Option<DIDCommBridge>>, AppError> {
         match self {
             Self::DIDComm { bridge, .. } => {
                 let guard = bridge.read().await;
@@ -637,7 +641,11 @@ impl<'a> WebvhTransport<'a> {
     async fn request_uri(&self, path: Option<&str>) -> Result<RequestUriResponse, AppError> {
         match self {
             Self::Rest(c) => c.request_uri(path).await,
-            Self::DIDComm { vta_did, server_did, .. } => {
+            Self::DIDComm {
+                vta_did,
+                server_did,
+                ..
+            } => {
                 let guard = self.acquire_bridge().await?;
                 let b = guard.as_ref().unwrap();
                 WebvhDIDCommClient::new(b, vta_did, server_did)
@@ -650,7 +658,11 @@ impl<'a> WebvhTransport<'a> {
     async fn publish_did(&self, mnemonic: &str, log_content: &str) -> Result<(), AppError> {
         match self {
             Self::Rest(c) => c.publish_did(mnemonic, log_content).await,
-            Self::DIDComm { vta_did, server_did, .. } => {
+            Self::DIDComm {
+                vta_did,
+                server_did,
+                ..
+            } => {
                 let guard = self.acquire_bridge().await?;
                 let b = guard.as_ref().unwrap();
                 WebvhDIDCommClient::new(b, vta_did, server_did)
@@ -663,7 +675,11 @@ impl<'a> WebvhTransport<'a> {
     async fn delete_did(&self, mnemonic: &str) -> Result<(), AppError> {
         match self {
             Self::Rest(c) => c.delete_did(mnemonic).await,
-            Self::DIDComm { vta_did, server_did, .. } => {
+            Self::DIDComm {
+                vta_did,
+                server_did,
+                ..
+            } => {
                 let guard = self.acquire_bridge().await?;
                 let b = guard.as_ref().unwrap();
                 WebvhDIDCommClient::new(b, vta_did, server_did)

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -22,7 +22,7 @@ use crate::keys::imported;
 use crate::keys::paths::allocate_path;
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
-use crate::keys::{self, KeyOrigin, KeyRecord, KeyStatus, KeyType};
+use crate::keys::{self, KeyOrigin, KeyRecord, KeyStatus, KeyType, encode_private_multibase, encode_public_multibase};
 use crate::store::KeyspaceHandle;
 
 pub struct CreateKeyParams {
@@ -468,7 +468,7 @@ pub async fn get_key_secret(
             let mut secret_bytes = imported::load_secret(
                 imported_ks, keys_ks, &seed, key_id, &record.key_type.to_string(),
             ).await?;
-            let priv_mb = multibase::encode(Base::Base58Btc, &secret_bytes);
+            let priv_mb = encode_private_multibase(&record.key_type, &secret_bytes);
             secret_bytes.zeroize();
             (record.public_key.clone(), priv_mb)
         }
@@ -498,8 +498,8 @@ pub async fn get_key_secret(
                     let p256_secret = bip32.derive_p256(&record.derivation_path)?;
                     let public_key = p256_secret.secret_key.public_key();
                     let encoded = public_key.to_encoded_point(true);
-                    let pub_mb = multibase::encode(Base::Base58Btc, encoded.as_bytes());
-                    let priv_mb = multibase::encode(Base::Base58Btc, p256_secret.secret_key.to_bytes());
+                    let pub_mb = encode_public_multibase(&KeyType::P256, encoded.as_bytes());
+                    let priv_mb = encode_private_multibase(&KeyType::P256, &p256_secret.secret_key.to_bytes());
                     (pub_mb, priv_mb)
                 }
             }

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -8,8 +8,11 @@ use tracing::info;
 use zeroize::Zeroize;
 
 use vta_sdk::protocols::key_management::{
-    create::CreateKeyResultBody, list::ListKeysResultBody, rename::RenameKeyResultBody,
-    revoke::RevokeKeyResultBody, secret::GetKeySecretResultBody,
+    create::CreateKeyResultBody,
+    list::ListKeysResultBody,
+    rename::RenameKeyResultBody,
+    revoke::RevokeKeyResultBody,
+    secret::GetKeySecretResultBody,
     sign::{SignAlgorithm, SignResultBody},
 };
 
@@ -22,7 +25,10 @@ use crate::keys::imported;
 use crate::keys::paths::allocate_path;
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
-use crate::keys::{self, KeyOrigin, KeyRecord, KeyStatus, KeyType, encode_private_multibase, encode_public_multibase};
+use crate::keys::{
+    self, KeyOrigin, KeyRecord, KeyStatus, KeyType, encode_private_multibase,
+    encode_public_multibase,
+};
 use crate::store::KeyspaceHandle;
 
 pub struct CreateKeyParams {
@@ -132,8 +138,22 @@ pub async fn create_key(
     keys_ks.insert(keys::store_key(&key_id), &record).await?;
 
     info!(channel, key_id = %key_id, key_type = ?params.key_type, path = %derivation_path, "key created");
-    audit!("key.create", actor = &auth.did, resource = &key_id, outcome = "success");
-    let _ = audit::record(audit_ks, "key.create", &auth.did, Some(&key_id), "success", Some(channel), context_id.as_deref()).await;
+    audit!(
+        "key.create",
+        actor = &auth.did,
+        resource = &key_id,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "key.create",
+        &auth.did,
+        Some(&key_id),
+        "success",
+        Some(channel),
+        context_id.as_deref(),
+    )
+    .await;
 
     Ok(CreateKeyResultBody {
         key_id,
@@ -187,22 +207,23 @@ pub async fn import_key(
     let (public_key, key_type_str) = match params.key_type {
         KeyType::Ed25519 => {
             if private_bytes.len() != 32 {
-                return Err(AppError::Validation(
-                    format!("Ed25519 private key must be 32 bytes, got {}", private_bytes.len()),
-                ));
+                return Err(AppError::Validation(format!(
+                    "Ed25519 private key must be 32 bytes, got {}",
+                    private_bytes.len()
+                )));
             }
-            let signing_key = ed25519_dalek::SigningKey::from_bytes(
-                private_bytes.as_slice().try_into().unwrap(),
-            );
+            let signing_key =
+                ed25519_dalek::SigningKey::from_bytes(private_bytes.as_slice().try_into().unwrap());
             let pub_bytes = signing_key.verifying_key().to_bytes();
             let pub_multibase = keys::ed25519_multibase_pubkey(&pub_bytes);
             (pub_multibase, "ed25519")
         }
         KeyType::X25519 => {
             if private_bytes.len() != 32 {
-                return Err(AppError::Validation(
-                    format!("X25519 private key must be 32 bytes, got {}", private_bytes.len()),
-                ));
+                return Err(AppError::Validation(format!(
+                    "X25519 private key must be 32 bytes, got {}",
+                    private_bytes.len()
+                )));
             }
             let secret_bytes: [u8; 32] = private_bytes.as_slice().try_into().unwrap();
             let secret = x25519_dalek::StaticSecret::from(secret_bytes);
@@ -221,9 +242,10 @@ pub async fn import_key(
     };
 
     let now = Utc::now();
-    let key_id = params.label.clone().unwrap_or_else(|| {
-        format!("imported-{}-{}", key_type_str, now.format("%Y%m%d%H%M%S"))
-    });
+    let key_id = params
+        .label
+        .clone()
+        .unwrap_or_else(|| format!("imported-{}-{}", key_type_str, now.format("%Y%m%d%H%M%S")));
 
     // Encrypt and store the secret
     let active_id = get_active_seed_id(keys_ks)
@@ -233,8 +255,15 @@ pub async fn import_key(
         .await
         .map_err(|e| AppError::Internal(format!("{e}")))?;
 
-    imported::store_secret(imported_ks, keys_ks, &seed, &key_id, key_type_str, &private_bytes)
-        .await?;
+    imported::store_secret(
+        imported_ks,
+        keys_ks,
+        &seed,
+        &key_id,
+        key_type_str,
+        &private_bytes,
+    )
+    .await?;
 
     // Zeroize private key material
     private_bytes.zeroize();
@@ -256,8 +285,22 @@ pub async fn import_key(
     keys_ks.insert(keys::store_key(&key_id), &record).await?;
 
     info!(channel, key_id = %key_id, key_type = ?params.key_type, "key imported");
-    audit!("key.import", actor = &auth.did, resource = &key_id, outcome = "success");
-    let _ = audit::record(audit_ks, "key.import", &auth.did, Some(&key_id), "success", Some(channel), context_id.as_deref()).await;
+    audit!(
+        "key.import",
+        actor = &auth.did,
+        resource = &key_id,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "key.import",
+        &auth.did,
+        Some(&key_id),
+        "success",
+        Some(channel),
+        context_id.as_deref(),
+    )
+    .await;
 
     Ok(CreateKeyResultBody {
         key_id,
@@ -378,8 +421,22 @@ pub async fn rename_key(
     }
 
     info!(channel, old_id = %key_id, new_id = %new_key_id, "key renamed");
-    audit!("key.rename", actor = &auth.did, resource = new_key_id, outcome = "success");
-    let _ = audit::record(audit_ks, "key.rename", &auth.did, Some(new_key_id), "success", Some(channel), record.context_id.as_deref()).await;
+    audit!(
+        "key.rename",
+        actor = &auth.did,
+        resource = new_key_id,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "key.rename",
+        &auth.did,
+        Some(new_key_id),
+        "success",
+        Some(channel),
+        record.context_id.as_deref(),
+    )
+    .await;
 
     Ok(RenameKeyResultBody {
         key_id: new_key_id.to_string(),
@@ -427,8 +484,22 @@ pub async fn revoke_key(
     keys_ks.insert(store_key, &record).await?;
 
     info!(channel, key_id = %key_id, "key revoked");
-    audit!("key.revoke", actor = &auth.did, resource = key_id, outcome = "success");
-    let _ = audit::record(audit_ks, "key.revoke", &auth.did, Some(key_id), "success", Some(channel), record.context_id.as_deref()).await;
+    audit!(
+        "key.revoke",
+        actor = &auth.did,
+        resource = key_id,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "key.revoke",
+        &auth.did,
+        Some(key_id),
+        "success",
+        Some(channel),
+        record.context_id.as_deref(),
+    )
+    .await;
 
     Ok(RevokeKeyResultBody {
         key_id: key_id.to_string(),
@@ -466,8 +537,13 @@ pub async fn get_key_secret(
                 .await
                 .map_err(|e| AppError::Internal(format!("{e}")))?;
             let mut secret_bytes = imported::load_secret(
-                imported_ks, keys_ks, &seed, key_id, &record.key_type.to_string(),
-            ).await?;
+                imported_ks,
+                keys_ks,
+                &seed,
+                key_id,
+                &record.key_type.to_string(),
+            )
+            .await?;
             let priv_mb = encode_private_multibase(&record.key_type, &secret_bytes);
             secret_bytes.zeroize();
             (record.public_key.clone(), priv_mb)
@@ -476,8 +552,9 @@ pub async fn get_key_secret(
             let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
                 .await
                 .map_err(|e| AppError::Internal(format!("{e}")))?;
-            let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
-                .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+            let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed).map_err(|e| {
+                key_derivation_error(format!("failed to create BIP-32 root key: {e}"))
+            })?;
 
             match record.key_type {
                 KeyType::Ed25519 => {
@@ -499,7 +576,10 @@ pub async fn get_key_secret(
                     let public_key = p256_secret.secret_key.public_key();
                     let encoded = public_key.to_encoded_point(true);
                     let pub_mb = encode_public_multibase(&KeyType::P256, encoded.as_bytes());
-                    let priv_mb = encode_private_multibase(&KeyType::P256, &p256_secret.secret_key.to_bytes());
+                    let priv_mb = encode_private_multibase(
+                        &KeyType::P256,
+                        &p256_secret.secret_key.to_bytes(),
+                    );
                     (pub_mb, priv_mb)
                 }
             }
@@ -507,8 +587,22 @@ pub async fn get_key_secret(
     };
 
     info!(channel, key_id = %key_id, "key secret retrieved");
-    audit!("key.secret_export", actor = &auth.did, resource = key_id, outcome = "success");
-    let _ = audit::record(audit_ks, "key.secret_export", &auth.did, Some(key_id), "success", Some(channel), record.context_id.as_deref()).await;
+    audit!(
+        "key.secret_export",
+        actor = &auth.did,
+        resource = key_id,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "key.secret_export",
+        &auth.did,
+        Some(key_id),
+        "success",
+        Some(channel),
+        record.context_id.as_deref(),
+    )
+    .await;
 
     Ok(GetKeySecretResultBody {
         key_id: record.key_id,
@@ -523,6 +617,7 @@ pub async fn get_key_secret(
 /// For derived keys, re-derives from BIP-32 seed. For imported keys,
 /// decrypts from the imported_secrets keyspace. Key material is zeroized
 /// after signing.
+#[allow(clippy::too_many_arguments)]
 pub async fn sign_payload(
     keys_ks: &KeyspaceHandle,
     imported_ks: &KeyspaceHandle,
@@ -559,15 +654,21 @@ pub async fn sign_payload(
                 .await
                 .map_err(|e| AppError::Internal(format!("{e}")))?;
             let mut secret_bytes = imported::load_secret(
-                imported_ks, keys_ks, &seed, key_id, &record.key_type.to_string(),
-            ).await?;
+                imported_ks,
+                keys_ks,
+                &seed,
+                key_id,
+                &record.key_type.to_string(),
+            )
+            .await?;
 
             let sig = match (algorithm, &record.key_type) {
                 (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
                     let signing_key = ed25519_dalek::SigningKey::from_bytes(
-                        secret_bytes.as_slice().try_into().map_err(|_| {
-                            AppError::Internal("invalid Ed25519 key length".into())
-                        })?,
+                        secret_bytes
+                            .as_slice()
+                            .try_into()
+                            .map_err(|_| AppError::Internal("invalid Ed25519 key length".into()))?,
                     );
                     use ed25519_dalek::Signer;
                     signing_key.sign(payload).to_bytes().to_vec()
@@ -595,15 +696,16 @@ pub async fn sign_payload(
             let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
                 .await
                 .map_err(|e| AppError::Internal(format!("{e}")))?;
-            let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
-                .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+            let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed).map_err(|e| {
+                key_derivation_error(format!("failed to create BIP-32 root key: {e}"))
+            })?;
 
             match (algorithm, &record.key_type) {
                 (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
-                    let derivation_path: ed25519_dalek_bip32::DerivationPath = record
-                        .derivation_path
-                        .parse()
-                        .map_err(|e| key_derivation_error(format!("invalid derivation path: {e}")))?;
+                    let derivation_path: ed25519_dalek_bip32::DerivationPath =
+                        record.derivation_path.parse().map_err(|e| {
+                            key_derivation_error(format!("invalid derivation path: {e}"))
+                        })?;
                     let derived = bip32
                         .derive(&derivation_path)
                         .map_err(|e| key_derivation_error(format!("derivation failed: {e}")))?;

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -741,3 +741,216 @@ pub async fn sign_payload(
         algorithm: algorithm.clone(),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    use vti_common::acl::Role;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    use crate::auth::AuthClaims;
+    use crate::contexts::create_context;
+    use crate::keys::seed_store::SeedStore;
+
+    /// A mock seed store backed by a Mutex so `set` actually persists.
+    struct MockSeedStore(Mutex<Option<Vec<u8>>>);
+
+    impl SeedStore for MockSeedStore {
+        fn get(
+            &self,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<Vec<u8>>, crate::error::AppError>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            Box::pin(async { Ok(self.0.lock().await.clone()) })
+        }
+        fn set(
+            &self,
+            seed: &[u8],
+        ) -> Pin<
+            Box<dyn std::future::Future<Output = Result<(), crate::error::AppError>> + Send + '_>,
+        > {
+            let seed = seed.to_vec();
+            Box::pin(async move {
+                *self.0.lock().await = Some(seed);
+                Ok(())
+            })
+        }
+    }
+
+    /// Helper: open a temp store and return the keyspace handles needed by key operations.
+    struct TestHarness {
+        keys_ks: KeyspaceHandle,
+        contexts_ks: KeyspaceHandle,
+        audit_ks: KeyspaceHandle,
+        imported_ks: KeyspaceHandle,
+        seed_store: Arc<dyn SeedStore>,
+        _dir: tempfile::TempDir,
+    }
+
+    impl TestHarness {
+        async fn new() -> Self {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let store_config = StoreConfig {
+                data_dir: dir.path().to_path_buf(),
+            };
+            let store = Store::open(&store_config).expect("open store");
+
+            let keys_ks = store.keyspace("keys").unwrap();
+            let contexts_ks = store.keyspace("contexts").unwrap();
+            let audit_ks = store.keyspace("audit").unwrap();
+            let imported_ks = store.keyspace("imported_secrets").unwrap();
+
+            // 32-byte seed; will be expanded to 64 bytes by BIP-32 internally
+            let seed_store: Arc<dyn SeedStore> =
+                Arc::new(MockSeedStore(Mutex::new(Some(vec![0xABu8; 32]))));
+
+            // Create a test context so create_key can resolve it
+            create_context(&contexts_ks, "test-ctx", "Test Context")
+                .await
+                .expect("create context");
+
+            Self {
+                keys_ks,
+                contexts_ks,
+                audit_ks,
+                imported_ks,
+                seed_store,
+                _dir: dir,
+            }
+        }
+
+        fn super_admin_auth(&self) -> AuthClaims {
+            AuthClaims {
+                did: "did:key:z6MkTestAdmin".to_string(),
+                role: Role::Admin,
+                allowed_contexts: vec![], // empty = super admin
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_key_ed25519() {
+        let h = TestHarness::new().await;
+        let auth = h.super_admin_auth();
+
+        let result = create_key(
+            &h.keys_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &auth,
+            CreateKeyParams {
+                key_type: KeyType::Ed25519,
+                derivation_path: None,
+                key_id: Some("test-ed25519".into()),
+                mnemonic: None,
+                label: None,
+                context_id: Some("test-ctx".into()),
+            },
+            "test",
+        )
+        .await
+        .expect("create_key should succeed");
+
+        assert_eq!(result.key_type, KeyType::Ed25519);
+        assert_eq!(result.status, KeyStatus::Active);
+        assert!(
+            !result.public_key.is_empty(),
+            "public_key must be non-empty"
+        );
+        assert_eq!(result.key_id, "test-ed25519");
+    }
+
+    #[tokio::test]
+    async fn test_create_key_p256() {
+        let h = TestHarness::new().await;
+        let auth = h.super_admin_auth();
+
+        let result = create_key(
+            &h.keys_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &auth,
+            CreateKeyParams {
+                key_type: KeyType::P256,
+                derivation_path: None,
+                key_id: Some("test-p256".into()),
+                mnemonic: None,
+                label: None,
+                context_id: Some("test-ctx".into()),
+            },
+            "test",
+        )
+        .await
+        .expect("create_key should succeed");
+
+        assert_eq!(result.key_type, KeyType::P256);
+        assert_eq!(result.status, KeyStatus::Active);
+        assert!(
+            !result.public_key.is_empty(),
+            "public_key must be non-empty"
+        );
+        assert_eq!(result.key_id, "test-p256");
+    }
+
+    #[tokio::test]
+    async fn test_sign_and_verify_ed25519() {
+        let h = TestHarness::new().await;
+        let auth = h.super_admin_auth();
+
+        // First create a key
+        let key = create_key(
+            &h.keys_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &auth,
+            CreateKeyParams {
+                key_type: KeyType::Ed25519,
+                derivation_path: None,
+                key_id: Some("sign-test-key".into()),
+                mnemonic: None,
+                label: None,
+                context_id: Some("test-ctx".into()),
+            },
+            "test",
+        )
+        .await
+        .expect("create_key should succeed");
+
+        // Sign a payload
+        let payload = b"hello world";
+        let result = sign_payload(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.seed_store,
+            &auth,
+            &key.key_id,
+            payload,
+            &SignAlgorithm::EdDSA,
+            "test",
+        )
+        .await
+        .expect("sign_payload should succeed");
+
+        assert_eq!(result.key_id, "sign-test-key");
+        assert_eq!(result.algorithm, SignAlgorithm::EdDSA);
+        // Verify the signature is valid base64url
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(&result.signature)
+            .expect("signature should be valid base64url");
+        assert!(!decoded.is_empty(), "decoded signature must be non-empty");
+        // Ed25519 signatures are 64 bytes
+        assert_eq!(decoded.len(), 64, "Ed25519 signature should be 64 bytes");
+    }
+}

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 use multibase::Base;
 use p256::elliptic_curve::sec1::ToEncodedPoint;
 use tracing::info;
+use zeroize::Zeroize;
 
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody, list::ListKeysResultBody, rename::RenameKeyResultBody,
@@ -17,10 +18,11 @@ use crate::auth::AuthClaims;
 use crate::contexts::get_context;
 use crate::error::{AppError, key_derivation_error};
 use crate::keys::derivation::Bip32Extension;
+use crate::keys::imported;
 use crate::keys::paths::allocate_path;
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
-use crate::keys::{self, KeyRecord, KeyStatus, KeyType};
+use crate::keys::{self, KeyOrigin, KeyRecord, KeyStatus, KeyType};
 use crate::store::KeyspaceHandle;
 
 pub struct CreateKeyParams {
@@ -122,6 +124,7 @@ pub async fn create_key(
         label: params.label.clone(),
         context_id: context_id.clone(),
         seed_id: Some(active_id),
+        origin: keys::KeyOrigin::Derived,
         created_at: now,
         updated_at: now,
     };
@@ -139,6 +142,131 @@ pub async fn create_key(
         public_key,
         status: KeyStatus::Active,
         label: params.label,
+        origin: keys::KeyOrigin::Derived,
+        created_at: now,
+    })
+}
+
+// ── Import key ─────────────────────────────────────────────────────
+
+pub struct ImportKeyParams {
+    pub key_type: KeyType,
+    pub private_key_bytes: Vec<u8>,
+    pub label: Option<String>,
+    pub context_id: Option<String>,
+}
+
+pub async fn import_key(
+    keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
+    seed_store: &Arc<dyn SeedStore>,
+    audit_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    params: ImportKeyParams,
+    channel: &str,
+) -> Result<CreateKeyResultBody, AppError> {
+    // Require admin role (stricter than create_key which allows initiator)
+    auth.require_admin()?;
+
+    // Resolve context
+    let context_id = if let Some(ref ctx) = params.context_id {
+        auth.require_context(ctx)?;
+        Some(ctx.clone())
+    } else if auth.is_super_admin() {
+        None
+    } else if let Some(ctx) = auth.default_context() {
+        Some(ctx.to_string())
+    } else {
+        return Err(AppError::Forbidden(
+            "context_id required: admin has access to multiple contexts".into(),
+        ));
+    };
+
+    // Validate key bytes and derive public key
+    let mut private_bytes = params.private_key_bytes;
+    let (public_key, key_type_str) = match params.key_type {
+        KeyType::Ed25519 => {
+            if private_bytes.len() != 32 {
+                return Err(AppError::Validation(
+                    format!("Ed25519 private key must be 32 bytes, got {}", private_bytes.len()),
+                ));
+            }
+            let signing_key = ed25519_dalek::SigningKey::from_bytes(
+                private_bytes.as_slice().try_into().unwrap(),
+            );
+            let pub_bytes = signing_key.verifying_key().to_bytes();
+            let pub_multibase = keys::ed25519_multibase_pubkey(&pub_bytes);
+            (pub_multibase, "ed25519")
+        }
+        KeyType::X25519 => {
+            if private_bytes.len() != 32 {
+                return Err(AppError::Validation(
+                    format!("X25519 private key must be 32 bytes, got {}", private_bytes.len()),
+                ));
+            }
+            let secret_bytes: [u8; 32] = private_bytes.as_slice().try_into().unwrap();
+            let secret = x25519_dalek::StaticSecret::from(secret_bytes);
+            let public = x25519_dalek::PublicKey::from(&secret);
+            let pub_multibase = multibase::encode(Base::Base58Btc, public.as_bytes());
+            (pub_multibase, "x25519")
+        }
+        KeyType::P256 => {
+            let secret_key = p256::SecretKey::from_slice(&private_bytes)
+                .map_err(|e| AppError::Validation(format!("invalid P-256 private key: {e}")))?;
+            let public = secret_key.public_key();
+            let encoded = public.to_encoded_point(true);
+            let pub_multibase = multibase::encode(Base::Base58Btc, encoded.as_bytes());
+            (pub_multibase, "p256")
+        }
+    };
+
+    let now = Utc::now();
+    let key_id = params.label.clone().unwrap_or_else(|| {
+        format!("imported-{}-{}", key_type_str, now.format("%Y%m%d%H%M%S"))
+    });
+
+    // Encrypt and store the secret
+    let active_id = get_active_seed_id(keys_ks)
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    let seed = load_seed_bytes(keys_ks, &**seed_store, Some(active_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+    imported::store_secret(imported_ks, keys_ks, &seed, &key_id, key_type_str, &private_bytes)
+        .await?;
+
+    // Zeroize private key material
+    private_bytes.zeroize();
+
+    // Create key record
+    let record = KeyRecord {
+        key_id: key_id.clone(),
+        derivation_path: String::new(),
+        key_type: params.key_type.clone(),
+        status: KeyStatus::Active,
+        public_key: public_key.clone(),
+        label: params.label.clone(),
+        context_id: context_id.clone(),
+        seed_id: None,
+        origin: KeyOrigin::Imported,
+        created_at: now,
+        updated_at: now,
+    };
+    keys_ks.insert(keys::store_key(&key_id), &record).await?;
+
+    info!(channel, key_id = %key_id, key_type = ?params.key_type, "key imported");
+    audit!("key.import", actor = &auth.did, resource = &key_id, outcome = "success");
+    let _ = audit::record(audit_ks, "key.import", &auth.did, Some(&key_id), "success", Some(channel), context_id.as_deref()).await;
+
+    Ok(CreateKeyResultBody {
+        key_id,
+        key_type: params.key_type,
+        derivation_path: String::new(),
+        public_key,
+        status: KeyStatus::Active,
+        label: params.label,
+        origin: KeyOrigin::Imported,
         created_at: now,
     })
 }
@@ -261,6 +389,7 @@ pub async fn rename_key(
 
 pub async fn revoke_key(
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     key_id: &str,
@@ -287,6 +416,11 @@ pub async fn revoke_key(
         )));
     }
 
+    // Secure deletion for imported keys: destroy the encrypted secret
+    if record.origin == KeyOrigin::Imported {
+        imported::delete_secret(imported_ks, key_id).await?;
+    }
+
     record.status = KeyStatus::Revoked;
     record.updated_at = Utc::now();
 
@@ -305,6 +439,7 @@ pub async fn revoke_key(
 
 pub async fn get_key_secret(
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
@@ -324,34 +459,50 @@ pub async fn get_key_secret(
         ));
     }
 
-    let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
-        .await
-        .map_err(|e| AppError::Internal(format!("{e}")))?;
-    let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
-        .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+    let (public_key_multibase, private_key_multibase) = match record.origin {
+        KeyOrigin::Imported => {
+            // Decrypt from imported_secrets keyspace
+            let seed = load_seed_bytes(keys_ks, &**seed_store, None)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let mut secret_bytes = imported::load_secret(
+                imported_ks, keys_ks, &seed, key_id, &record.key_type.to_string(),
+            ).await?;
+            let priv_mb = multibase::encode(Base::Base58Btc, &secret_bytes);
+            secret_bytes.zeroize();
+            (record.public_key.clone(), priv_mb)
+        }
+        KeyOrigin::Derived => {
+            let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
+                .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
 
-    let (public_key_multibase, private_key_multibase) = match record.key_type {
-        KeyType::Ed25519 => {
-            let secret = bip32.derive_ed25519(&record.derivation_path)?;
-            (
-                secret.get_public_keymultibase()?,
-                secret.get_private_keymultibase()?,
-            )
-        }
-        KeyType::X25519 => {
-            let secret = bip32.derive_x25519(&record.derivation_path)?;
-            (
-                secret.get_public_keymultibase()?,
-                secret.get_private_keymultibase()?,
-            )
-        }
-        KeyType::P256 => {
-            let p256_secret = bip32.derive_p256(&record.derivation_path)?;
-            let public_key = p256_secret.secret_key.public_key();
-            let encoded = public_key.to_encoded_point(true);
-            let pub_mb = multibase::encode(Base::Base58Btc, encoded.as_bytes());
-            let priv_mb = multibase::encode(Base::Base58Btc, p256_secret.secret_key.to_bytes());
-            (pub_mb, priv_mb)
+            match record.key_type {
+                KeyType::Ed25519 => {
+                    let secret = bip32.derive_ed25519(&record.derivation_path)?;
+                    (
+                        secret.get_public_keymultibase()?,
+                        secret.get_private_keymultibase()?,
+                    )
+                }
+                KeyType::X25519 => {
+                    let secret = bip32.derive_x25519(&record.derivation_path)?;
+                    (
+                        secret.get_public_keymultibase()?,
+                        secret.get_private_keymultibase()?,
+                    )
+                }
+                KeyType::P256 => {
+                    let p256_secret = bip32.derive_p256(&record.derivation_path)?;
+                    let public_key = p256_secret.secret_key.public_key();
+                    let encoded = public_key.to_encoded_point(true);
+                    let pub_mb = multibase::encode(Base::Base58Btc, encoded.as_bytes());
+                    let priv_mb = multibase::encode(Base::Base58Btc, p256_secret.secret_key.to_bytes());
+                    (pub_mb, priv_mb)
+                }
+            }
         }
     };
 
@@ -369,10 +520,12 @@ pub async fn get_key_secret(
 
 /// Sign a payload using a VTA-managed key.
 ///
-/// Derives the key from the BIP-32 seed, signs in memory, and returns
-/// the base64url-encoded signature. Key material is dropped after signing.
+/// For derived keys, re-derives from BIP-32 seed. For imported keys,
+/// decrypts from the imported_secrets keyspace. Key material is zeroized
+/// after signing.
 pub async fn sign_payload(
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     auth: &AuthClaims,
     key_id: &str,
@@ -399,39 +552,80 @@ pub async fn sign_payload(
         ));
     }
 
-    let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
-        .await
-        .map_err(|e| AppError::Internal(format!("{e}")))?;
-    let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
-        .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+    let signature_bytes = match record.origin {
+        KeyOrigin::Imported => {
+            // Decrypt imported secret and sign
+            let seed = load_seed_bytes(keys_ks, &**seed_store, None)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let mut secret_bytes = imported::load_secret(
+                imported_ks, keys_ks, &seed, key_id, &record.key_type.to_string(),
+            ).await?;
 
-    let signature_bytes = match (algorithm, &record.key_type) {
-        (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
-            let derivation_path: ed25519_dalek_bip32::DerivationPath = record
-                .derivation_path
-                .parse()
-                .map_err(|e| key_derivation_error(format!("invalid derivation path: {e}")))?;
-            let derived = bip32
-                .derive(&derivation_path)
-                .map_err(|e| key_derivation_error(format!("derivation failed: {e}")))?;
-            let signing_key =
-                ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes());
-            use ed25519_dalek::Signer;
-            let sig = signing_key.sign(payload);
-            sig.to_bytes().to_vec()
+            let sig = match (algorithm, &record.key_type) {
+                (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
+                    let signing_key = ed25519_dalek::SigningKey::from_bytes(
+                        secret_bytes.as_slice().try_into().map_err(|_| {
+                            AppError::Internal("invalid Ed25519 key length".into())
+                        })?,
+                    );
+                    use ed25519_dalek::Signer;
+                    signing_key.sign(payload).to_bytes().to_vec()
+                }
+                (SignAlgorithm::ES256, KeyType::P256) => {
+                    let secret_key = p256::SecretKey::from_slice(&secret_bytes)
+                        .map_err(|e| AppError::Internal(format!("invalid P-256 key: {e}")))?;
+                    let signing_key = p256::ecdsa::SigningKey::from(&secret_key);
+                    use p256::ecdsa::signature::Signer;
+                    let sig: p256::ecdsa::Signature = signing_key.sign(payload);
+                    sig.to_bytes().to_vec()
+                }
+                _ => {
+                    secret_bytes.zeroize();
+                    return Err(AppError::Validation(format!(
+                        "algorithm {} incompatible with key type {}",
+                        algorithm, record.key_type
+                    )));
+                }
+            };
+            secret_bytes.zeroize();
+            sig
         }
-        (SignAlgorithm::ES256, KeyType::P256) => {
-            let p256_secret = bip32.derive_p256(&record.derivation_path)?;
-            let signing_key = p256::ecdsa::SigningKey::from(&p256_secret.secret_key);
-            use p256::ecdsa::signature::Signer;
-            let sig: p256::ecdsa::Signature = signing_key.sign(payload);
-            sig.to_bytes().to_vec()
-        }
-        _ => {
-            return Err(AppError::Validation(format!(
-                "algorithm {} incompatible with key type {}",
-                algorithm, record.key_type
-            )));
+        KeyOrigin::Derived => {
+            let seed = load_seed_bytes(keys_ks, &**seed_store, record.seed_id)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
+                .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+
+            match (algorithm, &record.key_type) {
+                (SignAlgorithm::EdDSA, KeyType::Ed25519) => {
+                    let derivation_path: ed25519_dalek_bip32::DerivationPath = record
+                        .derivation_path
+                        .parse()
+                        .map_err(|e| key_derivation_error(format!("invalid derivation path: {e}")))?;
+                    let derived = bip32
+                        .derive(&derivation_path)
+                        .map_err(|e| key_derivation_error(format!("derivation failed: {e}")))?;
+                    let signing_key =
+                        ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes());
+                    use ed25519_dalek::Signer;
+                    signing_key.sign(payload).to_bytes().to_vec()
+                }
+                (SignAlgorithm::ES256, KeyType::P256) => {
+                    let p256_secret = bip32.derive_p256(&record.derivation_path)?;
+                    let signing_key = p256::ecdsa::SigningKey::from(&p256_secret.secret_key);
+                    use p256::ecdsa::signature::Signer;
+                    let sig: p256::ecdsa::Signature = signing_key.sign(payload);
+                    sig.to_bytes().to_vec()
+                }
+                _ => {
+                    return Err(AppError::Validation(format!(
+                        "algorithm {} incompatible with key type {}",
+                        algorithm, record.key_type
+                    )));
+                }
+            }
         }
     };
 

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -11,3 +11,45 @@ pub mod credentials;
 pub mod did_webvh;
 pub mod keys;
 pub mod seeds;
+
+use crate::store::KeyspaceHandle;
+
+/// Shared keyspace handles passed to operations that need multiple keyspaces.
+pub struct Keyspaces<'a> {
+    pub keys: &'a KeyspaceHandle,
+    pub acl: &'a KeyspaceHandle,
+    pub contexts: &'a KeyspaceHandle,
+    pub audit: &'a KeyspaceHandle,
+    pub imported: &'a KeyspaceHandle,
+    #[cfg(feature = "webvh")]
+    pub webvh: &'a KeyspaceHandle,
+}
+
+impl<'a> Keyspaces<'a> {
+    /// Borrow keyspaces from an `AppState`.
+    pub fn from_app_state(s: &'a crate::server::AppState) -> Self {
+        Self {
+            keys: &s.keys_ks,
+            acl: &s.acl_ks,
+            contexts: &s.contexts_ks,
+            audit: &s.audit_ks,
+            imported: &s.imported_ks,
+            #[cfg(feature = "webvh")]
+            webvh: &s.webvh_ks,
+        }
+    }
+
+    /// Borrow keyspaces from a `VtaState` (DIDComm handlers).
+    #[cfg(feature = "didcomm")]
+    pub fn from_vta_state(s: &'a crate::messaging::router::VtaState) -> Self {
+        Self {
+            keys: &s.keys_ks,
+            acl: &s.acl_ks,
+            contexts: &s.contexts_ks,
+            audit: &s.audit_ks,
+            imported: &s.imported_ks,
+            #[cfg(feature = "webvh")]
+            webvh: &s.webvh_ks,
+        }
+    }
+}

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -10,10 +10,10 @@ use vta_sdk::protocols::seed_management::{
 };
 
 use crate::error::AppError;
+use crate::keys::KeyRecord;
 use crate::keys::imported;
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{self as seeds, get_active_seed_id, load_seed_bytes};
-use crate::keys::KeyRecord;
 use crate::store::KeyspaceHandle;
 
 pub async fn list_seeds(
@@ -86,13 +86,32 @@ pub async fn rotate_seed(
         .collect();
 
     if !imported_keys.is_empty() {
-        let count = imported::reencrypt_all(imported_ks, keys_ks, &old_seed, &new_seed, &imported_keys).await?;
-        info!(channel, count, "re-encrypted imported secrets after seed rotation");
+        let count =
+            imported::reencrypt_all(imported_ks, keys_ks, &old_seed, &new_seed, &imported_keys)
+                .await?;
+        info!(
+            channel,
+            count, "re-encrypted imported secrets after seed rotation"
+        );
     }
 
     info!(channel, previous_id, new_id, "seed rotated");
-    audit!("seed.rotate", actor = actor, resource = "seed", outcome = "success");
-    let _ = audit::record(audit_ks, "seed.rotate", actor, Some("seed"), "success", Some(channel), None).await;
+    audit!(
+        "seed.rotate",
+        actor = actor,
+        resource = "seed",
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit_ks,
+        "seed.rotate",
+        actor,
+        Some("seed"),
+        "success",
+        Some(channel),
+        None,
+    )
+    .await;
 
     Ok(RotateSeedResultBody {
         previous_seed_id: previous_id,

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -3,14 +3,17 @@ use std::sync::Arc;
 use tracing::info;
 
 use crate::audit::{self, audit};
+use vta_sdk::keys::KeyOrigin;
 use vta_sdk::protocols::seed_management::{
     list::{ListSeedsResultBody, SeedInfo},
     rotate::RotateSeedResultBody,
 };
 
 use crate::error::AppError;
+use crate::keys::imported;
 use crate::keys::seed_store::SeedStore;
-use crate::keys::seeds::{self as seeds, get_active_seed_id};
+use crate::keys::seeds::{self as seeds, get_active_seed_id, load_seed_bytes};
+use crate::keys::KeyRecord;
 use crate::store::KeyspaceHandle;
 
 pub async fn list_seeds(
@@ -48,6 +51,7 @@ pub async fn list_seeds(
 
 pub async fn rotate_seed(
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     audit_ks: &KeyspaceHandle,
     actor: &str,
@@ -58,9 +62,33 @@ pub async fn rotate_seed(
         .await
         .map_err(|e| AppError::Internal(format!("{e}")))?;
 
+    // Load old seed for re-encryption of imported secrets
+    let old_seed = load_seed_bytes(keys_ks, &**seed_store, Some(previous_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+
     let new_id = seeds::rotate_seed(keys_ks, &**seed_store, mnemonic)
         .await
         .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+    // Re-encrypt imported secrets with the new seed
+    let new_seed = load_seed_bytes(keys_ks, &**seed_store, Some(new_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+    // Collect imported key records for AAD
+    let raw = keys_ks.prefix_iter_raw("key:").await?;
+    let imported_keys: Vec<(String, String)> = raw
+        .into_iter()
+        .filter_map(|(_, v)| serde_json::from_slice::<KeyRecord>(&v).ok())
+        .filter(|r| r.origin == KeyOrigin::Imported && r.status == vta_sdk::keys::KeyStatus::Active)
+        .map(|r| (r.key_id, r.key_type.to_string()))
+        .collect();
+
+    if !imported_keys.is_empty() {
+        let count = imported::reencrypt_all(imported_ks, keys_ks, &old_seed, &new_seed, &imported_keys).await?;
+        info!(channel, count, "re-encrypted imported secrets after seed rotation");
+    }
 
     info!(channel, previous_id, new_id, "seed rotated");
     audit!("seed.rotate", actor = actor, resource = "seed", outcome = "success");

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -118,3 +118,156 @@ pub async fn rotate_seed(
         new_seed_id: new_id,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    use crate::keys::seed_store::SeedStore;
+    use crate::keys::seeds::{SeedRecord, get_seed_record, save_seed_record};
+    use crate::store::KeyspaceHandle;
+
+    /// A mock seed store backed by a Mutex so `set` persists across calls.
+    struct MockSeedStore(Mutex<Option<Vec<u8>>>);
+
+    impl SeedStore for MockSeedStore {
+        fn get(
+            &self,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<Vec<u8>>, crate::error::AppError>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            Box::pin(async { Ok(self.0.lock().await.clone()) })
+        }
+        fn set(
+            &self,
+            seed: &[u8],
+        ) -> Pin<
+            Box<dyn std::future::Future<Output = Result<(), crate::error::AppError>> + Send + '_>,
+        > {
+            let seed = seed.to_vec();
+            Box::pin(async move {
+                *self.0.lock().await = Some(seed);
+                Ok(())
+            })
+        }
+    }
+
+    struct TestHarness {
+        keys_ks: KeyspaceHandle,
+        imported_ks: KeyspaceHandle,
+        audit_ks: KeyspaceHandle,
+        seed_store: Arc<dyn SeedStore>,
+        _dir: tempfile::TempDir,
+    }
+
+    impl TestHarness {
+        async fn new() -> Self {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let store_config = StoreConfig {
+                data_dir: dir.path().to_path_buf(),
+            };
+            let store = Store::open(&store_config).expect("open store");
+
+            let keys_ks = store.keyspace("keys").unwrap();
+            let imported_ks = store.keyspace("imported_secrets").unwrap();
+            let audit_ks = store.keyspace("audit").unwrap();
+
+            let initial_seed = vec![0xABu8; 32];
+            let seed_store: Arc<dyn SeedStore> =
+                Arc::new(MockSeedStore(Mutex::new(Some(initial_seed))));
+
+            // Bootstrap: create a seed record for generation 0 so rotation works
+            let now = chrono::Utc::now();
+            save_seed_record(
+                &keys_ks,
+                &SeedRecord {
+                    id: 0,
+                    seed_hex: None,
+                    created_at: now,
+                    retired_at: None,
+                },
+            )
+            .await
+            .expect("save initial seed record");
+
+            Self {
+                keys_ks,
+                imported_ks,
+                audit_ks,
+                seed_store,
+                _dir: dir,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rotate_seed() {
+        let h = TestHarness::new().await;
+
+        // Verify initial state: active_seed_id == 0
+        let initial_id = get_active_seed_id(&h.keys_ks)
+            .await
+            .expect("get active seed id");
+        assert_eq!(initial_id, 0);
+
+        // Rotate the seed
+        let result = rotate_seed(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            "did:key:z6MkTestAdmin",
+            None,
+            "test",
+        )
+        .await
+        .expect("rotate_seed should succeed");
+
+        assert_eq!(result.previous_seed_id, 0);
+        assert_eq!(result.new_seed_id, 1);
+
+        // The old seed (generation 0) should now be retired (archived with seed_hex)
+        let old_record = get_seed_record(&h.keys_ks, 0)
+            .await
+            .expect("get seed record")
+            .expect("old seed record should exist");
+        assert!(
+            old_record.seed_hex.is_some(),
+            "retired seed should have archived hex"
+        );
+        assert!(
+            old_record.retired_at.is_some(),
+            "retired seed should have retired_at timestamp"
+        );
+
+        // The new seed (generation 1) should be active (no seed_hex)
+        let new_record = get_seed_record(&h.keys_ks, 1)
+            .await
+            .expect("get seed record")
+            .expect("new seed record should exist");
+        assert!(
+            new_record.seed_hex.is_none(),
+            "active seed should not have archived hex"
+        );
+        assert!(
+            new_record.retired_at.is_none(),
+            "active seed should not have retired_at"
+        );
+
+        // Active seed ID should now be 1
+        let new_active_id = get_active_seed_id(&h.keys_ks)
+            .await
+            .expect("get active seed id");
+        assert_eq!(new_active_id, 1);
+    }
+}

--- a/vta-service/src/routes/attestation.rs
+++ b/vta-service/src/routes/attestation.rs
@@ -10,9 +10,11 @@ use crate::tee::types::{AttestationRequest, AttestationResponse, TeeStatus};
 
 /// GET /attestation/status — TEE detection status (unauthenticated).
 pub async fn status(State(state): State<AppState>) -> Result<Json<TeeStatus>, AppError> {
-    let tee_state = state.tee.as_ref().map(|tc| &tc.state).ok_or_else(|| {
-        tee_attestation_error("TEE attestation is not enabled on this VTA")
-    })?;
+    let tee_state = state
+        .tee
+        .as_ref()
+        .map(|tc| &tc.state)
+        .ok_or_else(|| tee_attestation_error("TEE attestation is not enabled on this VTA"))?;
 
     Ok(Json(operations::attestation::get_tee_status(tee_state)))
 }
@@ -22,9 +24,11 @@ pub async fn generate_report(
     State(state): State<AppState>,
     Json(body): Json<AttestationRequest>,
 ) -> Result<Json<AttestationResponse>, AppError> {
-    let tee_state = state.tee.as_ref().map(|tc| &tc.state).ok_or_else(|| {
-        tee_attestation_error("TEE attestation is not enabled on this VTA")
-    })?;
+    let tee_state = state
+        .tee
+        .as_ref()
+        .map(|tc| &tc.state)
+        .ok_or_else(|| tee_attestation_error("TEE attestation is not enabled on this VTA"))?;
 
     let response =
         operations::attestation::generate_attestation_report(tee_state, &state.config, &body.nonce)
@@ -37,9 +41,11 @@ pub async fn generate_report(
 pub async fn cached_report(
     State(state): State<AppState>,
 ) -> Result<Json<AttestationResponse>, AppError> {
-    let tee_state = state.tee.as_ref().map(|tc| &tc.state).ok_or_else(|| {
-        tee_attestation_error("TEE attestation is not enabled on this VTA")
-    })?;
+    let tee_state = state
+        .tee
+        .as_ref()
+        .map(|tc| &tc.state)
+        .ok_or_else(|| tee_attestation_error("TEE attestation is not enabled on this VTA"))?;
 
     let response = operations::attestation::get_cached_report(tee_state, &state.config).await?;
 
@@ -50,20 +56,14 @@ pub async fn cached_report(
 ///
 /// The DID log is public data (it's published to a web server). This endpoint
 /// is only available when the VTA auto-generated a did:webvh identity on first boot.
-pub async fn did_log(
-    State(state): State<AppState>,
-) -> Result<String, AppError> {
-    let log_bytes = state
-        .keys_ks
-        .get_raw("tee:did_log")
-        .await?
-        .ok_or_else(|| {
-            AppError::NotFound(
-                "no auto-generated DID log found — the VTA may not have \
+pub async fn did_log(State(state): State<AppState>) -> Result<String, AppError> {
+    let log_bytes = state.keys_ks.get_raw("tee:did_log").await?.ok_or_else(|| {
+        AppError::NotFound(
+            "no auto-generated DID log found — the VTA may not have \
                  been configured with a vta_did_template"
-                    .into(),
-            )
-        })?;
+                .into(),
+        )
+    })?;
 
     String::from_utf8(log_bytes)
         .map_err(|e| AppError::Internal(format!("DID log is not valid UTF-8: {e}")))
@@ -77,9 +77,7 @@ pub async fn did_log(
 ///
 /// Only available when the VTA auto-bootstrapped a super-admin credential
 /// on first boot via `admin_bootstrap::maybe_bootstrap_admin()`.
-pub async fn admin_credential(
-    State(state): State<AppState>,
-) -> Result<String, AppError> {
+pub async fn admin_credential(State(state): State<AppState>) -> Result<String, AppError> {
     let cred_bytes = state
         .keys_ks
         .get_raw("tee:admin_credential")
@@ -107,9 +105,15 @@ pub async fn mnemonic_status(
     _auth: SuperAdminAuth,
     State(state): State<AppState>,
 ) -> Result<Json<MnemonicExportStatus>, AppError> {
-    let guard = state.tee.as_ref().and_then(|tc| tc.mnemonic_guard.as_ref()).ok_or_else(|| {
-        tee_attestation_error("mnemonic export not available (TEE mode not active or no KMS bootstrap)")
-    })?;
+    let guard = state
+        .tee
+        .as_ref()
+        .and_then(|tc| tc.mnemonic_guard.as_ref())
+        .ok_or_else(|| {
+            tee_attestation_error(
+                "mnemonic export not available (TEE mode not active or no KMS bootstrap)",
+            )
+        })?;
 
     Ok(Json(guard.status()))
 }
@@ -125,9 +129,15 @@ pub async fn mnemonic_export(
     _auth: SuperAdminAuth,
     State(state): State<AppState>,
 ) -> Result<Json<MnemonicExportResponse>, AppError> {
-    let guard = state.tee.as_ref().and_then(|tc| tc.mnemonic_guard.as_ref()).ok_or_else(|| {
-        tee_attestation_error("mnemonic export not available (TEE mode not active or no KMS bootstrap)")
-    })?;
+    let guard = state
+        .tee
+        .as_ref()
+        .and_then(|tc| tc.mnemonic_guard.as_ref())
+        .ok_or_else(|| {
+            tee_attestation_error(
+                "mnemonic export not available (TEE mode not active or no KMS bootstrap)",
+            )
+        })?;
 
     let response = guard.export()?;
     Ok(Json(response))

--- a/vta-service/src/routes/audit.rs
+++ b/vta-service/src/routes/audit.rs
@@ -17,9 +17,8 @@ pub async fn list_audit_logs(
     State(state): State<AppState>,
     Query(params): Query<ListAuditLogsBody>,
 ) -> Result<Json<ListAuditLogsResultBody>, AppError> {
-    let result = operations::audit::list_audit_logs(
-        &state.audit_ks, &auth.0, &params, "rest",
-    ).await?;
+    let result =
+        operations::audit::list_audit_logs(&state.audit_ks, &auth.0, &params, "rest").await?;
     Ok(Json(result))
 }
 
@@ -30,9 +29,7 @@ pub async fn get_retention(
     auth: AdminAuth,
     State(state): State<AppState>,
 ) -> Result<Json<RetentionResultBody>, AppError> {
-    let result = operations::audit::get_retention(
-        &state.config, &auth.0, "rest",
-    ).await?;
+    let result = operations::audit::get_retention(&state.config, &auth.0, "rest").await?;
     Ok(Json(result))
 }
 
@@ -45,7 +42,12 @@ pub async fn update_retention(
     Json(body): Json<UpdateRetentionBody>,
 ) -> Result<Json<RetentionResultBody>, AppError> {
     let result = operations::audit::update_retention(
-        &state.config, &state.audit_ks, &auth.0, body.retention_days, "rest",
-    ).await?;
+        &state.config,
+        &state.audit_ks,
+        &auth.0,
+        body.retention_days,
+        "rest",
+    )
+    .await?;
     Ok(Json(result))
 }

--- a/vta-service/src/routes/auth.rs
+++ b/vta-service/src/routes/auth.rs
@@ -12,14 +12,14 @@ use vta_sdk::protocols::credential_management::generate::GenerateCredentialsResu
 
 use crate::acl::{Role, check_acl, check_acl_full};
 use crate::audit::audit;
-use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::auth::session::{
     Session, SessionState, delete_session, get_session, get_session_by_refresh, list_sessions,
     now_epoch, store_refresh_index, store_session, update_session,
 };
+use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
+use crate::error::AppError;
 #[cfg(feature = "tee")]
 use crate::error::tee_attestation_error;
-use crate::error::AppError;
 use crate::operations;
 use crate::server::AppState;
 #[cfg(feature = "tee")]
@@ -64,13 +64,19 @@ pub async fn challenge(
     // Challenges are random 32 bytes so collision is negligible, but this
     // provides defense in depth against replay attacks.
     let nonce_key = format!("nonce:{challenge}");
-    if state.sessions_ks.get_raw(nonce_key.clone()).await?.is_some() {
+    if state
+        .sessions_ks
+        .get_raw(nonce_key.clone())
+        .await?
+        .is_some()
+    {
         warn!(challenge = %challenge, "challenge nonce collision detected — regenerating");
         // Extremely unlikely (2^-256) but handle gracefully
         rand::fill(&mut challenge_bytes);
         challenge = hex::encode(challenge_bytes);
     }
-    state.sessions_ks
+    state
+        .sessions_ks
         .insert_raw(format!("nonce:{challenge}"), session_id.as_bytes().to_vec())
         .await?;
 
@@ -114,7 +120,9 @@ pub async fn challenge(
                         "TEE attestation failed (mode=required): {e}"
                     )));
                 }
-                warn!("TEE attestation failed (mode=optional) — challenge served without attestation: {e}");
+                warn!(
+                    "TEE attestation failed (mode=optional) — challenge served without attestation: {e}"
+                );
                 None
             }
         }
@@ -125,7 +133,12 @@ pub async fn challenge(
     let tee_attestation = None;
 
     info!(did = %session.did, session_id = %session.session_id, "auth challenge issued");
-    audit!("auth.challenge", actor = &session.did, resource =&session.session_id, outcome = "success");
+    audit!(
+        "auth.challenge",
+        actor = &session.did,
+        resource = &session.session_id,
+        outcome = "success"
+    );
 
     Ok(Json(ChallengeResponse {
         session_id,
@@ -187,34 +200,58 @@ pub async fn authenticate(
 
     if session.state != SessionState::ChallengeSent {
         warn!(session_id, "authentication rejected: session replay");
-        audit!("auth.authenticate", actor = sender_did.split('#').next().unwrap_or(sender_did), resource =session_id, outcome = "denied:replay");
+        audit!(
+            "auth.authenticate",
+            actor = sender_did.split('#').next().unwrap_or(sender_did),
+            resource = session_id,
+            outcome = "denied:replay"
+        );
         return Err(AppError::Authentication(
             "session already authenticated (replay)".into(),
         ));
     }
     if session.challenge != challenge {
         warn!(session_id, "authentication rejected: challenge mismatch");
-        audit!("auth.authenticate", actor = sender_did.split('#').next().unwrap_or(sender_did), resource =session_id, outcome = "denied:challenge_mismatch");
+        audit!(
+            "auth.authenticate",
+            actor = sender_did.split('#').next().unwrap_or(sender_did),
+            resource = session_id,
+            outcome = "denied:challenge_mismatch"
+        );
         return Err(AppError::Authentication("challenge mismatch".into()));
     }
     // Match the DID (compare base DID, ignoring any fragment)
     let sender_base = sender_did.split('#').next().unwrap_or(sender_did);
     if session.did != sender_base {
         warn!(session_id, sender = %sender_base, expected = %session.did, "authentication rejected: DID mismatch");
-        audit!("auth.authenticate", actor = sender_base, resource =session_id, outcome = "denied:did_mismatch");
+        audit!(
+            "auth.authenticate",
+            actor = sender_base,
+            resource = session_id,
+            outcome = "denied:did_mismatch"
+        );
         return Err(AppError::Authentication("DID mismatch".into()));
     }
 
     // Read all auth config values in a single lock acquisition
     let (challenge_ttl, access_expiry, refresh_expiry) = {
         let config = state.config.read().await;
-        (config.auth.challenge_ttl, config.auth.access_token_expiry, config.auth.refresh_token_expiry)
+        (
+            config.auth.challenge_ttl,
+            config.auth.access_token_expiry,
+            config.auth.refresh_token_expiry,
+        )
     };
 
     // Check challenge TTL
     if now_epoch().saturating_sub(session.created_at) > challenge_ttl {
         warn!(session_id, "authentication rejected: challenge expired");
-        audit!("auth.authenticate", actor = sender_base, resource =session_id, outcome = "denied:expired");
+        audit!(
+            "auth.authenticate",
+            actor = sender_base,
+            resource = session_id,
+            outcome = "denied:expired"
+        );
         return Err(AppError::Authentication("challenge expired".into()));
     }
 
@@ -251,7 +288,12 @@ pub async fn authenticate(
     store_refresh_index(&state.sessions_ks, &refresh_token, &session.session_id).await?;
 
     info!(did = %session.did, session_id = %session.session_id, "authentication successful");
-    audit!("auth.authenticate", actor = &session.did, resource =&session.session_id, outcome = "success");
+    audit!(
+        "auth.authenticate",
+        actor = &session.did,
+        resource = &session.session_id,
+        outcome = "success"
+    );
 
     Ok(Json(AuthenticateResponse {
         session_id: Some(session.session_id),
@@ -358,7 +400,12 @@ pub async fn refresh(
     let access_token = jwt_keys.encode(&claims)?;
 
     info!(did = %session.did, session_id = %session.session_id, "token refreshed");
-    audit!("auth.refresh", actor = &session.did, resource =&session.session_id, outcome = "success");
+    audit!(
+        "auth.refresh",
+        actor = &session.did,
+        resource = &session.session_id,
+        outcome = "success"
+    );
 
     Ok(Json(RefreshResponse {
         session_id: session.session_id,
@@ -396,7 +443,12 @@ pub async fn generate_credentials(
         "rest",
     )
     .await?;
-    audit!("credentials.generate", actor = &auth.0.did, resource =&role_str, outcome = "success");
+    audit!(
+        "credentials.generate",
+        actor = &auth.0.did,
+        resource = &role_str,
+        outcome = "success"
+    );
     Ok((StatusCode::CREATED, Json(result)))
 }
 
@@ -456,7 +508,12 @@ pub async fn revoke_session(
 
     delete_session(&state.sessions_ks, &session_id).await?;
     info!(caller = %auth.did, session_id = %session_id, "session revoked");
-    audit!("session.revoke", actor = &auth.did, resource =&session_id, outcome = "success");
+    audit!(
+        "session.revoke",
+        actor = &auth.did,
+        resource = &session_id,
+        outcome = "success"
+    );
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -489,6 +546,11 @@ pub async fn revoke_sessions_by_did(
     }
 
     info!(caller = %_auth.0.did, target_did = %query.did, revoked, "sessions revoked by DID");
-    audit!("session.revoke_by_did", actor = &_auth.0.did, resource =&query.did, outcome = "success");
+    audit!(
+        "session.revoke_by_did",
+        actor = &_auth.0.did,
+        resource = &query.did,
+        outcome = "success"
+    );
     Ok(Json(RevokeByDidResponse { revoked }))
 }

--- a/vta-service/src/routes/backup.rs
+++ b/vta-service/src/routes/backup.rs
@@ -1,7 +1,7 @@
 use axum::Json;
 use axum::extract::State;
 
-use crate::auth::AuthClaims;
+use crate::auth::{AuthClaims, SuperAdminAuth};
 use crate::error::AppError;
 use crate::operations;
 use crate::server::AppState;
@@ -10,9 +10,9 @@ use vta_sdk::protocols::backup_management::types::{
     BackupEnvelope, ExportRequest, ImportRequest, ImportResult,
 };
 
-/// POST /backup/export — export VTA state to an encrypted backup.
+/// POST /backup/export — export VTA state to an encrypted backup. Auth: Super Admin.
 pub async fn export(
-    auth: AuthClaims,
+    SuperAdminAuth(auth): SuperAdminAuth,
     State(state): State<AppState>,
     Json(req): Json<ExportRequest>,
 ) -> Result<Json<BackupEnvelope>, AppError> {

--- a/vta-service/src/routes/backup.rs
+++ b/vta-service/src/routes/backup.rs
@@ -17,14 +17,9 @@ pub async fn export(
     Json(req): Json<ExportRequest>,
 ) -> Result<Json<BackupEnvelope>, AppError> {
     let config = state.config.read().await;
+    let ks = operations::Keyspaces::from_app_state(&state);
     let envelope = operations::backup::export_backup(
-        &state.keys_ks,
-        &state.acl_ks,
-        &state.contexts_ks,
-        &state.audit_ks,
-        &state.imported_ks,
-        #[cfg(feature = "webvh")]
-        &state.webvh_ks,
+        &ks,
         &*state.seed_store,
         &config,
         &auth,
@@ -65,15 +60,10 @@ pub async fn import(
     // Full import — decrypt once (skip building a throwaway preview)
     let payload = operations::backup::decrypt_backup(&req.backup, &req.password)?;
 
+    let ks = operations::Keyspaces::from_app_state(&state);
     let result = operations::backup::apply_import(
         &payload,
-        &state.keys_ks,
-        &state.acl_ks,
-        &state.contexts_ks,
-        &state.audit_ks,
-        &state.imported_ks,
-        #[cfg(feature = "webvh")]
-        &state.webvh_ks,
+        &ks,
         &state.seed_store,
         &state.config,
         None, // Store passed for TEE re-encryption (REST has no store access; handled on restart)

--- a/vta-service/src/routes/backup.rs
+++ b/vta-service/src/routes/backup.rs
@@ -22,6 +22,7 @@ pub async fn export(
         &state.acl_ks,
         &state.contexts_ks,
         &state.audit_ks,
+        &state.imported_ks,
         #[cfg(feature = "webvh")]
         &state.webvh_ks,
         &*state.seed_store,
@@ -70,6 +71,7 @@ pub async fn import(
         &state.acl_ks,
         &state.contexts_ks,
         &state.audit_ks,
+        &state.imported_ks,
         #[cfg(feature = "webvh")]
         &state.webvh_ks,
         &state.seed_store,

--- a/vta-service/src/routes/cache.rs
+++ b/vta-service/src/routes/cache.rs
@@ -20,23 +20,25 @@ pub async fn get_cached(
     }
 }
 
-/// PUT /cache/{key} — store or update a cached value. Auth: any authenticated user.
+/// PUT /cache/{key} — store or update a cached value. Auth: Application or higher.
 pub async fn put_cached(
     auth: AuthClaims,
     State(state): State<AppState>,
     Path(key): Path<String>,
     Json(req): Json<CachePutRequest>,
 ) -> Result<(StatusCode, Json<CachePutResponse>), AppError> {
+    auth.require_write()?;
     let resp = operations::cache::put_cached(&state.cache_ks, &auth, &key, &req, "rest").await?;
     Ok((StatusCode::OK, Json(resp)))
 }
 
-/// DELETE /cache/{key} — remove a cached value. Auth: any authenticated user.
+/// DELETE /cache/{key} — remove a cached value. Auth: Application or higher.
 pub async fn delete_cached(
     auth: AuthClaims,
     State(state): State<AppState>,
     Path(key): Path<String>,
 ) -> Result<StatusCode, AppError> {
+    auth.require_write()?;
     operations::cache::delete_cached(&state.cache_ks, &auth, &key, "rest").await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -4,8 +4,7 @@ use axum::http::StatusCode;
 use serde::Deserialize;
 
 use vta_sdk::protocols::context_management::{
-    create::CreateContextResultBody,
-    delete::DeleteContextPreviewResultBody,
+    create::CreateContextResultBody, delete::DeleteContextPreviewResultBody,
     list::ListContextsResultBody,
 };
 
@@ -106,14 +105,9 @@ pub async fn update_context_did_handler(
     Path(id): Path<String>,
     Json(req): Json<UpdateDidRequest>,
 ) -> Result<Json<CreateContextResultBody>, AppError> {
-    let result = operations::contexts::update_context_did(
-        &state.contexts_ks,
-        &auth.0,
-        &id,
-        req.did,
-        "rest",
-    )
-    .await?;
+    let result =
+        operations::contexts::update_context_did(&state.contexts_ks, &auth.0, &id, req.did, "rest")
+            .await?;
     Ok(Json(result))
 }
 
@@ -144,17 +138,7 @@ pub async fn delete_context_handler(
     Path(id): Path<String>,
     Query(query): Query<DeleteContextQuery>,
 ) -> Result<StatusCode, AppError> {
-    operations::contexts::delete_context(
-        &state.contexts_ks,
-        &state.keys_ks,
-        &state.acl_ks,
-        #[cfg(feature = "webvh")]
-        &state.webvh_ks,
-        &auth.0,
-        &id,
-        query.force,
-        "rest",
-    )
-    .await?;
+    let ks = operations::Keyspaces::from_app_state(&state);
+    operations::contexts::delete_context(&ks, &auth.0, &id, query.force, "rest").await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -9,7 +9,7 @@ use vta_sdk::protocols::context_management::{
     list::ListContextsResultBody,
 };
 
-use crate::auth::{AuthClaims, SuperAdminAuth};
+use crate::auth::{AdminAuth, AuthClaims, SuperAdminAuth};
 use crate::error::AppError;
 use crate::operations;
 use crate::server::AppState;
@@ -88,6 +88,29 @@ pub async fn update_context_handler(
             did: req.did,
             description: req.description,
         },
+        "rest",
+    )
+    .await?;
+    Ok(Json(result))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateDidRequest {
+    pub did: String,
+}
+
+/// PUT /contexts/{id}/did — update the DID for a context. Auth: Admin with context access.
+pub async fn update_context_did_handler(
+    auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<UpdateDidRequest>,
+) -> Result<Json<CreateContextResultBody>, AppError> {
+    let result = operations::contexts::update_context_did(
+        &state.contexts_ks,
+        &auth.0,
+        &id,
+        req.did,
         "rest",
     )
     .await?;

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -202,13 +202,14 @@ pub struct SignRequest {
     pub algorithm: SignAlgorithm,
 }
 
-/// POST /keys/{key_id}/sign — sign a base64url payload with the specified key. Auth: any authenticated user.
+/// POST /keys/{key_id}/sign — sign a base64url payload with the specified key. Auth: Application or higher.
 pub async fn sign_with_key(
     auth: AuthClaims,
     State(state): State<AppState>,
     Path(key_id): Path<String>,
     Json(req): Json<SignRequest>,
 ) -> Result<Json<SignResultBody>, AppError> {
+    auth.require_write()?;
     use base64::Engine;
     let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(&req.payload)

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -4,8 +4,11 @@ use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
 
 use vta_sdk::protocols::key_management::{
-    create::CreateKeyResultBody, list::ListKeysResultBody, rename::RenameKeyResultBody,
-    revoke::RevokeKeyResultBody, secret::GetKeySecretResultBody,
+    create::CreateKeyResultBody,
+    list::ListKeysResultBody,
+    rename::RenameKeyResultBody,
+    revoke::RevokeKeyResultBody,
+    secret::GetKeySecretResultBody,
     sign::{SignAlgorithm, SignResultBody},
 };
 use vta_sdk::protocols::seed_management::{
@@ -91,7 +94,15 @@ pub async fn invalidate_key(
     State(state): State<AppState>,
     Path(key_id): Path<String>,
 ) -> Result<Json<RevokeKeyResultBody>, AppError> {
-    let result = operations::keys::revoke_key(&state.keys_ks, &state.imported_ks, &state.audit_ks, &auth.0, &key_id, "rest").await?;
+    let result = operations::keys::revoke_key(
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.audit_ks,
+        &auth.0,
+        &key_id,
+        "rest",
+    )
+    .await?;
     Ok(Json(result))
 }
 
@@ -107,8 +118,15 @@ pub async fn rename_key(
     Path(key_id): Path<String>,
     Json(req): Json<RenameKeyRequest>,
 ) -> Result<Json<RenameKeyResultBody>, AppError> {
-    let result =
-        operations::keys::rename_key(&state.keys_ks, &state.audit_ks, &auth.0, &key_id, &req.key_id, "rest").await?;
+    let result = operations::keys::rename_key(
+        &state.keys_ks,
+        &state.audit_ks,
+        &auth.0,
+        &key_id,
+        &req.key_id,
+        "rest",
+    )
+    .await?;
     Ok(Json(result))
 }
 

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -1,7 +1,7 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody, list::ListKeysResultBody, rename::RenameKeyResultBody,
@@ -64,6 +64,7 @@ pub async fn get_key_secret(
 ) -> Result<Json<GetKeySecretResultBody>, AppError> {
     let result = operations::keys::get_key_secret(
         &state.keys_ks,
+        &state.imported_ks,
         &state.seed_store,
         &state.audit_ks,
         &auth.0,
@@ -90,7 +91,7 @@ pub async fn invalidate_key(
     State(state): State<AppState>,
     Path(key_id): Path<String>,
 ) -> Result<Json<RevokeKeyResultBody>, AppError> {
-    let result = operations::keys::revoke_key(&state.keys_ks, &state.audit_ks, &auth.0, &key_id, "rest").await?;
+    let result = operations::keys::revoke_key(&state.keys_ks, &state.imported_ks, &state.audit_ks, &auth.0, &key_id, "rest").await?;
     Ok(Json(result))
 }
 
@@ -164,6 +165,7 @@ pub async fn rotate_seed(
 ) -> Result<Json<RotateSeedResultBody>, AppError> {
     let result = operations::seeds::rotate_seed(
         &state.keys_ks,
+        &state.imported_ks,
         &state.seed_store,
         &state.audit_ks,
         &_auth.0.did,
@@ -196,6 +198,7 @@ pub async fn sign_with_key(
 
     let result = operations::keys::sign_payload(
         &state.keys_ks,
+        &state.imported_ks,
         &state.seed_store,
         &auth,
         &key_id,
@@ -205,4 +208,76 @@ pub async fn sign_with_key(
     )
     .await?;
     Ok(Json(result))
+}
+
+// ── Import key endpoints ─────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct WrappingKeyResponse {
+    pub kid: String,
+    pub kty: String,
+    pub crv: String,
+    pub x: String,
+}
+
+/// GET /keys/import/wrapping-key — get an ephemeral X25519 public key for REST key wrapping.
+pub async fn get_wrapping_key(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<WrappingKeyResponse>, AppError> {
+    let (kid, x) = state.wrapping_cache.generate().await;
+    Ok(Json(WrappingKeyResponse {
+        kid,
+        kty: "OKP".into(),
+        crv: "X25519".into(),
+        x,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ImportKeyRestRequest {
+    pub key_type: KeyType,
+    /// JWE compact serialization of the private key (REST transport).
+    pub private_key_jwe: Option<String>,
+    /// Multibase-encoded private key (DIDComm transport — should not be used via REST).
+    pub private_key_multibase: Option<String>,
+    pub label: Option<String>,
+    pub context_id: Option<String>,
+}
+
+/// POST /keys/import — import an externally-created private key. Auth: Admin only.
+pub async fn import_key(
+    auth: AdminAuth,
+    State(state): State<AppState>,
+    Json(req): Json<ImportKeyRestRequest>,
+) -> Result<(StatusCode, Json<CreateKeyResultBody>), AppError> {
+    // Unwrap the private key based on transport
+    let private_key_bytes = if let Some(jwe) = req.private_key_jwe {
+        state.wrapping_cache.unwrap_jwe(&jwe).await?
+    } else if let Some(ref mb) = req.private_key_multibase {
+        let (_, bytes) = multibase::decode(mb)
+            .map_err(|e| AppError::Validation(format!("invalid multibase private key: {e}")))?;
+        bytes
+    } else {
+        return Err(AppError::Validation(
+            "either private_key_jwe or private_key_multibase is required".into(),
+        ));
+    };
+
+    let result = operations::keys::import_key(
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.seed_store,
+        &state.audit_ks,
+        &auth.0,
+        operations::keys::ImportKeyParams {
+            key_type: req.key_type,
+            private_key_bytes,
+            label: req.label,
+            context_id: req.context_id,
+        },
+        "rest",
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(result)))
 }

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -1,7 +1,7 @@
 mod acl;
-mod audit;
 #[cfg(feature = "tee")]
 mod attestation;
+mod audit;
 mod auth;
 mod backup;
 mod cache;
@@ -102,10 +102,7 @@ pub fn router() -> Router<AppState> {
     // TEE attestation routes (feature-gated)
     #[cfg(feature = "tee")]
     let router = router
-        .route(
-            "/attestation/status",
-            get(attestation::status),
-        )
+        .route("/attestation/status", get(attestation::status))
         .route(
             "/attestation/report",
             get(attestation::cached_report).post(attestation::generate_report),
@@ -116,10 +113,7 @@ pub fn router() -> Router<AppState> {
             get(attestation::mnemonic_status).post(attestation::mnemonic_export),
         )
         // Auto-generated DID log (unauthenticated — public data)
-        .route(
-            "/attestation/did-log",
-            get(attestation::did_log),
-        )
+        .route("/attestation/did-log", get(attestation::did_log))
         // Bootstrapped admin credential (unauthenticated — one-time retrieval)
         .route(
             "/attestation/admin-credential",
@@ -146,10 +140,7 @@ pub fn router() -> Router<AppState> {
             "/webvh/dids/{did}",
             get(did_webvh::get_did_handler).delete(did_webvh::delete_did_handler),
         )
-        .route(
-            "/webvh/dids/{did}/log",
-            get(did_webvh::get_did_log_handler),
-        );
+        .route("/webvh/dids/{did}/log", get(did_webvh::get_did_log_handler));
 
     // VTA management routes
     let router = router

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -54,6 +54,8 @@ pub fn router() -> Router<AppState> {
         )
         .route("/keys/{key_id}/secret", get(keys::get_key_secret))
         .route("/keys/{key_id}/sign", post(keys::sign_with_key))
+        .route("/keys/import/wrapping-key", get(keys::get_wrapping_key))
+        .route("/keys/import", post(keys::import_key))
         .route("/keys/seeds", get(keys::list_seeds))
         .route("/keys/seeds/rotate", post(keys::rotate_seed))
         // Context routes

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -15,7 +15,7 @@ mod vta;
 
 use axum::Router;
 use axum::extract::DefaultBodyLimit;
-use axum::routing::{delete, get, post};
+use axum::routing::{delete, get, post, put};
 
 use crate::server::AppState;
 
@@ -68,6 +68,10 @@ pub fn router() -> Router<AppState> {
             get(contexts::get_context_handler)
                 .patch(contexts::update_context_handler)
                 .delete(contexts::delete_context_handler),
+        )
+        .route(
+            "/contexts/{id}/did",
+            put(contexts::update_context_did_handler),
         )
         .route(
             "/contexts/{id}/delete-preview",

--- a/vta-service/src/seal.rs
+++ b/vta-service/src/seal.rs
@@ -105,9 +105,9 @@ pub async fn run_unseal_challenge(store: &Store) -> Result<(), AppError> {
     let acl_ks = store.keyspace("acl")?;
 
     // Verify the VTA is actually sealed
-    let seal = get_seal(&acl_ks).await?.ok_or_else(|| {
-        AppError::Config("VTA is not sealed — nothing to unseal".into())
-    })?;
+    let seal = get_seal(&acl_ks)
+        .await?
+        .ok_or_else(|| AppError::Config("VTA is not sealed — nothing to unseal".into()))?;
 
     // Find super admin DIDs
     let entries = acl::list_acl_entries(&acl_ks).await?;
@@ -131,11 +131,18 @@ pub async fn run_unseal_challenge(store: &Store) -> Result<(), AppError> {
     eprintln!("=== VTA Unseal Challenge ===");
     eprintln!();
     eprintln!("  Sealed by: {}", seal.sealed_by);
-    eprintln!("  Sealed at: {}", seal.sealed_at.format("%Y-%m-%d %H:%M:%S UTC"));
+    eprintln!(
+        "  Sealed at: {}",
+        seal.sealed_at.format("%Y-%m-%d %H:%M:%S UTC")
+    );
     eprintln!();
     eprintln!("  Authorized super admin DIDs:");
     for admin in &super_admins {
-        eprintln!("    - {} ({})", admin.did, admin.label.as_deref().unwrap_or("no label"));
+        eprintln!(
+            "    - {} ({})",
+            admin.did,
+            admin.label.as_deref().unwrap_or("no label")
+        );
     }
     eprintln!();
     eprintln!("  Challenge (hex):");
@@ -160,9 +167,7 @@ pub async fn run_unseal_challenge(store: &Store) -> Result<(), AppError> {
     let admin_entry = super_admins
         .iter()
         .find(|e| e.did == admin_did)
-        .ok_or_else(|| {
-            AppError::Forbidden(format!("DID is not a super admin: {admin_did}"))
-        })?;
+        .ok_or_else(|| AppError::Forbidden(format!("DID is not a super admin: {admin_did}")))?;
 
     // Read the signature
     eprint!("  Signature (hex): ");
@@ -183,7 +188,8 @@ pub async fn run_unseal_challenge(store: &Store) -> Result<(), AppError> {
 
     eprintln!();
     eprintln!("  VTA unsealed successfully.");
-    eprintln!("  Authenticated as: {} ({})",
+    eprintln!(
+        "  Authenticated as: {} ({})",
         admin_did,
         admin_entry.label.as_deref().unwrap_or("no label")
     );
@@ -248,11 +254,12 @@ fn verify_challenge_signature(
         .map_err(|e| AppError::Validation(format!("invalid Ed25519 signature: {e}")))?;
 
     // Verify
-    verifying_key
-        .verify(challenge, &signature)
-        .map_err(|_| AppError::Forbidden(
-            "signature verification failed — challenge was not signed by this DID's private key".into(),
-        ))?;
+    verifying_key.verify(challenge, &signature).map_err(|_| {
+        AppError::Forbidden(
+            "signature verification failed — challenge was not signed by this DID's private key"
+                .into(),
+        )
+    })?;
 
     Ok(())
 }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -78,9 +78,11 @@ pub struct AppState {
     pub acl_ks: KeyspaceHandle,
     pub contexts_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
+    pub imported_ks: KeyspaceHandle,
     pub cache_ks: KeyspaceHandle,
     #[cfg(feature = "webvh")]
     pub webvh_ks: KeyspaceHandle,
+    pub wrapping_cache: crate::keys::wrapping::WrappingKeyCache,
     pub config: Arc<RwLock<AppConfig>>,
     pub seed_store: Arc<dyn SeedStore>,
     pub did_resolver: Option<DIDCacheClient>,
@@ -132,6 +134,7 @@ pub async fn build_app_state(
     let acl_ks = apply_encryption(store.keyspace("acl")?);
     let contexts_ks = apply_encryption(store.keyspace("contexts")?);
     let audit_ks = apply_encryption(store.keyspace("audit")?);
+    let imported_ks = apply_encryption(store.keyspace("imported_secrets")?);
     let cache_ks = store.keyspace("cache")?;
     #[cfg(feature = "webvh")]
     let webvh_ks = apply_encryption(store.keyspace("webvh")?);
@@ -145,9 +148,11 @@ pub async fn build_app_state(
         acl_ks,
         contexts_ks,
         audit_ks,
+        imported_ks,
         cache_ks,
         #[cfg(feature = "webvh")]
         webvh_ks,
+        wrapping_cache: crate::keys::wrapping::WrappingKeyCache::new(),
         config: Arc::new(RwLock::new(config)),
         seed_store,
         did_resolver,
@@ -215,6 +220,7 @@ pub async fn run(
         let acl_ks = apply_encryption(store.keyspace("acl")?);
         let contexts_ks = apply_encryption(store.keyspace("contexts")?);
         let audit_ks = apply_encryption(store.keyspace("audit")?);
+        let imported_ks = apply_encryption(store.keyspace("imported_secrets")?);
         let cache_ks = store.keyspace("cache")?;
         #[cfg(feature = "webvh")]
         let webvh_ks = apply_encryption(store.keyspace("webvh")?);
@@ -273,6 +279,7 @@ pub async fn run(
                 acl_ks: acl_ks.clone(),
                 contexts_ks: contexts_ks.clone(),
                 audit_ks: audit_ks.clone(),
+                imported_ks: imported_ks.clone(),
                 #[cfg(feature = "webvh")]
                 webvh_ks: webvh_ks.clone(),
                 seed_store: seed_store.clone(),
@@ -290,15 +297,20 @@ pub async fn run(
         #[cfg(feature = "rest")]
         let rest_handle = if let Some(ref listener_ref) = std_listener {
             let listener = listener_ref.try_clone().map_err(AppError::Io)?;
+            let wrapping_cache = crate::keys::wrapping::WrappingKeyCache::new();
+            wrapping_cache.clone().spawn_reaper();
+
             let state = AppState {
                 keys_ks,
                 sessions_ks,
                 acl_ks,
                 contexts_ks,
                 audit_ks,
+                imported_ks,
                 cache_ks,
                 #[cfg(feature = "webvh")]
                 webvh_ks,
+                wrapping_cache,
                 config: Arc::new(RwLock::new(config.clone())),
                 seed_store: seed_store.clone(),
                 did_resolver,

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -60,7 +60,6 @@ pub struct TeeContext {
 #[cfg(not(feature = "tee"))]
 pub struct TeeContext(());
 
-
 /// Trigger a soft restart after a short delay, allowing the current
 /// response to be sent before threads shut down.
 pub fn trigger_restart(restart_tx: &watch::Sender<bool>) {
@@ -269,7 +268,8 @@ pub async fn run(
 
         // Shared DIDComm bridge (still used by REST handlers for WebVH request-response)
         #[cfg(feature = "didcomm")]
-        let didcomm_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> = Arc::new(tokio::sync::RwLock::new(None));
+        let didcomm_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> =
+            Arc::new(tokio::sync::RwLock::new(None));
 
         // Build VtaState for the DIDComm service router
         #[cfg(feature = "didcomm")]
@@ -388,10 +388,14 @@ pub async fn run(
                         }],
                     };
 
-                    let router = messaging::router::build_router(Arc::clone(vta_state))
-                        .map_err(|e| AppError::Internal(format!("failed to build DIDComm router: {e}")))?;
+                    let router =
+                        messaging::router::build_router(Arc::clone(vta_state)).map_err(|e| {
+                            AppError::Internal(format!("failed to build DIDComm router: {e}"))
+                        })?;
 
-                    match DIDCommService::start(service_config, router, didcomm_shutdown.clone()).await {
+                    match DIDCommService::start(service_config, router, didcomm_shutdown.clone())
+                        .await
+                    {
                         Ok(service) => {
                             info!("DIDComm service started");
                             Some(service)
@@ -598,8 +602,7 @@ fn run_rest_thread(
                     .on_response(DefaultOnResponse::new().level(Level::INFO)),
             );
 
-        let app = traced_routes
-            .merge(routes::health_router().with_state(state));
+        let app = traced_routes.merge(routes::health_router().with_state(state));
 
         let shutdown_rx = shutdown_rx.clone();
         axum::serve(listener, app)
@@ -763,14 +766,24 @@ async fn init_auth(
             Ok(k) => k,
             Err(e) => {
                 warn!("failed to load JWT signing key: {e} — auth endpoints will not work");
-                return (Some(did_resolver), Some(Arc::new(secrets_resolver)), None, None);
+                return (
+                    Some(did_resolver),
+                    Some(Arc::new(secrets_resolver)),
+                    None,
+                    None,
+                );
             }
         },
         None => {
             warn!(
                 "auth.jwt_signing_key not configured — auth endpoints will not work (run setup first)"
             );
-            return (Some(did_resolver), Some(Arc::new(secrets_resolver)), None, None);
+            return (
+                Some(did_resolver),
+                Some(Arc::new(secrets_resolver)),
+                None,
+                None,
+            );
         }
     };
 
@@ -784,13 +797,15 @@ async fn init_auth(
             .build();
         match tdk_config {
             Ok(cfg) => match TDKSharedState::new(cfg).await {
-                Ok(tdk) => match ATM::new(ATMConfig::builder().build().unwrap(), Arc::new(tdk)).await {
-                    Ok(a) => Some(a),
-                    Err(e) => {
-                        warn!("failed to create ATM for auth unpack: {e}");
-                        None
+                Ok(tdk) => {
+                    match ATM::new(ATMConfig::builder().build().unwrap(), Arc::new(tdk)).await {
+                        Ok(a) => Some(a),
+                        Err(e) => {
+                            warn!("failed to create ATM for auth unpack: {e}");
+                            None
+                        }
                     }
-                },
+                }
                 Err(e) => {
                     warn!("failed to create TDK shared state: {e}");
                     None

--- a/vta-service/src/setup.rs
+++ b/vta-service/src/setup.rs
@@ -548,7 +548,9 @@ pub async fn run_setup_wizard(
             public_url: None,
             server: ServerConfig::default(),
             log: LogConfig::default(),
-            store: StoreConfig { data_dir: PathBuf::from("data/vta") },
+            store: StoreConfig {
+                data_dir: PathBuf::from("data/vta"),
+            },
             services: ServicesConfig::default(),
             messaging: None,
             auth: AuthConfig::default(),
@@ -1276,13 +1278,18 @@ async fn create_webvh_did(
         next_key_hashes: if next_key_hashes.is_empty() {
             None
         } else {
-            Some(Arc::new(next_key_hashes.into_iter().map(Into::into).collect()))
+            Some(Arc::new(
+                next_key_hashes.into_iter().map(Into::into).collect(),
+            ))
         },
         ..Default::default()
     };
 
     // Create the DID
-    let url_str = webvh_url.get_http_url(None).map_err(|e| format!("{e}"))?.to_string();
+    let url_str = webvh_url
+        .get_http_url(None)
+        .map_err(|e| format!("{e}"))?
+        .to_string();
     let create_config = CreateDIDConfig::builder()
         .address(url_str)
         .authorization_key(derived.signing_secret.clone())
@@ -1291,7 +1298,8 @@ async fn create_webvh_did(
         .build()
         .map_err(|e| format!("failed to build DID config: {e}"))?;
 
-    let result = create_did(create_config).await
+    let result = create_did(create_config)
+        .await
         .map_err(|e| format!("failed to create DID: {e}"))?;
 
     let final_did = result.did().to_string();

--- a/vta-service/src/tee/admin_bootstrap.rs
+++ b/vta-service/src/tee/admin_bootstrap.rs
@@ -102,7 +102,10 @@ pub async fn maybe_bootstrap_admin(
     } else {
         // No admin_did configured — generate a random did:key and store the
         // credential bundle for retrieval via REST.
-        info!(context_id, "no admin_did configured — generating random admin credential");
+        info!(
+            context_id,
+            "no admin_did configured — generating random admin credential"
+        );
 
         let (did, private_key_multibase) = generate_did_key();
 

--- a/vta-service/src/tee/did_autogen.rs
+++ b/vta-service/src/tee/did_autogen.rs
@@ -143,9 +143,15 @@ pub async fn maybe_generate_vta_did(
         .map_err(|e| AppError::Internal(format!("failed to serialize DID log: {e}")))?;
 
     // Save key records
-    keys::save_entity_key_records(&final_did, &derived, &keys_ks, Some("vta"), Some(active_seed_id))
-        .await
-        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    keys::save_entity_key_records(
+        &final_did,
+        &derived,
+        &keys_ks,
+        Some("vta"),
+        Some(active_seed_id),
+    )
+    .await
+    .map_err(|e| AppError::Internal(format!("{e}")))?;
 
     // Update context with the new DID
     let mut ctx = ctx;
@@ -237,18 +243,19 @@ fn build_vta_did_document(
 
     // Add TeeAttestation service if configured
     if config.tee.embed_in_did
-        && let Some(ref public_url) = config.public_url {
-            let services = did_document
-                .as_object_mut()
-                .unwrap()
-                .entry("service")
-                .or_insert_with(|| json!([]));
-            services.as_array_mut().unwrap().push(json!({
-                "id": "{DID}#tee-attestation",
-                "type": "TeeAttestation",
-                "serviceEndpoint": format!("{}/attestation/report", public_url.trim_end_matches('/'))
-            }));
-        }
+        && let Some(ref public_url) = config.public_url
+    {
+        let services = did_document
+            .as_object_mut()
+            .unwrap()
+            .entry("service")
+            .or_insert_with(|| json!([]));
+        services.as_array_mut().unwrap().push(json!({
+            "id": "{DID}#tee-attestation",
+            "type": "TeeAttestation",
+            "serviceEndpoint": format!("{}/attestation/report", public_url.trim_end_matches('/'))
+        }));
+    }
 
     did_document
 }
@@ -259,13 +266,11 @@ fn build_vta_did_document(
 /// `did:webvh:{SCID}:example.com%3A8080:vta` → `https://example.com:8080/vta`
 fn template_to_url(template: &str) -> Result<String, AppError> {
     // Strip "did:webvh:{SCID}:" prefix
-    let rest = template
-        .strip_prefix("did:webvh:{SCID}:")
-        .ok_or_else(|| {
-            AppError::Config(format!(
-                "vta_did_template must start with 'did:webvh:{{SCID}}:' — got: {template}"
-            ))
-        })?;
+    let rest = template.strip_prefix("did:webvh:{SCID}:").ok_or_else(|| {
+        AppError::Config(format!(
+            "vta_did_template must start with 'did:webvh:{{SCID}}:' — got: {template}"
+        ))
+    })?;
 
     if rest.is_empty() {
         return Err(AppError::Config(
@@ -275,7 +280,10 @@ fn template_to_url(template: &str) -> Result<String, AppError> {
 
     // did:webvh encoding: ":" separates path segments, "%3A" is a literal colon (port)
     // Decode %3A back to ":" for port numbers, then replace ":" with "/" for path
-    let url_path = rest.replace("%3A", "\x00").replace(':', "/").replace('\x00', ":");
+    let url_path = rest
+        .replace("%3A", "\x00")
+        .replace(':', "/")
+        .replace('\x00', ":");
 
     Ok(format!("https://{url_path}"))
 }

--- a/vta-service/src/tee/kms_bootstrap.rs
+++ b/vta-service/src/tee/kms_bootstrap.rs
@@ -64,7 +64,6 @@ impl Drop for BootstrappedSecrets {
     }
 }
 
-
 /// Well-known keys in the bootstrap keyspace.
 ///
 /// The data key is generated via KMS `GenerateDataKey` (with attestation when
@@ -101,9 +100,9 @@ pub async fn bootstrap_secrets(
             Ok(data_key) => {
                 let seed = aes_gcm_decrypt(&data_key, &seed_ciphertext)?;
                 let jwt_bytes = aes_gcm_decrypt(&data_key, &jwt_ciphertext)?;
-                let jwt_key: [u8; 32] = jwt_bytes.try_into().map_err(|_| {
-                    tee_attestation_error("JWT key must be exactly 32 bytes")
-                })?;
+                let jwt_key: [u8; 32] = jwt_bytes
+                    .try_into()
+                    .map_err(|_| tee_attestation_error("JWT key must be exactly 32 bytes"))?;
 
                 verify_jwt_fingerprint(&bs_ks, &jwt_key).await?;
                 info!("secrets decrypted from KMS — subsequent boot");
@@ -161,8 +160,12 @@ pub async fn bootstrap_secrets(
     let jwt_ciphertext = aes_gcm_encrypt(&data_key, &jwt_key)?;
 
     bs_ks.insert_raw(BOOTSTRAP_DK_CT_KEY, dk_ciphertext).await?;
-    bs_ks.insert_raw(BOOTSTRAP_SEED_CT_KEY, seed_ciphertext).await?;
-    bs_ks.insert_raw(BOOTSTRAP_JWT_CT_KEY, jwt_ciphertext).await?;
+    bs_ks
+        .insert_raw(BOOTSTRAP_SEED_CT_KEY, seed_ciphertext)
+        .await?;
+    bs_ks
+        .insert_raw(BOOTSTRAP_JWT_CT_KEY, jwt_ciphertext)
+        .await?;
     store_jwt_fingerprint(&bs_ks, &jwt_key).await?;
 
     // Flush to ensure ciphertexts survive if the enclave crashes during startup
@@ -212,8 +215,12 @@ pub async fn re_encrypt_bootstrap_secrets(
 
     // Store everything in the bootstrap keyspace
     bs_ks.insert_raw(BOOTSTRAP_DK_CT_KEY, dk_ciphertext).await?;
-    bs_ks.insert_raw(BOOTSTRAP_SEED_CT_KEY, seed_ciphertext).await?;
-    bs_ks.insert_raw(BOOTSTRAP_JWT_CT_KEY, jwt_ciphertext).await?;
+    bs_ks
+        .insert_raw(BOOTSTRAP_SEED_CT_KEY, seed_ciphertext)
+        .await?;
+    bs_ks
+        .insert_raw(BOOTSTRAP_JWT_CT_KEY, jwt_ciphertext)
+        .await?;
     store_jwt_fingerprint(&bs_ks, jwt_key).await?;
 
     // Flush immediately so ciphertexts survive if enclave restarts
@@ -243,7 +250,12 @@ async fn store_jwt_fingerprint(
     key: &[u8; 32],
 ) -> Result<(), AppError> {
     let fingerprint = jwt_fingerprint(key);
-    bs_ks.insert_raw(BOOTSTRAP_JWT_FINGERPRINT_KEY, fingerprint.as_bytes().to_vec()).await?;
+    bs_ks
+        .insert_raw(
+            BOOTSTRAP_JWT_FINGERPRINT_KEY,
+            fingerprint.as_bytes().to_vec(),
+        )
+        .await?;
     debug!(fingerprint = %fingerprint, "JWT key fingerprint stored");
     Ok(())
 }
@@ -295,15 +307,13 @@ pub(crate) fn derive_storage_key(seed: &[u8], salt: &str) -> [u8; 32] {
     type HmacSha256 = Hmac<Sha256>;
 
     // HKDF-Extract: PRK = HMAC-SHA256(salt, seed)
-    let mut mac = HmacSha256::new_from_slice(salt.as_bytes())
-        .expect("HMAC accepts any key length");
+    let mut mac = HmacSha256::new_from_slice(salt.as_bytes()).expect("HMAC accepts any key length");
     mac.update(seed);
     let prk = mac.finalize().into_bytes();
 
     // HKDF-Expand: OKM = HMAC-SHA256(PRK, info || 0x01)
     let info = b"aes-256-gcm-storage";
-    let mut mac = HmacSha256::new_from_slice(&prk)
-        .expect("HMAC accepts any key length");
+    let mut mac = HmacSha256::new_from_slice(&prk).expect("HMAC accepts any key length");
     mac.update(info);
     mac.update(&[0x01]);
     let okm = mac.finalize().into_bytes();
@@ -329,32 +339,24 @@ async fn kms_client(config: &TeeKmsConfig) -> aws_sdk_kms::Client {
 /// Generate an ephemeral RSA-2048 keypair and obtain an NSM attestation
 /// document binding the public key. Returns `(private_key, recipient_info)`
 /// for use with KMS attested operations.
-fn nsm_attested_recipient() -> Result<
-    (rsa::RsaPrivateKey, aws_sdk_kms::types::RecipientInfo),
-    AppError,
-> {
+fn nsm_attested_recipient()
+-> Result<(rsa::RsaPrivateKey, aws_sdk_kms::types::RecipientInfo), AppError> {
     use rsa::pkcs8::EncodePublicKey;
 
     let mut rng = rsa::rand_core::OsRng;
-    let private_key = rsa::RsaPrivateKey::new(&mut rng, 2048).map_err(|e| {
-        tee_attestation_error(format!("RSA key generation failed: {e}"))
-    })?;
+    let private_key = rsa::RsaPrivateKey::new(&mut rng, 2048)
+        .map_err(|e| tee_attestation_error(format!("RSA key generation failed: {e}")))?;
 
     let public_key_der = private_key
         .to_public_key()
         .to_public_key_der()
-        .map_err(|e| {
-            tee_attestation_error(format!("RSA public key DER encoding failed: {e}"))
-        })?;
+        .map_err(|e| tee_attestation_error(format!("RSA public key DER encoding failed: {e}")))?;
 
-    let attestation_doc =
-        super::nitro::request_nsm_attestation_for_kms(public_key_der.as_ref())?;
+    let attestation_doc = super::nitro::request_nsm_attestation_for_kms(public_key_der.as_ref())?;
 
     let recipient = aws_sdk_kms::types::RecipientInfo::builder()
         .attestation_document(aws_sdk_kms::primitives::Blob::new(attestation_doc))
-        .key_encryption_algorithm(
-            aws_sdk_kms::types::KeyEncryptionMechanism::RsaesOaepSha256,
-        )
+        .key_encryption_algorithm(aws_sdk_kms::types::KeyEncryptionMechanism::RsaesOaepSha256)
         .build();
 
     Ok((private_key, recipient))
@@ -430,10 +432,7 @@ async fn kms_decrypt_attested(
 }
 
 /// Direct KMS Decrypt without the Recipient parameter.
-async fn kms_decrypt_direct(
-    config: &TeeKmsConfig,
-    ciphertext: &[u8],
-) -> Result<Vec<u8>, AppError> {
+async fn kms_decrypt_direct(config: &TeeKmsConfig, ciphertext: &[u8]) -> Result<Vec<u8>, AppError> {
     let client = kms_client(config).await;
 
     let resp = client
@@ -457,9 +456,7 @@ async fn kms_decrypt_direct(
 ///
 /// Without NSM, calls `GenerateDataKey` directly (KMS returns plaintext in
 /// the response — suitable for development/simulated mode only).
-async fn kms_generate_data_key(
-    config: &TeeKmsConfig,
-) -> Result<(Vec<u8>, [u8; 32]), AppError> {
+async fn kms_generate_data_key(config: &TeeKmsConfig) -> Result<(Vec<u8>, [u8; 32]), AppError> {
     if std::path::Path::new("/dev/nsm").exists() {
         match kms_generate_data_key_attested(config).await {
             Ok(result) => {
@@ -501,11 +498,14 @@ async fn kms_generate_data_key_attested(
         .to_vec();
 
     let data_key_vec = unwrap_cms_response(resp.ciphertext_for_recipient(), &private_key)?;
-    let data_key: [u8; 32] = data_key_vec.try_into().map_err(|_| {
-        tee_attestation_error("data key is not 32 bytes")
-    })?;
+    let data_key: [u8; 32] = data_key_vec
+        .try_into()
+        .map_err(|_| tee_attestation_error("data key is not 32 bytes"))?;
 
-    debug!(kms_ct_len = kms_ciphertext.len(), "obtained attested data key");
+    debug!(
+        kms_ct_len = kms_ciphertext.len(),
+        "obtained attested data key"
+    );
     Ok((kms_ciphertext, data_key))
 }
 
@@ -532,9 +532,10 @@ async fn kms_generate_data_key_direct(
     let plaintext = resp
         .plaintext()
         .ok_or_else(|| tee_attestation_error("GenerateDataKey returned no Plaintext"))?;
-    let data_key: [u8; 32] = plaintext.as_ref().try_into().map_err(|_| {
-        tee_attestation_error("data key is not 32 bytes")
-    })?;
+    let data_key: [u8; 32] = plaintext
+        .as_ref()
+        .try_into()
+        .map_err(|_| tee_attestation_error("data key is not 32 bytes"))?;
 
     Ok((kms_ciphertext, data_key))
 }
@@ -545,16 +546,16 @@ async fn kms_generate_data_key_direct(
 
 /// AES-256-GCM encrypt, returning `[nonce: 12 bytes][ciphertext]`.
 fn aes_gcm_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, AppError> {
-    use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
     use aes_gcm::aead::generic_array::GenericArray;
+    use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
 
     let cipher = Aes256Gcm::new(GenericArray::from_slice(key));
     let mut nonce_bytes = [0u8; 12];
     rand::fill(&mut nonce_bytes);
     let nonce = GenericArray::from_slice(&nonce_bytes);
-    let ciphertext = cipher.encrypt(nonce, plaintext).map_err(|e| {
-        tee_attestation_error(format!("AES-GCM encryption failed: {e}"))
-    })?;
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|e| tee_attestation_error(format!("AES-GCM encryption failed: {e}")))?;
 
     let mut out = Vec::with_capacity(12 + ciphertext.len());
     out.extend_from_slice(&nonce_bytes);
@@ -564,8 +565,8 @@ fn aes_gcm_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, AppError
 
 /// AES-256-GCM decrypt a `[nonce: 12 bytes][ciphertext]` blob.
 fn aes_gcm_decrypt(key: &[u8], blob: &[u8]) -> Result<Vec<u8>, AppError> {
-    use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
     use aes_gcm::aead::generic_array::GenericArray;
+    use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
 
     if key.len() != 32 {
         return Err(tee_attestation_error(format!(
@@ -580,9 +581,9 @@ fn aes_gcm_decrypt(key: &[u8], blob: &[u8]) -> Result<Vec<u8>, AppError> {
     let nonce = GenericArray::from_slice(&blob[..12]);
     let ciphertext = &blob[12..];
     let cipher = Aes256Gcm::new(GenericArray::from_slice(key));
-    cipher.decrypt(nonce, ciphertext).map_err(|e| {
-        tee_attestation_error(format!("AES-GCM decryption failed: {e}"))
-    })
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|e| tee_attestation_error(format!("AES-GCM decryption failed: {e}")))
 }
 
 // ---------------------------------------------------------------------------
@@ -623,9 +624,7 @@ fn decrypt_cms_envelope(
             let padding = Oaep::new_with_mgf_hash::<sha2::Sha256, sha1::Sha1>();
             private_key.decrypt(padding, &fields.encrypted_key)
         })
-        .map_err(|e| {
-            tee_attestation_error(format!("RSA-OAEP decryption of CEK failed: {e}"))
-        })?;
+        .map_err(|e| tee_attestation_error(format!("RSA-OAEP decryption of CEK failed: {e}")))?;
 
     debug!(
         cek_len = cek.len(),
@@ -662,9 +661,8 @@ fn decrypt_cms_envelope(
         }
 
         let mut buf = fields.ciphertext.clone();
-        let decryptor = Aes256CbcDec::new_from_slices(&cek, &fields.iv).map_err(|e| {
-            tee_attestation_error(format!("AES-256-CBC init failed: {e}"))
-        })?;
+        let decryptor = Aes256CbcDec::new_from_slices(&cek, &fields.iv)
+            .map_err(|e| tee_attestation_error(format!("AES-256-CBC init failed: {e}")))?;
         let plaintext = decryptor
             .decrypt_padded_mut::<cbc::cipher::block_padding::Pkcs7>(&mut buf)
             .map_err(|e| {
@@ -673,8 +671,8 @@ fn decrypt_cms_envelope(
         plaintext.to_vec()
     } else if fields.content_encryption_oid == aes_256_gcm_oid {
         // AES-256-GCM
-        use aes_gcm::{AesGcm, KeyInit, aead::Aead};
         use aes_gcm::aead::generic_array::GenericArray;
+        use aes_gcm::{AesGcm, KeyInit, aead::Aead};
 
         match fields.iv.len() {
             12 => {
@@ -682,20 +680,22 @@ fn decrypt_cms_envelope(
                     GenericArray::from_slice(&cek),
                 );
                 cipher
-                    .decrypt(GenericArray::from_slice(&fields.iv), fields.ciphertext.as_ref())
-                    .map_err(|e| {
-                        tee_attestation_error(format!("AES-GCM decryption failed: {e}"))
-                    })?
+                    .decrypt(
+                        GenericArray::from_slice(&fields.iv),
+                        fields.ciphertext.as_ref(),
+                    )
+                    .map_err(|e| tee_attestation_error(format!("AES-GCM decryption failed: {e}")))?
             }
             16 => {
                 let cipher = AesGcm::<aes_gcm::aes::Aes256, aes_gcm::aead::consts::U16>::new(
                     GenericArray::from_slice(&cek),
                 );
                 cipher
-                    .decrypt(GenericArray::from_slice(&fields.iv), fields.ciphertext.as_ref())
-                    .map_err(|e| {
-                        tee_attestation_error(format!("AES-GCM decryption failed: {e}"))
-                    })?
+                    .decrypt(
+                        GenericArray::from_slice(&fields.iv),
+                        fields.ciphertext.as_ref(),
+                    )
+                    .map_err(|e| tee_attestation_error(format!("AES-GCM decryption failed: {e}")))?
             }
             n => {
                 return Err(tee_attestation_error(format!(
@@ -710,7 +710,10 @@ fn decrypt_cms_envelope(
         )));
     };
 
-    debug!(plaintext_len = plaintext.len(), "CMS envelope decrypted successfully");
+    debug!(
+        plaintext_len = plaintext.len(),
+        "CMS envelope decrypted successfully"
+    );
     Ok(plaintext)
 }
 
@@ -812,10 +815,11 @@ mod cms_der {
         Ok(ek_value.to_vec())
     }
 
+    /// (algorithm_oid, iv_or_nonce, ciphertext) parsed from CMS EncryptedContentInfo.
+    type EncryptedContentParts = (Vec<u8>, Vec<u8>, Vec<u8>);
+
     /// Returns (algorithm_oid, iv_or_nonce, ciphertext).
-    fn parse_encrypted_content_info(
-        eci_data: &[u8],
-    ) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>), AppError> {
+    fn parse_encrypted_content_info(eci_data: &[u8]) -> Result<EncryptedContentParts, AppError> {
         let mut pos = 0;
         // contentType OID — skip
         let _ = read_tlv(eci_data, &mut pos, "ECI contentType")?;
@@ -839,7 +843,9 @@ mod cms_der {
         pos += 1;
 
         if pos >= eci_data.len() {
-            return Err(tee_attestation_error("CMS: truncated encryptedContent length"));
+            return Err(tee_attestation_error(
+                "CMS: truncated encryptedContent length",
+            ));
         }
         let first_len = eci_data[pos];
         pos += 1;
@@ -1119,10 +1125,10 @@ mod tests {
     /// decrypt_cms_envelope round-trip without needing real KMS or NSM.
     #[test]
     fn test_cms_envelope_roundtrip() {
-        use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
         use aes_gcm::aead::generic_array::GenericArray;
-        use rsa::{RsaPrivateKey, Oaep};
+        use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
         use rsa::pkcs8::EncodePublicKey;
+        use rsa::{Oaep, RsaPrivateKey};
 
         // Generate RSA keypair (the "ephemeral" key the enclave would create)
         let mut rng = rsa::rand_core::OsRng;

--- a/vta-service/src/tee/mnemonic_guard.rs
+++ b/vta-service/src/tee/mnemonic_guard.rs
@@ -114,9 +114,8 @@ impl MnemonicExportGuard {
     pub fn status(&self) -> MnemonicExportStatus {
         let guard = self.inner.lock().unwrap();
         let elapsed = guard.created_at.elapsed().as_secs();
-        let window_active = guard.entropy.is_some()
-            && !guard.exported
-            && elapsed < guard.window_secs;
+        let window_active =
+            guard.entropy.is_some() && !guard.exported && elapsed < guard.window_secs;
         let remaining = if window_active {
             guard.window_secs.saturating_sub(elapsed)
         } else {

--- a/vta-service/src/tee/mod.rs
+++ b/vta-service/src/tee/mod.rs
@@ -1,6 +1,6 @@
 pub mod admin_bootstrap;
-pub mod did_autogen;
 mod detect;
+pub mod did_autogen;
 pub mod kms_bootstrap;
 pub mod mnemonic_guard;
 pub mod provider;
@@ -75,14 +75,18 @@ pub fn init_tee(config: &TeeConfig) -> Result<Option<TeeState>, AppError> {
                 }
                 None => {
                     if config.mode == TeeMode::Required {
-                        error!("TEE mode is 'required' but no TEE hardware detected — refusing to start");
+                        error!(
+                            "TEE mode is 'required' but no TEE hardware detected — refusing to start"
+                        );
                         Err(tee_attestation_error(
                             "TEE mode is 'required' but no TEE hardware was detected. \
                              Set tee.mode = 'optional' or 'disabled' to run without TEE, \
                              or deploy on TEE-capable hardware (AMD SEV-SNP, AWS Nitro).",
                         ))
                     } else {
-                        warn!("TEE mode is 'optional' but no TEE hardware detected — attestation will not be available");
+                        warn!(
+                            "TEE mode is 'optional' but no TEE hardware detected — attestation will not be available"
+                        );
                         Ok(None)
                     }
                 }

--- a/vta-service/src/tee/nitro.rs
+++ b/vta-service/src/tee/nitro.rs
@@ -55,11 +55,7 @@ impl TeeProvider for NitroProvider {
         })
     }
 
-    fn attest(
-        &self,
-        user_data: &[u8],
-        nonce: &[u8],
-    ) -> Result<AttestationReport, AppError> {
+    fn attest(&self, user_data: &[u8], nonce: &[u8]) -> Result<AttestationReport, AppError> {
         debug!(
             user_data_len = user_data.len(),
             nonce_len = nonce.len(),
@@ -68,7 +64,10 @@ impl TeeProvider for NitroProvider {
 
         let evidence = request_nsm_attestation(user_data, nonce)?;
 
-        debug!(evidence_len = evidence.len(), "Nitro attestation document generated");
+        debug!(
+            evidence_len = evidence.len(),
+            "Nitro attestation document generated"
+        );
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -104,7 +103,7 @@ impl TeeProvider for NitroProvider {
         // CBOR array(4): 0x84
         let first_byte = evidence[0];
         let valid_start = first_byte == 0xD8  // CBOR tag (2-byte form)
-            || first_byte == 0x84;             // CBOR array(4) — untagged COSE_Sign1
+            || first_byte == 0x84; // CBOR array(4) — untagged COSE_Sign1
 
         if !valid_start {
             debug!(
@@ -161,9 +160,7 @@ fn request_nsm_attestation(user_data: &[u8], nonce: &[u8]) -> Result<Vec<u8>, Ap
 /// only the enclave (holding the private key) can decrypt it.
 ///
 /// `public_key_der` must be the RSA public key in DER-encoded SPKI format.
-pub(crate) fn request_nsm_attestation_for_kms(
-    public_key_der: &[u8],
-) -> Result<Vec<u8>, AppError> {
+pub(crate) fn request_nsm_attestation_for_kms(public_key_der: &[u8]) -> Result<Vec<u8>, AppError> {
     let fd = open_nsm_device()?;
     let request = build_nsm_request(&[], &[], Some(public_key_der));
     let response = nsm_ioctl(fd.as_raw_fd(), &request)?;
@@ -181,7 +178,9 @@ impl NsmFd {
 
 impl Drop for NsmFd {
     fn drop(&mut self) {
-        unsafe { libc::close(self.0); }
+        unsafe {
+            libc::close(self.0);
+        }
     }
 }
 
@@ -235,22 +234,16 @@ fn nsm_ioctl(fd: std::os::unix::io::RawFd, request: &[u8]) -> Result<Vec<u8>, Ap
         },
     };
 
-    let ret = unsafe {
-        libc::ioctl(fd, NSM_IOCTL_REQUEST, &mut msg as *mut NsmMessage)
-    };
+    let ret = unsafe { libc::ioctl(fd, NSM_IOCTL_REQUEST, &mut msg as *mut NsmMessage) };
 
     if ret != 0 {
         let err = std::io::Error::last_os_error();
-        return Err(tee_attestation_error(format!(
-            "NSM ioctl failed: {err}"
-        )));
+        return Err(tee_attestation_error(format!("NSM ioctl failed: {err}")));
     }
 
     let actual_len = msg.response.len as usize;
     if actual_len == 0 {
-        return Err(tee_attestation_error(
-            "empty response from NSM device",
-        ));
+        return Err(tee_attestation_error("empty response from NSM device"));
     }
 
     response_buf.truncate(actual_len);
@@ -312,11 +305,7 @@ fn extract_attestation_document(response: &[u8]) -> Result<Vec<u8>, AppError> {
     let pos = response
         .windows(marker.len())
         .position(|w| w == marker)
-        .ok_or_else(|| {
-            tee_attestation_error(
-                "NSM response does not contain 'document' field",
-            )
-        })?;
+        .ok_or_else(|| tee_attestation_error("NSM response does not contain 'document' field"))?;
 
     // The byte string follows immediately after the "document" text
     let after_key = pos + marker.len();

--- a/vta-service/src/tee/provider.rs
+++ b/vta-service/src/tee/provider.rs
@@ -18,11 +18,7 @@ pub trait TeeProvider: Send + Sync {
     ///
     /// The `user_data` is typically the VTA DID (UTF-8 encoded).
     /// The `nonce` is a client-provided value for replay prevention.
-    fn attest(
-        &self,
-        user_data: &[u8],
-        nonce: &[u8],
-    ) -> Result<AttestationReport, AppError>;
+    fn attest(&self, user_data: &[u8], nonce: &[u8]) -> Result<AttestationReport, AppError>;
 
     /// Verify an attestation report (self-check).
     ///

--- a/vta-service/src/tee/sev_snp.rs
+++ b/vta-service/src/tee/sev_snp.rs
@@ -39,11 +39,7 @@ impl TeeProvider for SevSnpProvider {
     fn detect(&self) -> Result<TeeStatus, AppError> {
         let detected = std::path::Path::new("/dev/sev-guest").exists();
 
-        let platform_version = if detected {
-            read_sev_version()
-        } else {
-            None
-        };
+        let platform_version = if detected { read_sev_version() } else { None };
 
         if detected {
             info!(version = ?platform_version, "SEV-SNP guest device detected");
@@ -56,11 +52,7 @@ impl TeeProvider for SevSnpProvider {
         })
     }
 
-    fn attest(
-        &self,
-        user_data: &[u8],
-        nonce: &[u8],
-    ) -> Result<AttestationReport, AppError> {
+    fn attest(&self, user_data: &[u8], nonce: &[u8]) -> Result<AttestationReport, AppError> {
         let report_data = build_report_data(user_data, nonce);
 
         debug!(
@@ -72,8 +64,16 @@ impl TeeProvider for SevSnpProvider {
         let evidence = request_snp_report(&report_data)?;
 
         // Parse key fields from the report for logging
-        let policy = u64::from_le_bytes(evidence[POLICY_OFFSET..POLICY_OFFSET + 8].try_into().unwrap_or_default());
-        let guest_svn = u32::from_le_bytes(evidence[GUEST_SVN_OFFSET..GUEST_SVN_OFFSET + 4].try_into().unwrap_or_default());
+        let policy = u64::from_le_bytes(
+            evidence[POLICY_OFFSET..POLICY_OFFSET + 8]
+                .try_into()
+                .unwrap_or_default(),
+        );
+        let guest_svn = u32::from_le_bytes(
+            evidence[GUEST_SVN_OFFSET..GUEST_SVN_OFFSET + 4]
+                .try_into()
+                .unwrap_or_default(),
+        );
 
         debug!(
             evidence_len = evidence.len(),
@@ -133,7 +133,10 @@ impl TeeProvider for SevSnpProvider {
                 .unwrap_or_default(),
         );
         if sig_algo != 1 {
-            debug!(sig_algo, "unexpected signature algorithm (expected 1 = ECDSA P-384)");
+            debug!(
+                sig_algo,
+                "unexpected signature algorithm (expected 1 = ECDSA P-384)"
+            );
             return Ok(false);
         }
 
@@ -271,19 +274,19 @@ fn request_snp_report(report_data: &[u8; 64]) -> Result<Vec<u8>, AppError> {
     // struct snp_report_resp
     #[repr(C)]
     struct SnpReportResp {
-        status: u32,                    // Firmware status code (0 = success)
-        report_size: u32,               // Size of the report
-        rsvd: [u8; 24],                 // Reserved
-        report: [u8; SNP_REPORT_SIZE],  // The attestation report
+        status: u32,                   // Firmware status code (0 = success)
+        report_size: u32,              // Size of the report
+        rsvd: [u8; 24],                // Reserved
+        report: [u8; SNP_REPORT_SIZE], // The attestation report
     }
 
     // struct snp_guest_request_ioctl
     #[repr(C)]
     struct SnpGuestRequestIoctl {
-        msg_version: u8,    // Message version (must be 1)
-        req_data: u64,      // Pointer to request structure
-        resp_data: u64,     // Pointer to response structure
-        fw_err: u64,        // Firmware error code (output)
+        msg_version: u8, // Message version (must be 1)
+        req_data: u64,   // Pointer to request structure
+        resp_data: u64,  // Pointer to response structure
+        fw_err: u64,     // Firmware error code (output)
     }
 
     let mut req = SnpReportReq {

--- a/vta-service/src/tee/simulated.rs
+++ b/vta-service/src/tee/simulated.rs
@@ -28,11 +28,7 @@ impl TeeProvider for SimulatedProvider {
         })
     }
 
-    fn attest(
-        &self,
-        user_data: &[u8],
-        nonce: &[u8],
-    ) -> Result<AttestationReport, AppError> {
+    fn attest(&self, user_data: &[u8], nonce: &[u8]) -> Result<AttestationReport, AppError> {
         // Build a deterministic "evidence" blob by hashing the inputs.
         // This is NOT real attestation — it's structurally similar for testing.
         let mut hasher = Sha256::new();

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -162,7 +162,8 @@ pub async fn run_create_did(
     };
 
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
-    let no_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> = Arc::new(tokio::sync::RwLock::new(None));
+    let no_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> =
+        Arc::new(tokio::sync::RwLock::new(None));
     let result = operations::did_webvh::create_did_webvh(
         &keys_ks,
         &contexts_ks,
@@ -249,7 +250,8 @@ pub async fn run_delete_did(
 
     let auth = cli_super_admin();
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
-    let no_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> = Arc::new(tokio::sync::RwLock::new(None));
+    let no_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> =
+        Arc::new(tokio::sync::RwLock::new(None));
     operations::did_webvh::delete_did_webvh(
         &webvh_ks,
         &keys_ks,

--- a/vta-service/src/webvh_client.rs
+++ b/vta-service/src/webvh_client.rs
@@ -33,24 +33,21 @@ impl WebvhClient {
         self.access_token = Some(token);
     }
 
-    fn auth_header(&self) -> Option<String> {
-        self.access_token.as_ref().map(|t| format!("Bearer {t}"))
+    /// Apply authorization header (if set) to a request builder.
+    fn with_auth(&self, mut req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(ref token) = self.access_token {
+            req = req.header("Authorization", format!("Bearer {token}"));
+        }
+        req
     }
 
-    /// POST /api/dids — allocate URI (optional path).
-    pub async fn request_uri(&self, path: Option<&str>) -> Result<RequestUriResponse, AppError> {
-        let url = format!("{}/api/dids", self.server_url);
-        info!(method = "POST", %url, "webvh: sending via rest");
-        let mut req = self.http.post(&url);
-        if let Some(auth) = self.auth_header() {
-            req = req.header("Authorization", auth);
-        }
-        let body = match path {
-            Some(p) => serde_json::json!({ "path": p }),
-            None => serde_json::json!({}),
-        };
+    /// Send a request and check for success. Returns an error with context on failure.
+    async fn send(
+        &self,
+        req: reqwest::RequestBuilder,
+        context: &str,
+    ) -> Result<reqwest::Response, AppError> {
         let resp = req
-            .json(&body)
             .send()
             .await
             .map_err(|e| AppError::Internal(format!("webvh-server request failed: {e}")))?;
@@ -58,9 +55,22 @@ impl WebvhClient {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
             return Err(AppError::Internal(format!(
-                "webvh-server POST /api/dids failed ({status}): {text}"
+                "webvh-server {context} failed ({status}): {text}"
             )));
         }
+        Ok(resp)
+    }
+
+    /// POST /api/dids — allocate URI (optional path).
+    pub async fn request_uri(&self, path: Option<&str>) -> Result<RequestUriResponse, AppError> {
+        let url = format!("{}/api/dids", self.server_url);
+        info!(method = "POST", %url, "webvh: sending via rest");
+        let body = match path {
+            Some(p) => serde_json::json!({ "path": p }),
+            None => serde_json::json!({}),
+        };
+        let req = self.with_auth(self.http.post(&url)).json(&body);
+        let resp = self.send(req, "POST /api/dids").await?;
         debug!(method = "POST", status = 200, "webvh: received via rest");
         resp.json()
             .await
@@ -71,23 +81,11 @@ impl WebvhClient {
     pub async fn publish_did(&self, mnemonic: &str, log_content: &str) -> Result<(), AppError> {
         let url = format!("{}/api/dids/{mnemonic}", self.server_url);
         info!(method = "PUT", %url, "webvh: sending via rest");
-        let mut req = self.http.put(&url);
-        if let Some(auth) = self.auth_header() {
-            req = req.header("Authorization", auth);
-        }
-        let resp = req
+        let req = self
+            .with_auth(self.http.put(&url))
             .header("Content-Type", "application/jsonl")
-            .body(log_content.to_string())
-            .send()
-            .await
-            .map_err(|e| AppError::Internal(format!("webvh-server request failed: {e}")))?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            return Err(AppError::Internal(format!(
-                "webvh-server PUT /api/dids/{mnemonic} failed ({status}): {text}"
-            )));
-        }
+            .body(log_content.to_string());
+        self.send(req, &format!("PUT /api/dids/{mnemonic}")).await?;
         debug!(method = "PUT", status = 200, "webvh: received via rest");
         Ok(())
     }
@@ -96,21 +94,9 @@ impl WebvhClient {
     pub async fn delete_did(&self, mnemonic: &str) -> Result<(), AppError> {
         let url = format!("{}/api/dids/{mnemonic}", self.server_url);
         info!(method = "DELETE", %url, "webvh: sending via rest");
-        let mut req = self.http.delete(&url);
-        if let Some(auth) = self.auth_header() {
-            req = req.header("Authorization", auth);
-        }
-        let resp = req
-            .send()
-            .await
-            .map_err(|e| AppError::Internal(format!("webvh-server request failed: {e}")))?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            return Err(AppError::Internal(format!(
-                "webvh-server DELETE /api/dids/{mnemonic} failed ({status}): {text}"
-            )));
-        }
+        let req = self.with_auth(self.http.delete(&url));
+        self.send(req, &format!("DELETE /api/dids/{mnemonic}"))
+            .await?;
         debug!(method = "DELETE", status = 200, "webvh: received via rest");
         Ok(())
     }
@@ -118,22 +104,10 @@ impl WebvhClient {
     /// POST /api/dids/check — check if a path is available.
     pub async fn check_path(&self, path: &str) -> Result<CheckPathResponse, AppError> {
         let url = format!("{}/api/dids/check", self.server_url);
-        let mut req = self.http.post(&url);
-        if let Some(auth) = self.auth_header() {
-            req = req.header("Authorization", auth);
-        }
-        let resp = req
-            .json(&serde_json::json!({ "path": path }))
-            .send()
-            .await
-            .map_err(|e| AppError::Internal(format!("webvh-server request failed: {e}")))?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            return Err(AppError::Internal(format!(
-                "webvh-server POST /api/dids/check failed ({status}): {text}"
-            )));
-        }
+        let req = self
+            .with_auth(self.http.post(&url))
+            .json(&serde_json::json!({ "path": path }));
+        let resp = self.send(req, "POST /api/dids/check").await?;
         resp.json()
             .await
             .map_err(|e| AppError::Internal(format!("webvh-server response parse error: {e}")))

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -1125,3 +1125,55 @@ async fn non_admin_cannot_update_context_did() {
         .await;
     assert_eq!(status, StatusCode::FORBIDDEN);
 }
+
+// ── Reader role tests ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn reader_can_list_keys() {
+    let (app, ctx) = TestApp::new().await;
+    let reader_token = ctx
+        .auth_token("did:key:z6MkReader", "reader", vec!["test-ctx".into()])
+        .await;
+
+    let (status, _) = app
+        .request(get_auth("/keys?context_id=test-ctx", &reader_token))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn reader_cannot_sign() {
+    let (app, ctx) = TestApp::new().await;
+    let reader_token = ctx
+        .auth_token("did:key:z6MkReader", "reader", vec!["test-ctx".into()])
+        .await;
+
+    let (status, _) = app
+        .request(post_auth(
+            "/keys/test-key/sign",
+            &reader_token,
+            json!({"payload": "aGVsbG8", "algorithm": "EdDSA"}),
+        ))
+        .await;
+    assert!(
+        status == StatusCode::FORBIDDEN || status == StatusCode::UNPROCESSABLE_ENTITY,
+        "expected 403 or 422, got {status}"
+    );
+}
+
+#[tokio::test]
+async fn reader_cannot_create_key() {
+    let (app, ctx) = TestApp::new().await;
+    let reader_token = ctx
+        .auth_token("did:key:z6MkReader", "reader", vec!["test-ctx".into()])
+        .await;
+
+    let (status, _) = app
+        .request(post_auth(
+            "/keys",
+            &reader_token,
+            json!({"key_type": "Ed25519", "context_id": "test-ctx"}),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -238,6 +238,16 @@ fn patch_auth(uri: &str, token: &str, body: Value) -> Request<Body> {
         .unwrap()
 }
 
+fn put_auth(uri: &str, token: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method("PUT")
+        .uri(uri)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
 fn delete_auth(uri: &str, token: &str) -> Request<Body> {
     Request::builder()
         .method("DELETE")
@@ -886,4 +896,98 @@ async fn create_p256_key() {
     assert!(status.is_success(), "create p256: {status} {body}");
     assert_eq!(body["key_type"], "p256");
     assert!(body["public_key"].is_string());
+}
+
+// ── Context DID update (context admin) ────────────────────────────
+
+#[tokio::test]
+async fn context_admin_can_update_own_context_did() {
+    let (app, ctx) = TestApp::new().await;
+    let super_token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    // Create a context as super admin
+    let (status, _) = app
+        .request(post_auth(
+            "/contexts",
+            &super_token,
+            json!({"id": "myctx", "name": "My Context"}),
+        ))
+        .await;
+    assert!(status.is_success());
+
+    // Context-scoped admin can update DID on their own context
+    let scoped_token = ctx
+        .auth_token("did:key:z6MkScoped", "admin", vec!["myctx".into()])
+        .await;
+    let (status, body) = app
+        .request(put_auth(
+            "/contexts/myctx/did",
+            &scoped_token,
+            json!({"did": "did:webvh:abc:example.com"}),
+        ))
+        .await;
+    assert!(status.is_success(), "update did: {status} {body}");
+    assert_eq!(body["did"], "did:webvh:abc:example.com");
+}
+
+#[tokio::test]
+async fn context_admin_cannot_update_other_context_did() {
+    let (app, ctx) = TestApp::new().await;
+    let super_token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    // Create two contexts
+    app.request(post_auth("/contexts", &super_token, json!({"id": "ctx-a", "name": "A"}))).await;
+    app.request(post_auth("/contexts", &super_token, json!({"id": "ctx-b", "name": "B"}))).await;
+
+    // Admin scoped to ctx-a cannot update ctx-b's DID
+    let scoped_token = ctx
+        .auth_token("did:key:z6MkScopedA", "admin", vec!["ctx-a".into()])
+        .await;
+    let (status, _) = app
+        .request(put_auth(
+            "/contexts/ctx-b/did",
+            &scoped_token,
+            json!({"did": "did:webvh:nope:example.com"}),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn super_admin_can_update_any_context_did() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    app.request(post_auth("/contexts", &token, json!({"id": "anyctx", "name": "Any"}))).await;
+
+    let (status, body) = app
+        .request(put_auth(
+            "/contexts/anyctx/did",
+            &token,
+            json!({"did": "did:webvh:xyz:example.com"}),
+        ))
+        .await;
+    assert!(status.is_success(), "super admin update did: {status} {body}");
+    assert_eq!(body["did"], "did:webvh:xyz:example.com");
+}
+
+#[tokio::test]
+async fn non_admin_cannot_update_context_did() {
+    let (app, ctx) = TestApp::new().await;
+    let super_token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    app.request(post_auth("/contexts", &super_token, json!({"id": "restricted", "name": "R"}))).await;
+
+    // Application role cannot update DID
+    let app_token = ctx
+        .auth_token("did:key:z6MkApp", "application", vec!["restricted".into()])
+        .await;
+    let (status, _) = app
+        .request(put_auth(
+            "/contexts/restricted/did",
+            &app_token,
+            json!({"did": "did:webvh:bad:example.com"}),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
 }

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -50,13 +50,10 @@ impl TestApp {
         let webvh_ks = store.keyspace("webvh").unwrap();
 
         let jwt_seed = [0x42u8; 32];
-        let jwt_keys = Arc::new(
-            JwtKeys::from_ed25519_bytes(&jwt_seed, "VTA").expect("jwt keys"),
-        );
+        let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTA").expect("jwt keys"));
 
-        let seed_store: Arc<dyn vta_service::keys::seed_store::SeedStore> = Arc::new(
-            TestSeedStore(vec![0xABu8; 32]),
-        );
+        let seed_store: Arc<dyn vta_service::keys::seed_store::SeedStore> =
+            Arc::new(TestSeedStore(vec![0xABu8; 32]));
 
         let mut config: AppConfig = toml::from_str(&format!(
             r#"
@@ -123,8 +120,8 @@ impl TestApp {
             .expect("request failed");
         let status = resp.status();
         let body = resp.into_body().collect().await.unwrap().to_bytes();
-        let json: Value =
-            serde_json::from_slice(&body).unwrap_or_else(|_| json!({"raw": String::from_utf8_lossy(&body).to_string()}));
+        let json: Value = serde_json::from_slice(&body)
+            .unwrap_or_else(|_| json!({"raw": String::from_utf8_lossy(&body).to_string()}));
         (status, json)
     }
 }
@@ -185,11 +182,24 @@ impl TestContext {
 struct TestSeedStore(Vec<u8>);
 
 impl vta_service::keys::seed_store::SeedStore for TestSeedStore {
-    fn get(&self) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<Vec<u8>>, vti_common::error::AppError>> + Send + '_>> {
+    fn get(
+        &self,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<Option<Vec<u8>>, vti_common::error::AppError>>
+                + Send
+                + '_,
+        >,
+    > {
         let seed = self.0.clone();
         Box::pin(async move { Ok(Some(seed)) })
     }
-    fn set(&self, _seed: &[u8]) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), vti_common::error::AppError>> + Send + '_>> {
+    fn set(
+        &self,
+        _seed: &[u8],
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<(), vti_common::error::AppError>> + Send + '_>,
+    > {
         Box::pin(async { Ok(()) })
     }
 }
@@ -344,11 +354,7 @@ async fn initiator_cannot_access_super_admin_endpoints() {
         .await;
     // PATCH /config requires super admin
     let (status, _) = app
-        .request(patch_auth(
-            "/config",
-            &token,
-            json!({"vta_name": "hacked"}),
-        ))
+        .request(patch_auth("/config", &token, json!({"vta_name": "hacked"})))
         .await;
     assert_eq!(status, StatusCode::FORBIDDEN);
 }
@@ -385,11 +391,7 @@ async fn scoped_admin_cannot_update_config() {
         .auth_token("did:key:z6MkScoped", "admin", vec!["ctx1".into()])
         .await;
     let (status, _) = app
-        .request(patch_auth(
-            "/config",
-            &token,
-            json!({"vta_name": "nope"}),
-        ))
+        .request(patch_auth("/config", &token, json!({"vta_name": "nope"})))
         .await;
     assert_eq!(status, StatusCode::FORBIDDEN);
 }
@@ -559,7 +561,11 @@ async fn backup_export_rejects_short_password() {
             json!({"password": "short", "include_audit": false}),
         ))
         .await;
-    assert_eq!(status, StatusCode::BAD_REQUEST, "should reject short password: {body}");
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "should reject short password: {body}"
+    );
 }
 
 #[tokio::test]
@@ -618,9 +624,7 @@ async fn cache_put_get_delete() {
     assert_eq!(body["value"], "hello");
 
     // DELETE
-    let (status, _) = app
-        .request(delete_auth("/cache/test-key", &token))
-        .await;
+    let (status, _) = app.request(delete_auth("/cache/test-key", &token)).await;
     assert!(status.is_success(), "DELETE cache: {status}");
 
     // GET again → 404
@@ -656,28 +660,50 @@ async fn scoped_admin_can_only_access_own_context_keys() {
     let super_token = ctx.auth_token("did:key:z6MkSuper", "admin", vec![]).await;
 
     // Create two contexts
-    app.request(post_auth("/contexts", &super_token, json!({"id": "ctx-a", "name": "A"}))).await;
-    app.request(post_auth("/contexts", &super_token, json!({"id": "ctx-b", "name": "B"}))).await;
+    app.request(post_auth(
+        "/contexts",
+        &super_token,
+        json!({"id": "ctx-a", "name": "A"}),
+    ))
+    .await;
+    app.request(post_auth(
+        "/contexts",
+        &super_token,
+        json!({"id": "ctx-b", "name": "B"}),
+    ))
+    .await;
 
     // Create a key in ctx-a
-    let (status, key_body) = app.request(post_auth(
-        "/keys", &super_token, json!({"key_type": "ed25519", "context_id": "ctx-a"}),
-    )).await;
+    let (status, key_body) = app
+        .request(post_auth(
+            "/keys",
+            &super_token,
+            json!({"key_type": "ed25519", "context_id": "ctx-a"}),
+        ))
+        .await;
     assert!(status.is_success());
     let key_id = key_body["key_id"].as_str().unwrap();
 
     // Scoped admin for ctx-b cannot get the key in ctx-a (returns 403 or 404 — both are valid)
     let encoded_id = urlencoding::encode(key_id);
-    let scoped_b_token = ctx.auth_token("did:key:z6MkB", "admin", vec!["ctx-b".into()]).await;
-    let (status, _) = app.request(get_auth(&format!("/keys/{encoded_id}"), &scoped_b_token)).await;
+    let scoped_b_token = ctx
+        .auth_token("did:key:z6MkB", "admin", vec!["ctx-b".into()])
+        .await;
+    let (status, _) = app
+        .request(get_auth(&format!("/keys/{encoded_id}"), &scoped_b_token))
+        .await;
     assert!(
         status == StatusCode::FORBIDDEN || status == StatusCode::NOT_FOUND,
         "scoped admin should not access other context's key, got {status}"
     );
 
     // Scoped admin for ctx-a CAN get the key
-    let scoped_a_token = ctx.auth_token("did:key:z6MkA", "admin", vec!["ctx-a".into()]).await;
-    let (status, body) = app.request(get_auth(&format!("/keys/{encoded_id}"), &scoped_a_token)).await;
+    let scoped_a_token = ctx
+        .auth_token("did:key:z6MkA", "admin", vec!["ctx-a".into()])
+        .await;
+    let (status, body) = app
+        .request(get_auth(&format!("/keys/{encoded_id}"), &scoped_a_token))
+        .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["key_id"], key_id);
 }
@@ -690,20 +716,33 @@ async fn key_create_revoke_list_lifecycle() {
     let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
 
     // Create context + key
-    app.request(post_auth("/contexts", &token, json!({"id": "lc", "name": "Lifecycle"}))).await;
-    let (_, key_body) = app.request(post_auth(
-        "/keys", &token, json!({"key_type": "ed25519", "context_id": "lc"}),
-    )).await;
+    app.request(post_auth(
+        "/contexts",
+        &token,
+        json!({"id": "lc", "name": "Lifecycle"}),
+    ))
+    .await;
+    let (_, key_body) = app
+        .request(post_auth(
+            "/keys",
+            &token,
+            json!({"key_type": "ed25519", "context_id": "lc"}),
+        ))
+        .await;
     let key_id = key_body["key_id"].as_str().unwrap();
     assert_eq!(key_body["status"], "active");
 
     // Revoke the key (key_id may contain slashes from derivation path, URL-encode it)
     let encoded_id = urlencoding::encode(key_id);
-    let (status, body) = app.request(delete_auth(&format!("/keys/{encoded_id}"), &token)).await;
+    let (status, body) = app
+        .request(delete_auth(&format!("/keys/{encoded_id}"), &token))
+        .await;
     assert!(status.is_success(), "revoke: {status} {body}");
 
     // Get key — should show revoked status
-    let (status, body) = app.request(get_auth(&format!("/keys/{encoded_id}"), &token)).await;
+    let (status, body) = app
+        .request(get_auth(&format!("/keys/{encoded_id}"), &token))
+        .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["status"], "revoked");
 }
@@ -713,17 +752,30 @@ async fn key_rename() {
     let (app, ctx) = TestApp::new().await;
     let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
 
-    app.request(post_auth("/contexts", &token, json!({"id": "rn", "name": "Rename"}))).await;
-    let (_, key_body) = app.request(post_auth(
-        "/keys", &token, json!({"key_type": "ed25519", "context_id": "rn", "label": "original"}),
-    )).await;
+    app.request(post_auth(
+        "/contexts",
+        &token,
+        json!({"id": "rn", "name": "Rename"}),
+    ))
+    .await;
+    let (_, key_body) = app
+        .request(post_auth(
+            "/keys",
+            &token,
+            json!({"key_type": "ed25519", "context_id": "rn", "label": "original"}),
+        ))
+        .await;
     let key_id = key_body["key_id"].as_str().unwrap();
 
     // Rename the key (PATCH expects new key_id in body)
     let encoded_id = urlencoding::encode(key_id);
-    let (status, body) = app.request(patch_auth(
-        &format!("/keys/{encoded_id}"), &token, json!({"key_id": "renamed-key"}),
-    )).await;
+    let (status, body) = app
+        .request(patch_auth(
+            &format!("/keys/{encoded_id}"),
+            &token,
+            json!({"key_id": "renamed-key"}),
+        ))
+        .await;
     assert!(status.is_success(), "rename: {status} {body}");
     assert_eq!(body["key_id"], "renamed-key");
 }
@@ -747,16 +799,28 @@ async fn operations_create_audit_entries() {
     let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
 
     // Perform some operations that create audit entries
-    app.request(post_auth("/contexts", &token, json!({"id": "aud", "name": "Audit Test"}))).await;
     app.request(post_auth(
-        "/keys", &token, json!({"key_type": "ed25519", "context_id": "aud"}),
-    )).await;
+        "/contexts",
+        &token,
+        json!({"id": "aud", "name": "Audit Test"}),
+    ))
+    .await;
+    app.request(post_auth(
+        "/keys",
+        &token,
+        json!({"key_type": "ed25519", "context_id": "aud"}),
+    ))
+    .await;
 
     // Check audit logs contain entries
     let (status, body) = app.request(get_auth("/audit/logs", &token)).await;
     assert_eq!(status, StatusCode::OK);
     let entries = body["entries"].as_array().expect("entries");
-    assert!(!entries.is_empty(), "should have at least 1 audit entry, got {}", entries.len());
+    assert!(
+        !entries.is_empty(),
+        "should have at least 1 audit entry, got {}",
+        entries.len()
+    );
 
     // Verify audit entries have expected fields
     let entry = &entries[0];
@@ -779,9 +843,13 @@ async fn audit_retention_get_and_update() {
     assert!(body["retention_days"].is_number());
 
     // Update retention
-    let (status, body) = app.request(patch_auth(
-        "/audit/retention", &token, json!({"retention_days": 90}),
-    )).await;
+    let (status, body) = app
+        .request(patch_auth(
+            "/audit/retention",
+            &token,
+            json!({"retention_days": 90}),
+        ))
+        .await;
     assert!(status.is_success(), "update retention: {status} {body}");
 }
 
@@ -793,18 +861,28 @@ async fn backup_import_wrong_password_returns_auth_error() {
     let token = ctx.auth_token("did:key:z6MkSuper", "admin", vec![]).await;
 
     // Export with one password
-    let (status, envelope) = app.request(post_auth(
-        "/backup/export", &token,
-        json!({"password": "correct-password!!", "include_audit": false}),
-    )).await;
+    let (status, envelope) = app
+        .request(post_auth(
+            "/backup/export",
+            &token,
+            json!({"password": "correct-password!!", "include_audit": false}),
+        ))
+        .await;
     assert_eq!(status, StatusCode::OK);
 
     // Import with wrong password
-    let (status, body) = app.request(post_auth(
-        "/backup/import", &token,
-        json!({"backup": envelope, "password": "wrong-password!!!", "confirm": false}),
-    )).await;
-    assert_eq!(status, StatusCode::UNAUTHORIZED, "wrong password should → 401: {body}");
+    let (status, body) = app
+        .request(post_auth(
+            "/backup/import",
+            &token,
+            json!({"backup": envelope, "password": "wrong-password!!!", "confirm": false}),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "wrong password should → 401: {body}"
+    );
 }
 
 // ── ACL CRUD full lifecycle ────────────────────────────────────────
@@ -815,32 +893,46 @@ async fn acl_get_update_delete_lifecycle() {
     let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
 
     // Create
-    app.request(post_auth("/acl", &token, json!({
-        "did": "did:key:z6MkTarget",
-        "role": "application",
-        "label": "test",
-        "allowed_contexts": ["ctx1"]
-    }))).await;
+    app.request(post_auth(
+        "/acl",
+        &token,
+        json!({
+            "did": "did:key:z6MkTarget",
+            "role": "application",
+            "label": "test",
+            "allowed_contexts": ["ctx1"]
+        }),
+    ))
+    .await;
 
     // Get
-    let (status, body) = app.request(get_auth("/acl/did:key:z6MkTarget", &token)).await;
+    let (status, body) = app
+        .request(get_auth("/acl/did:key:z6MkTarget", &token))
+        .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["role"], "application");
 
     // Update
-    let (status, body) = app.request(patch_auth(
-        "/acl/did:key:z6MkTarget", &token,
-        json!({"role": "initiator", "label": "updated"}),
-    )).await;
+    let (status, body) = app
+        .request(patch_auth(
+            "/acl/did:key:z6MkTarget",
+            &token,
+            json!({"role": "initiator", "label": "updated"}),
+        ))
+        .await;
     assert!(status.is_success(), "update: {status} {body}");
     assert_eq!(body["role"], "initiator");
 
     // Delete
-    let (status, _) = app.request(delete_auth("/acl/did:key:z6MkTarget", &token)).await;
+    let (status, _) = app
+        .request(delete_auth("/acl/did:key:z6MkTarget", &token))
+        .await;
     assert!(status.is_success());
 
     // Verify deleted
-    let (status, _) = app.request(get_auth("/acl/did:key:z6MkTarget", &token)).await;
+    let (status, _) = app
+        .request(get_auth("/acl/did:key:z6MkTarget", &token))
+        .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
@@ -852,9 +944,13 @@ async fn context_create_get_update_delete() {
     let token = ctx.auth_token("did:key:z6MkSuper", "admin", vec![]).await;
 
     // Create
-    let (status, _) = app.request(post_auth(
-        "/contexts", &token, json!({"id": "lifecycle", "name": "Test", "description": "A test context"}),
-    )).await;
+    let (status, _) = app
+        .request(post_auth(
+            "/contexts",
+            &token,
+            json!({"id": "lifecycle", "name": "Test", "description": "A test context"}),
+        ))
+        .await;
     assert!(status.is_success());
 
     // Get
@@ -864,9 +960,13 @@ async fn context_create_get_update_delete() {
     assert_eq!(body["description"], "A test context");
 
     // Update
-    let (status, body) = app.request(patch_auth(
-        "/contexts/lifecycle", &token, json!({"name": "Updated"}),
-    )).await;
+    let (status, body) = app
+        .request(patch_auth(
+            "/contexts/lifecycle",
+            &token,
+            json!({"name": "Updated"}),
+        ))
+        .await;
     assert!(status.is_success(), "update: {status} {body}");
     assert_eq!(body["name"], "Updated");
 
@@ -877,7 +977,9 @@ async fn context_create_get_update_delete() {
     assert!(contexts.iter().any(|c| c["id"] == "lifecycle"));
 
     // Delete
-    let (status, _) = app.request(delete_auth("/contexts/lifecycle", &token)).await;
+    let (status, _) = app
+        .request(delete_auth("/contexts/lifecycle", &token))
+        .await;
     assert!(status.is_success());
 }
 
@@ -888,11 +990,20 @@ async fn create_p256_key() {
     let (app, ctx) = TestApp::new().await;
     let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
 
-    app.request(post_auth("/contexts", &token, json!({"id": "p256", "name": "P256 Test"}))).await;
+    app.request(post_auth(
+        "/contexts",
+        &token,
+        json!({"id": "p256", "name": "P256 Test"}),
+    ))
+    .await;
 
-    let (status, body) = app.request(post_auth(
-        "/keys", &token, json!({"key_type": "p256", "context_id": "p256"}),
-    )).await;
+    let (status, body) = app
+        .request(post_auth(
+            "/keys",
+            &token,
+            json!({"key_type": "p256", "context_id": "p256"}),
+        ))
+        .await;
     assert!(status.is_success(), "create p256: {status} {body}");
     assert_eq!(body["key_type"], "p256");
     assert!(body["public_key"].is_string());
@@ -936,8 +1047,18 @@ async fn context_admin_cannot_update_other_context_did() {
     let super_token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
 
     // Create two contexts
-    app.request(post_auth("/contexts", &super_token, json!({"id": "ctx-a", "name": "A"}))).await;
-    app.request(post_auth("/contexts", &super_token, json!({"id": "ctx-b", "name": "B"}))).await;
+    app.request(post_auth(
+        "/contexts",
+        &super_token,
+        json!({"id": "ctx-a", "name": "A"}),
+    ))
+    .await;
+    app.request(post_auth(
+        "/contexts",
+        &super_token,
+        json!({"id": "ctx-b", "name": "B"}),
+    ))
+    .await;
 
     // Admin scoped to ctx-a cannot update ctx-b's DID
     let scoped_token = ctx
@@ -958,7 +1079,12 @@ async fn super_admin_can_update_any_context_did() {
     let (app, ctx) = TestApp::new().await;
     let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
 
-    app.request(post_auth("/contexts", &token, json!({"id": "anyctx", "name": "Any"}))).await;
+    app.request(post_auth(
+        "/contexts",
+        &token,
+        json!({"id": "anyctx", "name": "Any"}),
+    ))
+    .await;
 
     let (status, body) = app
         .request(put_auth(
@@ -967,7 +1093,10 @@ async fn super_admin_can_update_any_context_did() {
             json!({"did": "did:webvh:xyz:example.com"}),
         ))
         .await;
-    assert!(status.is_success(), "super admin update did: {status} {body}");
+    assert!(
+        status.is_success(),
+        "super admin update did: {status} {body}"
+    );
     assert_eq!(body["did"], "did:webvh:xyz:example.com");
 }
 
@@ -976,7 +1105,12 @@ async fn non_admin_cannot_update_context_did() {
     let (app, ctx) = TestApp::new().await;
     let super_token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
 
-    app.request(post_auth("/contexts", &super_token, json!({"id": "restricted", "name": "R"}))).await;
+    app.request(post_auth(
+        "/contexts",
+        &super_token,
+        json!({"id": "restricted", "name": "R"}),
+    ))
+    .await;
 
     // Application role cannot update DID
     let app_token = ctx

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -75,15 +75,18 @@ impl TestApp {
 
         let (restart_tx, _rx) = watch::channel(false);
 
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
         let state = AppState {
             keys_ks: keys_ks.clone(),
             sessions_ks: sessions_ks.clone(),
             acl_ks: acl_ks.clone(),
             contexts_ks,
             audit_ks: audit_ks.clone(),
+            imported_ks,
             cache_ks,
             #[cfg(feature = "webvh")]
             webvh_ks,
+            wrapping_cache: vta_service::keys::wrapping::WrappingKeyCache::new(),
             config: Arc::new(RwLock::new(config)),
             seed_store,
             did_resolver: None,

--- a/vta-service/tests/auth_flow.rs
+++ b/vta-service/tests/auth_flow.rs
@@ -20,7 +20,8 @@ mod tests {
 
     #[test]
     fn challenge_response_has_required_fields() {
-        let json = r#"{"sessionId":"abc-123","data":{"challenge":"deadbeef","teeAttestation":null}}"#;
+        let json =
+            r#"{"sessionId":"abc-123","data":{"challenge":"deadbeef","teeAttestation":null}}"#;
         let resp: ChallengeResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.session_id, "abc-123");
         assert_eq!(resp.data.challenge, "deadbeef");
@@ -30,11 +31,17 @@ mod tests {
     fn did_base_extraction() {
         // The auth flow strips DID fragments before comparison
         let did_with_fragment = "did:key:z6MkTest123#key-0";
-        let base = did_with_fragment.split('#').next().unwrap_or(did_with_fragment);
+        let base = did_with_fragment
+            .split('#')
+            .next()
+            .unwrap_or(did_with_fragment);
         assert_eq!(base, "did:key:z6MkTest123");
 
         let did_without_fragment = "did:key:z6MkTest123";
-        let base = did_without_fragment.split('#').next().unwrap_or(did_without_fragment);
+        let base = did_without_fragment
+            .split('#')
+            .next()
+            .unwrap_or(did_without_fragment);
         assert_eq!(base, "did:key:z6MkTest123");
     }
 }

--- a/vta-service/tests/security.rs
+++ b/vta-service/tests/security.rs
@@ -98,6 +98,83 @@ mod auth_enforcement {
         assert!(application_claims().require_manage().is_err());
     }
 
+    fn reader_claims() -> AuthClaims {
+        AuthClaims {
+            did: "did:key:z6MkReader".into(),
+            role: Role::Reader,
+            allowed_contexts: vec!["ctx1".into()],
+        }
+    }
+
+    fn monitor_claims() -> AuthClaims {
+        AuthClaims {
+            did: "did:key:z6MkMonitor".into(),
+            role: Role::Monitor,
+            allowed_contexts: vec![],
+        }
+    }
+
+    // ── require_read ──
+
+    #[test]
+    fn reader_passes_require_read() {
+        assert!(reader_claims().require_read().is_ok());
+    }
+
+    #[test]
+    fn application_passes_require_read() {
+        assert!(application_claims().require_read().is_ok());
+    }
+
+    #[test]
+    fn admin_passes_require_read() {
+        assert!(admin_claims().require_read().is_ok());
+    }
+
+    #[test]
+    fn monitor_fails_require_read() {
+        assert!(monitor_claims().require_read().is_err());
+    }
+
+    // ── require_write ──
+
+    #[test]
+    fn application_passes_require_write() {
+        assert!(application_claims().require_write().is_ok());
+    }
+
+    #[test]
+    fn admin_passes_require_write() {
+        assert!(admin_claims().require_write().is_ok());
+    }
+
+    #[test]
+    fn initiator_passes_require_write() {
+        assert!(initiator_claims().require_write().is_ok());
+    }
+
+    #[test]
+    fn reader_fails_require_write() {
+        assert!(reader_claims().require_write().is_err());
+    }
+
+    #[test]
+    fn monitor_fails_require_write() {
+        assert!(monitor_claims().require_write().is_err());
+    }
+
+    // ── reader cannot manage or admin ──
+
+    #[test]
+    fn reader_fails_require_manage() {
+        assert!(reader_claims().require_manage().is_err());
+    }
+
+    #[test]
+    fn reader_fails_require_admin() {
+        assert!(reader_claims().require_admin().is_err());
+    }
+
     // ── context access ──
 
     #[test]
@@ -159,9 +236,26 @@ mod acl_validation {
 
     #[test]
     fn application_cannot_create_admin() {
-        // Only the admin role assignment is restricted
         let app = claims(Role::Application);
         assert!(validate_role_assignment(&app, &Role::Admin).is_err());
+    }
+
+    #[test]
+    fn reader_cannot_assign_any_role() {
+        let reader = claims(Role::Reader);
+        assert!(validate_role_assignment(&reader, &Role::Application).is_err());
+        assert!(validate_role_assignment(&reader, &Role::Reader).is_err());
+        assert!(validate_role_assignment(&reader, &Role::Monitor).is_err());
+    }
+
+    #[test]
+    fn initiator_can_create_reader() {
+        assert!(validate_role_assignment(&claims(Role::Initiator), &Role::Reader).is_ok());
+    }
+
+    #[test]
+    fn admin_can_create_reader() {
+        assert!(validate_role_assignment(&claims(Role::Admin), &Role::Reader).is_ok());
     }
 }
 

--- a/vta-service/tests/security.rs
+++ b/vta-service/tests/security.rs
@@ -98,7 +98,6 @@ mod auth_enforcement {
         assert!(application_claims().require_manage().is_err());
     }
 
-
     // ── context access ──
 
     #[test]

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version.workspace = true
+version = "0.2.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.3.0" }
+vti-common = { path = "../vti-common", version = "0.2.1" }
 vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = [
   "didcomm",
   "session",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -69,6 +69,7 @@ azure_security_keyvault_secrets = { version = "0.12", optional = true }
 azure_identity = { version = "0.33", optional = true }
 sha2 = { workspace = true }
 x25519-dalek = { workspace = true }
+zeroize = { version = "1", features = ["derive"] }
 multibase = { workspace = true }
 url = { workspace = true, optional = true }
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.2.1" }
+vti-common = { path = "../vti-common", version = "0.3.0" }
 vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = [
   "didcomm",
   "session",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -28,8 +28,8 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.2.0" }
-vta-sdk = { path = "../vta-sdk", version = "0.2.0", features = [
+vti-common = { path = "../vti-common", version = "0.3.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.3.0" }
+vti-common = { path = "../vti-common", version = "0.4.0" }
 vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = [
   "didcomm",
   "session",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/main.rs"
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.2.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.2.3"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,8 +28,8 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.4.0" }
-vta-sdk = { path = "../vta-sdk", version = "0.4.0", features = [
+vti-common = { path = "../vti-common", version = "0.3.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -49,7 +49,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-ed25519-dalek = "2"
+ed25519-dalek = { workspace = true }
 hex = "0.4"
 keyring = { version = "3", optional = true }
 aws-sdk-secretsmanager = { version = "1", optional = true }
@@ -64,7 +64,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 didwebvh-rs = { workspace = true, optional = true }
 rand = { workspace = true }
-dialoguer = { version = "0.12", optional = true }
+dialoguer = { workspace = true, optional = true }
 azure_security_keyvault_secrets = { version = "0.12", optional = true }
 azure_identity = { version = "0.33", optional = true }
 sha2 = { workspace = true }

--- a/vtc-service/src/auth/mod.rs
+++ b/vtc-service/src/auth/mod.rs
@@ -1,5 +1,7 @@
 pub mod credentials;
 
-pub use vti_common::auth::extractor::{AdminAuth, AuthClaims, AuthState, ManageAuth, SuperAdminAuth};
+pub use vti_common::auth::extractor::{
+    AdminAuth, AuthClaims, AuthState, ManageAuth, SuperAdminAuth,
+};
 pub use vti_common::auth::jwt;
 pub use vti_common::auth::session;

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -3,9 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 // Re-export shared config types
-pub use vti_common::config::{
-    AuthConfig, LogConfig, LogFormat, MessagingConfig, StoreConfig,
-};
+pub use vti_common::config::{AuthConfig, LogConfig, LogFormat, MessagingConfig, StoreConfig};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AppConfig {

--- a/vtc-service/src/did_webvh.rs
+++ b/vtc-service/src/did_webvh.rs
@@ -172,7 +172,10 @@ pub async fn run_create_did_webvh(
     };
 
     // Create the DID
-    let url_str = webvh_url.get_http_url(None).map_err(|e| format!("{e}"))?.to_string();
+    let url_str = webvh_url
+        .get_http_url(None)
+        .map_err(|e| format!("{e}"))?
+        .to_string();
     let create_config = CreateDIDConfig::builder()
         .address(url_str)
         .authorization_key(signing_secret.clone())
@@ -181,7 +184,8 @@ pub async fn run_create_did_webvh(
         .build()
         .map_err(|e| format!("failed to build DID config: {e}"))?;
 
-    let result = create_did(create_config).await
+    let result = create_did(create_config)
+        .await
         .map_err(|e| format!("failed to create DID: {e}"))?;
 
     let final_did = result.did().to_string();

--- a/vtc-service/src/did_webvh.rs
+++ b/vtc-service/src/did_webvh.rs
@@ -42,8 +42,12 @@ pub async fn run_create_did_webvh(
         .into());
     }
 
-    let ed25519_bytes: &[u8; 32] = key_material[..32].try_into().unwrap();
-    let x25519_bytes: &[u8; 32] = key_material[32..].try_into().unwrap();
+    let ed25519_bytes: &[u8; 32] = key_material[..32]
+        .try_into()
+        .map_err(|_| "key material corrupted")?;
+    let x25519_bytes: &[u8; 32] = key_material[32..]
+        .try_into()
+        .map_err(|_| "key material corrupted")?;
 
     let label = args.label.as_deref().unwrap_or("VTC");
 
@@ -237,9 +241,20 @@ pub async fn run_create_did_webvh(
         eprintln!("║  Store it securely and do not share it publicly.         ║");
         eprintln!("╚══════════════════════════════════════════════════════════╝\x1b[0m");
         eprintln!();
-        println!("{encoded}");
+        let default_secrets_file = format!("{label}-secrets.bundle");
+        let secrets_file: String = Input::new()
+            .with_prompt("Save secrets bundle to file")
+            .default(default_secrets_file)
+            .interact_text()?;
+        std::fs::write(&secrets_file, &encoded)
+            .map_err(|e| format!("Failed to write secrets bundle: {e}"))?;
+        eprintln!("  Secrets bundle saved to: {secrets_file}");
         eprintln!();
     }
+
+    // Zeroize key material
+    drop(signing_secret);
+    drop(ka_secret);
 
     Ok(())
 }

--- a/vtc-service/src/import_did.rs
+++ b/vtc-service/src/import_did.rs
@@ -27,7 +27,7 @@ pub async fn run_import_did(args: ImportDidArgs) -> Result<(), Box<dyn std::erro
     let role = match args.role {
         Some(r) => Role::parse(&r)?,
         None => {
-            let roles = ["admin", "initiator", "application"];
+            let roles = ["admin", "initiator", "application", "reader"];
             let selection = Select::new()
                 .with_prompt("Select role for this DID")
                 .items(roles)

--- a/vtc-service/src/keys/seed_store/mod.rs
+++ b/vtc-service/src/keys/seed_store/mod.rs
@@ -22,24 +22,12 @@ pub use gcp::GcpSecretStore;
 pub use keyring::KeyringSecretStore;
 pub use plaintext::PlaintextSecretStore;
 
-use std::future::Future;
-use std::pin::Pin;
-
 use crate::config::AppConfig;
 use crate::error::AppError;
 
-type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
-
 /// Store for VTC key material (64 bytes: 32 Ed25519 + 32 X25519).
-pub trait SecretStore: Send + Sync {
-    fn get(&self) -> BoxFuture<'_, Result<Option<Vec<u8>>, AppError>>;
-    fn set(&self, secret: &[u8]) -> BoxFuture<'_, Result<(), AppError>>;
-    /// Remove the secret from the backend. Default is a no-op (backends where
-    /// `set` overwrites in-place don't need explicit deletion).
-    fn delete(&self) -> BoxFuture<'_, Result<(), AppError>> {
-        Box::pin(async { Ok(()) })
-    }
-}
+/// Re-exports the shared SeedStore trait as SecretStore for VTC naming.
+pub use vti_common::seed_store::SeedStore as SecretStore;
 
 /// Create a secret store backend based on compiled features and configuration.
 ///

--- a/vtc-service/src/main.rs
+++ b/vtc-service/src/main.rs
@@ -60,7 +60,7 @@ enum Commands {
         /// The DID to import
         #[arg(long)]
         did: String,
-        /// Role to assign (admin, initiator, application)
+        /// Role to assign (admin, initiator, application, reader)
         #[arg(long)]
         role: Option<String>,
         /// Human-readable label for the ACL entry
@@ -81,7 +81,7 @@ enum AclCommands {
         /// Filter by context
         #[arg(long)]
         context: Option<String>,
-        /// Filter by role (admin, initiator, application)
+        /// Filter by role (admin, initiator, application, reader)
         #[arg(long)]
         role: Option<String>,
     },
@@ -94,7 +94,7 @@ enum AclCommands {
     Update {
         /// The DID to update
         did: String,
-        /// New role (admin, initiator, application)
+        /// New role (admin, initiator, application, reader)
         #[arg(long)]
         role: Option<String>,
         /// New label (empty string to clear)

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -27,7 +27,11 @@ pub async fn init_didcomm_connection(
     };
     // VTC doesn't support network-mode resolver (no TEE/enclave mode)
     vta_sdk::didcomm_init::init_didcomm_connection(
-        mediator_did, secrets_resolver, vtc_did, "VTC", None,
+        mediator_did,
+        secrets_resolver,
+        vtc_did,
+        "VTC",
+        None,
     )
     .await
 }

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -14,11 +14,11 @@ use crate::acl::{
     AclEntry, Role, check_acl, check_acl_full, store_acl_entry, validate_acl_modification,
 };
 use crate::auth::credentials::generate_did_key;
-use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::auth::session::{
     Session, SessionState, delete_session, get_session, get_session_by_refresh, list_sessions,
     now_epoch, store_refresh_index, store_session, update_session,
 };
+use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::error::AppError;
 use crate::server::AppState;
 use tracing::{info, warn};

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -356,8 +356,14 @@ async fn init_auth(
         return (None, None, None, None);
     }
 
-    let ed25519_bytes: &[u8; 32] = key_material[..32].try_into().unwrap();
-    let x25519_bytes: &[u8; 32] = key_material[32..].try_into().unwrap();
+    let Ok(ed25519_bytes): Result<&[u8; 32], _> = key_material[..32].try_into() else {
+        warn!("key material corrupted — auth endpoints will not work");
+        return (None, None, None, None);
+    };
+    let Ok(x25519_bytes): Result<&[u8; 32], _> = key_material[32..].try_into() else {
+        warn!("key material corrupted — auth endpoints will not work");
+        return (None, None, None, None);
+    };
 
     // 1. DID resolver (local mode)
     let did_resolver = match DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await {

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -11,9 +11,9 @@ use affinidi_tdk::secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, s
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 
+use crate::auth::AuthState;
 use crate::auth::jwt::JwtKeys;
 use crate::auth::session::cleanup_expired_sessions;
-use crate::auth::AuthState;
 use crate::config::{AppConfig, AuthConfig};
 use crate::error::AppError;
 use crate::keys::seed_store::SecretStore;
@@ -389,14 +389,24 @@ async fn init_auth(
             Ok(k) => k,
             Err(e) => {
                 warn!("failed to load JWT signing key: {e} — auth endpoints will not work");
-                return (Some(did_resolver), Some(Arc::new(secrets_resolver)), None, None);
+                return (
+                    Some(did_resolver),
+                    Some(Arc::new(secrets_resolver)),
+                    None,
+                    None,
+                );
             }
         },
         None => {
             warn!(
                 "auth.jwt_signing_key not configured — auth endpoints will not work (run setup first)"
             );
-            return (Some(did_resolver), Some(Arc::new(secrets_resolver)), None, None);
+            return (
+                Some(did_resolver),
+                Some(Arc::new(secrets_resolver)),
+                None,
+                None,
+            );
         }
     };
 
@@ -410,13 +420,15 @@ async fn init_auth(
             .build();
         match tdk_config {
             Ok(cfg) => match TDKSharedState::new(cfg).await {
-                Ok(tdk) => match ATM::new(ATMConfig::builder().build().unwrap(), Arc::new(tdk)).await {
-                    Ok(a) => Some(a),
-                    Err(e) => {
-                        warn!("failed to create ATM for auth unpack: {e}");
-                        None
+                Ok(tdk) => {
+                    match ATM::new(ATMConfig::builder().build().unwrap(), Arc::new(tdk)).await {
+                        Ok(a) => Some(a),
+                        Err(e) => {
+                            warn!("failed to create ATM for auth unpack: {e}");
+                            None
+                        }
                     }
-                },
+                }
                 Err(e) => {
                     warn!("failed to create TDK shared state: {e}");
                     None

--- a/vtc-service/src/setup.rs
+++ b/vtc-service/src/setup.rs
@@ -358,7 +358,9 @@ pub async fn run_setup_wizard(
             public_url: None,
             server: ServerConfig::default(),
             log: LogConfig::default(),
-            store: StoreConfig { data_dir: PathBuf::from("data/vtc") },
+            store: StoreConfig {
+                data_dir: PathBuf::from("data/vtc"),
+            },
             messaging: None,
             auth: AuthConfig::default(),
             secrets: secrets_config.clone(),
@@ -855,7 +857,10 @@ async fn create_webvh_did(
     };
 
     // Create the DID
-    let url_str = webvh_url.get_http_url(None).map_err(|e| format!("{e}"))?.to_string();
+    let url_str = webvh_url
+        .get_http_url(None)
+        .map_err(|e| format!("{e}"))?
+        .to_string();
     let create_config = CreateDIDConfig::builder()
         .address(url_str)
         .authorization_key(signing_secret.clone())
@@ -864,7 +869,8 @@ async fn create_webvh_did(
         .build()
         .map_err(|e| format!("failed to build DID config: {e}"))?;
 
-    let result = create_did(create_config).await
+    let result = create_did(create_config)
+        .await
         .map_err(|e| format!("failed to create DID: {e}"))?;
 
     let final_did = result.did().to_string();

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.4.0"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-ed25519-dalek = "2"
+ed25519-dalek = { workspace = true }
 
 # Secrets resolver (for error type)
 affinidi-tdk = { workspace = true }

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version.workspace = true
+version = "0.2.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -11,14 +11,16 @@ use crate::store::KeyspaceHandle;
 /// Hierarchy (most to least privileged):
 /// - **Admin** — full management access, can assign any role
 /// - **Initiator** — can manage ACL entries and application contexts
-/// - **Application** — standard API access within allowed contexts
-/// - **Monitor** — read-only access to metrics and health endpoints
+/// - **Application** — standard API access (sign, cache write) within allowed contexts
+/// - **Reader** — read-only access to keys, contexts, DIDs within allowed contexts
+/// - **Monitor** — infrastructure-only: metrics and health endpoints
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     Admin,
     Initiator,
     Application,
+    Reader,
     Monitor,
 }
 
@@ -28,6 +30,7 @@ impl fmt::Display for Role {
             Role::Admin => write!(f, "admin"),
             Role::Initiator => write!(f, "initiator"),
             Role::Application => write!(f, "application"),
+            Role::Reader => write!(f, "reader"),
             Role::Monitor => write!(f, "monitor"),
         }
     }
@@ -40,6 +43,7 @@ impl Role {
             "admin" => Ok(Role::Admin),
             "initiator" => Ok(Role::Initiator),
             "application" => Ok(Role::Application),
+            "reader" => Ok(Role::Reader),
             "monitor" => Ok(Role::Monitor),
             _ => Err(AppError::Internal(format!("unknown role: {s}"))),
         }
@@ -114,9 +118,12 @@ pub async fn check_acl_full(
 /// Validate that the caller is allowed to assign the given role.
 ///
 /// - Only Admins can assign the Admin role.
-/// - Monitor and Application roles cannot assign any role.
+/// - Reader, Application, and Monitor roles cannot assign any role.
 pub fn validate_role_assignment(caller: &AuthClaims, target_role: &Role) -> Result<(), AppError> {
-    if caller.role == Role::Monitor || caller.role == Role::Application {
+    if matches!(
+        caller.role,
+        Role::Monitor | Role::Reader | Role::Application
+    ) {
         return Err(AppError::Forbidden(
             "insufficient role to assign roles".into(),
         ));

--- a/vti-common/src/auth/extractor.rs
+++ b/vti-common/src/auth/extractor.rs
@@ -112,6 +112,30 @@ impl AuthClaims {
         }
     }
 
+    /// Require at least Reader role (all roles except Monitor).
+    ///
+    /// Use for read-only endpoints that access business data (keys, contexts, DIDs).
+    /// Monitor can only see metrics and health.
+    pub fn require_read(&self) -> Result<(), AppError> {
+        if self.role == Role::Monitor {
+            return Err(AppError::Forbidden("reader role or higher required".into()));
+        }
+        Ok(())
+    }
+
+    /// Require at least Application role (Admin, Initiator, or Application).
+    ///
+    /// Use for write operations: signing, cache writes, and other actions that
+    /// produce artifacts or modify state.
+    pub fn require_write(&self) -> Result<(), AppError> {
+        if matches!(self.role, Role::Admin | Role::Initiator | Role::Application) {
+            return Ok(());
+        }
+        Err(AppError::Forbidden(
+            "application role or higher required".into(),
+        ))
+    }
+
     /// Require the caller to have Admin role.
     pub fn require_admin(&self) -> Result<(), AppError> {
         if self.role == Role::Admin {
@@ -214,5 +238,34 @@ impl<S: AuthState> FromRequestParts<S> for SuperAdminAuth {
         }
 
         Ok(SuperAdminAuth(claims))
+    }
+}
+
+/// Extractor that requires the caller to have at least Application role
+/// (Admin, Initiator, or Application).
+///
+/// Use on endpoints that perform write operations — signing, cache writes,
+/// and other actions that produce artifacts or modify state:
+/// ```ignore
+/// async fn handler(auth: WriteAuth, ...) { }
+/// ```
+#[derive(Debug, Clone)]
+pub struct WriteAuth(pub AuthClaims);
+
+impl<S: AuthState> FromRequestParts<S> for WriteAuth {
+    type Rejection = AppError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let claims = AuthClaims::from_request_parts(parts, state).await?;
+
+        match claims.role {
+            Role::Admin | Role::Initiator | Role::Application => Ok(WriteAuth(claims)),
+            _ => {
+                warn!(did = %claims.did, role = %claims.role, "auth rejected: application role or higher required");
+                Err(AppError::Forbidden(
+                    "application role or higher required".into(),
+                ))
+            }
+        }
     }
 }

--- a/vti-common/src/auth/extractor.rs
+++ b/vti-common/src/auth/extractor.rs
@@ -36,10 +36,7 @@ pub struct AuthClaims {
 impl<S: AuthState> FromRequestParts<S> for AuthClaims {
     type Rejection = AppError;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        state: &S,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         // Extract Bearer token from Authorization header
         let TypedHeader(auth) =
             TypedHeader::<Authorization<Bearer>>::from_request_parts(parts, state)
@@ -154,10 +151,7 @@ pub struct ManageAuth(pub AuthClaims);
 impl<S: AuthState> FromRequestParts<S> for ManageAuth {
     type Rejection = AppError;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        state: &S,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let claims = AuthClaims::from_request_parts(parts, state).await?;
 
         match claims.role {
@@ -184,10 +178,7 @@ pub struct AdminAuth(pub AuthClaims);
 impl<S: AuthState> FromRequestParts<S> for AdminAuth {
     type Rejection = AppError;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        state: &S,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let claims = AuthClaims::from_request_parts(parts, state).await?;
 
         match claims.role {
@@ -214,10 +205,7 @@ pub struct SuperAdminAuth(pub AuthClaims);
 impl<S: AuthState> FromRequestParts<S> for SuperAdminAuth {
     type Rejection = AppError;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        state: &S,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let claims = AuthClaims::from_request_parts(parts, state).await?;
 
         if !claims.is_super_admin() {

--- a/vti-common/src/auth/jwt.rs
+++ b/vti-common/src/auth/jwt.rs
@@ -40,10 +40,7 @@ impl JwtKeys {
     ///
     /// Computes the public key and wraps both in DER format as required
     /// by `jsonwebtoken`'s `from_ed_der()` methods.
-    pub fn from_ed25519_bytes(
-        private_bytes: &[u8; 32],
-        audience: &str,
-    ) -> Result<Self, AppError> {
+    pub fn from_ed25519_bytes(private_bytes: &[u8; 32], audience: &str) -> Result<Self, AppError> {
         // Compute the Ed25519 public key from the private key seed
         let signing_key = ed25519_dalek::SigningKey::from_bytes(private_bytes);
         let public_bytes = signing_key.verifying_key().to_bytes();

--- a/vti-common/src/error.rs
+++ b/vti-common/src/error.rs
@@ -47,10 +47,7 @@ pub enum AppError {
     /// Catch-all for service-specific errors (e.g., KeyDerivation, BadGateway, TeeAttestation).
     /// Services create helper functions to construct these with appropriate status codes.
     #[error("{message}")]
-    ServiceError {
-        status: StatusCode,
-        message: String,
-    },
+    ServiceError { status: StatusCode, message: String },
 }
 
 impl IntoResponse for AppError {

--- a/vti-common/src/lib.rs
+++ b/vti-common/src/lib.rs
@@ -2,4 +2,5 @@ pub mod acl;
 pub mod auth;
 pub mod config;
 pub mod error;
+pub mod seed_store;
 pub mod store;

--- a/vti-common/src/seed_store.rs
+++ b/vti-common/src/seed_store.rs
@@ -1,0 +1,33 @@
+//! Shared trait for secret/seed storage backends.
+//!
+//! Both VTA (`SeedStore` — BIP-32 master seed) and VTC (`SecretStore` — raw key
+//! material) use this trait. Service crates provide their own implementations
+//! for AWS, GCP, Azure, OS keyring, etc.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::error::AppError;
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Backend for storing and retrieving secret key material.
+///
+/// Implementations should encrypt at rest (AWS KMS, GCP KMS, Azure Key Vault)
+/// or use OS-level protection (keyring). The plaintext file backend exists only
+/// as a development fallback.
+pub trait SeedStore: Send + Sync {
+    /// Retrieve the stored secret, if any.
+    fn get(&self) -> BoxFuture<'_, Result<Option<Vec<u8>>, AppError>>;
+
+    /// Store (or overwrite) the secret.
+    fn set(&self, secret: &[u8]) -> BoxFuture<'_, Result<(), AppError>>;
+
+    /// Remove the secret from the backend.
+    ///
+    /// Default is a no-op — backends where `set` overwrites in-place don't need
+    /// explicit deletion.
+    fn delete(&self) -> BoxFuture<'_, Result<(), AppError>> {
+        Box::pin(async { Ok(()) })
+    }
+}

--- a/vti-common/src/store/encryption.rs
+++ b/vti-common/src/store/encryption.rs
@@ -42,9 +42,11 @@ fn decrypt_value(key: &[u8; 32], data: &[u8]) -> Result<Vec<u8>, AppError> {
     let nonce = Nonce::from_slice(&data[..NONCE_LEN]);
     let ciphertext = &data[NONCE_LEN..];
 
-    cipher
-        .decrypt(nonce, ciphertext)
-        .map_err(|e| AppError::Internal(format!("AES-GCM decryption failed (data may be corrupt or key mismatch): {e}")))
+    cipher.decrypt(nonce, ciphertext).map_err(|e| {
+        AppError::Internal(format!(
+            "AES-GCM decryption failed (data may be corrupt or key mismatch): {e}"
+        ))
+    })
 }
 
 /// Decrypt bytes if an encryption key is provided, otherwise return a copy.

--- a/vti-common/src/store/mod.rs
+++ b/vti-common/src/store/mod.rs
@@ -23,12 +23,7 @@ where
     F: FnOnce() -> Result<T, AppError> + Send + 'static,
     T: Send + 'static,
 {
-    match tokio::time::timeout(
-        STORE_OP_TIMEOUT,
-        tokio::task::spawn_blocking(f),
-    )
-    .await
-    {
+    match tokio::time::timeout(STORE_OP_TIMEOUT, tokio::task::spawn_blocking(f)).await {
         Ok(Ok(result)) => result,
         Ok(Err(e)) => Err(AppError::Internal(format!("blocking task panicked: {e}"))),
         Err(_) => Err(AppError::Internal(format!(
@@ -85,7 +80,6 @@ impl Store {
             Store::Vsock(s) => s.persist().await,
         }
     }
-
 }
 
 // ===========================================================================
@@ -183,10 +177,7 @@ impl KeyspaceHandle {
         }
     }
 
-    pub async fn prefix_keys(
-        &self,
-        prefix: impl Into<Vec<u8>>,
-    ) -> Result<Vec<Vec<u8>>, AppError> {
+    pub async fn prefix_keys(&self, prefix: impl Into<Vec<u8>>) -> Result<Vec<Vec<u8>>, AppError> {
         match self {
             KeyspaceHandle::Local(h) => h.prefix_keys(prefix).await,
             #[cfg(feature = "vsock-store")]
@@ -267,9 +258,13 @@ impl LocalKeyspaceHandle {
 
     pub fn is_encrypted(&self) -> bool {
         #[cfg(feature = "encryption")]
-        { self.encryption_key.is_some() }
+        {
+            self.encryption_key.is_some()
+        }
         #[cfg(not(feature = "encryption"))]
-        { false }
+        {
+            false
+        }
     }
 
     pub async fn insert<V: Serialize>(
@@ -292,20 +287,18 @@ impl LocalKeyspaceHandle {
         let ks = self.keyspace.clone();
         #[cfg(feature = "encryption")]
         let enc_key = self.encryption_key.clone();
-        blocking_with_timeout(move || {
-            match ks.get(key)? {
-                Some(bytes) => {
-                    #[cfg(feature = "encryption")]
-                    let bytes = {
-                        let k = enc_key.as_ref().map(|arc| &***arc);
-                        encryption::maybe_decrypt_bytes(k, &bytes)?
-                    };
-                    #[cfg(not(feature = "encryption"))]
-                    let bytes = bytes.to_vec();
-                    Ok(Some(serde_json::from_slice(&bytes)?))
-                }
-                None => Ok(None),
+        blocking_with_timeout(move || match ks.get(key)? {
+            Some(bytes) => {
+                #[cfg(feature = "encryption")]
+                let bytes = {
+                    let k = enc_key.as_ref().map(|arc| &***arc);
+                    encryption::maybe_decrypt_bytes(k, &bytes)?
+                };
+                #[cfg(not(feature = "encryption"))]
+                let bytes = bytes.to_vec();
+                Ok(Some(serde_json::from_slice(&bytes)?))
             }
+            None => Ok(None),
         })
         .await
     }
@@ -332,20 +325,18 @@ impl LocalKeyspaceHandle {
         let ks = self.keyspace.clone();
         #[cfg(feature = "encryption")]
         let enc_key = self.encryption_key.clone();
-        blocking_with_timeout(move || {
-            match ks.get(key)? {
-                Some(bytes) => {
-                    #[cfg(feature = "encryption")]
-                    let bytes = {
-                        let k = enc_key.as_ref().map(|arc| &***arc);
-                        encryption::maybe_decrypt_bytes(k, &bytes)?
-                    };
-                    #[cfg(not(feature = "encryption"))]
-                    let bytes = bytes.to_vec();
-                    Ok(Some(bytes))
-                }
-                None => Ok(None),
+        blocking_with_timeout(move || match ks.get(key)? {
+            Some(bytes) => {
+                #[cfg(feature = "encryption")]
+                let bytes = {
+                    let k = enc_key.as_ref().map(|arc| &***arc);
+                    encryption::maybe_decrypt_bytes(k, &bytes)?
+                };
+                #[cfg(not(feature = "encryption"))]
+                let bytes = bytes.to_vec();
+                Ok(Some(bytes))
             }
+            None => Ok(None),
         })
         .await
     }
@@ -376,10 +367,7 @@ impl LocalKeyspaceHandle {
         .await
     }
 
-    pub async fn prefix_keys(
-        &self,
-        prefix: impl Into<Vec<u8>>,
-    ) -> Result<Vec<Vec<u8>>, AppError> {
+    pub async fn prefix_keys(&self, prefix: impl Into<Vec<u8>>) -> Result<Vec<Vec<u8>>, AppError> {
         let prefix = prefix.into();
         let ks = self.keyspace.clone();
         blocking_with_timeout(move || {
@@ -429,7 +417,9 @@ impl LocalKeyspaceHandle {
             }
         }
         #[cfg(not(feature = "encryption"))]
-        { Ok(plaintext) }
+        {
+            Ok(plaintext)
+        }
     }
 }
 
@@ -548,10 +538,7 @@ mod tests {
         let enc_key = [0x42; 32];
 
         // Write with encryption
-        let ks_enc = store
-            .keyspace("secrets")
-            .unwrap()
-            .with_encryption(enc_key);
+        let ks_enc = store.keyspace("secrets").unwrap().with_encryption(enc_key);
         ks_enc
             .insert_raw("test", b"plaintext secret".to_vec())
             .await

--- a/vti-common/src/store/vsock.rs
+++ b/vti-common/src/store/vsock.rs
@@ -42,7 +42,10 @@ fn decode_bytes(data: &[u8], offset: usize) -> Result<(&[u8], usize), String> {
         return Err("truncated length".into());
     }
     let len = u32::from_be_bytes([
-        data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
+        data[offset],
+        data[offset + 1],
+        data[offset + 2],
+        data[offset + 3],
     ]) as usize;
     let start = offset + 4;
     let end = start + len;
@@ -69,29 +72,40 @@ struct VsockConnection {
 impl VsockConnection {
     async fn connect(cid: u32, port: u32) -> Result<Self, AppError> {
         let addr = tokio_vsock::VsockAddr::new(cid, port);
-        let stream = tokio_vsock::VsockStream::connect(addr)
-            .await
-            .map_err(|e| AppError::Internal(format!("vsock connect to CID {cid}:{port} failed: {e}")))?;
+        let stream = tokio_vsock::VsockStream::connect(addr).await.map_err(|e| {
+            AppError::Internal(format!("vsock connect to CID {cid}:{port} failed: {e}"))
+        })?;
         Ok(Self { stream })
     }
 
     async fn request(&mut self, payload: &[u8]) -> Result<Vec<u8>, AppError> {
         // Write frame
-        self.stream.write_u32(payload.len() as u32).await
+        self.stream
+            .write_u32(payload.len() as u32)
+            .await
             .map_err(|e| AppError::Internal(format!("vsock write error: {e}")))?;
-        self.stream.write_all(payload).await
+        self.stream
+            .write_all(payload)
+            .await
             .map_err(|e| AppError::Internal(format!("vsock write error: {e}")))?;
-        self.stream.flush().await
+        self.stream
+            .flush()
+            .await
             .map_err(|e| AppError::Internal(format!("vsock flush error: {e}")))?;
 
         // Read frame
-        let len = self.stream.read_u32().await
+        let len = self
+            .stream
+            .read_u32()
+            .await
             .map_err(|e| AppError::Internal(format!("vsock read error: {e}")))?;
         if len > MAX_MESSAGE_SIZE {
             return Err(AppError::Internal(format!("response too large: {len}")));
         }
         let mut buf = vec![0u8; len as usize];
-        self.stream.read_exact(&mut buf).await
+        self.stream
+            .read_exact(&mut buf)
+            .await
             .map_err(|e| AppError::Internal(format!("vsock read error: {e}")))?;
         Ok(buf)
     }
@@ -199,9 +213,13 @@ impl VsockKeyspaceHandle {
 
     pub fn is_encrypted(&self) -> bool {
         #[cfg(feature = "encryption")]
-        { self.encryption_key.is_some() }
+        {
+            self.encryption_key.is_some()
+        }
         #[cfg(not(feature = "encryption"))]
-        { false }
+        {
+            false
+        }
     }
 
     pub async fn insert<V: Serialize>(
@@ -294,10 +312,7 @@ impl VsockKeyspaceHandle {
             .collect()
     }
 
-    pub async fn prefix_keys(
-        &self,
-        prefix: impl Into<Vec<u8>>,
-    ) -> Result<Vec<Vec<u8>>, AppError> {
+    pub async fn prefix_keys(&self, prefix: impl Into<Vec<u8>>) -> Result<Vec<Vec<u8>>, AppError> {
         let prefix = prefix.into();
         let mut payload = vec![OP_PREFIX_KEYS];
         encode_keyspace(&mut payload, &self.keyspace);
@@ -375,7 +390,9 @@ impl VsockKeyspaceHandle {
             }
         }
         #[cfg(not(feature = "encryption"))]
-        { Ok(plaintext) }
+        {
+            Ok(plaintext)
+        }
     }
 
     fn maybe_decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>, AppError> {
@@ -387,7 +404,9 @@ impl VsockKeyspaceHandle {
             }
         }
         #[cfg(not(feature = "encryption"))]
-        { Ok(ciphertext.to_vec()) }
+        {
+            Ok(ciphertext.to_vec())
+        }
     }
 }
 
@@ -397,16 +416,19 @@ impl VsockKeyspaceHandle {
 
 fn decode_ok(data: &[u8]) -> Result<(), AppError> {
     if data.is_empty() {
-        return Err(AppError::Internal("empty response from storage proxy".into()));
+        return Err(AppError::Internal(
+            "empty response from storage proxy".into(),
+        ));
     }
     match data[0] {
         STATUS_OK => Ok(()),
         STATUS_ERROR => {
             let (msg, _) = decode_bytes(data, 1)
                 .map_err(|e| AppError::Internal(format!("decode error: {e}")))?;
-            Err(AppError::Internal(
-                format!("storage proxy error: {}", String::from_utf8_lossy(msg)),
-            ))
+            Err(AppError::Internal(format!(
+                "storage proxy error: {}",
+                String::from_utf8_lossy(msg)
+            )))
         }
         s => Err(AppError::Internal(format!("unexpected status: {s:#04x}"))),
     }
@@ -414,7 +436,9 @@ fn decode_ok(data: &[u8]) -> Result<(), AppError> {
 
 fn decode_value(data: &[u8]) -> Result<Option<Vec<u8>>, AppError> {
     if data.is_empty() {
-        return Err(AppError::Internal("empty response from storage proxy".into()));
+        return Err(AppError::Internal(
+            "empty response from storage proxy".into(),
+        ));
     }
     match data[0] {
         STATUS_OK => {
@@ -426,9 +450,10 @@ fn decode_value(data: &[u8]) -> Result<Option<Vec<u8>>, AppError> {
         STATUS_ERROR => {
             let (msg, _) = decode_bytes(data, 1)
                 .map_err(|e| AppError::Internal(format!("decode error: {e}")))?;
-            Err(AppError::Internal(
-                format!("storage proxy error: {}", String::from_utf8_lossy(msg)),
-            ))
+            Err(AppError::Internal(format!(
+                "storage proxy error: {}",
+                String::from_utf8_lossy(msg)
+            )))
         }
         s => Err(AppError::Internal(format!("unexpected status: {s:#04x}"))),
     }
@@ -459,7 +484,10 @@ fn decode_kv_list(data: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, AppError> {
         STATUS_ERROR => {
             let (msg, _) = decode_bytes(data, 1)
                 .map_err(|e| AppError::Internal(format!("decode error: {e}")))?;
-            Err(AppError::Internal(format!("storage proxy error: {}", String::from_utf8_lossy(msg))))
+            Err(AppError::Internal(format!(
+                "storage proxy error: {}",
+                String::from_utf8_lossy(msg)
+            )))
         }
         s => Err(AppError::Internal(format!("unexpected status: {s:#04x}"))),
     }
@@ -488,7 +516,10 @@ fn decode_key_list(data: &[u8]) -> Result<Vec<Vec<u8>>, AppError> {
         STATUS_ERROR => {
             let (msg, _) = decode_bytes(data, 1)
                 .map_err(|e| AppError::Internal(format!("decode error: {e}")))?;
-            Err(AppError::Internal(format!("storage proxy error: {}", String::from_utf8_lossy(msg))))
+            Err(AppError::Internal(format!(
+                "storage proxy error: {}",
+                String::from_utf8_lossy(msg)
+            )))
         }
         s => Err(AppError::Internal(format!("unexpected status: {s:#04x}"))),
     }


### PR DESCRIPTION
## Summary

*adjusts tiny cap, consults spore notes*

Vellmark here. The forest floor has been busy. Here's what sprouted since 0.2.1:

### New Features
- **Reader role** — new context-scoped read-only role. Readers can see keys, contexts, DIDs, and config but cannot sign, write, or modify anything. Every endpoint is now classified as read/write/manage.
- **Integration module** (`vta_sdk::integration`) — one-call `startup()` for any service that needs a DID and keys from the VTA. Pluggable `SecretCache` trait for offline resilience.
- **Key labels as verification method IDs** — `fetch_did_secrets_bundle()` now uses human-readable labels in DID fragments.
- **Integration guide** — new `docs/integration-guide.md` for 3rd-party developers.

### Role Hierarchy
```
Super Admin > Admin > Initiator > Application > Reader > Monitor
```
- **Read** (Reader+): list/get keys, contexts, DIDs, config
- **Write** (Application+): sign, cache write/delete
- **Manage** (Initiator+): ACL, credentials
- **Admin+**: key create/delete/import, seeds, audit, DIDs
- **Super Admin**: config, context CRUD, backup, restart

### Security & Auth
- **DIDComm handler auth fixes** — 17 handlers now have explicit role checks matching REST (defense-in-depth). Fixed `handle_update_retention` requiring Admin instead of SuperAdmin.
- **Tightened endpoints** — sign and cache write/delete now require Application+. Backup export route uses SuperAdminAuth extractor.
- **VTC zeroization** — key material properly handled with error propagation instead of unwrap. Secrets written to file instead of stdout.
- **Session error visibility** — `.ok()?` chains replaced with `tracing::warn` logging so auth failures are diagnosable.

### Code Quality & Architecture
- **Zero clippy warnings** — `Keyspaces` struct, `DIDCommSendParams`, collapsible ifs, all resolved.
- **Shared `SeedStore` trait** — extracted to `vti-common`.
- **Workspace dependency consolidation** — `ed25519-dalek`, `dialoguer` moved to workspace-level.
- **HTTP client reuse** — `auth_light` accepts `&Client` for connection pooling.
- **GitHub Actions CI** — parallel check, test, clippy (`-D warnings`), fmt jobs.

### Testing
- **263 tests** (up from ~230), zero failures, zero warnings.
- New: Reader role enforcement (18 tests), operation unit tests (4), security tests.

### Versions
All crates bumped from **0.2.1 → 0.3.0**.

*tips cap, retreats into log* 🍄

## Test plan

- [x] `cargo check` — clean compile
- [x] `cargo test` — 263 tests, 0 failures
- [x] `cargo clippy --workspace` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] All crate versions 0.3.0, dependency refs consistent
- [x] Reader can list keys, cannot sign, cannot create keys (integration tests)
- [ ] Verify docs render correctly on GitHub
- [ ] Smoke test `pnm acl create --role reader` against a running VTA