### PR TITLE
docs(vtc): MVP design + Phase 0 plan

### DIFF
--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -80,6 +80,7 @@ ADR if circumstances change.
 | **Public community website is feature-gated** | Cargo feature `website`. Operators who use an external host disable the feature; routes 404. |
 | **Extensibility model = Rego + opaque JSON blobs** | Communities customize *behavior* via policies and *data* via `extensions: JsonValue` slots. No plugin loader, no WASM hooks, no custom REST modules. |
 | **Hygiene baked in from day one** | Versioned audit events, idempotency keys, `/v1/` URL prefix, cursor pagination on lists, multi-passkey-per-admin. These are load-bearing retrofits, not features. |
+| **VTC never targets TEE deployment** | Only the VTA runs in Nitro Enclave / TEE. The VTC stays a regular service. This is a *permanent* non-goal, not a deferral — public website serves from local filesystem, no vsock parity is required, and the storage abstraction can stay simple. If TEE-grade trust is needed for a community, the trust anchor remains the VTA. |
 
 ## 4. Bootstrap and setup
 
@@ -601,10 +602,20 @@ collection.
 
 ### 9.4 CORS
 
-`config.toml` carries an `allowed_origins: Vec<String>` list. Defaults
-to empty; install flow writes the admin UX origin during step 6.
+`config.toml` carries a `cors.allowed_origins: Vec<String>` list.
 Wildcard origins refused at config-load time. Preflight responses
 include `Idempotency-Key` in `Access-Control-Allow-Headers`.
+
+Interaction with admin UX hosting mode (§12.2):
+
+* `admin_ui.mode = "embedded"` — admin UX served same-origin (or by
+  Host-header routing to a configured subdomain); no CORS entry
+  required for the admin UX itself.
+* `admin_ui.mode = "external"` — the install flow writes the external
+  admin origin into `cors.allowed_origins` during step 6.
+
+The public website's own origin is auto-allowed so that static-site
+JS can POST to `/v1/join-requests` without a separate CORS config.
 
 ### 9.5 REST surface (representative — full OpenAPI in §16 followup)
 
@@ -667,6 +678,15 @@ DELETE /v1/relationships/{id}
 POST   /v1/credentials/endorsements      # mint VEC
 POST   /v1/credentials/witnesses         # mint VWC
 POST   /v1/credentials/rcards            # mint RCard
+
+# Public website (feature: website)
+GET    /v1/website/files                 # list current site tree
+GET    /v1/website/files/{path}          # fetch a file
+PUT    /v1/website/files/{path}          # upload (admin/moderator)
+DELETE /v1/website/files/{path}
+POST   /v1/website/deploy                # tar.gz bundle (atomic if managed)
+GET    /v1/website/generations           # managed mode only
+POST   /v1/website/rollback/{gen}        # managed mode only
 
 # Status lists
 GET    /v1/status-lists/revocation       # public (the VC)
@@ -921,20 +941,220 @@ See §6.5.
 
 ### 12.1 Public community website (`website` feature)
 
-* Markdown blobs stored in the `website_content` keyspace, keyed by
-  path (`/`, `/about`, `/join`).
-* Server-rendered HTML (pulldown-cmark) at request time. No client-side
-  scripting layer.
-* Asset passthrough for static files (logo, images).
-* Submit endpoint: `POST /v1/website/forms/join` (rate-limited, no
-  auth) routes to `POST /v1/join-requests` internally. CSRF token
-  required; double-submit cookie pattern.
-* Disabled (feature off): all `/v1/website/*` routes 404. Operator
-  points DNS at an external host.
-* No CMS UI in MVP. Authoring is REST: `PUT /v1/website/pages/{path}`
-  (admin/moderator).
+A generic static-file host. Community admins upload arbitrary HTML,
+CSS, JS, images, fonts — whatever they want — and the VTC serves it.
+No template language, no markdown rendering, no opinions about site
+structure. Operators can use plain HTML, an SPA, a static-site
+generator's output, or just dump a folder of files.
 
-### 12.2 VRC graph
+**Backing storage: local filesystem** (not fjall). Operators can
+update site files directly with `scp`, `rsync`, `git pull`, or a
+local editor and the changes are served on the next request. The
+REST API endpoints exist as the *convenient* way to update; direct
+filesystem editing is the *primary* one. This is possible because
+the VTC never runs in a TEE (§3) and the filesystem is reliably
+addressable.
+
+#### Configuration
+
+```toml
+[website]
+enabled       = true
+root_dir      = "/var/lib/vtc/website"  # served from here
+deploy_mode   = "live"                  # or "managed"
+spa_fallback  = false                   # serve /index.html for unmatched paths
+max_file_size_mb     = 10
+max_bundle_size_mb   = 50
+max_files_per_bundle = 1000
+```
+
+`deploy_mode`:
+
+* **`"live"`** (default) — files in `root_dir` are served as-is. No
+  generations, no atomic swap, no rollback. Operator owns the
+  filesystem layout. Bundle deploys overwrite files in place.
+  Matches the "just copy files and they're live" mental model.
+* **`"managed"`** — `root_dir` contains `gen-N/` subdirectories and a
+  `current → gen-N` symlink. Bundle deploys extract to a fresh
+  `gen-N+1/`, then atomically swap the symlink. Last 5 generations
+  retained (configurable). Rollback via `POST /v1/website/rollback/{gen}`.
+  Operators who need rollback semantics opt in.
+
+#### REST surface
+
+```
+GET    /v1/website/files            # list current site tree
+GET    /v1/website/files/{path}     # fetch a file
+PUT    /v1/website/files/{path}     # upload/overwrite (admin/moderator)
+DELETE /v1/website/files/{path}     # remove a file
+POST   /v1/website/deploy           # tar.gz bundle, atomic if managed
+GET    /v1/website/generations      # managed mode only
+POST   /v1/website/rollback/{gen}   # managed mode only
+```
+
+`POST /v1/website/deploy` accepts a `tar.gz` body up to
+`max_bundle_size_mb`. In `"live"` mode: extracted directly into
+`root_dir`, overwriting matching paths. In `"managed"` mode:
+extracted into a new generation, symlink swapped atomically.
+
+#### Serving
+
+* MIME types detected by file extension (`mime_guess`).
+* `ETag` (SHA-256 of content) + `Cache-Control: public, max-age=3600`
+  on every response so operators can put a CDN in front.
+* Directory paths (`/about/`) resolve to `index.html` in that
+  directory.
+* Unmatched paths: 404, or fall back to `/index.html` if
+  `spa_fallback = true`.
+* Path traversal (`..` escape) rejected with 400.
+* Hidden files (leading `.`) not served.
+
+#### Form submissions to the join flow
+
+The static site can POST directly to `/v1/join-requests` (CORS
+allows the website's own origin by default). No special "form
+proxy" endpoint — the API endpoint is the form target.
+
+#### Disabled mode
+
+`enabled = false` (or `website` cargo feature off): all
+`/v1/website/*` routes 404. Operator points DNS at an external host
+(GitHub Pages, Netlify, S3, whatever) and the community site is
+hosted externally.
+
+### 12.2 Admin UX hosting (`admin-ui` feature)
+
+The admin UX is a static SPA built and released from a separate
+sibling repository (`OpenVTC/vtc-admin-ui`). The VTC binary embeds
+that SPA at build time, then serves it from a configurable mount.
+
+#### Embedded build
+
+`vtc-service/build.rs` reads a pinned version from `Cargo.toml`
+(metadata field `[package.metadata.admin_ui] version = "x.y.z"`) and
+fetches the release artifact:
+
+```
+https://github.com/OpenVTC/vtc-admin-ui/releases/download/v{version}/admin-ui-dist.tar.gz
+```
+
+Extracts to `OUT_DIR/admin-ui-dist/`, then `include_dir!` bakes the
+tree into the binary. Build is reproducible: the release tarball is
+checksum-pinned (SHA-256 also in `Cargo.toml` metadata), and `build.rs`
+verifies before extracting.
+
+Offline builds: a vendored fallback at `vtc-service/vendor/admin-ui-dist/`
+is used if `VTC_OFFLINE_BUILD=1` is set. CI populates this; release
+tarballs ship with it bundled.
+
+#### Configuration
+
+```toml
+[admin_ui]
+enabled = true
+mode    = "embedded"   # or "external"
+mount   = "/admin"     # path; or use host below for subdomain mode
+host    = null         # e.g. "admin.example.com" for subdomain mode
+```
+
+* `mode = "embedded"`: VTC serves the baked-in SPA from `mount` /
+  `host`. No CORS needed (same origin or near-origin).
+* `mode = "external"`: VTC does not serve the SPA. The operator hosts
+  it elsewhere; the only thing VTC needs is the origin in
+  `cors.allowed_origins`. Useful when the operator wants to host the
+  admin UX on their own static infrastructure.
+
+#### WebAuthn `RP ID` and routing interaction
+
+The WebAuthn `RP ID` set at passkey registration must remain stable
+for passkeys to keep working. With path-prefix routing
+(`example.com/admin`) the `RP ID` is `example.com` and there's no
+issue. With subdomain routing (`admin.example.com`) the `RP ID`
+should be set to the *base* domain (`example.com`) so the credential
+is valid across subdomains. Otherwise moving the admin UX path later
+breaks every registered passkey. Codified in §17 as an operator-
+runbook item.
+
+### 12.3 Routing modes
+
+Each surface (API, admin UX, website) can be mounted on a path
+prefix, bound to a Host header, or both. Default is **path-prefix
+on the same host** — works on day one without DNS configuration.
+
+#### Default config (path-prefix mode)
+
+```toml
+[routing.api]
+mount = "/v1"
+
+[routing.admin_ui]
+mount = "/admin"
+
+[routing.website]
+mount = "/"          # catch-all, lowest priority
+```
+
+A single host serves everything. Route priority (highest first):
+
+1. `/health` (always)
+2. `/v1/*` → API
+3. `/admin/*` → admin UX (if enabled)
+4. `/v1/website/*` → website management API
+5. `/*` → public website (if enabled)
+
+#### Subdomain mode
+
+```toml
+[routing.api]
+host = "api.example.com"
+
+[routing.admin_ui]
+host = "admin.example.com"
+
+[routing.website]
+host = "example.com"
+```
+
+Tower middleware routes by `Host` header. Requests to a host that
+doesn't match any configured surface return 404.
+
+#### Mixed mode
+
+Any combination. Common pattern:
+
+```toml
+[routing.api]
+mount = "/v1"                        # same host as website
+host  = "example.com"
+
+[routing.admin_ui]
+host  = "admin.example.com"          # admin on its own subdomain
+
+[routing.website]
+mount = "/"
+host  = "example.com"
+```
+
+#### Combined vs separated daemon
+
+**MVP**: combined daemon only. One `vtc` process serves all three
+surfaces. The cargo features control what's compiled in; runtime
+config controls how each is exposed.
+
+**Separated daemons** (running multiple VTC binaries that share
+storage) is **not** in MVP. fjall is not multi-process-safe, so
+splitting requires either a proxy/cache architecture or a different
+storage backend. Documented as v2 work. Operators who need
+isolation today should:
+
+* Strip surfaces at compile time via cargo features per build.
+* Put a reverse proxy (nginx / Caddy / CloudFront) in front for
+  caching, TLS termination, and per-surface rate limiting.
+* Use subdomain routing with separate TLS certs.
+
+99% of communities never need to split.
+
+### 12.4 VRC graph
 
 * Self-issued only in MVP. Bilateral counter-signing v2.
 * `POST /v1/relationships` (or `relationships/1.0/publish`) — caller
@@ -965,10 +1185,16 @@ See §6.5.
 | `audit` | new | `timestamp → AuditEnvelope`; indices by type/actor/target |
 | `idempotency` | new | `key → (request_hash, response, expires_at)` |
 | `config` | new | `key → ConfigValue` — DB-layer overrides for runtime config |
-| `website_content` | new (gated) | `path → WebsitePage` |
 
-All keyspaces use the existing `KeyspaceHandle` enum (local fjall
-today; vsock parity later if VTC ever runs in a TEE).
+Public website content is **not** in fjall — it lives on the local
+filesystem at `website.root_dir` (§12.1). This keeps the storage
+abstraction small and lets operators update site files with standard
+filesystem tools.
+
+All fjall keyspaces use the existing `KeyspaceHandle` enum. Because
+the VTC never targets TEE (§3), no vsock-store parity work is
+required for the VTC and `KeyspaceHandle::Vsock` variants stay
+unused on the VTC code path.
 
 ## 14. Operational
 
@@ -1125,6 +1351,16 @@ users get a k8s `Deployment`.
 | `restart.drain_timeout` | ✓ | | ✓ | |
 | `storage.path` | | ✓ | ✓ | |
 | `community.profile.*` | ✓ | | ✓ | Goes through `/v1/community/profile`, not `/v1/admin/config`. |
+| `routing.api.{mount,host}` | | ✓ | ✓ | Affects URL surface. |
+| `routing.admin_ui.{mount,host}` | | ✓ | ✓ | |
+| `routing.website.{mount,host}` | | ✓ | ✓ | |
+| `admin_ui.mode` | | ✓ | ✓ | `"embedded"` vs `"external"`. |
+| `admin_ui.external_origin` | ✓ | | ✓ | Sets the CORS entry; only meaningful if mode = external. |
+| `website.enabled` | | ✓ | ✓ | Disabling unmounts the routes. |
+| `website.root_dir` | | ✓ | ✓ | Filesystem path. |
+| `website.deploy_mode` | ✓ | | ✓ | `"live"` vs `"managed"`. |
+| `website.spa_fallback` | ✓ | | ✓ | |
+| `website.max_*` | ✓ | | ✓ | Size limits on uploads. |
 | Secret backend (keyring / AWS / GCP / Azure) | | n/a | n/a | Selected by cargo feature at compile time; UX surfaces "active backend". |
 | Cargo features (`website`, etc.) | n/a | n/a | n/a | Compile-time only. UX surfaces "feature available" / "not built in". |
 
@@ -1191,7 +1427,7 @@ operator-visible increment.
 | **2 — Policy engine + DTG issuance** | regorus engine, policy upload/activate, `join.rego` driving the join flow, `removal.rego`, VMC + VEC issuance via VTA oracle, status-list publication, renewal endpoint, DID rotation (both methods). | The community has live policies and proper credential issuance. |
 | **3 — Trust-registry + extensibility** | Trust-registry publish on startup, three departure dispositions, `registry.rego`, `MembershipSyncer`, RTBF override path, hash-tagged audit envelopes, cross-community recognition policies. | The community is part of the wider DTG network. |
 | **4 — VRC + Personhood** | Self-issued VRC publishing + storage, `relationships.rego`, `personhood.rego` (deny-all stub) + assert/revoke endpoints, custom endorsement issuance (issuer role). | The graph and personhood semantics are live. |
-| **5 — Optional surfaces** | Public community website (feature-gated), admin web UX (separate repo, can land in parallel with any prior phase once REST surface is stable after phase 2). | MVP complete. |
+| **5 — Optional surfaces** | Public community website (filesystem-backed static hosting, `"live"` + `"managed"` deploy modes, bundle + per-file APIs), admin web UX (sibling repo `OpenVTC/vtc-admin-ui` consumed via `build.rs` tarball embed), routing config (path-prefix default + subdomain mode). Web UX repo can land in parallel with any prior phase once REST surface stabilises after phase 2. | MVP complete. |
 
 Phase 5 sub-tasks parallelize with phases 3 and 4. Phases 0–4 are
 strictly serial.
@@ -1231,9 +1467,26 @@ remains to validate during implementation.
    but adds state. Defer to a phase 2.5 hardening step.
 
 6. **CORS + WebAuthn `RP ID` coupling.** The admin UX origin must
-   match the WebAuthn `RP ID` set at passkey registration. Operators
-   who migrate the admin UX to a new domain re-register all passkeys.
-   Document as expected; codify in operator runbook.
+   match the WebAuthn `RP ID` set at passkey registration. With
+   subdomain routing (`admin.example.com`) the `RP ID` should be set
+   to the base domain (`example.com`) so credentials remain valid
+   across subdomains. Operators who migrate the admin UX to a new
+   base domain re-register all passkeys. Document as expected;
+   codify in operator runbook.
+
+7. **Admin UX release-tarball checksum management.** `build.rs`
+   pins the admin-ui release artifact by SHA-256. Bumping the admin
+   UX version requires an in-repo metadata change in `Cargo.toml`.
+   Operationally fine; tooling (`cargo xtask bump-admin-ui x.y.z`)
+   useful to write at phase 5.
+
+8. **Public website + filesystem reload semantics.** In
+   `deploy_mode = "live"`, files are served directly from disk. The
+   first request after an external edit pays an `mtime` stat
+   per-file; subsequent requests within a configurable window hit a
+   cached descriptor. Cache duration is a tradeoff between
+   live-reload-feel and per-request overhead. Spec'd as
+   `website.live_cache_ttl_seconds` (default 5).
 
 ## 18. Explicitly NOT in MVP
 
@@ -1255,8 +1508,18 @@ To preserve clarity about scope, the following are out:
 * **VPC (Persona credentials)** beyond reserving the type. Land in
   v2 when display-identity needs concrete.
 * **Bilateral VRC counter-signing.** Self-issued only in MVP.
-* **TEE / Nitro Enclave deployment** of the VTC binary. The vsock
-  store parity work in `vti-common` carries over when needed.
+* **TEE / Nitro Enclave deployment of the VTC binary** — *permanent*
+  non-goal, not a deferral. Only the VTA targets TEE. The VTC stays
+  a regular service. Communities that need TEE-grade trust anchor
+  back through the VTA.
+* **Separated daemons sharing storage** (running multiple `vtc`
+  binaries off the same fjall path). fjall is not multi-process-safe;
+  this requires a proxy/cache architecture or different storage
+  backend. v2 work. Operators who need isolation today use cargo
+  features per build + reverse proxy.
+* **Filesystem / S3 backends for fjall keyspaces** beyond what is
+  already explicitly filesystem-based (the public website root).
+  Other keyspaces stay in fjall.
 * **VTC-to-VTC community migration tooling.** Config export +
   community-data backup already give operators the primitives;
   packaged migration scripts are a follow-up.

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -1,0 +1,1281 @@
+# Spec: Verifiable Trust Community (VTC) — MVP
+
+Status: **Draft**
+Owner: Glenn Gore
+Last updated: 2026-05-11
+
+## 1. Objective
+
+Turn the existing skeletal `vtc-service` crate (auth, ACL, sessions,
+DIDComm, setup, did:webvh) into a minimum-viable **Verifiable Trust
+Community** capable of standing up a self-governing community on top
+of an existing VTA. A VTC manages community lifecycle, policy-driven
+join/leave, role-based access, DTG credential issuance, optional
+public hosting, and integrates with a trust-registry so other
+communities can verify cross-community membership.
+
+The product is a Rust backend service; an admin web UX lives in a
+separate sibling repository and consumes the VTC's REST API.
+
+### Why this matters
+
+The VTA gives an operator key-management and DID-management
+infrastructure. It does not give them a *community*. Without a VTC,
+each operator has to invent their own membership model, their own
+policy engine, their own cross-community trust story. The VTC ships
+that as opinionated, composable infrastructure that stays inside the
+DTG credential catalog and the wider workspace doctrine.
+
+### Non-goals
+
+* **Multi-tenant VTC.** One VTC binary hosts exactly one community.
+  Multi-community hosts are out of scope for MVP.
+* **Custom credential types.** The VTC issues and consumes only the
+  credentials defined in
+  [`openvtc/dtg-credentials`](https://github.com/OpenVTC/dtg-credentials)
+  (VMC, VRC, VIC, VPC, VEC, VWC, RCard). Communities extend behavior
+  via Rego + opaque JSON metadata blobs, not by adding new credential
+  shapes.
+* **TEE/Nitro deployment.** VTC ships as a regular service for MVP.
+  Enclaved variant follows the VTA's later TEE arc.
+* **N-of-M admin approvals**, **webhooks**, **bulk operations**,
+  **WASM plugins**, **i18n at the resource layer**. Each is a
+  defensible retrofit (see §16 and §17).
+
+## 2. Tech stack & codebase context
+
+* Rust workspace, edition 2024, MSRV 1.94.0.
+* `vtc-service` already provides: auth (challenge-response, JWT
+  audience `"VTC"`), ACL (with role enum to be extended),
+  session-mgmt, DIDComm bridge, fjall-backed storage, `did:webvh`
+  setup, OS-keyring secret backend.
+* New dependencies:
+  * `dtg-credentials = "0.1"` — closed credential catalog.
+  * `affinidi-trust-registry-rs` (TRQP v2.0 client) — entity-level
+    membership recognition.
+  * `affinidi-status-list = "0.1"` (from `affinidi-tdk-rs`) — W3C
+    Bitstring Status List v1.0 for per-VMC revocation.
+  * `regorus` — embedded Rego engine.
+  * `webauthn-rs` — passkey enrolment for admin login.
+* Existing dependencies stay: `vti-common` (Store, AppError, telemetry
+  sink, identifier validation), `vta-sdk` (REST + DIDComm client,
+  sealed-transfer, attestation, protocol types),
+  `affinidi-messaging-didcomm-service`, `fjall`, `axum`.
+
+## 3. Architectural decisions (pinned)
+
+These are settled. Do not re-litigate during implementation; raise an
+ADR if circumstances change.
+
+| Decision | Rationale |
+|---|---|
+| **1 VTC ⇄ 1 VTA topology** | The VTC has no key custody; every signature goes to the VTA signing oracle. Multi-VTA-per-VTC explodes the trust path without clear gain. |
+| **VTC is always authoritative for its own state** | ACL + keyspaces are source of truth. VMC/VEC are *projections* of that state, useful when the member operates outside the VTC. VTC's own authz code never reads the VCs it issued. |
+| **Credentials limited to DTG catalog** | VMC (membership), VEC (role + endorsement), VIC (invitation), VRC (relationship edge), VWC (witness, consumed only), RCard (contact), VPC (persona, v2). New credential types go upstream into dtg-credentials, not local extensions. |
+| **Embedded regorus, no OPA sidecar** | Single deploy artifact, lower latency, TEE-compatible later. Policy reload is explicit (`POST /v1/policies/{id}/activate`); no hot-reload watchers. |
+| **Trust-registry and StatusList are complementary** | StatusList answers "is this VC revoked?". Trust-registry answers "is this entity an active member?". A robust verifier consults both. |
+| **DTG VMC `validUntil` is mandatory and finite** | Per-community config; default 30 days. External verifiers MUST see a non-perpetual VMC. Inside the community, ACL is authoritative — expired VMC does not lock the member out. |
+| **Membership renewal is unconditional inside the community** | A member whose VMC expired three months ago can mint a fresh one any time, as long as ACL still says they're a member. No grace logic, no admin re-approval. |
+| **Admin UX is a separate sibling repository** | VTC ships pure backend. CORS configurable. |
+| **Public community website is feature-gated** | Cargo feature `website`. Operators who use an external host disable the feature; routes 404. |
+| **Extensibility model = Rego + opaque JSON blobs** | Communities customize *behavior* via policies and *data* via `extensions: JsonValue` slots. No plugin loader, no WASM hooks, no custom REST modules. |
+| **Hygiene baked in from day one** | Versioned audit events, idempotency keys, `/v1/` URL prefix, cursor pagination on lists, multi-passkey-per-admin. These are load-bearing retrofits, not features. |
+
+## 4. Bootstrap and setup
+
+### 4.1 CLI setup wizard — minimal handoff to web UX
+
+```text
+$ vtc setup
+? Public VTC URL [https://vtc.example.com]:
+? Public admin UX URL [https://admin.example.com]:
+? VTA URL for provisioning [https://vta.example.com]:
+
+✓ Minted VTC seed
+✓ Provisioned VTC DID via VTA (template: vtc-host)
+✓ Initialised keyspaces (sessions, acl, policies, members,
+  join_requests, status_lists, registry_records, audit,
+  idempotency, relationships)
+
+  Open this URL within 1 hour to finish setup:
+
+    https://admin.example.com/install#token=eyJhbGc…
+```
+
+The CLI does the bare minimum to make the daemon answerable. All
+human-facing configuration (community profile, policies, admin
+identity) happens in the admin UX.
+
+What the CLI actually does:
+
+1. Mints a 24-word BIP-39 seed via `affinidi-secrets-resolver`
+   (default backend: OS keyring; AWS/GCP/Azure available via feature
+   flags, same pattern as VTA).
+2. Calls VTA's `POST /provision-integration` with the
+   `vtc-host` DID template (new built-in template — see §4.4).
+   Receives a sealed bundle containing the VTC's `did:webvh`, signing
+   key references, and the VTA trust bundle. Opens the bundle locally
+   and persists secrets.
+3. Initializes all fjall keyspaces (§13).
+4. Mints a single-use **install token**: signed JWT with
+   `aud="vtc-install"`, `exp=now+1h`, `iat`, `jti`, plus an embedded
+   ephemeral Ed25519 keypair the install flow uses for the
+   challenge-response binding.
+5. Prints the install URL and starts the daemon listening on the
+   configured port.
+
+### 4.2 Install flow (admin UX side)
+
+1. Operator opens the install URL. The admin UX exchanges the install
+   token for a setup session via `POST /v1/install/claim` (kills the
+   install token atomically; carve-out pattern mirrors VTA's
+   `BOOTSTRAP_CARVEOUT_CLOSED_KEY`).
+2. WebAuthn passkey registration on the operator's authenticator
+   (`webauthn-rs`). The passkey's public key is bound to a fresh
+   `did:key` derived from it. This is the admin's DID.
+3. Operator enters community profile in the UX: `name`, `description`,
+   `logo_url`, `public_url`, `contact_email`, `language`.
+4. Operator picks a seed policy template (`policies.open`,
+   `policies.invite_only`, `policies.kyc_required`) which the UX
+   uploads via `POST /v1/policies` then activates via
+   `POST /v1/policies/{id}/activate`. Operators can edit policies
+   later through the UX.
+5. Operator chooses trust-registry behaviour: publish-on-join default,
+   default departure disposition (Purge / Tombstone / Historical),
+   whether to publish the VTC's own issuer profile on startup.
+6. Admin UX calls `POST /v1/admin/bootstrap` with the admin DID. VTC
+   writes the first ACL entry (`role: Admin`), permanently closes the
+   install token carve-out, and emits a `CommunityInstalled` audit
+   event.
+
+After step 6 the install URL is dead. All subsequent admin operations
+require an authenticated session against the admin DID's passkey.
+
+### 4.3 Multi-passkey per admin DID
+
+Admin entry shape in the `acl` keyspace for admin-role entries:
+
+```rust
+struct AdminEntry {
+    did: String,
+    role: VtcRole,
+    passkeys: Vec<RegisteredPasskey>,  // 1..N
+    joined_at: DateTime<Utc>,
+    extensions: Value,                  // opaque per-community blob
+}
+
+struct RegisteredPasskey {
+    credential_id: Vec<u8>,
+    public_key: Vec<u8>,
+    transports: Vec<AuthenticatorTransport>,
+    label: String,                      // e.g., "MacBook Air Touch ID"
+    registered_at: DateTime<Utc>,
+    last_used_at: Option<DateTime<Utc>>,
+}
+```
+
+Operations:
+
+* `POST /v1/admin/passkeys/register` — initiate WebAuthn ceremony for
+  an additional device. Requires an authenticated session (the
+  operator is logged in on device A and registering device B).
+* `DELETE /v1/admin/passkeys/{credential_id}` — revoke a lost
+  device. Refuses if it would leave the admin DID with zero passkeys
+  (use emergency-bootstrap instead).
+* `GET /v1/admin/passkeys` — list registered devices.
+
+Each passkey operation emits a versioned audit event
+(`AdminPasskeyRegistered`, `AdminPasskeyRevoked`).
+
+### 4.4 The `vtc-host` DID template
+
+New built-in DID template shipped with `vta-sdk`'s
+`did_templates::builtin` set. Mirrors the existing `webvh-control` /
+`webvh-daemon` shapes:
+
+* `kind: "vtc-host"`
+* Required vars: `vtc_url` (REST advertisement),
+  `community_name` (for service entry label).
+* Key shapes: one `assertionMethod` Ed25519 (for credential
+  signatures), one `authentication` Ed25519 (for session/DID auth),
+  one `keyAgreement` X25519 (for DIDComm + sealed-transfer reception).
+* Service entries: `#vtc-rest` (REST endpoint), `#vtc-status-list`
+  (where the BitstringStatusListCredential is hosted — see §6.2).
+* No DIDComm service entry by default — communities that need a
+  mediator add it later via the existing `services didcomm enable`
+  runtime-service-management flow against their VTA.
+
+### 4.5 Emergency bootstrap (recovery)
+
+If all admin passkeys are lost: `vtc admin emergency-bootstrap` on a
+stopped daemon emits a new install token (1h TTL) and re-opens the
+install carve-out exactly once. Documented as a destructive operator
+action: it writes a loud audit event
+(`EmergencyBootstrapInvoked { operator_host, timestamp }`) on next
+daemon start, visible in `GET /v1/audit?type=EmergencyBootstrapInvoked`.
+
+## 5. Core domain model
+
+### 5.1 Community profile
+
+Stored as a singleton record in the `community` keyspace.
+
+```rust
+struct CommunityProfile {
+    community_did: String,           // immutable; set at install
+    name: String,
+    description: String,
+    logo_url: Option<String>,
+    public_url: Option<String>,
+    contact_email: Option<String>,
+    language: String,                // BCP 47, default "en"
+    created_at: DateTime<Utc>,
+    extensions: Value,               // arbitrary community-defined fields
+}
+```
+
+Editable by `admin` role. Stored under a stable key
+(`community/profile`) for cheap reads.
+
+### 5.2 Member
+
+```rust
+struct Member {
+    did: String,                     // did:key or did:webvh
+    role: VtcRole,
+    joined_at: DateTime<Utc>,
+    status_list_index: u32,          // stable for member's lifetime
+    publish_consent: bool,           // trust-registry consent
+    departure_preference: Option<DepartureDisposition>,
+    current_vmc_id: Option<String>,  // latest issued VMC id
+    current_role_vec_id: Option<String>,
+    extensions: Value,
+}
+```
+
+ACL entry references the `Member` for non-admin roles. Admin entries
+carry `passkeys` directly (§4.3).
+
+### 5.3 Roles
+
+```rust
+enum VtcRole {
+    Admin,
+    Moderator,
+    Issuer,
+    Member,
+    Custom(String),   // community-defined; permissions via role_definitions.rego
+}
+```
+
+Default permissions (rough matrix; final permissions defined by
+`role_definitions.rego` and consulted on each authorized request):
+
+| Action | Admin | Moderator | Issuer | Member |
+|---|---|---|---|---|
+| Edit community profile | ✓ | | | |
+| Author / activate policies | ✓ | | | |
+| Approve/reject join requests | ✓ | ✓ | | |
+| Issue VEC / VWC / RCard on behalf of community | ✓ | | ✓ | |
+| Issue VMC | (only via join flow) | | | |
+| Remove other members | ✓ | ✓ (policy-gated) | | |
+| Self-remove | ✓ | ✓ | ✓ | ✓ |
+| Renew own VMC | ✓ | ✓ | ✓ | ✓ |
+| Publish self-issued VRC | ✓ | ✓ | ✓ | ✓ |
+| Rotate own DID | ✓ | ✓ | ✓ | ✓ |
+
+Custom roles must define their permissions in `role_definitions.rego`;
+unspecified actions default-deny.
+
+### 5.4 Policy bundle
+
+A `Policy` is a single Rego module plus metadata:
+
+```rust
+struct Policy {
+    id: Uuid,
+    name: String,                    // e.g., "join", "removal"
+    purpose: PolicyPurpose,
+    rego_source: String,
+    compiled: Vec<u8>,               // regorus pre-compiled bytecode
+    sha256: [u8; 32],
+    activated_at: Option<DateTime<Utc>>,
+    author_did: String,
+}
+
+enum PolicyPurpose {
+    Join,
+    Removal,
+    Personhood,
+    Registry,
+    Directory,
+    RoleDefinitions,
+    CrossCommunityRoles,
+    CrossCommunityRelationships,
+    Relationships,
+}
+```
+
+Exactly one Policy per `purpose` may be active at any time.
+Activating a new policy supersedes the prior one atomically; the prior
+is retained in the `policies` keyspace (archived) for audit.
+
+### 5.5 Join request
+
+```rust
+struct JoinRequest {
+    id: Uuid,
+    applicant_did: String,
+    vp: serde_json::Value,           // raw VP
+    submitted_at: DateTime<Utc>,
+    status: JoinStatus,
+    policy_decision: Option<PolicyDecision>,
+    registry_consent: Option<RegistryConsentRequest>,
+    extensions: Value,
+}
+
+enum JoinStatus { Pending, Approved, Rejected, Withdrawn, Deferred }
+```
+
+### 5.6 Status-list state
+
+```rust
+struct StatusListState {
+    purpose: StatusListPurpose,      // Revocation | Suspension
+    capacity: u32,                   // default 2^17 = 131_072
+    next_random_seed: u64,           // for random index allocation
+    occupied: u32,                   // count for the 75% alert
+    list_credential_id: String,
+}
+```
+
+### 5.7 Trust-registry record
+
+```rust
+struct RegistryRecord {
+    record_id: String,               // assigned by trust-registry
+    member_did: String,
+    status: RegistryStatus,
+    active_from: DateTime<Utc>,
+    active_to: Option<DateTime<Utc>>,
+    last_synced_at: DateTime<Utc>,
+}
+
+enum RegistryStatus { Active, Departed }
+```
+
+## 6. Credentials — DTG catalog mapping
+
+### 6.1 The closed catalog
+
+The VTC issues, consumes, or stores only credentials from
+`dtg-credentials`. The full mapping:
+
+| Use | Type | Issuer | Subject | Notes |
+|---|---|---|---|---|
+| Membership | **VMC** | community DID | member DID | `personhood: bool` gated by `personhood.rego`. `validUntil` mandatory (community config). `credentialStatus` points to community's BitstringStatusListCredential. |
+| Role grant | **VEC** | community DID | member DID | `endorsement = { type: "CommunityRole", role, communityDid }`. Issued alongside VMC at join; re-issued on role change. |
+| Invitation (gated communities) | **VIC** | community DID (admin/issuer) | applicant DID | Holder presents in VP at join. Policy can mandate. |
+| Member ↔ member trust edge | **VRC** | member DID | other member DID | Self-issued. Published to VTC for discoverability. |
+| Community ↔ community trust edge (v2) | VRC | community DID | other community DID | Pairs with trust-registry recognition. |
+| Member contact card | **RCard** | member or community | member | jCard value. Member-driven; VTC stores opaquely. |
+| Event/proximity witness | **VWC** | external | applicant | Consumed in join VPs; never issued by VTC. |
+| Custom endorsement | **VEC** | community (issuer role) | any DID | Community-defined `endorsement` value. The hook for badges, attestations, etc. — without inventing new credential types. |
+| Persona binding | VPC | community | member | **v2**. Not in MVP. |
+
+### 6.2 Status-list integration
+
+* On install, VTC mints two `BitstringStatusListCredential`s
+  (purpose `revocation`, purpose `suspension`), each with capacity
+  131,072 (configurable). Hosted at
+  `https://{vtc_public_url}/v1/status-lists/{purpose}` and referenced
+  in the VTC DID document via the `#vtc-status-list` service entry.
+* Index allocation is **random** with decoys (affinidi-status-list's
+  privacy mode).
+* Every VMC issued carries `credentialStatus = { id: ".../status-lists/revocation#<idx>", type: "BitstringStatusListEntry", purpose: "revocation", statusListIndex: <idx>, statusListCredential: ".../status-lists/revocation" }`.
+* On member departure: flip the bit at the member's index. Same index
+  is reused across the member's lifetime (renewals re-issue VMCs that
+  point to the same index).
+* On `Purge` disposition: bit flipped *and* index removed from the
+  member record; the slot becomes a decoy.
+* **Alert** when any status list crosses 75% occupancy (telemetry
+  event `StatusListOccupancyWarning`); MVP does **not** chain to a
+  second list — that's a v2 problem documented in §16.
+
+### 6.3 Renewal model
+
+Endpoint: `POST /v1/members/me/renew` (REST) and
+`community/1.0/renew-vmc` (DIDComm).
+
+Behavior:
+
+1. Auth check: member's session must match an active ACL entry.
+   No expiry/grace test.
+2. Mint new VMC (`validFrom = now, validUntil = now + community.membership.validity`)
+   via VTA signing oracle. Same `credentialStatus` index. Same
+   `subject` (member DID).
+3. Mint refreshed role VEC if any of: role changed since last issuance,
+   community profile changed (issuer DID renamed), policy version
+   updated such that role permissions changed.
+4. Sealed-transfer the credentials to the member's DID.
+5. Audit event `MembershipRenewed { member_did, vmc_id, validUntil }`.
+
+### 6.4 Personhood
+
+* New Rego policy `personhood.rego`. Ships as a **deny-all stub** by
+  default. Community admins author the actual rule (e.g., "require N
+  VWCs from event X plus M endorsements from existing personhood
+  holders").
+* Personhood is asserted via a separate explicit operation:
+  `POST /v1/members/{did}/personhood/assert`. Re-mints the member's
+  VMC with `personhood: true` (which adds the
+  `PersonhoodCredential` type marker per dtg-credentials).
+* Revoking personhood: `DELETE /v1/members/{did}/personhood` re-mints
+  the VMC with `personhood: false`. Audit logged.
+* Policy input contract: `data.input = { applicant_did, vp_claims }`.
+  Communities extend via additional `data.*` namespaces they populate
+  through custom REST hooks they wire up server-side (each
+  implementer reinvents — workspace doctrine).
+
+### 6.5 DID rotation per method
+
+| Member DID method | Mechanism |
+|---|---|
+| **did:webvh** | Native. VTC resolves the new DID, walks its `did.jsonl` history, finds the prior key matching the old ACL entry, verifies the rotation signature against the prior key. No additional credential required. |
+| **did:key** | Co-signed rotation attestation. Payload `{ old_did, new_did, vtc_did, rotation_id, expires_at: now+10m }` signed by **both** old-DID and new-DID keys. VTC verifies both signatures, atomically updates ACL (key change), reuses status-list index, re-issues VMC + role VEC to the new DID. Old DID's session invalidated. |
+
+Wire: `POST /v1/members/me/rotate` + `community/1.0/rotate-did`.
+Authentication is via the *new* DID's session (caller proves
+possession of the new key).
+
+In-flight VRCs keyed on the old DID are left intact (graph history
+preservation). Members who want continuity issue a fresh VRC linking
+new → old as a `controller-rotation` relationship.
+
+Members are expected to use `did:key` or `did:webvh` (workspace
+doctrine). Other DID methods are not supported in MVP.
+
+## 7. Policy engine (regorus)
+
+### 7.1 Required policies
+
+| Name | Purpose | Default-ship behavior |
+|---|---|---|
+| `join` | Decide on join requests | Template: `policies.open` (accept any signed VP) |
+| `removal` | Decide admin-initiated removals | Default: any admin may remove any non-admin |
+| `personhood` | Decide personhood assertion | **Deny-all stub** — admin must replace |
+| `registry` | Decide trust-registry publish + departure disposition | Default: publish on join, default disposition = Tombstone |
+| `directory` | Decide member-directory visibility | Default: members can see other members' DID + role only |
+| `role_definitions` | Map roles (incl. custom) to permissions | Default: the matrix in §5.3 |
+| `cross_community_roles` | Decide if external VEC role grants are honoured | **Deny-all** by default |
+| `cross_community_relationships` | Decide if external VRCs are stored | **Deny-all** by default |
+| `relationships` | Decide if a published VRC is stored / surfaced | Default: store if both parties are current members |
+
+### 7.2 Activation lifecycle
+
+* Upload via `POST /v1/policies` (`admin` role). Body includes Rego
+  source + metadata. VTC compiles via `regorus`, returns 400 with
+  compilation errors on failure.
+* Activate via `POST /v1/policies/{id}/activate`. Atomic swap: in-flight
+  requests against the old policy complete; new requests use the new
+  one. Old policy retained in `policies` keyspace as archived (audit).
+* Test via `POST /v1/policies/{id}/test` — evaluates the policy against
+  a provided input without activating.
+* No file-watching, no auto-reload. Reloads are deliberate.
+
+### 7.3 Input contracts
+
+All Rego policies receive `data.input` plus, for some, additional
+`data.*` namespaces.
+
+| Policy | `input` shape |
+|---|---|
+| `join` | `{ applicant_did, vp_claims, action: "join", now }` |
+| `removal` | `{ actor_did, target_did, target_role, reason, action: "remove", now }` |
+| `personhood` | `{ applicant_did, vp_claims }` (community extends) |
+| `registry` | `{ member, action: "join"\|"leave", requested_disposition? }` |
+| `directory` | `{ viewer_did, viewer_role, target_member, fields_requested }` |
+| `role_definitions` | `{ role, action, resource? }` |
+| `cross_community_roles` | `{ foreign_vec, target_role, vtc_state }` |
+| `relationships` | `{ vrc, issuer_member, subject_member }` |
+
+Communities adding policy-specific context inject it via REST hooks
+they author themselves; the workspace ships the contracts above and
+does not standardize extension shapes.
+
+## 8. Trust-registry integration
+
+### 8.1 Startup behaviour
+
+On daemon start (after install completes), VTC publishes its issuer
+profile to the configured trust-registry via
+`affinidi-trust-registry-rs`. Idempotent: re-publishing updates the
+existing record. Publish failures are non-fatal — the daemon logs and
+continues; the `MembershipSyncer` retries.
+
+### 8.2 Three departure dispositions
+
+| Disposition | Record state | Use case |
+|---|---|---|
+| **Purge** | Record deleted | Right-to-be-forgotten; private communities |
+| **Tombstone** | `status: Departed`, no date range | "Was a member, no longer" — minimal disclosure |
+| **Historical** | `status: Departed`, `active_from`/`active_to` populated | Audit / retroactive verification of attestations made during membership |
+
+Decision flow:
+
+1. **Community policy** (`registry.rego`) sets allowed envelope:
+   `publish_on_join`, `departure_options`, `default_departure`,
+   `min_disposition` (floor).
+2. **Member preference** (set at join, or at leave), clamped to the
+   policy's allowed set.
+3. **Right-to-be-forgotten override**: a member-initiated `Purge`
+   request *always wins* over `min_disposition`. Logged as
+   `RegistryRecordPolicyOverride { reason: "rtbf" }` with a hashed
+   member DID so the override is auditable without re-leaking the
+   identifier.
+
+### 8.3 MembershipSyncer
+
+A `MembershipSyncer` (Tokio task, analogous to `DrainSweeper` in
+vta-service) drives reconciliation:
+
+* Subscribes to local lifecycle events (`MemberAdded`, `MemberRemoved`,
+  `RoleChanged`).
+* For each event, computes the desired trust-registry + status-list
+  state and enqueues a `SyncJob`.
+* Retries with exponential backoff on registry-side failures.
+* Emits `RegistrySyncPending`, `RegistrySyncFailed`,
+  `StatusListUpdatePending`, `StatusListUpdateFailed` telemetry
+  events.
+* Boot-time replay of any outstanding jobs in the `sync_queue`
+  keyspace.
+
+### 8.4 Cross-community recognition
+
+A `cross_community_roles.rego` policy decides whether a foreign VEC's
+role claim should map to a local ACL role at this VTC. Default
+deny-all. Communities opt in to federated trust via Rego.
+
+Implementation hook: the auth extractor, when handed a session minted
+from a foreign VEC, runs `cross_community_roles.rego` to compute the
+effective local role. Empty result → 403.
+
+## 9. Wire protocols
+
+### 9.1 URL versioning
+
+All REST endpoints live under `/v1/`. Adding `/v2/` is the explicit
+mechanism for breaking changes. No unversioned routes other than
+`/health`.
+
+### 9.2 Idempotency keys
+
+Every mutating endpoint (`POST`, `PUT`, `DELETE`) accepts
+`Idempotency-Key: <uuid>`. VTC stores `(key, request_hash) → response`
+for 24 hours in the `idempotency` keyspace. Retries with the same key
+return the cached response; retries with the same key but a different
+request body return 422 `IdempotencyKeyConflict`.
+
+Required on: all bootstrap, install, member-lifecycle, policy,
+credential, and rotation endpoints. Optional but accepted on read
+endpoints (no-op).
+
+### 9.3 Cursor pagination
+
+Standard contract on every list endpoint:
+
+```
+GET /v1/<collection>?cursor=<opaque>&limit=<1..200>
+
+→ 200 OK
+{
+  "items": [...],
+  "next_cursor": "<opaque>" | null,
+  "total_estimate": <u64 | null>   // optional
+}
+```
+
+Cursor is opaque (server picks; typically a base64-encoded
+`(last_key, snapshot_id)` tuple). `next_cursor: null` means end of
+collection.
+
+### 9.4 CORS
+
+`config.toml` carries an `allowed_origins: Vec<String>` list. Defaults
+to empty; install flow writes the admin UX origin during step 6.
+Wildcard origins refused at config-load time. Preflight responses
+include `Idempotency-Key` in `Access-Control-Allow-Headers`.
+
+### 9.5 REST surface (representative — full OpenAPI in §16 followup)
+
+```
+# Install / admin lifecycle
+POST   /v1/install/claim
+POST   /v1/admin/bootstrap
+POST   /v1/admin/passkeys/register
+DELETE /v1/admin/passkeys/{credential_id}
+GET    /v1/admin/passkeys
+
+# Admin runtime configuration
+GET    /v1/admin/config
+PATCH  /v1/admin/config
+POST   /v1/admin/config/reload
+POST   /v1/admin/config/restart
+
+# Community
+GET    /v1/community/profile
+PUT    /v1/community/profile
+
+# Members
+GET    /v1/members
+GET    /v1/members/{did}
+GET    /v1/members/{did}/relationships
+PATCH  /v1/members/{did}                 # role / extensions
+DELETE /v1/members/{did}                 # admin removal
+DELETE /v1/members/me                    # self removal
+POST   /v1/members/me/renew
+POST   /v1/members/me/rotate
+POST   /v1/members/{did}/personhood/assert
+DELETE /v1/members/{did}/personhood
+
+# Join requests
+POST   /v1/join-requests                 # submit (unauth, rate-limited)
+GET    /v1/join-requests
+GET    /v1/join-requests/{id}
+POST   /v1/join-requests/{id}/approve
+POST   /v1/join-requests/{id}/reject
+POST   /v1/join-requests/{id}/defer
+
+# Invitations (VIC)
+POST   /v1/invitations
+GET    /v1/invitations
+DELETE /v1/invitations/{id}
+
+# Policies
+GET    /v1/policies
+POST   /v1/policies
+POST   /v1/policies/{id}/activate
+POST   /v1/policies/{id}/test
+GET    /v1/policies/active
+
+# Relationships (VRC)
+POST   /v1/relationships
+GET    /v1/relationships
+DELETE /v1/relationships/{id}
+
+# Credentials (Issuer/Admin)
+POST   /v1/credentials/endorsements      # mint VEC
+POST   /v1/credentials/witnesses         # mint VWC
+POST   /v1/credentials/rcards            # mint RCard
+
+# Status lists
+GET    /v1/status-lists/revocation       # public (the VC)
+GET    /v1/status-lists/suspension       # public (the VC)
+
+# Audit
+GET    /v1/audit
+
+# Backup
+POST   /v1/backup/export                 # admin only
+POST   /v1/backup/import                 # admin only
+POST   /v1/config/export
+POST   /v1/config/import
+
+# Trust-registry
+GET    /v1/registry/profile
+POST   /v1/registry/refresh
+
+# Health
+GET    /health
+GET    /v1/health/diagnostics            # admin only
+```
+
+### 9.6 DIDComm surface
+
+Symmetric protocols under `community/1.0/`:
+
+```
+community/1.0/join-request
+community/1.0/join-decision
+community/1.0/renew-vmc
+community/1.0/rotate-did
+community/1.0/self-remove
+community/1.0/role-update              # admin → member notification
+community/1.0/status-changed           # admin → member notification
+community/1.0/membership-revoked       # admin → member notification
+
+invitations/1.0/issue                  # admin/issuer
+invitations/1.0/redeem                 # applicant
+
+relationships/1.0/publish
+relationships/1.0/query
+
+policies/1.0/upload
+policies/1.0/activate
+policies/1.0/test
+
+credentials/1.0/issue-endorsement      # admin/issuer
+credentials/1.0/issue-witness
+credentials/1.0/issue-rcard
+```
+
+`community/1.0/install/*` does not exist — install is REST-only by
+nature (no DIDComm session before admin bootstrap).
+
+## 10. Audit log
+
+### 10.1 Event vocabulary (versioned)
+
+```rust
+#[serde(tag = "type", content = "data")]
+enum AuditEvent {
+    // v1 events
+    CommunityInstalled(CommunityInstalledData),
+    EmergencyBootstrapInvoked(EmergencyBootstrapData),
+
+    AdminPasskeyRegistered(AdminPasskeyRegisteredData),
+    AdminPasskeyRevoked(AdminPasskeyRevokedData),
+
+    JoinRequestSubmitted(JoinRequestSubmittedData),
+    JoinRequestApproved(JoinDecisionData),
+    JoinRequestRejected(JoinDecisionData),
+    JoinRequestDeferred(JoinDecisionData),
+
+    MemberAdded(MemberLifecycleData),
+    MemberRemoved(MemberLifecycleData),
+    MembershipRenewed(MembershipRenewedData),
+    RoleChanged(RoleChangedData),
+    PersonhoodAsserted(PersonhoodData),
+    PersonhoodRevoked(PersonhoodData),
+    MemberDidRotated(DidRotationData),
+
+    RegistryRecordPublished(RegistryRecordData),
+    RegistryRecordUpdated(RegistryRecordData),
+    RegistryRecordRemoved(RegistryRecordData),
+    RegistryRecordPolicyOverride(RegistryOverrideData),
+
+    StatusListBitFlipped(StatusListBitFlippedData),
+    StatusListOccupancyWarning(StatusListWarningData),
+
+    PolicyUploaded(PolicyMetadata),
+    PolicyActivated(PolicyMetadata),
+
+    InvitationIssued(InvitationData),
+    InvitationRedeemed(InvitationData),
+    InvitationRevoked(InvitationData),
+
+    RelationshipPublished(RelationshipData),
+    RelationshipRemoved(RelationshipData),
+
+    CredentialIssued(CredentialIssuedData),    // VEC / VWC / RCard
+
+    ConfigChanged(ConfigChangedData),
+    ConfigReloaded(ConfigReloadedData),
+    RestartRequested(RestartRequestedData),
+}
+
+struct ConfigChangedData {
+    changes: Vec<ConfigChange>,
+    requires_restart: bool,
+}
+
+struct ConfigChange {
+    key: String,
+    old_value: Option<Value>,                  // null if previously unset
+    new_value: Value,
+    source_before: ConfigSource,               // "env" | "db" | "toml" | "default"
+}
+
+struct AuditEnvelope {
+    event_id: Uuid,
+    event_version: u32,                  // 1 for MVP; bumps on breaking shape change
+    schema_version: u32,                 // overall vocabulary version
+    timestamp: DateTime<Utc>,
+    actor_did_hash: [u8; 32],            // hashed for purge resilience
+    actor_did_plain: Option<String>,     // null after RTBF purge
+    target_did_hash: Option<[u8; 32]>,
+    target_did_plain: Option<String>,
+    event: AuditEvent,
+}
+```
+
+The hash-and-plaintext-pair pattern lets right-to-be-forgotten purges
+null the plaintext while keeping the hash for correlation across the
+audit log. Without hashes, every override leaks the DID it claimed to
+remove.
+
+### 10.2 Query surface
+
+```
+GET /v1/audit
+  ?since=<ISO8601>
+  &until=<ISO8601>
+  &type=<EventType>
+  &actor_did=<did>
+  &target_did=<did>
+  &cursor=<opaque>
+  &limit=<1..200>
+```
+
+Indexed columns in the `audit` keyspace: `timestamp` (primary),
+`type`, `actor_did_hash`, `target_did_hash`. Each yields a secondary
+index keyspace (`audit_by_type`, etc.) maintained on write.
+
+### 10.3 Retention
+
+* Default: retain forever (audit is forensic infrastructure).
+* Configurable per-event-type max retention via
+  `audit.retention.<event_type>`. Pruner task wakes hourly.
+* RTBF purges *null the plaintext fields*; the envelope (with hashes)
+  is retained for chain integrity.
+
+## 11. Member lifecycle
+
+### 11.1 Join
+
+```
+applicant → VTC (REST POST /v1/join-requests or DIDComm join-request):
+  {
+    applicant_did,
+    vp: <Verifiable Presentation>,
+    registry_consent: { publish, departure_preference } | null,
+    extensions: <opaque>
+  }
+
+VTC:
+  1. Validate VP signature (typestate: VerifiedJoinRequest)
+  2. Compile + run join.rego with input.vp_claims
+  3. If allow:
+     a. Allocate status-list index
+     b. Compute VMC validUntil = now + community.membership.validity
+     c. Mint VMC + role VEC via VTA signing oracle
+     d. Write ACL entry + Member record
+     e. Run registry.rego, enqueue MembershipSyncer job
+     f. Sealed-transfer credentials to applicant_did
+     g. Audit: JoinRequestApproved + MemberAdded
+  4. If deny:
+     a. Persist JoinRequest with status=Rejected + decision rationale
+     b. Send DIDComm reject message to applicant
+     c. Audit: JoinRequestRejected
+```
+
+### 11.2 Self-removal
+
+```
+member → VTC:
+  DELETE /v1/members/me
+  { disposition: "Purge" | "Tombstone" | "Historical" | "PolicyDefault" }
+
+VTC:
+  1. Auth check: caller's DID is in ACL
+  2. Compute effective disposition (clamp to registry.rego allowed set;
+     RTBF override path for Purge)
+  3. Atomic local: delete ACL entry, delete/anonymize Member, flip
+     status-list bit, emit MemberRemoved audit
+  4. Enqueue MembershipSyncer job for registry-side change
+  5. Return 200 with effective disposition + sync job id
+```
+
+### 11.3 Admin removal
+
+```
+admin → VTC:
+  DELETE /v1/members/{did}
+  { reason, disposition?: "..." }
+
+VTC:
+  1. Auth: admin role (or moderator if removal.rego allows)
+  2. Run removal.rego with { actor, target, reason }
+  3. If allow: same effects as self-removal, plus
+     audit event tagged with actor_did
+  4. Send community/1.0/membership-revoked DIDComm to target if
+     reachable
+```
+
+### 11.4 Renewal
+
+See §6.3. Unconditional on ACL membership.
+
+### 11.5 Role change
+
+```
+admin → VTC:
+  PATCH /v1/members/{did}
+  { role: "moderator" }
+
+VTC:
+  1. Auth check; validate role exists (standard or defined in
+     role_definitions.rego)
+  2. Update ACL entry
+  3. Mint new role VEC with endorsement.role=<new>
+     Old VEC superseded by validFrom timestamp ordering
+  4. Sealed-transfer new VEC to member
+  5. Audit: RoleChanged + DIDComm role-update notification
+```
+
+### 11.6 DID rotation
+
+See §6.5.
+
+## 12. Optional surfaces
+
+### 12.1 Public community website (`website` feature)
+
+* Markdown blobs stored in the `website_content` keyspace, keyed by
+  path (`/`, `/about`, `/join`).
+* Server-rendered HTML (pulldown-cmark) at request time. No client-side
+  scripting layer.
+* Asset passthrough for static files (logo, images).
+* Submit endpoint: `POST /v1/website/forms/join` (rate-limited, no
+  auth) routes to `POST /v1/join-requests` internally. CSRF token
+  required; double-submit cookie pattern.
+* Disabled (feature off): all `/v1/website/*` routes 404. Operator
+  points DNS at an external host.
+* No CMS UI in MVP. Authoring is REST: `PUT /v1/website/pages/{path}`
+  (admin/moderator).
+
+### 12.2 VRC graph
+
+* Self-issued only in MVP. Bilateral counter-signing v2.
+* `POST /v1/relationships` (or `relationships/1.0/publish`) — caller
+  submits a VRC they signed.
+* VTC verifies VRC signature against caller's known DID.
+* Run `relationships.rego` to decide whether to store.
+* `GET /v1/members/{did}/relationships` returns published VRCs where
+  the DID is issuer or subject. Pagination required.
+* On member departure: VRCs they issued are handled per departure
+  disposition (purged on `Purge`; retained on Tombstone/Historical
+  with status annotation).
+
+## 13. Storage (fjall keyspaces)
+
+| Keyspace | Existing | Schema |
+|---|---|---|
+| `sessions` | ✓ | unchanged |
+| `acl` | ✓ | extended: `VtcRole` enum + `extensions: Value` |
+| `community` | new | singleton key `profile` → `CommunityProfile` |
+| `policies` | new | `id → Policy`; `purpose_active/<purpose> → id` (secondary) |
+| `members` | new | `did → Member` |
+| `join_requests` | new | `id → JoinRequest`; `status/<status>/<id>` (secondary) |
+| `invitations` | new | `id → Invitation` |
+| `relationships` | new | `vrc_id → VrcRecord`; `by_member/<did>/<vrc_id>` (secondary) |
+| `status_lists` | new | per-purpose state + index allocations |
+| `registry_records` | new | `member_did → RegistryRecord` |
+| `sync_queue` | new | pending `MembershipSyncer` jobs |
+| `audit` | new | `timestamp → AuditEnvelope`; indices by type/actor/target |
+| `idempotency` | new | `key → (request_hash, response, expires_at)` |
+| `config` | new | `key → ConfigValue` — DB-layer overrides for runtime config |
+| `website_content` | new (gated) | `path → WebsitePage` |
+
+All keyspaces use the existing `KeyspaceHandle` enum (local fjall
+today; vsock parity later if VTC ever runs in a TEE).
+
+## 14. Operational
+
+### 14.1 Backup / restore
+
+Same pattern as VTA backup:
+
+* Argon2id KDF (≥12-char password) + AES-256-GCM.
+* `POST /v1/backup/export` returns the encrypted full state dump
+  (all keyspaces).
+* `POST /v1/backup/import` accepts a dump; refuses if `community_did`
+  doesn't match the running VTC's DID (`check_vtc_did_compatibility`
+  helper, mirror of VTA's check).
+* Fresh-install VTC accepts any backup (no DID set yet); a configured
+  VTC rejects mismatched backups.
+
+### 14.2 Configuration export/import
+
+Separate from data backup. Exports only configuration shape:
+
+* Community profile.
+* Policy bundle (all policies + the active set per purpose).
+* CORS configured origins.
+* `community.membership.validity`, status-list capacities, audit
+  retention settings, registry endpoints.
+
+Use case: promote-from-staging, migrate between hosts without copying
+member data, share a community template.
+
+`POST /v1/config/export` returns plain JSON.
+`POST /v1/config/import` applies it transactionally; on conflict with
+existing community profile, refuses (force flag = different endpoint).
+
+### 14.3 Telemetry
+
+Reuses `vti_common::telemetry::TelemetrySink` (existing ring-buffer
+default). New event kinds:
+
+* `JoinRequestSubmitted`, `JoinRequestDecided`
+* `MemberAdded`, `MemberRemoved`, `MembershipRenewed`, `RoleChanged`
+* `RegistrySyncPending`, `RegistrySyncFailed`, `StatusListUpdatePending`,
+  `StatusListUpdateFailed`
+* `StatusListOccupancyWarning`
+* `PolicyActivated`
+* `IdempotencyConflict`
+* `CrossCommunityRoleEvaluated`
+
+### 14.4 Health / diagnostics
+
+* `GET /health` — unauth, returns 200 if the daemon is up and storage
+  is reachable.
+* `GET /v1/health/diagnostics` — admin only. Returns:
+  * Status-list occupancy per purpose (count + percentage).
+  * MembershipSyncer queue depth, last-success/failure timestamps.
+  * Active policy ids per purpose with their SHA-256.
+  * Trust-registry last-publish timestamp + status.
+  * Telemetry ring-buffer snapshot summary.
+
+### 14.5 Runtime guards (preserve)
+
+* Rate limit on unauth routes via `tower-governor`: 5 rps + 10 burst
+  per source IP. Applies to `/v1/join-requests` (submit), `/v1/install/*`,
+  `/health`, and public website forms.
+* Body cap: 1 MB globally.
+* Audience isolation: VTC JWTs only — `aud: "VTC"`. Cross-audience
+  tokens rejected.
+* Install carve-out: single-use, like VTA's bootstrap carve-out.
+
+### 14.6 Runtime configuration management
+
+Every configurable VTC option is settable through the admin web UX
+via REST. Settings that can take effect without interrupting service
+(log level, CORS origins, rate limits, audit retention, membership
+validity defaults) apply on explicit reload. Settings that require a
+process restart to take effect (bind address, TLS certificates,
+storage path) are flagged in the UX response and applied via an
+explicit restart action.
+
+#### Persistence model
+
+Configuration is a three-layer overlay, evaluated right-to-left at
+boot and on reload:
+
+```
+effective = env_vars > db_overrides > config.toml > defaults
+```
+
+* `config.toml` is the on-disk seed loaded at boot (compatibility with
+  the existing config story).
+* `db_overrides` is a new `config` keyspace; the admin UX writes here.
+* Environment variables (`VTC_*`) win over everything for ops-style
+  emergency overrides.
+
+`GET /v1/admin/config` returns the effective config with per-field
+annotations: `source: "env" | "db" | "toml" | "default"` and
+`requires_restart: bool`.
+
+#### REST surface
+
+```
+GET   /v1/admin/config
+PATCH /v1/admin/config            # partial update
+POST  /v1/admin/config/reload     # apply reloadable changes in-place
+POST  /v1/admin/config/restart    # graceful shutdown for restart-required changes
+```
+
+`PATCH` accepts a JSON object with any subset of mutable config keys.
+Writes to the `config` keyspace and returns:
+
+```json
+{
+  "applied":          ["log.level", "cors.allowed_origins"],
+  "pending_restart":  ["server.port"],
+  "rejected":         []
+}
+```
+
+`pending_restart` fields are persisted but not yet active. Calling
+`POST /v1/admin/config/reload` re-applies the effective config to
+running subsystems for hot-reloadable settings. Calling
+`POST /v1/admin/config/restart` initiates graceful shutdown:
+
+1. Stop accepting new HTTP / DIDComm requests.
+2. Drain in-flight requests with a configurable
+   `restart.drain_timeout` (default 30s).
+3. Flush `MembershipSyncer` queue (bounded wait, also 30s).
+4. Emit `RestartRequested` audit event.
+5. Exit with status 0.
+
+A process supervisor (systemd `Restart=always`, kubernetes,
+supervisord) is required to actually restart the binary; the spec
+documents this as an explicit operational dependency. CLI users get
+`vtc daemon` (existing) supervised by their init system; container
+users get a k8s `Deployment`.
+
+#### Config taxonomy
+
+| Key | Reload | Restart | UX-settable | Notes |
+|---|---|---|---|---|
+| `server.host` | | ✓ | ✓ | |
+| `server.port` | | ✓ | ✓ | |
+| `server.tls.cert_path` | | ✓ | ✓ | |
+| `server.tls.key_path` | | ✓ | ✓ | |
+| `log.level` | ✓ | | ✓ | |
+| `cors.allowed_origins` | ✓ | | ✓ | |
+| `audit.retention.*` | ✓ | | ✓ | |
+| `membership.validity` | ✓ | | ✓ | New value applies to *subsequent* VMC issuance; existing VMCs retain their issued validUntil. |
+| `status_list.capacity` | | ✓ | ✓ | Existing lists keep their capacity; new lists (on chaining) adopt the new value. |
+| `registry.endpoint` | ✓ | | ✓ | Triggers reconnect. |
+| `registry.publish_on_startup` | ✓ | | ✓ | |
+| `rate_limit.unauth_rps` | ✓ | | ✓ | |
+| `rate_limit.unauth_burst` | ✓ | | ✓ | |
+| `body_cap_bytes` | ✓ | | ✓ | |
+| `restart.drain_timeout` | ✓ | | ✓ | |
+| `storage.path` | | ✓ | ✓ | |
+| `community.profile.*` | ✓ | | ✓ | Goes through `/v1/community/profile`, not `/v1/admin/config`. |
+| Secret backend (keyring / AWS / GCP / Azure) | | n/a | n/a | Selected by cargo feature at compile time; UX surfaces "active backend". |
+| Cargo features (`website`, etc.) | n/a | n/a | n/a | Compile-time only. UX surfaces "feature available" / "not built in". |
+
+#### Audit + telemetry
+
+Every mutation emits a versioned audit event (see §10.1
+additions). `ConfigChanged` carries the per-key change set;
+`ConfigReloaded` and `RestartRequested` mark control-plane actions.
+
+Telemetry counters: `config_patched`, `config_reloaded`,
+`config_restart_requested`, `config_reload_failed`.
+
+#### Relationship to `/v1/config/{export,import}`
+
+`/v1/config/export` (§14.2) returns the union of community profile +
+policy bundle + DB-layer config overrides — exactly what's needed to
+recreate a community on a fresh VTC. It does **not** include
+TOML-layer or env-layer values, since those are deployment-specific.
+`/v1/config/import` writes to the DB layer; restart-required fields
+take effect at next process start.
+
+## 15. CLI surface
+
+`cnm-cli` extension. The community-network-manager binary already
+exists; new subcommands added under `cnm community`:
+
+```
+cnm community setup
+cnm community status
+
+cnm community profile        {show, set}
+cnm community policies       {list, upload, activate, show, test}
+cnm community members        {list, show, role, remove}
+cnm community join           {list, approve, reject, defer, show}
+cnm community invitations    {list, issue, revoke}
+cnm community website        {publish, unpublish, list}     # feature-gated
+cnm community registry       {publish, refresh, status}
+cnm community status-lists   {show, occupancy}
+cnm community audit          {list, since, type, actor, target}
+cnm community backup         {export, import}
+cnm community config         {show, set, reload, restart, export, import}
+cnm community daemon         {reload, restart, status}
+```
+
+`cnm community config show` returns the effective config with source
+annotations. `cnm community config set <key> <value>` PATCHes a single
+key. `cnm community config reload` and `restart` map directly to the
+REST control-plane endpoints. `cnm community daemon` is a thin alias
+for the reload/restart actions, parallel to how operators think about
+the running process.
+
+CLI commands are thin wrappers over `vta-sdk` REST/DIDComm clients
+(workspace doctrine: CLI logic in `vta-cli-common`).
+
+## 16. Phasing / milestones
+
+Phases are ordered by dependency. Each ships independently as an
+operator-visible increment.
+
+| Phase | Deliverable | Gates next phase by |
+|---|---|---|
+| **0 — Provisioning + install** | `vtc-host` DID template, `vtc setup` CLI wizard, install-token + WebAuthn install flow, multi-passkey admin DID, community profile keyspace. | DID + auth foundation. |
+| **1 — IAM + member lifecycle** | Role enum + custom roles, ACL extension, member CRUD, join requests (manual approve/reject), self-removal + admin-removal (no policy yet), audit events v1, idempotency keys, cursor pagination, `/v1/` URL versioning. | The community can have members. |
+| **2 — Policy engine + DTG issuance** | regorus engine, policy upload/activate, `join.rego` driving the join flow, `removal.rego`, VMC + VEC issuance via VTA oracle, status-list publication, renewal endpoint, DID rotation (both methods). | The community has live policies and proper credential issuance. |
+| **3 — Trust-registry + extensibility** | Trust-registry publish on startup, three departure dispositions, `registry.rego`, `MembershipSyncer`, RTBF override path, hash-tagged audit envelopes, cross-community recognition policies. | The community is part of the wider DTG network. |
+| **4 — VRC + Personhood** | Self-issued VRC publishing + storage, `relationships.rego`, `personhood.rego` (deny-all stub) + assert/revoke endpoints, custom endorsement issuance (issuer role). | The graph and personhood semantics are live. |
+| **5 — Optional surfaces** | Public community website (feature-gated), admin web UX (separate repo, can land in parallel with any prior phase once REST surface is stable after phase 2). | MVP complete. |
+
+Phase 5 sub-tasks parallelize with phases 3 and 4. Phases 0–4 are
+strictly serial.
+
+## 17. Open questions
+
+These are *not* blockers — they have proposed answers documented in
+prior turns of design. Listed here so the spec is honest about what
+remains to validate during implementation.
+
+1. **Personhood policy input schema beyond the minimal contract.**
+   Each community extends; the workspace does not standardize. Risk:
+   community implementations diverge wildly. Mitigation: publish at
+   least one reference personhood policy in `docs/04-reference/`
+   after Phase 4 lands.
+
+2. **Status-list chaining strategy.** MVP alerts at 75% occupancy and
+   declines beyond capacity. Production communities will exceed
+   131,072 members eventually. Plan: introduce a successor-list
+   pointer header in the BitstringStatusListCredential and a
+   `chained_status_lists` keyspace. Spec'd as a v2 add-on.
+
+3. **Member DID rotation atomicity under registry lag.** If a `did:key`
+   rotation succeeds locally but the trust-registry sync to update the
+   record's member DID lags, external verifiers briefly see the old
+   DID as active and the new DID as unknown. Workspace doctrine
+   accepts this: registry lag is a known property; verifiers should
+   re-query on mismatch.
+
+4. **Audit hash function and salt strategy.** Currently spec'd as
+   plain SHA-256 over the DID string. Could be salted per-community
+   to prevent cross-community correlation attacks. v2 question.
+
+5. **DIDComm join-request DoS exposure.** Unlike REST (rate-limited by
+   IP), DIDComm doesn't have an obvious rate-limiting axis. Per-DID
+   rate-limit on `community/1.0/join-request` is the obvious answer
+   but adds state. Defer to a phase 2.5 hardening step.
+
+6. **CORS + WebAuthn `RP ID` coupling.** The admin UX origin must
+   match the WebAuthn `RP ID` set at passkey registration. Operators
+   who migrate the admin UX to a new domain re-register all passkeys.
+   Document as expected; codify in operator runbook.
+
+## 18. Explicitly NOT in MVP
+
+To preserve clarity about scope, the following are out:
+
+* **N-of-M admin approvals** for sensitive operations. Retrofit cost
+  is bounded (insert a `proposal` phase ahead of ~8 endpoints); design
+  doesn't need to anticipate it now.
+* **Webhooks / external event subscribers.** Audit event vocabulary
+  is stable from MVP (§10), so this is delivery-layer additive.
+* **Bulk operations** (mass-invite, mass-remove, mass-export). Each
+  is a new endpoint on top of the per-item ones; additive.
+* **WASM / plugin extensions.** Communities extend via Rego + JSON
+  blobs, not custom code. Hard "no" in MVP.
+* **i18n at the resource layer** (translated profile fields, role
+  names, policy messages). Migration plan: introduce
+  `name_translations` field with fallback to `name`. Not
+  architecturally load-bearing — defer with confidence.
+* **VPC (Persona credentials)** beyond reserving the type. Land in
+  v2 when display-identity needs concrete.
+* **Bilateral VRC counter-signing.** Self-issued only in MVP.
+* **TEE / Nitro Enclave deployment** of the VTC binary. The vsock
+  store parity work in `vti-common` carries over when needed.
+* **VTC-to-VTC community migration tooling.** Config export +
+  community-data backup already give operators the primitives;
+  packaged migration scripts are a follow-up.
+* **Onboarding state machine** for new members ("welcome flow",
+  required first actions). Encode in policy + admin UX initially.
+* **Multi-tenant** (one VTC binary hosts multiple communities).
+  Architectural rewrite, intentionally out.
+
+## 19. Related work
+
+* `docs/05-design-notes/runtime-service-management.md` — the service-
+  advertisement primitives the VTC inherits via `vta-sdk`.
+* `docs/03-integrating/provision-integration.md` — how the VTC's own
+  DID is minted from its VTA.
+* `docs/05-design-notes/pnm-setup-deferred-vta-did.md` — the deferred-
+  DID pattern, useful reference for the VTC install flow.
+* [`openvtc/dtg-credentials`](https://github.com/OpenVTC/dtg-credentials)
+  — the credential catalog.
+* [`affinidi/affinidi-trust-registry-rs`](https://github.com/affinidi/affinidi-trust-registry-rs)
+  — TRQP v2.0 server + client.
+* [`affinidi/affinidi-tdk-rs`](https://github.com/affinidi/affinidi-tdk-rs)
+  — `affinidi-status-list`, `affinidi-vc`, `affinidi-data-integrity`.

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -81,6 +81,7 @@ ADR if circumstances change.
 | **Extensibility model = Rego + opaque JSON blobs** | Communities customize *behavior* via policies and *data* via `extensions: JsonValue` slots. No plugin loader, no WASM hooks, no custom REST modules. |
 | **Hygiene baked in from day one** | Versioned audit events, idempotency keys, `/v1/` URL prefix, cursor pagination on lists, multi-passkey-per-admin. These are load-bearing retrofits, not features. |
 | **VTC never targets TEE deployment** | Only the VTA runs in Nitro Enclave / TEE. The VTC stays a regular service. This is a *permanent* non-goal, not a deferral — public website serves from local filesystem, no vsock parity is required, and the storage abstraction can stay simple. If TEE-grade trust is needed for a community, the trust anchor remains the VTA. |
+| **Every wire operation is a registered Trust Task** | REST endpoints and DIDComm messages are bound to a versioned Trust Task identifier hosted on [trusttasks.org](https://trusttasks.org). A Trust Task is the formal definition of an operation — what's being requested, what inputs/credentials are required, what outputs are produced, and what trust assumptions the verifier makes. This is opt-in discipline applied **from day one** so the wire surface is self-describing; soft-gated for MVP (Draft IDs stable; Published status targets v1.0). See §16. |
 
 ## 4. Bootstrap and setup
 
@@ -1415,7 +1416,245 @@ the running process.
 CLI commands are thin wrappers over `vta-sdk` REST/DIDComm clients
 (workspace doctrine: CLI logic in `vta-cli-common`).
 
-## 16. Phasing / milestones
+## 16. Trust Tasks
+
+Every wire operation in the VTC — REST or DIDComm — is a registered
+Trust Task. A Trust Task is the formal, versioned definition of a
+task being requested. It combines:
+
+* **Operation semantics** — what the task does, and what success means.
+* **Inputs** — the credentials, claims, attestations, and parameters
+  the caller must present.
+* **Outputs** — the artefacts (records, credentials, audit events)
+  the task produces.
+* **Trust assumptions** — what the producer relies on about the
+  caller, the inputs, and the surrounding system.
+
+Trust Tasks are identified by a stable URL on
+[trusttasks.org](https://trusttasks.org) and referenced on the wire
+from day one. This is opt-in discipline applied **before MVP code
+ships**, not retrofitted later.
+
+### 16.1 Identifier scheme
+
+```
+https://trusttasks.org/{org}/{domain}/{path}/{major}.{minor}
+```
+
+For this workspace: `org = openvtc`, `domain = vtc`. Example:
+
+```
+https://trusttasks.org/openvtc/vtc/join/request/submit/1.0
+```
+
+Versioning:
+
+* Minor bumps are additive (new optional inputs, new response
+  fields). Backwards compatible.
+* Major bumps are breaking — a new registry entry, the old one stays
+  resolvable as Deprecated.
+
+### 16.2 Wire binding
+
+#### REST
+
+Every request carries a `Trust-Task` header naming the task it
+intends to invoke:
+
+```
+POST /v1/join-requests HTTP/1.1
+Host: vtc.example.com
+Trust-Task: https://trusttasks.org/openvtc/vtc/join/request/submit/1.0
+Idempotency-Key: 8a9c…
+Content-Type: application/json
+
+{ "applicant_did": "...", "vp": { ... } }
+```
+
+VTC checks the header matches the endpoint's registered task. A
+mismatch returns 415 `TrustTaskMismatch` with a structured payload
+identifying the expected task. Missing header on a registered
+endpoint returns 400 `TrustTaskMissing`. The header is not validated
+against trusttasks.org at request time — the URL is treated as an
+opaque identifier the workspace knows about. Network-resolution of
+the URL is the responsibility of operators inspecting traffic.
+
+Response bodies include `trust_task: "<resolved URL>"` so the caller
+sees which task the server actually invoked.
+
+#### DIDComm
+
+The DIDComm message `type` field **is** the Trust Task URL — same
+shape, same registry. The earlier-planned shorthand types like
+`community/1.0/join-request` are rewritten as:
+
+```
+https://trusttasks.org/openvtc/vtc/community/join-request/1.0
+```
+
+No additional envelope field is required; DIDComm v2 already routes
+by message type, and the Trust Task registry is just the canonical
+home for those types.
+
+### 16.3 Spec format
+
+Each Trust Task is two artefacts under a versioned directory in the
+workspace at `trust-tasks/{path}/{major}.{minor}/`:
+
+```
+trust-tasks/
+├── index.json                                    # registry manifest
+├── join/request/submit/1.0/
+│   ├── spec.md                                   # human-readable
+│   └── schema.json                               # JSON Schema for input/output
+├── members/renew/1.0/
+│   ├── spec.md
+│   └── schema.json
+└── …
+```
+
+`spec.md` carries structured frontmatter:
+
+```yaml
+---
+id: https://trusttasks.org/openvtc/vtc/join/request/submit/1.0
+title: VTC — Submit join request
+status: Draft                       # Draft | Reviewing | Published | Deprecated
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+created: 2026-05-11
+updated: 2026-05-11
+applies_to:
+  - rest: POST /v1/join-requests
+  - didcomm: https://trusttasks.org/openvtc/vtc/community/join-request/1.0
+inputs:
+  - name: applicant_did
+    type: did
+    required: true
+  - name: vp
+    type: VerifiablePresentation
+    required: true
+  - name: registry_consent
+    type: RegistryConsentRequest
+    required: false
+outputs:
+  - JoinRequestRecord
+  - AuditEvent[JoinRequestSubmitted]
+trust_assumptions:
+  - Caller's outer auth (REST bearer / DIDComm authcrypt sender) authenticates the relayer.
+  - VP DataIntegrityProof authenticates the holder.
+related:
+  - https://trusttasks.org/openvtc/vtc/policy/join/evaluation/1.0
+  - https://trusttasks.org/openvtc/vtc/credentials/vmc/issue/1.0
+---
+```
+
+The body of `spec.md` is the narrative spec: motivation, normative
+behaviour, error vocabulary, examples, security considerations.
+
+`schema.json` is a JSON Schema covering the wire input + output. Used
+for runtime validation and for binding generation in client SDKs.
+
+`trust-tasks/index.json` is the workspace's registry manifest — a
+list of all task IDs the workspace defines, used by CI to publish to
+trusttasks.org and by the VTC at boot to register handlers.
+
+### 16.4 Catalog (VTC MVP)
+
+Approximately fifty Trust Tasks across the operation surface. Each
+entry below is a stable ID assigned at the time the corresponding
+endpoint is designed; the `spec.md` and `schema.json` may be skeletal
+at first and tightened during implementation.
+
+| Area | Trust Task IDs |
+|---|---|
+| Install | `install/claim/1.0`; `admin/bootstrap/1.0` |
+| Admin passkeys | `admin/passkeys/register/1.0`; `admin/passkeys/revoke/1.0`; `admin/passkeys/list/1.0` |
+| Admin config | `admin/config/show/1.0`; `admin/config/patch/1.0`; `admin/config/reload/1.0`; `admin/config/restart/1.0` |
+| Community profile | `community/profile/show/1.0`; `community/profile/update/1.0` |
+| Members | `members/list/1.0`; `members/show/1.0`; `members/role/update/1.0`; `members/remove-admin/1.0`; `members/remove-self/1.0`; `members/renew/1.0`; `members/rotate-did/1.0`; `members/personhood/assert/1.0`; `members/personhood/revoke/1.0`; `members/relationships/list/1.0` |
+| Join | `community/join-request/1.0`; `join/request/list/1.0`; `join/request/show/1.0`; `join/request/approve/1.0`; `join/request/reject/1.0`; `join/request/defer/1.0` |
+| Invitations | `invitations/issue/1.0`; `invitations/list/1.0`; `invitations/revoke/1.0`; `invitations/redeem/1.0` |
+| Policies | `policies/list/1.0`; `policies/upload/1.0`; `policies/activate/1.0`; `policies/test/1.0`; `policies/show-active/1.0` |
+| Relationships | `relationships/publish/1.0`; `relationships/list/1.0`; `relationships/remove/1.0`; `relationships/query/1.0` |
+| Credentials issued | `credentials/endorsement/issue/1.0` (VEC); `credentials/witness/issue/1.0` (VWC); `credentials/rcard/issue/1.0` |
+| Status lists | `status-lists/get/1.0` |
+| Audit | `audit/query/1.0` |
+| Backup | `backup/export/1.0`; `backup/import/1.0`; `config/export/1.0`; `config/import/1.0` |
+| Trust registry | `registry/profile/show/1.0`; `registry/refresh/1.0` |
+| Website | `website/files/list/1.0`; `website/files/get/1.0`; `website/files/upload/1.0`; `website/files/delete/1.0`; `website/deploy/1.0`; `website/generations/list/1.0`; `website/rollback/1.0` |
+| Health | `health/check/1.0`; `health/diagnostics/1.0` |
+
+(Full URLs in `trust-tasks/index.json`. The CLI surface §15 does not
+get its own Trust Task IDs — the CLI invokes the same REST tasks.)
+
+### 16.5 Publication workflow
+
+Source-of-truth for `openvtc/vtc/*` Trust Tasks lives in this
+workspace under `trust-tasks/`. trusttasks.org pulls published
+versions via a discovery manifest hosted at
+`https://openvtc.org/trust-tasks/manifest.json`. Status flow:
+
+```
+Draft ──── Reviewing ──── Published ──── Deprecated
+                            │                ▲
+                            └────(major bump)┘
+```
+
+* **Draft** — spec file exists with a stable ID. Wire surface may
+  reference it. `schema.json` may be incomplete.
+* **Reviewing** — open PR; schema stable; conformance tests in
+  progress. Visible publicly as Draft on trusttasks.org with a
+  "review" marker.
+* **Published** — ratified. Schema frozen. Promoted on the registry
+  site. Backwards-compatible minor revisions allowed; major changes
+  require a new registry entry.
+* **Deprecated** — superseded by a higher major. Stays resolvable for
+  a sunset window (default 1 year); registry entry includes a
+  `successor` pointer.
+
+CI publishes on every merge to main: Draft entries land as Draft;
+Reviewing entries get the review marker; Published entries are
+frozen-on-publish.
+
+### 16.6 Governance
+
+* Each `spec.md` has an `authors` list pinned to DIDs.
+* Changes to Draft / Reviewing tasks: PR against this repo.
+* Changes to Published tasks: only via deprecation + new major.
+* Adding a new Trust Task to `openvtc/vtc/*`: PR in this repo by an
+  author DID. Tasks under other paths (`openvtc/vta/*`,
+  `openvtc/dtg/*`, etc.) live in their own source repos.
+
+### 16.7 MVP gate (soft)
+
+Trust Tasks are a **soft gate** for MVP:
+
+* Every operation that ships in MVP must have a Trust Task with a
+  stable ID and at least a Draft `spec.md` before its endpoint
+  ships. ID assignment is non-negotiable; spec body can be skeletal.
+* No published-status requirement for MVP shipping. Promotion to
+  Published is a target for the v1.0 release of the VTC.
+* Published status for v1.0 requires: `schema.json` complete, at
+  least one conformance test in the workspace test suite, no breaking
+  changes since first Draft (or a clean major bump if there were).
+
+### 16.8 Workspace integration
+
+* New crate (or sub-module of `vti-common`) `vti-trust-tasks` holds
+  the registry manifest types + a `TrustTask` extractor for Axum.
+* REST routes register their expected `Trust-Task` value at handler
+  attach time. The extractor checks the header on each request and
+  emits structured 4xx on mismatch.
+* DIDComm dispatch already routes by message type; the trust-task
+  type URL replaces the previously planned shorthand.
+* The `vta-sdk` client gains a `with_trust_task(url)` builder method
+  for explicit task selection. SDK callers don't pick the task
+  manually — each client method sets the right one — but the API
+  surface allows it for protocol explorers.
+
+## 17. Phasing / milestones
 
 Phases are ordered by dependency. Each ships independently as an
 operator-visible increment.
@@ -1432,7 +1671,13 @@ operator-visible increment.
 Phase 5 sub-tasks parallelize with phases 3 and 4. Phases 0–4 are
 strictly serial.
 
-## 17. Open questions
+Each phase's PR set includes the Draft Trust Task spec files
+(`trust-tasks/.../{spec.md,schema.json}`) alongside the code that
+implements the operations. A phase doesn't ship until every wire op
+it introduces has a stable Trust Task ID assigned and at least a
+skeletal `spec.md` — see §16.7.
+
+## 18. Open questions
 
 These are *not* blockers — they have proposed answers documented in
 prior turns of design. Listed here so the spec is honest about what
@@ -1488,7 +1733,30 @@ remains to validate during implementation.
    live-reload-feel and per-request overhead. Spec'd as
    `website.live_cache_ttl_seconds` (default 5).
 
-## 18. Explicitly NOT in MVP
+9. **Trust Task source-of-truth location.** Initial proposal: live
+   under `trust-tasks/` in this workspace, published from here to
+   trusttasks.org via CI. Alternative: a dedicated
+   `OpenVTC/trust-tasks` repo aggregating tasks across multiple
+   workspace projects (VTC, VTA, DTG). Decision deferred until the
+   VTA workspace also wants registry entries. If VTA-side Trust
+   Tasks land before we hit that decision, expect to factor out.
+
+10. **trusttasks.org formal spec evolving in parallel.** The
+    Trust Task concept itself is not yet fully formalised on
+    trusttasks.org. The shape used here (frontmatter, schema,
+    publication workflow) is a reasonable starting point but may
+    need to align with the registry's eventual canonical format.
+    Workspace impact: if the canonical format changes, the
+    `trust-tasks/` files migrate but the wire URLs (which are the
+    contract) stay stable.
+
+11. **Conformance test pattern.** Each Published task needs at least
+    one conformance test. Pattern not yet pinned: probably golden
+    request/response pairs validated against `schema.json` plus a
+    minimal behavioural assertion. Land with the first Published
+    task and standardise from there.
+
+## 19. Explicitly NOT in MVP
 
 To preserve clarity about scope, the following are out:
 
@@ -1528,8 +1796,11 @@ To preserve clarity about scope, the following are out:
 * **Multi-tenant** (one VTC binary hosts multiple communities).
   Architectural rewrite, intentionally out.
 
-## 19. Related work
+## 20. Related work
 
+* [`trusttasks.org`](https://trusttasks.org) — the canonical
+  registry for Trust Task specifications referenced from the
+  VTC wire surface (§16).
 * `docs/05-design-notes/runtime-service-management.md` — the service-
   advertisement primitives the VTC inherits via `vta-sdk`.
 * `docs/03-integrating/provision-integration.md` — how the VTC's own

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -6,622 +6,538 @@ Last updated: 2026-05-11
 
 ## 1. Objective
 
-Turn the existing skeletal `vtc-service` crate (auth, ACL, sessions,
-DIDComm, setup, did:webvh) into a minimum-viable **Verifiable Trust
-Community** capable of standing up a self-governing community on top
-of an existing VTA. A VTC manages community lifecycle, policy-driven
-join/leave, role-based access, DTG credential issuance, optional
-public hosting, and integrates with a trust-registry so other
-communities can verify cross-community membership.
+Turn the skeletal `vtc-service` crate (auth, ACL, sessions, DIDComm,
+setup, `did:webvh`) into a minimum-viable **Verifiable Trust
+Community** — a self-governing community service that sits on top of
+an existing VTA, manages members through policy-driven join/leave,
+issues DTG credentials, integrates with a trust-registry, and
+optionally hosts a public website. The admin web UX lives in a
+separate sibling repo and consumes the REST API.
 
-The product is a Rust backend service; an admin web UX lives in a
-separate sibling repository and consumes the VTC's REST API.
+**Non-goals (MVP)**
 
-### Why this matters
+- Multi-tenant VTC. One binary, one community.
+- Custom credential types. Strictly the DTG catalog (§6.1).
+- TEE deployment of the VTC. *Permanent* non-goal (§3).
+- N-of-M admin approvals; webhooks; bulk ops; WASM plugins; i18n at
+  the resource layer. Defensible retrofits (§18).
 
-The VTA gives an operator key-management and DID-management
-infrastructure. It does not give them a *community*. Without a VTC,
-each operator has to invent their own membership model, their own
-policy engine, their own cross-community trust story. The VTC ships
-that as opinionated, composable infrastructure that stays inside the
-DTG credential catalog and the wider workspace doctrine.
+## 2. Dependencies
 
-### Non-goals
+Rust workspace, edition 2024, MSRV 1.94.0.
 
-* **Multi-tenant VTC.** One VTC binary hosts exactly one community.
-  Multi-community hosts are out of scope for MVP.
-* **Custom credential types.** The VTC issues and consumes only the
-  credentials defined in
-  [`openvtc/dtg-credentials`](https://github.com/OpenVTC/dtg-credentials)
-  (VMC, VRC, VIC, VPC, VEC, VWC, RCard). Communities extend behavior
-  via Rego + opaque JSON metadata blobs, not by adding new credential
-  shapes.
-* **TEE/Nitro deployment.** VTC ships as a regular service for MVP.
-  Enclaved variant follows the VTA's later TEE arc.
-* **N-of-M admin approvals**, **webhooks**, **bulk operations**,
-  **WASM plugins**, **i18n at the resource layer**. Each is a
-  defensible retrofit (see §16 and §17).
+Internal: `vti-common`, `vta-sdk` (REST + DIDComm + sealed-transfer),
+`affinidi-messaging-didcomm-service`, `fjall`, `axum`.
 
-## 2. Tech stack & codebase context
+New external:
 
-* Rust workspace, edition 2024, MSRV 1.94.0.
-* `vtc-service` already provides: auth (challenge-response, JWT
-  audience `"VTC"`), ACL (with role enum to be extended),
-  session-mgmt, DIDComm bridge, fjall-backed storage, `did:webvh`
-  setup, OS-keyring secret backend.
-* New dependencies:
-  * `dtg-credentials = "0.1"` — closed credential catalog.
-  * `affinidi-trust-registry-rs` (TRQP v2.0 client) — entity-level
-    membership recognition.
-  * `affinidi-status-list = "0.1"` (from `affinidi-tdk-rs`) — W3C
-    Bitstring Status List v1.0 for per-VMC revocation.
-  * `regorus` — embedded Rego engine.
-  * `webauthn-rs` — passkey enrolment for admin login.
-* Existing dependencies stay: `vti-common` (Store, AppError, telemetry
-  sink, identifier validation), `vta-sdk` (REST + DIDComm client,
-  sealed-transfer, attestation, protocol types),
-  `affinidi-messaging-didcomm-service`, `fjall`, `axum`.
+- [`dtg-credentials`](https://github.com/OpenVTC/dtg-credentials) —
+  the closed credential catalog.
+- [`affinidi-trust-registry-rs`](https://github.com/affinidi/affinidi-trust-registry-rs)
+  — TRQP v2.0 client.
+- [`affinidi-status-list`](https://github.com/affinidi/affinidi-tdk-rs)
+  — W3C Bitstring Status List v1.0.
+- `regorus` — embedded Rego engine.
+- `webauthn-rs` — passkey enrolment.
 
-## 3. Architectural decisions (pinned)
+## 3. Pinned architectural decisions
 
-These are settled. Do not re-litigate during implementation; raise an
-ADR if circumstances change.
+Single source of truth. Downstream sections cite §3 by row letter and
+do not restate.
 
-| Decision | Rationale |
-|---|---|
-| **1 VTC ⇄ 1 VTA topology** | The VTC has no key custody; every signature goes to the VTA signing oracle. Multi-VTA-per-VTC explodes the trust path without clear gain. |
-| **VTC is always authoritative for its own state** | ACL + keyspaces are source of truth. VMC/VEC are *projections* of that state, useful when the member operates outside the VTC. VTC's own authz code never reads the VCs it issued. |
-| **Credentials limited to DTG catalog** | VMC (membership), VEC (role + endorsement), VIC (invitation), VRC (relationship edge), VWC (witness, consumed only), RCard (contact), VPC (persona, v2). New credential types go upstream into dtg-credentials, not local extensions. |
-| **Embedded regorus, no OPA sidecar** | Single deploy artifact, lower latency, TEE-compatible later. Policy reload is explicit (`POST /v1/policies/{id}/activate`); no hot-reload watchers. |
-| **Trust-registry and StatusList are complementary** | StatusList answers "is this VC revoked?". Trust-registry answers "is this entity an active member?". A robust verifier consults both. |
-| **DTG VMC `validUntil` is mandatory and finite** | Per-community config; default 30 days. External verifiers MUST see a non-perpetual VMC. Inside the community, ACL is authoritative — expired VMC does not lock the member out. |
-| **Membership renewal is unconditional inside the community** | A member whose VMC expired three months ago can mint a fresh one any time, as long as ACL still says they're a member. No grace logic, no admin re-approval. |
-| **Admin UX is a separate sibling repository** | VTC ships pure backend. CORS configurable. |
-| **Public community website is feature-gated** | Cargo feature `website`. Operators who use an external host disable the feature; routes 404. |
-| **Extensibility model = Rego + opaque JSON blobs** | Communities customize *behavior* via policies and *data* via `extensions: JsonValue` slots. No plugin loader, no WASM hooks, no custom REST modules. |
-| **Hygiene baked in from day one** | Versioned audit events, idempotency keys, `/v1/` URL prefix, cursor pagination on lists, multi-passkey-per-admin. These are load-bearing retrofits, not features. |
-| **VTC never targets TEE deployment** | Only the VTA runs in Nitro Enclave / TEE. The VTC stays a regular service. This is a *permanent* non-goal, not a deferral — public website serves from local filesystem, no vsock parity is required, and the storage abstraction can stay simple. If TEE-grade trust is needed for a community, the trust anchor remains the VTA. |
-| **Every wire operation is a registered Trust Task** | REST endpoints and DIDComm messages are bound to a versioned Trust Task identifier hosted on [trusttasks.org](https://trusttasks.org). A Trust Task is the formal definition of an operation — what's being requested, what inputs/credentials are required, what outputs are produced, and what trust assumptions the verifier makes. This is opt-in discipline applied **from day one** so the wire surface is self-describing; soft-gated for MVP (Draft IDs stable; Published status targets v1.0). See §16. |
+| | Decision | Rationale |
+|---|---|---|
+| **A** | **1 VTC ⇄ 1 VTA** | The VTC has no key custody; every signature delegates to the VTA signing oracle. |
+| **B** | **VTC is always authoritative for its own state** | ACL + keyspaces are truth. VMC/VEC are *projections* useful only when the member operates outside the VTC. VTC authz never reads its own issued VCs. |
+| **C** | **Credentials limited to the DTG catalog** | New credential needs go upstream into `dtg-credentials`, not local extensions. |
+| **D** | **Embedded `regorus`, no OPA sidecar** | Single artefact, lower latency. Policy activation is explicit; no hot-reload watchers. |
+| **E** | **Trust-registry and StatusList are complementary** | StatusList = "is this VC revoked?"; trust-registry = "is this entity an active member?". Robust verifiers consult both. |
+| **F** | **VMC `validUntil` is mandatory, finite, configurable** (default 30d) | External verifiers MUST see a bounded VMC. Inside the community, ACL is authoritative — expired VMC does not lock the member out (membership renewal is unconditional on ACL membership; see §6.3). |
+| **G** | **Admin UX is a separate sibling repo** | VTC ships pure backend; admin UX consumed as a release artefact (§12.2). |
+| **H** | **Public website is feature-gated and filesystem-backed** | Operators can disable to host externally, or update files in place via standard tools (§12.1). |
+| **I** | **Extensibility = Rego + opaque JSON blobs** | Communities customise behaviour via policies and data via `extensions: JsonValue` slots. No plugin loader. |
+| **J** | **Hygiene from day one** | Versioned audit events with HMAC-hashed actors, idempotency keys, `/v1/` URL prefix, cursor pagination, multi-passkey-per-admin. Retrofits are painful. |
+| **K** | **VTC never targets TEE deployment** | *Permanent* non-goal. Trust anchor for TEE remains the VTA. |
+| **L** | **Every wire op is a registered Trust Task** | REST endpoints and DIDComm messages bind to a versioned Trust Task on [trusttasks.org](https://trusttasks.org). Soft gate for MVP — stable IDs + Draft `spec.md` required before an endpoint ships (§9.4). |
+| **M** | **`extensions: JsonValue` is the universal extensibility slot** | Present on `CommunityProfile`, `Member`, `JoinRequest`, `AdminEntry`, audit envelopes. Opaque to the VTC. Validated only for size and JSON well-formedness. Communities own its shape. |
 
-## 4. Bootstrap and setup
+## 4. Bootstrap & install
 
-### 4.1 CLI setup wizard — minimal handoff to web UX
+### 4.1 CLI wizard — minimal handoff to web UX
 
-```text
-$ vtc setup
-? Public VTC URL [https://vtc.example.com]:
-? Public admin UX URL [https://admin.example.com]:
-? VTA URL for provisioning [https://vta.example.com]:
-
-✓ Minted VTC seed
-✓ Provisioned VTC DID via VTA (template: vtc-host)
-✓ Initialised keyspaces (sessions, acl, policies, members,
-  join_requests, status_lists, registry_records, audit,
-  idempotency, relationships)
-
-  Open this URL within 1 hour to finish setup:
-
-    https://admin.example.com/install#token=eyJhbGc…
-```
-
-The CLI does the bare minimum to make the daemon answerable. All
-human-facing configuration (community profile, policies, admin
-identity) happens in the admin UX.
-
-What the CLI actually does:
+`vtc setup` asks three questions (public VTC URL, public admin UX
+URL, VTA URL), then does the bare minimum to make the daemon
+answerable:
 
 1. Mints a 24-word BIP-39 seed via `affinidi-secrets-resolver`
-   (default backend: OS keyring; AWS/GCP/Azure available via feature
-   flags, same pattern as VTA).
-2. Calls VTA's `POST /provision-integration` with the
-   `vtc-host` DID template (new built-in template — see §4.4).
-   Receives a sealed bundle containing the VTC's `did:webvh`, signing
-   key references, and the VTA trust bundle. Opens the bundle locally
-   and persists secrets.
-3. Initializes all fjall keyspaces (§13).
-4. Mints a single-use **install token**: signed JWT with
-   `aud="vtc-install"`, `exp=now+1h`, `iat`, `jti`, plus an embedded
-   ephemeral Ed25519 keypair the install flow uses for the
-   challenge-response binding.
-5. Prints the install URL and starts the daemon listening on the
-   configured port.
+   (default backend: OS keyring).
+2. Provisions the VTC's `did:webvh` against the VTA using the new
+   `vtc-host` DID template (§4.4).
+3. Initialises all fjall keyspaces (§13).
+4. Mints a single-use **install token** (signed JWT, 15-minute TTL,
+   single-use, with a one-time WebAuthn ceremony nonce embedded).
+5. Prints an install URL and starts the daemon.
 
-### 4.2 Install flow (admin UX side)
+**Install token transport hardening.** The install URL is printed
+once to the operator's terminal. The token alone is *insufficient*
+to claim admin — `POST /v1/install/claim` requires a WebAuthn
+ceremony bound to the embedded nonce. Stolen tokens cannot be
+claimed without the operator's authenticator.
 
-1. Operator opens the install URL. The admin UX exchanges the install
-   token for a setup session via `POST /v1/install/claim` (kills the
-   install token atomically; carve-out pattern mirrors VTA's
-   `BOOTSTRAP_CARVEOUT_CLOSED_KEY`).
-2. WebAuthn passkey registration on the operator's authenticator
-   (`webauthn-rs`). The passkey's public key is bound to a fresh
-   `did:key` derived from it. This is the admin's DID.
-3. Operator enters community profile in the UX: `name`, `description`,
-   `logo_url`, `public_url`, `contact_email`, `language`.
-4. Operator picks a seed policy template (`policies.open`,
-   `policies.invite_only`, `policies.kyc_required`) which the UX
-   uploads via `POST /v1/policies` then activates via
-   `POST /v1/policies/{id}/activate`. Operators can edit policies
-   later through the UX.
-5. Operator chooses trust-registry behaviour: publish-on-join default,
-   default departure disposition (Purge / Tombstone / Historical),
-   whether to publish the VTC's own issuer profile on startup.
-6. Admin UX calls `POST /v1/admin/bootstrap` with the admin DID. VTC
-   writes the first ACL entry (`role: Admin`), permanently closes the
-   install token carve-out, and emits a `CommunityInstalled` audit
-   event.
+### 4.2 Web install flow
 
-After step 6 the install URL is dead. All subsequent admin operations
-require an authenticated session against the admin DID's passkey.
+Admin UX opens the URL, then:
+
+1. **Claim** — `POST /v1/install/claim` with the WebAuthn challenge
+   response. VTC verifies the ceremony, the embedded nonce, and the
+   token's single-use carve-out (gated by a process-wide async
+   mutex; mirrors VTA's `MODE_B_LOCK` invariant — concurrent claims
+   are impossible). Carve-out closes atomically on first success.
+2. **Passkey ↔ DID binding.** WebAuthn enrolment is restricted to
+   Ed25519 (`COSEAlgorithmIdentifier = -8 EdDSA`) so the passkey
+   public key can be projected into a `did:key` directly. Operators
+   whose authenticators don't support Ed25519 see an install error
+   pointing at supported devices. The admin's DID is `did:key:<...>`
+   derived from the WebAuthn credential's public key, and the
+   install ceremony also requires the candidate DID to sign a server-
+   issued challenge — proving both the passkey and the DID-signing
+   path operate over the same keypair.
+3. **Profile + policies** — operator enters community profile, picks
+   a seed policy template, configures trust-registry behaviour.
+4. **Bootstrap** — `POST /v1/admin/bootstrap` writes the first ACL
+   entry (`role: Admin`) and emits `CommunityInstalled`.
+
+After bootstrap the install URL is dead.
 
 ### 4.3 Multi-passkey per admin DID
 
-Admin entry shape in the `acl` keyspace for admin-role entries:
+Admin entries carry `passkeys: Vec<RegisteredPasskey>` from day one.
+Each passkey records `credential_id`, `public_key`, `transports`,
+`label`, `registered_at`, `last_used_at`.
 
-```rust
-struct AdminEntry {
-    did: String,
-    role: VtcRole,
-    passkeys: Vec<RegisteredPasskey>,  // 1..N
-    joined_at: DateTime<Utc>,
-    extensions: Value,                  // opaque per-community blob
-}
+Endpoints:
 
-struct RegisteredPasskey {
-    credential_id: Vec<u8>,
-    public_key: Vec<u8>,
-    transports: Vec<AuthenticatorTransport>,
-    label: String,                      // e.g., "MacBook Air Touch ID"
-    registered_at: DateTime<Utc>,
-    last_used_at: Option<DateTime<Utc>>,
-}
-```
+- `POST /v1/admin/passkeys/register` — enrol an additional device.
+- `DELETE /v1/admin/passkeys/{credential_id}` — revoke a device.
+- `GET /v1/admin/passkeys` — list.
 
-Operations:
+**Reauth invariant.** Passkey enrolment and revocation **require a
+fresh WebAuthn user-verification ceremony in the same request** (not
+just a valid session). A stolen session cannot persist by binding a
+new authenticator. The user-verification flag in the WebAuthn
+assertion must be `true`.
 
-* `POST /v1/admin/passkeys/register` — initiate WebAuthn ceremony for
-  an additional device. Requires an authenticated session (the
-  operator is logged in on device A and registering device B).
-* `DELETE /v1/admin/passkeys/{credential_id}` — revoke a lost
-  device. Refuses if it would leave the admin DID with zero passkeys
-  (use emergency-bootstrap instead).
-* `GET /v1/admin/passkeys` — list registered devices.
+**Concurrency invariant.** Passkey writes serialise per admin DID
+under a fjall compare-and-set. The "refuses to leave zero passkeys"
+check executes inside the same transaction.
 
-Each passkey operation emits a versioned audit event
-(`AdminPasskeyRegistered`, `AdminPasskeyRevoked`).
+**REST-only.** Passkey ceremonies are origin-bound by the browser.
+The corresponding DIDComm protocol is **not** provided — passkey
+registration over DIDComm would bypass WebAuthn's RP-ID enforcement
+and is explicitly forbidden.
 
 ### 4.4 The `vtc-host` DID template
 
-New built-in DID template shipped with `vta-sdk`'s
-`did_templates::builtin` set. Mirrors the existing `webvh-control` /
-`webvh-daemon` shapes:
+New built-in template in `vta-sdk::did_templates::builtin`. Required
+vars: `vtc_url`, `community_name`. Mints:
 
-* `kind: "vtc-host"`
-* Required vars: `vtc_url` (REST advertisement),
-  `community_name` (for service entry label).
-* Key shapes: one `assertionMethod` Ed25519 (for credential
-  signatures), one `authentication` Ed25519 (for session/DID auth),
-  one `keyAgreement` X25519 (for DIDComm + sealed-transfer reception).
-* Service entries: `#vtc-rest` (REST endpoint), `#vtc-status-list`
-  (where the BitstringStatusListCredential is hosted — see §6.2).
-* No DIDComm service entry by default — communities that need a
-  mediator add it later via the existing `services didcomm enable`
-  runtime-service-management flow against their VTA.
+- one `assertionMethod` Ed25519 (credential signatures)
+- one `authentication` Ed25519 (session auth)
+- one `keyAgreement` X25519 (sealed-transfer + DIDComm reception)
+
+Service entries: `#vtc-rest`, `#vtc-status-list`. DIDComm service is
+not advertised by default — added later via the existing
+runtime-service-management flow if the community needs a mediator.
 
 ### 4.5 Emergency bootstrap (recovery)
 
-If all admin passkeys are lost: `vtc admin emergency-bootstrap` on a
-stopped daemon emits a new install token (1h TTL) and re-opens the
-install carve-out exactly once. Documented as a destructive operator
-action: it writes a loud audit event
-(`EmergencyBootstrapInvoked { operator_host, timestamp }`) on next
-daemon start, visible in `GET /v1/audit?type=EmergencyBootstrapInvoked`.
+If every admin passkey is lost: `vtc admin emergency-bootstrap` on a
+stopped daemon re-opens the install carve-out exactly once. **The
+command requires possession of the master seed mnemonic** — without
+the mnemonic, a filesystem-level attacker cannot trigger a takeover
+by stopping the process. Audit event `EmergencyBootstrapInvoked` is
+emitted on next daemon start, with operator hostname + timestamp,
+prominently surfaced in `/v1/health/diagnostics`. Documented as a
+destructive operator action.
 
-## 5. Core domain model
+## 5. Domain model
 
-### 5.1 Community profile
+### 5.1 `CommunityProfile` (singleton, key `community/profile`)
 
-Stored as a singleton record in the `community` keyspace.
+Fields: `community_did` (immutable), `name`, `description`,
+`logo_url`, `public_url`, `contact_email`, `language` (BCP 47,
+default `"en"`), `created_at`, `extensions` (§3-M).
 
-```rust
-struct CommunityProfile {
-    community_did: String,           // immutable; set at install
-    name: String,
-    description: String,
-    logo_url: Option<String>,
-    public_url: Option<String>,
-    contact_email: Option<String>,
-    language: String,                // BCP 47, default "en"
-    created_at: DateTime<Utc>,
-    extensions: Value,               // arbitrary community-defined fields
-}
+### 5.2 `Member`
+
+```
+did, role, joined_at, status_list_index, publish_consent,
+departure_preference, current_vmc_id, current_role_vec_id, extensions
 ```
 
-Editable by `admin` role. Stored under a stable key
-(`community/profile`) for cheap reads.
+Admin entries additionally carry `passkeys: Vec<RegisteredPasskey>`
+(§4.3).
 
-### 5.2 Member
+### 5.3 `Role`
 
-```rust
-struct Member {
-    did: String,                     // did:key or did:webvh
-    role: VtcRole,
-    joined_at: DateTime<Utc>,
-    status_list_index: u32,          // stable for member's lifetime
-    publish_consent: bool,           // trust-registry consent
-    departure_preference: Option<DepartureDisposition>,
-    current_vmc_id: Option<String>,  // latest issued VMC id
-    current_role_vec_id: Option<String>,
-    extensions: Value,
-}
+```
+enum VtcRole { Admin, Moderator, Issuer, Member, Custom(String) }
 ```
 
-ACL entry references the `Member` for non-admin roles. Admin entries
-carry `passkeys` directly (§4.3).
+Default permission matrix for **standard roles**:
 
-### 5.3 Roles
-
-```rust
-enum VtcRole {
-    Admin,
-    Moderator,
-    Issuer,
-    Member,
-    Custom(String),   // community-defined; permissions via role_definitions.rego
-}
-```
-
-Default permissions (rough matrix; final permissions defined by
-`role_definitions.rego` and consulted on each authorized request):
-
-| Action | Admin | Moderator | Issuer | Member |
+| Action | Admin | Mod | Issuer | Member |
 |---|---|---|---|---|
 | Edit community profile | ✓ | | | |
 | Author / activate policies | ✓ | | | |
-| Approve/reject join requests | ✓ | ✓ | | |
+| Approve / reject join requests | ✓ | ✓ | | |
 | Issue VEC / VWC / RCard on behalf of community | ✓ | | ✓ | |
 | Issue VMC | (only via join flow) | | | |
+| Promote to Admin | ✓ (§10.4) | | | |
 | Remove other members | ✓ | ✓ (policy-gated) | | |
-| Self-remove | ✓ | ✓ | ✓ | ✓ |
+| Self-remove | ✓ (§10.2) | ✓ | ✓ | ✓ |
 | Renew own VMC | ✓ | ✓ | ✓ | ✓ |
 | Publish self-issued VRC | ✓ | ✓ | ✓ | ✓ |
 | Rotate own DID | ✓ | ✓ | ✓ | ✓ |
 
-Custom roles must define their permissions in `role_definitions.rego`;
-unspecified actions default-deny.
+**Custom roles**: `Role::Custom(String)` receives *no* implicit
+grants from the matrix. The only authoritative source of Custom-role
+permissions is `role_definitions.rego` (§7.1). Unspecified actions
+default-deny. The standard matrix above applies *only* to the four
+named roles; do not bridge it onto Custom roles by similarity.
 
-### 5.4 Policy bundle
+### 5.4 `Policy`
 
-A `Policy` is a single Rego module plus metadata:
+Rego module + metadata (`id`, `name`, `purpose`, `rego_source`,
+`compiled` bytecode, `sha256`, `activated_at`, `author_did`). Exactly
+one policy per `purpose` is active. Activating a new policy
+atomically supersedes the prior one; the prior is retained as
+archived.
 
-```rust
-struct Policy {
-    id: Uuid,
-    name: String,                    // e.g., "join", "removal"
-    purpose: PolicyPurpose,
-    rego_source: String,
-    compiled: Vec<u8>,               // regorus pre-compiled bytecode
-    sha256: [u8; 32],
-    activated_at: Option<DateTime<Utc>>,
-    author_did: String,
-}
+### 5.5 `JoinRequest`
 
-enum PolicyPurpose {
-    Join,
-    Removal,
-    Personhood,
-    Registry,
-    Directory,
-    RoleDefinitions,
-    CrossCommunityRoles,
-    CrossCommunityRelationships,
-    Relationships,
-}
+```
+id, applicant_did, vp, submitted_at, status,
+policy_decision, registry_consent, extensions
 ```
 
-Exactly one Policy per `purpose` may be active at any time.
-Activating a new policy supersedes the prior one atomically; the prior
-is retained in the `policies` keyspace (archived) for audit.
+`status ∈ { Pending, Approved, Rejected, Withdrawn, Deferred }`.
+Rejected and withdrawn requests retained for 30 days (configurable
+via `join_requests.retention_days`), then purged by the retention
+sweeper. VP contents may include PII — the retention window is the
+sole control.
 
-### 5.5 Join request
+### 5.6 `StatusListState`
 
-```rust
-struct JoinRequest {
-    id: Uuid,
-    applicant_did: String,
-    vp: serde_json::Value,           // raw VP
-    submitted_at: DateTime<Utc>,
-    status: JoinStatus,
-    policy_decision: Option<PolicyDecision>,
-    registry_consent: Option<RegistryConsentRequest>,
-    extensions: Value,
-}
-
-enum JoinStatus { Pending, Approved, Rejected, Withdrawn, Deferred }
+```
+purpose ∈ { Revocation, Suspension }
+capacity (default 2^17 = 131_072)
+next_random_seed
+occupied
+list_credential_id
 ```
 
-### 5.6 Status-list state
+### 5.7 `RegistryRecord`
 
-```rust
-struct StatusListState {
-    purpose: StatusListPurpose,      // Revocation | Suspension
-    capacity: u32,                   // default 2^17 = 131_072
-    next_random_seed: u64,           // for random index allocation
-    occupied: u32,                   // count for the 75% alert
-    list_credential_id: String,
-}
+```
+record_id, member_did, status ∈ { Active, Departed },
+active_from, active_to, last_synced_at
 ```
 
-### 5.7 Trust-registry record
+## 6. Credentials — DTG catalog
 
-```rust
-struct RegistryRecord {
-    record_id: String,               // assigned by trust-registry
-    member_did: String,
-    status: RegistryStatus,
-    active_from: DateTime<Utc>,
-    active_to: Option<DateTime<Utc>>,
-    last_synced_at: DateTime<Utc>,
-}
-
-enum RegistryStatus { Active, Departed }
-```
-
-## 6. Credentials — DTG catalog mapping
-
-### 6.1 The closed catalog
-
-The VTC issues, consumes, or stores only credentials from
-`dtg-credentials`. The full mapping:
+### 6.1 Mapping
 
 | Use | Type | Issuer | Subject | Notes |
 |---|---|---|---|---|
-| Membership | **VMC** | community DID | member DID | `personhood: bool` gated by `personhood.rego`. `validUntil` mandatory (community config). `credentialStatus` points to community's BitstringStatusListCredential. |
-| Role grant | **VEC** | community DID | member DID | `endorsement = { type: "CommunityRole", role, communityDid }`. Issued alongside VMC at join; re-issued on role change. |
-| Invitation (gated communities) | **VIC** | community DID (admin/issuer) | applicant DID | Holder presents in VP at join. Policy can mandate. |
-| Member ↔ member trust edge | **VRC** | member DID | other member DID | Self-issued. Published to VTC for discoverability. |
-| Community ↔ community trust edge (v2) | VRC | community DID | other community DID | Pairs with trust-registry recognition. |
-| Member contact card | **RCard** | member or community | member | jCard value. Member-driven; VTC stores opaquely. |
-| Event/proximity witness | **VWC** | external | applicant | Consumed in join VPs; never issued by VTC. |
-| Custom endorsement | **VEC** | community (issuer role) | any DID | Community-defined `endorsement` value. The hook for badges, attestations, etc. — without inventing new credential types. |
-| Persona binding | VPC | community | member | **v2**. Not in MVP. |
+| Membership | **VMC** | community DID | member DID | `personhood: bool` gated by §6.4. `validUntil` mandatory (§3-F). |
+| Role grant | **VEC** | community DID | member DID | `endorsement = { type: "CommunityRole", role, communityDid }`. Re-issued on role change. |
+| Invitation | **VIC** | community DID (admin/issuer) | applicant DID | Required by gated communities' join policies. |
+| Member ↔ member trust edge | **VRC** | member DID | other member DID | Self-issued, optionally published (§12.3). |
+| Member contact card | **RCard** | member or community | member | jCard value. |
+| Event/proximity witness | **VWC** | external | applicant | Consumed in join VPs; VTC does not issue. |
+| Custom endorsement (badges, attestations) | **VEC** | community (issuer role) | any DID | Community-defined `endorsement` value. The hook for "we don't invent credential types". |
+| Persona | VPC | community | member | **v2**. Not in MVP. |
 
-### 6.2 Status-list integration
+### 6.2 Status list
 
-* On install, VTC mints two `BitstringStatusListCredential`s
-  (purpose `revocation`, purpose `suspension`), each with capacity
-  131,072 (configurable). Hosted at
-  `https://{vtc_public_url}/v1/status-lists/{purpose}` and referenced
-  in the VTC DID document via the `#vtc-status-list` service entry.
-* Index allocation is **random** with decoys (affinidi-status-list's
+- VTC mints two `BitstringStatusListCredential`s on install
+  (revocation + suspension), capacity 131K each. Hosted under the
+  `#vtc-status-list` service entry on the VTC DID — not the
+  deployment URL — so a host migration does not break issued VMCs.
+- Every VMC carries `credentialStatus` referencing the appropriate
+  list and index.
+- **Index allocation is random with decoys** (affinidi-status-list's
   privacy mode).
-* Every VMC issued carries `credentialStatus = { id: ".../status-lists/revocation#<idx>", type: "BitstringStatusListEntry", purpose: "revocation", statusListIndex: <idx>, statusListCredential: ".../status-lists/revocation" }`.
-* On member departure: flip the bit at the member's index. Same index
-  is reused across the member's lifetime (renewals re-issue VMCs that
-  point to the same index).
-* On `Purge` disposition: bit flipped *and* index removed from the
-  member record; the slot becomes a decoy.
-* **Alert** when any status list crosses 75% occupancy (telemetry
-  event `StatusListOccupancyWarning`); MVP does **not** chain to a
-  second list — that's a v2 problem documented in §16.
+- **Flipped indices are never reallocated.** Once a member departs
+  and their bit is flipped (revoked or suspended), the index is
+  permanently reserved as a decoy. Allocating it to a new member
+  would let external verifiers correlate the new member's slot with
+  the departed identity. Index space is sized accordingly.
+- Telemetry emits `StatusListOccupancyWarning` at 75% (live +
+  reserved). Chaining is v2 (§17).
 
-### 6.3 Renewal model
+### 6.3 Renewal — unconditional on ACL membership
 
-Endpoint: `POST /v1/members/me/renew` (REST) and
-`community/1.0/renew-vmc` (DIDComm).
+`POST /v1/members/me/renew`. Auth check verifies the caller's
+session matches an active ACL entry. **No expiry check, no grace
+window.** Per §3-F, VMC validity is an external-verifier concern;
+inside the community, ACL is truth.
 
-Behavior:
+Issuance steps:
 
-1. Auth check: member's session must match an active ACL entry.
-   No expiry/grace test.
-2. Mint new VMC (`validFrom = now, validUntil = now + community.membership.validity`)
-   via VTA signing oracle. Same `credentialStatus` index. Same
-   `subject` (member DID).
-3. Mint refreshed role VEC if any of: role changed since last issuance,
-   community profile changed (issuer DID renamed), policy version
-   updated such that role permissions changed.
-4. Sealed-transfer the credentials to the member's DID.
-5. Audit event `MembershipRenewed { member_did, vmc_id, validUntil }`.
+1. Mint new VMC (`validFrom = now`, `validUntil = now + community.membership.validity`)
+   via the VTA signing oracle. Same status-list index.
+2. Re-issue role VEC (always — both for ACL/role drift and to keep
+   external chains current).
+3. Re-evaluate `personhood.rego` (§6.4) and surface the resulting
+   `personhood` flag on the new VMC. If the flag changes from the
+   prior VMC, the audit event `MembershipRenewed` records
+   `personhood_changed: true`.
+4. Sealed-transfer to member's DID.
 
 ### 6.4 Personhood
 
-* New Rego policy `personhood.rego`. Ships as a **deny-all stub** by
-  default. Community admins author the actual rule (e.g., "require N
-  VWCs from event X plus M endorsements from existing personhood
-  holders").
-* Personhood is asserted via a separate explicit operation:
-  `POST /v1/members/{did}/personhood/assert`. Re-mints the member's
-  VMC with `personhood: true` (which adds the
-  `PersonhoodCredential` type marker per dtg-credentials).
-* Revoking personhood: `DELETE /v1/members/{did}/personhood` re-mints
-  the VMC with `personhood: false`. Audit logged.
-* Policy input contract: `data.input = { applicant_did, vp_claims }`.
-  Communities extend via additional `data.*` namespaces they populate
-  through custom REST hooks they wire up server-side (each
-  implementer reinvents — workspace doctrine).
+`personhood.rego` ships as a **deny-all stub**. Community admins
+author the actual rule. Personhood is asserted via a dedicated
+`POST /v1/members/{did}/personhood/assert` (re-mints VMC with
+`personhood: true`), and revoked via `DELETE` (re-mints with
+`false`). The policy re-evaluates on every renewal (§6.3 step 3) —
+losing personhood is not gated on operator action.
 
-### 6.5 DID rotation per method
+Policy input contract: `data.input = { applicant_did, vp_claims }`.
+Communities extend via `data.*` namespaces they populate themselves.
 
-| Member DID method | Mechanism |
-|---|---|
-| **did:webvh** | Native. VTC resolves the new DID, walks its `did.jsonl` history, finds the prior key matching the old ACL entry, verifies the rotation signature against the prior key. No additional credential required. |
-| **did:key** | Co-signed rotation attestation. Payload `{ old_did, new_did, vtc_did, rotation_id, expires_at: now+10m }` signed by **both** old-DID and new-DID keys. VTC verifies both signatures, atomically updates ACL (key change), reuses status-list index, re-issues VMC + role VEC to the new DID. Old DID's session invalidated. |
-
-Wire: `POST /v1/members/me/rotate` + `community/1.0/rotate-did`.
-Authentication is via the *new* DID's session (caller proves
-possession of the new key).
-
-In-flight VRCs keyed on the old DID are left intact (graph history
-preservation). Members who want continuity issue a fresh VRC linking
-new → old as a `controller-rotation` relationship.
-
-Members are expected to use `did:key` or `did:webvh` (workspace
-doctrine). Other DID methods are not supported in MVP.
-
-## 7. Policy engine (regorus)
+## 7. Policy engine
 
 ### 7.1 Required policies
 
-| Name | Purpose | Default-ship behavior |
+| Name | Purpose | Default-ship |
 |---|---|---|
-| `join` | Decide on join requests | Template: `policies.open` (accept any signed VP) |
-| `removal` | Decide admin-initiated removals | Default: any admin may remove any non-admin |
-| `personhood` | Decide personhood assertion | **Deny-all stub** — admin must replace |
-| `registry` | Decide trust-registry publish + departure disposition | Default: publish on join, default disposition = Tombstone |
-| `directory` | Decide member-directory visibility | Default: members can see other members' DID + role only |
-| `role_definitions` | Map roles (incl. custom) to permissions | Default: the matrix in §5.3 |
-| `cross_community_roles` | Decide if external VEC role grants are honoured | **Deny-all** by default |
-| `cross_community_relationships` | Decide if external VRCs are stored | **Deny-all** by default |
-| `relationships` | Decide if a published VRC is stored / surfaced | Default: store if both parties are current members |
+| `join` | Decide join requests | Template `policies.open` (accept any signed VP) |
+| `removal` | Decide admin-initiated removals | Any admin may remove any non-admin |
+| `personhood` | Decide personhood assertion | **Deny-all stub** |
+| `registry` | Trust-registry publish + departure disposition | Publish on join; default disposition `Tombstone` |
+| `directory` | Member-directory visibility | Members see DID + role only |
+| `role_definitions` | Map roles to permissions (incl. Custom) | The matrix in §5.3 for standard roles only |
+| `cross_community_roles` | Honour external VEC role grants | **Deny-all** |
+| `cross_community_relationships` | Store external VRCs | **Deny-all** |
+| `relationships` | Store published VRCs | Store if both parties are current members |
 
-### 7.2 Activation lifecycle
+### 7.2 Activation
 
-* Upload via `POST /v1/policies` (`admin` role). Body includes Rego
-  source + metadata. VTC compiles via `regorus`, returns 400 with
-  compilation errors on failure.
-* Activate via `POST /v1/policies/{id}/activate`. Atomic swap: in-flight
-  requests against the old policy complete; new requests use the new
-  one. Old policy retained in `policies` keyspace as archived (audit).
-* Test via `POST /v1/policies/{id}/test` — evaluates the policy against
-  a provided input without activating.
-* No file-watching, no auto-reload. Reloads are deliberate.
+`POST /v1/policies` (admin) uploads + compiles via `regorus` — 400
+with compilation errors on failure. `POST /v1/policies/{id}/activate`
+atomically swaps the active policy for its purpose; in-flight
+requests against the old policy complete; new requests use the new.
+`POST /v1/policies/{id}/test` evaluates without activating. No
+file-watching, no auto-reload.
 
 ### 7.3 Input contracts
-
-All Rego policies receive `data.input` plus, for some, additional
-`data.*` namespaces.
 
 | Policy | `input` shape |
 |---|---|
 | `join` | `{ applicant_did, vp_claims, action: "join", now }` |
 | `removal` | `{ actor_did, target_did, target_role, reason, action: "remove", now }` |
-| `personhood` | `{ applicant_did, vp_claims }` (community extends) |
-| `registry` | `{ member, action: "join"\|"leave", requested_disposition? }` |
+| `personhood` | `{ applicant_did, vp_claims }` |
+| `registry` | `{ member, action, requested_disposition? }` |
 | `directory` | `{ viewer_did, viewer_role, target_member, fields_requested }` |
 | `role_definitions` | `{ role, action, resource? }` |
 | `cross_community_roles` | `{ foreign_vec, target_role, vtc_state }` |
+| `cross_community_relationships` | `{ vrc, viewer_member, vtc_state }` |
 | `relationships` | `{ vrc, issuer_member, subject_member }` |
-
-Communities adding policy-specific context inject it via REST hooks
-they author themselves; the workspace ships the contracts above and
-does not standardize extension shapes.
 
 ## 8. Trust-registry integration
 
-### 8.1 Startup behaviour
+### 8.1 Startup
 
-On daemon start (after install completes), VTC publishes its issuer
-profile to the configured trust-registry via
-`affinidi-trust-registry-rs`. Idempotent: re-publishing updates the
-existing record. Publish failures are non-fatal — the daemon logs and
-continues; the `MembershipSyncer` retries.
+VTC publishes its issuer profile via `affinidi-trust-registry-rs` on
+boot. Idempotent. Publish failures are non-fatal but raise a state
+flag in `GET /v1/community/profile` (`registry_status:
+"degraded" | "active"`) and in `/v1/health/diagnostics`. Operators
+see the lag without having to grep telemetry.
 
-### 8.2 Three departure dispositions
+**PII boundary.** Only `member_did`, `status`, `active_from`,
+`active_to`, and `record_id` are written to the registry. The VTC
+refuses to publish `extensions`, emails, names, or any other
+community-defined fields.
+
+### 8.2 Departure dispositions
 
 | Disposition | Record state | Use case |
 |---|---|---|
 | **Purge** | Record deleted | Right-to-be-forgotten; private communities |
 | **Tombstone** | `status: Departed`, no date range | "Was a member, no longer" — minimal disclosure |
-| **Historical** | `status: Departed`, `active_from`/`active_to` populated | Audit / retroactive verification of attestations made during membership |
+| **Historical** | `status: Departed`, dates populated | Audit / retroactive verification |
 
-Decision flow:
+Decision flow: `registry.rego` sets the envelope
+(`publish_on_join`, `departure_options`, `default_departure`,
+`min_disposition` floor). Member preference clamps within the
+envelope. A member-initiated `Purge` **always overrides
+`min_disposition`** (RTBF). Logged as
+`RegistryRecordPolicyOverride { reason: "rtbf" }` with HMAC-hashed
+identifier (§11.1).
 
-1. **Community policy** (`registry.rego`) sets allowed envelope:
-   `publish_on_join`, `departure_options`, `default_departure`,
-   `min_disposition` (floor).
-2. **Member preference** (set at join, or at leave), clamped to the
-   policy's allowed set.
-3. **Right-to-be-forgotten override**: a member-initiated `Purge`
-   request *always wins* over `min_disposition`. Logged as
-   `RegistryRecordPolicyOverride { reason: "rtbf" }` with a hashed
-   member DID so the override is auditable without re-leaking the
-   identifier.
+**Timing-correlation mitigation.** RTBF-triggered registry mutations
+are coalesced into a daily batch (configurable;
+`registry.rtbf_batch_window_hours`, default 24) so that record
+disappearance cannot be timed-aligned with a specific override
+event. Status-list bit flips remain immediate locally.
 
-### 8.3 MembershipSyncer
+### 8.3 Reconciliation (`MembershipSyncer`)
 
-A `MembershipSyncer` (Tokio task, analogous to `DrainSweeper` in
-vta-service) drives reconciliation:
+Tokio task subscribed to `MemberAdded`, `MemberRemoved`,
+`RoleChanged`. Enqueues `SyncJob`s into a `sync_queue` keyspace;
+retries with exponential backoff. Boot-time replay.
 
-* Subscribes to local lifecycle events (`MemberAdded`, `MemberRemoved`,
-  `RoleChanged`).
-* For each event, computes the desired trust-registry + status-list
-  state and enqueues a `SyncJob`.
-* Retries with exponential backoff on registry-side failures.
-* Emits `RegistrySyncPending`, `RegistrySyncFailed`,
-  `StatusListUpdatePending`, `StatusListUpdateFailed` telemetry
-  events.
-* Boot-time replay of any outstanding jobs in the `sync_queue`
-  keyspace.
+**Visible failure.** Persistent sync failure (default ≥ 1 hour
+behind, configurable) surfaces in:
+- `GET /v1/community/profile` (`registry_status`)
+- `GET /v1/health/diagnostics`
+- Admin UX status pings
+
+For `Purge` jobs that fail to sync, the warning is escalated — a
+locally-deleted member still recognised externally is the silent
+privacy regression the disposition is meant to prevent.
 
 ### 8.4 Cross-community recognition
 
-A `cross_community_roles.rego` policy decides whether a foreign VEC's
-role claim should map to a local ACL role at this VTC. Default
-deny-all. Communities opt in to federated trust via Rego.
+`cross_community_roles.rego` decides whether a foreign VEC's role
+claim maps to a local ACL role. Default deny-all.
 
-Implementation hook: the auth extractor, when handed a session minted
-from a foreign VEC, runs `cross_community_roles.rego` to compute the
-effective local role. Empty result → 403.
+**Session-mint hardening.**
+
+- The foreign VEC must pass StatusList revocation check at
+  session-mint time (the issuer's status list URL is resolved live).
+- The foreign issuer must be present in the trust-registry's
+  recognition graph at the time of mint.
+- The minted session's TTL is clamped to the shortest of: the JWT
+  audience default, the foreign VEC's `validUntil`, the foreign
+  VMC's `validUntil`.
+- Recognition is **not cached**; every session mint re-runs the
+  full policy + StatusList + trust-registry check. A peer community
+  removed from the registry mid-session does not retain access on
+  refresh.
 
 ## 9. Wire protocols
 
-### 9.1 URL versioning
+### 9.1 Common conventions
 
-All REST endpoints live under `/v1/`. Adding `/v2/` is the explicit
-mechanism for breaking changes. No unversioned routes other than
-`/health`.
+- **URL versioning.** All REST under `/v1/`. Adding `/v2/` is the
+  explicit mechanism for breaking changes.
+- **Idempotency keys.** Every mutating endpoint accepts
+  `Idempotency-Key: <uuid>`. Cache key is `(session_id, idempotency_key)` —
+  **not** global. Idempotent retries from a different principal
+  receive their own response, not the cached one. Cache TTL: 24 h
+  for non-destructive operations; **destructive operations
+  (`DELETE`, removal, revocation) cache for 60 s only**, and re-validate
+  target state before returning a cached response. Same key + different
+  body → 422 `IdempotencyKeyConflict`.
+- **Cursor pagination.** All list endpoints accept
+  `?cursor=&limit=` (limit 1..200). Response includes `next_cursor`
+  (nullable) and optional `total_estimate`.
 
-### 9.2 Idempotency keys
+### 9.2 Routing modes
 
-Every mutating endpoint (`POST`, `PUT`, `DELETE`) accepts
-`Idempotency-Key: <uuid>`. VTC stores `(key, request_hash) → response`
-for 24 hours in the `idempotency` keyspace. Retries with the same key
-return the cached response; retries with the same key but a different
-request body return 422 `IdempotencyKeyConflict`.
+Each surface (API, admin UX, website) mounts on a path prefix, a
+Host header, or both. Default is **path-prefix on a single host** —
+works on day one without DNS configuration.
 
-Required on: all bootstrap, install, member-lifecycle, policy,
-credential, and rotation endpoints. Optional but accepted on read
-endpoints (no-op).
-
-### 9.3 Cursor pagination
-
-Standard contract on every list endpoint:
-
-```
-GET /v1/<collection>?cursor=<opaque>&limit=<1..200>
-
-→ 200 OK
-{
-  "items": [...],
-  "next_cursor": "<opaque>" | null,
-  "total_estimate": <u64 | null>   // optional
-}
+```toml
+# Default (path mode)
+[routing.api]       mount = "/v1"
+[routing.admin_ui]  mount = "/admin"
+[routing.website]   mount = "/"            # catch-all, lowest priority
 ```
 
-Cursor is opaque (server picks; typically a base64-encoded
-`(last_key, snapshot_id)` tuple). `next_cursor: null` means end of
-collection.
+Route priority (highest first): `/health`, `/v1/*`,
+`/v1/website/*` (management API), `/admin/*`, `/*` (public site).
 
-### 9.4 CORS
+**Subdomain mode**: per-surface `host` set; tower middleware routes
+by `Host`. Hosts not matching any surface return 404. Subdomain mode
+implies the operator handles per-surface TLS certs and DNS.
 
-`config.toml` carries a `cors.allowed_origins: Vec<String>` list.
-Wildcard origins refused at config-load time. Preflight responses
-include `Idempotency-Key` in `Access-Control-Allow-Headers`.
+**Multi-process daemons are not in MVP.** fjall is not multi-process-safe.
+Operators who need isolation strip surfaces at compile time via cargo
+features and put a reverse proxy / CDN in front.
 
-Interaction with admin UX hosting mode (§12.2):
+### 9.3 CORS + cookie scope
 
-* `admin_ui.mode = "embedded"` — admin UX served same-origin (or by
-  Host-header routing to a configured subdomain); no CORS entry
-  required for the admin UX itself.
-* `admin_ui.mode = "external"` — the install flow writes the external
-  admin origin into `cors.allowed_origins` during step 6.
+`cors.allowed_origins` is a configured allowlist. Wildcards refused.
 
-The public website's own origin is auto-allowed so that static-site
-JS can POST to `/v1/join-requests` without a separate CORS config.
+**Isolation invariant.** When the public website (§12.1) and the
+admin UX (§12.2) are served on the same domain, they **must** be on
+different cookie scopes. Path-mode default achieves this by setting
+the admin session cookie with `Path=/admin; SameSite=Strict;
+Secure; HttpOnly`; the public website's origin gains no
+implicit access to admin session cookies.
 
-### 9.5 REST surface (representative — full OpenAPI in §16 followup)
+Admin UX in `embedded` mode: same-origin or near-origin; no CORS
+allowance for the admin UX itself.
+Admin UX in `external` mode: install flow writes the external origin
+into `cors.allowed_origins`.
+
+The public website's origin is **not** auto-allowed for admin
+endpoints. The public site can POST to `/v1/join-requests`
+(unauthenticated) without preflight via simple-request semantics.
+
+**CSRF on admin mutating endpoints.** Every admin endpoint requires
+either `Sec-Fetch-Site: same-origin` or a CSRF double-submit cookie.
+Both checks are belt-and-braces: form-encoded POSTs from public-site
+JavaScript can't forge admin actions.
+
+### 9.4 Trust Tasks
+
+Every wire op binds to a versioned Trust Task identified by URL on
+[trusttasks.org](https://trusttasks.org):
 
 ```
-# Install / admin lifecycle
+https://trusttasks.org/{org}/{domain}/{path}/{major}.{minor}
+```
+
+For this workspace: `org = openvtc`, `domain = vtc`. Example:
+`https://trusttasks.org/openvtc/vtc/join/request/submit/1.0`.
+
+**REST binding.** Every request carries a `Trust-Task` header. The
+header is **exact-matched** against the handler's registered task
+URL at route attach time — not by prefix, not by major-version
+family. Mismatch → 415 `TrustTaskMismatch`; missing → 400
+`TrustTaskMissing`. **Exception**: `/health` is exempt to keep
+monitoring trivial; this is the only exempt endpoint and is
+documented.
+
+**DIDComm binding.** The DIDComm message `type` field **is** the
+Trust Task URL. No shorthand; no parallel registry.
+
+**Spec format.** Two artefacts under `trust-tasks/{path}/{major}.{minor}/`:
+
+- `spec.md` — narrative with frontmatter (id, title, status,
+  authors, inputs/outputs, trust assumptions, related).
+- `schema.json` — JSON Schema for input/output.
+
+Plus `trust-tasks/index.json` manifest. trusttasks.org publishes
+from this manifest via CI on merge to main.
+
+**Status lifecycle.** Draft → Reviewing → Published → Deprecated.
+Draft entries are wire-referenceable. Published entries have frozen
+schemas; further changes require a major bump.
+
+**MVP gate (soft).** Every operation that ships in MVP must have a
+Trust Task with a stable ID and at least a Draft `spec.md` before
+its endpoint ships. Published status is the target for v1.0 of the
+VTC, not the MVP gate. Published requires `schema.json` complete +
+at least one conformance test + no breaking changes since first
+Draft.
+
+Source-of-truth location, full ~50-entry catalog, governance, and
+the workspace's `vti-trust-tasks` integration crate live in the
+sibling document `trust-tasks-spec.md` — they are too long for the
+core MVP spec.
+
+### 9.5 REST surface (canonical)
+
+```
+# Install + admin
 POST   /v1/install/claim
 POST   /v1/admin/bootstrap
 POST   /v1/admin/passkeys/register
@@ -633,6 +549,8 @@ GET    /v1/admin/config
 PATCH  /v1/admin/config
 POST   /v1/admin/config/reload
 POST   /v1/admin/config/restart
+POST   /v1/admin/config/export
+POST   /v1/admin/config/import
 
 # Community
 GET    /v1/community/profile
@@ -642,1174 +560,514 @@ PUT    /v1/community/profile
 GET    /v1/members
 GET    /v1/members/{did}
 GET    /v1/members/{did}/relationships
-PATCH  /v1/members/{did}                 # role / extensions
-DELETE /v1/members/{did}                 # admin removal
-DELETE /v1/members/me                    # self removal
+PATCH  /v1/members/{did}                        # role / extensions
+POST   /v1/members/{did}/promote-to-admin       # separate audited path
+DELETE /v1/members/{did}                        # admin removal
+DELETE /v1/members/me                           # self removal
 POST   /v1/members/me/renew
 POST   /v1/members/me/rotate
 POST   /v1/members/{did}/personhood/assert
 DELETE /v1/members/{did}/personhood
 
-# Join requests
-POST   /v1/join-requests                 # submit (unauth, rate-limited)
+# Join
+POST   /v1/join-requests                        # submit (unauth, rate-limited)
 GET    /v1/join-requests
 GET    /v1/join-requests/{id}
 POST   /v1/join-requests/{id}/approve
 POST   /v1/join-requests/{id}/reject
 POST   /v1/join-requests/{id}/defer
 
-# Invitations (VIC)
-POST   /v1/invitations
-GET    /v1/invitations
-DELETE /v1/invitations/{id}
+# Invitations / policies / relationships / credentials issued
+POST,GET,DELETE /v1/invitations[/{id}]
+GET,POST       /v1/policies[/{id}/{activate,test}]
+POST,GET,DELETE /v1/relationships[/{id}]
+POST           /v1/credentials/{endorsements,witnesses,rcards}
 
-# Policies
-GET    /v1/policies
-POST   /v1/policies
-POST   /v1/policies/{id}/activate
-POST   /v1/policies/{id}/test
-GET    /v1/policies/active
-
-# Relationships (VRC)
-POST   /v1/relationships
-GET    /v1/relationships
-DELETE /v1/relationships/{id}
-
-# Credentials (Issuer/Admin)
-POST   /v1/credentials/endorsements      # mint VEC
-POST   /v1/credentials/witnesses         # mint VWC
-POST   /v1/credentials/rcards            # mint RCard
+# Status lists, audit, backup, registry
+GET            /v1/status-lists/{revocation,suspension}
+GET            /v1/audit
+POST           /v1/admin/backup/{export,import}
+GET,POST       /v1/registry/{profile,refresh}
 
 # Public website (feature: website)
-GET    /v1/website/files                 # list current site tree
-GET    /v1/website/files/{path}          # fetch a file
-PUT    /v1/website/files/{path}          # upload (admin/moderator)
-DELETE /v1/website/files/{path}
-POST   /v1/website/deploy                # tar.gz bundle (atomic if managed)
-GET    /v1/website/generations           # managed mode only
-POST   /v1/website/rollback/{gen}        # managed mode only
-
-# Status lists
-GET    /v1/status-lists/revocation       # public (the VC)
-GET    /v1/status-lists/suspension       # public (the VC)
-
-# Audit
-GET    /v1/audit
-
-# Backup
-POST   /v1/backup/export                 # admin only
-POST   /v1/backup/import                 # admin only
-POST   /v1/config/export
-POST   /v1/config/import
-
-# Trust-registry
-GET    /v1/registry/profile
-POST   /v1/registry/refresh
+GET,PUT,DELETE /v1/website/files[/{path}]
+POST           /v1/website/deploy
+GET,POST       /v1/website/{generations,rollback/{gen}}
 
 # Health
-GET    /health
-GET    /v1/health/diagnostics            # admin only
+GET            /health                          # Trust-Task exempt (§9.4)
+GET            /v1/health/diagnostics           # admin only
 ```
 
 ### 9.6 DIDComm surface
 
-Symmetric protocols under `community/1.0/`:
+Every REST mutating op has a DIDComm twin under the Trust Task URL.
+The DIDComm `type` field is the Trust Task URL directly — no
+shorthand. Notable absences:
+
+- Install + passkey registration: REST-only (§4.3).
+- `/health` + diagnostics: REST-only.
+- Website management: REST-only.
+
+**Per-DID rate limit.** DIDComm strips IP, so unauthenticated rate
+limiting on `community/1.0/join-request` uses a per-sender-DID
+leaky bucket (`didcomm.join_rate.bucket_capacity` and `refill_per_min`)
+in the DIDComm handler, executed *before* policy evaluation. Other
+DIDComm routes inherit the same per-DID limit, configurable per
+Trust Task ID.
+
+### 9.7 Auth + sessions
+
+- Challenge-response with JWT audience `"VTC"` — cross-audience
+  tokens rejected.
+- Sessions issued from REST (Bearer) or DIDComm (authcrypt sender).
+- **Step-up reauth** required for: passkey enrolment / revocation,
+  admin promotion, emergency operations. Implemented as a fresh
+  WebAuthn user-verification ceremony embedded in the request.
+- Cross-community sessions (§8.4): TTL clamped to inputs, recognition
+  re-evaluated on every refresh.
+
+## 10. Member lifecycle
+
+### 10.1 Join
 
 ```
-community/1.0/join-request
-community/1.0/join-decision
-community/1.0/renew-vmc
-community/1.0/rotate-did
-community/1.0/self-remove
-community/1.0/role-update              # admin → member notification
-community/1.0/status-changed           # admin → member notification
-community/1.0/membership-revoked       # admin → member notification
-
-invitations/1.0/issue                  # admin/issuer
-invitations/1.0/redeem                 # applicant
-
-relationships/1.0/publish
-relationships/1.0/query
-
-policies/1.0/upload
-policies/1.0/activate
-policies/1.0/test
-
-credentials/1.0/issue-endorsement      # admin/issuer
-credentials/1.0/issue-witness
-credentials/1.0/issue-rcard
-```
-
-`community/1.0/install/*` does not exist — install is REST-only by
-nature (no DIDComm session before admin bootstrap).
-
-## 10. Audit log
-
-### 10.1 Event vocabulary (versioned)
-
-```rust
-#[serde(tag = "type", content = "data")]
-enum AuditEvent {
-    // v1 events
-    CommunityInstalled(CommunityInstalledData),
-    EmergencyBootstrapInvoked(EmergencyBootstrapData),
-
-    AdminPasskeyRegistered(AdminPasskeyRegisteredData),
-    AdminPasskeyRevoked(AdminPasskeyRevokedData),
-
-    JoinRequestSubmitted(JoinRequestSubmittedData),
-    JoinRequestApproved(JoinDecisionData),
-    JoinRequestRejected(JoinDecisionData),
-    JoinRequestDeferred(JoinDecisionData),
-
-    MemberAdded(MemberLifecycleData),
-    MemberRemoved(MemberLifecycleData),
-    MembershipRenewed(MembershipRenewedData),
-    RoleChanged(RoleChangedData),
-    PersonhoodAsserted(PersonhoodData),
-    PersonhoodRevoked(PersonhoodData),
-    MemberDidRotated(DidRotationData),
-
-    RegistryRecordPublished(RegistryRecordData),
-    RegistryRecordUpdated(RegistryRecordData),
-    RegistryRecordRemoved(RegistryRecordData),
-    RegistryRecordPolicyOverride(RegistryOverrideData),
-
-    StatusListBitFlipped(StatusListBitFlippedData),
-    StatusListOccupancyWarning(StatusListWarningData),
-
-    PolicyUploaded(PolicyMetadata),
-    PolicyActivated(PolicyMetadata),
-
-    InvitationIssued(InvitationData),
-    InvitationRedeemed(InvitationData),
-    InvitationRevoked(InvitationData),
-
-    RelationshipPublished(RelationshipData),
-    RelationshipRemoved(RelationshipData),
-
-    CredentialIssued(CredentialIssuedData),    // VEC / VWC / RCard
-
-    ConfigChanged(ConfigChangedData),
-    ConfigReloaded(ConfigReloadedData),
-    RestartRequested(RestartRequestedData),
-}
-
-struct ConfigChangedData {
-    changes: Vec<ConfigChange>,
-    requires_restart: bool,
-}
-
-struct ConfigChange {
-    key: String,
-    old_value: Option<Value>,                  // null if previously unset
-    new_value: Value,
-    source_before: ConfigSource,               // "env" | "db" | "toml" | "default"
-}
-
-struct AuditEnvelope {
-    event_id: Uuid,
-    event_version: u32,                  // 1 for MVP; bumps on breaking shape change
-    schema_version: u32,                 // overall vocabulary version
-    timestamp: DateTime<Utc>,
-    actor_did_hash: [u8; 32],            // hashed for purge resilience
-    actor_did_plain: Option<String>,     // null after RTBF purge
-    target_did_hash: Option<[u8; 32]>,
-    target_did_plain: Option<String>,
-    event: AuditEvent,
-}
-```
-
-The hash-and-plaintext-pair pattern lets right-to-be-forgotten purges
-null the plaintext while keeping the hash for correlation across the
-audit log. Without hashes, every override leaks the DID it claimed to
-remove.
-
-### 10.2 Query surface
-
-```
-GET /v1/audit
-  ?since=<ISO8601>
-  &until=<ISO8601>
-  &type=<EventType>
-  &actor_did=<did>
-  &target_did=<did>
-  &cursor=<opaque>
-  &limit=<1..200>
-```
-
-Indexed columns in the `audit` keyspace: `timestamp` (primary),
-`type`, `actor_did_hash`, `target_did_hash`. Each yields a secondary
-index keyspace (`audit_by_type`, etc.) maintained on write.
-
-### 10.3 Retention
-
-* Default: retain forever (audit is forensic infrastructure).
-* Configurable per-event-type max retention via
-  `audit.retention.<event_type>`. Pruner task wakes hourly.
-* RTBF purges *null the plaintext fields*; the envelope (with hashes)
-  is retained for chain integrity.
-
-## 11. Member lifecycle
-
-### 11.1 Join
-
-```
-applicant → VTC (REST POST /v1/join-requests or DIDComm join-request):
-  {
-    applicant_did,
-    vp: <Verifiable Presentation>,
-    registry_consent: { publish, departure_preference } | null,
-    extensions: <opaque>
-  }
+applicant → POST /v1/join-requests (or DIDComm twin)
+  { applicant_did, vp, registry_consent?, extensions? }
 
 VTC:
-  1. Validate VP signature (typestate: VerifiedJoinRequest)
-  2. Compile + run join.rego with input.vp_claims
-  3. If allow:
-     a. Allocate status-list index
-     b. Compute VMC validUntil = now + community.membership.validity
-     c. Mint VMC + role VEC via VTA signing oracle
-     d. Write ACL entry + Member record
-     e. Run registry.rego, enqueue MembershipSyncer job
-     f. Sealed-transfer credentials to applicant_did
-     g. Audit: JoinRequestApproved + MemberAdded
-  4. If deny:
-     a. Persist JoinRequest with status=Rejected + decision rationale
-     b. Send DIDComm reject message to applicant
+  1. Verify VP signature → VerifiedJoinRequest (typestate)
+  2. Run join.rego with input.vp_claims
+  3. allow:
+     a. Allocate status-list index (random; flipped slots excluded)
+     b. Mint VMC + role VEC via VTA oracle (§14.2 for VTA timeout)
+     c. Write ACL + Member, enqueue registry.rego decision
+     d. Sealed-transfer credentials to applicant_did
+     e. Audit: JoinRequestApproved + MemberAdded
+  4. deny:
+     a. Persist JoinRequest as Rejected with decision rationale
+     b. DIDComm reject (where reachable)
      c. Audit: JoinRequestRejected
 ```
 
-### 11.2 Self-removal
+### 10.2 Removal
+
+**No-last-admin invariant.** Self-removal by the sole remaining
+admin is refused with 409 `LastAdminProtected`. Admin must demote
+or promote a successor first. Same check applies to admin removal
+of another admin — refused if the result would be zero admins.
+
+Self-removal (`DELETE /v1/members/me`):
 
 ```
-member → VTC:
-  DELETE /v1/members/me
-  { disposition: "Purge" | "Tombstone" | "Historical" | "PolicyDefault" }
-
-VTC:
-  1. Auth check: caller's DID is in ACL
-  2. Compute effective disposition (clamp to registry.rego allowed set;
-     RTBF override path for Purge)
-  3. Atomic local: delete ACL entry, delete/anonymize Member, flip
-     status-list bit, emit MemberRemoved audit
-  4. Enqueue MembershipSyncer job for registry-side change
-  5. Return 200 with effective disposition + sync job id
+{ disposition: Purge | Tombstone | Historical | PolicyDefault }
 ```
 
-### 11.3 Admin removal
+Atomic local: delete ACL, anonymise Member record, flip status-list
+bit (immediate), emit `MemberRemoved`. Registry sync enqueued.
 
-```
-admin → VTC:
-  DELETE /v1/members/{did}
-  { reason, disposition?: "..." }
+Admin removal (`DELETE /v1/members/{did}`): admin role plus
+`removal.rego` policy gate. Otherwise same effects.
 
-VTC:
-  1. Auth: admin role (or moderator if removal.rego allows)
-  2. Run removal.rego with { actor, target, reason }
-  3. If allow: same effects as self-removal, plus
-     audit event tagged with actor_did
-  4. Send community/1.0/membership-revoked DIDComm to target if
-     reachable
-```
-
-### 11.4 Renewal
+### 10.3 Renewal
 
 See §6.3. Unconditional on ACL membership.
 
-### 11.5 Role change
+### 10.4 Role change
+
+`PATCH /v1/members/{did}` accepts role changes **except** to
+`Admin`. Admin promotion is a separate endpoint:
 
 ```
-admin → VTC:
-  PATCH /v1/members/{did}
-  { role: "moderator" }
-
-VTC:
-  1. Auth check; validate role exists (standard or defined in
-     role_definitions.rego)
-  2. Update ACL entry
-  3. Mint new role VEC with endorsement.role=<new>
-     Old VEC superseded by validFrom timestamp ordering
-  4. Sealed-transfer new VEC to member
-  5. Audit: RoleChanged + DIDComm role-update notification
+POST /v1/members/{did}/promote-to-admin
 ```
 
-### 11.6 DID rotation
+requiring:
 
-See §6.5.
+- caller role = `Admin`
+- step-up WebAuthn UV ceremony in the same request (§9.7)
+- audit event `AdminPromoted` (its own variant, not a generic
+  `RoleChanged`) — distinct event type for SIEM filtering
+
+ACL update + new VEC issuance + sealed transfer + DIDComm
+notification mirror non-admin role change.
+
+### 10.5 DID rotation
+
+| Member DID method | Mechanism |
+|---|---|
+| **did:webvh** | Native: VTC resolves new DID, walks `did.jsonl` history, verifies prior-key signature. No additional credential. |
+| **did:key** | Co-signed rotation attestation. |
+
+**did:key rotation contract.**
+
+- VTC issues a single-use `rotation_id` via
+  `POST /v1/members/me/rotate/challenge` (auth: old DID's current session).
+  Server-issued, bound to old DID, 10-minute TTL.
+- Rotation payload `{ old_did, new_did, vtc_did, rotation_id, expires_at }`
+  is **domain-tag-prefixed** with the literal `vtc-did-rotation/v1\0`
+  before signing (mirrors `vta-sealed-transfer/v1` doctrine). Domain
+  separation prevents cross-protocol signature reuse.
+- Payload signed by **both** old and new keys.
+- `POST /v1/members/me/rotate` authenticates via the *new* DID's
+  session; VTC verifies both signatures, the rotation_id is consumed,
+  ACL updated atomically.
+- **All sessions, refresh tokens, idempotency-cached responses, and
+  in-flight DIDComm threads keyed on the old DID are revoked in the
+  same transaction.**
+- Status-list index reused (member identity continuous), VMC + role
+  VEC re-issued to new DID.
+
+Members must use `did:key` or `did:webvh` (workspace doctrine).
+
+### 10.6 Personhood
+
+See §6.4.
+
+## 11. Audit log
+
+### 11.1 Envelope + identifier hashing
+
+```
+struct AuditEnvelope {
+    event_id: Uuid,
+    event_version: u32,        // bumped on breaking shape change
+    schema_version: u32,
+    timestamp: DateTime<Utc>,
+    actor_did_hash:  [u8; 32], // HMAC-SHA256(audit_key, did_bytes)
+    actor_did_plain: Option<String>,
+    target_did_hash:  Option<[u8; 32]>,
+    target_did_plain: Option<String>,
+    event: AuditEvent,         // tagged enum, see §11.4
+}
+```
+
+**HMAC, not plain hash.** The audit secret `audit_key` is stored
+separately from the audit log (own keyspace, encrypted under the
+VTC seed), per-community. Plain SHA-256 over a DID is reversible by
+enumeration (DIDs are a small public space).
+
+**RTBF.** Right-to-be-forgotten requests null the `*_plain` fields
+and **rotate the `audit_key`**. Pre-rotation hashes become opaque to
+anyone without the prior key; post-rotation events use the new key.
+Audit chain integrity preserved via the per-envelope `event_id`.
+
+### 11.2 Query
+
+`GET /v1/audit?since=&until=&type=&actor_did=&target_did=&cursor=&limit=`.
+Indices on `timestamp`, `type`, `actor_did_hash`, `target_did_hash`
+maintained on write.
+
+### 11.3 Retention
+
+Default: retain forever. Per-event-type max retention configurable
+via `audit.retention.<event_type>`. **Pruner concurrency**: pruner
+reads a snapshot cutoff timestamp; writes are append-only above the
+cutoff. Pruner never deletes events younger than
+`cutoff + audit.pruner_safety_margin` (default 1 h) — protects
+against in-flight events being dropped.
+
+### 11.4 Event vocabulary
+
+Tagged enum (`#[serde(tag = "type", content = "data")]`). Variants
+emitted from each lifecycle section (§4, §10, §6, §8, §14.6).
+`AdminPromoted` is its own variant (§10.4). `ConfigChanged` carries
+per-key sensitivity: keys flagged `sensitive: true` redact
+`old_value` + `new_value` in the audit record (e.g., TLS paths;
+future webhook URLs with tokens). Complete catalog lives alongside
+the source in `vti-common::audit::events`.
 
 ## 12. Optional surfaces
 
 ### 12.1 Public community website (`website` feature)
 
-A generic static-file host. Community admins upload arbitrary HTML,
-CSS, JS, images, fonts — whatever they want — and the VTC serves it.
-No template language, no markdown rendering, no opinions about site
-structure. Operators can use plain HTML, an SPA, a static-site
-generator's output, or just dump a folder of files.
+Filesystem-backed static hosting. Files live at
+`website.root_dir`; can be edited directly (`scp`, `rsync`, `git`)
+or via the REST API. No template engine, no opinions about site
+structure.
 
-**Backing storage: local filesystem** (not fjall). Operators can
-update site files directly with `scp`, `rsync`, `git pull`, or a
-local editor and the changes are served on the next request. The
-REST API endpoints exist as the *convenient* way to update; direct
-filesystem editing is the *primary* one. This is possible because
-the VTC never runs in a TEE (§3) and the filesystem is reliably
-addressable.
+**Deploy modes** (config `website.deploy_mode`):
 
-#### Configuration
+- **`"live"`** (default): files served as-is from `root_dir`; bundle
+  deploys extract via a *staging directory + atomic rename*, never
+  in place (avoids partial reads under concurrent serving).
+- **`"managed"`**: `root_dir/gen-N/` directories + `current → gen-N`
+  symlink. Bundle deploys extract to a fresh generation; symlink
+  swapped atomically. Last 5 generations retained.
 
-```toml
-[website]
-enabled       = true
-root_dir      = "/var/lib/vtc/website"  # served from here
-deploy_mode   = "live"                  # or "managed"
-spa_fallback  = false                   # serve /index.html for unmatched paths
-max_file_size_mb     = 10
-max_bundle_size_mb   = 50
-max_files_per_bundle = 1000
-```
+**Path safety.**
 
-`deploy_mode`:
+- All paths canonicalised to `root_dir` real path; any resolution
+  that escapes `root_dir` is rejected (400).
+- Symlinks within `root_dir` are not followed.
+- Unicode-normalised to NFC; non-NFC paths rejected.
+- Null bytes, control characters in paths rejected.
+- Hidden files (leading `.`) not served.
 
-* **`"live"`** (default) — files in `root_dir` are served as-is. No
-  generations, no atomic swap, no rollback. Operator owns the
-  filesystem layout. Bundle deploys overwrite files in place.
-  Matches the "just copy files and they're live" mental model.
-* **`"managed"`** — `root_dir` contains `gen-N/` subdirectories and a
-  `current → gen-N` symlink. Bundle deploys extract to a fresh
-  `gen-N+1/`, then atomically swap the symlink. Last 5 generations
-  retained (configurable). Rollback via `POST /v1/website/rollback/{gen}`.
-  Operators who need rollback semantics opt in.
+**Content security.**
 
-#### REST surface
+- `X-Content-Type-Options: nosniff` on every response.
+- Default CSP disables inline JavaScript on the public site:
+  `default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'`.
+  Configurable per-site for SPA needs.
+- MIME types from extension (`mime_guess`), no sniffing.
+- Forbid serving files with executable bits or with extensions in
+  the configured `website.executable_blocklist` (default: `.cgi`,
+  `.php`, `.exe`).
 
-```
-GET    /v1/website/files            # list current site tree
-GET    /v1/website/files/{path}     # fetch a file
-PUT    /v1/website/files/{path}     # upload/overwrite (admin/moderator)
-DELETE /v1/website/files/{path}     # remove a file
-POST   /v1/website/deploy           # tar.gz bundle, atomic if managed
-GET    /v1/website/generations      # managed mode only
-POST   /v1/website/rollback/{gen}   # managed mode only
-```
+**Cookie isolation.** See §9.3. The website's origin must not share
+cookie scope with the admin UX.
 
-`POST /v1/website/deploy` accepts a `tar.gz` body up to
-`max_bundle_size_mb`. In `"live"` mode: extracted directly into
-`root_dir`, overwriting matching paths. In `"managed"` mode:
-extracted into a new generation, symlink swapped atomically.
+**Form submission.** The static site POSTs directly to
+`/v1/join-requests`. No proxy endpoint.
 
-#### Serving
+`ETag` (SHA-256 of content) + `Cache-Control` so a CDN can sit in
+front. Live-mode file-descriptor cache TTL configurable
+(`website.live_cache_ttl_seconds`, default 5).
 
-* MIME types detected by file extension (`mime_guess`).
-* `ETag` (SHA-256 of content) + `Cache-Control: public, max-age=3600`
-  on every response so operators can put a CDN in front.
-* Directory paths (`/about/`) resolve to `index.html` in that
-  directory.
-* Unmatched paths: 404, or fall back to `/index.html` if
-  `spa_fallback = true`.
-* Path traversal (`..` escape) rejected with 400.
-* Hidden files (leading `.`) not served.
+### 12.2 Admin UX (`admin-ui` feature)
 
-#### Form submissions to the join flow
+The admin UX is a static SPA built and released from
+[OpenVTC/vtc-admin-ui](https://github.com/OpenVTC/vtc-admin-ui).
+`vtc-service`'s `build.rs` fetches a SHA-256-pinned release tarball
+and bakes it via `include_dir!`. Tarball must be **signed by the
+OpenVTC release key**; `build.rs` verifies the signature *and* the
+digest before extracting. Offline builds use a vendored fallback
+under `VTC_OFFLINE_BUILD=1`.
 
-The static site can POST directly to `/v1/join-requests` (CORS
-allows the website's own origin by default). No special "form
-proxy" endpoint — the API endpoint is the form target.
+`admin_ui.mode = "embedded"` (default) serves the baked SPA at the
+configured mount. `mode = "external"` skips embedding; the operator
+hosts the UX elsewhere and the VTC just allows the origin in CORS.
 
-#### Disabled mode
+**WebAuthn `RP ID`.** With path-mode routing the `RP ID` is the base
+host. With subdomain routing, set `RP ID` to the *base domain* so
+credentials remain valid across subdomains. Migrating the admin UX
+to a different base domain re-registers all passkeys; documented in
+the operator runbook.
 
-`enabled = false` (or `website` cargo feature off): all
-`/v1/website/*` routes 404. Operator points DNS at an external host
-(GitHub Pages, Netlify, S3, whatever) and the community site is
-hosted externally.
+### 12.3 VRC graph
 
-### 12.2 Admin UX hosting (`admin-ui` feature)
+Self-issued only in MVP. Members mint VRCs in their wallet/PNM, then:
 
-The admin UX is a static SPA built and released from a separate
-sibling repository (`OpenVTC/vtc-admin-ui`). The VTC binary embeds
-that SPA at build time, then serves it from a configurable mount.
+`POST /v1/relationships` — caller submits a VRC they signed. VTC
+verifies signature against the issuer's known DID, runs
+`relationships.rego` (default: store if both parties are current
+members). Stored in the `relationships` keyspace.
 
-#### Embedded build
+`GET /v1/members/{did}/relationships` returns published VRCs where
+the DID is issuer or subject (paginated).
 
-`vtc-service/build.rs` reads a pinned version from `Cargo.toml`
-(metadata field `[package.metadata.admin_ui] version = "x.y.z"`) and
-fetches the release artifact:
+**Departure handling.** When a member is removed:
+- VRCs they *issued* are handled per their departure disposition
+  (purged on `Purge`).
+- VRCs naming them as *subject* — issued by remaining members — are
+  also redacted from list endpoints when the departed member chose
+  `Purge`. The VRC record itself remains in storage referenced by
+  issuer; the public listing strips it.
 
-```
-https://github.com/OpenVTC/vtc-admin-ui/releases/download/v{version}/admin-ui-dist.tar.gz
-```
+Bilateral counter-signing is v2.
 
-Extracts to `OUT_DIR/admin-ui-dist/`, then `include_dir!` bakes the
-tree into the binary. Build is reproducible: the release tarball is
-checksum-pinned (SHA-256 also in `Cargo.toml` metadata), and `build.rs`
-verifies before extracting.
-
-Offline builds: a vendored fallback at `vtc-service/vendor/admin-ui-dist/`
-is used if `VTC_OFFLINE_BUILD=1` is set. CI populates this; release
-tarballs ship with it bundled.
-
-#### Configuration
-
-```toml
-[admin_ui]
-enabled = true
-mode    = "embedded"   # or "external"
-mount   = "/admin"     # path; or use host below for subdomain mode
-host    = null         # e.g. "admin.example.com" for subdomain mode
-```
-
-* `mode = "embedded"`: VTC serves the baked-in SPA from `mount` /
-  `host`. No CORS needed (same origin or near-origin).
-* `mode = "external"`: VTC does not serve the SPA. The operator hosts
-  it elsewhere; the only thing VTC needs is the origin in
-  `cors.allowed_origins`. Useful when the operator wants to host the
-  admin UX on their own static infrastructure.
-
-#### WebAuthn `RP ID` and routing interaction
-
-The WebAuthn `RP ID` set at passkey registration must remain stable
-for passkeys to keep working. With path-prefix routing
-(`example.com/admin`) the `RP ID` is `example.com` and there's no
-issue. With subdomain routing (`admin.example.com`) the `RP ID`
-should be set to the *base* domain (`example.com`) so the credential
-is valid across subdomains. Otherwise moving the admin UX path later
-breaks every registered passkey. Codified in §17 as an operator-
-runbook item.
-
-### 12.3 Routing modes
-
-Each surface (API, admin UX, website) can be mounted on a path
-prefix, bound to a Host header, or both. Default is **path-prefix
-on the same host** — works on day one without DNS configuration.
-
-#### Default config (path-prefix mode)
-
-```toml
-[routing.api]
-mount = "/v1"
-
-[routing.admin_ui]
-mount = "/admin"
-
-[routing.website]
-mount = "/"          # catch-all, lowest priority
-```
-
-A single host serves everything. Route priority (highest first):
-
-1. `/health` (always)
-2. `/v1/*` → API
-3. `/admin/*` → admin UX (if enabled)
-4. `/v1/website/*` → website management API
-5. `/*` → public website (if enabled)
-
-#### Subdomain mode
-
-```toml
-[routing.api]
-host = "api.example.com"
-
-[routing.admin_ui]
-host = "admin.example.com"
-
-[routing.website]
-host = "example.com"
-```
-
-Tower middleware routes by `Host` header. Requests to a host that
-doesn't match any configured surface return 404.
-
-#### Mixed mode
-
-Any combination. Common pattern:
-
-```toml
-[routing.api]
-mount = "/v1"                        # same host as website
-host  = "example.com"
-
-[routing.admin_ui]
-host  = "admin.example.com"          # admin on its own subdomain
-
-[routing.website]
-mount = "/"
-host  = "example.com"
-```
-
-#### Combined vs separated daemon
-
-**MVP**: combined daemon only. One `vtc` process serves all three
-surfaces. The cargo features control what's compiled in; runtime
-config controls how each is exposed.
-
-**Separated daemons** (running multiple VTC binaries that share
-storage) is **not** in MVP. fjall is not multi-process-safe, so
-splitting requires either a proxy/cache architecture or a different
-storage backend. Documented as v2 work. Operators who need
-isolation today should:
-
-* Strip surfaces at compile time via cargo features per build.
-* Put a reverse proxy (nginx / Caddy / CloudFront) in front for
-  caching, TLS termination, and per-surface rate limiting.
-* Use subdomain routing with separate TLS certs.
-
-99% of communities never need to split.
-
-### 12.4 VRC graph
-
-* Self-issued only in MVP. Bilateral counter-signing v2.
-* `POST /v1/relationships` (or `relationships/1.0/publish`) — caller
-  submits a VRC they signed.
-* VTC verifies VRC signature against caller's known DID.
-* Run `relationships.rego` to decide whether to store.
-* `GET /v1/members/{did}/relationships` returns published VRCs where
-  the DID is issuer or subject. Pagination required.
-* On member departure: VRCs they issued are handled per departure
-  disposition (purged on `Purge`; retained on Tombstone/Historical
-  with status annotation).
-
-## 13. Storage (fjall keyspaces)
+## 13. Storage
 
 | Keyspace | Existing | Schema |
 |---|---|---|
 | `sessions` | ✓ | unchanged |
-| `acl` | ✓ | extended: `VtcRole` enum + `extensions: Value` |
-| `community` | new | singleton key `profile` → `CommunityProfile` |
-| `policies` | new | `id → Policy`; `purpose_active/<purpose> → id` (secondary) |
+| `acl` | ✓ | extended: `VtcRole` enum + `extensions` |
+| `community` | new | singleton key `profile` |
+| `policies` | new | active + archived |
 | `members` | new | `did → Member` |
-| `join_requests` | new | `id → JoinRequest`; `status/<status>/<id>` (secondary) |
-| `invitations` | new | `id → Invitation` |
-| `relationships` | new | `vrc_id → VrcRecord`; `by_member/<did>/<vrc_id>` (secondary) |
-| `status_lists` | new | per-purpose state + index allocations |
-| `registry_records` | new | `member_did → RegistryRecord` |
-| `sync_queue` | new | pending `MembershipSyncer` jobs |
-| `audit` | new | `timestamp → AuditEnvelope`; indices by type/actor/target |
-| `idempotency` | new | `key → (request_hash, response, expires_at)` |
-| `config` | new | `key → ConfigValue` — DB-layer overrides for runtime config |
+| `join_requests` | new | with retention sweeper |
+| `invitations` | new | |
+| `relationships` | new | |
+| `status_lists` | new | per-purpose state + reserved index set |
+| `registry_records` | new | |
+| `sync_queue` | new | `MembershipSyncer` jobs |
+| `audit` | new | `AuditEnvelope` + secondary indices |
+| `audit_key` | new | per-community HMAC key + rotation history |
+| `idempotency` | new | `(session_id, key) → (request_hash, response, expires_at)` |
+| `config` | new | DB-layer overrides |
 
-Public website content is **not** in fjall — it lives on the local
-filesystem at `website.root_dir` (§12.1). This keeps the storage
-abstraction small and lets operators update site files with standard
-filesystem tools.
-
-All fjall keyspaces use the existing `KeyspaceHandle` enum. Because
-the VTC never targets TEE (§3), no vsock-store parity work is
-required for the VTC and `KeyspaceHandle::Vsock` variants stay
-unused on the VTC code path.
+Public website lives on filesystem at `website.root_dir`, not in
+fjall (§3-K).
 
 ## 14. Operational
 
 ### 14.1 Backup / restore
 
-Same pattern as VTA backup:
+`POST /v1/admin/backup/export` returns an encrypted dump (Argon2id +
+AES-256-GCM). Password strength enforced via `zxcvbn` (minimum
+score 3) — `≥12 chars` alone is too weak.
 
-* Argon2id KDF (≥12-char password) + AES-256-GCM.
-* `POST /v1/backup/export` returns the encrypted full state dump
-  (all keyspaces).
-* `POST /v1/backup/import` accepts a dump; refuses if `community_did`
-  doesn't match the running VTC's DID (`check_vtc_did_compatibility`
-  helper, mirror of VTA's check).
-* Fresh-install VTC accepts any backup (no DID set yet); a configured
-  VTC rejects mismatched backups.
+**Cross-VTC restore protection.** Each backup is wrapped under a key
+derived from the VTC's master seed (`HKDF(seed, "vtc-backup-key")`),
+not just the public DID. A spoofer who provisions a new VTC with the
+same DNS cannot restore a stolen backup — they would need the
+original master seed, which is OS-keyring-resident.
 
-### 14.2 Configuration export/import
+A fresh-install VTC accepts any backup once. A configured VTC refuses
+backups whose `community_did` doesn't match. Same primitive as VTA's
+`check_vta_did_compatibility`.
 
-Separate from data backup. Exports only configuration shape:
+**Scrub on export.** `sessions` and `idempotency` keyspaces are
+excluded from backups — they contain ephemeral state and may include
+secret-bearing cached responses.
 
-* Community profile.
-* Policy bundle (all policies + the active set per purpose).
-* CORS configured origins.
-* `community.membership.validity`, status-list capacities, audit
-  retention settings, registry endpoints.
+### 14.2 Runtime configuration
 
-Use case: promote-from-staging, migrate between hosts without copying
-member data, share a community template.
-
-`POST /v1/config/export` returns plain JSON.
-`POST /v1/config/import` applies it transactionally; on conflict with
-existing community profile, refuses (force flag = different endpoint).
-
-### 14.3 Telemetry
-
-Reuses `vti_common::telemetry::TelemetrySink` (existing ring-buffer
-default). New event kinds:
-
-* `JoinRequestSubmitted`, `JoinRequestDecided`
-* `MemberAdded`, `MemberRemoved`, `MembershipRenewed`, `RoleChanged`
-* `RegistrySyncPending`, `RegistrySyncFailed`, `StatusListUpdatePending`,
-  `StatusListUpdateFailed`
-* `StatusListOccupancyWarning`
-* `PolicyActivated`
-* `IdempotencyConflict`
-* `CrossCommunityRoleEvaluated`
-
-### 14.4 Health / diagnostics
-
-* `GET /health` — unauth, returns 200 if the daemon is up and storage
-  is reachable.
-* `GET /v1/health/diagnostics` — admin only. Returns:
-  * Status-list occupancy per purpose (count + percentage).
-  * MembershipSyncer queue depth, last-success/failure timestamps.
-  * Active policy ids per purpose with their SHA-256.
-  * Trust-registry last-publish timestamp + status.
-  * Telemetry ring-buffer snapshot summary.
-
-### 14.5 Runtime guards (preserve)
-
-* Rate limit on unauth routes via `tower-governor`: 5 rps + 10 burst
-  per source IP. Applies to `/v1/join-requests` (submit), `/v1/install/*`,
-  `/health`, and public website forms.
-* Body cap: 1 MB globally.
-* Audience isolation: VTC JWTs only — `aud: "VTC"`. Cross-audience
-  tokens rejected.
-* Install carve-out: single-use, like VTA's bootstrap carve-out.
-
-### 14.6 Runtime configuration management
-
-Every configurable VTC option is settable through the admin web UX
-via REST. Settings that can take effect without interrupting service
-(log level, CORS origins, rate limits, audit retention, membership
-validity defaults) apply on explicit reload. Settings that require a
-process restart to take effect (bind address, TLS certificates,
-storage path) are flagged in the UX response and applied via an
-explicit restart action.
-
-#### Persistence model
-
-Configuration is a three-layer overlay, evaluated right-to-left at
-boot and on reload:
-
-```
-effective = env_vars > db_overrides > config.toml > defaults
-```
-
-* `config.toml` is the on-disk seed loaded at boot (compatibility with
-  the existing config story).
-* `db_overrides` is a new `config` keyspace; the admin UX writes here.
-* Environment variables (`VTC_*`) win over everything for ops-style
-  emergency overrides.
+Three-layer overlay:
+`env_vars > db_overrides > config.toml > defaults`.
 
 `GET /v1/admin/config` returns the effective config with per-field
-annotations: `source: "env" | "db" | "toml" | "default"` and
-`requires_restart: bool`.
-
-#### REST surface
-
-```
-GET   /v1/admin/config
-PATCH /v1/admin/config            # partial update
-POST  /v1/admin/config/reload     # apply reloadable changes in-place
-POST  /v1/admin/config/restart    # graceful shutdown for restart-required changes
-```
-
-`PATCH` accepts a JSON object with any subset of mutable config keys.
-Writes to the `config` keyspace and returns:
-
-```json
-{
-  "applied":          ["log.level", "cors.allowed_origins"],
-  "pending_restart":  ["server.port"],
-  "rejected":         []
-}
-```
-
-`pending_restart` fields are persisted but not yet active. Calling
-`POST /v1/admin/config/reload` re-applies the effective config to
-running subsystems for hot-reloadable settings. Calling
-`POST /v1/admin/config/restart` initiates graceful shutdown:
-
-1. Stop accepting new HTTP / DIDComm requests.
-2. Drain in-flight requests with a configurable
-   `restart.drain_timeout` (default 30s).
-3. Flush `MembershipSyncer` queue (bounded wait, also 30s).
-4. Emit `RestartRequested` audit event.
-5. Exit with status 0.
-
-A process supervisor (systemd `Restart=always`, kubernetes,
-supervisord) is required to actually restart the binary; the spec
-documents this as an explicit operational dependency. CLI users get
-`vtc daemon` (existing) supervised by their init system; container
-users get a k8s `Deployment`.
-
-#### Config taxonomy
-
-| Key | Reload | Restart | UX-settable | Notes |
-|---|---|---|---|---|
-| `server.host` | | ✓ | ✓ | |
-| `server.port` | | ✓ | ✓ | |
-| `server.tls.cert_path` | | ✓ | ✓ | |
-| `server.tls.key_path` | | ✓ | ✓ | |
-| `log.level` | ✓ | | ✓ | |
-| `cors.allowed_origins` | ✓ | | ✓ | |
-| `audit.retention.*` | ✓ | | ✓ | |
-| `membership.validity` | ✓ | | ✓ | New value applies to *subsequent* VMC issuance; existing VMCs retain their issued validUntil. |
-| `status_list.capacity` | | ✓ | ✓ | Existing lists keep their capacity; new lists (on chaining) adopt the new value. |
-| `registry.endpoint` | ✓ | | ✓ | Triggers reconnect. |
-| `registry.publish_on_startup` | ✓ | | ✓ | |
-| `rate_limit.unauth_rps` | ✓ | | ✓ | |
-| `rate_limit.unauth_burst` | ✓ | | ✓ | |
-| `body_cap_bytes` | ✓ | | ✓ | |
-| `restart.drain_timeout` | ✓ | | ✓ | |
-| `storage.path` | | ✓ | ✓ | |
-| `community.profile.*` | ✓ | | ✓ | Goes through `/v1/community/profile`, not `/v1/admin/config`. |
-| `routing.api.{mount,host}` | | ✓ | ✓ | Affects URL surface. |
-| `routing.admin_ui.{mount,host}` | | ✓ | ✓ | |
-| `routing.website.{mount,host}` | | ✓ | ✓ | |
-| `admin_ui.mode` | | ✓ | ✓ | `"embedded"` vs `"external"`. |
-| `admin_ui.external_origin` | ✓ | | ✓ | Sets the CORS entry; only meaningful if mode = external. |
-| `website.enabled` | | ✓ | ✓ | Disabling unmounts the routes. |
-| `website.root_dir` | | ✓ | ✓ | Filesystem path. |
-| `website.deploy_mode` | ✓ | | ✓ | `"live"` vs `"managed"`. |
-| `website.spa_fallback` | ✓ | | ✓ | |
-| `website.max_*` | ✓ | | ✓ | Size limits on uploads. |
-| Secret backend (keyring / AWS / GCP / Azure) | | n/a | n/a | Selected by cargo feature at compile time; UX surfaces "active backend". |
-| Cargo features (`website`, etc.) | n/a | n/a | n/a | Compile-time only. UX surfaces "feature available" / "not built in". |
-
-#### Audit + telemetry
-
-Every mutation emits a versioned audit event (see §10.1
-additions). `ConfigChanged` carries the per-key change set;
-`ConfigReloaded` and `RestartRequested` mark control-plane actions.
-
-Telemetry counters: `config_patched`, `config_reloaded`,
-`config_restart_requested`, `config_reload_failed`.
-
-#### Relationship to `/v1/config/{export,import}`
-
-`/v1/config/export` (§14.2) returns the union of community profile +
-policy bundle + DB-layer config overrides — exactly what's needed to
-recreate a community on a fresh VTC. It does **not** include
-TOML-layer or env-layer values, since those are deployment-specific.
-`/v1/config/import` writes to the DB layer; restart-required fields
-take effect at next process start.
-
-## 15. CLI surface
-
-`cnm-cli` extension. The community-network-manager binary already
-exists; new subcommands added under `cnm community`:
-
-```
-cnm community setup
-cnm community status
-
-cnm community profile        {show, set}
-cnm community policies       {list, upload, activate, show, test}
-cnm community members        {list, show, role, remove}
-cnm community join           {list, approve, reject, defer, show}
-cnm community invitations    {list, issue, revoke}
-cnm community website        {publish, unpublish, list}     # feature-gated
-cnm community registry       {publish, refresh, status}
-cnm community status-lists   {show, occupancy}
-cnm community audit          {list, since, type, actor, target}
-cnm community backup         {export, import}
-cnm community config         {show, set, reload, restart, export, import}
-cnm community daemon         {reload, restart, status}
-```
-
-`cnm community config show` returns the effective config with source
-annotations. `cnm community config set <key> <value>` PATCHes a single
-key. `cnm community config reload` and `restart` map directly to the
-REST control-plane endpoints. `cnm community daemon` is a thin alias
-for the reload/restart actions, parallel to how operators think about
-the running process.
-
-CLI commands are thin wrappers over `vta-sdk` REST/DIDComm clients
-(workspace doctrine: CLI logic in `vta-cli-common`).
-
-## 16. Trust Tasks
-
-Every wire operation in the VTC — REST or DIDComm — is a registered
-Trust Task. A Trust Task is the formal, versioned definition of a
-task being requested. It combines:
-
-* **Operation semantics** — what the task does, and what success means.
-* **Inputs** — the credentials, claims, attestations, and parameters
-  the caller must present.
-* **Outputs** — the artefacts (records, credentials, audit events)
-  the task produces.
-* **Trust assumptions** — what the producer relies on about the
-  caller, the inputs, and the surrounding system.
-
-Trust Tasks are identified by a stable URL on
-[trusttasks.org](https://trusttasks.org) and referenced on the wire
-from day one. This is opt-in discipline applied **before MVP code
-ships**, not retrofitted later.
-
-### 16.1 Identifier scheme
-
-```
-https://trusttasks.org/{org}/{domain}/{path}/{major}.{minor}
-```
-
-For this workspace: `org = openvtc`, `domain = vtc`. Example:
-
-```
-https://trusttasks.org/openvtc/vtc/join/request/submit/1.0
-```
-
-Versioning:
-
-* Minor bumps are additive (new optional inputs, new response
-  fields). Backwards compatible.
-* Major bumps are breaking — a new registry entry, the old one stays
-  resolvable as Deprecated.
-
-### 16.2 Wire binding
-
-#### REST
-
-Every request carries a `Trust-Task` header naming the task it
-intends to invoke:
-
-```
-POST /v1/join-requests HTTP/1.1
-Host: vtc.example.com
-Trust-Task: https://trusttasks.org/openvtc/vtc/join/request/submit/1.0
-Idempotency-Key: 8a9c…
-Content-Type: application/json
-
-{ "applicant_did": "...", "vp": { ... } }
-```
-
-VTC checks the header matches the endpoint's registered task. A
-mismatch returns 415 `TrustTaskMismatch` with a structured payload
-identifying the expected task. Missing header on a registered
-endpoint returns 400 `TrustTaskMissing`. The header is not validated
-against trusttasks.org at request time — the URL is treated as an
-opaque identifier the workspace knows about. Network-resolution of
-the URL is the responsibility of operators inspecting traffic.
-
-Response bodies include `trust_task: "<resolved URL>"` so the caller
-sees which task the server actually invoked.
-
-#### DIDComm
-
-The DIDComm message `type` field **is** the Trust Task URL — same
-shape, same registry. The earlier-planned shorthand types like
-`community/1.0/join-request` are rewritten as:
-
-```
-https://trusttasks.org/openvtc/vtc/community/join-request/1.0
-```
-
-No additional envelope field is required; DIDComm v2 already routes
-by message type, and the Trust Task registry is just the canonical
-home for those types.
-
-### 16.3 Spec format
-
-Each Trust Task is two artefacts under a versioned directory in the
-workspace at `trust-tasks/{path}/{major}.{minor}/`:
-
-```
-trust-tasks/
-├── index.json                                    # registry manifest
-├── join/request/submit/1.0/
-│   ├── spec.md                                   # human-readable
-│   └── schema.json                               # JSON Schema for input/output
-├── members/renew/1.0/
-│   ├── spec.md
-│   └── schema.json
-└── …
-```
-
-`spec.md` carries structured frontmatter:
-
-```yaml
----
-id: https://trusttasks.org/openvtc/vtc/join/request/submit/1.0
-title: VTC — Submit join request
-status: Draft                       # Draft | Reviewing | Published | Deprecated
-version: "1.0"
-authors:
-  - did:webvh:openvtc.org
-created: 2026-05-11
-updated: 2026-05-11
-applies_to:
-  - rest: POST /v1/join-requests
-  - didcomm: https://trusttasks.org/openvtc/vtc/community/join-request/1.0
-inputs:
-  - name: applicant_did
-    type: did
-    required: true
-  - name: vp
-    type: VerifiablePresentation
-    required: true
-  - name: registry_consent
-    type: RegistryConsentRequest
-    required: false
-outputs:
-  - JoinRequestRecord
-  - AuditEvent[JoinRequestSubmitted]
-trust_assumptions:
-  - Caller's outer auth (REST bearer / DIDComm authcrypt sender) authenticates the relayer.
-  - VP DataIntegrityProof authenticates the holder.
-related:
-  - https://trusttasks.org/openvtc/vtc/policy/join/evaluation/1.0
-  - https://trusttasks.org/openvtc/vtc/credentials/vmc/issue/1.0
----
-```
-
-The body of `spec.md` is the narrative spec: motivation, normative
-behaviour, error vocabulary, examples, security considerations.
-
-`schema.json` is a JSON Schema covering the wire input + output. Used
-for runtime validation and for binding generation in client SDKs.
-
-`trust-tasks/index.json` is the workspace's registry manifest — a
-list of all task IDs the workspace defines, used by CI to publish to
-trusttasks.org and by the VTC at boot to register handlers.
-
-### 16.4 Catalog (VTC MVP)
-
-Approximately fifty Trust Tasks across the operation surface. Each
-entry below is a stable ID assigned at the time the corresponding
-endpoint is designed; the `spec.md` and `schema.json` may be skeletal
-at first and tightened during implementation.
-
-| Area | Trust Task IDs |
-|---|---|
-| Install | `install/claim/1.0`; `admin/bootstrap/1.0` |
-| Admin passkeys | `admin/passkeys/register/1.0`; `admin/passkeys/revoke/1.0`; `admin/passkeys/list/1.0` |
-| Admin config | `admin/config/show/1.0`; `admin/config/patch/1.0`; `admin/config/reload/1.0`; `admin/config/restart/1.0` |
-| Community profile | `community/profile/show/1.0`; `community/profile/update/1.0` |
-| Members | `members/list/1.0`; `members/show/1.0`; `members/role/update/1.0`; `members/remove-admin/1.0`; `members/remove-self/1.0`; `members/renew/1.0`; `members/rotate-did/1.0`; `members/personhood/assert/1.0`; `members/personhood/revoke/1.0`; `members/relationships/list/1.0` |
-| Join | `community/join-request/1.0`; `join/request/list/1.0`; `join/request/show/1.0`; `join/request/approve/1.0`; `join/request/reject/1.0`; `join/request/defer/1.0` |
-| Invitations | `invitations/issue/1.0`; `invitations/list/1.0`; `invitations/revoke/1.0`; `invitations/redeem/1.0` |
-| Policies | `policies/list/1.0`; `policies/upload/1.0`; `policies/activate/1.0`; `policies/test/1.0`; `policies/show-active/1.0` |
-| Relationships | `relationships/publish/1.0`; `relationships/list/1.0`; `relationships/remove/1.0`; `relationships/query/1.0` |
-| Credentials issued | `credentials/endorsement/issue/1.0` (VEC); `credentials/witness/issue/1.0` (VWC); `credentials/rcard/issue/1.0` |
-| Status lists | `status-lists/get/1.0` |
-| Audit | `audit/query/1.0` |
-| Backup | `backup/export/1.0`; `backup/import/1.0`; `config/export/1.0`; `config/import/1.0` |
-| Trust registry | `registry/profile/show/1.0`; `registry/refresh/1.0` |
-| Website | `website/files/list/1.0`; `website/files/get/1.0`; `website/files/upload/1.0`; `website/files/delete/1.0`; `website/deploy/1.0`; `website/generations/list/1.0`; `website/rollback/1.0` |
-| Health | `health/check/1.0`; `health/diagnostics/1.0` |
-
-(Full URLs in `trust-tasks/index.json`. The CLI surface §15 does not
-get its own Trust Task IDs — the CLI invokes the same REST tasks.)
-
-### 16.5 Publication workflow
-
-Source-of-truth for `openvtc/vtc/*` Trust Tasks lives in this
-workspace under `trust-tasks/`. trusttasks.org pulls published
-versions via a discovery manifest hosted at
-`https://openvtc.org/trust-tasks/manifest.json`. Status flow:
-
-```
-Draft ──── Reviewing ──── Published ──── Deprecated
-                            │                ▲
-                            └────(major bump)┘
-```
-
-* **Draft** — spec file exists with a stable ID. Wire surface may
-  reference it. `schema.json` may be incomplete.
-* **Reviewing** — open PR; schema stable; conformance tests in
-  progress. Visible publicly as Draft on trusttasks.org with a
-  "review" marker.
-* **Published** — ratified. Schema frozen. Promoted on the registry
-  site. Backwards-compatible minor revisions allowed; major changes
-  require a new registry entry.
-* **Deprecated** — superseded by a higher major. Stays resolvable for
-  a sunset window (default 1 year); registry entry includes a
-  `successor` pointer.
-
-CI publishes on every merge to main: Draft entries land as Draft;
-Reviewing entries get the review marker; Published entries are
-frozen-on-publish.
-
-### 16.6 Governance
-
-* Each `spec.md` has an `authors` list pinned to DIDs.
-* Changes to Draft / Reviewing tasks: PR against this repo.
-* Changes to Published tasks: only via deprecation + new major.
-* Adding a new Trust Task to `openvtc/vtc/*`: PR in this repo by an
-  author DID. Tasks under other paths (`openvtc/vta/*`,
-  `openvtc/dtg/*`, etc.) live in their own source repos.
-
-### 16.7 MVP gate (soft)
-
-Trust Tasks are a **soft gate** for MVP:
-
-* Every operation that ships in MVP must have a Trust Task with a
-  stable ID and at least a Draft `spec.md` before its endpoint
-  ships. ID assignment is non-negotiable; spec body can be skeletal.
-* No published-status requirement for MVP shipping. Promotion to
-  Published is a target for the v1.0 release of the VTC.
-* Published status for v1.0 requires: `schema.json` complete, at
-  least one conformance test in the workspace test suite, no breaking
-  changes since first Draft (or a clean major bump if there were).
-
-### 16.8 Workspace integration
-
-* New crate (or sub-module of `vti-common`) `vti-trust-tasks` holds
-  the registry manifest types + a `TrustTask` extractor for Axum.
-* REST routes register their expected `Trust-Task` value at handler
-  attach time. The extractor checks the header on each request and
-  emits structured 4xx on mismatch.
-* DIDComm dispatch already routes by message type; the trust-task
-  type URL replaces the previously planned shorthand.
-* The `vta-sdk` client gains a `with_trust_task(url)` builder method
-  for explicit task selection. SDK callers don't pick the task
-  manually — each client method sets the right one — but the API
-  surface allows it for protocol explorers.
-
-## 17. Phasing / milestones
-
-Phases are ordered by dependency. Each ships independently as an
-operator-visible increment.
-
-| Phase | Deliverable | Gates next phase by |
+`source` annotation and `requires_restart: bool`. `PATCH` writes to
+the `config` keyspace. `POST .../reload` re-applies hot-reloadable
+settings; `POST .../restart` initiates graceful shutdown.
+
+**Restart-endpoint supervisor handshake.** The restart endpoint
+refuses to exit unless a supervisor is detected — either
+`VTC_SUPERVISED=1` or the systemd notify socket (`NOTIFY_SOCKET`)
+or k8s downward-API marker present. Without a supervisor, restart
+would be a one-shot DoS.
+
+**Sensitive-path PATCH guard.** Mutable config keys carry a
+sensitivity flag. `server.tls.cert_path`, `server.tls.key_path`,
+and `storage.path` are configured to **a directory allowlist**;
+PATCH values outside the allowlist are rejected (refusing requests
+to point TLS at `/etc/shadow` or to relocate storage transparently).
+
+**Config import audit.** `POST /v1/admin/config/import` runs a
+diff-and-confirm flow: the response surfaces every changed field
+with a pre-apply preview; a second call with `confirm=true` applies.
+Per-field audit events emitted on apply.
+
+Full config taxonomy (which key reloads, which restarts, which is
+UX-settable, sensitive-flag) lives in `docs/04-reference/vtc-config.md`,
+not in this spec.
+
+**VTA oracle dependence.** Every VMC / VEC issuance blocks on the
+paired VTA's signing oracle. The VTC enforces a per-call timeout
+(`vta.signing_timeout_seconds`, default 5) and a circuit breaker
+(`vta.circuit_breaker_threshold`, default 5 consecutive failures).
+On breaker-open: join requests are queued (returned as `Deferred`
+instead of 500), renewals return 503, and `/v1/health/diagnostics`
+surfaces VTA health.
+
+### 14.3 Telemetry + diagnostics
+
+Reuses `vti_common::telemetry::TelemetrySink`. `/v1/health/diagnostics`
+(admin) surfaces:
+
+- VTA oracle health + last-success timestamp
+- Status-list occupancy per purpose
+- `MembershipSyncer` queue depth + last-success/failure
+- Active policy IDs + SHA-256 per purpose
+- Trust-registry sync status
+- Telemetry ring-buffer snapshot
+
+`/health` (unauthenticated, Trust-Task-exempt §9.4) returns 200 when
+the daemon is responsive and storage is reachable.
+
+### 14.4 Runtime guards (workspace doctrine)
+
+Inherited from the workspace's standard guards: tower-governor on
+unauth routes (5 rps + 10 burst per IP); 1 MB global body cap;
+audience-isolated JWTs; install carve-out is single-use (§4).
+
+**Body-cap exception.** Website upload routes
+(`POST /v1/website/deploy`, `PUT /v1/website/files/{path}`) override
+the global body cap with per-route caps from
+`website.max_bundle_size_mb` (default 50) and `max_file_size_mb`
+(default 10). All other routes inherit 1 MB.
+
+## 15. CLI
+
+`cnm-cli` gains `cnm community` subcommands grouped by area
+(`setup`, `status`, `profile`, `policies`, `members`, `join`,
+`invitations`, `website`, `registry`, `status-lists`, `audit`,
+`backup`, `config`, `daemon`).
+
+Commands are thin wrappers over `vta-sdk` REST/DIDComm clients —
+workspace doctrine. Detailed verb list lives in
+`docs/04-reference/cnm-vtc-cli.md`.
+
+## 16. Phasing
+
+| Phase | Deliverable | Gate |
 |---|---|---|
-| **0 — Provisioning + install** | `vtc-host` DID template, `vtc setup` CLI wizard, install-token + WebAuthn install flow, multi-passkey admin DID, community profile keyspace. | DID + auth foundation. |
-| **1 — IAM + member lifecycle** | Role enum + custom roles, ACL extension, member CRUD, join requests (manual approve/reject), self-removal + admin-removal (no policy yet), audit events v1, idempotency keys, cursor pagination, `/v1/` URL versioning. | The community can have members. |
-| **2 — Policy engine + DTG issuance** | regorus engine, policy upload/activate, `join.rego` driving the join flow, `removal.rego`, VMC + VEC issuance via VTA oracle, status-list publication, renewal endpoint, DID rotation (both methods). | The community has live policies and proper credential issuance. |
-| **3 — Trust-registry + extensibility** | Trust-registry publish on startup, three departure dispositions, `registry.rego`, `MembershipSyncer`, RTBF override path, hash-tagged audit envelopes, cross-community recognition policies. | The community is part of the wider DTG network. |
-| **4 — VRC + Personhood** | Self-issued VRC publishing + storage, `relationships.rego`, `personhood.rego` (deny-all stub) + assert/revoke endpoints, custom endorsement issuance (issuer role). | The graph and personhood semantics are live. |
-| **5 — Optional surfaces** | Public community website (filesystem-backed static hosting, `"live"` + `"managed"` deploy modes, bundle + per-file APIs), admin web UX (sibling repo `OpenVTC/vtc-admin-ui` consumed via `build.rs` tarball embed), routing config (path-prefix default + subdomain mode). Web UX repo can land in parallel with any prior phase once REST surface stabilises after phase 2. | MVP complete. |
+| **0** | `vtc-host` template, install wizard, WebAuthn install flow, multi-passkey admin DID, community profile, config plumbing | DID + auth foundation. |
+| **1** | Role enum + custom roles, ACL extension, member CRUD with manual approval, self/admin removal (no-last-admin), audit envelope + HMAC, idempotency, `/v1/` versioning, cursor pagination | Members can exist. |
+| **2** | `regorus`, policy upload + activate, `join.rego` + `removal.rego`, VMC + VEC issuance via VTA oracle (with timeout + breaker), status-list with reserved-index discipline, renewal, DID rotation (both methods, domain-tagged) | Live policy + credentials. |
+| **3** | Trust-registry publish, three departure dispositions, `registry.rego`, `MembershipSyncer` + diagnostic surfacing, RTBF override + batched timing, cross-community recognition (session-mint hardening) | Community on the wider network. |
+| **4** | VRC self-issuance + `relationships.rego`, `personhood.rego` (deny-all stub) + assert/revoke + renewal re-eval, custom endorsement issuance (issuer role) | Graph + personhood live. |
+| **5** | Public website (filesystem-backed, CSP, path safety), admin UX consumed via `build.rs` (release-key-signed tarball), path-prefix routing default + subdomain support | MVP complete. |
 
-Phase 5 sub-tasks parallelize with phases 3 and 4. Phases 0–4 are
-strictly serial.
+Phase 5 sub-tasks parallelise with phases 3–4. Phases 0–4 strictly
+serial. Each phase's PR set includes the Draft Trust Task spec files
+alongside the code that implements the operations (§9.4 soft gate).
 
-Each phase's PR set includes the Draft Trust Task spec files
-(`trust-tasks/.../{spec.md,schema.json}`) alongside the code that
-implements the operations. A phase doesn't ship until every wire op
-it introduces has a stable Trust Task ID assigned and at least a
-skeletal `spec.md` — see §16.7.
+## 17. Open questions
 
-## 18. Open questions
+These have proposed answers in the design history but remain to
+validate at implementation:
 
-These are *not* blockers — they have proposed answers documented in
-prior turns of design. Listed here so the spec is honest about what
-remains to validate during implementation.
+1. **Personhood policy reference implementation.** Stub ships
+   deny-all; the workspace should publish at least one reference
+   policy (`docs/04-reference/personhood-templates.md`) once Phase 4
+   lands so communities don't reinvent from scratch.
+2. **Status-list chaining strategy.** MVP alerts at 75% and refuses
+   beyond capacity. Production communities will exceed 131K members
+   eventually. Plan: chained-list pointer in the BitstringStatusList
+   credential header.
+3. **Trust Tasks source-of-truth location.** Currently
+   `trust-tasks/` in this workspace. May factor out to a dedicated
+   `OpenVTC/trust-tasks` repo when VTA-side tasks appear.
+4. **Conformance test pattern for Published Trust Tasks.** Probably
+   golden request/response pairs + schema validation. Land with the
+   first Published task and standardise.
+5. **Audit `audit_key` rotation cadence.** RTBF triggers rotation;
+   spec is silent on routine rotation. Default policy TBD —
+   probably annual + on every backup-export rekey.
+6. **VRC issuance over DIDComm vs REST UX.** Both work; member
+   wallets typically prefer DIDComm. No technical fork; UX call.
 
-1. **Personhood policy input schema beyond the minimal contract.**
-   Each community extends; the workspace does not standardize. Risk:
-   community implementations diverge wildly. Mitigation: publish at
-   least one reference personhood policy in `docs/04-reference/`
-   after Phase 4 lands.
+## 18. Explicitly NOT in MVP
 
-2. **Status-list chaining strategy.** MVP alerts at 75% occupancy and
-   declines beyond capacity. Production communities will exceed
-   131,072 members eventually. Plan: introduce a successor-list
-   pointer header in the BitstringStatusListCredential and a
-   `chained_status_lists` keyspace. Spec'd as a v2 add-on.
+- **TEE / Nitro Enclave deployment of the VTC binary** — permanent
+  non-goal (§3-K). Trust anchor for TEE remains the VTA.
+- **Multi-tenant** (one binary hosts multiple communities).
+- **Multi-process daemons sharing fjall storage.** Operator
+  isolation via cargo features + reverse proxy is the MVP path.
+- **N-of-M admin approvals.** Retrofit is bounded (insert a
+  `proposal` phase before ~8 endpoints).
+- **Webhooks / external event subscribers.** Stable audit event
+  vocabulary (§11.4) makes this a delivery layer on top.
+- **Bulk operations** (mass-invite, mass-remove, mass-export).
+- **WASM / plugin extensions.** Communities extend via Rego +
+  JSON blobs only.
+- **i18n at the resource layer** (translated profile fields, role
+  names). Additive migration via `name_translations` field with
+  fallback.
+- **VPC (Persona credentials)** beyond type-reservation.
+- **Bilateral VRC counter-signing.** Self-issued only in MVP.
+- **VTC-to-VTC community migration tooling.** Config export +
+  backup are the primitives; packaged scripts are a follow-up.
+- **Onboarding state machine** for new members. Encode in policy +
+  admin UX initially.
+- **Filesystem / S3 backends for fjall keyspaces** beyond the
+  public website root.
 
-3. **Member DID rotation atomicity under registry lag.** If a `did:key`
-   rotation succeeds locally but the trust-registry sync to update the
-   record's member DID lags, external verifiers briefly see the old
-   DID as active and the new DID as unknown. Workspace doctrine
-   accepts this: registry lag is a known property; verifiers should
-   re-query on mismatch.
+## 19. Related work
 
-4. **Audit hash function and salt strategy.** Currently spec'd as
-   plain SHA-256 over the DID string. Could be salted per-community
-   to prevent cross-community correlation attacks. v2 question.
-
-5. **DIDComm join-request DoS exposure.** Unlike REST (rate-limited by
-   IP), DIDComm doesn't have an obvious rate-limiting axis. Per-DID
-   rate-limit on `community/1.0/join-request` is the obvious answer
-   but adds state. Defer to a phase 2.5 hardening step.
-
-6. **CORS + WebAuthn `RP ID` coupling.** The admin UX origin must
-   match the WebAuthn `RP ID` set at passkey registration. With
-   subdomain routing (`admin.example.com`) the `RP ID` should be set
-   to the base domain (`example.com`) so credentials remain valid
-   across subdomains. Operators who migrate the admin UX to a new
-   base domain re-register all passkeys. Document as expected;
-   codify in operator runbook.
-
-7. **Admin UX release-tarball checksum management.** `build.rs`
-   pins the admin-ui release artifact by SHA-256. Bumping the admin
-   UX version requires an in-repo metadata change in `Cargo.toml`.
-   Operationally fine; tooling (`cargo xtask bump-admin-ui x.y.z`)
-   useful to write at phase 5.
-
-8. **Public website + filesystem reload semantics.** In
-   `deploy_mode = "live"`, files are served directly from disk. The
-   first request after an external edit pays an `mtime` stat
-   per-file; subsequent requests within a configurable window hit a
-   cached descriptor. Cache duration is a tradeoff between
-   live-reload-feel and per-request overhead. Spec'd as
-   `website.live_cache_ttl_seconds` (default 5).
-
-9. **Trust Task source-of-truth location.** Initial proposal: live
-   under `trust-tasks/` in this workspace, published from here to
-   trusttasks.org via CI. Alternative: a dedicated
-   `OpenVTC/trust-tasks` repo aggregating tasks across multiple
-   workspace projects (VTC, VTA, DTG). Decision deferred until the
-   VTA workspace also wants registry entries. If VTA-side Trust
-   Tasks land before we hit that decision, expect to factor out.
-
-10. **trusttasks.org formal spec evolving in parallel.** The
-    Trust Task concept itself is not yet fully formalised on
-    trusttasks.org. The shape used here (frontmatter, schema,
-    publication workflow) is a reasonable starting point but may
-    need to align with the registry's eventual canonical format.
-    Workspace impact: if the canonical format changes, the
-    `trust-tasks/` files migrate but the wire URLs (which are the
-    contract) stay stable.
-
-11. **Conformance test pattern.** Each Published task needs at least
-    one conformance test. Pattern not yet pinned: probably golden
-    request/response pairs validated against `schema.json` plus a
-    minimal behavioural assertion. Land with the first Published
-    task and standardise from there.
-
-## 19. Explicitly NOT in MVP
-
-To preserve clarity about scope, the following are out:
-
-* **N-of-M admin approvals** for sensitive operations. Retrofit cost
-  is bounded (insert a `proposal` phase ahead of ~8 endpoints); design
-  doesn't need to anticipate it now.
-* **Webhooks / external event subscribers.** Audit event vocabulary
-  is stable from MVP (§10), so this is delivery-layer additive.
-* **Bulk operations** (mass-invite, mass-remove, mass-export). Each
-  is a new endpoint on top of the per-item ones; additive.
-* **WASM / plugin extensions.** Communities extend via Rego + JSON
-  blobs, not custom code. Hard "no" in MVP.
-* **i18n at the resource layer** (translated profile fields, role
-  names, policy messages). Migration plan: introduce
-  `name_translations` field with fallback to `name`. Not
-  architecturally load-bearing — defer with confidence.
-* **VPC (Persona credentials)** beyond reserving the type. Land in
-  v2 when display-identity needs concrete.
-* **Bilateral VRC counter-signing.** Self-issued only in MVP.
-* **TEE / Nitro Enclave deployment of the VTC binary** — *permanent*
-  non-goal, not a deferral. Only the VTA targets TEE. The VTC stays
-  a regular service. Communities that need TEE-grade trust anchor
-  back through the VTA.
-* **Separated daemons sharing storage** (running multiple `vtc`
-  binaries off the same fjall path). fjall is not multi-process-safe;
-  this requires a proxy/cache architecture or different storage
-  backend. v2 work. Operators who need isolation today use cargo
-  features per build + reverse proxy.
-* **Filesystem / S3 backends for fjall keyspaces** beyond what is
-  already explicitly filesystem-based (the public website root).
-  Other keyspaces stay in fjall.
-* **VTC-to-VTC community migration tooling.** Config export +
-  community-data backup already give operators the primitives;
-  packaged migration scripts are a follow-up.
-* **Onboarding state machine** for new members ("welcome flow",
-  required first actions). Encode in policy + admin UX initially.
-* **Multi-tenant** (one VTC binary hosts multiple communities).
-  Architectural rewrite, intentionally out.
-
-## 20. Related work
-
-* [`trusttasks.org`](https://trusttasks.org) — the canonical
-  registry for Trust Task specifications referenced from the
-  VTC wire surface (§16).
-* `docs/05-design-notes/runtime-service-management.md` — the service-
+- [`trusttasks.org`](https://trusttasks.org) — canonical Trust Task
+  registry (§9.4).
+- `docs/05-design-notes/runtime-service-management.md` — service-
   advertisement primitives the VTC inherits via `vta-sdk`.
-* `docs/03-integrating/provision-integration.md` — how the VTC's own
+- `docs/03-integrating/provision-integration.md` — how the VTC's own
   DID is minted from its VTA.
-* `docs/05-design-notes/pnm-setup-deferred-vta-did.md` — the deferred-
+- `docs/05-design-notes/pnm-setup-deferred-vta-did.md` — deferred-
   DID pattern, useful reference for the VTC install flow.
-* [`openvtc/dtg-credentials`](https://github.com/OpenVTC/dtg-credentials)
-  — the credential catalog.
-* [`affinidi/affinidi-trust-registry-rs`](https://github.com/affinidi/affinidi-trust-registry-rs)
-  — TRQP v2.0 server + client.
-* [`affinidi/affinidi-tdk-rs`](https://github.com/affinidi/affinidi-tdk-rs)
+- [`openvtc/dtg-credentials`](https://github.com/OpenVTC/dtg-credentials)
+  — the credential catalog (§6).
+- [`affinidi/affinidi-trust-registry-rs`](https://github.com/affinidi/affinidi-trust-registry-rs)
+  — TRQP v2.0 server + client (§8).
+- [`affinidi/affinidi-tdk-rs`](https://github.com/affinidi/affinidi-tdk-rs)
   — `affinidi-status-list`, `affinidi-vc`, `affinidi-data-integrity`.

--- a/tasks/vtc-mvp/plan.md
+++ b/tasks/vtc-mvp/plan.md
@@ -1,0 +1,233 @@
+# Plan: VTC MVP — Phase 0
+
+Companion to `docs/05-design-notes/vtc-mvp.md`. This document is the
+implementation plan for Phase 0. `todo.md` is the actionable task
+list with acceptance criteria.
+
+## Objective
+
+Stand up the **DID + auth foundation** for the VTC MVP:
+
+- `vtc-host` DID template in `vta-sdk` so the VTC can mint its own
+  `did:webvh` via the existing `provision-integration` flow.
+- A minimal CLI wizard (`vtc setup`) that mints the seed, provisions
+  the VTC DID, initialises all keyspaces, and hands off to the admin
+  web UX via a one-time install URL.
+- A WebAuthn-bound install flow that turns the install token into a
+  bootstrapped admin DID with multi-passkey support from day one.
+- Cross-cutting hygiene primitives (Trust-Task extractor, versioned
+  audit envelope with HMAC actor hashing, scoped idempotency cache,
+  cursor pagination) added to `vti-common` so every endpoint that
+  ships in Phase 1+ inherits them.
+- Community profile + runtime configuration plumbing (read/write
+  config via REST, reload, restart-with-supervisor-handshake).
+- Path-prefix routing default with cookie-scope isolation invariants
+  enforced at config-load time.
+
+Phase 0 is the gate that unblocks every subsequent phase. Nothing
+here issues credentials, evaluates policy, or touches the trust-
+registry — those are Phases 1-3.
+
+## Scope
+
+### In scope (per spec §16)
+
+Spec §3, §4, §5.1, §5.3, §9.1, §9.2, §9.3, §9.4 (MVP soft gate),
+§9.5 (Phase-0 subset), §10.4 (admin promotion plumbing — endpoint
+stub only, since "members" don't fully exist yet), §11.1, §11.4
+(envelope only; full vocabulary in Phase 1), §14.2, §14.4.
+
+### Out of scope
+
+- Member CRUD, join requests, policies, regorus — Phase 1+
+- VMC / VEC / status-list issuance — Phase 2
+- Trust-registry publishing — Phase 3
+- VRC, personhood — Phase 4
+- Public website, admin UX bundling, subdomain routing test
+  surface — Phase 5
+- DIDComm transport for Phase 0 operations (passkey ops are REST-
+  only by spec; install is REST-only by nature; admin/config and
+  community/profile DIDComm twins land in Phase 1)
+
+## Dependency graph
+
+```
+                M0.1 hygiene primitives (vti-common)
+                ╱      │           │           ╲
+       ┌──────┘       │           │            └──────┐
+       ▼              ▼           ▼                   ▼
+  M0.3 /v1/   M0.7 community   M0.8 config     M0.4 install token
+  migration   profile          plumbing        + carve-out
+       │              │           │                   │
+       │              │           │                   ▼
+       │              │           │           M0.5 WebAuthn claim flow
+       │              │           │                   │
+       │              │           │                   ▼
+       │              │           │           M0.6 admin bootstrap
+       │              │           │           + multi-passkey schema
+       │              │           │                   │
+       │              │           │                   ▼
+       │              │           │           M0.10 emergency bootstrap
+       └──────────────┴───────────┴───────────────────┘
+                          │
+                          ▼
+              M0.11 routing + CORS + cookie-scope
+                          │
+                          ▼
+              M0.12 install-flow integration tests
+
+  M0.2 vtc-host template (vta-sdk) — fully parallel with M0.1
+  M0.9 CLI setup wizard — depends on M0.2 + M0.4
+```
+
+Critical path: M0.1 → M0.4 → M0.5 → M0.6 → M0.10 → M0.11 → M0.12.
+
+Parallelisable side tracks:
+
+- **M0.2** (DID template in `vta-sdk`) is in a different crate and
+  has no internal dependencies — can start at day one.
+- **M0.7** (community profile) and **M0.8** (config plumbing) only
+  depend on M0.1; can be developed concurrently once M0.1.4 lands.
+- **M0.9** (CLI wizard) needs M0.2 and the install-token primitive
+  from M0.4 but not the WebAuthn server side.
+
+## Milestones
+
+| ID | Title | Critical path | Description |
+|---|---|---|---|
+| **M0.1** | Hygiene primitives | ✓ | Trust-Task extractor, audit envelope + HMAC, idempotency keyspace, cursor pagination. Lands in `vti-common`. Everything downstream depends on these. |
+| **M0.2** | `vtc-host` DID template | parallel | New built-in template in `vta-sdk::did_templates`. Provisionable via the existing `provision-integration` flow against any running VTA. |
+| **M0.3** | `/v1/` URL migration | ✓ | Move existing routes under `/v1/` prefix, wire the Trust-Task extractor, add Trust-Task-exempt path for `/health`. Migration is destructive to the public surface but pre-Phase-0 there are no external consumers. |
+| **M0.4** | Install token + carve-out | ✓ | Single-use signed JWT install token (15-min TTL, embedded WebAuthn ceremony nonce + ephemeral keypair) and process-wide async mutex around the install carve-out. |
+| **M0.5** | WebAuthn claim flow | ✓ | `POST /v1/install/claim` accepts the WebAuthn assertion bound to the token's nonce; Ed25519-only; cosigned DID-binding challenge proves same-key control. |
+| **M0.6** | Admin bootstrap + multi-passkey schema | ✓ | `POST /v1/admin/bootstrap` writes first ACL admin entry; ACL schema extended for `passkeys: Vec<RegisteredPasskey>`; passkey register/revoke/list with step-up UV reauth and CAS-protected last-passkey check. |
+| **M0.7** | Community profile | parallel | `CommunityProfile` schema; `community` keyspace; `GET / PUT /v1/community/profile` with `extensions: JsonValue` slot. |
+| **M0.8** | Config plumbing | parallel | Three-layer config overlay (env > db > toml > defaults); `config` keyspace; `GET / PATCH /v1/admin/config`; reload/restart/export/import. Restart endpoint refuses without supervisor handshake. Sensitive-path PATCH gated by directory allowlist. |
+| **M0.9** | CLI setup wizard | parallel | Rewrite `vtc setup` to the minimal 3-question wizard. Mints seed, calls VTA provision-integration with `vtc-host`, initialises keyspaces, mints install token, prints install URL. Replaces the existing 930-line setup.rs. |
+| **M0.10** | Emergency bootstrap | ✓ | `vtc admin emergency-bootstrap` on a stopped daemon, gated by master seed mnemonic possession (not just stopped-daemon). Loud audit event on next boot. |
+| **M0.11** | Routing + CORS + cookie-scope | ✓ | Path-prefix routing config; admin session cookie scoped to `/admin`; CORS allowlist with wildcard refusal; cookie-scope invariant verified at config-load time. |
+| **M0.12** | Install-flow integration tests | ✓ | End-to-end test exercising the install + bootstrap + first-admin-passkey path through `Router::oneshot`, plus the emergency-bootstrap path. Phase 0 gate. |
+
+## Pre-implementation design decisions
+
+Each of these is a small but real decision that should land before
+the corresponding milestone starts. Recorded here so they're visible
+not buried inside individual tasks.
+
+| ID | Decision | Required before | Default we'll adopt unless we agree otherwise |
+|---|---|---|---|
+| **D1** | Trust Task `schema.json` shape | M0.1.1 | JSON Schema draft 2020-12. Single schema file per task with `$id` matching the Trust Task URL. |
+| **D2** | WebAuthn ceremony nonce ↔ install-token binding | M0.4 | Token carries a `cnonce` claim (32 bytes, base64url-encoded). Server stores the nonce alongside the install-token state; claim flow requires the WebAuthn `clientDataJSON.challenge` to match `cnonce`. **Token consumption follows webvh-common's `claimed_at` window pattern** (D12), not immediate single-use. |
+| **D3** | `audit_key` storage + lifecycle | M0.1.2 | Per-community 32-byte HMAC-SHA256 key. Initial key derived via `HKDF-SHA256(master_seed, info: "vtc-audit-key/v1", salt: empty)`. Subsequent rotations generate fresh random keys (not deterministic). See **D10** for the full rotation/retention policy. |
+| **D4** | `extensions` size limit | M0.7 | 16 KiB per `extensions` JSON blob. Larger blobs return 413. Configurable later if needed. |
+| **D5** | Existing `vtc-service` code reuse strategy | M0.9 | **The existing `vtc-service` is throw-away** — it predates the spec rewrite and should not be salvaged. The **VTA service (`vta-service`) is the latest working reference implementation** for setup, did:webvh creation, secret-store wiring, and route patterns. M0.9.1 reviews `vta-service`, not the current `vtc-service`. Anything genuinely shared between VTA and VTC (config types, store abstractions, auth extractors, audit, WebAuthn) lives in `vti-common`. The new `vtc-service` shape emerges as a thin consumer of `vti-common` + `vta-sdk`. |
+| **D6** | Idempotency "destructive op" identification | M0.1.3 | Explicit annotation on the route at attach time (`.with_idempotency(IdempotencyClass::Destructive)`). **Clarity-over-cleverness**: a future reader of the route file sees the class directly next to the handler, with no heuristic to reverse-engineer. Default class is `NonDestructive` (24 h TTL); destructive routes are explicit. |
+| **D7** | WebAuthn `RP ID` derivation | M0.5 | **Single source: `public_url` config field, parsed as a URL; `rp_id = url.domain()`, `origin = url`.** Adopted directly from `webvh-common::server::passkey::build_webauthn`. Drop the earlier multi-source cascade — webvh-service proves the single-field pattern is robust enough and operator-friendly. Operator runbook (spec §17 Q6) covers domain-migration consequences. |
+| **D8** | Trust-Task `Trust-Task` HTTP header name | M0.1.1 | Literal `Trust-Task`. Reserved against future workspace conflict. |
+| **D9** | Route-attachment macro vs explicit registration | M0.1.1 | Explicit registration via a typed `TrustTaskRouter` builder. No macros for MVP — readable, debuggable. |
+| **D10** | `audit_key` rotation cadence + retention | M0.1.2 | **Rotation triggers**: (a) RTBF event (immediate, key-id specific); (b) **routine annual rotation** (background task wakes hourly, rotates when `last_rotated_at` is > 365 days old; configurable as `audit.routine_rotation_days`); (c) explicit `vtc admin rotate-audit-key` CLI. **Retention**: **all prior keys retained indefinitely** in the `audit_key` keyspace — 32 bytes each, one rotation/year × 100 years = 3.2 KB. Lookups walk newest-first. Each entry: `{ key_id: Uuid, key: [u8;32] (encrypted via store::encryption), valid_from, valid_until: Option, rotation_reason: enum }`. Verification walks all keys until one verifies (typical case is the active key; pre-rotation hashes only need older keys during compliance investigations). |
+| **D11** | WebAuthn / passkey infrastructure location | M0.1 + M0.5 | **Lives in `vti-common::auth::passkey`**, adopting the `webvh-common::server::passkey` pattern. Components: `PasskeyState` trait (services implement it), `build_webauthn(public_url) -> Webauthn` helper, `Enrollment` + `PasskeyUser` + `CredentialMapping` storage types, `enroll_start` / `enroll_finish` / `login_*` route handlers generic over `S: PasskeyState`. The `vtc-service` implements `PasskeyState` on its `AppState`; VTA can later implement it too if it needs admin-passkey auth. This is a new task **M0.1.6** added to Phase 0. |
+| **D12** | Install-token consumption pattern | M0.4 | **Adopt webvh-common's `claimed_at` window**, not immediate single-use. State machine: `Issued { exp, cnonce, ephemeral_privkey }` → on `enroll_start` (= our `/v1/install/claim/start`) set `claimed_at` (locks concurrent claims for `ENROLLMENT_CLAIM_WINDOW_SECS = 300`) → on successful WebAuthn ceremony, **consume** → on failure or 5-minute timeout, allow retry. The carve-out only closes after `POST /v1/admin/bootstrap` succeeds. This protects legitimate operators from denial-of-service caused by a stolen URL being clicked-then-abandoned. |
+| **D13** | `Debug` redaction of bearer secrets | M0.4, M0.5, M0.6 | **Adopt webvh-common's manual `Debug` impl pattern**: types holding bearer tokens (install token, session token, refresh token, idempotency key) implement `Debug` manually, printing only a short prefix or `<redacted>` for the secret. Prevents accidental log leakage via stray `tracing::debug!(?token, …)`. Codified as a workspace-wide pattern in CLAUDE.md after Phase 0 lands. |
+
+## Parallelisation strategy
+
+After M0.1 ships, three concurrent tracks open up:
+
+1. **Install + auth track** (critical path): M0.4 → M0.5 → M0.6 → M0.10
+2. **Surfaces track**: M0.7 (community profile) and M0.8 (config)
+   land independently; can be a second engineer's queue.
+3. **DID-template track**: M0.2 lands without any internal deps and
+   can be picked up as the first "real" change (lowest-risk PR to
+   sanity-check the workflow).
+
+M0.11 (routing) is a single-engineer task that gates M0.12 and is
+the last thing on the critical path; it touches all surfaces, so
+it lands after the other tracks merge.
+
+## Checkpoints
+
+Five checkpoints between milestones. Each is a green-build gate
+plus a working capability the team can demo.
+
+- **CP-A — Hygiene foundation green.** After M0.1: Trust-Task
+  extractor + audit envelope + idempotency keyspace + cursor
+  pagination are unit-tested and exported from `vti-common`. No
+  consumer yet, but the primitives compile and have golden tests.
+
+- **CP-B — DID template provisionable.** After M0.2: a developer
+  can stand up a fresh VTA, point the existing
+  `vta bootstrap provision-integration` flow at the new `vtc-host`
+  template, and receive a sealed bundle containing a valid
+  `did:webvh` for a VTC. No VTC binary needed yet.
+
+- **CP-C — Install-token primitive works.** After M0.4: install
+  tokens can be minted and atomically consumed; concurrent claims
+  on the same token race correctly through the mutex. No WebAuthn
+  yet; tests exercise the JWT plumbing only.
+
+- **CP-D — End-to-end first-admin install.** After M0.6: a fresh
+  VTC binary can be set up, the install URL claimed via WebAuthn
+  in a test harness, the admin DID bootstrapped, and a second
+  passkey registered against the same admin. The community has its
+  first admin and the install carve-out is permanently closed.
+
+- **CP-E — Phase 0 gate met.** After M0.12: full install flow runs
+  through Router::oneshot, including emergency-bootstrap
+  recovery; community profile and config endpoints work; routing +
+  cookie-scope + CORS invariants enforced; all Phase-0 endpoints
+  have Draft Trust Task spec files on disk. Phase 1 can start.
+
+## Reference implementations
+
+We don't invent these patterns. They're already in production.
+
+| Topic | Reference | What we adopt |
+|---|---|---|
+| WebAuthn / passkey enrolment + login | [`affinidi/affinidi-webvh-service` — `webvh-common/src/server/passkey/{mod,store,routes}.rs`](https://github.com/affinidi/affinidi-webvh-service/tree/main/webvh-common/src/server/passkey) | `PasskeyState` trait, `build_webauthn(public_url)` helper, `Enrollment` token shape with `claimed_at` window, `PasskeyUser` + `CredentialMapping` storage, route handlers generic over `S: PasskeyState`, redacted-token `Debug` impls. |
+| `public_url` ↔ `RP ID` derivation | `webvh-common::server::passkey::build_webauthn` | Single-source `public_url` → `Webauthn` builder. |
+| Setup wizard / did:webvh creation / secret-store wiring | The workspace's own `vta-service` — current latest impl. | The shape of an install/setup module that's actually production-ready. The current `vtc-service` is **not** a reference — it's throw-away. |
+| Audit envelope shape, store abstractions, JWT auth | `vti-common` itself (existing) + `vta-service` consumers | Extend in place per the new spec; don't fork. |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| **WebAuthn test harness complexity.** Browser WebAuthn ceremonies are not trivial to fake in Rust tests. | `webauthn-rs` ships a deterministic test mode; webvh-common already proves this pattern in production. M0.5 includes a separate task to validate the harness works end-to-end before any production code depends on it (task M0.5.0). |
+| **Ed25519-only authenticator availability.** Apple Touch ID / Windows Hello typically default to ES256, not EdDSA. The spec mandates Ed25519 for the passkey ↔ DID binding. | Acknowledged in spec §4.2. Operators see an install error pointing at supported devices. Cover in operator-facing docs alongside M0.9. Long-term: revisit if Ed25519 adoption stalls. |
+| **Replacing the existing 930-line setup.rs.** A lot of did:webvh creation logic lives there; some of it is reusable. | M0.9 has an explicit "salvage pass" sub-task to identify reusable helpers before the bulk rewrite. |
+| **Config migration from existing `vtc-service` layout.** Current config has fields the new spec doesn't, and vice versa. | M0.8 includes a sub-task for config migration: existing TOML keys map to the new shape; unknown keys log a warning rather than fail. |
+| **`/v1/` URL migration breaks existing integration tests.** | M0.3 migrates the tests in lockstep. The current public surface has no external consumers (pre-MVP), so the change is in-tree only. |
+| **Trust Task source repo location decision (spec §17 Q3) not yet made.** | Treat `trust-tasks/` in this workspace as authoritative for MVP. Spec already notes this as an open question; revisit when VTA-side tasks appear. |
+
+## Definition of done — Phase 0
+
+All of the following must hold for Phase 0 to be considered complete
+and Phase 1 to start:
+
+1. `cargo build` and `cargo test` green workspace-wide.
+2. `cargo clippy -- -D warnings` clean.
+3. `cargo fmt --check` clean.
+4. A developer can run `vtc setup` against a freshly-provisioned VTA
+   and reach the install URL.
+5. The install URL can be claimed end-to-end in an integration test
+   (mocked WebAuthn ceremony) and produces a bootstrapped admin DID
+   with a working session.
+6. A second passkey can be registered against the same admin DID.
+7. `vtc admin emergency-bootstrap` works when the master seed
+   mnemonic is provided.
+8. `GET /v1/community/profile` returns the configured profile;
+   `PUT` updates it.
+9. `GET / PATCH /v1/admin/config` round-trips a setting.
+10. `POST /v1/admin/config/restart` refuses without
+    `VTC_SUPERVISED=1`; accepts with it.
+11. Routing config in path-prefix mode mounts `/v1`, `/admin`, `/`
+    correctly; cookie-scope isolation invariants enforced.
+12. Every Phase-0 REST endpoint has a Draft `trust-tasks/.../spec.md`
+    + `schema.json` on disk; manifest `trust-tasks/index.json` is
+    populated.
+13. Each milestone landed via its own DCO-signed PR; commits formatted
+    per workspace conventions.
+14. Memory entry `project_vtc_mvp.md` updated to reflect any
+    discovered design tweaks (mirror of the "Phase 1 outcome" notes
+    in the prior DIDComm plan).

--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -1,0 +1,872 @@
+# Todo: VTC MVP — Phase 0
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done · `[!]` blocked
+
+Each task lists: **acceptance** (what must be true), **verify** (how
+to prove it), **files** (what's touched), **deps** (which task IDs
+must land first). Tasks within a milestone that share `deps` can run
+in parallel.
+
+Spec: `docs/05-design-notes/vtc-mvp.md`
+Plan: `tasks/vtc-mvp/plan.md`
+
+Every code task also drafts the matching Trust Task spec
+(`trust-tasks/.../spec.md` + `schema.json`) in the same PR — soft
+gate per spec §9.4. Stable IDs are non-negotiable; spec body can be
+skeletal.
+
+Every PR must be DCO-signed (`git commit -s`) and pass
+`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`.
+
+---
+
+## M0.1 — Hygiene primitives (`vti-common`)
+
+### `[ ]` M0.1.0 — Add `webauthn-rs` to workspace deps + scaffold `vtc-service` import
+
+- **Acceptance**
+  - `webauthn-rs = "0.5"` (or current stable) added to workspace deps
+  - Re-exported into `vtc-service`'s `Cargo.toml`
+  - Empty `vtc-service/src/webauthn.rs` module compiles
+- **Verify** `cargo build --package vtc-service` succeeds
+- **Files**
+  - `Cargo.toml` (workspace)
+  - `vtc-service/Cargo.toml`
+  - `vtc-service/src/webauthn.rs` (new, empty)
+  - `vtc-service/src/lib.rs` (add module)
+- **Deps**: none
+
+### `[ ]` M0.1.1 — Trust-Task extractor + `TrustTaskRouter` builder
+
+- **Acceptance**
+  - `vti-common::trust_task::TrustTask` newtype around a validated
+    `https://trusttasks.org/.../{maj}.{min}` URL
+  - Axum extractor `TrustTaskHeader` reads the `Trust-Task` header
+    and parses it into `TrustTask`; missing → 400 `TrustTaskMissing`;
+    malformed → 400 `TrustTaskMalformed`
+  - `TrustTaskRouter` builder wraps Axum `Router` with an explicit
+    `.route_with_task(path, method, handler, task)` method that
+    enforces **exact-match** on the header at request time
+  - `.route_exempt(path, method, handler)` for `/health` (and only
+    `/health` — codified in docs)
+  - Errors are typed (`AppError::TrustTaskMissing`,
+    `AppError::TrustTaskMismatch`) with structured JSON responses
+    naming the expected task
+- **Verify**
+  - Unit tests: missing header, malformed URL, mismatched URL,
+    exact match
+  - Doctest example wiring a handler to a task
+- **Files**
+  - `vti-common/src/trust_task/mod.rs` (new)
+  - `vti-common/src/trust_task/extractor.rs` (new)
+  - `vti-common/src/trust_task/router.rs` (new)
+  - `vti-common/src/error.rs` (new variants)
+  - `vti-common/src/lib.rs` (re-export)
+- **Deps**: M0.1.0
+- **Pre-impl decision**: D1 (schema format), D8 (header name), D9
+  (builder vs macros)
+
+### `[ ]` M0.1.2 — Audit envelope + HMAC actor hashing + `audit_key` keyspace
+
+- **Acceptance**
+  - `AuditEnvelope` struct per spec §11.1, including `event_version`,
+    `schema_version`, `event_id`, `timestamp`, hash + plaintext pairs
+  - `AuditEvent` tagged enum (`#[serde(tag = "type", content = "data")]`)
+    with a single variant `Generic { kind: String, payload: Value }`
+    as a placeholder — full Phase-0 variants land in M0.1.5
+  - `AuditWriter` that takes events, hashes actor/target with HMAC,
+    persists into an `audit` keyspace
+  - `AuditKeyStore` manages the per-community `audit_key` lifecycle:
+    generate-on-first-use, persist under `HKDF(seed, "vtc-audit-key/v1")`,
+    rotate-on-RTBF, retain history for verifying pre-rotation hashes
+- **Verify**
+  - Round-trip a `Generic` event through `AuditWriter` and read back
+  - Two events with the same actor DID yield the same hash within one
+    `audit_key` epoch
+  - `rotate_audit_key()` causes new events to use the new key;
+    pre-rotation events still verify under the retained prior key
+  - Snapshot test of the wire JSON shape of `AuditEnvelope` (catches
+    accidental schema drift)
+- **Files**
+  - `vti-common/src/audit/mod.rs` (new)
+  - `vti-common/src/audit/envelope.rs` (new)
+  - `vti-common/src/audit/writer.rs` (new)
+  - `vti-common/src/audit/key_store.rs` (new)
+  - `vti-common/src/lib.rs`
+- **Deps**: M0.1.0
+- **Pre-impl decision**: D3 (audit_key storage)
+
+### `[ ]` M0.1.3 — Idempotency keyspace + middleware
+
+- **Acceptance**
+  - `IdempotencyClass` enum: `NonDestructive` (24 h TTL) and
+    `Destructive` (60 s TTL with target-state revalidation hook)
+  - `IdempotencyStore` keyed by `(session_id, idempotency_key)` →
+    `(request_hash, response_bytes, expires_at)`
+  - Axum middleware that:
+    - reads `Idempotency-Key` header
+    - hashes the request body (sha256)
+    - on cache hit with matching hash, returns the cached response
+    - on cache hit with mismatched hash, returns 422 `IdempotencyKeyConflict`
+    - for `Destructive` class, calls a per-route revalidation closure
+      before serving the cached response
+  - Per-route registration via `.with_idempotency(class)` on
+    `TrustTaskRouter`
+- **Verify**
+  - Unit tests for the three branches (miss → store; hit + match →
+    cached; hit + mismatch → 422)
+  - Test that two principals with the same key get separate cache
+    entries (session_id scoping)
+  - Test that the destructive class fires the revalidation closure
+- **Files**
+  - `vti-common/src/idempotency/mod.rs` (new)
+  - `vti-common/src/idempotency/store.rs` (new)
+  - `vti-common/src/idempotency/middleware.rs` (new)
+  - `vti-common/src/trust_task/router.rs` (extend builder)
+- **Deps**: M0.1.1
+- **Pre-impl decision**: D6 (destructive op identification)
+
+### `[ ]` M0.1.4 — Cursor pagination contract
+
+- **Acceptance**
+  - `Cursor` newtype: opaque base64url-encoded
+    `(last_key: String, snapshot_id: u64)` tuple, signed under the
+    audit_key so cursors can't be forged across communities
+  - `Paginated<T>` response wrapper with `items`, `next_cursor`,
+    optional `total_estimate`
+  - Helper `paginate<K, V, T>` that takes a fjall iterator + a
+    cursor + a limit + a mapper and returns the wrapper
+- **Verify**
+  - Unit test: walk a populated keyspace via repeated calls,
+    confirm all items returned exactly once with monotonic cursor
+  - Limit clamping (`1..200`)
+  - Forged cursor (different audit_key) returns 400
+- **Files**
+  - `vti-common/src/pagination/mod.rs` (new)
+  - `vti-common/src/lib.rs`
+- **Deps**: M0.1.2 (uses audit_key for cursor signing)
+
+### `[ ]` M0.1.5 — Phase-0 audit event variants
+
+- **Acceptance**
+  - `AuditEvent` variants added (replacing the `Generic` placeholder):
+    `CommunityInstalled`, `EmergencyBootstrapInvoked`,
+    `AdminPasskeyRegistered`, `AdminPasskeyRevoked`,
+    `ConfigChanged`, `ConfigReloaded`, `RestartRequested`,
+    `CommunityProfileUpdated`, `AuditKeyRotated`
+  - `ConfigChanged.data` carries the sensitivity-flag-aware redaction
+    logic (per spec §11.4)
+- **Verify**
+  - Snapshot test per variant
+  - Round-trip every variant through `AuditWriter`
+- **Files**
+  - `vti-common/src/audit/envelope.rs`
+- **Deps**: M0.1.2
+
+### `[ ]` M0.1.6 — Reusable passkey infrastructure in `vti-common`
+
+Per **D11** + the `webvh-common::server::passkey` reference (see
+`plan.md` Reference implementations). This is foundational: M0.5
+consumes it, and a future VTA admin-passkey surface can too.
+
+- **Acceptance**
+  - New module `vti-common::auth::passkey` (feature-gated `passkey`)
+  - `PasskeyState` trait (extends existing `AuthState`):
+    `webauthn() -> Option<&Arc<Webauthn>>`, `acl_ks() -> &KeyspaceHandle`,
+    `access_token_expiry()`, `refresh_token_expiry()`,
+    `public_url() -> Option<&str>`, `enrollment_ttl()`
+  - `build_webauthn(public_url: &str) -> Result<Webauthn, AppError>`
+    — single-source RP ID derivation per **D7**
+  - Storage types: `Enrollment` (with manual redacted `Debug` per
+    **D13**), `PasskeyUser`, `CredentialMapping`
+  - Storage helpers: `store_enrollment`, `get_enrollment`,
+    `take_enrollment`, `store_passkey_user`, `get_passkey_user_by_did`,
+    `get_passkey_user_by_credential`
+  - `ENROLLMENT_CLAIM_WINDOW_SECS = 300` constant (claim-window
+    pattern per **D12**)
+  - Route handlers `enroll_start`, `enroll_finish`, `login_start`,
+    `login_finish` generic over `S: PasskeyState` — these are the
+    Phase-0 building blocks; M0.5 wires them into VTC-specific
+    install routes
+  - **No** VTC-specific install logic here — that goes in
+    `vtc-service::install` in M0.5
+- **Verify**
+  - Unit tests for `build_webauthn` (valid URL, no domain, malformed)
+  - Unit tests for `Enrollment` round-trip + `Debug` redaction
+  - End-to-end round-trip test via a stub `PasskeyState` impl in
+    `tests/` (creates an enrollment, runs ceremony via a test
+    authenticator, asserts ACL entry created)
+- **Files**
+  - `vti-common/src/auth/passkey/mod.rs` (new)
+  - `vti-common/src/auth/passkey/store.rs` (new)
+  - `vti-common/src/auth/passkey/routes.rs` (new)
+  - `vti-common/Cargo.toml` (add `webauthn-rs` behind `passkey` feature)
+  - `vti-common/src/lib.rs`
+- **Deps**: M0.1.2 (audit), M0.1.0 (workspace dep). Independent of
+  M0.1.1, M0.1.3, M0.1.4.
+
+### Checkpoint A — Hygiene foundation green
+After M0.1.0–M0.1.5: `cargo test --package vti-common` clean. No
+consumer yet; primitives ready for the rest of Phase 0 to depend on.
+
+---
+
+## M0.2 — `vtc-host` DID template (`vta-sdk`)
+
+### `[ ]` M0.2.1 — Author `vtc-host.json` template
+
+- **Acceptance**
+  - `vta-sdk/templates/vtc-host.json` exists, structurally validated
+    by the existing `DidTemplate::from_json` parser
+  - `kind: "vtc-host"`, `methods: ["webvh", "web"]`
+  - `requiredVars`: `URL`, `COMMUNITY_NAME`
+  - `optionalVars`: `STATUS_LIST_PATH` (default `/v1/status-lists`),
+    `ACCEPT` (default `["didcomm/v2"]`, used only if a mediator is
+    added in a later phase)
+  - Document mints three keys: assertionMethod Ed25519, authentication
+    Ed25519, keyAgreement X25519
+  - Service entries: `#vtc-rest` (`type: "VTCRest"`, endpoint = `{URL}`)
+    and `#vtc-status-list` (`type: "VTCStatusList"`, endpoint =
+    `{URL}{STATUS_LIST_PATH}`) — the latter is a placeholder URL
+    until Phase 2 wires the actual status list, gracefully present
+- **Verify**
+  - `every_builtin_parses_and_validates` test (existing in
+    `builtin.rs`) covers the new template automatically
+  - Snapshot test of the rendered document for a known input
+- **Files**
+  - `vta-sdk/templates/vtc-host.json` (new)
+  - `vta-sdk/src/did_templates/builtin.rs` (add to `BUILTIN_NAMES`
+    + `load_embedded` switch)
+- **Deps**: none — fully parallel with M0.1
+
+### `[ ]` M0.2.2 — Documentation entry for `vtc-host`
+
+- **Acceptance**
+  - `docs/03-integrating/did-templates.md` updated with `vtc-host`
+    template description, vars, usage example
+- **Verify** doc renders; no broken links
+- **Files**
+  - `docs/03-integrating/did-templates.md`
+- **Deps**: M0.2.1
+
+### Checkpoint B — DID template provisionable
+After M0.2.1–M0.2.2: a developer can run
+`vta bootstrap provision-integration --template vtc-host --var URL=…
+--var COMMUNITY_NAME=…` against any local VTA and receive a sealed
+bundle containing a valid VTC `did:webvh`. No VTC binary needed yet.
+
+---
+
+## M0.3 — `/v1/` URL migration + Trust-Task wiring
+
+### `[ ]` M0.3.1 — Move existing routes under `/v1/` prefix
+
+- **Acceptance**
+  - `vtc-service/src/routes/mod.rs` mounts auth + acl + config
+    routes under `/v1/`
+  - `/health` stays at root and is Trust-Task-exempt
+  - Existing integration tests in `vtc-service/tests/` updated to use
+    `/v1/` paths
+- **Verify**
+  - `cargo test --package vtc-service` green
+- **Files**
+  - `vtc-service/src/routes/mod.rs`
+  - `vtc-service/tests/auth_audience.rs` (path updates)
+- **Deps**: M0.1.1 (for `TrustTaskRouter`)
+
+### `[ ]` M0.3.2 — Wire Trust-Task header on existing routes (placeholder IDs)
+
+- **Acceptance**
+  - Each existing route registered with a placeholder Trust Task ID
+    matching its eventual stable ID (e.g., the legacy auth routes
+    get IDs we'll revisit in Phase 1; for now they pass through with
+    `auth/legacy/challenge/1.0` etc.)
+  - `TrustTask` header missing → 400 with structured error
+  - `TrustTask` header mismatched → 415 with structured error
+- **Verify**
+  - Integration test: each route returns 400 / 415 appropriately
+  - `/health` does not require the header
+- **Files**
+  - `vtc-service/src/routes/auth.rs`
+  - `vtc-service/src/routes/acl.rs`
+  - `vtc-service/src/routes/config.rs`
+  - `trust-tasks/auth/legacy/...` (Draft `spec.md` + `schema.json`
+    stubs; will be revisited)
+  - `trust-tasks/index.json`
+- **Deps**: M0.3.1
+
+---
+
+## M0.4 — Install token + carve-out primitive
+
+### `[ ]` M0.4.1 — `InstallToken` struct + JWT signer
+
+- **Acceptance**
+  - `InstallToken` claims: `iss` (VTC DID), `sub` ("install"),
+    `aud` ("vtc-install"), `exp` (15 min), `iat`, `jti`, `cnonce`
+    (32-byte WebAuthn challenge), `epubkey` (ephemeral Ed25519
+    pubkey for the ceremony)
+  - `mint_install_token()` produces a signed JWT using a fresh
+    ephemeral keypair (private key retained server-side in a new
+    `install` keyspace keyed by `jti`)
+  - `parse_install_token()` validates signature, audience, expiry,
+    and the `cnonce` length
+- **Verify**
+  - Round-trip a minted token
+  - Expired token rejected
+  - Wrong audience rejected
+  - Tampered signature rejected
+- **Files**
+  - `vtc-service/src/install/token.rs` (new)
+  - `vtc-service/src/install/mod.rs` (new)
+  - `vtc-service/src/lib.rs`
+- **Deps**: M0.1.0
+- **Pre-impl decision**: D2 (nonce binding mechanism)
+
+### `[ ]` M0.4.2 — Install carve-out keyspace with claim-window state machine
+
+Per **D12**: webvh-common's claim-window pattern, not immediate
+single-use.
+
+- **Acceptance**
+  - New `install` keyspace stores `(jti → InstallTokenState)`:
+    - `Issued { exp, cnonce, ephemeral_privkey, claimed_at: Option<DateTime> }`
+    - `Consumed { at }`
+    - `Closed`
+  - Single global `INSTALL_CARVEOUT_LOCK: tokio::sync::Mutex<()>`
+    in `vtc-service`
+  - `start_claim(jti, now)` (called from `/v1/install/claim/start`):
+    takes the lock, reads state, refuses if `Consumed` or `Closed`,
+    refuses if `claimed_at` is set within
+    `ENROLLMENT_CLAIM_WINDOW_SECS = 300`, otherwise sets `claimed_at`
+    and returns the ephemeral private key + cnonce for the WebAuthn
+    ceremony. **Does not consume.**
+  - `finish_claim(jti)` (called from `/v1/install/claim/finish`
+    after WebAuthn success): transitions `Issued → Consumed`
+  - `close_carveout()` (called after admin bootstrap) sets the
+    keyspace's `Closed` marker; subsequent `mint_install_token()`
+    calls return `AppError::InstallCarveoutClosed`
+- **Verify**
+  - Concurrent `start_claim` calls on the same JTI within the
+    300s window: exactly one succeeds; second waits or fails
+  - `start_claim` → 5min timeout (no `finish_claim`) → retry
+    `start_claim` succeeds
+  - Re-minting after `close_carveout` is rejected
+  - State machine transitions audited in tests
+- **Files**
+  - `vtc-service/src/install/state_machine.rs` (new)
+  - `vtc-service/src/install/mod.rs`
+- **Deps**: M0.4.1
+- **Pre-impl decision**: D12
+
+### Checkpoint C — Install-token primitive works
+After M0.4.1–M0.4.2: install tokens mint/claim/close atomically;
+concurrent claims race correctly through the mutex. No WebAuthn yet.
+
+---
+
+## M0.5 — WebAuthn claim flow
+
+### `[ ]` M0.5.0 — WebAuthn test harness validation
+
+- **Acceptance**
+  - A test helper in `vtc-service/tests/common/webauthn_harness.rs`
+    can produce deterministic registration + authentication
+    responses for a fake authenticator
+  - Helper covers Ed25519 (EdDSA, `COSEAlgorithmIdentifier = -8`)
+  - At least one trivial test confirms the helper drives
+    `webauthn-rs` server-side validation green
+- **Verify**
+  - A standalone test (`tests/webauthn_harness.rs`) exercises the
+    helper through a full register-and-authenticate cycle
+- **Files**
+  - `vtc-service/tests/common/mod.rs`
+  - `vtc-service/tests/common/webauthn_harness.rs`
+  - `vtc-service/tests/webauthn_harness.rs`
+- **Deps**: M0.1.0 (just for the dep import)
+
+### `[ ]` M0.5.1 — VTC `AppState` implements `PasskeyState`
+
+- **Acceptance**
+  - `vtc-service::server::AppState` implements
+    `vti_common::auth::passkey::PasskeyState`
+  - `build_webauthn` called once at startup using `public_url` from
+    the new `community.public_url` / routing config; resulting
+    `Arc<Webauthn>` lives in `AppState`
+  - **Ed25519-only enforcement**: VTC's `PasskeyState` wraps
+    `build_webauthn`'s output to advertise only
+    `COSEAlgorithmIdentifier::EDDSA` in registration challenges;
+    rejection if the authenticator returns anything else
+    (`AppError::WebAuthnAlgorithmRejected`)
+- **Verify**
+  - Startup test: missing `public_url` → WebAuthn disabled,
+    `webauthn()` returns `None`, install routes return 503
+  - Ed25519 enforcement: ES256 registration attempt is rejected
+- **Files**
+  - `vtc-service/src/server.rs` (extend `AppState`)
+  - `vtc-service/src/webauthn.rs` (thin Ed25519-restricting wrapper)
+  - `vtc-service/src/config.rs` (`public_url` field)
+- **Deps**: M0.5.0, M0.1.6
+- **Pre-impl decision**: D7, D11
+
+### `[ ]` M0.5.2 — Install claim endpoints (start + finish)
+
+Per **D12**: two-phase ceremony, not a single endpoint. Adopts the
+webvh-common `enroll_start` / `enroll_finish` shape but specialised
+for the install carve-out (one-shot, not an ongoing invite system).
+
+- **Acceptance**
+  - `POST /v1/install/claim/start`: accepts `{ install_token }`,
+    validates via `parse_install_token`, calls
+    `install::state_machine::start_claim`, then calls
+    `vti_common::auth::passkey::enroll_start` to begin the
+    WebAuthn registration ceremony. Returns
+    `{ registration_id, options: CreationChallengeResponse }`.
+    Challenge bound to the token's `cnonce`.
+  - `POST /v1/install/claim/finish`: accepts
+    `{ registration_id, webauthn_response, candidate_did_signature }`,
+    completes the ceremony via `enroll_finish`, calls
+    `install::state_machine::finish_claim`, verifies
+    `candidate_did_signature` over a server-issued nonce using the
+    candidate `did:key`. Returns a setup-session token
+    (audience `"vtc-install-session"`) + the candidate admin DID.
+  - Trust Task IDs: `install/claim/start/1.0`,
+    `install/claim/finish/1.0`
+- **Verify**
+  - End-to-end test using `Router::oneshot` + the harness from M0.5.0
+  - Failure cases: bad token, expired token, replayed token after
+    consume, mismatched cnonce, wrong DID signature, non-Ed25519
+    algorithm, second concurrent `claim/start` within the 5min
+    claim window, abandoned ceremony followed by retry after
+    timeout (succeeds)
+- **Files**
+  - `vtc-service/src/routes/install.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/install/claim/start/1.0/{spec.md,schema.json}`
+  - `trust-tasks/install/claim/finish/1.0/{spec.md,schema.json}`
+  - `trust-tasks/index.json`
+- **Deps**: M0.4.2, M0.5.1, M0.3.1, M0.1.6
+- **Pre-impl decision**: D2, D12
+
+---
+
+## M0.6 — Admin bootstrap + multi-passkey schema
+
+### `[ ]` M0.6.1 — Extend ACL `Role` enum + `AdminEntry` shape
+
+- **Acceptance**
+  - `VtcRole` per spec §5.3 (`Admin`, `Moderator`, `Issuer`,
+    `Member`, `Custom(String)`)
+  - `AclEntry` extended: admin-role entries carry
+    `passkeys: Vec<RegisteredPasskey>` and `extensions: JsonValue`
+  - Migration path from existing ACL entries documented (existing
+    `Admin` rows get an empty `passkeys` vec)
+- **Verify**
+  - Unit tests for serialization round-trip
+  - Backwards-compat test: existing ACL records deserialize cleanly
+- **Files**
+  - `vti-common/src/acl/mod.rs`
+  - `vtc-service/src/acl/mod.rs`
+- **Deps**: M0.1.0
+
+### `[ ]` M0.6.2 — `POST /v1/admin/bootstrap`
+
+- **Acceptance**
+  - Endpoint accepts the setup-session token from M0.5.2 and the
+    candidate admin DID + first passkey
+  - Atomically: writes ACL entry with `role: Admin`, single passkey,
+    emits `CommunityInstalled` audit event, calls
+    `install::carveout::close_carveout()`
+  - Returns 409 if any admin already exists (defence-in-depth even
+    though the install carve-out should prevent this)
+  - Trust Task ID: `admin/bootstrap/1.0`
+- **Verify**
+  - End-to-end happy path test
+  - Bootstrap-after-bootstrap returns 409
+  - `CommunityInstalled` event present in audit log
+- **Files**
+  - `vtc-service/src/routes/admin/bootstrap.rs` (new)
+  - `vtc-service/src/routes/admin/mod.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/admin/bootstrap/1.0/{spec.md,schema.json}`
+- **Deps**: M0.5.2, M0.6.1, M0.1.2
+
+### `[ ]` M0.6.3 — Multi-passkey endpoints with step-up UV reauth
+
+- **Acceptance**
+  - `POST /v1/admin/passkeys/register`: requires authenticated
+    session AND fresh WebAuthn UV in the same request
+  - `DELETE /v1/admin/passkeys/{credential_id}`: same UV requirement;
+    CAS-protected last-passkey check (refuses if it would leave
+    zero passkeys)
+  - `GET /v1/admin/passkeys`: lists with `credential_id`, `label`,
+    `transports`, `registered_at`, `last_used_at`
+  - Trust Task IDs: `admin/passkeys/{register,revoke,list}/1.0`
+- **Verify**
+  - Register-with-stale-session (no UV) → 401
+  - Revoke last passkey → 409 `LastPasskeyProtected`
+  - Concurrent revoke calls do not race past the CAS check
+  - Each operation emits the correct audit event
+- **Files**
+  - `vtc-service/src/routes/admin/passkeys.rs` (new)
+  - `vtc-service/src/auth/extractor.rs` (extend with
+    `StepUpUvAuth` extractor)
+  - `trust-tasks/admin/passkeys/register/1.0/{spec.md,schema.json}`
+  - `trust-tasks/admin/passkeys/revoke/1.0/{spec.md,schema.json}`
+  - `trust-tasks/admin/passkeys/list/1.0/{spec.md,schema.json}`
+- **Deps**: M0.6.2, M0.5.0
+
+### Checkpoint D — End-to-end first-admin install
+After M0.6.1–M0.6.3: a fresh VTC binary can be set up, install URL
+claimed via WebAuthn (test harness), admin DID bootstrapped, and a
+second passkey registered. Install carve-out permanently closed.
+
+---
+
+## M0.7 — Community profile (parallel track)
+
+### `[ ]` M0.7.1 — `CommunityProfile` schema + `community` keyspace
+
+- **Acceptance**
+  - `CommunityProfile` per spec §5.1 (community_did immutable, all
+    other fields editable; `extensions: JsonValue`)
+  - `extensions` enforced at ≤ 16 KiB (per D4); larger → 413
+  - Stored under stable key `community/profile` in a new keyspace
+- **Verify**
+  - Round-trip serialization
+  - `extensions` size-limit test
+- **Files**
+  - `vtc-service/src/community/mod.rs` (new)
+  - `vtc-service/src/community/profile.rs` (new)
+  - `vtc-service/src/store/mod.rs` (register keyspace)
+- **Deps**: M0.1.0
+- **Pre-impl decision**: D4
+
+### `[ ]` M0.7.2 — `GET / PUT /v1/community/profile`
+
+- **Acceptance**
+  - `GET` returns the singleton profile; 404 if not yet initialised
+  - `PUT` requires `Admin` role; rejects changes to `community_did`
+  - Successful `PUT` emits `CommunityProfileUpdated` audit event
+  - Trust Task IDs: `community/profile/{show,update}/1.0`
+- **Verify**
+  - Integration tests cover happy + immutable-field rejection +
+    non-admin auth failure
+- **Files**
+  - `vtc-service/src/routes/community/mod.rs` (new)
+  - `vtc-service/src/routes/community/profile.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/community/profile/show/1.0/{spec.md,schema.json}`
+  - `trust-tasks/community/profile/update/1.0/{spec.md,schema.json}`
+- **Deps**: M0.7.1, M0.6.1
+
+---
+
+## M0.8 — Config plumbing (parallel track)
+
+### `[ ]` M0.8.1 — Three-layer config overlay
+
+- **Acceptance**
+  - `EffectiveConfig` struct exposes the merged view with per-field
+    `source: ConfigSource` annotation (`env` / `db` / `toml` /
+    `default`) and `requires_restart: bool`
+  - `config` keyspace stores DB-layer overrides as `key → ConfigValue`
+  - Existing `config.rs` shapes adapted (additive) so existing tests
+    keep passing
+- **Verify**
+  - Layer-precedence tests: env beats db beats toml beats default
+  - Unknown key in TOML logs a warning, doesn't fail
+- **Files**
+  - `vtc-service/src/config.rs`
+  - `vtc-service/src/config_store.rs` (new)
+- **Deps**: M0.1.0
+
+### `[ ]` M0.8.2 — `GET / PATCH /v1/admin/config`
+
+- **Acceptance**
+  - `GET` returns `EffectiveConfig`
+  - `PATCH` writes to DB layer; refuses sensitive-path values outside
+    the directory allowlist (per spec §14.2)
+  - Returns `{ applied, pending_restart, rejected }` per spec
+  - Emits `ConfigChanged` audit event with sensitivity-flag-aware
+    redaction
+  - Trust Task IDs: `admin/config/{show,patch}/1.0`
+- **Verify**
+  - Integration tests cover allowlist enforcement, sensitive-key
+    redaction in the audit log
+- **Files**
+  - `vtc-service/src/routes/admin/config.rs` (new)
+  - `trust-tasks/admin/config/show/1.0/{spec.md,schema.json}`
+  - `trust-tasks/admin/config/patch/1.0/{spec.md,schema.json}`
+- **Deps**: M0.8.1, M0.6.2
+
+### `[ ]` M0.8.3 — Reload + restart endpoints with supervisor handshake
+
+- **Acceptance**
+  - `POST /v1/admin/config/reload` reapplies hot-reloadable settings
+  - `POST /v1/admin/config/restart` initiates graceful shutdown
+    only if **one of**: `VTC_SUPERVISED=1` env var OR `NOTIFY_SOCKET`
+    present OR a k8s downward-API marker is detected; otherwise
+    returns 412 `SupervisorRequired`
+  - Both endpoints emit audit events (`ConfigReloaded` /
+    `RestartRequested`)
+  - Trust Task IDs: `admin/config/{reload,restart}/1.0`
+- **Verify**
+  - Test without supervisor env: restart returns 412
+  - Test with `VTC_SUPERVISED=1`: graceful shutdown completes within
+    `restart.drain_timeout` (default 30 s); audit event recorded
+    before exit
+- **Files**
+  - `vtc-service/src/routes/admin/config.rs`
+  - `vtc-service/src/supervisor.rs` (new)
+  - `trust-tasks/admin/config/reload/1.0/{spec.md,schema.json}`
+  - `trust-tasks/admin/config/restart/1.0/{spec.md,schema.json}`
+- **Deps**: M0.8.2
+
+### `[ ]` M0.8.4 — Config export / import (diff-and-confirm)
+
+- **Acceptance**
+  - `POST /v1/admin/config/export` returns plain JSON of community
+    profile + DB-layer config (no TOML / env values)
+  - `POST /v1/admin/config/import` runs diff-and-confirm:
+    `?confirm=false` (default) returns the diff; `?confirm=true`
+    applies; per-field audit events emitted on apply
+  - Refuses if `community_did` mismatch
+  - Trust Task IDs: `admin/config/{export,import}/1.0`
+- **Verify**
+  - Round-trip test: export → fresh VTC → import → equivalence
+  - Mismatched community_did → 409
+  - Diff response shape stable
+- **Files**
+  - `vtc-service/src/routes/admin/config.rs`
+  - `trust-tasks/admin/config/export/1.0/{spec.md,schema.json}`
+  - `trust-tasks/admin/config/import/1.0/{spec.md,schema.json}`
+- **Deps**: M0.8.3
+
+---
+
+## M0.9 — CLI setup wizard rewrite
+
+### `[ ]` M0.9.1 — Map `vta-service` setup shape onto VTC needs
+
+Per **D5**: `vta-service` is the latest working reference;
+`vtc-service`'s existing code is throw-away. This task is **research,
+not code** — produces a markdown findings doc that drives M0.9.2.
+
+- **Acceptance**
+  - Read `vta-service/src/main.rs`, `vta-service/src/setup/*`, the
+    seed-store wiring, the `provision-integration` client path
+  - Identify helpers genuinely shared between VTA setup and VTC
+    setup (likely candidates: seed generation, secret-backend
+    selection, keyspace bootstrap, `vta-sdk` client construction)
+  - Decide for each: keep in `vta-service` and call cross-crate
+    (no), promote to `vti-common` (yes for genuinely shared), or
+    reimplement thin in `vtc-service` (yes for VTC-specific).
+  - Output: `tasks/vtc-mvp/setup-mapping.md` with a 3-column table
+    `(vta-service helper, decision, target location)` and a sketch
+    of the new `vtc setup` wizard's call graph
+- **Verify** the doc exists and the call graph is unambiguous
+  enough that M0.9.2 can be implemented from it
+- **Files**
+  - `tasks/vtc-mvp/setup-mapping.md` (new, ~1 page)
+- **Deps**: none — research task; can start at day one in parallel
+  with M0.1
+- **Pre-impl decision**: D5
+
+### `[ ]` M0.9.2 — New minimal `vtc setup` wizard
+
+- **Acceptance**
+  - Three questions: VTC URL, admin UX URL, VTA URL
+  - Mints seed via `affinidi-secrets-resolver` (default keyring)
+  - Calls VTA's `POST /provision-integration` with `vtc-host` template
+    using the existing `vta-sdk` client; opens sealed bundle locally
+  - Initialises all Phase-0 keyspaces (sessions, acl, install,
+    audit, audit_key, idempotency, community, config)
+  - Mints install token via `install::token::mint_install_token()`
+  - Prints install URL and starts the daemon
+- **Verify**
+  - End-to-end test against a running VTA fixture (likely a Docker
+    Compose service in CI, or skipped with `#[ignore]` locally)
+  - Idempotent: re-running `vtc setup` on an already-set-up daemon
+    is refused with a clear error
+- **Files**
+  - `vtc-service/src/setup/wizard.rs` (new)
+  - `vtc-service/src/main.rs` (wire the new wizard)
+- **Deps**: M0.2.1, M0.4.2, M0.9.1, M0.6.1, M0.7.1, M0.8.1
+
+### `[ ]` M0.9.3 — Retire entire legacy `vtc-service` install/setup surface
+
+Per **D5**: the existing `vtc-service` predates the spec and is
+throw-away. The new install path arrives in M0.9.2; M0.9.3 deletes
+everything the new path replaces.
+
+- **Acceptance**
+  - Delete `vtc-service/src/setup.rs` (legacy)
+  - Delete `vtc-service/src/did_webvh.rs` if replaced by
+    `vta-sdk::did_templates::builtin::vtc-host` consumption
+  - Delete `vtc-service/src/import_did.rs` (legacy cold-start path
+    not in the new spec)
+  - Delete `vtc-service/src/acl_cli.rs` (CLI-side ACL CRUD that
+    predates the install flow; replaced by web UX in Phase 0+)
+  - Delete any other module M0.9.1's mapping doc identifies as
+    superseded
+  - All references in `main.rs` / `lib.rs` updated
+  - `cargo build` + `cargo clippy --workspace -- -D warnings` clean
+- **Verify** workspace builds; no dead-code warnings
+- **Files**
+  - `vtc-service/src/setup.rs` (delete)
+  - `vtc-service/src/did_webvh.rs` (delete if superseded)
+  - `vtc-service/src/import_did.rs` (delete)
+  - `vtc-service/src/acl_cli.rs` (delete)
+  - `vtc-service/src/lib.rs`
+  - `vtc-service/src/main.rs`
+- **Deps**: M0.9.2
+
+---
+
+## M0.10 — Emergency bootstrap
+
+### `[ ]` M0.10.1 — `vtc admin emergency-bootstrap` subcommand
+
+- **Acceptance**
+  - CLI subcommand runs only when the daemon is stopped (file-lock
+    check on the fjall directory)
+  - Prompts for the 24-word BIP-39 mnemonic; verifies it derives
+    the same VTC master seed as the stored seed
+  - On success: opens a fresh install token via the same
+    `mint_install_token()` path, reopens the install carve-out
+    keyspace marker, prints the install URL
+  - Persists a `pending_emergency_bootstrap_at: DateTime<Utc>`
+    marker that the daemon reads on next boot and emits the
+    `EmergencyBootstrapInvoked` audit event
+  - Trust Task ID: none (CLI-only, not a wire op)
+- **Verify**
+  - Wrong mnemonic → command refuses without changing state
+  - Correct mnemonic → install URL printed; daemon on next boot
+    emits the loud audit event
+- **Files**
+  - `vtc-service/src/setup/emergency.rs` (new)
+  - `vtc-service/src/main.rs` (subcommand wiring)
+- **Deps**: M0.4.2, M0.9.2
+
+---
+
+## M0.11 — Routing + CORS + cookie-scope
+
+### `[ ]` M0.11.1 — Routing config + mount logic
+
+- **Acceptance**
+  - `RoutingConfig` per spec §9.2 supports `mount` + optional `host`
+    per surface (api, admin_ui, website — website mount accepted in
+    config but routes 404 until Phase 5)
+  - Path-prefix default: `/v1`, `/admin`, `/` (catch-all)
+  - Subdomain mode supported by `Host`-header middleware (codified
+    but not exercised by Phase-0 tests)
+  - Mount conflicts at config-load time produce a clear startup
+    error
+- **Verify**
+  - Path-prefix routing test: `/v1/community/profile` resolves;
+    `/admin/some/path` returns 404 (since admin UX not bundled yet)
+  - Subdomain config parses but does not break path-prefix tests
+- **Files**
+  - `vtc-service/src/config.rs` (add `RoutingConfig`)
+  - `vtc-service/src/routes/mod.rs`
+- **Deps**: M0.3.2
+
+### `[ ]` M0.11.2 — CORS + cookie-scope invariants
+
+- **Acceptance**
+  - `cors.allowed_origins` allowlist; wildcards refused at config-load
+  - Admin session cookie set with `Path=/admin; SameSite=Strict;
+    Secure; HttpOnly` in path mode
+  - Public-website origin auto-allow disabled (no public website yet)
+  - Config-load-time invariant: refuses to start if cookie scopes
+    would overlap (e.g., admin mounted at `/` is rejected)
+- **Verify**
+  - Bad-config startup tests fail loud
+  - CORS preflight test includes `Idempotency-Key`,
+    `Trust-Task` in `Access-Control-Allow-Headers`
+- **Files**
+  - `vtc-service/src/config.rs`
+  - `vtc-service/src/server.rs`
+- **Deps**: M0.11.1
+
+---
+
+## M0.12 — Install-flow integration tests + Phase 0 gate
+
+### `[ ]` M0.12.1 — End-to-end install integration test
+
+- **Acceptance**
+  - Single integration test exercises:
+    1. `vtc setup` mints seed + install token (test harness shortcut
+       — provisioning against a fake VTA is acceptable)
+    2. `POST /v1/install/claim` succeeds with mocked WebAuthn
+    3. `POST /v1/admin/bootstrap` succeeds
+    4. `POST /v1/admin/passkeys/register` adds a second passkey
+    5. `GET /v1/admin/passkeys` returns both
+    6. `GET /v1/community/profile` returns the configured profile
+    7. `PATCH /v1/admin/config` updates a setting
+    8. `POST /v1/admin/config/restart` refuses without supervisor
+    9. Second `POST /v1/install/claim` fails (carve-out closed)
+- **Verify** test green
+- **Files**
+  - `vtc-service/tests/install_flow.rs` (new)
+- **Deps**: M0.6.3, M0.7.2, M0.8.3, M0.11.2
+
+### `[ ]` M0.12.2 — Emergency bootstrap integration test
+
+- **Acceptance**
+  - Test exercises the full recovery path:
+    1. Set up a VTC + bootstrap admin
+    2. Simulate "all passkeys lost" by removing them
+    3. Stop daemon, run `vtc admin emergency-bootstrap` with the
+       correct mnemonic
+    4. Restart daemon; confirm `EmergencyBootstrapInvoked` in audit
+    5. Re-claim install + bootstrap with a new admin
+- **Verify** test green
+- **Files**
+  - `vtc-service/tests/emergency_bootstrap.rs` (new)
+- **Deps**: M0.10.1, M0.12.1
+
+### `[ ]` M0.12.3 — Workspace gate green
+
+- **Acceptance**
+  - `cargo build --workspace` green
+  - `cargo test --workspace` green
+  - `cargo clippy --workspace -- -D warnings` clean
+  - `cargo fmt --check` clean
+  - `trust-tasks/index.json` lists every Phase-0 Trust Task in
+    `Draft` status with corresponding `spec.md` + `schema.json` on
+    disk
+  - Memory entry `project_vtc_mvp.md` updated with any tweaks
+    discovered during implementation
+- **Verify** CI green on the merge commit
+- **Files**
+  - `trust-tasks/index.json`
+  - `/Users/glenngore/.claude/projects/-Users-glenngore-devel-fpp-verifiable-trust-infrastructure/memory/project_vtc_mvp.md`
+- **Deps**: M0.12.1, M0.12.2
+
+### Checkpoint E — Phase 0 gate met
+After M0.12.1–M0.12.3: full install flow runs through
+`Router::oneshot`, including emergency-bootstrap recovery; community
+profile and config endpoints work; routing + cookie-scope + CORS
+invariants enforced; all Phase-0 endpoints have Draft Trust Task
+spec files on disk. Phase 1 can start.
+
+---
+
+## Open questions surfaced during planning
+
+These are not blockers — they have proposed defaults in `plan.md`
+under "Pre-implementation design decisions". Listed here so they're
+findable from the todo:
+
+- D1 (Trust Task schema format), D2 (nonce binding), D3 (audit_key
+  storage), D4 (extensions size limit), D5 (setup.rs strategy),
+  D6 (destructive op identification), D7 (RP ID derivation), D8
+  (Trust-Task header name), D9 (builder vs macros).
+
+Any decision that drifts from the default during implementation
+should be recorded in `plan.md` under a "Phase 0 outcome" header
+(mirroring the prior DIDComm plan's pattern).


### PR DESCRIPTION
## Summary

- New design spec for the Verifiable Trust Community (VTC) MVP at `docs/05-design-notes/vtc-mvp.md` (1073 lines).
- Phase 0 implementation plan + actionable task list under `tasks/vtc-mvp/{plan,todo}.md`.
- **Docs-only PR.** No code changes; no behaviour changes. Foundation for the implementation PRs that follow.

## What's in the spec

Captures architectural decisions reached over seven rounds of iterative design, plus a security/privacy audit + clarity review:

- 1 VTC ⇄ 1 VTA topology; VTC has no key custody.
- DTG credential catalog is closed (consumes `openvtc/dtg-credentials` only).
- VTC is always authoritative for its own state; ACL is truth, VMC/VEC are projections.
- VMC `validUntil` mandatory + finite; renewal unconditional inside the community.
- Trust-registry (TRQP) + StatusList are complementary, not redundant.
- Three departure dispositions (Purge / Tombstone / Historical) with RTBF override + daily batching to defeat timing correlation.
- Embedded `regorus` policy engine; `personhood.rego` ships deny-all and re-evaluates on every VMC renewal.
- DID rotation hardened: did:webvh native; did:key uses server-issued `rotation_id` + domain-tag-prefixed co-signed attestation.
- Cross-community recognition is default-deny, no caching, re-evaluated on every refresh.
- VRC self-issued in MVP (bilateral is v2).
- VTC never targets TEE — permanent non-goal.
- Public website is filesystem-backed static hosting; admin UX is a sibling repo consumed via `build.rs` (release-key-signed tarball).
- Path-prefix routing default; admin UX and public website cannot share cookie scope.
- Every wire op is a registered Trust Task on trusttasks.org; soft gate for MVP.

Security/privacy hardening embedded across the spec: install token bound to a WebAuthn ceremony nonce; Ed25519-only passkeys with cosigned DID-binding challenge; install carve-out behind a process-wide mutex; emergency bootstrap requires the master seed mnemonic; no-last-admin invariant; admin promotion is a separate endpoint with step-up UV and its own audit variant; audit hashes use HMAC with a per-community key that rotates on RTBF; idempotency cache scoped by `(session_id, key)` with shorter TTL for destructive ops; backups encrypted under HKDF(master_seed); restart endpoint requires supervisor handshake.

## What's in the plan

- 12 milestones (M0.1–M0.12), 26 numbered tasks, 5 checkpoints (CP-A–CP-E).
- Critical path: M0.1 → M0.4 → M0.5 → M0.6 → M0.10 → M0.11 → M0.12.
- Parallel tracks for surfaces (M0.7 + M0.8) and DID template (M0.2).
- 13 pre-implementation design decisions with proposed defaults.
- Pinned defaults for `audit_key` lifecycle (HKDF-derived initial, annual + on-RTBF rotation, all prior keys retained indefinitely).
- Reference implementations identified — adopts `affinidi-webvh-service`'s passkey pattern directly (`PasskeyState` trait in `vti-common::auth::passkey`, `public_url`-driven RP ID derivation, `claimed_at` ceremony window instead of immediate single-use).
- `vta-service` named as the latest reference implementation for setup shape; existing `vtc-service` code is throw-away.

## Branch strategy that follows

Once this merges:

1. `feat/vta-sdk-vtc-host-template` (M0.2) — VTA-only PR, ~150 LOC.
2. `feat/vti-common-passkey` (M0.1.6) — adopts the webvh-common pattern into `vti-common`.
3. `feat/vti-common-vtc-primitives` (M0.1.1–1.5) — Trust-Task extractor, audit envelope, idempotency, pagination.
4. Then per-milestone `feat/vtc-mvp-m0-N-*` branches off main.

Each PR is scoped to a single crate where possible.

## Test plan

This is a docs-only PR. Verification:

- [ ] Read the spec; push back on anything that disagrees with intended design.
- [ ] Read the plan; confirm milestone breakdown matches your delivery model.
- [ ] Confirm pre-implementation defaults (D1–D13 in `plan.md`); push back on any you want changed before M0.1 starts.
- [ ] No code, no tests to run.