### PR TITLE
feat(vti-common): audit envelope + HMAC key lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8951,6 +8951,8 @@ dependencies = [
  "ed25519-dalek",
  "fjall",
  "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "http-body-util",
  "jsonwebtoken",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,12 @@ hex = "0.4"
 aes-gcm = "0.10"
 hkdf = "0.13"
 
+# HMAC-SHA256 for vti-common's audit-log actor/target identifier
+# hashing. The key is per-community and rotated on RTBF, so a plain
+# SHA-256 over a DID would be reversible by enumeration — see spec
+# §11.1.
+hmac = "0.13"
+
 # Vsock-store deps shared by vti-common's vsock keyspace and the enclave
 # bootstrap; libc is also used by vta-service's vsock-bridge helpers.
 tokio-vsock = "0.7"

--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -66,7 +66,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 - **Pre-impl decision**: D1 (schema format), D8 (header name), D9
   (builder vs macros)
 
-### `[ ]` M0.1.2 — Audit envelope + HMAC actor hashing + `audit_key` keyspace
+### `[x]` M0.1.2 — Audit envelope + HMAC actor hashing + `audit_key` keyspace
 
 - **Acceptance**
   - `AuditEnvelope` struct per spec §11.1, including `event_version`,

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 
 [features]
 default = []
-encryption = ["dep:aes-gcm", "dep:zeroize", "dep:rand"]
+encryption = ["dep:aes-gcm", "dep:zeroize"]
 vsock-store = ["dep:tokio-vsock", "dep:libc"]
 # Exposes `AuthClaims::unsafe_local_cli_super_admin` — a synthesizer that
 # produces a super-admin claim without any wire-level verification. Only
@@ -24,7 +24,7 @@ cli-synthesis = []
 # `AppState` and gain reusable enrolment + login storage primitives. The
 # concrete route handlers ship in a follow-up so this feature stays
 # storage-only for now.
-passkey = ["dep:webauthn-rs", "dep:url", "dep:uuid", "dep:hex", "dep:rand"]
+passkey = ["dep:webauthn-rs", "dep:url", "dep:hex"]
 
 [dependencies]
 async-trait = "0.1"
@@ -40,28 +40,34 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 ed25519-dalek = { workspace = true }
 sha2 = { workspace = true }
+hmac = { workspace = true }
+hkdf = { workspace = true }
+rand = { workspace = true }
+uuid = { workspace = true }
+base64 = { workspace = true }
 
 # Secrets resolver (for error type)
 affinidi-tdk = { workspace = true }
 
-# Encryption (feature-gated)
+# Encryption (feature-gated; `rand` is non-optional and lives in the main
+# dep block since audit_key rotation also needs OS randomness).
 aes-gcm = { workspace = true, optional = true }
 zeroize = { version = "1", features = ["derive"], optional = true }
-rand = { workspace = true, optional = true }
 
 # Vsock storage proxy client (feature-gated, Linux only)
 tokio-vsock = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
 
-# Passkey feature deps (`rand` already declared above for `encryption`)
+# Passkey feature deps (`rand` already declared above for `encryption`;
+# `uuid` is non-optional and lives in the main dep block).
 webauthn-rs = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
-uuid = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"
-base64 = { workspace = true }
+# `base64` is now in the main `[dependencies]` (audit envelope encodes
+# 32-byte hashes as base64url strings).
 # Drives Router::oneshot in the trust_task router tests. Same pattern
 # vtc-service / vta-service use for integration tests.
 tower = { version = "0.5", features = ["util"] }

--- a/vti-common/src/audit/envelope.rs
+++ b/vti-common/src/audit/envelope.rs
@@ -1,0 +1,204 @@
+//! [`AuditEnvelope`] — the wire-stable shape that wraps every
+//! [`AuditEvent`].
+//!
+//! Carries:
+//!
+//! - the event id, timestamps, version stamps
+//! - HMAC-hashed + plaintext pairs for actor + (optional) target
+//!   identifiers
+//! - the tagged event payload
+//!
+//! RTBF mechanics: nulling the `*_plain` field while retaining the
+//! HMAC hash keeps the envelope correlatable across the audit log
+//! without re-leaking the DID. Rotating the `audit_key` (see
+//! [`super::key_store::AuditKeyStore`]) makes pre-rotation hashes
+//! opaque to anyone who doesn't hold the prior key. See spec §11.1.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::event::AuditEvent;
+use super::key_store::KeyId;
+
+/// Envelope schema version. Bumps **only** on a breaking-shape change
+/// to [`AuditEnvelope`] itself. Phase 0 ships v1.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Default event version, applied when an event variant doesn't pin
+/// its own value. Per-variant overrides are added when an existing
+/// variant's payload shape changes (callers bump just that variant
+/// and bake the new version into the constructor).
+pub const EVENT_VERSION: u32 = 1;
+
+/// A persisted audit-log entry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditEnvelope {
+    /// Stable identifier for this specific event. Becomes the
+    /// secondary-key component for cursor-based queries.
+    pub event_id: Uuid,
+
+    /// Variant-specific schema version. Bumped on a breaking change
+    /// to a particular variant's payload; the envelope's
+    /// [`SCHEMA_VERSION`] tracks the wrapper-shape version
+    /// independently.
+    pub event_version: u32,
+
+    /// Envelope-shape version. See [`SCHEMA_VERSION`] for the
+    /// semantics.
+    pub schema_version: u32,
+
+    /// Wall-clock at write time. Drives the primary `<timestamp>:<event_id>`
+    /// audit-keyspace ordering.
+    pub timestamp: DateTime<Utc>,
+
+    /// Identifier of the audit_key used to compute the hashes below.
+    /// Verifiers walk the key history newest-first; this lets them
+    /// skip the search when they already know the right key.
+    pub audit_key_id: KeyId,
+
+    /// HMAC-SHA256 of the actor DID under [`Self::audit_key_id`].
+    /// Always present so RTBF can null the plaintext without losing
+    /// the correlation handle.
+    #[serde(with = "hash32_b64")]
+    pub actor_did_hash: [u8; 32],
+
+    /// Plaintext actor DID. `None` after an RTBF override has redacted
+    /// this row.
+    pub actor_did_plain: Option<String>,
+
+    /// HMAC-SHA256 of the target DID, if the event has one. `None`
+    /// for events whose target is the community itself (e.g.
+    /// `CommunityProfileUpdated`).
+    #[serde(with = "hash32_opt_b64")]
+    pub target_did_hash: Option<[u8; 32]>,
+
+    /// Plaintext target DID. Same null-on-RTBF semantics as
+    /// [`Self::actor_did_plain`].
+    pub target_did_plain: Option<String>,
+
+    /// The tagged event payload.
+    pub event: AuditEvent,
+}
+
+// ---------------------------------------------------------------------------
+// Serde helpers — base64url for 32-byte hashes
+// ---------------------------------------------------------------------------
+
+pub(crate) const B64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+mod hash32_b64 {
+    use super::B64;
+    use base64::Engine as _;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8; 32], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&B64.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[u8; 32], D::Error> {
+        let s = String::deserialize(d)?;
+        let v = B64.decode(&s).map_err(serde::de::Error::custom)?;
+        v.try_into()
+            .map_err(|_| serde::de::Error::custom("expected 32-byte hash"))
+    }
+}
+
+mod hash32_opt_b64 {
+    use super::B64;
+    use base64::Engine as _;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &Option<[u8; 32]>, s: S) -> Result<S::Ok, S::Error> {
+        match bytes {
+            Some(b) => s.serialize_some(&B64.encode(b)),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<[u8; 32]>, D::Error> {
+        let opt: Option<String> = Option::deserialize(d)?;
+        match opt {
+            Some(s) => {
+                let v = B64.decode(&s).map_err(serde::de::Error::custom)?;
+                let arr = v
+                    .try_into()
+                    .map_err(|_| serde::de::Error::custom("expected 32-byte hash"))?;
+                Ok(Some(arr))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_envelope() -> AuditEnvelope {
+        AuditEnvelope {
+            event_id: Uuid::nil(),
+            event_version: EVENT_VERSION,
+            schema_version: SCHEMA_VERSION,
+            timestamp: DateTime::parse_from_rfc3339("2026-05-11T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            audit_key_id: KeyId::nil(),
+            actor_did_hash: [0xAB; 32],
+            actor_did_plain: Some("did:key:z6Mk".into()),
+            target_did_hash: Some([0xCD; 32]),
+            target_did_plain: Some("did:key:z6Mk2".into()),
+            event: AuditEvent::Generic {
+                kind: "TestEvent".into(),
+                payload: json!({ "answer": 42 }),
+            },
+        }
+    }
+
+    #[test]
+    fn envelope_roundtrips_through_serde() {
+        let e = sample_envelope();
+        let s = serde_json::to_string(&e).unwrap();
+        let back: AuditEnvelope = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, e);
+    }
+
+    #[test]
+    fn hashes_serialize_as_base64url_strings() {
+        let e = sample_envelope();
+        let v: serde_json::Value = serde_json::to_value(&e).unwrap();
+        // 32 bytes base64url-encoded with no padding = 43 chars
+        let actor = v["actor_did_hash"].as_str().unwrap();
+        assert_eq!(actor.len(), 43);
+        // All-0xAB bytes encode deterministically.
+        assert_eq!(actor, "q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s");
+        let target = v["target_did_hash"].as_str().unwrap();
+        assert_eq!(target.len(), 43);
+    }
+
+    #[test]
+    fn null_target_hash_omits_or_nulls_in_json() {
+        let mut e = sample_envelope();
+        e.target_did_hash = None;
+        e.target_did_plain = None;
+        let v: serde_json::Value = serde_json::to_value(&e).unwrap();
+        assert!(v["target_did_hash"].is_null());
+        assert!(v["target_did_plain"].is_null());
+    }
+
+    #[test]
+    fn rtbf_redaction_preserves_hashes() {
+        let mut e = sample_envelope();
+        // Simulate RTBF: null the plaintext, keep the hashes.
+        e.actor_did_plain = None;
+        e.target_did_plain = None;
+        let s = serde_json::to_string(&e).unwrap();
+        let back: AuditEnvelope = serde_json::from_str(&s).unwrap();
+        assert!(back.actor_did_plain.is_none());
+        assert!(back.target_did_plain.is_none());
+        assert_eq!(back.actor_did_hash, [0xAB; 32]);
+        assert_eq!(back.target_did_hash, Some([0xCD; 32]));
+    }
+}

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -1,0 +1,63 @@
+//! [`AuditEvent`] — the tagged enum of every audit-log variant.
+//!
+//! Currently a single `Generic` placeholder. Phase-0 variants
+//! (`CommunityInstalled`, `EmergencyBootstrapInvoked`,
+//! `AdminPasskeyRegistered`, `AdminPasskeyRevoked`, `ConfigChanged`,
+//! `ConfigReloaded`, `RestartRequested`, `CommunityProfileUpdated`,
+//! `AuditKeyRotated`) land in M0.1.5 once the corresponding
+//! lifecycle code arrives. Phase-1+ variants land alongside their
+//! features.
+//!
+//! The tagged enum form (`#[serde(tag = "type", content = "data")]`)
+//! is workspace doctrine — see spec §11.4. External consumers (SIEM,
+//! later webhooks) discriminate by the `type` field, so the variant
+//! identifiers are part of the wire contract: don't rename.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Audit-event payload. Tagged on the `type` field with the variant
+/// name and the variant's data under `data`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "data")]
+pub enum AuditEvent {
+    /// Placeholder for arbitrary structured payloads. Used by
+    /// pre-Phase-1 emitters that need to record an event before its
+    /// dedicated variant lands. New emitters should add a concrete
+    /// variant rather than reaching for `Generic`.
+    Generic {
+        /// Short identifier (e.g. `"ConfigBootstrap"`). Free-form for
+        /// now; will tighten when the full vocabulary lands.
+        kind: String,
+        /// Variant-specific structured data.
+        payload: Value,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn generic_round_trips_through_serde() {
+        let e = AuditEvent::Generic {
+            kind: "TestEvent".into(),
+            payload: json!({ "answer": 42 }),
+        };
+        let s = serde_json::to_string(&e).unwrap();
+        let back: AuditEvent = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, e);
+    }
+
+    #[test]
+    fn generic_wire_shape_is_tagged() {
+        let e = AuditEvent::Generic {
+            kind: "X".into(),
+            payload: json!(null),
+        };
+        let v: Value = serde_json::to_value(&e).unwrap();
+        assert_eq!(v["type"], "Generic");
+        assert_eq!(v["data"]["kind"], "X");
+    }
+}

--- a/vti-common/src/audit/key_store.rs
+++ b/vti-common/src/audit/key_store.rs
@@ -1,0 +1,401 @@
+//! `audit_key` lifecycle — HKDF-derived initial key, fresh-random
+//! rotations, indefinite retention.
+//!
+//! See plan **D3 + D10** in `tasks/vtc-mvp/plan.md` for the full
+//! rationale. Highlights:
+//!
+//! - **Algorithm**: HMAC-SHA256 over UTF-8 DID bytes.
+//! - **Initial key**: deterministic
+//!   `HKDF-SHA256(master_seed, info: "vtc-audit-key/v1")` — so a
+//!   backup+restore on the same master seed reproduces it.
+//! - **Subsequent rotations**: 32 fresh random bytes via `rand::fill`
+//!   (the workspace pattern; backed by the OS RNG). Deterministic
+//!   rotations would defeat the point of RTBF — a rotated key's
+//!   predecessor needs to be genuinely unrecoverable from the seed
+//!   alone.
+//! - **Retention**: every prior key stays in the keyspace under its
+//!   own `audit_key:<key_id>` entry. 32 bytes × one rotation/year ×
+//!   100 years = 3.2 KB. Lookups walk newest-first; the active key
+//!   answers the typical case and pre-rotation hashes only need
+//!   older keys during compliance investigations.
+//!
+//! ## Storage layout
+//!
+//! Two key spaces under the `audit_key` keyspace:
+//!
+//! - `audit_key:<key_id>` → [`AuditKey`] (JSON-encoded, encrypted via
+//!   the standard [`crate::store::KeyspaceHandle`] encryption layer
+//!   if the consumer enables it).
+//! - `audit_key:active` → `<key_id>` as bytes — the marker for the
+//!   currently-issuing key. Updated atomically on rotation.
+
+use chrono::{DateTime, Utc};
+use hkdf::Hkdf;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use uuid::Uuid;
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+/// Stable identifier for an audit_key. Wrapper around [`Uuid`] so
+/// public APIs stay typed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct KeyId(pub Uuid);
+
+impl KeyId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    pub fn nil() -> Self {
+        Self(Uuid::nil())
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+}
+
+impl Default for KeyId {
+    fn default() -> Self {
+        Self::nil()
+    }
+}
+
+impl std::fmt::Display for KeyId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Why an [`AuditKey`] was rotated. Recorded on the **successor** key
+/// so an investigator can tell why a particular epoch ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RotationReason {
+    /// Initial key derived from the master seed via HKDF. Always
+    /// present as the first row.
+    Initial,
+    /// Routine age-triggered rotation (the audit background task fired).
+    Routine,
+    /// Operator invoked the rotate CLI / endpoint.
+    Manual,
+    /// Right-to-be-forgotten override — the rotation closes the
+    /// previous epoch and makes its hashes opaque.
+    Rtbf,
+}
+
+/// A persisted audit_key. Stored under `audit_key:<key_id>`. Manual
+/// [`std::fmt::Debug`] redacts the key material so a stray
+/// `tracing::debug!(?key, …)` never leaks it.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AuditKey {
+    pub key_id: KeyId,
+    /// 32-byte HMAC-SHA256 key. Serialised as a JSON array of bytes;
+    /// in production the surrounding keyspace handle should be
+    /// configured with the workspace's standard encryption-at-rest
+    /// layer so the value never touches disk in the clear.
+    pub key: [u8; 32],
+    pub valid_from: DateTime<Utc>,
+    /// `None` for the currently-active key; populated on rotation.
+    pub valid_until: Option<DateTime<Utc>>,
+    pub rotation_reason: RotationReason,
+}
+
+impl std::fmt::Debug for AuditKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuditKey")
+            .field("key_id", &self.key_id)
+            .field("key", &"<redacted>")
+            .field("valid_from", &self.valid_from)
+            .field("valid_until", &self.valid_until)
+            .field("rotation_reason", &self.rotation_reason)
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+const ACTIVE_MARKER_KEY: &[u8] = b"audit_key:active";
+
+fn key_storage_key(key_id: &KeyId) -> Vec<u8> {
+    format!("audit_key:{}", key_id.0).into_bytes()
+}
+
+// ---------------------------------------------------------------------------
+// AuditKeyStore
+// ---------------------------------------------------------------------------
+
+/// Manager for the audit_key history under a single keyspace.
+///
+/// All methods are async because the underlying keyspace I/O is
+/// async. Concurrent rotations on the same store are *not*
+/// serialised in this layer — the caller (services) owns the
+/// invariant that rotation happens from a single coordinator path.
+#[derive(Clone)]
+pub struct AuditKeyStore {
+    ks: KeyspaceHandle,
+}
+
+impl AuditKeyStore {
+    /// Wrap a keyspace handle. The caller is responsible for
+    /// configuring encryption-at-rest if desired.
+    pub fn new(ks: KeyspaceHandle) -> Self {
+        Self { ks }
+    }
+
+    /// Read the currently active key. Returns
+    /// [`AppError::NotFound`] if no initial key has been derived yet
+    /// — callers should invoke [`Self::ensure_initial`] on boot.
+    pub async fn active(&self) -> Result<AuditKey, AppError> {
+        let id_bytes = self
+            .ks
+            .get_raw(ACTIVE_MARKER_KEY.to_vec())
+            .await?
+            .ok_or_else(|| {
+                AppError::NotFound(
+                    "no active audit_key; call ensure_initial(master_seed) first".into(),
+                )
+            })?;
+        let id_str = String::from_utf8(id_bytes)
+            .map_err(|e| AppError::Internal(format!("invalid audit_key id encoding: {e}")))?;
+        let key_id = KeyId(
+            Uuid::parse_str(&id_str)
+                .map_err(|e| AppError::Internal(format!("invalid audit_key uuid: {e}")))?,
+        );
+        self.fetch(&key_id).await?.ok_or_else(|| {
+            AppError::Internal(format!(
+                "active marker points at unknown audit_key {key_id}"
+            ))
+        })
+    }
+
+    /// Fetch a specific key by id. Used by verifiers walking history
+    /// to find the key that produced a given hash.
+    pub async fn fetch(&self, key_id: &KeyId) -> Result<Option<AuditKey>, AppError> {
+        self.ks.get(key_storage_key(key_id)).await
+    }
+
+    /// List every key in the store, newest first. Used by
+    /// `verify_actor`-style helpers in [`super::writer::AuditWriter`]
+    /// to walk history when the envelope's `audit_key_id` is
+    /// unavailable (defensive — every envelope written here has one).
+    pub async fn history(&self) -> Result<Vec<AuditKey>, AppError> {
+        let pairs = self.ks.prefix_iter_raw(b"audit_key:".to_vec()).await?;
+        let mut keys: Vec<AuditKey> = pairs
+            .into_iter()
+            .filter(|(k, _)| k.as_slice() != ACTIVE_MARKER_KEY)
+            .filter_map(|(_, v)| serde_json::from_slice::<AuditKey>(&v).ok())
+            .collect();
+        keys.sort_by_key(|k| std::cmp::Reverse(k.valid_from));
+        Ok(keys)
+    }
+
+    /// Derive the initial audit_key from `master_seed` and persist it.
+    /// Idempotent: if an initial key already exists, returns it
+    /// unchanged. Safe to call on every daemon start.
+    ///
+    /// The derivation is deterministic
+    /// (`HKDF-SHA256(master_seed, info: "vtc-audit-key/v1")`) so a
+    /// backup+restore on the same seed reproduces the initial key
+    /// and pre-rotation hashes stay verifiable.
+    pub async fn ensure_initial(&self, master_seed: &[u8]) -> Result<AuditKey, AppError> {
+        if let Some(existing) = self.try_active().await? {
+            return Ok(existing);
+        }
+
+        let mut key = [0u8; 32];
+        Hkdf::<Sha256>::new(None, master_seed)
+            .expand(b"vtc-audit-key/v1", &mut key)
+            .map_err(|e| AppError::Internal(format!("HKDF expand failed: {e}")))?;
+
+        let initial = AuditKey {
+            key_id: KeyId::new(),
+            key,
+            valid_from: Utc::now(),
+            valid_until: None,
+            rotation_reason: RotationReason::Initial,
+        };
+        self.persist(&initial).await?;
+        self.set_active(&initial.key_id).await?;
+        Ok(initial)
+    }
+
+    /// Rotate the active key. The previous key gets `valid_until: now`
+    /// and a fresh-random successor is generated + activated.
+    /// Returns the new active key.
+    ///
+    /// Concurrent rotations are **not** safe at this layer — the
+    /// caller must hold a logical exclusivity lock.
+    pub async fn rotate(&self, reason: RotationReason) -> Result<AuditKey, AppError> {
+        let now = Utc::now();
+        let mut prev = self.active().await?;
+        prev.valid_until = Some(now);
+        self.persist(&prev).await?;
+
+        let key = random_32_bytes();
+        let successor = AuditKey {
+            key_id: KeyId::new(),
+            key,
+            valid_from: now,
+            valid_until: None,
+            rotation_reason: reason,
+        };
+        self.persist(&successor).await?;
+        self.set_active(&successor.key_id).await?;
+        Ok(successor)
+    }
+
+    /// Look up the active marker without raising if it's absent.
+    async fn try_active(&self) -> Result<Option<AuditKey>, AppError> {
+        let id_bytes = match self.ks.get_raw(ACTIVE_MARKER_KEY.to_vec()).await? {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+        let id_str = String::from_utf8(id_bytes)
+            .map_err(|e| AppError::Internal(format!("invalid audit_key id encoding: {e}")))?;
+        let key_id = KeyId(
+            Uuid::parse_str(&id_str)
+                .map_err(|e| AppError::Internal(format!("invalid audit_key uuid: {e}")))?,
+        );
+        self.fetch(&key_id).await
+    }
+
+    async fn persist(&self, key: &AuditKey) -> Result<(), AppError> {
+        self.ks.insert(key_storage_key(&key.key_id), key).await
+    }
+
+    async fn set_active(&self, key_id: &KeyId) -> Result<(), AppError> {
+        self.ks
+            .insert_raw(
+                ACTIVE_MARKER_KEY.to_vec(),
+                key_id.0.to_string().into_bytes(),
+            )
+            .await
+    }
+}
+
+fn random_32_bytes() -> [u8; 32] {
+    let mut out = [0u8; 32];
+    rand::fill(&mut out);
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+
+    fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).expect("store");
+        let ks = store.keyspace("audit_key-test").expect("keyspace");
+        (ks, dir)
+    }
+
+    #[tokio::test]
+    async fn ensure_initial_is_deterministic() {
+        let (ks_a, _a) = temp_ks();
+        let (ks_b, _b) = temp_ks();
+        let seed = [0xAB; 32];
+
+        let store_a = AuditKeyStore::new(ks_a);
+        let store_b = AuditKeyStore::new(ks_b);
+
+        let a = store_a.ensure_initial(&seed).await.unwrap();
+        let b = store_b.ensure_initial(&seed).await.unwrap();
+
+        // Same seed → same HKDF output, even though the key_id /
+        // valid_from differ. The 32-byte key bytes are the load-bearing
+        // determinism.
+        assert_eq!(a.key, b.key);
+    }
+
+    #[tokio::test]
+    async fn ensure_initial_is_idempotent() {
+        let (ks, _dir) = temp_ks();
+        let store = AuditKeyStore::new(ks);
+
+        let first = store.ensure_initial(&[0x01; 32]).await.unwrap();
+        let second = store.ensure_initial(&[0x99; 32]).await.unwrap();
+
+        // The seed argument is *ignored* on the second call — once an
+        // initial key exists, ensure_initial returns it unchanged.
+        assert_eq!(first.key_id, second.key_id);
+        assert_eq!(first.key, second.key);
+    }
+
+    #[tokio::test]
+    async fn rotate_generates_fresh_random_and_closes_prior() {
+        let (ks, _dir) = temp_ks();
+        let store = AuditKeyStore::new(ks);
+
+        let initial = store.ensure_initial(&[0x33; 32]).await.unwrap();
+        assert_eq!(initial.rotation_reason, RotationReason::Initial);
+        assert!(initial.valid_until.is_none());
+
+        let rotated = store.rotate(RotationReason::Rtbf).await.unwrap();
+        assert_eq!(rotated.rotation_reason, RotationReason::Rtbf);
+        assert_ne!(rotated.key_id, initial.key_id);
+        assert_ne!(rotated.key, initial.key);
+        assert!(rotated.valid_until.is_none());
+
+        // Initial now has a `valid_until` populated.
+        let prior = store.fetch(&initial.key_id).await.unwrap().expect("prior");
+        assert!(prior.valid_until.is_some());
+
+        // Active reads return the successor.
+        let active = store.active().await.unwrap();
+        assert_eq!(active.key_id, rotated.key_id);
+    }
+
+    #[tokio::test]
+    async fn history_lists_newest_first() {
+        let (ks, _dir) = temp_ks();
+        let store = AuditKeyStore::new(ks);
+
+        let k1 = store.ensure_initial(&[0x33; 32]).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        let k2 = store.rotate(RotationReason::Routine).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        let k3 = store.rotate(RotationReason::Manual).await.unwrap();
+
+        let history = store.history().await.unwrap();
+        assert_eq!(history.len(), 3);
+        assert_eq!(history[0].key_id, k3.key_id);
+        assert_eq!(history[1].key_id, k2.key_id);
+        assert_eq!(history[2].key_id, k1.key_id);
+    }
+
+    #[tokio::test]
+    async fn active_is_not_found_before_initial() {
+        let (ks, _dir) = temp_ks();
+        let store = AuditKeyStore::new(ks);
+        let err = store.active().await.expect_err("no active key yet");
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn debug_redacts_key_material() {
+        let k = AuditKey {
+            key_id: KeyId::new(),
+            key: [0xAB; 32],
+            valid_from: Utc::now(),
+            valid_until: None,
+            rotation_reason: RotationReason::Initial,
+        };
+        let s = format!("{k:?}");
+        assert!(!s.contains("AB"), "key bytes leaked: {s}");
+        assert!(s.contains("<redacted>"), "missing redaction marker: {s}");
+    }
+}

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -1,0 +1,34 @@
+//! Audit log infrastructure — versioned envelope with HMAC-hashed
+//! actor / target identifiers and an in-store key history that
+//! survives right-to-be-forgotten rotations.
+//!
+//! See spec §11 of `docs/05-design-notes/vtc-mvp.md` for the design
+//! rationale. This crate ships the workspace-wide foundation; the
+//! Phase-0 audit-event vocabulary (`CommunityInstalled`,
+//! `AdminPasskeyRegistered`, `ConfigChanged`, …) lands in M0.1.5
+//! and gets folded into [`event::AuditEvent`] there.
+//!
+//! ## Module layout
+//!
+//! - [`event`] — the tagged [`AuditEvent`] enum. A single `Generic`
+//!   placeholder variant ships now; concrete variants are added per
+//!   the spec's event vocabulary as the rest of Phase 0 lands.
+//! - [`envelope`] — the [`AuditEnvelope`] wire shape (event id,
+//!   version, timestamps, HMAC-hashed + plaintext identifier pairs).
+//! - [`key_store`] — the [`AuditKeyStore`] managing per-community
+//!   `audit_key` history: HKDF-derived initial, fresh-random
+//!   rotations, indefinite retention so pre-rotation hashes stay
+//!   verifiable during compliance investigations.
+//! - [`writer`] — [`AuditWriter`] takes events + identifiers, hashes
+//!   the identifiers with the active key, and persists the envelope
+//!   into an `audit` keyspace.
+
+pub mod envelope;
+pub mod event;
+pub mod key_store;
+pub mod writer;
+
+pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
+pub use event::AuditEvent;
+pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
+pub use writer::AuditWriter;

--- a/vti-common/src/audit/writer.rs
+++ b/vti-common/src/audit/writer.rs
@@ -1,0 +1,306 @@
+//! [`AuditWriter`] — writes [`AuditEnvelope`]s using the active
+//! audit_key for actor/target hashing, plus a `verify_actor` helper
+//! that walks key history to confirm a candidate DID matches an
+//! envelope's hash.
+
+use chrono::Utc;
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
+use uuid::Uuid;
+
+use super::envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
+use super::event::AuditEvent;
+use super::key_store::AuditKeyStore;
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Computes the envelope key (`<rfc3339-timestamp>:<event_id>`) so a
+/// prefix-iter scan walks rows in time order. Visible to other
+/// modules for migration helpers.
+pub fn envelope_storage_key(env: &AuditEnvelope) -> Vec<u8> {
+    format!("{}:{}", env.timestamp.to_rfc3339(), env.event_id).into_bytes()
+}
+
+/// Persistent writer that combines an `audit` keyspace with the
+/// matching [`AuditKeyStore`]. Cheap to clone — every field is
+/// reference-counted internally.
+#[derive(Clone)]
+pub struct AuditWriter {
+    audit_ks: KeyspaceHandle,
+    key_store: AuditKeyStore,
+}
+
+impl AuditWriter {
+    pub fn new(audit_ks: KeyspaceHandle, key_store: AuditKeyStore) -> Self {
+        Self {
+            audit_ks,
+            key_store,
+        }
+    }
+
+    /// Write an audit event. Hashes `actor_did` (mandatory) and
+    /// `target_did` (optional) under the currently-active key,
+    /// returns the persisted envelope so callers can echo the
+    /// `event_id` back to their handlers.
+    ///
+    /// The `actor_did` is stored both as its HMAC hash and as
+    /// plaintext (for normal queries); RTBF code paths null the
+    /// plaintext separately, leaving the hash + envelope in place.
+    pub async fn write(
+        &self,
+        actor_did: &str,
+        target_did: Option<&str>,
+        event: AuditEvent,
+    ) -> Result<AuditEnvelope, AppError> {
+        let key = self.key_store.active().await?;
+
+        let actor_did_hash = hmac_did(&key.key, actor_did);
+        let target_did_hash = target_did.map(|d| hmac_did(&key.key, d));
+
+        let envelope = AuditEnvelope {
+            event_id: Uuid::new_v4(),
+            event_version: EVENT_VERSION,
+            schema_version: SCHEMA_VERSION,
+            timestamp: Utc::now(),
+            audit_key_id: key.key_id,
+            actor_did_hash,
+            actor_did_plain: Some(actor_did.to_string()),
+            target_did_hash,
+            target_did_plain: target_did.map(str::to_string),
+            event,
+        };
+
+        self.audit_ks
+            .insert(envelope_storage_key(&envelope), &envelope)
+            .await?;
+        Ok(envelope)
+    }
+
+    /// Verify that `candidate_did` matches the actor recorded on
+    /// `envelope`, even after the active key has rotated. Walks the
+    /// `audit_key` history to find the key referenced by
+    /// `envelope.audit_key_id`; an unknown id returns
+    /// `Ok(false)` (the corresponding key was garbage-collected or
+    /// the envelope is corrupt — either way the candidate does
+    /// not match).
+    pub async fn verify_actor(
+        &self,
+        envelope: &AuditEnvelope,
+        candidate_did: &str,
+    ) -> Result<bool, AppError> {
+        let key = match self.key_store.fetch(&envelope.audit_key_id).await? {
+            Some(k) => k,
+            None => return Ok(false),
+        };
+        let recomputed = hmac_did(&key.key, candidate_did);
+        Ok(constant_time_eq(&recomputed, &envelope.actor_did_hash))
+    }
+
+    /// Symmetric helper for the optional target DID.
+    pub async fn verify_target(
+        &self,
+        envelope: &AuditEnvelope,
+        candidate_did: &str,
+    ) -> Result<bool, AppError> {
+        let expected = match envelope.target_did_hash {
+            Some(h) => h,
+            None => return Ok(false),
+        };
+        let key = match self.key_store.fetch(&envelope.audit_key_id).await? {
+            Some(k) => k,
+            None => return Ok(false),
+        };
+        let recomputed = hmac_did(&key.key, candidate_did);
+        Ok(constant_time_eq(&recomputed, &expected))
+    }
+}
+
+fn hmac_did(key: &[u8; 32], did: &str) -> [u8; 32] {
+    let mut mac = HmacSha256::new_from_slice(key).expect("32-byte HMAC key");
+    mac.update(did.as_bytes());
+    mac.finalize().into_bytes().into()
+}
+
+/// Constant-time comparison so a side-channel observer can't learn
+/// match progress from response timing. `[u8; 32]` only.
+fn constant_time_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    let mut diff = 0u8;
+    for i in 0..32 {
+        diff |= a[i] ^ b[i];
+    }
+    diff == 0
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::key_store::RotationReason;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+    use serde_json::json;
+
+    struct Fixture {
+        writer: AuditWriter,
+        key_store: AuditKeyStore,
+        _dir: tempfile::TempDir,
+    }
+
+    fn fixture() -> Fixture {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).expect("store");
+        let audit_ks = store.keyspace("audit").expect("audit ks");
+        let key_ks = store.keyspace("audit_key").expect("audit_key ks");
+        let key_store = AuditKeyStore::new(key_ks);
+        let writer = AuditWriter::new(audit_ks, key_store.clone());
+        Fixture {
+            writer,
+            key_store,
+            _dir: dir,
+        }
+    }
+
+    fn sample_event() -> AuditEvent {
+        AuditEvent::Generic {
+            kind: "TestEvent".into(),
+            payload: json!({ "x": 1 }),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_persists_envelope_and_hashes_actor() {
+        let f = fixture();
+        f.key_store.ensure_initial(&[0x01; 32]).await.unwrap();
+
+        let env = f
+            .writer
+            .write("did:key:z6Mk", None, sample_event())
+            .await
+            .unwrap();
+
+        assert_eq!(env.event_version, EVENT_VERSION);
+        assert_eq!(env.schema_version, SCHEMA_VERSION);
+        assert_eq!(env.actor_did_plain.as_deref(), Some("did:key:z6Mk"));
+        assert!(env.target_did_hash.is_none());
+
+        // The hash is not the SHA-256 of the DID — it's HMAC-keyed.
+        // Concretely, it must differ from a plain SHA-256.
+        use sha2::Digest;
+        let plain_sha: [u8; 32] = sha2::Sha256::digest(b"did:key:z6Mk").into();
+        assert_ne!(env.actor_did_hash, plain_sha);
+    }
+
+    #[tokio::test]
+    async fn same_actor_same_key_yields_same_hash() {
+        let f = fixture();
+        f.key_store.ensure_initial(&[0x02; 32]).await.unwrap();
+
+        let a = f
+            .writer
+            .write("did:key:abc", None, sample_event())
+            .await
+            .unwrap();
+        let b = f
+            .writer
+            .write("did:key:abc", None, sample_event())
+            .await
+            .unwrap();
+        assert_eq!(a.actor_did_hash, b.actor_did_hash);
+        assert_eq!(a.audit_key_id, b.audit_key_id);
+    }
+
+    #[tokio::test]
+    async fn different_actors_yield_different_hashes() {
+        let f = fixture();
+        f.key_store.ensure_initial(&[0x03; 32]).await.unwrap();
+        let a = f
+            .writer
+            .write("did:key:alice", None, sample_event())
+            .await
+            .unwrap();
+        let b = f
+            .writer
+            .write("did:key:bob", None, sample_event())
+            .await
+            .unwrap();
+        assert_ne!(a.actor_did_hash, b.actor_did_hash);
+    }
+
+    #[tokio::test]
+    async fn rotation_changes_subsequent_hashes() {
+        let f = fixture();
+        f.key_store.ensure_initial(&[0x04; 32]).await.unwrap();
+        let before = f
+            .writer
+            .write("did:key:alice", None, sample_event())
+            .await
+            .unwrap();
+        f.key_store.rotate(RotationReason::Manual).await.unwrap();
+        let after = f
+            .writer
+            .write("did:key:alice", None, sample_event())
+            .await
+            .unwrap();
+        assert_ne!(before.actor_did_hash, after.actor_did_hash);
+        assert_ne!(before.audit_key_id, after.audit_key_id);
+    }
+
+    #[tokio::test]
+    async fn verify_actor_walks_history_across_rotation() {
+        let f = fixture();
+        f.key_store.ensure_initial(&[0x05; 32]).await.unwrap();
+
+        let pre = f
+            .writer
+            .write("did:key:alice", None, sample_event())
+            .await
+            .unwrap();
+        f.key_store.rotate(RotationReason::Routine).await.unwrap();
+        let post = f
+            .writer
+            .write("did:key:bob", None, sample_event())
+            .await
+            .unwrap();
+
+        // Pre-rotation envelope still verifies against alice via the
+        // retained prior key.
+        assert!(f.writer.verify_actor(&pre, "did:key:alice").await.unwrap());
+        assert!(!f.writer.verify_actor(&pre, "did:key:bob").await.unwrap());
+
+        // Post-rotation envelope verifies against bob via the new key.
+        assert!(f.writer.verify_actor(&post, "did:key:bob").await.unwrap());
+        assert!(!f.writer.verify_actor(&post, "did:key:alice").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn target_hash_set_when_target_supplied() {
+        let f = fixture();
+        f.key_store.ensure_initial(&[0x06; 32]).await.unwrap();
+        let env = f
+            .writer
+            .write("did:key:admin", Some("did:key:member"), sample_event())
+            .await
+            .unwrap();
+        assert!(env.target_did_hash.is_some());
+        assert!(
+            f.writer
+                .verify_target(&env, "did:key:member")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !f.writer
+                .verify_target(&env, "did:key:somebody-else")
+                .await
+                .unwrap()
+        );
+    }
+}

--- a/vti-common/src/lib.rs
+++ b/vti-common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod acl;
+pub mod audit;
 pub mod auth;
 pub mod config;
 pub mod error;


### PR DESCRIPTION
## Summary

Implements **M0.1.2** of the VTC MVP Phase 0 plan. Adds the workspace-wide audit-log primitive that every endpoint emits into, plus the per-community `audit_key` lifecycle that backs HMAC identifier hashing.

## What's in this PR

New module `vti_common::audit`:

- **`event::AuditEvent`** — tagged enum (`#[serde(tag = "type", content = "data")]`). Ships a single `Generic { kind, payload }` placeholder; concrete variants land in M0.1.5 as the rest of Phase 0 emits events.
- **`envelope::AuditEnvelope`** — wire-stable shape per spec §11.1. Carries event id, per-variant + envelope schema versions, timestamp, HMAC-hashed + plaintext pairs for actor and (optional) target identifiers. 32-byte hashes serialise as base64url strings.
- **`key_store::AuditKeyStore`** — per-community key history under an `audit_key` keyspace.
  - Initial key derived via `HKDF-SHA256(master_seed, info: "vtc-audit-key/v1")` — deterministic so backup+restore reproduces it.
  - Rotations generate fresh random 32 bytes via `rand::fill`. **Not deterministic** — defeats the point of RTBF if a rotated key's predecessor could be recovered from the seed alone.
  - Every prior key retained indefinitely (32 bytes × ~one rotation/year = trivial storage) and exposed via `fetch(key_id)` / `history()` so verifiers can confirm pre-rotation hashes during compliance investigations.
  - Active marker (`audit_key:active`) updated atomically on rotation.
  - Per plan **D3 + D10**.
- **`writer::AuditWriter`** — combines an `audit` keyspace with the matching `AuditKeyStore`.
  - `write(actor, target?, event)` hashes both DIDs under the active key, persists the envelope keyed by `<rfc3339-timestamp>:<event_id>` for time-ordered scans, returns the envelope.
  - `verify_actor` / `verify_target` walk the key history to validate hashes after rotation — constant-time byte comparison so timing observers can't learn match progress.
- Manual `Debug` redaction of `AuditKey.key` per plan **D13**.

## Workspace + crate plumbing

- New workspace dep `hmac = "0.13"` (aligns with existing `sha2 = "0.11"`).
- `vti-common` dep block reshape:
  - `hmac`, `hkdf`, `uuid`, `base64`, `rand` promoted to **non-optional** — audit needs them workspace-wide.
  - `encryption` feature no longer lists `dep:rand` (rand is now always available).
  - `passkey` feature no longer lists `dep:uuid` / `dep:rand` for the same reason.
- `base64` removed from `[dev-dependencies]` (now in main `[dependencies]`).

## Test coverage (18 new tests, all green)

| Area | Tests |
|---|---|
| `AuditEvent` serde | Tagged round-trip; wire-shape uses `type` + `data`. |
| `AuditEnvelope` | Full round-trip; hashes encode as 43-char base64url strings; null target hash serialises as JSON `null`; **RTBF redaction preserves hashes**. |
| `AuditKeyStore` | HKDF determinism (same seed → same initial key across fresh stores); `ensure_initial` idempotent; rotation generates distinct key and closes prior with `valid_until`; history orders newest-first; absent-marker → `NotFound`; `Debug` redacts key material. |
| `AuditWriter` | Hash differs from plain SHA-256 (proves HMAC keying); same actor + same key yields stable hash; different actors → different hashes; rotation changes subsequent hashes + `audit_key_id`; **`verify_actor` walks history correctly across one rotation**; target hash set + verifiable. |

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo test --package vti-common` — 109 unit tests + 14 integration tests pass.
- [x] `cargo test --package vti-common audit::` — 18/18 new tests pass.
- [x] `cargo clippy --package vti-common --features "passkey encryption" -- -D warnings` — clean across feature combos.
- [x] `cargo fmt --check` — clean.

## Notes

- Concurrent rotations on the same `AuditKeyStore` are **not** serialised at this layer — services own the invariant that rotation runs from a single coordinator path. This is consistent with the spec's design (RTBF + manual rotations are admin-coordinated; routine rotation runs from a single background task).
- The audit secret `audit_key` is encrypted at rest only if the consumer configures the surrounding `KeyspaceHandle` with the standard encryption layer. Service-level setup (M0.7 / M0.8) will wire this in.