### PR TITLE
Release 0.3.3: DIDComm message expiry and problem-report logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.3.3 — 2026-04-13
+
+### Fixed
+
+- **DIDComm message expiry** — Outbound DIDComm messages now include
+  `created_time` and `expires_time` fields, preventing stale messages
+  from accumulating at the mediator between sessions. Expiry matches
+  the caller's timeout (30 seconds for WebVH operations).
+- **Problem-report logging** — Unhandled problem-report messages (e.g.,
+  protocol-specific types from WebVH servers) now log `code`, `comment`,
+  `from`, and `msg_type` instead of just "unknown message type". The
+  standard problem-report handler also includes `msg_type` to
+  distinguish between protocol-specific and standard problem reports.
+- **Stale message detection** — The DIDComm bridge now logs unmatched
+  responses (messages with a `thid` that don't match any pending
+  request) at DEBUG level, identifying them as likely stale messages
+  from a previous session.
+
 ## 0.3.2 — 2026-04-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7703,7 +7703,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/didcomm_transport.rs
+++ b/vta-sdk/src/didcomm_transport.rs
@@ -46,9 +46,15 @@ pub async fn send_and_wait_raw(params: DIDCommSendParams<'_>) -> Result<Message,
         timeout_secs,
     } = params;
     let msg_id = uuid::Uuid::new_v4().to_string();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
     let msg = Message::build(msg_id.clone(), msg_type.to_string(), body)
         .from(from_did.to_string())
         .to(to_did.to_string())
+        .created_time(now)
+        .expires_time(now + timeout_secs)
         .finalize();
 
     // Register pending before sending

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1107,10 +1107,10 @@ pub async fn handle_problem_report(_ctx: HandlerContext, message: Message) -> Ha
         .body
         .get("comment")
         .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .unwrap_or("no details provided");
     let from = message.from.as_deref().unwrap_or("unknown");
     let thid = message.thid.as_deref().unwrap_or("none");
-    warn!(from, code, comment, thid, "received problem-report");
+    warn!(from, code, comment, thid, msg_type = %message.typ, "received problem-report");
     Ok(None)
 }
 
@@ -1174,7 +1174,33 @@ pub async fn handle_discover_capabilities(
 }
 
 pub async fn handle_unknown(_ctx: HandlerContext, message: Message) -> HandlerResult {
-    warn!(msg_type = %message.typ, "unknown message type — ignoring");
+    let from = message.from.as_deref().unwrap_or("unknown");
+    let thid = message.thid.as_deref().unwrap_or("none");
+
+    // Extract problem-report details if present in the body
+    if message.typ.contains("problem-report") {
+        let code = message
+            .body
+            .get("code")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let comment = message
+            .body
+            .get("comment")
+            .and_then(|v| v.as_str())
+            .unwrap_or("no details provided");
+        warn!(
+            from,
+            code,
+            comment,
+            thid,
+            msg_type = %message.typ,
+            "received unhandled problem-report"
+        );
+        return Ok(None);
+    }
+
+    warn!(from, thid, msg_type = %message.typ, "unknown message type — ignoring");
     Ok(Some(DIDCommResponse::problem_report(
         ProblemReport::bad_request(format!("unsupported message type: {}", message.typ)),
     )))

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -11,6 +11,7 @@ use affinidi_messaging_didcomm_service::{
     TRUST_PING_TYPE, handler_fn, ignore_handler, trust_ping_handler,
 };
 use tokio::sync::RwLock;
+use tracing::debug;
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 
@@ -87,6 +88,16 @@ impl affinidi_messaging_didcomm_service::DIDCommHandler for BridgeHandler {
         // Route responses to pending outbound requests before normal dispatch.
         if self.bridge.try_complete(&message) {
             return Ok(None);
+        }
+
+        // Log unmatched responses (likely stale messages from a previous session)
+        if message.thid.is_some() {
+            debug!(
+                msg_type = %message.typ,
+                thid = message.thid.as_deref().unwrap_or(""),
+                from = message.from.as_deref().unwrap_or("unknown"),
+                "unmatched response — no pending request for thread (stale message)"
+            );
         }
 
         self.inner.handle(ctx, message, meta).await


### PR DESCRIPTION
## Summary
- Bump vta-sdk to 0.3.2, vta-service to 0.3.3
- Set `created_time` and `expires_time` on outbound DIDComm messages, preventing stale messages from accumulating at the mediator (30s expiry for WebVH operations)
- Improve problem-report logging — unhandled problem-reports now display `code`, `comment`, `from`, and `msg_type` instead of just "unknown message type"
- Add stale message detection in DIDComm bridge with DEBUG-level logging for unmatched responses

## Checklist
- [x] All tests pass
- [x] CHANGELOG.md updated
- [x] Version references in README.md updated (no version refs found)
- [x] No clippy warnings
- [x] Documentation builds cleanly