### PR TITLE
feat(vta-sdk): add vtc-host DID template

### DIFF
--- a/docs/03-integrating/did-templates.md
+++ b/docs/03-integrating/did-templates.md
@@ -14,7 +14,7 @@ consumer gets the new shape on the next create. No redeploy.
 
 - **Data, not code.** An operator can ship a new agent kind by dropping a JSON
   file, no recompile. The built-ins (`didcomm-mediator`, `vta-admin`,
-  `webvh-control`, `webvh-daemon`, `webvh-server`) are baseline shapes, not
+  `vtc-host`, `webvh-control`, `webvh-daemon`, `webvh-server`) are baseline shapes, not
   the only shapes.
 - **Method-agnostic.** Same format works for `did:webvh`, `did:web`, or
   `did:key` — the loader only knows about `{TOKEN}` placeholders. Method-
@@ -140,6 +140,15 @@ template without explicit scope is **context → global → builtin**:
   - `didcomm-mediator` — DIDComm v2 routing mediator with a URL-based service
     endpoint.
   - `vta-admin` — did:key admin DID for provision-integration admin rollover.
+  - `vtc-host` — Verifiable Trust Community (VTC) service identity. Mints
+    the did:webvh under which a `vtc-service` binary operates and advertises
+    its REST endpoint plus a placeholder URL for the BitstringStatusList
+    credentials (populated in Phase 2 of the VTC MVP). DIDComm is not
+    advertised by default — communities that need a mediator add it later
+    via the runtime-service-management flow (see
+    `runtime-service-management.md`). Requires `URL`; optional
+    `STATUS_LIST_PATH` (default `/v1/status-lists`). `URL` must not have a
+    trailing slash.
   - `webvh-control` — webvh control-plane node exposing both a
     `WebVHHosting` service (URL-based) **and** a `DIDCommMessaging` service
     routed through a mediator. Use for nodes that publish DID logs over

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -138,16 +138,28 @@ and is explicitly forbidden.
 
 ### 4.4 The `vtc-host` DID template
 
-New built-in template in `vta-sdk::did_templates::builtin`. Required
-vars: `vtc_url`, `community_name`. Mints:
+Built-in template in `vta-sdk::did_templates::builtin`. Required
+var: `URL` (no trailing slash). Optional: `STATUS_LIST_PATH`
+(default `/v1/status-lists`).
 
-- one `assertionMethod` Ed25519 (credential signatures)
-- one `authentication` Ed25519 (session auth)
-- one `keyAgreement` X25519 (sealed-transfer + DIDComm reception)
+Mints two keys, following the workspace convention used by every
+other built-in template:
 
-Service entries: `#vtc-rest`, `#vtc-status-list`. DIDComm service is
-not advertised by default — added later via the existing
-runtime-service-management flow if the community needs a mediator.
+- **`#key-0`** Ed25519 — `assertionMethod` + `authentication` (one
+  signing key serves both purposes; matches `webvh-control` and
+  friends).
+- **`#key-1`** X25519 — `keyAgreement` (sealed-transfer + later
+  DIDComm reception).
+
+Service entries: `#vtc-rest` (`type: VTCRest`, endpoint = `{URL}`),
+`#vtc-status-list` (`type: VTCStatusList`, endpoint =
+`{URL}{STATUS_LIST_PATH}`). The status-list endpoint is gracefully
+present from day one so external verifiers can pre-cache resolution;
+the actual BitstringStatusList credentials are populated in Phase 2.
+
+DIDComm is not advertised by default — communities that need a
+mediator add it later via the existing runtime-service-management
+flow.
 
 ### 4.5 Emergency bootstrap (recovery)
 

--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -213,7 +213,7 @@ consumer yet; primitives ready for the rest of Phase 0 to depend on.
 
 ## M0.2 — `vtc-host` DID template (`vta-sdk`)
 
-### `[ ]` M0.2.1 — Author `vtc-host.json` template
+### `[x]` M0.2.1 — Author `vtc-host.json` template
 
 - **Acceptance**
   - `vta-sdk/templates/vtc-host.json` exists, structurally validated
@@ -239,7 +239,7 @@ consumer yet; primitives ready for the rest of Phase 0 to depend on.
     + `load_embedded` switch)
 - **Deps**: none — fully parallel with M0.1
 
-### `[ ]` M0.2.2 — Documentation entry for `vtc-host`
+### `[x]` M0.2.2 — Documentation entry for `vtc-host`
 
 - **Acceptance**
   - `docs/03-integrating/did-templates.md` updated with `vtc-host`

--- a/vta-sdk/src/did_templates/builtin.rs
+++ b/vta-sdk/src/did_templates/builtin.rs
@@ -11,6 +11,7 @@ use super::{DidTemplate, TemplateError};
 pub const BUILTIN_NAMES: &[&str] = &[
     "didcomm-mediator",
     "vta-admin",
+    "vtc-host",
     "webvh-control",
     "webvh-daemon",
     "webvh-server",
@@ -18,6 +19,7 @@ pub const BUILTIN_NAMES: &[&str] = &[
 
 const DIDCOMM_MEDIATOR: &str = include_str!("../../templates/didcomm-mediator.json");
 const VTA_ADMIN: &str = include_str!("../../templates/vta-admin.json");
+const VTC_HOST: &str = include_str!("../../templates/vtc-host.json");
 const WEBVH_CONTROL: &str = include_str!("../../templates/webvh-control.json");
 const WEBVH_DAEMON: &str = include_str!("../../templates/webvh-daemon.json");
 const WEBVH_SERVER: &str = include_str!("../../templates/webvh-server.json");
@@ -28,6 +30,7 @@ pub fn load_embedded(name: &str) -> Result<DidTemplate, TemplateError> {
     let raw = match name {
         "didcomm-mediator" => DIDCOMM_MEDIATOR,
         "vta-admin" => VTA_ADMIN,
+        "vtc-host" => VTC_HOST,
         "webvh-control" => WEBVH_CONTROL,
         "webvh-daemon" => WEBVH_DAEMON,
         "webvh-server" => WEBVH_SERVER,

--- a/vta-sdk/src/did_templates/tests.rs
+++ b/vta-sdk/src/did_templates/tests.rs
@@ -636,3 +636,85 @@ fn webvh_server_builtin_rejects_unknown_placeholder_in_template() {
         "got: {err}"
     );
 }
+
+// ─── vtc-host built-in ───────────────────────────────────────────────
+
+#[test]
+fn vtc_host_renders_with_minimal_vars() {
+    let tpl = load_embedded("vtc-host").unwrap();
+    let mut vars = ambient_vars();
+    vars.insert_string("KA_KEY_MB", "z6LSKeyAgreement");
+    vars.insert_string("URL", "https://vtc.example.com");
+
+    let out = tpl.render(&vars).unwrap();
+
+    assert_eq!(out["id"], "did:webvh:example.com:abc");
+    assert_eq!(
+        out["verificationMethod"][0]["id"],
+        "did:webvh:example.com:abc#key-0"
+    );
+    assert_eq!(
+        out["verificationMethod"][0]["publicKeyMultibase"],
+        "z6MkSigning"
+    );
+    assert_eq!(
+        out["verificationMethod"][1]["id"],
+        "did:webvh:example.com:abc#key-1"
+    );
+    assert_eq!(
+        out["verificationMethod"][1]["publicKeyMultibase"],
+        "z6LSKeyAgreement"
+    );
+    assert_eq!(out["assertionMethod"][0], "did:webvh:example.com:abc#key-0");
+    assert_eq!(out["authentication"][0], "did:webvh:example.com:abc#key-0");
+    assert_eq!(out["keyAgreement"][0], "did:webvh:example.com:abc#key-1");
+
+    // Two services: #vtc-rest at the URL, #vtc-status-list at URL + default path.
+    assert_eq!(
+        out["service"][0]["id"],
+        "did:webvh:example.com:abc#vtc-rest"
+    );
+    assert_eq!(out["service"][0]["type"], "VTCRest");
+    assert_eq!(
+        out["service"][0]["serviceEndpoint"],
+        "https://vtc.example.com"
+    );
+    assert_eq!(
+        out["service"][1]["id"],
+        "did:webvh:example.com:abc#vtc-status-list"
+    );
+    assert_eq!(out["service"][1]["type"], "VTCStatusList");
+    assert_eq!(
+        out["service"][1]["serviceEndpoint"],
+        "https://vtc.example.com/v1/status-lists",
+    );
+}
+
+#[test]
+fn vtc_host_status_list_path_override() {
+    let tpl = load_embedded("vtc-host").unwrap();
+    let mut vars = ambient_vars();
+    vars.insert_string("KA_KEY_MB", "z6LSKeyAgreement");
+    vars.insert_string("URL", "https://vtc.example.com");
+    vars.insert_string("STATUS_LIST_PATH", "/custom/status");
+
+    let out = tpl.render(&vars).unwrap();
+    assert_eq!(
+        out["service"][1]["serviceEndpoint"],
+        "https://vtc.example.com/custom/status",
+    );
+}
+
+#[test]
+fn vtc_host_requires_url() {
+    let tpl = load_embedded("vtc-host").unwrap();
+    let mut vars = ambient_vars();
+    vars.insert_string("KA_KEY_MB", "z6LSKeyAgreement");
+    // URL deliberately omitted.
+
+    let err = tpl.render(&vars).expect_err("URL is required");
+    assert!(
+        matches!(&err, TemplateError::MissingVars(m) if m.contains("URL")),
+        "got: {err}"
+    );
+}

--- a/vta-sdk/templates/vtc-host.json
+++ b/vta-sdk/templates/vtc-host.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": 1,
+  "name": "vtc-host",
+  "kind": "vtc-host",
+  "description": "Verifiable Trust Community (VTC) service identity. Provisions the did:webvh that a vtc-service binary operates under. The document advertises the VTC's REST endpoint and the URL where its BitstringStatusList credentials will be hosted (populated in Phase 2 of the VTC MVP — the endpoint is gracefully present in the DID document from day one so external verifiers can pre-cache the resolution). DIDComm is not advertised here by default; communities that need a mediator add it later via the runtime-service-management flow (see docs/03-integrating/runtime-service-management.md). The URL variable must not end with a trailing slash to avoid double-slash artefacts in the status-list endpoint.",
+  "methods": ["webvh", "web"],
+  "requiredVars": ["URL"],
+  "optionalVars": {
+    "STATUS_LIST_PATH": "/v1/status-lists"
+  },
+  "defaults": {
+    "preRotationCount": 2,
+    "portable": false
+  },
+  "document": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://www.w3.org/ns/cid/v1",
+      "https://w3id.org/security/multikey/v1"
+    ],
+    "id": "{DID}",
+    "verificationMethod": [
+      {
+        "id": "{DID}#key-0",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{SIGNING_KEY_MB}"
+      },
+      {
+        "id": "{DID}#key-1",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{KA_KEY_MB}"
+      }
+    ],
+    "assertionMethod": ["{DID}#key-0"],
+    "authentication": ["{DID}#key-0"],
+    "keyAgreement": ["{DID}#key-1"],
+    "service": [
+      {
+        "id": "{DID}#vtc-rest",
+        "type": "VTCRest",
+        "serviceEndpoint": "{URL}"
+      },
+      {
+        "id": "{DID}#vtc-status-list",
+        "type": "VTCStatusList",
+        "serviceEndpoint": "{URL}{STATUS_LIST_PATH}"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- New built-in DID template `vtc-host` for provisioning the `did:webvh` under which a `vtc-service` binary operates.
- First implementation PR for VTC MVP Phase 0 (M0.2 in `tasks/vtc-mvp/todo.md`).
- Small spec correction in `docs/05-design-notes/vtc-mvp.md` §4.4 to match workspace conventions discovered during implementation.

## What's in the template

| Field | Value |
|---|---|
| Required vars | `URL` (no trailing slash) |
| Optional vars | `STATUS_LIST_PATH` (default `/v1/status-lists`) |
| Methods | `webvh`, `web` |
| Keys | `#key-0` Ed25519 (`assertionMethod` + `authentication`); `#key-1` X25519 (`keyAgreement`) |
| Services | `#vtc-rest` (`VTCRest`, endpoint = `{URL}`); `#vtc-status-list` (`VTCStatusList`, endpoint = `{URL}{STATUS_LIST_PATH}`) |
| DIDComm | Not advertised by default — added later via runtime-service-management |

## Spec correction in this PR

The earlier draft of `docs/05-design-notes/vtc-mvp.md` §4.4 specified:

- Three keys (separate `assertionMethod` vs `authentication`)
- Required vars: `URL` + `community_name`

Both are corrected to match what the workspace renderer actually supports + the convention used by every other built-in template:

- **Two keys**: combined signing on `#key-0`, keyAgreement on `#key-1`. Matches `webvh-control`, `webvh-daemon`, `webvh-server`, `didcomm-mediator`. The renderer only mints two key placeholders (`SIGNING_KEY_MB`, `KA_KEY_MB`); separating assertion from authentication would require renderer changes for a marginal hygiene gain.
- **URL-only required var**: dropped `community_name` because DID Core service entries have no standard label field; community name lives in the VTC profile, not the DID document.

## Test plan

- [x] `cargo test --package vta-sdk did_templates` — all 89 tests pass, including 3 new vtc-host tests (renders, optional path override, missing-URL rejection).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --package vta-sdk -- -D warnings` clean.
- [x] Existing `every_builtin_parses_and_validates` test automatically covers `vtc-host` load + validate.
- [ ] Manual smoke test: provision `vtc-host` via `vta bootstrap provision-integration --template vtc-host --var URL=https://vtc.example.com` against any local VTA. (Optional — the new render tests cover the same code path through `tpl.render`.)

## Notes

This PR is intentionally scoped to `vta-sdk` only (plus docs). It's the only PR in the VTC MVP plan that touches VTA-owned code; everything else lands in `vti-common` or `vtc-service`. Reviewable in 10 minutes.