### PR TITLE
feat(vtc): migrate routes to /v1/ + Trust-Task headers

### DIFF
--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -285,7 +285,7 @@ bundle containing a valid VTC `did:webvh`. No VTC binary needed yet.
 
 ## M0.3 — `/v1/` URL migration + Trust-Task wiring
 
-### `[ ]` M0.3.1 — Move existing routes under `/v1/` prefix
+### `[x]` M0.3.1 — Move existing routes under `/v1/` prefix
 
 - **Acceptance**
   - `vtc-service/src/routes/mod.rs` mounts auth + acl + config
@@ -300,7 +300,7 @@ bundle containing a valid VTC `did:webvh`. No VTC binary needed yet.
   - `vtc-service/tests/auth_audience.rs` (path updates)
 - **Deps**: M0.1.1 (for `TrustTaskRouter`)
 
-### `[ ]` M0.3.2 — Wire Trust-Task header on existing routes (placeholder IDs)
+### `[x]` M0.3.2 — Wire Trust-Task header on existing routes (placeholder IDs)
 
 - **Acceptance**
   - Each existing route registered with a placeholder Trust Task ID

--- a/trust-tasks/acl/legacy/entry/1.0/schema.json
+++ b/trust-tasks/acl/legacy/entry/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Legacy — ACL Entry",
+  "description": "Stub — subsumed by members/* tasks in M0.6+.",
+  "type": "object"
+}

--- a/trust-tasks/acl/legacy/entry/1.0/spec.md
+++ b/trust-tasks/acl/legacy/entry/1.0/spec.md
@@ -1,0 +1,25 @@
+---
+id: https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0
+title: VTC Legacy — ACL Entry
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/acl/{did}
+  - rest: PATCH /v1/acl/{did}
+  - rest: DELETE /v1/acl/{did}
+---
+
+# VTC Legacy — ACL Entry
+
+Placeholder Trust Task for the pre-MVP per-entry ACL endpoints
+(show + update + delete) inherited from the `vtc-service`
+skeleton. Three HTTP methods share this task because they target
+the same resource.
+
+The shape of this Trust Task will be revised in M0.6+ when the
+member-lifecycle endpoints land. The legacy per-DID ACL surface
+will eventually be subsumed by `members/show/1.0` /
+`members/role/update/1.0` / `members/remove-admin/1.0` /
+`members/remove-self/1.0` per spec §16.4.

--- a/trust-tasks/acl/legacy/manage/1.0/schema.json
+++ b/trust-tasks/acl/legacy/manage/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Legacy — ACL Collection",
+  "description": "Stub — subsumed by members/* tasks in M0.6+.",
+  "type": "object"
+}

--- a/trust-tasks/acl/legacy/manage/1.0/spec.md
+++ b/trust-tasks/acl/legacy/manage/1.0/spec.md
@@ -1,0 +1,23 @@
+---
+id: https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0
+title: VTC Legacy — ACL Collection
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/acl
+  - rest: POST /v1/acl
+---
+
+# VTC Legacy — ACL Collection
+
+Placeholder Trust Task for the pre-MVP ACL collection endpoints
+(list + create) inherited from the `vtc-service` skeleton. Two
+HTTP methods share this task because they target the same
+resource collection.
+
+The shape of this Trust Task will be revised in M0.6+ when the
+member-lifecycle endpoints land. The legacy ACL surface will
+eventually be subsumed by `members/list/1.0` and the
+provision-integration / passkey flows.

--- a/trust-tasks/auth/legacy/authenticate/1.0/schema.json
+++ b/trust-tasks/auth/legacy/authenticate/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/auth/legacy/authenticate/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Legacy — Authenticate",
+  "description": "Stub — refined when the auth surface is revised.",
+  "type": "object"
+}

--- a/trust-tasks/auth/legacy/authenticate/1.0/spec.md
+++ b/trust-tasks/auth/legacy/authenticate/1.0/spec.md
@@ -1,0 +1,21 @@
+---
+id: https://trusttasks.org/openvtc/vtc/auth/legacy/authenticate/1.0
+title: VTC Legacy — Authenticate
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/auth/
+---
+
+# VTC Legacy — Authenticate
+
+Placeholder Trust Task for the pre-MVP authenticate endpoint
+inherited from the `vtc-service` skeleton. The endpoint's
+behaviour is unchanged in M0.3; this stub registers a stable Trust
+Task ID so the wire surface is self-describing from day one (spec
+§9.4 soft gate).
+
+The shape of this Trust Task will be revised in Phase 1+ when the
+auth surface gets re-aligned with the new install + passkey flows.

--- a/trust-tasks/auth/legacy/challenge/1.0/schema.json
+++ b/trust-tasks/auth/legacy/challenge/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Legacy — Auth Challenge",
+  "description": "Stub — refined when the auth surface is revised.",
+  "type": "object"
+}

--- a/trust-tasks/auth/legacy/challenge/1.0/spec.md
+++ b/trust-tasks/auth/legacy/challenge/1.0/spec.md
@@ -1,0 +1,21 @@
+---
+id: https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0
+title: VTC Legacy — Auth Challenge
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/auth/challenge
+---
+
+# VTC Legacy — Auth Challenge
+
+Placeholder Trust Task for the pre-MVP auth-challenge endpoint
+inherited from the `vtc-service` skeleton. The endpoint's
+behaviour is unchanged in M0.3; this stub registers a stable Trust
+Task ID so the wire surface is self-describing from day one (spec
+§9.4 soft gate).
+
+The shape of this Trust Task will be revised in Phase 1+ when the
+auth surface gets re-aligned with the new install + passkey flows.

--- a/trust-tasks/auth/legacy/refresh/1.0/schema.json
+++ b/trust-tasks/auth/legacy/refresh/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/auth/legacy/refresh/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Legacy — Refresh Token",
+  "description": "Stub — refined when the auth surface is revised.",
+  "type": "object"
+}

--- a/trust-tasks/auth/legacy/refresh/1.0/spec.md
+++ b/trust-tasks/auth/legacy/refresh/1.0/spec.md
@@ -1,0 +1,21 @@
+---
+id: https://trusttasks.org/openvtc/vtc/auth/legacy/refresh/1.0
+title: VTC Legacy — Refresh Token
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/auth/refresh
+---
+
+# VTC Legacy — Refresh Token
+
+Placeholder Trust Task for the pre-MVP refresh-token endpoint
+inherited from the `vtc-service` skeleton. The endpoint's
+behaviour is unchanged in M0.3; this stub registers a stable Trust
+Task ID so the wire surface is self-describing from day one (spec
+§9.4 soft gate).
+
+The shape of this Trust Task will be revised in Phase 1+ when the
+auth surface gets re-aligned with the new install + passkey flows.

--- a/trust-tasks/auth/legacy/sessions/manage/1.0/schema.json
+++ b/trust-tasks/auth/legacy/sessions/manage/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Legacy — Sessions Management",
+  "description": "Stub — refined when the auth surface is revised.",
+  "type": "object"
+}

--- a/trust-tasks/auth/legacy/sessions/manage/1.0/spec.md
+++ b/trust-tasks/auth/legacy/sessions/manage/1.0/spec.md
@@ -1,0 +1,23 @@
+---
+id: https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0
+title: VTC Legacy — Sessions Management
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/auth/sessions
+  - rest: DELETE /v1/auth/sessions
+---
+
+# VTC Legacy — Sessions Management
+
+Placeholder Trust Task for the pre-MVP collection-level sessions
+endpoints (list + bulk revoke-by-DID) inherited from the
+`vtc-service` skeleton. Two HTTP methods share this task because
+they target the same resource collection.
+
+The shape of this Trust Task will be revised in Phase 1+ when the
+auth surface gets re-aligned with the new install + passkey flows.
+At that point, GET and DELETE will likely split into separate
+Trust Tasks.

--- a/trust-tasks/auth/legacy/sessions/revoke/1.0/schema.json
+++ b/trust-tasks/auth/legacy/sessions/revoke/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/revoke/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Legacy — Revoke Single Session",
+  "description": "Stub — refined when the auth surface is revised.",
+  "type": "object"
+}

--- a/trust-tasks/auth/legacy/sessions/revoke/1.0/spec.md
+++ b/trust-tasks/auth/legacy/sessions/revoke/1.0/spec.md
@@ -1,0 +1,21 @@
+---
+id: https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/revoke/1.0
+title: VTC Legacy — Revoke Single Session
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: DELETE /v1/auth/sessions/{session_id}
+---
+
+# VTC Legacy — Revoke Single Session
+
+Placeholder Trust Task for the pre-MVP single-session revocation
+endpoint inherited from the `vtc-service` skeleton. The endpoint's
+behaviour is unchanged in M0.3; this stub registers a stable Trust
+Task ID so the wire surface is self-describing from day one (spec
+§9.4 soft gate).
+
+The shape of this Trust Task will be revised in Phase 1+ when the
+auth surface gets re-aligned with the new install + passkey flows.

--- a/trust-tasks/config/legacy/manage/1.0/schema.json
+++ b/trust-tasks/config/legacy/manage/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Legacy — Config Management",
+  "description": "Stub — refined when config split into show/patch/reload/restart in M0.8.",
+  "type": "object"
+}

--- a/trust-tasks/config/legacy/manage/1.0/spec.md
+++ b/trust-tasks/config/legacy/manage/1.0/spec.md
@@ -1,0 +1,22 @@
+---
+id: https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0
+title: VTC Legacy — Config Management
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/config
+  - rest: PATCH /v1/config
+---
+
+# VTC Legacy — Config Management
+
+Placeholder Trust Task for the pre-MVP config endpoints (read +
+patch) inherited from the `vtc-service` skeleton. Two HTTP methods
+share this task because they operate on the same resource.
+
+The shape of this Trust Task will be revised in M0.8 when the
+config endpoints get split into `admin/config/show/1.0` /
+`admin/config/patch/1.0` / `admin/config/reload/1.0` /
+`admin/config/restart/1.0` per spec §14.6.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://trusttasks.org/manifest/v1.json",
+  "version": 1,
+  "org": "openvtc",
+  "domain": "vtc",
+  "description": "OpenVTC Verifiable Trust Community — Trust Task manifest. Source of truth for trusttasks.org publication; CI publishes Draft entries on every merge to main per spec §9.4.",
+  "tasks": [
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0",
+      "status": "Draft",
+      "path": "auth/legacy/challenge/1.0",
+      "rest": "POST /v1/auth/challenge"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/authenticate/1.0",
+      "status": "Draft",
+      "path": "auth/legacy/authenticate/1.0",
+      "rest": "POST /v1/auth/"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/refresh/1.0",
+      "status": "Draft",
+      "path": "auth/legacy/refresh/1.0",
+      "rest": "POST /v1/auth/refresh"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0",
+      "status": "Draft",
+      "path": "auth/legacy/sessions/manage/1.0",
+      "rest": "GET, DELETE /v1/auth/sessions"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/revoke/1.0",
+      "status": "Draft",
+      "path": "auth/legacy/sessions/revoke/1.0",
+      "rest": "DELETE /v1/auth/sessions/{session_id}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0",
+      "status": "Draft",
+      "path": "config/legacy/manage/1.0",
+      "rest": "GET, PATCH /v1/config"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
+      "status": "Draft",
+      "path": "acl/legacy/manage/1.0",
+      "rest": "GET, POST /v1/acl"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0",
+      "status": "Draft",
+      "path": "acl/legacy/entry/1.0",
+      "rest": "GET, PATCH, DELETE /v1/acl/{did}"
+    }
+  ]
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -6,30 +6,80 @@ mod health;
 use axum::Router;
 use axum::routing::{delete, get, post};
 
+use vti_common::trust_task::{TrustTask, TrustTaskRouter};
+
 use crate::server::AppState;
 
+/// Build the public router.
+///
+/// Migrates the pre-MVP route table under `/v1/` and attaches a
+/// Trust-Task header check to every endpoint per spec §9.4. The
+/// existing handlers are unchanged in behaviour — only the wire
+/// surface moves. Trust Task IDs use a `*/legacy/*` namespace
+/// because these endpoints will be re-shaped during M0.5+ to align
+/// with the install + passkey + admin flows; the placeholder IDs
+/// give the wire surface a stable identifier from day one (soft
+/// gate from spec §9.4 / plan M0.1.1).
+///
+/// `/health` is the **single** Trust-Task-exempt endpoint — kept at
+/// the root path for trivial monitoring integration.
 pub fn router() -> Router<AppState> {
-    Router::new()
-        .route("/health", get(health::health))
-        // Auth routes (flattened to avoid nest + root-route matching issues in Axum 0.8)
-        .route("/auth/challenge", post(auth::challenge))
-        .route("/auth/", post(auth::authenticate))
-        .route("/auth/refresh", post(auth::refresh))
-        .route(
-            "/auth/sessions",
+    let auth_challenge =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0")
+            .expect("static Trust-Task URL");
+    let auth_authenticate =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/authenticate/1.0")
+            .expect("static Trust-Task URL");
+    let auth_refresh = TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/refresh/1.0")
+        .expect("static Trust-Task URL");
+    let auth_sessions_manage =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0")
+            .expect("static Trust-Task URL");
+    let auth_sessions_revoke =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/revoke/1.0")
+            .expect("static Trust-Task URL");
+    let config_manage =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0")
+            .expect("static Trust-Task URL");
+    let acl_manage = TrustTask::new("https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0")
+        .expect("static Trust-Task URL");
+    let acl_entry = TrustTask::new("https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0")
+        .expect("static Trust-Task URL");
+
+    TrustTaskRouter::<AppState>::new()
+        .route_exempt("/health", get(health::health))
+        // Auth routes
+        .route_with_task("/v1/auth/challenge", post(auth::challenge), auth_challenge)
+        .route_with_task("/v1/auth/", post(auth::authenticate), auth_authenticate)
+        .route_with_task("/v1/auth/refresh", post(auth::refresh), auth_refresh)
+        .route_with_task(
+            "/v1/auth/sessions",
             get(auth::session_list).delete(auth::revoke_sessions_by_did),
+            auth_sessions_manage,
         )
-        .route("/auth/sessions/{session_id}", delete(auth::revoke_session))
-        .route(
-            "/config",
+        .route_with_task(
+            "/v1/auth/sessions/{session_id}",
+            delete(auth::revoke_session),
+            auth_sessions_revoke,
+        )
+        // Config
+        .route_with_task(
+            "/v1/config",
             get(config::get_config).patch(config::update_config),
+            config_manage,
         )
-        // ACL routes (flattened for consistency)
-        .route("/acl", get(acl::list_acl).post(acl::create_acl))
-        .route(
-            "/acl/{did}",
+        // ACL
+        .route_with_task(
+            "/v1/acl",
+            get(acl::list_acl).post(acl::create_acl),
+            acl_manage,
+        )
+        .route_with_task(
+            "/v1/acl/{did}",
             get(acl::get_acl)
                 .patch(acl::update_acl)
                 .delete(acl::delete_acl),
+            acl_entry,
         )
+        .into_router()
 }

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -107,7 +107,11 @@ async fn vta_audience_token_rejected_by_vtc_route() {
 
     let req = Request::builder()
         .method("GET")
-        .uri("/acl")
+        .uri("/v1/acl")
+        .header(
+            "Trust-Task",
+            "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
+        )
         .header("Authorization", format!("Bearer {foreign_token}"))
         .body(Body::empty())
         .unwrap();
@@ -140,7 +144,11 @@ async fn unknown_audience_token_rejected_by_vtc_route() {
 
     let req = Request::builder()
         .method("GET")
-        .uri("/acl")
+        .uri("/v1/acl")
+        .header(
+            "Trust-Task",
+            "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
+        )
         .header("Authorization", format!("Bearer {foreign_token}"))
         .body(Body::empty())
         .unwrap();
@@ -154,7 +162,11 @@ async fn no_token_rejected_by_vtc_route() {
 
     let req = Request::builder()
         .method("GET")
-        .uri("/acl")
+        .uri("/v1/acl")
+        .header(
+            "Trust-Task",
+            "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
+        )
         .body(Body::empty())
         .unwrap();
     let (status, _body) = request(&router, req).await;
@@ -163,4 +175,49 @@ async fn no_token_rejected_by_vtc_route() {
         StatusCode::UNAUTHORIZED,
         "missing Authorization header must be rejected"
     );
+}
+
+#[tokio::test]
+async fn missing_trust_task_header_returns_400() {
+    let (router, _, _dir) = build_test_router().await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/acl")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = request(&router, req).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["error"], "TrustTaskMissing");
+}
+
+#[tokio::test]
+async fn mismatched_trust_task_header_returns_415() {
+    let (router, _, _dir) = build_test_router().await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/acl")
+        .header(
+            "Trust-Task",
+            "https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0",
+        )
+        .body(Body::empty())
+        .unwrap();
+    let (status, _body) = request(&router, req).await;
+    assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn health_is_exempt_from_trust_task() {
+    let (router, _, _dir) = build_test_router().await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _body) = request(&router, req).await;
+    assert_eq!(status, StatusCode::OK);
 }


### PR DESCRIPTION
## Summary

Implements **M0.3** of the VTC MVP Phase 0 plan. First PR that touches `vtc-service` after the M0.1.x `vti-common` foundation. Moves the existing routes under `/v1/`, attaches Trust-Task header validation on each via `vti_common::trust_task::TrustTaskRouter`, and creates the `trust-tasks/` directory at repo root for Phase-0 spec stubs.

## Wire-surface changes

- All non-health routes move under `/v1/`.
- `/health` stays at root and is the **single** Trust-Task-exempt endpoint (spec §9.4).
- Each route registers a Trust-Task identifier and validates the `Trust-Task` header on every request:
  - Missing header → 400 `TrustTaskMissing`.
  - Mismatched header → 415 `TrustTaskMismatch` with structured `{ expected, received }` JSON payload.

## Trust Task IDs assigned

Namespaced `*/legacy/*` because these routes will be re-shaped in Phase 1+ when the auth surface aligns with the new install + passkey flows:

| Route | Methods | Trust Task ID |
|---|---|---|
| `/v1/auth/challenge` | POST | `auth/legacy/challenge/1.0` |
| `/v1/auth/` | POST | `auth/legacy/authenticate/1.0` |
| `/v1/auth/refresh` | POST | `auth/legacy/refresh/1.0` |
| `/v1/auth/sessions` | GET, DELETE | `auth/legacy/sessions/manage/1.0` |
| `/v1/auth/sessions/{session_id}` | DELETE | `auth/legacy/sessions/revoke/1.0` |
| `/v1/config` | GET, PATCH | `config/legacy/manage/1.0` |
| `/v1/acl` | GET, POST | `acl/legacy/manage/1.0` |
| `/v1/acl/{did}` | GET, PATCH, DELETE | `acl/legacy/entry/1.0` |
| `/health` | GET | (exempt) |

Combined HTTP methods on the same path share one Trust Task today; they'll likely split into per-method tasks when the surfaces get revised in M0.5+.

## New `trust-tasks/` directory at repo root

- `trust-tasks/index.json` — manifest listing every Phase-0 Trust Task with status / source path / REST binding. The eventual CI pipeline will read this when publishing to trusttasks.org.
- Per-task `spec.md` + `schema.json` stubs (16 files for the 8 legacy tasks). Frontmatter pins the wire id, status (Draft), authors, and REST bindings. Bodies note that the shape will be revised when the eventual feature work lands. Schemas are minimal valid JSON Schema (`type: object`) — refined alongside wire-shape revisions.

This is the source-of-truth location for `openvtc/vtc/*` per spec §16.5; M0.5+ adds more entries here as new endpoints land.

## Test coverage

**6 tests in `vtc-service/tests/auth_audience.rs`** (3 original + 3 new):

| Existing tests, paths updated to `/v1/acl` + Trust-Task header | Behavior |
|---|---|
| `vta_audience_token_rejected_by_vtc_route` | Cross-audience JWT → 401 |
| `unknown_audience_token_rejected_by_vtc_route` | Custom audience JWT → 401 |
| `no_token_rejected_by_vtc_route` | Missing Authorization → 401 |

| New tests | Behavior |
|---|---|
| `missing_trust_task_header_returns_400` | No `Trust-Task` header → 400, body `{ error: "TrustTaskMissing" }` |
| `mismatched_trust_task_header_returns_415` | Wrong Trust-Task URL → 415 |
| `health_is_exempt_from_trust_task` | GET /health (no header) → 200 |

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo test --package vtc-service` — 6/6 pass.
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Notes

- The Trust-Task gate runs **before** the auth check, so the audience-isolation invariant is unchanged: a request without Authorization but **with** a valid Trust-Task still returns 401 from the auth layer; without Trust-Task it returns 400 first. Order is correct (Trust-Task is the cheaper gate).
- Combined `MethodRouter`s (e.g., GET + DELETE on `/v1/auth/sessions`) share one Trust Task because Axum merges method routers under a single layer at the same path. Per-method tasks would require splitting the route definitions; left for the M0.5+ rewrites to address since those routes will be replaced.
- No changes to handler code — only the routing layer and the test paths.

## Phase 0 status

M0.1.x foundation + M0.3 wire migration done. Next branches off main:

- **M0.4** — Install token primitive + carve-out state machine (critical path)
- **M0.1.6b** — Passkey route handlers (independent; needed for M0.5)
- **M0.7** — Community profile (parallel surfaces track)
- **M0.8** — Config plumbing (parallel surfaces track)