### PR TITLE
chore(deps): bump affinidi-tdk 0.7.0→0.7.1, tdk-common 0.6.0→0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d404c97e3e486236306a7d46d49b1404cccff6402c6024b5b0664d64813a6c0d"
+checksum = "2e81cd0d2e2de8abfff4b90690fb7a389adfd2bbec388f6ee936541965fe5b87"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802ae641e52f10c753f784b9ba0b405a8b761537c491b2e9e6e8e89cbaa83473"
+checksum = "8a70cf88c7fc0c7dc4fa085ea89efaefd647887b37cff2581c04e120ac3af970"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",


### PR DESCRIPTION
## Summary
- Picks up the just-published patch releases of `affinidi-tdk` (0.7.0 → 0.7.1) and `affinidi-tdk-common` (0.6.0 → 0.6.1) on the existing `^0.7` / `^0.6` workspace pins.
- Lockfile-only change — `Cargo.toml` is untouched, no source edits.
- Verified beforehand against a local `[patch.crates-io]` redirect to the sibling `affinidi-tdk-rs` checkout (the about-to-publish state), then re-verified with the patch removed once the crates landed on crates.io.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — **822 passed, 0 failed, 11 ignored**
- [x] `cargo metadata` confirms zero affinidi-* crates resolving from local paths; all 18 come from `registry+https://github.com/rust-lang/crates.io-index`
- [ ] CI green