### PR TITLE
feat(runtime-services): P0 foundations — spec, typed errors, snapshot store, invariant helper

### DIFF
--- a/docs/05-design-notes/runtime-service-management-plan.md
+++ b/docs/05-design-notes/runtime-service-management-plan.md
@@ -1,0 +1,321 @@
+# Plan: Runtime service-endpoint management
+
+Status: **DRAFT — Phase 2 (Plan)**
+Companion to: `runtime-service-management.md` (the approved spec)
+Owner: Glenn Gore
+Last updated: 2026-05-06
+
+This plan decomposes the spec into ordered phases, identifies what
+can run in parallel, lists the major risks, and pins the verification
+checkpoint at each phase boundary. Tasks (Phase 3) are generated
+**from this plan** in a separate doc.
+
+## P0. Foundations (blocks everything else)
+
+These need to land first. Tiny, individually trivial, but absolutely
+on the critical path.
+
+* **P0.1 — Resolve §10 open questions.** Convert the four spec open
+  questions into decisions:
+  * DIDComm-preferred encoding: choose array-ordering (DIDComm
+    first) **or** DIDComm v2 `priority` key. Recommendation: array
+    ordering — it's universally honored by DID-Core resolvers,
+    `priority` is only DIDComm v2 spec-aware. Confirm by reading
+    the existing built-in templates' service shapes.
+  * URL reachability probing: **don't probe.** Trust the operator,
+    consistent with mediator DID handling.
+  * `routing_keys`: confirm the existing
+    `vta_sdk::protocol::protocol_management` shape carries it; if
+    not, extend before P1.
+  * `services list` JSON shape: minimal — `{kind, enabled, config}`
+    per kind. Don't reuse `services report`'s telemetry-heavy
+    schema.
+* **P0.2 — Add new typed errors to `VtaError`.** `NoPriorMutation`,
+  `UnsupportedTransport`, `LastServiceRefused`, `ServiceNotPresent`,
+  `ServiceAlreadyEnabled`, `MediatorHandshakeFailed`,
+  `DrainTtlOutOfBounds`. Some may already exist — audit
+  `vta-sdk/src/error.rs` first.
+* **P0.3 — Previous-config snapshot store.** New fjall keyspace
+  `service-prev-config/<kind>`; module
+  `vta-service/src/operations/protocol/snapshot.rs` with
+  `read`/`write`/`clear` accessors. **Order invariant:** snapshot
+  is persisted *before* the runtime mutation runs, so a crash
+  between snapshot and mutation just means rollback target is the
+  current state (no-op). Crash between mutation and LogEntry
+  publication is the existing transactional-rollback pattern.
+* **P0.4 — Brick-prevention invariant helper.**
+  `protocol::invariant::would_violate_last_service(state, op) ->
+  Result<(), VtaError>`. Used by every `disable` and every
+  `rollback` path. Single source of truth — no duplicated
+  conditionals.
+
+**Verification:** `cargo build --workspace --all-features` clean.
+New errors round-trip through serde (REST + DIDComm transports).
+
+## P1. REST operations (parallel with P2)
+
+* **P1.1 — Wire types** in `vta-sdk::protocol::services`:
+  `EnableRestRequest`, `UpdateRestRequest`, `DisableRestRequest`,
+  `RollbackRestRequest`, `ServiceMutationResponse`.
+* **P1.2 — URL validator** in vta-sdk: shared by REST + service-entry
+  rendering. `https://` only, `url::Url` parse, no fragment, no
+  userinfo.
+* **P1.3 — REST operations** under `vta-service/src/operations/protocol/`:
+  `enable_rest.rs`, `update_rest.rs`, `disable_rest.rs`. Each:
+  * validate input
+  * check brick-prevention (disable only)
+  * persist snapshot (P0.3)
+  * mutate DID-doc service[]
+  * publish LogEntry
+  * emit telemetry
+* **P1.4 — REST route handlers** in `routes/protocol.rs`. Wire to
+  the shared operation layer (no duplicated logic).
+* **P1.5 — DIDComm handlers for REST operations** in
+  `messaging/handlers_protocol.rs`. Same shared operation layer.
+
+**Verification:** unit tests in each `operations/protocol/*_rest.rs`
+file cover happy path + each rejection variant. Manual smoke:
+`curl -X POST .../services/rest/update -d '{"url":"..."}'` against
+a local VTA changes the URL on next `did.jsonl` fetch.
+
+## P2. DIDComm refactor (parallel with P1)
+
+Goal: bring the existing DIDComm operations onto the shared snapshot
+store + brick-prevention helper without changing observable behavior.
+**Refactor first; add features second.** Each step here should be
+zero-behavior-change relative to today's tests.
+
+* **P2.1 — Adopt P0.3 snapshot store** in `enable_didcomm.rs`,
+  `disable_didcomm.rs`, `migrate_mediator.rs`. Replace any ad-hoc
+  "previous mediator" tracking with the new module.
+* **P2.2 — Adopt P0.4 invariant helper** in `disable_didcomm.rs`.
+  Existing `LastServiceRefused`-equivalent check is replaced by
+  the shared helper.
+* **P2.3 — Rename for spec alignment.** Internal: keep file names
+  but expose the operations as `update_didcomm` (was migrate). No
+  semantic change. The `migrate_mediator.rs` file can stay; just
+  rename the public `pub fn` and update call sites. (Optional —
+  only do this if it doesn't sprawl. If it does, defer to a
+  follow-up.)
+* **P2.4 — DIDComm-preferred ordering** per P0.1 decision. One
+  function in `did_webvh/render.rs` (or wherever service[] is
+  built) sorts the array. Touched by every operation but lives in
+  one place.
+
+**Verification:** all existing protocol-management tests still pass
+unchanged. `git diff` on each refactor commit shows mechanical
+changes only — no logic edits.
+
+## P3. Fail-forward rollback
+
+Builds on P0.3 (snapshot store), P1 (REST ops), P2 (DIDComm
+refactor). Rollback is *literally* "read snapshot → run forward
+operation → done." That's why the snapshot store has to exist
+first.
+
+* **P3.1 — `rollback_rest.rs`.** Reads snapshot for `rest`, dispatches
+  to `enable_rest` / `update_rest` / `disable_rest` based on what
+  the snapshot reveals.
+* **P3.2 — `rollback_didcomm.rs`.** Same pattern. Replaces today's
+  rollback path; **breaking** semantic change from "rewind" to
+  "fail-forward." Update existing tests.
+* **P3.3 — Telemetry `triggered_by` field.** The forward operations
+  emit `service.<kind>.<verb>` events. Rollback dispatches into
+  them with a context flag that adds `triggered_by: "rollback"` to
+  the event metadata. Simple enum on the operation entry point.
+* **P3.4 — Brick-prevention on rollback.** Reuses P0.4. Tested by
+  the §7a.5 history scenarios that resolve to `LastServiceRefused`.
+
+**Verification:** unit tests for each rollback path covering the
+§7a.5 histories at unit level. e2e versions come in P6.
+
+## P4. `services list` query
+
+* **P4.1 — Operation** `protocol::list::list_services()` returning
+  `ServicesListResponse` (per P0.1 minimal shape).
+* **P4.2 — REST + DIDComm handlers** wiring to P4.1.
+
+**Verification:** unit test against synthetic state covering S1, S2,
+S3.
+
+## P5. CLI surface
+
+Breaking change to the user-facing CLI per the spec. Touch carefully:
+the `pnm`/`cnm`/`vta` binaries all share `vta-cli-common`.
+
+* **P5.1 — Delete `vta-cli-common/src/commands/mediator.rs`.**
+  Update `mod.rs` re-exports.
+* **P5.2 — Rewrite `vta-cli-common/src/commands/services.rs`** to
+  the §5.1 shape. New functions per (kind, verb) pair.
+* **P5.3 — `pnm-cli`/`cnm-cli` clap definitions.** Drop `mediator`
+  subcommand; expand `services` subcommand to the new tree.
+* **P5.4 — `vta services …`** — add to `vta-service/src/main.rs`.
+* **P5.5 — Operator-error guidance.** Per CLAUDE.md, when a
+  command fails with a typed `VtaError`, the CLI prints the
+  corrected command. Specifically:
+  * `LastServiceRefused` → suggest enabling the other transport
+    first
+  * `ServiceNotPresent` on `update` → suggest `enable`
+  * `ServiceAlreadyEnabled` on `enable` → suggest `update`
+  * `NoPriorMutation` on `rollback` → "no prior mutation to roll
+    back to; use `services <kind> <verb>` directly"
+* **P5.6 — Migration cue.** When the old `pnm mediator` command
+  is invoked, clap will reject it (subcommand not found). Add a
+  custom error message printer that catches the unknown-subcommand
+  path and suggests the new shape, e.g., "the `mediator` subcommand
+  was retired; try `pnm services didcomm …`."
+
+**Verification:** `pnm --help`, `cnm --help`, `vta --help` all show
+the new tree. `pnm mediator migrate <did>` prints the migration cue.
+Each of the new commands runs against a local VTA end-to-end.
+
+## P6. End-to-end test matrix
+
+Per spec §7a. ~64 tests. Build the harness once; the tests are
+small. The harness is the bulk of the work.
+
+* **P6.1 — State fixtures** in `tests/e2e`: helpers
+  `setup_vta_in_state(S1|S2|S3)` that produce a freshly-set-up VTA
+  in each starting state. Foundational — every other test depends.
+* **P6.2 — State × Op matrix tests (§7a.2).** 24 cells. Each test
+  asserts: outcome (state transition or typed error), one new
+  LogEntry (or none for error paths), `verificationMethod`
+  byte-identical. Most cells are 10–20 lines.
+* **P6.3 — Transport coverage (§7a.3).** Re-run §7a.2's accepted
+  cells over DIDComm transport using the existing test mediator.
+  Done as a parameterized test rather than copy-paste.
+* **P6.4 — Drain interaction tests (§7a.4).** 11 scenarios. Each
+  exercises drain set persistence, sticky routing, restart
+  replay, TTL bounds.
+* **P6.5 — Rollback history tests (§7a.5).** 11 scenarios.
+* **P6.6 — Sequencing soak paths (§7a.6).** 6 paths. These look
+  like operator session transcripts.
+* **P6.7 — Restart-resilience harness.** Helper to kill + restart
+  the VTA process mid-test. Used by §7a.4 restart row and §7a.6
+  path 5.
+
+**Verification:** all e2e tests green under `cargo nextest run -p
+e2e`. CI time delta tracked — if it doubles, we parallelize harder
+or split into a separate CI job.
+
+## P7. Documentation
+
+* **P7.1 — New operator guide:**
+  `docs/03-integrating/runtime-service-management.md`. Walks
+  through every command with an example transcript.
+* **P7.2 — Retire/redirect:**
+  `docs/03-integrating/didcomm-protocol-management.md` and
+  `docs/05-design-notes/didcomm-protocol-management.md`. Either
+  fold their content into the new doc and leave a stub redirect,
+  or update them to scope-only-DIDComm-specifics. Pick one in P7
+  start.
+* **P7.3 — Workspace CLAUDE.md.** Update the "DIDComm protocol
+  management" integration-flow section to reflect the
+  generalization. Rename it to "Runtime service management."
+* **P7.4 — Migration note.** Brief upgrade guide for the breaking
+  CLI changes. Likely lives at top of P7.1 doc.
+* **P7.5 — Two memory entries** (per the auto-memory system):
+  one updating `project_didcomm_protocol_management.md` to
+  "subsumed by runtime-service-management"; one new project
+  memory recording the architectural choice (per-kind snapshot
+  store, fail-forward rollback) so future sessions don't
+  re-litigate it.
+
+**Verification:** docs reviewed. CLAUDE.md updated. Memory entries
+written.
+
+## Critical-path graph
+
+```
+        ┌──── P1 (REST ops) ────┐
+P0 ────┤                          ├──→ P3 (rollback) ──→ P4 (list) ──→ P5 (CLI) ──→ P6 (e2e) ──→ P7 (docs)
+        └──── P2 (DIDComm refactor)
+```
+
+* P0 is fully sequential and small.
+* P1 and P2 are independent and run in parallel.
+* P3 needs both P1 and P2 done.
+* P4 is a small leaf; runs alongside P3 if convenient.
+* P5 needs operations stable (P3 done).
+* P6 needs CLI stable (P5 done) — well, the e2e tests can use the
+  REST API directly without CLI, so P6.1–P6.6 *could* start after
+  P3, with the CLI-using paths in P6.6 deferred. Worth doing if P5
+  becomes a bottleneck.
+* P7 is parallel-with-P6 territory.
+
+## Parallelism opportunities
+
+| Pair | Can run in parallel? |
+|---|---|
+| P1 ↔ P2 | Yes — different code paths, both depend only on P0 |
+| P3.1 ↔ P3.2 | Yes — REST and DIDComm rollback are independent |
+| P6.2 ↔ P6.4 ↔ P6.5 | Yes — different test categories |
+| P6 ↔ P7 | Yes — docs work doesn't need green tests |
+
+Phases that **cannot** parallelize:
+- P0 must finish before any other phase
+- P5 cannot start until P3 is stable (CLI calls operations)
+- P6 transport-coverage tests need P5's DIDComm handlers (or hit
+  the messaging layer directly)
+
+## Risks (specific to this implementation)
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| P2 refactor accidentally regresses drain timing or handshake | medium | high | Refactor commits must show no test diff; existing 111-test suite is the trip-wire |
+| Snapshot persisted, mutation succeeds, LogEntry publish fails | low | medium | Same transactional-rollback pattern as today's `migrate_mediator`; test crash injection at each step |
+| DIDComm-preferred encoding (P2.4) breaks compat with existing chains | medium | high | Add a one-time chain-replay test on a fixture chain produced by current main; assert clients still resolve correctly |
+| Single-step rollback semantics surprise an operator | low | low | Doc'd in spec §3.5a; `services list` shows previous-config so operator can self-check |
+| ~64 e2e tests blow CI time | high | medium | Parameterize §7a.2/§7a.3 in nextest; split into a separate CI job if > 10 min |
+| Breaking CLI change reaches a user mid-session | low | low | P5.6 migration cue; release notes on next version bump |
+| `pnm mediator` references inside our own docs | medium | low | Grep audit in P7 |
+
+## Verification checkpoints (gate to next phase)
+
+* **End of P0:** workspace builds clean, errors serialize, snapshot
+  store has a passing read/write/clear test.
+* **End of P1:** REST operations have unit tests passing, manual
+  smoke against a local VTA changes the URL.
+* **End of P2:** existing test suite still green, mechanical-diff
+  refactor commits.
+* **End of P3:** rollback unit tests pass for both kinds, including
+  brick-prevention rejections.
+* **End of P4:** `services list` returns the documented shape from
+  S1/S2/S3 fixtures.
+* **End of P5:** new CLI surface live, old commands print
+  migration cue, operator-error guidance verified by manual
+  invocation.
+* **End of P6:** all 64 e2e tests green; CI time within budget.
+* **End of P7:** docs reviewed, CLAUDE.md updated, memory entries
+  written.
+
+## What this plan does **not** decide
+
+These remain spec-internal questions and are deferred to the Tasks
+phase or implementation:
+
+* Exact field names in wire types (`mediator_did` vs `mediator`)
+* Telemetry event JSON schema beyond name + LogEntry version-id
+* CI job split vs. single job for new e2e tests
+* Whether to fold `didcomm-protocol-management.md` docs into the
+  new doc or leave them as historical notes (decide in P7)
+
+## Open items requiring user input before Phase 3
+
+These are go/no-go decisions before I generate tasks:
+
+1. **P2.3 — internal rename `migrate_mediator` → `update_didcomm`.**
+   Worth doing, or leave the file/function names as-is and only
+   rename at the public surface? My lean: rename for symmetry with
+   the spec, but if it sprawls, defer.
+2. **P6 ordering — start e2e harness work (P6.1) in parallel with
+   P3?** This is "build the harness early so we can use it for P3
+   verification." Lean: yes — P6.1 has no deps on P3.
+3. **P7 docs disposition — fold `didcomm-protocol-management.md`
+   docs into the new unified doc, or leave them as
+   pre-generalization historical notes?** Lean: fold and leave a
+   redirect, since the new content is a strict superset.
+
+Once you give a thumbs-up (and resolve those three), I'll generate
+the Phase 3 task list with explicit acceptance criteria and file
+paths per task.

--- a/docs/05-design-notes/runtime-service-management-tasks.md
+++ b/docs/05-design-notes/runtime-service-management-tasks.md
@@ -1,0 +1,485 @@
+# Tasks: Runtime service-endpoint management
+
+Status: **DRAFT — Phase 3 (Tasks)**
+Companion to: `runtime-service-management.md` (spec) and
+`runtime-service-management-plan.md` (plan).
+Owner: Glenn Gore
+Last updated: 2026-05-06
+
+Decisions locked in with the user (2026-05-06):
+- **Rename:** `migrate_mediator` → `update_didcomm` end-to-end
+  (file, fn, message types, telemetry, CLI). It's not really a
+  migration — it's an update to which mediator is active.
+- **P6.1 parallel with P3:** start the e2e harness alongside
+  rollback work.
+- **Fold docs:** the existing `didcomm-protocol-management.md`
+  pages become redirects to a unified runtime-service-management
+  operator guide.
+
+Each task below is sized to land in a single focused session and
+touch ≲ 5 files. Tasks are ordered by dependency. `Deps:` lists
+prerequisite task IDs; tasks with no `Deps:` are eligible from the
+start of their phase.
+
+---
+
+## P0 — Foundations
+
+### T0.1 · Resolve §10 open questions and audit pre-existing code
+- **Acceptance:** Spec §10 items 1–4 are converted to decisions and
+  recorded in the spec. The `routing_keys` shape in
+  `vta_sdk::protocol::protocol_management` is confirmed
+  sufficient (or extension scoped if not).
+- **Verify:** `git diff docs/05-design-notes/runtime-service-management.md`
+  shows the four decisions; grep confirms the `routing_keys` field.
+- **Files:** `docs/05-design-notes/runtime-service-management.md`,
+  spot-edits to `vta-sdk/src/protocol/protocol_management.rs`
+  if extension is needed.
+
+### T0.2 · Add new typed errors to `VtaError`
+- **Acceptance:** `LastServiceRefused`, `ServiceNotPresent`,
+  `ServiceAlreadyEnabled`, `MediatorHandshakeFailed { reason }`,
+  `DrainTtlOutOfBounds { min, max, requested }`, `NoPriorMutation`,
+  `UnsupportedTransport` are present (added or confirmed already
+  present). Each round-trips through serde via REST and DIDComm
+  envelopes.
+- **Verify:** `cargo test -p vta-sdk error::serde_round_trip` (new
+  parameterized test); audit existing variants to avoid duplicates.
+- **Files:** `vta-sdk/src/error.rs`, plus a new test module.
+
+### T0.3 · Per-kind previous-config snapshot store
+- **Acceptance:** `vta-service/src/operations/protocol/snapshot.rs`
+  exposes `read(&Store, ServiceKind) -> Option<ServiceConfigSnapshot>`,
+  `write(&Store, ServiceKind, ServiceConfigSnapshot)`, and
+  `clear(&Store, ServiceKind)`. Backed by a new fjall keyspace
+  `service-prev-config`. Snapshot persists *before* the runtime
+  mutation that depends on it.
+- **Verify:** unit tests covering write→read, clear→read=None,
+  overwrite, vsock-store parity for the enclave path.
+- **Files:** `vta-service/src/operations/protocol/snapshot.rs`
+  (new), `vta-service/src/operations/protocol/mod.rs`,
+  `vti-common/src/store/keyspace.rs` (or wherever keyspaces are
+  registered).
+
+### T0.4 · Brick-prevention invariant helper
+- **Acceptance:** `protocol::invariant::would_violate_last_service(
+  state: &CurrentServices, op: ProposedOp) -> Result<(), VtaError>`.
+  Single source of truth for the §3.2 invariant. Used by every
+  `disable` and every `rollback` path.
+- **Verify:** unit tests covering all three states × all
+  brick-causing ops.
+- **Files:** `vta-service/src/operations/protocol/invariant.rs`
+  (new), `vta-service/src/operations/protocol/mod.rs`.
+
+---
+
+## P1 — REST operations (parallel with P2)
+
+### T1.1 · Wire types in `vta_sdk::protocol::services`
+- **Acceptance:** New module exposes `EnableRestRequest`,
+  `UpdateRestRequest`, `DisableRestRequest`, `RollbackRestRequest`,
+  `ServiceMutationResponse` per spec §4.
+- **Verify:** serde round-trip tests for each type.
+- **Files:** `vta-sdk/src/protocol/services.rs` (new),
+  `vta-sdk/src/protocol/mod.rs`.
+- **Deps:** —
+
+### T1.2 · URL validator helper
+- **Acceptance:** `vta_sdk::protocol::services::validate_service_url`
+  enforces `https://`, `url::Url` parse, no fragment, no userinfo.
+  Returns the typed `VtaError` rejection variant.
+- **Verify:** unit tests for each rejection branch + happy path.
+- **Files:** `vta-sdk/src/protocol/services.rs`,
+  `vta-sdk/src/error.rs`.
+- **Deps:** T0.2
+
+### T1.3 · `enable_rest` / `update_rest` / `disable_rest` operations
+- **Acceptance:** Three new ops under
+  `vta-service/src/operations/protocol/`. Each: validate input →
+  invariant check (disable only) → snapshot → mutate DID-doc
+  service[] → publish LogEntry → emit telemetry. Errors map to
+  typed `VtaError` per the §7a.2 matrix.
+- **Verify:** unit tests for happy path + each rejection per
+  operation.
+- **Files:** `vta-service/src/operations/protocol/{enable_rest,
+  update_rest, disable_rest}.rs` (new),
+  `vta-service/src/operations/protocol/mod.rs`,
+  `vta-service/src/operations/did_webvh/render.rs` (or wherever
+  service[] is built).
+- **Deps:** T0.3, T0.4, T1.1, T1.2
+
+### T1.4 · REST route handlers for rest operations
+- **Acceptance:** `POST /services/rest/{enable,update,disable}`
+  wired to T1.3 ops; super-admin auth gating; serde shapes match
+  §4.
+- **Verify:** Axum handler tests + manual smoke against a local
+  VTA (`curl` updates the URL on next `did.jsonl` fetch).
+- **Files:** `vta-service/src/routes/protocol.rs`.
+- **Deps:** T1.3
+
+### T1.5 · DIDComm handlers for rest operations
+- **Acceptance:** Three new DIDComm message types registered;
+  handlers in `messaging/handlers_protocol.rs` call the same op
+  layer. Authcrypt + ACL gates identical to existing protocol-mgmt.
+- **Verify:** handler unit tests against test mediator harness.
+- **Files:** `vta-service/src/messaging/handlers_protocol.rs`,
+  `vta-sdk/src/protocol/services.rs` (DIDComm message type IDs).
+- **Deps:** T1.3
+
+---
+
+## P2 — DIDComm refactor (parallel with P1)
+
+Each task in P2 must be a **mechanical, no-behavior-change**
+commit. Tripwire: existing 111-test protocol-mgmt suite runs green
+unchanged.
+
+### T2.1 · Adopt snapshot store in existing DIDComm ops
+- **Acceptance:** `enable_didcomm`, `disable_didcomm`,
+  `migrate_mediator` use `protocol::snapshot::*` instead of any
+  ad-hoc previous-mediator tracking.
+- **Verify:** existing test suite green; `git diff` shows only
+  storage substitution.
+- **Files:** `vta-service/src/operations/protocol/{enable_didcomm,
+  disable_didcomm, migrate_mediator}.rs`.
+- **Deps:** T0.3
+
+### T2.2 · Adopt invariant helper in `disable_didcomm`
+- **Acceptance:** Existing brick-prevention check replaced by
+  `protocol::invariant::would_violate_last_service`. No behavior
+  change.
+- **Verify:** existing tests pass.
+- **Files:** `vta-service/src/operations/protocol/disable_didcomm.rs`.
+- **Deps:** T0.4
+
+### T2.3 · Rename `migrate_mediator` → `update_didcomm`
+- **Acceptance:** File renamed
+  `migrate_mediator.rs` → `update_didcomm.rs`. Public function
+  `migrate_mediator` → `update_didcomm`. SDK message types renamed
+  on both REST and DIDComm transports. Telemetry event names
+  updated. CLI not touched yet (P5 owns that). Old name absent
+  from the codebase (`grep -ri migrate_mediator` returns zero).
+- **Verify:** `cargo build --workspace --all-features` clean;
+  `cargo test --workspace` green; grep for old name empty.
+- **Files:** `vta-service/src/operations/protocol/update_didcomm.rs`
+  (renamed), `vta-service/src/operations/protocol/mod.rs`,
+  `vta-service/src/routes/protocol.rs`,
+  `vta-service/src/messaging/handlers_protocol.rs`,
+  `vta-sdk/src/protocol/protocol_management.rs` (message types).
+  May exceed 5 files — split commit by layer (ops → routes/msg →
+  sdk) if it keeps each commit reviewable.
+- **Deps:** T2.1, T2.2
+
+### T2.4 · DIDComm-preferred ordering in DID-doc rendering
+- **Acceptance:** When both REST and DIDComm services are
+  advertised, the rendered service[] places DIDComm first (per
+  T0.1 decision: array-ordering convention).
+- **Verify:** new render unit test; chain-replay test against a
+  fixture LogEntry chain produced from current `main` confirms
+  no client-resolution regression.
+- **Files:** `vta-service/src/operations/did_webvh/render.rs`,
+  `vta-service/tests/fixtures/` (new fixture chain).
+- **Deps:** T0.1
+
+---
+
+## P3 — Fail-forward rollback
+
+### T3.1 · `rollback_rest` operation
+- **Acceptance:** Reads snapshot for `rest`, dispatches to
+  `enable_rest` / `update_rest` / `disable_rest` based on snapshot
+  contents. Brick-prevention rejects via T0.4. Emits
+  `service.rest.<verb>` telemetry with `triggered_by: "rollback"`
+  (T3.3).
+- **Verify:** unit tests for each §7a.5 REST history scenario.
+- **Files:** `vta-service/src/operations/protocol/rollback_rest.rs`
+  (new), `vta-service/src/operations/protocol/mod.rs`.
+- **Deps:** T0.3, T0.4, T1.3, T3.3
+
+### T3.2 · `rollback_didcomm` operation (rewrite as fail-forward)
+- **Acceptance:** Replaces existing rollback code. Reads snapshot
+  for `didcomm`, dispatches to `enable_didcomm` / `update_didcomm`
+  / `disable_didcomm`. Optional `drain_ttl` flows into
+  `update_didcomm` / `disable_didcomm`.
+- **Verify:** unit tests for each §7a.5 DIDComm history scenario;
+  existing rollback tests rewritten to assert fail-forward
+  semantic.
+- **Files:** `vta-service/src/operations/protocol/rollback_didcomm.rs`
+  (new), `vta-service/src/operations/protocol/mod.rs`,
+  any existing `rollback`-suffixed file gets folded in or deleted.
+- **Deps:** T0.3, T0.4, T2.1, T2.3, T3.3
+
+### T3.3 · `triggered_by` telemetry context
+- **Acceptance:** Forward operations accept an `OpContext` enum
+  (`Direct` | `Rollback`) and include it in the emitted telemetry
+  event payload.
+- **Verify:** assertion test that a direct call emits no
+  `triggered_by` field and a rollback-routed call emits
+  `triggered_by: "rollback"`.
+- **Files:** `vta-service/src/operations/protocol/mod.rs`, each
+  forward operation file (light touch — pass-through arg),
+  `vti-common/src/telemetry/` (event field documented).
+- **Deps:** T1.3, T2.1
+
+### T3.4 · Route + DIDComm handlers for rollback
+- **Acceptance:** `POST /services/{rest,didcomm}/rollback` wired
+  to T3.1/T3.2; matching DIDComm handlers; auth + ACL identical
+  to existing protocol-mgmt.
+- **Verify:** handler tests; smoke against local VTA.
+- **Files:** `vta-service/src/routes/protocol.rs`,
+  `vta-service/src/messaging/handlers_protocol.rs`,
+  `vta-sdk/src/protocol/services.rs` (DIDComm message type IDs).
+- **Deps:** T3.1, T3.2
+
+---
+
+## P4 — `services list` query
+
+### T4.1 · `list_services` operation + handlers
+- **Acceptance:** Returns minimal `ServicesListResponse =
+  Vec<ServiceState>` where each entry is `{ kind, enabled, config:
+  Option<ServiceConfig> }`. REST + DIDComm handlers share one op.
+  Super-admin only.
+- **Verify:** unit tests against synthetic state for each of
+  S1/S2/S3.
+- **Files:** `vta-service/src/operations/protocol/list.rs` (new),
+  `vta-service/src/routes/protocol.rs`,
+  `vta-service/src/messaging/handlers_protocol.rs`,
+  `vta-sdk/src/protocol/services.rs`.
+- **Deps:** T1.3, T2.1
+
+---
+
+## P5 — CLI surface
+
+### T5.1 · Delete `vta-cli-common::commands::mediator`
+- **Acceptance:** File `vta-cli-common/src/commands/mediator.rs`
+  deleted; `mod.rs` re-export removed; pnm/cnm clap definitions
+  for `mediator` subcommand removed; `cargo build` clean.
+- **Verify:** `grep -ri 'commands::mediator' vta-cli-common pnm-cli
+  cnm-cli` empty; `cargo build --workspace`.
+- **Files:** `vta-cli-common/src/commands/mediator.rs` (delete),
+  `vta-cli-common/src/commands/mod.rs`, `pnm-cli/src/main.rs`,
+  `cnm-cli/src/main.rs` (or wherever subcommands are defined).
+- **Deps:** T2.3
+
+### T5.2 · Rewrite `services.rs` for §5.1 shape
+- **Acceptance:** 12 command functions for the §5.1 surface, each
+  calling the relevant `vta-sdk` client. No clap definitions in
+  this file (those live in pnm/cnm/vta).
+- **Verify:** `cargo build --workspace`; manual smoke for one
+  command per kind.
+- **Files:** `vta-cli-common/src/commands/services.rs` (rewrite),
+  `vta-cli-common/src/commands/mod.rs`.
+- **Deps:** T1.3, T1.4, T1.5, T2.3, T3.4, T4.1
+
+### T5.3 · Wire pnm-cli + cnm-cli clap subcommands
+- **Acceptance:** Clap tree matches §5.1 exactly; help output
+  verified. `pnm services rest enable --url X` reaches T5.2's
+  function.
+- **Verify:** `pnm services --help`, `cnm services --help`.
+- **Files:** `pnm-cli/src/main.rs`, `cnm-cli/src/main.rs`.
+- **Deps:** T5.2
+
+### T5.4 · Add `vta services …` to vta-service main
+- **Acceptance:** Same 12 commands available via the `vta` local
+  CLI, dispatched through the same `vta-cli-common::services`
+  entry points.
+- **Verify:** `vta services --help`; one happy-path command
+  end-to-end.
+- **Files:** `vta-service/src/main.rs`.
+- **Deps:** T5.2
+
+### T5.5 · Operator-error guidance in CLI
+- **Acceptance:** Each typed `VtaError` from spec §4 prints a
+  suggested-next-command line per CLAUDE.md "operator errors
+  should suggest the fix":
+  - `LastServiceRefused` → "enable the other transport first via …"
+  - `ServiceNotPresent` on update/disable → "this service isn't
+    enabled; run `services <kind> enable …`"
+  - `ServiceAlreadyEnabled` on enable → "this service is already
+    enabled; use `services <kind> update …` to change it"
+  - `NoPriorMutation` on rollback → "no prior mutation; use
+    `services <kind> <verb>` directly"
+  - `DrainTtlOutOfBounds` → "drain TTL must be between {min} and
+    {max}"
+- **Verify:** manual invocation of each error path.
+- **Files:** `vta-cli-common/src/commands/services.rs`, possibly
+  a small shared formatter helper.
+- **Deps:** T5.2
+
+### T5.6 · Migration cue for retired `mediator` subcommand
+- **Acceptance:** `pnm mediator …` and `cnm mediator …` print
+  "the `mediator` subcommand was retired in version X.Y; use
+  `pnm services didcomm …` instead" and exit non-zero. Custom
+  unknown-subcommand handler.
+- **Verify:** manual invocation; exit code != 0.
+- **Files:** `pnm-cli/src/main.rs`, `cnm-cli/src/main.rs`.
+- **Deps:** T5.1
+
+---
+
+## P6 — End-to-end test matrix
+
+T6.1 starts in parallel with P3 (it has no deps on P3 code; it
+hits routes that already exist or land with P1/P2).
+
+### T6.1 · State fixtures in `tests/e2e`
+- **Acceptance:** Helpers `setup_vta_in_state(S1)`,
+  `setup_vta_in_state(S2)`, `setup_vta_in_state(S3)` produce a
+  fresh-fjall, fresh-mediator VTA in the documented state.
+  Asserted by reading the DID doc and matching service[].
+- **Verify:** `cargo nextest run -p e2e fixtures::`.
+- **Files:** `tests/e2e/src/fixtures.rs` (new) + `lib.rs`.
+- **Deps:** T1.4 (REST routes available), T2.3 (mediator update
+  route renamed)
+
+### T6.2 · State × Op matrix tests (§7a.2 + §7a.3)
+- **Acceptance:** 24 cell tests, each parameterized over transport
+  where the cell is reachable on both. Each test asserts: state
+  transition or typed error, exactly one new LogEntry on success
+  (zero on error), `verificationMethod` byte-identical pre/post.
+- **Verify:** `cargo nextest run -p e2e --test state_op_matrix`.
+- **Files:** `tests/e2e/tests/state_op_matrix.rs` (new).
+- **Deps:** T6.1, T1.5, T3.4, T4.1
+
+### T6.3 · Drain interaction tests (§7a.4)
+- **Acceptance:** 11 scenarios from spec §7a.4. Includes
+  process-restart-mid-drain (depends on T6.7).
+- **Verify:** `cargo nextest run -p e2e --test drain`.
+- **Files:** `tests/e2e/tests/drain.rs` (new).
+- **Deps:** T6.1, T6.7
+
+### T6.4 · Rollback history tests (§7a.5)
+- **Acceptance:** 11 scenarios from spec §7a.5 (6 DIDComm + 5
+  REST), including the `LastServiceRefused` brick-attempts.
+- **Verify:** `cargo nextest run -p e2e --test rollback`.
+- **Files:** `tests/e2e/tests/rollback.rs` (new).
+- **Deps:** T6.1, T3.4
+
+### T6.5 · Sequencing soak paths (§7a.6)
+- **Acceptance:** 6 multi-step paths from spec §7a.6.
+- **Verify:** `cargo nextest run -p e2e --test sequencing`.
+- **Files:** `tests/e2e/tests/sequencing.rs` (new).
+- **Deps:** T6.1, T6.7 (path 5 needs restart-resilience)
+
+### T6.6 · Restart-resilience harness
+- **Acceptance:** `tests/e2e/src/restart.rs` exposes
+  `kill_and_restart(&mut TestVta)` that preserves the on-disk
+  fjall store and re-binds the same listener config.
+- **Verify:** trivial test that kills a VTA mid-handshake and
+  verifies it resumes.
+- **Files:** `tests/e2e/src/restart.rs` (new), `tests/e2e/src/lib.rs`.
+- **Deps:** T6.1
+
+### T6.7 · CI runtime budget check
+- **Acceptance:** Total e2e suite runtime ≤ 10 min on CI runner;
+  if exceeded, split into `e2e-fast` and `e2e-slow` jobs.
+- **Verify:** GitHub Actions run timing.
+- **Files:** `.github/workflows/*.yml`.
+- **Deps:** T6.2, T6.3, T6.4, T6.5
+
+---
+
+## P7 — Documentation + memory
+
+### T7.1 · New operator guide
+- **Acceptance:** `docs/03-integrating/runtime-service-management.md`
+  walks through every §5.1 command with an example transcript.
+  Top of the file has the migration note (T7.4 folds in here).
+- **Verify:** manual review.
+- **Files:** `docs/03-integrating/runtime-service-management.md`
+  (new).
+- **Deps:** T5.4 (so transcripts use the final command shape)
+
+### T7.2 · Fold + redirect old DIDComm docs
+- **Acceptance:** `docs/03-integrating/didcomm-protocol-management.md`
+  becomes a one-screen redirect stub linking to T7.1.
+  `docs/05-design-notes/didcomm-protocol-management.md` updated to
+  state it has been superseded by `runtime-service-management.md`.
+- **Verify:** broken-link grep clean; manual review.
+- **Files:** `docs/03-integrating/didcomm-protocol-management.md`,
+  `docs/05-design-notes/didcomm-protocol-management.md`.
+- **Deps:** T7.1
+
+### T7.3 · Update workspace `CLAUDE.md`
+- **Acceptance:** "DIDComm protocol management" integration-flow
+  section renamed to "Runtime service management"; content
+  reflects the generalization (REST + DIDComm, fail-forward
+  rollback, snapshot store, brick-prevention, 24h drain default).
+- **Verify:** read the section; ensure code-path references match
+  current file paths post-rename.
+- **Files:** `CLAUDE.md` (workspace root).
+- **Deps:** T2.3, T3.2
+
+### T7.4 · Migration note for breaking CLI changes
+- **Acceptance:** Top-of-doc section in T7.1 lists removed
+  commands and their new equivalents, plus the 24h default drain
+  behavior change.
+- **Verify:** read the section.
+- **Files:** `docs/03-integrating/runtime-service-management.md`.
+- **Deps:** T7.1
+
+### T7.5 · Memory updates
+- **Acceptance:** Existing
+  `project_didcomm_protocol_management.md` updated to "subsumed
+  by runtime-service-management feature." A new project memory
+  records the load-bearing architectural choices (per-kind
+  snapshot store, fail-forward rollback, brick-prevention
+  invariant, 24h drain default) so future sessions don't
+  re-litigate them.
+- **Verify:** memory entries readable via the auto-memory system.
+- **Files:** `~/.claude/projects/.../memory/project_didcomm_protocol_management.md`,
+  `~/.claude/projects/.../memory/project_runtime_service_management.md`,
+  `~/.claude/projects/.../memory/MEMORY.md`.
+- **Deps:** all prior phases done
+
+---
+
+## Phase summary
+
+| Phase | Tasks | Critical-path tasks |
+|---|---|---|
+| P0 | T0.1 – T0.4 | T0.3, T0.4 |
+| P1 | T1.1 – T1.5 | T1.3 |
+| P2 | T2.1 – T2.4 | T2.3 |
+| P3 | T3.1 – T3.4 | T3.4 |
+| P4 | T4.1 | T4.1 |
+| P5 | T5.1 – T5.6 | T5.2 → T5.3/T5.4 |
+| P6 | T6.1 – T6.7 | T6.1 → T6.2 |
+| P7 | T7.1 – T7.5 | T7.1 |
+
+**Total:** 33 tasks. Median ~3 files / task; longest is T2.3
+(rename) which is split by review-friendly layers.
+
+## Implementation order — recommended commit landing sequence
+
+If a single engineer is driving this end-to-end, the order that
+keeps each commit reviewable and CI green is:
+
+1. T0.1 → T0.2 → T0.3 → T0.4
+2. T1.1 → T1.2 (parallel safe with anything below)
+3. T2.1 → T2.2 (mechanical, no behavior change)
+4. T2.3 (rename — the breaking-API commit)
+5. T2.4 (ordering — landed once because every later test depends)
+6. T1.3 → T1.4 → T1.5 (REST surface goes live)
+7. T6.1 (e2e harness — start using it for everything below)
+8. T6.6 (restart helper — needed for drain tests soon)
+9. T3.3 → T3.1 → T3.2 → T3.4 (rollback)
+10. T4.1 (list)
+11. T6.2 → T6.4 → T6.3 → T6.5 (test matrix progressively)
+12. T5.1 → T5.2 → T5.3 → T5.4 → T5.5 → T5.6 (CLI flip)
+13. T7.1 → T7.2 → T7.3 → T7.4 → T7.5 (docs + memory)
+14. T6.7 (CI budget check — last, when full suite exists)
+
+## Once tasks are approved
+
+I'll move to Phase 4 (Implement) starting at T0.1. Each task is
+landed via:
+1. Branch from `main`: `feat/runtime-services-T<id>`
+2. Implement → unit tests → `cargo fmt`
+3. Open PR; CI green; review
+4. Merge with DCO sign-off
+
+Per CLAUDE.md commit hygiene: no `--no-verify`, no skipping DCO
+signatures, no amending merged commits.

--- a/docs/05-design-notes/runtime-service-management.md
+++ b/docs/05-design-notes/runtime-service-management.md
@@ -678,29 +678,56 @@ All previously-open questions are resolved. Audit performed on
    symmetric — each publishes a new LogEntry that re-applies
    its kind's prior config.
 
-### Implementation note — REST service entry is net-new
+### Implementation note — REST service entry already exists
 
-Today the VTA's own DID document does **not** advertise a REST
-service entry. `config.public_url` is used internally but never
-rendered into `service[]`
-(`vta-service/src/operations/did_webvh/document.rs:79`). So
-`services rest enable` is the path that adds the entry for the
-first time. **An upgraded VTA boots with no REST service entry
-in its DID doc** — the operator must explicitly opt in via
-`pnm services rest enable --url <url>` to advertise REST. This
-matches the spec's "operator drives every service mutation"
-model and avoids an implicit behavior change on upgrade.
+The VTA's own DID document **already advertises** a REST service
+entry today. The rendering goes through the
+`additional_services` extension point of `build_did_document_inner`
+rather than being baked into the inner function directly:
 
-A REST service entry uses `type: ["VerifiableTrustAgent"]` (new
-kind, distinct from `LinkedDomains` which has weaker semantics).
-The exact shape is finalized in T1.3.
+* `vta-service/src/setup.rs:86` — `build_vta_additional_services`
+  produces a single entry:
+  ```json
+  {
+    "id":   "{DID}#vta-rest",
+    "type": "VTARest",
+    "serviceEndpoint": "<public_url>"
+  }
+  ```
+* Emitted iff `services.rest == true` AND `public_url` is set
+  (matrix test in `setup.rs:175`).
+* SDK resolves it via `find_service("vta-rest")` at
+  `vta-sdk/src/session.rs:1100`. The resolve path is
+  load-bearing for the SDK's own routing.
 
-**Initial state of all three states post-upgrade:** an upgraded
-VTA with both `public_url` configured and DIDComm enabled comes
-up in **S2** (DIDComm-only), not S3. Operators who want REST
-advertised run `services rest enable` once. The §7a.1 state
-model still applies — S1/S2/S3 are reachable by operator action
-from any starting point.
+This **constrains** the runtime-mutation work in P1.3 / T2.4:
+
+* **Wire shape is fixed.** Keep `id: "{DID}#vta-rest"`, keep
+  `type: "VTARest"`. SDK consumers depend on these strings.
+* **Rendering is moved, not invented.** P1.3 lifts the rendering
+  out of `setup::build_vta_additional_services` and into the
+  shared service-rendering layer, so the same JSON is emitted
+  whether it comes from setup or from a runtime
+  `services rest enable/update`. The setup path delegates to the
+  shared layer.
+* **§3.3 ordering note:** today the array is
+  `[#vta-didcomm (if mediator), #vta-rest, #tee-attestation
+  (if tee)]`. To honor "DIDComm preferred," the existing order is
+  already correct — DIDComm is first. Confirmed in T0.1 audit
+  against `document.rs:79` + `setup.rs:86`. T2.4 just locks this
+  in via a render-layer test.
+
+**Initial state post-upgrade.** An upgraded VTA with
+`services.rest = true` + `public_url` set + `services.didcomm =
+true` boots in **S3** (both advertised) — there is no implicit
+state change from upgrade. Existing config drives the same shape
+the runtime commands produce. A VTA configured today with
+`services.rest = false` + `services.didcomm = false` is already
+unreachable (its DID doc has no transport service entries) —
+that's a pre-existing config foot-gun, not something this spec
+introduces. Per §3.2, the runtime commands enforce the
+"at-least-one" invariant going forward; existing misconfigured
+VTAs are not auto-repaired.
 
 ## 11. Lifecycle
 

--- a/docs/05-design-notes/runtime-service-management.md
+++ b/docs/05-design-notes/runtime-service-management.md
@@ -1,0 +1,711 @@
+# Spec: Runtime service-endpoint management
+
+Status: **DRAFT — Phase 1 (Specify)**
+Owner: Glenn Gore
+Last updated: 2026-05-06
+
+## 1. Objective
+
+Allow a super-admin to add, update, or remove service entries on a
+**running VTA's DID document** without rebuilding the binary or
+re-running setup. Each mutation publishes a new WebVH LogEntry that
+re-uses the existing verification methods. The mutation is reachable
+from both the VTA local CLI (`vta`) and PNM (`pnm`), over both REST
+and DIDComm transports — except where a transport must necessarily be
+absent (you cannot enable DIDComm over DIDComm).
+
+This generalizes the DIDComm-specific protocol-management work that
+shipped on `sealed-bootstrap` (commits up to 88dab00) into a unified
+service-management surface that also handles REST. The DIDComm-only
+operator surface (`pnm services enable|disable didcomm`,
+`pnm mediator …`) is **retired** and replaced by the new unified shape.
+
+### Why this matters
+
+* Operators today must rebuild and re-deploy a VTA to change its
+  published REST URL (e.g., domain migration).
+* "DIDComm-only" and "REST-only" deployments are valid topologies but
+  the only way to reach them today is editing config files at boot.
+* The DIDComm migrate-with-drain machinery is already well-tested;
+  exposing it through a generic service-management surface makes the
+  REST equivalent (URL update, on/off) a thin extension instead of a
+  parallel system.
+
+### Non-goals
+
+* Hot-swapping the Axum listener bind address, port, or TLS cert.
+  Those remain process-config and are set at boot. This spec only
+  changes what the DID document **advertises**.
+* Adding service kinds beyond REST and DIDComm. Operator-defined
+  service types are a separate, larger design (extensible kinds need
+  schema, validation, telemetry hooks).
+* REST drain/replay. REST is request/response; removing a URL from
+  the DID document means clients resolve a 410 and retry. There is
+  no buffered-message concept on the REST side.
+* Multi-service atomic transactions. Each mutation is one LogEntry,
+  one transport, one service. See §6.
+
+## 2. Tech Stack & Codebase Context
+
+* Rust workspace, edition 2024, MSRV 1.94.0
+* Existing modules to extend (do **not** fork):
+  * `vta-service/src/operations/protocol/` — operation handlers
+  * `vta-service/src/messaging/{registry,drain_store,drain_sweeper,handshake,live_prover,transient_handshake}.rs` — DIDComm mediator state machinery
+  * `vta-service/src/operations/did_webvh/mod.rs` — LogEntry publication
+  * `vta-service/src/routes/protocol.rs` — REST handlers
+  * `vta-service/src/messaging/handlers_protocol.rs` — DIDComm handlers
+  * `vta-sdk/src/protocol/` — wire types (`vta_sdk::protocol::*`)
+  * `vta-cli-common/src/commands/{services,mediator}.rs` — CLI commands
+  * `vti-common/src/telemetry/` — pluggable telemetry sink
+* Existing invariants that must continue to hold:
+  * `verificationMethod` is byte-identical across LogEntries
+  * Each service mutation publishes exactly one LogEntry
+  * Drain set is fjall-persisted, restart-resilient, capped at
+    30 days (`MAX_DRAIN_TTL`)
+  * `MIN_DRAIN_TTL_OVER_DIDCOMM = 3600s` floor when the disable
+    command is *itself* delivered over DIDComm (so the operator
+    isn't cut off mid-command)
+
+## 3. Functional Requirements
+
+### 3.1 Service kinds and operations
+
+Two transport kinds are managed: `rest` and `didcomm`.
+
+| Kind | enable | update | disable | rollback | drain |
+|------|:------:|:------:|:-------:|:--------:|:-----:|
+| rest | ✓ | ✓ | ✓ | ✓ | — |
+| didcomm | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+REST mutations are immediate (publication-only; no in-flight state).
+DIDComm mutations route through the existing handshake / drain /
+sweeper machinery unchanged.
+
+**Rollback is fail-forward** for both kinds — see §3.5a.
+
+### 3.2 Brick-prevention invariant
+
+**At least one service kind must be enabled at all times.**
+
+The operation layer rejects any mutation that would leave the DID
+document with zero advertised services. Specifically:
+
+* `services rest disable` is rejected with `409 LastServiceRefused`
+  if DIDComm is currently disabled.
+* `services didcomm disable` is rejected with `409 LastServiceRefused`
+  if REST is currently disabled.
+
+There is **no `--force` escape hatch.** If an operator genuinely
+wants a totally-unreachable VTA they can rotate it out and replace
+it via setup; the CLI will not provide a foot-gun.
+
+### 3.3 DIDComm-preferred ordering
+
+When both services are advertised, the DID document MUST signal
+DIDComm as the preferred transport for clients that support it.
+Encoding mechanism is finalized in Phase 2 (Plan); candidates:
+
+* DIDComm v2 `priority` key on the DIDComm service entry
+  (lower number = higher priority)
+* Array ordering convention (DIDComm before REST)
+
+Whichever is chosen, the rendering is centralized in the WebVH
+operation layer so REST clients see consistent ordering.
+
+### 3.4 REST-specific behavior
+
+* `services rest enable --url <url>` adds a service entry of
+  type `LinkedDomains` (or our REST-specific type — to be confirmed
+  in Plan against the existing DID template's REST shape) with
+  the supplied URL.
+* `services rest update --url <url>` replaces the URL on the
+  existing REST service entry. Errors with `409 ServiceNotPresent`
+  if REST isn't currently advertised.
+* `services rest disable` removes the REST service entry.
+
+The Axum listener itself is **not** torn down — it stays running so
+local CLI traffic and management endpoints remain reachable. Only
+the *advertisement* changes.
+
+URL validation: must be `https://` (TLS-only), parsable by `url::Url`,
+no fragment, no userinfo. Enforced in `vta-sdk` so both transports
+share the rule.
+
+### 3.5 DIDComm-specific behavior
+
+`services didcomm enable --mediator <did>` is REST-only by nature
+(can't bootstrap DIDComm over DIDComm). Internally identical to
+today's `enable_didcomm` operation:
+
+1. Transient `DIDCommService` spun up
+2. Handshake against the candidate mediator
+3. On success, mediator pinned, transient teardown
+4. LogEntry published with DIDComm service entry
+
+`services didcomm update --mediator <new-did> [--drain-ttl <dur>]`
+replaces today's `pnm mediator migrate`:
+
+1. Live `DIDCommServiceProver` handshake against new mediator
+2. New mediator becomes primary; old mediator moved to drain set
+3. Drain TTL = `--drain-ttl` arg, else **24h default** (new — see §3.6)
+4. LogEntry published with updated DIDComm service entry
+
+`services didcomm disable [--drain-ttl <dur>]` replaces today's
+`disable_didcomm`. Removes DIDComm service entry; pins drain TTL on
+the previously-active mediator. Refused if REST is also disabled
+(see §3.2).
+
+`services didcomm rollback` is described in §3.5a (transport-agnostic
+fail-forward semantic).
+
+`services didcomm drain list` shows current drain set.
+`services didcomm drain cancel <mediator-did>` removes a mediator
+from the drain set immediately. Both already exist; only renamed.
+
+### 3.5a Rollback semantic — fail-forward
+
+WebVH is an append-only ledger. We never rewind the chain; we never
+mark an entry "reverted." `rollback` is operator-friendly
+terminology for **"publish a new LogEntry that re-applies the
+previous service configuration for this kind."**
+
+Mechanics:
+
+1. The operation layer looks up the kind's *prior* config — the
+   service-entry shape that was in effect immediately before the
+   most recent mutation of that kind.
+2. It runs the equivalent forward operation:
+   * Most recent mutation was `update X→Y` → rollback runs an
+     `update Y→X`.
+   * Most recent mutation was `disable` (from config X) → rollback
+     runs an `enable X`.
+   * Most recent mutation was `enable X` → rollback runs `disable`
+     (subject to §3.2 brick-prevention).
+3. A new LogEntry is published with the resulting service[].
+4. For DIDComm, the drain set is updated by the same path the
+   forward operation would use — e.g., rolling back an `update
+   A→B` puts mediator B into the drain set with the supplied
+   `--drain-ttl` (default 24h).
+
+Properties:
+
+* **Single-step only.** Rollback reverts exactly one prior
+  mutation per kind. Rolling back twice in a row first undoes the
+  most recent mutation, then would undo the *next* most recent
+  mutation — which is two distinct user actions, not one.
+* **Independent per kind.** REST rollback ignores DIDComm history
+  and vice versa. Each kind tracks its own "previous-config"
+  pointer.
+* **Subject to §3.2.** A rollback that would leave zero advertised
+  services is rejected with `LastServiceRefused`, identical to a
+  direct `disable`.
+* **Subject to TTL bounds.** A DIDComm rollback that would put a
+  mediator into the drain set obeys the same `MIN_DRAIN_TTL_OVER_
+  DIDCOMM` / `MAX_DRAIN_TTL` bounds as a direct `update`.
+* **No special "reverted" telemetry.** The emitted event is the
+  forward operation's event (`service.didcomm.updated`,
+  `service.rest.enabled`, etc.) with a `triggered_by: "rollback"`
+  field, so operators see in telemetry what actually changed.
+
+Implementation note: each successful mutation persists its
+"previous-config" snapshot in fjall, replacing the one from before.
+Rollback consumes the snapshot. After rollback, the snapshot
+reflects the state from *before* the rollback (so a second
+consecutive rollback would revert the rollback — a no-op cycle the
+operator can avoid by checking `services list` first).
+
+### 3.6 Default drain TTL
+
+* New default: **24 hours** when the operator omits `--drain-ttl`
+  on `update` or `disable`.
+* Floor: existing `MIN_DRAIN_TTL_OVER_DIDCOMM = 3600s` retained
+  (only when the command is delivered over DIDComm).
+* Cap: existing `MAX_DRAIN_TTL = 30 days` retained.
+* Per the user's input, this default is applied retroactively — no
+  feature flag or migration period (no production users yet).
+
+### 3.7 Audit & telemetry
+
+Each successful mutation emits a telemetry event via the existing
+`vti_common::telemetry::TelemetrySink`. Event names:
+
+* `service.rest.enabled` / `service.rest.updated` / `service.rest.disabled`
+* `service.didcomm.enabled` / `service.didcomm.updated` /
+  `service.didcomm.disabled` / `service.didcomm.rolled_back`
+* Existing drain events (`drain.started`, `drain.expired`,
+  `drain.cancelled`) keep their current names
+
+Each event carries the new LogEntry version-id so an external
+verifier can join telemetry to WebVH history.
+
+### 3.8 Authorization
+
+Super-admin only on every operation. No context-admin path.
+Implementation reuses the existing JWT role check from
+`routes/protocol.rs`; no new claim shapes.
+
+## 4. Wire Types (additions to vta-sdk)
+
+New module: `vta_sdk::protocol::services` (existing
+`vta_sdk::protocol` houses DIDComm-specific types; we extend it).
+
+```rust
+// Request shapes — exact field names finalized in Plan
+pub struct EnableRestRequest { pub url: Url }
+pub struct UpdateRestRequest { pub url: Url }
+pub struct DisableRestRequest;
+
+pub struct EnableDidcommRequest {
+    pub mediator_did: String,
+    pub routing_keys: Option<Vec<String>>,
+}
+pub struct UpdateDidcommRequest {
+    pub mediator_did: String,
+    pub routing_keys: Option<Vec<String>>,
+    pub drain_ttl: Option<Duration>,
+}
+pub struct DisableDidcommRequest {
+    pub drain_ttl: Option<Duration>,
+}
+
+// Rollback (per §3.5a, fail-forward — the new LogEntry is just a
+// re-application of the prior config, no special chain marker).
+pub struct RollbackRestRequest;
+pub struct RollbackDidcommRequest {
+    // Used only when the rollback target is the previous mediator
+    // and that target had a drain TTL set; lets the operator
+    // override the 24h default.
+    pub drain_ttl: Option<Duration>,
+}
+
+// Response (unified)
+pub struct ServiceMutationResponse {
+    pub log_entry_version_id: String,
+    pub effective_at: DateTime<Utc>,
+    pub drain_until: Option<DateTime<Utc>>,  // didcomm only
+}
+```
+
+`VtaError` gains typed variants so the CLI can emit guidance
+(per CLAUDE.md "Operator errors should suggest the fix"):
+
+* `LastServiceRefused` — would leave the VTA unreachable
+* `ServiceNotPresent` — `update`/`disable` on a kind that's already off
+* `ServiceAlreadyEnabled` — `enable` on a kind that's already on
+* `MediatorHandshakeFailed { reason }` — DIDComm handshake refused
+* `DrainTtlOutOfBounds { min, max, requested }`
+* `NoPriorMutation` — `rollback` with no eligible prior mutation
+* `UnsupportedTransport` — command delivered over a transport that
+  cannot serve it (e.g., `services didcomm enable` over DIDComm)
+
+## 5. CLI Surface
+
+### 5.1 Final shape
+
+```
+pnm services list
+pnm services rest enable      --url <url>
+pnm services rest update      --url <url>
+pnm services rest disable
+pnm services rest rollback
+pnm services didcomm enable   --mediator <did> [--routing-keys <k1,k2>]
+pnm services didcomm update   --mediator <did> [--routing-keys ...] [--drain-ttl 24h]
+pnm services didcomm disable  [--drain-ttl 24h]
+pnm services didcomm rollback [--drain-ttl 24h]
+pnm services didcomm drain list
+pnm services didcomm drain cancel <mediator-did>
+pnm services report
+```
+
+The `vta` local CLI mirrors the same shape (`vta services …`).
+
+### 5.2 Removed commands
+
+These are **deleted** (breaking change per user direction):
+
+* `pnm services enable didcomm`
+* `pnm services disable didcomm`
+* `pnm mediator migrate`
+* `pnm mediator rollback`
+* `pnm mediator drain cancel`
+* `pnm mediator report`
+
+The `mediator` subcommand namespace is removed entirely from `pnm`
+and `cnm`. `vta-cli-common/src/commands/mediator.rs` is deleted;
+`services.rs` is rewritten.
+
+### 5.3 CLI surface — design rationale
+
+I considered four shapes and picked Option B. Recording the rejected
+alternatives so future contributors know why we didn't go that way:
+
+* **Option A — keep separate.** `pnm services enable|disable rest`
+  alongside `pnm mediator migrate`. Asymmetric: DIDComm gets a
+  privileged top-level namespace, REST doesn't. Rejected.
+* **Option B — unify under `pnm services`. ✓ chosen.** One namespace;
+  `<kind>` is the dispatch axis. Verbs like `update`, `rollback`,
+  `drain` slot under the kind they apply to. Adding a future
+  protocol kind is purely additive.
+* **Option C — move under `pnm setup`.** `pnm setup services rest …`.
+  Rejected: `setup` today is a *cold-start* lifecycle (mints initial
+  DID, establishes operator-VTA relationship). Service mutation is
+  steady-state. Conflating one-shot bootstrap with everyday
+  reconfiguration in muscle memory invites mistakes — operators run
+  setup once but may run service mutations many times.
+* **Option D — flat verbs with `--kind` flag.** `pnm services add
+  --kind rest --url …`. Shallow tree but every command needs the
+  flag, and DIDComm-only verbs (`drain`, `rollback`) read awkwardly.
+  Rejected.
+
+## 6. Atomicity Model
+
+* **One LogEntry per mutation. One mutation per command.**
+* No multi-service atomic ops. Per user direction in clarifying Q6,
+  the CLI deliberately does not offer "change REST and DIDComm at
+  the same time" — that's how operators brick themselves.
+* Sequence: validate → mutate runtime state (e.g., mediator pin,
+  drain set) → publish LogEntry → emit telemetry. If LogEntry
+  publication fails, runtime state must roll back. Tested in
+  `migrate_mediator.rs` today; reuse that pattern for REST.
+
+## 7. Acceptance Criteria
+
+A criterion is met when there's a passing test (unit, integration,
+or e2e against the test mediator) demonstrating it. Manual checks
+are not sufficient.
+
+### Functional
+- [ ] `pnm services list` returns current services with their config
+      (URL for REST; mediator DID + drain set for DIDComm).
+- [ ] `pnm services rest enable --url https://x.example` adds a REST
+      service entry and publishes one LogEntry; `verificationMethod`
+      unchanged.
+- [ ] `pnm services rest update --url …` replaces the URL on the
+      existing entry; one new LogEntry.
+- [ ] `pnm services rest disable` removes the REST entry; one new
+      LogEntry; rejected with `LastServiceRefused` if DIDComm is off.
+- [ ] `pnm services didcomm enable --mediator did:…` mints DIDComm
+      service entry via existing `enable_didcomm` flow; one LogEntry.
+- [ ] `pnm services didcomm update --mediator did:new` migrates;
+      old mediator joins drain set with default 24h TTL.
+- [ ] `pnm services didcomm disable` removes DIDComm entry; previous
+      mediator drains for 24h by default; rejected with
+      `LastServiceRefused` if REST is off.
+- [ ] `pnm services didcomm rollback` fail-forwards the most
+      recent DIDComm mutation (update, disable, *or* enable),
+      publishing a new LogEntry that re-applies the prior config.
+- [ ] `pnm services rest rollback` fail-forwards the most recent
+      REST mutation symmetrically (update, disable, *or* enable),
+      publishing a new LogEntry.
+- [ ] `pnm services didcomm drain list` shows currently-draining
+      mediators with TTL countdown.
+- [ ] `pnm services didcomm drain cancel <did>` removes mediator
+      from drain set.
+
+### Invariant
+- [ ] No mutation produces a DID document with zero advertised
+      services. Verified by property test over all command sequences.
+- [ ] Every mutation publishes exactly one new WebVH LogEntry whose
+      `verificationMethod` is byte-identical to the prior entry's.
+- [ ] Drain TTL clamped to `[3600s over DIDComm | 0 over REST,
+      30 days]`; out-of-range requests return
+      `DrainTtlOutOfBounds`.
+- [ ] DIDComm service entry, when present alongside REST, is
+      ordered/priorityed such that a v2-aware client picks DIDComm.
+
+### Transport coverage
+- [ ] Every command (except `services didcomm enable`) is reachable
+      over both REST and DIDComm. `services didcomm enable` is
+      REST-only and rejects DIDComm delivery.
+- [ ] REST and DIDComm handlers share the same operation layer —
+      no duplicated business logic.
+
+### CLI surface
+- [ ] `pnm` and `vta` expose the §5.1 surface; `pnm mediator` and
+      `pnm services {enable,disable} didcomm` are gone (no
+      deprecation alias).
+- [ ] Operator errors print suggested commands per CLAUDE.md
+      ("operator errors should suggest the fix").
+
+### Telemetry
+- [ ] Each mutation emits a `service.<kind>.<verb>` event carrying
+      the new LogEntry version-id.
+- [ ] Existing `RingBufferTelemetry` swappability test still passes
+      with the new event types.
+
+### Tests
+- [ ] Unit tests in each `operations/protocol/*` file cover happy
+      path + each rejection variant.
+- [ ] Integration tests in `tests/e2e` cover the full coverage
+      matrix in §7a against the test mediator.
+- [ ] Restart-resilience: drain set survives a process restart
+      (existing test extended for the new defaults).
+
+## 7a. End-to-End Coverage Matrix
+
+This section is **part of the acceptance criteria**, not an
+appendix. The implementation is not done until every cell below has
+a passing test in `tests/e2e`.
+
+### 7a.1 State model
+
+The VTA's published service surface has exactly three valid states
+under the §3.2 invariant:
+
+| State | REST | DIDComm |
+|:-----:|:----:|:-------:|
+| **S1** | on   | off     |
+| **S2** | off  | on      |
+| **S3** | on   | on      |
+
+`(off, off)` is invariant-violating and is itself a test target —
+every command that *would* produce it must be rejected.
+
+### 7a.2 State × Operation matrix
+
+Every cell is a separate e2e test. "✓ → Sn" means accepted and the
+state transitions to Sn (or stays). Error cells assert the typed
+`VtaError` variant fires; no implementation may collapse them to a
+generic string.
+
+| From | rest enable | rest update | rest disable | rest rollback | didcomm enable | didcomm update | didcomm disable | didcomm rollback |
+|:----:|:-----------:|:-----------:|:------------:|:-------------:|:--------------:|:--------------:|:---------------:|:----------------:|
+| **S1** | `ServiceAlreadyEnabled` | ✓ → S1 | `LastServiceRefused` | history-dependent (§7a.5) | ✓ → S3 | `ServiceNotPresent` | `ServiceNotPresent` | `NoPriorMutation` |
+| **S2** | ✓ → S3 | `ServiceNotPresent` | `ServiceNotPresent` | history-dependent (§7a.5) | `ServiceAlreadyEnabled` | ✓ → S2 | `LastServiceRefused` | history-dependent (§7a.5) |
+| **S3** | `ServiceAlreadyEnabled` | ✓ → S3 | ✓ → S2 | history-dependent (§7a.5) | `ServiceAlreadyEnabled` | ✓ → S3 | ✓ → S1 | history-dependent (§7a.5) |
+
+`NoPriorMutation` is a new typed error variant — added to the §4
+list. It fires when `rollback` is called on a service kind that has
+no recorded prior mutation to fail-forward from.
+
+Rollback cells say "history-dependent" because, per §3.5a, the
+result depends on what the most recent mutation of that kind *was*
+— the cell can resolve to any other ✓ outcome or to
+`NoPriorMutation` / `LastServiceRefused`.
+
+Total: **24 cells.** All must have an e2e test.
+
+### 7a.3 Transport coverage
+
+Each accepted (✓) cell above is run **twice**: once delivered over
+REST, once over DIDComm. Exception: `services didcomm enable` is
+REST-only by nature and the DIDComm-transport variant is replaced
+by an `UnsupportedTransport` rejection test.
+
+For S2 (REST off), REST-transport variants of the operations are
+delivered against the still-bound local Axum listener — recall
+§3.4: the listener stays running, only its DID-doc advertisement is
+removed. The test fixture asserts this distinction.
+
+Total: **2× the accepted cells, plus the `UnsupportedTransport`
+test.**
+
+### 7a.4 Drain interaction matrix
+
+Drain semantics are DIDComm-only. These are *additional* scenarios
+on top of §7a.2:
+
+| Scenario | Expected |
+|---|---|
+| `didcomm update` from S2 → drain set has 1 entry, 24h default TTL | drain entry exists; drain countdown visible in `drain list` |
+| `didcomm update` while a previous drain is still active | drain set has 2 entries; sticky outbound routing per §3.5 |
+| `didcomm disable` from S3 → drain entry created with default 24h | drain entry exists; LogEntry has no DIDComm service |
+| `didcomm rollback` while drain active for the prior `update` | drain canceled, prior mediator restored, no new LogEntry chain branching |
+| `didcomm rollback` of a `disable` while drain still active | DIDComm re-advertised, drain entry removed atomically |
+| Drain TTL expiry → `DIDCommService::remove_listener` called | listener removed; mediator no longer in registry |
+| Process restart mid-drain → drain set replayed with remaining TTL | sweeper resumes, no double-counting |
+| `drain cancel <did>` on an active drain | drain entry removed immediately; listener removed |
+| `--drain-ttl 0` on `disable` | no drain set; immediate listener removal (allowed only over REST transport) |
+| `--drain-ttl 30s` over DIDComm transport | rejected with `DrainTtlOutOfBounds` (below `MIN_DRAIN_TTL_OVER_DIDCOMM`) |
+| `--drain-ttl 31d` | rejected with `DrainTtlOutOfBounds` (above `MAX_DRAIN_TTL`) |
+
+Total: **11 drain scenarios.**
+
+### 7a.5 Rollback history scenarios
+
+Rollback is history-sensitive, so it gets its own enumerated set
+rather than a single state×op cell. Per §3.5a, every rollback
+publishes a new LogEntry — the chain only grows.
+
+#### DIDComm rollback
+
+| History | Then `didcomm rollback` | Expected |
+|---|---|---|
+| S1 (no DIDComm history) | | `NoPriorMutation` |
+| S1 → S3 (didcomm enable X) → rollback | | new LogEntry → S1 (DIDComm absent again) |
+| S2 → S2 (didcomm update A→B, B draining never started since A→B drains A) → rollback | | new LogEntry → S2 with mediator A primary; B enters drain set with default 24h |
+| S3 → S1 (didcomm disable from mediator A, A draining) → rollback | | new LogEntry → S3; mediator A re-pinned as primary; A's drain entry removed |
+| Two consecutive didcomm updates A→B→C, then rollback | | new LogEntry → B primary; C enters drain set; A continues draining on its existing schedule (single-step rollback only) |
+| S2 (no DIDComm history at all — VTA was set up REST-first then `didcomm enable`) | rollback after the enable → S2 with no DIDComm | rejected `LastServiceRefused` (would brick) |
+
+#### REST rollback
+
+| History | Then `rest rollback` | Expected |
+|---|---|---|
+| S2 (no REST history at all) | | `NoPriorMutation` |
+| S2 → S3 (rest enable X) → rollback | | new LogEntry → S2 (REST absent again) |
+| S3 → S3 (rest update X→Y) → rollback | | new LogEntry → S3 with REST URL X |
+| S3 → S2 (rest disable from URL X) → rollback | | new LogEntry → S3 with REST URL X re-advertised |
+| S1 (REST-only, no DIDComm) → rollback the most recent rest enable | | rejected `LastServiceRefused` (would brick) |
+
+Total: **11 rollback histories** (6 DIDComm + 5 REST).
+
+### 7a.6 Sequencing / soak paths
+
+A handful of multi-step "operator day-in-the-life" paths to catch
+state-leak bugs the cell-by-cell tests miss:
+
+1. **Domain migration**: S3 → `rest update` → S3 (different URL) →
+   verify both transports still functional, LogEntry chain has
+   exactly one new entry.
+2. **DIDComm-only deployment**: setup-S3 → `rest disable` → S2 →
+   `didcomm update` → S2 (new mediator) → operate over DIDComm
+   only for the rest of the test.
+3. **REST-only deployment**: setup-S3 → `didcomm disable` → drain
+   to expiry → S1 → operate over REST only.
+4. **Mediator failover with rollback**: S3 → `didcomm update` to
+   broken mediator → handshake fails → state still S3 with
+   original mediator → `didcomm update` to good mediator →
+   rollback → original restored.
+5. **Restart-during-drain**: S3 → `didcomm update` → kill VTA
+   process during drain window → restart → drain timers replayed
+   → drain expires on schedule.
+6. **Brick attempt**: S2 → `didcomm disable` → rejected
+   `LastServiceRefused` → state still S2 → `rest enable` → S3 →
+   `didcomm disable` → S1.
+
+Total: **6 sequencing paths.**
+
+### 7a.7 Test infrastructure
+
+* All e2e tests live in `tests/e2e/` (existing crate from PR #36).
+* `affinidi-messaging-test-mediator` is the DIDComm test peer
+  (already on crates.io as of c0bfc30).
+* Each test starts from a fresh fjall store + a freshly-set-up
+  VTA in a known state — no shared state between tests.
+* WebVH LogEntry chain assertions use the existing did_webvh
+  helpers in `vta-service/src/operations/did_webvh/`.
+* Telemetry assertions read from `RingBufferTelemetry`.
+
+### 7a.8 Counting
+
+Approximate test count for this matrix:
+
+| Category | Count |
+|---|---|
+| §7a.2 cells × ~2 transports | ~36 |
+| §7a.4 drain scenarios | 11 |
+| §7a.5 rollback histories | 11 |
+| §7a.6 sequencing paths | 6 |
+| **Total** | **~64 e2e tests** |
+
+This is large but tractable; the harness is shared, so most tests
+are short. The matrix is the gate for shipping.
+
+## 8. Boundaries
+
+**Always:**
+* Run `cargo fmt` before committing
+* DCO-sign every commit (`git commit -s`)
+* Reuse `affinidi-vc` / `affinidi-data-integrity` for any
+  signed-envelope work — no hand-rolled JSON signing
+* Apply `Verified*` typestate pattern to any new wire form that
+  carries a signature (per CLAUDE.md)
+* Update `docs/03-integrating/didcomm-protocol-management.md` and
+  add a new `docs/03-integrating/runtime-service-management.md`
+  operator guide
+
+**Ask first:**
+* Adding a third service kind beyond REST/DIDComm
+* Changing `MAX_DRAIN_TTL` or `MIN_DRAIN_TTL_OVER_DIDCOMM`
+* Adding a `--force` flag to bypass `LastServiceRefused`
+* Changing the JWT audience model or adding a new claim
+* Adding a new `SealedPayloadV1` variant (touch the seal helper in
+  `provision_integration/seal.rs`)
+
+**Never:**
+* Provide a multi-service atomic mutation API (foot-gun)
+* Allow zero advertised services
+* Re-issue or rotate `verificationMethod` as a side effect of a
+  service mutation
+* Re-introduce `pnm mediator …` as an alias
+* Bypass the existing `MODE_B_LOCK` / carve-out gating in
+  TEE bootstrap
+* Skip telemetry emission "because the operation is fast"
+
+## 9. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Operator removes the only reachable transport | `LastServiceRefused` invariant; no `--force` |
+| Mediator migration races with in-flight inbound | Existing drain set, sticky outbound routing |
+| LogEntry publication fails after runtime mutation | Transactional rollback (existing pattern in `migrate_mediator.rs`) |
+| Operator scripts break on CLI rename | Documented breaking change; user confirmed acceptable |
+| 24h default surprises an operator who relied on whatever-it-was-before | No production users; one-line note in upgrade guide |
+| WebVH LogEntry chain grows unbounded with frequent service mutations | Out of scope — existing chain-pruning concerns apply equally |
+
+## 10. Resolved Questions
+
+All previously-open questions are resolved. Audit performed on
+2026-05-06 against `main` at 88dab00.
+
+1. **DIDComm-preferred ordering:** array-ordering convention.
+   The VTA DID-doc rendering function
+   (`vta-service/src/operations/did_webvh/document.rs:79`) builds
+   `service[]` in a fixed order. Today's order is
+   mediator-didcomm → additional_services → tee-attestation.
+   When REST joins the array, it goes **after** the
+   DIDComm entry, preserving "DIDComm-first." No `priority` key
+   is used; resolvers that walk the array in order will pick
+   DIDComm first.
+2. **URL reachability probing on `rest enable`:** **don't probe.**
+   Trust the operator, consistent with mediator DID handling.
+3. **`routing_keys` for DIDComm:** the field is already
+   well-established in the mediator template
+   (`vta-sdk/templates/didcomm-mediator.json:49`,
+   `routingKeys`) and in
+   `EnableDidcommRequest`. The current VTA `#vta-didcomm` service
+   entry omits it; we'll add it as an optional pass-through when
+   the operator supplies `--routing-keys`. No SDK extension
+   required.
+4. **`services list` JSON shape:** minimal —
+   `{ kind, enabled, config: Option<…> }` per kind. Reusing
+   `services report`'s telemetry-heavy shape is rejected; report
+   is a different operation (per-mediator counters, sender
+   last-seen).
+5. **Rollback scope:** per-kind and fail-forward (§3.5a).
+   `services rest rollback` and `services didcomm rollback` are
+   symmetric — each publishes a new LogEntry that re-applies
+   its kind's prior config.
+
+### Implementation note — REST service entry is net-new
+
+Today the VTA's own DID document does **not** advertise a REST
+service entry. `config.public_url` is used internally but never
+rendered into `service[]`
+(`vta-service/src/operations/did_webvh/document.rs:79`). So
+`services rest enable` is the path that adds the entry for the
+first time. **An upgraded VTA boots with no REST service entry
+in its DID doc** — the operator must explicitly opt in via
+`pnm services rest enable --url <url>` to advertise REST. This
+matches the spec's "operator drives every service mutation"
+model and avoids an implicit behavior change on upgrade.
+
+A REST service entry uses `type: ["VerifiableTrustAgent"]` (new
+kind, distinct from `LinkedDomains` which has weaker semantics).
+The exact shape is finalized in T1.3.
+
+**Initial state of all three states post-upgrade:** an upgraded
+VTA with both `public_url` configured and DIDComm enabled comes
+up in **S2** (DIDComm-only), not S3. Operators who want REST
+advertised run `services rest enable` once. The §7a.1 state
+model still applies — S1/S2/S3 are reachable by operator action
+from any starting point.
+
+## 11. Lifecycle
+
+* Phase 1 (this doc) — review and sign-off
+* Phase 2 — Plan: component breakdown, dependency order, parallelism
+* Phase 3 — Tasks: discrete units with acceptance criteria each
+* Phase 4 — Implement: incremental, TDD, each task lands behind
+  green CI before the next starts

--- a/vta-sdk/src/error.rs
+++ b/vta-sdk/src/error.rs
@@ -71,9 +71,80 @@ pub enum VtaError {
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    // ── Runtime service-management variants (spec §4) ──────────────
+    //
+    // These are emitted by the post-setup service-management surface
+    // (`services {rest,didcomm} {enable,update,disable,rollback}`).
+    // Structured data for the variants that carry numeric fields
+    // round-trips lossless via [`TypedErrorPayload`] across both
+    // REST response bodies and DIDComm problem-report args.
+    /// The operation would leave the VTA's DID document with no
+    /// advertised transport services. Per spec §3.2, this is rejected
+    /// without a `--force` escape hatch — enable the other transport
+    /// first if a swap is intended.
+    #[error("refusing operation: would leave the VTA with no advertised services")]
+    LastServiceRefused,
+
+    /// `update`, `disable`, or a kind-specific drain action was
+    /// invoked for a service kind that isn't currently enabled.
+    #[error("service is not present (not currently enabled)")]
+    ServiceNotPresent,
+
+    /// `enable` was invoked for a service kind that's already
+    /// enabled. Use `update` to change its configuration.
+    #[error("service is already enabled")]
+    ServiceAlreadyEnabled,
+
+    /// DIDComm handshake against the candidate mediator failed
+    /// (trust-ping refused, timed out, or peer was unreachable).
+    #[error("mediator handshake failed: {reason}")]
+    MediatorHandshakeFailed { reason: String },
+
+    /// Drain TTL is outside the valid range. Bounds are
+    /// `MIN_DRAIN_TTL_OVER_DIDCOMM` (3600s, when the disable command
+    /// is itself delivered over DIDComm) and `MAX_DRAIN_TTL`
+    /// (30 days). All three fields are in seconds.
+    #[error("drain ttl {requested}s outside allowed range [{min}s, {max}s]")]
+    DrainTtlOutOfBounds { min: u64, max: u64, requested: u64 },
+
+    /// `rollback` was invoked for a service kind that has no prior
+    /// mutation in its snapshot store to fail-forward from.
+    #[error("no prior mutation to roll back from")]
+    NoPriorMutation,
+
     /// Catch-all for other errors.
     #[error("{0}")]
     Other(String),
+}
+
+/// Wire-format companion to the typed [`VtaError`] variants emitted
+/// by the runtime service-management surface.
+///
+/// The free-form `comment` string carried by DIDComm problem-reports
+/// (and the `body` string of REST error responses) is fine for the
+/// variants whose only data is a human-readable message
+/// ([`VtaError::Conflict`], [`VtaError::NotFound`], …) but lossy for
+/// variants like [`VtaError::DrainTtlOutOfBounds`] that carry three
+/// numeric fields the CLI needs to switch on.
+///
+/// Servers serialize a `TypedErrorPayload` into the response body
+/// (REST) or problem-report `args` (DIDComm); clients deserialize
+/// it back via [`VtaError::from_typed_payload`]. The discriminator
+/// is the kebab-cased variant name in the `code` field.
+///
+/// Variants line up 1:1 with the §4 spec list — the existing
+/// [`VtaError::UnsupportedTransport`] is included so the same
+/// channel carries every typed-error wire form.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "code", rename_all = "kebab-case")]
+pub enum TypedErrorPayload {
+    LastServiceRefused,
+    ServiceNotPresent,
+    ServiceAlreadyEnabled,
+    MediatorHandshakeFailed { reason: String },
+    DrainTtlOutOfBounds { min: u64, max: u64, requested: u64 },
+    NoPriorMutation,
+    UnsupportedTransport { detail: String },
 }
 
 impl VtaError {
@@ -119,6 +190,67 @@ impl VtaError {
                 code: other.to_string(),
                 comment,
             },
+        }
+    }
+
+    /// Reconstruct the typed [`VtaError`] variant from a wire-format
+    /// [`TypedErrorPayload`]. Used by the client when decoding REST
+    /// response bodies / DIDComm problem-report args for the runtime
+    /// service-management surface (spec §4).
+    pub fn from_typed_payload(payload: TypedErrorPayload) -> Self {
+        match payload {
+            TypedErrorPayload::LastServiceRefused => Self::LastServiceRefused,
+            TypedErrorPayload::ServiceNotPresent => Self::ServiceNotPresent,
+            TypedErrorPayload::ServiceAlreadyEnabled => Self::ServiceAlreadyEnabled,
+            TypedErrorPayload::MediatorHandshakeFailed { reason } => {
+                Self::MediatorHandshakeFailed { reason }
+            }
+            TypedErrorPayload::DrainTtlOutOfBounds {
+                min,
+                max,
+                requested,
+            } => Self::DrainTtlOutOfBounds {
+                min,
+                max,
+                requested,
+            },
+            TypedErrorPayload::NoPriorMutation => Self::NoPriorMutation,
+            TypedErrorPayload::UnsupportedTransport { detail } => {
+                Self::UnsupportedTransport(detail)
+            }
+        }
+    }
+
+    /// Project this error onto the wire-format [`TypedErrorPayload`]
+    /// when the variant is one of the runtime service-management
+    /// errors. Returns `None` for variants that don't have a
+    /// structured wire form (network errors, generic conflicts,
+    /// programmer-level protocol errors, …).
+    #[must_use]
+    pub fn to_typed_payload(&self) -> Option<TypedErrorPayload> {
+        match self {
+            Self::LastServiceRefused => Some(TypedErrorPayload::LastServiceRefused),
+            Self::ServiceNotPresent => Some(TypedErrorPayload::ServiceNotPresent),
+            Self::ServiceAlreadyEnabled => Some(TypedErrorPayload::ServiceAlreadyEnabled),
+            Self::MediatorHandshakeFailed { reason } => {
+                Some(TypedErrorPayload::MediatorHandshakeFailed {
+                    reason: reason.clone(),
+                })
+            }
+            Self::DrainTtlOutOfBounds {
+                min,
+                max,
+                requested,
+            } => Some(TypedErrorPayload::DrainTtlOutOfBounds {
+                min: *min,
+                max: *max,
+                requested: *requested,
+            }),
+            Self::NoPriorMutation => Some(TypedErrorPayload::NoPriorMutation),
+            Self::UnsupportedTransport(detail) => Some(TypedErrorPayload::UnsupportedTransport {
+                detail: detail.clone(),
+            }),
+            _ => None,
         }
     }
 
@@ -204,6 +336,38 @@ impl VtaError {
                 "Network error reaching the VTA. Confirm the URL is correct and the \
                  host is reachable.",
             ),
+            // Runtime service-management variants (spec §4). The CLI
+            // layer enriches these with the specific kind/command
+            // it just ran; this is the generic fallback hint for
+            // non-CLI consumers.
+            Self::LastServiceRefused => Some(
+                "This operation would leave the VTA with no advertised transport \
+                 services. Enable the other transport first (REST or DIDComm) \
+                 before disabling this one.",
+            ),
+            Self::ServiceNotPresent => Some(
+                "The service kind isn't currently enabled. Use \
+                 `services <kind> enable …` to bring it online before \
+                 updating, disabling, or rolling it back.",
+            ),
+            Self::ServiceAlreadyEnabled => Some(
+                "The service kind is already enabled. Use \
+                 `services <kind> update …` to change its configuration, \
+                 or `disable` to remove it.",
+            ),
+            Self::MediatorHandshakeFailed { .. } => Some(
+                "DIDComm handshake against the candidate mediator failed. \
+                 Confirm the mediator DID is correct and the mediator is \
+                 reachable; check the inner reason for the specific cause.",
+            ),
+            Self::DrainTtlOutOfBounds { .. } => Some(
+                "The supplied drain TTL is outside the allowed range. Pick a \
+                 value within the [min, max] interval shown in the error message.",
+            ),
+            Self::NoPriorMutation => Some(
+                "No prior mutation for this service kind to roll back from. Use \
+                 the direct `enable`/`update`/`disable` command instead.",
+            ),
             // No generic hint for these — the message itself is the
             // hint, or the failure is a protocol/programmer error
             // surface that an automated suggestion would only confuse.
@@ -284,6 +448,28 @@ mod tests {
                 .is_some()
         );
 
+        // Runtime service-management variants (spec §4) all have hints.
+        assert!(VtaError::LastServiceRefused.suggested_fix().is_some());
+        assert!(VtaError::ServiceNotPresent.suggested_fix().is_some());
+        assert!(VtaError::ServiceAlreadyEnabled.suggested_fix().is_some());
+        assert!(
+            VtaError::MediatorHandshakeFailed {
+                reason: "trust-ping timeout".into()
+            }
+            .suggested_fix()
+            .is_some()
+        );
+        assert!(
+            VtaError::DrainTtlOutOfBounds {
+                min: 3600,
+                max: 2_592_000,
+                requested: 30,
+            }
+            .suggested_fix()
+            .is_some()
+        );
+        assert!(VtaError::NoPriorMutation.suggested_fix().is_some());
+
         // Self-explanatory / programmer-error: no canned hint.
         assert!(VtaError::NotFound("x".into()).suggested_fix().is_none());
         assert!(VtaError::Protocol("shape".into()).suggested_fix().is_none());
@@ -295,5 +481,126 @@ mod tests {
             .suggested_fix()
             .is_none()
         );
+    }
+
+    /// Every typed runtime service-management variant must round-trip
+    /// through [`TypedErrorPayload`] without losing structured data.
+    /// The test cases line up 1:1 with the spec §4 list.
+    #[test]
+    fn typed_payload_round_trips_every_runtime_service_variant() {
+        let cases: Vec<VtaError> = vec![
+            VtaError::LastServiceRefused,
+            VtaError::ServiceNotPresent,
+            VtaError::ServiceAlreadyEnabled,
+            VtaError::MediatorHandshakeFailed {
+                reason: "trust-ping timeout after 10s".into(),
+            },
+            VtaError::DrainTtlOutOfBounds {
+                min: 3600,
+                max: 2_592_000,
+                requested: 30,
+            },
+            VtaError::NoPriorMutation,
+            VtaError::UnsupportedTransport("services didcomm enable is REST-only".into()),
+        ];
+
+        for original in cases {
+            let payload = original.to_typed_payload().unwrap_or_else(|| {
+                panic!("variant must project to TypedErrorPayload: {original:?}")
+            });
+
+            // Round-trip through JSON to mirror what REST and DIDComm
+            // transports actually do on the wire.
+            let json = serde_json::to_string(&payload)
+                .unwrap_or_else(|e| panic!("payload must serialize: {e}"));
+            let restored: TypedErrorPayload = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("payload must deserialize: {e}; raw={json}"));
+
+            assert_eq!(
+                payload, restored,
+                "TypedErrorPayload must round-trip through JSON",
+            );
+
+            // Reconstructing back to VtaError preserves the variant
+            // discriminant and any structured data.
+            let reconstructed = VtaError::from_typed_payload(restored);
+            match (&original, &reconstructed) {
+                (VtaError::LastServiceRefused, VtaError::LastServiceRefused)
+                | (VtaError::ServiceNotPresent, VtaError::ServiceNotPresent)
+                | (VtaError::ServiceAlreadyEnabled, VtaError::ServiceAlreadyEnabled)
+                | (VtaError::NoPriorMutation, VtaError::NoPriorMutation) => {}
+                (
+                    VtaError::MediatorHandshakeFailed { reason: a },
+                    VtaError::MediatorHandshakeFailed { reason: b },
+                ) => assert_eq!(a, b),
+                (
+                    VtaError::DrainTtlOutOfBounds {
+                        min: m1,
+                        max: x1,
+                        requested: r1,
+                    },
+                    VtaError::DrainTtlOutOfBounds {
+                        min: m2,
+                        max: x2,
+                        requested: r2,
+                    },
+                ) => {
+                    assert_eq!(m1, m2);
+                    assert_eq!(x1, x2);
+                    assert_eq!(r1, r2);
+                }
+                (VtaError::UnsupportedTransport(a), VtaError::UnsupportedTransport(b)) => {
+                    assert_eq!(a, b)
+                }
+                (a, b) => panic!("variant changed across round-trip: {a:?} → {b:?}"),
+            }
+        }
+    }
+
+    /// The kebab-case `code` discriminator on the wire JSON is part of
+    /// the contract for both REST and DIDComm transports — pin it
+    /// explicitly so a `serde(rename)` change doesn't silently break
+    /// existing peers.
+    #[test]
+    fn typed_payload_wire_discriminator_is_kebab_case() {
+        let payload = TypedErrorPayload::DrainTtlOutOfBounds {
+            min: 3600,
+            max: 2_592_000,
+            requested: 30,
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["code"], "drain-ttl-out-of-bounds");
+        assert_eq!(json["min"], 3600);
+        assert_eq!(json["max"], 2_592_000);
+        assert_eq!(json["requested"], 30);
+    }
+
+    /// `to_typed_payload` returns `None` for variants outside the
+    /// runtime service-management surface — the wire-format channel
+    /// is reserved for those typed variants and shouldn't blanket
+    /// every error.
+    #[test]
+    fn typed_payload_is_none_for_non_service_management_variants() {
+        assert!(VtaError::Auth("x".into()).to_typed_payload().is_none());
+        assert!(VtaError::NotFound("x".into()).to_typed_payload().is_none());
+        assert!(VtaError::Conflict("x".into()).to_typed_payload().is_none());
+        assert!(
+            VtaError::Server {
+                status: 500,
+                body: "x".into(),
+            }
+            .to_typed_payload()
+            .is_none()
+        );
+        assert!(VtaError::Protocol("x".into()).to_typed_payload().is_none());
+        assert!(
+            VtaError::DidcommRemote {
+                code: "e.x".into(),
+                comment: "x".into()
+            }
+            .to_typed_payload()
+            .is_none()
+        );
+        assert!(VtaError::Other("x".into()).to_typed_payload().is_none());
     }
 }

--- a/vta-service/src/operations/protocol/invariant.rs
+++ b/vta-service/src/operations/protocol/invariant.rs
@@ -1,0 +1,235 @@
+//! Brick-prevention invariant for runtime service-management.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.2.
+//!
+//! At least one transport service (REST or DIDComm) must be
+//! advertised in the VTA's DID document at all times. Disable /
+//! rollback paths funnel through [`would_violate_last_service`] to
+//! enforce this — there is no `--force` escape hatch and no
+//! per-call-site duplication of the predicate.
+//!
+//! The function is pure: callers compute the post-mutation enabled
+//! state for the kind they're touching and pass it in. State for
+//! the *other* kind is read off the supplied [`CurrentServices`]
+//! snapshot. This keeps the predicate testable in isolation and
+//! independent of the persistence layer.
+
+use vta_sdk::error::VtaError;
+
+use crate::operations::protocol::snapshot::ServiceKind;
+
+/// Snapshot of which transport services the VTA is currently
+/// advertising in its DID document.
+///
+/// Read by the operation layer from `AppConfig.services` (or the
+/// most recent WebVH LogEntry's `service[]` array, when the
+/// caller is acting on observed-on-chain state). Both sources
+/// must agree — divergence is itself a bug worth surfacing
+/// elsewhere.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CurrentServices {
+    pub rest_enabled: bool,
+    pub didcomm_enabled: bool,
+}
+
+impl CurrentServices {
+    pub const fn new(rest_enabled: bool, didcomm_enabled: bool) -> Self {
+        Self {
+            rest_enabled,
+            didcomm_enabled,
+        }
+    }
+}
+
+/// A proposed mutation, expressed as the **post-mutation** enabled
+/// state for a single kind.
+///
+/// The shape deliberately doesn't enumerate enable / update /
+/// disable / rollback — the invariant only cares about the result
+/// of the transition. Callers compute the post-state from their
+/// op semantics and feed it in. Most ops use one of the
+/// [`Self::enable`] / [`Self::disable`] constructors; rollback
+/// dispatchers compute the post-state from the snapshot they're
+/// fail-forwarding into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProposedOp {
+    pub kind: ServiceKind,
+    pub kind_will_be_enabled: bool,
+}
+
+impl ProposedOp {
+    /// The kind will be enabled after the op (e.g. `services rest
+    /// enable`, `services didcomm rollback` of a previous disable).
+    pub const fn enable(kind: ServiceKind) -> Self {
+        Self {
+            kind,
+            kind_will_be_enabled: true,
+        }
+    }
+
+    /// The kind will be disabled after the op (e.g. `services rest
+    /// disable`, `services didcomm rollback` of a previous enable).
+    pub const fn disable(kind: ServiceKind) -> Self {
+        Self {
+            kind,
+            kind_will_be_enabled: false,
+        }
+    }
+}
+
+/// Reject the mutation if it would leave the VTA's DID document
+/// advertising zero transport services.
+///
+/// Returns [`VtaError::LastServiceRefused`] when the post-op state
+/// would have both REST and DIDComm disabled. The single source
+/// of truth for spec §3.2 — every disable / rollback path goes
+/// through here, no duplicated conditionals.
+///
+/// Note: the function does not consult the snapshot store, the
+/// fjall keyspaces, or the live registry. It is a pure predicate
+/// over the supplied state, making it cheap to call defensively
+/// (e.g. as the first thing inside a mutation entry point).
+pub fn would_violate_last_service(state: &CurrentServices, op: ProposedOp) -> Result<(), VtaError> {
+    let (rest_after, didcomm_after) = match op.kind {
+        ServiceKind::Rest => (op.kind_will_be_enabled, state.didcomm_enabled),
+        ServiceKind::Didcomm => (state.rest_enabled, op.kind_will_be_enabled),
+    };
+    if !rest_after && !didcomm_after {
+        return Err(VtaError::LastServiceRefused);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Spec §7a.1 state model — the four (rest, didcomm) combinations.
+    /// `S0` is invariant-violating but a valid input to the predicate
+    /// (because the predicate is also called from `enable` paths
+    /// that bring the VTA *out* of the bricked state).
+    const S0: CurrentServices = CurrentServices::new(false, false);
+    const S1: CurrentServices = CurrentServices::new(true, false); // rest only
+    const S2: CurrentServices = CurrentServices::new(false, true); // didcomm only
+    const S3: CurrentServices = CurrentServices::new(true, true);
+
+    /// Disabling either kind from S3 leaves the other on — never
+    /// rejects.
+    #[test]
+    fn s3_can_disable_either_kind() {
+        assert!(would_violate_last_service(&S3, ProposedOp::disable(ServiceKind::Rest)).is_ok());
+        assert!(would_violate_last_service(&S3, ProposedOp::disable(ServiceKind::Didcomm)).is_ok());
+    }
+
+    /// Disabling the only-on kind from S1/S2 brings the VTA to S0
+    /// — must reject with `LastServiceRefused`.
+    #[test]
+    fn s1_disable_rest_is_rejected() {
+        let err =
+            would_violate_last_service(&S1, ProposedOp::disable(ServiceKind::Rest)).unwrap_err();
+        assert!(matches!(err, VtaError::LastServiceRefused));
+    }
+
+    #[test]
+    fn s2_disable_didcomm_is_rejected() {
+        let err =
+            would_violate_last_service(&S2, ProposedOp::disable(ServiceKind::Didcomm)).unwrap_err();
+        assert!(matches!(err, VtaError::LastServiceRefused));
+    }
+
+    /// Disabling the *already-off* kind is a no-op for the
+    /// invariant — it doesn't change the post-state. The predicate
+    /// must accept it (the higher-level op layer rejects this with
+    /// `ServiceNotPresent`, but that's a different concern).
+    #[test]
+    fn s1_disable_didcomm_is_accepted_by_invariant() {
+        // S1 = rest on, didcomm off. Disabling didcomm: post-state
+        // is still (rest on, didcomm off). Invariant intact.
+        assert!(would_violate_last_service(&S1, ProposedOp::disable(ServiceKind::Didcomm)).is_ok());
+    }
+
+    #[test]
+    fn s2_disable_rest_is_accepted_by_invariant() {
+        assert!(would_violate_last_service(&S2, ProposedOp::disable(ServiceKind::Rest)).is_ok());
+    }
+
+    /// Enabling brings (or leaves) a kind on — never violates.
+    #[test]
+    fn enable_never_violates() {
+        for state in &[S0, S1, S2, S3] {
+            for kind in &[ServiceKind::Rest, ServiceKind::Didcomm] {
+                assert!(
+                    would_violate_last_service(state, ProposedOp::enable(*kind)).is_ok(),
+                    "enable from {state:?} for {kind:?} must be accepted",
+                );
+            }
+        }
+    }
+
+    /// From S0 (already bricked), enabling either kind brings the
+    /// VTA back to S1 or S2 — those operations must succeed at the
+    /// invariant layer so the operator can climb out.
+    #[test]
+    fn s0_enable_either_kind_is_accepted() {
+        assert!(would_violate_last_service(&S0, ProposedOp::enable(ServiceKind::Rest)).is_ok());
+        assert!(would_violate_last_service(&S0, ProposedOp::enable(ServiceKind::Didcomm)).is_ok());
+    }
+
+    /// S0 + a *disable* is doubly-bad (already bricked, this op
+    /// would keep us bricked). Reject — even though it's a no-op
+    /// in practice, the typed error gives the operator a clearer
+    /// message than silent acceptance.
+    #[test]
+    fn s0_disable_is_rejected() {
+        assert!(matches!(
+            would_violate_last_service(&S0, ProposedOp::disable(ServiceKind::Rest)).unwrap_err(),
+            VtaError::LastServiceRefused,
+        ));
+        assert!(matches!(
+            would_violate_last_service(&S0, ProposedOp::disable(ServiceKind::Didcomm)).unwrap_err(),
+            VtaError::LastServiceRefused,
+        ));
+    }
+
+    /// Exhaustive sweep of every (state, kind, post-state) cell —
+    /// guards against future divergence between the two-kind logic
+    /// arms inside the function.
+    #[test]
+    fn full_truth_table() {
+        // (state, kind, kind_will_be_enabled, expected_ok)
+        let cases = [
+            (S0, ServiceKind::Rest, false, false),
+            (S0, ServiceKind::Rest, true, true),
+            (S0, ServiceKind::Didcomm, false, false),
+            (S0, ServiceKind::Didcomm, true, true),
+            (S1, ServiceKind::Rest, false, false), // s1 disable-rest = brick
+            (S1, ServiceKind::Rest, true, true),
+            (S1, ServiceKind::Didcomm, false, true), // s1 disable-didcomm = no-op
+            (S1, ServiceKind::Didcomm, true, true),
+            (S2, ServiceKind::Rest, false, true), // s2 disable-rest = no-op
+            (S2, ServiceKind::Rest, true, true),
+            (S2, ServiceKind::Didcomm, false, false), // s2 disable-didcomm = brick
+            (S2, ServiceKind::Didcomm, true, true),
+            (S3, ServiceKind::Rest, false, true),
+            (S3, ServiceKind::Rest, true, true),
+            (S3, ServiceKind::Didcomm, false, true),
+            (S3, ServiceKind::Didcomm, true, true),
+        ];
+
+        for (state, kind, kind_will_be_enabled, expected_ok) in cases {
+            let op = ProposedOp {
+                kind,
+                kind_will_be_enabled,
+            };
+            let result = would_violate_last_service(&state, op);
+            assert_eq!(
+                result.is_ok(),
+                expected_ok,
+                "case ({state:?}, {kind:?}, {kind_will_be_enabled}) — expected ok={expected_ok}, got {result:?}",
+            );
+            if !expected_ok {
+                assert!(matches!(result.unwrap_err(), VtaError::LastServiceRefused));
+            }
+        }
+    }
+}

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -11,6 +11,7 @@ pub mod disable_didcomm;
 pub mod document;
 pub mod drain_cancel;
 pub mod enable_didcomm;
+pub mod invariant;
 pub mod migrate_mediator;
 pub mod report;
 pub mod snapshot;

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -13,6 +13,7 @@ pub mod drain_cancel;
 pub mod enable_didcomm;
 pub mod migrate_mediator;
 pub mod report;
+pub mod snapshot;
 
 /// Process-wide lock serializing every protocol-state mutation
 /// (enable / disable / migrate / drain-cancel). Modeled on

--- a/vta-service/src/operations/protocol/snapshot.rs
+++ b/vta-service/src/operations/protocol/snapshot.rs
@@ -1,0 +1,378 @@
+//! Per-kind previous-config snapshot for fail-forward rollback.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.5a.
+//!
+//! The snapshot captures a service kind's pre-mutation state — the
+//! configuration that was in effect *before* the most recent
+//! successful mutation of that kind. `services {kind} rollback`
+//! consumes the snapshot via [`read`], dispatches into the
+//! equivalent forward operation, and the new mutation's pre-state
+//! then replaces the snapshot via [`write`]. There is no "rewind"
+//! of the WebVH chain — every mutation, rollback or otherwise,
+//! appends a new LogEntry.
+//!
+//! ## Storage
+//!
+//! * Keyspace: [`KEYSPACE_NAME`] (`service_prev_config`).
+//! * Key: `rest` or `didcomm` — exactly one entry per kind.
+//! * Value: serialized [`ServiceConfigSnapshot`]. The variant tag
+//!   in the serialized form mirrors the kind, so a misdirected
+//!   write (e.g. storing a `Didcomm` payload under the `rest` key)
+//!   is caught by [`read`] before it reaches the rollback dispatch.
+//!
+//! ## Order discipline
+//!
+//! Per spec §3.5a, the operation layer is responsible for writing
+//! the snapshot **before** the runtime mutation. A crash between
+//! snapshot persist and runtime mutation leaves the snapshot
+//! describing the current state — a subsequent rollback would find
+//! snapshot ≡ current and is a no-op (handled in T3.1/T3.2). A
+//! crash between runtime mutation and LogEntry publication uses the
+//! existing transactional-rollback pattern from `migrate_mediator`.
+
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// Fjall keyspace name for snapshots. Callers fetch the
+/// [`KeyspaceHandle`] via [`vti_common::store::Store::keyspace`]
+/// once at startup (or in tests) and pass it to [`read`] / [`write`]
+/// / [`clear`].
+pub const KEYSPACE_NAME: &str = "service_prev_config";
+
+/// Identifier for which transport kind a snapshot pertains to.
+///
+/// Lives in this module rather than in `vta_sdk` because the
+/// snapshot store is server-side only — the SDK doesn't need it.
+/// The CLI / wire-type layers use their own kind discriminator
+/// (the `code` field on `TypedErrorPayload`); both stay in sync
+/// because the kebab-case strings match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceKind {
+    Rest,
+    Didcomm,
+}
+
+impl ServiceKind {
+    /// Storage key for this kind. Stable wire form — changing this
+    /// invalidates every persisted snapshot.
+    pub(crate) fn storage_key(self) -> &'static str {
+        match self {
+            ServiceKind::Rest => "rest",
+            ServiceKind::Didcomm => "didcomm",
+        }
+    }
+}
+
+/// Snapshot of a single transport's pre-mutation state.
+///
+/// The variant tag (`kind`) doubles as a self-validation marker:
+/// [`read`] checks it against the requested kind and surfaces an
+/// internal error on mismatch rather than handing the rollback
+/// dispatcher a payload that doesn't fit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum ServiceConfigSnapshot {
+    Rest(RestSnapshot),
+    Didcomm(DidcommSnapshot),
+}
+
+impl ServiceConfigSnapshot {
+    pub fn kind(&self) -> ServiceKind {
+        match self {
+            ServiceConfigSnapshot::Rest(_) => ServiceKind::Rest,
+            ServiceConfigSnapshot::Didcomm(_) => ServiceKind::Didcomm,
+        }
+    }
+}
+
+/// Pre-mutation state for the REST kind.
+///
+/// `Disabled` is meaningful — when the most recent mutation was
+/// `services rest enable`, the snapshot records that REST was
+/// previously off so rollback knows to re-disable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum RestSnapshot {
+    Enabled { url: String },
+    Disabled,
+}
+
+/// Pre-mutation state for the DIDComm kind. `routing_keys` is
+/// optional and elided from the wire form when empty.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum DidcommSnapshot {
+    Enabled {
+        mediator_did: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        routing_keys: Vec<String>,
+    },
+    Disabled,
+}
+
+/// Read the snapshot for `kind`, or [`None`] if no prior mutation
+/// has been recorded.
+///
+/// Returns [`AppError::Internal`] when the persisted variant tag
+/// doesn't match the requested kind — that's a programmer error
+/// (someone wrote the wrong kind under this key) and should
+/// surface loudly rather than corrupt a rollback dispatch.
+pub async fn read(
+    ks: &KeyspaceHandle,
+    kind: ServiceKind,
+) -> Result<Option<ServiceConfigSnapshot>, AppError> {
+    let key = kind.storage_key().as_bytes().to_vec();
+    let snap: Option<ServiceConfigSnapshot> = ks.get(key).await?;
+    if let Some(s) = &snap {
+        let stored_kind = s.kind();
+        if stored_kind != kind {
+            return Err(AppError::Internal(format!(
+                "snapshot kind mismatch under key {key:?}: stored {stored_kind:?}, \
+                 requested {kind:?}",
+                key = kind.storage_key(),
+            )));
+        }
+    }
+    Ok(snap)
+}
+
+/// Replace the snapshot for `snapshot.kind()` with the supplied
+/// payload. Overwrites any existing snapshot for that kind. The
+/// kind is derived from the payload — there is no separate kind
+/// argument because the variant already carries it.
+pub async fn write(ks: &KeyspaceHandle, snapshot: ServiceConfigSnapshot) -> Result<(), AppError> {
+    let key = snapshot.kind().storage_key().as_bytes().to_vec();
+    ks.insert(key, &snapshot).await
+}
+
+/// Remove the snapshot for `kind`. No-op if no snapshot is
+/// present.
+pub async fn clear(ks: &KeyspaceHandle, kind: ServiceKind) -> Result<(), AppError> {
+    let key = kind.storage_key().as_bytes().to_vec();
+    ks.remove(key).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    /// Allocates a fresh on-disk fjall store + a handle on the
+    /// snapshot keyspace. Returns the `TempDir` so the caller can
+    /// keep it alive for the duration of the test.
+    async fn empty_snapshot_keyspace() -> (tempfile::TempDir, KeyspaceHandle) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .expect("open store");
+        let ks = store.keyspace(KEYSPACE_NAME).expect("keyspace");
+        (dir, ks)
+    }
+
+    #[tokio::test]
+    async fn read_returns_none_when_no_snapshot_present() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        assert!(read(&ks, ServiceKind::Rest).await.unwrap().is_none());
+        assert!(read(&ks, ServiceKind::Didcomm).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips_rest_enabled() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        let snap = ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+            url: "https://vta.example.com".into(),
+        });
+        write(&ks, snap.clone()).await.unwrap();
+
+        let restored = read(&ks, ServiceKind::Rest).await.unwrap().unwrap();
+        assert_eq!(restored, snap);
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips_rest_disabled() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        let snap = ServiceConfigSnapshot::Rest(RestSnapshot::Disabled);
+        write(&ks, snap.clone()).await.unwrap();
+
+        let restored = read(&ks, ServiceKind::Rest).await.unwrap().unwrap();
+        assert_eq!(restored, snap);
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips_didcomm_enabled_with_routing_keys() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        let snap = ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Enabled {
+            mediator_did: "did:peer:2.Vz...mediator".into(),
+            routing_keys: vec!["did:peer:2.Vz...key1".into(), "did:peer:2.Vz...key2".into()],
+        });
+        write(&ks, snap.clone()).await.unwrap();
+
+        let restored = read(&ks, ServiceKind::Didcomm).await.unwrap().unwrap();
+        assert_eq!(restored, snap);
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips_didcomm_enabled_no_routing_keys() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        let snap = ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Enabled {
+            mediator_did: "did:peer:2.Vz...mediator".into(),
+            routing_keys: vec![],
+        });
+        write(&ks, snap.clone()).await.unwrap();
+
+        let restored = read(&ks, ServiceKind::Didcomm).await.unwrap().unwrap();
+        assert_eq!(restored, snap);
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips_didcomm_disabled() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        let snap = ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Disabled);
+        write(&ks, snap.clone()).await.unwrap();
+
+        let restored = read(&ks, ServiceKind::Didcomm).await.unwrap().unwrap();
+        assert_eq!(restored, snap);
+    }
+
+    #[tokio::test]
+    async fn second_write_overwrites_first_for_same_kind() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        let first = ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+            url: "https://old.example.com".into(),
+        });
+        write(&ks, first).await.unwrap();
+
+        let second = ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+            url: "https://new.example.com".into(),
+        });
+        write(&ks, second.clone()).await.unwrap();
+
+        let restored = read(&ks, ServiceKind::Rest).await.unwrap().unwrap();
+        assert_eq!(restored, second);
+    }
+
+    #[tokio::test]
+    async fn clear_removes_snapshot() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        write(
+            &ks,
+            ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+                url: "https://vta.example.com".into(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        clear(&ks, ServiceKind::Rest).await.unwrap();
+        assert!(read(&ks, ServiceKind::Rest).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn clear_is_a_noop_when_nothing_is_present() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+        clear(&ks, ServiceKind::Rest).await.unwrap();
+        clear(&ks, ServiceKind::Didcomm).await.unwrap();
+    }
+
+    /// REST and DIDComm snapshots live under different storage keys
+    /// and must not affect each other.
+    #[tokio::test]
+    async fn rest_and_didcomm_snapshots_are_independent() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        let rest = ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+            url: "https://vta.example.com".into(),
+        });
+        let didcomm = ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Enabled {
+            mediator_did: "did:peer:2.Vz...mediator".into(),
+            routing_keys: vec![],
+        });
+
+        write(&ks, rest.clone()).await.unwrap();
+        write(&ks, didcomm.clone()).await.unwrap();
+
+        assert_eq!(read(&ks, ServiceKind::Rest).await.unwrap().unwrap(), rest,);
+        assert_eq!(
+            read(&ks, ServiceKind::Didcomm).await.unwrap().unwrap(),
+            didcomm,
+        );
+
+        // Clearing one leaves the other intact.
+        clear(&ks, ServiceKind::Rest).await.unwrap();
+        assert!(read(&ks, ServiceKind::Rest).await.unwrap().is_none());
+        assert_eq!(
+            read(&ks, ServiceKind::Didcomm).await.unwrap().unwrap(),
+            didcomm,
+        );
+    }
+
+    /// The wire form's discriminator (`kind` outer tag, `state`
+    /// inner tag) is part of the persisted contract. Pin it so a
+    /// `serde(rename)` change can't silently drop existing
+    /// snapshots after an upgrade.
+    #[test]
+    fn snapshot_wire_form_is_stable() {
+        // REST enabled
+        let snap = ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+            url: "https://vta.example.com".into(),
+        });
+        let json = serde_json::to_value(&snap).unwrap();
+        assert_eq!(json["kind"], "rest");
+        assert_eq!(json["state"], "enabled");
+        assert_eq!(json["url"], "https://vta.example.com");
+
+        // DIDComm enabled with routing keys
+        let snap = ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Enabled {
+            mediator_did: "did:peer:2.M".into(),
+            routing_keys: vec!["did:peer:2.K".into()],
+        });
+        let json = serde_json::to_value(&snap).unwrap();
+        assert_eq!(json["kind"], "didcomm");
+        assert_eq!(json["state"], "enabled");
+        assert_eq!(json["mediator_did"], "did:peer:2.M");
+        assert_eq!(json["routing_keys"][0], "did:peer:2.K");
+
+        // DIDComm disabled — no extra fields
+        let snap = ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Disabled);
+        let json = serde_json::to_value(&snap).unwrap();
+        assert_eq!(json["kind"], "didcomm");
+        assert_eq!(json["state"], "disabled");
+    }
+
+    /// Storing a payload under a key whose [`ServiceKind`] doesn't
+    /// match the payload's variant must surface as `Internal` on
+    /// the next [`read`] — never as a silent type confusion.
+    #[tokio::test]
+    async fn read_rejects_kind_mismatch() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        // Manually write a DIDComm payload under the REST key. This
+        // should never happen in practice — `write` always uses the
+        // payload-derived kind — but the read path defends against
+        // it as a bug-detector.
+        let didcomm_payload = ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Disabled);
+        let bytes = serde_json::to_vec(&didcomm_payload).unwrap();
+        ks.insert_raw(ServiceKind::Rest.storage_key().as_bytes().to_vec(), bytes)
+            .await
+            .unwrap();
+
+        let err = read(&ks, ServiceKind::Rest).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("kind mismatch"),
+            "expected kind-mismatch error, got: {msg}",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Foundation phase (P0) for the **runtime service-endpoint management** feature. Generalizes the existing DIDComm-only protocol-management surface to a unified REST + DIDComm management surface with fail-forward rollback (per spec §3.5a).

This PR lands only the foundations — no behavior change for existing protocol-management code paths. P1 (REST operations) and P2 (DIDComm refactor onto these foundations) follow in subsequent PRs.

## What this PR contains

**Design artifacts** (3 docs, ~1500 lines)
- `docs/05-design-notes/runtime-service-management.md` — approved spec
- `docs/05-design-notes/runtime-service-management-plan.md` — 8-phase implementation plan
- `docs/05-design-notes/runtime-service-management-tasks.md` — 33-task breakdown

**T0.2 — Typed `VtaError` variants** (`vta-sdk/src/error.rs`)
- Adds `LastServiceRefused`, `ServiceNotPresent`, `ServiceAlreadyEnabled`, `MediatorHandshakeFailed { reason }`, `DrainTtlOutOfBounds { min, max, requested }`, `NoPriorMutation`. `UnsupportedTransport` confirmed already present.
- New `TypedErrorPayload` companion enum (serde tag = `code`, kebab-case) for lossless round-trip of structured fields across REST + DIDComm transports.
- `from_typed_payload` / `to_typed_payload` conversions; `suggested_fix` extended.

**T0.3 — Per-kind snapshot store** (`vta-service/src/operations/protocol/snapshot.rs`)
- New fjall keyspace `service_prev_config`. One entry per kind (`rest` / `didcomm`).
- `read` / `write` / `clear` accessors over `&KeyspaceHandle`.
- `ServiceConfigSnapshot` enum with self-validating outer `kind` tag — read rejects mismatched kind/key.
- Storage discipline: snapshot persists *before* runtime mutation (per spec §3.5a). T3.x consumes it.

**T0.4 — Brick-prevention invariant helper** (`vta-service/src/operations/protocol/invariant.rs`)
- Pure predicate `would_violate_last_service(state, op) -> Result<(), VtaError>` — single source of truth for spec §3.2 (at least one transport service must remain advertised at all times).
- Returns `VtaError::LastServiceRefused` when the post-op state would have both REST and DIDComm disabled. No `--force` escape hatch.
- `ProposedOp::enable(kind)` / `ProposedOp::disable(kind)` constructors; rollback dispatchers compute post-state from snapshot.

## Test plan

- [x] `cargo build --workspace --all-features` clean
- [x] All 27 new tests green:
  - 6 in `vta_sdk::error::tests::*` (existing 4 + 3 new round-trip tests, plus extended `suggested_fix` coverage)
  - 12 in `operations::protocol::snapshot::tests::*` (round-trips, overwrite, clear, two-kind independence, wire-form stability, kind-mismatch defense)
  - 9 in `operations::protocol::invariant::tests::*` (full §7a.1 truth table — S0/S1/S2/S3 × both kinds × both post-states)
- [x] Existing 264 vta-sdk lib tests still green
- [x] Existing 225 vta-service lib tests still green
- [ ] Reviewer confirms spec design choices (fail-forward rollback, brick-prevention without `--force`, 24h default drain TTL)

## Audit finding worth flagging

The VTA's DID document **already** advertises a REST service entry today (`#vta-rest`, type `VTARest`) via `setup::build_vta_additional_services` (`vta-service/src/setup.rs:86`). The SDK depends on this shape for routing (`vta-sdk/src/session.rs:1100`). P1.3 will lift the rendering into a shared layer rather than invent a new shape. Documented in spec §10.

## Out of scope (follow-up PRs)

- P1 — REST operations (`enable_rest`, `update_rest`, `disable_rest`) + REST/DIDComm route handlers
- P2 — DIDComm refactor onto P0 foundations (`enable_didcomm`, `disable_didcomm`, `migrate_mediator` → `update_didcomm` rename)
- P3 — fail-forward `rollback_rest` / `rollback_didcomm`
- P4 — `services list` query
- P5 — unified `pnm services …` CLI surface, retiring `pnm mediator …`
- P6 — full §7a end-to-end test matrix (~64 e2e tests against the test mediator)
- P7 — operator docs + memory updates