### PR TITLE
feat(vtc): WebAuthn install ceremony — soft EdDSA harness + claim endpoints (M0.5.0 + M0.5.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8903,6 +8903,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "ciborium",
  "clap",
  "dialoguer",
  "didwebvh-rs",

--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -465,43 +465,69 @@ concurrent claims race correctly through the mutex. No WebAuthn yet.
 - **Deps**: M0.5.0 (test harness — deferred to PR B), M0.1.6
 - **Pre-impl decision**: D7, D11
 
-### `[ ]` M0.5.2 — Install claim endpoints (start + finish)
+### `[x]` M0.5.2 — Install claim endpoints (start + finish)
 
 Per **D12**: two-phase ceremony, not a single endpoint. Adopts the
-webvh-common `enroll_start` / `enroll_finish` shape but specialised
-for the install carve-out (one-shot, not an ongoing invite system).
+`webvh-common::server::passkey::routes` `enroll_*` shape but
+specialised for the install carve-out (one-shot, not an ongoing
+invite system).
 
 - **Acceptance**
-  - `POST /v1/install/claim/start`: accepts `{ install_token }`,
-    validates via `parse_install_token`, calls
-    `install::state_machine::start_claim`, then calls
-    `vti_common::auth::passkey::enroll_start` to begin the
-    WebAuthn registration ceremony. Returns
-    `{ registration_id, options: CreationChallengeResponse }`.
-    Challenge bound to the token's `cnonce`.
-  - `POST /v1/install/claim/finish`: accepts
-    `{ registration_id, webauthn_response, candidate_did_signature }`,
-    completes the ceremony via `enroll_finish`, calls
-    `install::state_machine::finish_claim`, verifies
-    `candidate_did_signature` over a server-issued nonce using the
-    candidate `did:key`. Returns a setup-session token
-    (audience `"vtc-install-session"`) + the candidate admin DID.
+  - `POST /v1/install/claim/start`: parses install token, calls
+    `InstallTokenStore::start_claim` (300 s ceremony lock), then
+    `vtc_service::webauthn::start_eddsa_passkey_registration` to
+    begin the WebAuthn registration ceremony. Returns
+    `{ registrationId, options, didBindingChallenge }`.
+  - `POST /v1/install/claim/finish`: takes the persisted
+    `PasskeyRegistration` state, runs
+    `finish_eddsa_passkey_registration`, derives the candidate
+    `did:key` from the credential's Ed25519 x coordinate, verifies
+    the DID-binding Ed25519 signature against the server-issued
+    32-byte challenge, calls
+    `InstallTokenStore::finish_claim` (Issued → Consumed), persists
+    `PasskeyUser` + `CredentialMapping`, and mints a 5-minute
+    setup-session JWT (`aud = vtc-install-session`). Carve-out
+    stays open — closed by M0.6's bootstrap.
   - Trust Task IDs: `install/claim/start/1.0`,
-    `install/claim/finish/1.0`
+    `install/claim/finish/1.0`.
 - **Verify**
-  - End-to-end test using `Router::oneshot` + the harness from M0.5.0
-  - Failure cases: bad token, expired token, replayed token after
-    consume, mismatched cnonce, wrong DID signature, non-Ed25519
-    algorithm, second concurrent `claim/start` within the 5min
-    claim window, abandoned ceremony followed by retry after
-    timeout (succeeds)
+  - 11 integration tests in `tests/install_claim.rs` driving the
+    `Router::oneshot` stack:
+    - `full_ceremony_completes_end_to_end` — happy path + replay
+      finish returns 401.
+    - `start_returns_503_when_install_signer_missing`
+    - `start_returns_503_when_webauthn_missing`
+    - `start_rejects_unsigned_token`
+    - `start_rejects_unknown_jti`
+    - `second_concurrent_start_within_window_is_conflict`
+    - `finish_rejects_mismatched_registration_id`
+    - `finish_rejects_wrong_did_binding_signature`
+    - `finish_without_start_fails`
+    - `missing_trust_task_header_returns_400`
+    - `wrong_trust_task_header_returns_415`
+  - 6 unit tests in `routes::install::tests::*` covering DID-key
+    derivation + DID-binding signature verification primitives.
+  - "Abandoned-ceremony retry after window" succeeds — covered
+    by the unit-level `install::state_machine::retry_after_window_succeeds`
+    from M0.4.2.
 - **Files**
-  - `vtc-service/src/routes/install.rs` (new)
-  - `vtc-service/src/routes/mod.rs`
+  - `vtc-service/src/routes/install.rs` (new — ~370 lines incl.
+    unit tests)
+  - `vtc-service/src/routes/mod.rs` (mount + 2 Trust Tasks)
+  - `vtc-service/src/server.rs` (`install_ks`, `install_signer`,
+    `install_store` on AppState; `init_auth` returns
+    `install_signer`)
+  - `vtc-service/src/install/{mod,token}.rs` (add
+    `InstallSessionClaims`, `INSTALL_SESSION_AUDIENCE`,
+    `mint_install_session_token`, signer
+    `encode_session`/`decode_session`)
+  - `vtc-service/tests/install_claim.rs` (new — 11 tests)
+  - `vtc-service/tests/{admin_config,auth_audience,community_profile,passkey_state}.rs`
+    (new AppState fields)
   - `trust-tasks/install/claim/start/1.0/{spec.md,schema.json}`
   - `trust-tasks/install/claim/finish/1.0/{spec.md,schema.json}`
   - `trust-tasks/index.json`
-- **Deps**: M0.4.2, M0.5.1, M0.3.1, M0.1.6
+- **Deps**: M0.4.2, M0.5.0, M0.5.1
 - **Pre-impl decision**: D2, D12
 
 ---

--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -393,23 +393,37 @@ concurrent claims race correctly through the mutex. No WebAuthn yet.
 
 ## M0.5 — WebAuthn claim flow
 
-### `[ ]` M0.5.0 — WebAuthn test harness validation
+### `[x]` M0.5.0 — WebAuthn test harness validation
 
 - **Acceptance**
-  - A test helper in `vtc-service/tests/common/webauthn_harness.rs`
-    can produce deterministic registration + authentication
-    responses for a fake authenticator
-  - Helper covers Ed25519 (EdDSA, `COSEAlgorithmIdentifier = -8`)
-  - At least one trivial test confirms the helper drives
-    `webauthn-rs` server-side validation green
+  - `tests/common/webauthn_harness.rs` ships a
+    `SoftEd25519Authenticator` producing deterministic CTAP-format
+    registration + authentication responses (none-attestation, COSE
+    OKP Ed25519 public keys via `ciborium` CBOR encoding, signatures
+    from `ed25519-dalek`).
+  - The harness refuses non-EdDSA registration challenges with a
+    panic — protects callers that bypass
+    `vtc_service::webauthn::start_eddsa_passkey_registration`.
 - **Verify**
-  - A standalone test (`tests/webauthn_harness.rs`) exercises the
-    helper through a full register-and-authenticate cycle
+  - `tests/webauthn_harness.rs` × 3 tests:
+    - `register_then_authenticate_completes_end_to_end` — full
+      ceremony succeeds, harness pubkey matches the passkey's stored
+      COSE `x` coordinate (proves the byte that becomes the
+      `did:key` is the one the authenticator generated).
+    - `second_authenticate_increments_sign_count` — counter
+      monotonicity holds across multiple assertions.
+    - `register_panics_when_challenge_lacks_eddsa` — guard against
+      misuse by tests that drive the upstream challenge directly.
 - **Files**
-  - `vtc-service/tests/common/mod.rs`
-  - `vtc-service/tests/common/webauthn_harness.rs`
-  - `vtc-service/tests/webauthn_harness.rs`
-- **Deps**: M0.1.0 (just for the dep import)
+  - `vtc-service/tests/common/mod.rs` (new)
+  - `vtc-service/tests/common/webauthn_harness.rs` (new — ~260 lines)
+  - `vtc-service/tests/webauthn_harness.rs` (new — 3 validation tests)
+  - `vtc-service/Cargo.toml` (`ciborium` dev-dep)
+- **Deps**: M0.5.1 (uses the EdDSA-restricting wrappers as the
+  challenge producer)
+- **Note**: Upstream `webauthn-authenticator-rs::SoftPasskey` is
+  hard-coded to ES256 (`openssl::ec`) and was unsuitable; the
+  in-tree harness sidesteps that.
 
 ### `[x]` M0.5.1 — VTC `AppState` implements `PasskeyState`
 

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -64,6 +64,18 @@
       "status": "Draft",
       "path": "admin/config/manage/1.0",
       "rest": "GET, PATCH /v1/admin/config"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0",
+      "status": "Draft",
+      "path": "install/claim/start/1.0",
+      "rest": "POST /v1/install/claim/start"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0",
+      "status": "Draft",
+      "path": "install/claim/finish/1.0",
+      "rest": "POST /v1/install/claim/finish"
     }
   ]
 }

--- a/trust-tasks/install/claim/finish/1.0/schema.json
+++ b/trust-tasks/install/claim/finish/1.0/schema.json
@@ -1,0 +1,44 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Install — Claim (Finish)",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "required": [
+        "install_token",
+        "registration_id",
+        "webauthn_response",
+        "did_binding_signature"
+      ],
+      "properties": {
+        "install_token": { "type": "string" },
+        "registration_id": { "type": "string", "format": "uuid" },
+        "webauthn_response": {
+          "type": "object",
+          "description": "RegisterPublicKeyCredential from navigator.credentials.create()."
+        },
+        "did_binding_signature": {
+          "type": "string",
+          "description": "Base64url-no-pad 64-byte Ed25519 signature over the didBindingChallenge."
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["adminDid", "setupSessionToken"],
+      "properties": {
+        "adminDid": {
+          "type": "string",
+          "pattern": "^did:key:z",
+          "description": "Candidate admin DID derived from the passkey's Ed25519 public key."
+        },
+        "setupSessionToken": {
+          "type": "string",
+          "description": "EdDSA JWT (aud=vtc-install-session, TTL 5min) consumed by /v1/admin/bootstrap."
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/install/claim/finish/1.0/spec.md
+++ b/trust-tasks/install/claim/finish/1.0/spec.md
@@ -1,0 +1,49 @@
+---
+id: https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0
+title: VTC Install — Claim (Finish)
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/install/claim/finish
+---
+
+# VTC Install — Claim (Finish)
+
+Phase 2 of the WebAuthn install ceremony (spec §4.2). The operator's
+UA submits:
+
+1. The same install-token JWT used at `start`.
+2. The `registration_id` echoed from `start`.
+3. The WebAuthn `RegisterPublicKeyCredential` returned by
+   `navigator.credentials.create()`.
+4. The Ed25519 signature (base64url-no-pad, 64 bytes) over the
+   server-issued DID-binding challenge.
+
+The VTC:
+
+- Verifies the WebAuthn registration via the EdDSA-restricting
+  wrapper (`webauthn-rs` finish + `cred_algorithm() == EDDSA`).
+- Projects the credential's Ed25519 public key into a `did:key`
+  (multicodec `0xed01` + base58btc).
+- Verifies the DID-binding signature with the same public key,
+  proving single-key control over both signing paths.
+- Marks the install token `Consumed` in the claim-window state
+  machine.
+- Persists the passkey + `did:key → user UUID` mapping in the
+  `passkey` keyspace.
+- Mints a setup-session JWT (`aud = vtc-install-session`, TTL 5
+  minutes) consumed by `POST /v1/admin/bootstrap` (M0.6).
+
+The install carve-out **stays open** after `finish` — only the
+bootstrap call closes it. Until then no other ceremony can re-use
+the same install token (state is `Consumed`).
+
+## Errors
+
+- `401 Unauthorized` — install token invalid; `registration_id`
+  doesn't match `jti`; WebAuthn ceremony rejected; DID-binding
+  signature doesn't verify; token already consumed.
+- `503 Service Unavailable` — WebAuthn or install signer not
+  configured.

--- a/trust-tasks/install/claim/start/1.0/schema.json
+++ b/trust-tasks/install/claim/start/1.0/schema.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Install — Claim (Start)",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "required": ["install_token"],
+      "properties": {
+        "install_token": {
+          "type": "string",
+          "description": "EdDSA-signed install JWT (aud=vtc-install) printed by `vtc setup`."
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["registrationId", "options", "didBindingChallenge"],
+      "properties": {
+        "registrationId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Echoes the install token's jti; must be passed back to claim/finish."
+        },
+        "options": {
+          "type": "object",
+          "description": "WebAuthn PublicKeyCredentialCreationOptions, pubKeyCredParams = [{public-key, -8}]."
+        },
+        "didBindingChallenge": {
+          "type": "string",
+          "description": "Base64url-no-pad 32 random server bytes the candidate did:key must sign."
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/install/claim/start/1.0/spec.md
+++ b/trust-tasks/install/claim/start/1.0/spec.md
@@ -1,0 +1,38 @@
+---
+id: https://trusttasks.org/openvtc/vtc/install/claim/start/1.0
+title: VTC Install — Claim (Start)
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/install/claim/start
+---
+
+# VTC Install — Claim (Start)
+
+Phase 1 of the WebAuthn install ceremony (spec §4.2). The
+operator's UA submits the install-token JWT printed by `vtc setup`;
+the VTC verifies the token, locks the claim window (300 s) for the
+token's `jti`, and returns:
+
+- A WebAuthn `PublicKeyCredentialCreationOptions` restricted to
+  Ed25519 (`COSEAlgorithmIdentifier = -8`). The UA passes this to
+  `navigator.credentials.create()`.
+- A 32-byte server-issued "DID-binding challenge" (base64url-no-pad).
+  The operator must sign this challenge with the Ed25519 private
+  key materialised inside their authenticator and present the
+  signature to `POST /v1/install/claim/finish`. Proves single-key
+  control over both the WebAuthn assertion path and the
+  `did:key` signing path.
+
+## Errors
+
+- `401 Unauthorized` — install token signature invalid, expired,
+  unknown `jti`, audience mismatch, or carve-out closed.
+- `409 Conflict` — a previous `start` for this token is still
+  inside the 300-second claim window. Retrying after the window
+  succeeds (the previous ceremony is presumed abandoned).
+- `503 Service Unavailable` — VTC was started without a
+  `public_url` (no WebAuthn relying party) or before key
+  material was loaded (no install signer).

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -92,6 +92,12 @@ tempfile = "3"
 # `Router::oneshot` — same pattern as `vta-service/tests/api_integration.rs`.
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
+# CBOR encoding for the soft Ed25519 authenticator harness
+# (`tests/common/webauthn_harness.rs`). Produces the CTAP attestation
+# object + COSE public key on the same wire shape `webauthn-rs-core`
+# parses (it uses `serde_cbor_2` internally — `ciborium` is canonical
+# enough for both to agree).
+ciborium = "0.2"
 
 [lints]
 workspace = true

--- a/vtc-service/src/install/mod.rs
+++ b/vtc-service/src/install/mod.rs
@@ -25,8 +25,9 @@ pub mod token;
 
 pub use state_machine::{InstallTokenState, InstallTokenStore, StartClaimOutcome};
 pub use token::{
-    INSTALL_AUDIENCE, INSTALL_SUBJECT, INSTALL_TOKEN_DEFAULT_TTL_SECS, InstallTokenClaims,
-    InstallTokenSigner, mint_install_token, parse_install_token,
+    INSTALL_AUDIENCE, INSTALL_SESSION_AUDIENCE, INSTALL_SESSION_DEFAULT_TTL_SECS, INSTALL_SUBJECT,
+    INSTALL_TOKEN_DEFAULT_TTL_SECS, InstallSessionClaims, InstallTokenClaims, InstallTokenSigner,
+    mint_install_session_token, mint_install_token, parse_install_token,
 };
 
 use tokio::sync::Mutex;

--- a/vtc-service/src/install/token.rs
+++ b/vtc-service/src/install/token.rs
@@ -66,6 +66,18 @@ pub const INSTALL_SUBJECT: &str = "install";
 /// URL doesn't sit redeemable for hours.
 pub const INSTALL_TOKEN_DEFAULT_TTL_SECS: u64 = 15 * 60;
 
+/// Audience claim for the setup-session token minted by
+/// `/v1/install/claim/finish`. The token bridges the install
+/// ceremony to M0.6's `/v1/admin/bootstrap`; `"VTC"` and
+/// `"vtc-install"` audience decoders both reject it by design.
+pub const INSTALL_SESSION_AUDIENCE: &str = "vtc-install-session";
+
+/// Default setup-session token lifetime in seconds. The operator
+/// has just completed the WebAuthn ceremony; they need a few
+/// minutes to round-trip to the bootstrap endpoint before the
+/// receipt expires.
+pub const INSTALL_SESSION_DEFAULT_TTL_SECS: u64 = 5 * 60;
+
 const HKDF_INFO: &[u8] = b"vtc-install-jwt-key/v1";
 
 // ---------------------------------------------------------------------------
@@ -171,6 +183,55 @@ impl InstallTokenSigner {
         }
         Ok(claims)
     }
+
+    /// Sign an [`InstallSessionClaims`] into an EdDSA JWT. Shares the
+    /// underlying signing key with [`Self::encode`]; the
+    /// `"vtc-install-session"` audience separates the two token
+    /// families at every decoder.
+    pub fn encode_session(&self, claims: &InstallSessionClaims) -> Result<String, AppError> {
+        let header = Header::new(Algorithm::EdDSA);
+        jsonwebtoken::encode(&header, claims, &self.encoding)
+            .map_err(|e| AppError::Internal(format!("install session JWT encode failed: {e}")))
+    }
+
+    /// Verify + decode an install-session token. Returns
+    /// `AppError::Unauthorized` on every failure for the same
+    /// defence-in-depth reason [`Self::decode`] does.
+    pub fn decode_session(&self, token: &str) -> Result<InstallSessionClaims, AppError> {
+        let mut validation = Validation::new(Algorithm::EdDSA);
+        validation.set_audience(&[INSTALL_SESSION_AUDIENCE]);
+        validation.set_required_spec_claims(&["exp", "sub", "aud", "iat", "iss"]);
+
+        jsonwebtoken::decode::<InstallSessionClaims>(token, &self.decoding, &validation)
+            .map(|data| data.claims)
+            .map_err(|_| AppError::Unauthorized("invalid install session token".into()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Install-session claims
+// ---------------------------------------------------------------------------
+
+/// JWT claims for the setup-session token minted at the end of the
+/// install claim ceremony. `sub` is the candidate admin DID; M0.6's
+/// `/v1/admin/bootstrap` will accept this token exactly once,
+/// matching `sub` against the ACL entry it writes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallSessionClaims {
+    /// Issuer — the VTC DID.
+    pub iss: String,
+    /// Subject — the candidate admin `did:key` derived from the
+    /// passkey's COSE public key.
+    pub sub: String,
+    /// Always [`INSTALL_SESSION_AUDIENCE`].
+    pub aud: String,
+    /// Unix-second expiry.
+    pub exp: u64,
+    /// Unix-second issued-at.
+    pub iat: u64,
+    /// Random identifier — M0.6's bootstrap endpoint can drop a
+    /// once-only marker keyed by `jti` to prevent replay.
+    pub jti: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -250,6 +311,33 @@ pub fn parse_install_token(
     token: &str,
 ) -> Result<InstallTokenClaims, AppError> {
     signer.decode(token)
+}
+
+/// Mint a setup-session token for `admin_did`. Called from
+/// `POST /v1/install/claim/finish` after the WebAuthn ceremony and
+/// DID-binding signature both verify.
+pub fn mint_install_session_token(
+    signer: &InstallTokenSigner,
+    issuer_did: &str,
+    admin_did: &str,
+    ttl_seconds: u64,
+) -> Result<String, AppError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let exp = now + ttl_seconds;
+    let jti = Uuid::new_v4().to_string();
+
+    let claims = InstallSessionClaims {
+        iss: issuer_did.to_string(),
+        sub: admin_did.to_string(),
+        aud: INSTALL_SESSION_AUDIENCE.to_string(),
+        exp,
+        iat: now,
+        jti,
+    };
+    signer.encode_session(&claims)
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -1,0 +1,450 @@
+//! `POST /v1/install/claim/{start,finish}` — WebAuthn install
+//! ceremony for the very first admin.
+//!
+//! Implements **M0.5.2** of the VTC MVP Phase 0 plan. The flow:
+//!
+//! ```text
+//! operator  ──install_token──▶  start  ──ccr+did_binding_challenge──▶ operator
+//! operator  ──finish(webauthn_response, did_binding_signature)──▶  finish
+//! finish    ──admin_did + setup_session_token──▶  operator
+//! ```
+//!
+//! - `start` verifies the install token, takes the install-keyspace
+//!   ceremony lock (`InstallTokenStore::start_claim`), and returns a
+//!   WebAuthn `CreationChallengeResponse` constrained to Ed25519 via
+//!   `vtc_service::webauthn::start_eddsa_passkey_registration`. It
+//!   also returns a server-issued 32-byte "DID-binding challenge"
+//!   that the operator must sign with their newly-minted Ed25519 key.
+//! - `finish` verifies the WebAuthn response, derives the candidate
+//!   admin `did:key` from the credential's Ed25519 public key,
+//!   verifies the DID-binding signature with that same key (proves
+//!   single-key control over both signing paths — spec §4.2 third
+//!   bullet), consumes the install token, persists the passkey,
+//!   and mints a short-lived setup-session token consumed by M0.6's
+//!   `/v1/admin/bootstrap`.
+//!
+//! The carve-out *stays open* until admin bootstrap; until then the
+//! install token is consumed but the `InstallTokenStore::close_carveout`
+//! call lives in M0.6. A second `start` on the same token after a
+//! successful `finish` returns 401 because the state machine sees
+//! `Consumed`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use uuid::Uuid;
+use vti_common::auth::passkey::store::{
+    PasskeyUser, delete_registration_user, get_registration_user, store_credential_mapping,
+    store_passkey_user, store_registration_state, store_registration_user, take_registration_state,
+};
+use vti_common::error::AppError;
+use webauthn_rs::prelude::{
+    CreationChallengeResponse, Passkey, RegisterPublicKeyCredential, Webauthn,
+};
+
+use crate::install::{
+    INSTALL_SESSION_DEFAULT_TTL_SECS, InstallTokenSigner, mint_install_session_token,
+    parse_install_token,
+};
+use crate::server::AppState;
+use crate::webauthn::{finish_eddsa_passkey_registration, start_eddsa_passkey_registration};
+
+// ---------------------------------------------------------------------------
+// Wire shapes
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct ClaimStartRequest {
+    pub install_token: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimStartResponse {
+    /// Echoes the install token's `jti`. Consumer must pass this
+    /// back to `claim/finish` so the server can index the stored
+    /// registration state.
+    pub registration_id: String,
+    /// The WebAuthn `PublicKeyCredentialCreationOptions` payload —
+    /// the operator's UA passes this to `navigator.credentials.create()`.
+    pub options: CreationChallengeResponse,
+    /// 32 random server bytes (base64url-no-pad). The operator
+    /// signs these with the Ed25519 private key materialised inside
+    /// their authenticator and returns the signature in
+    /// `claim/finish` — proves the WebAuthn key and the candidate
+    /// `did:key` are the same keypair.
+    pub did_binding_challenge: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClaimFinishRequest {
+    pub install_token: String,
+    pub registration_id: String,
+    pub webauthn_response: RegisterPublicKeyCredential,
+    /// Base64url-no-pad Ed25519 signature over the raw 32 bytes the
+    /// server returned in `did_binding_challenge`.
+    pub did_binding_signature: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFinishResponse {
+    pub admin_did: String,
+    pub setup_session_token: String,
+}
+
+// ---------------------------------------------------------------------------
+// Storage key helpers
+// ---------------------------------------------------------------------------
+
+fn did_binding_key(jti: &Uuid) -> Vec<u8> {
+    format!("install_did_binding:{jti}").into_bytes()
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+pub async fn claim_start(
+    State(state): State<AppState>,
+    Json(req): Json<ClaimStartRequest>,
+) -> Result<(StatusCode, Json<ClaimStartResponse>), AppError> {
+    let signer = require_install_signer(&state)?;
+    let webauthn = require_webauthn(&state)?;
+    let store = &state.install_store;
+
+    let claims = parse_install_token(signer, &req.install_token)?;
+    let jti = parse_jti(&claims.jti)?;
+
+    // Take the ceremony lock. `start_claim` validates `Issued`, not
+    // expired, carve-out open; on success the `claimed_at` window is
+    // set to "now" so a second concurrent start sees the lock.
+    let _outcome = store.start_claim(&jti).await?;
+
+    let user_uuid = jti;
+    // `user_name` / `user_display_name` are operator-visible labels in
+    // the authenticator's UI. The install URL only exists pre-bootstrap
+    // — no real admin DID yet — so we use a stable, install-specific
+    // placeholder. The label is overwritten when M0.6 bootstraps the
+    // real admin DID.
+    let user_label = format!("vtc-install-{jti}");
+    let (ccr, reg_state) =
+        start_eddsa_passkey_registration(webauthn, user_uuid, &user_label, &user_label, None)?;
+
+    // Persist the registration state under `jti` so `claim_finish`
+    // can complete the ceremony against the same challenge.
+    store_registration_state(&state.passkey_ks, &jti.to_string(), &reg_state).await?;
+
+    // Carry the user UUID forward so the M0.6 bootstrap can look up
+    // the PasskeyUser by registration_id without re-deriving it.
+    store_registration_user(&state.passkey_ks, &jti.to_string(), &user_uuid).await?;
+
+    // 32 random bytes for the DID-binding challenge.
+    let mut challenge_bytes = [0u8; 32];
+    rand::fill(&mut challenge_bytes);
+    state
+        .passkey_ks
+        .insert_raw(did_binding_key(&jti), challenge_bytes.to_vec())
+        .await?;
+
+    info!(jti = %jti, "install claim ceremony started");
+
+    Ok((
+        StatusCode::OK,
+        Json(ClaimStartResponse {
+            registration_id: jti.to_string(),
+            options: ccr,
+            did_binding_challenge: B64.encode(challenge_bytes),
+        }),
+    ))
+}
+
+pub async fn claim_finish(
+    State(state): State<AppState>,
+    Json(req): Json<ClaimFinishRequest>,
+) -> Result<(StatusCode, Json<ClaimFinishResponse>), AppError> {
+    let signer = require_install_signer(&state)?;
+    let webauthn = require_webauthn(&state)?;
+    let store = &state.install_store;
+
+    let claims = parse_install_token(signer, &req.install_token)?;
+    let jti = parse_jti(&claims.jti)?;
+    let reg_id = parse_jti(&req.registration_id)?;
+    if reg_id != jti {
+        return Err(AppError::Unauthorized(
+            "registration_id does not match install token".into(),
+        ));
+    }
+
+    let reg_state = take_registration_state(&state.passkey_ks, &jti.to_string())
+        .await?
+        .ok_or_else(|| {
+            AppError::Unauthorized(
+                "no registration in progress for this install token (start the ceremony first)"
+                    .into(),
+            )
+        })?;
+
+    let challenge_bytes = state
+        .passkey_ks
+        .get_raw(did_binding_key(&jti))
+        .await?
+        .ok_or_else(|| AppError::Internal("missing DID-binding challenge".into()))?;
+    let challenge: [u8; 32] = challenge_bytes
+        .try_into()
+        .map_err(|_| AppError::Internal("DID-binding challenge malformed".into()))?;
+
+    // Run the WebAuthn ceremony. EdDSA enforcement happens here and
+    // is asserted twice — once by webauthn-rs against the rewritten
+    // `credential_algorithms` list, once by
+    // `finish_eddsa_passkey_registration` checking `cred_algorithm()`.
+    let passkey = finish_eddsa_passkey_registration(webauthn, &req.webauthn_response, &reg_state)?;
+
+    let ed25519_pub = extract_ed25519_public_key(&passkey)?;
+    let admin_did = ed25519_pub_to_did_key(&ed25519_pub);
+
+    // Verify the DID-binding signature: proves the operator can sign
+    // raw bytes with the same Ed25519 key that the authenticator
+    // generated. Without this an attacker who acquired only the
+    // WebAuthn assertion couldn't reproduce the candidate did:key's
+    // signing path.
+    verify_did_binding(&ed25519_pub, &challenge, &req.did_binding_signature)?;
+
+    // Consume the install token (Issued → Consumed). Carve-out stays
+    // open until M0.6's bootstrap closes it.
+    store.finish_claim(&jti).await?;
+
+    // Drop the one-shot DID-binding challenge.
+    state.passkey_ks.remove(did_binding_key(&jti)).await?;
+
+    // Persist the passkey + credential mapping so M0.6's bootstrap
+    // and subsequent passkey login can find the credential.
+    let user_uuid = get_registration_user(&state.passkey_ks, &jti.to_string())
+        .await?
+        .ok_or_else(|| AppError::Internal("missing registration_user mapping".into()))?;
+    delete_registration_user(&state.passkey_ks, &jti.to_string()).await?;
+    let user = PasskeyUser {
+        user_uuid,
+        did: admin_did.clone(),
+        display_name: admin_did.clone(),
+        credentials: vec![passkey.clone()],
+    };
+    store_passkey_user(&state.passkey_ks, &user).await?;
+    let cred_id_hex = hex::encode(passkey.cred_id().as_ref() as &[u8]);
+    store_credential_mapping(&state.passkey_ks, &cred_id_hex, user_uuid).await?;
+
+    let issuer_did = state
+        .config
+        .read()
+        .await
+        .vtc_did
+        .clone()
+        .unwrap_or_else(|| "did:key:vtc-install-uninitialised".to_string());
+
+    let setup_session_token = mint_install_session_token(
+        signer,
+        &issuer_did,
+        &admin_did,
+        INSTALL_SESSION_DEFAULT_TTL_SECS,
+    )?;
+
+    info!(jti = %jti, %admin_did, "install claim ceremony completed");
+
+    Ok((
+        StatusCode::OK,
+        Json(ClaimFinishResponse {
+            admin_did,
+            setup_session_token,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_install_signer(state: &AppState) -> Result<&Arc<InstallTokenSigner>, AppError> {
+    state
+        .install_signer
+        .as_ref()
+        .ok_or_else(|| AppError::ServiceError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: "install signer not configured (run setup first)".into(),
+        })
+}
+
+fn require_webauthn(state: &AppState) -> Result<&Webauthn, AppError> {
+    state
+        .webauthn
+        .as_deref()
+        .ok_or_else(|| AppError::ServiceError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: "WebAuthn not configured (public_url required)".into(),
+        })
+}
+
+fn parse_jti(s: &str) -> Result<Uuid, AppError> {
+    Uuid::parse_str(s)
+        .map_err(|_| AppError::Unauthorized("invalid install token (malformed jti)".into()))
+}
+
+/// Lift the raw 32-byte Ed25519 public key out of a registered
+/// [`Passkey`]. webauthn-rs serialises the COSE key under
+/// `cred.cred.key.EC_OKP.x` (base64url-no-pad string) in the current
+/// shape; we serde-walk it rather than depend on the
+/// `danger-credential-internals` feature.
+fn extract_ed25519_public_key(passkey: &Passkey) -> Result<[u8; 32], AppError> {
+    let value = serde_json::to_value(passkey)
+        .map_err(|e| AppError::Internal(format!("passkey serialise: {e}")))?;
+    let bytes = walk_eddsa_x(&value)
+        .ok_or_else(|| AppError::Internal("passkey has no Ed25519 x coordinate".into()))?;
+    bytes
+        .try_into()
+        .map_err(|_| AppError::Internal("Ed25519 x coordinate not 32 bytes".into()))
+}
+
+fn walk_eddsa_x(value: &serde_json::Value) -> Option<Vec<u8>> {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(x) = map.get("x")
+                && let Some(bytes) = decode_x_value(x)
+            {
+                return Some(bytes);
+            }
+            for v in map.values() {
+                if let Some(found) = walk_eddsa_x(v) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(walk_eddsa_x),
+        _ => None,
+    }
+}
+
+fn decode_x_value(value: &serde_json::Value) -> Option<Vec<u8>> {
+    if let Ok(bytes) = serde_json::from_value::<Vec<u8>>(value.clone())
+        && bytes.len() == 32
+    {
+        return Some(bytes);
+    }
+    if let Some(s) = value.as_str()
+        && let Ok(bytes) = B64.decode(s)
+        && bytes.len() == 32
+    {
+        return Some(bytes);
+    }
+    None
+}
+
+/// Project a 32-byte Ed25519 public key into a `did:key`. Multicodec
+/// prefix `0xed01` + raw key, multibase-encoded with `z` (base58btc).
+fn ed25519_pub_to_did_key(pubkey: &[u8; 32]) -> String {
+    format!(
+        "did:key:{}",
+        vta_sdk::did_key::ed25519_multibase_pubkey(pubkey)
+    )
+}
+
+/// Verify a base64url-no-pad Ed25519 signature over `challenge`
+/// using `pubkey`.
+fn verify_did_binding(
+    pubkey: &[u8; 32],
+    challenge: &[u8; 32],
+    signature_b64u: &str,
+) -> Result<(), AppError> {
+    let sig_bytes = B64
+        .decode(signature_b64u)
+        .map_err(|_| AppError::Unauthorized("invalid DID-binding signature encoding".into()))?;
+    let sig_arr: [u8; 64] = sig_bytes
+        .try_into()
+        .map_err(|_| AppError::Unauthorized("DID-binding signature must be 64 bytes".into()))?;
+    let verifying = VerifyingKey::from_bytes(pubkey)
+        .map_err(|_| AppError::Internal("malformed Ed25519 public key".into()))?;
+    verifying
+        .verify(challenge, &Signature::from_bytes(&sig_arr))
+        .map_err(|_| AppError::Unauthorized("DID-binding signature does not verify".into()))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    #[test]
+    fn eddsa_alg_constant_matches_cose() {
+        // Drift sentinel — if `EDDSA_ALG` ever changes the install
+        // route's enforcement is no longer aligned with the rest of
+        // the workspace.
+        assert_eq!(crate::webauthn::EDDSA_ALG, -8);
+    }
+
+    #[test]
+    fn did_key_round_trips_through_vta_sdk() {
+        let pubkey = [0xAA; 32];
+        let did = ed25519_pub_to_did_key(&pubkey);
+        assert!(did.starts_with("did:key:z"));
+        // Decode back via the SDK to confirm the same bytes survive.
+        let mb = did.strip_prefix("did:key:").unwrap();
+        let decoded = vta_sdk::did_key::decode_ed25519_public_key_multibase(mb).unwrap();
+        assert_eq!(decoded, pubkey);
+    }
+
+    #[test]
+    fn verify_did_binding_accepts_valid_signature() {
+        let signing = SigningKey::from_bytes(&[0x11; 32]);
+        let pubkey = signing.verifying_key().to_bytes();
+        let challenge = [0x42u8; 32];
+        let sig = signing.sign(&challenge).to_bytes();
+        verify_did_binding(&pubkey, &challenge, &B64.encode(sig)).unwrap();
+    }
+
+    #[test]
+    fn verify_did_binding_rejects_wrong_pubkey() {
+        let signing = SigningKey::from_bytes(&[0x11; 32]);
+        let other = SigningKey::from_bytes(&[0x22; 32]);
+        let challenge = [0x42u8; 32];
+        let sig = signing.sign(&challenge).to_bytes();
+        let err = verify_did_binding(
+            &other.verifying_key().to_bytes(),
+            &challenge,
+            &B64.encode(sig),
+        )
+        .expect_err("must reject");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn verify_did_binding_rejects_tampered_challenge() {
+        let signing = SigningKey::from_bytes(&[0x11; 32]);
+        let pubkey = signing.verifying_key().to_bytes();
+        let challenge = [0x42u8; 32];
+        let sig = signing.sign(&challenge).to_bytes();
+        let mut tampered = challenge;
+        tampered[0] ^= 0x01;
+        let err =
+            verify_did_binding(&pubkey, &tampered, &B64.encode(sig)).expect_err("must reject");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn verify_did_binding_rejects_short_signature() {
+        let pubkey = [0u8; 32];
+        let err = verify_did_binding(&pubkey, &[0u8; 32], &B64.encode([0u8; 16]))
+            .expect_err("must reject");
+        assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -4,6 +4,7 @@ mod auth;
 mod community;
 mod config;
 mod health;
+pub(crate) mod install;
 
 use axum::Router;
 use axum::routing::{delete, get, post};
@@ -52,6 +53,12 @@ pub fn router() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let admin_config = TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/config/manage/1.0")
         .expect("static Trust-Task URL");
+    let install_claim_start =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/start/1.0")
+            .expect("static Trust-Task URL");
+    let install_claim_finish =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0")
+            .expect("static Trust-Task URL");
 
     TrustTaskRouter::<AppState>::new()
         .route_exempt("/health", get(health::health))
@@ -104,6 +111,19 @@ pub fn router() -> Router<AppState> {
             "/v1/admin/config",
             get(admin::config::get_config).patch(admin::config::patch_config),
             admin_config,
+        )
+        // Install claim (M0.5.2) — distinct Trust Tasks because the
+        // two phases of the WebAuthn ceremony have different
+        // semantics. Both are POST-only.
+        .route_with_task(
+            "/v1/install/claim/start",
+            post(install::claim_start),
+            install_claim_start,
+        )
+        .route_with_task(
+            "/v1/install/claim/finish",
+            post(install::claim_finish),
+            install_claim_finish,
         )
         .into_router()
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -16,6 +16,7 @@ use crate::auth::jwt::JwtKeys;
 use crate::auth::session::cleanup_expired_sessions;
 use crate::config::{AppConfig, AuthConfig};
 use crate::error::AppError;
+use crate::install::{InstallTokenSigner, InstallTokenStore};
 use crate::keys::seed_store::SecretStore;
 use crate::messaging;
 use crate::routes;
@@ -40,6 +41,7 @@ pub struct AppState {
     pub community_ks: KeyspaceHandle,
     pub config_ks: KeyspaceHandle,
     pub passkey_ks: KeyspaceHandle,
+    pub install_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
     pub did_resolver: Option<DIDCacheClient>,
     pub secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
@@ -53,6 +55,13 @@ pub struct AppState {
     /// Held alongside the `Webauthn` so the trait impl doesn't need
     /// to take an async read-lock on the config every request.
     pub public_url: Option<String>,
+    /// EdDSA signer that verifies install tokens and mints setup-session
+    /// tokens at the end of the claim ceremony. `None` until the secret
+    /// store yields key material — install routes 503 in that case.
+    pub install_signer: Option<Arc<InstallTokenSigner>>,
+    /// Wraps `install_ks` with the claim-window state machine. Cheap
+    /// to clone; always present once `install_ks` is open.
+    pub install_store: InstallTokenStore,
 }
 
 impl AuthState for AppState {
@@ -114,9 +123,12 @@ pub async fn run(
     let community_ks = store.keyspace("community")?;
     let config_ks = store.keyspace("config")?;
     let passkey_ks = store.keyspace("passkey")?;
+    let install_ks = store.keyspace("install")?;
+    let install_store = InstallTokenStore::new(install_ks.clone());
 
     // Initialize auth infrastructure
-    let (did_resolver, secrets_resolver, jwt_keys, atm) = init_auth(&config, &*secret_store).await;
+    let (did_resolver, secrets_resolver, jwt_keys, atm, install_signer) =
+        init_auth(&config, &*secret_store).await;
 
     // Build WebAuthn relying party handle from `public_url`. Optional —
     // a serverless / pre-setup deployment has no public URL yet and
@@ -173,6 +185,7 @@ pub async fn run(
         community_ks,
         config_ks,
         passkey_ks,
+        install_ks,
         config: Arc::new(RwLock::new(config)),
         did_resolver,
         secrets_resolver,
@@ -180,6 +193,8 @@ pub async fn run(
         atm,
         webauthn,
         public_url,
+        install_signer,
+        install_store,
     };
 
     // Spawn three named OS threads
@@ -400,12 +415,13 @@ async fn init_auth(
     Option<Arc<ThreadedSecretsResolver>>,
     Option<Arc<JwtKeys>>,
     Option<ATM>,
+    Option<Arc<InstallTokenSigner>>,
 ) {
     let vtc_did = match &config.vtc_did {
         Some(did) => did.clone(),
         None => {
             warn!("vtc_did not configured — auth endpoints will not work (run setup first)");
-            return (None, None, None, None);
+            return (None, None, None, None, None);
         }
     };
 
@@ -414,11 +430,11 @@ async fn init_auth(
         Ok(Some(s)) => s,
         Ok(None) => {
             warn!("no key material found — auth endpoints will not work (run setup first)");
-            return (None, None, None, None);
+            return (None, None, None, None, None);
         }
         Err(e) => {
             warn!("failed to load key material: {e} — auth endpoints will not work");
-            return (None, None, None, None);
+            return (None, None, None, None, None);
         }
     };
 
@@ -427,16 +443,30 @@ async fn init_auth(
             "key material is {} bytes, expected 64 — auth endpoints will not work",
             key_material.len()
         );
-        return (None, None, None, None);
+        return (None, None, None, None, None);
     }
 
     let Ok(ed25519_bytes): Result<&[u8; 32], _> = key_material[..32].try_into() else {
         warn!("key material corrupted — auth endpoints will not work");
-        return (None, None, None, None);
+        return (None, None, None, None, None);
     };
     let Ok(x25519_bytes): Result<&[u8; 32], _> = key_material[32..].try_into() else {
         warn!("key material corrupted — auth endpoints will not work");
-        return (None, None, None, None);
+        return (None, None, None, None, None);
+    };
+
+    // Derive the install-token signer from the full 64-byte secret.
+    // HKDF's `info = "vtc-install-jwt-key/v1"` domain-separates this
+    // key from every other seed-derived secret in the daemon (audit
+    // key, future session key). Available even if downstream auth
+    // init fails, so the install routes can run before the VTC's
+    // own DIDComm transport comes up.
+    let install_signer = match InstallTokenSigner::from_master_seed(&key_material) {
+        Ok(s) => Some(Arc::new(s)),
+        Err(e) => {
+            warn!("failed to derive install token signer: {e} — install routes disabled");
+            None
+        }
     };
 
     // 1. DID resolver (local mode)
@@ -444,7 +474,7 @@ async fn init_auth(
         Ok(r) => r,
         Err(e) => {
             warn!("failed to create DID resolver: {e} — auth endpoints will not work");
-            return (None, None, None, None);
+            return (None, None, None, None, install_signer);
         }
     };
 
@@ -474,6 +504,7 @@ async fn init_auth(
                     Some(Arc::new(secrets_resolver)),
                     None,
                     None,
+                    install_signer,
                 );
             }
         },
@@ -486,6 +517,7 @@ async fn init_auth(
                 Some(Arc::new(secrets_resolver)),
                 None,
                 None,
+                install_signer,
             );
         }
     };
@@ -528,6 +560,7 @@ async fn init_auth(
         Some(secrets_resolver),
         Some(Arc::new(jwt_keys)),
         atm,
+        install_signer,
     )
 }
 

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -52,6 +52,7 @@ async fn build() -> Fixture {
     let community_ks = store.keyspace("community").unwrap();
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -75,6 +76,7 @@ async fn build() -> Fixture {
         community_ks,
         config_ks,
         passkey_ks,
+        install_ks: install_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,
@@ -82,6 +84,8 @@ async fn build() -> Fixture {
         atm: None,
         webauthn: None,
         public_url: None,
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
     };
 
     let router = routes::router().with_state(state.clone());

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -52,6 +52,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let community_ks = store.keyspace("community").unwrap();
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -75,6 +76,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         community_ks,
         config_ks,
         passkey_ks,
+        install_ks: install_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,
@@ -82,6 +84,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         atm: None,
         webauthn: None,
         public_url: None,
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
     };
 
     let router = routes::router().with_state(state);

--- a/vtc-service/tests/common/mod.rs
+++ b/vtc-service/tests/common/mod.rs
@@ -1,0 +1,8 @@
+//! Shared test fixtures for vtc-service integration tests.
+//!
+//! Pulled in via `mod common;` from each integration test file —
+//! every binary under `tests/` is its own crate, so importable
+//! helpers live here.
+
+#[allow(dead_code)] // pulled into different test binaries; not every file uses every helper
+pub mod webauthn_harness;

--- a/vtc-service/tests/common/webauthn_harness.rs
+++ b/vtc-service/tests/common/webauthn_harness.rs
@@ -1,0 +1,332 @@
+//! Deterministic soft authenticator for WebAuthn integration tests.
+//!
+//! Implements **M0.5.0** of the VTC MVP Phase 0 plan. The harness
+//! produces real CTAP attestation objects + COSE OKP-Ed25519 public
+//! keys that `webauthn-rs-core` can parse, so route-level integration
+//! tests can drive a complete register + authenticate ceremony
+//! without a browser.
+//!
+//! ## Why we ship our own instead of `webauthn-authenticator-rs::SoftPasskey`
+//!
+//! The upstream `SoftPasskey` (`webauthn-authenticator-rs` 0.5)
+//! generates ES256/EC keys only — its key-generation code is
+//! hard-coded to `openssl::ec`. VTC's install flow demands EdDSA
+//! (spec §4.2: the passkey's COSE public key projects directly into
+//! a `did:key`), so we need an authenticator that produces COSE OKP
+//! Ed25519 credentials. This module is ~250 lines of CTAP-format
+//! encoding on top of `ed25519-dalek` — small enough to ship and
+//! understand in tree.
+//!
+//! ## Scope
+//!
+//! - Format: WebAuthn CTAP 2 "none" attestation. No attestation
+//!   signature, no `attStmt`. Sufficient because `webauthn-rs`'s
+//!   `start_passkey_registration` uses
+//!   `AttestationConveyancePreference::None`.
+//! - Algorithm: EdDSA only. `register()` panics if the challenge's
+//!   `pub_key_cred_params` doesn't include `alg == -8` — the very
+//!   contract `vtc_service::webauthn::start_eddsa_passkey_registration`
+//!   enforces.
+//! - Resident-key / discoverable-credential semantics are out of
+//!   scope (start_passkey_registration sets
+//!   `require_resident_key = false`).
+//!
+//! ## Encoding references
+//!
+//! - <https://www.w3.org/TR/webauthn-3/#attestation-object>
+//! - <https://www.w3.org/TR/webauthn-3/#sctn-authenticator-data>
+//! - <https://datatracker.ietf.org/doc/html/rfc8152#section-13>
+//!   (COSE Key — OKP)
+
+use std::collections::HashMap;
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use ed25519_dalek::{Signer, SigningKey};
+use sha2::{Digest, Sha256};
+use webauthn_rs::prelude::{
+    Base64UrlSafeData, CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
+    RequestChallengeResponse,
+};
+use webauthn_rs_proto::{AuthenticatorAssertionResponseRaw, AuthenticatorAttestationResponseRaw};
+
+/// Flags byte: User Present.
+const FLAG_UP: u8 = 0x01;
+/// Flags byte: User Verified.
+const FLAG_UV: u8 = 0x04;
+/// Flags byte: Attested Credential Data present.
+const FLAG_AT: u8 = 0x40;
+
+/// COSE algorithm identifier for EdDSA.
+const COSE_ALG_EDDSA: i64 = -8;
+
+/// Pinned AAGUID for the harness — distinctive enough to spot in
+/// debug output without colliding with any real authenticator's
+/// identifier.
+const HARNESS_AAGUID: [u8; 16] = *b"vtc-soft-eddsa\0\0";
+
+/// Soft Ed25519 authenticator. Owns the credentials it mints; pass
+/// `&mut self` to `register()` to add a new one, `&mut self` to
+/// `authenticate()` to sign + bump the per-credential counter.
+pub struct SoftEd25519Authenticator {
+    credentials: HashMap<Vec<u8>, CredentialEntry>,
+}
+
+struct CredentialEntry {
+    signing_key: SigningKey,
+    sign_count: u32,
+}
+
+impl Default for SoftEd25519Authenticator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SoftEd25519Authenticator {
+    pub fn new() -> Self {
+        Self {
+            credentials: HashMap::new(),
+        }
+    }
+
+    /// Process a [`CreationChallengeResponse`] and return a fake
+    /// [`RegisterPublicKeyCredential`] plus the Ed25519 verifying-key
+    /// bytes (32 bytes) of the credential just minted. The
+    /// verifying-key bytes are what consumers project into a `did:key`.
+    ///
+    /// Asserts the challenge advertises EdDSA in
+    /// `pubKeyCredParams` — `vtc_service::webauthn::start_eddsa_passkey_registration`
+    /// is the only sanctioned producer of these challenges, and it
+    /// always restricts to `[{public-key, -8}]`. Other test code that
+    /// drives the upstream-default challenge directly will trip this
+    /// panic, which is the intended failure mode.
+    pub fn register(
+        &mut self,
+        ccr: &CreationChallengeResponse,
+        origin: &str,
+    ) -> (RegisterPublicKeyCredential, [u8; 32]) {
+        let cred_params = &ccr.public_key.pub_key_cred_params;
+        assert!(
+            cred_params.iter().any(|p| p.alg == COSE_ALG_EDDSA),
+            "soft authenticator only produces EdDSA credentials but challenge advertises {cred_params:?}",
+        );
+
+        // Deterministic seed: SHA-256 of the challenge bytes + the
+        // RP id. Tests that want distinct credentials for the same
+        // challenge can mutate either side; the default gives a
+        // stable, reproducible key per ceremony.
+        let mut seed_input = Vec::new();
+        seed_input.extend_from_slice(ccr.public_key.challenge.as_ref());
+        seed_input.extend_from_slice(ccr.public_key.rp.id.as_bytes());
+        seed_input.extend_from_slice(b"soft-eddsa-seed/v1");
+        let seed: [u8; 32] = Sha256::digest(&seed_input).into();
+        let signing_key = SigningKey::from_bytes(&seed);
+        let verifying_key = signing_key.verifying_key().to_bytes();
+
+        // 16-byte credential ID — short enough to look like a passkey
+        // synced credential, deterministic for reproducibility.
+        let mut cred_id_input = Vec::new();
+        cred_id_input.extend_from_slice(&verifying_key);
+        cred_id_input.extend_from_slice(b"cred-id/v1");
+        let cred_id = Sha256::digest(&cred_id_input)[..16].to_vec();
+
+        let client_data_json =
+            client_data_json("webauthn.create", ccr.public_key.challenge.as_ref(), origin);
+
+        let auth_data = authenticator_data(
+            &ccr.public_key.rp.id,
+            FLAG_UP | FLAG_UV | FLAG_AT,
+            0,
+            Some(AttestedCredentialData {
+                aaguid: &HARNESS_AAGUID,
+                credential_id: &cred_id,
+                cose_public_key: &cose_okp_ed25519(&verifying_key),
+            }),
+        );
+
+        let attestation_object = attestation_object_none(&auth_data);
+
+        self.credentials.insert(
+            cred_id.clone(),
+            CredentialEntry {
+                signing_key,
+                sign_count: 0,
+            },
+        );
+
+        let credential = RegisterPublicKeyCredential {
+            id: B64.encode(&cred_id),
+            raw_id: Base64UrlSafeData::from(cred_id),
+            response: AuthenticatorAttestationResponseRaw {
+                attestation_object: Base64UrlSafeData::from(attestation_object),
+                client_data_json: Base64UrlSafeData::from(client_data_json),
+                transports: None,
+            },
+            type_: "public-key".to_string(),
+            extensions: Default::default(),
+        };
+
+        (credential, verifying_key)
+    }
+
+    /// Process a [`RequestChallengeResponse`] and produce a signed
+    /// [`PublicKeyCredential`] for one of the credentials this
+    /// authenticator owns. Increments the credential's `sign_count`
+    /// on success.
+    ///
+    /// Picks the first credential in `allowCredentials` that this
+    /// authenticator owns. Panics if none match — a programming bug
+    /// in the calling test.
+    pub fn authenticate(
+        &mut self,
+        rcr: &RequestChallengeResponse,
+        origin: &str,
+    ) -> PublicKeyCredential {
+        let cred_id = rcr
+            .public_key
+            .allow_credentials
+            .iter()
+            .find_map(|allow| {
+                let id_bytes: Vec<u8> = allow.id.as_ref().to_vec();
+                if self.credentials.contains_key(&id_bytes) {
+                    Some(id_bytes)
+                } else {
+                    None
+                }
+            })
+            .expect("no credential in allowCredentials is known to this authenticator");
+
+        let entry = self
+            .credentials
+            .get_mut(&cred_id)
+            .expect("cred_id resolved above");
+        entry.sign_count = entry.sign_count.wrapping_add(1);
+        let sign_count = entry.sign_count;
+
+        let client_data_json =
+            client_data_json("webauthn.get", rcr.public_key.challenge.as_ref(), origin);
+        let client_data_hash = Sha256::digest(&client_data_json);
+
+        let auth_data =
+            authenticator_data(&rcr.public_key.rp_id, FLAG_UP | FLAG_UV, sign_count, None);
+
+        // EdDSA signature is over `authenticatorData || clientDataHash`.
+        let mut signed = Vec::with_capacity(auth_data.len() + client_data_hash.len());
+        signed.extend_from_slice(&auth_data);
+        signed.extend_from_slice(&client_data_hash);
+        let signature = entry.signing_key.sign(&signed).to_bytes();
+
+        PublicKeyCredential {
+            id: B64.encode(&cred_id),
+            raw_id: Base64UrlSafeData::from(cred_id),
+            response: AuthenticatorAssertionResponseRaw {
+                authenticator_data: Base64UrlSafeData::from(auth_data),
+                client_data_json: Base64UrlSafeData::from(client_data_json),
+                signature: Base64UrlSafeData::from(signature.to_vec()),
+                user_handle: None,
+            },
+            type_: "public-key".to_string(),
+            extensions: Default::default(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoding helpers
+// ---------------------------------------------------------------------------
+
+struct AttestedCredentialData<'a> {
+    aaguid: &'a [u8; 16],
+    credential_id: &'a [u8],
+    cose_public_key: &'a [u8],
+}
+
+/// Build the WebAuthn `authenticatorData` byte string. Spec ref:
+/// <https://www.w3.org/TR/webauthn-3/#sctn-authenticator-data>.
+fn authenticator_data(
+    rp_id: &str,
+    flags: u8,
+    sign_count: u32,
+    attested: Option<AttestedCredentialData<'_>>,
+) -> Vec<u8> {
+    let rp_id_hash = Sha256::digest(rp_id.as_bytes());
+
+    let mut out = Vec::with_capacity(37 + 16 + 2 + 16 + 64);
+    out.extend_from_slice(&rp_id_hash);
+    out.push(flags);
+    out.extend_from_slice(&sign_count.to_be_bytes());
+
+    if let Some(data) = attested {
+        debug_assert!(
+            flags & FLAG_AT != 0,
+            "AT flag must be set with attested data"
+        );
+        out.extend_from_slice(data.aaguid);
+        out.extend_from_slice(
+            &u16::try_from(data.credential_id.len())
+                .expect("credential ID fits in u16")
+                .to_be_bytes(),
+        );
+        out.extend_from_slice(data.credential_id);
+        out.extend_from_slice(data.cose_public_key);
+    }
+
+    out
+}
+
+/// Encode the CTAP attestation object using format `"none"`. Spec ref:
+/// <https://www.w3.org/TR/webauthn-3/#sctn-attestation-formats>.
+fn attestation_object_none(auth_data: &[u8]) -> Vec<u8> {
+    use ciborium::Value;
+    let map = Value::Map(vec![
+        (
+            Value::Text("fmt".to_string()),
+            Value::Text("none".to_string()),
+        ),
+        (Value::Text("attStmt".to_string()), Value::Map(vec![])),
+        (
+            Value::Text("authData".to_string()),
+            Value::Bytes(auth_data.to_vec()),
+        ),
+    ]);
+    let mut out = Vec::new();
+    ciborium::into_writer(&map, &mut out).expect("CBOR encode never fails for owned Value");
+    out
+}
+
+/// Encode a COSE OKP Ed25519 public key. Spec ref:
+/// <https://datatracker.ietf.org/doc/html/rfc8152#section-13.2>.
+fn cose_okp_ed25519(public_key: &[u8; 32]) -> Vec<u8> {
+    use ciborium::Value;
+    // Key parameters (CBOR integer keys):
+    //   1 (kty)  = 1 (OKP)
+    //   3 (alg)  = -8 (EdDSA)
+    //  -1 (crv)  = 6 (Ed25519)
+    //  -2 (x)    = <32-byte public key>
+    let map = Value::Map(vec![
+        (Value::Integer(1.into()), Value::Integer(1.into())),
+        (Value::Integer(3.into()), Value::Integer((-8).into())),
+        (Value::Integer((-1).into()), Value::Integer(6.into())),
+        (
+            Value::Integer((-2).into()),
+            Value::Bytes(public_key.to_vec()),
+        ),
+    ]);
+    let mut out = Vec::new();
+    ciborium::into_writer(&map, &mut out).expect("CBOR encode never fails for owned Value");
+    out
+}
+
+/// Build the WebAuthn `clientDataJSON` byte string. Spec ref:
+/// <https://www.w3.org/TR/webauthn-3/#dictionary-client-data>.
+fn client_data_json(type_: &str, challenge_bytes: &[u8], origin: &str) -> Vec<u8> {
+    let challenge = B64.encode(challenge_bytes);
+    serde_json::to_vec(&serde_json::json!({
+        "type": type_,
+        "challenge": challenge,
+        "origin": origin,
+        "crossOrigin": false,
+    }))
+    .expect("static JSON serialises")
+}

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -53,6 +53,7 @@ async fn build() -> Fixture {
     let community_ks = store.keyspace("community").unwrap();
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -76,6 +77,7 @@ async fn build() -> Fixture {
         community_ks,
         config_ks,
         passkey_ks,
+        install_ks: install_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,
@@ -83,6 +85,8 @@ async fn build() -> Fixture {
         atm: None,
         webauthn: None,
         public_url: None,
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
     };
 
     let router = routes::router().with_state(state.clone());

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -1,0 +1,490 @@
+//! End-to-end coverage for `POST /v1/install/claim/{start,finish}`.
+//!
+//! Drives the full install ceremony through `Router::oneshot`,
+//! using the soft EdDSA authenticator harness (`tests/common`) to
+//! produce real WebAuthn responses and the install module's own
+//! signer/store to mint and consume install tokens.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use chrono::{Duration as ChronoDuration, Utc};
+use ed25519_dalek::Signer;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use uuid::Uuid;
+use vti_common::auth::passkey::build_webauthn;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+use webauthn_rs::prelude::CreationChallengeResponse;
+
+use vtc_service::config::AppConfig;
+use vtc_service::install::{InstallTokenSigner, InstallTokenStore, mint_install_token};
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+use common::webauthn_harness::SoftEd25519Authenticator;
+
+const RP_ORIGIN: &str = "https://vtc.example.com";
+const START_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0";
+const FINISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    install_signer: Arc<InstallTokenSigner>,
+    install_store: InstallTokenStore,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let webauthn = public_url.map(|u| Arc::new(build_webauthn(u).expect("build webauthn")));
+    let install_signer = if with_install_signer {
+        // 64 bytes of test entropy mirror what production loads from
+        // the secret store (32 Ed25519 + 32 X25519); HKDF only cares
+        // about length.
+        Some(Arc::new(
+            InstallTokenSigner::from_master_seed(&[0xAB; 64]).unwrap(),
+        ))
+    } else {
+        None
+    };
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks: install_ks.clone(),
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: None,
+        atm: None,
+        webauthn,
+        public_url: public_url.map(|s| s.to_string()),
+        install_signer: install_signer.clone(),
+        install_store: install_store.clone(),
+    };
+
+    let router = routes::router().with_state(state);
+
+    Fixture {
+        router,
+        install_signer: install_signer.clone().unwrap_or_else(|| {
+            Arc::new(InstallTokenSigner::from_master_seed(&[0xCD; 64]).unwrap())
+        }),
+        install_store,
+        _dir: dir,
+    }
+}
+
+async fn mint_token_and_record(fix: &Fixture, ttl_seconds: u64) -> (String, Uuid) {
+    let minted = mint_install_token(
+        &fix.install_signer,
+        "did:webvh:vtc.example.com:abc",
+        ttl_seconds,
+    )
+    .expect("mint install token");
+    let exp = Utc::now() + ChronoDuration::seconds(ttl_seconds as i64);
+    fix.install_store
+        .record_issued(
+            &minted.jti,
+            minted.cnonce_bytes,
+            *minted.ephemeral_signing_key,
+            exp,
+        )
+        .await
+        .expect("record_issued");
+    (minted.jwt, minted.jti)
+}
+
+async fn post_json(
+    router: &axum::Router,
+    path: &str,
+    trust_task: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    let res = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/json")
+                .header("Trust-Task", trust_task)
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+fn parse_ccr(body: &Value) -> CreationChallengeResponse {
+    serde_json::from_value(body.get("options").cloned().expect("options field"))
+        .expect("CreationChallengeResponse parses")
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn full_ceremony_completes_end_to_end() {
+    let fix = build_fixture(Some(RP_ORIGIN), true).await;
+    let (token, _jti) = mint_token_and_record(&fix, 600).await;
+
+    // -- start ---------------------------------------------------------
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": token }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "start: {body}");
+
+    let registration_id = body["registrationId"].as_str().unwrap().to_string();
+    let challenge_b64 = body["didBindingChallenge"].as_str().unwrap().to_string();
+    let challenge: [u8; 32] = B64.decode(&challenge_b64).unwrap().try_into().unwrap();
+    let ccr = parse_ccr(&body);
+
+    // -- harness produces the registration response --------------------
+    let mut authenticator = SoftEd25519Authenticator::new();
+    let (register_cred, ed25519_pub) = authenticator.register(&ccr, RP_ORIGIN);
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&harness_seed_for(
+        ccr.public_key.challenge.as_ref(),
+        &ccr.public_key.rp.id,
+    ));
+    // Sanity: derived key matches what the harness gave us.
+    assert_eq!(signing_key.verifying_key().to_bytes(), ed25519_pub);
+
+    let did_binding_signature = B64.encode(signing_key.sign(&challenge).to_bytes());
+
+    // -- finish --------------------------------------------------------
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/install/claim/finish",
+        FINISH_TASK,
+        json!({
+            "install_token": token,
+            "registration_id": registration_id,
+            "webauthn_response": register_cred,
+            "did_binding_signature": did_binding_signature,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "finish: {body}");
+    let admin_did = body["adminDid"].as_str().unwrap();
+    assert!(admin_did.starts_with("did:key:z"));
+    assert!(!body["setupSessionToken"].as_str().unwrap().is_empty());
+
+    // -- replay finish: must fail (token is now Consumed) --------------
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/finish",
+        FINISH_TASK,
+        json!({
+            "install_token": token,
+            "registration_id": registration_id,
+            "webauthn_response": register_cred,
+            "did_binding_signature": did_binding_signature,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+/// Reconstruct the harness's deterministic Ed25519 seed for the given
+/// (challenge, rp_id) pair. Mirrors the algorithm in
+/// `tests/common/webauthn_harness.rs::SoftEd25519Authenticator::register`.
+fn harness_seed_for(challenge: &[u8], rp_id: &str) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(challenge);
+    h.update(rp_id.as_bytes());
+    h.update(b"soft-eddsa-seed/v1");
+    h.finalize().into()
+}
+
+// ---------------------------------------------------------------------------
+// 503 paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn start_returns_503_when_install_signer_missing() {
+    let fix = build_fixture(Some(RP_ORIGIN), false).await;
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": "bogus" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn start_returns_503_when_webauthn_missing() {
+    let fix = build_fixture(None, true).await;
+    let (token, _jti) = mint_token_and_record(&fix, 600).await;
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": token }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+// ---------------------------------------------------------------------------
+// Failure modes — auth + ceremony state
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn start_rejects_unsigned_token() {
+    let fix = build_fixture(Some(RP_ORIGIN), true).await;
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": "not.a.real.jwt" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn start_rejects_unknown_jti() {
+    // Mint a valid token but never call `record_issued` — the install
+    // store has no state for the jti and `start_claim` must fail.
+    let fix = build_fixture(Some(RP_ORIGIN), true).await;
+    let minted =
+        mint_install_token(&fix.install_signer, "did:webvh:vtc.example.com:abc", 600).unwrap();
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": minted.jwt }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn second_concurrent_start_within_window_is_conflict() {
+    let fix = build_fixture(Some(RP_ORIGIN), true).await;
+    let (token, _jti) = mint_token_and_record(&fix, 600).await;
+
+    let (status1, _) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": &token }),
+    )
+    .await;
+    assert_eq!(status1, StatusCode::OK);
+
+    let (status2, _) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": &token }),
+    )
+    .await;
+    assert_eq!(status2, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn finish_rejects_mismatched_registration_id() {
+    let fix = build_fixture(Some(RP_ORIGIN), true).await;
+    let (token, _jti) = mint_token_and_record(&fix, 600).await;
+
+    let (_status, body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": token }),
+    )
+    .await;
+    let challenge_b64 = body["didBindingChallenge"].as_str().unwrap().to_string();
+    let ccr = parse_ccr(&body);
+    let mut authenticator = SoftEd25519Authenticator::new();
+    let (register_cred, _pub) = authenticator.register(&ccr, RP_ORIGIN);
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&harness_seed_for(
+        ccr.public_key.challenge.as_ref(),
+        &ccr.public_key.rp.id,
+    ));
+    let challenge: [u8; 32] = B64.decode(&challenge_b64).unwrap().try_into().unwrap();
+    let sig = B64.encode(signing_key.sign(&challenge).to_bytes());
+
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/finish",
+        FINISH_TASK,
+        json!({
+            "install_token": token,
+            "registration_id": Uuid::new_v4().to_string(),
+            "webauthn_response": register_cred,
+            "did_binding_signature": sig,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn finish_rejects_wrong_did_binding_signature() {
+    let fix = build_fixture(Some(RP_ORIGIN), true).await;
+    let (token, _jti) = mint_token_and_record(&fix, 600).await;
+
+    let (_status, body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": &token }),
+    )
+    .await;
+    let registration_id = body["registrationId"].as_str().unwrap().to_string();
+    let ccr = parse_ccr(&body);
+    let mut authenticator = SoftEd25519Authenticator::new();
+    let (register_cred, _pub) = authenticator.register(&ccr, RP_ORIGIN);
+
+    // Sign a *different* 32-byte buffer — the server's challenge was
+    // discarded but the attacker doesn't know that, so any non-matching
+    // signature must be rejected.
+    let wrong_signer = ed25519_dalek::SigningKey::from_bytes(&[0x99; 32]);
+    let bogus_sig = B64.encode(wrong_signer.sign(&[0u8; 32]).to_bytes());
+
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/finish",
+        FINISH_TASK,
+        json!({
+            "install_token": token,
+            "registration_id": registration_id,
+            "webauthn_response": register_cred,
+            "did_binding_signature": bogus_sig,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn finish_without_start_fails() {
+    let fix = build_fixture(Some(RP_ORIGIN), true).await;
+    let (token, jti) = mint_token_and_record(&fix, 600).await;
+
+    // Skip start. Fabricate a registration_id and a placeholder
+    // webauthn_response — finish must refuse because no
+    // registration state exists for this jti.
+    let dummy_cred = json!({
+        "id": "AAAA",
+        "rawId": "AAAA",
+        "response": {
+            "attestationObject": "AA",
+            "clientDataJSON": "AA"
+        },
+        "type": "public-key"
+    });
+
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/finish",
+        FINISH_TASK,
+        json!({
+            "install_token": token,
+            "registration_id": jti.to_string(),
+            "webauthn_response": dummy_cred,
+            "did_binding_signature": B64.encode([0u8; 64]),
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// Trust-Task gate
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn missing_trust_task_header_returns_400() {
+    let fix = build_fixture(Some(RP_ORIGIN), true).await;
+    let res = fix
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/install/claim/start")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"install_token":"x"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn wrong_trust_task_header_returns_415() {
+    let fix = build_fixture(Some(RP_ORIGIN), true).await;
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        FINISH_TASK, // start endpoint with finish task
+        json!({ "install_token": "x" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -36,6 +36,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let community_ks = store.keyspace("community").unwrap();
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
 
     let config: AppConfig = toml::from_str(&format!(
         r#"
@@ -55,6 +56,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         community_ks,
         config_ks,
         passkey_ks,
+        install_ks: install_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,
@@ -62,6 +64,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         atm: None,
         webauthn,
         public_url: public_url.map(|s| s.to_string()),
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
     };
     (state, dir)
 }

--- a/vtc-service/tests/webauthn_harness.rs
+++ b/vtc-service/tests/webauthn_harness.rs
@@ -1,0 +1,202 @@
+//! Validation of the deterministic soft EdDSA authenticator harness
+//! (`tests/common/webauthn_harness.rs`).
+//!
+//! Drives a full register + authenticate ceremony through `webauthn-rs`,
+//! using the EdDSA-restricting wrappers from
+//! `vtc_service::webauthn::start_eddsa_passkey_registration`. If this
+//! test passes end-to-end then the harness produces wire output
+//! `webauthn-rs-core` accepts and signatures `webauthn-rs` verifies —
+//! which is the contract M0.5.2's install-claim integration tests
+//! depend on.
+//!
+//! Also asserts the Ed25519 verifying-key bytes the harness returns
+//! match the COSE public key webauthn-rs ultimately stores in the
+//! `Passkey` — without that, callers can't reliably derive a `did:key`
+//! from the registered credential.
+
+mod common;
+
+use base64::Engine;
+use uuid::Uuid;
+use vti_common::auth::passkey::build_webauthn;
+use webauthn_rs::Webauthn;
+use webauthn_rs_proto::COSEAlgorithm;
+
+use vtc_service::webauthn::{finish_eddsa_passkey_registration, start_eddsa_passkey_registration};
+
+use common::webauthn_harness::SoftEd25519Authenticator;
+
+const RP_ORIGIN: &str = "https://vtc.example.com";
+
+fn webauthn() -> Webauthn {
+    build_webauthn(RP_ORIGIN).expect("webauthn builder")
+}
+
+#[test]
+fn register_then_authenticate_completes_end_to_end() {
+    let webauthn = webauthn();
+    let mut authenticator = SoftEd25519Authenticator::new();
+
+    // -- register ------------------------------------------------------
+    let user_uuid = Uuid::new_v4();
+    let (ccr, reg_state) = start_eddsa_passkey_registration(
+        &webauthn,
+        user_uuid,
+        "did:key:zHarness",
+        "did:key:zHarness",
+        None,
+    )
+    .expect("start_eddsa_passkey_registration");
+
+    let (register_cred, ed25519_pub) = authenticator.register(&ccr, RP_ORIGIN);
+
+    let passkey = finish_eddsa_passkey_registration(&webauthn, &register_cred, &reg_state)
+        .expect("finish_eddsa_passkey_registration");
+
+    // Sanity: webauthn-rs registered an EdDSA passkey, not something
+    // else that webauthn-rs core's algorithm filter let through.
+    assert_eq!(passkey.cred_algorithm(), &COSEAlgorithm::EDDSA);
+
+    // The verifying-key bytes the harness handed back must equal the
+    // raw Ed25519 `x` coordinate webauthn-rs stored on the Passkey.
+    // The COSE key shape is internal to `webauthn-rs-core`; we lift it
+    // out via serde rather than depending on the `danger-credential-internals`
+    // feature. Spec ref RFC 8152 §13.2: OKP `x` parameter is integer
+    // key `-2`.
+    let passkey_json = serde_json::to_value(&passkey).expect("passkey serialises");
+    let cose_x = walk_eddsa_x(&passkey_json).unwrap_or_else(|| {
+        panic!(
+            "EDDSA `x` coordinate not found in Passkey JSON:\n{}",
+            serde_json::to_string_pretty(&passkey_json).unwrap()
+        )
+    });
+    assert_eq!(
+        cose_x.as_slice(),
+        ed25519_pub.as_slice(),
+        "harness pubkey must match passkey's stored Ed25519 x coordinate",
+    );
+
+    // -- authenticate --------------------------------------------------
+    let (rcr, auth_state) = webauthn
+        .start_passkey_authentication(std::slice::from_ref(&passkey))
+        .expect("start_passkey_authentication");
+
+    let auth_cred = authenticator.authenticate(&rcr, RP_ORIGIN);
+
+    let _auth_result = webauthn
+        .finish_passkey_authentication(&auth_cred, &auth_state)
+        .expect("finish_passkey_authentication");
+    // Don't assert on `needs_update()` — it reflects flag drift the
+    // RP should persist (counter, backup-eligibility) and is true on
+    // the very first authentication after register. The contract
+    // we're verifying here is "ceremony succeeds without error".
+}
+
+#[test]
+fn second_authenticate_increments_sign_count() {
+    let webauthn = webauthn();
+    let mut authenticator = SoftEd25519Authenticator::new();
+
+    let (ccr, reg_state) = start_eddsa_passkey_registration(
+        &webauthn,
+        Uuid::new_v4(),
+        "did:key:zHarness2",
+        "did:key:zHarness2",
+        None,
+    )
+    .unwrap();
+    let (register_cred, _ed25519_pub) = authenticator.register(&ccr, RP_ORIGIN);
+    let passkey = finish_eddsa_passkey_registration(&webauthn, &register_cred, &reg_state).unwrap();
+
+    // First authentication.
+    let (rcr1, state1) = webauthn
+        .start_passkey_authentication(std::slice::from_ref(&passkey))
+        .unwrap();
+    let auth1 = authenticator.authenticate(&rcr1, RP_ORIGIN);
+    let result1 = webauthn
+        .finish_passkey_authentication(&auth1, &state1)
+        .unwrap();
+
+    // Second authentication. The harness counter must monotonically
+    // increase so webauthn-rs accepts the second assertion — a regression
+    // here typically presents as `CredentialCounterUpdated` errors.
+    let (rcr2, state2) = webauthn
+        .start_passkey_authentication(std::slice::from_ref(&passkey))
+        .unwrap();
+    let auth2 = authenticator.authenticate(&rcr2, RP_ORIGIN);
+    let result2 = webauthn
+        .finish_passkey_authentication(&auth2, &state2)
+        .unwrap();
+
+    assert!(result1.counter() < result2.counter());
+}
+
+#[test]
+fn register_panics_when_challenge_lacks_eddsa() {
+    let webauthn = webauthn();
+    let mut authenticator = SoftEd25519Authenticator::new();
+
+    // Drive the upstream challenge directly (no EdDSA restriction). The
+    // harness must refuse — it produces only EdDSA credentials, so
+    // accepting a non-EdDSA challenge would silently emit a mismatched
+    // attestation that webauthn-rs's finish-side validation rejects
+    // with a misleading error.
+    let (ccr, _state) = webauthn
+        .start_passkey_registration(Uuid::new_v4(), "did:key:zNoEdDSA", "did:key:zNoEdDSA", None)
+        .unwrap();
+    assert!(
+        !ccr.public_key
+            .pub_key_cred_params
+            .iter()
+            .any(|p| p.alg == -8)
+    );
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        authenticator.register(&ccr, RP_ORIGIN)
+    }));
+    assert!(result.is_err(), "harness must refuse non-EdDSA challenges");
+}
+
+/// Walk a JSON value looking for the COSE OKP `x` coordinate. The
+/// upstream serde shape isn't documented and shifts between minor
+/// versions of `webauthn-rs-core` (today it's
+/// `cred.cred.key.EC_OKP.x` and serialised as a base64url-no-pad
+/// string). Rather than pin to one shape, we recurse and pick the
+/// first value at key `"x"` that decodes to 32 raw bytes.
+fn walk_eddsa_x(value: &serde_json::Value) -> Option<Vec<u8>> {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(x) = map.get("x")
+                && let Some(bytes) = decode_x_value(x)
+            {
+                return Some(bytes);
+            }
+            for v in map.values() {
+                if let Some(found) = walk_eddsa_x(v) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(walk_eddsa_x),
+        _ => None,
+    }
+}
+
+fn decode_x_value(value: &serde_json::Value) -> Option<Vec<u8>> {
+    // `Vec<u8>` form (older serde shapes).
+    if let Ok(bytes) = serde_json::from_value::<Vec<u8>>(value.clone())
+        && bytes.len() == 32
+    {
+        return Some(bytes);
+    }
+    // base64url-no-pad string form (current `webauthn-rs-core 0.5.5`
+    // shape).
+    if let Some(s) = value.as_str()
+        && let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(s)
+        && bytes.len() == 32
+    {
+        return Some(bytes);
+    }
+    None
+}


### PR DESCRIPTION
## Summary

Bundles **M0.5.0 + M0.5.2** of the VTC MVP Phase 0 plan. Originally split across two stacked PRs, but the M0.5.0 harness PR (#60) merged into a base branch that was deleted before the contents propagated to `main`, so this PR resurfaces both commits.

## What's in this PR

**M0.5.0 — Soft Ed25519 WebAuthn authenticator harness** (commit 1):
- `tests/common/webauthn_harness.rs` — produces real CTAP attestation
  objects + COSE OKP-Ed25519 public keys that `webauthn-rs-core`
  parses end-to-end.
- `tests/webauthn_harness.rs` — 3 validation tests proving the
  harness drives a full register + authenticate ceremony green.
- Adds `ciborium` dev-dep for CBOR encoding.
- `webauthn-authenticator-rs::SoftPasskey` was unsuitable because it
  hard-codes ES256.

**M0.5.2 — Install claim start/finish endpoints** (commit 2):
- `POST /v1/install/claim/start` — verifies install token, takes the
  300 s ceremony lock, returns EdDSA-only WebAuthn options + a
  32-byte DID-binding challenge.
- `POST /v1/install/claim/finish` — verifies WebAuthn assertion,
  derives candidate `did:key` from the credential's Ed25519 x
  coordinate, verifies the operator's Ed25519 signature over the
  DID-binding challenge (spec §4.2 — proves single-key control over
  both signing paths), consumes the install token, persists the
  passkey, mints a 5-minute setup-session JWT
  (`aud = vtc-install-session`) for M0.6's `/v1/admin/bootstrap`.
- Wires `install_ks`, `install_signer`, and `install_store` through
  AppState; install signer derived from the 64-byte secret store via
  HKDF info `vtc-install-jwt-key/v1`.
- `InstallTokenSigner::encode_session`/`decode_session` +
  `mint_install_session_token` for the setup-session token.

Carve-out stays open after `finish` — token is `Consumed` but
`close_carveout` lives in M0.6.

## Trust Tasks

New entries in `trust-tasks/index.json`:
- `install/claim/start/1.0`
- `install/claim/finish/1.0`

Each ships with `spec.md` + `schema.json`.

## Test plan

- [x] `cargo test --package vtc-service` — 115 tests pass:
  - 69 lib unit (incl. 6 new in `routes::install::tests::*` —
    DID-key derivation + DID-binding signature primitives).
  - 10 admin_config + 6 auth_audience + 10 community_profile +
    5 passkey_state (unchanged).
  - **3 new `tests/webauthn_harness.rs`** — full register +
    authenticate cycle with pubkey↔COSE-x assertion, counter
    monotonicity, non-EdDSA refusal.
  - **11 new `tests/install_claim.rs`** — full ceremony with
    replay-rejection, 503 paths, 401 paths, 409 (concurrent start),
    400/415 (Trust-Task gate).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --lib` clean.

## What's next

This closes **M0.5** entirely. Next milestone is **M0.6 — admin
bootstrap + multi-passkey schema**:
- `POST /v1/admin/bootstrap` consumes the setup-session JWT, writes
  the first ACL entry, emits `CommunityInstalled`, and closes the
  install carve-out.
- Role enum extension.
- Passkey register/revoke/list endpoints with step-up UV reauth.