### PR TITLE
fix: remove stale COPY crates/ from Dockerfile.nitro

### DIFF
--- a/Dockerfile.nitro
+++ b/Dockerfile.nitro
@@ -33,7 +33,6 @@ WORKDIR /build
 
 # Cache dependency builds: copy manifests first, create dummy sources, build deps
 COPY Cargo.toml Cargo.lock ./
-COPY crates/ crates/
 COPY vta-sdk/Cargo.toml vta-sdk/Cargo.toml
 COPY vta-service/Cargo.toml vta-service/Cargo.toml
 COPY vta-enclave/Cargo.toml vta-enclave/Cargo.toml


### PR DESCRIPTION
## Summary
- Remove `COPY crates/ crates/` from `Dockerfile.nitro` — the `crates/` directory no longer exists after the workspace was restructured to top-level directories
- This fixes the Nitro enclave Docker build which was failing with: `"/crates": not found`

## Test plan
- [ ] Run `docker build -f Dockerfile.nitro --build-arg FEATURES="didcomm,vsock-store,vsock-log" -t vta-nitro .` and verify it passes the COPY stage