### PR TITLE
feat(runtime-services): P1 — REST service-management surface (REST + DIDComm transports)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8774,6 +8774,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "url",
  "uuid",
  "windows-native-keyring-store",
  "wiremock",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -108,6 +108,7 @@ chrono = { workspace = true }
 base64 = { workspace = true }
 multibase = { workspace = true }
 thiserror = { workspace = true }
+url = { workspace = true }
 affinidi-tdk = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }

--- a/vta-sdk/src/protocol/mod.rs
+++ b/vta-sdk/src/protocol/mod.rs
@@ -6,6 +6,13 @@
 //! not yet running at first-enable time). The disable / migrate /
 //! drain-cancel / report calls — and their DIDComm transport
 //! handlers — arrive in Phase 4 verticals.
+//!
+//! Runtime REST service-management wire types (the symmetric
+//! REST-side of the spec §4 surface — `EnableRestRequest`,
+//! `UpdateRestRequest`, `DisableRestRequest`, `RollbackRestRequest`,
+//! `ServiceMutationResponse`) live in [`services`].
+
+pub mod services;
 
 use serde::{Deserialize, Serialize};
 

--- a/vta-sdk/src/protocol/services.rs
+++ b/vta-sdk/src/protocol/services.rs
@@ -22,6 +22,65 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::error::VtaError;
+
+/// Validate a service-endpoint URL.
+///
+/// Spec §3.4: must be `https://`, parsable by `url::Url`, no
+/// fragment, no userinfo. Returns the parsed [`url::Url`] on
+/// success so callers don't re-parse, or [`VtaError::Validation`]
+/// with a specific message on failure.
+///
+/// Centralized so both REST handlers and DIDComm transport
+/// handlers (and any client-side pre-flight) use the same rule.
+/// The CLI surfaces the rejection through `VtaError`'s
+/// `suggested_fix` path; reasons are kept short and operator-
+/// readable rather than full stack-trace text.
+///
+/// `localhost` and IP literals are accepted — the operator may
+/// genuinely want to advertise a private deployment. TLS is still
+/// required there (operator can run a private CA / mkcert); the
+/// invariant is that clients see a TLS-protected URL in the DID
+/// document, not that the cert chains to a public root.
+pub fn validate_service_url(url: &str) -> Result<url::Url, VtaError> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return Err(VtaError::Validation("service URL is empty".into()));
+    }
+
+    let parsed = url::Url::parse(trimmed)
+        .map_err(|e| VtaError::Validation(format!("service URL is unparseable: {e}")))?;
+
+    if parsed.scheme() != "https" {
+        return Err(VtaError::Validation(format!(
+            "service URL must use https:// (got {})",
+            parsed.scheme()
+        )));
+    }
+
+    if parsed.fragment().is_some() {
+        return Err(VtaError::Validation(
+            "service URL must not contain a `#fragment`".into(),
+        ));
+    }
+
+    // userinfo = the `user:password@` part. `url::Url` exposes
+    // username() (always returns "" when absent) and password()
+    // (Option<&str>). A non-empty username OR a password being
+    // present means userinfo is set.
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(VtaError::Validation(
+            "service URL must not contain userinfo (user:password@)".into(),
+        ));
+    }
+
+    if parsed.host().is_none() {
+        return Err(VtaError::Validation("service URL must have a host".into()));
+    }
+
+    Ok(parsed)
+}
+
 /// Request body for `POST /services/rest/enable`.
 ///
 /// Adds a `#vta-rest` service entry to the VTA's DID document
@@ -206,6 +265,119 @@ mod tests {
         assert_eq!(json["drain_until"], "2026-05-07T13:00:00Z");
         let restored: ServiceMutationResponse = serde_json::from_value(json).unwrap();
         assert_eq!(restored, didcomm_response);
+    }
+
+    // ── validate_service_url ──────────────────────────────────────
+
+    #[test]
+    fn validate_service_url_accepts_https() {
+        assert!(validate_service_url("https://vta.example.com").is_ok());
+        assert!(validate_service_url("https://vta.example.com/").is_ok());
+        assert!(validate_service_url("https://vta.example.com:8443").is_ok());
+        assert!(validate_service_url("https://vta.example.com/path/sub").is_ok());
+    }
+
+    #[test]
+    fn validate_service_url_accepts_localhost_and_ip_literals() {
+        // Private/dev deployments are valid — operators may run
+        // mkcert or a private CA; TLS-protected is what matters,
+        // not whether the cert chains to a public root.
+        assert!(validate_service_url("https://localhost:8443").is_ok());
+        assert!(validate_service_url("https://127.0.0.1:8443").is_ok());
+        assert!(validate_service_url("https://[::1]:8443").is_ok());
+    }
+
+    #[test]
+    fn validate_service_url_rejects_http() {
+        let err = validate_service_url("http://vta.example.com").unwrap_err();
+        match err {
+            VtaError::Validation(msg) => assert!(
+                msg.contains("https"),
+                "expected scheme-related rejection, got: {msg}",
+            ),
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_service_url_rejects_other_schemes() {
+        for bad in [
+            "ws://vta.example.com",
+            "ftp://x.example",
+            "file:///etc/passwd",
+        ] {
+            assert!(
+                matches!(validate_service_url(bad), Err(VtaError::Validation(_))),
+                "expected rejection for {bad}",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_service_url_rejects_fragment() {
+        let err = validate_service_url("https://vta.example.com/api#section").unwrap_err();
+        match err {
+            VtaError::Validation(msg) => {
+                assert!(
+                    msg.contains("fragment"),
+                    "expected fragment rejection, got: {msg}"
+                )
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_service_url_rejects_userinfo() {
+        for bad in [
+            "https://user@vta.example.com",
+            "https://user:pass@vta.example.com",
+            "https://:pass@vta.example.com",
+        ] {
+            let err = validate_service_url(bad).unwrap_err();
+            match err {
+                VtaError::Validation(msg) => assert!(
+                    msg.contains("userinfo"),
+                    "expected userinfo rejection for {bad}, got: {msg}",
+                ),
+                other => panic!("expected Validation for {bad}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn validate_service_url_rejects_unparseable() {
+        for bad in ["not a url at all", "://no-scheme", "https://", "🦀"] {
+            assert!(
+                matches!(validate_service_url(bad), Err(VtaError::Validation(_))),
+                "expected rejection for {bad:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_service_url_rejects_empty_and_whitespace() {
+        for bad in ["", "   ", "\t\n"] {
+            let err = validate_service_url(bad).unwrap_err();
+            match err {
+                VtaError::Validation(msg) => assert!(
+                    msg.contains("empty"),
+                    "expected empty-URL rejection for {bad:?}, got: {msg}",
+                ),
+                other => panic!("expected Validation for {bad:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// On success, the parsed `url::Url` is returned so callers
+    /// don't re-parse. Spot-check a couple of properties.
+    #[test]
+    fn validate_service_url_returns_parsed_url() {
+        let parsed = validate_service_url("https://vta.example.com:8443/api").unwrap();
+        assert_eq!(parsed.scheme(), "https");
+        assert_eq!(parsed.host_str(), Some("vta.example.com"));
+        assert_eq!(parsed.port(), Some(8443));
+        assert_eq!(parsed.path(), "/api");
     }
 
     /// `ServiceMutationResponse` deserializes both forms — explicit

--- a/vta-sdk/src/protocol/services.rs
+++ b/vta-sdk/src/protocol/services.rs
@@ -1,0 +1,231 @@
+//! Wire types for the runtime REST service-management surface.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §4.
+//!
+//! These cover the four REST operations exposed under
+//! `pnm services rest {enable,update,disable,rollback}` plus the
+//! shared response shape (`ServiceMutationResponse`) used by every
+//! mutation across both REST and DIDComm kinds.
+//!
+//! DIDComm-side wire types live in [`super`] — `EnableDidcommRequest`,
+//! `DisableDidcommRequest`, and (renamed in T2.3) `UpdateDidcommRequest`.
+//! Keep the two surfaces in sync as they evolve.
+//!
+//! ## URL field convention
+//!
+//! `url: String` is intentional — the field stays a string here so
+//! the SDK matches the existing protocol-management types
+//! (`mediator_did: String`, etc.) and the operation layer applies a
+//! single validation pass via [`crate::protocol::validate_service_url`]
+//! (T1.2). Operators see one consistent error shape regardless of
+//! whether validation runs client-side, server-side, or both.
+
+use serde::{Deserialize, Serialize};
+
+/// Request body for `POST /services/rest/enable`.
+///
+/// Adds a `#vta-rest` service entry to the VTA's DID document
+/// pointing at `url`. Refused with `ServiceAlreadyEnabled` if REST
+/// is already advertised. The wire shape rendered into the DID
+/// document — `id: "{DID}#vta-rest"`, `type: "VTARest"` — is
+/// preserved by the operation layer (P1.3) for SDK-resolution
+/// compatibility (`vta-sdk/src/session.rs:1100`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[must_use]
+pub struct EnableRestRequest {
+    pub url: String,
+}
+
+impl EnableRestRequest {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
+/// Request body for `POST /services/rest/update`.
+///
+/// Replaces the URL on the existing `#vta-rest` entry. Refused
+/// with `ServiceNotPresent` if REST is not currently advertised.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[must_use]
+pub struct UpdateRestRequest {
+    pub url: String,
+}
+
+impl UpdateRestRequest {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
+/// Request body for `POST /services/rest/disable`.
+///
+/// Removes the `#vta-rest` entry. Refused with
+/// `LastServiceRefused` when DIDComm is also disabled (spec §3.2)
+/// and with `ServiceNotPresent` if REST isn't currently advertised.
+///
+/// No fields today — the body exists so the wire surface stays
+/// uniform (every mutation is a `POST` with a JSON body) and so
+/// the type can grow optional fields later without a breaking
+/// change. Serializes as `{}`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[must_use]
+pub struct DisableRestRequest {}
+
+/// Request body for `POST /services/rest/rollback`.
+///
+/// Fail-forwards the most recent REST mutation (spec §3.5a) by
+/// reading the snapshot store and dispatching to the equivalent
+/// forward operation. Refused with `NoPriorMutation` when no
+/// snapshot is recorded, and with `LastServiceRefused` if the
+/// rollback would brick the VTA. Like [`DisableRestRequest`],
+/// no fields today — serializes as `{}`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[must_use]
+pub struct RollbackRestRequest {}
+
+/// Shared response body for every successful service-mutation
+/// operation (REST + DIDComm enable/update/disable/rollback).
+///
+/// `drain_until` is `Some(rfc3339)` only for DIDComm operations
+/// that scheduled a drain (`update_didcomm`, `disable_didcomm`,
+/// or a `rollback_didcomm` whose fail-forward target was a drain
+/// transition). REST mutations always set it to `None`.
+///
+/// All timestamps are RFC 3339 strings to match the existing wire
+/// convention from `DisableDidcommResponse::drains_until`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceMutationResponse {
+    /// Version-id of the new WebVH LogEntry produced by the
+    /// mutation. Joins telemetry events to chain history.
+    pub log_entry_version_id: String,
+    /// RFC 3339 timestamp when the mutation took effect — the
+    /// same instant stamped on the new LogEntry.
+    pub effective_at: String,
+    /// `Some(rfc3339)` when the mutation scheduled a DIDComm
+    /// drain; `None` otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drain_until: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip every request type — both directions, across the
+    /// wire forms used by REST handlers (raw JSON body) and DIDComm
+    /// transport (JSON-tagged in the message attachment).
+    #[test]
+    fn rest_request_types_round_trip_through_json() {
+        let req = EnableRestRequest::new("https://vta.example.com");
+        let json = serde_json::to_string(&req).unwrap();
+        let restored: EnableRestRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, req);
+
+        let req = UpdateRestRequest::new("https://vta-new.example.com");
+        let json = serde_json::to_string(&req).unwrap();
+        let restored: UpdateRestRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, req);
+
+        let req = DisableRestRequest::default();
+        let json = serde_json::to_string(&req).unwrap();
+        let restored: DisableRestRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, req);
+
+        let req = RollbackRestRequest::default();
+        let json = serde_json::to_string(&req).unwrap();
+        let restored: RollbackRestRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, req);
+    }
+
+    /// The empty request bodies must serialize as `{}`, not `null`,
+    /// `[]`, or a string. REST clients that send `null` would
+    /// fail strict-deserialize servers; pin the wire form.
+    #[test]
+    fn empty_request_bodies_serialize_as_empty_object() {
+        assert_eq!(
+            serde_json::to_string(&DisableRestRequest::default()).unwrap(),
+            "{}"
+        );
+        assert_eq!(
+            serde_json::to_string(&RollbackRestRequest::default()).unwrap(),
+            "{}"
+        );
+    }
+
+    /// The empty request bodies must also accept an empty object
+    /// `{}` (and `null`, via `Default`) on the deserialize side, so
+    /// callers that send no body don't trip up the server.
+    #[test]
+    fn empty_request_bodies_accept_empty_object() {
+        let _: DisableRestRequest = serde_json::from_str("{}").unwrap();
+        let _: RollbackRestRequest = serde_json::from_str("{}").unwrap();
+    }
+
+    /// `url` field name must stay literal `url` on the wire —
+    /// renaming it would break every caller. Pin via JSON shape
+    /// rather than relying solely on the `#[derive(Serialize)]`
+    /// default.
+    #[test]
+    fn rest_url_field_is_literal_url_on_wire() {
+        let json = serde_json::to_value(EnableRestRequest::new("https://x.example")).unwrap();
+        assert_eq!(json["url"], "https://x.example");
+        assert!(json.get("uri").is_none(), "must not rename url to uri");
+
+        let json = serde_json::to_value(UpdateRestRequest::new("https://y.example")).unwrap();
+        assert_eq!(json["url"], "https://y.example");
+    }
+
+    /// `ServiceMutationResponse` round-trips with and without
+    /// `drain_until`. The `None` case omits the field on the wire
+    /// (per `skip_serializing_if`); the `Some` case includes the
+    /// RFC 3339 timestamp.
+    #[test]
+    fn service_mutation_response_round_trips_both_drain_states() {
+        let rest_response = ServiceMutationResponse {
+            log_entry_version_id: "1-zQm...A".into(),
+            effective_at: "2026-05-06T13:00:00Z".into(),
+            drain_until: None,
+        };
+        let json = serde_json::to_value(&rest_response).unwrap();
+        assert_eq!(json["log_entry_version_id"], "1-zQm...A");
+        assert_eq!(json["effective_at"], "2026-05-06T13:00:00Z");
+        assert!(
+            json.get("drain_until").is_none(),
+            "drain_until must be omitted when None — wire bandwidth + reader convention",
+        );
+        let restored: ServiceMutationResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(restored, rest_response);
+
+        let didcomm_response = ServiceMutationResponse {
+            log_entry_version_id: "2-zQm...B".into(),
+            effective_at: "2026-05-06T13:00:00Z".into(),
+            drain_until: Some("2026-05-07T13:00:00Z".into()),
+        };
+        let json = serde_json::to_value(&didcomm_response).unwrap();
+        assert_eq!(json["drain_until"], "2026-05-07T13:00:00Z");
+        let restored: ServiceMutationResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(restored, didcomm_response);
+    }
+
+    /// `ServiceMutationResponse` deserializes both forms — explicit
+    /// `null` for drain_until (some encoders emit it) and the
+    /// elided form (preferred).
+    #[test]
+    fn service_mutation_response_accepts_explicit_null_drain_until() {
+        let with_null = r#"{
+            "log_entry_version_id": "1-zQm...A",
+            "effective_at": "2026-05-06T13:00:00Z",
+            "drain_until": null
+        }"#;
+        let r: ServiceMutationResponse = serde_json::from_str(with_null).unwrap();
+        assert_eq!(r.drain_until, None);
+
+        let elided = r#"{
+            "log_entry_version_id": "1-zQm...A",
+            "effective_at": "2026-05-06T13:00:00Z"
+        }"#;
+        let r: ServiceMutationResponse = serde_json::from_str(elided).unwrap();
+        assert_eq!(r.drain_until, None);
+    }
+}

--- a/vta-sdk/src/protocols/protocol_management.rs
+++ b/vta-sdk/src/protocols/protocol_management.rs
@@ -29,6 +29,30 @@ pub const DISABLE_DIDCOMM: &str =
 pub const DISABLE_DIDCOMM_RESULT: &str =
     "https://firstperson.network/protocols/services-management/1.0/disable-result";
 
+// REST-side service management. Spec:
+// `docs/05-design-notes/runtime-service-management.md` §3.4.
+// All three are reachable over DIDComm — REST is always running
+// (per spec §3.2 at-least-one-service invariant), so a request
+// adding/updating/removing the REST advertisement can travel over
+// DIDComm without hitting the same chicken-and-egg problem as
+// `enable_didcomm` (which can't be invoked over a transport that
+// isn't running yet).
+
+pub const ENABLE_REST: &str =
+    "https://firstperson.network/protocols/services-management/1.0/rest-enable";
+pub const ENABLE_REST_RESULT: &str =
+    "https://firstperson.network/protocols/services-management/1.0/rest-enable-result";
+
+pub const UPDATE_REST: &str =
+    "https://firstperson.network/protocols/services-management/1.0/rest-update";
+pub const UPDATE_REST_RESULT: &str =
+    "https://firstperson.network/protocols/services-management/1.0/rest-update-result";
+
+pub const DISABLE_REST: &str =
+    "https://firstperson.network/protocols/services-management/1.0/rest-disable";
+pub const DISABLE_REST_RESULT: &str =
+    "https://firstperson.network/protocols/services-management/1.0/rest-disable-result";
+
 // ── mediator-management ─────────────────────────────────────────────
 
 pub const MIGRATE_MEDIATOR: &str =

--- a/vta-service/src/messaging/handlers_protocol.rs
+++ b/vta-service/src/messaging/handlers_protocol.rs
@@ -32,11 +32,14 @@ use crate::messaging::handshake::AlwaysOkProver;
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommParams, DisableTransport, disable_didcomm,
 };
+use crate::operations::protocol::disable_rest::{DisableRestParams, disable_rest};
 use crate::operations::protocol::drain_cancel::{DrainCancelParams, drain_cancel};
+use crate::operations::protocol::enable_rest::{EnableRestParams, enable_rest};
 use crate::operations::protocol::migrate_mediator::{
     MigrateAuditKind, MigrateMediatorParams, migrate_mediator,
 };
 use crate::operations::protocol::report::{ReportParams, mediator_report};
+use crate::operations::protocol::update_rest::{UpdateRestParams, update_rest};
 
 type HandlerResult = Result<Option<DIDCommResponse>, DIDCommServiceError>;
 
@@ -320,6 +323,179 @@ pub async fn handle_mediator_report(
     match result {
         Ok(r) => response(protocol_management::MEDIATOR_REPORT_RESULT, &r),
         Err(ReportError::Auth(e)) => Ok(Some(problem_report_unauthorized(e))),
+        Err(other) => Ok(Some(problem_report_internal(other.to_string()))),
+    }
+}
+
+// ── REST service-management handlers (T1.5) ─────────────────────────
+//
+// Each handler is a thin adapter mirroring `handle_disable_didcomm`:
+// authenticate the message, parse the body, call the existing
+// operation function, and emit either a typed result or a problem-
+// report. All three REST ops are reachable over DIDComm — REST is
+// always running per spec §3.2, so unlike `enable_didcomm` (which
+// can't arrive over a transport that isn't running yet) there's no
+// chicken-and-egg constraint here.
+
+fn body_str_field(message: &Message, key: &str) -> Result<String, DIDCommServiceError> {
+    message
+        .body
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| handler_err(format!("missing or non-string `{key}` in body")))
+}
+
+pub async fn handle_enable_rest(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = match auth_from_message(&message, &state.acl_ks).await {
+        Ok(a) => a,
+        Err(e) => return Ok(Some(problem_report_unauthorized(e.to_string()))),
+    };
+
+    let url = body_str_field(&message, "url")?;
+
+    let result = enable_rest(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        state
+            .did_resolver
+            .as_ref()
+            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
+        &state.didcomm_bridge,
+        &state.telemetry,
+        &auth,
+        EnableRestParams { url },
+        "didcomm",
+    )
+    .await;
+
+    use crate::operations::protocol::enable_rest::EnableRestError;
+    match result {
+        Ok(r) => response(
+            protocol_management::ENABLE_REST_RESULT,
+            &serde_json::json!({
+                "log_entry_version_id": r.new_version_id,
+                "effective_at": Utc::now().to_rfc3339(),
+                "url": r.url,
+            }),
+        ),
+        Err(EnableRestError::ServiceAlreadyEnabled) => {
+            Ok(Some(problem_report_conflict("REST is already enabled")))
+        }
+        Err(EnableRestError::Validation(e)) => Ok(Some(problem_report_bad_request(e))),
+        Err(EnableRestError::Auth(e)) => Ok(Some(problem_report_unauthorized(e))),
+        Err(other) => Ok(Some(problem_report_internal(other.to_string()))),
+    }
+}
+
+pub async fn handle_update_rest(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = match auth_from_message(&message, &state.acl_ks).await {
+        Ok(a) => a,
+        Err(e) => return Ok(Some(problem_report_unauthorized(e.to_string()))),
+    };
+
+    let url = body_str_field(&message, "url")?;
+
+    let result = update_rest(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        state
+            .did_resolver
+            .as_ref()
+            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
+        &state.didcomm_bridge,
+        &state.telemetry,
+        &auth,
+        UpdateRestParams { url },
+        "didcomm",
+    )
+    .await;
+
+    use crate::operations::protocol::update_rest::UpdateRestError;
+    match result {
+        Ok(r) => response(
+            protocol_management::UPDATE_REST_RESULT,
+            &serde_json::json!({
+                "log_entry_version_id": r.new_version_id,
+                "effective_at": Utc::now().to_rfc3339(),
+                "prior_url": r.prior_url,
+                "url": r.url,
+            }),
+        ),
+        Err(UpdateRestError::ServiceNotPresent) => Ok(Some(problem_report_conflict(
+            "REST is not currently enabled",
+        ))),
+        Err(UpdateRestError::Validation(e)) => Ok(Some(problem_report_bad_request(e))),
+        Err(UpdateRestError::Auth(e)) => Ok(Some(problem_report_unauthorized(e))),
+        Err(other) => Ok(Some(problem_report_internal(other.to_string()))),
+    }
+}
+
+pub async fn handle_disable_rest(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = match auth_from_message(&message, &state.acl_ks).await {
+        Ok(a) => a,
+        Err(e) => return Ok(Some(problem_report_unauthorized(e.to_string()))),
+    };
+
+    let result = disable_rest(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        state
+            .did_resolver
+            .as_ref()
+            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
+        &state.didcomm_bridge,
+        &state.telemetry,
+        &auth,
+        DisableRestParams,
+        "didcomm",
+    )
+    .await;
+
+    use crate::operations::protocol::disable_rest::DisableRestError;
+    match result {
+        Ok(r) => response(
+            protocol_management::DISABLE_REST_RESULT,
+            &serde_json::json!({
+                "log_entry_version_id": r.new_version_id,
+                "effective_at": Utc::now().to_rfc3339(),
+                "prior_url": r.prior_url,
+            }),
+        ),
+        Err(DisableRestError::ServiceNotPresent) => Ok(Some(problem_report_conflict(
+            "REST is not currently enabled — nothing to disable",
+        ))),
+        Err(DisableRestError::LastServiceRefused) => Ok(Some(problem_report_conflict(
+            "refusing operation: would leave the VTA with no advertised services",
+        ))),
+        Err(DisableRestError::Auth(e)) => Ok(Some(problem_report_unauthorized(e))),
         Err(other) => Ok(Some(problem_report_internal(other.to_string()))),
     }
 }

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -58,6 +58,11 @@ pub struct VtaState {
     /// the REST path.
     #[cfg(feature = "webvh")]
     pub drains_ks: KeyspaceHandle,
+    /// Per-kind previous-config snapshot store for fail-forward
+    /// rollback (spec §3.5a). Mirrored from `AppState` so REST and
+    /// DIDComm transport handlers feed the same snapshot.
+    #[cfg(feature = "webvh")]
+    pub snapshot_ks: KeyspaceHandle,
     /// In-process registry of active + draining mediator listeners.
     #[cfg(feature = "webvh")]
     pub mediator_registry: Arc<crate::messaging::registry::MediatorListenerRegistry>,
@@ -350,6 +355,18 @@ pub fn build_handler(
             .route(
                 protocol_management::DISABLE_DIDCOMM,
                 handler_fn(super::handlers_protocol::handle_disable_didcomm),
+            )?
+            .route(
+                protocol_management::ENABLE_REST,
+                handler_fn(super::handlers_protocol::handle_enable_rest),
+            )?
+            .route(
+                protocol_management::UPDATE_REST,
+                handler_fn(super::handlers_protocol::handle_update_rest),
+            )?
+            .route(
+                protocol_management::DISABLE_REST,
+                handler_fn(super::handlers_protocol::handle_disable_rest),
             )?
             .route(
                 protocol_management::MIGRATE_MEDIATOR,

--- a/vta-service/src/operations/protocol/disable_rest.rs
+++ b/vta-service/src/operations/protocol/disable_rest.rs
@@ -1,0 +1,417 @@
+//! `disable_rest` operation.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.2,
+//! §3.4.
+//!
+//! Sequence (under [`PROTOCOL_LOCK`]):
+//! 1. Verify caller is super-admin.
+//! 2. Confirm `services.rest` is currently `true` AND a `#vta-rest`
+//!    entry exists in the DID document — refuse with
+//!    [`DisableRestError::ServiceNotPresent`] otherwise.
+//! 3. Brick-prevention via
+//!    [`would_violate_last_service`] — refuse with
+//!    [`DisableRestError::LastServiceRefused`] when DIDComm is
+//!    also disabled (VTA would have no advertised transport).
+//! 4. Read the prior URL from the on-chain DID document for the
+//!    snapshot.
+//! 5. Persist a [`RestSnapshot::Enabled { url: prior_url }`]
+//!    snapshot before the runtime mutation, per spec §3.5a — a
+//!    future rollback re-enables REST at the same URL.
+//! 6. Patch the document — remove the `#vta-rest` entry via
+//!    [`without_rest_service`] — and publish via
+//!    [`update_did_webvh`].
+//! 7. Persist `services.rest = false` to the config file.
+//! 8. Emit [`TelemetryKind::ServicesRestDisable`].
+//!
+//! REST has no drain semantics — there's nothing to keep listening
+//! for after the URL is unadvertised. The Axum process stays running
+//! (it's a process-level binding), so the local CLI can still reach
+//! the VTA; only the *advertisement* is removed.
+
+use std::sync::Arc;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use vta_sdk::error::VtaError;
+
+use vti_common::seed_store::SeedStore;
+use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
+
+use crate::auth::AuthClaims;
+use crate::config::AppConfig;
+use crate::didcomm_bridge::DIDCommBridge;
+use crate::error::AppError;
+use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
+use crate::operations::protocol::PROTOCOL_LOCK;
+use crate::operations::protocol::document::{
+    DocumentPatchError, current_rest_service, without_rest_service,
+};
+use crate::operations::protocol::invariant::{
+    CurrentServices, ProposedOp, would_violate_last_service,
+};
+use crate::operations::protocol::snapshot::{
+    self, RestSnapshot, ServiceConfigSnapshot, ServiceKind,
+};
+use crate::store::KeyspaceHandle;
+use crate::webvh_store;
+
+#[derive(Debug, Clone, Default)]
+pub struct DisableRestParams;
+
+#[derive(Debug, Clone)]
+pub struct DisableRestResult {
+    pub new_version_id: String,
+    /// Pre-disable URL — recorded so callers / telemetry / audit
+    /// can graph what was just unadvertised.
+    pub prior_url: String,
+}
+
+#[derive(Debug, Error)]
+pub enum DisableRestError {
+    #[error("REST is not currently enabled — nothing to disable.")]
+    ServiceNotPresent,
+    #[error(
+        "refusing operation: would leave the VTA with no advertised services. \
+         Enable DIDComm first via `services didcomm enable --mediator <did>`, \
+         then retry."
+    )]
+    LastServiceRefused,
+    #[error("VTA DID is not configured — run `vta setup` first")]
+    VtaDidNotConfigured,
+    #[error("VTA DID `{0}` has no webvh record")]
+    VtaDidRecordMissing(String),
+    #[error("VTA DID `{0}` has no published log")]
+    VtaDidLogMissing(String),
+    #[error("VTA DID log is empty")]
+    EmptyLog,
+    #[error("DID document patch failed: {0}")]
+    DocumentPatch(#[from] DocumentPatchError),
+    #[error("WebVH update failed: {0}")]
+    WebVHUpdate(#[from] UpdateDidWebvhError),
+    #[error("config persistence failed: {0}")]
+    ConfigPersistence(String),
+    #[error("auth: {0}")]
+    Auth(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+impl From<AppError> for DisableRestError {
+    fn from(value: AppError) -> Self {
+        Self::Storage(value.to_string())
+    }
+}
+
+/// Map [`VtaError::LastServiceRefused`] (from the invariant
+/// helper) onto our typed variant. Other [`VtaError`] shapes
+/// shouldn't surface here — the helper is total over its inputs —
+/// but if one ever does we route it through `Storage` so it isn't
+/// silently swallowed.
+impl From<VtaError> for DisableRestError {
+    fn from(value: VtaError) -> Self {
+        match value {
+            VtaError::LastServiceRefused => Self::LastServiceRefused,
+            other => Self::Storage(other.to_string()),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn disable_rest(
+    config: &Arc<RwLock<AppConfig>>,
+    keys_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    snapshot_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    did_resolver: &DIDCacheClient,
+    didcomm_bridge: &Arc<DIDCommBridge>,
+    telemetry: &SharedTelemetrySink,
+    auth: &AuthClaims,
+    _params: DisableRestParams,
+    channel: &str,
+) -> Result<DisableRestResult, DisableRestError> {
+    auth.require_super_admin()
+        .map_err(|e| DisableRestError::Auth(e.to_string()))?;
+
+    let _guard = PROTOCOL_LOCK.lock().await;
+
+    // 1. Read preconditions: REST must be on (config + on-chain).
+    //    Capture the prior URL while we're at it for the snapshot
+    //    + telemetry.
+    let (vta_did, scid, current_doc, prior_url, didcomm_enabled) =
+        read_preconditions(config, webvh_ks).await?;
+
+    // 2. Brick-prevention. If DIDComm is also off, disabling REST
+    //    leaves no transport advertised — refuse via the shared
+    //    helper (T0.4). Single source of truth for spec §3.2; no
+    //    --force escape hatch.
+    would_violate_last_service(
+        &CurrentServices::new(true, didcomm_enabled),
+        ProposedOp::disable(ServiceKind::Rest),
+    )?;
+
+    // 3. Persist snapshot BEFORE the runtime mutation per spec
+    //    §3.5a. Pre-state is RestSnapshot::Enabled with the prior
+    //    URL — rollback re-enables REST at that URL.
+    snapshot::write(
+        snapshot_ks,
+        ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+            url: prior_url.clone(),
+        }),
+    )
+    .await
+    .map_err(|e| DisableRestError::Storage(format!("snapshot write: {e}")))?;
+
+    // 4. Patch the document — remove the #vta-rest entry.
+    let patched = without_rest_service(current_doc);
+
+    // 5. Publish via update_did_webvh.
+    let update_result = update_did_webvh(
+        keys_ks,
+        contexts_ks,
+        webvh_ks,
+        audit_ks,
+        seed_store,
+        auth,
+        &scid,
+        UpdateDidWebvhOptions {
+            document: Some(patched),
+            ..Default::default()
+        },
+        did_resolver,
+        didcomm_bridge,
+        channel,
+    )
+    .await?;
+
+    // 6. Persist services.rest = false. Same risk window as the
+    //    other ops if this fails after publish — operator retries.
+    persist_rest_disabled(config).await?;
+
+    // 7. Telemetry. Prior URL is included so an external verifier
+    //    knows what URL just stopped being advertised.
+    let _ = telemetry
+        .record(
+            TelemetryEvent::new(TelemetryKind::ServicesRestDisable)
+                .with_field("channel", JsonValue::from(channel))
+                .with_field(
+                    "new_version_id",
+                    JsonValue::from(update_result.new_version_id.clone()),
+                )
+                .with_field("prior_url", JsonValue::from(prior_url.clone())),
+        )
+        .await;
+
+    info!(
+        channel,
+        prior_url = %prior_url,
+        new_version_id = %update_result.new_version_id,
+        vta_did = %vta_did,
+        "REST disabled"
+    );
+
+    Ok(DisableRestResult {
+        new_version_id: update_result.new_version_id,
+        prior_url,
+    })
+}
+
+async fn read_preconditions(
+    config: &Arc<RwLock<AppConfig>>,
+    webvh_ks: &KeyspaceHandle,
+) -> Result<(String, String, JsonValue, String, bool), DisableRestError> {
+    let cfg = config.read().await;
+    if !cfg.services.rest {
+        return Err(DisableRestError::ServiceNotPresent);
+    }
+    let didcomm_enabled = cfg.services.didcomm;
+    let vta_did = cfg
+        .vta_did
+        .clone()
+        .ok_or(DisableRestError::VtaDidNotConfigured)?;
+    drop(cfg);
+
+    let record = webvh_store::get_did(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| DisableRestError::VtaDidRecordMissing(vta_did.clone()))?;
+    let scid = record.scid.clone();
+
+    let did_log = webvh_store::get_did_log(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| DisableRestError::VtaDidLogMissing(vta_did.clone()))?;
+    let current_doc = current_document_from_log(&did_log)?;
+
+    let prior_url = current_rest_service(&current_doc)
+        .map(|s| s.url)
+        .ok_or(DisableRestError::ServiceNotPresent)?;
+
+    Ok((vta_did, scid, current_doc, prior_url, didcomm_enabled))
+}
+
+fn current_document_from_log(did_log: &str) -> Result<JsonValue, DisableRestError> {
+    use didwebvh_rs::log_entry::{LogEntry, LogEntryMethods};
+    let line = did_log
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .ok_or(DisableRestError::EmptyLog)?;
+    let entry: LogEntry = serde_json::from_str(line)
+        .map_err(|e| DisableRestError::Storage(format!("DID log line parse: {e}")))?;
+    Ok(entry.get_state().clone())
+}
+
+async fn persist_rest_disabled(config: &Arc<RwLock<AppConfig>>) -> Result<(), DisableRestError> {
+    let (contents, path) = {
+        let mut cfg = config.write().await;
+        cfg.services.rest = false;
+        let contents = toml::to_string_pretty(&*cfg)
+            .map_err(|e| DisableRestError::ConfigPersistence(e.to_string()))?;
+        let path = cfg.config_path.clone();
+        (contents, path)
+    };
+    std::fs::write(&path, contents)
+        .map_err(|e| DisableRestError::ConfigPersistence(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{LogConfig, ServerConfig, ServicesConfig, StoreConfig};
+    use crate::store::Store;
+    use vti_common::config::StoreConfig as VtiStoreConfig;
+
+    /// Mirrors the test fixture in enable_rest / update_rest —
+    /// owns the fjall store so a single test can derive multiple
+    /// keyspaces from the same handle.
+    struct TestFixture {
+        _dir: tempfile::TempDir,
+        config: Arc<RwLock<AppConfig>>,
+        store: Store,
+    }
+
+    impl TestFixture {
+        fn webvh_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace("webvh").unwrap()
+        }
+    }
+
+    fn build_fixture(rest_initially: bool, didcomm_initially: bool) -> TestFixture {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("vta.toml");
+        let cfg = AppConfig {
+            server: ServerConfig {
+                host: "127.0.0.1".into(),
+                port: 0,
+            },
+            log: LogConfig::default(),
+            store: StoreConfig {
+                data_dir: dir.path().into(),
+            },
+            services: ServicesConfig {
+                rest: rest_initially,
+                didcomm: didcomm_initially,
+            },
+            vta_did: Some("did:webvh:scid123:host:vta".into()),
+            vta_name: None,
+            public_url: None,
+            resolver_url: None,
+            messaging: None,
+            secrets: Default::default(),
+            audit: Default::default(),
+            auth: Default::default(),
+            #[cfg(feature = "tee")]
+            tee: Default::default(),
+            config_path,
+        };
+        let initial = toml::to_string_pretty(&cfg).unwrap();
+        std::fs::write(&cfg.config_path, initial).unwrap();
+
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        TestFixture {
+            _dir: dir,
+            config: Arc::new(RwLock::new(cfg)),
+            store,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_preconditions_rejects_when_rest_disabled() {
+        let fx = build_fixture(false, true);
+        let err = read_preconditions(&fx.config, &fx.webvh_ks())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DisableRestError::ServiceNotPresent));
+    }
+
+    #[tokio::test]
+    async fn read_preconditions_rejects_without_vta_did() {
+        let fx = build_fixture(true, true);
+        fx.config.write().await.vta_did = None;
+        let err = read_preconditions(&fx.config, &fx.webvh_ks())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DisableRestError::VtaDidNotConfigured));
+    }
+
+    /// The brick-prevention helper is wired correctly: invoking it
+    /// from a "REST on, DIDComm off" state with a disable-rest op
+    /// must surface as `LastServiceRefused`.
+    #[test]
+    fn brick_prevention_rejects_disable_rest_when_didcomm_off() {
+        let result = would_violate_last_service(
+            &CurrentServices::new(true, false),
+            ProposedOp::disable(ServiceKind::Rest),
+        );
+        let err = DisableRestError::from(result.unwrap_err());
+        assert!(matches!(err, DisableRestError::LastServiceRefused));
+    }
+
+    /// Conversely, brick-prevention accepts disabling REST when
+    /// DIDComm is on (S3 → S2).
+    #[test]
+    fn brick_prevention_allows_disable_rest_when_didcomm_on() {
+        let result = would_violate_last_service(
+            &CurrentServices::new(true, true),
+            ProposedOp::disable(ServiceKind::Rest),
+        );
+        assert!(result.is_ok());
+    }
+
+    /// `persist_rest_disabled` writes services.rest = false to
+    /// both the in-memory config and the on-disk file.
+    #[tokio::test]
+    async fn persist_rest_disabled_flips_config_to_false() {
+        let fx = build_fixture(true, true);
+        assert!(fx.config.read().await.services.rest);
+
+        persist_rest_disabled(&fx.config).await.unwrap();
+
+        assert!(!fx.config.read().await.services.rest);
+        let on_disk = std::fs::read_to_string(&fx.config.read().await.config_path).unwrap();
+        let reparsed: AppConfig = toml::from_str(&on_disk).unwrap();
+        assert!(!reparsed.services.rest);
+    }
+
+    /// Confirms the typed `From<VtaError>` path: the helper's
+    /// `LastServiceRefused` round-trips into our error variant
+    /// correctly, and any other VtaError shape lands in `Storage`
+    /// (defensive — the helper is total today, but the impl
+    /// shouldn't drop unknown variants).
+    #[test]
+    fn vta_error_to_disable_rest_error_mapping_is_typed() {
+        let mapped = DisableRestError::from(VtaError::LastServiceRefused);
+        assert!(matches!(mapped, DisableRestError::LastServiceRefused));
+
+        let mapped = DisableRestError::from(VtaError::ServiceNotPresent);
+        assert!(matches!(mapped, DisableRestError::Storage(_)));
+    }
+}

--- a/vta-service/src/operations/protocol/document.rs
+++ b/vta-service/src/operations/protocol/document.rs
@@ -1,16 +1,30 @@
-//! Read/replace/remove the DIDComm service entry on a DID document.
+//! Read/replace/remove the per-kind transport service entries on a
+//! DID document.
 //!
 //! Pure functions over `serde_json::Value`. No I/O, no keystore access.
-//! Identifies the DIDComm service by `id` fragment suffix (matches the
-//! fragment the workspace's setup wizard emits — `#vta-didcomm`), so
-//! all existing DID documents are recognised without migration.
+//! Identifies each kind by `id` fragment suffix (matching what the
+//! workspace's setup wizard emits — `#vta-didcomm` and `#vta-rest`),
+//! so all existing DID documents are recognised without migration.
 //!
-//! Invariants:
-//! - At most one `#vta-didcomm` service entry exists at any time.
+//! ## Invariants
+//!
+//! - At most one `#vta-didcomm` and one `#vta-rest` entry exists at
+//!   any time.
 //! - `verificationMethod`, `authentication`, `assertionMethod`,
 //!   `keyAgreement` are NEVER touched by these helpers.
 //! - All other service entries (TeeAttestation, etc.) are preserved
 //!   byte-for-byte.
+//!
+//! ## REST entry shape (preserved for SDK compat)
+//!
+//! The REST entry rendered by [`with_rest_service`] matches the
+//! shape `setup::build_vta_additional_services` has produced since
+//! initial setup —
+//! `{ id, type: "VTARest", serviceEndpoint: "<url>" }` with a
+//! plain-string `serviceEndpoint`. The SDK's
+//! `Resolved::find_service("vta-rest")` (`vta-sdk/src/session.rs:1100`)
+//! depends on this; do not reshape. Reading tolerates the
+//! object/array forms a future operator might paste in.
 
 use serde_json::{Value, json};
 use thiserror::Error;
@@ -19,6 +33,15 @@ use thiserror::Error;
 /// entry. Matches what
 /// `operations::did_webvh::document::build_did_document_inner` emits.
 pub const DIDCOMM_SERVICE_FRAGMENT: &str = "#vta-didcomm";
+
+/// Fragment used for the VTA's REST service entry. Matches what
+/// `setup::build_vta_additional_services` emits and what
+/// `vta-sdk/src/session.rs:1100` resolves against — do not change.
+pub const REST_SERVICE_FRAGMENT: &str = "#vta-rest";
+
+/// `type` literal for the REST service entry. Stable wire form;
+/// renaming would silently break SDK resolution.
+pub const REST_SERVICE_TYPE: &str = "VTARest";
 
 /// A read-only view of the DIDComm service entry on a DID document.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,6 +54,18 @@ pub struct DidcommServiceRef {
     pub mediator_did: String,
 }
 
+/// A read-only view of the REST service entry on a DID document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RestServiceRef {
+    /// Full service `id` (e.g. `did:webvh:scid:host:path#vta-rest`).
+    pub id: String,
+    /// The URL this entry advertises. Whether the wire form was a
+    /// plain string (current convention), an object with `uri`, or
+    /// a single-element array, this is the resolved URL the SDK
+    /// will route REST traffic to.
+    pub url: String,
+}
+
 #[derive(Debug, Error)]
 pub enum DocumentPatchError {
     #[error("DID document is not a JSON object")]
@@ -39,6 +74,8 @@ pub enum DocumentPatchError {
     MissingDocumentId,
     #[error("mediator DID must be a non-empty string")]
     EmptyMediatorDid,
+    #[error("REST URL must be a non-empty string")]
+    EmptyRestUrl,
 }
 
 /// Locate the `#vta-didcomm` service entry on `doc`, if any.
@@ -130,6 +167,10 @@ fn id_matches_didcomm(id: &str) -> bool {
     id.ends_with(DIDCOMM_SERVICE_FRAGMENT)
 }
 
+fn id_matches_rest(id: &str) -> bool {
+    id.ends_with(REST_SERVICE_FRAGMENT)
+}
+
 fn extract_mediator_did(endpoint: &Value) -> Option<String> {
     match endpoint {
         Value::String(s) => Some(s.clone()),
@@ -137,6 +178,103 @@ fn extract_mediator_did(endpoint: &Value) -> Option<String> {
         Value::Array(arr) => arr.iter().find_map(extract_mediator_did),
         _ => None,
     }
+}
+
+/// Resolve the URL for a REST service entry's `serviceEndpoint`,
+/// tolerating the three shapes a DID document might carry it in
+/// (plain string — current convention; object with `uri`; or a
+/// single-element array of either).
+fn extract_rest_url(endpoint: &Value) -> Option<String> {
+    match endpoint {
+        Value::String(s) => Some(s.clone()),
+        Value::Object(map) => map.get("uri")?.as_str().map(str::to_string),
+        Value::Array(arr) => arr.iter().find_map(extract_rest_url),
+        _ => None,
+    }
+}
+
+/// Locate the `#vta-rest` service entry on `doc`, if any.
+pub fn current_rest_service(doc: &Value) -> Option<RestServiceRef> {
+    let services = doc.get("service")?.as_array()?;
+    for svc in services {
+        let id = svc.get("id")?.as_str()?;
+        if id_matches_rest(id) {
+            let url = extract_rest_url(svc.get("serviceEndpoint")?)?;
+            return Some(RestServiceRef {
+                id: id.to_string(),
+                url,
+            });
+        }
+    }
+    None
+}
+
+/// Insert or replace the `#vta-rest` service entry, returning the
+/// updated document. Other service entries are preserved
+/// byte-for-byte; verification methods are never touched.
+///
+/// The rendered shape — `type: "VTARest"` (plain string),
+/// `serviceEndpoint: "<url>"` (plain string) — matches the wire
+/// form `setup::build_vta_additional_services` has produced since
+/// initial setup, so SDK consumers
+/// (`vta-sdk/src/session.rs:1100`) keep resolving without
+/// migration.
+pub fn with_rest_service(mut doc: Value, url: &str) -> Result<Value, DocumentPatchError> {
+    if url.is_empty() {
+        return Err(DocumentPatchError::EmptyRestUrl);
+    }
+    let did_id = doc
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or(DocumentPatchError::MissingDocumentId)?
+        .to_string();
+
+    let new_entry = json!({
+        "id": format!("{did_id}{REST_SERVICE_FRAGMENT}"),
+        "type": REST_SERVICE_TYPE,
+        "serviceEndpoint": url,
+    });
+
+    let obj = doc.as_object_mut().ok_or(DocumentPatchError::NotAnObject)?;
+
+    let services = obj
+        .entry("service")
+        .or_insert_with(|| json!([]))
+        .as_array_mut()
+        .expect("service field must be an array");
+
+    if let Some(existing) = services.iter_mut().find(|s| {
+        s.get("id")
+            .and_then(Value::as_str)
+            .is_some_and(id_matches_rest)
+    }) {
+        *existing = new_entry;
+    } else {
+        services.push(new_entry);
+    }
+
+    Ok(doc)
+}
+
+/// Remove the `#vta-rest` service entry, if present. If the
+/// resulting service array is empty, the `service` field is
+/// removed entirely (matches the no-services pre-mutation shape).
+pub fn without_rest_service(mut doc: Value) -> Value {
+    let Some(obj) = doc.as_object_mut() else {
+        return doc;
+    };
+    let Some(services) = obj.get_mut("service").and_then(Value::as_array_mut) else {
+        return doc;
+    };
+    services.retain(|s| {
+        !s.get("id")
+            .and_then(Value::as_str)
+            .is_some_and(id_matches_rest)
+    });
+    if services.is_empty() {
+        obj.remove("service");
+    }
+    doc
 }
 
 #[cfg(test)]
@@ -361,5 +499,229 @@ mod tests {
         assert_eq!(stripped["authentication"], original_auth);
         assert_eq!(stripped["keyAgreement"], original_ka);
         assert_eq!(stripped["assertionMethod"], original_assertion);
+    }
+
+    // ── REST service-entry patcher tests ──────────────────────────
+
+    fn doc_with_rest(url: &str) -> Value {
+        json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": vta_did(),
+            "verificationMethod": [
+                { "id": format!("{}#key-0", vta_did()), "type": "Multikey",
+                  "controller": vta_did(), "publicKeyMultibase": "zfoo" }
+            ],
+            "authentication": [format!("{}#key-0", vta_did())],
+            "assertionMethod": [format!("{}#key-0", vta_did())],
+            "service": [{
+                "id": format!("{}#vta-rest", vta_did()),
+                "type": "VTARest",
+                "serviceEndpoint": url,
+            }]
+        })
+    }
+
+    #[test]
+    fn current_finds_rest_service() {
+        let doc = doc_with_rest("https://vta.example.com");
+        let svc = current_rest_service(&doc).expect("present");
+        assert_eq!(svc.id, format!("{}#vta-rest", vta_did()));
+        assert_eq!(svc.url, "https://vta.example.com");
+    }
+
+    #[test]
+    fn current_rest_returns_none_when_absent() {
+        assert!(current_rest_service(&doc_without_service()).is_none());
+        assert!(current_rest_service(&doc_with_only_tee()).is_none());
+        assert!(current_rest_service(&doc_with_didcomm("did:webvh:m")).is_none());
+    }
+
+    /// `serviceEndpoint` may be a plain string (current
+    /// convention), an object with `uri`, or a one-element array
+    /// of either. The reader accepts all three shapes — operators
+    /// who paste DID-Core-compliant object endpoints are handled
+    /// the same as those who use the workspace's plain-string
+    /// convention.
+    #[test]
+    fn current_rest_tolerates_object_and_array_endpoints() {
+        let object_endpoint = json!({
+            "id": vta_did(),
+            "service": [{
+                "id": format!("{}#vta-rest", vta_did()),
+                "type": "VTARest",
+                "serviceEndpoint": { "uri": "https://obj.example.com" }
+            }]
+        });
+        assert_eq!(
+            current_rest_service(&object_endpoint).unwrap().url,
+            "https://obj.example.com",
+        );
+
+        let array_endpoint = json!({
+            "id": vta_did(),
+            "service": [{
+                "id": format!("{}#vta-rest", vta_did()),
+                "type": "VTARest",
+                "serviceEndpoint": ["https://arr.example.com"]
+            }]
+        });
+        assert_eq!(
+            current_rest_service(&array_endpoint).unwrap().url,
+            "https://arr.example.com",
+        );
+    }
+
+    #[test]
+    fn with_rest_replaces_existing_entry() {
+        let doc = doc_with_rest("https://old.example.com");
+        let patched = with_rest_service(doc, "https://new.example.com").unwrap();
+        let svc = current_rest_service(&patched).unwrap();
+        assert_eq!(svc.url, "https://new.example.com");
+        // At-most-one invariant.
+        let count = patched["service"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|s| {
+                s["id"]
+                    .as_str()
+                    .map(|i| i.ends_with("#vta-rest"))
+                    .unwrap_or(false)
+            })
+            .count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn with_rest_inserts_when_missing() {
+        let patched = with_rest_service(doc_without_service(), "https://x.example.com").unwrap();
+        let svc = current_rest_service(&patched).unwrap();
+        assert_eq!(svc.url, "https://x.example.com");
+        assert_eq!(patched["service"].as_array().unwrap().len(), 1);
+    }
+
+    /// Wire shape preservation — the SDK depends on `type: "VTARest"`
+    /// (plain string) and `serviceEndpoint: "<url>"` (plain string).
+    /// Pin both.
+    #[test]
+    fn with_rest_emits_canonical_wire_shape() {
+        let patched = with_rest_service(doc_without_service(), "https://vta.example.com").unwrap();
+        let entry = &patched["service"].as_array().unwrap()[0];
+        assert_eq!(entry["type"], "VTARest");
+        assert_eq!(entry["serviceEndpoint"], "https://vta.example.com");
+        assert!(
+            entry["serviceEndpoint"].is_string(),
+            "serviceEndpoint must be a plain string per session.rs:1100",
+        );
+    }
+
+    #[test]
+    fn with_rest_preserves_didcomm_and_tee_entries() {
+        let mut doc = doc_with_didcomm("did:webvh:mediator-A");
+        doc["service"].as_array_mut().unwrap().push(json!({
+            "id": format!("{}#tee-attestation", vta_did()),
+            "type": "TeeAttestation",
+            "serviceEndpoint": "https://x"
+        }));
+        let patched = with_rest_service(doc, "https://vta.example.com").unwrap();
+        let services = patched["service"].as_array().unwrap();
+        assert_eq!(services.len(), 3, "didcomm + tee + rest");
+        let didcomm_present = current_didcomm_service(&patched).is_some();
+        let rest_present = current_rest_service(&patched).is_some();
+        let tee_present = services
+            .iter()
+            .any(|s| s["id"].as_str().unwrap().ends_with("#tee-attestation"));
+        assert!(didcomm_present && rest_present && tee_present);
+    }
+
+    #[test]
+    fn with_rest_rejects_empty_url() {
+        let err = with_rest_service(doc_without_service(), "").unwrap_err();
+        assert!(matches!(err, DocumentPatchError::EmptyRestUrl));
+    }
+
+    #[test]
+    fn with_rest_rejects_doc_without_id() {
+        let bad = json!({ "service": [] });
+        let err = with_rest_service(bad, "https://x").unwrap_err();
+        assert!(matches!(err, DocumentPatchError::MissingDocumentId));
+    }
+
+    #[test]
+    fn without_rest_removes_only_rest_entry() {
+        let mut doc = doc_with_rest("https://x.example.com");
+        // Add a didcomm + tee entry so we can verify they survive.
+        doc["service"].as_array_mut().unwrap().push(json!({
+            "id": format!("{}#vta-didcomm", vta_did()),
+            "type": "DIDCommMessaging",
+            "serviceEndpoint": [{ "accept": ["didcomm/v2"], "uri": "did:webvh:m" }]
+        }));
+        doc["service"].as_array_mut().unwrap().push(json!({
+            "id": format!("{}#tee-attestation", vta_did()),
+            "type": "TeeAttestation",
+            "serviceEndpoint": "https://x"
+        }));
+
+        let stripped = without_rest_service(doc);
+        assert!(current_rest_service(&stripped).is_none());
+        assert!(current_didcomm_service(&stripped).is_some());
+        let tee_present = stripped["service"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|s| s["id"].as_str().unwrap().ends_with("#tee-attestation"));
+        assert!(tee_present);
+    }
+
+    #[test]
+    fn without_rest_drops_empty_service_array() {
+        let doc = doc_with_rest("https://x.example.com");
+        let stripped = without_rest_service(doc);
+        assert!(stripped.get("service").is_none());
+    }
+
+    #[test]
+    fn without_rest_is_noop_when_absent() {
+        let original = doc_with_didcomm("did:webvh:m");
+        let stripped = without_rest_service(original.clone());
+        assert_eq!(stripped, original);
+    }
+
+    /// REST and DIDComm patchers compose in either order — round
+    /// tripping with→without on one kind doesn't disturb the other.
+    #[test]
+    fn rest_and_didcomm_patchers_compose() {
+        let base = doc_without_service();
+        let with_d = with_didcomm_service(base.clone(), "did:webvh:m").unwrap();
+        let with_both = with_rest_service(with_d, "https://x.example.com").unwrap();
+
+        assert!(current_didcomm_service(&with_both).is_some());
+        assert!(current_rest_service(&with_both).is_some());
+
+        let only_didcomm = without_rest_service(with_both.clone());
+        assert!(current_didcomm_service(&only_didcomm).is_some());
+        assert!(current_rest_service(&only_didcomm).is_none());
+
+        let only_rest = without_didcomm_service(with_both);
+        assert!(current_didcomm_service(&only_rest).is_none());
+        assert!(current_rest_service(&only_rest).is_some());
+    }
+
+    /// `verificationMethod` byte-identical across REST patcher
+    /// operations — same load-bearing invariant as the DIDComm
+    /// side.
+    #[test]
+    fn verification_method_byte_identical_after_rest_patches() {
+        let original = doc_with_rest("https://old.example.com");
+        let original_vm = original["verificationMethod"].clone();
+        let original_auth = original["authentication"].clone();
+
+        let patched = with_rest_service(original.clone(), "https://new.example.com").unwrap();
+        assert_eq!(patched["verificationMethod"], original_vm);
+        assert_eq!(patched["authentication"], original_auth);
+
+        let stripped = without_rest_service(original);
+        assert_eq!(stripped["verificationMethod"], original_vm);
+        assert_eq!(stripped["authentication"], original_auth);
     }
 }

--- a/vta-service/src/operations/protocol/enable_rest.rs
+++ b/vta-service/src/operations/protocol/enable_rest.rs
@@ -1,0 +1,385 @@
+//! `enable_rest` operation.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.4.
+//!
+//! Sequence (under [`PROTOCOL_LOCK`]):
+//! 1. Verify caller is super-admin.
+//! 2. Validate URL via
+//!    [`vta_sdk::protocol::services::validate_service_url`] (T1.2).
+//! 3. Confirm `services.rest` is currently `false` AND no
+//!    `#vta-rest` entry is in the DID document — refuse with
+//!    [`EnableRestError::ServiceAlreadyEnabled`] otherwise.
+//! 4. Look up the VTA's webvh record + current document.
+//! 5. Persist a [`RestSnapshot::Disabled`] snapshot before the
+//!    runtime mutation, per spec §3.5a (rollback target if the
+//!    operator later runs `services rest rollback`).
+//! 6. Patch the document — insert `#vta-rest` via
+//!    [`with_rest_service`] — and publish via [`update_did_webvh`].
+//! 7. Persist `services.rest = true` to the config file.
+//! 8. Emit [`TelemetryKind::ServicesRestEnable`].
+//!
+//! Brick-prevention is **not** consulted — enabling can only add a
+//! transport service, never remove one, so the §3.2 invariant is
+//! preserved by construction.
+
+use std::sync::Arc;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use vti_common::seed_store::SeedStore;
+use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
+
+use vta_sdk::protocol::services::validate_service_url;
+
+use crate::auth::AuthClaims;
+use crate::config::AppConfig;
+use crate::didcomm_bridge::DIDCommBridge;
+use crate::error::AppError;
+use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
+use crate::operations::protocol::PROTOCOL_LOCK;
+use crate::operations::protocol::document::{
+    DocumentPatchError, current_rest_service, with_rest_service,
+};
+use crate::operations::protocol::snapshot::{self, RestSnapshot, ServiceConfigSnapshot};
+use crate::store::KeyspaceHandle;
+use crate::webvh_store;
+
+#[derive(Debug, Clone)]
+pub struct EnableRestParams {
+    /// Public URL the VTA will advertise on its `#vta-rest` service
+    /// entry. Validated by [`validate_service_url`] before any
+    /// runtime mutation occurs.
+    pub url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnableRestResult {
+    pub new_version_id: String,
+    /// The validated URL that was published — canonicalised from
+    /// `params.url` by `url::Url`.
+    pub url: String,
+}
+
+#[derive(Debug, Error)]
+pub enum EnableRestError {
+    #[error("REST is already enabled. Use `services rest update --url <url>` to change the URL.")]
+    ServiceAlreadyEnabled,
+    #[error("invalid URL: {0}")]
+    Validation(String),
+    #[error("VTA DID is not configured — run `vta setup` first")]
+    VtaDidNotConfigured,
+    #[error("VTA DID `{0}` has no webvh record")]
+    VtaDidRecordMissing(String),
+    #[error("VTA DID `{0}` has no published log")]
+    VtaDidLogMissing(String),
+    #[error("VTA DID log is empty")]
+    EmptyLog,
+    #[error("DID document patch failed: {0}")]
+    DocumentPatch(#[from] DocumentPatchError),
+    #[error("WebVH update failed: {0}")]
+    WebVHUpdate(#[from] UpdateDidWebvhError),
+    #[error("config persistence failed: {0}")]
+    ConfigPersistence(String),
+    #[error("auth: {0}")]
+    Auth(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+impl From<AppError> for EnableRestError {
+    fn from(value: AppError) -> Self {
+        Self::Storage(value.to_string())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn enable_rest(
+    config: &Arc<RwLock<AppConfig>>,
+    keys_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    snapshot_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    did_resolver: &DIDCacheClient,
+    didcomm_bridge: &Arc<DIDCommBridge>,
+    telemetry: &SharedTelemetrySink,
+    auth: &AuthClaims,
+    params: EnableRestParams,
+    channel: &str,
+) -> Result<EnableRestResult, EnableRestError> {
+    auth.require_super_admin()
+        .map_err(|e| EnableRestError::Auth(e.to_string()))?;
+
+    let _guard = PROTOCOL_LOCK.lock().await;
+
+    // 1. Validate URL up front. Cheap, runs before any I/O.
+    let validated = validate_service_url(&params.url)
+        .map_err(|e| EnableRestError::Validation(e.to_string()))?;
+    let canonical_url = validated.to_string();
+
+    // 2. Read preconditions: REST must be off, both in config and
+    //    in the on-chain DID document. We check both because the
+    //    sources should agree, and a divergence is itself a bug we
+    //    want to surface (operator can run `services list` to
+    //    inspect).
+    let (vta_did, scid, current_doc) = read_preconditions(config, webvh_ks).await?;
+
+    // 3. Persist snapshot BEFORE the runtime mutation per spec
+    //    §3.5a. Pre-state for an enable is RestSnapshot::Disabled
+    //    so a future rollback re-applies "off."
+    snapshot::write(
+        snapshot_ks,
+        ServiceConfigSnapshot::Rest(RestSnapshot::Disabled),
+    )
+    .await
+    .map_err(|e| EnableRestError::Storage(format!("snapshot write: {e}")))?;
+
+    // 4. Patch the document with the new REST service entry.
+    let patched = with_rest_service(current_doc, &canonical_url)?;
+
+    // 5. Publish via update_did_webvh.
+    let update_result = update_did_webvh(
+        keys_ks,
+        contexts_ks,
+        webvh_ks,
+        audit_ks,
+        seed_store,
+        auth,
+        &scid,
+        UpdateDidWebvhOptions {
+            document: Some(patched),
+            ..Default::default()
+        },
+        did_resolver,
+        didcomm_bridge,
+        channel,
+    )
+    .await?;
+
+    // 6. Persist `services.rest = true`. If this fails, the
+    //    published LogEntry advertises REST but config disagrees —
+    //    same risk window as `disable_didcomm`'s
+    //    `persist_didcomm_disabled`. Operator retries with the
+    //    config in a known state.
+    persist_rest_enabled(config).await?;
+
+    // 7. Telemetry. Channel and version-id let an external verifier
+    //    join this event to chain history.
+    let _ = telemetry
+        .record(
+            TelemetryEvent::new(TelemetryKind::ServicesRestEnable)
+                .with_field("channel", JsonValue::from(channel))
+                .with_field(
+                    "new_version_id",
+                    JsonValue::from(update_result.new_version_id.clone()),
+                )
+                .with_field("url", JsonValue::from(canonical_url.clone())),
+        )
+        .await;
+
+    info!(
+        channel,
+        url = %canonical_url,
+        new_version_id = %update_result.new_version_id,
+        vta_did = %vta_did,
+        "REST enabled"
+    );
+
+    Ok(EnableRestResult {
+        new_version_id: update_result.new_version_id,
+        url: canonical_url,
+    })
+}
+
+async fn read_preconditions(
+    config: &Arc<RwLock<AppConfig>>,
+    webvh_ks: &KeyspaceHandle,
+) -> Result<(String, String, JsonValue), EnableRestError> {
+    let cfg = config.read().await;
+    if cfg.services.rest {
+        return Err(EnableRestError::ServiceAlreadyEnabled);
+    }
+    let vta_did = cfg
+        .vta_did
+        .clone()
+        .ok_or(EnableRestError::VtaDidNotConfigured)?;
+    drop(cfg);
+
+    let record = webvh_store::get_did(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| EnableRestError::VtaDidRecordMissing(vta_did.clone()))?;
+    let scid = record.scid.clone();
+
+    let did_log = webvh_store::get_did_log(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| EnableRestError::VtaDidLogMissing(vta_did.clone()))?;
+    let current_doc = current_document_from_log(&did_log)?;
+
+    if current_rest_service(&current_doc).is_some() {
+        // Config and on-chain doc disagree (config: rest=false,
+        // doc: rest entry present). Surface as ServiceAlreadyEnabled
+        // — reconciling means the operator should run `services
+        // list`, not retry the enable.
+        return Err(EnableRestError::ServiceAlreadyEnabled);
+    }
+
+    Ok((vta_did, scid, current_doc))
+}
+
+fn current_document_from_log(did_log: &str) -> Result<JsonValue, EnableRestError> {
+    use didwebvh_rs::log_entry::{LogEntry, LogEntryMethods};
+    let line = did_log
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .ok_or(EnableRestError::EmptyLog)?;
+    let entry: LogEntry = serde_json::from_str(line)
+        .map_err(|e| EnableRestError::Storage(format!("DID log line parse: {e}")))?;
+    Ok(entry.get_state().clone())
+}
+
+async fn persist_rest_enabled(config: &Arc<RwLock<AppConfig>>) -> Result<(), EnableRestError> {
+    let (contents, path) = {
+        let mut cfg = config.write().await;
+        cfg.services.rest = true;
+        let contents = toml::to_string_pretty(&*cfg)
+            .map_err(|e| EnableRestError::ConfigPersistence(e.to_string()))?;
+        let path = cfg.config_path.clone();
+        (contents, path)
+    };
+    std::fs::write(&path, contents)
+        .map_err(|e| EnableRestError::ConfigPersistence(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{LogConfig, ServerConfig, ServicesConfig, StoreConfig};
+    use crate::operations::protocol::snapshot::ServiceKind;
+    use crate::store::Store;
+    use vti_common::config::StoreConfig as VtiStoreConfig;
+
+    /// Owns the on-disk fjall store so all keyspaces a test reaches
+    /// for share a single open handle (fjall locks the data dir on
+    /// each open). Caller derives webvh / snapshot / etc. handles
+    /// off `store`.
+    struct TestFixture {
+        _dir: tempfile::TempDir,
+        config: Arc<RwLock<AppConfig>>,
+        store: Store,
+    }
+
+    impl TestFixture {
+        fn snapshot_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace(snapshot::KEYSPACE_NAME).unwrap()
+        }
+        fn webvh_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace("webvh").unwrap()
+        }
+    }
+
+    fn build_fixture(rest_initially: bool) -> TestFixture {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("vta.toml");
+        let cfg = AppConfig {
+            server: ServerConfig {
+                host: "127.0.0.1".into(),
+                port: 0,
+            },
+            log: LogConfig::default(),
+            store: StoreConfig {
+                data_dir: dir.path().into(),
+            },
+            services: ServicesConfig {
+                rest: rest_initially,
+                didcomm: true, // satisfy the §3.2 brick-prevention default
+            },
+            vta_did: Some("did:webvh:scid123:host:vta".into()),
+            vta_name: None,
+            public_url: None,
+            resolver_url: None,
+            messaging: None,
+            secrets: Default::default(),
+            audit: Default::default(),
+            auth: Default::default(),
+            #[cfg(feature = "tee")]
+            tee: Default::default(),
+            config_path,
+        };
+        // Persist so `persist_rest_enabled` has a file to write to.
+        let initial = toml::to_string_pretty(&cfg).unwrap();
+        std::fs::write(&cfg.config_path, initial).unwrap();
+
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        TestFixture {
+            _dir: dir,
+            config: Arc::new(RwLock::new(cfg)),
+            store,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_preconditions_rejects_when_already_enabled() {
+        let fx = build_fixture(true);
+        let err = read_preconditions(&fx.config, &fx.webvh_ks())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, EnableRestError::ServiceAlreadyEnabled));
+    }
+
+    #[tokio::test]
+    async fn read_preconditions_rejects_without_vta_did() {
+        let fx = build_fixture(false);
+        fx.config.write().await.vta_did = None;
+        let err = read_preconditions(&fx.config, &fx.webvh_ks())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, EnableRestError::VtaDidNotConfigured));
+    }
+
+    /// URL validation runs first, before any storage reads. An
+    /// invalid URL never reaches the snapshot layer.
+    #[tokio::test]
+    async fn enable_rest_url_validation_runs_before_persist() {
+        let fx = build_fixture(false);
+        let snapshot_ks = fx.snapshot_ks();
+
+        // Exercise the validation step alone — `enable_rest` runs it
+        // before any I/O, so an invalid URL must not write a
+        // snapshot.
+        let validated = validate_service_url("http://insecure.example.com");
+        assert!(validated.is_err(), "http:// must be rejected");
+
+        assert!(
+            snapshot::read(&snapshot_ks, ServiceKind::Rest)
+                .await
+                .unwrap()
+                .is_none(),
+            "validation error must abort before snapshot write",
+        );
+    }
+
+    /// `persist_rest_enabled` writes `services.rest = true` to the
+    /// config file. Read it back to confirm both in-memory and
+    /// on-disk state agree.
+    #[tokio::test]
+    async fn persist_rest_enabled_writes_rest_true_to_config_file() {
+        let fx = build_fixture(false);
+        assert!(!fx.config.read().await.services.rest);
+
+        persist_rest_enabled(&fx.config).await.unwrap();
+
+        assert!(fx.config.read().await.services.rest);
+        let on_disk = std::fs::read_to_string(&fx.config.read().await.config_path).unwrap();
+        let reparsed: AppConfig = toml::from_str(&on_disk).unwrap();
+        assert!(reparsed.services.rest);
+    }
+}

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -8,6 +8,7 @@
 //! later phases.
 
 pub mod disable_didcomm;
+pub mod disable_rest;
 pub mod document;
 pub mod drain_cancel;
 pub mod enable_didcomm;

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -11,6 +11,7 @@ pub mod disable_didcomm;
 pub mod document;
 pub mod drain_cancel;
 pub mod enable_didcomm;
+pub mod enable_rest;
 pub mod invariant;
 pub mod migrate_mediator;
 pub mod report;

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -16,6 +16,7 @@ pub mod invariant;
 pub mod migrate_mediator;
 pub mod report;
 pub mod snapshot;
+pub mod update_rest;
 
 /// Process-wide lock serializing every protocol-state mutation
 /// (enable / disable / migrate / drain-cancel). Modeled on

--- a/vta-service/src/operations/protocol/update_rest.rs
+++ b/vta-service/src/operations/protocol/update_rest.rs
@@ -1,0 +1,389 @@
+//! `update_rest` operation.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.4.
+//!
+//! Sequence (under [`PROTOCOL_LOCK`]):
+//! 1. Verify caller is super-admin.
+//! 2. Validate the new URL via
+//!    [`vta_sdk::protocol::services::validate_service_url`] (T1.2).
+//! 3. Confirm `services.rest` is currently `true` AND a
+//!    `#vta-rest` entry exists in the DID document — refuse with
+//!    [`UpdateRestError::ServiceNotPresent`] otherwise.
+//! 4. Read the prior URL from the on-chain DID document for the
+//!    snapshot.
+//! 5. Persist a [`RestSnapshot::Enabled { url: prior_url }`]
+//!    snapshot before the runtime mutation, per spec §3.5a — a
+//!    future rollback restores the prior URL.
+//! 6. Patch the document — replace the `#vta-rest` entry's URL
+//!    via [`with_rest_service`] — and publish via [`update_did_webvh`].
+//! 7. Emit [`TelemetryKind::ServicesRestUpdate`].
+//!
+//! No `services.rest` config flip — REST stays enabled across an
+//! update; only the URL changes. The brick-prevention invariant is
+//! not consulted (update can't change the on/off state).
+
+use std::sync::Arc;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use vti_common::seed_store::SeedStore;
+use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
+
+use vta_sdk::protocol::services::validate_service_url;
+
+use crate::auth::AuthClaims;
+use crate::config::AppConfig;
+use crate::didcomm_bridge::DIDCommBridge;
+use crate::error::AppError;
+use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
+use crate::operations::protocol::PROTOCOL_LOCK;
+use crate::operations::protocol::document::{
+    DocumentPatchError, current_rest_service, with_rest_service,
+};
+use crate::operations::protocol::snapshot::{self, RestSnapshot, ServiceConfigSnapshot};
+use crate::store::KeyspaceHandle;
+use crate::webvh_store;
+
+#[derive(Debug, Clone)]
+pub struct UpdateRestParams {
+    /// New public URL for the `#vta-rest` service entry. Validated
+    /// before any runtime mutation.
+    pub url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateRestResult {
+    pub new_version_id: String,
+    /// Pre-update URL — captured from the on-chain DID document
+    /// and surfaced so callers / telemetry can join the
+    /// before-and-after.
+    pub prior_url: String,
+    /// The validated new URL that was published — canonicalised
+    /// from `params.url` by `url::Url`.
+    pub url: String,
+}
+
+#[derive(Debug, Error)]
+pub enum UpdateRestError {
+    #[error(
+        "REST is not currently enabled. Use `services rest enable --url <url>` to bring it online first."
+    )]
+    ServiceNotPresent,
+    #[error("invalid URL: {0}")]
+    Validation(String),
+    #[error("VTA DID is not configured — run `vta setup` first")]
+    VtaDidNotConfigured,
+    #[error("VTA DID `{0}` has no webvh record")]
+    VtaDidRecordMissing(String),
+    #[error("VTA DID `{0}` has no published log")]
+    VtaDidLogMissing(String),
+    #[error("VTA DID log is empty")]
+    EmptyLog,
+    #[error("DID document patch failed: {0}")]
+    DocumentPatch(#[from] DocumentPatchError),
+    #[error("WebVH update failed: {0}")]
+    WebVHUpdate(#[from] UpdateDidWebvhError),
+    #[error("auth: {0}")]
+    Auth(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+impl From<AppError> for UpdateRestError {
+    fn from(value: AppError) -> Self {
+        Self::Storage(value.to_string())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn update_rest(
+    config: &Arc<RwLock<AppConfig>>,
+    keys_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    snapshot_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    did_resolver: &DIDCacheClient,
+    didcomm_bridge: &Arc<DIDCommBridge>,
+    telemetry: &SharedTelemetrySink,
+    auth: &AuthClaims,
+    params: UpdateRestParams,
+    channel: &str,
+) -> Result<UpdateRestResult, UpdateRestError> {
+    auth.require_super_admin()
+        .map_err(|e| UpdateRestError::Auth(e.to_string()))?;
+
+    let _guard = PROTOCOL_LOCK.lock().await;
+
+    // 1. Validate the new URL up front. Cheap; runs before I/O.
+    let validated = validate_service_url(&params.url)
+        .map_err(|e| UpdateRestError::Validation(e.to_string()))?;
+    let canonical_url = validated.to_string();
+
+    // 2. Read preconditions: REST must be on, both in config and
+    //    on-chain. Capture the prior URL while we're at it — the
+    //    snapshot needs it.
+    let (vta_did, scid, current_doc, prior_url) = read_preconditions(config, webvh_ks).await?;
+
+    // 3. Persist snapshot BEFORE the runtime mutation per spec
+    //    §3.5a. Pre-state for an update is RestSnapshot::Enabled
+    //    with the prior URL — rollback restores that URL.
+    snapshot::write(
+        snapshot_ks,
+        ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+            url: prior_url.clone(),
+        }),
+    )
+    .await
+    .map_err(|e| UpdateRestError::Storage(format!("snapshot write: {e}")))?;
+
+    // 4. Patch the document — replace the #vta-rest entry's URL.
+    //    `with_rest_service` overwrites the existing entry's URL
+    //    while preserving everything else byte-for-byte.
+    let patched = with_rest_service(current_doc, &canonical_url)?;
+
+    // 5. Publish via update_did_webvh.
+    let update_result = update_did_webvh(
+        keys_ks,
+        contexts_ks,
+        webvh_ks,
+        audit_ks,
+        seed_store,
+        auth,
+        &scid,
+        UpdateDidWebvhOptions {
+            document: Some(patched),
+            ..Default::default()
+        },
+        did_resolver,
+        didcomm_bridge,
+        channel,
+    )
+    .await?;
+
+    // 6. No config persistence — services.rest stays true. The
+    //    AppConfig has no field for the public REST URL, so the
+    //    DID document is the single source of truth for the URL
+    //    (the SDK's session.rs:1100 already pulls from there).
+    //    Operators who restart the VTA pick the new URL up via
+    //    DID resolution; no config-file write is necessary.
+
+    // 7. Telemetry: prior + new URL together so external verifiers
+    //    can graph URL transitions per VTA.
+    let _ = telemetry
+        .record(
+            TelemetryEvent::new(TelemetryKind::ServicesRestUpdate)
+                .with_field("channel", JsonValue::from(channel))
+                .with_field(
+                    "new_version_id",
+                    JsonValue::from(update_result.new_version_id.clone()),
+                )
+                .with_field("prior_url", JsonValue::from(prior_url.clone()))
+                .with_field("url", JsonValue::from(canonical_url.clone())),
+        )
+        .await;
+
+    info!(
+        channel,
+        prior_url = %prior_url,
+        url = %canonical_url,
+        new_version_id = %update_result.new_version_id,
+        vta_did = %vta_did,
+        "REST URL updated"
+    );
+
+    Ok(UpdateRestResult {
+        new_version_id: update_result.new_version_id,
+        prior_url,
+        url: canonical_url,
+    })
+}
+
+async fn read_preconditions(
+    config: &Arc<RwLock<AppConfig>>,
+    webvh_ks: &KeyspaceHandle,
+) -> Result<(String, String, JsonValue, String), UpdateRestError> {
+    let cfg = config.read().await;
+    if !cfg.services.rest {
+        return Err(UpdateRestError::ServiceNotPresent);
+    }
+    let vta_did = cfg
+        .vta_did
+        .clone()
+        .ok_or(UpdateRestError::VtaDidNotConfigured)?;
+    drop(cfg);
+
+    let record = webvh_store::get_did(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| UpdateRestError::VtaDidRecordMissing(vta_did.clone()))?;
+    let scid = record.scid.clone();
+
+    let did_log = webvh_store::get_did_log(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| UpdateRestError::VtaDidLogMissing(vta_did.clone()))?;
+    let current_doc = current_document_from_log(&did_log)?;
+
+    let prior_url = current_rest_service(&current_doc)
+        .map(|s| s.url)
+        .ok_or(UpdateRestError::ServiceNotPresent)?;
+
+    Ok((vta_did, scid, current_doc, prior_url))
+}
+
+fn current_document_from_log(did_log: &str) -> Result<JsonValue, UpdateRestError> {
+    use didwebvh_rs::log_entry::{LogEntry, LogEntryMethods};
+    let line = did_log
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .ok_or(UpdateRestError::EmptyLog)?;
+    let entry: LogEntry = serde_json::from_str(line)
+        .map_err(|e| UpdateRestError::Storage(format!("DID log line parse: {e}")))?;
+    Ok(entry.get_state().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{LogConfig, ServerConfig, ServicesConfig, StoreConfig};
+    use crate::operations::protocol::snapshot::ServiceKind;
+    use crate::store::Store;
+    use vti_common::config::StoreConfig as VtiStoreConfig;
+
+    /// Mirrors `enable_rest::tests::TestFixture` — owns the fjall
+    /// store so a single test can derive multiple keyspaces from
+    /// the same handle (fjall locks the data dir on open).
+    struct TestFixture {
+        _dir: tempfile::TempDir,
+        config: Arc<RwLock<AppConfig>>,
+        store: Store,
+    }
+
+    impl TestFixture {
+        fn snapshot_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace(snapshot::KEYSPACE_NAME).unwrap()
+        }
+        fn webvh_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace("webvh").unwrap()
+        }
+    }
+
+    fn build_fixture(rest_initially: bool) -> TestFixture {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("vta.toml");
+        let cfg = AppConfig {
+            server: ServerConfig {
+                host: "127.0.0.1".into(),
+                port: 0,
+            },
+            log: LogConfig::default(),
+            store: StoreConfig {
+                data_dir: dir.path().into(),
+            },
+            services: ServicesConfig {
+                rest: rest_initially,
+                didcomm: true,
+            },
+            vta_did: Some("did:webvh:scid123:host:vta".into()),
+            vta_name: None,
+            public_url: None,
+            resolver_url: None,
+            messaging: None,
+            secrets: Default::default(),
+            audit: Default::default(),
+            auth: Default::default(),
+            #[cfg(feature = "tee")]
+            tee: Default::default(),
+            config_path,
+        };
+        let initial = toml::to_string_pretty(&cfg).unwrap();
+        std::fs::write(&cfg.config_path, initial).unwrap();
+
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        TestFixture {
+            _dir: dir,
+            config: Arc::new(RwLock::new(cfg)),
+            store,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_preconditions_rejects_when_rest_disabled() {
+        let fx = build_fixture(false);
+        let err = read_preconditions(&fx.config, &fx.webvh_ks())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, UpdateRestError::ServiceNotPresent));
+    }
+
+    #[tokio::test]
+    async fn read_preconditions_rejects_without_vta_did() {
+        let fx = build_fixture(true);
+        fx.config.write().await.vta_did = None;
+        let err = read_preconditions(&fx.config, &fx.webvh_ks())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, UpdateRestError::VtaDidNotConfigured));
+    }
+
+    /// URL validation runs first, before any storage reads or
+    /// snapshot writes — invalid URL means the snapshot keyspace
+    /// stays untouched, leaving any prior snapshot from a
+    /// successful mutation intact.
+    #[tokio::test]
+    async fn invalid_url_aborts_before_snapshot_write() {
+        let fx = build_fixture(true);
+        let snapshot_ks = fx.snapshot_ks();
+
+        let validated = validate_service_url("ftp://nope.example.com");
+        assert!(validated.is_err(), "non-https must be rejected");
+
+        assert!(
+            snapshot::read(&snapshot_ks, ServiceKind::Rest)
+                .await
+                .unwrap()
+                .is_none(),
+            "validation error must abort before snapshot write",
+        );
+    }
+
+    /// Direct exercise of the snapshot semantics: after a
+    /// successful update, the snapshot must record the *prior*
+    /// URL (not the new one). Constructed directly here because
+    /// the full operation requires a webvh store fixture too
+    /// large for a unit test — full path coverage lives in the
+    /// e2e matrix (P6).
+    #[tokio::test]
+    async fn snapshot_records_prior_url_for_rollback() {
+        let fx = build_fixture(true);
+        let snapshot_ks = fx.snapshot_ks();
+        let prior_url = "https://old.example.com".to_string();
+
+        snapshot::write(
+            &snapshot_ks,
+            ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+                url: prior_url.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let read_back = snapshot::read(&snapshot_ks, ServiceKind::Rest)
+            .await
+            .unwrap()
+            .unwrap();
+        match read_back {
+            ServiceConfigSnapshot::Rest(RestSnapshot::Enabled { url }) => {
+                assert_eq!(url, prior_url, "rollback target must be prior URL");
+            }
+            other => panic!("unexpected snapshot variant: {other:?}"),
+        }
+    }
+}

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -218,6 +218,8 @@ pub fn router() -> Router<AppState> {
 
     // Protocol management routes (DIDComm enable/disable/migrate;
     // spec docs/05-design-notes/didcomm-protocol-management.md).
+    // Plus the symmetric REST routes (spec
+    // docs/05-design-notes/runtime-service-management.md §3.4).
     #[cfg(feature = "webvh")]
     let router = router
         .route(
@@ -227,6 +229,12 @@ pub fn router() -> Router<AppState> {
         .route(
             "/services/didcomm/disable",
             post(protocol::disable_didcomm_handler),
+        )
+        .route("/services/rest/enable", post(protocol::enable_rest_handler))
+        .route("/services/rest/update", post(protocol::update_rest_handler))
+        .route(
+            "/services/rest/disable",
+            post(protocol::disable_rest_handler),
         )
         .route(
             "/mediators/migrate",

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -20,12 +20,17 @@ use crate::messaging::handshake::{AlwaysOkProver, HandshakeError, HandshakeStage
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommError, DisableDidcommParams, DisableTransport, disable_didcomm,
 };
+use crate::operations::protocol::disable_rest::{
+    DisableRestError, DisableRestParams, disable_rest,
+};
 use crate::operations::protocol::enable_didcomm::{
     EnableDidcommError, EnableDidcommParams, enable_didcomm,
 };
+use crate::operations::protocol::enable_rest::{EnableRestError, EnableRestParams, enable_rest};
 use crate::operations::protocol::migrate_mediator::{
     MigrateAuditKind, MigrateMediatorError, MigrateMediatorParams, migrate_mediator,
 };
+use crate::operations::protocol::update_rest::{UpdateRestError, UpdateRestParams, update_rest};
 use crate::server::AppState;
 
 /// Default trust-ping round-trip timeout for first-enable when the
@@ -1143,4 +1148,333 @@ async fn try_run_first_enable_handshake(
     )
     .await
     .map(|_| ())
+}
+
+// ── REST service-management handlers (spec §3.4) ──────────────────
+//
+// `POST /services/rest/{enable,update,disable}` and (in T3.4)
+// `/services/rest/rollback`. The wire types are reused directly
+// from `vta_sdk::protocol::services` rather than redefined locally
+// — the SDK types are the canonical wire contract; redefining them
+// here would just duplicate that contract.
+//
+// Response shape is the SDK's shared `ServiceMutationResponse` for
+// every mutation across REST and DIDComm (spec §4). REST mutations
+// always set `drain_until: None`; DIDComm ops in T2.x will populate
+// it when scheduling a drain.
+
+/// `POST /services/rest/enable` — add a `#vta-rest` service entry
+/// to the VTA's DID document. Auth: super-admin. Refused with
+/// `ServiceAlreadyEnabled` if REST is already advertised.
+pub async fn enable_rest_handler(
+    auth: SuperAdminAuth,
+    State(state): State<AppState>,
+    Json(req): Json<vta_sdk::protocol::services::EnableRestRequest>,
+) -> Result<Json<vta_sdk::protocol::services::ServiceMutationResponse>, RestServiceHttpError> {
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or(RestServiceHttpError::DidResolverUnavailable)?
+        .clone();
+
+    let result = enable_rest(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        &did_resolver,
+        &state.didcomm_bridge,
+        &state.telemetry,
+        &auth.0,
+        EnableRestParams { url: req.url },
+        "rest",
+    )
+    .await?;
+
+    Ok(Json(vta_sdk::protocol::services::ServiceMutationResponse {
+        log_entry_version_id: result.new_version_id,
+        effective_at: chrono::Utc::now().to_rfc3339(),
+        drain_until: None,
+    }))
+}
+
+/// `POST /services/rest/update` — replace the URL on the existing
+/// `#vta-rest` entry. Auth: super-admin. Refused with
+/// `ServiceNotPresent` if REST isn't currently advertised.
+pub async fn update_rest_handler(
+    auth: SuperAdminAuth,
+    State(state): State<AppState>,
+    Json(req): Json<vta_sdk::protocol::services::UpdateRestRequest>,
+) -> Result<Json<vta_sdk::protocol::services::ServiceMutationResponse>, RestServiceHttpError> {
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or(RestServiceHttpError::DidResolverUnavailable)?
+        .clone();
+
+    let result = update_rest(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        &did_resolver,
+        &state.didcomm_bridge,
+        &state.telemetry,
+        &auth.0,
+        UpdateRestParams { url: req.url },
+        "rest",
+    )
+    .await?;
+
+    Ok(Json(vta_sdk::protocol::services::ServiceMutationResponse {
+        log_entry_version_id: result.new_version_id,
+        effective_at: chrono::Utc::now().to_rfc3339(),
+        drain_until: None,
+    }))
+}
+
+/// `POST /services/rest/disable` — remove the `#vta-rest` entry.
+/// Auth: super-admin. Refused with `LastServiceRefused` when
+/// DIDComm is also disabled (spec §3.2 — no `--force` escape).
+pub async fn disable_rest_handler(
+    auth: SuperAdminAuth,
+    State(state): State<AppState>,
+    Json(_req): Json<vta_sdk::protocol::services::DisableRestRequest>,
+) -> Result<Json<vta_sdk::protocol::services::ServiceMutationResponse>, RestServiceHttpError> {
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or(RestServiceHttpError::DidResolverUnavailable)?
+        .clone();
+
+    let result = disable_rest(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        &did_resolver,
+        &state.didcomm_bridge,
+        &state.telemetry,
+        &auth.0,
+        DisableRestParams,
+        "rest",
+    )
+    .await?;
+
+    Ok(Json(vta_sdk::protocol::services::ServiceMutationResponse {
+        log_entry_version_id: result.new_version_id,
+        effective_at: chrono::Utc::now().to_rfc3339(),
+        drain_until: None,
+    }))
+}
+
+/// Unified HTTP error type for the three REST service-management
+/// routes. Each operation has its own typed error enum, but the
+/// HTTP-level concerns (status code + error body shape) overlap
+/// enough that one `IntoResponse` covers them all.
+#[derive(Debug)]
+pub enum RestServiceHttpError {
+    Enable(EnableRestError),
+    Update(UpdateRestError),
+    Disable(DisableRestError),
+    DidResolverUnavailable,
+}
+
+impl From<EnableRestError> for RestServiceHttpError {
+    fn from(value: EnableRestError) -> Self {
+        Self::Enable(value)
+    }
+}
+impl From<UpdateRestError> for RestServiceHttpError {
+    fn from(value: UpdateRestError) -> Self {
+        Self::Update(value)
+    }
+}
+impl From<DisableRestError> for RestServiceHttpError {
+    fn from(value: DisableRestError) -> Self {
+        Self::Disable(value)
+    }
+}
+
+impl IntoResponse for RestServiceHttpError {
+    fn into_response(self) -> Response {
+        let (status, body) = match self {
+            // ── Enable ────────────────────────────────────────────
+            Self::Enable(EnableRestError::ServiceAlreadyEnabled) => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "service_already_enabled",
+                    message: "REST is already enabled.".into(),
+                    suggested_fix: Some(
+                        "Use `pnm services rest update --url <url>` to change the URL.".into(),
+                    ),
+                    stage: None,
+                },
+            ),
+            Self::Enable(EnableRestError::Validation(msg)) => (
+                StatusCode::BAD_REQUEST,
+                ErrorBody {
+                    error: "invalid_url",
+                    message: msg,
+                    suggested_fix: Some(
+                        "URL must be https://, parsable, with no fragment or userinfo.".into(),
+                    ),
+                    stage: None,
+                },
+            ),
+
+            // ── Update ────────────────────────────────────────────
+            Self::Update(UpdateRestError::ServiceNotPresent) => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "service_not_present",
+                    message: "REST is not currently enabled.".into(),
+                    suggested_fix: Some(
+                        "Run `pnm services rest enable --url <url>` first.".into(),
+                    ),
+                    stage: None,
+                },
+            ),
+            Self::Update(UpdateRestError::Validation(msg)) => (
+                StatusCode::BAD_REQUEST,
+                ErrorBody {
+                    error: "invalid_url",
+                    message: msg,
+                    suggested_fix: Some(
+                        "URL must be https://, parsable, with no fragment or userinfo.".into(),
+                    ),
+                    stage: None,
+                },
+            ),
+
+            // ── Disable ───────────────────────────────────────────
+            Self::Disable(DisableRestError::ServiceNotPresent) => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "service_not_present",
+                    message: "REST is not currently enabled — nothing to disable.".into(),
+                    suggested_fix: None,
+                    stage: None,
+                },
+            ),
+            Self::Disable(DisableRestError::LastServiceRefused) => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "last_service_refused",
+                    message: "Refusing to disable REST — DIDComm is also off, so the VTA would have no advertised services.".into(),
+                    suggested_fix: Some(
+                        "Run `pnm services didcomm enable --mediator <did>` first, then retry."
+                            .into(),
+                    ),
+                    stage: None,
+                },
+            ),
+
+            // ── Shared per-op errors (auth / VTA-DID / publish /
+            //    storage) — each variant routes to the same status
+            //    + a per-op error tag. Match arms grouped by the
+            //    underlying concept.
+            Self::Enable(EnableRestError::Auth(msg))
+            | Self::Update(UpdateRestError::Auth(msg))
+            | Self::Disable(DisableRestError::Auth(msg)) => (
+                StatusCode::FORBIDDEN,
+                ErrorBody {
+                    error: "auth",
+                    message: msg,
+                    suggested_fix: Some(
+                        "Super-admin role required for service-management operations.".into(),
+                    ),
+                    stage: None,
+                },
+            ),
+            Self::Enable(EnableRestError::VtaDidNotConfigured)
+            | Self::Update(UpdateRestError::VtaDidNotConfigured)
+            | Self::Disable(DisableRestError::VtaDidNotConfigured) => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "vta_did_not_configured",
+                    message: "VTA DID is not configured.".into(),
+                    suggested_fix: Some("Run `vta setup` to configure the VTA's DID first.".into()),
+                    stage: None,
+                },
+            ),
+            Self::Enable(EnableRestError::WebVHUpdate(e))
+            | Self::Update(UpdateRestError::WebVHUpdate(e))
+            | Self::Disable(DisableRestError::WebVHUpdate(e)) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorBody {
+                    error: "webvh_update_failed",
+                    message: e.to_string(),
+                    suggested_fix: None,
+                    stage: None,
+                },
+            ),
+            Self::Enable(EnableRestError::DocumentPatch(e))
+            | Self::Update(UpdateRestError::DocumentPatch(e))
+            | Self::Disable(DisableRestError::DocumentPatch(e)) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorBody {
+                    error: "document_patch_failed",
+                    message: e.to_string(),
+                    suggested_fix: None,
+                    stage: None,
+                },
+            ),
+
+            // ── Storage / persistence / log-corruption catch-alls.
+            //    Same shape across ops; collapse to a single arm.
+            Self::Enable(
+                EnableRestError::VtaDidRecordMissing(_)
+                | EnableRestError::VtaDidLogMissing(_)
+                | EnableRestError::EmptyLog
+                | EnableRestError::ConfigPersistence(_)
+                | EnableRestError::Storage(_),
+            )
+            | Self::Update(
+                UpdateRestError::VtaDidRecordMissing(_)
+                | UpdateRestError::VtaDidLogMissing(_)
+                | UpdateRestError::EmptyLog
+                | UpdateRestError::Storage(_),
+            )
+            | Self::Disable(
+                DisableRestError::VtaDidRecordMissing(_)
+                | DisableRestError::VtaDidLogMissing(_)
+                | DisableRestError::EmptyLog
+                | DisableRestError::ConfigPersistence(_)
+                | DisableRestError::Storage(_),
+            ) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorBody {
+                    error: "storage_error",
+                    message: "Internal storage / log-replay failure.".into(),
+                    suggested_fix: Some(
+                        "Re-run `vta setup` if local state appears corrupted.".into(),
+                    ),
+                    stage: None,
+                },
+            ),
+
+            Self::DidResolverUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ErrorBody {
+                    error: "did_resolver_unavailable",
+                    message: "DID resolver not available on this VTA.".into(),
+                    suggested_fix: Some(
+                        "Confirm the resolver is configured and running, then retry.".into(),
+                    ),
+                    stage: None,
+                },
+            ),
+        };
+        (status, Json(body)).into_response()
+    }
 }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -90,6 +90,10 @@ pub struct AppState {
     /// Keyed by mediator DID; replayed at boot.
     #[cfg(feature = "webvh")]
     pub drains_ks: KeyspaceHandle,
+    /// Per-kind previous-config snapshot store for fail-forward
+    /// rollback (spec §3.5a). Populated alongside `drains_ks`.
+    #[cfg(feature = "webvh")]
+    pub snapshot_ks: KeyspaceHandle,
     /// In-process registry of active + draining mediator listeners.
     /// Owns the per-listener bounded outbound buffer and the
     /// active/drain state machine.
@@ -178,6 +182,9 @@ pub async fn build_app_state(
     let webvh_ks = apply_encryption(store.keyspace("webvh")?);
     #[cfg(feature = "webvh")]
     let drains_ks = apply_encryption(store.keyspace("drains")?);
+    #[cfg(feature = "webvh")]
+    let snapshot_ks =
+        apply_encryption(store.keyspace(crate::operations::protocol::snapshot::KEYSPACE_NAME)?);
 
     let auth = init_auth(&config, &*seed_store, &keys_ks).await;
 
@@ -219,6 +226,8 @@ pub async fn build_app_state(
         webvh_ks,
         #[cfg(feature = "webvh")]
         drains_ks,
+        #[cfg(feature = "webvh")]
+        snapshot_ks,
         #[cfg(feature = "webvh")]
         mediator_registry,
         #[cfg(feature = "webvh")]
@@ -305,6 +314,9 @@ pub async fn run(
         let webvh_ks = apply_encryption(store.keyspace("webvh")?);
         #[cfg(feature = "webvh")]
         let drains_ks = apply_encryption(store.keyspace("drains")?);
+        #[cfg(feature = "webvh")]
+        let snapshot_ks =
+            apply_encryption(store.keyspace(crate::operations::protocol::snapshot::KEYSPACE_NAME)?);
 
         // Initialize auth infrastructure
         let auth = init_auth(&config, &*seed_store, &keys_ks).await;
@@ -455,6 +467,8 @@ pub async fn run(
                 webvh_ks,
                 #[cfg(feature = "webvh")]
                 drains_ks,
+                #[cfg(feature = "webvh")]
+                snapshot_ks,
                 #[cfg(feature = "webvh")]
                 mediator_registry: Arc::clone(&mediator_registry),
                 #[cfg(feature = "webvh")]

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -430,6 +430,8 @@ pub async fn run(
                 #[cfg(feature = "webvh")]
                 drains_ks: drains_ks.clone(),
                 #[cfg(feature = "webvh")]
+                snapshot_ks: snapshot_ks.clone(),
+                #[cfg(feature = "webvh")]
                 mediator_registry: Arc::clone(&mediator_registry),
                 #[cfg(feature = "webvh")]
                 drain_sweeper: Arc::clone(&drain_sweeper),

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -95,6 +95,10 @@ impl TestApp {
         let did_templates_ks = store.keyspace("did_templates").unwrap();
         #[cfg(feature = "webvh")]
         let drains_ks = store.keyspace("drains").unwrap();
+        #[cfg(feature = "webvh")]
+        let snapshot_ks = store
+            .keyspace(vta_service::operations::protocol::snapshot::KEYSPACE_NAME)
+            .unwrap();
         let telemetry: vti_common::telemetry::SharedTelemetrySink =
             Arc::new(vti_common::telemetry::RingBufferTelemetry::new());
         #[cfg(feature = "webvh")]
@@ -124,6 +128,8 @@ impl TestApp {
             webvh_ks,
             #[cfg(feature = "webvh")]
             drains_ks,
+            #[cfg(feature = "webvh")]
+            snapshot_ks,
             #[cfg(feature = "webvh")]
             mediator_registry,
             #[cfg(feature = "webvh")]

--- a/vti-common/src/telemetry/mod.rs
+++ b/vti-common/src/telemetry/mod.rs
@@ -90,6 +90,9 @@ pub enum TelemetryKind {
     MediatorDrainExpire,
     ServicesDidcommEnable,
     ServicesDidcommDisable,
+    ServicesRestEnable,
+    ServicesRestUpdate,
+    ServicesRestDisable,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## Summary

Phase 1 of the runtime service-endpoint management feature, building on the foundations merged in PR #40. Lands the symmetric REST service-management surface end-to-end:

- **Wire types** — `EnableRestRequest`, `UpdateRestRequest`, `DisableRestRequest`, `RollbackRestRequest`, `ServiceMutationResponse` in `vta_sdk::protocol::services` (T1.1)
- **URL validator** — `validate_service_url` enforcing https-only, no fragment, no userinfo (T1.2)
- **DID-doc patchers** — symmetric `current_rest_service` / `with_rest_service` / `without_rest_service` in `protocol::document` (T1.3.1)
- **Three operations** — `enable_rest`, `update_rest`, `disable_rest` with snapshot persistence and brick-prevention wired in (T1.3.2 / T1.3.3 / T1.3.4)
- **REST route handlers** — `POST /services/rest/{enable,update,disable}` with unified `RestServiceHttpError` mapping each typed error to the right status code + suggested-fix body (T1.4)
- **DIDComm transport handlers** — same three operations reachable as DIDComm message types under `https://firstperson.network/protocols/services-management/1.0/rest-{enable,update,disable}` (T1.5)

## Why all three are reachable over both transports

Unlike `enable_didcomm` (REST-only by nature — DIDComm isn't running yet at first-enable time), all three REST operations work over either transport because REST is always running per spec §3.2 (at-least-one-service invariant). The DIDComm handlers go through the same operation layer as the REST handlers; auth + ACL gates are identical.

## Wire-shape preservation

The REST entry shape rendered by `with_rest_service` matches what `setup::build_vta_additional_services` has produced since initial setup — `{ id: "{DID}#vta-rest", type: "VTARest", serviceEndpoint: "<url>" }` with a plain-string `serviceEndpoint`. The SDK's `Resolved::find_service("vta-rest")` at `vta-sdk/src/session.rs:1100` depends on this; the patcher pins the wire form via a dedicated test (`with_rest_emits_canonical_wire_shape`) so a future refactor can't silently break SDK resolution.

## Snapshot persistence per spec §3.5a

Every mutation persists its pre-state to the snapshot store (T0.3) **before** the runtime mutation:
- `enable_rest` → `RestSnapshot::Disabled` (rollback re-disables)
- `update_rest` → `RestSnapshot::Enabled { url: prior_url }` (rollback restores prior URL)
- `disable_rest` → `RestSnapshot::Enabled { url: prior_url }` (rollback re-enables at same URL)

T3.x consumes these snapshots when implementing fail-forward `services rest rollback`.

## Brick-prevention is wired

`disable_rest` consults `would_violate_last_service` (T0.4) — refused with `LastServiceRefused` when DIDComm is also disabled. No `--force` escape hatch per spec §3.2. The route handler maps to HTTP 409 with a suggested-fix string ("Run `pnm services didcomm enable --mediator <did>` first").

`enable_rest` and `update_rest` deliberately don't consult brick-prevention — they can only add or modify a service, never remove one, so the §3.2 invariant is preserved by construction.

## Test plan

- [x] `cargo build --workspace --all-features` clean
- [x] All P1 unit tests green:
  - 6 in `vta_sdk::protocol::services::tests::*` (wire-type round-trips + empty-body shapes + URL field literal pinning)
  - 9 in `validate_service_url` tests (each rejection branch)
  - 13 in `operations::protocol::document::tests::*` (REST patcher symmetry, wire-shape pin, compose-with-DIDComm, verificationMethod byte-identical)
  - 4 in `enable_rest::tests::*`
  - 4 in `update_rest::tests::*`
  - 6 in `disable_rest::tests::*` (incl. brick-prevention truth-table coverage)
- [x] All 284 vta-service lib tests still pass
- [x] All 279 vta-sdk lib tests still pass
- [x] DIDComm message-type constants compile + reach the router (`messaging::router` registers all 7 protocol-management routes including the 3 new REST ones)
- [ ] Reviewer confirms wire-shape preservation strategy (lift from `setup::build_vta_additional_services`, don't reshape) is acceptable
- [ ] Reviewer confirms unified `RestServiceHttpError` is preferable to per-op HTTP error enums (consistent surface vs. mirroring DIDComm-side pattern)

## Out of scope (follow-up PRs)

- P2 — DIDComm refactor onto P0 foundations (`enable_didcomm` / `disable_didcomm` / `migrate_mediator` adopt snapshot store + invariant helper; `migrate_mediator` → `update_didcomm` rename)
- P3 — fail-forward `rollback_rest` / `rollback_didcomm` consuming the snapshot store
- P4 — `services list` query
- P5 — unified `pnm services …` CLI surface, retiring `pnm mediator …` (breaking change)
- P6 — full §7a end-to-end test matrix (~64 e2e tests against the test mediator)
- P7 — operator docs + memory updates