### PR TITLE
test(vtc): soft Ed25519 authenticator harness for WebAuthn integration tests (M0.5.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8903,6 +8903,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "ciborium",
  "clap",
  "dialoguer",
  "didwebvh-rs",

--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -393,23 +393,37 @@ concurrent claims race correctly through the mutex. No WebAuthn yet.
 
 ## M0.5 — WebAuthn claim flow
 
-### `[ ]` M0.5.0 — WebAuthn test harness validation
+### `[x]` M0.5.0 — WebAuthn test harness validation
 
 - **Acceptance**
-  - A test helper in `vtc-service/tests/common/webauthn_harness.rs`
-    can produce deterministic registration + authentication
-    responses for a fake authenticator
-  - Helper covers Ed25519 (EdDSA, `COSEAlgorithmIdentifier = -8`)
-  - At least one trivial test confirms the helper drives
-    `webauthn-rs` server-side validation green
+  - `tests/common/webauthn_harness.rs` ships a
+    `SoftEd25519Authenticator` producing deterministic CTAP-format
+    registration + authentication responses (none-attestation, COSE
+    OKP Ed25519 public keys via `ciborium` CBOR encoding, signatures
+    from `ed25519-dalek`).
+  - The harness refuses non-EdDSA registration challenges with a
+    panic — protects callers that bypass
+    `vtc_service::webauthn::start_eddsa_passkey_registration`.
 - **Verify**
-  - A standalone test (`tests/webauthn_harness.rs`) exercises the
-    helper through a full register-and-authenticate cycle
+  - `tests/webauthn_harness.rs` × 3 tests:
+    - `register_then_authenticate_completes_end_to_end` — full
+      ceremony succeeds, harness pubkey matches the passkey's stored
+      COSE `x` coordinate (proves the byte that becomes the
+      `did:key` is the one the authenticator generated).
+    - `second_authenticate_increments_sign_count` — counter
+      monotonicity holds across multiple assertions.
+    - `register_panics_when_challenge_lacks_eddsa` — guard against
+      misuse by tests that drive the upstream challenge directly.
 - **Files**
-  - `vtc-service/tests/common/mod.rs`
-  - `vtc-service/tests/common/webauthn_harness.rs`
-  - `vtc-service/tests/webauthn_harness.rs`
-- **Deps**: M0.1.0 (just for the dep import)
+  - `vtc-service/tests/common/mod.rs` (new)
+  - `vtc-service/tests/common/webauthn_harness.rs` (new — ~260 lines)
+  - `vtc-service/tests/webauthn_harness.rs` (new — 3 validation tests)
+  - `vtc-service/Cargo.toml` (`ciborium` dev-dep)
+- **Deps**: M0.5.1 (uses the EdDSA-restricting wrappers as the
+  challenge producer)
+- **Note**: Upstream `webauthn-authenticator-rs::SoftPasskey` is
+  hard-coded to ES256 (`openssl::ec`) and was unsuitable; the
+  in-tree harness sidesteps that.
 
 ### `[x]` M0.5.1 — VTC `AppState` implements `PasskeyState`
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -92,6 +92,12 @@ tempfile = "3"
 # `Router::oneshot` — same pattern as `vta-service/tests/api_integration.rs`.
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
+# CBOR encoding for the soft Ed25519 authenticator harness
+# (`tests/common/webauthn_harness.rs`). Produces the CTAP attestation
+# object + COSE public key on the same wire shape `webauthn-rs-core`
+# parses (it uses `serde_cbor_2` internally — `ciborium` is canonical
+# enough for both to agree).
+ciborium = "0.2"
 
 [lints]
 workspace = true

--- a/vtc-service/tests/common/mod.rs
+++ b/vtc-service/tests/common/mod.rs
@@ -1,0 +1,8 @@
+//! Shared test fixtures for vtc-service integration tests.
+//!
+//! Pulled in via `mod common;` from each integration test file —
+//! every binary under `tests/` is its own crate, so importable
+//! helpers live here.
+
+#[allow(dead_code)] // pulled into different test binaries; not every file uses every helper
+pub mod webauthn_harness;

--- a/vtc-service/tests/common/webauthn_harness.rs
+++ b/vtc-service/tests/common/webauthn_harness.rs
@@ -1,0 +1,332 @@
+//! Deterministic soft authenticator for WebAuthn integration tests.
+//!
+//! Implements **M0.5.0** of the VTC MVP Phase 0 plan. The harness
+//! produces real CTAP attestation objects + COSE OKP-Ed25519 public
+//! keys that `webauthn-rs-core` can parse, so route-level integration
+//! tests can drive a complete register + authenticate ceremony
+//! without a browser.
+//!
+//! ## Why we ship our own instead of `webauthn-authenticator-rs::SoftPasskey`
+//!
+//! The upstream `SoftPasskey` (`webauthn-authenticator-rs` 0.5)
+//! generates ES256/EC keys only — its key-generation code is
+//! hard-coded to `openssl::ec`. VTC's install flow demands EdDSA
+//! (spec §4.2: the passkey's COSE public key projects directly into
+//! a `did:key`), so we need an authenticator that produces COSE OKP
+//! Ed25519 credentials. This module is ~250 lines of CTAP-format
+//! encoding on top of `ed25519-dalek` — small enough to ship and
+//! understand in tree.
+//!
+//! ## Scope
+//!
+//! - Format: WebAuthn CTAP 2 "none" attestation. No attestation
+//!   signature, no `attStmt`. Sufficient because `webauthn-rs`'s
+//!   `start_passkey_registration` uses
+//!   `AttestationConveyancePreference::None`.
+//! - Algorithm: EdDSA only. `register()` panics if the challenge's
+//!   `pub_key_cred_params` doesn't include `alg == -8` — the very
+//!   contract `vtc_service::webauthn::start_eddsa_passkey_registration`
+//!   enforces.
+//! - Resident-key / discoverable-credential semantics are out of
+//!   scope (start_passkey_registration sets
+//!   `require_resident_key = false`).
+//!
+//! ## Encoding references
+//!
+//! - <https://www.w3.org/TR/webauthn-3/#attestation-object>
+//! - <https://www.w3.org/TR/webauthn-3/#sctn-authenticator-data>
+//! - <https://datatracker.ietf.org/doc/html/rfc8152#section-13>
+//!   (COSE Key — OKP)
+
+use std::collections::HashMap;
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use ed25519_dalek::{Signer, SigningKey};
+use sha2::{Digest, Sha256};
+use webauthn_rs::prelude::{
+    Base64UrlSafeData, CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
+    RequestChallengeResponse,
+};
+use webauthn_rs_proto::{AuthenticatorAssertionResponseRaw, AuthenticatorAttestationResponseRaw};
+
+/// Flags byte: User Present.
+const FLAG_UP: u8 = 0x01;
+/// Flags byte: User Verified.
+const FLAG_UV: u8 = 0x04;
+/// Flags byte: Attested Credential Data present.
+const FLAG_AT: u8 = 0x40;
+
+/// COSE algorithm identifier for EdDSA.
+const COSE_ALG_EDDSA: i64 = -8;
+
+/// Pinned AAGUID for the harness — distinctive enough to spot in
+/// debug output without colliding with any real authenticator's
+/// identifier.
+const HARNESS_AAGUID: [u8; 16] = *b"vtc-soft-eddsa\0\0";
+
+/// Soft Ed25519 authenticator. Owns the credentials it mints; pass
+/// `&mut self` to `register()` to add a new one, `&mut self` to
+/// `authenticate()` to sign + bump the per-credential counter.
+pub struct SoftEd25519Authenticator {
+    credentials: HashMap<Vec<u8>, CredentialEntry>,
+}
+
+struct CredentialEntry {
+    signing_key: SigningKey,
+    sign_count: u32,
+}
+
+impl Default for SoftEd25519Authenticator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SoftEd25519Authenticator {
+    pub fn new() -> Self {
+        Self {
+            credentials: HashMap::new(),
+        }
+    }
+
+    /// Process a [`CreationChallengeResponse`] and return a fake
+    /// [`RegisterPublicKeyCredential`] plus the Ed25519 verifying-key
+    /// bytes (32 bytes) of the credential just minted. The
+    /// verifying-key bytes are what consumers project into a `did:key`.
+    ///
+    /// Asserts the challenge advertises EdDSA in
+    /// `pubKeyCredParams` — `vtc_service::webauthn::start_eddsa_passkey_registration`
+    /// is the only sanctioned producer of these challenges, and it
+    /// always restricts to `[{public-key, -8}]`. Other test code that
+    /// drives the upstream-default challenge directly will trip this
+    /// panic, which is the intended failure mode.
+    pub fn register(
+        &mut self,
+        ccr: &CreationChallengeResponse,
+        origin: &str,
+    ) -> (RegisterPublicKeyCredential, [u8; 32]) {
+        let cred_params = &ccr.public_key.pub_key_cred_params;
+        assert!(
+            cred_params.iter().any(|p| p.alg == COSE_ALG_EDDSA),
+            "soft authenticator only produces EdDSA credentials but challenge advertises {cred_params:?}",
+        );
+
+        // Deterministic seed: SHA-256 of the challenge bytes + the
+        // RP id. Tests that want distinct credentials for the same
+        // challenge can mutate either side; the default gives a
+        // stable, reproducible key per ceremony.
+        let mut seed_input = Vec::new();
+        seed_input.extend_from_slice(ccr.public_key.challenge.as_ref());
+        seed_input.extend_from_slice(ccr.public_key.rp.id.as_bytes());
+        seed_input.extend_from_slice(b"soft-eddsa-seed/v1");
+        let seed: [u8; 32] = Sha256::digest(&seed_input).into();
+        let signing_key = SigningKey::from_bytes(&seed);
+        let verifying_key = signing_key.verifying_key().to_bytes();
+
+        // 16-byte credential ID — short enough to look like a passkey
+        // synced credential, deterministic for reproducibility.
+        let mut cred_id_input = Vec::new();
+        cred_id_input.extend_from_slice(&verifying_key);
+        cred_id_input.extend_from_slice(b"cred-id/v1");
+        let cred_id = Sha256::digest(&cred_id_input)[..16].to_vec();
+
+        let client_data_json =
+            client_data_json("webauthn.create", ccr.public_key.challenge.as_ref(), origin);
+
+        let auth_data = authenticator_data(
+            &ccr.public_key.rp.id,
+            FLAG_UP | FLAG_UV | FLAG_AT,
+            0,
+            Some(AttestedCredentialData {
+                aaguid: &HARNESS_AAGUID,
+                credential_id: &cred_id,
+                cose_public_key: &cose_okp_ed25519(&verifying_key),
+            }),
+        );
+
+        let attestation_object = attestation_object_none(&auth_data);
+
+        self.credentials.insert(
+            cred_id.clone(),
+            CredentialEntry {
+                signing_key,
+                sign_count: 0,
+            },
+        );
+
+        let credential = RegisterPublicKeyCredential {
+            id: B64.encode(&cred_id),
+            raw_id: Base64UrlSafeData::from(cred_id),
+            response: AuthenticatorAttestationResponseRaw {
+                attestation_object: Base64UrlSafeData::from(attestation_object),
+                client_data_json: Base64UrlSafeData::from(client_data_json),
+                transports: None,
+            },
+            type_: "public-key".to_string(),
+            extensions: Default::default(),
+        };
+
+        (credential, verifying_key)
+    }
+
+    /// Process a [`RequestChallengeResponse`] and produce a signed
+    /// [`PublicKeyCredential`] for one of the credentials this
+    /// authenticator owns. Increments the credential's `sign_count`
+    /// on success.
+    ///
+    /// Picks the first credential in `allowCredentials` that this
+    /// authenticator owns. Panics if none match — a programming bug
+    /// in the calling test.
+    pub fn authenticate(
+        &mut self,
+        rcr: &RequestChallengeResponse,
+        origin: &str,
+    ) -> PublicKeyCredential {
+        let cred_id = rcr
+            .public_key
+            .allow_credentials
+            .iter()
+            .find_map(|allow| {
+                let id_bytes: Vec<u8> = allow.id.as_ref().to_vec();
+                if self.credentials.contains_key(&id_bytes) {
+                    Some(id_bytes)
+                } else {
+                    None
+                }
+            })
+            .expect("no credential in allowCredentials is known to this authenticator");
+
+        let entry = self
+            .credentials
+            .get_mut(&cred_id)
+            .expect("cred_id resolved above");
+        entry.sign_count = entry.sign_count.wrapping_add(1);
+        let sign_count = entry.sign_count;
+
+        let client_data_json =
+            client_data_json("webauthn.get", rcr.public_key.challenge.as_ref(), origin);
+        let client_data_hash = Sha256::digest(&client_data_json);
+
+        let auth_data =
+            authenticator_data(&rcr.public_key.rp_id, FLAG_UP | FLAG_UV, sign_count, None);
+
+        // EdDSA signature is over `authenticatorData || clientDataHash`.
+        let mut signed = Vec::with_capacity(auth_data.len() + client_data_hash.len());
+        signed.extend_from_slice(&auth_data);
+        signed.extend_from_slice(&client_data_hash);
+        let signature = entry.signing_key.sign(&signed).to_bytes();
+
+        PublicKeyCredential {
+            id: B64.encode(&cred_id),
+            raw_id: Base64UrlSafeData::from(cred_id),
+            response: AuthenticatorAssertionResponseRaw {
+                authenticator_data: Base64UrlSafeData::from(auth_data),
+                client_data_json: Base64UrlSafeData::from(client_data_json),
+                signature: Base64UrlSafeData::from(signature.to_vec()),
+                user_handle: None,
+            },
+            type_: "public-key".to_string(),
+            extensions: Default::default(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoding helpers
+// ---------------------------------------------------------------------------
+
+struct AttestedCredentialData<'a> {
+    aaguid: &'a [u8; 16],
+    credential_id: &'a [u8],
+    cose_public_key: &'a [u8],
+}
+
+/// Build the WebAuthn `authenticatorData` byte string. Spec ref:
+/// <https://www.w3.org/TR/webauthn-3/#sctn-authenticator-data>.
+fn authenticator_data(
+    rp_id: &str,
+    flags: u8,
+    sign_count: u32,
+    attested: Option<AttestedCredentialData<'_>>,
+) -> Vec<u8> {
+    let rp_id_hash = Sha256::digest(rp_id.as_bytes());
+
+    let mut out = Vec::with_capacity(37 + 16 + 2 + 16 + 64);
+    out.extend_from_slice(&rp_id_hash);
+    out.push(flags);
+    out.extend_from_slice(&sign_count.to_be_bytes());
+
+    if let Some(data) = attested {
+        debug_assert!(
+            flags & FLAG_AT != 0,
+            "AT flag must be set with attested data"
+        );
+        out.extend_from_slice(data.aaguid);
+        out.extend_from_slice(
+            &u16::try_from(data.credential_id.len())
+                .expect("credential ID fits in u16")
+                .to_be_bytes(),
+        );
+        out.extend_from_slice(data.credential_id);
+        out.extend_from_slice(data.cose_public_key);
+    }
+
+    out
+}
+
+/// Encode the CTAP attestation object using format `"none"`. Spec ref:
+/// <https://www.w3.org/TR/webauthn-3/#sctn-attestation-formats>.
+fn attestation_object_none(auth_data: &[u8]) -> Vec<u8> {
+    use ciborium::Value;
+    let map = Value::Map(vec![
+        (
+            Value::Text("fmt".to_string()),
+            Value::Text("none".to_string()),
+        ),
+        (Value::Text("attStmt".to_string()), Value::Map(vec![])),
+        (
+            Value::Text("authData".to_string()),
+            Value::Bytes(auth_data.to_vec()),
+        ),
+    ]);
+    let mut out = Vec::new();
+    ciborium::into_writer(&map, &mut out).expect("CBOR encode never fails for owned Value");
+    out
+}
+
+/// Encode a COSE OKP Ed25519 public key. Spec ref:
+/// <https://datatracker.ietf.org/doc/html/rfc8152#section-13.2>.
+fn cose_okp_ed25519(public_key: &[u8; 32]) -> Vec<u8> {
+    use ciborium::Value;
+    // Key parameters (CBOR integer keys):
+    //   1 (kty)  = 1 (OKP)
+    //   3 (alg)  = -8 (EdDSA)
+    //  -1 (crv)  = 6 (Ed25519)
+    //  -2 (x)    = <32-byte public key>
+    let map = Value::Map(vec![
+        (Value::Integer(1.into()), Value::Integer(1.into())),
+        (Value::Integer(3.into()), Value::Integer((-8).into())),
+        (Value::Integer((-1).into()), Value::Integer(6.into())),
+        (
+            Value::Integer((-2).into()),
+            Value::Bytes(public_key.to_vec()),
+        ),
+    ]);
+    let mut out = Vec::new();
+    ciborium::into_writer(&map, &mut out).expect("CBOR encode never fails for owned Value");
+    out
+}
+
+/// Build the WebAuthn `clientDataJSON` byte string. Spec ref:
+/// <https://www.w3.org/TR/webauthn-3/#dictionary-client-data>.
+fn client_data_json(type_: &str, challenge_bytes: &[u8], origin: &str) -> Vec<u8> {
+    let challenge = B64.encode(challenge_bytes);
+    serde_json::to_vec(&serde_json::json!({
+        "type": type_,
+        "challenge": challenge,
+        "origin": origin,
+        "crossOrigin": false,
+    }))
+    .expect("static JSON serialises")
+}

--- a/vtc-service/tests/webauthn_harness.rs
+++ b/vtc-service/tests/webauthn_harness.rs
@@ -1,0 +1,202 @@
+//! Validation of the deterministic soft EdDSA authenticator harness
+//! (`tests/common/webauthn_harness.rs`).
+//!
+//! Drives a full register + authenticate ceremony through `webauthn-rs`,
+//! using the EdDSA-restricting wrappers from
+//! `vtc_service::webauthn::start_eddsa_passkey_registration`. If this
+//! test passes end-to-end then the harness produces wire output
+//! `webauthn-rs-core` accepts and signatures `webauthn-rs` verifies —
+//! which is the contract M0.5.2's install-claim integration tests
+//! depend on.
+//!
+//! Also asserts the Ed25519 verifying-key bytes the harness returns
+//! match the COSE public key webauthn-rs ultimately stores in the
+//! `Passkey` — without that, callers can't reliably derive a `did:key`
+//! from the registered credential.
+
+mod common;
+
+use base64::Engine;
+use uuid::Uuid;
+use vti_common::auth::passkey::build_webauthn;
+use webauthn_rs::Webauthn;
+use webauthn_rs_proto::COSEAlgorithm;
+
+use vtc_service::webauthn::{finish_eddsa_passkey_registration, start_eddsa_passkey_registration};
+
+use common::webauthn_harness::SoftEd25519Authenticator;
+
+const RP_ORIGIN: &str = "https://vtc.example.com";
+
+fn webauthn() -> Webauthn {
+    build_webauthn(RP_ORIGIN).expect("webauthn builder")
+}
+
+#[test]
+fn register_then_authenticate_completes_end_to_end() {
+    let webauthn = webauthn();
+    let mut authenticator = SoftEd25519Authenticator::new();
+
+    // -- register ------------------------------------------------------
+    let user_uuid = Uuid::new_v4();
+    let (ccr, reg_state) = start_eddsa_passkey_registration(
+        &webauthn,
+        user_uuid,
+        "did:key:zHarness",
+        "did:key:zHarness",
+        None,
+    )
+    .expect("start_eddsa_passkey_registration");
+
+    let (register_cred, ed25519_pub) = authenticator.register(&ccr, RP_ORIGIN);
+
+    let passkey = finish_eddsa_passkey_registration(&webauthn, &register_cred, &reg_state)
+        .expect("finish_eddsa_passkey_registration");
+
+    // Sanity: webauthn-rs registered an EdDSA passkey, not something
+    // else that webauthn-rs core's algorithm filter let through.
+    assert_eq!(passkey.cred_algorithm(), &COSEAlgorithm::EDDSA);
+
+    // The verifying-key bytes the harness handed back must equal the
+    // raw Ed25519 `x` coordinate webauthn-rs stored on the Passkey.
+    // The COSE key shape is internal to `webauthn-rs-core`; we lift it
+    // out via serde rather than depending on the `danger-credential-internals`
+    // feature. Spec ref RFC 8152 §13.2: OKP `x` parameter is integer
+    // key `-2`.
+    let passkey_json = serde_json::to_value(&passkey).expect("passkey serialises");
+    let cose_x = walk_eddsa_x(&passkey_json).unwrap_or_else(|| {
+        panic!(
+            "EDDSA `x` coordinate not found in Passkey JSON:\n{}",
+            serde_json::to_string_pretty(&passkey_json).unwrap()
+        )
+    });
+    assert_eq!(
+        cose_x.as_slice(),
+        ed25519_pub.as_slice(),
+        "harness pubkey must match passkey's stored Ed25519 x coordinate",
+    );
+
+    // -- authenticate --------------------------------------------------
+    let (rcr, auth_state) = webauthn
+        .start_passkey_authentication(std::slice::from_ref(&passkey))
+        .expect("start_passkey_authentication");
+
+    let auth_cred = authenticator.authenticate(&rcr, RP_ORIGIN);
+
+    let _auth_result = webauthn
+        .finish_passkey_authentication(&auth_cred, &auth_state)
+        .expect("finish_passkey_authentication");
+    // Don't assert on `needs_update()` — it reflects flag drift the
+    // RP should persist (counter, backup-eligibility) and is true on
+    // the very first authentication after register. The contract
+    // we're verifying here is "ceremony succeeds without error".
+}
+
+#[test]
+fn second_authenticate_increments_sign_count() {
+    let webauthn = webauthn();
+    let mut authenticator = SoftEd25519Authenticator::new();
+
+    let (ccr, reg_state) = start_eddsa_passkey_registration(
+        &webauthn,
+        Uuid::new_v4(),
+        "did:key:zHarness2",
+        "did:key:zHarness2",
+        None,
+    )
+    .unwrap();
+    let (register_cred, _ed25519_pub) = authenticator.register(&ccr, RP_ORIGIN);
+    let passkey = finish_eddsa_passkey_registration(&webauthn, &register_cred, &reg_state).unwrap();
+
+    // First authentication.
+    let (rcr1, state1) = webauthn
+        .start_passkey_authentication(std::slice::from_ref(&passkey))
+        .unwrap();
+    let auth1 = authenticator.authenticate(&rcr1, RP_ORIGIN);
+    let result1 = webauthn
+        .finish_passkey_authentication(&auth1, &state1)
+        .unwrap();
+
+    // Second authentication. The harness counter must monotonically
+    // increase so webauthn-rs accepts the second assertion — a regression
+    // here typically presents as `CredentialCounterUpdated` errors.
+    let (rcr2, state2) = webauthn
+        .start_passkey_authentication(std::slice::from_ref(&passkey))
+        .unwrap();
+    let auth2 = authenticator.authenticate(&rcr2, RP_ORIGIN);
+    let result2 = webauthn
+        .finish_passkey_authentication(&auth2, &state2)
+        .unwrap();
+
+    assert!(result1.counter() < result2.counter());
+}
+
+#[test]
+fn register_panics_when_challenge_lacks_eddsa() {
+    let webauthn = webauthn();
+    let mut authenticator = SoftEd25519Authenticator::new();
+
+    // Drive the upstream challenge directly (no EdDSA restriction). The
+    // harness must refuse — it produces only EdDSA credentials, so
+    // accepting a non-EdDSA challenge would silently emit a mismatched
+    // attestation that webauthn-rs's finish-side validation rejects
+    // with a misleading error.
+    let (ccr, _state) = webauthn
+        .start_passkey_registration(Uuid::new_v4(), "did:key:zNoEdDSA", "did:key:zNoEdDSA", None)
+        .unwrap();
+    assert!(
+        !ccr.public_key
+            .pub_key_cred_params
+            .iter()
+            .any(|p| p.alg == -8)
+    );
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        authenticator.register(&ccr, RP_ORIGIN)
+    }));
+    assert!(result.is_err(), "harness must refuse non-EdDSA challenges");
+}
+
+/// Walk a JSON value looking for the COSE OKP `x` coordinate. The
+/// upstream serde shape isn't documented and shifts between minor
+/// versions of `webauthn-rs-core` (today it's
+/// `cred.cred.key.EC_OKP.x` and serialised as a base64url-no-pad
+/// string). Rather than pin to one shape, we recurse and pick the
+/// first value at key `"x"` that decodes to 32 raw bytes.
+fn walk_eddsa_x(value: &serde_json::Value) -> Option<Vec<u8>> {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(x) = map.get("x")
+                && let Some(bytes) = decode_x_value(x)
+            {
+                return Some(bytes);
+            }
+            for v in map.values() {
+                if let Some(found) = walk_eddsa_x(v) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(walk_eddsa_x),
+        _ => None,
+    }
+}
+
+fn decode_x_value(value: &serde_json::Value) -> Option<Vec<u8>> {
+    // `Vec<u8>` form (older serde shapes).
+    if let Ok(bytes) = serde_json::from_value::<Vec<u8>>(value.clone())
+        && bytes.len() == 32
+    {
+        return Some(bytes);
+    }
+    // base64url-no-pad string form (current `webauthn-rs-core 0.5.5`
+    // shape).
+    if let Some(s) = value.as_str()
+        && let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(s)
+        && bytes.len() == 32
+    {
+        return Some(bytes);
+    }
+    None
+}


### PR DESCRIPTION
## Summary

Stacked on **#59** (`feat/vtc-passkey-state`). GitHub will auto-retarget to `main` when #59 merges.

- Implements **M0.5.0** of the VTC MVP Phase 0 plan.
- New `tests/common/webauthn_harness.rs` — `SoftEd25519Authenticator`
  produces real CTAP attestation + COSE OKP-Ed25519 public keys that
  `webauthn-rs-core` parses end-to-end.
- New `tests/webauthn_harness.rs` — 3 validation tests covering the
  full register + authenticate lifecycle.
- Adds `ciborium` 0.2 as a dev-dep for CBOR encoding.

## Why we ship our own harness

`webauthn-authenticator-rs::SoftPasskey` (the obvious upstream
candidate) hard-codes ES256 via `openssl::ec`. It doesn't produce
EdDSA credentials, so it can't drive VTC's install flow — spec §4.2
requires the passkey's COSE public key to project directly into a
`did:key`, which only Ed25519 supports.

The in-tree harness is ~260 lines of CTAP + COSE encoding on top of
`ed25519-dalek` and `ciborium`. It implements the WebAuthn CTAP 2
"none" attestation format (sufficient because
`start_passkey_registration` uses `AttestationConveyancePreference::None`).
The harness panics on non-EdDSA challenges, protecting callers from
silently bypassing #59's EdDSA-restricting wrappers.

## What's deferred to PR C

M0.5.2 (install claim start/finish endpoints + DID-binding +
Trust-Tasks files) ships in the follow-up. This PR is harness only —
the validation tests confirm the harness is correct in isolation
before any production route consumes it.

## Test plan

- [x] `cargo test --package vtc-service --test webauthn_harness` —
      3 tests pass:
  - `register_then_authenticate_completes_end_to_end` — full ceremony
    succeeds, harness pubkey matches the passkey's stored COSE `x`
    coordinate (proves the byte that becomes a `did:key` is the one
    the authenticator generated).
  - `second_authenticate_increments_sign_count` — counter monotonicity
    holds across multiple assertions.
  - `register_panics_when_challenge_lacks_eddsa` — misuse guard.
- [x] No regression: `cargo test --package vtc-service` — 98 tests
      pass total (95 from before + 3 new harness tests).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --lib` clean.