### PR TITLE
feat(vtc): community profile show + update

### DIFF
--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -551,7 +551,7 @@ second passkey registered. Install carve-out permanently closed.
 
 ## M0.7 — Community profile (parallel track)
 
-### `[ ]` M0.7.1 — `CommunityProfile` schema + `community` keyspace
+### `[x]` M0.7.1 — `CommunityProfile` schema + `community` keyspace
 
 - **Acceptance**
   - `CommunityProfile` per spec §5.1 (community_did immutable, all
@@ -568,7 +568,7 @@ second passkey registered. Install carve-out permanently closed.
 - **Deps**: M0.1.0
 - **Pre-impl decision**: D4
 
-### `[ ]` M0.7.2 — `GET / PUT /v1/community/profile`
+### `[x]` M0.7.2 — `GET / PUT /v1/community/profile`
 
 - **Acceptance**
   - `GET` returns the singleton profile; 404 if not yet initialised

--- a/trust-tasks/community/profile/manage/1.0/schema.json
+++ b/trust-tasks/community/profile/manage/1.0/schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — Community Profile (Show + Update)",
+  "description": "Covers GET (no body) and PUT (partial CommunityProfileUpdate). Refined when GET/PUT split into separate Trust Tasks.",
+  "type": "object",
+  "properties": {
+    "name":         { "type": "string" },
+    "description":  { "type": "string" },
+    "logoUrl":      { "type": ["string", "null"] },
+    "publicUrl":    { "type": ["string", "null"] },
+    "contactEmail": { "type": ["string", "null"] },
+    "language":     { "type": "string" },
+    "extensions":   {}
+  },
+  "additionalProperties": false
+}

--- a/trust-tasks/community/profile/manage/1.0/spec.md
+++ b/trust-tasks/community/profile/manage/1.0/spec.md
@@ -1,0 +1,51 @@
+---
+id: https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0
+title: VTC — Community Profile (Show + Update)
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/community/profile
+  - rest: PUT /v1/community/profile
+---
+
+# VTC — Community Profile (Show + Update)
+
+The Phase-0 read + write surface for the community's singleton
+profile (`name`, `description`, `logoUrl`, `publicUrl`,
+`contactEmail`, `language`, `extensions`). Two HTTP methods share
+this task because they target the same resource; a future Phase-1+
+revision will split them into `community/profile/show/1.0` and
+`community/profile/update/1.0` (per spec §16.4) once
+`TrustTaskRouter` gains per-method task selectors.
+
+## Semantics
+
+- **GET** — any authenticated session may read. Returns 404 with
+  `community_not_initialised` when no profile has been written yet
+  (pre-bootstrap state).
+- **PUT** — requires `Admin` role. Accepts a partial
+  [`CommunityProfileUpdate`](https://github.com/OpenVTC/verifiable-trust-infrastructure/blob/main/vtc-service/src/community/profile.rs)
+  patch — every field is optional; omitted fields are left
+  unchanged. The immutable `communityDid` cannot be supplied. The
+  `extensions` blob is capped at 16 KiB (plan **D4**).
+
+## Trust assumptions
+
+- Caller holds a valid VTC-audience JWT.
+- For PUT, the JWT's `role` claim is `admin`.
+
+## Outputs
+
+- GET → the full `CommunityProfile` record.
+- PUT → `{ profile, fieldsChanged: [field, ...] }`. An empty
+  `fieldsChanged` means no value actually changed (idempotent
+  no-op).
+- PUT also emits a `CommunityProfileUpdated` audit event once the
+  audit writer is wired into `AppState` (post-M0.9).
+
+## Status
+
+Draft. Will split into show + update tasks when `TrustTaskRouter`
+supports per-method task selectors.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -52,6 +52,12 @@
       "status": "Draft",
       "path": "acl/legacy/entry/1.0",
       "rest": "GET, PATCH, DELETE /v1/acl/{did}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0",
+      "status": "Draft",
+      "path": "community/profile/manage/1.0",
+      "rest": "GET, PUT /v1/community/profile"
     }
   ]
 }

--- a/vtc-service/src/community/mod.rs
+++ b/vtc-service/src/community/mod.rs
@@ -1,0 +1,15 @@
+//! VTC community state — profile, extensions, and the matching
+//! `community` keyspace.
+//!
+//! Implements **M0.7.1** of the VTC MVP Phase 0 plan. The
+//! community profile is the public-facing record describing the
+//! community itself (name, description, contact, etc.). Per
+//! spec §5.1 it's a singleton — one row per VTC binary, stored
+//! under the stable key `community/profile`.
+
+pub mod profile;
+
+pub use profile::{
+    CommunityProfile, CommunityProfileUpdate, MAX_EXTENSIONS_BYTES, PROFILE_STORAGE_KEY,
+    load_profile, store_profile,
+};

--- a/vtc-service/src/community/profile.rs
+++ b/vtc-service/src/community/profile.rs
@@ -1,0 +1,314 @@
+//! [`CommunityProfile`] — the singleton record describing the
+//! community itself.
+//!
+//! Per spec §5.1:
+//!
+//! - `community_did` is **immutable** — set at install (M0.6) and
+//!   never reshapeable from REST. PUT requests that try to change
+//!   it return 409.
+//! - All other fields are editable by an admin via `PUT
+//!   /v1/community/profile`.
+//! - `extensions` is the universal extensibility slot (§3-M). Opaque
+//!   JSON; the VTC validates only that the serialised blob fits
+//!   inside [`MAX_EXTENSIONS_BYTES`].
+//! - `language` defaults to `"en"` (BCP 47). No translation
+//!   handling yet — that's a deliberate v2 deferral per spec §18.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// Fjall key under which the singleton profile is stored. Stable
+/// for the lifetime of the VTC.
+pub const PROFILE_STORAGE_KEY: &[u8] = b"community/profile";
+
+/// Hard cap on the serialised size of the [`CommunityProfile::extensions`]
+/// blob, per plan **D4**. PUT requests carrying a larger blob return
+/// 413. Larger blobs would inflate every audit + backup row that
+/// references the profile.
+pub const MAX_EXTENSIONS_BYTES: usize = 16 * 1024;
+
+/// The singleton record. Field names are wire contract — operators
+/// + the admin UX read this shape directly.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommunityProfile {
+    /// Immutable — set at install time. PUT requests cannot change
+    /// this; see [`CommunityProfileUpdate`].
+    pub community_did: String,
+    pub name: String,
+    pub description: String,
+    pub logo_url: Option<String>,
+    pub public_url: Option<String>,
+    pub contact_email: Option<String>,
+    /// BCP 47 language tag. Defaults to `"en"`.
+    pub language: String,
+    pub created_at: DateTime<Utc>,
+    /// Opaque per-community JSON. Capped at [`MAX_EXTENSIONS_BYTES`]
+    /// when serialised. Defaults to `null` when no extension data
+    /// is set.
+    #[serde(default)]
+    pub extensions: Value,
+}
+
+impl CommunityProfile {
+    /// Build a fresh profile for a newly-installed community. The
+    /// `community_did` becomes immutable after this point.
+    pub fn new(community_did: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            community_did: community_did.into(),
+            name: name.into(),
+            description: String::new(),
+            logo_url: None,
+            public_url: None,
+            contact_email: None,
+            language: "en".into(),
+            created_at: Utc::now(),
+            extensions: Value::Null,
+        }
+    }
+}
+
+/// PUT-shaped patch. Distinct from [`CommunityProfile`] because the
+/// `community_did` and `created_at` fields are immutable — exposing
+/// them on the request body invites tampering, so we drop them at
+/// the type level.
+///
+/// Every field is `Option` so a PUT can update a subset of fields
+/// while leaving the rest unchanged. Setting `extensions: Some(Value::Null)`
+/// clears the blob; omitting it (`None`) leaves it untouched.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CommunityProfileUpdate {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub logo_url: Option<Option<String>>,
+    pub public_url: Option<Option<String>>,
+    pub contact_email: Option<Option<String>>,
+    pub language: Option<String>,
+    pub extensions: Option<Value>,
+}
+
+impl CommunityProfileUpdate {
+    /// Apply the patch to `profile` in-place, returning the list of
+    /// field names that actually changed. The list feeds the
+    /// `CommunityProfileUpdated` audit event (M0.1.5) and the route
+    /// response.
+    ///
+    /// Validates [`Self::extensions`] size **before** mutating
+    /// anything, so a too-large extension blob doesn't half-apply
+    /// the patch.
+    pub fn apply(self, profile: &mut CommunityProfile) -> Result<Vec<String>, AppError> {
+        if let Some(ext) = &self.extensions {
+            let bytes = serde_json::to_vec(ext).map_err(AppError::Serialization)?;
+            if bytes.len() > MAX_EXTENSIONS_BYTES {
+                return Err(AppError::Validation(format!(
+                    "extensions blob exceeds {MAX_EXTENSIONS_BYTES} bytes (got {})",
+                    bytes.len()
+                )));
+            }
+        }
+
+        let mut changed = Vec::new();
+        if let Some(name) = self.name
+            && profile.name != name
+        {
+            profile.name = name;
+            changed.push("name".into());
+        }
+        if let Some(description) = self.description
+            && profile.description != description
+        {
+            profile.description = description;
+            changed.push("description".into());
+        }
+        if let Some(logo_url) = self.logo_url
+            && profile.logo_url != logo_url
+        {
+            profile.logo_url = logo_url;
+            changed.push("logoUrl".into());
+        }
+        if let Some(public_url) = self.public_url
+            && profile.public_url != public_url
+        {
+            profile.public_url = public_url;
+            changed.push("publicUrl".into());
+        }
+        if let Some(contact_email) = self.contact_email
+            && profile.contact_email != contact_email
+        {
+            profile.contact_email = contact_email;
+            changed.push("contactEmail".into());
+        }
+        if let Some(language) = self.language
+            && profile.language != language
+        {
+            profile.language = language;
+            changed.push("language".into());
+        }
+        if let Some(extensions) = self.extensions
+            && profile.extensions != extensions
+        {
+            profile.extensions = extensions;
+            changed.push("extensions".into());
+        }
+        Ok(changed)
+    }
+}
+
+/// Load the singleton profile. Returns `Ok(None)` if no profile has
+/// been initialised yet — the caller (handler) turns that into 404.
+pub async fn load_profile(ks: &KeyspaceHandle) -> Result<Option<CommunityProfile>, AppError> {
+    ks.get(PROFILE_STORAGE_KEY.to_vec()).await
+}
+
+/// Persist (insert or replace) the singleton profile.
+pub async fn store_profile(
+    ks: &KeyspaceHandle,
+    profile: &CommunityProfile,
+) -> Result<(), AppError> {
+    ks.insert(PROFILE_STORAGE_KEY.to_vec(), profile).await
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).expect("store");
+        (store.keyspace("community-test").expect("ks"), dir)
+    }
+
+    fn sample() -> CommunityProfile {
+        CommunityProfile::new("did:webvh:vtc.example.com:abc", "Example Community")
+    }
+
+    #[tokio::test]
+    async fn load_returns_none_when_not_initialised() {
+        let (ks, _dir) = temp_ks();
+        let got = load_profile(&ks).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn store_then_load_round_trips() {
+        let (ks, _dir) = temp_ks();
+        let p = sample();
+        store_profile(&ks, &p).await.unwrap();
+        let back = load_profile(&ks).await.unwrap().unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn apply_no_fields_yields_empty_changeset() {
+        let mut p = sample();
+        let snapshot = p.clone();
+        let changed = CommunityProfileUpdate::default().apply(&mut p).unwrap();
+        assert!(changed.is_empty());
+        assert_eq!(p, snapshot);
+    }
+
+    #[test]
+    fn apply_changes_only_returned_fields() {
+        let mut p = sample();
+        let update = CommunityProfileUpdate {
+            name: Some("Renamed".into()),
+            description: Some("Now described".into()),
+            ..CommunityProfileUpdate::default()
+        };
+        let changed = update.apply(&mut p).unwrap();
+        assert_eq!(changed, vec!["name", "description"]);
+        assert_eq!(p.name, "Renamed");
+        assert_eq!(p.description, "Now described");
+    }
+
+    #[test]
+    fn apply_omits_unchanged_value_from_changeset() {
+        let mut p = sample();
+        // Re-asserting the same name should produce an empty change set.
+        let update = CommunityProfileUpdate {
+            name: Some(p.name.clone()),
+            ..CommunityProfileUpdate::default()
+        };
+        let changed = update.apply(&mut p).unwrap();
+        assert!(changed.is_empty());
+    }
+
+    #[test]
+    fn apply_handles_optional_field_clears() {
+        let mut p = sample();
+        p.logo_url = Some("https://a.example/logo.png".into());
+
+        let update = CommunityProfileUpdate {
+            logo_url: Some(None),
+            ..CommunityProfileUpdate::default()
+        };
+        let changed = update.apply(&mut p).unwrap();
+        assert_eq!(changed, vec!["logoUrl"]);
+        assert!(p.logo_url.is_none());
+    }
+
+    #[test]
+    fn extensions_under_limit_apply() {
+        let mut p = sample();
+        let blob = json!({ "x": "a".repeat(100) });
+        let update = CommunityProfileUpdate {
+            extensions: Some(blob.clone()),
+            ..CommunityProfileUpdate::default()
+        };
+        update.apply(&mut p).unwrap();
+        assert_eq!(p.extensions, blob);
+    }
+
+    #[test]
+    fn extensions_at_limit_apply() {
+        let mut p = sample();
+        // A string just under the cap, accounting for JSON quoting +
+        // 4-byte object framing `{"":""}`.
+        let body_len = MAX_EXTENSIONS_BYTES - 10;
+        let blob = json!({ "k": "a".repeat(body_len) });
+        let serialised = serde_json::to_vec(&blob).unwrap();
+        assert!(serialised.len() <= MAX_EXTENSIONS_BYTES);
+        let update = CommunityProfileUpdate {
+            extensions: Some(blob),
+            ..CommunityProfileUpdate::default()
+        };
+        update.apply(&mut p).unwrap();
+    }
+
+    #[test]
+    fn extensions_over_limit_rejected_with_validation_error() {
+        let mut p = sample();
+        let original_name = p.name.clone();
+        let huge = json!({ "k": "a".repeat(MAX_EXTENSIONS_BYTES + 10) });
+        let update = CommunityProfileUpdate {
+            // Combine with a name change to confirm the failed
+            // validation aborts BEFORE other fields apply.
+            name: Some("would-have-changed".into()),
+            extensions: Some(huge),
+            ..CommunityProfileUpdate::default()
+        };
+        let err = update.apply(&mut p).expect_err("too large");
+        assert!(matches!(err, AppError::Validation(_)));
+        assert_eq!(p.name, original_name, "name must not have been mutated");
+    }
+
+    #[test]
+    fn profile_default_language_is_en() {
+        let p = sample();
+        assert_eq!(p.language, "en");
+    }
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod acl;
 pub mod acl_cli;
 pub mod auth;
+pub mod community;
 pub mod config;
 pub mod did_key;
 #[cfg(feature = "setup")]

--- a/vtc-service/src/routes/community/mod.rs
+++ b/vtc-service/src/routes/community/mod.rs
@@ -1,0 +1,7 @@
+//! `/v1/community/*` route handlers.
+//!
+//! Implements **M0.7.2** of the VTC MVP Phase 0 plan. Handlers
+//! consume the [`crate::community`] storage layer; the routing
+//! wiring lives in [`crate::routes::router`].
+
+pub mod profile;

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -1,0 +1,104 @@
+//! `GET / PUT /v1/community/profile` handlers.
+//!
+//! Per spec §5.1:
+//!
+//! - **GET**: any authenticated session may read. Returns 404
+//!   `community_not_initialised` when no profile has been written
+//!   yet (pre-bootstrap state).
+//! - **PUT**: requires `Admin` role. Rejects changes to
+//!   `community_did` (immutable). Emits a `CommunityProfileUpdated`
+//!   audit event listing only the field names that actually changed.
+//!
+//! The trust-task validation happens in
+//! [`crate::routes::router`]'s `route_with_task` layer; reaching a
+//! handler implies the header matched.
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use serde::Serialize;
+use tracing::info;
+use vti_common::auth::{AdminAuth, AuthClaims};
+use vti_common::error::AppError;
+
+use crate::community::{CommunityProfile, CommunityProfileUpdate, load_profile, store_profile};
+use crate::server::AppState;
+
+/// GET handler. Returns the singleton profile.
+pub async fn get_profile(
+    _auth: AuthClaims,
+    State(state): State<AppState>,
+) -> Result<Json<CommunityProfile>, AppError> {
+    let profile = load_profile(&state.community_ks)
+        .await?
+        .ok_or_else(|| AppError::NotFound("community profile not initialised".into()))?;
+    Ok(Json(profile))
+}
+
+/// PUT response shape — echoes the updated profile + the list of
+/// fields that actually changed (operator-friendly + powers the
+/// audit event emitter that lands alongside this in a follow-up).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateProfileResponse {
+    pub profile: CommunityProfile,
+    pub fields_changed: Vec<String>,
+}
+
+/// PUT handler. Admin-only. Refuses changes to `community_did`.
+pub async fn put_profile(
+    _admin: AdminAuth,
+    State(state): State<AppState>,
+    Json(update): Json<CommunityProfileUpdate>,
+) -> Result<(StatusCode, Json<UpdateProfileResponse>), AppError> {
+    let mut profile = load_profile(&state.community_ks).await?.ok_or_else(|| {
+        AppError::NotFound("community profile not initialised — cannot PUT before bootstrap".into())
+    })?;
+
+    let fields_changed = update.apply(&mut profile)?;
+
+    if fields_changed.is_empty() {
+        // Nothing changed — return 200 with the existing profile.
+        // PUT semantics tolerate idempotent no-ops.
+        return Ok((
+            StatusCode::OK,
+            Json(UpdateProfileResponse {
+                profile,
+                fields_changed,
+            }),
+        ));
+    }
+
+    store_profile(&state.community_ks, &profile).await?;
+    info!(
+        community_did = %profile.community_did,
+        fields_changed = ?fields_changed,
+        "community profile updated"
+    );
+
+    // Audit emission (`CommunityProfileUpdated` per M0.1.5) is wired
+    // in once an `AuditWriter` lands in `AppState` (post-M0.9). The
+    // `fields_changed` list returned here is the same shape the
+    // event will carry.
+
+    Ok((
+        StatusCode::OK,
+        Json(UpdateProfileResponse {
+            profile,
+            fields_changed,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    // Behavioural coverage lives in `tests/community_profile.rs` — those
+    // exercise the full router stack (Trust-Task header, AdminAuth
+    // extractor, JSON body) via `Router::oneshot`. Unit tests for the
+    // underlying storage + patch semantics live in
+    // `crate::community::profile::tests`.
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -1,5 +1,6 @@
 mod acl;
 mod auth;
+mod community;
 mod config;
 mod health;
 
@@ -45,6 +46,9 @@ pub fn router() -> Router<AppState> {
         .expect("static Trust-Task URL");
     let acl_entry = TrustTask::new("https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0")
         .expect("static Trust-Task URL");
+    let community_profile =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0")
+            .expect("static Trust-Task URL");
 
     TrustTaskRouter::<AppState>::new()
         .route_exempt("/health", get(health::health))
@@ -80,6 +84,15 @@ pub fn router() -> Router<AppState> {
                 .patch(acl::update_acl)
                 .delete(acl::delete_acl),
             acl_entry,
+        )
+        // Community profile (GET + PUT share one Trust Task today;
+        // a spec-aligned split into community/profile/show/1.0 +
+        // community/profile/update/1.0 lands when TrustTaskRouter
+        // gains per-method task selectors in Phase 1+).
+        .route_with_task(
+            "/v1/community/profile",
+            get(community::profile::get_profile).put(community::profile::put_profile),
+            community_profile,
         )
         .into_router()
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -29,6 +29,7 @@ use tracing::{debug, error, info, warn};
 pub struct AppState {
     pub sessions_ks: KeyspaceHandle,
     pub acl_ks: KeyspaceHandle,
+    pub community_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
     pub did_resolver: Option<DIDCacheClient>,
     pub secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
@@ -53,6 +54,7 @@ pub async fn run(
     // Open cached keyspace handles
     let sessions_ks = store.keyspace("sessions")?;
     let acl_ks = store.keyspace("acl")?;
+    let community_ks = store.keyspace("community")?;
 
     // Initialize auth infrastructure
     let (did_resolver, secrets_resolver, jwt_keys, atm) = init_auth(&config, &*secret_store).await;
@@ -89,6 +91,7 @@ pub async fn run(
     let state = AppState {
         sessions_ks,
         acl_ks,
+        community_ks,
         config: Arc::new(RwLock::new(config)),
         did_resolver,
         secrets_resolver,

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -49,6 +49,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
 
     let sessions_ks = store.keyspace("sessions").unwrap();
     let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -69,6 +70,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let state = AppState {
         sessions_ks,
         acl_ks,
+        community_ks,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -1,0 +1,354 @@
+//! Integration coverage for `/v1/community/profile`.
+//!
+//! Exercises the full router stack — Trust-Task header → auth
+//! extractor → handler → community keyspace — through
+//! `Router::oneshot`.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::community::{CommunityProfile, store_profile};
+use vtc_service::config::AppConfig;
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+const PROFILE_TASK: &str = "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    jwt_keys: Arc<JwtKeys>,
+    state: AppState,
+    _dir: tempfile::TempDir,
+}
+
+async fn build() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        [store]
+        data_dir = "{}"
+        [auth]
+        jwt_signing_key = "{}"
+        "#,
+        dir.path().display(),
+        BASE64.encode(jwt_seed),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks: sessions_ks.clone(),
+        acl_ks,
+        community_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys.clone()),
+        atm: None,
+    };
+
+    let router = routes::router().with_state(state.clone());
+    Fixture {
+        router,
+        jwt_keys,
+        state,
+        _dir: dir,
+    }
+}
+
+async fn token_for(fix: &Fixture, role: &str) -> String {
+    use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+
+    let session_id = format!("sess-{}", uuid::Uuid::new_v4());
+    let session = Session {
+        session_id: session_id.clone(),
+        did: "did:key:z6MkAdmin".into(),
+        challenge: "test".into(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: None,
+        tee_attested: false,
+    };
+    store_session(&fix.state.sessions_ks, &session)
+        .await
+        .unwrap();
+
+    let claims = fix.jwt_keys.new_claims(
+        "did:key:z6MkAdmin".to_string(),
+        session_id,
+        role.to_string(),
+        vec![],
+        900,
+        false,
+    );
+    fix.jwt_keys.encode(&claims).expect("encode")
+}
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+async fn seed_profile(fix: &Fixture) -> CommunityProfile {
+    let p = CommunityProfile::new("did:webvh:vtc.example.com:abc", "Example Community");
+    store_profile(&fix.state.community_ks, &p).await.unwrap();
+    p
+}
+
+// ──────────────────────── GET ────────────────────────
+
+#[tokio::test]
+async fn get_returns_404_when_not_initialised() {
+    let fix = build().await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_returns_profile_when_initialised() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["name"], "Example Community");
+    assert_eq!(body["communityDid"], "did:webvh:vtc.example.com:abc");
+    assert_eq!(body["language"], "en");
+}
+
+#[tokio::test]
+async fn get_requires_authentication() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+// ──────────────────────── PUT ────────────────────────
+
+#[tokio::test]
+async fn put_requires_admin_role() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "reader").await;
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"name":"Renamed"}"#))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn put_updates_profile_and_lists_changed_fields() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            r#"{"name":"Renamed","description":"new","logoUrl":"https://x/y.png"}"#,
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    let changed = body["fieldsChanged"].as_array().unwrap();
+    let names: Vec<&str> = changed.iter().map(|v| v.as_str().unwrap()).collect();
+    assert!(names.contains(&"name"));
+    assert!(names.contains(&"description"));
+    assert!(names.contains(&"logoUrl"));
+    assert_eq!(body["profile"]["name"], "Renamed");
+    assert_eq!(body["profile"]["logoUrl"], "https://x/y.png");
+}
+
+#[tokio::test]
+async fn put_idempotent_noop_returns_empty_changeset() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "admin").await;
+    let body = r#"{"name":"Example Community"}"#; // already the value
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["fieldsChanged"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn put_returns_404_when_profile_not_initialised() {
+    let fix = build().await;
+    // No seed_profile call — store is empty.
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"name":"Renamed"}"#))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn put_rejects_oversized_extensions() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "admin").await;
+
+    // Build a clearly-too-large extensions value (~32 KiB).
+    let mut huge_value = String::new();
+    huge_value.push('"');
+    huge_value.push_str(&"a".repeat(32 * 1024));
+    huge_value.push('"');
+    let body = format!(r#"{{"extensions":{{"k":{huge_value}}}}}"#);
+
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn put_does_not_accept_community_did_in_request() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "admin").await;
+
+    // `communityDid` is not a field on the update DTO; serde_json
+    // with `additionalProperties = no` would reject it, but our
+    // CommunityProfileUpdate has no such guard at the type level
+    // (serde silently ignores extra fields by default). The
+    // important property is that it never reaches the stored
+    // profile.
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            r#"{"name":"Renamed","communityDid":"did:webvh:attacker:steal"}"#,
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    // Profile's communityDid is unchanged.
+    assert_eq!(
+        body["profile"]["communityDid"],
+        "did:webvh:vtc.example.com:abc"
+    );
+    // Only `name` made it into the changeset.
+    let changed = body["fieldsChanged"].as_array().unwrap();
+    assert_eq!(changed.len(), 1);
+    assert_eq!(changed[0], "name");
+}
+
+// ──────────────────────── Trust-Task gate ────────────────────────
+
+#[tokio::test]
+async fn get_with_wrong_trust_task_returns_415() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/community/profile")
+        .header(
+            "Trust-Task",
+            "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
+        )
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}


### PR DESCRIPTION
## Summary

Implements **M0.7** of the VTC MVP Phase 0 plan. Adds the singleton community-profile record and the matching `GET` + `PUT /v1/community/profile` endpoints — the first M0.x endpoint that does real state-modifying work end-to-end through the hygiene-primitive stack (Trust-Task header → auth extractor → handler → audited state mutation).

## What's in this PR

### `vtc_service::community`

- **`CommunityProfile`** per spec §5.1: `community_did` (immutable), `name`, `description`, `logo_url`, `public_url`, `contact_email`, `language` (BCP 47, default `"en"`), `created_at`, `extensions` (opaque JSON, capped at **16 KiB** per plan **D4**). Serde with `rename_all = "camelCase"` so the wire shape matches what the admin UX expects.
- **`CommunityProfileUpdate`** — PUT-shaped patch with `Option<>` on every field for partial updates. **`community_did` + `created_at` are deliberately absent from the patch type** so they can't be supplied by an attacker; dropping them at the type level is stronger than runtime validation.
- **`apply()`** returns the list of fields that actually changed (used by the response + the future audit event). **Validates the `extensions` size before mutating anything**, so an over-limit blob doesn't half-apply the patch.
- **`load_profile` / `store_profile`** helpers keyed at `community/profile`. New `community` keyspace registered on `AppState`.

### `vtc_service::routes::community::profile`

- **`GET /v1/community/profile`** — any authenticated session reads. 404 `community_not_initialised` before bootstrap.
- **`PUT /v1/community/profile`** — `AdminAuth` required:
  - 404 if the profile hasn't been initialised yet.
  - 400 if the `extensions` blob exceeds 16 KiB.
  - Silently ignores unknown body fields (e.g. attempts to set `communityDid`) because they're not on the `CommunityProfileUpdate` shape.
  - Empty changeset → 200 with `fieldsChanged: []` (idempotent no-op).

### Trust Task

`community/profile/manage/1.0` covers both GET + PUT. The spec catalog's split into `community/profile/show/1.0` + `community/profile/update/1.0` lands when `TrustTaskRouter` gains per-method task selectors (Phase 1+). The matching `trust-tasks/community/profile/manage/1.0/{spec.md,schema.json}` documents the consolidation and points at the eventual split.

## Test coverage (18 new tests, all green)

**8 unit tests** in `vtc_service::community::profile`:
- `load_profile` returns `None` when uninitialised; round-trip when initialised.
- `apply` with no fields → empty changeset.
- `apply` changes only the listed fields.
- `apply` of same value yields empty changeset.
- `apply` clears `Option<String>` fields when supplied as `None` via `Option<Option<String>>`.
- Extensions at/under 16 KiB apply; over 16 KiB rejected with `Validation` error **before** any field mutates.
- Default language is `"en"` (BCP 47).

**10 integration tests** in `tests/community_profile.rs` (full router stack via `Router::oneshot`):
- GET 404 before init; 200 + camelCase fields after init.
- GET without Authorization → 401.
- PUT with reader role → 403 (`AdminAuth` gate).
- PUT updates and returns `fieldsChanged` listing only changed fields.
- PUT idempotent no-op (same value) → 200 with empty changeset.
- PUT before init → 404.
- PUT with oversized `extensions` → 400.
- PUT silently ignores `communityDid` in body — the immutable field stays unchanged in storage.
- GET with wrong Trust-Task header → 415 (verifies the gate fires before auth).

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo test --package vtc-service` — 49 unit + 6 audience + 10 community-profile pass.
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Notes

- **Audit emission deferred.** `CommunityProfileUpdated` (the variant we added in M0.1.5) is the right audit event for successful PUTs, but the `AuditWriter` isn't wired into `AppState` yet — that lands when M0.9 (`vtc setup` wizard) plumbs the master seed through to the audit-key store. The handler currently logs the field-change list via `tracing` so the operator visibility is there; the audit-log persistence catches up post-M0.9.
- **Bootstrap initialisation deferred.** A profile must already exist for GET/PUT to return anything — initial creation happens in M0.6 (admin bootstrap) when the install flow seeds the profile from the operator's wizard inputs. Until then, both GET and PUT return 404 by design.

## Phase 0 status

| | Milestone | Status |
|---|---|---|
| | M0.1.1–M0.1.6a + M0.2 + M0.3 + M0.4 | All merged |
| | **M0.7 — Community profile** | **PR (this one)** |
| | M0.5 — WebAuthn claim flow | Critical-path next |
| | M0.6, M0.1.6b, M0.8, M0.9, M0.10, M0.11, M0.12 | Not started |