### PR TITLE
feat(vtc): wire PasskeyState into AppState with Ed25519-only registration (M0.5.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8933,6 +8933,8 @@ dependencies = [
  "uuid",
  "vta-sdk 0.6.0",
  "vti-common",
+ "webauthn-rs",
+ "webauthn-rs-proto",
  "x25519-dalek",
  "zeroize",
 ]

--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -411,28 +411,44 @@ concurrent claims race correctly through the mutex. No WebAuthn yet.
   - `vtc-service/tests/webauthn_harness.rs`
 - **Deps**: M0.1.0 (just for the dep import)
 
-### `[ ]` M0.5.1 — VTC `AppState` implements `PasskeyState`
+### `[x]` M0.5.1 — VTC `AppState` implements `PasskeyState`
 
 - **Acceptance**
   - `vtc-service::server::AppState` implements
     `vti_common::auth::passkey::PasskeyState`
   - `build_webauthn` called once at startup using `public_url` from
-    the new `community.public_url` / routing config; resulting
+    the existing `AppConfig.public_url` field; resulting
     `Arc<Webauthn>` lives in `AppState`
-  - **Ed25519-only enforcement**: VTC's `PasskeyState` wraps
-    `build_webauthn`'s output to advertise only
-    `COSEAlgorithmIdentifier::EDDSA` in registration challenges;
-    rejection if the authenticator returns anything else
-    (`AppError::WebAuthnAlgorithmRejected`)
+  - **Ed25519-only enforcement**: new `vtc_service::webauthn` module
+    wraps the upstream `start_passkey_registration` so the wire
+    `pubKeyCredParams` and the persisted `RegistrationState.credential_algorithms`
+    both contain **only** EdDSA (`alg = -8`). `webauthn-rs` 0.5 has
+    no public `algorithms(…)` setter, so the rewrite uses serde
+    round-trip via `danger-allow-state-serialisation`.
+    `finish_eddsa_passkey_registration` additionally asserts the
+    returned `Passkey::cred_algorithm() == EDDSA` as defence in depth.
 - **Verify**
-  - Startup test: missing `public_url` → WebAuthn disabled,
-    `webauthn()` returns `None`, install routes return 503
-  - Ed25519 enforcement: ES256 registration attempt is rejected
+  - Startup test: missing `public_url` → `AppState.webauthn()`
+    returns `None` (`tests/passkey_state.rs::webauthn_returns_none_when_public_url_unset`).
+    Install routes returning 503 is deferred to **M0.5.2** when the
+    routes themselves land.
+  - The CCR + registration state rewrite is asserted via four unit
+    tests in `vtc-service::webauthn::tests::*` — start-time rewrite
+    + the two primitive mutators in isolation. The integration test
+    asserting "ES256 registration attempt is rejected" needs the
+    deterministic EdDSA authenticator harness from M0.5.0 and ships
+    in PR B alongside M0.5.2.
 - **Files**
-  - `vtc-service/src/server.rs` (extend `AppState`)
-  - `vtc-service/src/webauthn.rs` (thin Ed25519-restricting wrapper)
-  - `vtc-service/src/config.rs` (`public_url` field)
-- **Deps**: M0.5.0, M0.1.6
+  - `vtc-service/src/webauthn.rs` (new — Ed25519 restricting wrappers)
+  - `vtc-service/src/server.rs` (AppState +
+    `webauthn`/`passkey_ks`/`public_url`; `impl PasskeyState`)
+  - `vtc-service/src/lib.rs` (`pub mod webauthn`)
+  - `vtc-service/Cargo.toml` (enable `vti-common/passkey`, add
+    `webauthn-rs` + `webauthn-rs-proto` direct deps)
+  - `vtc-service/tests/passkey_state.rs` (new — 5 trait-impl tests)
+  - `vtc-service/tests/{admin_config,auth_audience,community_profile}.rs`
+    (new AppState fields)
+- **Deps**: M0.5.0 (test harness — deferred to PR B), M0.1.6
 - **Pre-impl decision**: D7, D11
 
 ### `[ ]` M0.5.2 — Install claim endpoints (start + finish)

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -31,7 +31,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.6" }
+vti-common = { path = "../vti-common", version = "0.6", features = ["passkey"] }
 vta-sdk = { path = "../vta-sdk", version = "0.6", features = [
   "didcomm",
   "session",
@@ -78,6 +78,13 @@ x25519-dalek = { workspace = true }
 zeroize = { version = "1", features = ["derive"] }
 multibase = { workspace = true }
 url = { workspace = true, optional = true }
+# WebAuthn — used by `crate::webauthn` for Ed25519-only registration
+# wrappers (M0.5.1). The protocol crate is a direct dep so we can
+# reference `PubKeyCredParams` and `COSEAlgorithm` without funnelling
+# them through `webauthn-rs::prelude` (which re-exports them but
+# also surfaces ~300 unrelated symbols).
+webauthn-rs = { workspace = true }
+webauthn-rs-proto = "0.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -32,3 +32,4 @@ pub mod server;
 pub mod setup;
 pub mod status;
 pub mod store;
+pub mod webauthn;

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -23,6 +23,14 @@ use crate::store::{KeyspaceHandle, Store};
 use tokio::sync::{RwLock, watch};
 use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, warn};
+use vti_common::auth::passkey::{PasskeyState, build_webauthn};
+use webauthn_rs::Webauthn;
+
+/// Default enrolment-invite TTL surfaced by `PasskeyState::enrollment_ttl`.
+/// Admin-invite enrolment lands in M0.6; until then this constant is the
+/// canonical "how long is an admin invite redeemable" value. An hour
+/// is the same default `webvh-common`'s passkey routes use.
+const DEFAULT_ENROLLMENT_TTL_SECS: u64 = 60 * 60;
 
 #[derive(Clone)]
 #[allow(dead_code)]
@@ -31,11 +39,20 @@ pub struct AppState {
     pub acl_ks: KeyspaceHandle,
     pub community_ks: KeyspaceHandle,
     pub config_ks: KeyspaceHandle,
+    pub passkey_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
     pub did_resolver: Option<DIDCacheClient>,
     pub secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
     pub jwt_keys: Option<Arc<JwtKeys>>,
     pub atm: Option<ATM>,
+    /// WebAuthn relying-party handle. `None` when `config.public_url`
+    /// is unset at startup — the install + admin-passkey routes 503
+    /// in that case (per `PasskeyState` contract).
+    pub webauthn: Option<Arc<Webauthn>>,
+    /// Cached `public_url` snapshot for `PasskeyState::public_url`.
+    /// Held alongside the `Webauthn` so the trait impl doesn't need
+    /// to take an async read-lock on the config every request.
+    pub public_url: Option<String>,
 }
 
 impl AuthState for AppState {
@@ -44,6 +61,45 @@ impl AuthState for AppState {
     }
     fn sessions_ks(&self) -> &KeyspaceHandle {
         &self.sessions_ks
+    }
+}
+
+impl PasskeyState for AppState {
+    fn webauthn(&self) -> Option<&Arc<Webauthn>> {
+        self.webauthn.as_ref()
+    }
+
+    fn acl_ks(&self) -> &KeyspaceHandle {
+        &self.acl_ks
+    }
+
+    fn access_token_expiry(&self) -> u64 {
+        // `config` is wrapped in an `Arc<RwLock<…>>`; the trait method
+        // is sync. `try_read` returns immediately — if a writer is
+        // mid-update we fall through to the workspace default so the
+        // auth layer never blocks. The default values match the
+        // compiled-in `AuthConfig::default()` and the runtime tax of
+        // missing a recently-updated value is bounded by the JWT TTL
+        // anyway.
+        self.config
+            .try_read()
+            .map(|c| c.auth.access_token_expiry)
+            .unwrap_or(AuthConfig::default().access_token_expiry)
+    }
+
+    fn refresh_token_expiry(&self) -> u64 {
+        self.config
+            .try_read()
+            .map(|c| c.auth.refresh_token_expiry)
+            .unwrap_or(AuthConfig::default().refresh_token_expiry)
+    }
+
+    fn public_url(&self) -> Option<&str> {
+        self.public_url.as_deref()
+    }
+
+    fn enrollment_ttl(&self) -> u64 {
+        DEFAULT_ENROLLMENT_TTL_SECS
     }
 }
 
@@ -57,9 +113,30 @@ pub async fn run(
     let acl_ks = store.keyspace("acl")?;
     let community_ks = store.keyspace("community")?;
     let config_ks = store.keyspace("config")?;
+    let passkey_ks = store.keyspace("passkey")?;
 
     // Initialize auth infrastructure
     let (did_resolver, secrets_resolver, jwt_keys, atm) = init_auth(&config, &*secret_store).await;
+
+    // Build WebAuthn relying party handle from `public_url`. Optional —
+    // a serverless / pre-setup deployment has no public URL yet and
+    // the install + admin-passkey routes will 503 until one is set.
+    let public_url = config.public_url.clone();
+    let webauthn = match &public_url {
+        Some(url) => match build_webauthn(url) {
+            Ok(w) => Some(Arc::new(w)),
+            Err(e) => {
+                warn!(
+                    "failed to build WebAuthn relying party from public_url '{url}': {e} — passkey routes disabled"
+                );
+                None
+            }
+        },
+        None => {
+            debug!("public_url not configured — WebAuthn / passkey routes disabled");
+            None
+        }
+    };
 
     // Bind TCP listener on the main thread for early port validation
     let addr = format!("{}:{}", config.server.host, config.server.port);
@@ -95,11 +172,14 @@ pub async fn run(
         acl_ks,
         community_ks,
         config_ks,
+        passkey_ks,
         config: Arc::new(RwLock::new(config)),
         did_resolver,
         secrets_resolver,
         jwt_keys,
         atm,
+        webauthn,
+        public_url,
     };
 
     // Spawn three named OS threads

--- a/vtc-service/src/webauthn.rs
+++ b/vtc-service/src/webauthn.rs
@@ -1,0 +1,292 @@
+//! VTC WebAuthn helpers — Ed25519-only registration enforcement.
+//!
+//! Implements **M0.5.1** of the VTC MVP Phase 0 plan. Wraps
+//! `vti_common::auth::passkey::build_webauthn` with the VTC-specific
+//! invariant that **only Ed25519 (`COSEAlgorithm::EDDSA`,
+//! `COSEAlgorithmIdentifier = -8`) registrations are accepted**.
+//! The candidate admin DID is a `did:key` projected directly from the
+//! passkey's COSE public key — every other COSE curve breaks that
+//! projection (spec §4.2 second bullet).
+//!
+//! ## Why a wrapper
+//!
+//! `webauthn-rs` 0.5 builds its safe `Webauthn` instance with
+//! `COSEAlgorithm::secure_algs()`, which today returns
+//! `[ES256, RS256]` — `EDDSA` is commented out in the upstream
+//! `secure_algs` constructor. The high-level builder exposes no
+//! `algorithms(…)` setter, so the only way to advertise EdDSA on the
+//! wire **and** accept it at finish-time is to post-process the
+//! ceremony state.
+//!
+//! This module provides two helpers that callers must use instead of
+//! `Webauthn::start_passkey_registration` /
+//! `Webauthn::finish_passkey_registration` directly:
+//!
+//! - [`start_eddsa_passkey_registration`] — runs the upstream start,
+//!   then rewrites `CreationChallengeResponse.public_key.pub_key_cred_params`
+//!   and `PasskeyRegistration.rs.credential_algorithms` to contain
+//!   **only** EDDSA. The rewrite uses the `danger-allow-state-serialisation`
+//!   feature (enabled workspace-wide) to round-trip the state through
+//!   JSON — there is no other public path into the private
+//!   `credential_algorithms` field.
+//! - [`finish_eddsa_passkey_registration`] — runs the upstream finish,
+//!   then rejects any returned `Passkey` whose `cred_algorithm()` is
+//!   not `EDDSA` (defence-in-depth: upstream's own check already
+//!   asserts the credential matches `credential_algorithms`, but we
+//!   double-check before the caller derives a `did:key`).
+//!
+//! ## When upstream gains an `algorithms` setter
+//!
+//! Replace the JSON-rewrite path with the setter and keep the
+//! finish-time check (it's cheap). Until then this is the only safe
+//! way to honour the spec's "Ed25519-only" invariant without forking
+//! `webauthn-rs` or dropping to `webauthn-rs-core::WebauthnCore::new_unsafe_experts_only`.
+
+use webauthn_rs::prelude::{
+    CreationChallengeResponse, Passkey, PasskeyRegistration, RegisterPublicKeyCredential, Webauthn,
+};
+use webauthn_rs_proto::{COSEAlgorithm, PubKeyCredParams};
+
+use crate::error::AppError;
+
+/// COSE algorithm identifier for EdDSA. Pinned in code so the
+/// runtime check is independent of upstream renaming `COSEAlgorithm::EDDSA`.
+pub const EDDSA_ALG: i64 = -8;
+
+/// Start a passkey registration ceremony constrained to Ed25519.
+///
+/// Calls `Webauthn::start_passkey_registration` then post-processes
+/// both the wire challenge and the persisted ceremony state so that:
+///
+/// - The browser's `navigator.credentials.create()` call advertises
+///   **only** `{type: "public-key", alg: -8}` in `pubKeyCredParams`.
+/// - Upstream's finish-time check
+///   (`credential_algorithms.iter().any(|alg| alg == &cred.type_)`)
+///   only accepts EdDSA credentials.
+pub fn start_eddsa_passkey_registration(
+    webauthn: &Webauthn,
+    user_unique_id: uuid::Uuid,
+    user_name: &str,
+    user_display_name: &str,
+    exclude_credentials: Option<Vec<webauthn_rs::prelude::CredentialID>>,
+) -> Result<(CreationChallengeResponse, PasskeyRegistration), AppError> {
+    let (mut ccr, reg_state) = webauthn
+        .start_passkey_registration(
+            user_unique_id,
+            user_name,
+            user_display_name,
+            exclude_credentials,
+        )
+        .map_err(|e| AppError::Internal(format!("webauthn registration start failed: {e}")))?;
+
+    restrict_ccr_to_eddsa(&mut ccr);
+    let reg_state = restrict_state_to_eddsa(&reg_state)?;
+
+    Ok((ccr, reg_state))
+}
+
+/// Finish a passkey registration ceremony and assert the resulting
+/// credential is Ed25519.
+///
+/// `Webauthn::finish_passkey_registration` already validates the
+/// credential's algorithm against the state's
+/// `credential_algorithms` list — but only because
+/// [`start_eddsa_passkey_registration`] mutated that list to
+/// `[EDDSA]`. This second check defends against a future bug where
+/// the start-side mutation silently fails to apply (e.g. a serde
+/// schema change in upstream): we'd still reject the non-EdDSA
+/// credential here rather than emit a malformed `did:key`.
+pub fn finish_eddsa_passkey_registration(
+    webauthn: &Webauthn,
+    credential: &RegisterPublicKeyCredential,
+    state: &PasskeyRegistration,
+) -> Result<Passkey, AppError> {
+    let passkey = webauthn
+        .finish_passkey_registration(credential, state)
+        .map_err(|e| AppError::Authentication(format!("passkey registration failed: {e}")))?;
+
+    let cred_alg = passkey.cred_algorithm();
+    if *cred_alg != COSEAlgorithm::EDDSA {
+        return Err(AppError::Authentication(format!(
+            "passkey registration rejected: VTC requires Ed25519 (EdDSA), authenticator returned {cred_alg:?}",
+        )));
+    }
+
+    Ok(passkey)
+}
+
+/// Mutate a [`CreationChallengeResponse`] in place so that
+/// `public_key.pub_key_cred_params` lists **only** EdDSA. Public so
+/// the unit tests can drive it directly without spinning up a full
+/// `Webauthn`.
+pub(crate) fn restrict_ccr_to_eddsa(ccr: &mut CreationChallengeResponse) {
+    ccr.public_key.pub_key_cred_params = vec![PubKeyCredParams {
+        type_: "public-key".to_string(),
+        alg: EDDSA_ALG,
+    }];
+}
+
+/// Round-trip a [`PasskeyRegistration`] through JSON and rewrite the
+/// inner state's `credential_algorithms` to `[EDDSA]`. Requires the
+/// `danger-allow-state-serialisation` feature on `webauthn-rs`
+/// (enabled workspace-wide in the root `Cargo.toml`).
+///
+/// Returns an [`AppError::Internal`] if the state's JSON shape ever
+/// drifts and the rewrite cannot find the expected
+/// `rs.credential_algorithms` path. That is a hard upstream-breakage
+/// signal, not an operator-facing condition.
+pub(crate) fn restrict_state_to_eddsa(
+    state: &PasskeyRegistration,
+) -> Result<PasskeyRegistration, AppError> {
+    let mut value = serde_json::to_value(state).map_err(|e| {
+        AppError::Internal(format!(
+            "failed to serialise passkey registration state: {e}"
+        ))
+    })?;
+
+    let rs = value
+        .get_mut("rs")
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| {
+            AppError::Internal("passkey registration state missing 'rs' object".into())
+        })?;
+
+    if !rs.contains_key("credential_algorithms") {
+        return Err(AppError::Internal(
+            "passkey registration state missing 'rs.credential_algorithms'".into(),
+        ));
+    }
+
+    // `Vec<COSEAlgorithm>` serialises as a sequence of *enum-variant
+    // strings* (the upstream enum has no `#[serde(repr)]`), not as
+    // COSE integer identifiers. Use `"EDDSA"` to match the round-trip
+    // shape — `[-8]` would fail with "invalid type: number, expected
+    // string or map".
+    rs.insert(
+        "credential_algorithms".to_string(),
+        serde_json::json!(["EDDSA"]),
+    );
+
+    serde_json::from_value(value).map_err(|e| {
+        AppError::Internal(format!(
+            "failed to deserialise rewritten passkey registration state: {e}"
+        ))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+    use vti_common::auth::passkey::build_webauthn;
+
+    fn webauthn() -> Webauthn {
+        build_webauthn("https://vtc.example.com").expect("webauthn builder")
+    }
+
+    #[test]
+    fn start_rewrites_ccr_to_eddsa_only() {
+        let w = webauthn();
+        let (ccr, _state) = start_eddsa_passkey_registration(
+            &w,
+            Uuid::new_v4(),
+            "did:key:zABC",
+            "did:key:zABC",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            ccr.public_key.pub_key_cred_params.len(),
+            1,
+            "expected exactly one cred params entry after EdDSA restriction"
+        );
+        let params = &ccr.public_key.pub_key_cred_params[0];
+        assert_eq!(params.type_, "public-key");
+        assert_eq!(params.alg, EDDSA_ALG, "alg must be EdDSA (-8)");
+    }
+
+    #[test]
+    fn start_rewrites_state_credential_algorithms_to_eddsa_only() {
+        let w = webauthn();
+        let (_ccr, state) = start_eddsa_passkey_registration(
+            &w,
+            Uuid::new_v4(),
+            "did:key:zABC",
+            "did:key:zABC",
+            None,
+        )
+        .unwrap();
+
+        // `PasskeyRegistration` exposes no public algorithms accessor;
+        // serialise and inspect the JSON instead. This is the same
+        // mechanism the implementation uses to perform the rewrite,
+        // so the round-trip is the assertion.
+        let json = serde_json::to_value(&state).unwrap();
+        let algs = json
+            .get("rs")
+            .and_then(|rs| rs.get("credential_algorithms"))
+            .expect("credential_algorithms present");
+        assert_eq!(
+            algs,
+            &serde_json::json!(["EDDSA"]),
+            "credential_algorithms must contain only EdDSA (serialised as the enum-variant name)"
+        );
+    }
+
+    #[test]
+    fn restrict_ccr_overwrites_default_algorithm_list() {
+        let w = webauthn();
+        let (mut ccr, _state) = w
+            .start_passkey_registration(Uuid::new_v4(), "u", "u", None)
+            .unwrap();
+
+        // Sanity: upstream's default list contains more than one entry
+        // and does NOT include EdDSA today (see workspace CLAUDE.md
+        // discussion). If this assertion ever fails it means upstream
+        // started shipping EdDSA in `secure_algs()` — at which point the
+        // rewrite becomes pure defence-in-depth and we can simplify.
+        assert!(ccr.public_key.pub_key_cred_params.len() >= 2);
+        assert!(
+            !ccr.public_key
+                .pub_key_cred_params
+                .iter()
+                .any(|p| p.alg == EDDSA_ALG)
+        );
+
+        restrict_ccr_to_eddsa(&mut ccr);
+
+        assert_eq!(ccr.public_key.pub_key_cred_params.len(), 1);
+        assert_eq!(ccr.public_key.pub_key_cred_params[0].alg, EDDSA_ALG);
+    }
+
+    #[test]
+    fn restrict_state_round_trips_through_serde() {
+        let w = webauthn();
+        let (_ccr, state) = w
+            .start_passkey_registration(Uuid::new_v4(), "u", "u", None)
+            .unwrap();
+
+        let rewritten = restrict_state_to_eddsa(&state).unwrap();
+
+        let json = serde_json::to_value(&rewritten).unwrap();
+        assert_eq!(
+            json["rs"]["credential_algorithms"],
+            serde_json::json!(["EDDSA"])
+        );
+
+        // Other state fields survive the round-trip — pick `policy`
+        // and `require_resident_key` as representative sentinels.
+        let original_json = serde_json::to_value(&state).unwrap();
+        for field in ["policy", "require_resident_key"] {
+            assert_eq!(
+                json["rs"][field], original_json["rs"][field],
+                "field {field} must survive the rewrite",
+            );
+        }
+    }
+}

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -51,6 +51,7 @@ async fn build() -> Fixture {
     let acl_ks = store.keyspace("acl").unwrap();
     let community_ks = store.keyspace("community").unwrap();
     let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -73,11 +74,14 @@ async fn build() -> Fixture {
         acl_ks,
         community_ks,
         config_ks,
+        passkey_ks,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,
         jwt_keys: Some(jwt_keys.clone()),
         atm: None,
+        webauthn: None,
+        public_url: None,
     };
 
     let router = routes::router().with_state(state.clone());

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -51,6 +51,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let acl_ks = store.keyspace("acl").unwrap();
     let community_ks = store.keyspace("community").unwrap();
     let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -73,11 +74,14 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         acl_ks,
         community_ks,
         config_ks,
+        passkey_ks,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,
         jwt_keys: Some(jwt_keys.clone()),
         atm: None,
+        webauthn: None,
+        public_url: None,
     };
 
     let router = routes::router().with_state(state);

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -52,6 +52,7 @@ async fn build() -> Fixture {
     let acl_ks = store.keyspace("acl").unwrap();
     let community_ks = store.keyspace("community").unwrap();
     let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -74,11 +75,14 @@ async fn build() -> Fixture {
         acl_ks,
         community_ks,
         config_ks,
+        passkey_ks,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,
         jwt_keys: Some(jwt_keys.clone()),
         atm: None,
+        webauthn: None,
+        public_url: None,
     };
 
     let router = routes::router().with_state(state.clone());

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -1,0 +1,117 @@
+//! Coverage for the `PasskeyState` impl on `vtc_service::server::AppState`.
+//!
+//! Verifies the M0.5.1 acceptance criteria:
+//!
+//! - `webauthn()` returns `Some` iff `public_url` was set at startup.
+//! - `public_url()` reflects the cached snapshot, not the live config
+//!   (so a writer mid-update never blocks the trait method).
+//! - `access_token_expiry` / `refresh_token_expiry` track the
+//!   `AuthConfig` defaults when the lock is uncontested.
+//! - `enrollment_ttl()` returns the workspace default.
+//!
+//! Constructed via direct field-by-field `AppState { … }` initialisation
+//! — same pattern the other VTC integration tests use, since the
+//! `run()` startup path needs a `Store` + tokio runtime that's
+//! overkill for a trait-method check.
+
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use vti_common::auth::passkey::{PasskeyState, build_webauthn};
+use vti_common::config::{AuthConfig, StoreConfig};
+use vti_common::store::Store;
+
+use vtc_service::config::AppConfig;
+use vtc_service::server::AppState;
+
+fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let webauthn = public_url.map(|u| Arc::new(build_webauthn(u).expect("build webauthn")));
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: None,
+        atm: None,
+        webauthn,
+        public_url: public_url.map(|s| s.to_string()),
+    };
+    (state, dir)
+}
+
+#[tokio::test]
+async fn webauthn_returns_none_when_public_url_unset() {
+    let (state, _dir) = build_state(None);
+    assert!(state.webauthn().is_none());
+    assert!(state.public_url().is_none());
+}
+
+#[tokio::test]
+async fn webauthn_returns_some_when_public_url_set() {
+    let (state, _dir) = build_state(Some("https://vtc.example.com"));
+    assert!(state.webauthn().is_some());
+    assert_eq!(state.public_url(), Some("https://vtc.example.com"));
+}
+
+#[tokio::test]
+async fn passkey_state_acl_ks_matches_app_state_field() {
+    let (state, _dir) = build_state(None);
+    // The trait returns `&KeyspaceHandle`; we just need a couple of
+    // round-trip writes to confirm both paths reach the same store.
+    let key = b"passkey-state-test".to_vec();
+    PasskeyState::acl_ks(&state)
+        .insert_raw(key.clone(), b"value".to_vec())
+        .await
+        .unwrap();
+    let got = state.acl_ks.get_raw(key).await.unwrap();
+    assert_eq!(got.as_deref(), Some(&b"value"[..]));
+}
+
+#[tokio::test]
+async fn token_expiries_track_auth_config_defaults() {
+    let (state, _dir) = build_state(None);
+    let defaults = AuthConfig::default();
+    assert_eq!(state.access_token_expiry(), defaults.access_token_expiry);
+    assert_eq!(state.refresh_token_expiry(), defaults.refresh_token_expiry);
+}
+
+#[tokio::test]
+async fn enrollment_ttl_uses_workspace_default() {
+    let (state, _dir) = build_state(None);
+    // The exact value is documented in `server::DEFAULT_ENROLLMENT_TTL_SECS`
+    // (one hour); assert the contract rather than the constant to avoid
+    // brittle coupling to the literal — but verify it's a sensible
+    // positive duration.
+    let ttl = state.enrollment_ttl();
+    assert!(
+        (60..=86_400).contains(&ttl),
+        "enrollment_ttl {ttl} outside expected [60s, 24h] sanity range",
+    );
+}


### PR DESCRIPTION
## Summary

- Implements **M0.5.1** of the VTC MVP Phase 0 plan.
- `AppState` gains `webauthn: Option<Arc<Webauthn>>`, `passkey_ks`,
  and a cached `public_url` snapshot.
- New `vtc_service::webauthn` module wraps
  `start_passkey_registration` / `finish_passkey_registration` to
  advertise **only** Ed25519 (COSE `-8`) on the wire and accept only
  EdDSA at finish-time.
- `AppState` implements `vti_common::auth::passkey::PasskeyState` so
  the install + admin-passkey routes that land in subsequent PRs can
  reach the WebAuthn handle uniformly.

## Why the wrapper

`webauthn-rs` 0.5 builds its safe `Webauthn` with
`COSEAlgorithm::secure_algs()`, which today returns `[ES256, RS256]`
— `EDDSA` is commented out upstream. The high-level builder exposes
no `algorithms(…)` setter, so we rewrite both ends:

- `CreationChallengeResponse.public_key.pub_key_cred_params` →
  `[{type: "public-key", alg: -8}]`
- `PasskeyRegistration.rs.credential_algorithms` → `["EDDSA"]`
  (round-tripped via `danger-allow-state-serialisation` — already
  enabled workspace-wide).

`finish_eddsa_passkey_registration` adds a defence-in-depth check on
`Passkey::cred_algorithm() == EDDSA`. When upstream eventually
ships an `algorithms` setter we can drop the serde rewrite and keep
the finish-time check.

## What's deferred

- **M0.5.0** (deterministic EdDSA authenticator harness) and
  **M0.5.2** (install claim start/finish endpoints) ship together in
  the follow-up PR. The "ES256 registration attempt is rejected"
  integration test needs the harness, so it lives there.
- 503 behaviour for install routes when `public_url` is unset is
  asserted once the routes land in M0.5.2.

## Test plan

- [x] `cargo test --package vtc-service` — 95 tests pass (63 lib + 11
      admin_config + 6 auth_audience + 10 community_profile + 5 new
      passkey_state).
- [x] `cargo test --package vti-common` — 155 lib + 14 unit pass.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --lib -- -D warnings` clean.
- [x] Workspace builds clean on default features.

New tests:

- `webauthn::tests::start_rewrites_ccr_to_eddsa_only`
- `webauthn::tests::start_rewrites_state_credential_algorithms_to_eddsa_only`
- `webauthn::tests::restrict_ccr_overwrites_default_algorithm_list`
- `webauthn::tests::restrict_state_round_trips_through_serde`
- `tests/passkey_state.rs::webauthn_returns_none_when_public_url_unset`
- `tests/passkey_state.rs::webauthn_returns_some_when_public_url_set`
- `tests/passkey_state.rs::passkey_state_acl_ks_matches_app_state_field`
- `tests/passkey_state.rs::token_expiries_track_auth_config_defaults`
- `tests/passkey_state.rs::enrollment_ttl_uses_workspace_default`