### PR TITLE
Release 0.3.2: Fix DIDComm bridge and unify mediator connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.3.2 — 2026-04-12
+
+### Fixed
+
+- **DIDComm outbound response routing** — The `DIDCommBridge` now
+  correctly receives responses to outbound request-response messages
+  (e.g., WebVH DID creation via DIDComm transport). Previously,
+  `try_complete()` was never called on inbound messages, so
+  `send_and_wait` would always time out.
+- **Single mediator connection** — Replaced the dual-ATM architecture
+  (one for the listener, one for the bridge) with a single shared
+  connection. The new `BridgeHandler` wrapper captures the listener's
+  ATM from `HandlerContext` and intercepts response messages before
+  normal handler dispatch. This eliminates the
+  `w.websocket.duplicate-channel` error loop that occurred when two
+  connections used the same DID.
+
 ## 0.3.1 — 2026-04-11
 
 ### Client-Provided DID Documents for WebVH Creation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7740,6 +7740,7 @@ dependencies = [
  "affinidi-tdk",
  "affinidi-tdk-common",
  "argon2",
+ "async-trait",
  "aws-config",
  "aws-sdk-kms",
  "aws-sdk-secretsmanager",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -52,6 +52,7 @@ hkdf = "0.12"
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.13"
 affinidi-messaging-didcomm-service = { workspace = true }
+async-trait = "0.1"
 affinidi-tdk-common = "0.5"
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 tokio-util = { version = "0.7", features = ["rt"] }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -140,8 +140,8 @@ pub async fn run_create_did_webvh(
     // Build params and call the operations layer
     let auth = cli_super_admin();
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
-    let no_bridge: Arc<tokio::sync::RwLock<Option<crate::didcomm_bridge::DIDCommBridge>>> =
-        Arc::new(tokio::sync::RwLock::new(None));
+    let no_bridge: Arc<crate::didcomm_bridge::DIDCommBridge> =
+        Arc::new(crate::didcomm_bridge::DIDCommBridge::new());
 
     let params = CreateDidWebvhParams {
         context_id: args.context.clone(),

--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -24,6 +24,12 @@ pub struct DIDCommBridge {
     pending: PendingMap,
 }
 
+impl Default for DIDCommBridge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DIDCommBridge {
     /// Create a new bridge in disconnected state.
     ///
@@ -46,7 +52,7 @@ impl DIDCommBridge {
     }
 
     /// Try to complete a pending outbound request. Returns true if the
-    /// message was routed to a waiting [`send_and_wait`] caller.
+    /// message was routed to a waiting [`Self::send_and_wait`] caller.
     pub fn try_complete(&self, msg: &Message) -> bool {
         if let Some(thid) = &msg.thid
             && let Some(tx) = self.pending.lock().unwrap().remove(thid)

--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -8,27 +8,45 @@ use vta_sdk::didcomm_transport::{DIDCommSendParams, PendingMap, send_and_wait_ra
 
 use crate::error::{AppError, bad_gateway_error};
 
-/// Bridge between REST/DIDComm handlers and the main ATM connection.
+/// Bridge between REST/DIDComm handlers and the DIDComm listener's ATM.
 ///
-/// Provides request-response DIDComm messaging by registering oneshot channels
-/// keyed by message ID. The main DIDComm loop checks incoming messages against
-/// pending requests and routes matches directly to the waiting handler.
+/// Provides outbound request-response DIDComm messaging by registering
+/// oneshot channels keyed by message ID. The [`BridgeHandler`] wrapper
+/// calls [`try_complete`] on each inbound message to route responses
+/// back to the waiting handler.
+///
+/// The bridge starts disconnected. The listener's ATM is captured via
+/// [`update_connection`] when the first inbound message arrives.
+///
+/// [`BridgeHandler`]: crate::messaging::router::BridgeHandler
 pub struct DIDCommBridge {
-    pub atm: Arc<ATM>,
-    pub profile: Arc<ATMProfile>,
+    connection: tokio::sync::RwLock<Option<(ATM, Arc<ATMProfile>)>>,
     pending: PendingMap,
 }
 
 impl DIDCommBridge {
-    pub fn new(atm: Arc<ATM>, profile: Arc<ATMProfile>) -> Self {
+    /// Create a new bridge in disconnected state.
+    ///
+    /// The connection will be populated by [`BridgeHandler`] once the
+    /// DIDComm listener connects to the mediator.
+    pub fn new() -> Self {
         Self {
-            atm,
-            profile,
+            connection: tokio::sync::RwLock::new(None),
             pending: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
-    /// Try to complete a pending request. Returns true if the message was routed.
+    /// Store the listener's ATM connection for outbound use.
+    ///
+    /// Called by [`BridgeHandler`] on every inbound message to keep
+    /// the reference current across listener reconnects.
+    pub async fn update_connection(&self, atm: ATM, profile: Arc<ATMProfile>) {
+        let mut guard = self.connection.write().await;
+        *guard = Some((atm, profile));
+    }
+
+    /// Try to complete a pending outbound request. Returns true if the
+    /// message was routed to a waiting [`send_and_wait`] caller.
     pub fn try_complete(&self, msg: &Message) -> bool {
         if let Some(thid) = &msg.thid
             && let Some(tx) = self.pending.lock().unwrap().remove(thid)
@@ -51,9 +69,21 @@ impl DIDCommBridge {
         problem_report_type: &str,
         timeout_secs: u64,
     ) -> Result<Message, AppError> {
+        let (atm, profile) = {
+            let guard = self.connection.read().await;
+            guard
+                .as_ref()
+                .map(|(a, p)| (a.clone(), p.clone()))
+                .ok_or_else(|| {
+                    AppError::Internal(
+                        "DIDComm not available — mediator connection not established".into(),
+                    )
+                })?
+        };
+
         send_and_wait_raw(DIDCommSendParams {
-            atm: &self.atm,
-            profile: &self.profile,
+            atm: &atm,
+            profile: &profile,
             pending: &self.pending,
             from_did: vta_did,
             to_did: server_did,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -801,8 +801,6 @@ pub async fn handle_delete_did_webvh(
         .did_resolver
         .as_ref()
         .ok_or_else(|| handler_err("DID resolver not available"))?;
-    // NOTE: Bridge not yet wired — see handle_create_did_webvh comment
-    let bridge = std::sync::Arc::new(tokio::sync::RwLock::new(None));
     let result = operations::did_webvh::delete_did_webvh(
         &state.webvh_ks,
         &state.keys_ks,
@@ -811,7 +809,7 @@ pub async fn handle_delete_did_webvh(
         &auth,
         &body.did,
         did_resolver,
-        &bridge,
+        &state.didcomm_bridge,
         "didcomm",
     )
     .await

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -15,6 +15,7 @@ use tokio::sync::RwLock;
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 
 use crate::config::AppConfig;
+use crate::didcomm_bridge::DIDCommBridge;
 use crate::keys::seed_store::SeedStore;
 use crate::store::KeyspaceHandle;
 
@@ -43,15 +44,63 @@ pub struct VtaState {
     pub config: Arc<RwLock<AppConfig>>,
     pub did_resolver: Option<DIDCacheClient>,
     /// DIDComm bridge for outbound WebVH server communication.
-    pub didcomm_bridge: Arc<tokio::sync::RwLock<Option<crate::didcomm_bridge::DIDCommBridge>>>,
+    pub didcomm_bridge: Arc<DIDCommBridge>,
     #[cfg(feature = "tee")]
     pub tee_state: Option<crate::tee::TeeState>,
     /// Send `true` to trigger a soft restart.
     pub restart_tx: tokio::sync::watch::Sender<bool>,
 }
 
-/// Build the DIDComm message router with all VTA protocol handlers.
-pub fn build_router(state: Arc<VtaState>) -> Result<Router, DIDCommServiceError> {
+// ---------------------------------------------------------------------------
+// BridgeHandler — wraps the Router to intercept outbound-response routing
+// ---------------------------------------------------------------------------
+
+/// Handler wrapper that bridges the DIDComm listener's ATM to the
+/// outbound [`DIDCommBridge`].
+///
+/// On every inbound message this handler:
+/// 1. Captures the listener's ATM/profile so the bridge can reuse the
+///    same mediator connection for outbound sends.
+/// 2. Checks if the message completes a pending outbound request
+///    (via [`DIDCommBridge::try_complete`]). If so, the message is
+///    consumed and not dispatched to the inner Router.
+/// 3. Otherwise delegates to the inner Router for normal handler dispatch.
+pub struct BridgeHandler {
+    inner: Router,
+    bridge: Arc<DIDCommBridge>,
+}
+
+#[async_trait::async_trait]
+impl affinidi_messaging_didcomm_service::DIDCommHandler for BridgeHandler {
+    async fn handle(
+        &self,
+        ctx: affinidi_messaging_didcomm_service::HandlerContext,
+        message: affinidi_messaging_didcomm::Message,
+        meta: affinidi_messaging_didcomm::UnpackMetadata,
+    ) -> Result<Option<affinidi_messaging_didcomm_service::DIDCommResponse>, DIDCommServiceError>
+    {
+        // Keep the bridge's ATM current (cheap clone — ATM wraps Arc internally).
+        self.bridge
+            .update_connection(ctx.atm.clone(), ctx.profile.clone())
+            .await;
+
+        // Route responses to pending outbound requests before normal dispatch.
+        if self.bridge.try_complete(&message) {
+            return Ok(None);
+        }
+
+        self.inner.handle(ctx, message, meta).await
+    }
+}
+
+/// Build the DIDComm message handler with all VTA protocol handlers.
+///
+/// Returns a [`BridgeHandler`] that wraps the Router and integrates
+/// outbound request-response routing via the shared [`DIDCommBridge`].
+pub fn build_handler(
+    state: Arc<VtaState>,
+    bridge: Arc<DIDCommBridge>,
+) -> Result<BridgeHandler, DIDCommServiceError> {
     let mut router = Router::new()
         .extension(state)
         // Built-in protocol handlers
@@ -265,5 +314,8 @@ pub fn build_router(state: Arc<VtaState>) -> Result<Router, DIDCommServiceError>
         )
         .layer(RequestLogging);
 
-    Ok(router)
+    Ok(BridgeHandler {
+        inner: router,
+        bridge,
+    })
 }

--- a/vta-service/src/operations/did_webvh.rs
+++ b/vta-service/src/operations/did_webvh.rs
@@ -202,7 +202,7 @@ pub async fn create_did_webvh(
     auth: &AuthClaims,
     params: CreateDidWebvhParams,
     did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<tokio::sync::RwLock<Option<DIDCommBridge>>>,
+    didcomm_bridge: &Arc<DIDCommBridge>,
     channel: &str,
 ) -> Result<CreateDidWebvhResultBody, AppError> {
     auth.require_admin()?;
@@ -778,7 +778,7 @@ pub async fn delete_did_webvh(
     auth: &AuthClaims,
     did: &str,
     did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<tokio::sync::RwLock<Option<DIDCommBridge>>>,
+    didcomm_bridge: &Arc<DIDCommBridge>,
     channel: &str,
 ) -> Result<DeleteDidWebvhResultBody, AppError> {
     auth.require_admin()?;
@@ -930,7 +930,7 @@ pub async fn remove_webvh_server(
 enum WebvhTransport<'a> {
     Rest(WebvhClient),
     DIDComm {
-        bridge: &'a Arc<tokio::sync::RwLock<Option<DIDCommBridge>>>,
+        bridge: &'a DIDCommBridge,
         vta_did: &'a str,
         server_did: String,
     },
@@ -943,7 +943,7 @@ impl<'a> WebvhTransport<'a> {
     async fn from_server(
         server: &WebvhServerRecord,
         did_resolver: &DIDCacheClient,
-        didcomm_bridge: &'a Arc<tokio::sync::RwLock<Option<DIDCommBridge>>>,
+        didcomm_bridge: &'a Arc<DIDCommBridge>,
         config: &'a AppConfig,
     ) -> Result<Self, AppError> {
         let resolved = did_resolver.resolve(&server.did).await.map_err(|e| {
@@ -958,15 +958,6 @@ impl<'a> WebvhTransport<'a> {
             .any(|svc| svc.type_.iter().any(|t| t == "DIDCommMessaging"));
         if has_didcomm {
             info!(server_did = %server.did, transport = "didcomm", "resolved webvh server endpoint");
-            let guard = didcomm_bridge.read().await;
-            let _bridge = guard.as_ref().ok_or_else(|| {
-                AppError::Internal(
-                    "DIDComm not available — mediator connection not established".into(),
-                )
-            })?;
-            // Drop the guard — we'll re-acquire when needed via the enum variant.
-            // For now, just validate it's available.
-            drop(guard);
             let vta_did = config.vta_did.as_deref().ok_or_else(|| {
                 AppError::Internal(
                     "VTA DID not configured — cannot communicate with WebVH server via DIDComm"
@@ -1001,35 +992,15 @@ impl<'a> WebvhTransport<'a> {
         )))
     }
 
-    /// Acquire the DIDComm bridge and return an error if the connection is down.
-    async fn acquire_bridge(
-        &self,
-    ) -> Result<tokio::sync::RwLockReadGuard<'_, Option<DIDCommBridge>>, AppError> {
-        match self {
-            Self::DIDComm { bridge, .. } => {
-                let guard = bridge.read().await;
-                if guard.is_none() {
-                    return Err(AppError::Internal(
-                        "DIDComm not available — mediator connection not established".into(),
-                    ));
-                }
-                Ok(guard)
-            }
-            _ => Err(AppError::Internal("not a DIDComm transport".into())),
-        }
-    }
-
     async fn request_uri(&self, path: Option<&str>) -> Result<RequestUriResponse, AppError> {
         match self {
             Self::Rest(c) => c.request_uri(path).await,
             Self::DIDComm {
+                bridge,
                 vta_did,
                 server_did,
-                ..
             } => {
-                let guard = self.acquire_bridge().await?;
-                let b = guard.as_ref().unwrap();
-                WebvhDIDCommClient::new(b, vta_did, server_did)
+                WebvhDIDCommClient::new(bridge, vta_did, server_did)
                     .request_uri(path)
                     .await
             }
@@ -1040,13 +1011,11 @@ impl<'a> WebvhTransport<'a> {
         match self {
             Self::Rest(c) => c.publish_did(mnemonic, log_content).await,
             Self::DIDComm {
+                bridge,
                 vta_did,
                 server_did,
-                ..
             } => {
-                let guard = self.acquire_bridge().await?;
-                let b = guard.as_ref().unwrap();
-                WebvhDIDCommClient::new(b, vta_did, server_did)
+                WebvhDIDCommClient::new(bridge, vta_did, server_did)
                     .publish_did(mnemonic, log_content)
                     .await
             }
@@ -1057,13 +1026,11 @@ impl<'a> WebvhTransport<'a> {
         match self {
             Self::Rest(c) => c.delete_did(mnemonic).await,
             Self::DIDComm {
+                bridge,
                 vta_did,
                 server_did,
-                ..
             } => {
-                let guard = self.acquire_bridge().await?;
-                let b = guard.as_ref().unwrap();
-                WebvhDIDCommClient::new(b, vta_did, server_did)
+                WebvhDIDCommClient::new(bridge, vta_did, server_did)
                     .delete_did(mnemonic)
                     .await
             }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -87,7 +87,7 @@ pub struct AppState {
     pub did_resolver: Option<DIDCacheClient>,
     pub secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
     #[cfg(feature = "didcomm")]
-    pub didcomm_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>>,
+    pub didcomm_bridge: Arc<DIDCommBridge>,
     pub jwt_keys: Option<Arc<JwtKeys>>,
     pub atm: Option<ATM>,
     pub tee: Option<TeeContext>,
@@ -157,7 +157,7 @@ pub async fn build_app_state(
         did_resolver,
         secrets_resolver,
         #[cfg(feature = "didcomm")]
-        didcomm_bridge: Arc::new(tokio::sync::RwLock::new(None)),
+        didcomm_bridge: Arc::new(DIDCommBridge::new()),
         jwt_keys,
         atm,
         tee: tee_context,
@@ -266,10 +266,11 @@ pub async fn run(
         let storage_auth_config = config.auth.clone();
         let has_auth = jwt_keys.is_some();
 
-        // Shared DIDComm bridge (still used by REST handlers for WebVH request-response)
+        // Shared DIDComm bridge for outbound request-response messaging.
+        // Starts disconnected; the BridgeHandler captures the listener's ATM
+        // on the first inbound message.
         #[cfg(feature = "didcomm")]
-        let didcomm_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> =
-            Arc::new(tokio::sync::RwLock::new(None));
+        let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::new());
 
         // Build VtaState for the DIDComm service router
         #[cfg(feature = "didcomm")]
@@ -389,12 +390,15 @@ pub async fn run(
                         }],
                     };
 
-                    let router =
-                        messaging::router::build_router(Arc::clone(vta_state)).map_err(|e| {
-                            AppError::Internal(format!("failed to build DIDComm router: {e}"))
-                        })?;
+                    let handler = messaging::router::build_handler(
+                        Arc::clone(vta_state),
+                        didcomm_bridge.clone(),
+                    )
+                    .map_err(|e| {
+                        AppError::Internal(format!("failed to build DIDComm handler: {e}"))
+                    })?;
 
-                    match DIDCommService::start(service_config, router, didcomm_shutdown.clone())
+                    match DIDCommService::start(service_config, handler, didcomm_shutdown.clone())
                         .await
                     {
                         Ok(service) => {

--- a/vta-service/src/setup.rs
+++ b/vta-service/src/setup.rs
@@ -909,8 +909,8 @@ async fn build_wizard_did(
 
     let auth = cli_super_admin();
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
-    let no_bridge: Arc<tokio::sync::RwLock<Option<crate::didcomm_bridge::DIDCommBridge>>> =
-        Arc::new(tokio::sync::RwLock::new(None));
+    let no_bridge: Arc<crate::didcomm_bridge::DIDCommBridge> =
+        Arc::new(crate::didcomm_bridge::DIDCommBridge::new());
 
     let params = CreateDidWebvhParams {
         context_id: context_id.to_string(),

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -168,8 +168,7 @@ pub async fn run_create_did(
     };
 
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
-    let no_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> =
-        Arc::new(tokio::sync::RwLock::new(None));
+    let no_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::new());
     let result = operations::did_webvh::create_did_webvh(
         &keys_ks,
         &imported_ks,
@@ -257,8 +256,7 @@ pub async fn run_delete_did(
 
     let auth = cli_super_admin();
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
-    let no_bridge: Arc<tokio::sync::RwLock<Option<DIDCommBridge>>> =
-        Arc::new(tokio::sync::RwLock::new(None));
+    let no_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::new());
     operations::did_webvh::delete_did_webvh(
         &webvh_ks,
         &keys_ks,

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -96,7 +96,7 @@ impl TestApp {
             },
             secrets_resolver: None,
             #[cfg(feature = "didcomm")]
-            didcomm_bridge: Arc::new(tokio::sync::RwLock::new(None)),
+            didcomm_bridge: Arc::new(vta_service::didcomm_bridge::DIDCommBridge::new()),
             jwt_keys: Some(jwt_keys.clone()),
             atm: None,
             tee: None,


### PR DESCRIPTION
## Summary
- Bump vta-service to 0.3.2
- Fix DIDComm outbound response routing — `try_complete()` was never called on inbound messages, so `send_and_wait` always timed out
- Unify to single mediator connection via `BridgeHandler` wrapper that captures the listener's ATM and intercepts response messages
- Eliminate `w.websocket.duplicate-channel` infinite reconnect loop caused by dual ATM connections

## Changes
- **`didcomm_bridge.rs`** — Restructured to separate ATM connection from pending map; starts disconnected, ATM captured lazily from listener's `HandlerContext`
- **`messaging/router.rs`** — Added `BridgeHandler` wrapping the Router; calls `update_connection` and `try_complete` before normal dispatch
- **`server.rs`** — Removed `init_didcomm_bridge()` and all second-ATM setup; bridge shares the listener's single websocket
- **`operations/did_webvh.rs`** — Simplified bridge type from `Arc<RwLock<Option<DIDCommBridge>>>` to `Arc<DIDCommBridge>`; removed `acquire_bridge()` double-unwrap pattern

## Checklist
- [x] All tests pass
- [x] CHANGELOG.md updated
- [x] No clippy warnings
- [x] Documentation builds cleanly