### PR TITLE
feat(vtc): install token + carve-out state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8911,6 +8911,7 @@ dependencies = [
  "google-cloud-auth",
  "google-cloud-secretmanager-v1",
  "hex",
+ "hkdf 0.13.0",
  "http-body-util",
  "jsonwebtoken",
  "keyring-core",

--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -325,7 +325,7 @@ bundle containing a valid VTC `did:webvh`. No VTC binary needed yet.
 
 ## M0.4 — Install token + carve-out primitive
 
-### `[ ]` M0.4.1 — `InstallToken` struct + JWT signer
+### `[x]` M0.4.1 — `InstallToken` struct + JWT signer
 
 - **Acceptance**
   - `InstallToken` claims: `iss` (VTC DID), `sub` ("install"),
@@ -349,7 +349,7 @@ bundle containing a valid VTC `did:webvh`. No VTC binary needed yet.
 - **Deps**: M0.1.0
 - **Pre-impl decision**: D2 (nonce binding mechanism)
 
-### `[ ]` M0.4.2 — Install carve-out keyspace with claim-window state machine
+### `[x]` M0.4.2 — Install carve-out keyspace with claim-window state machine
 
 Per **D12**: webvh-common's claim-window pattern, not immediate
 single-use.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -73,6 +73,7 @@ dialoguer = { workspace = true, optional = true }
 azure_security_keyvault_secrets = { workspace = true, optional = true }
 azure_identity = { workspace = true, optional = true }
 sha2 = { workspace = true }
+hkdf = { workspace = true }
 x25519-dalek = { workspace = true }
 zeroize = { version = "1", features = ["derive"] }
 multibase = { workspace = true }

--- a/vtc-service/src/install/mod.rs
+++ b/vtc-service/src/install/mod.rs
@@ -1,0 +1,39 @@
+//! Install token + carve-out state machine.
+//!
+//! Implements **M0.4** of the VTC MVP Phase 0 plan. The install
+//! token is the one-time bearer credential the operator clicks to
+//! turn `vtc setup` into a bootstrapped admin via the WebAuthn
+//! ceremony (M0.5 follow-up). This module owns:
+//!
+//! - **[`token`]** — `InstallToken` claims + the EdDSA JWT
+//!   signer/verifier derived from the VTC's master seed via HKDF.
+//! - **[`state_machine`]** — the `install` keyspace state machine
+//!   that gates the install carve-out (`Issued` → `Consumed` →
+//!   `Closed`), with the **claim-window** pattern adopted from
+//!   `webvh-common::server::passkey::store` (plan D12). A failed
+//!   WebAuthn ceremony doesn't burn the token — only a successful
+//!   `finish_claim` does.
+//! - **[`INSTALL_CARVEOUT_LOCK`]** — a single process-wide async
+//!   mutex guarding the state-machine transitions so two concurrent
+//!   `start_claim` calls on the same token can't both pass the
+//!   "claimed_at not set within the window" check.
+//!
+//! See spec §4.1 / §4.2 for the consumer-facing flow.
+
+pub mod state_machine;
+pub mod token;
+
+pub use state_machine::{InstallTokenState, InstallTokenStore, StartClaimOutcome};
+pub use token::{
+    INSTALL_AUDIENCE, INSTALL_SUBJECT, INSTALL_TOKEN_DEFAULT_TTL_SECS, InstallTokenClaims,
+    InstallTokenSigner, mint_install_token, parse_install_token,
+};
+
+use tokio::sync::Mutex;
+
+/// Process-wide async mutex serialising every install-token state
+/// machine transition. Mirrors VTA's `MODE_B_LOCK` invariant — the
+/// claim-check then claim-set sequence must be atomic across
+/// concurrent Axum tasks. Operators don't pay for it post-install
+/// (the carve-out is `Closed` and the mutex sits idle).
+pub static INSTALL_CARVEOUT_LOCK: Mutex<()> = Mutex::const_new(());

--- a/vtc-service/src/install/state_machine.rs
+++ b/vtc-service/src/install/state_machine.rs
@@ -1,0 +1,436 @@
+//! Install carve-out state machine.
+//!
+//! Implements **M0.4.2** of the VTC MVP Phase 0 plan. Adopts the
+//! claim-window pattern from `webvh-common::server::passkey::store`
+//! (plan **D12**): an in-flight WebAuthn ceremony locks out
+//! concurrent claims for [`ENROLLMENT_CLAIM_WINDOW_SECS`] (5
+//! minutes) but is **not** consumed until the ceremony succeeds —
+//! a failed ceremony leaves the token redeemable by the legitimate
+//! operator after the window expires.
+//!
+//! Storage:
+//!
+//! - `install:token:<jti>` → [`InstallTokenState`] (`Issued` /
+//!   `Consumed`).
+//! - `install:carveout:closed` → presence marker (any non-empty
+//!   value) — once written, every subsequent state transition
+//!   that would issue or claim a token rejects with the carve-out-
+//!   closed variant.
+//!
+//! Concurrency: every transition takes [`super::INSTALL_CARVEOUT_LOCK`]
+//! before reading + writing state. The lock serialises across
+//! Axum tasks so two `start_claim` calls on the same JTI cannot
+//! both pass the "claimed_at not set within the window" check.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use super::INSTALL_CARVEOUT_LOCK;
+use crate::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// How long an in-flight WebAuthn ceremony locks out concurrent
+/// claims on the same install token. Tracks the same value as
+/// `vti_common::auth::passkey::ENROLLMENT_CLAIM_WINDOW_SECS` (300 s).
+/// Duplicated locally rather than depending on the `passkey` feature
+/// of `vti-common` — the install state machine doesn't need anything
+/// else from that module, and feature-gating one constant through
+/// the dependency tree adds more friction than it's worth. M0.5 will
+/// switch to the shared constant when it enables the `passkey`
+/// feature.
+pub const ENROLLMENT_CLAIM_WINDOW_SECS: u64 = 300;
+
+const TOKEN_KEY_PREFIX: &[u8] = b"install:token:";
+const CARVEOUT_CLOSED_KEY: &[u8] = b"install:carveout:closed";
+
+fn token_key(jti: &Uuid) -> Vec<u8> {
+    let mut out = TOKEN_KEY_PREFIX.to_vec();
+    out.extend_from_slice(jti.to_string().as_bytes());
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Per-token state held in the `install` keyspace.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum InstallTokenState {
+    /// Issued but not yet successfully consumed. `claimed_at` is set
+    /// when a `start_claim` call is in progress; the window
+    /// expires after [`ENROLLMENT_CLAIM_WINDOW_SECS`] so a failed
+    /// ceremony doesn't permanently lock the token.
+    Issued {
+        /// Wall-clock expiry; once exceeded, the token cannot
+        /// progress to `Consumed`.
+        exp: DateTime<Utc>,
+        /// Raw 32 cnonce bytes; the WebAuthn ceremony's
+        /// `clientDataJSON.challenge` is validated against this.
+        #[serde(with = "raw_bytes_b64")]
+        cnonce: [u8; 32],
+        /// Raw 32 ephemeral Ed25519 private key bytes. Only present
+        /// in `Issued`; nulled on transition to `Consumed`.
+        #[serde(with = "raw_bytes_b64")]
+        ephemeral_signing_key: [u8; 32],
+        /// Wall-clock when an in-flight `start_claim` set the
+        /// ceremony lock. `None` means no ceremony has been
+        /// initiated since issuance.
+        claimed_at: Option<DateTime<Utc>>,
+    },
+    /// Ceremony succeeded — token is permanently spent. Retained for
+    /// idempotency / audit; a later `start_claim` for the same JTI
+    /// returns [`AppError::Unauthorized`].
+    Consumed { at: DateTime<Utc> },
+}
+
+mod raw_bytes_b64 {
+    use base64::Engine;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    const B64: base64::engine::general_purpose::GeneralPurpose =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    pub fn serialize<S: Serializer>(bytes: &[u8; 32], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&B64.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[u8; 32], D::Error> {
+        let s = String::deserialize(d)?;
+        let v = B64.decode(&s).map_err(serde::de::Error::custom)?;
+        v.try_into()
+            .map_err(|_| serde::de::Error::custom("expected 32 bytes"))
+    }
+}
+
+/// Successful [`InstallTokenStore::start_claim`] outcome. The
+/// caller hands `ephemeral_signing_key` + `cnonce` to the WebAuthn
+/// route handler; on ceremony success the route calls
+/// [`InstallTokenStore::finish_claim`] to consume.
+#[derive(Debug)]
+pub struct StartClaimOutcome {
+    pub ephemeral_signing_key: Zeroizing<[u8; 32]>,
+    pub cnonce: [u8; 32],
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/// Wraps the `install` keyspace with the state-machine semantics.
+/// Cheap to clone (the underlying handle is `Arc`-shared).
+#[derive(Clone)]
+pub struct InstallTokenStore {
+    ks: KeyspaceHandle,
+}
+
+impl InstallTokenStore {
+    pub fn new(ks: KeyspaceHandle) -> Self {
+        Self { ks }
+    }
+
+    /// Persist a freshly-minted token's state. Refuses if the
+    /// carve-out is closed — once admin bootstrap completes, no
+    /// further install tokens may be issued.
+    ///
+    /// Caller must hold no other lock on the install keyspace; we
+    /// take [`INSTALL_CARVEOUT_LOCK`] internally for the
+    /// check-then-write sequence.
+    pub async fn record_issued(
+        &self,
+        jti: &Uuid,
+        cnonce: [u8; 32],
+        ephemeral_signing_key: [u8; 32],
+        exp: DateTime<Utc>,
+    ) -> Result<(), AppError> {
+        let _guard = INSTALL_CARVEOUT_LOCK.lock().await;
+        if self.carveout_is_closed_raw().await? {
+            return Err(AppError::Conflict("install carve-out is closed".into()));
+        }
+        let state = InstallTokenState::Issued {
+            exp,
+            cnonce,
+            ephemeral_signing_key,
+            claimed_at: None,
+        };
+        self.ks.insert(token_key(jti), &state).await
+    }
+
+    /// Begin a WebAuthn ceremony on `jti`.
+    ///
+    /// Returns `Ok(StartClaimOutcome)` if the token is `Issued`,
+    /// not expired, the carve-out is open, and no concurrent
+    /// ceremony has set `claimed_at` within the
+    /// [`ENROLLMENT_CLAIM_WINDOW_SECS`] window. Sets `claimed_at`
+    /// as a side-effect so a second concurrent caller sees the
+    /// in-progress lock.
+    ///
+    /// Errors with [`AppError::Unauthorized`] on every other state
+    /// — the structured detail stays out of the response for
+    /// defence in depth.
+    pub async fn start_claim(&self, jti: &Uuid) -> Result<StartClaimOutcome, AppError> {
+        let _guard = INSTALL_CARVEOUT_LOCK.lock().await;
+        if self.carveout_is_closed_raw().await? {
+            return Err(AppError::Unauthorized("install carve-out is closed".into()));
+        }
+
+        let key = token_key(jti);
+        let state: Option<InstallTokenState> = self.ks.get(key.clone()).await?;
+        let state =
+            state.ok_or_else(|| AppError::Unauthorized("install token not found".into()))?;
+
+        match state {
+            InstallTokenState::Consumed { .. } => {
+                Err(AppError::Unauthorized("install token consumed".into()))
+            }
+            InstallTokenState::Issued {
+                exp,
+                cnonce,
+                ephemeral_signing_key,
+                claimed_at,
+            } => {
+                let now = Utc::now();
+                if now >= exp {
+                    return Err(AppError::Unauthorized("install token expired".into()));
+                }
+                if let Some(prev) = claimed_at {
+                    let elapsed = now - prev;
+                    if elapsed < Duration::seconds(ENROLLMENT_CLAIM_WINDOW_SECS as i64) {
+                        return Err(AppError::Conflict(
+                            "install ceremony already in progress".into(),
+                        ));
+                    }
+                }
+                let next = InstallTokenState::Issued {
+                    exp,
+                    cnonce,
+                    ephemeral_signing_key,
+                    claimed_at: Some(now),
+                };
+                self.ks.insert(key, &next).await?;
+                Ok(StartClaimOutcome {
+                    cnonce,
+                    ephemeral_signing_key: Zeroizing::new(ephemeral_signing_key),
+                })
+            }
+        }
+    }
+
+    /// Complete the ceremony — transitions `Issued` → `Consumed`.
+    /// Errors with [`AppError::Unauthorized`] if the token is already
+    /// consumed or expired.
+    ///
+    /// The caller (M0.5 `/install/claim/finish` handler) calls this
+    /// **only** after the WebAuthn assertion validates against the
+    /// `cnonce` and the candidate DID signature has been verified.
+    pub async fn finish_claim(&self, jti: &Uuid) -> Result<(), AppError> {
+        let _guard = INSTALL_CARVEOUT_LOCK.lock().await;
+        let key = token_key(jti);
+        let state: Option<InstallTokenState> = self.ks.get(key.clone()).await?;
+        let state =
+            state.ok_or_else(|| AppError::Unauthorized("install token not found".into()))?;
+        match state {
+            InstallTokenState::Consumed { .. } => {
+                Err(AppError::Unauthorized("install token consumed".into()))
+            }
+            InstallTokenState::Issued { exp, .. } => {
+                let now = Utc::now();
+                if now >= exp {
+                    return Err(AppError::Unauthorized("install token expired".into()));
+                }
+                let next = InstallTokenState::Consumed { at: now };
+                self.ks.insert(key, &next).await
+            }
+        }
+    }
+
+    /// Permanently close the install carve-out. Once written, every
+    /// subsequent [`Self::record_issued`] returns
+    /// [`AppError::Conflict`], and every [`Self::start_claim`] /
+    /// [`Self::finish_claim`] returns [`AppError::Unauthorized`].
+    ///
+    /// Idempotent — calling on an already-closed store is a no-op.
+    pub async fn close_carveout(&self) -> Result<(), AppError> {
+        let _guard = INSTALL_CARVEOUT_LOCK.lock().await;
+        self.ks
+            .insert_raw(CARVEOUT_CLOSED_KEY.to_vec(), b"1".to_vec())
+            .await
+    }
+
+    /// Inspect carve-out status. Read-only; doesn't take the lock.
+    pub async fn carveout_is_closed(&self) -> Result<bool, AppError> {
+        self.carveout_is_closed_raw().await
+    }
+
+    async fn carveout_is_closed_raw(&self) -> Result<bool, AppError> {
+        Ok(self
+            .ks
+            .get_raw(CARVEOUT_CLOSED_KEY.to_vec())
+            .await?
+            .is_some())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn temp_store() -> (InstallTokenStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).expect("store");
+        let ks = store.keyspace("install-test").expect("ks");
+        (InstallTokenStore::new(ks), dir)
+    }
+
+    async fn issue(store: &InstallTokenStore, ttl: i64) -> Uuid {
+        let jti = Uuid::new_v4();
+        let exp = Utc::now() + Duration::seconds(ttl);
+        store
+            .record_issued(&jti, [0xAB; 32], [0xCD; 32], exp)
+            .await
+            .unwrap();
+        jti
+    }
+
+    #[tokio::test]
+    async fn start_then_finish_consumes_token() {
+        let (store, _dir) = temp_store();
+        let jti = issue(&store, 600).await;
+
+        let outcome = store.start_claim(&jti).await.unwrap();
+        assert_eq!(outcome.cnonce, [0xAB; 32]);
+        assert_eq!(*outcome.ephemeral_signing_key, [0xCD; 32]);
+
+        store.finish_claim(&jti).await.unwrap();
+        // Second finish returns "consumed".
+        let err = store.finish_claim(&jti).await.expect_err("second finish");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[tokio::test]
+    async fn second_concurrent_start_within_window_is_rejected() {
+        let (store, _dir) = temp_store();
+        let jti = issue(&store, 600).await;
+
+        let _first = store.start_claim(&jti).await.unwrap();
+        // Immediately try a second start — the claim window is 5
+        // minutes, so this must be rejected.
+        let err = store.start_claim(&jti).await.expect_err("conflict");
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn retry_after_window_succeeds() {
+        let (store, _dir) = temp_store();
+        let jti = issue(&store, 600).await;
+
+        let _first = store.start_claim(&jti).await.unwrap();
+        // Backdate `claimed_at` past the window so the next call
+        // sees a stale lock and overwrites it.
+        let key = token_key(&jti);
+        let mut state: InstallTokenState = store.ks.get(key.clone()).await.unwrap().unwrap();
+        if let InstallTokenState::Issued {
+            ref mut claimed_at, ..
+        } = state
+        {
+            *claimed_at =
+                Some(Utc::now() - Duration::seconds((ENROLLMENT_CLAIM_WINDOW_SECS as i64) + 10));
+        }
+        store.ks.insert(key, &state).await.unwrap();
+
+        let _retry = store.start_claim(&jti).await.expect("retry after window");
+    }
+
+    #[tokio::test]
+    async fn expired_token_rejected_on_start() {
+        let (store, _dir) = temp_store();
+        let jti = issue(&store, -1).await;
+        let err = store.start_claim(&jti).await.expect_err("expired");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[tokio::test]
+    async fn expired_token_rejected_on_finish() {
+        let (store, _dir) = temp_store();
+        let jti = issue(&store, 600).await;
+        let _ = store.start_claim(&jti).await.unwrap();
+
+        // Backdate the expiry to now-1s.
+        let key = token_key(&jti);
+        let mut state: InstallTokenState = store.ks.get(key.clone()).await.unwrap().unwrap();
+        if let InstallTokenState::Issued { ref mut exp, .. } = state {
+            *exp = Utc::now() - Duration::seconds(1);
+        }
+        store.ks.insert(key, &state).await.unwrap();
+
+        let err = store.finish_claim(&jti).await.expect_err("expired");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[tokio::test]
+    async fn close_carveout_blocks_subsequent_issuance() {
+        let (store, _dir) = temp_store();
+        store.close_carveout().await.unwrap();
+        assert!(store.carveout_is_closed().await.unwrap());
+
+        let jti = Uuid::new_v4();
+        let exp = Utc::now() + Duration::seconds(600);
+        let err = store
+            .record_issued(&jti, [0u8; 32], [0u8; 32], exp)
+            .await
+            .expect_err("conflict");
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn close_carveout_blocks_subsequent_start_claim() {
+        let (store, _dir) = temp_store();
+        let jti = issue(&store, 600).await;
+        store.close_carveout().await.unwrap();
+        let err = store.start_claim(&jti).await.expect_err("closed");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[tokio::test]
+    async fn close_carveout_is_idempotent() {
+        let (store, _dir) = temp_store();
+        store.close_carveout().await.unwrap();
+        store.close_carveout().await.unwrap();
+        assert!(store.carveout_is_closed().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn missing_token_returns_unauthorized() {
+        let (store, _dir) = temp_store();
+        let phantom_jti = Uuid::new_v4();
+        let err = store
+            .start_claim(&phantom_jti)
+            .await
+            .expect_err("not found");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[tokio::test]
+    async fn state_machine_serde_round_trip() {
+        let state = InstallTokenState::Issued {
+            exp: Utc::now() + Duration::seconds(60),
+            cnonce: [0xAB; 32],
+            ephemeral_signing_key: [0xCD; 32],
+            claimed_at: Some(Utc::now()),
+        };
+        let s = serde_json::to_string(&state).unwrap();
+        let back: InstallTokenState = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, state);
+    }
+}

--- a/vtc-service/src/install/token.rs
+++ b/vtc-service/src/install/token.rs
@@ -1,0 +1,378 @@
+//! [`InstallTokenClaims`] + [`InstallTokenSigner`] — the JWT bearer
+//! credential `vtc setup` prints to the operator after provisioning.
+//!
+//! ## Design (plan D2)
+//!
+//! - **Signature**: EdDSA over an Ed25519 key derived from the VTC
+//!   master seed via `HKDF-SHA256` with `info = b"vtc-install-jwt-key/v1"`.
+//!   Distinct from every other seed-derived secret in the workspace
+//!   (audit_key uses `vtc-audit-key/v1`, the eventual session key
+//!   uses its own info). Same trust boundary signs + verifies, so
+//!   a symmetric MAC would also work — EdDSA is chosen to match the
+//!   workspace JWT convention so the wire shape is identical to
+//!   the session JWTs that follow.
+//! - **Audience**: `"vtc-install"` (pinned). A session-token decoder
+//!   configured for `"VTC"` will reject this token, and vice versa.
+//! - **Subject**: `"install"`. Distinguishes the install bearer
+//!   from any future operator/admin tokens minted under the same
+//!   audience family.
+//! - **TTL**: 15 minutes (`INSTALL_TOKEN_DEFAULT_TTL_SECS`).
+//! - **Per-token state**: each token carries a random `jti` (Uuid),
+//!   the WebAuthn ceremony nonce (`cnonce`, 32 random bytes
+//!   base64url-encoded), and the **public** half of an ephemeral
+//!   Ed25519 keypair (`epubkey`, base64url-encoded). The matching
+//!   private half lives in the `install` keyspace under the `jti`,
+//!   never touches the wire.
+//!
+//! ## Why both wire and server hold the cnonce
+//!
+//! The browser reads `cnonce` from the parsed token (no server
+//! round-trip needed to start a WebAuthn ceremony). The server
+//! stores its own copy so it can validate the WebAuthn assertion's
+//! `clientDataJSON.challenge` field against the **authoritative**
+//! value indexed by `jti`. A stolen token alone is insufficient —
+//! the WebAuthn ceremony binds to the cnonce the server holds, and
+//! a manipulated wire `cnonce` would mismatch the stored one.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use ed25519_dalek::SigningKey;
+use hkdf::Hkdf;
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use crate::error::AppError;
+
+const B64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+/// Audience claim every install token carries. Pinned in code; a
+/// session-token decoder configured for the `"VTC"` audience will
+/// reject install tokens by design.
+pub const INSTALL_AUDIENCE: &str = "vtc-install";
+
+/// Subject claim every install token carries. Distinguishes the
+/// install bearer from any future operator/admin token shaped under
+/// the same audience family.
+pub const INSTALL_SUBJECT: &str = "install";
+
+/// Default install-token lifetime in seconds. Spec §4.1 — long
+/// enough that an operator who clicked the URL has time to complete
+/// the WebAuthn ceremony, short enough that an unobserved leaked
+/// URL doesn't sit redeemable for hours.
+pub const INSTALL_TOKEN_DEFAULT_TTL_SECS: u64 = 15 * 60;
+
+const HKDF_INFO: &[u8] = b"vtc-install-jwt-key/v1";
+
+// ---------------------------------------------------------------------------
+// Claims
+// ---------------------------------------------------------------------------
+
+/// JWT claims for an install token. Field names match RFC 7519
+/// where applicable; custom fields keep `snake_case` for
+/// readability (this token isn't consumed by external SIEM
+/// tooling).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallTokenClaims {
+    /// Issuer — the VTC DID (or `did:key:vtc-install-uninitialised`
+    /// when minted before the VTC DID is known, e.g. during the
+    /// very first `vtc setup` run before the DID is provisioned).
+    pub iss: String,
+    /// Always [`INSTALL_SUBJECT`].
+    pub sub: String,
+    /// Always [`INSTALL_AUDIENCE`].
+    pub aud: String,
+    /// Unix-second expiry timestamp.
+    pub exp: u64,
+    /// Unix-second issued-at timestamp.
+    pub iat: u64,
+    /// Stable identifier — used as the key in the `install`
+    /// keyspace state machine (M0.4.2).
+    pub jti: String,
+    /// Base64url-encoded 32-byte WebAuthn ceremony nonce. The
+    /// browser reads this directly from the parsed JWT to start the
+    /// ceremony; the server stores its own authoritative copy and
+    /// validates the WebAuthn assertion against it.
+    pub cnonce: String,
+    /// Base64url-encoded **public** half of the ephemeral Ed25519
+    /// keypair. Used by `/install/claim/finish` to verify the
+    /// candidate `did:key` signature without trusting the wire
+    /// shape of the ceremony alone.
+    pub epubkey: String,
+}
+
+// ---------------------------------------------------------------------------
+// Signer
+// ---------------------------------------------------------------------------
+
+/// Holds the EdDSA encode/decode keys derived from the master seed.
+/// Cheap to clone (jsonwebtoken's keys are small).
+pub struct InstallTokenSigner {
+    encoding: EncodingKey,
+    decoding: DecodingKey,
+}
+
+impl InstallTokenSigner {
+    /// Derive the install-token signing key from `master_seed` via
+    /// HKDF. Idempotent — same seed yields the same encode/decode
+    /// keys, so a restart doesn't invalidate outstanding tokens.
+    pub fn from_master_seed(master_seed: &[u8]) -> Result<Self, AppError> {
+        let mut signing_key_bytes = Zeroizing::new([0u8; 32]);
+        Hkdf::<Sha256>::new(None, master_seed)
+            .expand(HKDF_INFO, signing_key_bytes.as_mut())
+            .map_err(|e| AppError::Internal(format!("HKDF expand failed: {e}")))?;
+
+        let signing_key = SigningKey::from_bytes(&signing_key_bytes);
+        let public_bytes = signing_key.verifying_key().to_bytes();
+
+        // PKCS8 v1 DER wrap for the private key (mirror of
+        // vti_common::auth::jwt::JwtKeys — the DER bytes are stable
+        // and well-known so we duplicate them here rather than
+        // extracting a helper).
+        let mut pkcs8 = Vec::with_capacity(48);
+        pkcs8.extend_from_slice(&[
+            0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22,
+            0x04, 0x20,
+        ]);
+        pkcs8.extend_from_slice(signing_key_bytes.as_ref());
+
+        let encoding = EncodingKey::from_ed_der(&pkcs8);
+        let decoding = DecodingKey::from_ed_der(&public_bytes);
+        Ok(Self { encoding, decoding })
+    }
+
+    /// Sign a `InstallTokenClaims` into an EdDSA-signed JWT.
+    pub fn encode(&self, claims: &InstallTokenClaims) -> Result<String, AppError> {
+        let header = Header::new(Algorithm::EdDSA);
+        jsonwebtoken::encode(&header, claims, &self.encoding)
+            .map_err(|e| AppError::Internal(format!("install JWT encode failed: {e}")))
+    }
+
+    /// Verify + decode an install token. Validates the signature,
+    /// audience, subject, and required claims; returns
+    /// `AppError::Unauthorized` on every failure (the caller's
+    /// 401/403 response carries no detail to avoid revealing which
+    /// check rejected).
+    pub fn decode(&self, token: &str) -> Result<InstallTokenClaims, AppError> {
+        let mut validation = Validation::new(Algorithm::EdDSA);
+        validation.set_audience(&[INSTALL_AUDIENCE]);
+        validation.set_required_spec_claims(&["exp", "sub", "aud", "iat", "iss"]);
+
+        let claims = jsonwebtoken::decode::<InstallTokenClaims>(token, &self.decoding, &validation)
+            .map(|data| data.claims)
+            .map_err(|_| AppError::Unauthorized("invalid install token".into()))?;
+
+        if claims.sub != INSTALL_SUBJECT {
+            return Err(AppError::Unauthorized("invalid install token".into()));
+        }
+        Ok(claims)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mint / parse helpers
+// ---------------------------------------------------------------------------
+
+/// Outcome of [`mint_install_token`]: the signed JWT, the random
+/// `jti`, the ephemeral signing key the caller must persist into
+/// the `install` keyspace state alongside `(jti, cnonce_bytes)`,
+/// and the wall-clock expiry.
+#[derive(Debug)]
+pub struct MintedInstallToken {
+    pub jwt: String,
+    pub jti: Uuid,
+    pub claims: InstallTokenClaims,
+    /// Raw 32-byte cnonce (the JWT carries the base64url-encoded
+    /// form; the keyspace state machine wants the raw bytes for
+    /// constant-time comparison against the WebAuthn assertion).
+    pub cnonce_bytes: [u8; 32],
+    /// Ephemeral private key the keyspace state machine must hold;
+    /// the browser only sees the matching public half via
+    /// [`InstallTokenClaims::epubkey`].
+    pub ephemeral_signing_key: Zeroizing<[u8; 32]>,
+    pub expires_at_unix: u64,
+}
+
+/// Mint a fresh install token. Generates the `jti`, the WebAuthn
+/// ceremony nonce, and the ephemeral keypair internally — the caller
+/// only supplies the issuer DID and TTL.
+pub fn mint_install_token(
+    signer: &InstallTokenSigner,
+    issuer_did: &str,
+    ttl_seconds: u64,
+) -> Result<MintedInstallToken, AppError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let exp = now + ttl_seconds;
+    let jti = Uuid::new_v4();
+
+    let mut cnonce_bytes = [0u8; 32];
+    rand::fill(&mut cnonce_bytes);
+    let cnonce = B64.encode(cnonce_bytes);
+
+    let mut ephemeral_bytes = Zeroizing::new([0u8; 32]);
+    rand::fill(&mut *ephemeral_bytes);
+    let ephemeral_signing_key = SigningKey::from_bytes(&ephemeral_bytes);
+    let epubkey = B64.encode(ephemeral_signing_key.verifying_key().to_bytes());
+
+    let claims = InstallTokenClaims {
+        iss: issuer_did.to_string(),
+        sub: INSTALL_SUBJECT.to_string(),
+        aud: INSTALL_AUDIENCE.to_string(),
+        exp,
+        iat: now,
+        jti: jti.to_string(),
+        cnonce,
+        epubkey,
+    };
+    let jwt = signer.encode(&claims)?;
+
+    Ok(MintedInstallToken {
+        jwt,
+        jti,
+        claims,
+        cnonce_bytes,
+        ephemeral_signing_key: ephemeral_bytes,
+        expires_at_unix: exp,
+    })
+}
+
+/// Verify + decode an install token. Thin wrapper over
+/// [`InstallTokenSigner::decode`] for ergonomic call sites.
+pub fn parse_install_token(
+    signer: &InstallTokenSigner,
+    token: &str,
+) -> Result<InstallTokenClaims, AppError> {
+    signer.decode(token)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Once;
+
+    /// Pin jsonwebtoken's default `CryptoProvider` to `aws_lc_rs`
+    /// once per process (matches the workspace pattern from
+    /// `vti_common::auth::jwt::tests::init_jwt_provider`).
+    fn init_jwt_provider() {
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+        });
+    }
+
+    const SEED: [u8; 32] = [0xAB; 32];
+
+    fn signer() -> InstallTokenSigner {
+        init_jwt_provider();
+        InstallTokenSigner::from_master_seed(&SEED).unwrap()
+    }
+
+    #[test]
+    fn round_trip_returns_same_claims() {
+        let signer = signer();
+        let minted = mint_install_token(&signer, "did:webvh:vtc.example.com:abc", 600).unwrap();
+        let back = parse_install_token(&signer, &minted.jwt).unwrap();
+        assert_eq!(back.iss, "did:webvh:vtc.example.com:abc");
+        assert_eq!(back.aud, INSTALL_AUDIENCE);
+        assert_eq!(back.sub, INSTALL_SUBJECT);
+        assert_eq!(back.jti, minted.jti.to_string());
+        assert_eq!(back.cnonce, minted.claims.cnonce);
+        assert_eq!(back.epubkey, minted.claims.epubkey);
+    }
+
+    #[test]
+    fn different_seeds_produce_disjoint_keys() {
+        init_jwt_provider();
+        let a = InstallTokenSigner::from_master_seed(&[0x01; 32]).unwrap();
+        let b = InstallTokenSigner::from_master_seed(&[0x02; 32]).unwrap();
+        let minted = mint_install_token(&a, "did:webvh:x", 60).unwrap();
+        let err = parse_install_token(&b, &minted.jwt).expect_err("must reject");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        let signer = signer();
+        // TTL = 0 means `exp == iat`; jsonwebtoken treats `exp <= now`
+        // as expired.
+        let minted = mint_install_token(&signer, "did:webvh:x", 0).unwrap();
+        // Allow the second to tick — jsonwebtoken's clock-skew
+        // tolerance is 60s by default, but `validate_exp = true` with
+        // `leeway = 0` (Validation::new default sets leeway=60) means
+        // we need to sleep past leeway. Use a deliberately stale
+        // token instead: re-mint with a backdated exp.
+        let claims = InstallTokenClaims {
+            exp: 1, // 1970-01-01
+            iat: 0,
+            ..minted.claims.clone()
+        };
+        let stale = signer.encode(&claims).unwrap();
+        let err = parse_install_token(&signer, &stale).expect_err("expired");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn wrong_audience_is_rejected() {
+        let signer = signer();
+        let minted = mint_install_token(&signer, "did:webvh:x", 600).unwrap();
+        // Re-sign with a different aud claim.
+        let mut claims = minted.claims.clone();
+        claims.aud = "VTC".to_string();
+        let stale = signer.encode(&claims).unwrap();
+        let err = parse_install_token(&signer, &stale).expect_err("wrong aud");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn wrong_subject_is_rejected() {
+        let signer = signer();
+        let minted = mint_install_token(&signer, "did:webvh:x", 600).unwrap();
+        let mut claims = minted.claims.clone();
+        claims.sub = "session".to_string();
+        let stale = signer.encode(&claims).unwrap();
+        let err = parse_install_token(&signer, &stale).expect_err("wrong sub");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn tampered_signature_is_rejected() {
+        let signer = signer();
+        let minted = mint_install_token(&signer, "did:webvh:x", 600).unwrap();
+        // Flip the very last byte of the base64-encoded signature.
+        let mut bytes = minted.jwt.into_bytes();
+        let last = bytes.len() - 1;
+        bytes[last] = if bytes[last] == b'A' { b'B' } else { b'A' };
+        let tampered = String::from_utf8(bytes).unwrap();
+        let err = parse_install_token(&signer, &tampered).expect_err("tampered");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn cnonce_is_32_bytes_base64url() {
+        let signer = signer();
+        let minted = mint_install_token(&signer, "did:webvh:x", 600).unwrap();
+        let decoded = B64.decode(&minted.claims.cnonce).unwrap();
+        assert_eq!(decoded.len(), 32);
+        // And the round-tripped raw bytes match.
+        assert_eq!(decoded.as_slice(), &minted.cnonce_bytes[..]);
+    }
+
+    #[test]
+    fn epubkey_is_32_bytes_base64url() {
+        let signer = signer();
+        let minted = mint_install_token(&signer, "did:webvh:x", 600).unwrap();
+        let decoded = B64.decode(&minted.claims.epubkey).unwrap();
+        assert_eq!(decoded.len(), 32);
+    }
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -21,6 +21,7 @@ pub mod did_key;
 pub mod did_webvh;
 pub mod error;
 pub mod import_did;
+pub mod install;
 pub mod keys;
 pub mod messaging;
 pub mod routes;


### PR DESCRIPTION
## Summary

Implements **M0.4** of the VTC MVP Phase 0 plan. First chunk of the WebAuthn-bound install flow — the bearer credential `vtc setup` prints to the operator, and the state machine that gates the single-use carve-out.

This is **on the Phase-0 critical path**. After this lands, M0.5 (WebAuthn claim flow) and M0.6 (admin bootstrap) can build on top.

## Module `vtc_service::install`

### `token::*` — JWT bearer credential

- **`InstallTokenClaims`** — JWT shape per plan **D2**. Claims: `iss` (VTC DID), `sub` (`"install"`), `aud` (`"vtc-install"`), `exp` (15 min default), `iat`, `jti` (random Uuid), `cnonce` (32-byte WebAuthn ceremony nonce, base64url-encoded), `epubkey` (ephemeral Ed25519 public key, base64url-encoded). Audience pinned so a session-token decoder configured for `"VTC"` will reject install tokens by design.
- **`InstallTokenSigner`** — EdDSA signer derived from the master seed via `HKDF-SHA256` with `info = b"vtc-install-jwt-key/v1"`. Distinct from every other seed-derived secret in the workspace. Idempotent — daemon restart doesn't invalidate outstanding tokens.
- **`mint_install_token`** — generates the random `jti`, `cnonce`, and ephemeral keypair internally; caller supplies issuer DID + TTL. Returns the JWT plus the secrets (cnonce bytes + ephemeral private key) the state machine will hold.
- **`parse_install_token`** — verifies signature, audience, subject, required spec claims. Returns `AppError::Unauthorized` on every failure (defence in depth — caller's 401 response doesn't reveal which check rejected).

### `state_machine::*` — the carve-out state machine

- **`InstallTokenState`** = `Issued { exp, cnonce, ephemeral_signing_key, claimed_at }` | `Consumed { at }`. The `claimed_at` field implements the **claim-window pattern** adopted from `webvh-common` (plan **D12**): a ceremony in progress locks out concurrent claims for `ENROLLMENT_CLAIM_WINDOW_SECS` (300s) but does **not** consume the token. A failed WebAuthn ceremony leaves the token redeemable by the legitimate operator after the window expires.
- **`InstallTokenStore::{record_issued, start_claim, finish_claim, close_carveout, carveout_is_closed}`** — keyspace-backed ops. Each transition takes `INSTALL_CARVEOUT_LOCK` (process-wide `tokio::sync::Mutex`) so two concurrent `start_claim` calls on the same jti can't both pass the "claimed_at not set within the window" check. Mirrors VTA's `MODE_B_LOCK` invariant.
- **`close_carveout()`** writes a sentinel at `install:carveout:closed`. Once written, every subsequent `record_issued` returns `Conflict` and every `start_claim` / `finish_claim` returns `Unauthorized`. Idempotent — calling on an already-closed store is a no-op.

## Test coverage (18 new tests, all green)

| Area | Tests |
|---|---|
| `InstallTokenSigner` HKDF | Same seed → same keys; disjoint seeds reject each other's tokens. |
| `parse_install_token` | Round-trip; expired rejected; wrong-aud rejected; wrong-sub rejected; tampered signature rejected. |
| Token claims | `cnonce` + `epubkey` are 32-byte base64url, round-trip raw bytes. |
| State machine | start→finish consumes; second concurrent start within window → Conflict; retry after window succeeds; expired token rejected on start; expired rejected on finish; close_carveout blocks record_issued (Conflict) and start_claim (Unauthorized); close idempotent; missing token → Unauthorized; serde round-trip. |

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo test --package vtc-service install::` — 18/18 new tests pass.
- [x] `cargo test --package vtc-service` — 6 existing integration tests still pass.
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Notes

- The `ENROLLMENT_CLAIM_WINDOW_SECS = 300` constant is duplicated locally in `state_machine.rs` rather than imported from `vti_common::auth::passkey` because that module is behind the `passkey` cargo feature and `vtc-service` doesn't enable it yet. M0.5 (WebAuthn claim flow) will enable the feature and switch to the shared constant.
- The install-token signer derives a signing key from the master seed deterministically. **The master seed isn't fetched here** — the consumer (M0.9 `vtc setup` wizard) fetches it from the secret store and constructs `InstallTokenSigner::from_master_seed(&seed)`. Same pattern as `vti_common::audit::AuditKeyStore::ensure_initial(&seed)`.
- `vti-common::audit::AuditEvent::CommunityInstalled.install_token_jti` (added in M0.1.5) is the audit-trail field that pairs with this token's `jti` for forensic correlation when admin bootstrap completes.

## Phase 0 status

| | Milestone | Status |
|---|---|---|
| | M0.1.1–M0.1.5 + M0.1.6a | All merged |
| | M0.2 — `vtc-host` template | Merged |
| | M0.3 — `/v1/` migration | Merged |
| | **M0.4 — Install token + carve-out** | **PR (this one)** |
| | M0.5 — WebAuthn claim flow | Next on critical path |
| | M0.6 — Admin bootstrap + multi-passkey | After M0.5 |
| | M0.7, M0.8, M0.9, M0.10, M0.11, M0.12 | Not started |