### PR TITLE
feat(vti-common): reusable passkey scaffold + storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,11 +756,27 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -768,6 +784,18 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -1537,6 +1565,17 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
+dependencies = [
+ "base64 0.21.7",
+ "pastey",
+ "serde",
+]
 
 [[package]]
 name = "bech32"
@@ -2559,11 +2598,25 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.1",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -5201,7 +5254,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tracing",
- "x509-parser",
+ "x509-parser 0.17.0",
  "zip",
 ]
 
@@ -5394,11 +5447,20 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.1",
 ]
 
 [[package]]
@@ -5600,6 +5662,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pct-str"
@@ -6920,6 +6988,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half 1.8.3",
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor_2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aec2709de9078e077090abd848e967abab63c9fb3fdb5d4799ad359d8d482c"
+dependencies = [
+ "half 2.7.1",
  "serde",
 ]
 
@@ -8871,6 +8949,7 @@ dependencies = [
  "chrono",
  "ed25519-dalek",
  "fjall",
+ "hex",
  "jsonwebtoken",
  "libc",
  "rand 0.10.1",
@@ -8882,6 +8961,9 @@ dependencies = [
  "tokio",
  "tokio-vsock",
  "tracing",
+ "url",
+ "uuid",
+ "webauthn-rs",
  "zeroize",
 ]
 
@@ -9094,6 +9176,74 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webauthn-attestation-ca"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6475c0bbd1a3f04afaa3e98880408c5be61680c5e6bd3c6f8c250990d5d3e18e"
+dependencies = [
+ "base64urlsafedata",
+ "openssl",
+ "openssl-sys",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c548915e0e92ee946bbf2aecf01ea21bef53d974b0793cc6732ba81a03fc422"
+dependencies = [
+ "base64urlsafedata",
+ "serde",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+]
+
+[[package]]
+name = "webauthn-rs-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296d2d501feb715d80b8e186fb88bab1073bca17f460303a1013d17b673bea6a"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "der-parser 9.0.0",
+ "hex",
+ "nom",
+ "openssl",
+ "openssl-sys",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "serde",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-attestation-ca",
+ "webauthn-rs-proto",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "webauthn-rs-proto"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37393beac9c1ed1ca6dbb30b1e01783fb316ab3a45d90ecd48c99052dd7ef1e"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -9750,16 +9900,33 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.7.1",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.1",
  "data-encoding",
- "der-parser",
+ "der-parser 10.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.8.1",
  "ring",
  "rusticata-macros",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,15 @@ azure_identity = "0.35"
 # that want the offline-only cache can opt out via `default-features = false`.
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 
+# WebAuthn / passkey infrastructure. Used by vti-common's `passkey` feature
+# for shared enrolment + login ceremonies — both VTA (admin auth, later) and
+# VTC (install + admin login) consume it. The version pin matches what
+# `affinidi-webvh-service` ships against, since we adopt that crate's
+# passkey module pattern.
+webauthn-rs = { version = "0.5", features = [
+  "danger-allow-state-serialisation",
+] }
+
 # OS keyring API (replaces legacy `keyring` v3 crate). keyring-core 1.0 split
 # the API from the backend stores; each binary picks a platform-native store
 # and registers it once at startup via `vta_sdk::keyring_init::install_default_store`.

--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -163,47 +163,73 @@ Every PR must be DCO-signed (`git commit -s`) and pass
   - `vti-common/src/audit/envelope.rs`
 - **Deps**: M0.1.2
 
-### `[ ]` M0.1.6 — Reusable passkey infrastructure in `vti-common`
+### M0.1.6 — Reusable passkey infrastructure in `vti-common`
 
 Per **D11** + the `webvh-common::server::passkey` reference (see
-`plan.md` Reference implementations). This is foundational: M0.5
-consumes it, and a future VTA admin-passkey surface can too.
+`plan.md` Reference implementations). Split into two PRs during
+implementation: scaffold + storage lands first, route handlers
+follow once consumers (M0.5) need them.
+
+#### `[x]` M0.1.6a — Scaffold + types + storage
 
 - **Acceptance**
-  - New module `vti-common::auth::passkey` (feature-gated `passkey`)
-  - `PasskeyState` trait (extends existing `AuthState`):
-    `webauthn() -> Option<&Arc<Webauthn>>`, `acl_ks() -> &KeyspaceHandle`,
-    `access_token_expiry()`, `refresh_token_expiry()`,
-    `public_url() -> Option<&str>`, `enrollment_ttl()`
-  - `build_webauthn(public_url: &str) -> Result<Webauthn, AppError>`
-    — single-source RP ID derivation per **D7**
-  - Storage types: `Enrollment` (with manual redacted `Debug` per
-    **D13**), `PasskeyUser`, `CredentialMapping`
-  - Storage helpers: `store_enrollment`, `get_enrollment`,
-    `take_enrollment`, `store_passkey_user`, `get_passkey_user_by_did`,
-    `get_passkey_user_by_credential`
-  - `ENROLLMENT_CLAIM_WINDOW_SECS = 300` constant (claim-window
-    pattern per **D12**)
-  - Route handlers `enroll_start`, `enroll_finish`, `login_start`,
-    `login_finish` generic over `S: PasskeyState` — these are the
-    Phase-0 building blocks; M0.5 wires them into VTC-specific
-    install routes
-  - **No** VTC-specific install logic here — that goes in
-    `vtc-service::install` in M0.5
+  - `webauthn-rs` added to workspace dependencies.
+  - New feature `passkey` on `vti-common` gating the module.
+  - New module `vti-common::auth::passkey` containing:
+    - `PasskeyState` trait extending `AuthState`.
+    - `build_webauthn(public_url: &str) -> Result<Webauthn, AppError>`
+      with single-source RP-ID derivation per **D7**.
+    - `ENROLLMENT_CLAIM_WINDOW_SECS = 300` constant per **D12**.
+  - Sub-module `store` containing:
+    - Types: `Enrollment` (with manual redacted `Debug` per **D13**),
+      `PasskeyUser`, `CredentialMapping`.
+    - Module-local `take` / `take_raw` helpers (sequenced
+      `get` + `remove`; the atomicity gap is documented and
+      acceptable for in-process use).
+    - Storage helpers covering enrolments, registration state,
+      authentication state, registration → user mapping,
+      registration → enrolment mapping, passkey users, credential
+      mappings.
+  - 10 unit tests cover `build_webauthn` (happy + invalid URL +
+    no-domain), `Enrollment` `Debug` redaction, every storage
+    round-trip plus the `take` consumption semantics.
 - **Verify**
-  - Unit tests for `build_webauthn` (valid URL, no domain, malformed)
-  - Unit tests for `Enrollment` round-trip + `Debug` redaction
-  - End-to-end round-trip test via a stub `PasskeyState` impl in
-    `tests/` (creates an enrollment, runs ceremony via a test
-    authenticator, asserts ACL entry created)
+  - `cargo test --package vti-common --features passkey passkey::`
+    runs all 10 new tests green.
+  - `cargo clippy --package vti-common --features passkey -- -D warnings`
+    clean.
+  - `cargo build --workspace` clean (default features unaffected).
 - **Files**
+  - `Cargo.toml` (workspace `webauthn-rs` dep)
+  - `vti-common/Cargo.toml` (passkey feature + per-feature deps)
+  - `vti-common/src/auth/mod.rs` (gate the new module)
   - `vti-common/src/auth/passkey/mod.rs` (new)
   - `vti-common/src/auth/passkey/store.rs` (new)
+- **Deps**: none (replaces M0.1.0's "add webauthn-rs to workspace +
+  scaffold vtc-service import" — the dep is added here and `vtc-service`
+  will consume `vti-common::auth::passkey` rather than depending on
+  `webauthn-rs` directly).
+
+#### `[ ]` M0.1.6b — Route handlers
+
+- **Acceptance**
+  - `enroll_start`, `enroll_finish`, `login_start`, `login_finish`
+    route handlers generic over `S: PasskeyState`, in a new
+    `vti-common::auth::passkey::routes` module.
+  - Helper `require_webauthn`, `require_jwt_keys`, `token_prefix`.
+  - Uses the existing `vti-common::auth::session::create_authenticated_session`
+    + `vti-common::acl::check_acl` for post-ceremony session minting
+    (so the handler returns a `TokenResponse` ready for the service
+    to forward).
+  - Round-trip integration test using `webauthn-rs`'s deterministic
+    test authenticator harness — exercises `enroll_start` →
+    ceremony → `enroll_finish` end-to-end through a stub
+    `PasskeyState` impl.
+- **Files**
   - `vti-common/src/auth/passkey/routes.rs` (new)
-  - `vti-common/Cargo.toml` (add `webauthn-rs` behind `passkey` feature)
-  - `vti-common/src/lib.rs`
-- **Deps**: M0.1.2 (audit), M0.1.0 (workspace dep). Independent of
-  M0.1.1, M0.1.3, M0.1.4.
+  - `vti-common/src/auth/passkey/mod.rs` (re-export)
+- **Deps**: M0.1.6a + access to the existing session/ACL helpers
+  (already in vti-common).
 
 ### Checkpoint A — Hygiene foundation green
 After M0.1.0–M0.1.5: `cargo test --package vti-common` clean. No

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -19,6 +19,12 @@ vsock-store = ["dep:tokio-vsock", "dep:libc"]
 # for the local/dev `vta` binary's CLI, where the trust boundary is the
 # OS process (not the network). NEVER enable in enclave builds.
 cli-synthesis = []
+# Shared WebAuthn / passkey infrastructure (types + storage). Services
+# (VTA, VTC) implement the `auth::passkey::PasskeyState` trait on their
+# `AppState` and gain reusable enrolment + login storage primitives. The
+# concrete route handlers ship in a follow-up so this feature stays
+# storage-only for now.
+passkey = ["dep:webauthn-rs", "dep:url", "dep:uuid", "dep:hex", "dep:rand"]
 
 [dependencies]
 async-trait = "0.1"
@@ -46,6 +52,12 @@ rand = { workspace = true, optional = true }
 # Vsock storage proxy client (feature-gated, Linux only)
 tokio-vsock = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
+
+# Passkey feature deps (`rand` already declared above for `encryption`)
+webauthn-rs = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/vti-common/src/auth/mod.rs
+++ b/vti-common/src/auth/mod.rs
@@ -1,5 +1,7 @@
 pub mod extractor;
 pub mod jwt;
+#[cfg(feature = "passkey")]
+pub mod passkey;
 pub mod session;
 
 pub use extractor::{AdminAuth, AuthClaims, AuthState, ManageAuth, SuperAdminAuth, WriteAuth};

--- a/vti-common/src/auth/passkey/mod.rs
+++ b/vti-common/src/auth/passkey/mod.rs
@@ -1,0 +1,140 @@
+//! Shared WebAuthn / passkey infrastructure (types + storage).
+//!
+//! The shape — `PasskeyState` trait, `build_webauthn(public_url)` helper,
+//! `Enrollment` / `PasskeyUser` / `CredentialMapping` storage types,
+//! `claimed_at` ceremony-lock pattern — is adopted from
+//! [`affinidi/affinidi-webvh-service`](https://github.com/affinidi/affinidi-webvh-service)
+//! (`webvh-common/src/server/passkey/`), which already proves the
+//! pattern in production. Both VTA and VTC implement `PasskeyState`
+//! on their `AppState` and reuse the same enrolment + login
+//! primitives.
+//!
+//! ## Module scope
+//!
+//! This crate ships the **storage layer + supporting types**:
+//!
+//! - [`PasskeyState`] trait, defining what state services must expose.
+//! - [`build_webauthn`] helper that turns a `public_url` config into a
+//!   [`webauthn_rs::Webauthn`] instance using the URL's domain as the
+//!   relying-party ID and the full URL as the origin.
+//! - The persistence layer (see [`store`] sub-module) — enrolment
+//!   tokens, passkey users, credential mappings, registration /
+//!   authentication ceremony state.
+//!
+//! The matching route handlers (`enroll_start`, `enroll_finish`,
+//! `login_start`, `login_finish`) ship in a follow-up; this PR is
+//! intentionally storage-only so consumers can build their own
+//! orchestration on top.
+
+pub mod store;
+
+use std::sync::Arc;
+
+use url::Url;
+use webauthn_rs::prelude::*;
+
+use crate::auth::extractor::AuthState;
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+/// How long an in-progress enrolment claim blocks other concurrent
+/// claims on the same token. Sized for a generous WebAuthn ceremony
+/// (browser dialog + key tap); a legitimate user retrying after a
+/// failed ceremony only waits this long before the claim expires.
+///
+/// Lifted unchanged from `webvh-common`.
+pub const ENROLLMENT_CLAIM_WINDOW_SECS: u64 = 300;
+
+/// Trait that application states implement to support passkey routes.
+///
+/// Extends [`AuthState`] (which provides JWT keys + sessions keyspace)
+/// with the WebAuthn and ACL access that the enrolment + login flows
+/// need. The intentionally narrow surface keeps services free to add
+/// their own state without leaking it into the shared module.
+pub trait PasskeyState: AuthState {
+    /// Returns the WebAuthn relying-party handle if configured. `None`
+    /// means the service didn't supply a `public_url` at startup —
+    /// passkey routes should 503 in that case.
+    fn webauthn(&self) -> Option<&Arc<Webauthn>>;
+
+    /// ACL keyspace. Used to confirm the enrolling DID has a matching
+    /// ACL entry and to issue the post-ceremony session with the
+    /// correct role.
+    fn acl_ks(&self) -> &KeyspaceHandle;
+
+    /// Access-token lifetime in seconds (returned by enrolment + login).
+    fn access_token_expiry(&self) -> u64;
+
+    /// Refresh-token lifetime in seconds.
+    fn refresh_token_expiry(&self) -> u64;
+
+    /// Public base URL used by admin endpoints to render enrolment
+    /// links. `None` disables admin invite endpoints.
+    fn public_url(&self) -> Option<&str>;
+
+    /// Default enrolment-invite TTL in seconds, used when an admin
+    /// creates a new invite without an explicit expiry.
+    fn enrollment_ttl(&self) -> u64;
+}
+
+/// Build a [`Webauthn`] instance from the service's `public_url`.
+///
+/// - **Relying-party ID** = the URL's domain (e.g. `example.com`).
+/// - **Origin** = the parsed URL (e.g. `https://example.com`).
+///
+/// Single-source derivation matches the workspace's spec decision
+/// (see `docs/05-design-notes/vtc-mvp.md` §4.2 + the M0.1.6 plan
+/// entry under D7). Operators who migrate to a different base domain
+/// re-register every passkey — documented in the operator runbook.
+pub fn build_webauthn(public_url: &str) -> Result<Webauthn, AppError> {
+    let url = Url::parse(public_url)
+        .map_err(|e| AppError::Config(format!("invalid public_url '{public_url}': {e}")))?;
+
+    let rp_id = url
+        .domain()
+        .ok_or_else(|| AppError::Config("public_url has no domain".into()))?
+        .to_string();
+
+    let builder = WebauthnBuilder::new(&rp_id, &url)
+        .map_err(|e| AppError::Config(format!("failed to build WebauthnBuilder: {e}")))?;
+
+    let webauthn = builder
+        .rp_name("Verifiable Trust Infrastructure")
+        .build()
+        .map_err(|e| AppError::Config(format!("failed to build Webauthn: {e}")))?;
+
+    Ok(webauthn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_webauthn_happy_path() {
+        let w = build_webauthn("https://vtc.example.com").expect("ok");
+        // Sanity: the builder constructed something usable. The
+        // webauthn-rs API doesn't expose its `rp_id` directly, but if
+        // we got this far the URL parsing + builder both worked.
+        // Subsequent ceremony-level tests cover the actual binding.
+        drop(w);
+    }
+
+    #[test]
+    fn build_webauthn_rejects_invalid_url() {
+        let err = build_webauthn("not-a-url").expect_err("invalid URL");
+        assert!(
+            matches!(err, AppError::Config(ref m) if m.contains("invalid public_url")),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_webauthn_rejects_url_without_domain() {
+        let err = build_webauthn("file:///tmp/foo").expect_err("no domain");
+        assert!(
+            matches!(err, AppError::Config(ref m) if m.contains("no domain")),
+            "got: {err}"
+        );
+    }
+}

--- a/vti-common/src/auth/passkey/store.rs
+++ b/vti-common/src/auth/passkey/store.rs
@@ -1,0 +1,553 @@
+//! Passkey storage layer.
+//!
+//! Adapted from `webvh-common/src/server/passkey/store.rs`. Adjusts
+//! imports to vti-common's paths; the data shapes and key conventions
+//! are preserved unchanged.
+//!
+//! ## Atomic take semantics
+//!
+//! webvh-common's storage relies on an atomic `take` (get + delete in
+//! one step) for race protection: a second concurrent finish-ceremony
+//! call must see `None` after the first has consumed the state.
+//! vti-common's [`KeyspaceHandle`] doesn't expose `take` directly, so
+//! we sequence `get` + `remove` in this module's helpers
+//! [`take`] / [`take_raw`]. This is **not** crash-atomic — if the
+//! process dies between read and delete, the next call returns the
+//! value again. For the WebAuthn ceremony state we manage here that's
+//! fine: stale registration state simply blocks another enrolment
+//! until it expires or is overwritten. Concurrent in-process calls
+//! are sequenced through Tokio's storage layer and never both see the
+//! same value as `Some(_)`.
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use webauthn_rs::prelude::*;
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// One-time enrolment invitation. The `token` is the bearer credential
+/// — embedded in the URL the operator clicks. Manual [`std::fmt::Debug`]
+/// keeps the diagnostic fields visible while redacting the token, so a
+/// stray `tracing::debug!(?enrollment, …)` never leaks it.
+#[derive(Serialize, Deserialize)]
+pub struct Enrollment {
+    pub token: String,
+    pub did: String,
+    pub role: String,
+    pub created_at: u64,
+    pub expires_at: u64,
+    /// Set when a route handler has begun the WebAuthn ceremony for
+    /// this token. Within [`super::ENROLLMENT_CLAIM_WINDOW_SECS`] of
+    /// this timestamp, a second concurrent claim is rejected as
+    /// "in progress". Only consumed (via [`take_enrollment`]) once
+    /// the ceremony successfully completes.
+    ///
+    /// `#[serde(default)]` for backwards-compat with persisted
+    /// enrolments from pre-claim-window deployments.
+    #[serde(default)]
+    pub claimed_at: Option<u64>,
+}
+
+impl std::fmt::Debug for Enrollment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Enrollment")
+            .field("token", &"<redacted>")
+            .field("did", &self.did)
+            .field("role", &self.role)
+            .field("created_at", &self.created_at)
+            .field("expires_at", &self.expires_at)
+            .field("claimed_at", &self.claimed_at)
+            .finish()
+    }
+}
+
+/// Maps a credential id (hex-encoded) to the owning user UUID. Lets
+/// `login_finish` find the right `PasskeyUser` without scanning.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CredentialMapping {
+    pub user_uuid: Uuid,
+}
+
+/// A passkey user. May have multiple credentials (one per registered
+/// device). Updated on every successful enrolment + login.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PasskeyUser {
+    pub user_uuid: Uuid,
+    pub did: String,
+    pub display_name: String,
+    pub credentials: Vec<Passkey>,
+}
+
+// ---------------------------------------------------------------------------
+// Key helpers
+// ---------------------------------------------------------------------------
+
+fn enrollment_key(token: &str) -> String {
+    format!("enroll:{token}")
+}
+
+fn registration_state_key(id: &str) -> String {
+    format!("pk_reg:{id}")
+}
+
+fn auth_state_key(id: &str) -> String {
+    format!("pk_auth:{id}")
+}
+
+fn registration_user_key(reg_id: &str) -> String {
+    format!("pk_reg_user:{reg_id}")
+}
+
+/// Maps a registration_id to the enrolment token that authorised it.
+/// Used by `enroll_finish` to consume the enrolment **after** the
+/// WebAuthn ceremony succeeds — so a failed ceremony (browser closed,
+/// key not present, RP mismatch, decline-after-click) leaves the
+/// invite intact for the legitimate user to retry.
+fn registration_enrollment_key(reg_id: &str) -> String {
+    format!("pk_reg_enroll:{reg_id}")
+}
+
+fn credential_mapping_key(cred_id_hex: &str) -> String {
+    format!("pk_cred:{cred_id_hex}")
+}
+
+fn passkey_user_key(uuid: &Uuid) -> String {
+    format!("pk_user:{uuid}")
+}
+
+fn passkey_did_key(did: &str) -> String {
+    format!("pk_did:{did}")
+}
+
+// ---------------------------------------------------------------------------
+// `take` helpers — sequenced get + remove (see module docs)
+// ---------------------------------------------------------------------------
+
+async fn take<V>(ks: &KeyspaceHandle, key: String) -> Result<Option<V>, AppError>
+where
+    V: DeserializeOwned + Send + 'static,
+{
+    let key_bytes = key.into_bytes();
+    let value: Option<V> = ks.get(key_bytes.clone()).await?;
+    if value.is_some() {
+        ks.remove(key_bytes).await?;
+    }
+    Ok(value)
+}
+
+async fn take_raw(ks: &KeyspaceHandle, key: String) -> Result<Option<Vec<u8>>, AppError> {
+    let key_bytes = key.into_bytes();
+    let value = ks.get_raw(key_bytes.clone()).await?;
+    if value.is_some() {
+        ks.remove(key_bytes).await?;
+    }
+    Ok(value)
+}
+
+// ---------------------------------------------------------------------------
+// Enrolment CRUD
+// ---------------------------------------------------------------------------
+
+pub async fn store_enrollment(
+    ks: &KeyspaceHandle,
+    enrollment: &Enrollment,
+) -> Result<(), AppError> {
+    ks.insert(enrollment_key(&enrollment.token), enrollment)
+        .await
+}
+
+/// Atomically (per the module's `take` semantics) retrieve and delete
+/// an enrolment by token. Returns `None` if already consumed.
+pub async fn take_enrollment(
+    ks: &KeyspaceHandle,
+    token: &str,
+) -> Result<Option<Enrollment>, AppError> {
+    take(ks, enrollment_key(token)).await
+}
+
+/// Retrieve an enrolment by token **without** consuming it. Used by
+/// admin management endpoints (list / update) and by `enroll_start`,
+/// which only sets `claimed_at`.
+pub async fn get_enrollment(
+    ks: &KeyspaceHandle,
+    token: &str,
+) -> Result<Option<Enrollment>, AppError> {
+    ks.get(enrollment_key(token)).await
+}
+
+/// List every enrolment currently in the store. Silently skips
+/// entries that fail to deserialise (corrupt / old schema) so a
+/// single bad row doesn't hide the rest from admins.
+pub async fn list_enrollments(ks: &KeyspaceHandle) -> Result<Vec<Enrollment>, AppError> {
+    let pairs = ks.prefix_iter_raw(b"enroll:".to_vec()).await?;
+    let mut out = Vec::with_capacity(pairs.len());
+    for (_key, value) in pairs {
+        match serde_json::from_slice::<Enrollment>(&value) {
+            Ok(e) => out.push(e),
+            Err(e) => tracing::warn!(error = %e, "skipping unparseable enrollment entry"),
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Registration state (in-flight WebAuthn ceremony state)
+// ---------------------------------------------------------------------------
+
+pub async fn store_registration_state(
+    ks: &KeyspaceHandle,
+    id: &str,
+    state: &PasskeyRegistration,
+) -> Result<(), AppError> {
+    ks.insert(registration_state_key(id), state).await
+}
+
+pub async fn take_registration_state(
+    ks: &KeyspaceHandle,
+    id: &str,
+) -> Result<Option<PasskeyRegistration>, AppError> {
+    take(ks, registration_state_key(id)).await
+}
+
+// ---------------------------------------------------------------------------
+// Authentication state (in-flight WebAuthn ceremony state)
+// ---------------------------------------------------------------------------
+
+pub async fn store_auth_state(
+    ks: &KeyspaceHandle,
+    id: &str,
+    state: &PasskeyAuthentication,
+) -> Result<(), AppError> {
+    ks.insert(auth_state_key(id), state).await
+}
+
+pub async fn take_auth_state(
+    ks: &KeyspaceHandle,
+    id: &str,
+) -> Result<Option<PasskeyAuthentication>, AppError> {
+    take(ks, auth_state_key(id)).await
+}
+
+// ---------------------------------------------------------------------------
+// Registration-to-user mapping (links reg_id to user UUID during the ceremony)
+// ---------------------------------------------------------------------------
+
+pub async fn store_registration_user(
+    ks: &KeyspaceHandle,
+    reg_id: &str,
+    user_uuid: &Uuid,
+) -> Result<(), AppError> {
+    ks.insert_raw(
+        registration_user_key(reg_id),
+        user_uuid.to_string().into_bytes(),
+    )
+    .await
+}
+
+pub async fn get_registration_user(
+    ks: &KeyspaceHandle,
+    reg_id: &str,
+) -> Result<Option<Uuid>, AppError> {
+    match ks.get_raw(registration_user_key(reg_id)).await? {
+        Some(bytes) => {
+            let s = String::from_utf8(bytes)
+                .map_err(|e| AppError::Internal(format!("invalid registration user UUID: {e}")))?;
+            let uuid = Uuid::parse_str(&s)
+                .map_err(|e| AppError::Internal(format!("invalid registration user UUID: {e}")))?;
+            Ok(Some(uuid))
+        }
+        None => Ok(None),
+    }
+}
+
+pub async fn delete_registration_user(ks: &KeyspaceHandle, reg_id: &str) -> Result<(), AppError> {
+    ks.remove(registration_user_key(reg_id)).await
+}
+
+// ---------------------------------------------------------------------------
+// Registration-to-enrolment-token mapping (defer-take semantics)
+// ---------------------------------------------------------------------------
+
+/// Persist the enrolment token that authorised a registration
+/// ceremony so `enroll_finish` can consume it after the WebAuthn
+/// ceremony succeeds. A failed ceremony never reaches finish and the
+/// invite stays intact.
+pub async fn store_registration_enrollment(
+    ks: &KeyspaceHandle,
+    reg_id: &str,
+    enrollment_token: &str,
+) -> Result<(), AppError> {
+    ks.insert_raw(
+        registration_enrollment_key(reg_id),
+        enrollment_token.as_bytes().to_vec(),
+    )
+    .await
+}
+
+pub async fn take_registration_enrollment(
+    ks: &KeyspaceHandle,
+    reg_id: &str,
+) -> Result<Option<String>, AppError> {
+    match take_raw(ks, registration_enrollment_key(reg_id)).await? {
+        Some(bytes) => Ok(Some(String::from_utf8(bytes).map_err(|e| {
+            AppError::Internal(format!("invalid enrolment token bytes: {e}"))
+        })?)),
+        None => Ok(None),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PasskeyUser CRUD
+// ---------------------------------------------------------------------------
+
+pub async fn store_passkey_user(ks: &KeyspaceHandle, user: &PasskeyUser) -> Result<(), AppError> {
+    ks.insert(passkey_user_key(&user.user_uuid), user).await?;
+    // Maintain DID → user UUID reverse index so `get_passkey_user_by_did`
+    // can be O(1) instead of a full prefix scan.
+    ks.insert_raw(
+        passkey_did_key(&user.did),
+        user.user_uuid.to_string().into_bytes(),
+    )
+    .await
+}
+
+pub async fn get_passkey_user(
+    ks: &KeyspaceHandle,
+    uuid: &Uuid,
+) -> Result<Option<PasskeyUser>, AppError> {
+    ks.get(passkey_user_key(uuid)).await
+}
+
+/// Find a [`PasskeyUser`] by credential id (the hex-encoded value the
+/// authenticator returned on a successful ceremony).
+pub async fn get_passkey_user_by_cred(
+    ks: &KeyspaceHandle,
+    cred_id_hex: &str,
+) -> Result<Option<PasskeyUser>, AppError> {
+    let mapping: Option<CredentialMapping> = ks.get(credential_mapping_key(cred_id_hex)).await?;
+    match mapping {
+        Some(m) => get_passkey_user(ks, &m.user_uuid).await,
+        None => Ok(None),
+    }
+}
+
+/// Find a [`PasskeyUser`] by DID. Tries the `pk_did:` reverse index
+/// first, falls back to a linear scan for pre-index data.
+pub async fn get_passkey_user_by_did(
+    ks: &KeyspaceHandle,
+    did: &str,
+) -> Result<Option<PasskeyUser>, AppError> {
+    if let Some(bytes) = ks.get_raw(passkey_did_key(did)).await? {
+        let uuid_str = String::from_utf8(bytes)
+            .map_err(|e| AppError::Internal(format!("invalid DID index UUID: {e}")))?;
+        let uuid = Uuid::parse_str(&uuid_str)
+            .map_err(|e| AppError::Internal(format!("invalid DID index UUID: {e}")))?;
+        if let Some(user) = get_passkey_user(ks, &uuid).await? {
+            return Ok(Some(user));
+        }
+    }
+
+    // Fallback for any rows persisted before the reverse index existed.
+    let entries = ks.prefix_iter_raw(b"pk_user:".to_vec()).await?;
+    for (_key, value) in entries {
+        if let Ok(user) = serde_json::from_slice::<PasskeyUser>(&value)
+            && user.did == did
+        {
+            return Ok(Some(user));
+        }
+    }
+    Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// Credential mapping
+// ---------------------------------------------------------------------------
+
+pub async fn store_credential_mapping(
+    ks: &KeyspaceHandle,
+    cred_id_hex: &str,
+    user_uuid: Uuid,
+) -> Result<(), AppError> {
+    let mapping = CredentialMapping { user_uuid };
+    ks.insert(credential_mapping_key(cred_id_hex), &mapping)
+        .await
+}
+
+/// Collect every stored passkey for discoverable-credential login.
+/// Scans the `pk_user:` prefix and flattens out each user's
+/// credentials. Tolerates corrupt rows the same way [`list_enrollments`]
+/// does.
+pub async fn get_all_passkeys(ks: &KeyspaceHandle) -> Result<Vec<Passkey>, AppError> {
+    let entries = ks.prefix_iter_raw(b"pk_user:".to_vec()).await?;
+    let mut passkeys = Vec::new();
+    for (_key, value) in entries {
+        if let Ok(user) = serde_json::from_slice::<PasskeyUser>(&value) {
+            passkeys.extend(user.credentials);
+        }
+    }
+    Ok(passkeys)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+
+    fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).expect("store");
+        let ks = store.keyspace("passkey-test").expect("keyspace");
+        (ks, dir)
+    }
+
+    fn sample_enrollment() -> Enrollment {
+        Enrollment {
+            token: "abcd1234".into(),
+            did: "did:key:z6Mk".into(),
+            role: "admin".into(),
+            created_at: 100,
+            expires_at: 200,
+            claimed_at: None,
+        }
+    }
+
+    #[test]
+    fn enrollment_debug_redacts_token() {
+        let e = sample_enrollment();
+        let s = format!("{e:?}");
+        assert!(!s.contains("abcd1234"), "raw token leaked: {s}");
+        assert!(s.contains("<redacted>"), "redaction marker missing: {s}");
+        // Diagnostic fields stay visible.
+        assert!(s.contains("did:key:z6Mk"));
+        assert!(s.contains("admin"));
+    }
+
+    #[tokio::test]
+    async fn enrollment_roundtrip() {
+        let (ks, _dir) = temp_ks();
+        let e = sample_enrollment();
+
+        store_enrollment(&ks, &e).await.unwrap();
+        let got = get_enrollment(&ks, &e.token).await.unwrap().expect("found");
+        assert_eq!(got.did, e.did);
+        assert_eq!(got.role, e.role);
+
+        // Take consumes.
+        let taken = take_enrollment(&ks, &e.token)
+            .await
+            .unwrap()
+            .expect("taken");
+        assert_eq!(taken.token, e.token);
+        let after = get_enrollment(&ks, &e.token).await.unwrap();
+        assert!(after.is_none(), "take did not consume");
+
+        // Second take returns None — protects ceremony-finish from races.
+        let again = take_enrollment(&ks, &e.token).await.unwrap();
+        assert!(again.is_none());
+    }
+
+    #[tokio::test]
+    async fn registration_enrollment_mapping_roundtrip() {
+        let (ks, _dir) = temp_ks();
+        store_registration_enrollment(&ks, "reg-1", "tok-abc")
+            .await
+            .unwrap();
+        let taken = take_registration_enrollment(&ks, "reg-1").await.unwrap();
+        assert_eq!(taken.as_deref(), Some("tok-abc"));
+        // Idempotent second take.
+        let again = take_registration_enrollment(&ks, "reg-1").await.unwrap();
+        assert!(again.is_none());
+    }
+
+    #[tokio::test]
+    async fn registration_user_mapping_roundtrip() {
+        let (ks, _dir) = temp_ks();
+        let uuid = Uuid::new_v4();
+        store_registration_user(&ks, "reg-1", &uuid).await.unwrap();
+        let got = get_registration_user(&ks, "reg-1").await.unwrap();
+        assert_eq!(got, Some(uuid));
+        delete_registration_user(&ks, "reg-1").await.unwrap();
+        let gone = get_registration_user(&ks, "reg-1").await.unwrap();
+        assert!(gone.is_none());
+    }
+
+    #[tokio::test]
+    async fn passkey_user_roundtrip_by_uuid_and_did() {
+        let (ks, _dir) = temp_ks();
+        let uuid = Uuid::new_v4();
+        let user = PasskeyUser {
+            user_uuid: uuid,
+            did: "did:key:z6Mk1".into(),
+            display_name: "did:key:z6Mk1".into(),
+            credentials: Vec::new(),
+        };
+
+        store_passkey_user(&ks, &user).await.unwrap();
+
+        let by_uuid = get_passkey_user(&ks, &uuid)
+            .await
+            .unwrap()
+            .expect("by uuid");
+        assert_eq!(by_uuid.did, user.did);
+
+        let by_did = get_passkey_user_by_did(&ks, &user.did)
+            .await
+            .unwrap()
+            .expect("by did");
+        assert_eq!(by_did.user_uuid, uuid);
+
+        let absent = get_passkey_user_by_did(&ks, "did:key:nope").await.unwrap();
+        assert!(absent.is_none());
+    }
+
+    #[tokio::test]
+    async fn credential_mapping_resolves_to_user() {
+        let (ks, _dir) = temp_ks();
+        let uuid = Uuid::new_v4();
+        let user = PasskeyUser {
+            user_uuid: uuid,
+            did: "did:key:z6Mk2".into(),
+            display_name: "did:key:z6Mk2".into(),
+            credentials: Vec::new(),
+        };
+        store_passkey_user(&ks, &user).await.unwrap();
+        store_credential_mapping(&ks, "deadbeef", uuid)
+            .await
+            .unwrap();
+
+        let got = get_passkey_user_by_cred(&ks, "deadbeef")
+            .await
+            .unwrap()
+            .expect("user");
+        assert_eq!(got.user_uuid, uuid);
+
+        let missing = get_passkey_user_by_cred(&ks, "0000").await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_enrollments_returns_all() {
+        let (ks, _dir) = temp_ks();
+        for token in ["t1", "t2", "t3"] {
+            let mut e = sample_enrollment();
+            e.token = token.into();
+            store_enrollment(&ks, &e).await.unwrap();
+        }
+        let all = list_enrollments(&ks).await.unwrap();
+        assert_eq!(all.len(), 3);
+    }
+}


### PR DESCRIPTION
## Summary

First slice of **M0.1.6** from `tasks/vtc-mvp/todo.md`. Adds a shared WebAuthn / passkey foundation in `vti-common` that both VTA (later) and VTC (M0.5 onwards) can consume. The shape — `PasskeyState` trait, single-source RP-ID derivation, claim-window enrolment pattern, `Debug`-redacted bearer secrets — is adopted directly from [`affinidi/affinidi-webvh-service`](https://github.com/affinidi/affinidi-webvh-service)'s `webvh-common/server/passkey`, which already proves the design in production.

## What's in this PR

- **Workspace dep**: `webauthn-rs = "0.5"` (with `danger-allow-state-serialisation` so ceremony state can round-trip through fjall).
- **New feature on `vti-common`**: `passkey`, pulling in `webauthn-rs`, `url`, `uuid`, `hex`, `rand` (all already workspace deps).
- **New module `vti-common::auth::passkey`**:
  - `PasskeyState` trait extending `AuthState`.
  - `build_webauthn(public_url)` — RP ID = `Url::parse(public_url).domain()`, origin = the parsed URL. Matches spec §4.2 + plan D7.
  - `ENROLLMENT_CLAIM_WINDOW_SECS = 300` constant for the claim-window race protection.
- **New module `vti-common::auth::passkey::store`**:
  - Types: `Enrollment` (with manual `Debug` redacting the bearer token), `PasskeyUser`, `CredentialMapping`.
  - Storage layer: enrolment CRUD with `take_enrollment` consume semantics, ceremony state (registration + authentication), registration↔user + registration↔enrolment mappings (the defer-take pattern that lets failed ceremonies leave the invite intact), passkey-user CRUD with a `pk_did:` reverse index, credential mapping, `get_all_passkeys` for discoverable-credential login.
  - Module-local `take` / `take_raw` helpers sequence `get` + `remove`. Atomicity gap documented in the module header — acceptable for in-process use (concurrent in-process calls are sequenced through Tokio's storage layer; crash recovery yields a stale state row that subsequent enrolment overwrites).
- **10 unit tests** cover `build_webauthn` (happy + invalid URL + no-domain), `Enrollment` `Debug` redaction, every storage round-trip plus `take` consumption semantics.

## Out of scope (deferred to M0.1.6b)

The four route handlers — `enroll_start`, `enroll_finish`, `login_start`, `login_finish` — depend on the existing `create_authenticated_session` + `check_acl` helpers and a `webauthn-rs` deterministic-authenticator test harness. Ship in a follow-up so this PR stays storage-only and reviewable in 15 minutes.

The plan's M0.1.0 task ("add webauthn-rs to workspace + scaffold `vtc-service` import") is absorbed here — `vtc-service` will consume `vti-common::auth::passkey` rather than depending on `webauthn-rs` directly, so no scaffolding is needed there.

## Test plan

- [x] `cargo build --workspace` — clean (default features unaffected).
- [x] `cargo build --package vti-common --features passkey` — clean.
- [x] `cargo test --package vti-common --features passkey passkey::` — 10/10 pass.
- [x] `cargo test --package vti-common` — full crate green (default features).
- [x] `cargo clippy --package vti-common --features passkey -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Acknowledgement

Storage layer adapted from `affinidi/affinidi-webvh-service` (`webvh-common/src/server/passkey/store.rs`), Apache-2.0. Data shapes and key conventions preserved unchanged; imports adjusted to `vti-common`'s module paths.