### PR TITLE
test(vta-sdk): add REST + DIDComm coverage harnesses (62% → 81%)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d587ab2b2c982d9f5de4c2bbb78c1c1453e837ceb6837acf8cc7beaa51a864b"
 dependencies = [
  "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk",
+ "affinidi-messaging-sdk 0.17.0",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
  "async-trait",
@@ -303,16 +303,16 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa61f5cbd099b3986ffcefe524f78b14fc82b593564ff625721f1968655ab4d"
+checksum = "41c730596a858bf36acc8ed2127e5175ba8fae328f719bccf551a31bdd4bda1d"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-mediator-common",
- "affinidi-messaging-sdk",
+ "affinidi-messaging-sdk 0.18.0",
  "affinidi-secrets-resolver",
  "ahash 0.8.12",
  "async-convert",
@@ -361,12 +361,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da34b5693b0489f38ce94d0a71fcac9e1753969df5dc3a7ae7ae0fc3fc041ef"
+checksum = "6faadc81a450189b68640e5da379ee49f86d190845499b254ec46b4ed9fdae7c"
 dependencies = [
  "aes-gcm",
- "affinidi-messaging-sdk",
  "ahash 0.8.12",
  "argon2",
  "async-trait",
@@ -382,6 +381,7 @@ dependencies = [
  "num-format",
  "rand 0.10.1",
  "redis",
+ "regex",
  "reqwest 0.13.3",
  "rustls 0.23.40",
  "semver",
@@ -429,15 +429,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "affinidi-messaging-test-mediator"
-version = "0.1.0"
+name = "affinidi-messaging-sdk"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8503e0eac797f071a397a9192d0d3a60bc584e5bcb10b7a2f00fbeb1598651"
+checksum = "9269b5c55e8fd580a399464d9919e04ce5ffb2854d64f3ccea015a47a74a0243"
+dependencies = [
+ "affinidi-did-authentication",
+ "affinidi-did-common",
+ "affinidi-encoding",
+ "affinidi-messaging-didcomm",
+ "affinidi-messaging-mediator-common",
+ "affinidi-secrets-resolver",
+ "affinidi-tdk-common",
+ "ahash 0.8.12",
+ "base64 0.22.1",
+ "futures-util",
+ "regex",
+ "rustls 0.23.40",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "sha256",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "affinidi-messaging-test-mediator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15008eff3383a46c1c7b725456ace0d07e94397b3f4715641fce20827ed59c7"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-mediator",
  "affinidi-messaging-mediator-common",
- "affinidi-messaging-sdk",
+ "affinidi-messaging-sdk 0.18.0",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "async-trait",
@@ -504,7 +533,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-meeting-place",
  "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk",
+ "affinidi-messaging-sdk 0.17.0",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
  "clap",
@@ -8934,10 +8963,13 @@ name = "vti-e2e-tests"
 version = "0.5.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-messaging-sdk 0.17.0",
  "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
+ "ed25519-dalek",
+ "multibase",
  "reqwest 0.13.3",
  "serde_json",
  "tempfile",
@@ -8946,6 +8978,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
  "vta-sdk 0.5.0",
  "vta-service",
  "vti-common",

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -19,7 +19,7 @@ autobins = false
 
 [dev-dependencies]
 # Embedded mediator fixture from affinidi-tdk-rs.
-affinidi-messaging-test-mediator = "0.1"
+affinidi-messaging-test-mediator = "0.2"
 
 # VTA: enable the `test-support` feature so we can stand up complete VTA
 # state (in-memory keyspaces, default `AppConfig`, bootstrap helpers)
@@ -32,10 +32,14 @@ affinidi-tdk = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 affinidi-messaging-sdk = "0.17"
+affinidi-messaging-didcomm = "0.13"
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }
 tempfile = "3"
 reqwest = { workspace = true }
+ed25519-dalek = { workspace = true }
+multibase = { workspace = true }
+uuid = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 serde_json = { workspace = true }

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -1,0 +1,805 @@
+//! Coverage for `VtaClient::Transport::DIDComm` arms — each REST
+//! method's DIDComm path through `session::send_and_wait`.
+//!
+//! Builds a `VtaClient` via `connect_didcomm` against a `TestMediator`
+//! and a `TestVtaResponder` that runs as the VTA. Each test exercises
+//! a single SDK method and asserts the SDK's request shape (msg_type)
+//! and response decoding work end-to-end through the routing/2.0
+//! forward envelope path enforced by the test mediator.
+
+use ed25519_dalek::SigningKey;
+use serde_json::{Value, json};
+use vta_sdk::client::*;
+use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::error::VtaError;
+use vta_sdk::keys::{KeyOrigin, KeyStatus, KeyType};
+use vta_sdk::protocols::key_management::sign::SignAlgorithm;
+use vta_sdk::protocols::{
+    acl_management, audit_management, backup_management, context_management, did_management,
+    did_template_management, discovery, key_management, seed_management, vta_management,
+};
+
+mod common;
+use common::test_vta_responder::{ResponderReply, TestVtaResponder};
+
+// ── Test fixtures ───────────────────────────────────────────────────
+
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = SigningKey::from_bytes(&seed);
+    let pk = sk.verifying_key().to_bytes();
+    let did = format!("did:key:{}", ed25519_multibase_pubkey(&pk));
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    let priv_mb = multibase::encode(multibase::Base::Base58Btc, &buf);
+    (did, priv_mb)
+}
+
+/// Stand up mediator + responder + VtaClient bound to them. Returns
+/// owned handles so the caller controls shutdown order. The handler
+/// receives `(msg_type, body)` and returns a [`ResponderReply`].
+async fn build_didcomm<F>(
+    handler: F,
+) -> (
+    affinidi_messaging_test_mediator::TestMediatorHandle,
+    TestVtaResponder,
+    VtaClient,
+)
+where
+    F: Fn(&str, &Value) -> ResponderReply + Send + Sync + 'static,
+{
+    common::init_tracing();
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (mediator, responder) =
+        TestVtaResponder::spawn_with_mediator(vec![client_did.clone()], handler)
+            .await
+            .expect("responder + mediator spawn");
+    let client = VtaClient::connect_didcomm(
+        &client_did,
+        &client_priv,
+        responder.did(),
+        mediator.did(),
+        None,
+    )
+    .await
+    .expect("client connects via didcomm");
+    (mediator, responder, client)
+}
+
+async fn shutdown_all(
+    client: VtaClient,
+    responder: TestVtaResponder,
+    mediator: affinidi_messaging_test_mediator::TestMediatorHandle,
+) {
+    client.shutdown().await;
+    responder.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins");
+}
+
+fn key_record_json(id: &str) -> Value {
+    json!({
+        "key_id": id,
+        "derivation_path": "m/0/0",
+        "key_type": "ed25519",
+        "status": "active",
+        "public_key": "z6Mkpub",
+        "label": null,
+        "context_id": null,
+        "seed_id": 1,
+        "origin": "derived",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    })
+}
+
+fn context_json(id: &str) -> Value {
+    json!({
+        "id": id,
+        "name": "Primary",
+        "did": "did:web:vta.example.com",
+        "description": null,
+        "base_path": "m/26'/2'/0'",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    })
+}
+
+fn acl_entry_json(did: &str) -> Value {
+    json!({
+        "did": did,
+        "role": "admin",
+        "label": "ops",
+        "allowed_contexts": ["primary"],
+        "created_at": 1_700_000_000_u64,
+        "created_by": "did:web:vta",
+        "expires_at": null
+    })
+}
+
+// ── Discovery / VTA management ──────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn capabilities_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == discovery::DISCOVER_CAPABILITIES {
+            ResponderReply::ok(
+                discovery::DISCOVER_CAPABILITIES_RESULT,
+                json!({
+                    "version": "0.5.0",
+                    "features": {"webvh": true, "didcomm": true, "tee": false, "rest": true},
+                    "services": {"rest": true, "didcomm": true},
+                    "webvh_servers": [],
+                    "did_creation_modes": ["webvh"]
+                }),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let caps = client.capabilities().await.unwrap();
+    assert_eq!(caps.version, "0.5.0");
+    assert!(caps.features.didcomm);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn restart_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == vta_management::RESTART {
+            ResponderReply::ok(
+                vta_management::RESTART_RESULT,
+                json!({"status": "restarting"}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    assert_eq!(client.restart().await.unwrap().status, "restarting");
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_config_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == vta_management::GET_CONFIG {
+            ResponderReply::ok(
+                vta_management::GET_CONFIG_RESULT,
+                json!({
+                    "vta_did": "did:web:vta.example.com",
+                    "vta_name": "primary",
+                    "public_url": "https://vta.example.com"
+                }),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let cfg = client.get_config().await.unwrap();
+    assert_eq!(cfg.community_vta_name.as_deref(), Some("primary"));
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── Keys ────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_keys_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == key_management::LIST_KEYS {
+            ResponderReply::ok(
+                key_management::LIST_KEYS_RESULT,
+                json!({"keys": [key_record_json("k1"), key_record_json("k2")], "total": 2}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let resp = client.list_keys(0, 10, None, None).await.unwrap();
+    assert_eq!(resp.total, 2);
+    assert_eq!(resp.keys.len(), 2);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_key_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == key_management::GET_KEY {
+            ResponderReply::ok(key_management::GET_KEY_RESULT, key_record_json("k1"))
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let key = client.get_key("k1").await.unwrap();
+    assert_eq!(key.key_id, "k1");
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_key_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if msg_type == key_management::CREATE_KEY {
+            assert_eq!(body["key_type"], "ed25519");
+            ResponderReply::ok(
+                key_management::CREATE_KEY_RESULT,
+                json!({
+                    "key_id": "k1",
+                    "key_type": "ed25519",
+                    "derivation_path": "m/0/0",
+                    "public_key": "z6Mkpub",
+                    "status": "active",
+                    "label": null,
+                    "created_at": "2026-01-01T00:00:00Z"
+                }),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let req = CreateKeyRequest::new(KeyType::Ed25519);
+    let resp = client.create_key(req).await.unwrap();
+    assert_eq!(resp.key_id, "k1");
+    assert_eq!(resp.status, KeyStatus::Active);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sign_via_didcomm_round_trips_payload() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if msg_type == key_management::SIGN_REQUEST {
+            // Verify the SDK base64url-encoded the payload.
+            assert_eq!(body["payload"], "aGVsbG8");
+            ResponderReply::ok(
+                key_management::SIGN_RESULT,
+                json!({"key_id": "k1", "signature": "AQID", "algorithm": "eddsa"}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let sig = client
+        .sign("k1", b"hello", SignAlgorithm::EdDSA)
+        .await
+        .unwrap();
+    assert_eq!(sig.signature, "AQID");
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalidate_key_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == key_management::REVOKE_KEY {
+            ResponderReply::ok(
+                key_management::REVOKE_KEY_RESULT,
+                json!({
+                    "key_id": "k1",
+                    "status": "revoked",
+                    "updated_at": "2026-01-01T00:00:00Z"
+                }),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let resp = client.invalidate_key("k1").await.unwrap();
+    assert_eq!(resp.status, KeyStatus::Revoked);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rename_key_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == key_management::RENAME_KEY {
+            ResponderReply::ok(
+                key_management::RENAME_KEY_RESULT,
+                json!({"key_id": "new", "updated_at": "2026-01-01T00:00:00Z"}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let resp = client.rename_key("old", "new").await.unwrap();
+    assert_eq!(resp.key_id, "new");
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn import_key_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == key_management::IMPORT_KEY {
+            ResponderReply::ok(
+                key_management::IMPORT_KEY_RESULT,
+                json!({
+                    "key_id": "imported",
+                    "key_type": "ed25519",
+                    "public_key": "z6Mkpub",
+                    "status": "active",
+                    "label": null,
+                    "origin": "imported",
+                    "created_at": "2026-01-01T00:00:00Z"
+                }),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let req = ImportKeyRequest {
+        key_type: KeyType::Ed25519,
+        private_key_sealed: None,
+        private_key_jwe: None,
+        private_key_multibase: Some("zSeed".into()),
+        label: None,
+        context_id: None,
+    };
+    let resp = client.import_key(req).await.unwrap();
+    assert_eq!(resp.key_id, "imported");
+    assert_eq!(resp.origin, KeyOrigin::Imported);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_key_secret_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == key_management::GET_KEY_SECRET {
+            ResponderReply::ok(
+                key_management::GET_KEY_SECRET_RESULT,
+                json!({
+                    "key_id": "k1",
+                    "key_type": "ed25519",
+                    "public_key_multibase": "z6Mkpub",
+                    "private_key_multibase": "zPriv"
+                }),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let s = client.get_key_secret("k1").await.unwrap();
+    assert_eq!(s.private_key_multibase, "zPriv");
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── Seeds ───────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_seeds_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == seed_management::LIST_SEEDS {
+            ResponderReply::ok(
+                seed_management::LIST_SEEDS_RESULT,
+                json!({
+                    "seeds": [{
+                        "id": 1, "status": "active",
+                        "created_at": "2026-01-01T00:00:00Z", "retired_at": null
+                    }],
+                    "active_seed_id": 1
+                }),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let r = client.list_seeds().await.unwrap();
+    assert_eq!(r.active_seed_id, 1);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rotate_seed_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == seed_management::ROTATE_SEED {
+            ResponderReply::ok(
+                seed_management::ROTATE_SEED_RESULT,
+                json!({"previous_seed_id": 1, "new_seed_id": 2}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let r = client.rotate_seed(None).await.unwrap();
+    assert_eq!(r.new_seed_id, 2);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── ACL ─────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_acl_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == acl_management::LIST_ACL {
+            ResponderReply::ok(
+                acl_management::LIST_ACL_RESULT,
+                json!({"entries": [acl_entry_json("did:key:zAdmin")]}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let r = client.list_acl(None).await.unwrap();
+    assert_eq!(r.entries.len(), 1);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_acl_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == acl_management::CREATE_ACL {
+            ResponderReply::ok(
+                acl_management::CREATE_ACL_RESULT,
+                acl_entry_json("did:key:zAdmin"),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let req = CreateAclRequest::new("did:key:zAdmin", "admin");
+    let resp = client.create_acl(req).await.unwrap();
+    assert_eq!(resp.did, "did:key:zAdmin");
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_acl_via_didcomm_returns_unit() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == acl_management::DELETE_ACL {
+            // rpc_void path: any non-error response works; the SDK
+            // doesn't deserialize the body for unit-returning calls.
+            ResponderReply::ok(acl_management::DELETE_ACL_RESULT, json!({}))
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    client.delete_acl("did:key:zAdmin").await.unwrap();
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_acl_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == acl_management::UPDATE_ACL {
+            ResponderReply::ok(
+                acl_management::UPDATE_ACL_RESULT,
+                acl_entry_json("did:key:zAdmin"),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let req = UpdateAclRequest {
+        role: Some("reader".into()),
+        label: None,
+        allowed_contexts: None,
+    };
+    client.update_acl("did:key:zAdmin", req).await.unwrap();
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── Contexts ────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_contexts_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == context_management::LIST_CONTEXTS {
+            ResponderReply::ok(
+                context_management::LIST_CONTEXTS_RESULT,
+                json!({"contexts": [context_json("primary")]}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let r = client.list_contexts().await.unwrap();
+    assert_eq!(r.contexts.len(), 1);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_context_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == context_management::CREATE_CONTEXT {
+            ResponderReply::ok(
+                context_management::CREATE_CONTEXT_RESULT,
+                context_json("primary"),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let req = CreateContextRequest::new("primary", "Primary");
+    client.create_context(req).await.unwrap();
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_context_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if msg_type == context_management::DELETE_CONTEXT {
+            assert_eq!(body["force"], true);
+            ResponderReply::ok(context_management::DELETE_CONTEXT_RESULT, json!({}))
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    client.delete_context("primary", true).await.unwrap();
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── Audit ───────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_audit_retention_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == audit_management::GET_RETENTION {
+            ResponderReply::ok(
+                audit_management::GET_RETENTION_RESULT,
+                json!({"retention_days": 90}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let r = client.get_audit_retention().await.unwrap();
+    assert_eq!(r.retention_days, 90);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── DID templates ───────────────────────────────────────────────────
+
+fn template_record_json(name: &str) -> Value {
+    json!({
+        "schemaVersion": 1,
+        "name": name,
+        "kind": "custom",
+        "description": null,
+        "methods": [],
+        "requiredVars": [],
+        "optionalVars": {},
+        "defaults": {},
+        "document": {"id": "{DID}"},
+        "scope": {"type": "global"},
+        "created_at": 1_700_000_000_u64,
+        "updated_at": 1_700_000_000_u64,
+        "created_by": "did:web:vta"
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_did_templates_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == did_template_management::LIST_TEMPLATES {
+            ResponderReply::ok(
+                did_template_management::LIST_TEMPLATES_RESULT,
+                json!({"templates": [template_record_json("custom-1")]}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let r = client.list_did_templates().await.unwrap();
+    assert_eq!(r.len(), 1);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── WebVH ────────────────────────────────────────────────────────────
+
+fn webvh_did_record_json(did: &str) -> Value {
+    json!({
+        "did": did,
+        "server_id": "s1",
+        "mnemonic": "",
+        "scid": "Qabc",
+        "context_id": "primary",
+        "portable": false,
+        "log_entry_count": 1,
+        "pre_rotation_count": 0,
+        "next_fragment_id": 1,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_dids_webvh_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == did_management::LIST_DIDS_WEBVH {
+            ResponderReply::ok(
+                did_management::LIST_DIDS_WEBVH_RESULT,
+                json!({"dids": [webvh_did_record_json("did:webvh:abc")]}),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let r = client.list_dids_webvh(None, None).await.unwrap();
+    assert_eq!(r.dids.len(), 1);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_did_webvh_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == did_management::DELETE_DID_WEBVH {
+            ResponderReply::ok(did_management::DELETE_DID_WEBVH_RESULT, json!({}))
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    client.delete_did_webvh("did:webvh:abc").await.unwrap();
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── Backup ──────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn backup_export_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
+        if msg_type == backup_management::EXPORT_BACKUP {
+            ResponderReply::ok(
+                backup_management::EXPORT_BACKUP_RESULT,
+                json!({
+                    "version": 1,
+                    "format": "vtabak/v1",
+                    "created_at": "2026-05-05T12:00:00Z",
+                    "source_version": "0.5.0",
+                    "kdf": {"algorithm": "argon2id", "salt": "AAAA", "m_cost": 65536, "t_cost": 3, "p_cost": 4},
+                    "encryption": {"algorithm": "AES-256-GCM", "nonce": "AAAA"},
+                    "includes_audit": false,
+                    "ciphertext": "AAAA"
+                }),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    let env = client.backup_export("hunter2hunter2", false).await.unwrap();
+    assert_eq!(env.version, 1);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── Error mapping through the rpc layer ─────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_keys_problem_report_maps_to_typed_error() {
+    let (mediator, responder, client) = build_didcomm(|_msg_type, _body| {
+        ResponderReply::problem_report("e.p.msg.unauthorized", "expired token")
+    })
+    .await;
+
+    let err = client.list_keys(0, 10, None, None).await.unwrap_err();
+    assert!(matches!(err, VtaError::Auth(_)), "got {err:?}");
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_keys_unknown_problem_code_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|_msg_type, _body| {
+        ResponderReply::problem_report("e.custom.weird", "domain-specific")
+    })
+    .await;
+
+    let err = client.list_keys(0, 10, None, None).await.unwrap_err();
+    match err {
+        VtaError::DidcommRemote { code, .. } => assert_eq!(code, "e.custom.weird"),
+        other => panic!("expected DidcommRemote, got {other:?}"),
+    }
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── Unsupported-transport branches ──────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_wrapping_key_returns_unsupported_transport_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|_, _| ResponderReply::Drop).await;
+
+    let err = client.get_wrapping_key().await.unwrap_err();
+    assert!(
+        matches!(err, VtaError::UnsupportedTransport(_)),
+        "got {err:?}"
+    );
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn health_via_didcomm_without_rest_url_is_unsupported_transport() {
+    let (mediator, responder, client) = build_didcomm(|_, _| ResponderReply::Drop).await;
+
+    // `connect_didcomm` was called with `rest_url: None`, so the
+    // DIDComm transport's `health()` arm rejects with
+    // `UnsupportedTransport`.
+    let err = client.health().await.unwrap_err();
+    assert!(
+        matches!(err, VtaError::UnsupportedTransport(_)),
+        "got {err:?}"
+    );
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── check_auth: DIDComm-side always returns true ────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn check_auth_via_didcomm_always_true() {
+    let (mediator, responder, client) = build_didcomm(|_, _| ResponderReply::Drop).await;
+
+    // Documented behavior: DIDComm sessions are always authenticated.
+    assert!(client.check_auth().await.unwrap());
+
+    shutdown_all(client, responder, mediator).await;
+}

--- a/tests/e2e/tests/common/mod.rs
+++ b/tests/e2e/tests/common/mod.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 
 pub mod test_vta;
+pub mod test_vta_responder;
 
 use std::sync::Once;
 

--- a/tests/e2e/tests/common/test_vta_responder.rs
+++ b/tests/e2e/tests/common/test_vta_responder.rs
@@ -1,0 +1,421 @@
+//! VTA-side DIDComm responder for SDK round-trip tests.
+//!
+//! [`TestVtaResponder`] spawns a `did:peer:2.*` identity, registers
+//! itself as a LOCAL account on the supplied test mediator, opens a
+//! WebSocket inbound stream, and dispatches each incoming message to a
+//! caller-supplied handler. The handler returns either a typed result
+//! payload (msg_type + body) or a problem-report code/comment, which
+//! the responder packs as a DIDComm reply (with `thid` threaded back to
+//! the requester) and sends through the mediator.
+//!
+//! This is the harness that lets the SDK's `Transport::DIDComm` arms
+//! and `session::send_and_wait` success paths be exercised in a test
+//! — without it the SDK can `pack_encrypted` and `send_message` but
+//! never sees a matching response, so the entire response-handling
+//! branch (problem-report decoding, type-check, deserialize) stays
+//! uncovered.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let mediator = TestMediator::builder()
+//!     .local_did(client_did.clone())
+//!     .spawn().await.unwrap();
+//! let responder = TestVtaResponder::spawn(
+//!     mediator.did(),
+//!     |msg_type, _body| {
+//!         if msg_type.ends_with("/list-keys") {
+//!             ResponderReply::ok(
+//!                 format!("{msg_type}-result"),
+//!                 json!({"keys": [], "total": 0}),
+//!             )
+//!         } else {
+//!             ResponderReply::problem_report(
+//!                 "e.p.msg.not-found",
+//!                 format!("no handler for {msg_type}"),
+//!             )
+//!         }
+//!     },
+//! ).await.unwrap();
+//! // build a VtaClient via connect_didcomm(... responder.did(), mediator.did(), None)
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use affinidi_messaging_test_mediator::{TestMediator, TestMediatorHandle};
+use affinidi_secrets_resolver::SecretsResolver;
+use affinidi_secrets_resolver::secrets::Secret;
+use affinidi_tdk::common::TDKSharedState;
+use affinidi_tdk::common::config::TDKConfig;
+use affinidi_tdk::didcomm::Message;
+use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
+use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::config::ATMConfig;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use serde_json::Value;
+use tokio::sync::oneshot;
+
+/// Reply the responder builds for an inbound message.
+pub enum ResponderReply {
+    /// Successful result. `result_type` is the DIDComm `typ` field of
+    /// the reply (typically the request `typ` with `-result` suffix);
+    /// `body` is the JSON the SDK will deserialize into its `T`.
+    Ok { result_type: String, body: Value },
+    /// Problem report. The SDK maps `e.p.msg.{conflict,not-found,
+    /// unauthorized,bad-request,internal-error}` to typed `VtaError`
+    /// variants; everything else lands in `VtaError::DidcommRemote`.
+    Problem { code: String, comment: String },
+    /// No reply at all — used to test the `send_and_wait` timeout path.
+    Drop,
+}
+
+impl ResponderReply {
+    pub fn ok(result_type: impl Into<String>, body: Value) -> Self {
+        Self::Ok {
+            result_type: result_type.into(),
+            body,
+        }
+    }
+
+    pub fn problem_report(code: impl Into<String>, comment: impl Into<String>) -> Self {
+        Self::Problem {
+            code: code.into(),
+            comment: comment.into(),
+        }
+    }
+}
+
+/// Errors from the responder fixture itself.
+#[derive(Debug, thiserror::Error)]
+pub enum ResponderError {
+    #[error("did:peer generation failed: {0}")]
+    DidGeneration(String),
+    #[error("TDK init failed: {0}")]
+    TdkInit(String),
+    #[error("ATM init failed: {0}")]
+    AtmInit(String),
+    #[error("profile creation failed: {0}")]
+    Profile(String),
+    #[error("websocket enable failed: {0}")]
+    Websocket(String),
+}
+
+/// A `did:peer:2`-identified DIDComm responder, listening on a
+/// supplied test mediator. Drop or call [`Self::shutdown`] to tear it
+/// down cleanly.
+pub struct TestVtaResponder {
+    pub did: String,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    join_handle: tokio::task::JoinHandle<()>,
+}
+
+impl TestVtaResponder {
+    /// Spawn a responder that runs `handler` for every inbound DIDComm
+    /// message until `shutdown` is called. The handler must be
+    /// `Send + Sync + 'static` because it runs in a tokio task on the
+    /// shared runtime.
+    pub async fn spawn<F>(mediator_did: &str, handler: F) -> Result<Self, ResponderError>
+    where
+        F: Fn(&str, &Value) -> ResponderReply + Send + Sync + 'static,
+    {
+        // 1. Mint a fresh did:peer:2 identity.
+        let (did, secrets) = DID::generate_did_peer(
+            vec![
+                (PeerKeyRole::Verification, KeyType::Ed25519),
+                (PeerKeyRole::Encryption, KeyType::X25519),
+            ],
+            None,
+        )
+        .map_err(|e| ResponderError::DidGeneration(e.to_string()))?;
+
+        // 2. Stand up TDK + ATM + profile.
+        let tdk = TDKSharedState::new(
+            TDKConfig::builder()
+                .build()
+                .map_err(|e| ResponderError::TdkInit(format!("config: {e}")))?,
+        )
+        .await
+        .map_err(|e| ResponderError::TdkInit(e.to_string()))?;
+        for s in &secrets {
+            tdk.secrets_resolver().insert(s.clone()).await;
+        }
+
+        let atm = ATM::new(
+            ATMConfig::builder()
+                .build()
+                .map_err(|e| ResponderError::AtmInit(format!("config: {e}")))?,
+            Arc::new(tdk),
+        )
+        .await
+        .map_err(|e| ResponderError::AtmInit(e.to_string()))?;
+        let atm = Arc::new(atm);
+
+        let profile = ATMProfile::new(&atm, None, did.clone(), Some(mediator_did.to_string()))
+            .await
+            .map_err(|e| ResponderError::Profile(e.to_string()))?;
+        let profile = Arc::new(profile);
+
+        // 3. Open inbound WebSocket so live_stream_next has a channel.
+        atm.profile_enable_websocket(&profile)
+            .await
+            .map_err(|e| ResponderError::Websocket(e.to_string()))?;
+
+        // 4. Spawn the dispatch loop.
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+        let handler = Arc::new(handler);
+        let responder_did = did.clone();
+        let atm_loop = atm.clone();
+        let profile_loop = profile.clone();
+        let join_handle = tokio::spawn(async move {
+            run_dispatch_loop(
+                atm_loop,
+                profile_loop,
+                responder_did,
+                handler,
+                &mut shutdown_rx,
+            )
+            .await;
+        });
+
+        Ok(Self {
+            did,
+            shutdown_tx: Some(shutdown_tx),
+            join_handle,
+        })
+    }
+
+    /// Convenience: spawn a responder that registers itself as
+    /// `local_did` on a fresh `TestMediator`. `extra_local_dids` lets
+    /// the caller register additional client DIDs (which also need
+    /// the LOCAL bit to open WebSocket inbound to the same mediator)
+    /// in one shot. Returns both handles so the test owns their
+    /// lifetimes.
+    pub async fn spawn_with_mediator<F>(
+        extra_local_dids: Vec<String>,
+        handler: F,
+    ) -> Result<(TestMediatorHandle, Self), ResponderError>
+    where
+        F: Fn(&str, &Value) -> ResponderReply + Send + Sync + 'static,
+    {
+        // We need the responder DID *before* spawning the mediator so
+        // we can register it as LOCAL. Generate it inline here, then
+        // pass the secrets through to a dedicated constructor.
+        let (did, secrets) = DID::generate_did_peer(
+            vec![
+                (PeerKeyRole::Verification, KeyType::Ed25519),
+                (PeerKeyRole::Encryption, KeyType::X25519),
+            ],
+            None,
+        )
+        .map_err(|e| ResponderError::DidGeneration(e.to_string()))?;
+
+        let mut builder = TestMediator::builder().local_did(did.clone());
+        for extra in &extra_local_dids {
+            builder = builder.local_did(extra.clone());
+        }
+        let mediator = builder
+            .spawn()
+            .await
+            .map_err(|e| ResponderError::AtmInit(format!("test mediator spawn: {e}")))?;
+
+        let responder =
+            Self::spawn_with_existing_identity(mediator.did(), did, secrets, handler).await?;
+
+        Ok((mediator, responder))
+    }
+
+    async fn spawn_with_existing_identity<F>(
+        mediator_did: &str,
+        did: String,
+        secrets: Vec<Secret>,
+        handler: F,
+    ) -> Result<Self, ResponderError>
+    where
+        F: Fn(&str, &Value) -> ResponderReply + Send + Sync + 'static,
+    {
+        let tdk = TDKSharedState::new(
+            TDKConfig::builder()
+                .build()
+                .map_err(|e| ResponderError::TdkInit(format!("config: {e}")))?,
+        )
+        .await
+        .map_err(|e| ResponderError::TdkInit(e.to_string()))?;
+        for s in &secrets {
+            tdk.secrets_resolver().insert(s.clone()).await;
+        }
+
+        let atm = ATM::new(
+            ATMConfig::builder()
+                .build()
+                .map_err(|e| ResponderError::AtmInit(format!("config: {e}")))?,
+            Arc::new(tdk),
+        )
+        .await
+        .map_err(|e| ResponderError::AtmInit(e.to_string()))?;
+        let atm = Arc::new(atm);
+
+        let profile = ATMProfile::new(&atm, None, did.clone(), Some(mediator_did.to_string()))
+            .await
+            .map_err(|e| ResponderError::Profile(e.to_string()))?;
+        let profile = Arc::new(profile);
+
+        atm.profile_enable_websocket(&profile)
+            .await
+            .map_err(|e| ResponderError::Websocket(e.to_string()))?;
+
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+        let handler = Arc::new(handler);
+        let responder_did = did.clone();
+        let atm_loop = atm.clone();
+        let profile_loop = profile.clone();
+        let join_handle = tokio::spawn(async move {
+            run_dispatch_loop(
+                atm_loop,
+                profile_loop,
+                responder_did,
+                handler,
+                &mut shutdown_rx,
+            )
+            .await;
+        });
+
+        Ok(Self {
+            did,
+            shutdown_tx: Some(shutdown_tx),
+            join_handle,
+        })
+    }
+
+    pub fn did(&self) -> &str {
+        &self.did
+    }
+
+    /// Stop the dispatch loop and wait for the task to finish. Safe to
+    /// call multiple times — subsequent calls are no-ops.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        // Fire-and-forget join; we tolerate errors (the dispatch loop
+        // can exit on its own if the mediator drops the connection).
+        let _ = self.join_handle.await;
+    }
+}
+
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// The dispatch loop: receive → handle → reply, until shutdown.
+///
+/// The mediator refuses direct delivery of inner messages, so the
+/// reply path is two hops:
+///   1. Pack the application reply encrypted to the requester (inner JWE).
+///   2. Wrap the inner JWE in a `routing/2.0/forward` envelope addressed
+///      to the mediator (with `next = requester_did`), pack that
+///      anoncrypt to the mediator, and ship it.
+/// The mediator unpacks the outer envelope, sees the `next` hop, and
+/// queues the inner JWE for the requester's pickup.
+async fn run_dispatch_loop<F>(
+    atm: Arc<ATM>,
+    profile: Arc<ATMProfile>,
+    responder_did: String,
+    handler: Arc<F>,
+    shutdown_rx: &mut oneshot::Receiver<()>,
+) where
+    F: Fn(&str, &Value) -> ResponderReply + Send + Sync + 'static,
+{
+    let mediator_did = profile
+        .inner
+        .mediator
+        .as_ref()
+        .as_ref()
+        .map(|m| m.did.clone())
+        .unwrap_or_default();
+
+    loop {
+        if shutdown_rx.try_recv().is_ok() {
+            break;
+        }
+
+        let next = atm
+            .message_pickup()
+            .live_stream_next(&profile, Some(POLL_INTERVAL), true)
+            .await;
+
+        let Ok(Some((msg, _meta))) = next else {
+            continue;
+        };
+
+        // Skip problem-reports — replying to them would feed the
+        // mediator's policy back into the loop and spin.
+        if msg.typ.contains("problem-report") || msg.typ.contains("report-problem") {
+            continue;
+        }
+
+        // Skip forward envelopes that arrive un-unwrapped (defensive —
+        // ATM's `unpack_forwards: true` should have unwrapped them
+        // already, but if not, re-dispatch would treat the envelope as
+        // an application message).
+        if msg.typ == "https://didcomm.org/routing/2.0/forward" {
+            continue;
+        }
+
+        let Some(sender) = msg.from.clone() else {
+            continue;
+        };
+
+        let reply = handler(&msg.typ, &msg.body);
+        let (result_type, body) = match reply {
+            ResponderReply::Ok { result_type, body } => (result_type, body),
+            ResponderReply::Problem { code, comment } => (
+                "https://didcomm.org/report-problem/2.0/problem-report".to_string(),
+                serde_json::json!({ "code": code, "comment": comment }),
+            ),
+            ResponderReply::Drop => continue,
+        };
+
+        let reply_id = uuid::Uuid::new_v4().to_string();
+        let reply_msg = Message::build(reply_id.clone(), result_type, body)
+            .from(responder_did.clone())
+            .to(sender.clone())
+            .thid(msg.id.clone())
+            .finalize();
+
+        // Step 1: authcrypt the inner reply to the requester.
+        let inner_jwe = match atm
+            .pack_encrypted(
+                &reply_msg,
+                &sender,
+                Some(&responder_did),
+                Some(&responder_did),
+            )
+            .await
+        {
+            Ok((p, _)) => p,
+            Err(_) => continue,
+        };
+
+        // Step 2: hand off to the SDK's forward+send helper, which
+        // wraps the inner JWE in a `routing/2.0/forward` envelope and
+        // authcrypts it to the mediator (matches the strict
+        // `local_direct_delivery_allowed: false` policy).
+        if mediator_did.is_empty() {
+            continue;
+        }
+        let _ = atm
+            .forward_and_send_message(
+                &profile,
+                false, // authcrypt the forward envelope
+                &inner_jwe,
+                Some(&reply_id),
+                &mediator_did,
+                &sender,
+                None,
+                None,
+                false,
+            )
+            .await;
+    }
+
+    atm.graceful_shutdown().await;
+}

--- a/tests/e2e/tests/didcomm_session.rs
+++ b/tests/e2e/tests/didcomm_session.rs
@@ -1,0 +1,315 @@
+//! Coverage for `vta_sdk::didcomm_session::DIDCommSession` against a
+//! live `TestMediator`. The session module is heavyweight — it sets up
+//! a TDK runtime, resolves DIDs over a real cache, opens a WebSocket
+//! to the mediator, and exchanges DIDComm messages. wiremock can't
+//! stand in here, so these tests run against the embedded mediator.
+//!
+//! The success-direction round-trip (`send_and_wait` returning a
+//! valid response) needs a live VTA-side responder, which is too
+//! heavy for the harness; we cover that path via the timeout branch
+//! and the unreachable-mediator branch instead. Together they
+//! exercise the entire `connect` flow plus the `send_and_wait`
+//! pack/send path up to the response-wait loop.
+
+use std::time::Duration;
+
+use affinidi_messaging_test_mediator::TestMediator;
+use ed25519_dalek::SigningKey;
+use serde_json::json;
+use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::didcomm_session::DIDCommSession;
+use vta_sdk::error::VtaError;
+
+mod common;
+use common::test_vta_responder::{ResponderReply, TestVtaResponder};
+
+/// Build a deterministic `did:key` + matching multibase private-key
+/// string from a seed byte. Mirrors the helper used in the SDK's REST
+/// test harnesses; kept inline here so this binary stays self-contained.
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = SigningKey::from_bytes(&seed);
+    let pk = sk.verifying_key().to_bytes();
+    let did = format!("did:key:{}", ed25519_multibase_pubkey(&pk));
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    let priv_mb = multibase::encode(multibase::Base::Base58Btc, &buf);
+    (did, priv_mb)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connect_via_live_mediator_succeeds() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+
+    // Mediator must accept the client DID as a LOCAL account so the
+    // WebSocket upgrade succeeds (matching the pattern used in
+    // `transient_handshake.rs`).
+    let mediator = TestMediator::builder()
+        .local_did(client_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let session = DIDCommSession::connect(&client_did, &client_priv, &vta_did, mediator.did())
+        .await
+        .expect("DIDComm session connects against live mediator");
+
+    // Clean shutdown must not panic.
+    session.shutdown().await;
+
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_and_wait_times_out_when_no_responder() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+
+    let mediator = TestMediator::builder()
+        .local_did(client_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let session = DIDCommSession::connect(&client_did, &client_priv, &vta_did, mediator.did())
+        .await
+        .expect("session connects");
+
+    // No VTA listening on `vta_did`, so `send_and_wait` packs +
+    // sends successfully but never sees a matching response.
+    let timeout_secs = 2;
+    let start = std::time::Instant::now();
+    let result: Result<serde_json::Value, _> = session
+        .send_and_wait(
+            "https://example.com/protocols/test/1.0/ping",
+            serde_json::json!({}),
+            "https://example.com/protocols/test/1.0/pong",
+            timeout_secs,
+        )
+        .await;
+    let elapsed = start.elapsed();
+
+    let err = result.expect_err("must time out");
+    assert!(
+        matches!(err, VtaError::DidcommTransport(ref msg) if msg.contains("timeout")),
+        "expected DidcommTransport timeout, got {err:?}"
+    );
+
+    // The timeout should hit close to the requested duration, not
+    // multiples of it (catching regressions in the wait loop's
+    // deadline arithmetic).
+    assert!(
+        elapsed < Duration::from_secs(timeout_secs * 2 + 5),
+        "send_and_wait honored timeout poorly: {elapsed:?}"
+    );
+
+    session.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connect_fails_when_mediator_did_unresolvable() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+
+    // `did:peer:2.unresolvable` is syntactically valid but the cache
+    // resolver rejects it before any network round-trip — same fixture
+    // pattern used in `transient_handshake.rs`.
+    let bogus_mediator = "did:peer:2.unresolvable";
+
+    let result = DIDCommSession::connect(&client_did, &client_priv, &vta_did, bogus_mediator).await;
+    assert!(
+        result.is_err(),
+        "connect against unresolvable mediator must fail"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_and_wait_round_trip_success() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (mediator, responder) =
+        TestVtaResponder::spawn_with_mediator(vec![client_did.clone()], |msg_type, _body| {
+            if msg_type.ends_with("/list-keys") {
+                ResponderReply::ok(
+                    format!("{msg_type}-result"),
+                    json!({"keys": [], "total": 0}),
+                )
+            } else {
+                ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+            }
+        })
+        .await
+        .expect("responder spawns with mediator");
+
+    let session =
+        DIDCommSession::connect(&client_did, &client_priv, responder.did(), mediator.did())
+            .await
+            .expect("session connects");
+
+    let resp: serde_json::Value = session
+        .send_and_wait(
+            "https://firstperson.network/protocols/key-management/1.0/list-keys",
+            json!({"offset": 0, "limit": 10}),
+            "https://firstperson.network/protocols/key-management/1.0/list-keys-result",
+            10,
+        )
+        .await
+        .expect("round-trip returns the responder's body");
+
+    assert_eq!(resp["total"], 0);
+    assert!(resp["keys"].as_array().unwrap().is_empty());
+
+    session.shutdown().await;
+    responder.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_and_wait_problem_report_maps_to_typed_error() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (mediator, responder) =
+        TestVtaResponder::spawn_with_mediator(vec![client_did.clone()], |_msg_type, _body| {
+            ResponderReply::problem_report("e.p.msg.conflict", "key already exists")
+        })
+        .await
+        .expect("responder spawns");
+
+    let session =
+        DIDCommSession::connect(&client_did, &client_priv, responder.did(), mediator.did())
+            .await
+            .expect("session connects");
+
+    let err = session
+        .send_and_wait::<serde_json::Value>(
+            "https://firstperson.network/protocols/key-management/1.0/create-key",
+            json!({}),
+            "https://firstperson.network/protocols/key-management/1.0/create-key-result",
+            10,
+        )
+        .await
+        .expect_err("problem report propagates");
+
+    assert!(err.is_conflict(), "got {err:?}");
+
+    session.shutdown().await;
+    responder.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_and_wait_unknown_problem_code_lands_in_didcomm_remote() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (mediator, responder) =
+        TestVtaResponder::spawn_with_mediator(vec![client_did.clone()], |_msg_type, _body| {
+            ResponderReply::problem_report("e.custom.unique", "domain-specific failure")
+        })
+        .await
+        .expect("responder spawns");
+
+    let session =
+        DIDCommSession::connect(&client_did, &client_priv, responder.did(), mediator.did())
+            .await
+            .expect("session connects");
+
+    let err = session
+        .send_and_wait::<serde_json::Value>(
+            "https://firstperson.network/protocols/key-management/1.0/get-key",
+            json!({"key_id": "x"}),
+            "https://firstperson.network/protocols/key-management/1.0/get-key-result",
+            10,
+        )
+        .await
+        .expect_err("unknown problem code propagates");
+
+    match err {
+        VtaError::DidcommRemote { code, .. } => {
+            assert_eq!(code, "e.custom.unique");
+        }
+        other => panic!("expected DidcommRemote, got {other:?}"),
+    }
+
+    session.shutdown().await;
+    responder.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_and_wait_wrong_response_type_is_protocol_error() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (mediator, responder) =
+        TestVtaResponder::spawn_with_mediator(vec![client_did.clone()], |_msg_type, _body| {
+            ResponderReply::ok(
+                "https://example.com/something/different/1.0/result",
+                json!({"unexpected": true}),
+            )
+        })
+        .await
+        .expect("responder spawns");
+
+    let session =
+        DIDCommSession::connect(&client_did, &client_priv, responder.did(), mediator.did())
+            .await
+            .expect("session connects");
+
+    let err = session
+        .send_and_wait::<serde_json::Value>(
+            "https://firstperson.network/protocols/key-management/1.0/list-keys",
+            json!({}),
+            "https://firstperson.network/protocols/key-management/1.0/list-keys-result",
+            10,
+        )
+        .await
+        .expect_err("wrong type triggers Protocol error");
+
+    match err {
+        VtaError::Protocol(msg) => assert!(
+            msg.contains("unexpected response type"),
+            "expected 'unexpected response type' guidance, got: {msg}"
+        ),
+        other => panic!("expected Protocol, got {other:?}"),
+    }
+
+    session.shutdown().await;
+    responder.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connect_fails_with_invalid_private_key() {
+    common::init_tracing();
+
+    // `did:key:` for the client but a private-key multibase that
+    // doesn't decode to 32 bytes — caught by
+    // `decode_private_key_multibase` before any network call.
+    let (client_did, _) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let bogus_mediator_did = "did:peer:2.med";
+
+    let result =
+        DIDCommSession::connect(&client_did, "z2truncated", &vta_did, bogus_mediator_did).await;
+    assert!(
+        result.is_err(),
+        "invalid private key must surface as an error"
+    );
+}

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -179,9 +179,34 @@ impl DIDCommSession {
 
         debug!(msg_type, msg_id, "sending via DIDComm");
 
-        // Send the message (fire-and-forget to mediator, don't wait for response)
+        // Wrap the inner JWE in a `routing/2.0/forward` envelope addressed
+        // to the mediator and ship it. Strict mediators
+        // (`local_direct_delivery_allowed: false`) refuse direct delivery
+        // — same path the production VTA-side `affinidi-messaging-didcomm-service`
+        // takes via `forward_and_send_message`.
+        let mediator_did = self
+            .profile
+            .inner
+            .mediator
+            .as_ref()
+            .as_ref()
+            .map(|m| m.did.clone())
+            .ok_or_else(|| {
+                VtaError::DidcommTransport("no mediator configured on profile".into())
+            })?;
+
         self.atm
-            .send_message(&self.profile, &packed, &msg_id, false, false)
+            .forward_and_send_message(
+                &self.profile,
+                false, // authcrypt the forward envelope (mediator policy)
+                &packed,
+                Some(&msg_id),
+                &mediator_did,
+                &self.vta_did,
+                None,
+                None,
+                false,
+            )
             .await
             .map_err(|e| VtaError::DidcommTransport(format!("failed to send message: {e}")))?;
 

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -1,0 +1,529 @@
+//! Coverage harness for `vta_sdk::auth_light` and the auth-touching
+//! paths in `vta_sdk::client::VtaClient` (`from_credential`,
+//! `ensure_token_valid` refresh-on-expiry, full re-auth fallback).
+//!
+//! All tests run against a `wiremock` server. Where a real `did:key` is
+//! required for DIDComm anoncrypt packing, we derive one from a fixed
+//! seed via `ed25519_dalek` + the SDK's own multibase helpers — no
+//! private key material leaves the test process.
+
+#![cfg(feature = "client")]
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ed25519_dalek::SigningKey;
+use serde_json::json;
+use vta_sdk::auth_light::{
+    authenticate_with_credential, challenge_response_light, refresh_token_light,
+};
+use vta_sdk::client::VtaClient;
+use vta_sdk::credentials::CredentialBundle;
+use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::error::VtaError;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── Test fixtures ───────────────────────────────────────────────────
+
+/// Build a deterministic `did:key` + matching multibase private-key
+/// string from a seed byte. Both client and VTA DIDs need to be valid
+/// `did:key`s because `auth_light` calls `pack_auth_message`, which
+/// derives X25519 keys from the embedded Ed25519 multibase.
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = SigningKey::from_bytes(&seed);
+    let pk = sk.verifying_key().to_bytes();
+    let did = format!("did:key:{}", ed25519_multibase_pubkey(&pk));
+    // Multicodec Ed25519 private-key prefix (0x1300 → varint 0x80 0x26)
+    // followed by the 32-byte seed, base58btc multibase encoded.
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    let priv_mb = multibase::encode(multibase::Base::Base58Btc, &buf);
+    (did, priv_mb)
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+async fn mount_challenge(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/auth/challenge"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess-test",
+            "data": { "challenge": "c-nonce-123" }
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_authenticate(server: &MockServer, expires_at: u64) {
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess-test",
+            "data": {
+                "accessToken": "access-jwt",
+                "accessExpiresAt": expires_at,
+                "refreshToken": "refresh-tok",
+                "refreshExpiresAt": expires_at + 3600
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+// ── challenge_response_light ────────────────────────────────────────
+
+#[tokio::test]
+async fn challenge_response_success_returns_tokens() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    mount_authenticate(&server, 1_700_001_000).await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let http = reqwest::Client::new();
+
+    let result =
+        challenge_response_light(&http, &server.uri(), &client_did, &client_priv, &vta_did)
+            .await
+            .unwrap();
+
+    assert_eq!(result.access_token, "access-jwt");
+    assert_eq!(result.access_expires_at, 1_700_001_000);
+    assert_eq!(result.refresh_token.as_deref(), Some("refresh-tok"));
+    assert_eq!(result.refresh_expires_at, Some(1_700_001_000 + 3600));
+}
+
+#[tokio::test]
+async fn challenge_endpoint_401_maps_to_auth() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/auth/challenge"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("not authorized"))
+        .mount(&server)
+        .await;
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let http = reqwest::Client::new();
+    let err = challenge_response_light(&http, &server.uri(), &client_did, &client_priv, &vta_did)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, VtaError::Auth(_)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn challenge_endpoint_500_maps_to_server() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/auth/challenge"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .mount(&server)
+        .await;
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let http = reqwest::Client::new();
+    let err = challenge_response_light(&http, &server.uri(), &client_did, &client_priv, &vta_did)
+        .await
+        .unwrap_err();
+    match err {
+        VtaError::Server { status, .. } => assert_eq!(status, 500),
+        other => panic!("expected Server, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn authenticate_endpoint_401_maps_to_auth() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("bad challenge"))
+        .mount(&server)
+        .await;
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let http = reqwest::Client::new();
+    let err = challenge_response_light(&http, &server.uri(), &client_did, &client_priv, &vta_did)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, VtaError::Auth(_)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn pack_failure_with_invalid_vta_did_maps_to_validation() {
+    // `pack_auth_message` calls `parse_did_key_ed25519`, which returns
+    // an error for non-`did:key` strings. `auth_light` wraps that into
+    // `VtaError::Validation`.
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let http = reqwest::Client::new();
+    let err = challenge_response_light(
+        &http,
+        &server.uri(),
+        &client_did,
+        &client_priv,
+        "did:web:not-a-key",
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, VtaError::Validation(_)), "got {err:?}");
+}
+
+// ── refresh_token_light ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn refresh_token_success_rotates_tokens() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/auth/refresh"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "accessToken": "new-access",
+                "accessExpiresAt": 2_000_000_000_u64,
+                "refreshToken": "new-refresh",
+                "refreshExpiresAt": 2_000_003_600_u64
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let (client_did, _) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let http = reqwest::Client::new();
+    let result = refresh_token_light(&http, &server.uri(), &client_did, &vta_did, "old-refresh")
+        .await
+        .unwrap();
+    assert_eq!(result.access_token, "new-access");
+    assert_eq!(result.refresh_token.as_deref(), Some("new-refresh"));
+}
+
+#[tokio::test]
+async fn refresh_token_401_maps_to_auth() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/auth/refresh"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("refresh token not found"))
+        .mount(&server)
+        .await;
+    let (client_did, _) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let http = reqwest::Client::new();
+    let err = refresh_token_light(&http, &server.uri(), &client_did, &vta_did, "old")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, VtaError::Auth(_)));
+}
+
+#[tokio::test]
+async fn refresh_token_pack_failure_with_invalid_did() {
+    let server = MockServer::start().await;
+    let (client_did, _) = did_key_from_seed(0x11);
+    let http = reqwest::Client::new();
+    let err = refresh_token_light(
+        &http,
+        &server.uri(),
+        &client_did,
+        "did:web:not-a-key",
+        "old",
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, VtaError::Validation(_)), "got {err:?}");
+}
+
+// ── authenticate_with_credential ────────────────────────────────────
+
+#[tokio::test]
+async fn authenticate_with_credential_uses_url_override() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    mount_authenticate(&server, 1_700_001_000).await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    // Bundle has no URL — override drives the call.
+    let cred = CredentialBundle::new(client_did, client_priv, vta_did);
+    let (result, returned_cred, _http) = authenticate_with_credential(&cred, Some(&server.uri()))
+        .await
+        .unwrap();
+    assert_eq!(result.access_token, "access-jwt");
+    // Bundle echoed back unchanged.
+    assert_eq!(returned_cred.did, cred.did);
+}
+
+#[tokio::test]
+async fn authenticate_with_credential_uses_bundle_url() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    mount_authenticate(&server, 1_700_001_000).await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let cred = CredentialBundle::new(client_did, client_priv, vta_did).vta_url(server.uri());
+    let (result, _, _) = authenticate_with_credential(&cred, None).await.unwrap();
+    assert_eq!(result.access_token, "access-jwt");
+}
+
+#[tokio::test]
+async fn authenticate_with_credential_no_url_anywhere_fails() {
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let cred = CredentialBundle::new(client_did, client_priv, vta_did);
+    let err = authenticate_with_credential(&cred, None).await.unwrap_err();
+    match err {
+        VtaError::Validation(msg) => assert!(msg.contains("no VTA URL")),
+        other => panic!("expected Validation, got {other:?}"),
+    }
+}
+
+// ── VtaClient::from_credential + token-refresh integration ──────────
+
+#[tokio::test]
+async fn from_credential_authenticates_and_exposes_token() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    mount_authenticate(&server, 1_700_001_000).await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let cred = CredentialBundle::new(client_did, client_priv, vta_did).vta_url(server.uri());
+
+    let client = VtaClient::from_credential(&cred, None).await.unwrap();
+    assert_eq!(client.token_expires_at().await, Some(1_700_001_000));
+    assert_eq!(client.base_url(), server.uri().trim_end_matches('/'));
+}
+
+#[tokio::test]
+async fn from_credential_url_override_wins_over_bundle() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    mount_authenticate(&server, 1_700_001_000).await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let cred = CredentialBundle::new(client_did, client_priv, vta_did)
+        .vta_url("https://stale.example.com");
+    let client = VtaClient::from_credential(&cred, Some(&server.uri()))
+        .await
+        .unwrap();
+    assert_eq!(client.base_url(), server.uri().trim_end_matches('/'));
+}
+
+/// Exercise `client::ensure_token_valid`'s refresh-on-expiry path:
+/// the initial auth returns an already-expired access token plus a
+/// still-valid refresh token. The next authenticated call must hit
+/// `/auth/refresh` first, then proceed with the new access token.
+#[tokio::test]
+async fn ensure_token_valid_refreshes_expired_access_token() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+
+    // Initial auth: access already expired (1970), refresh still good.
+    let future = now_secs() + 3600;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess",
+            "data": {
+                "accessToken": "expired-access",
+                "accessExpiresAt": 100_u64,
+                "refreshToken": "live-refresh",
+                "refreshExpiresAt": future
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Refresh: returns a fresh access token (future expiry).
+    Mock::given(method("POST"))
+        .and(path("/auth/refresh"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "accessToken": "fresh-access",
+                "accessExpiresAt": future,
+                "refreshToken": "newer-refresh",
+                "refreshExpiresAt": future + 3600
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Downstream call must carry the *refreshed* token, not the expired one.
+    Mock::given(method("GET"))
+        .and(path("/config"))
+        .and(wiremock::matchers::header(
+            "authorization",
+            "Bearer fresh-access",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "vta_did": null, "vta_name": null, "public_url": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let cred = CredentialBundle::new(client_did, client_priv, vta_did).vta_url(server.uri());
+    let client = VtaClient::from_credential(&cred, None).await.unwrap();
+
+    // Trigger an authenticated call → ensure_token_valid sees expired
+    // access, calls refresh, then proceeds. wiremock's expect counters
+    // verify the order of calls.
+    client.get_config().await.unwrap();
+    assert_eq!(client.token_expires_at().await, Some(future));
+}
+
+/// When the refresh token is itself expired, `ensure_token_valid` falls
+/// through to a full re-authentication via `challenge_response_light`.
+#[tokio::test]
+async fn ensure_token_valid_full_reauth_when_refresh_expired() {
+    let server = MockServer::start().await;
+
+    // Two sequential challenge calls expected (initial + re-auth).
+    Mock::given(method("POST"))
+        .and(path("/auth/challenge"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess",
+            "data": { "challenge": "c" }
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let future = now_secs() + 3600;
+    // wiremock matches mocks in registration order until each
+    // `up_to_n_times` budget is exhausted. So the first /auth/ call
+    // hits the "stale tokens" mock; the second hits the "reauth" mock.
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess",
+            "data": {
+                "accessToken": "stale-access",
+                "accessExpiresAt": 100_u64,
+                "refreshToken": "stale-refresh",
+                "refreshExpiresAt": 100_u64
+            }
+        })))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess",
+            "data": {
+                "accessToken": "reauth-access",
+                "accessExpiresAt": future,
+                "refreshToken": "reauth-refresh",
+                "refreshExpiresAt": future + 3600
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/config"))
+        .and(wiremock::matchers::header(
+            "authorization",
+            "Bearer reauth-access",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "vta_did": null, "vta_name": null, "public_url": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let cred = CredentialBundle::new(client_did, client_priv, vta_did).vta_url(server.uri());
+    let client = VtaClient::from_credential(&cred, None).await.unwrap();
+    client.get_config().await.unwrap();
+}
+
+/// If the refresh endpoint itself fails, `ensure_token_valid` must fall
+/// through to a full re-auth instead of bubbling the refresh error.
+#[tokio::test]
+async fn ensure_token_valid_falls_through_when_refresh_fails() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/auth/challenge"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess",
+            "data": { "challenge": "c" }
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let future = now_secs() + 3600;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess",
+            "data": {
+                "accessToken": "expired",
+                "accessExpiresAt": 100_u64,
+                "refreshToken": "live-but-server-rejects",
+                "refreshExpiresAt": future
+            }
+        })))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess",
+            "data": {
+                "accessToken": "fallback-access",
+                "accessExpiresAt": future,
+                "refreshToken": "fallback-refresh",
+                "refreshExpiresAt": future + 3600
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Refresh returns 401: invalid → should be tolerated, full re-auth runs.
+    Mock::given(method("POST"))
+        .and(path("/auth/refresh"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("token reuse detected"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/config"))
+        .and(wiremock::matchers::header(
+            "authorization",
+            "Bearer fallback-access",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "vta_did": null, "vta_name": null, "public_url": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let cred = CredentialBundle::new(client_did, client_priv, vta_did).vta_url(server.uri());
+    let client = VtaClient::from_credential(&cred, None).await.unwrap();
+    client.get_config().await.unwrap();
+}

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1,0 +1,1576 @@
+//! REST client coverage harness for `vta_sdk::client::VtaClient`.
+//!
+//! Exercises every public REST endpoint the SDK exposes against a
+//! `wiremock` server. For each endpoint we verify:
+//!   - request method + path (incl. URL-encoding for DIDs/IDs with
+//!     reserved characters)
+//!   - the `Authorization: Bearer …` header is attached
+//!   - the SDK deserializes a happy-path response body correctly
+//!   - HTTP error status codes map to the expected `VtaError` variant
+//!
+//! Out of scope: DIDComm transport (covered separately by
+//! `provision_client_e2e.rs` and the inline `didcomm_session` tests),
+//! attestation verification (in `attestation.rs`), and the sealed-bundle
+//! open path (in `sealed_transfer/`).
+
+#![cfg(feature = "client")]
+
+use chrono::Utc;
+use serde_json::{Value, json};
+use vta_sdk::client::*;
+use vta_sdk::error::VtaError;
+use vta_sdk::keys::{KeyOrigin, KeyStatus, KeyType};
+use vta_sdk::protocols::key_management::sign::SignAlgorithm;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── Test harness ────────────────────────────────────────────────────
+
+const TOKEN: &str = "test-token";
+
+async fn client(server: &MockServer) -> VtaClient {
+    let c = VtaClient::new(&server.uri());
+    c.set_token_async(TOKEN.into()).await;
+    c
+}
+
+fn err_body(msg: &str) -> Value {
+    json!({ "error": msg })
+}
+
+fn auth_match() -> impl wiremock::Match {
+    header("authorization", &*format!("Bearer {TOKEN}"))
+}
+
+/// Helper to mount a single mock that matches method + path + auth and
+/// returns a JSON body. The mock is auto-asserted via `.expect(1)` so a
+/// missing or extra call surfaces in the test failure.
+async fn mount_json(
+    server: &MockServer,
+    m: &str,
+    p: &str,
+    status: u16,
+    body: Value,
+) -> wiremock::MockGuard {
+    let resp = ResponseTemplate::new(status).set_body_json(body);
+    Mock::given(method(m))
+        .and(path(p))
+        .and(auth_match())
+        .respond_with(resp)
+        .expect(1)
+        .mount_as_scoped(server)
+        .await
+}
+
+async fn mount_status(server: &MockServer, m: &str, p: &str, status: u16) -> wiremock::MockGuard {
+    Mock::given(method(m))
+        .and(path(p))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(status).set_body_json(err_body("bad")))
+        .expect(1)
+        .mount_as_scoped(server)
+        .await
+}
+
+fn iso(s: &str) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+// ── Health (no auth) ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn health_returns_status() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "ok",
+            "version": "0.5.0",
+            "mediator_url": "https://mediator.example.com",
+            "mediator_did": "did:web:mediator.example.com"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = VtaClient::new(&server.uri());
+    let h = c.health().await.unwrap();
+    assert_eq!(h.status, "ok");
+    assert_eq!(h.version.as_deref(), Some("0.5.0"));
+    assert_eq!(
+        h.mediator_did.as_deref(),
+        Some("did:web:mediator.example.com")
+    );
+}
+
+#[tokio::test]
+async fn health_minimal_body_deserializes() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"status": "ok"})))
+        .mount(&server)
+        .await;
+    let c = VtaClient::new(&server.uri());
+    let h = c.health().await.unwrap();
+    assert_eq!(h.status, "ok");
+    assert!(h.version.is_none());
+}
+
+#[tokio::test]
+async fn health_500_maps_to_server_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(ResponseTemplate::new(503).set_body_json(err_body("down")))
+        .mount(&server)
+        .await;
+    let c = VtaClient::new(&server.uri());
+    let err = c.health().await.unwrap_err();
+    assert!(matches!(err, VtaError::Server { status: 503, .. }));
+}
+
+// ── Discovery + VTA management ──────────────────────────────────────
+
+#[tokio::test]
+async fn capabilities_returns_features() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/capabilities",
+        200,
+        json!({
+            "version": "0.5.0",
+            "features": {"webvh": true, "didcomm": false, "tee": false, "rest": true},
+            "services": {"rest": true, "didcomm": false},
+            "webvh_servers": [{"id": "s1"}],
+            "did_creation_modes": ["webvh"]
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let caps = c.capabilities().await.unwrap();
+    assert_eq!(caps.version, "0.5.0");
+    assert!(caps.features.webvh);
+    assert!(!caps.features.didcomm);
+    assert_eq!(caps.webvh_servers.len(), 1);
+    assert_eq!(caps.webvh_servers[0].id, "s1");
+}
+
+#[tokio::test]
+async fn restart_returns_status() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/vta/restart",
+        200,
+        json!({"status": "restarting"}),
+    )
+    .await;
+    let c = client(&server).await;
+    assert_eq!(c.restart().await.unwrap().status, "restarting");
+}
+
+#[tokio::test]
+async fn get_config_returns_fields() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/config",
+        200,
+        json!({
+            "vta_did": "did:web:vta.example.com",
+            "vta_name": "primary",
+            "public_url": "https://vta.example.com"
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let cfg = c.get_config().await.unwrap();
+    assert_eq!(
+        cfg.community_vta_did.as_deref(),
+        Some("did:web:vta.example.com")
+    );
+    assert_eq!(cfg.community_vta_name.as_deref(), Some("primary"));
+}
+
+#[tokio::test]
+async fn update_config_sends_patch_body() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PATCH",
+        "/config",
+        200,
+        json!({
+            "vta_did": "did:web:new",
+            "vta_name": "new",
+            "public_url": null
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let req = UpdateConfigRequest {
+        vta_did: Some("did:web:new".into()),
+        vta_name: Some("new".into()),
+        public_url: None,
+    };
+    let cfg = c.update_config(req).await.unwrap();
+    assert_eq!(cfg.community_vta_name.as_deref(), Some("new"));
+}
+
+// ── Backup ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn backup_export_returns_envelope() {
+    let server = MockServer::start().await;
+    let envelope = json!({
+        "version": 1,
+        "format": "vtabak/v1",
+        "created_at": "2026-05-05T12:00:00Z",
+        "source_version": "0.5.0",
+        "kdf": {"algorithm": "argon2id", "salt": "AAAA", "m_cost": 65536, "t_cost": 3, "p_cost": 4},
+        "encryption": {"algorithm": "AES-256-GCM", "nonce": "AAAA"},
+        "includes_audit": false,
+        "ciphertext": "AAAA"
+    });
+    let _g = mount_json(&server, "POST", "/backup/export", 200, envelope).await;
+    let c = client(&server).await;
+    let env = c.backup_export("hunter2hunter2", false).await.unwrap();
+    assert_eq!(env.version, 1);
+    assert!(!env.includes_audit);
+}
+
+#[tokio::test]
+async fn backup_export_403_maps_to_forbidden() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "POST", "/backup/export", 403).await;
+    let c = client(&server).await;
+    let err = c.backup_export("pw", false).await.unwrap_err();
+    assert!(matches!(err, VtaError::Forbidden(_)));
+    assert!(err.is_auth());
+}
+
+// ── Keys ────────────────────────────────────────────────────────────
+
+fn key_record_json(id: &str) -> Value {
+    json!({
+        "key_id": id,
+        "derivation_path": "m/44'/0'/0'",
+        "key_type": "ed25519",
+        "status": "active",
+        "public_key": "z6Mkpub",
+        "label": null,
+        "context_id": null,
+        "seed_id": 1,
+        "origin": "derived",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    })
+}
+
+#[tokio::test]
+async fn create_key_round_trip() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/keys",
+        200,
+        json!({
+            "key_id": "k1",
+            "key_type": "ed25519",
+            "derivation_path": "m/0/0",
+            "public_key": "z6Mkpub",
+            "status": "active",
+            "label": null,
+            "created_at": "2026-01-01T00:00:00Z"
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let req = CreateKeyRequest::new(KeyType::Ed25519)
+        .derivation_path("m/0/0")
+        .label("k1");
+    let resp = c.create_key(req).await.unwrap();
+    assert_eq!(resp.key_id, "k1");
+    assert_eq!(resp.key_type, KeyType::Ed25519);
+    assert_eq!(resp.status, KeyStatus::Active);
+}
+
+#[tokio::test]
+async fn list_keys_paginates_query_params() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/keys"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param("offset", "10"))
+        .and(wiremock::matchers::query_param("limit", "5"))
+        .and(wiremock::matchers::query_param("status", "active"))
+        .and(wiremock::matchers::query_param("context_id", "ctx-a"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "keys": [key_record_json("k1")],
+            "total": 1
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let resp = c
+        .list_keys(10, 5, Some("active"), Some("ctx-a"))
+        .await
+        .unwrap();
+    assert_eq!(resp.total, 1);
+    assert_eq!(resp.keys.len(), 1);
+}
+
+#[tokio::test]
+async fn get_key_path_encodes_did_fragment() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/keys/did:web:example.com%23key-1",
+        200,
+        key_record_json("did:web:example.com#key-1"),
+    )
+    .await;
+    let c = client(&server).await;
+    let key = c.get_key("did:web:example.com#key-1").await.unwrap();
+    assert_eq!(key.key_id, "did:web:example.com#key-1");
+}
+
+#[tokio::test]
+async fn get_key_404_maps_to_not_found() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "GET", "/keys/missing", 404).await;
+    let c = client(&server).await;
+    let err = c.get_key("missing").await.unwrap_err();
+    assert!(err.is_not_found(), "got {err:?}");
+}
+
+#[tokio::test]
+async fn get_key_secret_returns_multibase() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/keys/k1/secret",
+        200,
+        json!({
+            "key_id": "k1",
+            "key_type": "ed25519",
+            "public_key_multibase": "z6Mkpub",
+            "private_key_multibase": "zPriv"
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let s = c.get_key_secret("k1").await.unwrap();
+    assert_eq!(s.private_key_multibase, "zPriv");
+    assert_eq!(s.key_type, KeyType::Ed25519);
+}
+
+#[tokio::test]
+async fn sign_posts_base64url_payload() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/keys/k1/sign",
+        200,
+        json!({
+            "key_id": "k1",
+            "signature": "AQID",
+            "algorithm": "eddsa"
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let sig = c.sign("k1", b"hello", SignAlgorithm::EdDSA).await.unwrap();
+    assert_eq!(sig.signature, "AQID");
+    assert_eq!(sig.algorithm, SignAlgorithm::EdDSA);
+}
+
+#[tokio::test]
+async fn invalidate_key_deletes() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "DELETE",
+        "/keys/k1",
+        200,
+        json!({
+            "key_id": "k1",
+            "status": "revoked",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let resp = c.invalidate_key("k1").await.unwrap();
+    assert_eq!(resp.status, KeyStatus::Revoked);
+}
+
+#[tokio::test]
+async fn rename_key_patches() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PATCH",
+        "/keys/old",
+        200,
+        json!({"key_id": "new", "updated_at": "2026-01-01T00:00:00Z"}),
+    )
+    .await;
+    let c = client(&server).await;
+    let resp = c.rename_key("old", "new").await.unwrap();
+    assert_eq!(resp.key_id, "new");
+}
+
+#[tokio::test]
+async fn rename_key_409_maps_to_conflict() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "PATCH", "/keys/old", 409).await;
+    let c = client(&server).await;
+    let err = c.rename_key("old", "new").await.unwrap_err();
+    assert!(err.is_conflict());
+}
+
+#[tokio::test]
+async fn get_wrapping_key_returns_jwk() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/keys/import/wrapping-key",
+        200,
+        json!({"kid": "k1", "kty": "OKP", "crv": "X25519", "x": "AAAA"}),
+    )
+    .await;
+    let c = client(&server).await;
+    let k = c.get_wrapping_key().await.unwrap();
+    assert_eq!(k.kid, "k1");
+    assert_eq!(k.crv, "X25519");
+}
+
+#[tokio::test]
+async fn import_key_posts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/keys/import",
+        200,
+        json!({
+            "key_id": "imported",
+            "key_type": "ed25519",
+            "public_key": "z6Mkpub",
+            "status": "active",
+            "label": null,
+            "origin": "imported",
+            "created_at": "2026-01-01T00:00:00Z"
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let req = ImportKeyRequest {
+        key_type: KeyType::Ed25519,
+        private_key_sealed: Some("armored".into()),
+        private_key_jwe: None,
+        private_key_multibase: None,
+        label: Some("imported".into()),
+        context_id: None,
+    };
+    let resp = c.import_key(req).await.unwrap();
+    assert_eq!(resp.key_id, "imported");
+    assert_eq!(resp.origin, KeyOrigin::Imported);
+}
+
+// ── Seeds ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_seeds_returns_active() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/keys/seeds",
+        200,
+        json!({
+            "seeds": [
+                {"id": 1, "status": "active", "created_at": "2026-01-01T00:00:00Z", "retired_at": null}
+            ],
+            "active_seed_id": 1
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let resp = c.list_seeds().await.unwrap();
+    assert_eq!(resp.active_seed_id, 1);
+    assert_eq!(resp.seeds.len(), 1);
+}
+
+#[tokio::test]
+async fn rotate_seed_with_mnemonic() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/keys/seeds/rotate",
+        200,
+        json!({"previous_seed_id": 1, "new_seed_id": 2}),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.rotate_seed(Some("word ".repeat(24))).await.unwrap();
+    assert_eq!(r.previous_seed_id, 1);
+    assert_eq!(r.new_seed_id, 2);
+}
+
+// ── ACL ─────────────────────────────────────────────────────────────
+
+fn acl_entry_json(did: &str) -> Value {
+    json!({
+        "did": did,
+        "role": "admin",
+        "label": "ops",
+        "allowed_contexts": ["ctx-a"],
+        "created_at": 1_700_000_000_u64,
+        "created_by": "did:web:vta",
+        "expires_at": null
+    })
+}
+
+#[tokio::test]
+async fn list_acl_no_filter() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/acl",
+        200,
+        json!({"entries": [acl_entry_json("did:key:zAdmin")]}),
+    )
+    .await;
+    let c = client(&server).await;
+    let resp = c.list_acl(None).await.unwrap();
+    assert_eq!(resp.entries.len(), 1);
+}
+
+#[tokio::test]
+async fn list_acl_with_context_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/acl"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param("context", "ctx-a"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"entries": []})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let resp = c.list_acl(Some("ctx-a")).await.unwrap();
+    assert!(resp.entries.is_empty());
+}
+
+#[tokio::test]
+async fn get_acl_path_encodes_did() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/acl/did:web:example.com",
+        200,
+        acl_entry_json("did:web:example.com"),
+    )
+    .await;
+    let c = client(&server).await;
+    let resp = c.get_acl("did:web:example.com").await.unwrap();
+    assert_eq!(resp.did, "did:web:example.com");
+}
+
+#[tokio::test]
+async fn create_acl_posts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/acl",
+        200,
+        acl_entry_json("did:key:zAdmin"),
+    )
+    .await;
+    let c = client(&server).await;
+    let req = CreateAclRequest::new("did:key:zAdmin", "admin")
+        .label("ops")
+        .contexts(vec!["ctx-a".into()])
+        .expires_at(1_700_000_000);
+    let resp = c.create_acl(req).await.unwrap();
+    assert_eq!(resp.did, "did:key:zAdmin");
+}
+
+#[tokio::test]
+async fn create_acl_409_maps_to_conflict() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "POST", "/acl", 409).await;
+    let c = client(&server).await;
+    let req = CreateAclRequest::new("did:key:zAdmin", "admin");
+    let err = c.create_acl(req).await.unwrap_err();
+    assert!(err.is_conflict());
+}
+
+#[tokio::test]
+async fn update_acl_patches() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PATCH",
+        "/acl/did:key:zAdmin",
+        200,
+        acl_entry_json("did:key:zAdmin"),
+    )
+    .await;
+    let c = client(&server).await;
+    let req = UpdateAclRequest {
+        role: Some("reader".into()),
+        label: None,
+        allowed_contexts: Some(vec!["ctx-b".into()]),
+    };
+    let resp = c.update_acl("did:key:zAdmin", req).await.unwrap();
+    assert_eq!(resp.did, "did:key:zAdmin");
+}
+
+#[tokio::test]
+async fn delete_acl_returns_unit() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/acl/did:key:zAdmin"))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.delete_acl("did:key:zAdmin").await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_acl_404_maps_to_not_found() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "DELETE", "/acl/x", 404).await;
+    let c = client(&server).await;
+    let err = c.delete_acl("x").await.unwrap_err();
+    assert!(err.is_not_found());
+}
+
+// ── Contexts ────────────────────────────────────────────────────────
+
+fn context_json(id: &str) -> Value {
+    json!({
+        "id": id,
+        "name": "Primary",
+        "did": "did:web:vta.example.com",
+        "description": null,
+        "base_path": "m/26'/2'/0'",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    })
+}
+
+#[tokio::test]
+async fn list_contexts_returns_array() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/contexts",
+        200,
+        json!({"contexts": [context_json("primary")]}),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.list_contexts().await.unwrap();
+    assert_eq!(r.contexts.len(), 1);
+    assert_eq!(r.contexts[0].id, "primary");
+}
+
+#[tokio::test]
+async fn get_context_path_encodes_id() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/contexts/with%2Fslash",
+        200,
+        context_json("with/slash"),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.get_context("with/slash").await.unwrap();
+    assert_eq!(r.id, "with/slash");
+}
+
+#[tokio::test]
+async fn create_context_posts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(&server, "POST", "/contexts", 200, context_json("primary")).await;
+    let c = client(&server).await;
+    let req = CreateContextRequest::new("primary", "Primary").description("first");
+    let r = c.create_context(req).await.unwrap();
+    assert_eq!(r.id, "primary");
+    assert_eq!(r.created_at, iso("2026-01-01T00:00:00Z"));
+}
+
+#[tokio::test]
+async fn update_context_patches() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PATCH",
+        "/contexts/primary",
+        200,
+        context_json("primary"),
+    )
+    .await;
+    let c = client(&server).await;
+    let req = UpdateContextRequest {
+        name: Some("Renamed".into()),
+        did: None,
+        description: None,
+    };
+    c.update_context("primary", req).await.unwrap();
+}
+
+#[tokio::test]
+async fn update_context_did_puts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PUT",
+        "/contexts/primary/did",
+        200,
+        context_json("primary"),
+    )
+    .await;
+    let c = client(&server).await;
+    c.update_context_did("primary", "did:web:new")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn preview_delete_context_returns_summary() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/contexts/primary/delete-preview",
+        200,
+        json!({
+            "id": "primary",
+            "keys": ["k1"],
+            "webvh_dids": [],
+            "acl_entries_removed": [],
+            "acl_entries_updated": [],
+            "did_templates": []
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.preview_delete_context("primary").await.unwrap();
+    assert_eq!(r.id, "primary");
+    assert_eq!(r.keys.len(), 1);
+}
+
+#[tokio::test]
+async fn delete_context_with_force_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/contexts/primary"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param("force", "true"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.delete_context("primary", true).await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_context_no_force_omits_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/contexts/primary"))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.delete_context("primary", false).await.unwrap();
+}
+
+// ── WebVH servers ───────────────────────────────────────────────────
+
+fn webvh_server_json(id: &str) -> Value {
+    json!({
+        "id": id,
+        "did": "did:web:server.example.com",
+        "label": null,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    })
+}
+
+#[tokio::test]
+async fn add_webvh_server_posts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/webvh/servers",
+        200,
+        webvh_server_json("s1"),
+    )
+    .await;
+    let c = client(&server).await;
+    let req = AddWebvhServerRequest {
+        id: "s1".into(),
+        did: "did:web:server.example.com".into(),
+        label: None,
+    };
+    let r = c.add_webvh_server(req).await.unwrap();
+    assert_eq!(r.id, "s1");
+}
+
+#[tokio::test]
+async fn list_webvh_servers_returns_array() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/webvh/servers",
+        200,
+        json!({"servers": [webvh_server_json("s1")]}),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.list_webvh_servers().await.unwrap();
+    assert_eq!(r.servers.len(), 1);
+}
+
+#[tokio::test]
+async fn update_webvh_server_patches() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PATCH",
+        "/webvh/servers/s1",
+        200,
+        webvh_server_json("s1"),
+    )
+    .await;
+    let c = client(&server).await;
+    let req = UpdateWebvhServerRequest {
+        label: Some("primary".into()),
+    };
+    c.update_webvh_server("s1", req).await.unwrap();
+}
+
+#[tokio::test]
+async fn remove_webvh_server_deletes() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/webvh/servers/s1"))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.remove_webvh_server("s1").await.unwrap();
+}
+
+// ── WebVH DIDs ──────────────────────────────────────────────────────
+
+fn webvh_did_record_json(did: &str) -> Value {
+    json!({
+        "did": did,
+        "server_id": "s1",
+        "mnemonic": "",
+        "scid": "Qabc",
+        "context_id": "primary",
+        "portable": false,
+        "log_entry_count": 1,
+        "pre_rotation_count": 0,
+        "next_fragment_id": 1,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z"
+    })
+}
+
+#[tokio::test]
+async fn create_did_webvh_posts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/webvh/dids",
+        200,
+        json!({
+            "did": "did:webvh:Qabc:server.example.com:primary",
+            "context_id": "primary",
+            "server_id": "s1",
+            "mnemonic": null,
+            "scid": "Qabc",
+            "portable": false,
+            "signing_key_id": "k0",
+            "ka_key_id": "k1",
+            "pre_rotation_key_count": 0,
+            "created_at": "2026-01-01T00:00:00Z"
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let req = CreateDidWebvhRequest {
+        context_id: "primary".into(),
+        server_id: Some("s1".into()),
+        url: None,
+        path: None,
+        label: None,
+        portable: false,
+        add_mediator_service: false,
+        additional_services: None,
+        pre_rotation_count: 0,
+        did_document: None,
+        did_log: None,
+        set_primary: true,
+        signing_key_id: None,
+        ka_key_id: None,
+        template: None,
+        template_context: None,
+        template_vars: Default::default(),
+    };
+    let r = c.create_did_webvh(req).await.unwrap();
+    assert_eq!(r.scid, "Qabc");
+}
+
+#[tokio::test]
+async fn list_dids_webvh_filters_by_context() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/webvh/dids"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param("context_id", "primary"))
+        .and(wiremock::matchers::query_param("server_id", "s1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "dids": [webvh_did_record_json("did:webvh:Qabc:server.example.com:primary")]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let r = c
+        .list_dids_webvh(Some("primary"), Some("s1"))
+        .await
+        .unwrap();
+    assert_eq!(r.dids.len(), 1);
+}
+
+#[tokio::test]
+async fn get_did_webvh_returns_record() {
+    let server = MockServer::start().await;
+    let did = "did:webvh:Qabc:server.example.com:primary";
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/webvh/dids/did:webvh:Qabc:server.example.com:primary",
+        200,
+        webvh_did_record_json(did),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.get_did_webvh(did).await.unwrap();
+    assert_eq!(r.did, did);
+}
+
+#[tokio::test]
+async fn get_did_webvh_log_returns_log() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/webvh/dids/did:webvh:abc/log",
+        200,
+        json!({"did": "did:webvh:abc", "log": "{\"versionId\":\"1\"}\n"}),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.get_did_webvh_log("did:webvh:abc").await.unwrap();
+    assert!(r.log.is_some());
+}
+
+#[tokio::test]
+async fn delete_did_webvh_returns_unit() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/webvh/dids/did:webvh:abc"))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.delete_did_webvh("did:webvh:abc").await.unwrap();
+}
+
+#[tokio::test]
+async fn update_did_webvh_posts_to_context_path() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/contexts/primary/dids/Qabc/update",
+        200,
+        json!({
+            "did": "did:webvh:Qabc",
+            "new_version_id": "2-z",
+            "new_scid": "Qabc",
+            "new_log_entry": "{}",
+            "update_keys_count": 1,
+            "pre_rotation_key_count": 0
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let body = vta_sdk::protocols::did_management::update::UpdateDidWebvhBody {
+        document: Some(json!({"id": "did:webvh:Qabc"})),
+        ..Default::default()
+    };
+    let r = c.update_did_webvh("primary", "Qabc", body).await.unwrap();
+    assert_eq!(r.new_version_id, "2-z");
+}
+
+#[tokio::test]
+async fn rotate_did_webvh_keys_posts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/contexts/primary/dids/Qabc/rotate-keys",
+        200,
+        json!({
+            "did": "did:webvh:Qabc",
+            "new_version_id": "3-z",
+            "new_scid": "Qabc",
+            "new_log_entry": "{}",
+            "update_keys_count": 1,
+            "pre_rotation_key_count": 2
+        }),
+    )
+    .await;
+    let c = client(&server).await;
+    let body = vta_sdk::protocols::did_management::update::RotateDidWebvhKeysBody {
+        pre_rotation_count: Some(2),
+        label: Some("scheduled".into()),
+    };
+    let r = c
+        .rotate_did_webvh_keys("primary", "Qabc", body)
+        .await
+        .unwrap();
+    assert_eq!(r.pre_rotation_key_count, 2);
+}
+
+// ── Audit ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_audit_logs_paginates() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/audit/logs"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param("page", "2"))
+        .and(wiremock::matchers::query_param("page_size", "25"))
+        .and(wiremock::matchers::query_param("action", "key.create"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "entries": [],
+            "total": 0,
+            "page": 2,
+            "page_size": 25,
+            "total_pages": 0
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let params = vta_sdk::protocols::audit_management::list::ListAuditLogsBody {
+        page: 2,
+        page_size: 25,
+        action: Some("key.create".into()),
+        ..Default::default()
+    };
+    let r = c.list_audit_logs(&params).await.unwrap();
+    assert_eq!(r.page, 2);
+}
+
+#[tokio::test]
+async fn get_audit_retention_returns_days() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/audit/retention",
+        200,
+        json!({"retention_days": 90}),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.get_audit_retention().await.unwrap();
+    assert_eq!(r.retention_days, 90);
+}
+
+#[tokio::test]
+async fn update_audit_retention_patches() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PATCH",
+        "/audit/retention",
+        200,
+        json!({"retention_days": 30}),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.update_audit_retention(30).await.unwrap();
+    assert_eq!(r.retention_days, 30);
+}
+
+// ── DID templates: global ───────────────────────────────────────────
+
+fn template_record_json(name: &str) -> Value {
+    json!({
+        "schemaVersion": 1,
+        "name": name,
+        "kind": "custom",
+        "description": null,
+        "methods": [],
+        "requiredVars": [],
+        "optionalVars": {},
+        "defaults": {},
+        "document": {"id": "{DID}"},
+        "scope": {"type": "global"},
+        "created_at": 1_700_000_000_u64,
+        "updated_at": 1_700_000_000_u64,
+        "created_by": "did:web:vta"
+    })
+}
+
+fn sample_template(name: &str) -> vta_sdk::did_templates::DidTemplate {
+    serde_json::from_value(json!({
+        "schemaVersion": 1,
+        "name": name,
+        "kind": "custom",
+        "document": {"id": "{DID}"}
+    }))
+    .unwrap()
+}
+
+#[tokio::test]
+async fn list_did_templates_returns_array() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/did-templates",
+        200,
+        json!({"templates": [template_record_json("custom-1")]}),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.list_did_templates().await.unwrap();
+    assert_eq!(r.len(), 1);
+}
+
+#[tokio::test]
+async fn get_did_template_returns_one() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/did-templates/custom-1",
+        200,
+        template_record_json("custom-1"),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.get_did_template("custom-1").await.unwrap();
+    assert_eq!(r.template.name, "custom-1");
+}
+
+#[tokio::test]
+async fn create_did_template_posts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/did-templates",
+        200,
+        template_record_json("new"),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c.create_did_template(sample_template("new")).await.unwrap();
+    assert_eq!(r.template.name, "new");
+}
+
+#[tokio::test]
+async fn update_did_template_puts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PUT",
+        "/did-templates/x",
+        200,
+        template_record_json("x"),
+    )
+    .await;
+    let c = client(&server).await;
+    c.update_did_template("x", sample_template("x"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn delete_did_template_returns_unit() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/did-templates/x"))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.delete_did_template("x").await.unwrap();
+}
+
+#[tokio::test]
+async fn render_did_template_unwraps_document() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/did-templates/x/render",
+        200,
+        json!({"document": {"id": "did:web:rendered"}}),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c
+        .render_did_template("x", Default::default())
+        .await
+        .unwrap();
+    assert_eq!(r["id"], "did:web:rendered");
+}
+
+// ── DID templates: context-scoped ───────────────────────────────────
+
+#[tokio::test]
+async fn list_context_did_templates_returns_array() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/contexts/primary/did-templates",
+        200,
+        json!({"templates": []}),
+    )
+    .await;
+    let c = client(&server).await;
+    assert!(
+        c.list_context_did_templates("primary")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn get_context_did_template_returns_one() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "GET",
+        "/contexts/primary/did-templates/x",
+        200,
+        template_record_json("x"),
+    )
+    .await;
+    let c = client(&server).await;
+    c.get_context_did_template("primary", "x").await.unwrap();
+}
+
+#[tokio::test]
+async fn create_context_did_template_posts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/contexts/primary/did-templates",
+        200,
+        template_record_json("x"),
+    )
+    .await;
+    let c = client(&server).await;
+    c.create_context_did_template("primary", sample_template("x"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn update_context_did_template_puts() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PUT",
+        "/contexts/primary/did-templates/x",
+        200,
+        template_record_json("x"),
+    )
+    .await;
+    let c = client(&server).await;
+    c.update_context_did_template("primary", "x", sample_template("x"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn delete_context_did_template_returns_unit() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/contexts/primary/did-templates/x"))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.delete_context_did_template("primary", "x").await.unwrap();
+}
+
+#[tokio::test]
+async fn render_context_did_template_unwraps_document() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "POST",
+        "/contexts/primary/did-templates/x/render",
+        200,
+        json!({"document": {"id": "did:web:ctx-rendered"}}),
+    )
+    .await;
+    let c = client(&server).await;
+    let r = c
+        .render_context_did_template("primary", "x", Default::default())
+        .await
+        .unwrap();
+    assert_eq!(r["id"], "did:web:ctx-rendered");
+}
+
+// ── check_auth ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn check_auth_true_when_200() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health/details"))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    assert!(c.check_auth().await.unwrap());
+}
+
+#[tokio::test]
+async fn check_auth_false_when_401() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health/details"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(err_body("expired")))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    assert!(!c.check_auth().await.unwrap());
+}
+
+// ── Convenience: paginated secret fetch ─────────────────────────────
+
+#[tokio::test]
+async fn fetch_context_secrets_walks_all_pages() {
+    let server = MockServer::start().await;
+
+    // Page 1: 100 keys, total = 101
+    let mut page1_keys = Vec::new();
+    for i in 0..100 {
+        page1_keys.push(key_record_json(&format!("k{i}")));
+    }
+    Mock::given(method("GET"))
+        .and(path("/keys"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param("offset", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "keys": page1_keys,
+            "total": 101
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Page 2: 1 key
+    Mock::given(method("GET"))
+        .and(path("/keys"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param("offset", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "keys": [key_record_json("k100")],
+            "total": 101
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Each get_key_secret responds with a fixed multibase pair. The
+    // mock matches /keys/{id}/secret regardless of which key id; the
+    // x25519 multibase below is a literal `[2u8; 32]` encoded with
+    // multicodec X25519 (0xec01) — `secret_from_key_response` accepts
+    // any 32-byte key, so the value just needs to round-trip.
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/keys/[^/]+/secret$"))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "key_id": "k",
+            "key_type": "x25519",
+            "public_key_multibase": "z6LSqHQEbN8eMpx9NhMTXmxqYDhtbW5kqwQYWN9y91vxqMtq",
+            "private_key_multibase": "z3wei5qxuQ8mvebtP4WQiK3CsPuiL6XvfVmuhXKfzKKAwgvY"
+        })))
+        .expect(101)
+        .mount(&server)
+        .await;
+
+    let c = client(&server).await;
+    let secrets = c.fetch_context_secrets("primary").await.unwrap();
+    assert_eq!(secrets.len(), 101);
+}
+
+// `path_regex` is in `wiremock::matchers` — re-exported here for
+// readability above.
+use wiremock::matchers::path_regex;
+
+// ── Error-mapping coverage (status → typed variant) ─────────────────
+
+#[tokio::test]
+async fn http_400_maps_to_validation() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "GET", "/config", 400).await;
+    let c = client(&server).await;
+    let err = c.get_config().await.unwrap_err();
+    assert!(matches!(err, VtaError::Validation(_)));
+}
+
+#[tokio::test]
+async fn http_401_maps_to_auth() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "GET", "/config", 401).await;
+    let c = client(&server).await;
+    let err = c.get_config().await.unwrap_err();
+    assert!(matches!(err, VtaError::Auth(_)));
+}
+
+#[tokio::test]
+async fn http_410_maps_to_gone() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "GET", "/config", 410).await;
+    let c = client(&server).await;
+    let err = c.get_config().await.unwrap_err();
+    assert!(err.is_gone());
+}
+
+#[tokio::test]
+async fn http_422_maps_to_validation() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "GET", "/config", 422).await;
+    let c = client(&server).await;
+    let err = c.get_config().await.unwrap_err();
+    assert!(matches!(err, VtaError::Validation(_)));
+}
+
+#[tokio::test]
+async fn http_418_maps_to_other() {
+    let server = MockServer::start().await;
+    let _g = mount_status(&server, "GET", "/config", 418).await;
+    let c = client(&server).await;
+    let err = c.get_config().await.unwrap_err();
+    assert!(matches!(err, VtaError::Other(_)));
+}
+
+#[tokio::test]
+async fn malformed_error_body_falls_back_to_unknown() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/config"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("not json"))
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let err = c.get_config().await.unwrap_err();
+    match err {
+        VtaError::Server { status, body } => {
+            assert_eq!(status, 500);
+            assert_eq!(body, "unknown error");
+        }
+        other => panic!("expected Server, got {other:?}"),
+    }
+}
+
+// ── Connection/transport ────────────────────────────────────────────
+
+#[tokio::test]
+async fn network_error_when_server_unreachable() {
+    // Port 1 is reserved (TCPMUX) and effectively never listens on
+    // dev/CI machines — connection refused → reqwest::Error → Network.
+    let c = VtaClient::new("http://127.0.0.1:1");
+    c.set_token_async(TOKEN.into()).await;
+    let err = c.get_config().await.unwrap_err();
+    assert!(err.is_network(), "got {err:?}");
+}
+
+// ── Base URL accessors ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn base_url_returned_after_construction() {
+    let c = VtaClient::new("https://vta.example.com");
+    assert_eq!(c.base_url(), "https://vta.example.com");
+}
+
+#[tokio::test]
+async fn token_expires_at_none_until_set() {
+    let c = VtaClient::new("https://vta.example.com");
+    assert!(c.token_expires_at().await.is_none());
+}
+
+#[tokio::test]
+async fn shutdown_is_noop_for_rest() {
+    // REST-only client: shutdown() is documented as a no-op. Just make
+    // sure it doesn't panic or hang.
+    let c = VtaClient::new("https://vta.example.com");
+    c.shutdown().await;
+}

--- a/vta-sdk/tests/protocol_rest.rs
+++ b/vta-sdk/tests/protocol_rest.rs
@@ -1,0 +1,307 @@
+//! Coverage harness for `vta_sdk::protocol` (DIDComm protocol-management
+//! REST surface on `VtaClient`). These calls are REST-only by design —
+//! `enable_didcomm` runs before any DIDComm transport exists, and the
+//! disable / migrate / drain-cancel / report operations are mirrored
+//! over DIDComm in `vta-service` but the SDK side just shapes JSON
+//! requests, so wiremock is sufficient here.
+
+#![cfg(feature = "client")]
+
+use serde_json::{Value, json};
+use vta_sdk::client::VtaClient;
+use vta_sdk::error::VtaError;
+use vta_sdk::protocol::{
+    DisableDidcommRequest, DrainCancelRequest, EnableDidcommRequest, MigrateMediatorRequest,
+};
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TOKEN: &str = "test-token";
+
+async fn client(server: &MockServer) -> VtaClient {
+    let c = VtaClient::new(&server.uri());
+    c.set_token_async(TOKEN.into()).await;
+    c
+}
+
+fn auth() -> impl wiremock::Match {
+    header("authorization", &*format!("Bearer {TOKEN}"))
+}
+
+// ── enable_didcomm ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enable_didcomm_posts_request_and_decodes_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/services/didcomm/enable"))
+        .and(auth())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "new_version_id": "2-zVer",
+            "mediator_did": "did:peer:2.med",
+            "mediator_endpoint": "https://mediator.example.com"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let req = EnableDidcommRequest::new("did:peer:2.med")
+        .force(true)
+        .handshake_timeout_secs(20);
+    let resp = c.enable_didcomm(req).await.unwrap();
+    assert_eq!(resp.new_version_id, "2-zVer");
+    assert_eq!(resp.mediator_did, "did:peer:2.med");
+}
+
+#[tokio::test]
+async fn enable_didcomm_409_maps_to_conflict() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/services/didcomm/enable"))
+        .respond_with(ResponseTemplate::new(409).set_body_json(json!({"error": "already on"})))
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let err = c
+        .enable_didcomm(EnableDidcommRequest::new("did:peer:2.med"))
+        .await
+        .unwrap_err();
+    assert!(err.is_conflict(), "got {err:?}");
+}
+
+// ── disable_didcomm ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn disable_didcomm_with_immediate_drain() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/services/didcomm/disable"))
+        .and(auth())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "new_version_id": "3-zVer",
+            "prior_mediator_did": "did:peer:2.med",
+            "drains_until": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let resp = c
+        .disable_didcomm(DisableDidcommRequest::new(0))
+        .await
+        .unwrap();
+    assert_eq!(resp.prior_mediator_did, "did:peer:2.med");
+    assert!(resp.drains_until.is_none());
+}
+
+#[tokio::test]
+async fn disable_didcomm_with_drain_window() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/services/didcomm/disable"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "new_version_id": "3-zVer",
+            "prior_mediator_did": "did:peer:2.med",
+            "drains_until": "2026-05-12T00:00:00Z"
+        })))
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let resp = c
+        .disable_didcomm(DisableDidcommRequest::new(3600))
+        .await
+        .unwrap();
+    assert_eq!(resp.drains_until.as_deref(), Some("2026-05-12T00:00:00Z"));
+}
+
+// ── migrate_mediator ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn migrate_mediator_posts_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/mediators/migrate"))
+        .and(auth())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "new_version_id": "4-zVer",
+            "prior_mediator_did": "did:peer:2.old",
+            "active_mediator_did": "did:peer:2.new",
+            "active_mediator_endpoint": "https://new.mediator.example.com",
+            "drains_until": "2026-05-12T00:00:00Z"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let req = MigrateMediatorRequest::new("did:peer:2.new", 3600)
+        .force(false)
+        .rollback(true)
+        .handshake_timeout_secs(15);
+    let resp = c.migrate_mediator(req).await.unwrap();
+    assert_eq!(resp.active_mediator_did, "did:peer:2.new");
+    assert_eq!(resp.prior_mediator_did, "did:peer:2.old");
+}
+
+#[tokio::test]
+async fn migrate_mediator_500_maps_to_server_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/mediators/migrate"))
+        .respond_with(
+            ResponseTemplate::new(500).set_body_json(json!({"error": "handshake failed"})),
+        )
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let err = c
+        .migrate_mediator(MigrateMediatorRequest::new("did:peer:2.new", 3600))
+        .await
+        .unwrap_err();
+    match err {
+        VtaError::Server { status, .. } => assert_eq!(status, 500),
+        other => panic!("expected Server, got {other:?}"),
+    }
+}
+
+// ── drain_cancel ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn drain_cancel_posts_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/mediators/drain/cancel"))
+        .and(auth())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "mediator_did": "did:peer:2.draining"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let req = DrainCancelRequest {
+        mediator_did: "did:peer:2.draining".into(),
+    };
+    let resp = c.drain_cancel(req).await.unwrap();
+    assert_eq!(resp.mediator_did, "did:peer:2.draining");
+}
+
+#[tokio::test]
+async fn drain_cancel_404_when_not_in_drain() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/mediators/drain/cancel"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({"error": "not draining"})))
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let err = c
+        .drain_cancel(DrainCancelRequest {
+            mediator_did: "did:peer:2.x".into(),
+        })
+        .await
+        .unwrap_err();
+    assert!(err.is_not_found(), "got {err:?}");
+}
+
+// ── mediator_report ─────────────────────────────────────────────────
+
+fn report_body() -> Value {
+    json!({
+        "since": "2026-05-01T00:00:00Z",
+        "until": "2026-05-05T00:00:00Z",
+        "mediators": [{
+            "mediator_did": "did:peer:2.med",
+            "inbound_count": 42,
+            "first_seen": "2026-05-01T00:00:00Z",
+            "last_seen": "2026-05-04T00:00:00Z"
+        }],
+        "senders": [{
+            "sender_did": "did:key:zSender",
+            "last_seen_mediator": "did:peer:2.med",
+            "last_seen_at": "2026-05-04T12:00:00Z"
+        }]
+    })
+}
+
+#[tokio::test]
+async fn mediator_report_no_query_params() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/mediators/report"))
+        .and(auth())
+        .respond_with(ResponseTemplate::new(200).set_body_json(report_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let resp = c.mediator_report(None, None).await.unwrap();
+    assert_eq!(resp.mediators.len(), 1);
+    assert_eq!(resp.mediators[0].inbound_count, 42);
+    assert_eq!(resp.senders[0].last_seen_mediator, "did:peer:2.med");
+}
+
+#[tokio::test]
+async fn mediator_report_with_since_until_url_encodes_timestamps() {
+    let server = MockServer::start().await;
+    // RFC 3339 timestamps contain `:` which must be %3A-encoded.
+    // wiremock's `query_param` matches against the *decoded* value, so
+    // assert on what the SDK conceptually sent: literal `:` after decode.
+    Mock::given(method("GET"))
+        .and(path("/mediators/report"))
+        .and(auth())
+        .and(query_param("since", "2026-05-01T00:00:00Z"))
+        .and(query_param("until", "2026-05-05T00:00:00Z"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(report_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.mediator_report(Some("2026-05-01T00:00:00Z"), Some("2026-05-05T00:00:00Z"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn mediator_report_only_since() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/mediators/report"))
+        .and(query_param("since", "2026-05-01T00:00:00Z"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(report_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.mediator_report(Some("2026-05-01T00:00:00Z"), None)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn mediator_report_only_until() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/mediators/report"))
+        .and(query_param("until", "2026-05-05T00:00:00Z"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(report_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.mediator_report(None, Some("2026-05-05T00:00:00Z"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn mediator_report_403_when_not_authorized() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/mediators/report"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(json!({"error": "no"})))
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let err = c.mediator_report(None, None).await.unwrap_err();
+    assert!(err.is_auth(), "got {err:?}");
+}

--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -1,0 +1,609 @@
+//! Coverage for `vta_sdk::session::SessionStore` and its backends.
+//!
+//! Three test layers:
+//!   1. **Backend ops** — pure storage round-trips with the in-memory
+//!      backend (`store_direct`, `store_pending_rotation`,
+//!      `loaded_session`, `session_status`, `logout`).
+//!   2. **`FileBackend`** — exercise the on-disk plaintext fallback by
+//!      constructing `SessionStore::new(...)` against a tempdir, where
+//!      the SDK's feature-gate cascade lands on `FileBackend`.
+//!   3. **Network paths** — `login` / `ensure_authenticated` /
+//!      `rotate_key` against a `wiremock` server, using `did:key` DIDs
+//!      so TDK's resolver doesn't need outbound DNS.
+
+#![cfg(all(feature = "session", feature = "test-support"))]
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ed25519_dalek::SigningKey;
+use serde_json::json;
+#[cfg(not(any(feature = "keyring", feature = "azure-secrets")))]
+use tempfile::tempdir;
+use vta_sdk::credentials::CredentialBundle;
+use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::session::testing::InMemorySessionBackend;
+use vta_sdk::session::{
+    SessionStore, TokenStatus, VtaEndpoint, resolve_vta_endpoint, resolve_vta_url,
+};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── Test fixtures ───────────────────────────────────────────────────
+
+fn store() -> SessionStore {
+    SessionStore::with_backend(Box::new(InMemorySessionBackend::new()))
+}
+
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = SigningKey::from_bytes(&seed);
+    let pk = sk.verifying_key().to_bytes();
+    let did = format!("did:key:{}", ed25519_multibase_pubkey(&pk));
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    let priv_mb = multibase::encode(multibase::Base::Base58Btc, &buf);
+    (did, priv_mb)
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+// ── Backend round-trips (no network) ────────────────────────────────
+
+#[test]
+fn store_direct_round_trips_through_loaded_session() {
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    s.store_direct("k", &did, &pk, &vta_did).unwrap();
+
+    assert!(s.has_session("k"));
+    let info = s.loaded_session("k").unwrap();
+    assert_eq!(info.client_did, did);
+    assert_eq!(info.vta_did.as_deref(), Some(vta_did.as_str()));
+    assert_eq!(info.private_key_multibase, pk);
+}
+
+#[test]
+fn store_pending_rotation_marks_needs_rotation() {
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    s.store_pending_rotation("k", &did, &pk, &vta_did).unwrap();
+
+    // The needs_rotation flag isn't directly visible via SessionInfo,
+    // but `session_status` returns TokenStatus::None (no token yet).
+    let status = s.session_status("k").unwrap();
+    assert_eq!(status.client_did, did);
+    assert!(matches!(status.token_status, TokenStatus::None));
+}
+
+#[test]
+fn logout_clears_entry() {
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    s.store_direct("k", &did, &pk, &vta_did).unwrap();
+    assert!(s.has_session("k"));
+    s.logout("k");
+    assert!(!s.has_session("k"));
+    assert!(s.loaded_session("k").is_none());
+    assert!(s.session_status("k").is_none());
+}
+
+#[test]
+fn has_session_false_for_missing_entry() {
+    let s = store();
+    assert!(!s.has_session("never-stored"));
+    assert!(s.loaded_session("never-stored").is_none());
+}
+
+#[test]
+fn session_status_none_when_no_token_cached() {
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    s.store_direct("k", &did, &pk, &vta_did).unwrap();
+    let status = s.session_status("k").unwrap();
+    assert!(matches!(status.token_status, TokenStatus::None));
+}
+
+// ── FileBackend (on-disk plaintext fallback) ────────────────────────
+//
+// Only exercised when no other session backend is compiled in. Under
+// workspace cov runs the `keyring` feature is unified on (pnm-cli /
+// cnm-cli enable it), and `default_backend` returns `KeyringBackend`
+// instead — so these tests would no-op against a different code path.
+// Running `cargo test -p vta-sdk --test session_store --features
+// "session test-support"` exercises this path.
+
+#[cfg(not(any(feature = "keyring", feature = "azure-secrets")))]
+#[test]
+fn file_backend_round_trips_via_session_store_new() {
+    // SessionStore::new() with no keyring/azure features compiled
+    // (the default for these tests) lands on FileBackend with
+    // warn=true. Save → load → clear must round-trip through
+    // `<sessions_dir>/sessions.json`.
+    let dir = tempdir().unwrap();
+    let store = SessionStore::new("test-svc", dir.path().to_path_buf());
+
+    let (did, pk) = did_key_from_seed(0x30);
+    let (vta_did, _) = did_key_from_seed(0x40);
+    store.store_direct("file-k", &did, &pk, &vta_did).unwrap();
+
+    // The on-disk file is created.
+    let sessions_file = dir.path().join("sessions.json");
+    assert!(
+        sessions_file.exists(),
+        "FileBackend should create sessions.json"
+    );
+
+    // Round-trip via a fresh store instance pointing at the same dir.
+    let store2 = SessionStore::new("test-svc", dir.path().to_path_buf());
+    let info = store2.loaded_session("file-k").unwrap();
+    assert_eq!(info.client_did, did);
+    assert_eq!(info.vta_did.as_deref(), Some(vta_did.as_str()));
+
+    store2.logout("file-k");
+    assert!(!store2.has_session("file-k"));
+    // A subsequent load on a fresh store sees the cleared state.
+    let store3 = SessionStore::new("test-svc", dir.path().to_path_buf());
+    assert!(store3.loaded_session("file-k").is_none());
+}
+
+#[cfg(not(any(feature = "keyring", feature = "azure-secrets")))]
+#[test]
+fn file_backend_load_on_missing_dir_returns_none() {
+    // Pointing at a non-existent path must not panic; load returns None.
+    let store = SessionStore::new(
+        "test-svc",
+        std::path::PathBuf::from("/tmp/never-created-vta-sdk-tests-xyz"),
+    );
+    assert!(!store.has_session("missing"));
+    assert!(store.loaded_session("missing").is_none());
+}
+
+// ── Network paths via wiremock ──────────────────────────────────────
+
+async fn mount_challenge(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/auth/challenge"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess",
+            "data": { "challenge": "c-nonce" }
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_authenticate(server: &MockServer, expires_at: u64) {
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessionId": "sess",
+            "data": {
+                "accessToken": "access-jwt",
+                "accessExpiresAt": expires_at
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn login_authenticates_and_persists_token() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    let future = now_secs() + 3600;
+    mount_authenticate(&server, future).await;
+
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    let bundle = CredentialBundle::new(&did, &pk, &vta_did);
+
+    let result = s.login(&bundle, &server.uri(), "k").await.unwrap();
+    assert_eq!(result.client_did, did);
+    assert_eq!(result.vta_did.as_deref(), Some(vta_did.as_str()));
+
+    let status = s.session_status("k").unwrap();
+    match status.token_status {
+        TokenStatus::Valid { expires_in_secs } => assert!(expires_in_secs > 3000),
+        other => panic!("expected Valid token, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn login_propagates_challenge_failure() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/auth/challenge"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("nope"))
+        .mount(&server)
+        .await;
+
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    let bundle = CredentialBundle::new(&did, &pk, &vta_did);
+    let err = s.login(&bundle, &server.uri(), "k").await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("challenge request failed") || msg.contains("401"),
+        "expected challenge-failure surface, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn ensure_authenticated_returns_cached_token_if_valid() {
+    // Pre-populate a session with a token expiring far in the future.
+    // ensure_authenticated should NOT touch the network — wiremock has
+    // no /auth mocks mounted, so any HTTP attempt would fail.
+    let server = MockServer::start().await;
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+
+    // Use login to populate a valid token via wiremock, then call
+    // ensure_authenticated against a *different* (un-mocked) URL — the
+    // cache should make that a no-op.
+    mount_challenge(&server).await;
+    let future = now_secs() + 3600;
+    mount_authenticate(&server, future).await;
+    let bundle = CredentialBundle::new(&did, &pk, &vta_did);
+    s.login(&bundle, &server.uri(), "k").await.unwrap();
+
+    // Different URL — would 404 if hit. Cached token means it isn't.
+    let token = s
+        .ensure_authenticated("http://127.0.0.1:1", "k")
+        .await
+        .unwrap();
+    assert_eq!(token, "access-jwt");
+}
+
+#[tokio::test]
+async fn ensure_authenticated_re_authenticates_when_token_expired() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    // Two sequential responses: first auth gives an expired token, second
+    // gives a fresh one. wiremock matches in registration order with
+    // up_to_n_times.
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "accessToken": "expired", "accessExpiresAt": 100_u64 }
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    let future = now_secs() + 3600;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "accessToken": "fresh", "accessExpiresAt": future }
+        })))
+        .mount(&server)
+        .await;
+
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    let bundle = CredentialBundle::new(&did, &pk, &vta_did);
+    s.login(&bundle, &server.uri(), "k").await.unwrap();
+
+    // Cached token is expired → ensure_authenticated runs a new
+    // challenge-response and returns the fresh token.
+    let token = s.ensure_authenticated(&server.uri(), "k").await.unwrap();
+    assert_eq!(token, "fresh");
+}
+
+#[tokio::test]
+async fn ensure_authenticated_errors_when_no_session() {
+    let s = store();
+    let err = s
+        .ensure_authenticated("http://localhost", "missing")
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Not authenticated"),
+        "expected 'Not authenticated' guidance, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn ensure_authenticated_errors_when_pending_vta_binding() {
+    // store_pending_vta_binding leaves vta_did = None. require_vta_did
+    // (gated on entry to ensure_authenticated) must reject this state
+    // with operator-actionable guidance.
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    s.store_pending_vta_binding("k", &did, &pk).unwrap();
+    let err = s
+        .ensure_authenticated("http://localhost", "k")
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("setup continue") || msg.contains("VTA"),
+        "expected pending-binding guidance, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn ensure_authenticated_runs_full_rotation_flow() {
+    // Pending-rotation session: first auth as the temp DID succeeds,
+    // then ensure_authenticated fetches the temp DID's ACL entry, mints
+    // a fresh did:key, creates a new ACL entry, runs a *second*
+    // challenge-response as the new DID, and best-effort deletes the
+    // temp ACL entry.
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+
+    let future = now_secs() + 3600;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "accessToken": "temp-token", "accessExpiresAt": future }
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "accessToken": "rotated-token", "accessExpiresAt": future }
+        })))
+        .mount(&server)
+        .await;
+
+    let (temp_did, temp_pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+
+    // GET /acl/{temp_did} — return the entry the admin granted.
+    Mock::given(method("GET"))
+        .and(path(format!("/acl/{temp_did}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "did": temp_did,
+            "role": "admin",
+            "label": "ops",
+            "allowed_contexts": ["primary"],
+            "created_at": 1_700_000_000_u64,
+            "created_by": "did:web:vta",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // POST /acl — create entry for new DID. We don't know the new DID
+    // ahead of time (it's randomly generated), so don't assert path
+    // beyond /acl + method.
+    Mock::given(method("POST"))
+        .and(path("/acl"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "did": "did:key:zNew",
+            "role": "admin",
+            "label": "ops",
+            "allowed_contexts": ["primary"],
+            "created_at": 1_700_000_000_u64,
+            "created_by": "did:web:vta",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // DELETE /acl/{temp_did} — best-effort cleanup of the temp DID.
+    Mock::given(method("DELETE"))
+        .and(path(format!("/acl/{temp_did}")))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let s = store();
+    s.store_pending_rotation("k", &temp_did, &temp_pk, &vta_did)
+        .unwrap();
+
+    let token = s.ensure_authenticated(&server.uri(), "k").await.unwrap();
+    assert_eq!(token, "rotated-token");
+
+    // After rotation, the session reflects the *new* DID, not the temp.
+    let info = s.loaded_session("k").unwrap();
+    assert_ne!(info.client_did, temp_did, "rotation must replace temp DID");
+    assert!(info.client_did.starts_with("did:key:"));
+}
+
+#[tokio::test]
+async fn ensure_authenticated_rotation_fails_when_acl_read_fails() {
+    // If the GET /acl/{temp_did} call fails, the rotation must bail
+    // BEFORE deleting the temp ACL entry — so the temp DID stays
+    // authoritative and the caller can retry.
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    let future = now_secs() + 3600;
+    mount_authenticate(&server, future).await;
+
+    let (temp_did, temp_pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/acl/{temp_did}")))
+        .respond_with(ResponseTemplate::new(404).set_body_string("no entry yet"))
+        .mount(&server)
+        .await;
+
+    // Important: NO /acl POST mock — if rotation tries to create a new
+    // entry without a successful read, the test fails on the unmatched
+    // request.
+
+    let s = store();
+    s.store_pending_rotation("k", &temp_did, &temp_pk, &vta_did)
+        .unwrap();
+
+    let err = s
+        .ensure_authenticated(&server.uri(), "k")
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("temp DID's ACL"),
+        "expected ACL-read failure guidance, got: {msg}"
+    );
+
+    // Session is still the temp DID after a failed rotation.
+    let info = s.loaded_session("k").unwrap();
+    assert_eq!(info.client_did, temp_did);
+}
+
+// ── connect() with URL override (REST path) ─────────────────────────
+
+#[tokio::test]
+async fn connect_with_url_override_uses_rest_and_attaches_token() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    let future = now_secs() + 3600;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "accessToken": "connect-token", "accessExpiresAt": future }
+        })))
+        .mount(&server)
+        .await;
+    // Authenticated request after connect() returns: should carry the
+    // token established during the auth round-trip.
+    Mock::given(method("GET"))
+        .and(path("/config"))
+        .and(wiremock::matchers::header(
+            "authorization",
+            "Bearer connect-token",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "vta_did": null, "vta_name": null, "public_url": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    s.store_direct("k", &did, &pk, &vta_did).unwrap();
+
+    let client = s.connect("k", Some(&server.uri())).await.unwrap();
+    // Round-trip an authenticated call to prove the token was attached.
+    client.get_config().await.unwrap();
+}
+
+// ── resolve_vta_url / resolve_vta_endpoint URL-fallback paths ───────
+//
+// These exercise the cache-resolver-fails → `url_from_did` fallback
+// that runs against unreachable / unresolvable DIDs (the `did:web:`
+// path looks up nothing on the network in test).
+
+#[tokio::test]
+async fn resolve_vta_url_falls_back_to_did_web_parse() {
+    // The cache resolver tries to fetch `did:web:nonexistent.invalid`
+    // and fails, so `resolve_vta_url` falls through to `url_from_did`,
+    // which strips `did:web:` and produces `https://<host>`.
+    let url = resolve_vta_url("did:web:vta.example.invalid")
+        .await
+        .unwrap();
+    assert_eq!(url, "https://vta.example.invalid");
+}
+
+#[tokio::test]
+async fn resolve_vta_url_falls_back_to_did_webvh_parse() {
+    let url = resolve_vta_url("did:webvh:Qabc:vta.example.invalid:primary")
+        .await
+        .unwrap();
+    assert_eq!(url, "https://vta.example.invalid");
+}
+
+#[tokio::test]
+async fn resolve_vta_url_decodes_percent_encoded_port() {
+    // `:` in the host segment is percent-encoded as `%3A`. The
+    // fallback parser must decode it so the URL is usable.
+    let url = resolve_vta_url("did:web:vta.example.invalid%3A8100")
+        .await
+        .unwrap();
+    assert_eq!(url, "https://vta.example.invalid:8100");
+}
+
+#[tokio::test]
+async fn resolve_vta_url_unparseable_did_errors() {
+    // `did:key:` doesn't have a host segment — `url_from_did` returns
+    // None, so `resolve_vta_url` errors with operator-actionable
+    // guidance.
+    let err = resolve_vta_url("did:key:z6Mkpub").await.unwrap_err();
+    assert!(err.to_string().contains("Could not determine VTA URL"));
+}
+
+#[tokio::test]
+async fn resolve_vta_endpoint_falls_back_to_rest_for_did_web() {
+    let endpoint = resolve_vta_endpoint("did:web:vta.example.invalid")
+        .await
+        .unwrap();
+    match endpoint {
+        VtaEndpoint::Rest { url } => assert_eq!(url, "https://vta.example.invalid"),
+        VtaEndpoint::DIDComm { .. } => panic!("expected Rest fallback, got DIDComm"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_vta_endpoint_unparseable_did_errors() {
+    let err = match resolve_vta_endpoint("did:key:z6Mkpub").await {
+        Ok(_) => panic!("expected unparseable did:key to fail resolution"),
+        Err(e) => e,
+    };
+    assert!(err.to_string().contains("Could not determine VTA URL"));
+}
+
+#[tokio::test]
+async fn connect_url_override_skips_resolution() {
+    // SessionStore::connect with a URL override goes straight to the
+    // REST path — never calls resolve_vta_endpoint. Verifies that even
+    // a session bound to an unresolvable did:key VTA still connects
+    // when the operator passes `--url`.
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    mount_authenticate(&server, now_secs() + 3600).await;
+
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20); // did:key, no service entry
+    s.store_direct("k", &did, &pk, &vta_did).unwrap();
+
+    // Round-trip an authenticated call to prove the client is wired.
+    Mock::given(method("GET"))
+        .and(path("/config"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "vta_did": null, "vta_name": null, "public_url": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = s
+        .connect("k", Some(&server.uri()))
+        .await
+        .expect("connect with url override");
+    client.get_config().await.unwrap();
+}
+
+// ── connect() ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn connect_errors_when_no_session() {
+    let s = store();
+    let err = match s.connect("missing", Some("http://localhost")).await {
+        Ok(_) => panic!("expected connect to fail with no session"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("auth login") || err.to_string().contains("Not authenticated")
+    );
+}


### PR DESCRIPTION
## Summary

Lifts `vta-sdk` line coverage from **62.5% → 81.3%** (+18.8 pts) and function coverage from **50.4% → 80.1%** (+29.7 pts) by adding focused test harnesses for the REST client, auth flow, session store, DIDComm protocol-management surface, and end-to-end DIDComm transport against a live `affinidi-messaging-test-mediator`.

Includes one SDK fix surfaced while building the round-trip tests: `didcomm_session::send_and_wait` now wraps outbound traffic in a `routing/2.0/forward` envelope (matching the production `affinidi-messaging-didcomm-service` send path). Without this, the SDK's DIDComm transport would fail against any mediator with `local_direct_delivery_allowed: false`.

### Coverage by file

| File | Before | After |
|---|---:|---:|
| `auth_light.rs` | 0.0% | **100.0%** |
| `client.rs` | 14.0% | **91.1%** |
| `client/types.rs` | 0.0% | **80.7%** |
| `didcomm_light.rs` | 90.6% | **94.6%** |
| `didcomm_session.rs` | 0.0% | **80.4%** |
| `protocol/mod.rs` | 0.0% | **99.2%** |
| `session.rs` | 32.4% | **66.2%** |
| `session/backends/mod.rs` | 0.0% | **100.0%** |
| **vta-sdk total (lines)** | **62.5%** | **81.3%** |
| **Workspace (lines)** | 46.8% | 50.8% |

### What's in this PR

**vta-sdk inline-style tests** (wiremock; no extra infrastructure):

- `vta-sdk/tests/client_rest.rs` — 77 tests. Every `VtaClient` REST method: URL construction, path encoding for DIDs with reserved characters, query params, auth-header propagation, full status → `VtaError` mapping (400/401/403/404/409/410/422/500/418/malformed-body/connection-refused).
- `vta-sdk/tests/auth_light_rest.rs` — 16 tests. `auth_light` challenge-response, refresh-token rotation, full re-auth fallback, and the `ensure_token_valid` refresh path on `VtaClient::from_credential`.
- `vta-sdk/tests/protocol_rest.rs` — 13 tests. DIDComm protocol-management REST surface (enable/disable/migrate/drain-cancel/mediator report).
- `vta-sdk/tests/session_store.rs` — 24 tests. Backend round-trips (in-memory + on-disk file fallback), `login`/`ensure_authenticated`, full pending-rotation flow with abort-on-probe-failure, and the `resolve_vta_url` / `resolve_vta_endpoint` URL-parse fallback paths.

**End-to-end DIDComm tests** (against `affinidi-messaging-test-mediator`):

- `tests/e2e/tests/common/test_vta_responder.rs` — reusable DIDComm responder fixture. Spawns a `did:peer:2` identity on a `TestMediator`, loops on `live_stream_next`, dispatches inbound messages to a caller-supplied handler, and ships replies through the mediator's forward-routing path.
- `tests/e2e/tests/didcomm_session.rs` — 8 tests. `DIDCommSession` connect, `send_and_wait` round-trip success, problem-report mapping, unknown-code → `DidcommRemote`, wrong-typ → `Protocol` error, timeout, plus connect-failure paths.
- `tests/e2e/tests/client_didcomm.rs` — 30 tests. `VtaClient`'s `Transport::DIDComm` arms exercised end-to-end via the responder for 19 endpoint methods, plus error-mapping and unsupported-transport branches.

**SDK fix:** `vta-sdk/src/didcomm_session.rs::send_and_wait` swaps `atm.send_message(...)` for `atm.forward_and_send_message(...)` and pulls the mediator DID off the profile. ~20 LOC. Without this fix the test mediator (and any production mediator running with `local_direct_delivery_allowed: false`) refuses to relay the SDK's outbound traffic with `w.m.direct_delivery.denied`.

### Out of scope

- Remaining ~600 uncovered vta-sdk lines split between `session.rs` DIDComm methods (`ensure_authenticated_didcomm`, `rotate_key_didcomm`, `TrustPingSession`) needing a service-entry-aware responder, plus `session/backends/{file,keyring}.rs` which depend on whether the workspace `keyring` feature is unified on at cov time. Diminishing returns relative to test-infrastructure cost — leaving for a follow-up.

## Test plan

- [x] `cargo test -p vta-sdk --features "client"` (REST harnesses)
- [x] `cargo test -p vta-sdk --features "session test-support"` (session_store)
- [x] `cargo test -p vti-e2e-tests` (didcomm_session + client_didcomm + existing transient_handshake/mediator_smoke)
- [x] `cargo test --workspace` (no regressions)
- [x] `cargo fmt --all` (formatting clean)
- [ ] CI green