### PR TITLE
chore(deny): ignore GHSA-82j2-j2ch-gfr8 (rustls-webpki CRL panic)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -60,6 +60,28 @@ ignore = [
   rustls-webpki 0.101 ships a fix.
   """ },
 
+  { id = "GHSA-82j2-j2ch-gfr8", reason = """
+  rustls-webpki: index-out-of-bounds panic in `bit_string_flags()`
+  reachable through `BorrowedCertRevocationList::from_der()` via the
+  `issuingDistributionPoint` CRL extension when the BIT STRING
+  content is exactly `[0x00]`. Fixed in 0.103.13; 0.101.x and 0.102.x
+  branches are not patched.
+
+  Same precondition and same transitive path as RUSTSEC-2026-0104:
+  the upstream advisory is explicit that "CRL checking is opt-in" —
+  only applications that pass `RevocationOptions` to
+  `verify_for_usage()` and load attacker-influenced CRL bytes are
+  affected. Our 0.101.x copy lives behind AWS SDK's
+  `aws-smithy-http-client` → `hyper-rustls` 0.24 → rustls 0.21 used
+  for AWS API endpoint TLS; that path does not enable revocation
+  checking and never fetches CRLs. The default (and our actual)
+  rustls config is unaffected.
+
+  No RUSTSEC ID assigned at the time of writing (advisory published
+  2026-04-24). Drop when AWS SDK retires the rustls 0.21 code path,
+  or when rustls-webpki 0.101 ships a backported fix.
+  """ },
+
   { id = "RUSTSEC-2025-0134", reason = """
   rustls-pemfile is unmaintained. Pulled transitively (in two
   different versions) through the AWS SDK rustls 0.21 path —


### PR DESCRIPTION
## Summary

- Adds `GHSA-82j2-j2ch-gfr8` to the `deny.toml` advisory ignore list — same family as the existing `RUSTSEC-2026-0098/0099/0104` rustls-webpki ignores.
- The two matching Dependabot alerts (#22, #23) have already been dismissed as `tolerable_risk`.

## What's the advisory?

`rustls-webpki`: index-out-of-bounds panic in `bit_string_flags()` reachable through `BorrowedCertRevocationList::from_der()` via the `issuingDistributionPoint` CRL extension when the BIT STRING content is `[0x00]`. Fixed in 0.103.13. The 0.101.x and 0.102.x release lines are not patched.

## Why we're ignoring it

The upstream advisory is explicit:

> Precondition: CRL checking is opt-in in rustls-webpki. This vulnerability affects only applications that explicitly pass `RevocationOptions` to `verify_for_usage()` and load CRL bytes from a source the attacker can influence. The default rustls configuration (no `RevocationOptions`) is not affected.

Our only `rustls-webpki` 0.101.x is transitive through the AWS SDK rustls 0.21 chain:

```
aws-config → aws-smithy-http-client → hyper-rustls 0.24.2 → rustls 0.21.12 → rustls-webpki 0.101.7
```

That path is used solely for AWS API endpoint TLS (KMS, Secrets Manager, STS). It does not enable revocation checking and never fetches CRLs. Our 0.103.x copy of rustls-webpki is already at the patched 0.103.13.

This is the fourth advisory in the same family — same crate, same transitive path, same null attack surface. Drop all four when AWS SDK retires the rustls 0.21 code path.

## Test plan

- [x] `cargo deny check advisories` clean (only "advisory-not-detected" warnings for already-resolved older entries — separate cleanup).
- [x] Dependabot alerts #22 and #23 dismissed as `tolerable_risk`.