### PR TITLE
feat(vti-common): idempotency keyspace + middleware

### DIFF
--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -96,7 +96,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 - **Deps**: M0.1.0
 - **Pre-impl decision**: D3 (audit_key storage)
 
-### `[ ]` M0.1.3 — Idempotency keyspace + middleware
+### `[x]` M0.1.3 — Idempotency keyspace + middleware
 
 - **Acceptance**
   - `IdempotencyClass` enum: `NonDestructive` (24 h TTL) and

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -24,7 +24,7 @@ cli-synthesis = []
 # `AppState` and gain reusable enrolment + login storage primitives. The
 # concrete route handlers ship in a follow-up so this feature stays
 # storage-only for now.
-passkey = ["dep:webauthn-rs", "dep:url", "dep:hex"]
+passkey = ["dep:webauthn-rs", "dep:url"]
 
 [dependencies]
 async-trait = "0.1"
@@ -45,6 +45,11 @@ hkdf = { workspace = true }
 rand = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
+hex = { workspace = true }
+# Idempotency middleware buffers request + response bodies (bounded by
+# `MAX_BODY_BYTES`) so it can hash inputs + cache outputs.
+http-body-util = "0.1"
+bytes = "1"
 
 # Secrets resolver (for error type)
 affinidi-tdk = { workspace = true }
@@ -58,11 +63,11 @@ zeroize = { version = "1", features = ["derive"], optional = true }
 tokio-vsock = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
 
-# Passkey feature deps (`rand` already declared above for `encryption`;
-# `uuid` is non-optional and lives in the main dep block).
+# Passkey feature deps. `rand` / `uuid` / `hex` are non-optional and
+# live in the main dep block since audit + idempotency need them
+# unconditionally.
 webauthn-rs = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
-hex = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/vti-common/src/error.rs
+++ b/vti-common/src/error.rs
@@ -67,6 +67,14 @@ pub enum AppError {
     #[error("malformed Trust-Task identifier: {0}")]
     TrustTaskMalformed(String),
 
+    /// A request reused an `Idempotency-Key` it had previously sent
+    /// with a *different* body hash. The cached response is preserved
+    /// for the original requester; the conflicting retry is rejected
+    /// with 422 so clients don't silently get a stale response from a
+    /// drifting payload.
+    #[error("Idempotency-Key conflict: same key, different request body")]
+    IdempotencyKeyConflict,
+
     /// Catch-all for service-specific errors (e.g., KeyDerivation, BadGateway, TeeAttestation).
     /// Services create helper functions to construct these with appropriate status codes.
     #[error("{message}")]
@@ -114,6 +122,7 @@ impl IntoResponse for AppError {
             AppError::TrustTaskMissing => StatusCode::BAD_REQUEST,
             AppError::TrustTaskMismatch { .. } => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             AppError::TrustTaskMalformed(_) => StatusCode::BAD_REQUEST,
+            AppError::IdempotencyKeyConflict => StatusCode::UNPROCESSABLE_ENTITY,
             AppError::ServiceError { status, .. } => *status,
             AppError::Vsock { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         };
@@ -143,6 +152,10 @@ impl IntoResponse for AppError {
                 "error": "TrustTaskMalformed",
                 "message": self.to_string(),
                 "received": value,
+            }),
+            AppError::IdempotencyKeyConflict => serde_json::json!({
+                "error": "IdempotencyKeyConflict",
+                "message": self.to_string(),
             }),
             _ => serde_json::json!({ "error": self.to_string() }),
         };

--- a/vti-common/src/idempotency/class.rs
+++ b/vti-common/src/idempotency/class.rs
@@ -1,0 +1,46 @@
+//! [`IdempotencyClass`] — the op-class enum that drives cache TTL.
+
+use serde::{Deserialize, Serialize};
+
+/// Op class for an idempotent route, set explicitly at registration
+/// time (plan **D6**: clarity over cleverness; no heuristic on HTTP
+/// method).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum IdempotencyClass {
+    /// Standard create / update / read. Cached for 24 h —
+    /// long retry window for offline-then-online clients.
+    NonDestructive,
+
+    /// Delete / revoke / destructive mutation. Cached for **60 s only**
+    /// so a network-flake retry returns the same outcome but a later
+    /// intentional re-creation under the same UUID isn't silently
+    /// no-op'd against a freshly-deleted target.
+    Destructive,
+}
+
+impl IdempotencyClass {
+    /// Cache lifetime in seconds. Pinned in code rather than config
+    /// to keep the semantic boundary between the two classes obvious
+    /// — operators don't tune it.
+    pub fn ttl_seconds(self) -> u64 {
+        match self {
+            Self::NonDestructive => 24 * 60 * 60,
+            Self::Destructive => 60,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_destructive_caches_for_24_hours() {
+        assert_eq!(IdempotencyClass::NonDestructive.ttl_seconds(), 86_400);
+    }
+
+    #[test]
+    fn destructive_caches_for_60_seconds() {
+        assert_eq!(IdempotencyClass::Destructive.ttl_seconds(), 60);
+    }
+}

--- a/vti-common/src/idempotency/middleware.rs
+++ b/vti-common/src/idempotency/middleware.rs
@@ -1,0 +1,470 @@
+//! Axum middleware that implements the `Idempotency-Key` cache.
+//!
+//! Wired in via [`axum::middleware::from_fn_with_state`] using
+//! [`IdempotencyLayerState`] for the captured store + class. The
+//! middleware buffers both the request body (for hashing) and the
+//! response body (for caching), so consumers attaching it to a route
+//! MUST ensure the route's expected body fits inside
+//! [`MAX_BODY_BYTES`] (1 MB — matches the workspace's global cap,
+//! spec §14.4).
+//!
+//! # Flow
+//!
+//! 1. Request arrives; pull `Idempotency-Key` header. **Absent →
+//!    pass through.** Idempotency keys are optional per the spec
+//!    (only retries need them).
+//! 2. Derive [`Principal`] from request parts (Auth-token bytes
+//!    hashed, else IP, else anonymous).
+//! 3. Buffer the request body and hash it.
+//! 4. Look up `(principal, key)` in the store:
+//!    - Hit, request hash matches → **replay** the cached response.
+//!    - Hit, request hash differs → 422 [`AppError::IdempotencyKeyConflict`].
+//!    - Miss → forward to inner service.
+//! 5. After the inner service responds, buffer + store the response,
+//!    then return it unchanged. Storage failures are logged but **do
+//!    not** fail the request — a cache miss is always survivable.
+
+use axum::body::{Body, Bytes};
+use axum::extract::{Request, State};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Response, StatusCode};
+use axum::middleware::Next;
+use chrono::{Duration, Utc};
+use http_body_util::BodyExt;
+use sha2::{Digest, Sha256};
+use tracing::{debug, warn};
+
+use super::class::IdempotencyClass;
+use super::store::{CacheEntry, IdempotencyStore, principal_from_request};
+use crate::error::AppError;
+
+/// Canonical `Idempotency-Key` HTTP header name.
+pub const IDEMPOTENCY_HEADER: &str = "Idempotency-Key";
+
+/// Hard cap on request + response body sizes the middleware will
+/// buffer. Matches the workspace's global 1 MB body cap. Routes whose
+/// bodies legitimately exceed this (e.g. website upload) should not
+/// attach the idempotency layer.
+pub const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// State passed to [`idempotency_middleware`] via
+/// [`axum::middleware::from_fn_with_state`]. Cheap to clone — the
+/// underlying [`IdempotencyStore`] is `Arc`-shared.
+#[derive(Clone)]
+pub struct IdempotencyLayerState {
+    pub store: IdempotencyStore,
+    pub class: IdempotencyClass,
+}
+
+/// Axum-compatible middleware function. Wire this in via
+/// [`axum::middleware::from_fn_with_state`] (the workspace's
+/// canonical state-capturing-middleware pattern):
+///
+/// ```ignore
+/// use axum::middleware::from_fn_with_state;
+/// use vti_common::idempotency::{
+///     idempotency_middleware, IdempotencyLayerState, IdempotencyClass,
+/// };
+///
+/// let state = IdempotencyLayerState {
+///     store: store.clone(),
+///     class: IdempotencyClass::Destructive,
+/// };
+/// router.route_with_task(
+///     "/v1/members/{did}",
+///     delete(remove_handler)
+///         .layer(from_fn_with_state(state, idempotency_middleware)),
+///     task,
+/// )
+/// ```
+pub async fn idempotency_middleware(
+    State(state): State<IdempotencyLayerState>,
+    request: Request,
+    next: Next,
+) -> Result<Response<Body>, AppError> {
+    run(state.store, state.class, request, next).await
+}
+
+async fn run(
+    store: IdempotencyStore,
+    class: IdempotencyClass,
+    request: Request,
+    next: Next,
+) -> Result<Response<Body>, AppError> {
+    // 1. Header present?
+    let idempotency_key = match request
+        .headers()
+        .get(IDEMPOTENCY_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+    {
+        Some(k) if !k.is_empty() => k,
+        // No key, or empty → pass straight through. Optional header.
+        _ => return Ok(next.run(request).await),
+    };
+
+    // Reject control characters in the key — they would corrupt the
+    // storage key (`idem:<hash>:<key>`) and could mask cache entries.
+    if idempotency_key
+        .chars()
+        .any(|c| c.is_control() || c == ':' || c == '\n' || c == '\r')
+    {
+        return Err(AppError::Validation(format!(
+            "Idempotency-Key contains a disallowed character: {:?}",
+            idempotency_key
+        )));
+    }
+
+    // 2. Derive principal.
+    let (parts, body) = request.into_parts();
+    let principal = principal_from_request(&parts);
+    let principal_hash = principal.hash();
+
+    // 3. Buffer + hash the request body.
+    let body_bytes = collect_body(body).await?;
+    let request_hash = sha256(&body_bytes);
+
+    // 4. Cache lookup.
+    if let Some(existing) = store.get(&principal_hash, &idempotency_key).await? {
+        if existing.request_hash == request_hash {
+            debug!(
+                idempotency_key = %idempotency_key,
+                "serving cached idempotent response"
+            );
+            return rebuild_response(&existing);
+        }
+        warn!(
+            idempotency_key = %idempotency_key,
+            "Idempotency-Key conflict — same key, different request body"
+        );
+        return Err(AppError::IdempotencyKeyConflict);
+    }
+
+    // 5. Forward to handler.
+    let request = Request::from_parts(parts, Body::from(body_bytes));
+    let response = next.run(request).await;
+
+    // Cache the response. Storage failures are non-fatal — they just
+    // mean a retry will hit the handler again rather than serve from
+    // cache. We log and proceed.
+    let (resp_parts, resp_body) = response.into_parts();
+    let resp_bytes = match collect_body(resp_body).await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(error = %e, "could not buffer response for idempotency cache; skipping cache");
+            // Re-emit a response with an empty body — the original is
+            // gone. The caller still sees the status + headers.
+            return Ok(Response::from_parts(resp_parts, Body::empty()));
+        }
+    };
+
+    let now = Utc::now();
+    let entry = CacheEntry {
+        idempotency_key: idempotency_key.clone(),
+        request_hash,
+        response_status: resp_parts.status.as_u16(),
+        response_headers: capture_headers(&resp_parts.headers),
+        response_body: resp_bytes.to_vec(),
+        class,
+        created_at: now,
+        expires_at: now + Duration::seconds(class.ttl_seconds() as i64),
+    };
+    if let Err(e) = store.put(&principal_hash, &entry).await {
+        warn!(error = %e, "idempotency cache write failed; response will not be replayed on retry");
+    }
+
+    let mut rebuilt = Response::new(Body::from(resp_bytes));
+    *rebuilt.status_mut() = resp_parts.status;
+    *rebuilt.headers_mut() = resp_parts.headers;
+    Ok(rebuilt)
+}
+
+async fn collect_body(body: Body) -> Result<Bytes, AppError> {
+    let bytes = http_body_util::Limited::new(body, MAX_BODY_BYTES)
+        .collect()
+        .await
+        .map_err(|e| AppError::Validation(format!("body exceeds idempotency buffer limit: {e}")))?
+        .to_bytes();
+    Ok(bytes)
+}
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+fn capture_headers(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .filter_map(|(k, v)| match v.to_str() {
+            Ok(value) => Some((k.as_str().to_string(), value.to_string())),
+            Err(_) => {
+                // Non-UTF-8 header values (rare) can't round-trip through
+                // our cache. Drop them with a warning rather than fail
+                // the response.
+                warn!(header = %k, "skipping non-UTF-8 response header in idempotency cache");
+                None
+            }
+        })
+        .collect()
+}
+
+fn rebuild_response(entry: &CacheEntry) -> Result<Response<Body>, AppError> {
+    let mut response = Response::new(Body::from(entry.response_body.clone()));
+    *response.status_mut() = StatusCode::from_u16(entry.response_status)
+        .map_err(|e| AppError::Internal(format!("invalid cached status: {e}")))?;
+    for (name, value) in &entry.response_headers {
+        let name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|e| AppError::Internal(format!("invalid cached header name: {e}")))?;
+        let value = HeaderValue::from_str(value)
+            .map_err(|e| AppError::Internal(format!("invalid cached header value: {e}")))?;
+        response.headers_mut().insert(name, value);
+    }
+    Ok(response)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+    use axum::Router;
+    use axum::http::Request as HttpRequest;
+    use axum::routing::post;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use tower::ServiceExt;
+
+    fn temp_store() -> (IdempotencyStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).expect("store");
+        let ks = store.keyspace("idempotency-mw-test").expect("ks");
+        (IdempotencyStore::new(ks), dir)
+    }
+
+    /// Test handler that counts invocations and echoes the request
+    /// body in a JSON response.
+    fn counted_router(
+        store: IdempotencyStore,
+        class: IdempotencyClass,
+        counter: Arc<AtomicU32>,
+    ) -> Router {
+        let state = IdempotencyLayerState { store, class };
+        Router::new().route(
+            "/",
+            post({
+                let counter = counter.clone();
+                move |body: Bytes| {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        Response::builder()
+                            .status(StatusCode::CREATED)
+                            .header("content-type", "application/json")
+                            .body(Body::from(format!(
+                                r#"{{"echo":"{}"}}"#,
+                                String::from_utf8_lossy(&body)
+                            )))
+                            .unwrap()
+                    }
+                }
+            })
+            .layer(axum::middleware::from_fn_with_state(
+                state,
+                idempotency_middleware,
+            )),
+        )
+    }
+
+    fn req_with_key(key: Option<&str>, body: &str) -> HttpRequest<Body> {
+        let mut builder = HttpRequest::builder().method("POST").uri("/");
+        if let Some(k) = key {
+            builder = builder.header(IDEMPOTENCY_HEADER, k);
+        }
+        builder
+            .header("authorization", "Bearer test-token")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    async fn body_text(resp: Response<Body>) -> (StatusCode, String) {
+        let status = resp.status();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        (status, String::from_utf8(bytes.to_vec()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn no_header_passes_through_and_does_not_cache() {
+        let (store, _dir) = temp_store();
+        let counter = Arc::new(AtomicU32::new(0));
+        let app = counted_router(
+            store.clone(),
+            IdempotencyClass::NonDestructive,
+            counter.clone(),
+        );
+
+        // Two requests, neither carries a key: handler called twice.
+        for body in ["one", "two"] {
+            let resp = app.clone().oneshot(req_with_key(None, body)).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::CREATED);
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn same_key_same_body_replays_cached_response() {
+        let (store, _dir) = temp_store();
+        let counter = Arc::new(AtomicU32::new(0));
+        let app = counted_router(
+            store.clone(),
+            IdempotencyClass::NonDestructive,
+            counter.clone(),
+        );
+
+        let first = app
+            .clone()
+            .oneshot(req_with_key(Some("abc-123"), "payload"))
+            .await
+            .unwrap();
+        let (status1, body1) = body_text(first).await;
+        assert_eq!(status1, StatusCode::CREATED);
+        assert!(body1.contains("payload"));
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        let second = app
+            .clone()
+            .oneshot(req_with_key(Some("abc-123"), "payload"))
+            .await
+            .unwrap();
+        let (status2, body2) = body_text(second).await;
+        assert_eq!(status2, StatusCode::CREATED);
+        assert_eq!(body2, body1, "cached body should match");
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "handler should not be re-invoked"
+        );
+    }
+
+    #[tokio::test]
+    async fn same_key_different_body_returns_422() {
+        let (store, _dir) = temp_store();
+        let counter = Arc::new(AtomicU32::new(0));
+        let app = counted_router(
+            store.clone(),
+            IdempotencyClass::NonDestructive,
+            counter.clone(),
+        );
+
+        let _first = app
+            .clone()
+            .oneshot(req_with_key(Some("key-x"), "body-A"))
+            .await
+            .unwrap();
+        let second = app
+            .clone()
+            .oneshot(req_with_key(Some("key-x"), "body-B"))
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        let (_, body) = body_text(second).await;
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["error"], "IdempotencyKeyConflict");
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "second handler call must be rejected pre-handler"
+        );
+    }
+
+    #[tokio::test]
+    async fn destructive_class_caches_for_60s_only() {
+        let (store, _dir) = temp_store();
+        let counter = Arc::new(AtomicU32::new(0));
+        let app = counted_router(
+            store.clone(),
+            IdempotencyClass::Destructive,
+            counter.clone(),
+        );
+
+        let resp = app
+            .clone()
+            .oneshot(req_with_key(Some("d-1"), "del"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // Cache entry has the short TTL.
+        let principal =
+            super::super::store::Principal::AuthToken(b"Bearer test-token".to_vec()).hash();
+        let entry = store.get(&principal, "d-1").await.unwrap().unwrap();
+        assert_eq!(entry.class, IdempotencyClass::Destructive);
+        let ttl = (entry.expires_at - entry.created_at).num_seconds();
+        assert!((59..=61).contains(&ttl), "ttl was {ttl}s");
+    }
+
+    #[tokio::test]
+    async fn different_principals_have_separate_caches() {
+        let (store, _dir) = temp_store();
+        let counter = Arc::new(AtomicU32::new(0));
+        let app = counted_router(
+            store.clone(),
+            IdempotencyClass::NonDestructive,
+            counter.clone(),
+        );
+
+        // Alice
+        let a = HttpRequest::builder()
+            .method("POST")
+            .uri("/")
+            .header(IDEMPOTENCY_HEADER, "shared-key")
+            .header("authorization", "Bearer alice")
+            .body(Body::from("a"))
+            .unwrap();
+        let _ = app.clone().oneshot(a).await.unwrap();
+
+        // Bob using the same idempotency-key but a different bearer
+        let b = HttpRequest::builder()
+            .method("POST")
+            .uri("/")
+            .header(IDEMPOTENCY_HEADER, "shared-key")
+            .header("authorization", "Bearer bob")
+            .body(Body::from("b"))
+            .unwrap();
+        let resp = app.clone().oneshot(b).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // Both reached the handler — same key, different principals
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn idempotency_key_with_control_chars_rejected() {
+        let (store, _dir) = temp_store();
+        let counter = Arc::new(AtomicU32::new(0));
+        let app = counted_router(
+            store.clone(),
+            IdempotencyClass::NonDestructive,
+            counter.clone(),
+        );
+
+        let bad = HttpRequest::builder()
+            .method("POST")
+            .uri("/")
+            .header(IDEMPOTENCY_HEADER, "evil:injected")
+            .header("authorization", "Bearer test")
+            .body(Body::from("x"))
+            .unwrap();
+        let resp = app.clone().oneshot(bad).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+    }
+}

--- a/vti-common/src/idempotency/mod.rs
+++ b/vti-common/src/idempotency/mod.rs
@@ -1,0 +1,55 @@
+//! `Idempotency-Key` header support.
+//!
+//! Implements **M0.1.3** of the VTC MVP Phase 0 plan. Every mutating
+//! endpoint accepts an optional `Idempotency-Key` header — the workspace
+//! caches `(principal, key) → response` so safe retries return the
+//! original outcome instead of creating duplicate state.
+//!
+//! ## Key design properties (spec §9.1 + plan D6)
+//!
+//! - **Cache key is scoped by principal, never global.** A second
+//!   principal that re-uses the same idempotency value gets its own
+//!   cache namespace — no cross-principal leakage of cached responses.
+//!   The principal identifier is derived from the Authorization
+//!   header (hashed) on authenticated requests, or the source IP on
+//!   unauthenticated routes. See [`Principal`] for the full
+//!   derivation.
+//! - **TTL discriminates by op class.** [`IdempotencyClass::NonDestructive`]
+//!   caches for 24 h (standard create/update retry window).
+//!   [`IdempotencyClass::Destructive`] caches for 60 s only — long
+//!   enough to absorb a network-flake retry, short enough that a
+//!   later (intentional) re-create with the same UUID is not
+//!   accidentally treated as a no-op against an already-deleted
+//!   target.
+//! - **Same key + different body → 422 `IdempotencyKeyConflict`.**
+//!   Prevents a drifting payload from silently returning a stale
+//!   cached response.
+//! - **Annotation is explicit per-route.** No heuristic on HTTP
+//!   method (`DELETE /idempotency/{key}` is itself a meta-op). Each
+//!   route opts in to a class at registration via
+//!   [`crate::trust_task::TrustTaskRouter::route_idempotent`] (added
+//!   to the router builder when the consuming service wires this in).
+//!
+//! ## What's NOT in this module yet
+//!
+//! - **Target-state revalidation for `Destructive`**: the spec calls
+//!   for the destructive class to re-check that the cached response
+//!   still describes accurate state before serving it (e.g. a cached
+//!   delete returning 204 after the target has been re-created
+//!   should *not* be served). Plumbed-through as an optional closure
+//!   on the [`store::IdempotencyStore`] in a follow-up; MVP ships
+//!   TTL-only.
+//! - **Background eviction sweeper**: expired entries are filtered
+//!   out at read time (no stale responses ever served). A sweeper
+//!   that reclaims their disk space lands alongside the audit-log
+//!   pruner in a later phase.
+
+pub mod class;
+pub mod middleware;
+pub mod store;
+
+pub use class::IdempotencyClass;
+pub use middleware::{
+    IDEMPOTENCY_HEADER, IdempotencyLayerState, MAX_BODY_BYTES, idempotency_middleware,
+};
+pub use store::{CacheEntry, IdempotencyStore, Principal, principal_from_request};

--- a/vti-common/src/idempotency/store.rs
+++ b/vti-common/src/idempotency/store.rs
@@ -1,0 +1,260 @@
+//! Persistent idempotency cache: `(principal, key) → CacheEntry`.
+
+use std::net::IpAddr;
+
+use axum::extract::ConnectInfo;
+use axum::http::request::Parts;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::class::IdempotencyClass;
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+/// Identifier scoping the idempotency cache. **Never plaintext on
+/// disk** — the principal bytes are hashed and the hash becomes part
+/// of the storage key. Different principals therefore inhabit
+/// disjoint namespaces.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Principal {
+    /// Authenticated request — principal is the bearer credential
+    /// itself (hashed at storage time, never persisted in the clear).
+    /// Different tokens are different principals; token rotation
+    /// resets the cache namespace (conservatively).
+    AuthToken(Vec<u8>),
+    /// Unauthenticated request scoped to the source IP. Phase-0
+    /// unauth surfaces are `/v1/join-requests` and `/v1/install/*`;
+    /// the IP-scoping prevents one IP's idempotent retry returning
+    /// another IP's cached response.
+    Ip(IpAddr),
+    /// Fallback when neither Authorization nor `ConnectInfo` is
+    /// available (e.g. unit tests). Cache is effectively shared
+    /// across anonymous callers — acceptable because no Phase-0
+    /// production path lacks both signals.
+    Anonymous,
+}
+
+impl Principal {
+    /// 32-byte hash of the principal — the actual cache namespace.
+    /// Stable across calls; equal `Principal`s hash to equal bytes.
+    pub fn hash(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        match self {
+            Principal::AuthToken(bytes) => {
+                hasher.update(b"auth-token:");
+                hasher.update(bytes);
+            }
+            Principal::Ip(ip) => {
+                hasher.update(b"ip:");
+                hasher.update(ip.to_string().as_bytes());
+            }
+            Principal::Anonymous => {
+                hasher.update(b"anonymous");
+            }
+        }
+        hasher.finalize().into()
+    }
+}
+
+/// Derive a [`Principal`] from request parts.
+///
+/// Prefers the Authorization header (hashed) when present, falls
+/// back to `ConnectInfo<SocketAddr>` (which Axum populates from
+/// `into_make_service_with_connect_info`), and finally to
+/// [`Principal::Anonymous`].
+///
+/// Public so a service can inspect / log the principal without
+/// re-implementing the precedence.
+pub fn principal_from_request(parts: &Parts) -> Principal {
+    if let Some(auth) = parts.headers.get(axum::http::header::AUTHORIZATION) {
+        return Principal::AuthToken(auth.as_bytes().to_vec());
+    }
+    if let Some(ConnectInfo(addr)) = parts.extensions.get::<ConnectInfo<std::net::SocketAddr>>() {
+        return Principal::Ip(addr.ip());
+    }
+    Principal::Anonymous
+}
+
+// ---------------------------------------------------------------------------
+// Cache entry
+// ---------------------------------------------------------------------------
+
+/// Persisted cache record. The response is held in full so a retry
+/// reproduces every header + body byte the original delivered.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CacheEntry {
+    pub idempotency_key: String,
+    /// SHA-256 over the request body. Differing hashes for the same
+    /// `(principal, key)` cause [`AppError::IdempotencyKeyConflict`].
+    pub request_hash: [u8; 32],
+    pub response_status: u16,
+    pub response_headers: Vec<(String, String)>,
+    pub response_body: Vec<u8>,
+    pub class: IdempotencyClass,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+impl CacheEntry {
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        self.expires_at <= now
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IdempotencyStore
+// ---------------------------------------------------------------------------
+
+/// Wraps an `idempotency` keyspace. Cheap to clone — the underlying
+/// keyspace handle is `Arc`-shared.
+#[derive(Clone)]
+pub struct IdempotencyStore {
+    ks: KeyspaceHandle,
+}
+
+impl IdempotencyStore {
+    pub fn new(ks: KeyspaceHandle) -> Self {
+        Self { ks }
+    }
+
+    /// Look up an existing entry. **Expired entries are treated as
+    /// absent** so a long-stale cached response is never served, even
+    /// if a background sweeper hasn't yet reclaimed the disk space.
+    pub async fn get(
+        &self,
+        principal_hash: &[u8; 32],
+        key: &str,
+    ) -> Result<Option<CacheEntry>, AppError> {
+        let storage_key = storage_key(principal_hash, key);
+        let entry: Option<CacheEntry> = self.ks.get(storage_key).await?;
+        let now = Utc::now();
+        Ok(entry.filter(|e| !e.is_expired(now)))
+    }
+
+    /// Insert or replace a cache entry. Caller is responsible for
+    /// setting `expires_at = created_at + class.ttl_seconds()`.
+    pub async fn put(&self, principal_hash: &[u8; 32], entry: &CacheEntry) -> Result<(), AppError> {
+        let storage_key = storage_key(principal_hash, &entry.idempotency_key);
+        self.ks.insert(storage_key, entry).await
+    }
+}
+
+fn storage_key(principal_hash: &[u8; 32], key: &str) -> Vec<u8> {
+    // Hex-encode the principal hash so the resulting fjall key stays
+    // ASCII for grepping during debugging. Newlines / NUL bytes are
+    // rejected upstream by the idempotency middleware's header
+    // validation, so the unencoded `key` part is safe to embed
+    // directly.
+    let mut out = Vec::with_capacity(64 + key.len() + 5);
+    out.extend_from_slice(b"idem:");
+    out.extend_from_slice(hex::encode(principal_hash).as_bytes());
+    out.push(b':');
+    out.extend_from_slice(key.as_bytes());
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+    use chrono::Duration;
+
+    fn temp_store() -> (IdempotencyStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).expect("store");
+        let ks = store.keyspace("idempotency-test").expect("ks");
+        (IdempotencyStore::new(ks), dir)
+    }
+
+    fn sample_entry() -> CacheEntry {
+        let now = Utc::now();
+        CacheEntry {
+            idempotency_key: "key-1".into(),
+            request_hash: [0xAB; 32],
+            response_status: 201,
+            response_headers: vec![("content-type".into(), "application/json".into())],
+            response_body: br#"{"ok":true}"#.to_vec(),
+            class: IdempotencyClass::NonDestructive,
+            created_at: now,
+            expires_at: now
+                + Duration::seconds(IdempotencyClass::NonDestructive.ttl_seconds() as i64),
+        }
+    }
+
+    #[test]
+    fn principal_hash_is_stable_and_distinct_across_kinds() {
+        let a = Principal::AuthToken(b"Bearer abc".to_vec());
+        let a_again = Principal::AuthToken(b"Bearer abc".to_vec());
+        let b = Principal::AuthToken(b"Bearer xyz".to_vec());
+        let ip = Principal::Ip(IpAddr::V4("127.0.0.1".parse().unwrap()));
+        let anon = Principal::Anonymous;
+
+        assert_eq!(a.hash(), a_again.hash());
+        assert_ne!(a.hash(), b.hash());
+        assert_ne!(a.hash(), ip.hash());
+        assert_ne!(a.hash(), anon.hash());
+        assert_ne!(ip.hash(), anon.hash());
+    }
+
+    #[tokio::test]
+    async fn put_then_get_returns_entry() {
+        let (store, _dir) = temp_store();
+        let principal = Principal::AuthToken(b"Bearer t".to_vec()).hash();
+        let entry = sample_entry();
+
+        store.put(&principal, &entry).await.unwrap();
+        let got = store.get(&principal, &entry.idempotency_key).await.unwrap();
+        assert_eq!(got.as_ref(), Some(&entry));
+    }
+
+    #[tokio::test]
+    async fn entries_are_scoped_by_principal() {
+        let (store, _dir) = temp_store();
+        let a = Principal::AuthToken(b"alice".to_vec()).hash();
+        let b = Principal::AuthToken(b"bob".to_vec()).hash();
+        let entry = sample_entry();
+
+        store.put(&a, &entry).await.unwrap();
+        let got_a = store.get(&a, &entry.idempotency_key).await.unwrap();
+        let got_b = store.get(&b, &entry.idempotency_key).await.unwrap();
+        assert!(got_a.is_some());
+        assert!(got_b.is_none(), "principal scoping leaked");
+    }
+
+    #[tokio::test]
+    async fn expired_entries_are_filtered_at_read_time() {
+        let (store, _dir) = temp_store();
+        let principal = Principal::AuthToken(b"Bearer t".to_vec()).hash();
+        let mut entry = sample_entry();
+        entry.expires_at = Utc::now() - Duration::seconds(1);
+        store.put(&principal, &entry).await.unwrap();
+
+        let got = store.get(&principal, &entry.idempotency_key).await.unwrap();
+        assert!(got.is_none(), "stale entry served");
+    }
+
+    #[tokio::test]
+    async fn put_overwrites_existing_entry_under_same_key() {
+        let (store, _dir) = temp_store();
+        let principal = Principal::AuthToken(b"Bearer t".to_vec()).hash();
+        let first = sample_entry();
+        store.put(&principal, &first).await.unwrap();
+
+        let mut second = first.clone();
+        second.response_status = 204;
+        second.response_body = b"updated".to_vec();
+        store.put(&principal, &second).await.unwrap();
+
+        let got = store.get(&principal, &first.idempotency_key).await.unwrap();
+        assert_eq!(got.unwrap().response_status, 204);
+    }
+}

--- a/vti-common/src/lib.rs
+++ b/vti-common/src/lib.rs
@@ -3,6 +3,7 @@ pub mod audit;
 pub mod auth;
 pub mod config;
 pub mod error;
+pub mod idempotency;
 pub mod identifier;
 pub mod seed_store;
 pub mod store;


### PR DESCRIPTION
## Summary

Implements **M0.1.3** of the VTC MVP Phase 0 plan. Adds the `Idempotency-Key` cache primitive that every mutating endpoint can attach to gain safe-retry semantics.

## What's in this PR

New module `vti_common::idempotency`:

- **`class::IdempotencyClass`** — `NonDestructive` (24h cache TTL) / `Destructive` (60s) per spec §9.1. TTL is class-pinned in code; not operator-tunable. Per plan **D6** — explicit annotation, no HTTP-method heuristic.

- **`store::Principal`** — `AuthToken(Vec<u8>)` for authenticated requests, `Ip(IpAddr)` for unauth via Axum's `ConnectInfo`, `Anonymous` as fallback. **Always SHA-256-hashed before becoming part of the storage key** — the principal never lives on disk in the clear. Different principals occupy disjoint cache namespaces (the spec's "scoped by `(session_id, key)`, never global" invariant). The Authorization-header-bytes proxy for session_id is conservative — a token refresh resets the cache namespace, which is the safer direction.

- **`store::IdempotencyStore`** — wraps an `idempotency` keyspace. `get` filters expired entries at read time so a stale response is never served, even before a background sweeper reclaims its disk space. Storage key is `idem:<hex(principal_hash)>:<idempotency_key>` (hex-encoded so the row is grep-friendly during debugging).

- **`middleware::idempotency_middleware`** — Axum middleware generic over `from_fn_with_state` with `IdempotencyLayerState { store, class }`.
  - Header absent → pass through (idempotency is opt-in per request).
  - Control-character keys rejected with 400 (would corrupt the storage key).
  - Body buffered + SHA-256-hashed via `http_body_util::Limited` capped at `MAX_BODY_BYTES = 1 MiB`.
  - Cache hit + body match → replays cached response.
  - Cache hit + body mismatch → 422 `IdempotencyKeyConflict`.
  - Cache miss → forward to handler, buffer + cache response.
  - Storage failures are **non-fatal** — they degrade gracefully to "cache miss next time" rather than failing the request.

- **`AppError::IdempotencyKeyConflict`** (422) with structured `{ error, message }` body. Matches the workspace's existing Trust-Task structured-error pattern.

## Workspace plumbing

- `vti-common`'s `hex` promoted to non-optional (`store` uses it for storage-key hex-encoding).
- `http-body-util` + `bytes` promoted from dev-deps to main deps (the middleware needs the body collector at runtime).
- `passkey` feature drops `dep:hex` since hex is now always available.

## Test coverage (13 new tests, all green)

| Area | Tests |
|---|---|
| `IdempotencyClass` | TTL constants correct (24h / 60s). |
| `Principal` + `IdempotencyStore` | Principal hash stable + cross-kind distinct; cache round-trip; principal scoping (alice's cache invisible to bob); expired entries filtered at read; overwrite semantics. |
| `idempotency_middleware` | No header → pass through (handler called both times); same key + same body → cached response replayed, handler invoked **once**; same key + different body → 422 with `IdempotencyKeyConflict`; destructive class TTL really is 60s; different principals get separate caches under the same key; control-char key rejected with 400 pre-handler. |

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo test --package vti-common` — 122 unit tests + 14 integration tests pass.
- [x] `cargo test --package vti-common idempotency` — 13/13 new tests pass.
- [x] `cargo clippy --package vti-common --features "passkey encryption" -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Notes

- The spec's "target-state revalidation hook" for `Destructive` class (revalidate that the cached delete still describes accurate state before serving) is **plumbed-through as a follow-up**. MVP ships TTL-only — acceptable because the 60s destructive window is narrow enough that target-state drift is unlikely under typical retry patterns.
- Wiring example (for the consuming service's M0.3+ work):
  ```rust
  use axum::middleware::from_fn_with_state;
  use vti_common::idempotency::{idempotency_middleware, IdempotencyLayerState, IdempotencyClass};

  let state = IdempotencyLayerState { store: store.clone(), class: IdempotencyClass::Destructive };
  router.route_with_task(
      "/v1/members/{did}",
      delete(remove_handler).layer(from_fn_with_state(state, idempotency_middleware)),
      task,
  )
  ```