### PR TITLE
fix: harden TEE deployment prereq checks

### DIFF
--- a/deploy/nitro/README.md
+++ b/deploy/nitro/README.md
@@ -148,6 +148,45 @@ These values are set in `config.toml` before building the EIF:
 | IMDS hop limit | Must be **2** (see below) |
 | IAM role | Minimal: `kms:Decrypt`, `kms:GenerateDataKey` only (see Step 3) |
 
+### Enclave Support
+
+Nitro Enclave support must be **enabled on the EC2 instance** — it cannot be
+turned on while the instance is running. If you forgot to enable it at launch
+time, you must stop the instance, enable it, then start it again:
+
+```bash
+# Check if enclave support is enabled
+aws ec2 describe-instances --instance-ids <your-instance-id> \
+    --query 'Reservations[].Instances[].EnclaveOptions'
+# → [{"Enabled": true}]
+```
+
+If `Enabled` is `false`:
+
+```bash
+# Stop the instance first (not reboot — enclave options require a full stop)
+aws ec2 stop-instances --instance-ids <your-instance-id>
+aws ec2 wait instance-stopped --instance-ids <your-instance-id>
+
+# Enable enclave support
+aws ec2 modify-instance-attribute --instance-id <your-instance-id> \
+    --enclave-options Enabled=true
+
+# Start the instance
+aws ec2 start-instances --instance-ids <your-instance-id>
+```
+
+Or enable it at launch time:
+
+```bash
+aws ec2 run-instances ... --enclave-options Enabled=true
+```
+
+Without enclave support enabled, the `nitro_enclaves` kernel module will not
+load and the `nitro-enclaves-allocator` service will fail with
+*"The CPU pool file is missing. Please make sure the Nitro Enclaves driver is
+inserted."*
+
 ### IMDS Hop Limit
 
 The AWS SDK inside the enclave fetches IAM credentials from the Instance

--- a/deploy/nitro/README.md
+++ b/deploy/nitro/README.md
@@ -225,6 +225,26 @@ sudo systemctl enable --now nitro-enclaves-allocator docker
 sudo usermod -aG docker,ne $USER
 ```
 
+**Rust toolchain** (required on the parent EC2 instance):
+
+The `enclave-proxy` binary is built from source on the parent instance
+(see [Step 6](#step-6-start-the-parent-proxy-before-the-enclave)), and the
+DID resolver sidecar is installed via `cargo install`
+(see [DID Resolution](#did-resolution)). Both require a working Rust
+toolchain — the `enclave-proxy` crate's MSRV is **Rust 1.91.0**.
+
+```bash
+# Install rustup (official installer — picks up a current stable toolchain)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+
+# Verify
+cargo --version   # cargo 1.91.0 or newer
+```
+
+Rust is **not** required on the build machine where the Docker image and
+EIF are built — only on the EC2 parent instance that runs the enclave.
+
 > **You MUST log out and log back in** (or start a new SSH session) after
 > adding groups. Until your session picks up the new membership, `docker`
 > commands will fail with "permission denied" and `nitro-cli` commands will

--- a/deploy/nitro/README.md
+++ b/deploy/nitro/README.md
@@ -136,30 +136,6 @@ These values are set in `config.toml` before building the EIF:
 | B (Full API, REST + DIDComm) | Required | Required | Recommended |
 | C (REST only) | Required | Not needed | Recommended |
 
-## Quick Start
-
-For an interactive end-to-end deployment, use the deployment script:
-
-```bash
-./deploy/nitro/deploy-vta.sh
-```
-
-This walks through all the steps below — prerequisite checks, build profile
-selection, signing key generation, IAM and KMS setup, Docker/EIF builds,
-enclave launch, and parent proxy startup.
-
-For CI/CD, use non-interactive mode with environment variables:
-
-```bash
-VTA_PROFILE=hardened \
-VTA_REGION=us-east-1 \
-VTA_ROLE_NAME=vta-enclave-role \
-VTA_MEDIATOR_DID="did:web:mediator.example.com" \
-./deploy/nitro/deploy-vta.sh --non-interactive
-```
-
-The rest of this guide documents each step in detail.
-
 ## Prerequisites
 
 ### EC2 Instance
@@ -226,6 +202,36 @@ cpu_count: 1
 ```bash
 sudo systemctl restart nitro-enclaves-allocator
 ```
+
+## Quick Start
+
+> **You MUST complete all of the prerequisites above before running the
+> deployment script.** The script checks for required tools, AWS credentials,
+> and group memberships at startup, but it cannot install packages, configure
+> enclave resources, or set the IMDS hop limit for you. Skipping these steps
+> will cause hard-to-diagnose failures during the build or enclave launch.
+
+For an interactive end-to-end deployment, use the deployment script:
+
+```bash
+./deploy/nitro/deploy-vta.sh
+```
+
+This walks through all the steps below — build profile selection, signing key
+generation, IAM and KMS setup, Docker/EIF builds, enclave launch, and parent
+proxy startup.
+
+For CI/CD, use non-interactive mode with environment variables:
+
+```bash
+VTA_PROFILE=hardened \
+VTA_REGION=us-east-1 \
+VTA_ROLE_NAME=vta-enclave-role \
+VTA_MEDIATOR_DID="did:web:mediator.example.com" \
+./deploy/nitro/deploy-vta.sh --non-interactive
+```
+
+The rest of this guide documents each step in detail.
 
 ## Step 1: Generate EIF Signing Key
 

--- a/deploy/nitro/README.md
+++ b/deploy/nitro/README.md
@@ -223,11 +223,15 @@ sudo systemctl enable --now nitro-enclaves-allocator docker
 
 # Add your user to the docker and ne groups (required before building images)
 sudo usermod -aG docker,ne $USER
-
-# IMPORTANT: Log out and back in (or run `newgrp docker`) for group changes
-# to take effect. Docker commands will fail with "permission denied" until
-# your session picks up the new group membership.
 ```
+
+> **You MUST log out and log back in** (or start a new SSH session) after
+> adding groups. Until your session picks up the new membership, `docker`
+> commands will fail with "permission denied" and `nitro-cli` commands will
+> fail with "operation not permitted". The `deploy-vta.sh` script checks
+> for these group memberships and will refuse to continue if they are missing
+> from your current session. Running `newgrp docker && newgrp ne` in your
+> current shell is a quick alternative to a full logout.
 
 ### Configure Enclave Resources
 

--- a/deploy/nitro/deploy-vta.sh
+++ b/deploy/nitro/deploy-vta.sh
@@ -167,15 +167,10 @@ else
     exit 1
 fi
 
-# Check Docker is running
-if docker info &>/dev/null; then
-    ok "Docker daemon is running"
-else
-    err "Docker daemon is not running. Start it and re-run."
-    exit 1
-fi
-
-# Check group memberships for the current user
+# Check group memberships for the current user.
+# This runs BEFORE the Docker daemon check because a missing 'docker' group
+# membership causes 'docker info' to fail with a permission error that looks
+# like the daemon isn't running.
 CURRENT_USER=$(id -un)
 USER_GROUPS=$(id -Gn)
 
@@ -186,7 +181,12 @@ check_group() {
     else
         err "User '$CURRENT_USER' is NOT in the '$group' group"
         err "$hint"
-        err "After adding, log out and back in (or run 'newgrp $group') for it to take effect."
+        err ""
+        err "IMPORTANT: After adding the group, you MUST log out and log back in"
+        err "(or start a new SSH session) for the change to take effect."
+        err "Alternatively, run 'newgrp $group' in your current shell."
+        err "Until you do this, commands like 'docker info' will fail with"
+        err "'permission denied' even though the group has been added."
         MISSING+=("$group group membership")
     fi
 }
@@ -195,6 +195,20 @@ check_group "docker" "Run: sudo usermod -aG docker $CURRENT_USER"
 
 if [ "$HAS_NITRO_CLI" = true ]; then
     check_group "ne" "Run: sudo usermod -aG ne $CURRENT_USER"
+fi
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    err "Missing requirements: ${MISSING[*]}"
+    err "Fix the above issues, then log out and back in before re-running this script."
+    exit 1
+fi
+
+# Check Docker is running (after group check so permission errors are caught above)
+if docker info &>/dev/null; then
+    ok "Docker daemon is running"
+else
+    err "Docker daemon is not running. Start it with: sudo systemctl start docker"
+    exit 1
 fi
 
 # Check Nitro Enclave allocator resources

--- a/deploy/nitro/deploy-vta.sh
+++ b/deploy/nitro/deploy-vta.sh
@@ -197,6 +197,22 @@ if [ "$HAS_NITRO_CLI" = true ]; then
     check_group "ne" "Run: sudo usermod -aG ne $CURRENT_USER"
 fi
 
+# Rust toolchain is required on the parent EC2 instance (where HAS_NITRO_CLI=true)
+# to build the enclave-proxy from source and to install the DID resolver sidecar
+# via `cargo install`. Not needed on a build-only machine.
+if [ "$HAS_NITRO_CLI" = true ]; then
+    if command -v cargo &>/dev/null; then
+        ok "cargo found: $(command -v cargo) ($(cargo --version 2>/dev/null))"
+    else
+        err "cargo (Rust toolchain) not found"
+        err "Required on the parent EC2 instance to build the enclave-proxy"
+        err "and install the DID resolver sidecar. Install with:"
+        err "  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+        err "  source \"\$HOME/.cargo/env\""
+        MISSING+=("cargo")
+    fi
+fi
+
 if [ ${#MISSING[@]} -gt 0 ]; then
     err "Missing requirements: ${MISSING[*]}"
     err "Fix the above issues, then log out and back in before re-running this script."

--- a/deploy/nitro/deploy-vta.sh
+++ b/deploy/nitro/deploy-vta.sh
@@ -180,6 +180,41 @@ if [ "$HAS_NITRO_CLI" = true ]; then
     check_group "ne" "Run: sudo usermod -aG ne $CURRENT_USER"
 fi
 
+# Check Nitro Enclave allocator resources
+ALLOCATOR_YAML="/etc/nitro_enclaves/allocator.yaml"
+if [ "$HAS_NITRO_CLI" = true ]; then
+    if [ -f "$ALLOCATOR_YAML" ]; then
+        ALLOC_CPU=$(grep -E '^\s*cpu_count\s*:' "$ALLOCATOR_YAML" | awk '{print $2}')
+        ALLOC_MEM=$(grep -E '^\s*memory_mib\s*:' "$ALLOCATOR_YAML" | awk '{print $2}')
+        ALLOC_CPU="${ALLOC_CPU:-0}"
+        ALLOC_MEM="${ALLOC_MEM:-0}"
+
+        REQUESTED_CPU="${VTA_ENCLAVE_CPU:-1}"
+        REQUESTED_MEM="${VTA_ENCLAVE_MEM:-512}"
+
+        if [ "$ALLOC_CPU" -ge "$REQUESTED_CPU" ] 2>/dev/null; then
+            ok "Enclave allocator: ${ALLOC_CPU} CPUs reserved (need ${REQUESTED_CPU})"
+        else
+            err "Enclave allocator has ${ALLOC_CPU} CPUs reserved but ${REQUESTED_CPU} required"
+            err "Edit $ALLOCATOR_YAML and set cpu_count: ${REQUESTED_CPU}"
+            err "Then run: sudo systemctl restart nitro-enclaves-allocator"
+            MISSING+=("enclave allocator CPU")
+        fi
+
+        if [ "$ALLOC_MEM" -ge "$REQUESTED_MEM" ] 2>/dev/null; then
+            ok "Enclave allocator: ${ALLOC_MEM} MiB reserved (need ${REQUESTED_MEM})"
+        else
+            err "Enclave allocator has ${ALLOC_MEM} MiB reserved but ${REQUESTED_MEM} MiB required"
+            err "Edit $ALLOCATOR_YAML and set memory_mib: ${REQUESTED_MEM}"
+            err "Then run: sudo systemctl restart nitro-enclaves-allocator"
+            MISSING+=("enclave allocator memory")
+        fi
+    else
+        warn "$ALLOCATOR_YAML not found — cannot verify enclave resource allocation"
+        warn "Ensure the nitro-enclaves-allocator is installed and configured"
+    fi
+fi
+
 if [ ${#MISSING[@]} -gt 0 ]; then
     err "Missing requirements: ${MISSING[*]}"
     err "Fix the above issues and re-run this script."

--- a/deploy/nitro/deploy-vta.sh
+++ b/deploy/nitro/deploy-vta.sh
@@ -127,6 +127,23 @@ check_cmd jq
 if command -v nitro-cli &>/dev/null; then
     ok "nitro-cli found"
     HAS_NITRO_CLI=true
+
+    # Verify the nitro_enclaves kernel module is loaded (requires enclave support
+    # to be enabled on the EC2 instance at launch or via modify-instance-attribute)
+    if [ -d /sys/module/nitro_enclaves ]; then
+        ok "nitro_enclaves kernel module is loaded"
+    else
+        err "nitro_enclaves kernel module is NOT loaded"
+        err "Enclave support is not enabled on this EC2 instance."
+        err ""
+        err "To fix, stop the instance (not reboot), enable enclave support, then start:"
+        err "  aws ec2 stop-instances --instance-ids \$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
+        err "  aws ec2 modify-instance-attribute --instance-id <instance-id> --enclave-options Enabled=true"
+        err "  aws ec2 start-instances --instance-id <instance-id>"
+        err ""
+        err "Or re-launch with: aws ec2 run-instances ... --enclave-options Enabled=true"
+        MISSING+=("nitro_enclaves kernel module")
+    fi
 else
     warn "nitro-cli not found — EIF build and enclave launch will be skipped"
     warn "This is expected if you're building on a developer machine"

--- a/deploy/nitro/deploy-vta.sh
+++ b/deploy/nitro/deploy-vta.sh
@@ -158,6 +158,34 @@ else
     exit 1
 fi
 
+# Check group memberships for the current user
+CURRENT_USER=$(id -un)
+USER_GROUPS=$(id -Gn)
+
+check_group() {
+    local group="$1" hint="$2"
+    if echo "$USER_GROUPS" | grep -qw "$group"; then
+        ok "User '$CURRENT_USER' is in the '$group' group"
+    else
+        err "User '$CURRENT_USER' is NOT in the '$group' group"
+        err "$hint"
+        err "After adding, log out and back in (or run 'newgrp $group') for it to take effect."
+        MISSING+=("$group group membership")
+    fi
+}
+
+check_group "docker" "Run: sudo usermod -aG docker $CURRENT_USER"
+
+if [ "$HAS_NITRO_CLI" = true ]; then
+    check_group "ne" "Run: sudo usermod -aG ne $CURRENT_USER"
+fi
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    err "Missing requirements: ${MISSING[*]}"
+    err "Fix the above issues and re-run this script."
+    exit 1
+fi
+
 # =============================================================================
 # Step 1: Build Profile
 # =============================================================================


### PR DESCRIPTION
## Summary

Strengthens the prerequisite checks in `deploy/nitro/deploy-vta.sh` and the deployment README so users hit clear, actionable errors instead of cryptic mid-deploy failures.

- **Group membership checks** for `docker` and `ne` (when `nitro-cli` is present), with explicit logout/login guidance.
- **Nitro enclaves kernel module** check via `/sys/module/nitro_enclaves`, with the exact stop/modify/start commands to enable enclave support on the EC2 instance.
- **Allocator resource check** that parses `/etc/nitro_enclaves/allocator.yaml` and verifies CPU/memory match the requested enclave config (catches the common mismatch where the allocator default of 2 CPUs conflicts with the deploy default of 1).
- **Rust toolchain** required as a prereq on parent instances (gated on `HAS_NITRO_CLI=true`) since `enclave-proxy` and the DID resolver sidecar are built/installed via cargo.
- **Check ordering**: group membership now runs before the Docker daemon check, so users get the real cause instead of a misleading "daemon not running" error.
- **README**: Quick Start moved below Prerequisites with a warning, and a new Enclave Support section documenting the requirement.

## Test plan

- [ ] Run `deploy/nitro/deploy-vta.sh` on a fresh EC2 instance missing `docker`/`ne` group membership and confirm the error message
- [ ] Run on an instance without enclave support enabled and confirm the kernel module check fires
- [ ] Run on an instance with mismatched allocator config and confirm the resource check fires
- [ ] Run on an instance without `cargo` installed and confirm the Rust prereq check fires
- [ ] Run on a fully provisioned parent instance and confirm all checks pass