### PR TITLE
Release 0.3.1: Client DID documents, capabilities discovery, and user-specified keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,100 @@
 # Changelog
 
+## 0.3.1 — 2026-04-11
+
+### Client-Provided DID Documents for WebVH Creation
+
+- **Three DID creation modes** — `POST /webvh/dids` now supports three
+  mutually exclusive modes:
+  - **VTA-built** (default) — VTA derives keys and builds the DID
+    Document internally (existing behavior, unchanged).
+  - **Template mode** (`did_document` field) — Client provides a DID
+    Document template with `{DID}` placeholders. VTA derives keys,
+    signs the log entry, and resolves placeholders via `didwebvh-rs`.
+    `add_mediator_service` and `additional_services` are ignored.
+  - **Final mode** (`did_log` field) — Client provides a complete,
+    pre-signed `did.jsonl` log entry. VTA publishes it as-is without
+    deriving keys or creating a log entry. No key records are stored.
+- **`set_primary` flag** — Optional boolean (default `true`). When
+  `false`, the context's primary DID (`ctx.did`) is not updated,
+  allowing multiple DIDs per context without overwriting the primary.
+- **CLI support** — `pnm webvh create-did` gains `--did-document <FILE>`,
+  `--did-log <FILE>`, and `--no-primary` flags.
+- **5 new integration tests** — Mutual exclusivity validation, template
+  mode with custom keys, final mode storage, and `set_primary`
+  true/false behavior.
+
+### User-Specified Keys for DID Creation
+
+- **`signing_key_id` / `ka_key_id` fields** — Optionally specify
+  existing VTA-managed keys (imported or derived) for DID creation
+  instead of having the VTA derive fresh keys. The signing key must
+  be Ed25519; the KA key must be X25519.
+- **Signing-only DIDs** — When only `signing_key_id` is provided, the
+  DID Document is created with authentication/assertion but no
+  keyAgreement, suitable for non-DIDComm use cases.
+- **DIDComm validation** — If the DID Document includes
+  `DIDCommMessaging` services (via `add_mediator_service`,
+  `additional_services`, or a template), `ka_key_id` is required.
+- **CLI support** — `pnm webvh create-did` gains `--signing-key` and
+  `--ka-key` flags.
+- **5 new integration tests** — Signing-only, both keys, KA-without-
+  signing rejection, DIDComm-requires-KA, wrong key type rejection.
+
+### Setup Wizard Improvements
+
+- **Simple/advanced toggle** — VTA DID creation now offers a simple
+  path (VTA creates everything) and an advanced path that reveals
+  template mode, pre-signed log import, and user-specified key options.
+- **Consolidated DID creation** — `did_webvh.rs` standalone CLI
+  rewritten as a thin interactive wrapper around `operations::create_did_webvh()`,
+  removing ~200 lines of duplicate key derivation and document building.
+- **VTA DID via operations layer** — `create_vta_did()` in the setup
+  wizard now uses `build_wizard_did()` → `operations::create_did_webvh()`
+  instead of direct `didwebvh-rs` calls.
+- **Pre-rotation UX** — Replaced interactive loop ("Generate another?")
+  with a count prompt ("Number of pre-rotation keys", default: 1).
+- **Post-creation hosting instructions** — After saving `did.jsonl`,
+  the wizard now shows the URL where it should be uploaded.
+
+### Capabilities Discovery
+
+- **`GET /capabilities`** — New authenticated endpoint reporting VTA
+  features (webvh, didcomm, tee, rest), enabled services, configured
+  WebVH servers, and supported DID creation modes. Allows 3rd party
+  apps using `vta-sdk` to probe what the VTA supports before attempting
+  operations.
+- **DIDComm discovery protocol** — `discover-capabilities` message type
+  returns the same information via DIDComm.
+- **`VtaClient::capabilities()`** — SDK client method for discovery.
+
+### Infrastructure & Bug Fixes
+
+- **Unified `build_did_document`** — merged `build_did_document` and
+  `build_did_document_from_keys` into a single function with `include_ka`
+  parameter.
+- **DID deletion cleans up key records** — `delete_did_webvh` now removes
+  associated signing, KA, and pre-rotation key records.
+- **DIDComm bridge wired in handler path** — WebVH server communication
+  via DIDComm now uses the real bridge instead of a dummy.
+- **Pre-rotation keys in TEE autogen** — TEE auto-generated DIDs now
+  include 1 pre-rotation key by default.
+- **Mediator DID format validation** — Setup wizard validates `did:`
+  prefix when entering an existing mediator DID.
+
+### Code Consolidation
+
+- **Eliminated `CreateDidRequest`** — REST route now uses
+  `CreateDidWebvhBody` from SDK protocol types directly.
+- **`From<CreateDidWebvhBody> for CreateDidWebvhParams`** —
+  Centralizes default value logic, replacing boilerplate conversions
+  in REST and DIDComm handlers.
+- **Removed ~316 lines of duplicate code** — Deleted `create_webvh_did()`
+  and `prompt_pre_rotation_keys()` from `setup.rs` after migrating
+  all callers to `build_wizard_did()`.
+- **Cleaned up unused imports** — Removed `didwebvh-rs` direct
+  dependencies from `setup.rs` now that it uses the operations layer.
+
 ## 0.3.0 — 2026-04-01
 
 ### Reader Role & Action Classification

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "cnm-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2014,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -2215,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14711600a0c983ff7195141aff297d24f4b316de605fceb5eca4914d563b152"
+checksum = "61e0b3a4da26dd37c613d2c2e4593e931f024bdd3dd67cc6c13a7b816aa7ea8e"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -2289,7 +2289,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2502,7 +2502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3410,7 +3410,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -4518,7 +4518,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5023,7 +5023,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnm-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "chrono",
@@ -5226,7 +5226,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5264,9 +5264,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5761,7 +5761,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5850,7 +5850,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6843,7 +6843,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -7688,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "vta-enclave"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7703,7 +7703,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7798,7 +7798,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -8176,7 +8176,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.3" }
 affinidi-did-resolver-cache-sdk = "0.8"
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.3.0" }
+vta-sdk = { path = "../vta-sdk", version = "0.3", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.3" }
 affinidi-did-resolver-cache-sdk = "0.8"
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -198,6 +198,21 @@ enum WebvhCommands {
         /// Number of pre-rotation keys to generate
         #[arg(long, default_value = "0")]
         pre_rotation: u32,
+        /// Path to a JSON file containing a DID Document template (template mode)
+        #[arg(long)]
+        did_document: Option<String>,
+        /// Path to a did.jsonl file containing a pre-signed log entry (final mode)
+        #[arg(long)]
+        did_log: Option<String>,
+        /// Do not set this DID as the primary DID for the context
+        #[arg(long)]
+        no_primary: bool,
+        /// Use an existing key ID as the signing verification method
+        #[arg(long)]
+        signing_key: Option<String>,
+        /// Use an existing key ID as the key-agreement verification method
+        #[arg(long)]
+        ka_key: Option<String>,
     },
     /// List WebVH DIDs
     ListDids {
@@ -938,32 +953,35 @@ async fn main() {
                 mediator_service,
                 services,
                 pre_rotation,
+                did_document,
+                did_log,
+                no_primary,
+                signing_key,
+                ka_key,
             } => {
                 if server.is_none() && did_url.is_none() {
                     Err("either --server or --did-url is required".into())
                 } else if server.is_some() && did_url.is_some() {
                     Err("--server and --did-url are mutually exclusive".into())
                 } else {
-                    match services
-                        .map(|s| serde_json::from_str::<Vec<serde_json::Value>>(&s))
-                        .transpose()
-                    {
-                        Err(e) => Err(format!("invalid --services JSON: {e}").into()),
-                        Ok(additional_services) => {
-                            let req = vta_sdk::client::CreateDidWebvhRequest {
-                                context_id: context,
-                                server_id: server,
-                                url: did_url,
-                                path,
-                                label,
-                                portable,
-                                add_mediator_service: mediator_service,
-                                additional_services,
-                                pre_rotation_count: pre_rotation,
-                            };
-                            webvh::cmd_webvh_did_create(&client, req).await
-                        }
-                    }
+                    webvh::cmd_webvh_did_create_with_files(
+                        &client,
+                        context,
+                        server,
+                        did_url,
+                        path,
+                        label,
+                        portable,
+                        mediator_service,
+                        services,
+                        pre_rotation,
+                        did_document,
+                        did_log,
+                        no_primary,
+                        signing_key,
+                        ka_key,
+                    )
+                    .await
                 }
             }
             WebvhCommands::ListDids { context, server } => {

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3", features = ["client"] }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }
 ratatui = { workspace = true }

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -309,6 +309,11 @@ pub async fn cmd_context_provision(
             add_mediator_service: opts.add_mediator_service,
             additional_services: None,
             pre_rotation_count: opts.pre_rotation_count,
+            did_document: None,
+            did_log: None,
+            set_primary: true,
+            signing_key_id: None,
+            ka_key_id: None,
         };
         let did_result = client.create_did_webvh(req).await?;
 

--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -149,6 +149,66 @@ pub async fn cmd_webvh_did_create(
     Ok(())
 }
 
+/// Helper that reads optional file inputs before building a `CreateDidWebvhRequest`.
+#[allow(clippy::too_many_arguments)]
+pub async fn cmd_webvh_did_create_with_files(
+    client: &VtaClient,
+    context_id: String,
+    server_id: Option<String>,
+    url: Option<String>,
+    path: Option<String>,
+    label: Option<String>,
+    portable: bool,
+    add_mediator_service: bool,
+    services: Option<String>,
+    pre_rotation_count: u32,
+    did_document_path: Option<String>,
+    did_log_path: Option<String>,
+    no_primary: bool,
+    signing_key_id: Option<String>,
+    ka_key_id: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let did_document = match did_document_path {
+        Some(p) => {
+            let content =
+                std::fs::read_to_string(&p).map_err(|e| format!("failed to read {p}: {e}"))?;
+            Some(
+                serde_json::from_str::<serde_json::Value>(&content)
+                    .map_err(|e| format!("invalid JSON in {p}: {e}"))?,
+            )
+        }
+        None => None,
+    };
+    let did_log = match did_log_path {
+        Some(p) => {
+            Some(std::fs::read_to_string(&p).map_err(|e| format!("failed to read {p}: {e}"))?)
+        }
+        None => None,
+    };
+    let additional_services = services
+        .map(|s| serde_json::from_str::<Vec<serde_json::Value>>(&s))
+        .transpose()
+        .map_err(|e| format!("invalid --services JSON: {e}"))?;
+
+    let req = CreateDidWebvhRequest {
+        context_id,
+        server_id,
+        url,
+        path,
+        label,
+        portable,
+        add_mediator_service,
+        additional_services,
+        pre_rotation_count,
+        did_document,
+        did_log,
+        set_primary: !no_primary,
+        signing_key_id,
+        ka_key_id,
+    };
+    cmd_webvh_did_create(client, req).await
+}
+
 pub async fn cmd_webvh_did_list(
     client: &VtaClient,
     context_id: Option<&str>,

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -23,8 +23,8 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.3.0", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.3", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.3", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client.rs
+++ b/vta-sdk/src/client.rs
@@ -387,6 +387,15 @@ pub struct CreateDidWebvhRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_services: Option<Vec<serde_json::Value>>,
     pub pre_rotation_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub did_document: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub did_log: Option<String>,
+    pub set_primary: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signing_key_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ka_key_id: Option<String>,
 }
 
 // ── WebVH DID log types ──────────────────────────────────────────────
@@ -792,6 +801,26 @@ impl VtaClient {
 
 #[cfg(feature = "client")]
 impl VtaClient {
+    // ── Discovery ──────────────────────────────────────────────────
+
+    /// Discover VTA capabilities: enabled features, services, WebVH servers,
+    /// and supported DID creation modes.
+    ///
+    /// Requires authentication — any role (including Reader) can access.
+    pub async fn capabilities(
+        &self,
+    ) -> Result<crate::protocols::discovery::CapabilitiesResponse, VtaError> {
+        use crate::protocols::discovery;
+        self.rpc(
+            discovery::DISCOVER_CAPABILITIES,
+            serde_json::json!({}),
+            discovery::DISCOVER_CAPABILITIES_RESULT,
+            30,
+            |c, url| c.get(format!("{url}/capabilities")),
+        )
+        .await
+    }
+
     // ── VTA Management ──────────────────────────────────────────────
 
     /// Trigger a soft restart of the VTA.

--- a/vta-sdk/src/didcomm_light.rs
+++ b/vta-sdk/src/didcomm_light.rs
@@ -223,7 +223,7 @@ fn aes_key_unwrap(
     use aes::Aes256;
     use aes::cipher::{BlockDecrypt, KeyInit as AesKeyInit};
 
-    if ciphertext.len() % 8 != 0 || ciphertext.len() < 24 {
+    if !ciphertext.len().is_multiple_of(8) || ciphertext.len() < 24 {
         return Err("key unwrap input must be at least 24 bytes and a multiple of 8".into());
     }
 

--- a/vta-sdk/src/protocols/did_management/create.rs
+++ b/vta-sdk/src/protocols/did_management/create.rs
@@ -20,6 +20,29 @@ pub struct CreateDidWebvhBody {
     pub additional_services: Option<Vec<serde_json::Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pre_rotation_count: Option<u32>,
+    /// Client-provided DID Document template. When set, the VTA uses this
+    /// instead of building the document internally. `{DID}` placeholders are
+    /// resolved by `didwebvh-rs`. Mutually exclusive with `did_log`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub did_document: Option<serde_json::Value>,
+    /// Complete, pre-signed did.jsonl log entry. When set, the VTA publishes
+    /// it as-is without deriving keys or creating a log entry. Mutually
+    /// exclusive with `did_document`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub did_log: Option<String>,
+    /// Whether to set this DID as the primary DID for the context.
+    /// Defaults to `true` for backwards compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub set_primary: Option<bool>,
+    /// Use an existing key as the signing (Ed25519) verification method.
+    /// When set, the VTA skips key derivation and uses this key instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing_key_id: Option<String>,
+    /// Use an existing key as the key-agreement (X25519) verification method.
+    /// Required when the DID document includes DIDCommMessaging services.
+    /// Requires `signing_key_id` to also be set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ka_key_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/vta-sdk/src/protocols/discovery.rs
+++ b/vta-sdk/src/protocols/discovery.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+
+pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/discovery/1.0";
+
+pub const DISCOVER_CAPABILITIES: &str =
+    "https://firstperson.network/protocols/discovery/1.0/discover-capabilities";
+pub const DISCOVER_CAPABILITIES_RESULT: &str =
+    "https://firstperson.network/protocols/discovery/1.0/discover-capabilities-result";
+
+/// Response describing the VTA's capabilities and enabled features.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilitiesResponse {
+    /// Crate version of the VTA service.
+    pub version: String,
+    /// Enabled features/modules.
+    pub features: FeaturesInfo,
+    /// Enabled services (REST, DIDComm).
+    pub services: ServicesInfo,
+    /// Configured WebVH servers available for DID creation.
+    pub webvh_servers: Vec<WebvhServerInfo>,
+    /// Supported DID creation modes.
+    pub did_creation_modes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeaturesInfo {
+    pub webvh: bool,
+    pub didcomm: bool,
+    pub tee: bool,
+    pub rest: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServicesInfo {
+    pub rest: bool,
+    pub didcomm: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebvhServerInfo {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -6,6 +6,7 @@ pub mod backup_management;
 pub mod context_management;
 pub mod credential_management;
 pub mod did_management;
+pub mod discovery;
 pub mod key_management;
 pub mod seed_management;
 pub mod vta_management;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -45,8 +45,8 @@ name = "vta"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.3.0", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = ["didcomm"] }
+vti-common = { path = "../vti-common", version = "0.3", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.3", features = ["didcomm"] }
 hkdf = "0.12"
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.13"

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -1,22 +1,20 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use chrono::Utc;
 use dialoguer::{Confirm, Input, Select};
-use didwebvh_rs::create::{CreateDIDConfig, create_did};
-use didwebvh_rs::parameters::Parameters as WebVHParameters;
 use serde_json::json;
+
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 
 use vta_sdk::did_secrets::{DidSecretsBundle, SecretEntry};
 
 use crate::config::AppConfig;
-use crate::contexts::{self, get_context, store_context};
 use crate::keys::seed_store::create_seed_store;
-use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
-use crate::keys::{self, KeyType as SdkKeyType};
-use crate::operations::did_webvh as ops;
+use crate::operations;
+use crate::operations::did_webvh::CreateDidWebvhParams;
 use crate::setup;
 use crate::store::Store;
+use crate::webvh_cli::cli_super_admin;
 
 pub struct CreateDidWebvhArgs {
     pub config_path: Option<PathBuf>,
@@ -30,15 +28,12 @@ pub async fn run_create_did_webvh(
     let config = AppConfig::load(args.config_path)?;
     let store = Store::open(&config.store)?;
     let keys_ks = store.keyspace("keys")?;
+    let imported_ks = store.keyspace("imported_secrets")?;
     let contexts_ks = store.keyspace("contexts")?;
-
-    // Load seed from configured backend using the active generation
-    let seed_store = create_seed_store(&config)?;
-    let active_seed_id = get_active_seed_id(&keys_ks).await?;
-    let seed = load_seed_bytes(&keys_ks, &*seed_store, Some(active_seed_id)).await?;
+    let webvh_ks = store.keyspace("webvh")?;
 
     // Resolve context
-    let mut ctx = match get_context(&contexts_ks, &args.context).await? {
+    let ctx = match crate::contexts::get_context(&contexts_ks, &args.context).await? {
         Some(ctx) => ctx,
         None => {
             eprintln!("Context '{}' does not exist.", args.context);
@@ -46,7 +41,7 @@ pub async fn run_create_did_webvh(
                 .with_prompt("Create it with name")
                 .default(args.context.clone())
                 .interact_text()?;
-            let ctx = contexts::create_context(&contexts_ks, &args.context, &name).await?;
+            let ctx = crate::contexts::create_context(&contexts_ks, &args.context, &name).await?;
             eprintln!("Created context: {} ({})", ctx.id, ctx.base_path);
             ctx
         }
@@ -54,8 +49,29 @@ pub async fn run_create_did_webvh(
 
     let label = args.label.as_deref().unwrap_or(&args.context);
 
-    // Derive entity keys
-    let mut derived = keys::derive_entity_keys(
+    // Prompt for URL
+    let webvh_url = setup::prompt_webvh_url(label)?;
+    let url_str = webvh_url
+        .get_http_url(None)
+        .map_err(|e| format!("{e}"))?
+        .to_string();
+
+    // Build base DID document using shared helper (without services)
+    let seed_store = create_seed_store(&config)?;
+    let seed = crate::keys::seeds::load_seed_bytes(
+        &keys_ks,
+        &*seed_store,
+        Some(
+            crate::keys::seeds::get_active_seed_id(&keys_ks)
+                .await
+                .map_err(|e| format!("{e}"))?,
+        ),
+    )
+    .await
+    .map_err(|e| format!("{e}"))?;
+
+    // Derive keys temporarily just to build a preview document
+    let derived = crate::keys::derive_entity_keys(
         &seed,
         &ctx.base_path,
         &format!("{label} signing key"),
@@ -64,20 +80,8 @@ pub async fn run_create_did_webvh(
     )
     .await?;
 
-    // Prompt for URL and convert to WebVHURL
-    let webvh_url = setup::prompt_webvh_url(label)?;
-
-    // Convert the Signing Key ID to did:key format (required by didwebvh-rs)
-    derived.signing_secret.id = [
-        "did:key:",
-        &derived.signing_secret.get_public_keymultibase().unwrap(),
-        "#",
-        &derived.signing_secret.get_public_keymultibase().unwrap(),
-    ]
-    .concat();
-
-    // Build base DID document using shared helper (without services)
-    let mut did_document = ops::build_did_document(&derived, &config, false, &None);
+    let mut did_document =
+        operations::did_webvh::build_did_document(&derived, &config, false, &None);
 
     // Interactive service endpoint selection
     if let Some(ref msg) = config.messaging {
@@ -92,7 +96,6 @@ pub async fn run_create_did_webvh(
             .interact()?;
 
         if service_choice == 0 {
-            // Reference the mediator DID for routing
             did_document["service"] = json!([
                 {
                     "id": "{DID}#vta-didcomm",
@@ -128,94 +131,71 @@ pub async fn run_create_did_webvh(
         .default(true)
         .interact()?;
 
-    // Pre-rotation keys
-    let (next_key_hashes, pre_rotation_keys) =
-        setup::prompt_pre_rotation_keys(&seed, &ctx.base_path, label, &keys_ks).await?;
+    // Pre-rotation count
+    let pre_rotation_count: u32 = Input::new()
+        .with_prompt("Number of pre-rotation keys (0 = none, recommended: 1-3)")
+        .default(1u32)
+        .interact_text()?;
 
-    // Build parameters
-    let parameters = WebVHParameters {
-        update_keys: Some(Arc::new(vec![derived.signing_pub.clone().into()])),
-        portable: Some(portable),
-        next_key_hashes: if next_key_hashes.is_empty() {
-            None
-        } else {
-            Some(Arc::new(
-                next_key_hashes.into_iter().map(Into::into).collect(),
-            ))
-        },
-        ..Default::default()
+    // Build params and call the operations layer
+    let auth = cli_super_admin();
+    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let no_bridge: Arc<tokio::sync::RwLock<Option<crate::didcomm_bridge::DIDCommBridge>>> =
+        Arc::new(tokio::sync::RwLock::new(None));
+
+    let params = CreateDidWebvhParams {
+        context_id: args.context.clone(),
+        server_id: None,
+        url: Some(url_str.clone()),
+        path: None,
+        label: Some(label.to_string()),
+        portable,
+        add_mediator_service: false, // handled via did_document template
+        additional_services: None,
+        pre_rotation_count,
+        did_document: Some(did_document),
+        did_log: None,
+        set_primary: true,
+        signing_key_id: None,
+        ka_key_id: None,
     };
 
-    // Create the DID
-    let url_str = webvh_url
-        .get_http_url(None)
-        .map_err(|e| format!("{e}"))?
-        .to_string();
-    let create_config = CreateDIDConfig::builder()
-        .address(url_str)
-        .authorization_key(derived.signing_secret.clone())
-        .did_document(did_document)
-        .parameters(parameters)
-        .build()
-        .map_err(|e| format!("failed to build DID config: {e}"))?;
-
-    let result = create_did(create_config)
-        .await
-        .map_err(|e| format!("failed to create DID: {e}"))?;
-
-    let final_did = result.did().to_string();
-
-    eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");
-
-    // Save key records now that we have the final DID
-    keys::save_entity_key_records(
-        &final_did,
-        &derived,
+    let result = operations::did_webvh::create_did_webvh(
         &keys_ks,
-        Some(&ctx.id),
-        Some(active_seed_id),
+        &imported_ks,
+        &contexts_ks,
+        &webvh_ks,
+        &*seed_store,
+        &config,
+        &auth,
+        params,
+        &did_resolver,
+        &no_bridge,
+        "cli",
     )
     .await?;
 
-    // Save pre-rotation key records
-    for (i, pk) in pre_rotation_keys.iter().enumerate() {
-        keys::save_key_record(
-            &keys_ks,
-            &format!("{final_did}#pre-rotation-{i}"),
-            &pk.path,
-            SdkKeyType::Ed25519,
-            &pk.public_key,
-            &pk.label,
-            Some(&ctx.id),
-            Some(active_seed_id),
-        )
-        .await?;
-    }
-
-    // Update context with the new DID
-    ctx.did = Some(final_did.clone());
-    ctx.updated_at = Utc::now();
-    store_context(&contexts_ks, &ctx)
-        .await
-        .map_err(|e| format!("{e}"))?;
+    let final_did = &result.did;
+    eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");
 
     // Persist all writes
     store.persist().await?;
 
     // Save did.jsonl
-    let default_file = format!("{label}-did.jsonl");
-    let did_file: String = Input::new()
-        .with_prompt("Save DID log to file")
-        .default(default_file)
-        .interact_text()?;
+    if let Some(ref log_entry) = result.log_entry {
+        let default_file = format!("{label}-did.jsonl");
+        let did_file: String = Input::new()
+            .with_prompt("Save DID log to file")
+            .default(default_file)
+            .interact_text()?;
 
-    result
-        .log_entry()
-        .save_to_file(&did_file)
-        .map_err(|e| format!("Failed to save DID log file: {e}"))?;
-
-    eprintln!("  DID log saved to: {did_file}");
-    eprintln!("  Context '{}' updated with DID: {final_did}", ctx.id);
+        std::fs::write(&did_file, log_entry)?;
+        eprintln!("  DID log saved to: {did_file}");
+        eprintln!("  Context '{}' updated with DID: {final_did}", args.context);
+        eprintln!();
+        eprintln!("  \x1b[2mTo self-host this DID, upload {did_file} to:");
+        eprintln!("  {url_str}\x1b[0m");
+    }
 
     // Optionally export secrets bundle
     if Confirm::new()
@@ -223,20 +203,48 @@ pub async fn run_create_did_webvh(
         .default(false)
         .interact()?
     {
+        // Fetch key secrets via the operations layer
+        let signing_secret = crate::operations::keys::get_key_secret(
+            &keys_ks,
+            &imported_ks,
+            &Arc::from(seed_store),
+            &store.keyspace("audit")?,
+            &auth,
+            &result.signing_key_id,
+            "cli",
+        )
+        .await
+        .map_err(|e| format!("failed to fetch signing key secret: {e}"))?;
+
+        let mut secrets = vec![SecretEntry {
+            key_id: result.signing_key_id.clone(),
+            key_type: vta_sdk::keys::KeyType::Ed25519,
+            private_key_multibase: signing_secret.private_key_multibase,
+        }];
+
+        if !result.ka_key_id.is_empty() {
+            let ka_secret = crate::operations::keys::get_key_secret(
+                &keys_ks,
+                &imported_ks,
+                &Arc::from(create_seed_store(&config)?),
+                &store.keyspace("audit")?,
+                &auth,
+                &result.ka_key_id,
+                "cli",
+            )
+            .await
+            .map_err(|e| format!("failed to fetch KA key secret: {e}"))?;
+
+            secrets.push(SecretEntry {
+                key_id: result.ka_key_id.clone(),
+                key_type: vta_sdk::keys::KeyType::X25519,
+                private_key_multibase: ka_secret.private_key_multibase,
+            });
+        }
+
         let bundle = DidSecretsBundle {
             did: final_did.clone(),
-            secrets: vec![
-                SecretEntry {
-                    key_id: format!("{final_did}#key-0"),
-                    key_type: SdkKeyType::Ed25519,
-                    private_key_multibase: derived.signing_priv.clone(),
-                },
-                SecretEntry {
-                    key_id: format!("{final_did}#key-1"),
-                    key_type: SdkKeyType::X25519,
-                    private_key_multibase: derived.ka_priv.clone(),
-                },
-            ],
+            secrets,
         };
         let encoded = bundle.encode().map_err(|e| format!("{e}"))?;
         eprintln!();

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -697,32 +697,17 @@ pub async fn handle_create_did_webvh(
         .as_ref()
         .ok_or_else(|| handler_err("DID resolver not available"))?;
 
-    // NOTE: The DIDComm bridge for WebVH server communication is not yet
-    // available in the new service handler path. This will be wired in PR 3
-    // when DIDCommService replaces the manual thread. For now, pass a dummy
-    // empty bridge that will use REST fallback if available.
-    let bridge = std::sync::Arc::new(tokio::sync::RwLock::new(None));
-
     let result = operations::did_webvh::create_did_webvh(
         &state.keys_ks,
+        &state.imported_ks,
         &state.contexts_ks,
         &state.webvh_ks,
         &*state.seed_store,
         &config,
         &auth,
-        operations::did_webvh::CreateDidWebvhParams {
-            context_id: body.context_id,
-            server_id: body.server_id,
-            url: body.url,
-            path: body.path,
-            label: body.label,
-            portable: body.portable.unwrap_or(true),
-            add_mediator_service: body.add_mediator_service.unwrap_or(false),
-            additional_services: body.additional_services,
-            pre_rotation_count: body.pre_rotation_count.unwrap_or(0),
-        },
+        body.into(),
         did_resolver,
-        &bridge,
+        &state.didcomm_bridge,
         "didcomm",
     )
     .await
@@ -1129,6 +1114,65 @@ pub async fn handle_problem_report(_ctx: HandlerContext, message: Message) -> Ha
     let thid = message.thid.as_deref().unwrap_or("none");
     warn!(from, code, comment, thid, "received problem-report");
     Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+pub async fn handle_discover_capabilities(
+    _ctx: HandlerContext,
+    _message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let config = state.config.read().await;
+
+    let features = vta_sdk::protocols::discovery::FeaturesInfo {
+        webvh: cfg!(feature = "webvh"),
+        didcomm: cfg!(feature = "didcomm"),
+        tee: cfg!(feature = "tee"),
+        rest: cfg!(feature = "rest"),
+    };
+
+    let services = vta_sdk::protocols::discovery::ServicesInfo {
+        rest: config.services.rest,
+        didcomm: config.services.didcomm,
+    };
+
+    #[cfg(feature = "webvh")]
+    let webvh_servers = {
+        let servers = crate::webvh_store::list_servers(&state.webvh_ks)
+            .await
+            .map_err(handler_err)?;
+        servers
+            .into_iter()
+            .map(|s| vta_sdk::protocols::discovery::WebvhServerInfo {
+                id: s.id,
+                label: s.label,
+            })
+            .collect()
+    };
+    #[cfg(not(feature = "webvh"))]
+    let webvh_servers: Vec<vta_sdk::protocols::discovery::WebvhServerInfo> = vec![];
+
+    let mut did_creation_modes = vec!["vta-built".to_string()];
+    if cfg!(feature = "webvh") {
+        did_creation_modes.push("template".to_string());
+        did_creation_modes.push("final".to_string());
+        did_creation_modes.push("user-specified-keys".to_string());
+    }
+
+    let result = vta_sdk::protocols::discovery::CapabilitiesResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        features,
+        services,
+        webvh_servers,
+        did_creation_modes,
+    };
+    response(
+        vta_sdk::protocols::discovery::DISCOVER_CAPABILITIES_RESULT,
+        &result,
+    )
 }
 
 pub async fn handle_unknown(_ctx: HandlerContext, message: Message) -> HandlerResult {

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -42,6 +42,8 @@ pub struct VtaState {
     pub seed_store: Arc<dyn SeedStore>,
     pub config: Arc<RwLock<AppConfig>>,
     pub did_resolver: Option<DIDCacheClient>,
+    /// DIDComm bridge for outbound WebVH server communication.
+    pub didcomm_bridge: Arc<tokio::sync::RwLock<Option<crate::didcomm_bridge::DIDCommBridge>>>,
     #[cfg(feature = "tee")]
     pub tee_state: Option<crate::tee::TeeState>,
     /// Send `true` to trigger a soft restart.
@@ -245,6 +247,12 @@ pub fn build_router(state: Arc<VtaState>) -> Result<Router, DIDCommServiceError>
                 handler_fn(handlers::handle_request_attestation),
             )?;
     }
+
+    // Discovery (no auth required — the handler doesn't call auth_from_message)
+    router = router.route(
+        protocols::discovery::DISCOVER_CAPABILITIES,
+        handler_fn(handlers::handle_discover_capabilities),
+    )?;
 
     // Fallback, middleware, error handling
     router = router

--- a/vta-service/src/operations/backup.rs
+++ b/vta-service/src/operations/backup.rs
@@ -800,7 +800,7 @@ mod tests {
 
         assert_eq!(deserialized.version, envelope.version);
         assert_eq!(deserialized.format, envelope.format);
-        assert_eq!(deserialized.includes_audit, true);
+        assert!(deserialized.includes_audit);
         assert_eq!(deserialized.ciphertext, envelope.ciphertext);
 
         // Should still decrypt correctly

--- a/vta-service/src/operations/did_webvh.rs
+++ b/vta-service/src/operations/did_webvh.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use chrono::Utc;
 use didwebvh_rs::create::{CreateDIDConfig, create_did};
-use didwebvh_rs::log_entry::LogEntryMethods;
+use didwebvh_rs::log_entry::{LogEntry, LogEntryMethods};
 use didwebvh_rs::parameters::Parameters as WebVHParameters;
 use didwebvh_rs::url::WebVHURL;
 use serde_json::json;
@@ -15,7 +15,7 @@ use affinidi_tdk::secrets_resolver::secrets::Secret;
 use crate::didcomm_bridge::DIDCommBridge;
 
 use vta_sdk::protocols::did_management::{
-    create::CreateDidWebvhResultBody,
+    create::{CreateDidWebvhBody, CreateDidWebvhResultBody},
     delete::DeleteDidWebvhResultBody,
     list::ListDidsWebvhResultBody,
     servers::{
@@ -28,14 +28,17 @@ use vta_sdk::webvh::{WebvhDidRecord, WebvhServerRecord};
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::error::AppError;
+use crate::keys::imported;
 use crate::keys::paths::allocate_path;
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
-use crate::keys::{self, KeyType as SdkKeyType, PreRotationKeyData};
+use crate::keys::{self, KeyType as SdkKeyType, PreRotationKeyData, encode_private_multibase};
 use crate::store::KeyspaceHandle;
 use crate::webvh_client::{RequestUriResponse, WebvhClient};
 use crate::webvh_didcomm::WebvhDIDCommClient;
 use crate::webvh_store;
+use vta_sdk::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
+use zeroize::Zeroize;
 
 use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
 
@@ -49,11 +52,149 @@ pub struct CreateDidWebvhParams {
     pub add_mediator_service: bool,
     pub additional_services: Option<Vec<serde_json::Value>>,
     pub pre_rotation_count: u32,
+    /// Client-provided DID Document template. Mutually exclusive with `did_log`.
+    pub did_document: Option<serde_json::Value>,
+    /// Complete, pre-signed did.jsonl log entry. Mutually exclusive with `did_document`.
+    pub did_log: Option<String>,
+    /// Whether to set this DID as the primary DID for the context.
+    pub set_primary: bool,
+    /// Use an existing key as the signing verification method.
+    pub signing_key_id: Option<String>,
+    /// Use an existing key as the key-agreement verification method.
+    pub ka_key_id: Option<String>,
+}
+
+impl From<CreateDidWebvhBody> for CreateDidWebvhParams {
+    fn from(body: CreateDidWebvhBody) -> Self {
+        Self {
+            context_id: body.context_id,
+            server_id: body.server_id,
+            url: body.url,
+            path: body.path,
+            label: body.label,
+            portable: body.portable.unwrap_or(true),
+            add_mediator_service: body.add_mediator_service.unwrap_or(false),
+            additional_services: body.additional_services,
+            pre_rotation_count: body.pre_rotation_count.unwrap_or(0),
+            did_document: body.did_document,
+            did_log: body.did_log,
+            set_primary: body.set_primary.unwrap_or(true),
+            signing_key_id: body.signing_key_id,
+            ka_key_id: body.ka_key_id,
+        }
+    }
+}
+
+/// Load an existing key record and return it as a `Secret` for use in DID creation.
+///
+/// Validates key type, status, and context access. Returns the Secret,
+/// public key multibase, and the original KeyRecord.
+async fn load_key_as_secret(
+    keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    key_id: &str,
+    expected_type: KeyType,
+    auth: &AuthClaims,
+) -> Result<(Secret, String, KeyRecord), AppError> {
+    let record: KeyRecord = keys_ks
+        .get(keys::store_key(key_id))
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("key {key_id} not found")))?;
+
+    // Validate key type
+    if record.key_type != expected_type {
+        return Err(AppError::Validation(format!(
+            "key {key_id} is {} but expected {}",
+            record.key_type, expected_type
+        )));
+    }
+
+    // Validate status
+    if record.status != KeyStatus::Active {
+        return Err(AppError::Validation(format!(
+            "key {key_id} is not active (status: {:?})",
+            record.status
+        )));
+    }
+
+    // Validate context access
+    if let Some(ref ctx) = record.context_id {
+        auth.require_context(ctx)?;
+    } else if !auth.is_super_admin() {
+        return Err(AppError::Forbidden(
+            "only super admin can use keys without a context".into(),
+        ));
+    }
+
+    // Load private key material
+    let private_key_multibase = match record.origin {
+        KeyOrigin::Imported => {
+            let seed = load_seed_bytes(keys_ks, seed_store, None)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let mut secret_bytes = imported::load_secret(
+                imported_ks,
+                keys_ks,
+                &seed,
+                key_id,
+                &record.key_type.to_string(),
+            )
+            .await?;
+            let priv_mb = encode_private_multibase(&record.key_type, &secret_bytes);
+            secret_bytes.zeroize();
+            priv_mb
+        }
+        KeyOrigin::Derived => {
+            let seed = load_seed_bytes(keys_ks, seed_store, record.seed_id)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+            let bip32 = ExtendedSigningKey::from_seed(&seed).map_err(|e| {
+                AppError::Internal(format!("failed to create BIP-32 root key: {e}"))
+            })?;
+            let derivation_path: DerivationPath = record
+                .derivation_path
+                .parse()
+                .map_err(|e| AppError::Internal(format!("invalid derivation path: {e}")))?;
+            let derived_key = bip32
+                .derive(&derivation_path)
+                .map_err(|e| AppError::Internal(format!("key derivation failed: {e}")))?;
+            encode_private_multibase(&KeyType::Ed25519, derived_key.signing_key.as_bytes())
+        }
+    };
+
+    let secret = Secret::from_multibase(&private_key_multibase, None).map_err(|e| {
+        AppError::Internal(format!("failed to construct Secret from key {key_id}: {e}"))
+    })?;
+
+    Ok((secret, record.public_key.clone(), record))
+}
+
+/// Check whether a DID document (JSON) contains any DIDCommMessaging service.
+fn document_has_didcomm_service(doc: &serde_json::Value) -> bool {
+    doc.get("service")
+        .and_then(|s| s.as_array())
+        .is_some_and(|services| {
+            services.iter().any(|svc| {
+                svc.get("type")
+                    .and_then(|t| t.as_str())
+                    .is_some_and(|t| t == "DIDCommMessaging")
+                    || svc
+                        .get("type")
+                        .and_then(|t| t.as_array())
+                        .is_some_and(|types| {
+                            types
+                                .iter()
+                                .any(|t| t.as_str().is_some_and(|s| s == "DIDCommMessaging"))
+                        })
+            })
+        })
 }
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create_did_webvh(
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
     webvh_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
@@ -66,6 +207,20 @@ pub async fn create_did_webvh(
 ) -> Result<CreateDidWebvhResultBody, AppError> {
     auth.require_admin()?;
     auth.require_context(&params.context_id)?;
+
+    // Validate did_document and did_log are mutually exclusive
+    if params.did_document.is_some() && params.did_log.is_some() {
+        return Err(AppError::Validation(
+            "did_document and did_log are mutually exclusive".into(),
+        ));
+    }
+
+    // Validate ka_key_id requires signing_key_id
+    if params.ka_key_id.is_some() && params.signing_key_id.is_none() {
+        return Err(AppError::Validation(
+            "ka_key_id requires signing_key_id".into(),
+        ));
+    }
 
     // Validate exactly one of server_id / url is provided
     let serverless = match (&params.server_id, &params.url) {
@@ -88,26 +243,187 @@ pub async fn create_did_webvh(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("context not found: {}", params.context_id)))?;
 
-    // Load seed
-    let active_seed_id = get_active_seed_id(keys_ks)
-        .await
-        .map_err(|e| AppError::Internal(format!("{e}")))?;
-    let seed = load_seed_bytes(keys_ks, seed_store, Some(active_seed_id))
-        .await
-        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    let now = Utc::now();
+
+    // ── Final mode: client-provided pre-signed log entry ────────────
+    if let Some(ref did_log) = params.did_log {
+        let log_entry = LogEntry::deserialize_string(did_log, None)
+            .map_err(|e| AppError::Validation(format!("invalid did_log: {e}")))?;
+
+        let final_did_document = log_entry.get_did_document().map_err(|e| {
+            AppError::Validation(format!("failed to extract DID document from log: {e}"))
+        })?;
+        let final_did = final_did_document["id"]
+            .as_str()
+            .ok_or_else(|| AppError::Validation("DID document missing 'id' field".into()))?
+            .to_string();
+        let scid = log_entry.get_scid().unwrap_or_default().to_string();
+
+        // Publish to server if not serverless
+        if !serverless {
+            let server_id = params.server_id.as_ref().unwrap();
+            let server = webvh_store::get_server(webvh_ks, server_id)
+                .await?
+                .ok_or_else(|| {
+                    AppError::NotFound(format!("webvh server not found: {server_id}"))
+                })?;
+            let transport =
+                WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, config).await?;
+            // Final mode has no mnemonic from a server request — use the SCID as identifier
+            transport.publish_did(&scid, did_log).await?;
+        }
+
+        // Optionally set as primary DID
+        if params.set_primary {
+            ctx.did = Some(final_did.clone());
+            ctx.updated_at = now;
+            crate::contexts::store_context(contexts_ks, &ctx)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?;
+        }
+
+        // Store DID record and log
+        let server_id_str = params
+            .server_id
+            .as_deref()
+            .unwrap_or("serverless")
+            .to_string();
+        let did_record = WebvhDidRecord {
+            did: final_did.clone(),
+            server_id: server_id_str.clone(),
+            mnemonic: String::new(),
+            scid: scid.clone(),
+            context_id: params.context_id.clone(),
+            portable: params.portable,
+            log_entry_count: 1,
+            created_at: now,
+            updated_at: now,
+        };
+        webvh_store::store_did(webvh_ks, &did_record).await?;
+        webvh_store::store_did_log(webvh_ks, &final_did, did_log).await?;
+
+        info!(
+            channel,
+            did = %final_did,
+            context = %params.context_id,
+            "did:webvh created (final mode)"
+        );
+
+        return Ok(CreateDidWebvhResultBody {
+            did: final_did.clone(),
+            context_id: params.context_id,
+            server_id: if serverless { None } else { params.server_id },
+            mnemonic: None,
+            scid,
+            portable: params.portable,
+            signing_key_id: String::new(),
+            ka_key_id: String::new(),
+            pre_rotation_key_count: 0,
+            created_at: now,
+            did_document: Some(final_did_document),
+            log_entry: Some(did_log.clone()),
+        });
+    }
+
+    // ── VTA-built or template mode ──────────────────────────────────
 
     let label = params.label.as_deref().unwrap_or(&params.context_id);
 
-    // Derive entity keys
-    let mut derived = keys::derive_entity_keys(
-        &seed,
-        &ctx.base_path,
-        &format!("{label} signing key"),
-        &format!("{label} key-agreement key"),
-        keys_ks,
-    )
-    .await
-    .map_err(|e| AppError::Internal(format!("{e}")))?;
+    // Track whether keys were user-specified (affects key record saving)
+    let user_specified_keys = params.signing_key_id.is_some();
+
+    // Load or derive entity keys
+    let (derived, active_seed_id) = if let Some(ref signing_key_id) = params.signing_key_id {
+        // ── User-specified keys ─────────────────────────────────────
+        let (mut signing_secret, signing_pub, signing_record) = load_key_as_secret(
+            keys_ks,
+            imported_ks,
+            seed_store,
+            signing_key_id,
+            KeyType::Ed25519,
+            auth,
+        )
+        .await?;
+
+        // Convert signing key ID to did:key format (required by didwebvh-rs)
+        let pub_mb = signing_secret
+            .get_public_keymultibase()
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+        signing_secret.id = format!("did:key:{pub_mb}#{pub_mb}");
+
+        let (ka_secret, ka_pub, ka_path, ka_label) = if let Some(ref ka_key_id) = params.ka_key_id {
+            let (ka_secret, ka_pub, ka_record) = load_key_as_secret(
+                keys_ks,
+                imported_ks,
+                seed_store,
+                ka_key_id,
+                KeyType::X25519,
+                auth,
+            )
+            .await?;
+            (
+                ka_secret,
+                ka_pub,
+                ka_record.derivation_path,
+                ka_record
+                    .label
+                    .unwrap_or_else(|| format!("{label} key-agreement key")),
+            )
+        } else {
+            // No KA key — use dummy values (won't be in the document)
+            (
+                Secret::generate_ed25519(None, None),
+                String::new(),
+                String::new(),
+                String::new(),
+            )
+        };
+
+        let derived = keys::DerivedEntityKeys {
+            signing_secret,
+            signing_path: signing_record.derivation_path.clone(),
+            signing_pub,
+            signing_priv: String::new(), // Not needed for DID creation
+            signing_label: signing_record
+                .label
+                .unwrap_or_else(|| format!("{label} signing key")),
+            ka_secret,
+            ka_path,
+            ka_pub,
+            ka_priv: String::new(),
+            ka_label,
+        };
+
+        // seed_id from the signing key record (may be None for imported)
+        (derived, signing_record.seed_id)
+    } else {
+        // ── VTA-derived keys ────────────────────────────────────────
+        let active_seed_id = get_active_seed_id(keys_ks)
+            .await
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+        let seed = load_seed_bytes(keys_ks, seed_store, Some(active_seed_id))
+            .await
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+        let mut derived = keys::derive_entity_keys(
+            &seed,
+            &ctx.base_path,
+            &format!("{label} signing key"),
+            &format!("{label} key-agreement key"),
+            keys_ks,
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+        // Convert signing key ID to did:key format (required by didwebvh-rs)
+        let pub_mb = derived
+            .signing_secret
+            .get_public_keymultibase()
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+        derived.signing_secret.id = format!("did:key:{pub_mb}#{pub_mb}");
+
+        (derived, Some(active_seed_id))
+    };
 
     // Resolve URL: serverless uses user-provided URL, server-managed requests from server
     let (url_str, mnemonic) = if serverless {
@@ -136,38 +452,63 @@ pub async fn create_did_webvh(
         (uri_response.did_url, Some(uri_response.mnemonic))
     };
 
-    // Convert signing key ID to did:key format (required by didwebvh-rs)
-    derived.signing_secret.id = [
-        "did:key:",
-        &derived
-            .signing_secret
-            .get_public_keymultibase()
-            .map_err(|e| AppError::Internal(format!("{e}")))?,
-        "#",
-        &derived
-            .signing_secret
-            .get_public_keymultibase()
-            .map_err(|e| AppError::Internal(format!("{e}")))?,
-    ]
-    .concat();
+    // Build DID document: use client-provided template or build internally
+    let has_ka = params.ka_key_id.is_some() || !user_specified_keys;
+    let did_document = match params.did_document {
+        Some(doc) => doc,
+        None if user_specified_keys => {
+            // Build document from user-specified keys (signing only, or signing + KA)
+            build_did_document_with_options(
+                &derived,
+                config,
+                has_ka,
+                params.add_mediator_service,
+                &params.additional_services,
+            )
+        }
+        None => build_did_document(
+            &derived,
+            config,
+            params.add_mediator_service,
+            &params.additional_services,
+        ),
+    };
 
-    // Build DID document
-    let did_document = build_did_document(
-        &derived,
-        config,
-        params.add_mediator_service,
-        &params.additional_services,
-    );
+    // Validate DIDComm services require a KA key
+    if !has_ka && (params.add_mediator_service || document_has_didcomm_service(&did_document)) {
+        return Err(AppError::Validation(
+            "DIDCommMessaging services require a key-agreement key (ka_key_id)".into(),
+        ));
+    }
 
-    // Derive pre-rotation keys
-    let (next_key_hashes, pre_rotation_keys) = derive_pre_rotation_keys(
-        &seed,
-        &ctx.base_path,
-        label,
-        keys_ks,
-        params.pre_rotation_count,
-    )
-    .await?;
+    // Derive pre-rotation keys (requires seed)
+    let seed_for_pre_rotation = if params.pre_rotation_count > 0 {
+        let sid = match active_seed_id {
+            Some(id) => id,
+            None => get_active_seed_id(keys_ks)
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?,
+        };
+        Some(
+            load_seed_bytes(keys_ks, seed_store, Some(sid))
+                .await
+                .map_err(|e| AppError::Internal(format!("{e}")))?,
+        )
+    } else {
+        None
+    };
+    let (next_key_hashes, pre_rotation_keys) = if let Some(ref seed) = seed_for_pre_rotation {
+        derive_pre_rotation_keys(
+            seed,
+            &ctx.base_path,
+            label,
+            keys_ks,
+            params.pre_rotation_count,
+        )
+        .await?
+    } else {
+        (vec![], vec![])
+    };
 
     // Build parameters
     let parameters = WebVHParameters {
@@ -205,18 +546,51 @@ pub async fn create_did_webvh(
     let log_content = serde_json::to_string(result.log_entry())
         .map_err(|e| AppError::Internal(format!("failed to serialize DID log: {e}")))?;
 
-    // Save key records (common to both paths)
-    keys::save_entity_key_records(
-        &final_did,
-        &derived,
-        keys_ks,
-        Some(&params.context_id),
-        Some(active_seed_id),
-    )
-    .await
-    .map_err(|e| AppError::Internal(format!("{e}")))?;
+    // Save key records
+    if !user_specified_keys {
+        // VTA-derived: save both signing and KA key records
+        keys::save_entity_key_records(
+            &final_did,
+            &derived,
+            keys_ks,
+            Some(&params.context_id),
+            active_seed_id,
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    } else {
+        // User-specified: save key records referencing the user's keys
+        keys::save_key_record(
+            keys_ks,
+            &format!("{final_did}#key-0"),
+            &derived.signing_path,
+            SdkKeyType::Ed25519,
+            &derived.signing_pub,
+            &derived.signing_label,
+            Some(&params.context_id),
+            active_seed_id,
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+        if has_ka {
+            keys::save_key_record(
+                keys_ks,
+                &format!("{final_did}#key-1"),
+                &derived.ka_path,
+                SdkKeyType::X25519,
+                &derived.ka_pub,
+                &derived.ka_label,
+                Some(&params.context_id),
+                active_seed_id,
+            )
+            .await
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+        }
+    }
 
     // Save pre-rotation key records
+    let pre_rotation_seed_id = active_seed_id.unwrap_or(0);
     for (i, pk) in pre_rotation_keys.iter().enumerate() {
         keys::save_key_record(
             keys_ks,
@@ -226,13 +600,20 @@ pub async fn create_did_webvh(
             &pk.public_key,
             &pk.label,
             Some(&params.context_id),
-            Some(active_seed_id),
+            Some(pre_rotation_seed_id),
         )
         .await
         .map_err(|e| AppError::Internal(format!("{e}")))?;
     }
 
-    let now = Utc::now();
+    // Optionally set as primary DID
+    if params.set_primary {
+        ctx.did = Some(final_did.clone());
+        ctx.updated_at = now;
+        crate::contexts::store_context(contexts_ks, &ctx)
+            .await
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+    }
 
     if serverless {
         // Serverless: extract final DID document from log entry, return it + log entry.
@@ -242,13 +623,6 @@ pub async fn create_did_webvh(
             .get_did_document()
             .ok()
             .unwrap_or(did_document);
-
-        // Update context with the new DID
-        ctx.did = Some(final_did.clone());
-        ctx.updated_at = Utc::now();
-        crate::contexts::store_context(contexts_ks, &ctx)
-            .await
-            .map_err(|e| AppError::Internal(format!("{e}")))?;
 
         // Store DID record and log
         let did_record = WebvhDidRecord {
@@ -298,13 +672,6 @@ pub async fn create_did_webvh(
         let transport =
             WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, config).await?;
         transport.publish_did(mnemonic, &log_content).await?;
-
-        // Update context with the new DID
-        ctx.did = Some(final_did.clone());
-        ctx.updated_at = Utc::now();
-        crate::contexts::store_context(contexts_ks, &ctx)
-            .await
-            .map_err(|e| AppError::Internal(format!("{e}")))?;
 
         // Store DID record and log
         let did_record = WebvhDidRecord {
@@ -405,7 +772,7 @@ pub async fn list_dids_webvh(
 #[allow(clippy::too_many_arguments)]
 pub async fn delete_did_webvh(
     webvh_ks: &KeyspaceHandle,
-    _keys_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
     _seed_store: &dyn SeedStore,
     config: &AppConfig,
     auth: &AuthClaims,
@@ -436,8 +803,22 @@ pub async fn delete_did_webvh(
         }
     }
 
-    // Remove local records
+    // Remove local DID record and log
     webvh_store::delete_did(webvh_ks, did).await?;
+
+    // Clean up associated key records (best-effort)
+    for key_id in &[format!("{did}#key-0"), format!("{did}#key-1")] {
+        let _ = keys_ks.remove(keys::store_key(key_id)).await;
+    }
+    // Clean up pre-rotation key records
+    for i in 0..100u32 {
+        let key_id = format!("{did}#pre-rotation-{i}");
+        let store_key = keys::store_key(&key_id);
+        if keys_ks.get_raw(store_key.clone()).await?.is_none() {
+            break;
+        }
+        let _ = keys_ks.remove(store_key).await;
+    }
 
     info!(channel, did = %did, "webvh DID deleted");
     Ok(DeleteDidWebvhResultBody {
@@ -720,36 +1101,78 @@ async fn validate_server_did(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Build a DID document with the given keys.
+///
+/// When `include_ka` is true (default for VTA-derived keys), adds a
+/// keyAgreement verification method. When false (signing-only DID),
+/// the document contains only authentication/assertion.
 pub fn build_did_document(
     derived: &keys::DerivedEntityKeys,
     config: &AppConfig,
     add_mediator_service: bool,
     additional_services: &Option<Vec<serde_json::Value>>,
 ) -> serde_json::Value {
+    build_did_document_inner(
+        derived,
+        config,
+        true,
+        add_mediator_service,
+        additional_services,
+    )
+}
+
+/// Build a DID document with optional keyAgreement support.
+pub(crate) fn build_did_document_with_options(
+    derived: &keys::DerivedEntityKeys,
+    config: &AppConfig,
+    include_ka: bool,
+    add_mediator_service: bool,
+    additional_services: &Option<Vec<serde_json::Value>>,
+) -> serde_json::Value {
+    build_did_document_inner(
+        derived,
+        config,
+        include_ka,
+        add_mediator_service,
+        additional_services,
+    )
+}
+
+fn build_did_document_inner(
+    derived: &keys::DerivedEntityKeys,
+    config: &AppConfig,
+    include_ka: bool,
+    add_mediator_service: bool,
+    additional_services: &Option<Vec<serde_json::Value>>,
+) -> serde_json::Value {
+    let mut vm = vec![json!({
+        "id": "{DID}#key-0",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": &derived.signing_pub
+    })];
+
     let mut did_document = json!({
         "@context": [
             "https://www.w3.org/ns/did/v1",
             "https://www.w3.org/ns/cid/v1"
         ],
         "id": "{DID}",
-        "verificationMethod": [
-            {
-                "id": "{DID}#key-0",
-                "type": "Multikey",
-                "controller": "{DID}",
-                "publicKeyMultibase": &derived.signing_pub
-            },
-            {
-                "id": "{DID}#key-1",
-                "type": "Multikey",
-                "controller": "{DID}",
-                "publicKeyMultibase": &derived.ka_pub
-            }
-        ],
         "authentication": ["{DID}#key-0"],
-        "assertionMethod": ["{DID}#key-0"],
-        "keyAgreement": ["{DID}#key-1"]
+        "assertionMethod": ["{DID}#key-0"]
     });
+
+    if include_ka {
+        vm.push(json!({
+            "id": "{DID}#key-1",
+            "type": "Multikey",
+            "controller": "{DID}",
+            "publicKeyMultibase": &derived.ka_pub
+        }));
+        did_document["keyAgreement"] = json!(["{DID}#key-1"]);
+    }
+
+    did_document["verificationMethod"] = json!(vm);
 
     // Optionally add mediator DIDComm service
     if add_mediator_service && let Some(ref msg) = config.messaging {

--- a/vta-service/src/routes/capabilities.rs
+++ b/vta-service/src/routes/capabilities.rs
@@ -1,0 +1,65 @@
+use axum::Json;
+use axum::extract::State;
+
+use vta_sdk::protocols::discovery::{
+    CapabilitiesResponse, FeaturesInfo, ServicesInfo, WebvhServerInfo,
+};
+
+use crate::auth::AuthClaims;
+use crate::error::AppError;
+use crate::server::AppState;
+
+/// GET /capabilities — Discover VTA features, services, and WebVH servers.
+///
+/// Requires authentication — prevents leaking implementation details to
+/// unauthenticated callers. Any authenticated role (including Reader) can access.
+pub async fn capabilities(
+    _auth: AuthClaims,
+    State(state): State<AppState>,
+) -> Result<Json<CapabilitiesResponse>, AppError> {
+    let config = state.config.read().await;
+
+    // Detect compiled features at build time
+    let features = FeaturesInfo {
+        webvh: cfg!(feature = "webvh"),
+        didcomm: cfg!(feature = "didcomm"),
+        tee: cfg!(feature = "tee"),
+        rest: cfg!(feature = "rest"),
+    };
+
+    let services = ServicesInfo {
+        rest: config.services.rest,
+        didcomm: config.services.didcomm,
+    };
+
+    // List configured WebVH servers (if feature enabled)
+    #[cfg(feature = "webvh")]
+    let webvh_servers = {
+        let servers = crate::webvh_store::list_servers(&state.webvh_ks).await?;
+        servers
+            .into_iter()
+            .map(|s| WebvhServerInfo {
+                id: s.id,
+                label: s.label,
+            })
+            .collect()
+    };
+    #[cfg(not(feature = "webvh"))]
+    let webvh_servers: Vec<WebvhServerInfo> = vec![];
+
+    // Supported DID creation modes
+    let mut did_creation_modes = vec!["vta-built".to_string()];
+    if cfg!(feature = "webvh") {
+        did_creation_modes.push("template".to_string());
+        did_creation_modes.push("final".to_string());
+        did_creation_modes.push("user-specified-keys".to_string());
+    }
+
+    Ok(Json(CapabilitiesResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        features,
+        services,
+        webvh_servers,
+        did_creation_modes,
+    }))
+}

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -4,7 +4,7 @@ use axum::http::StatusCode;
 use serde::Deserialize;
 
 use vta_sdk::protocols::did_management::{
-    create::CreateDidWebvhResultBody,
+    create::{CreateDidWebvhBody, CreateDidWebvhResultBody},
     list::ListDidsWebvhResultBody,
     servers::{AddWebvhServerResultBody, ListWebvhServersResultBody, UpdateWebvhServerResultBody},
 };
@@ -20,26 +20,6 @@ pub struct AddServerRequest {
     pub id: String,
     pub did: String,
     pub label: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct CreateDidRequest {
-    pub context_id: String,
-    pub server_id: Option<String>,
-    pub url: Option<String>,
-    pub path: Option<String>,
-    pub label: Option<String>,
-    #[serde(default = "default_true")]
-    pub portable: bool,
-    #[serde(default)]
-    pub add_mediator_service: bool,
-    pub additional_services: Option<Vec<serde_json::Value>>,
-    #[serde(default)]
-    pub pre_rotation_count: u32,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 #[derive(Debug, Deserialize)]
@@ -116,26 +96,17 @@ pub async fn remove_server_handler(
 pub async fn create_did_handler(
     auth: AdminAuth,
     State(state): State<AppState>,
-    Json(req): Json<CreateDidRequest>,
+    Json(body): Json<CreateDidWebvhBody>,
 ) -> Result<(StatusCode, Json<CreateDidWebvhResultBody>), AppError> {
     let config = state.config.read().await;
-    let params = operations::did_webvh::CreateDidWebvhParams {
-        context_id: req.context_id,
-        server_id: req.server_id,
-        url: req.url,
-        path: req.path,
-        label: req.label,
-        portable: req.portable,
-        add_mediator_service: req.add_mediator_service,
-        additional_services: req.additional_services,
-        pre_rotation_count: req.pre_rotation_count,
-    };
+    let params = body.into();
     let did_resolver = state
         .did_resolver
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
     let result = operations::did_webvh::create_did_webvh(
         &state.keys_ks,
+        &state.imported_ks,
         &state.contexts_ks,
         &state.webvh_ks,
         &*state.seed_store,

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -5,6 +5,7 @@ mod audit;
 mod auth;
 mod backup;
 mod cache;
+mod capabilities;
 mod config;
 mod contexts;
 #[cfg(feature = "webvh")]
@@ -149,8 +150,10 @@ pub fn router() -> Router<AppState> {
         .route("/backup/export", post(backup::export))
         .route("/backup/import", post(backup::import));
 
-    // Authenticated health details endpoint
-    let router = router.route("/health/details", get(health::health_details));
+    // Authenticated health details and capabilities
+    let router = router
+        .route("/health/details", get(health::health_details))
+        .route("/capabilities", get(capabilities::capabilities));
 
     // Apply global request body size limit to protect enclave memory
     router.layer(DefaultBodyLimit::max(MAX_BODY_SIZE))

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -285,6 +285,7 @@ pub async fn run(
                 seed_store: seed_store.clone(),
                 config: Arc::new(RwLock::new(config.clone())),
                 did_resolver: did_resolver.clone(),
+                didcomm_bridge: didcomm_bridge.clone(),
                 #[cfg(feature = "tee")]
                 tee_state: tee_context.as_ref().map(|tc| tc.state.clone()),
                 restart_tx: restart_tx.clone(),

--- a/vta-service/src/setup.rs
+++ b/vta-service/src/setup.rs
@@ -1,16 +1,13 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use affinidi_tdk::secrets_resolver::secrets::Secret;
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use bip39::Mnemonic;
 use chrono::Utc;
 use dialoguer::{Confirm, Input, MultiSelect, Select};
-use didwebvh_rs::create::{CreateDIDConfig, create_did};
-use didwebvh_rs::parameters::Parameters as WebVHParameters;
 use didwebvh_rs::url::WebVHURL;
-use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
 use rand::Rng;
 use serde_json::json;
 use url::Url;
@@ -23,11 +20,13 @@ use crate::config::{
     ServicesConfig, StoreConfig,
 };
 use crate::contexts::{self, ContextRecord, store_context};
-use crate::keys::paths::allocate_path;
 use crate::keys::seed_store::create_seed_store;
 use crate::keys::seeds::{SeedRecord, save_seed_record, set_active_seed_id};
-use crate::keys::{self, DerivedEntityKeys, KeyType as SdkKeyType, PreRotationKeyData};
+use crate::keys::{self, KeyType as SdkKeyType};
+use crate::operations;
+use crate::operations::did_webvh::CreateDidWebvhParams;
 use crate::store::{KeyspaceHandle, Store};
+use crate::webvh_cli::cli_super_admin;
 
 /// Create a seed application context and store it.
 async fn create_seed_context(
@@ -39,7 +38,7 @@ async fn create_seed_context(
 }
 
 /// Derive an admin did:key Ed25519 key from the BIP-32 seed using a
-/// counter-allocated path under `base`, store it as a [`KeyRecord`],
+/// counter-allocated path under `base`, store it as a `KeyRecord`,
 /// and return `(did, private_key_multibase)`.
 ///
 /// The key_id uses the standard did:key fragment format: `{did}#{multibase_pubkey}`.
@@ -477,7 +476,9 @@ pub async fn run_setup_wizard(
         data_dir: PathBuf::from(&data_dir),
     })?;
     let keys_ks = store.keyspace("keys")?;
+    let imported_ks = store.keyspace("imported_secrets")?;
     let contexts_ks = store.keyspace("contexts")?;
+    let webvh_ks = store.keyspace("webvh")?;
 
     // Create seed application contexts
     let mut vta_ctx = create_seed_context(&contexts_ks, "vta", "Verifiable Trust Agent").await?;
@@ -580,20 +581,57 @@ pub async fn run_setup_wizard(
     rand::rng().fill_bytes(&mut jwt_key_bytes);
     let jwt_signing_key = BASE64.encode(jwt_key_bytes);
 
+    // Create a temporary AppConfig for the seed store (config hasn't been saved yet)
+    let wizard_config = AppConfig {
+        vta_did: None,
+        vta_name: None,
+        public_url: public_url.clone(),
+        server: ServerConfig {
+            host: host.clone(),
+            port,
+        },
+        log: LogConfig::default(),
+        store: StoreConfig {
+            data_dir: PathBuf::from(&data_dir),
+        },
+        services: ServicesConfig::default(),
+        messaging: None,
+        auth: AuthConfig::default(),
+        audit: Default::default(),
+        secrets: secrets_config.clone(),
+        #[cfg(feature = "tee")]
+        tee: Default::default(),
+        resolver_url: None,
+        config_path: config_path.clone(),
+    };
+    let wizard_seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
+        Arc::from(create_seed_store(&wizard_config).map_err(|e| format!("{e}"))?);
+
     // 12. DIDComm messaging
     let messaging = if enable_didcomm {
-        configure_messaging(&seed, &keys_ks, &contexts_ks).await?
+        configure_messaging(
+            &keys_ks,
+            &imported_ks,
+            &contexts_ks,
+            &webvh_ks,
+            &*wizard_seed_store,
+            &wizard_config,
+        )
+        .await?
     } else {
         None
     };
 
     // 13. VTA DID (after mediator so we can embed it as a service endpoint)
     let vta_did = create_vta_did(
-        &seed,
         messaging.as_ref(),
         &public_url,
-        &vta_ctx.base_path,
         &keys_ks,
+        &imported_ks,
+        &contexts_ks,
+        &webvh_ks,
+        &*wizard_seed_store,
+        &wizard_config,
     )
     .await?;
 
@@ -607,8 +645,19 @@ pub async fn run_setup_wizard(
     }
 
     // 14. Bootstrap admin DID in ACL (optional)
-    let admin_did = if let Some((admin_did, _credential)) =
-        create_admin_did(&seed, &vta_did, &public_url, &vta_ctx.base_path, &keys_ks).await?
+    let admin_did = if let Some((admin_did, _credential)) = create_admin_did(
+        &seed,
+        &vta_did,
+        &public_url,
+        &vta_ctx.base_path,
+        &keys_ks,
+        &imported_ks,
+        &contexts_ks,
+        &webvh_ks,
+        &*wizard_seed_store,
+        &wizard_config,
+    )
+    .await?
     {
         let acl_ks = store.keyspace("acl")?;
         let admin_entry = AclEntry {
@@ -743,17 +792,266 @@ pub async fn run_setup_wizard(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Shared DID creation helper
+// ---------------------------------------------------------------------------
+
+/// Interactive did:webvh creation using the operations layer.
+///
+/// Prompts for URL, offers simple/advanced mode, builds params, calls
+/// `operations::create_did_webvh()`, saves did.jsonl, optionally exports secrets.
+///
+/// `additional_services` lets callers inject custom services (e.g. mediator endpoints).
+#[allow(clippy::too_many_arguments)]
+async fn build_wizard_did(
+    label: &str,
+    context_id: &str,
+    additional_services: Option<Vec<serde_json::Value>>,
+    add_mediator_service: bool,
+    keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    seed_store: &dyn crate::keys::seed_store::SeedStore,
+    config: &AppConfig,
+) -> Result<String, Box<dyn std::error::Error>> {
+    // Prompt for URL
+    let webvh_url = prompt_webvh_url(label)?;
+    let url_str = webvh_url
+        .get_http_url(None)
+        .map_err(|e| format!("{e}"))?
+        .to_string();
+
+    // Simple vs advanced toggle
+    let mode_options = &[
+        "Simple — VTA creates keys and document (recommended)",
+        "Advanced — provide your own document, keys, or pre-signed log",
+    ];
+    let mode_choice = Select::new()
+        .with_prompt("DID creation mode")
+        .items(mode_options)
+        .default(0)
+        .interact()?;
+
+    let (did_document, did_log, signing_key_id, ka_key_id) = if mode_choice == 1 {
+        // Advanced mode
+        let adv_options = &[
+            "Provide a DID Document template (VTA signs it)",
+            "Import a pre-signed did.jsonl",
+            "Use existing imported keys",
+        ];
+        let adv_choice = Select::new()
+            .with_prompt("Advanced option")
+            .items(adv_options)
+            .default(0)
+            .interact()?;
+
+        match adv_choice {
+            0 => {
+                // Template mode
+                let path: String = Input::new()
+                    .with_prompt("Path to DID Document JSON file")
+                    .interact_text()?;
+                let content = std::fs::read_to_string(&path)
+                    .map_err(|e| format!("failed to read {path}: {e}"))?;
+                let doc: serde_json::Value = serde_json::from_str(&content)
+                    .map_err(|e| format!("invalid JSON in {path}: {e}"))?;
+                (Some(doc), None, None, None)
+            }
+            1 => {
+                // Final mode
+                let path: String = Input::new()
+                    .with_prompt("Path to did.jsonl file")
+                    .interact_text()?;
+                let log = std::fs::read_to_string(&path)
+                    .map_err(|e| format!("failed to read {path}: {e}"))?;
+                (None, Some(log), None, None)
+            }
+            _ => {
+                // User-specified keys
+                let signing: String = Input::new()
+                    .with_prompt("Signing key ID (Ed25519)")
+                    .interact_text()?;
+                let ka: String = Input::new()
+                    .with_prompt("Key-agreement key ID (X25519, leave empty to skip)")
+                    .allow_empty(true)
+                    .interact_text()?;
+                let ka_id = if ka.is_empty() { None } else { Some(ka) };
+                (None, None, Some(signing), ka_id)
+            }
+        }
+    } else {
+        (None, None, None, None)
+    };
+
+    // Portability (skip for final mode — document is already signed)
+    let portable = if did_log.is_none() {
+        Confirm::new()
+            .with_prompt("Make this DID portable (can move to a different domain later)?")
+            .default(true)
+            .interact()?
+    } else {
+        true
+    };
+
+    // Pre-rotation count (skip for final mode)
+    let pre_rotation_count = if did_log.is_none() {
+        eprintln!();
+        eprintln!("  \x1b[2mPre-rotation protects against key compromise by publishing hashes");
+        eprintln!("  of future keys now. Recommended: 1-3 keys.\x1b[0m");
+        Input::new()
+            .with_prompt("Number of pre-rotation keys")
+            .default(1u32)
+            .interact_text()?
+    } else {
+        0
+    };
+
+    let auth = cli_super_admin();
+    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let no_bridge: Arc<tokio::sync::RwLock<Option<crate::didcomm_bridge::DIDCommBridge>>> =
+        Arc::new(tokio::sync::RwLock::new(None));
+
+    let params = CreateDidWebvhParams {
+        context_id: context_id.to_string(),
+        server_id: None,
+        url: Some(url_str.clone()),
+        path: None,
+        label: Some(label.to_string()),
+        portable,
+        add_mediator_service,
+        additional_services,
+        pre_rotation_count,
+        did_document,
+        did_log,
+        set_primary: true,
+        signing_key_id,
+        ka_key_id,
+    };
+
+    let result = operations::did_webvh::create_did_webvh(
+        keys_ks,
+        imported_ks,
+        contexts_ks,
+        webvh_ks,
+        seed_store,
+        config,
+        &auth,
+        params,
+        &did_resolver,
+        &no_bridge,
+        "setup",
+    )
+    .await
+    .map_err(|e| format!("{e}"))?;
+
+    let final_did = result.did.clone();
+    eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");
+
+    // Save did.jsonl (serverless mode returns it in the response)
+    if let Some(ref log_entry) = result.log_entry {
+        let default_file = format!("{label}-did.jsonl");
+        let did_file: String = Input::new()
+            .with_prompt("Save DID log to file")
+            .default(default_file)
+            .interact_text()?;
+
+        std::fs::write(&did_file, log_entry)?;
+        eprintln!("  DID log saved to: {did_file}");
+        eprintln!();
+        eprintln!("  \x1b[2mTo self-host this DID, upload {did_file} to:");
+        eprintln!("  {url_str}\x1b[0m");
+    }
+
+    // Optionally export secrets bundle
+    if !result.signing_key_id.is_empty()
+        && Confirm::new()
+            .with_prompt("Export DID secrets bundle?")
+            .default(false)
+            .interact()?
+    {
+        // Use a temporary config to create a seed store for secret fetching
+        let temp_seed_store: Arc<dyn crate::keys::seed_store::SeedStore> = Arc::from(
+            crate::keys::seed_store::create_seed_store(config).map_err(|e| format!("{e}"))?,
+        );
+        let audit_ks = keys_ks; // Reuse keys_ks as dummy audit (no audit during setup)
+
+        let signing_secret = operations::keys::get_key_secret(
+            keys_ks,
+            imported_ks,
+            &temp_seed_store,
+            audit_ks,
+            &auth,
+            &result.signing_key_id,
+            "setup",
+        )
+        .await
+        .map_err(|e| format!("failed to fetch signing key: {e}"))?;
+
+        let mut secrets = vec![SecretEntry {
+            key_id: result.signing_key_id.clone(),
+            key_type: SdkKeyType::Ed25519,
+            private_key_multibase: signing_secret.private_key_multibase,
+        }];
+
+        if !result.ka_key_id.is_empty() {
+            let ka_secret = operations::keys::get_key_secret(
+                keys_ks,
+                imported_ks,
+                &temp_seed_store,
+                audit_ks,
+                &auth,
+                &result.ka_key_id,
+                "setup",
+            )
+            .await
+            .map_err(|e| format!("failed to fetch KA key: {e}"))?;
+
+            secrets.push(SecretEntry {
+                key_id: result.ka_key_id.clone(),
+                key_type: SdkKeyType::X25519,
+                private_key_multibase: ka_secret.private_key_multibase,
+            });
+        }
+
+        let bundle = DidSecretsBundle {
+            did: final_did.clone(),
+            secrets,
+        };
+        let encoded = bundle.encode().map_err(|e| format!("{e}"))?;
+        eprintln!();
+        eprintln!("\x1b[1;33m╔══════════════════════════════════════════════════════════╗");
+        eprintln!("║  WARNING: The secrets bundle contains private keys.      ║");
+        eprintln!("║  Store it securely and do not share it publicly.         ║");
+        eprintln!("╚══════════════════════════════════════════════════════════╝\x1b[0m");
+        eprintln!();
+        println!("{encoded}");
+        eprintln!();
+    }
+
+    Ok(final_did)
+}
+
+// ---------------------------------------------------------------------------
+// DID creation steps
+// ---------------------------------------------------------------------------
+
 /// Guide the user through creating or entering an admin DID.
 ///
 /// Returns `Some((did, Option<credential_string>))` or `None` if skipped.
-/// The credential string is only produced for the `did:key` option
-/// (base64-encoded JSON bundle).
+/// The credential string is only produced for the `did:key` option.
+#[allow(clippy::too_many_arguments)]
 async fn create_admin_did(
     seed: &[u8],
     vta_did: &Option<String>,
     public_url: &Option<String>,
     vta_base_path: &str,
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    seed_store: &dyn crate::keys::seed_store::SeedStore,
+    config: &AppConfig,
 ) -> Result<Option<(String, Option<String>)>, Box<dyn std::error::Error>> {
     let admin_options = &[
         "Generate a new did:key (Ed25519)",
@@ -809,47 +1107,24 @@ async fn create_admin_did(
             Ok(Some((did, Some(credential))))
         }
         1 => {
-            let mut derived = keys::derive_entity_keys(
-                seed,
-                vta_base_path,
-                "Admin signing key",
-                "Admin key-agreement key",
-                keys_ks,
-            )
-            .await?;
-
-            let did = create_webvh_did(
-                &mut derived,
+            let did = build_wizard_did(
                 "admin",
-                None,
-                None,
-                None,
-                seed,
-                vta_base_path,
                 "vta",
+                None,
+                false,
                 keys_ks,
+                imported_ks,
+                contexts_ks,
+                webvh_ks,
+                seed_store,
+                config,
             )
             .await?;
             Ok(Some((did, None)))
         }
         2 => {
-            // Enter existing DID
+            // Enter existing DID — just record it, no local key derivation
             let did: String = Input::new().with_prompt("Admin DID").interact_text()?;
-
-            // Store admin entity keys with the imported DID
-            let derived = keys::derive_entity_keys(
-                seed,
-                vta_base_path,
-                "Admin signing key",
-                "Admin key-agreement key",
-                keys_ks,
-            )
-            .await?;
-            keys::save_entity_key_records(&did, &derived, keys_ks, Some("vta"), Some(0)).await?;
-
-            // Also derive and store the did:key
-            let _ = derive_and_store_did_key(seed, vta_base_path, "vta", keys_ks, Some(0)).await?;
-
             Ok(Some((did, None)))
         }
         _ => Ok(None),
@@ -858,16 +1133,19 @@ async fn create_admin_did(
 
 /// Guide the user through creating (or entering) a did:webvh DID for the VTA.
 ///
-/// The mediator is added as a DIDCommMessaging service endpoint in the VTA's
-/// DID document.
+/// Uses the operations layer via `build_wizard_did()` with simple/advanced toggle.
 ///
 /// Returns `Some(did_string)` or `None` if skipped.
+#[allow(clippy::too_many_arguments)]
 async fn create_vta_did(
-    seed: &[u8],
     messaging: Option<&MessagingConfig>,
     public_url: &Option<String>,
-    vta_base_path: &str,
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    seed_store: &dyn crate::keys::seed_store::SeedStore,
+    config: &AppConfig,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     let did_options = &[
         "Create a new did:webvh DID",
@@ -882,41 +1160,42 @@ async fn create_vta_did(
 
     match choice {
         0 => {
-            let mut derived = keys::derive_entity_keys(
-                seed,
-                vta_base_path,
-                "VTA signing key",
-                "VTA key-agreement key",
-                keys_ks,
-            )
-            .await?;
+            // Build additional services based on config
+            let mut additional_services = Vec::new();
+            let add_mediator = messaging.is_some();
 
-            let did = create_webvh_did(
-                &mut derived,
+            // Add VTA REST service endpoint if public URL is configured
+            if let Some(url) = public_url {
+                additional_services.push(json!({
+                    "id": "{DID}#vta-rest",
+                    "type": "VTARest",
+                    "serviceEndpoint": url
+                }));
+            }
+
+            let services = if additional_services.is_empty() {
+                None
+            } else {
+                Some(additional_services)
+            };
+
+            let did = build_wizard_did(
                 "VTA",
-                None,
-                messaging,
-                public_url.as_deref(),
-                seed,
-                vta_base_path,
                 "vta",
+                services,
+                add_mediator,
                 keys_ks,
+                imported_ks,
+                contexts_ks,
+                webvh_ks,
+                seed_store,
+                config,
             )
             .await?;
             Ok(Some(did))
         }
         1 => {
             let did: String = Input::new().with_prompt("VTA DID").interact_text()?;
-
-            let derived = keys::derive_entity_keys(
-                seed,
-                vta_base_path,
-                "VTA signing key",
-                "VTA key-agreement key",
-                keys_ks,
-            )
-            .await?;
-            keys::save_entity_key_records(&did, &derived, keys_ks, Some("vta"), Some(0)).await?;
 
             Ok(Some(did))
         }
@@ -932,10 +1211,14 @@ async fn create_vta_did(
 /// 3. Skip DIDComm messaging entirely
 ///
 /// Returns `None` when the user chooses to skip.
+#[allow(clippy::too_many_arguments)]
 async fn configure_messaging(
-    seed: &[u8],
     keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    seed_store: &dyn crate::keys::seed_store::SeedStore,
+    config: &AppConfig,
 ) -> Result<Option<MessagingConfig>, Box<dyn std::error::Error>> {
     let options = &[
         "Use an existing mediator DID",
@@ -951,7 +1234,16 @@ async fn configure_messaging(
     match choice {
         // Existing DID — no local keys or context needed
         0 => {
-            let did: String = Input::new().with_prompt("Mediator DID").interact_text()?;
+            let did: String = Input::new()
+                .with_prompt("Mediator DID")
+                .validate_with(|input: &String| -> Result<(), String> {
+                    if input.starts_with("did:") {
+                        Ok(())
+                    } else {
+                        Err("DID must start with 'did:' (e.g. did:webvh:... or did:key:...)".into())
+                    }
+                })
+                .interact_text()?;
 
             Ok(Some(MessagingConfig {
                 mediator_url: String::new(),
@@ -963,37 +1255,43 @@ async fn configure_messaging(
         1 => {
             let mediator_url: String = Input::new().with_prompt("Mediator URL").interact_text()?;
 
-            let mut med_ctx =
+            // Create mediator context
+            let _med_ctx =
                 create_seed_context(contexts_ks, "mediator", "DIDComm Messaging Mediator").await?;
 
-            let mut derived = keys::derive_entity_keys(
-                seed,
-                &med_ctx.base_path,
-                "Mediator signing key",
-                "Mediator key-agreement key",
+            // Build mediator-specific services (DIDComm + Auth endpoints)
+            let wss_url = mediator_url
+                .replace("https://", "wss://")
+                .replace("http://", "ws://");
+            let mediator_services = vec![
+                json!({
+                    "id": "{DID}#didcomm",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": [
+                        { "accept": ["didcomm/v2"], "uri": &mediator_url },
+                        { "accept": ["didcomm/v2"], "uri": format!("{wss_url}/ws") }
+                    ]
+                }),
+                json!({
+                    "id": "{DID}#auth",
+                    "type": "Authentication",
+                    "serviceEndpoint": format!("{mediator_url}/authenticate")
+                }),
+            ];
+
+            let mediator_did = build_wizard_did(
+                "mediator",
+                "mediator",
+                Some(mediator_services),
+                false,
                 keys_ks,
+                imported_ks,
+                contexts_ks,
+                webvh_ks,
+                seed_store,
+                config,
             )
             .await?;
-
-            let mediator_did = create_webvh_did(
-                &mut derived,
-                "mediator",
-                Some(&mediator_url),
-                None,
-                None,
-                seed,
-                &med_ctx.base_path,
-                "mediator",
-                keys_ks,
-            )
-            .await?;
-
-            // Update the mediator context with the created DID
-            med_ctx.did = Some(mediator_did.clone());
-            med_ctx.updated_at = Utc::now();
-            store_context(contexts_ks, &med_ctx)
-                .await
-                .map_err(|e| format!("{e}"))?;
 
             Ok(Some(MessagingConfig {
                 mediator_url,
@@ -1054,321 +1352,4 @@ pub(crate) fn prompt_webvh_url(label: &str) -> Result<WebVHURL, Box<dyn std::err
             }
         }
     }
-}
-
-/// Prompt the user to optionally generate pre-rotation keys.
-///
-/// Keys are derived from the BIP-32 seed using counter-allocated paths under
-/// `base`.  Key records are **not** stored here — the caller saves them after
-/// the DID is created so the key_id can use the DID verification method format.
-///
-/// Returns `(hashes, key_data)`.  Both vecs are empty when the user declines.
-pub(crate) async fn prompt_pre_rotation_keys(
-    seed: &[u8],
-    base: &str,
-    label: &str,
-    keys_ks: &KeyspaceHandle,
-) -> Result<(Vec<String>, Vec<PreRotationKeyData>), Box<dyn std::error::Error>> {
-    eprintln!();
-    eprintln!("  Pre-rotation protects against an attacker changing your authorization keys.");
-    eprintln!("  You generate future keys now and only publish their hashes.  When you later");
-    eprintln!("  need to rotate keys, you reveal the actual key that matches the hash.");
-
-    if !Confirm::new()
-        .with_prompt("Enable key pre-rotation?")
-        .default(true)
-        .interact()?
-    {
-        return Ok((vec![], vec![]));
-    }
-
-    let root = ExtendedSigningKey::from_seed(seed)
-        .map_err(|e| format!("Failed to create BIP-32 root key: {e}"))?;
-
-    let mut hashes: Vec<String> = Vec::new();
-    let mut key_data: Vec<PreRotationKeyData> = Vec::new();
-
-    loop {
-        let path = allocate_path(keys_ks, base)
-            .await
-            .map_err(|e| format!("{e}"))?;
-        let derivation_path: DerivationPath = path
-            .parse()
-            .map_err(|e| format!("Invalid derivation path: {e}"))?;
-        let derived = root
-            .derive(&derivation_path)
-            .map_err(|e| format!("Key derivation failed: {e}"))?;
-
-        let secret = Secret::generate_ed25519(None, Some(derived.signing_key.as_bytes()));
-
-        let pub_mb = secret
-            .get_public_keymultibase()
-            .map_err(|e| format!("{e}"))?;
-        let hash = secret
-            .get_public_keymultibase_hash()
-            .map_err(|e| format!("{e}"))?;
-
-        let idx = hashes.len();
-        key_data.push(PreRotationKeyData {
-            path,
-            public_key: pub_mb.clone(),
-            label: format!("{label} pre-rotation key {idx}"),
-        });
-
-        eprintln!();
-        eprintln!("  publicKeyMultibase: {pub_mb}");
-
-        hashes.push(hash);
-
-        if !Confirm::new()
-            .with_prompt(format!(
-                "Generated {} pre-rotation key(s). Generate another?",
-                hashes.len()
-            ))
-            .default(false)
-            .interact()?
-        {
-            break;
-        }
-    }
-
-    Ok((hashes, key_data))
-}
-
-/// Interactive did:webvh creation flow shared by VTA and mediator DID setup.
-///
-/// Prompts for a URL, builds a DID document, creates the log entry,
-/// saves the `did.jsonl` file, and stores key records with DID-based key_ids.
-///
-/// `label` is used in prompts (e.g. "VTA" or "mediator").
-///
-/// Service endpoints are added based on the optional parameters:
-/// - `mediator_url`: when set, adds `#didcomm` (HTTPS + WSS) and `#auth`
-///   service endpoints for a mediator DID document.
-/// - `messaging`: when set, adds a `#vta-didcomm` service referencing the
-///   mediator DID for routing (used for the VTA DID document).
-#[allow(clippy::too_many_arguments)]
-async fn create_webvh_did(
-    derived: &mut DerivedEntityKeys,
-    label: &str,
-    mediator_url: Option<&str>,
-    messaging: Option<&MessagingConfig>,
-    vta_public_url: Option<&str>,
-    seed: &[u8],
-    base: &str,
-    context_id: &str,
-    keys_ks: &KeyspaceHandle,
-) -> Result<String, Box<dyn std::error::Error>> {
-    // Prompt for URL and convert to WebVHURL
-    let webvh_url = prompt_webvh_url(label)?;
-
-    // Convert the Signing Key ID to be correct
-    derived.signing_secret.id = [
-        "did:key:",
-        &derived.signing_secret.get_public_keymultibase().unwrap(),
-        "#",
-        &derived.signing_secret.get_public_keymultibase().unwrap(),
-    ]
-    .concat();
-
-    // Build DID document
-    let mut did_document = json!({
-        "@context": [
-            "https://www.w3.org/ns/did/v1",
-            "https://www.w3.org/ns/cid/v1"
-        ],
-        "id": "{DID}",
-        "verificationMethod": [
-            {
-                "id": "{DID}#key-0",
-                "type": "Multikey",
-                "controller": "{DID}",
-                "publicKeyMultibase": &derived.signing_pub
-            }
-        ],
-        "authentication": ["{DID}#key-0"],
-        "assertionMethod": ["{DID}#key-0"]
-    });
-
-    // Add X25519 key agreement method
-    did_document["verificationMethod"]
-        .as_array_mut()
-        .unwrap()
-        .push(json!({
-            "id": "{DID}#key-1",
-            "type": "Multikey",
-            "controller": "{DID}",
-            "publicKeyMultibase": &derived.ka_pub
-        }));
-    did_document["keyAgreement"] = json!(["{DID}#key-1"]);
-
-    // Add service endpoints
-    let mut services = Vec::new();
-
-    if let Some(url) = mediator_url {
-        // Mediator DID: add #didcomm with HTTPS + WSS endpoints, and #auth
-        let wss_url = url
-            .replace("https://", "wss://")
-            .replace("http://", "ws://");
-        services.push(json!({
-            "id": "{DID}#didcomm",
-            "type": "DIDCommMessaging",
-            "serviceEndpoint": [
-                {
-                    "accept": ["didcomm/v2"],
-                    "uri": url
-                },
-                {
-                    "accept": ["didcomm/v2"],
-                    "uri": format!("{wss_url}/ws")
-                }
-            ]
-        }));
-        services.push(json!({
-            "id": "{DID}#auth",
-            "type": "Authentication",
-            "serviceEndpoint": format!("{url}/authenticate")
-        }));
-    } else if let Some(msg) = messaging {
-        // VTA DID: add #vta-didcomm referencing the mediator DID
-        services.push(json!({
-            "id": "{DID}#vta-didcomm",
-            "type": "DIDCommMessaging",
-            "serviceEndpoint": [{
-                "accept": ["didcomm/v2"],
-                "uri": msg.mediator_did
-            }]
-        }));
-    }
-
-    // Add #vta-rest service endpoint if a public URL is configured
-    if let Some(url) = vta_public_url {
-        services.push(json!({
-            "id": "{DID}#vta-rest",
-            "type": "VTARest",
-            "serviceEndpoint": url
-        }));
-    }
-
-    if !services.is_empty() {
-        did_document["service"] = serde_json::Value::Array(services);
-    }
-
-    eprintln!();
-    eprintln!(
-        "\x1b[2mDID Document:\n{}\x1b[0m",
-        serde_json::to_string_pretty(&did_document)?
-    );
-    eprintln!();
-
-    // Portability
-    let portable = Confirm::new()
-        .with_prompt("Make this DID portable (can move to a different domain later)?")
-        .default(true)
-        .interact()?;
-
-    // Pre-rotation keys (share the same counter/base as entity keys)
-    let (next_key_hashes, pre_rotation_keys) =
-        prompt_pre_rotation_keys(seed, base, label, keys_ks).await?;
-
-    // Build parameters
-    let parameters = WebVHParameters {
-        update_keys: Some(Arc::new(vec![derived.signing_pub.clone().into()])),
-        portable: Some(portable),
-        next_key_hashes: if next_key_hashes.is_empty() {
-            None
-        } else {
-            Some(Arc::new(
-                next_key_hashes.into_iter().map(Into::into).collect(),
-            ))
-        },
-        ..Default::default()
-    };
-
-    // Create the DID
-    let url_str = webvh_url
-        .get_http_url(None)
-        .map_err(|e| format!("{e}"))?
-        .to_string();
-    let create_config = CreateDIDConfig::builder()
-        .address(url_str)
-        .authorization_key(derived.signing_secret.clone())
-        .did_document(did_document)
-        .parameters(parameters)
-        .build()
-        .map_err(|e| format!("failed to build DID config: {e}"))?;
-
-    let result = create_did(create_config)
-        .await
-        .map_err(|e| format!("failed to create DID: {e}"))?;
-
-    let final_did = result.did().to_string();
-
-    eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");
-
-    // Save key records now that we have the final DID
-    keys::save_entity_key_records(&final_did, derived, keys_ks, Some(context_id), Some(0)).await?;
-
-    // Save pre-rotation key records
-    for (i, pk) in pre_rotation_keys.iter().enumerate() {
-        keys::save_key_record(
-            keys_ks,
-            &format!("{final_did}#pre-rotation-{i}"),
-            &pk.path,
-            SdkKeyType::Ed25519,
-            &pk.public_key,
-            &pk.label,
-            Some(context_id),
-            Some(0),
-        )
-        .await?;
-    }
-
-    // Save did.jsonl
-    let default_file = format!("{label}-did.jsonl");
-    let did_file: String = Input::new()
-        .with_prompt("Save DID log to file")
-        .default(default_file)
-        .interact_text()?;
-
-    result
-        .log_entry()
-        .save_to_file(&did_file)
-        .map_err(|e| format!("Failed to save DID log file: {e}"))?;
-
-    eprintln!("  DID log saved to: {did_file}");
-
-    // Optionally export secrets bundle
-    if Confirm::new()
-        .with_prompt("Export DID secrets bundle?")
-        .default(false)
-        .interact()?
-    {
-        let bundle = DidSecretsBundle {
-            did: final_did.clone(),
-            secrets: vec![
-                SecretEntry {
-                    key_id: format!("{final_did}#key-0"),
-                    key_type: SdkKeyType::Ed25519,
-                    private_key_multibase: derived.signing_priv.clone(),
-                },
-                SecretEntry {
-                    key_id: format!("{final_did}#key-1"),
-                    key_type: SdkKeyType::X25519,
-                    private_key_multibase: derived.ka_priv.clone(),
-                },
-            ],
-        };
-        let encoded = bundle.encode().map_err(|e| format!("{e}"))?;
-        eprintln!();
-        eprintln!("\x1b[1;33m╔══════════════════════════════════════════════════════════╗");
-        eprintln!("║  WARNING: The secrets bundle contains private keys.      ║");
-        eprintln!("║  Store it securely and do not share it publicly.         ║");
-        eprintln!("╚══════════════════════════════════════════════════════════╝\x1b[0m");
-        eprintln!();
-        println!("{encoded}");
-        eprintln!();
-    }
-
-    Ok(final_did)
 }

--- a/vta-service/src/tee/did_autogen.rs
+++ b/vta-service/src/tee/did_autogen.rs
@@ -113,10 +113,28 @@ pub async fn maybe_generate_vta_did(
     // Build DID document (inline — avoids dependency on webvh feature-gated modules)
     let did_document = build_vta_did_document(&derived, config);
 
+    // Generate pre-rotation keys (default: 1)
+    let (next_key_hashes, pre_rotation_keys) =
+        crate::operations::did_webvh::derive_pre_rotation_keys(
+            &seed,
+            &ctx.base_path,
+            "VTA",
+            &keys_ks,
+            1,
+        )
+        .await?;
+
     // Build parameters
     let parameters = WebVHParameters {
         update_keys: Some(Arc::new(vec![derived.signing_pub.clone().into()])),
         portable: Some(true),
+        next_key_hashes: if next_key_hashes.is_empty() {
+            None
+        } else {
+            Some(Arc::new(
+                next_key_hashes.into_iter().map(Into::into).collect(),
+            ))
+        },
         ..Default::default()
     };
 
@@ -152,6 +170,22 @@ pub async fn maybe_generate_vta_did(
     )
     .await
     .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+    // Save pre-rotation key records
+    for (i, pk) in pre_rotation_keys.iter().enumerate() {
+        keys::save_key_record(
+            &keys_ks,
+            &format!("{final_did}#pre-rotation-{i}"),
+            &pk.path,
+            keys::KeyType::Ed25519,
+            &pk.public_key,
+            &pk.label,
+            Some("vta"),
+            Some(active_seed_id),
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    }
 
     // Update context with the new DID
     let mut ctx = ctx;

--- a/vta-service/src/tee/kms_bootstrap.rs
+++ b/vta-service/src/tee/kms_bootstrap.rs
@@ -1127,7 +1127,6 @@ mod tests {
     fn test_cms_envelope_roundtrip() {
         use aes_gcm::aead::generic_array::GenericArray;
         use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
-        use rsa::pkcs8::EncodePublicKey;
         use rsa::{Oaep, RsaPrivateKey};
 
         // Generate RSA keypair (the "ephemeral" key the enclave would create)

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -12,7 +12,7 @@ use crate::operations;
 use crate::store::Store;
 
 /// Create a synthetic super-admin AuthClaims for CLI operations.
-fn cli_super_admin() -> AuthClaims {
+pub(crate) fn cli_super_admin() -> AuthClaims {
     AuthClaims {
         did: "cli:local".to_string(),
         role: Role::Admin,
@@ -138,6 +138,7 @@ pub async fn run_create_did(
     let config = AppConfig::load(config_path.clone())?;
     let store = Store::open(&config.store)?;
     let keys_ks = store.keyspace("keys")?;
+    let imported_ks = store.keyspace("imported_secrets")?;
     let contexts_ks = store.keyspace("contexts")?;
     let webvh_ks = store.keyspace("webvh")?;
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
@@ -159,6 +160,11 @@ pub async fn run_create_did(
         add_mediator_service: mediator_service,
         additional_services,
         pre_rotation_count: pre_rotation.unwrap_or(0),
+        did_document: None,
+        did_log: None,
+        set_primary: true,
+        signing_key_id: None,
+        ka_key_id: None,
     };
 
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
@@ -166,6 +172,7 @@ pub async fn run_create_did(
         Arc::new(tokio::sync::RwLock::new(None));
     let result = operations::did_webvh::create_did_webvh(
         &keys_ks,
+        &imported_ks,
         &contexts_ks,
         &webvh_ks,
         &*seed_store,

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -64,7 +64,7 @@ impl TestApp {
             jwt_signing_key = "{}"
             "#,
             dir.path().display(),
-            BASE64.encode(&jwt_seed),
+            BASE64.encode(jwt_seed),
         ))
         .expect("parse config");
         // Set config_path to a writable location so update_config can persist
@@ -86,7 +86,14 @@ impl TestApp {
             wrapping_cache: vta_service::keys::wrapping::WrappingKeyCache::new(),
             config: Arc::new(RwLock::new(config)),
             seed_store,
-            did_resolver: None,
+            did_resolver: {
+                use affinidi_did_resolver_cache_sdk::{
+                    DIDCacheClient, config::DIDCacheConfigBuilder,
+                };
+                DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+                    .await
+                    .ok()
+            },
             secrets_resolver: None,
             #[cfg(feature = "didcomm")]
             didcomm_bridge: Arc::new(tokio::sync::RwLock::new(None)),
@@ -129,6 +136,7 @@ impl TestApp {
 struct TestContext {
     jwt_keys: Arc<JwtKeys>,
     sessions_ks: KeyspaceHandle,
+    #[allow(dead_code)]
     acl_ks: KeyspaceHandle,
     _dir: tempfile::TempDir,
 }
@@ -162,6 +170,7 @@ impl TestContext {
     }
 
     /// Create an ACL entry for a DID.
+    #[allow(dead_code)]
     async fn create_acl(&self, did: &str, role: Role, contexts: Vec<String>) {
         let entry = vti_common::acl::AclEntry {
             did: did.to_string(),
@@ -265,6 +274,31 @@ fn delete_auth(uri: &str, token: &str) -> Request<Body> {
         .header("Authorization", format!("Bearer {token}"))
         .body(Body::empty())
         .unwrap()
+}
+
+// ── Capabilities ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn capabilities_requires_auth() {
+    let (app, _ctx) = TestApp::new().await;
+    let (status, _) = app.request(get("/capabilities")).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn capabilities_returns_features() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx
+        .auth_token("did:key:z6MkReader", "reader", vec!["any".into()])
+        .await;
+    let (status, body) = app.request(get_auth("/capabilities", &token)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["version"].as_str().is_some());
+    assert!(body["features"].is_object());
+    assert!(body["services"].is_object());
+    assert!(body["did_creation_modes"].is_array());
+    // webvh feature is compiled in for tests
+    assert_eq!(body["features"]["webvh"], true);
 }
 
 // ── Health ─────────────────────────────────────────────────────────
@@ -1172,8 +1206,462 @@ async fn reader_cannot_create_key() {
         .request(post_auth(
             "/keys",
             &reader_token,
-            json!({"key_type": "Ed25519", "context_id": "test-ctx"}),
+            json!({"key_type": "ed25519", "context_id": "test-ctx"}),
         ))
         .await;
     assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+// ── WebVH DID creation mode tests ─────────────────────────────────
+
+/// Helper: create a context via the API and return admin token.
+async fn setup_webvh_context(app: &TestApp, ctx: &TestContext, context_id: &str) -> String {
+    let super_token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+    let (status, _) = app
+        .request(post_auth(
+            "/contexts",
+            &super_token,
+            json!({"id": context_id, "name": context_id}),
+        ))
+        .await;
+    assert!(status.is_success(), "create context: {status}");
+    super_token
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_rejects_both_document_and_log() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-reject").await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-reject",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "did_document": {"id": "{DID}"},
+                "did_log": "{\"some\": \"log\"}"
+            }),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "expected 400: {body}");
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_template_mode() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-template").await;
+
+    // Client-provided DID document template with {DID} placeholders
+    let template = json!({
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://www.w3.org/ns/cid/v1"
+        ],
+        "id": "{DID}",
+        "verificationMethod": [{
+            "id": "{DID}#custom-key",
+            "type": "Multikey",
+            "controller": "{DID}",
+            "publicKeyMultibase": "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+        }],
+        "authentication": ["{DID}#custom-key"],
+        "assertionMethod": ["{DID}#custom-key"]
+    });
+
+    let (status, body) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-template",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "did_document": template,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "template create: {status} {body}"
+    );
+    assert!(body["did"].as_str().is_some(), "response has did");
+    assert!(
+        body["did_document"].is_object(),
+        "response has did_document"
+    );
+    assert!(
+        body["log_entry"].as_str().is_some(),
+        "response has log_entry"
+    );
+    // Verify the template was used (custom key ID present in returned document)
+    let doc = &body["did_document"];
+    let vm = doc["verificationMethod"]
+        .as_array()
+        .expect("verificationMethod array");
+    assert!(
+        vm.iter().any(|v| {
+            v["id"]
+                .as_str()
+                .is_some_and(|id| id.ends_with("#custom-key"))
+        }),
+        "template's custom key should be in the returned document"
+    );
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_final_mode_stores_record() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-final").await;
+
+    // First, create a DID via VTA-built mode to get a valid log entry
+    let (status, created) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-final",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "set_primary": false,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "bootstrap create: {status} {created}"
+    );
+    let log_entry = created["log_entry"].as_str().expect("log_entry string");
+
+    // Now create another DID using the log entry in final mode, under a new context
+    let token2 = setup_webvh_context(&app, &ctx, "test-final-2").await;
+    let (status, body) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token2,
+            json!({
+                "context_id": "test-final-2",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "did_log": log_entry,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "final mode create: {status} {body}"
+    );
+    let final_did = body["did"].as_str().expect("did in response");
+    assert!(!final_did.is_empty());
+    // signing_key_id and ka_key_id are empty in final mode (VTA didn't derive keys)
+    assert_eq!(body["signing_key_id"].as_str().unwrap(), "");
+    assert_eq!(body["ka_key_id"].as_str().unwrap(), "");
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_set_primary_false() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-no-primary").await;
+
+    let (status, _) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-no-primary",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "set_primary": false,
+            }),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Context's primary DID should still be null
+    let (status, body) = app
+        .request(get_auth("/contexts/test-no-primary", &token))
+        .await;
+    assert!(status.is_success(), "get context: {status}");
+    assert!(
+        body["did"].is_null(),
+        "context did should be null when set_primary=false"
+    );
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_set_primary_true() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-primary").await;
+
+    let (status, created) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-primary",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "set_primary": true,
+            }),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let created_did = created["did"].as_str().expect("did");
+
+    // Context's primary DID should be set
+    let (status, body) = app
+        .request(get_auth("/contexts/test-primary", &token))
+        .await;
+    assert!(status.is_success(), "get context: {status}");
+    assert_eq!(
+        body["did"].as_str().unwrap(),
+        created_did,
+        "context did should match created DID"
+    );
+}
+
+// ── User-specified key tests ──────────────────────────────────────
+
+/// Helper: import an Ed25519 key and return the key_id.
+#[cfg(feature = "webvh")]
+async fn import_ed25519_key(app: &TestApp, token: &str, label: &str, context_id: &str) -> String {
+    // 32 deterministic bytes for the Ed25519 seed (test only)
+    let seed_bytes = [0x42u8; 32];
+    let mb = multibase::encode(multibase::Base::Base58Btc, seed_bytes);
+
+    let (status, body) = app
+        .request(post_auth(
+            "/keys/import",
+            token,
+            json!({
+                "key_type": "ed25519",
+                "private_key_multibase": mb,
+                "label": label,
+                "context_id": context_id,
+            }),
+        ))
+        .await;
+    assert!(status.is_success(), "import ed25519: {status} {body}");
+    body["key_id"].as_str().unwrap().to_string()
+}
+
+/// Helper: import an X25519 key and return the key_id.
+#[cfg(feature = "webvh")]
+async fn import_x25519_key(app: &TestApp, token: &str, label: &str, context_id: &str) -> String {
+    // 32 deterministic bytes for the X25519 private key (test only)
+    let key_bytes = [0x99u8; 32];
+    let mb = multibase::encode(multibase::Base::Base58Btc, key_bytes);
+
+    let (status, body) = app
+        .request(post_auth(
+            "/keys/import",
+            token,
+            json!({
+                "key_type": "x25519",
+                "private_key_multibase": mb,
+                "label": label,
+                "context_id": context_id,
+            }),
+        ))
+        .await;
+    assert!(status.is_success(), "import x25519: {status} {body}");
+    body["key_id"].as_str().unwrap().to_string()
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_with_user_signing_key() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-user-sign").await;
+    let signing_key = import_ed25519_key(&app, &token, "my-sign", "test-user-sign").await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-user-sign",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "signing_key_id": signing_key,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "signing-only create: {status} {body}"
+    );
+    assert!(body["did"].as_str().is_some());
+    // Document should have signing key but no keyAgreement
+    let doc = &body["did_document"];
+    assert!(doc["authentication"].is_array());
+    assert!(doc.get("keyAgreement").is_none() || doc["keyAgreement"].is_null());
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_with_user_signing_and_ka_keys() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-user-both").await;
+    let signing_key = import_ed25519_key(&app, &token, "my-sign", "test-user-both").await;
+    let ka_key = import_x25519_key(&app, &token, "my-ka", "test-user-both").await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-user-both",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "signing_key_id": signing_key,
+                "ka_key_id": ka_key,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "both keys create: {status} {body}"
+    );
+    let doc = &body["did_document"];
+    assert!(doc["keyAgreement"].is_array(), "should have keyAgreement");
+    let vm = doc["verificationMethod"].as_array().unwrap();
+    assert_eq!(vm.len(), 2, "should have 2 verification methods");
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_ka_without_signing_rejected() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-ka-only").await;
+    let ka_key = import_x25519_key(&app, &token, "my-ka", "test-ka-only").await;
+
+    let (status, _) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-ka-only",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "ka_key_id": ka_key,
+            }),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_didcomm_requires_ka_key() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-didcomm-ka").await;
+    let signing_key = import_ed25519_key(&app, &token, "my-sign", "test-didcomm-ka").await;
+
+    // Signing key only + mediator service → should fail
+    let (status, body) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-didcomm-ka",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "signing_key_id": signing_key,
+                "add_mediator_service": true,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "didcomm without ka: {status} {body}"
+    );
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_wrong_key_type_rejected() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-wrong-type").await;
+    let ka_key = import_x25519_key(&app, &token, "my-ka", "test-wrong-type").await;
+
+    // Use X25519 key as signing key → should fail
+    let (status, _) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-wrong-type",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "signing_key_id": ka_key,
+            }),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ── Server-managed DID creation tests ─────────────────────────────
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_unknown_server_returns_404() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-no-server").await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-no-server",
+                "server_id": "nonexistent-server",
+            }),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "unknown server_id: {status} {body}"
+    );
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_server_and_url_mutually_exclusive() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-exclusive").await;
+
+    let (status, _) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-exclusive",
+                "server_id": "some-server",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+            }),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_neither_server_nor_url_rejected() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-neither").await;
+
+    let (status, _) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-neither",
+            }),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
 }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,8 +28,8 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.3.0" }
-vta-sdk = { path = "../vta-sdk", version = "0.3.0", features = [
+vti-common = { path = "../vti-common", version = "0.3" }
+vta-sdk = { path = "../vta-sdk", version = "0.3", features = [
   "didcomm",
   "session",
   "config-session",


### PR DESCRIPTION
## Summary
- **Three DID creation modes**: VTA-built (default), template (`did_document`), and pre-signed log (`did_log`) for `POST /webvh/dids`
- **User-specified keys**: `signing_key_id` / `ka_key_id` fields allow using existing VTA-managed keys for DID creation
- **Capabilities discovery**: `GET /capabilities` endpoint + DIDComm `discover-capabilities` protocol + `VtaClient::capabilities()` SDK method
- **Setup wizard improvements**: Simple/advanced toggle, consolidated DID creation through operations layer
- **Bug fixes**: DID deletion cleans up key records, DIDComm bridge wired in handler path, pre-rotation keys in TEE autogen
- **Code consolidation**: Eliminated `CreateDidRequest`, unified `build_did_document`, removed ~316 lines of duplicate code
- **Dependency update**: didwebvh-rs 0.4.0 → 0.4.1
- **Bumped all workspace crates** to 0.3.1

## Checklist
- [x] All tests pass
- [x] CHANGELOG.md updated
- [x] No clippy warnings
- [x] Documentation builds cleanly
- [x] All workspace crate versions bumped consistently