### PR TITLE
Fix tee feature missing webvh dependency

### DIFF
--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -26,6 +26,7 @@ gcp-secrets = [
 ]
 azure-secrets = ["dep:azure_security_keyvault_secrets", "dep:azure_identity"]
 tee = [
+  "webvh",
   "dep:libc",
   "dep:aws-sdk-kms",
   "dep:aws-config",


### PR DESCRIPTION
## Summary
- The `tee` feature in `vta-service` included `dep:didwebvh-rs` but did not enable the `webvh` feature flag, so `crate::operations::did_webvh` was gated out at compile time
- This caused `cargo publish` verification to fail for vta-service 0.3.1
- Fix: add `"webvh"` to the `tee` feature list

## Test plan
- [ ] `cargo check --package vta-service --lib --no-default-features --features tee` compiles cleanly
- [ ] `cargo publish --package vta-service` succeeds