### PR TITLE
feat(runtime-services): P3 — fail-forward rollback for REST and DIDComm

### DIFF
--- a/vta-sdk/src/protocols/protocol_management.rs
+++ b/vta-sdk/src/protocols/protocol_management.rs
@@ -53,6 +53,23 @@ pub const DISABLE_REST: &str =
 pub const DISABLE_REST_RESULT: &str =
     "https://firstperson.network/protocols/services-management/1.0/rest-disable-result";
 
+// Fail-forward rollback ops (T3.x). Read the per-kind snapshot
+// and dispatch into the equivalent forward operation. Reachable
+// over both transports — REST is always running per spec §3.2,
+// and the dispatched forward ops handle the chicken-and-egg
+// concerns themselves (e.g. enable_didcomm is REST-only by
+// nature; rollback into it falls back to that constraint).
+
+pub const ROLLBACK_REST: &str =
+    "https://firstperson.network/protocols/services-management/1.0/rest-rollback";
+pub const ROLLBACK_REST_RESULT: &str =
+    "https://firstperson.network/protocols/services-management/1.0/rest-rollback-result";
+
+pub const ROLLBACK_DIDCOMM: &str =
+    "https://firstperson.network/protocols/services-management/1.0/didcomm-rollback";
+pub const ROLLBACK_DIDCOMM_RESULT: &str =
+    "https://firstperson.network/protocols/services-management/1.0/didcomm-rollback-result";
+
 // ── services-management (DIDComm side, continued) ───────────────────
 
 // T2.3 rename — was MIGRATE_MEDIATOR / mediator-management/1.0/migrate.

--- a/vta-service/src/messaging/handlers_protocol.rs
+++ b/vta-service/src/messaging/handlers_protocol.rs
@@ -37,6 +37,8 @@ use crate::operations::protocol::disable_rest::{DisableRestParams, disable_rest}
 use crate::operations::protocol::drain_cancel::{DrainCancelParams, drain_cancel};
 use crate::operations::protocol::enable_rest::{EnableRestParams, enable_rest};
 use crate::operations::protocol::report::{ReportParams, mediator_report};
+use crate::operations::protocol::rollback_didcomm::{RollbackDidcommParams, rollback_didcomm};
+use crate::operations::protocol::rollback_rest::{RollbackRestParams, rollback_rest};
 use crate::operations::protocol::update_didcomm::{
     MigrateAuditKind, UpdateDidcommParams, update_didcomm,
 };
@@ -504,6 +506,146 @@ pub async fn handle_disable_rest(
             "refusing operation: would leave the VTA with no advertised services",
         ))),
         Err(DisableRestError::Auth(e)) => Ok(Some(problem_report_unauthorized(e))),
+        Err(other) => Ok(Some(problem_report_internal(other.to_string()))),
+    }
+}
+
+// ── Fail-forward rollback over DIDComm (T3.4) ──────────────────────
+
+pub async fn handle_rollback_rest(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = match auth_from_message(&message, &state.acl_ks).await {
+        Ok(a) => a,
+        Err(e) => return Ok(Some(problem_report_unauthorized(e.to_string()))),
+    };
+
+    let result = rollback_rest(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        state
+            .did_resolver
+            .as_ref()
+            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
+        &state.didcomm_bridge,
+        &state.telemetry,
+        &auth,
+        RollbackRestParams,
+        "didcomm",
+    )
+    .await;
+
+    use crate::operations::protocol::rollback_rest::RollbackRestError;
+    match result {
+        Ok(r) => response(
+            protocol_management::ROLLBACK_REST_RESULT,
+            &serde_json::json!({
+                "log_entry_version_id": r.new_version_id.unwrap_or_default(),
+                "effective_at": Utc::now().to_rfc3339(),
+                "kind": match r.kind {
+                    crate::operations::protocol::rollback_rest::RollbackKind::Disabled => "disabled",
+                    crate::operations::protocol::rollback_rest::RollbackKind::Enabled => "enabled",
+                    crate::operations::protocol::rollback_rest::RollbackKind::Updated => "updated",
+                    crate::operations::protocol::rollback_rest::RollbackKind::NoOp => "no_op",
+                },
+            }),
+        ),
+        Err(RollbackRestError::NoPriorMutation) => Ok(Some(problem_report_conflict(
+            "no prior REST mutation to roll back from",
+        ))),
+        Err(RollbackRestError::DisableForward(
+            crate::operations::protocol::disable_rest::DisableRestError::LastServiceRefused,
+        )) => Ok(Some(problem_report_conflict(
+            "rolling back this REST mutation would leave the VTA with no advertised services",
+        ))),
+        Err(RollbackRestError::Auth(e)) => Ok(Some(problem_report_unauthorized(e))),
+        Err(other) => Ok(Some(problem_report_internal(other.to_string()))),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RollbackDidcommBody {
+    #[serde(default)]
+    drain_ttl_secs: Option<u64>,
+}
+
+pub async fn handle_rollback_didcomm(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = match auth_from_message(&message, &state.acl_ks).await {
+        Ok(a) => a,
+        Err(e) => return Ok(Some(problem_report_unauthorized(e.to_string()))),
+    };
+
+    let body: RollbackDidcommBody = serde_json::from_value(message.body).map_err(handler_err)?;
+    let drain_ttl = std::time::Duration::from_secs(body.drain_ttl_secs.unwrap_or(86_400));
+
+    let prover = AlwaysOkProver;
+
+    let result = rollback_didcomm(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.drains_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        state
+            .did_resolver
+            .as_ref()
+            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
+        &state.didcomm_bridge,
+        &state.mediator_registry,
+        &state.drain_sweeper,
+        &state.telemetry,
+        &prover,
+        &auth,
+        RollbackDidcommParams {
+            drain_ttl,
+            // The rollback request arrived over DIDComm transport,
+            // so the MIN_DRAIN_TTL_OVER_DIDCOMM floor applies if
+            // the dispatch ends up in disable_didcomm.
+            transport: DisableTransport::Didcomm,
+        },
+        "didcomm",
+    )
+    .await;
+
+    use crate::operations::protocol::rollback_didcomm::RollbackDidcommError;
+    match result {
+        Ok(r) => response(
+            protocol_management::ROLLBACK_DIDCOMM_RESULT,
+            &serde_json::json!({
+                "log_entry_version_id": r.new_version_id.unwrap_or_default(),
+                "effective_at": Utc::now().to_rfc3339(),
+                "kind": match r.kind {
+                    crate::operations::protocol::rollback_didcomm::RollbackKind::Disabled => "disabled",
+                    crate::operations::protocol::rollback_didcomm::RollbackKind::Enabled => "enabled",
+                    crate::operations::protocol::rollback_didcomm::RollbackKind::Updated => "updated",
+                    crate::operations::protocol::rollback_didcomm::RollbackKind::NoOp => "no_op",
+                },
+                "draining_mediator": r.draining_mediator,
+            }),
+        ),
+        Err(RollbackDidcommError::NoPriorMutation) => Ok(Some(problem_report_conflict(
+            "no prior DIDComm mutation to roll back from",
+        ))),
+        Err(RollbackDidcommError::DisableForward(
+            crate::operations::protocol::disable_didcomm::DisableDidcommError::NoProtocolRemaining,
+        )) => Ok(Some(problem_report_conflict(
+            "rolling back this DIDComm mutation would leave the VTA with no advertised services",
+        ))),
+        Err(RollbackDidcommError::Auth(e)) => Ok(Some(problem_report_unauthorized(e))),
         Err(other) => Ok(Some(problem_report_internal(other.to_string()))),
     }
 }

--- a/vta-service/src/messaging/handlers_protocol.rs
+++ b/vta-service/src/messaging/handlers_protocol.rs
@@ -29,6 +29,7 @@ use vta_sdk::protocols::protocol_management;
 use super::router::VtaState;
 use crate::messaging::auth::auth_from_message;
 use crate::messaging::handshake::AlwaysOkProver;
+use crate::operations::protocol::OpContext;
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommParams, DisableTransport, disable_didcomm,
 };
@@ -112,6 +113,7 @@ pub async fn handle_disable_didcomm(
             // 1h-min-TTL guard fires (spec criterion #12).
             transport: DisableTransport::Didcomm,
         },
+        OpContext::Direct,
         "didcomm",
     )
     .await;
@@ -207,6 +209,7 @@ pub async fn handle_update_didcomm(
             handshake_timeout: timeout,
             audit_kind,
         },
+        OpContext::Direct,
         "didcomm",
     )
     .await;
@@ -376,6 +379,7 @@ pub async fn handle_enable_rest(
         &state.telemetry,
         &auth,
         EnableRestParams { url },
+        OpContext::Direct,
         "didcomm",
     )
     .await;
@@ -427,6 +431,7 @@ pub async fn handle_update_rest(
         &state.telemetry,
         &auth,
         UpdateRestParams { url },
+        OpContext::Direct,
         "didcomm",
     )
     .await;
@@ -477,6 +482,7 @@ pub async fn handle_disable_rest(
         &state.telemetry,
         &auth,
         DisableRestParams,
+        OpContext::Direct,
         "didcomm",
     )
     .await;

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -369,8 +369,16 @@ pub fn build_handler(
                 handler_fn(super::handlers_protocol::handle_disable_rest),
             )?
             .route(
+                protocol_management::ROLLBACK_REST,
+                handler_fn(super::handlers_protocol::handle_rollback_rest),
+            )?
+            .route(
                 protocol_management::UPDATE_DIDCOMM,
                 handler_fn(super::handlers_protocol::handle_update_didcomm),
+            )?
+            .route(
+                protocol_management::ROLLBACK_DIDCOMM,
+                handler_fn(super::handlers_protocol::handle_rollback_didcomm),
             )?
             .route(
                 protocol_management::DRAIN_CANCEL,

--- a/vta-service/src/operations/protocol/disable_didcomm.rs
+++ b/vta-service/src/operations/protocol/disable_didcomm.rs
@@ -43,8 +43,8 @@ use crate::error::AppError;
 use crate::messaging::drain_sweeper::DrainSweeper;
 use crate::messaging::registry::{MediatorListenerRegistry, RegistryError};
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::PROTOCOL_LOCK;
 use crate::operations::protocol::document::{DocumentPatchError, without_didcomm_service};
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
@@ -146,6 +146,7 @@ pub async fn disable_didcomm(
     telemetry: &SharedTelemetrySink,
     auth: &AuthClaims,
     params: DisableDidcommParams,
+    ctx: OpContext,
     channel: &str,
 ) -> Result<DisableDidcommResult, DisableDidcommError> {
     auth.require_super_admin()
@@ -235,27 +236,27 @@ pub async fn disable_didcomm(
         Some(deadline)
     };
 
-    let _ = telemetry
-        .record(
-            TelemetryEvent::new(TelemetryKind::ServicesDidcommDisable)
-                .with_mediator(&prior_mediator)
-                .with_field(
-                    "drain_ttl_secs",
-                    JsonValue::from(params.drain_ttl.as_secs()),
-                )
-                .with_field(
-                    "new_version_id",
-                    JsonValue::from(update_result.new_version_id.clone()),
-                )
-                .with_field(
-                    "transport",
-                    JsonValue::from(match params.transport {
-                        DisableTransport::Rest => "rest",
-                        DisableTransport::Didcomm => "didcomm",
-                    }),
-                ),
+    let mut event = TelemetryEvent::new(TelemetryKind::ServicesDidcommDisable)
+        .with_mediator(&prior_mediator)
+        .with_field(
+            "drain_ttl_secs",
+            JsonValue::from(params.drain_ttl.as_secs()),
         )
-        .await;
+        .with_field(
+            "new_version_id",
+            JsonValue::from(update_result.new_version_id.clone()),
+        )
+        .with_field(
+            "transport",
+            JsonValue::from(match params.transport {
+                DisableTransport::Rest => "rest",
+                DisableTransport::Didcomm => "didcomm",
+            }),
+        );
+    if let Some(tag) = ctx.telemetry_triggered_by() {
+        event = event.with_field("triggered_by", JsonValue::from(tag));
+    }
+    let _ = telemetry.record(event).await;
 
     info!(
         channel,
@@ -494,6 +495,7 @@ mod tests {
             &sink,
             &super_admin(),
             rest_params(Duration::from_secs(3600)),
+            OpContext::Direct,
             "test",
         )
         .await
@@ -537,6 +539,7 @@ mod tests {
             &sink,
             &super_admin(),
             rest_params(Duration::from_secs(3600)),
+            OpContext::Direct,
             "test",
         )
         .await
@@ -577,6 +580,7 @@ mod tests {
             &sink,
             &super_admin(),
             didcomm_params(Duration::from_secs(1800)),
+            OpContext::Direct,
             "test",
         )
         .await
@@ -621,6 +625,7 @@ mod tests {
             &sink,
             &super_admin(),
             rest_params(Duration::from_secs(0)),
+            OpContext::Direct,
             "test",
         )
         .await
@@ -661,6 +666,7 @@ mod tests {
             &sink,
             &super_admin(),
             didcomm_params(Duration::from_secs(3600)),
+            OpContext::Direct,
             "test",
         )
         .await

--- a/vta-service/src/operations/protocol/disable_rest.rs
+++ b/vta-service/src/operations/protocol/disable_rest.rs
@@ -46,7 +46,6 @@ use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::PROTOCOL_LOCK;
 use crate::operations::protocol::document::{
     DocumentPatchError, current_rest_service, without_rest_service,
 };
@@ -56,6 +55,7 @@ use crate::operations::protocol::invariant::{
 use crate::operations::protocol::snapshot::{
     self, RestSnapshot, ServiceConfigSnapshot, ServiceKind,
 };
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
@@ -134,6 +134,7 @@ pub async fn disable_rest(
     telemetry: &SharedTelemetrySink,
     auth: &AuthClaims,
     _params: DisableRestParams,
+    ctx: OpContext,
     channel: &str,
 ) -> Result<DisableRestResult, DisableRestError> {
     auth.require_super_admin()
@@ -196,17 +197,17 @@ pub async fn disable_rest(
 
     // 7. Telemetry. Prior URL is included so an external verifier
     //    knows what URL just stopped being advertised.
-    let _ = telemetry
-        .record(
-            TelemetryEvent::new(TelemetryKind::ServicesRestDisable)
-                .with_field("channel", JsonValue::from(channel))
-                .with_field(
-                    "new_version_id",
-                    JsonValue::from(update_result.new_version_id.clone()),
-                )
-                .with_field("prior_url", JsonValue::from(prior_url.clone())),
+    let mut event = TelemetryEvent::new(TelemetryKind::ServicesRestDisable)
+        .with_field("channel", JsonValue::from(channel))
+        .with_field(
+            "new_version_id",
+            JsonValue::from(update_result.new_version_id.clone()),
         )
-        .await;
+        .with_field("prior_url", JsonValue::from(prior_url.clone()));
+    if let Some(tag) = ctx.telemetry_triggered_by() {
+        event = event.with_field("triggered_by", JsonValue::from(tag));
+    }
+    let _ = telemetry.record(event).await;
 
     info!(
         channel,

--- a/vta-service/src/operations/protocol/enable_didcomm.rs
+++ b/vta-service/src/operations/protocol/enable_didcomm.rs
@@ -46,8 +46,8 @@ use crate::messaging::handshake::{
 };
 use crate::messaging::registry::{MediatorBinding, MediatorListenerRegistry, RegistryError};
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::PROTOCOL_LOCK;
 use crate::operations::protocol::document::{DocumentPatchError, with_didcomm_service};
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
@@ -119,6 +119,7 @@ pub async fn enable_didcomm(
     prover: &(dyn ListenerProver + Send + Sync),
     auth: &AuthClaims,
     params: EnableDidcommParams,
+    ctx: OpContext,
     channel: &str,
 ) -> Result<EnableDidcommResult, EnableDidcommError> {
     auth.require_super_admin()
@@ -201,16 +202,16 @@ pub async fn enable_didcomm(
 
     // ServicesDidcommEnable: distinct from MigrateStart so reports
     // can distinguish "first-time enable" from "mediator migration".
-    let _ = telemetry
-        .record(
-            TelemetryEvent::new(TelemetryKind::ServicesDidcommEnable)
-                .with_mediator(&resolved.mediator_did)
-                .with_field(
-                    "new_version_id",
-                    JsonValue::from(update_result.new_version_id.clone()),
-                ),
-        )
-        .await;
+    let mut event = TelemetryEvent::new(TelemetryKind::ServicesDidcommEnable)
+        .with_mediator(&resolved.mediator_did)
+        .with_field(
+            "new_version_id",
+            JsonValue::from(update_result.new_version_id.clone()),
+        );
+    if let Some(tag) = ctx.telemetry_triggered_by() {
+        event = event.with_field("triggered_by", JsonValue::from(tag));
+    }
+    let _ = telemetry.record(event).await;
 
     info!(
         channel,
@@ -396,6 +397,7 @@ mod tests {
                 force: false,
                 handshake_timeout: Duration::from_secs(1),
             },
+            OpContext::Direct,
             "test",
         )
         .await;
@@ -444,6 +446,7 @@ mod tests {
                 force: false,
                 handshake_timeout: Duration::from_secs(1),
             },
+            OpContext::Direct,
             "test",
         )
         .await;
@@ -492,6 +495,7 @@ mod tests {
                 force: false,
                 handshake_timeout: Duration::from_secs(1),
             },
+            OpContext::Direct,
             "test",
         )
         .await;
@@ -550,6 +554,7 @@ mod tests {
                 force: false,
                 handshake_timeout: Duration::from_secs(1),
             },
+            OpContext::Direct,
             "test",
         )
         .await;

--- a/vta-service/src/operations/protocol/enable_rest.rs
+++ b/vta-service/src/operations/protocol/enable_rest.rs
@@ -40,11 +40,11 @@ use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::PROTOCOL_LOCK;
 use crate::operations::protocol::document::{
     DocumentPatchError, current_rest_service, with_rest_service,
 };
 use crate::operations::protocol::snapshot::{self, RestSnapshot, ServiceConfigSnapshot};
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
@@ -110,6 +110,7 @@ pub async fn enable_rest(
     telemetry: &SharedTelemetrySink,
     auth: &AuthClaims,
     params: EnableRestParams,
+    ctx: OpContext,
     channel: &str,
 ) -> Result<EnableRestResult, EnableRestError> {
     auth.require_super_admin()
@@ -170,17 +171,17 @@ pub async fn enable_rest(
 
     // 7. Telemetry. Channel and version-id let an external verifier
     //    join this event to chain history.
-    let _ = telemetry
-        .record(
-            TelemetryEvent::new(TelemetryKind::ServicesRestEnable)
-                .with_field("channel", JsonValue::from(channel))
-                .with_field(
-                    "new_version_id",
-                    JsonValue::from(update_result.new_version_id.clone()),
-                )
-                .with_field("url", JsonValue::from(canonical_url.clone())),
+    let mut event = TelemetryEvent::new(TelemetryKind::ServicesRestEnable)
+        .with_field("channel", JsonValue::from(channel))
+        .with_field(
+            "new_version_id",
+            JsonValue::from(update_result.new_version_id.clone()),
         )
-        .await;
+        .with_field("url", JsonValue::from(canonical_url.clone()));
+    if let Some(tag) = ctx.telemetry_triggered_by() {
+        event = event.with_field("triggered_by", JsonValue::from(tag));
+    }
+    let _ = telemetry.record(event).await;
 
     info!(
         channel,

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -15,6 +15,7 @@ pub mod enable_didcomm;
 pub mod enable_rest;
 pub mod invariant;
 pub mod report;
+pub mod rollback_rest;
 pub mod snapshot;
 pub mod update_didcomm;
 pub mod update_rest;

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -15,6 +15,7 @@ pub mod enable_didcomm;
 pub mod enable_rest;
 pub mod invariant;
 pub mod report;
+pub mod rollback_didcomm;
 pub mod rollback_rest;
 pub mod snapshot;
 pub mod update_didcomm;

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -29,6 +29,37 @@ pub mod update_rest;
 /// unconditionally.
 pub static PROTOCOL_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+/// Whether a forward operation was invoked directly by the
+/// operator or as the fail-forward dispatch from a rollback.
+///
+/// Threaded through every forward op (enable / update / disable
+/// for both REST and DIDComm) so the emitted telemetry event can
+/// carry a `triggered_by: "rollback"` field per spec §3.5a. The
+/// rollback layer (T3.1 / T3.2) reads the per-kind snapshot,
+/// computes the equivalent forward operation, and dispatches into
+/// it with [`OpContext::Rollback`]; the forward op runs unchanged
+/// modulo this telemetry tag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpContext {
+    Direct,
+    Rollback,
+}
+
+impl OpContext {
+    /// JSON value to surface in the `triggered_by` telemetry field
+    /// for this context. Returns `None` for [`OpContext::Direct`]
+    /// — direct operations don't carry the field at all (omitted
+    /// rather than serialized as `"direct"`, since the absence is
+    /// the conventional signal).
+    #[must_use]
+    pub fn telemetry_triggered_by(self) -> Option<&'static str> {
+        match self {
+            OpContext::Direct => None,
+            OpContext::Rollback => Some("rollback"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::PROTOCOL_LOCK;

--- a/vta-service/src/operations/protocol/rollback_didcomm.rs
+++ b/vta-service/src/operations/protocol/rollback_didcomm.rs
@@ -1,0 +1,474 @@
+//! `rollback_didcomm` operation — fail-forward dispatch.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.5a.
+//!
+//! Reads the per-kind snapshot store for `didcomm` and dispatches
+//! into the equivalent forward operation that returns the VTA's
+//! DIDComm service entry to the pre-mutation state. WebVH is
+//! append-only; rollback never rewinds the chain — it appends a
+//! new LogEntry plus, where the prior state involved an active
+//! mediator, drains the just-departed mediator with the supplied
+//! TTL.
+//!
+//! Dispatch table:
+//!
+//! | snapshot              | current state         | dispatched op            |
+//! |-----------------------|-----------------------|--------------------------|
+//! | `Disabled`            | enabled (mediator Y)  | `disable_didcomm`        |
+//! | `Enabled { X }`       | disabled              | `enable_didcomm` with X  |
+//! | `Enabled { X }`       | enabled (Y), X != Y   | `update_didcomm` X→Y     |
+//! | `Disabled`            | disabled              | no-op (snapshot≡current) |
+//! | `Enabled { X }`       | enabled (X)           | no-op (snapshot≡current) |
+//!
+//! The `update_didcomm` arm is the most common case in practice:
+//! rolling back a `services didcomm update A→B` re-promotes A
+//! and drains B. Spec §3.5a explicitly notes that drain is
+//! re-fed via the same forward path, so the new drain entry uses
+//! the operator-supplied `drain_ttl` (default 24h).
+//!
+//! Brick-prevention is enforced by the dispatched forward op
+//! (the `disable_didcomm` arm goes through
+//! `would_violate_last_service`). Rolling back a `services
+//! didcomm enable` when REST is also off surfaces
+//! `LastServiceRefused` verbatim per §7a.5.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use vti_common::seed_store::SeedStore;
+use vti_common::telemetry::SharedTelemetrySink;
+
+use crate::auth::AuthClaims;
+use crate::config::AppConfig;
+use crate::didcomm_bridge::DIDCommBridge;
+use crate::error::AppError;
+use crate::messaging::drain_sweeper::DrainSweeper;
+use crate::messaging::handshake::{HandshakeError, ListenerProver};
+use crate::messaging::registry::MediatorListenerRegistry;
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::OpContext;
+use crate::operations::protocol::disable_didcomm::{
+    DisableDidcommError, DisableDidcommParams, DisableTransport, disable_didcomm,
+};
+use crate::operations::protocol::document::{DocumentPatchError, current_didcomm_service};
+use crate::operations::protocol::enable_didcomm::{
+    EnableDidcommError, EnableDidcommParams, enable_didcomm,
+};
+use crate::operations::protocol::snapshot::{
+    self, DidcommSnapshot, ServiceConfigSnapshot, ServiceKind,
+};
+use crate::operations::protocol::update_didcomm::{
+    MigrateAuditKind, UpdateDidcommError, UpdateDidcommParams, update_didcomm,
+};
+use crate::store::KeyspaceHandle;
+use crate::webvh_store;
+
+/// Handshake timeout when re-promoting a prior mediator. Matches
+/// the default that the route layer applies for forward
+/// operations.
+const DEFAULT_ROLLBACK_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone)]
+pub struct RollbackDidcommParams {
+    /// Drain window applied to the mediator being demoted by this
+    /// rollback. Used by the `update_didcomm` arm (drains the
+    /// currently-active mediator while promoting the prior one)
+    /// and by the `disable_didcomm` arm (drains the
+    /// currently-active mediator on the way to "DIDComm off").
+    /// Spec §3.6 default: 24h.
+    pub drain_ttl: Duration,
+    /// Transport over which the rollback request was delivered.
+    /// Drives the same `MIN_DRAIN_TTL_OVER_DIDCOMM` floor that
+    /// applies to direct disable: a rollback that disables
+    /// DIDComm over the DIDComm transport with `drain_ttl < 1h`
+    /// is refused so the listener doesn't drop the response
+    /// mid-flight.
+    pub transport: DisableTransport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RollbackKind {
+    /// Snapshot was `Disabled`; rollback re-disabled DIDComm.
+    Disabled,
+    /// Snapshot was `Enabled { mediator: X }`; rollback re-enabled
+    /// DIDComm with X (forward operation: enable_didcomm).
+    Enabled,
+    /// Snapshot was `Enabled { mediator: X }`; current was Y;
+    /// rollback updated the mediator from Y back to X (forward
+    /// operation: update_didcomm).
+    Updated,
+    /// Snapshot ≡ current state. No LogEntry was published.
+    NoOp,
+}
+
+#[derive(Debug, Clone)]
+pub struct RollbackDidcommResult {
+    /// `Some(version_id)` when a LogEntry was published, `None`
+    /// when the rollback was a no-op (snapshot ≡ current).
+    pub new_version_id: Option<String>,
+    pub kind: RollbackKind,
+    /// Mediator being drained as part of this rollback (the
+    /// previously-active one), or `None` for `Enabled` /
+    /// `NoOp` arms where no drain is scheduled.
+    pub draining_mediator: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum RollbackDidcommError {
+    #[error(
+        "no prior mutation for `services didcomm` to roll back from. \
+         Use `services didcomm enable / update / disable` directly instead."
+    )]
+    NoPriorMutation,
+    #[error("VTA DID is not configured — run `vta setup` first")]
+    VtaDidNotConfigured,
+    #[error("VTA DID `{0}` has no webvh record")]
+    VtaDidRecordMissing(String),
+    #[error("VTA DID `{0}` has no published log")]
+    VtaDidLogMissing(String),
+    #[error("VTA DID log is empty")]
+    EmptyLog,
+
+    #[error(transparent)]
+    EnableForward(#[from] EnableDidcommError),
+    #[error(transparent)]
+    UpdateForward(#[from] UpdateDidcommError),
+    #[error(transparent)]
+    DisableForward(#[from] DisableDidcommError),
+
+    #[error(transparent)]
+    Handshake(#[from] HandshakeError),
+    #[error("DID document patch failed: {0}")]
+    DocumentPatch(#[from] DocumentPatchError),
+    #[error("WebVH update failed: {0}")]
+    WebVHUpdate(#[from] UpdateDidWebvhError),
+    #[error("auth: {0}")]
+    Auth(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+impl From<AppError> for RollbackDidcommError {
+    fn from(value: AppError) -> Self {
+        Self::Storage(value.to_string())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn rollback_didcomm(
+    config: &Arc<RwLock<AppConfig>>,
+    keys_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    drains_ks: &KeyspaceHandle,
+    snapshot_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    did_resolver: &DIDCacheClient,
+    didcomm_bridge: &Arc<DIDCommBridge>,
+    registry: &MediatorListenerRegistry,
+    sweeper: &DrainSweeper,
+    telemetry: &SharedTelemetrySink,
+    prover: &(dyn ListenerProver + Send + Sync),
+    auth: &AuthClaims,
+    params: RollbackDidcommParams,
+    channel: &str,
+) -> Result<RollbackDidcommResult, RollbackDidcommError> {
+    auth.require_super_admin()
+        .map_err(|e| RollbackDidcommError::Auth(e.to_string()))?;
+
+    // PROTOCOL_LOCK is taken by the dispatched forward op —
+    // holding it twice would deadlock. The snapshot read is
+    // atomic via fjall.
+    let snap = snapshot::read(snapshot_ks, ServiceKind::Didcomm)
+        .await
+        .map_err(|e| RollbackDidcommError::Storage(format!("snapshot read: {e}")))?
+        .ok_or(RollbackDidcommError::NoPriorMutation)?;
+    let didcomm_snap = match snap {
+        ServiceConfigSnapshot::Didcomm(s) => s,
+        other => {
+            return Err(RollbackDidcommError::Storage(format!(
+                "snapshot kind mismatch: stored {other:?}, requested Didcomm",
+            )));
+        }
+    };
+
+    let current_mediator = read_current_didcomm_mediator(config, webvh_ks).await?;
+
+    info!(
+        channel,
+        snapshot = ?didcomm_snap,
+        current = ?current_mediator,
+        "rollback_didcomm dispatching",
+    );
+
+    match (didcomm_snap, current_mediator.as_deref()) {
+        // Snapshot says off, currently on → disable.
+        (DidcommSnapshot::Disabled, Some(prior)) => {
+            let result = disable_didcomm(
+                config,
+                keys_ks,
+                contexts_ks,
+                webvh_ks,
+                audit_ks,
+                drains_ks,
+                snapshot_ks,
+                seed_store,
+                did_resolver,
+                didcomm_bridge,
+                registry,
+                sweeper,
+                telemetry,
+                auth,
+                DisableDidcommParams {
+                    drain_ttl: params.drain_ttl,
+                    transport: params.transport,
+                },
+                OpContext::Rollback,
+                channel,
+            )
+            .await?;
+            Ok(RollbackDidcommResult {
+                new_version_id: Some(result.new_version_id),
+                kind: RollbackKind::Disabled,
+                draining_mediator: Some(prior.to_string()),
+            })
+        }
+
+        // Snapshot says on with mediator X, currently off →
+        // enable with X. No drain (nothing is currently active
+        // to demote).
+        (
+            DidcommSnapshot::Enabled {
+                mediator_did,
+                routing_keys: _,
+            },
+            None,
+        ) => {
+            let result = enable_didcomm(
+                config,
+                keys_ks,
+                contexts_ks,
+                webvh_ks,
+                audit_ks,
+                snapshot_ks,
+                seed_store,
+                did_resolver,
+                didcomm_bridge,
+                registry,
+                telemetry,
+                prover,
+                auth,
+                EnableDidcommParams {
+                    mediator_did: mediator_did.clone(),
+                    force: false,
+                    handshake_timeout: DEFAULT_ROLLBACK_HANDSHAKE_TIMEOUT,
+                },
+                OpContext::Rollback,
+                channel,
+            )
+            .await?;
+            Ok(RollbackDidcommResult {
+                new_version_id: Some(result.new_version_id),
+                kind: RollbackKind::Enabled,
+                draining_mediator: None,
+            })
+        }
+
+        // Snapshot says on with mediator X, currently on with Y
+        // where X != Y → update Y→X. Drains Y for the supplied
+        // TTL.
+        (
+            DidcommSnapshot::Enabled {
+                mediator_did,
+                routing_keys: _,
+            },
+            Some(current),
+        ) if mediator_did != current => {
+            let result = update_didcomm(
+                config,
+                keys_ks,
+                contexts_ks,
+                webvh_ks,
+                audit_ks,
+                drains_ks,
+                snapshot_ks,
+                seed_store,
+                did_resolver,
+                didcomm_bridge,
+                registry,
+                sweeper,
+                telemetry,
+                prover,
+                auth,
+                UpdateDidcommParams {
+                    new_mediator_did: mediator_did.clone(),
+                    drain_ttl: params.drain_ttl,
+                    force: false,
+                    handshake_timeout: DEFAULT_ROLLBACK_HANDSHAKE_TIMEOUT,
+                    audit_kind: MigrateAuditKind::Rollback,
+                },
+                OpContext::Rollback,
+                channel,
+            )
+            .await?;
+            Ok(RollbackDidcommResult {
+                new_version_id: Some(result.new_version_id),
+                kind: RollbackKind::Updated,
+                draining_mediator: Some(result.prior_mediator_did),
+            })
+        }
+
+        // Snapshot ≡ current state — no-op.
+        _ => {
+            info!(
+                channel,
+                "rollback_didcomm: snapshot matches current state — no-op"
+            );
+            Ok(RollbackDidcommResult {
+                new_version_id: None,
+                kind: RollbackKind::NoOp,
+                draining_mediator: None,
+            })
+        }
+    }
+}
+
+async fn read_current_didcomm_mediator(
+    config: &Arc<RwLock<AppConfig>>,
+    webvh_ks: &KeyspaceHandle,
+) -> Result<Option<String>, RollbackDidcommError> {
+    let cfg = config.read().await;
+    let vta_did = cfg
+        .vta_did
+        .clone()
+        .ok_or(RollbackDidcommError::VtaDidNotConfigured)?;
+    drop(cfg);
+
+    let _record = webvh_store::get_did(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| RollbackDidcommError::VtaDidRecordMissing(vta_did.clone()))?;
+
+    let did_log = webvh_store::get_did_log(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| RollbackDidcommError::VtaDidLogMissing(vta_did.clone()))?;
+    let current_doc = current_document_from_log(&did_log)?;
+
+    Ok(current_didcomm_service(&current_doc).map(|svc| svc.mediator_did))
+}
+
+fn current_document_from_log(did_log: &str) -> Result<JsonValue, RollbackDidcommError> {
+    use didwebvh_rs::log_entry::{LogEntry, LogEntryMethods};
+    let line = did_log
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .ok_or(RollbackDidcommError::EmptyLog)?;
+    let entry: LogEntry = serde_json::from_str(line)
+        .map_err(|e| RollbackDidcommError::Storage(format!("DID log line parse: {e}")))?;
+    Ok(entry.get_state().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use vti_common::config::StoreConfig as VtiStoreConfig;
+
+    async fn empty_keyspace(name: &str) -> (tempfile::TempDir, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        let ks = store.keyspace(name).unwrap();
+        (dir, ks)
+    }
+
+    /// Empty snapshot keyspace yields the typed
+    /// NoPriorMutation error path. Pin the error message for
+    /// the CLI's suggested-fix string.
+    #[tokio::test]
+    async fn no_prior_mutation_error_message_is_actionable() {
+        let (_dir, ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
+        let snap = snapshot::read(&ks, ServiceKind::Didcomm).await.unwrap();
+        assert!(snap.is_none());
+
+        let err = RollbackDidcommError::NoPriorMutation;
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no prior mutation"),
+            "error message must point operator at the right next step, got: {msg}",
+        );
+        assert!(msg.contains("services didcomm enable"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_disabled_round_trips() {
+        let (_dir, ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
+        snapshot::write(
+            &ks,
+            ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Disabled),
+        )
+        .await
+        .unwrap();
+        let read = snapshot::read(&ks, ServiceKind::Didcomm)
+            .await
+            .unwrap()
+            .unwrap();
+        match read {
+            ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Disabled) => {}
+            other => panic!("expected Didcomm(Disabled), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_enabled_with_mediator_round_trips() {
+        let (_dir, ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
+        snapshot::write(
+            &ks,
+            ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Enabled {
+                mediator_did: "did:peer:2.M".into(),
+                routing_keys: vec![],
+            }),
+        )
+        .await
+        .unwrap();
+        let read = snapshot::read(&ks, ServiceKind::Didcomm)
+            .await
+            .unwrap()
+            .unwrap();
+        match read {
+            ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Enabled { mediator_did, .. }) => {
+                assert_eq!(mediator_did, "did:peer:2.M");
+            }
+            other => panic!("expected Didcomm(Enabled), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rollback_kind_variants_are_distinct() {
+        assert_ne!(RollbackKind::Disabled, RollbackKind::Enabled);
+        assert_ne!(RollbackKind::Enabled, RollbackKind::Updated);
+        assert_ne!(RollbackKind::Updated, RollbackKind::NoOp);
+    }
+
+    /// `RollbackDidcommParams` carries both drain_ttl and transport
+    /// — the transport drives the MIN_DRAIN_TTL_OVER_DIDCOMM floor
+    /// when the dispatched op is `disable_didcomm` over DIDComm
+    /// transport.
+    #[test]
+    fn params_carry_transport_and_ttl() {
+        let p = RollbackDidcommParams {
+            drain_ttl: Duration::from_secs(86_400),
+            transport: DisableTransport::Rest,
+        };
+        assert_eq!(p.drain_ttl.as_secs(), 86_400);
+        assert_eq!(p.transport, DisableTransport::Rest);
+    }
+}

--- a/vta-service/src/operations/protocol/rollback_rest.rs
+++ b/vta-service/src/operations/protocol/rollback_rest.rs
@@ -1,0 +1,467 @@
+//! `rollback_rest` operation — fail-forward dispatch.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.5a.
+//!
+//! Reads the per-kind snapshot store for `rest` and dispatches
+//! into the equivalent **forward** operation that returns the
+//! VTA's REST advertisement to the pre-mutation state. WebVH is
+//! append-only; rollback never rewinds the chain — it appends a
+//! new LogEntry whose `service[]` matches the snapshot.
+//!
+//! Dispatch table:
+//!
+//! | snapshot         | current state    | dispatched op            |
+//! |------------------|------------------|--------------------------|
+//! | `Disabled`       | enabled          | `disable_rest`           |
+//! | `Enabled { X }`  | disabled         | `enable_rest` with X     |
+//! | `Enabled { X }`  | enabled with Y   | `update_rest` with X     |
+//! | `Disabled`       | disabled         | no-op (snapshot≡current) |
+//! | `Enabled { X }`  | enabled with X   | no-op (snapshot≡current) |
+//!
+//! No-op rollbacks happen when (a) a previous mutation crashed
+//! between snapshot persist and runtime mutation (the snapshot
+//! describes the current state, so re-applying it is a no-op), or
+//! (b) the operator runs `rollback` twice in a row (a "rollback the
+//! rollback" cycle). Both are valid; the operator sees a result
+//! with `new_version_id: None` and a `kind == NoOp` marker so the
+//! CLI can print "nothing to do" without raising an error.
+//!
+//! Brick-prevention is enforced by the dispatched forward op,
+//! which already calls [`would_violate_last_service`] for its
+//! disable path. The §7a.5 rollback histories that resolve to
+//! `LastServiceRefused` (e.g. rolling back a `services rest enable`
+//! when DIDComm is disabled) surface the typed error from the
+//! forward op verbatim.
+
+use std::sync::Arc;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use vti_common::seed_store::SeedStore;
+use vti_common::telemetry::SharedTelemetrySink;
+
+use crate::auth::AuthClaims;
+use crate::config::AppConfig;
+use crate::didcomm_bridge::DIDCommBridge;
+use crate::error::AppError;
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::OpContext;
+use crate::operations::protocol::disable_rest::{
+    DisableRestError, DisableRestParams, disable_rest,
+};
+use crate::operations::protocol::document::{DocumentPatchError, current_rest_service};
+use crate::operations::protocol::enable_rest::{EnableRestError, EnableRestParams, enable_rest};
+use crate::operations::protocol::snapshot::{
+    self, RestSnapshot, ServiceConfigSnapshot, ServiceKind,
+};
+use crate::operations::protocol::update_rest::{UpdateRestError, UpdateRestParams, update_rest};
+use crate::store::KeyspaceHandle;
+use crate::webvh_store;
+
+#[derive(Debug, Clone, Default)]
+pub struct RollbackRestParams;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RollbackKind {
+    /// Snapshot was `Disabled`; rollback re-disabled REST.
+    Disabled,
+    /// Snapshot was `Enabled { url }`; rollback re-enabled REST
+    /// at the prior URL (forward operation: enable_rest).
+    Enabled,
+    /// Snapshot was `Enabled { url }`; rollback restored the prior
+    /// URL on an existing entry (forward operation: update_rest).
+    Updated,
+    /// Snapshot ≡ current state. No LogEntry was published.
+    NoOp,
+}
+
+#[derive(Debug, Clone)]
+pub struct RollbackRestResult {
+    /// `Some(version_id)` when a LogEntry was published, `None`
+    /// when the rollback was a no-op (snapshot ≡ current).
+    pub new_version_id: Option<String>,
+    pub kind: RollbackKind,
+}
+
+#[derive(Debug, Error)]
+pub enum RollbackRestError {
+    #[error(
+        "no prior mutation for `services rest` to roll back from. \
+         Use `services rest enable / update / disable` directly instead."
+    )]
+    NoPriorMutation,
+    #[error("VTA DID is not configured — run `vta setup` first")]
+    VtaDidNotConfigured,
+    #[error("VTA DID `{0}` has no webvh record")]
+    VtaDidRecordMissing(String),
+    #[error("VTA DID `{0}` has no published log")]
+    VtaDidLogMissing(String),
+    #[error("VTA DID log is empty")]
+    EmptyLog,
+
+    /// Forward dispatch into `enable_rest` failed. The inner error
+    /// carries any typed variants the operator should act on
+    /// (e.g. `Validation` if the snapshotted URL is malformed —
+    /// shouldn't happen since the snapshot was written by an
+    /// already-validated forward op, but defensive).
+    #[error(transparent)]
+    EnableForward(#[from] EnableRestError),
+    /// Forward dispatch into `update_rest` failed.
+    #[error(transparent)]
+    UpdateForward(#[from] UpdateRestError),
+    /// Forward dispatch into `disable_rest` failed. Includes
+    /// `LastServiceRefused` (rollback would brick the VTA per
+    /// spec §7a.5 — operator must enable DIDComm first).
+    #[error(transparent)]
+    DisableForward(#[from] DisableRestError),
+
+    /// Document patch failed mid-rollback. Surfaced separately so
+    /// the CLI can distinguish a snapshot-corruption from a
+    /// pre-mutation refusal.
+    #[error("DID document patch failed: {0}")]
+    DocumentPatch(#[from] DocumentPatchError),
+    #[error("WebVH update failed: {0}")]
+    WebVHUpdate(#[from] UpdateDidWebvhError),
+    #[error("auth: {0}")]
+    Auth(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+impl From<AppError> for RollbackRestError {
+    fn from(value: AppError) -> Self {
+        Self::Storage(value.to_string())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn rollback_rest(
+    config: &Arc<RwLock<AppConfig>>,
+    keys_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    snapshot_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    did_resolver: &DIDCacheClient,
+    didcomm_bridge: &Arc<DIDCommBridge>,
+    telemetry: &SharedTelemetrySink,
+    auth: &AuthClaims,
+    _params: RollbackRestParams,
+    channel: &str,
+) -> Result<RollbackRestResult, RollbackRestError> {
+    auth.require_super_admin()
+        .map_err(|e| RollbackRestError::Auth(e.to_string()))?;
+
+    // 1. Read the snapshot. None → NoPriorMutation. Note: we do
+    //    NOT take PROTOCOL_LOCK here because the dispatched
+    //    forward op takes it; holding it twice would deadlock.
+    let snap = snapshot::read(snapshot_ks, ServiceKind::Rest)
+        .await
+        .map_err(|e| RollbackRestError::Storage(format!("snapshot read: {e}")))?
+        .ok_or(RollbackRestError::NoPriorMutation)?;
+    let rest_snap = match snap {
+        ServiceConfigSnapshot::Rest(s) => s,
+        other => {
+            // `snapshot::read` already validates the variant tag
+            // matches the requested kind; if we land here the
+            // snapshot module's invariant is broken. Surface it.
+            return Err(RollbackRestError::Storage(format!(
+                "snapshot kind mismatch: stored {other:?}, requested Rest",
+            )));
+        }
+    };
+
+    // 2. Read the current REST state from config + the on-chain
+    //    DID document. We don't strictly need both; the on-chain
+    //    state is authoritative for the rollback decision (it's
+    //    what the snapshot will be compared against), and config
+    //    is asserted to match by the existing precondition checks
+    //    in the forward ops.
+    let current_url = read_current_rest_url(config, webvh_ks).await?;
+
+    // 3. Dispatch table (see module doc).
+    info!(
+        channel,
+        snapshot = ?rest_snap,
+        current = ?current_url,
+        "rollback_rest dispatching",
+    );
+    match (rest_snap, current_url.as_deref()) {
+        // Snapshot says off, currently on → disable.
+        (RestSnapshot::Disabled, Some(_)) => {
+            let result = disable_rest(
+                config,
+                keys_ks,
+                contexts_ks,
+                webvh_ks,
+                audit_ks,
+                snapshot_ks,
+                seed_store,
+                did_resolver,
+                didcomm_bridge,
+                telemetry,
+                auth,
+                DisableRestParams,
+                OpContext::Rollback,
+                channel,
+            )
+            .await?;
+            Ok(RollbackRestResult {
+                new_version_id: Some(result.new_version_id),
+                kind: RollbackKind::Disabled,
+            })
+        }
+
+        // Snapshot says on with URL X, currently off → enable.
+        (RestSnapshot::Enabled { url }, None) => {
+            let result = enable_rest(
+                config,
+                keys_ks,
+                contexts_ks,
+                webvh_ks,
+                audit_ks,
+                snapshot_ks,
+                seed_store,
+                did_resolver,
+                didcomm_bridge,
+                telemetry,
+                auth,
+                EnableRestParams { url: url.clone() },
+                OpContext::Rollback,
+                channel,
+            )
+            .await?;
+            Ok(RollbackRestResult {
+                new_version_id: Some(result.new_version_id),
+                kind: RollbackKind::Enabled,
+            })
+        }
+
+        // Snapshot says on with URL X, currently on with Y where
+        // X != Y → update.
+        (RestSnapshot::Enabled { url }, Some(current)) if url != current => {
+            let result = update_rest(
+                config,
+                keys_ks,
+                contexts_ks,
+                webvh_ks,
+                audit_ks,
+                snapshot_ks,
+                seed_store,
+                did_resolver,
+                didcomm_bridge,
+                telemetry,
+                auth,
+                UpdateRestParams { url: url.clone() },
+                OpContext::Rollback,
+                channel,
+            )
+            .await?;
+            Ok(RollbackRestResult {
+                new_version_id: Some(result.new_version_id),
+                kind: RollbackKind::Updated,
+            })
+        }
+
+        // Snapshot ≡ current state. No LogEntry, no telemetry.
+        // Operator sees `kind == NoOp` and can interpret as
+        // "rollback was already applied" or "no diff to revert."
+        _ => {
+            info!(
+                channel,
+                "rollback_rest: snapshot matches current state — no-op"
+            );
+            Ok(RollbackRestResult {
+                new_version_id: None,
+                kind: RollbackKind::NoOp,
+            })
+        }
+    }
+}
+
+/// Read the currently-advertised REST URL from the on-chain DID
+/// document. Returns `None` when no `#vta-rest` entry is present.
+async fn read_current_rest_url(
+    config: &Arc<RwLock<AppConfig>>,
+    webvh_ks: &KeyspaceHandle,
+) -> Result<Option<String>, RollbackRestError> {
+    let cfg = config.read().await;
+    let vta_did = cfg
+        .vta_did
+        .clone()
+        .ok_or(RollbackRestError::VtaDidNotConfigured)?;
+    drop(cfg);
+
+    let _record = webvh_store::get_did(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| RollbackRestError::VtaDidRecordMissing(vta_did.clone()))?;
+
+    let did_log = webvh_store::get_did_log(webvh_ks, &vta_did)
+        .await?
+        .ok_or_else(|| RollbackRestError::VtaDidLogMissing(vta_did.clone()))?;
+    let current_doc = current_document_from_log(&did_log)?;
+
+    Ok(current_rest_service(&current_doc).map(|svc| svc.url))
+}
+
+fn current_document_from_log(did_log: &str) -> Result<JsonValue, RollbackRestError> {
+    use didwebvh_rs::log_entry::{LogEntry, LogEntryMethods};
+    let line = did_log
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .ok_or(RollbackRestError::EmptyLog)?;
+    let entry: LogEntry = serde_json::from_str(line)
+        .map_err(|e| RollbackRestError::Storage(format!("DID log line parse: {e}")))?;
+    Ok(entry.get_state().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{LogConfig, ServerConfig, ServicesConfig, StoreConfig};
+    use crate::store::Store;
+    use vti_common::config::StoreConfig as VtiStoreConfig;
+
+    /// Owns the fjall store so a test can derive multiple keyspace
+    /// handles from the same open instance — fjall locks the data
+    /// dir on each open.
+    struct TestFixture {
+        _dir: tempfile::TempDir,
+        _config: Arc<RwLock<AppConfig>>,
+        store: Store,
+    }
+
+    impl TestFixture {
+        fn snapshot_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace(snapshot::KEYSPACE_NAME).unwrap()
+        }
+    }
+
+    fn build_fixture(rest: bool, didcomm: bool) -> TestFixture {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("vta.toml");
+        let cfg = AppConfig {
+            server: ServerConfig {
+                host: "127.0.0.1".into(),
+                port: 0,
+            },
+            log: LogConfig::default(),
+            store: StoreConfig {
+                data_dir: dir.path().into(),
+            },
+            services: ServicesConfig { rest, didcomm },
+            vta_did: Some("did:webvh:scid123:host:vta".into()),
+            vta_name: None,
+            public_url: None,
+            resolver_url: None,
+            messaging: None,
+            secrets: Default::default(),
+            audit: Default::default(),
+            auth: Default::default(),
+            #[cfg(feature = "tee")]
+            tee: Default::default(),
+            config_path,
+        };
+        let initial = toml::to_string_pretty(&cfg).unwrap();
+        std::fs::write(&cfg.config_path, initial).unwrap();
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        TestFixture {
+            _dir: dir,
+            _config: Arc::new(RwLock::new(cfg)),
+            store,
+        }
+    }
+
+    /// `rollback_rest` returns `NoPriorMutation` when the snapshot
+    /// keyspace is empty.
+    #[tokio::test]
+    async fn no_prior_mutation_when_snapshot_empty() {
+        let fx = build_fixture(true, true);
+        let snapshot_ks = fx.snapshot_ks();
+        // No snapshot written.
+        let snap = snapshot::read(&snapshot_ks, ServiceKind::Rest)
+            .await
+            .unwrap();
+        assert!(snap.is_none());
+
+        // The full rollback_rest call requires too many fixtures
+        // (resolver, seed_store, didcomm_bridge, etc.) for a unit
+        // test — full e2e coverage lives in P6's matrix. Here we
+        // just assert the precondition (empty snapshot) holds and
+        // that the typed error path is wired up via direct
+        // construction.
+        let err = RollbackRestError::NoPriorMutation;
+        let msg = err.to_string();
+        assert!(msg.contains("no prior mutation"));
+    }
+
+    /// Round-trip: write `Disabled` snapshot → reading it back
+    /// and inspecting the variant matches the expected dispatch
+    /// arm. The actual dispatch is integration-tested in P6.
+    #[tokio::test]
+    async fn snapshot_disabled_round_trips() {
+        let fx = build_fixture(true, true);
+        let snapshot_ks = fx.snapshot_ks();
+        snapshot::write(
+            &snapshot_ks,
+            ServiceConfigSnapshot::Rest(RestSnapshot::Disabled),
+        )
+        .await
+        .unwrap();
+
+        let read = snapshot::read(&snapshot_ks, ServiceKind::Rest)
+            .await
+            .unwrap()
+            .unwrap();
+        match read {
+            ServiceConfigSnapshot::Rest(RestSnapshot::Disabled) => {}
+            other => panic!("expected Rest(Disabled), got {other:?}"),
+        }
+    }
+
+    /// Round-trip: write `Enabled { url: X }` snapshot → reading
+    /// it back returns the URL X.
+    #[tokio::test]
+    async fn snapshot_enabled_with_url_round_trips() {
+        let fx = build_fixture(true, true);
+        let snapshot_ks = fx.snapshot_ks();
+        snapshot::write(
+            &snapshot_ks,
+            ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
+                url: "https://prior.example.com".into(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let read = snapshot::read(&snapshot_ks, ServiceKind::Rest)
+            .await
+            .unwrap()
+            .unwrap();
+        match read {
+            ServiceConfigSnapshot::Rest(RestSnapshot::Enabled { url }) => {
+                assert_eq!(url, "https://prior.example.com");
+            }
+            other => panic!("expected Rest(Enabled {{ url }}), got {other:?}"),
+        }
+    }
+
+    /// `RollbackKind` discriminants cover the four cases the
+    /// dispatch table produces. Pin the public surface so the
+    /// CLI layer can rely on it.
+    #[test]
+    fn rollback_kind_variants_are_distinct() {
+        assert_ne!(RollbackKind::Disabled, RollbackKind::Enabled);
+        assert_ne!(RollbackKind::Enabled, RollbackKind::Updated);
+        assert_ne!(RollbackKind::Updated, RollbackKind::NoOp);
+        assert_ne!(RollbackKind::NoOp, RollbackKind::Disabled);
+    }
+}

--- a/vta-service/src/operations/protocol/update_didcomm.rs
+++ b/vta-service/src/operations/protocol/update_didcomm.rs
@@ -45,10 +45,10 @@ use crate::messaging::handshake::{
 };
 use crate::messaging::registry::{MediatorBinding, MediatorListenerRegistry, RegistryError};
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::PROTOCOL_LOCK;
 use crate::operations::protocol::document::{
     DocumentPatchError, current_didcomm_service, with_didcomm_service,
 };
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
@@ -155,6 +155,7 @@ pub async fn update_didcomm(
     prover: &(dyn ListenerProver + Send + Sync),
     auth: &AuthClaims,
     params: UpdateDidcommParams,
+    ctx: OpContext,
     channel: &str,
 ) -> Result<UpdateDidcommResult, UpdateDidcommError> {
     auth.require_super_admin()
@@ -245,22 +246,22 @@ pub async fn update_didcomm(
     // Arm the sweeper so the drain TTL actually fires.
     sweeper.arm(&prior_mediator, deadline).await;
 
-    let _ = telemetry
-        .record(
-            TelemetryEvent::new(TelemetryKind::ServicesDidcommUpdate)
-                .with_mediator(&resolved.mediator_did)
-                .with_field("from", JsonValue::from(prior_mediator.clone()))
-                .with_field("audit_kind", JsonValue::from(params.audit_kind.as_str()))
-                .with_field(
-                    "new_version_id",
-                    JsonValue::from(update_result.new_version_id.clone()),
-                )
-                .with_field(
-                    "drain_ttl_secs",
-                    JsonValue::from(params.drain_ttl.as_secs()),
-                ),
+    let mut event = TelemetryEvent::new(TelemetryKind::ServicesDidcommUpdate)
+        .with_mediator(&resolved.mediator_did)
+        .with_field("from", JsonValue::from(prior_mediator.clone()))
+        .with_field("audit_kind", JsonValue::from(params.audit_kind.as_str()))
+        .with_field(
+            "new_version_id",
+            JsonValue::from(update_result.new_version_id.clone()),
         )
-        .await;
+        .with_field(
+            "drain_ttl_secs",
+            JsonValue::from(params.drain_ttl.as_secs()),
+        );
+    if let Some(tag) = ctx.telemetry_triggered_by() {
+        event = event.with_field("triggered_by", JsonValue::from(tag));
+    }
+    let _ = telemetry.record(event).await;
 
     info!(
         channel,
@@ -497,6 +498,7 @@ mod tests {
             &prover,
             &super_admin(),
             forward_params("did:m:B"),
+            OpContext::Direct,
             "test",
         )
         .await
@@ -537,6 +539,7 @@ mod tests {
             &prover,
             &super_admin(),
             forward_params("did:m:B"),
+            OpContext::Direct,
             "test",
         )
         .await
@@ -599,6 +602,7 @@ mod tests {
             &prover,
             &super_admin(),
             forward_params("did:m:B"),
+            OpContext::Direct,
             "test",
         )
         .await

--- a/vta-service/src/operations/protocol/update_rest.rs
+++ b/vta-service/src/operations/protocol/update_rest.rs
@@ -40,11 +40,11 @@ use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::PROTOCOL_LOCK;
 use crate::operations::protocol::document::{
     DocumentPatchError, current_rest_service, with_rest_service,
 };
 use crate::operations::protocol::snapshot::{self, RestSnapshot, ServiceConfigSnapshot};
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
@@ -113,6 +113,7 @@ pub async fn update_rest(
     telemetry: &SharedTelemetrySink,
     auth: &AuthClaims,
     params: UpdateRestParams,
+    ctx: OpContext,
     channel: &str,
 ) -> Result<UpdateRestResult, UpdateRestError> {
     auth.require_super_admin()
@@ -175,18 +176,18 @@ pub async fn update_rest(
 
     // 7. Telemetry: prior + new URL together so external verifiers
     //    can graph URL transitions per VTA.
-    let _ = telemetry
-        .record(
-            TelemetryEvent::new(TelemetryKind::ServicesRestUpdate)
-                .with_field("channel", JsonValue::from(channel))
-                .with_field(
-                    "new_version_id",
-                    JsonValue::from(update_result.new_version_id.clone()),
-                )
-                .with_field("prior_url", JsonValue::from(prior_url.clone()))
-                .with_field("url", JsonValue::from(canonical_url.clone())),
+    let mut event = TelemetryEvent::new(TelemetryKind::ServicesRestUpdate)
+        .with_field("channel", JsonValue::from(channel))
+        .with_field(
+            "new_version_id",
+            JsonValue::from(update_result.new_version_id.clone()),
         )
-        .await;
+        .with_field("prior_url", JsonValue::from(prior_url.clone()))
+        .with_field("url", JsonValue::from(canonical_url.clone()));
+    if let Some(tag) = ctx.telemetry_triggered_by() {
+        event = event.with_field("triggered_by", JsonValue::from(tag));
+    }
+    let _ = telemetry.record(event).await;
 
     info!(
         channel,

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -237,8 +237,16 @@ pub fn router() -> Router<AppState> {
             post(protocol::disable_rest_handler),
         )
         .route(
+            "/services/rest/rollback",
+            post(protocol::rollback_rest_handler),
+        )
+        .route(
             "/services/didcomm/update",
             post(protocol::update_didcomm_handler),
+        )
+        .route(
+            "/services/didcomm/rollback",
+            post(protocol::rollback_didcomm_handler),
         )
         .route(
             "/mediators/drain/cancel",

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::auth::SuperAdminAuth;
 use crate::messaging::handshake::{AlwaysOkProver, HandshakeError, HandshakeStage};
 use crate::operations::protocol::OpContext;
+use crate::operations::protocol::disable_didcomm::DisableTransport as DidcommTransport;
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommError, DisableDidcommParams, DisableTransport, disable_didcomm,
 };
@@ -28,6 +29,13 @@ use crate::operations::protocol::enable_didcomm::{
     EnableDidcommError, EnableDidcommParams, enable_didcomm,
 };
 use crate::operations::protocol::enable_rest::{EnableRestError, EnableRestParams, enable_rest};
+use crate::operations::protocol::rollback_didcomm::{
+    RollbackDidcommError, RollbackDidcommParams, RollbackKind as DidcommRollbackKind,
+    rollback_didcomm,
+};
+use crate::operations::protocol::rollback_rest::{
+    RollbackKind as RestRollbackKind, RollbackRestError, RollbackRestParams, rollback_rest,
+};
 use crate::operations::protocol::update_didcomm::{
     MigrateAuditKind, UpdateDidcommError, UpdateDidcommParams, update_didcomm,
 };
@@ -1481,6 +1489,294 @@ impl IntoResponse for RestServiceHttpError {
                     suggested_fix: Some(
                         "Confirm the resolver is configured and running, then retry.".into(),
                     ),
+                    stage: None,
+                },
+            ),
+        };
+        (status, Json(body)).into_response()
+    }
+}
+
+// ── Fail-forward rollback handlers (T3.4) ─────────────────────────
+//
+// `POST /services/{rest,didcomm}/rollback` — read the per-kind
+// snapshot store and dispatch into the appropriate forward op.
+// Spec §3.5a. The dispatched op publishes its own LogEntry; this
+// handler just routes the snapshot read + forwards the operator's
+// drain TTL where applicable.
+//
+// No-op rollbacks (snapshot ≡ current state) return a 200 with an
+// empty `log_entry_version_id` and a `kind` field set to "no_op".
+// CLIs surface this as "nothing to do" without raising an error.
+
+/// `POST /services/rest/rollback` — fail-forward the most recent
+/// REST mutation. Auth: super-admin. Refused with `NoPriorMutation`
+/// when no snapshot is recorded.
+pub async fn rollback_rest_handler(
+    auth: SuperAdminAuth,
+    State(state): State<AppState>,
+    Json(_req): Json<vta_sdk::protocol::services::RollbackRestRequest>,
+) -> Result<Json<RollbackResponse>, RollbackRestHttpError> {
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or(RollbackRestHttpError::DidResolverUnavailable)?
+        .clone();
+
+    let result = rollback_rest(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        &did_resolver,
+        &state.didcomm_bridge,
+        &state.telemetry,
+        &auth.0,
+        RollbackRestParams,
+        "rest",
+    )
+    .await?;
+
+    Ok(Json(RollbackResponse {
+        log_entry_version_id: result.new_version_id.unwrap_or_default(),
+        effective_at: chrono::Utc::now().to_rfc3339(),
+        kind: rest_kind_str(result.kind).into(),
+        drain_until: None,
+        draining_mediator: None,
+    }))
+}
+
+/// `POST /services/didcomm/rollback` — fail-forward the most recent
+/// DIDComm mutation. Auth: super-admin. Threads drain_ttl through
+/// to the dispatched forward op for the disable / update arms.
+pub async fn rollback_didcomm_handler(
+    auth: SuperAdminAuth,
+    State(state): State<AppState>,
+    Json(req): Json<RollbackDidcommHttpRequest>,
+) -> Result<Json<RollbackResponse>, RollbackDidcommHttpError> {
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or(RollbackDidcommHttpError::DidResolverUnavailable)?
+        .clone();
+    let bridge = Arc::clone(&state.didcomm_bridge);
+    let prover = AlwaysOkProver;
+
+    let drain_ttl = Duration::from_secs(req.drain_ttl_secs.unwrap_or(86_400));
+
+    let result = rollback_didcomm(
+        &state.config,
+        &state.keys_ks,
+        &state.contexts_ks,
+        &state.webvh_ks,
+        &state.audit_ks,
+        &state.drains_ks,
+        &state.snapshot_ks,
+        &*state.seed_store,
+        &did_resolver,
+        &bridge,
+        &state.mediator_registry,
+        &state.drain_sweeper,
+        &state.telemetry,
+        &prover,
+        &auth.0,
+        RollbackDidcommParams {
+            drain_ttl,
+            transport: DidcommTransport::Rest,
+        },
+        "rest",
+    )
+    .await?;
+
+    Ok(Json(RollbackResponse {
+        log_entry_version_id: result.new_version_id.unwrap_or_default(),
+        effective_at: chrono::Utc::now().to_rfc3339(),
+        kind: didcomm_kind_str(result.kind).into(),
+        drain_until: None,
+        draining_mediator: result.draining_mediator,
+    }))
+}
+
+/// REST handler request body for didcomm rollback. The drain_ttl
+/// is optional — server applies the spec §3.6 default (24h) when
+/// omitted.
+#[derive(Debug, Deserialize)]
+pub struct RollbackDidcommHttpRequest {
+    #[serde(default)]
+    pub drain_ttl_secs: Option<u64>,
+}
+
+/// Unified rollback response shape used by both REST handlers.
+/// Wider than `ServiceMutationResponse` because rollback adds two
+/// concepts: a `kind` discriminator (so the CLI can print
+/// "rolled back to enabled at https://x.example.com" vs.
+/// "rollback was a no-op") and a `draining_mediator` field
+/// for the DIDComm update / disable arms.
+#[derive(Debug, Serialize)]
+pub struct RollbackResponse {
+    /// New WebVH LogEntry version-id. Empty string when the
+    /// rollback was a no-op (snapshot ≡ current state).
+    pub log_entry_version_id: String,
+    pub effective_at: String,
+    /// One of: `disabled`, `enabled`, `updated`, `no_op`.
+    pub kind: String,
+    /// `Some(rfc3339)` when the rollback scheduled a drain on
+    /// the previously-active mediator (DIDComm update / disable
+    /// arms). `None` for REST and for the DIDComm enable / no-op
+    /// arms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drain_until: Option<String>,
+    /// Mediator DID currently being drained by this rollback's
+    /// dispatched op. `None` for REST and DIDComm enable / no-op
+    /// arms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub draining_mediator: Option<String>,
+}
+
+fn rest_kind_str(k: RestRollbackKind) -> &'static str {
+    match k {
+        RestRollbackKind::Disabled => "disabled",
+        RestRollbackKind::Enabled => "enabled",
+        RestRollbackKind::Updated => "updated",
+        RestRollbackKind::NoOp => "no_op",
+    }
+}
+
+fn didcomm_kind_str(k: DidcommRollbackKind) -> &'static str {
+    match k {
+        DidcommRollbackKind::Disabled => "disabled",
+        DidcommRollbackKind::Enabled => "enabled",
+        DidcommRollbackKind::Updated => "updated",
+        DidcommRollbackKind::NoOp => "no_op",
+    }
+}
+
+#[derive(Debug)]
+pub enum RollbackRestHttpError {
+    Op(RollbackRestError),
+    DidResolverUnavailable,
+}
+
+impl From<RollbackRestError> for RollbackRestHttpError {
+    fn from(value: RollbackRestError) -> Self {
+        Self::Op(value)
+    }
+}
+
+impl IntoResponse for RollbackRestHttpError {
+    fn into_response(self) -> Response {
+        let (status, body) = match self {
+            Self::Op(RollbackRestError::NoPriorMutation) => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "no_prior_mutation",
+                    message: "No prior REST mutation to roll back from.".into(),
+                    suggested_fix: Some(
+                        "Use `pnm services rest enable / update / disable` directly instead."
+                            .into(),
+                    ),
+                    stage: None,
+                },
+            ),
+            Self::Op(RollbackRestError::DisableForward(DisableRestError::LastServiceRefused)) => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "last_service_refused",
+                    message:
+                        "Rolling back this REST mutation would leave the VTA with no advertised \
+                         services. Enable DIDComm first and retry."
+                            .into(),
+                    suggested_fix: Some(
+                        "Run `pnm services didcomm enable --mediator <did>`, then retry rollback."
+                            .into(),
+                    ),
+                    stage: None,
+                },
+            ),
+            Self::Op(other) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorBody {
+                    error: "rollback_failed",
+                    message: other.to_string(),
+                    suggested_fix: None,
+                    stage: None,
+                },
+            ),
+            Self::DidResolverUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ErrorBody {
+                    error: "did_resolver_unavailable",
+                    message: "DID resolver not available on this VTA.".into(),
+                    suggested_fix: None,
+                    stage: None,
+                },
+            ),
+        };
+        (status, Json(body)).into_response()
+    }
+}
+
+#[derive(Debug)]
+pub enum RollbackDidcommHttpError {
+    Op(RollbackDidcommError),
+    DidResolverUnavailable,
+}
+
+impl From<RollbackDidcommError> for RollbackDidcommHttpError {
+    fn from(value: RollbackDidcommError) -> Self {
+        Self::Op(value)
+    }
+}
+
+impl IntoResponse for RollbackDidcommHttpError {
+    fn into_response(self) -> Response {
+        let (status, body) = match self {
+            Self::Op(RollbackDidcommError::NoPriorMutation) => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "no_prior_mutation",
+                    message: "No prior DIDComm mutation to roll back from.".into(),
+                    suggested_fix: Some(
+                        "Use `pnm services didcomm enable / update / disable` directly instead."
+                            .into(),
+                    ),
+                    stage: None,
+                },
+            ),
+            Self::Op(RollbackDidcommError::DisableForward(
+                DisableDidcommError::NoProtocolRemaining,
+            )) => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "last_service_refused",
+                    message:
+                        "Rolling back this DIDComm mutation would leave the VTA with no advertised \
+                         services. Enable REST first and retry."
+                            .into(),
+                    suggested_fix: Some(
+                        "Run `pnm services rest enable --url <url>`, then retry rollback.".into(),
+                    ),
+                    stage: None,
+                },
+            ),
+            Self::Op(other) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorBody {
+                    error: "rollback_failed",
+                    message: other.to_string(),
+                    suggested_fix: None,
+                    stage: None,
+                },
+            ),
+            Self::DidResolverUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ErrorBody {
+                    error: "did_resolver_unavailable",
+                    message: "DID resolver not available on this VTA.".into(),
+                    suggested_fix: None,
                     stage: None,
                 },
             ),

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::auth::SuperAdminAuth;
 use crate::messaging::handshake::{AlwaysOkProver, HandshakeError, HandshakeStage};
+use crate::operations::protocol::OpContext;
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommError, DisableDidcommParams, DisableTransport, disable_didcomm,
 };
@@ -127,6 +128,7 @@ pub async fn enable_didcomm_handler(
             force: req.force,
             handshake_timeout: timeout,
         },
+        OpContext::Direct,
         "rest",
     )
     .await?;
@@ -372,6 +374,7 @@ pub async fn disable_didcomm_handler(
             drain_ttl: Duration::from_secs(req.drain_ttl_secs),
             transport: DisableTransport::Rest,
         },
+        OpContext::Direct,
         "rest",
     )
     .await?;
@@ -642,6 +645,7 @@ pub async fn update_didcomm_handler(
             handshake_timeout: timeout,
             audit_kind,
         },
+        OpContext::Direct,
         "rest",
     )
     .await?;
@@ -1193,6 +1197,7 @@ pub async fn enable_rest_handler(
         &state.telemetry,
         &auth.0,
         EnableRestParams { url: req.url },
+        OpContext::Direct,
         "rest",
     )
     .await?;
@@ -1231,6 +1236,7 @@ pub async fn update_rest_handler(
         &state.telemetry,
         &auth.0,
         UpdateRestParams { url: req.url },
+        OpContext::Direct,
         "rest",
     )
     .await?;
@@ -1269,6 +1275,7 @@ pub async fn disable_rest_handler(
         &state.telemetry,
         &auth.0,
         DisableRestParams,
+        OpContext::Direct,
         "rest",
     )
     .await?;


### PR DESCRIPTION
## Summary

Phase 3 of the runtime service-endpoint management feature — implements **fail-forward rollback** per spec §3.5a. Rolling back a service mutation never rewinds the WebVH chain; it appends a new LogEntry whose `service[]` matches the snapshotted prior state. Both REST and DIDComm rollback are reachable over both transports.

## What this PR contains

**T3.3 — `OpContext` plumbing** (`commit 00c46e7`)
Cross-cutting prerequisite. Adds `OpContext { Direct | Rollback }` in `operations::protocol` and threads it through every forward op (`enable_rest`, `update_rest`, `disable_rest`, `enable_didcomm`, `disable_didcomm`, `update_didcomm`). Each op now appends `triggered_by: "rollback"` to its emitted telemetry when `ctx == Rollback`; direct operations omit the field per spec ("absence is the conventional signal"). All existing call sites pass `OpContext::Direct`.

**T3.1 — `rollback_rest`** (`commit 0bb0f8f`)
Reads the per-kind snapshot, dispatches into the equivalent forward op:

| snapshot         | current state    | dispatched op            |
|------------------|------------------|--------------------------|
| `Disabled`       | enabled          | `disable_rest`           |
| `Enabled { X }`  | disabled         | `enable_rest` with X     |
| `Enabled { X }`  | enabled with Y   | `update_rest` with X     |
| snapshot==current| -                | no-op (`RollbackKind::NoOp`) |

Brick-prevention is enforced by the dispatched forward op — rolling back a `services rest enable` when DIDComm is disabled surfaces `LastServiceRefused` from `disable_rest`'s invariant check verbatim. `PROTOCOL_LOCK` is intentionally not taken in `rollback_rest` (the dispatched forward op takes it; double-locking would deadlock).

**T3.2 — `rollback_didcomm`** (`commit dd677ad`)
Same shape but threads `drain_ttl` + `DisableTransport` through the chosen forward op so the existing `MIN_DRAIN_TTL_OVER_DIDCOMM` floor still fires when the rollback is delivered over DIDComm and dispatches into `disable_didcomm`. The most common case is the `update_didcomm` arm: rolling back a `services didcomm update A→B` re-promotes A and drains B with the operator-supplied TTL (default 24h).

**T3.4 — Route + DIDComm handlers** (`commit 5569c99`)
- REST routes: `POST /services/{rest,didcomm}/rollback`
- DIDComm message types: `services-management/1.0/{rest,didcomm}-rollback{,-result}`
- Unified `RollbackResponse` shape adds a `kind` discriminator and `draining_mediator` field on top of the existing `ServiceMutationResponse` shape
- Operator-actionable error bodies: `NoPriorMutation` → suggested-fix points at direct commands; `LastServiceRefused` (forwarded from the dispatched op) → suggested-fix points at "enable other transport first"

## How fail-forward + snapshot replacement work together

Per spec §3.5a:

> Each successful mutation persists its "previous-config" snapshot in fjall, replacing the one from before. Rollback consumes the snapshot. After rollback, the snapshot reflects the state from *before* the rollback (so a second consecutive rollback would revert the rollback — a no-op cycle).

The dispatched forward op writes its OWN snapshot (capturing the pre-rollback state) before applying the runtime mutation. After a successful rollback, a second rollback finds snapshot ≡ current state and emits `RollbackKind::NoOp`. The CLI surfaces this as "nothing to do" without raising an error.

## No-op rollback path

Two scenarios produce `kind: NoOp`:
1. A previous mutation crashed between snapshot persist and runtime mutation — the snapshot describes the current state, so re-applying it is a no-op.
2. The operator runs rollback twice in a row — a "rollback the rollback" cycle.

Both return 200 with `log_entry_version_id: ""` and `kind: "no_op"`. No LogEntry is published, no telemetry is emitted, no drain is scheduled.

## Test plan

- [x] `cargo build --workspace --all-features` clean
- [x] `cargo test -p vta-service --lib --all-features` — 298 tests pass (was 289 + 9 new in P3)
- [x] `cargo test -p vta-sdk --lib --all-features` — 279 tests pass unchanged
- [x] OpContext plumbing covered by existing tests (the `triggered_by` field appears only in `Rollback` paths; `Direct` calls emit telemetry unchanged)
- [x] Snapshot round-trip tests for both kinds (`RestSnapshot::Disabled`, `RestSnapshot::Enabled { url }`, `DidcommSnapshot::Disabled`, `DidcommSnapshot::Enabled { mediator_did, routing_keys }`)
- [x] `RollbackKind` discriminants are pinned (CLI stability)
- [ ] Reviewer confirms the `RollbackResponse` shape (extends `ServiceMutationResponse` with `kind` + `draining_mediator`) is the right call vs. reusing the existing shape with a sentinel `version_id = ""` on no-op
- [ ] Full §7a.5 e2e dispatch coverage (5 REST + 6 DIDComm rollback histories) lands in P6 against the live test mediator — flagged in tasks.md

## Out of scope (follow-up PRs)

- **P4** — `services list` query (the operator-facing read surface for inspecting current state before deciding whether to rollback)
- **P5** — unified `pnm services …` CLI surface, retiring `pnm mediator …` (breaking change)
- **P6** — full §7a.5 rollback histories e2e (11 scenarios) + the matrix overall
- **P7** — operator docs + memory updates