### PR TITLE
feat: did:key VTA identity, rate limiter fix, PNM URL persistence

### DIFF
--- a/cnm-cli/README.md
+++ b/cnm-cli/README.md
@@ -263,7 +263,7 @@ cnm config update --community-vta-name "My VTA" --public-url "https://vta.exampl
 | Command                                                                    | Description     |
 | -------------------------------------------------------------------------- | --------------- |
 | `keys list [--status active\|revoked] [--limit N] [--offset N]`            | List keys       |
-| `keys create --key-type ed25519\|x25519 [--context-id ID] [--label LABEL]` | Create a key    |
+| `keys create --key-type ed25519\|x25519\|p256 [--context-id ID] [--label LABEL]` | Create a key    |
 | `keys get <key_id>`                                                        | Get a key by ID |
 | `keys revoke <key_id>`                                                     | Revoke a key    |
 | `keys rename <key_id> <new_key_id>`                                        | Rename a key    |

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -503,7 +503,7 @@ enum AuthCredentialCommands {
 enum KeyCommands {
     /// Create a new key
     Create {
-        /// Key type: ed25519 or x25519
+        /// Key type: ed25519, x25519, or p256
         #[arg(long)]
         key_type: String,
         /// BIP-32 derivation path (auto-derived from context if omitted)

--- a/pnm-cli/README.md
+++ b/pnm-cli/README.md
@@ -185,7 +185,7 @@ url = "http://localhost:3000"
 | Command                                                                    | Description     |
 | -------------------------------------------------------------------------- | --------------- |
 | `keys list [--status active\|revoked] [--limit N] [--offset N]`            | List keys       |
-| `keys create --key-type ed25519\|x25519 [--context-id ID] [--label LABEL]` | Create a key (BIP-32 derived) |
+| `keys create --key-type ed25519\|x25519\|p256 [--context-id ID] [--label LABEL]` | Create a key (BIP-32 derived) |
 | `keys import --key-type TYPE --private-key KEY [--label L] [--context-id ID]` | Import an external private key |
 | `keys get <key_id>`                                                        | Get a key by ID |
 | `keys revoke <key_id>`                                                     | Revoke a key               |

--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -427,6 +427,7 @@ pub async fn run_connect(
         crate::config::VtaConfig {
             name: slug.clone(),
             vta_did: Some(credential.vta_did.clone()),
+            url: None,
         },
     );
     if pnm_config.default_vta.is_none() {

--- a/pnm-cli/src/config.rs
+++ b/pnm-cli/src/config.rs
@@ -21,6 +21,11 @@ pub struct VtaConfig {
     pub name: String,
     #[serde(default)]
     pub vta_did: Option<String>,
+    /// Explicit REST URL for DIDs that cannot advertise a service endpoint
+    /// (e.g. `did:key`). Ignored for `did:webvh` where the URL is derived
+    /// from the DID document.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 /// Returns `~/.config/pnm/`, creating it if it doesn't exist.
@@ -61,6 +66,7 @@ pub fn load_config() -> Result<PnmConfig, Box<dyn std::error::Error>> {
             VtaConfig {
                 name: "Default VTA".to_string(),
                 vta_did: None,
+                url: None,
             },
         );
         config.default_vta = Some("default".to_string());
@@ -162,6 +168,7 @@ mod tests {
             VtaConfig {
                 name: "Personal VTA".into(),
                 vta_did: Some("did:web:vta.example.com".into()),
+                url: None,
             },
         );
         config.vtas.insert(
@@ -169,6 +176,7 @@ mod tests {
             VtaConfig {
                 name: "Work VTA".into(),
                 vta_did: Some("did:webvh:abc:work.example.com:vta".into()),
+                url: None,
             },
         );
 
@@ -184,11 +192,11 @@ mod tests {
     }
 
     /// Existing config files written by older PNM versions carry a per-VTA
-    /// `url` field. After this change the field is no longer in the
-    /// `VtaConfig` struct; serde silently drops it on deserialize so legacy
-    /// configs keep loading.
+    /// `url` field. After the `did:key` URL support, the field is restored
+    /// for DIDs that cannot advertise a service endpoint. Legacy configs
+    /// with a URL now round-trip correctly.
     #[test]
-    fn test_legacy_per_vta_url_is_silently_dropped() {
+    fn test_legacy_per_vta_url_is_preserved() {
         let toml_str = r#"
 default_vta = "personal"
 [vtas.personal]
@@ -198,6 +206,10 @@ vta_did = "did:web:vta.example.com"
 "#;
         let restored: PnmConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(restored.vtas["personal"].name, "Personal");
+        assert_eq!(
+            restored.vtas["personal"].url.as_deref(),
+            Some("https://vta.example.com")
+        );
         assert_eq!(
             restored.vtas["personal"].vta_did.as_deref(),
             Some("did:web:vta.example.com")
@@ -233,6 +245,7 @@ vta_did = "did:web:vta.example.com"
             VtaConfig {
                 name: "Personal".into(),
                 vta_did: None,
+                url: None,
             },
         );
         let (slug, vta) = resolve_vta(Some("personal"), &config).unwrap();
@@ -251,6 +264,7 @@ vta_did = "did:web:vta.example.com"
             VtaConfig {
                 name: "Work".into(),
                 vta_did: None,
+                url: None,
             },
         );
         let (slug, _) = resolve_vta(None, &config).unwrap();

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -950,7 +950,7 @@ enum KeyCommands {
     /// identical arguments). Use `pnm keys list` to discover existing keys
     /// in a context first if you're trying to avoid duplicates.
     Create {
-        /// Key type: ed25519 or x25519
+        /// Key type: ed25519, x25519, or p256
         #[arg(long)]
         key_type: String,
         /// BIP-32 derivation path (auto-derived from context if omitted)

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -172,6 +172,10 @@ enum SetupCommands {
         /// VTA DID to bind (non-interactive). Must start with `did:`.
         #[arg(long)]
         vta_did: Option<String>,
+
+        /// VTA REST URL (required for did:key DIDs that cannot advertise a service endpoint).
+        #[arg(long)]
+        vta_url: Option<String>,
     },
 }
 
@@ -1237,6 +1241,7 @@ async fn main() {
                     Some(SetupCommands::Continue {
                         slug,
                         vta_did: None,
+                        ..
                     }),
                     None,
                 ) => setup::continue_non_tee_setup_interactive(&mut pnm_config, slug).await,
@@ -1244,10 +1249,11 @@ async fn main() {
                     Some(SetupCommands::Continue {
                         slug,
                         vta_did: Some(vta_did),
+                        vta_url,
                     }),
                     None,
                 ) => {
-                    setup::continue_non_tee_setup_non_interactive(&mut pnm_config, slug, vta_did)
+                    setup::continue_non_tee_setup_non_interactive(&mut pnm_config, slug, vta_did, vta_url.as_deref())
                         .await
                 }
                 (None, Some(name)) => {
@@ -1464,8 +1470,11 @@ async fn main() {
     eprintln!();
 
     // Build client
+    // For did:key VTAs, use the persisted URL as fallback (DID has no service endpoint).
+    let effective_url_override = url_override.as_deref().or(vta_config.url.as_deref());
+
     let client = if requires_auth(&cli.command) {
-        match auth::connect(url_override.as_deref(), &keyring_key).await {
+        match auth::connect(effective_url_override, &keyring_key).await {
             Ok(c) => c,
             Err(e) => {
                 vta_cli_common::render::print_cli_error(e.as_ref());
@@ -1478,7 +1487,7 @@ async fn main() {
         // `--url` override; otherwise resolve the VTA DID's REST endpoint
         // at runtime. Empty string is fine for commands that don't make
         // HTTP calls (the client is constructed but unused).
-        let url = match url_override.as_deref() {
+        let url = match effective_url_override {
             Some(u) => u.to_string(),
             None => match vta_config.vta_did.as_deref() {
                 Some(did) => vta_sdk::session::resolve_vta_url(did)
@@ -2472,7 +2481,7 @@ mod tests {
         ]);
         match cli.command {
             Commands::Setup {
-                command: Some(SetupCommands::Continue { slug, vta_did }),
+                command: Some(SetupCommands::Continue { slug, vta_did, .. }),
                 ..
             } => {
                 assert_eq!(slug, "my-vta");

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -1253,8 +1253,13 @@ async fn main() {
                     }),
                     None,
                 ) => {
-                    setup::continue_non_tee_setup_non_interactive(&mut pnm_config, slug, vta_did, vta_url.as_deref())
-                        .await
+                    setup::continue_non_tee_setup_non_interactive(
+                        &mut pnm_config,
+                        slug,
+                        vta_did,
+                        vta_url.as_deref(),
+                    )
+                    .await
                 }
                 (None, Some(name)) => {
                     setup::start_non_tee_setup_non_interactive(&mut pnm_config, name, *overwrite)

--- a/pnm-cli/src/setup.rs
+++ b/pnm-cli/src/setup.rs
@@ -171,6 +171,20 @@ async fn start_non_tee_setup_interactive(
 
     // Operator supplied the VTA DID up front → phase 1 + phase 2 in one
     // shot. Park in pending, then bind immediately.
+    // did:key has no service endpoints — prompt for URL so PNM can reach the VTA.
+    let vta_url = if vta_did_input.starts_with("did:key:") {
+        let url: String = Input::new()
+            .with_prompt("VTA URL (required for did:key — e.g. http://localhost:7001)")
+            .interact_text()?;
+        let url = url.trim().to_string();
+        if url.is_empty() {
+            return Err("did:key VTAs require an explicit URL (the DID has no service endpoint)".into());
+        }
+        Some(url)
+    } else {
+        None
+    };
+
     persist_pending(
         config,
         &slug,
@@ -179,7 +193,7 @@ async fn start_non_tee_setup_interactive(
         &did,
         &private_key_multibase,
     )?;
-    finalize_session(config, &slug, &name, vta_did_input, &did, false)?;
+    finalize_session(config, &slug, &name, vta_did_input, &did, vta_url.as_deref(), false)?;
 
     Ok(())
 }
@@ -258,7 +272,21 @@ pub async fn continue_non_tee_setup_interactive(
         return Err("VTA DID must start with `did:` (e.g. did:webvh:... or did:key:...)".into());
     }
 
-    finalize_session(config, slug, &name, vta_did, &existing_did, false)?;
+    // did:key has no service endpoints — prompt for URL so PNM can reach the VTA.
+    let vta_url = if vta_did.starts_with("did:key:") {
+        let url: String = Input::new()
+            .with_prompt("VTA URL (required for did:key — e.g. http://localhost:7001)")
+            .interact_text()?;
+        let url = url.trim().to_string();
+        if url.is_empty() {
+            return Err("did:key VTAs require an explicit URL (the DID has no service endpoint)".into());
+        }
+        Some(url)
+    } else {
+        None
+    };
+
+    finalize_session(config, slug, &name, vta_did, &existing_did, vta_url.as_deref(), false)?;
     Ok(())
 }
 
@@ -268,6 +296,7 @@ pub async fn continue_non_tee_setup_non_interactive(
     config: &mut PnmConfig,
     slug: &str,
     vta_did: &str,
+    vta_url: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let keyring_key = vta_keyring_key(slug);
     let (name, existing_did) = require_pending(config, slug, &keyring_key)?;
@@ -277,7 +306,19 @@ pub async fn continue_non_tee_setup_non_interactive(
         return Err("VTA DID must start with `did:` (e.g. did:webvh:... or did:key:...)".into());
     }
 
-    finalize_session(config, slug, &name, vta_did, &existing_did, true)?;
+    // did:key has no service endpoints — require --vta-url.
+    let vta_url = if vta_did.starts_with("did:key:") {
+        match vta_url {
+            Some(u) => Some(u),
+            None => return Err(
+                "did:key VTAs require --vta-url (the DID has no service endpoint)".into()
+            ),
+        }
+    } else {
+        vta_url
+    };
+
+    finalize_session(config, slug, &name, vta_did, &existing_did, vta_url, true)?;
     Ok(())
 }
 
@@ -302,6 +343,7 @@ fn persist_pending(
         VtaConfig {
             name: name.to_string(),
             vta_did: None,
+            url: None,
         },
     );
     if config.default_vta.is_none() || config.vtas.len() == 1 {
@@ -317,6 +359,7 @@ fn finalize_session(
     name: &str,
     vta_did: &str,
     did: &str,
+    vta_url: Option<&str>,
     non_interactive: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let keyring_key = vta_keyring_key(slug);
@@ -327,6 +370,7 @@ fn finalize_session(
         VtaConfig {
             name: name.to_string(),
             vta_did: Some(vta_did.to_string()),
+            url: vta_url.map(|u| u.trim_end_matches('/').to_string()),
         },
     );
     if config.default_vta.is_none() || config.vtas.len() == 1 {
@@ -508,6 +552,7 @@ async fn setup_tee(config: &mut PnmConfig) -> Result<(), Box<dyn std::error::Err
         VtaConfig {
             name: name.clone(),
             vta_did: Some(vta_did.clone()),
+            url: None,
         },
     );
     if config.default_vta.is_none() || config.vtas.len() == 1 {
@@ -546,6 +591,7 @@ mod tests {
             VtaConfig {
                 name: slug.to_string(),
                 vta_did: vta_did.map(str::to_string),
+                url: None,
             },
         );
         config.vtas = vtas;

--- a/pnm-cli/src/setup.rs
+++ b/pnm-cli/src/setup.rs
@@ -178,7 +178,9 @@ async fn start_non_tee_setup_interactive(
             .interact_text()?;
         let url = url.trim().to_string();
         if url.is_empty() {
-            return Err("did:key VTAs require an explicit URL (the DID has no service endpoint)".into());
+            return Err(
+                "did:key VTAs require an explicit URL (the DID has no service endpoint)".into(),
+            );
         }
         Some(url)
     } else {
@@ -193,7 +195,15 @@ async fn start_non_tee_setup_interactive(
         &did,
         &private_key_multibase,
     )?;
-    finalize_session(config, &slug, &name, vta_did_input, &did, vta_url.as_deref(), false)?;
+    finalize_session(
+        config,
+        &slug,
+        &name,
+        vta_did_input,
+        &did,
+        vta_url.as_deref(),
+        false,
+    )?;
 
     Ok(())
 }
@@ -279,14 +289,24 @@ pub async fn continue_non_tee_setup_interactive(
             .interact_text()?;
         let url = url.trim().to_string();
         if url.is_empty() {
-            return Err("did:key VTAs require an explicit URL (the DID has no service endpoint)".into());
+            return Err(
+                "did:key VTAs require an explicit URL (the DID has no service endpoint)".into(),
+            );
         }
         Some(url)
     } else {
         None
     };
 
-    finalize_session(config, slug, &name, vta_did, &existing_did, vta_url.as_deref(), false)?;
+    finalize_session(
+        config,
+        slug,
+        &name,
+        vta_did,
+        &existing_did,
+        vta_url.as_deref(),
+        false,
+    )?;
     Ok(())
 }
 
@@ -310,9 +330,11 @@ pub async fn continue_non_tee_setup_non_interactive(
     let vta_url = if vta_did.starts_with("did:key:") {
         match vta_url {
             Some(u) => Some(u),
-            None => return Err(
-                "did:key VTAs require --vta-url (the DID has no service endpoint)".into()
-            ),
+            None => {
+                return Err(
+                    "did:key VTAs require --vta-url (the DID has no service endpoint)".into(),
+                );
+            }
         }
     } else {
         vta_url

--- a/vta-cli-common/src/commands/keys.rs
+++ b/vta-cli-common/src/commands/keys.rs
@@ -19,8 +19,11 @@ pub async fn cmd_key_create(
     let key_type = match key_type {
         "ed25519" => KeyType::Ed25519,
         "x25519" => KeyType::X25519,
+        "p256" => KeyType::P256,
         other => {
-            return Err(format!("unknown key type '{other}', expected ed25519 or x25519").into());
+            return Err(
+                format!("unknown key type '{other}', expected ed25519, x25519, or p256").into(),
+            );
         }
     };
     let mut req = CreateKeyRequest::new(key_type);

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -147,8 +147,7 @@ pub async fn build_app_state(
     #[cfg(feature = "webvh")]
     let webvh_ks = apply_encryption(store.keyspace("webvh")?);
 
-    let (did_resolver, secrets_resolver, jwt_keys, atm) =
-        init_auth(&config, &*seed_store, &keys_ks).await;
+    let auth = init_auth(&config, &*seed_store, &keys_ks).await;
 
     Ok(AppState {
         keys_ks,
@@ -165,13 +164,13 @@ pub async fn build_app_state(
         wrapping_cache: crate::keys::wrapping::WrappingKeyCache::new(),
         config: Arc::new(RwLock::new(config)),
         seed_store,
-        did_resolver,
-        secrets_resolver,
+        did_resolver: auth.did_resolver,
+        secrets_resolver: auth.secrets_resolver,
         #[cfg(feature = "didcomm")]
         didcomm_bridge: Arc::new(DIDCommBridge::placeholder()),
 
-        jwt_keys,
-        atm,
+        jwt_keys: auth.jwt_keys,
+        atm: auth.atm,
         tee: tee_context,
         restart_tx,
         #[cfg(feature = "rest")]
@@ -239,12 +238,12 @@ pub async fn run(
         let webvh_ks = apply_encryption(store.keyspace("webvh")?);
 
         // Initialize auth infrastructure
-        let (did_resolver, secrets_resolver, jwt_keys, atm) =
+        let auth =
             init_auth(&config, &*seed_store, &keys_ks).await;
 
         // In TEE required mode, warn if auth isn't initialized.
         #[cfg(feature = "tee")]
-        if config.tee.mode == crate::config::TeeMode::Required && jwt_keys.is_none() {
+        if config.tee.mode == crate::config::TeeMode::Required && auth.jwt_keys.is_none() {
             warn!(
                 "TEE mode is 'required' but authentication is not initialized \
                  (vta_did not configured). The VTA will start but authenticated \
@@ -287,7 +286,7 @@ pub async fn run(
         let storage_acl_ks = acl_ks.clone();
         let storage_audit_config = config.audit.clone();
         let storage_auth_config = config.auth.clone();
-        let has_auth = jwt_keys.is_some();
+        let has_auth = auth.jwt_keys.is_some();
 
         // Shared DIDComm bridge for outbound request-response messaging.
         // The service reference is set after DIDCommService::start().
@@ -309,7 +308,7 @@ pub async fn run(
                 sealed_nonces_ks: sealed_nonces_ks.clone(),
                 seed_store: seed_store.clone(),
                 config: Arc::new(RwLock::new(config.clone())),
-                did_resolver: did_resolver.clone(),
+                did_resolver: auth.did_resolver.clone(),
                 didcomm_bridge: didcomm_bridge.clone(),
                 #[cfg(feature = "tee")]
                 tee_state: tee_context.as_ref().map(|tc| tc.state.clone()),
@@ -341,12 +340,12 @@ pub async fn run(
                 wrapping_cache,
                 config: Arc::new(RwLock::new(config.clone())),
                 seed_store: seed_store.clone(),
-                did_resolver,
-                secrets_resolver: secrets_resolver.clone(),
+                did_resolver: auth.did_resolver,
+                secrets_resolver: auth.secrets_resolver.clone(),
                 #[cfg(feature = "didcomm")]
                 didcomm_bridge: didcomm_bridge.clone(),
-                jwt_keys,
-                atm,
+                jwt_keys: auth.jwt_keys,
+                atm: auth.atm,
                 tee: tee_context.clone(),
                 restart_tx: restart_tx.clone(),
                 metrics_handle: None, // Set in REST thread after install
@@ -367,17 +366,20 @@ pub async fn run(
         // Start DIDComm service (conditional)
         #[cfg(feature = "didcomm")]
         let didcomm_service: Option<DIDCommService> = if let Some(ref vta_state) = vta_state {
-            match (&secrets_resolver, &config.vta_did, &config.messaging) {
+            match (&auth.secrets_resolver, &config.vta_did, &config.messaging) {
                 (Some(sr), Some(vta_did), Some(messaging_config)) => {
-                    // Collect secrets from the resolver for the TDKProfile
+                    // Collect secrets using the VM IDs from init_auth (correct for both
+                    // did:key and did:webvh — avoids hardcoding #key-0/#key-1 fragments).
                     let mut secrets = Vec::new();
-                    let signing_id = format!("{vta_did}#key-0");
-                    let ka_id = format!("{vta_did}#key-1");
-                    if let Some(s) = sr.get_secret(&signing_id).await {
-                        secrets.push(s);
+                    if let Some(ref signing_id) = auth.signing_vm_id {
+                        if let Some(s) = sr.get_secret(signing_id).await {
+                            secrets.push(s);
+                        }
                     }
-                    if let Some(s) = sr.get_secret(&ka_id).await {
-                        secrets.push(s);
+                    if let Some(ref ka_id) = auth.ka_vm_id {
+                        if let Some(s) = sr.get_secret(ka_id).await {
+                            secrets.push(s);
+                        }
                     }
 
                     let profile = TDKProfile::new(
@@ -681,21 +683,42 @@ fn run_rest_thread(
 ///
 /// Returns `None` values if the VTA DID is not configured (server still starts
 /// so the setup wizard can be run first).
+/// Result of auth initialization, bundling all outputs including the
+/// verification-method IDs that were inserted into the secrets resolver.
+struct AuthInit {
+    did_resolver: Option<DIDCacheClient>,
+    secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
+    jwt_keys: Option<Arc<JwtKeys>>,
+    atm: Option<ATM>,
+    /// Signing verification method ID (e.g. `{did}#key-0` or `{did}#{ed_pub_mb}`).
+    signing_vm_id: Option<String>,
+    /// Key-agreement verification method ID (e.g. `{did}#key-1` or `{did}#{x_pub_mb}`).
+    ka_vm_id: Option<String>,
+}
+
+impl AuthInit {
+    fn empty() -> Self {
+        Self {
+            did_resolver: None,
+            secrets_resolver: None,
+            jwt_keys: None,
+            atm: None,
+            signing_vm_id: None,
+            ka_vm_id: None,
+        }
+    }
+}
+
 async fn init_auth(
     config: &AppConfig,
     seed_store: &dyn SeedStore,
     keys_ks: &KeyspaceHandle,
-) -> (
-    Option<DIDCacheClient>,
-    Option<Arc<ThreadedSecretsResolver>>,
-    Option<Arc<JwtKeys>>,
-    Option<ATM>,
-) {
+) -> AuthInit {
     let vta_did = match &config.vta_did {
         Some(did) => did.clone(),
         None => {
             warn!("vta_did not configured — auth endpoints will not work (run setup first)");
-            return (None, None, None, None);
+            return AuthInit::empty();
         }
     };
 
@@ -706,7 +729,7 @@ async fn init_auth(
             warn!(
                 "failed to find VTA key records: {e} — auth endpoints will not work (run setup first)"
             );
-            return (None, None, None, None);
+            return AuthInit::empty();
         }
     };
 
@@ -715,7 +738,7 @@ async fn init_auth(
         Ok(s) => s,
         Err(e) => {
             warn!("failed to load seed: {e} — auth endpoints will not work");
-            return (None, None, None, None);
+            return AuthInit::empty();
         }
     };
 
@@ -723,7 +746,7 @@ async fn init_auth(
         Ok(r) => r,
         Err(e) => {
             warn!("failed to create BIP-32 root key: {e} — auth endpoints will not work");
-            return (None, None, None, None);
+            return AuthInit::empty();
         }
     };
 
@@ -742,12 +765,16 @@ async fn init_auth(
         Ok(r) => r,
         Err(e) => {
             warn!("failed to create DID resolver: {e} — auth endpoints will not work");
-            return (None, None, None, None);
+            return AuthInit::empty();
         }
     };
 
     // 2. Secrets resolver with VTA's Ed25519 + X25519 secrets
     let (secrets_resolver, _handle) = ThreadedSecretsResolver::new(None).await;
+
+    // Track verification-method IDs so DIDComm consumers use the right fragment.
+    let mut signing_vm_id: Option<String> = None;
+    let mut ka_vm_id: Option<String> = None;
 
     if vta_did.starts_with("did:key:") {
         // did:key uses fragment IDs like {did}#{ed_pub_mb} and {did}#{x_pub_mb},
@@ -757,7 +784,7 @@ async fn init_auth(
             Ok(p) => p,
             Err(e) => {
                 warn!("invalid signing derivation path: {e}");
-                return (Some(did_resolver), None, None, None);
+                return AuthInit { did_resolver: Some(did_resolver), ..AuthInit::empty() };
             }
         };
         match root.derive(&dp) {
@@ -765,13 +792,15 @@ async fn init_auth(
                 let seed_bytes: &[u8; 32] = derived.signing_key.as_bytes();
                 match vta_sdk::did_key::secrets_from_did_key(&vta_did, seed_bytes) {
                     Ok(secrets) => {
+                        signing_vm_id = Some(secrets.signing.id.clone());
+                        ka_vm_id = Some(secrets.key_agreement.id.clone());
                         info!(signing_id = %secrets.signing.id, ka_id = %secrets.key_agreement.id, "did:key secrets loaded");
                         secrets_resolver.insert(secrets.signing).await;
                         secrets_resolver.insert(secrets.key_agreement).await;
                     }
                     Err(e) => {
                         warn!("failed to build did:key secrets: {e} — auth will not work");
-                        return (Some(did_resolver), None, None, None);
+                        return AuthInit { did_resolver: Some(did_resolver), ..AuthInit::empty() };
                     }
                 }
             }
@@ -780,6 +809,8 @@ async fn init_auth(
     } else {
         // did:webvh / other methods: use #key-0 / #key-1 fragment convention
         // with independently derived Ed25519 + X25519 keys.
+        signing_vm_id = Some(format!("{vta_did}#key-0"));
+        ka_vm_id = Some(format!("{vta_did}#key-1"));
 
         // Load stored key records for validation
         let stored_signing: Option<KeyRecord> = keys_ks
@@ -803,7 +834,8 @@ async fn init_auth(
                                 key_id = %format!("{vta_did}#key-0"),
                                 stored = %record.public_key,
                                 runtime = %runtime_pub,
-                                "SIGNING KEY MISMATCH"
+                                "SIGNING KEY MISMATCH — DIDComm signing/verification will fail. \
+                                 This likely means the DID was created with a different seed."
                             );
                         }
                         Ok(runtime_pub) => {
@@ -828,7 +860,8 @@ async fn init_auth(
                                 key_id = %format!("{vta_did}#key-1"),
                                 stored = %record.public_key,
                                 runtime = %runtime_pub,
-                                "KEY-AGREEMENT KEY MISMATCH"
+                                "KEY-AGREEMENT KEY MISMATCH — DIDComm encryption will fail. \
+                                 This likely means the DID was created with a different seed."
                             );
                         }
                         Ok(runtime_pub) => {
@@ -850,24 +883,26 @@ async fn init_auth(
             Ok(k) => k,
             Err(e) => {
                 warn!("failed to load JWT signing key: {e} — auth endpoints will not work");
-                return (
-                    Some(did_resolver),
-                    Some(Arc::new(secrets_resolver)),
-                    None,
-                    None,
-                );
+                return AuthInit {
+                    did_resolver: Some(did_resolver),
+                    secrets_resolver: Some(Arc::new(secrets_resolver)),
+                    signing_vm_id,
+                    ka_vm_id,
+                    ..AuthInit::empty()
+                };
             }
         },
         None => {
             warn!(
                 "auth.jwt_signing_key not configured — auth endpoints will not work (run setup first)"
             );
-            return (
-                Some(did_resolver),
-                Some(Arc::new(secrets_resolver)),
-                None,
-                None,
-            );
+            return AuthInit {
+                did_resolver: Some(did_resolver),
+                secrets_resolver: Some(Arc::new(secrets_resolver)),
+                signing_vm_id,
+                ka_vm_id,
+                ..AuthInit::empty()
+            };
         }
     };
 
@@ -904,12 +939,14 @@ async fn init_auth(
 
     info!("auth initialized for DID {vta_did}");
 
-    (
-        Some(did_resolver),
-        Some(secrets_resolver),
-        Some(Arc::new(jwt_keys)),
+    AuthInit {
+        did_resolver: Some(did_resolver),
+        secrets_resolver: Some(secrets_resolver),
+        jwt_keys: Some(Arc::new(jwt_keys)),
         atm,
-    )
+        signing_vm_id,
+        ka_vm_id,
+    }
 }
 
 /// Look up VTA signing and key-agreement derivation paths from stored key records.

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -749,75 +749,99 @@ async fn init_auth(
     // 2. Secrets resolver with VTA's Ed25519 + X25519 secrets
     let (secrets_resolver, _handle) = ThreadedSecretsResolver::new(None).await;
 
-    // Load stored key records for validation
-    let stored_signing: Option<KeyRecord> = keys_ks
-        .get(crate::keys::store_key(&format!("{vta_did}#key-0")))
-        .await
-        .ok()
-        .flatten();
-    let stored_ka: Option<KeyRecord> = keys_ks
-        .get(crate::keys::store_key(&format!("{vta_did}#key-1")))
-        .await
-        .ok()
-        .flatten();
-
-    // Derive and insert VTA signing secret (Ed25519)
-    match root.derive_ed25519(&signing_path) {
-        Ok(mut signing_secret) => {
-            // Validate: runtime key must match what was stored at DID creation time
-            if let Some(ref record) = stored_signing {
-                match signing_secret.get_public_keymultibase() {
-                    Ok(runtime_pub) if runtime_pub != record.public_key => {
-                        error!(
-                            key_id = %format!("{vta_did}#key-0"),
-                            stored = %record.public_key,
-                            runtime = %runtime_pub,
-                            "SIGNING KEY MISMATCH: runtime-derived Ed25519 public key does not match \
-                             the key stored in the key record (and published in the DID document). \
-                             DIDComm message signing/verification will fail. \
-                             This likely means the DID was created with different code or seed."
-                        );
+    if vta_did.starts_with("did:key:") {
+        // did:key uses fragment IDs like {did}#{ed_pub_mb} and {did}#{x_pub_mb},
+        // and the X25519 key is derived FROM the Ed25519 key (not independently).
+        // Use the SDK helper which handles both correctly.
+        let dp: ed25519_dalek_bip32::DerivationPath = match signing_path.parse() {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("invalid signing derivation path: {e}");
+                return (Some(did_resolver), None, None, None);
+            }
+        };
+        match root.derive(&dp) {
+            Ok(derived) => {
+                let seed_bytes: &[u8; 32] = derived.signing_key.as_bytes();
+                match vta_sdk::did_key::secrets_from_did_key(&vta_did, seed_bytes) {
+                    Ok(secrets) => {
+                        info!(signing_id = %secrets.signing.id, ka_id = %secrets.key_agreement.id, "did:key secrets loaded");
+                        secrets_resolver.insert(secrets.signing).await;
+                        secrets_resolver.insert(secrets.key_agreement).await;
                     }
-                    Ok(runtime_pub) => {
-                        info!(key_id = %format!("{vta_did}#key-0"), pub_key = %runtime_pub, "signing key validated");
+                    Err(e) => {
+                        warn!("failed to build did:key secrets: {e} — auth will not work");
+                        return (Some(did_resolver), None, None, None);
                     }
-                    Err(e) => warn!("could not extract signing public key for validation: {e}"),
                 }
             }
-            signing_secret.id = format!("{vta_did}#key-0");
-            secrets_resolver.insert(signing_secret).await;
+            Err(e) => warn!("failed to derive VTA signing key: {e}"),
         }
-        Err(e) => warn!("failed to derive VTA signing key: {e}"),
-    }
+    } else {
+        // did:webvh / other methods: use #key-0 / #key-1 fragment convention
+        // with independently derived Ed25519 + X25519 keys.
 
-    // Derive and insert VTA key-agreement secret (X25519)
-    match root.derive_x25519(&ka_path) {
-        Ok(mut ka_secret) => {
-            // Validate: runtime key must match what was stored at DID creation time
-            if let Some(ref record) = stored_ka {
-                match ka_secret.get_public_keymultibase() {
-                    Ok(runtime_pub) if runtime_pub != record.public_key => {
-                        error!(
-                            key_id = %format!("{vta_did}#key-1"),
-                            stored = %record.public_key,
-                            runtime = %runtime_pub,
-                            "KEY-AGREEMENT KEY MISMATCH: runtime-derived X25519 public key does not match \
-                             the key stored in the key record (and published in the DID document). \
-                             DIDComm encryption/decryption will fail. Others will encrypt to the DID \
-                             document key but this VTA holds a different private key. \
-                             The DID document must be updated or the VTA identity must be regenerated."
-                        );
+        // Load stored key records for validation
+        let stored_signing: Option<KeyRecord> = keys_ks
+            .get(crate::keys::store_key(&format!("{vta_did}#key-0")))
+            .await
+            .ok()
+            .flatten();
+        let stored_ka: Option<KeyRecord> = keys_ks
+            .get(crate::keys::store_key(&format!("{vta_did}#key-1")))
+            .await
+            .ok()
+            .flatten();
+
+        // Derive and insert VTA signing secret (Ed25519)
+        match root.derive_ed25519(&signing_path) {
+            Ok(mut signing_secret) => {
+                if let Some(ref record) = stored_signing {
+                    match signing_secret.get_public_keymultibase() {
+                        Ok(runtime_pub) if runtime_pub != record.public_key => {
+                            error!(
+                                key_id = %format!("{vta_did}#key-0"),
+                                stored = %record.public_key,
+                                runtime = %runtime_pub,
+                                "SIGNING KEY MISMATCH"
+                            );
+                        }
+                        Ok(runtime_pub) => {
+                            info!(key_id = %format!("{vta_did}#key-0"), pub_key = %runtime_pub, "signing key validated");
+                        }
+                        Err(e) => warn!("could not extract signing public key for validation: {e}"),
                     }
-                    Ok(runtime_pub) => {
-                        info!(key_id = %format!("{vta_did}#key-1"), pub_key = %runtime_pub, "key-agreement key validated");
-                    }
-                    Err(e) => warn!("could not extract KA public key for validation: {e}"),
                 }
+                signing_secret.id = format!("{vta_did}#key-0");
+                secrets_resolver.insert(signing_secret).await;
             }
-            ka_secret.id = format!("{vta_did}#key-1");
-            secrets_resolver.insert(ka_secret).await;
+            Err(e) => warn!("failed to derive VTA signing key: {e}"),
         }
-        Err(e) => warn!("failed to derive VTA key-agreement key: {e}"),
+
+        // Derive and insert VTA key-agreement secret (X25519)
+        match root.derive_x25519(&ka_path) {
+            Ok(mut ka_secret) => {
+                if let Some(ref record) = stored_ka {
+                    match ka_secret.get_public_keymultibase() {
+                        Ok(runtime_pub) if runtime_pub != record.public_key => {
+                            error!(
+                                key_id = %format!("{vta_did}#key-1"),
+                                stored = %record.public_key,
+                                runtime = %runtime_pub,
+                                "KEY-AGREEMENT KEY MISMATCH"
+                            );
+                        }
+                        Ok(runtime_pub) => {
+                            info!(key_id = %format!("{vta_did}#key-1"), pub_key = %runtime_pub, "key-agreement key validated");
+                        }
+                        Err(e) => warn!("could not extract KA public key for validation: {e}"),
+                    }
+                }
+                ka_secret.id = format!("{vta_did}#key-1");
+                secrets_resolver.insert(ka_secret).await;
+            }
+            Err(e) => warn!("failed to derive VTA key-agreement key: {e}"),
+        }
     }
 
     // 3. JWT signing key from config (random key, not BIP-32 derived)

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -662,13 +662,16 @@ fn run_rest_thread(
         let app = traced_routes.merge(routes::health_router().with_state(state));
 
         let shutdown_rx = shutdown_rx.clone();
-        axum::serve(listener, app)
-            .with_graceful_shutdown(async move {
-                let mut rx = shutdown_rx;
-                let _ = rx.changed().await;
-            })
-            .await
-            .expect("axum serve failed");
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .with_graceful_shutdown(async move {
+            let mut rx = shutdown_rx;
+            let _ = rx.changed().await;
+        })
+        .await
+        .expect("axum serve failed");
 
         info!("REST thread shutting down");
     });

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -238,8 +238,7 @@ pub async fn run(
         let webvh_ks = apply_encryption(store.keyspace("webvh")?);
 
         // Initialize auth infrastructure
-        let auth =
-            init_auth(&config, &*seed_store, &keys_ks).await;
+        let auth = init_auth(&config, &*seed_store, &keys_ks).await;
 
         // In TEE required mode, warn if auth isn't initialized.
         #[cfg(feature = "tee")]
@@ -371,15 +370,15 @@ pub async fn run(
                     // Collect secrets using the VM IDs from init_auth (correct for both
                     // did:key and did:webvh — avoids hardcoding #key-0/#key-1 fragments).
                     let mut secrets = Vec::new();
-                    if let Some(ref signing_id) = auth.signing_vm_id {
-                        if let Some(s) = sr.get_secret(signing_id).await {
-                            secrets.push(s);
-                        }
+                    if let Some(ref signing_id) = auth.signing_vm_id
+                        && let Some(s) = sr.get_secret(signing_id).await
+                    {
+                        secrets.push(s);
                     }
-                    if let Some(ref ka_id) = auth.ka_vm_id {
-                        if let Some(s) = sr.get_secret(ka_id).await {
-                            secrets.push(s);
-                        }
+                    if let Some(ref ka_id) = auth.ka_vm_id
+                        && let Some(s) = sr.get_secret(ka_id).await
+                    {
+                        secrets.push(s);
                     }
 
                     let profile = TDKProfile::new(
@@ -784,7 +783,10 @@ async fn init_auth(
             Ok(p) => p,
             Err(e) => {
                 warn!("invalid signing derivation path: {e}");
-                return AuthInit { did_resolver: Some(did_resolver), ..AuthInit::empty() };
+                return AuthInit {
+                    did_resolver: Some(did_resolver),
+                    ..AuthInit::empty()
+                };
             }
         };
         match root.derive(&dp) {
@@ -800,7 +802,10 @@ async fn init_auth(
                     }
                     Err(e) => {
                         warn!("failed to build did:key secrets: {e} — auth will not work");
-                        return AuthInit { did_resolver: Some(did_resolver), ..AuthInit::empty() };
+                        return AuthInit {
+                            did_resolver: Some(did_resolver),
+                            ..AuthInit::empty()
+                        };
                     }
                 }
             }

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -207,6 +207,11 @@ pub enum VtaDidInput {
     Skip,
     /// Use a DID that already exists.
     Existing { did: String },
+    /// Mint a new `did:key` for the VTA. Uses BIP-32-derived Ed25519
+    /// keys from the active seed — same derivation scheme as `did:webvh`
+    /// but no external hosting needed. Ideal for local development and
+    /// deployments that don't need webvh's portability/rotation.
+    CreateDidKey,
     /// Mint a new `did:webvh` for the VTA. Always uses the operations
     /// layer's "simple mode" (VTA generates keys + document).
     CreateWebvh {
@@ -393,6 +398,11 @@ pub async fn apply_inputs(inputs: WizardInputs) -> Result<(), Box<dyn std::error
     let vta_did = match &inputs.vta_did {
         VtaDidInput::Skip => None,
         VtaDidInput::Existing { did } => Some(did.clone()),
+        VtaDidInput::CreateDidKey => {
+            let did =
+                create_vta_did_key("vta", &keys_ks, &contexts_ks, &*wizard_seed_store).await?;
+            Some(did)
+        }
         VtaDidInput::CreateWebvh {
             url,
             portable,
@@ -708,6 +718,88 @@ fn scratch_config_for_seed_store(
         resolver_url: None,
         config_path,
     }
+}
+
+/// Mint a `did:key` for the VTA identity using BIP-32-derived keys from
+/// the active seed. Stores key records (`#key-0` Ed25519 signing,
+/// `#key-1` X25519 key-agreement) so `init_auth` can find them at
+/// startup. No external hosting needed — `did:key` is self-resolving.
+async fn create_vta_did_key(
+    context_id: &str,
+    keys_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use crate::keys;
+    use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
+    use vta_sdk::keys::KeyType as SdkKeyType;
+
+    let active_seed_id = get_active_seed_id(keys_ks).await?;
+    let seed = load_seed_bytes(keys_ks, seed_store, Some(active_seed_id)).await?;
+
+    // Load context to get base derivation path
+    let ctx = crate::contexts::get_context(contexts_ks, context_id)
+        .await
+        .map_err(|e| format!("{e}"))?
+        .ok_or_else(|| format!("context '{context_id}' not found"))?;
+
+    let derived = keys::derive_entity_keys(
+        &seed,
+        &ctx.base_path,
+        "VTA signing key",
+        "VTA key-agreement key",
+        keys_ks,
+    )
+    .await?;
+
+    // Build did:key from the Ed25519 signing public key
+    let did = format!("did:key:{}", derived.signing_pub);
+
+    // Store key records so init_auth can find them at runtime
+    keys::save_key_record(
+        keys_ks,
+        &format!("{did}#key-0"),
+        &derived.signing_path,
+        SdkKeyType::Ed25519,
+        &derived.signing_pub,
+        "VTA signing key",
+        Some(context_id),
+        Some(active_seed_id),
+    )
+    .await?;
+
+    keys::save_key_record(
+        keys_ks,
+        &format!("{did}#key-1"),
+        &derived.ka_path,
+        SdkKeyType::X25519,
+        &derived.ka_pub,
+        "VTA key-agreement key",
+        Some(context_id),
+        Some(active_seed_id),
+    )
+    .await?;
+
+    // Derive and store sealed-transfer key for bootstrap assertions
+    let st = keys::derive_sealed_transfer_key(
+        &seed,
+        &ctx.base_path,
+        "VTA sealed-transfer producer-assertion key",
+        keys_ks,
+    )
+    .await?;
+    keys::save_sealed_transfer_key_record(
+        &did,
+        &st,
+        keys_ks,
+        Some(context_id),
+        Some(active_seed_id),
+    )
+    .await?;
+
+    eprintln!("  Created DID: {did}");
+
+    Ok(did)
 }
 
 /// Mint a `did:webvh` via the operations layer with no interactive

--- a/vta-service/src/status.rs
+++ b/vta-service/src/status.rs
@@ -321,6 +321,8 @@ async fn send_trust_ping(
     let root = ExtendedSigningKey::from_seed(&seed)?;
 
     let keys_ks = store.keyspace("keys")?;
+
+    // Internal storage always uses #key-0/#key-1, regardless of DID method.
     let signing_key_id = format!("{vta_did}#key-0");
     let ka_key_id = format!("{vta_did}#key-1");
 
@@ -328,20 +330,33 @@ async fn send_trust_ping(
         .get(crate::keys::store_key(&signing_key_id))
         .await?
         .ok_or("VTA signing key record not found")?;
-    let ka: KeyRecord = keys_ks
-        .get(crate::keys::store_key(&ka_key_id))
-        .await?
-        .ok_or("VTA key-agreement key record not found")?;
 
     let tdk = TDKSharedState::default().await;
 
-    let mut signing_secret = root.derive_ed25519(&signing.derivation_path)?;
-    signing_secret.id = signing_key_id;
-    tdk.secrets_resolver.insert(signing_secret).await;
+    if vta_did.starts_with("did:key:") {
+        // did:key: X25519 is curve-converted from Ed25519, and verification method
+        // IDs use multibase-encoded public key fragments, not #key-0/#key-1.
+        let dp: ed25519_dalek_bip32::DerivationPath = signing.derivation_path.parse()?;
+        let derived = root.derive(&dp)?;
+        let seed_bytes: &[u8; 32] = derived.signing_key.as_bytes();
+        let secrets = vta_sdk::did_key::secrets_from_did_key(vta_did, seed_bytes)?;
+        tdk.secrets_resolver.insert(secrets.signing).await;
+        tdk.secrets_resolver.insert(secrets.key_agreement).await;
+    } else {
+        // did:webvh / other methods: independently derived keys, #key-0/#key-1 IDs.
+        let ka: KeyRecord = keys_ks
+            .get(crate::keys::store_key(&ka_key_id))
+            .await?
+            .ok_or("VTA key-agreement key record not found")?;
 
-    let mut ka_secret = root.derive_x25519(&ka.derivation_path)?;
-    ka_secret.id = ka_key_id;
-    tdk.secrets_resolver.insert(ka_secret).await;
+        let mut signing_secret = root.derive_ed25519(&signing.derivation_path)?;
+        signing_secret.id = signing_key_id;
+        tdk.secrets_resolver.insert(signing_secret).await;
+
+        let mut ka_secret = root.derive_x25519(&ka.derivation_path)?;
+        ka_secret.id = ka_key_id;
+        tdk.secrets_resolver.insert(ka_secret).await;
+    }
 
     let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
 


### PR DESCRIPTION
## Summary

Adds `did:key`-based VTA identity support for localhost/development VTAs that don't need a `did:webvh` hosted on a public domain.

## Commits

### 1. `fix(vta): add ConnectInfo<SocketAddr> to axum::serve for rate limiter`
The `axum::serve()` call was missing `.into_make_service_with_connect_info::<SocketAddr>()`, causing the `ConnectInfo<SocketAddr>` extractor (used by the rate-limiter middleware) to panic at runtime. Now wired correctly.

### 2. `feat(vta): add create_did_key VTA identity option`
New `create_vta_did_key()` path in TOML-based setup that generates a `did:key` identity from the VTA's BIP-32 seed. Stores Ed25519 (signing) and X25519 (key-agreement) key records. `init_auth()` branches on `did:key:` prefix to use `secrets_from_did_key()` which handles multibase fragment IDs and curve-converted X25519.

### 3. `fix(cli): add P256 support to keys create command`
`pnm keys create --key-type p256` was failing with "unknown key type" even though the VTA server fully supports P256. Root cause: when P256 was added to the server (v0.2.0) and to `cmd_key_import` (v0.3.0), the `cmd_key_create` match arm was only refactored for builder pattern — P256 was never added. Fix adds the missing match arm and updates help text + README for both pnm-cli and cnm-cli.

### 4. `fix: DIDComm fragment-ID mismatch for did:key VTAs`
**Addresses review findings (🔴 merge-blocker + 🟡 + 🟢):**

**🔴 DIDComm fragment-ID mismatch:** `did:key` uses multibase fragment IDs (`{did}#{ed_pub_mb}`) while `did:webvh` uses `#key-0/#key-1`. Two consumer sites hardcoded the webvh convention:
- `server.rs` DIDComm service init → `get_secret("#key-0")` returned None for did:key → TDKProfile got zero secrets
- `status.rs` trust-ping → independently derived X25519 instead of curve-converting from Ed25519

Fix introduces `AuthInit` struct to carry verification-method IDs from `init_auth()` through to consumers, and branches `send_trust_ping()` on DID method.

**🟢 Restored operator-facing log prose** on SIGNING KEY MISMATCH / KEY-AGREEMENT KEY MISMATCH messages.

### 5. `fix(pnm): persist VTA URL for did:key DIDs`
The upstream URL refactor (derive from DID document) breaks `did:key` VTAs — `did:key` has no service endpoints, so `resolve_vta_url()` fails. Fix re-adds `VtaConfig.url` as an optional field used only for DIDs that cannot advertise endpoints:
- Interactive setup prompts for URL when VTA DID is `did:key:`
- Non-interactive requires `--vta-url` flag for `did:key:`
- Client construction uses persisted URL as fallback before DID resolution
- For `did:webvh`, the field stays None (URL derived at runtime)

## Testing
- `cargo test -p vta-service` — 34 tests pass
- `cargo test -p pnm-cli` — 36 tests pass
- Manual: `pnm keys create --key-type p256` works
- Manual: VTA starts with `did:key` identity, `pnm health` reaches it via persisted URL