### PR TITLE
feat(vtc): admin bootstrap endpoint + audit wiring (M0.6.1 + M0.6.2)

### DIFF
--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -534,44 +534,84 @@ invite system).
 
 ## M0.6 — Admin bootstrap + multi-passkey schema
 
-### `[ ]` M0.6.1 — Extend ACL `Role` enum + `AdminEntry` shape
+### `[x]` M0.6.1 — Extend ACL `Role` enum + `AdminEntry` shape
+
+Scope cut: the shared `vti_common::acl::Role` enum is unchanged
+(touching it would force VTA into the VTC role taxonomy). Instead
+this milestone ships the VTC admin extension as a **sister record**
+under `admin:<did>` in the existing `passkey` keyspace, coexisting
+with the canonical `acl:<did>` → `AclEntry` row. Phase 1 will unify
+once `vti-common::acl::AclEntry` becomes generic over `Role`.
 
 - **Acceptance**
-  - `VtcRole` per spec §5.3 (`Admin`, `Moderator`, `Issuer`,
-    `Member`, `Custom(String)`)
-  - `AclEntry` extended: admin-role entries carry
-    `passkeys: Vec<RegisteredPasskey>` and `extensions: JsonValue`
-  - Migration path from existing ACL entries documented (existing
-    `Admin` rows get an empty `passkeys` vec)
+  - New `vtc_service::acl::admin::AdminEntry { did, passkeys:
+    Vec<RegisteredPasskey>, extensions: JsonValue, created_at }`
+    plus `get_admin_entry` / `store_admin_entry` /
+    `list_admin_entries` CRUD.
+  - `RegisteredPasskey { credential_id, label, transports,
+    registered_at, last_used_at }` matches spec §4.3.
+  - Backwards-compat: `passkeys` and `extensions` default-on-missing
+    so future migrations stay decoding-safe.
+  - `VtcRole` introduction (spec §5.3) deferred to Phase 1+ when
+    Moderator / Issuer / Member roles are actually exercised by
+    endpoints.
 - **Verify**
-  - Unit tests for serialization round-trip
-  - Backwards-compat test: existing ACL records deserialize cleanly
+  - `acl::admin::tests::*` × 4 — store-and-retrieve, list, legacy
+    deserialise, camelCase wire shape.
 - **Files**
-  - `vti-common/src/acl/mod.rs`
-  - `vtc-service/src/acl/mod.rs`
+  - `vtc-service/src/acl/admin.rs` (new — ~190 lines incl. tests)
+  - `vtc-service/src/acl/mod.rs` (`pub mod admin`)
 - **Deps**: M0.1.0
 
-### `[ ]` M0.6.2 — `POST /v1/admin/bootstrap`
+### `[x]` M0.6.2 — `POST /v1/admin/bootstrap`
 
 - **Acceptance**
-  - Endpoint accepts the setup-session token from M0.5.2 and the
-    candidate admin DID + first passkey
-  - Atomically: writes ACL entry with `role: Admin`, single passkey,
-    emits `CommunityInstalled` audit event, calls
-    `install::carveout::close_carveout()`
-  - Returns 409 if any admin already exists (defence-in-depth even
-    though the install carve-out should prevent this)
+  - Endpoint accepts the setup-session JWT from M0.5.2 (decoder
+    rejects other audiences; `sub` carries the candidate admin DID
+    and `install_jti` propagates the originating install token).
+  - Looks up the persisted `PasskeyUser` (written at claim/finish),
+    lifts the first credential id into a `RegisteredPasskey`, and
+    writes the `AdminEntry` under `admin:<did>` in the `passkey`
+    keyspace.
+  - Writes the `Role::Admin` `AclEntry` under `acl:<did>` in the
+    `acl` keyspace.
+  - Calls `InstallTokenStore::close_carveout` (permanent).
+  - Emits `CommunityInstalled` to the audit log carrying
+    `community_did` and `install_token_jti`.
+  - 409 if any `Role::Admin` ACL entry already exists.
   - Trust Task ID: `admin/bootstrap/1.0`
 - **Verify**
-  - End-to-end happy path test
-  - Bootstrap-after-bootstrap returns 409
-  - `CommunityInstalled` event present in audit log
+  - 9 `tests/admin_bootstrap.rs` integration tests:
+    - `full_install_to_bootstrap_succeeds` — happy path; ACL +
+      admin entry + audit envelope written; carve-out closed.
+    - `second_bootstrap_returns_409` — replay rejected.
+    - `bootstrap_rejects_unsigned_token`
+    - `bootstrap_rejects_install_token_as_setup_token` — audience
+      separation between `vtc-install` and `vtc-install-session`.
+    - `bootstrap_rejects_when_no_passkey_user_exists`
+    - `bootstrap_returns_503_when_install_signer_missing`
+    - `bootstrap_returns_503_when_audit_writer_missing`
+    - `wrong_trust_task_returns_415`
+    - `missing_trust_task_returns_400`
 - **Files**
-  - `vtc-service/src/routes/admin/bootstrap.rs` (new)
-  - `vtc-service/src/routes/admin/mod.rs` (new)
-  - `vtc-service/src/routes/mod.rs`
+  - `vtc-service/src/routes/admin/bootstrap.rs` (new — ~190 lines)
+  - `vtc-service/src/routes/admin/mod.rs` (mount)
+  - `vtc-service/src/routes/mod.rs` (Trust Task + route)
+  - `vtc-service/src/server.rs` (AppState gains `audit_ks`,
+    `audit_key_ks`, `audit_writer`; `init_auth` derives the audit
+    key via `AuditKeyStore::ensure_initial` and threads the
+    writer through)
+  - `vtc-service/src/install/token.rs` (`InstallSessionClaims`
+    gains `install_jti`; `mint_install_session_token` takes the
+    new param)
+  - `vtc-service/src/routes/install.rs` (passes the install jti
+    forward at claim/finish)
+  - `vtc-service/tests/admin_bootstrap.rs` (new — 9 tests)
+  - `vtc-service/tests/{admin_config,auth_audience,community_profile,install_claim,passkey_state}.rs`
+    (new AppState fields)
   - `trust-tasks/admin/bootstrap/1.0/{spec.md,schema.json}`
-- **Deps**: M0.5.2, M0.6.1, M0.1.2
+  - `trust-tasks/index.json`
+- **Deps**: M0.5.2, M0.6.1, M0.3 (audit infrastructure)
 
 ### `[ ]` M0.6.3 — Multi-passkey endpoints with step-up UV reauth
 

--- a/trust-tasks/admin/bootstrap/1.0/schema.json
+++ b/trust-tasks/admin/bootstrap/1.0/schema.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Admin — Bootstrap",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "required": ["setup_session_token"],
+      "properties": {
+        "setup_session_token": {
+          "type": "string",
+          "description": "Setup-session JWT (aud=vtc-install-session) minted by /v1/install/claim/finish."
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["adminDid", "eventId"],
+      "properties": {
+        "adminDid": {
+          "type": "string",
+          "pattern": "^did:key:z",
+          "description": "The admin DID that was just written to the ACL."
+        },
+        "eventId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "event_id of the persisted CommunityInstalled audit envelope."
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/admin/bootstrap/1.0/spec.md
+++ b/trust-tasks/admin/bootstrap/1.0/spec.md
@@ -1,0 +1,49 @@
+---
+id: https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0
+title: VTC Admin — Bootstrap
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/admin/bootstrap
+---
+
+# VTC Admin — Bootstrap
+
+Closes the install ceremony. The operator submits the
+**setup-session JWT** issued by `POST /v1/install/claim/finish`
+(M0.5.2) which carries:
+
+- `sub` — the candidate admin `did:key`
+- `install_jti` — the originating install token's `jti`
+
+On success the VTC atomically:
+
+1. Confirms no `Admin` ACL entry exists (defence-in-depth against
+   double-bootstrap; the install carve-out should already block this).
+2. Writes an `AdminEntry` (with one `RegisteredPasskey` lifted from
+   the passkey persisted at `claim/finish`) under
+   `admin:<did>` in the `passkey` keyspace.
+3. Writes an `AclEntry { role: Admin }` under `acl:<did>` in the
+   `acl` keyspace.
+4. Closes the install carve-out — no further install token can be
+   minted or claimed without an `emergency-bootstrap` action.
+5. Emits `CommunityInstalled` to the audit log, carrying the
+   community DID and the `install_jti` so forensics can correlate
+   the install URL → bootstrap → carve-out-close chain.
+
+## Authentication
+
+**Unauthenticated** — the setup-session JWT is the auth credential.
+The endpoint sits behind the install carve-out, which gates against
+replay (the JWT's `install_jti` keys a `Consumed` install-token row).
+
+## Errors
+
+- `401 Unauthorized` — setup-session JWT invalid, expired, or
+  references an unknown install token; the corresponding
+  passkey user record is missing (claim/finish wasn't run).
+- `409 Conflict` — an admin ACL entry already exists.
+- `503 Service Unavailable` — install signer or audit writer not
+  configured (run `vtc setup` first).

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -76,6 +76,12 @@
       "status": "Draft",
       "path": "install/claim/finish/1.0",
       "rest": "POST /v1/install/claim/finish"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0",
+      "status": "Draft",
+      "path": "admin/bootstrap/1.0",
+      "rest": "POST /v1/admin/bootstrap"
     }
   ]
 }

--- a/vtc-service/src/acl/admin.rs
+++ b/vtc-service/src/acl/admin.rs
@@ -1,0 +1,191 @@
+//! VTC admin-entry domain model — multi-passkey + extensions.
+//!
+//! Implements **M0.6.1** of the VTC MVP Phase 0 plan. The spec (§5.2,
+//! §5.3) calls for admin ACL entries to carry `passkeys:
+//! Vec<RegisteredPasskey>` and an `extensions: JsonValue` slot.
+//! Touching the shared `vti_common::acl::AclEntry` would break VTA
+//! (which uses the same struct with its own `Role` enum), so this
+//! module stores the extension as a **sister record** under
+//! `admin:<did>` in the `passkey` keyspace:
+//!
+//! - `acl:<did>` → `AclEntry` — the canonical auth-gating record
+//!   (Role::Admin), continues to power `AdminAuth` and friends.
+//! - `admin:<did>` → `AdminEntry` — the VTC-specific multi-passkey
+//!   + extensions metadata.
+//!
+//! Both records are written atomically by
+//! [`crate::routes::admin::bootstrap`] under a single AppState
+//! reference. Phase-1 will unify these into a single VTC ACL shape
+//! when the shared crate gains generic-over-Role support.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// One device's worth of registered passkey metadata. Lives inside
+/// [`AdminEntry::passkeys`]; the actual credential bytes that
+/// `webauthn-rs` needs for re-authentication live in the
+/// `pk_user:<uuid>` records this passkey was already written to at
+/// `claim/finish` time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisteredPasskey {
+    /// Hex-encoded WebAuthn credential id. Matches the
+    /// `CredentialMapping` key in the passkey store.
+    pub credential_id: String,
+    /// Operator-supplied label (e.g. `"MacBook Air Touch ID"`).
+    pub label: String,
+    /// WebAuthn transports — `usb`, `nfc`, `ble`, `internal`, …
+    #[serde(default)]
+    pub transports: Vec<String>,
+    pub registered_at: DateTime<Utc>,
+    /// Updated by passkey-login on every successful assertion.
+    pub last_used_at: Option<DateTime<Utc>>,
+}
+
+/// VTC-specific admin metadata. One per admin DID. The list of
+/// passkeys is the source of truth for "which devices can act as
+/// this admin" — the `pk_user:<uuid>` records this list points into
+/// hold the credential bytes themselves.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminEntry {
+    pub did: String,
+    #[serde(default)]
+    pub passkeys: Vec<RegisteredPasskey>,
+    /// Community-owned extensibility slot. Bounded by the same
+    /// 16 KiB cap the community-profile extension uses (enforced by
+    /// route handlers, not this module).
+    #[serde(default)]
+    pub extensions: Value,
+    pub created_at: DateTime<Utc>,
+}
+
+impl AdminEntry {
+    /// New empty entry — used at bootstrap before the first passkey
+    /// gets appended in the same transaction.
+    pub fn new(did: impl Into<String>) -> Self {
+        Self {
+            did: did.into(),
+            passkeys: Vec::new(),
+            extensions: Value::Null,
+            created_at: Utc::now(),
+        }
+    }
+}
+
+const PREFIX: &[u8] = b"admin:";
+
+fn key(did: &str) -> Vec<u8> {
+    let mut k = PREFIX.to_vec();
+    k.extend_from_slice(did.as_bytes());
+    k
+}
+
+pub async fn get_admin_entry(
+    ks: &KeyspaceHandle,
+    did: &str,
+) -> Result<Option<AdminEntry>, AppError> {
+    ks.get(key(did)).await
+}
+
+pub async fn store_admin_entry(ks: &KeyspaceHandle, entry: &AdminEntry) -> Result<(), AppError> {
+    ks.insert(key(&entry.did), entry).await
+}
+
+pub async fn list_admin_entries(ks: &KeyspaceHandle) -> Result<Vec<AdminEntry>, AppError> {
+    let raw = ks.prefix_iter_raw(PREFIX.to_vec()).await?;
+    let mut out = Vec::with_capacity(raw.len());
+    for (_k, v) in raw {
+        match serde_json::from_slice(&v) {
+            Ok(e) => out.push(e),
+            Err(err) => tracing::warn!(error = %err, "skipping unparseable admin entry"),
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).expect("store");
+        let ks = store.keyspace("passkey-admin-test").expect("ks");
+        (ks, dir)
+    }
+
+    fn sample_passkey(cred_id: &str, label: &str) -> RegisteredPasskey {
+        RegisteredPasskey {
+            credential_id: cred_id.into(),
+            label: label.into(),
+            transports: vec!["internal".into()],
+            registered_at: DateTime::parse_from_rfc3339("2026-05-12T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            last_used_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip_stores_and_retrieves() {
+        let (ks, _dir) = temp_ks();
+        let mut entry = AdminEntry::new("did:key:zAdmin");
+        entry.passkeys.push(sample_passkey("deadbeef", "yubikey"));
+        entry.extensions = serde_json::json!({"team": "platform"});
+
+        store_admin_entry(&ks, &entry).await.unwrap();
+        let got = get_admin_entry(&ks, "did:key:zAdmin")
+            .await
+            .unwrap()
+            .expect("present");
+        assert_eq!(got, entry);
+    }
+
+    #[tokio::test]
+    async fn list_returns_every_admin() {
+        let (ks, _dir) = temp_ks();
+        for did in ["did:key:zA", "did:key:zB", "did:key:zC"] {
+            store_admin_entry(&ks, &AdminEntry::new(did)).await.unwrap();
+        }
+        let entries = list_admin_entries(&ks).await.unwrap();
+        assert_eq!(entries.len(), 3);
+        let dids: std::collections::HashSet<_> = entries.iter().map(|e| e.did.as_str()).collect();
+        for d in ["did:key:zA", "did:key:zB", "did:key:zC"] {
+            assert!(dids.contains(d));
+        }
+    }
+
+    #[test]
+    fn deserialises_legacy_shape_without_extensions() {
+        // A future migration might write `admin:` records without
+        // some of the newer fields. `#[serde(default)]` on
+        // `passkeys` + `extensions` keeps such rows readable; this
+        // test pins the contract.
+        let legacy = r#"{
+            "did": "did:key:zLegacy",
+            "createdAt": "2026-05-12T00:00:00Z"
+        }"#;
+        let entry: AdminEntry = serde_json::from_str(legacy).expect("legacy shape parses");
+        assert_eq!(entry.did, "did:key:zLegacy");
+        assert!(entry.passkeys.is_empty());
+        assert_eq!(entry.extensions, Value::Null);
+    }
+
+    #[test]
+    fn passkey_serialises_to_camel_case() {
+        let pk = sample_passkey("ab", "label");
+        let json = serde_json::to_value(&pk).unwrap();
+        assert!(json["credentialId"].is_string());
+        assert!(json["registeredAt"].is_string());
+        assert!(json["lastUsedAt"].is_null());
+    }
+}

--- a/vtc-service/src/acl/mod.rs
+++ b/vtc-service/src/acl/mod.rs
@@ -1,1 +1,3 @@
+pub mod admin;
+
 pub use vti_common::acl::*;

--- a/vtc-service/src/install/token.rs
+++ b/vtc-service/src/install/token.rs
@@ -232,6 +232,11 @@ pub struct InstallSessionClaims {
     /// Random identifier — M0.6's bootstrap endpoint can drop a
     /// once-only marker keyed by `jti` to prevent replay.
     pub jti: String,
+    /// The originating install token's `jti`. Lets the bootstrap
+    /// audit event (`CommunityInstalled.install_token_jti`)
+    /// correlate the carve-out close with the install URL the
+    /// operator clicked.
+    pub install_jti: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -315,11 +320,14 @@ pub fn parse_install_token(
 
 /// Mint a setup-session token for `admin_did`. Called from
 /// `POST /v1/install/claim/finish` after the WebAuthn ceremony and
-/// DID-binding signature both verify.
+/// DID-binding signature both verify. `install_jti` is the
+/// originating install token's `jti` — propagated forward so the
+/// bootstrap audit event can record it.
 pub fn mint_install_session_token(
     signer: &InstallTokenSigner,
     issuer_did: &str,
     admin_did: &str,
+    install_jti: &str,
     ttl_seconds: u64,
 ) -> Result<String, AppError> {
     let now = SystemTime::now()
@@ -336,6 +344,7 @@ pub fn mint_install_session_token(
         exp,
         iat: now,
         jti,
+        install_jti: install_jti.to_string(),
     };
     signer.encode_session(&claims)
 }

--- a/vtc-service/src/routes/admin/bootstrap.rs
+++ b/vtc-service/src/routes/admin/bootstrap.rs
@@ -1,0 +1,184 @@
+//! `POST /v1/admin/bootstrap` — finalises the install flow by
+//! writing the first admin ACL entry, emitting `CommunityInstalled`,
+//! and closing the install carve-out.
+//!
+//! Implements **M0.6.2** of the VTC MVP Phase 0 plan. Consumes the
+//! setup-session JWT minted by `POST /v1/install/claim/finish`
+//! (M0.5.2). The token carries:
+//!
+//! - `sub` — the candidate admin `did:key`
+//! - `install_jti` — the install-token `jti` it was derived from
+//!
+//! On success the install carve-out is **permanently closed**: no
+//! future install token can be minted or claimed without a deliberate
+//! `vtc admin emergency-bootstrap` (M0.10).
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use uuid::Uuid;
+use vti_common::acl::{AclEntry, Role, list_acl_entries, store_acl_entry};
+use vti_common::audit::{AuditEvent, AuditWriter, CommunityInstalledData};
+use vti_common::auth::passkey::store::get_passkey_user_by_did;
+use vti_common::error::AppError;
+
+use crate::acl::admin::{AdminEntry, RegisteredPasskey, store_admin_entry};
+use crate::install::InstallTokenSigner;
+use crate::server::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct BootstrapRequest {
+    pub setup_session_token: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BootstrapResponse {
+    pub admin_did: String,
+    /// `event_id` of the persisted `CommunityInstalled` audit
+    /// envelope. The caller can echo this in operator-facing UI so
+    /// the install URL → bootstrap → audit-row chain is traceable.
+    pub event_id: Uuid,
+}
+
+pub async fn bootstrap(
+    State(state): State<AppState>,
+    Json(req): Json<BootstrapRequest>,
+) -> Result<(StatusCode, Json<BootstrapResponse>), AppError> {
+    let signer = require_install_signer(&state)?;
+    let audit_writer = require_audit_writer(&state)?;
+
+    let claims = signer.decode_session(&req.setup_session_token)?;
+    let admin_did = claims.sub;
+    let install_jti = claims.install_jti;
+
+    // Defence-in-depth: refuse if any Admin ACL entry already exists.
+    // The install carve-out should make this impossible (the second
+    // install-token claim would fail), but a misconfigured backup
+    // restore could still land us here.
+    for entry in list_acl_entries(&state.acl_ks).await? {
+        if entry.role == Role::Admin {
+            return Err(AppError::Conflict(
+                "an admin already exists; refusing to bootstrap a second one".into(),
+            ));
+        }
+    }
+
+    // M0.5.2 wrote the PasskeyUser at claim/finish; look it up so
+    // the first RegisteredPasskey carries the same credential id
+    // the passkey-login flow will eventually match against.
+    let passkey_user = get_passkey_user_by_did(&state.passkey_ks, &admin_did)
+        .await?
+        .ok_or_else(|| {
+            AppError::Unauthorized(
+                "no passkey registered for the candidate admin DID — run the install claim first"
+                    .into(),
+            )
+        })?;
+    let first_cred = passkey_user.credentials.first().ok_or_else(|| {
+        AppError::Internal("admin passkey user has no credentials persisted".into())
+    })?;
+    let cred_id_hex = hex::encode(<_ as AsRef<[u8]>>::as_ref(first_cred.cred_id()));
+
+    let now = Utc::now();
+    let registered = RegisteredPasskey {
+        credential_id: cred_id_hex,
+        // The install ceremony has no operator label channel; the
+        // operator labels their device later via
+        // `PATCH /v1/admin/passkeys/{id}` (M0.6.3). Until then we
+        // ship a placeholder rather than an empty string so admin
+        // UIs don't render blank.
+        label: "install".into(),
+        transports: Vec::new(),
+        registered_at: now,
+        last_used_at: None,
+    };
+    let admin_entry = AdminEntry {
+        did: admin_did.clone(),
+        passkeys: vec![registered],
+        extensions: serde_json::Value::Null,
+        created_at: now,
+    };
+    store_admin_entry(&state.passkey_ks, &admin_entry).await?;
+
+    let acl_entry = AclEntry {
+        did: admin_did.clone(),
+        role: Role::Admin,
+        label: Some("first admin (install bootstrap)".into()),
+        allowed_contexts: vec![],
+        created_at: now_unix(),
+        created_by: "did:key:vtc-install".into(),
+        expires_at: None,
+    };
+    store_acl_entry(&state.acl_ks, &acl_entry).await?;
+
+    // Carve-out closes BEFORE the audit write so a crash between the
+    // two leaves the system locked down (an admin exists; further
+    // bootstraps are refused by the duplicate-admin check above).
+    state.install_store.close_carveout().await?;
+
+    let community_did = state
+        .config
+        .read()
+        .await
+        .vtc_did
+        .clone()
+        .unwrap_or_else(|| "did:key:vtc-uninitialised".to_string());
+
+    let envelope = audit_writer
+        .write(
+            &admin_did,
+            None,
+            AuditEvent::CommunityInstalled(CommunityInstalledData {
+                community_did,
+                install_token_jti: install_jti,
+            }),
+        )
+        .await?;
+
+    info!(%admin_did, event_id = %envelope.event_id, "community installed");
+
+    Ok((
+        StatusCode::OK,
+        Json(BootstrapResponse {
+            admin_did,
+            event_id: envelope.event_id,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_install_signer(state: &AppState) -> Result<&Arc<InstallTokenSigner>, AppError> {
+    state
+        .install_signer
+        .as_ref()
+        .ok_or_else(|| AppError::ServiceError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: "install signer not configured (run setup first)".into(),
+        })
+}
+
+fn require_audit_writer(state: &AppState) -> Result<&AuditWriter, AppError> {
+    state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::ServiceError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: "audit writer not configured (run setup first)".into(),
+        })
+}
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/vtc-service/src/routes/admin/mod.rs
+++ b/vtc-service/src/routes/admin/mod.rs
@@ -5,4 +5,5 @@
 //! reaching a handler implies both the role gate and the task gate
 //! have passed.
 
+pub mod bootstrap;
 pub mod config;

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -252,6 +252,7 @@ pub async fn claim_finish(
         signer,
         &issuer_did,
         &admin_did,
+        &jti.to_string(),
         INSTALL_SESSION_DEFAULT_TTL_SECS,
     )?;
 

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -59,6 +59,8 @@ pub fn router() -> Router<AppState> {
     let install_claim_finish =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0")
             .expect("static Trust-Task URL");
+    let admin_bootstrap = TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0")
+        .expect("static Trust-Task URL");
 
     TrustTaskRouter::<AppState>::new()
         .route_exempt("/health", get(health::health))
@@ -124,6 +126,14 @@ pub fn router() -> Router<AppState> {
             "/v1/install/claim/finish",
             post(install::claim_finish),
             install_claim_finish,
+        )
+        // Admin bootstrap (M0.6.2) — closes the install carve-out
+        // and writes the first admin ACL entry. Unauthenticated
+        // because the setup-session JWT IS the auth credential.
+        .route_with_task(
+            "/v1/admin/bootstrap",
+            post(admin::bootstrap::bootstrap),
+            admin_bootstrap,
         )
         .into_router()
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -24,6 +24,7 @@ use crate::store::{KeyspaceHandle, Store};
 use tokio::sync::{RwLock, watch};
 use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, warn};
+use vti_common::audit::{AuditKeyStore, AuditWriter};
 use vti_common::auth::passkey::{PasskeyState, build_webauthn};
 use webauthn_rs::Webauthn;
 
@@ -42,6 +43,8 @@ pub struct AppState {
     pub config_ks: KeyspaceHandle,
     pub passkey_ks: KeyspaceHandle,
     pub install_ks: KeyspaceHandle,
+    pub audit_ks: KeyspaceHandle,
+    pub audit_key_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
     pub did_resolver: Option<DIDCacheClient>,
     pub secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
@@ -62,6 +65,11 @@ pub struct AppState {
     /// Wraps `install_ks` with the claim-window state machine. Cheap
     /// to clone; always present once `install_ks` is open.
     pub install_store: InstallTokenStore,
+    /// HMAC-actor-hashing audit envelope writer. `None` until the
+    /// secret store yields key material (the audit key is HKDF-
+    /// derived from the master seed). Endpoints that emit audit
+    /// events 503 in that case.
+    pub audit_writer: Option<AuditWriter>,
 }
 
 impl AuthState for AppState {
@@ -125,10 +133,19 @@ pub async fn run(
     let passkey_ks = store.keyspace("passkey")?;
     let install_ks = store.keyspace("install")?;
     let install_store = InstallTokenStore::new(install_ks.clone());
+    let audit_ks = store.keyspace("audit")?;
+    let audit_key_ks = store.keyspace("audit_key")?;
 
-    // Initialize auth infrastructure
-    let (did_resolver, secrets_resolver, jwt_keys, atm, install_signer) =
-        init_auth(&config, &*secret_store).await;
+    // Initialize auth infrastructure. Pass the audit keyspaces in so
+    // `init_auth` can derive the HMAC audit key from the same secret
+    // store contents it uses for the install signer.
+    let (did_resolver, secrets_resolver, jwt_keys, atm, install_signer, audit_writer) = init_auth(
+        &config,
+        &*secret_store,
+        audit_ks.clone(),
+        audit_key_ks.clone(),
+    )
+    .await;
 
     // Build WebAuthn relying party handle from `public_url`. Optional —
     // a serverless / pre-setup deployment has no public URL yet and
@@ -186,6 +203,8 @@ pub async fn run(
         config_ks,
         passkey_ks,
         install_ks,
+        audit_ks,
+        audit_key_ks,
         config: Arc::new(RwLock::new(config)),
         did_resolver,
         secrets_resolver,
@@ -195,6 +214,7 @@ pub async fn run(
         public_url,
         install_signer,
         install_store,
+        audit_writer,
     };
 
     // Spawn three named OS threads
@@ -410,18 +430,21 @@ fn run_didcomm_thread(
 async fn init_auth(
     config: &AppConfig,
     secret_store: &dyn SecretStore,
+    audit_ks: KeyspaceHandle,
+    audit_key_ks: KeyspaceHandle,
 ) -> (
     Option<DIDCacheClient>,
     Option<Arc<ThreadedSecretsResolver>>,
     Option<Arc<JwtKeys>>,
     Option<ATM>,
     Option<Arc<InstallTokenSigner>>,
+    Option<AuditWriter>,
 ) {
     let vtc_did = match &config.vtc_did {
         Some(did) => did.clone(),
         None => {
             warn!("vtc_did not configured — auth endpoints will not work (run setup first)");
-            return (None, None, None, None, None);
+            return (None, None, None, None, None, None);
         }
     };
 
@@ -430,11 +453,11 @@ async fn init_auth(
         Ok(Some(s)) => s,
         Ok(None) => {
             warn!("no key material found — auth endpoints will not work (run setup first)");
-            return (None, None, None, None, None);
+            return (None, None, None, None, None, None);
         }
         Err(e) => {
             warn!("failed to load key material: {e} — auth endpoints will not work");
-            return (None, None, None, None, None);
+            return (None, None, None, None, None, None);
         }
     };
 
@@ -443,16 +466,16 @@ async fn init_auth(
             "key material is {} bytes, expected 64 — auth endpoints will not work",
             key_material.len()
         );
-        return (None, None, None, None, None);
+        return (None, None, None, None, None, None);
     }
 
     let Ok(ed25519_bytes): Result<&[u8; 32], _> = key_material[..32].try_into() else {
         warn!("key material corrupted — auth endpoints will not work");
-        return (None, None, None, None, None);
+        return (None, None, None, None, None, None);
     };
     let Ok(x25519_bytes): Result<&[u8; 32], _> = key_material[32..].try_into() else {
         warn!("key material corrupted — auth endpoints will not work");
-        return (None, None, None, None, None);
+        return (None, None, None, None, None, None);
     };
 
     // Derive the install-token signer from the full 64-byte secret.
@@ -469,12 +492,27 @@ async fn init_auth(
         }
     };
 
+    // Derive the HMAC audit key from the same master seed (different
+    // HKDF `info`) and build the writer. Idempotent across restarts;
+    // the very first boot creates an `Initial` row and the active
+    // marker, subsequent boots no-op.
+    let audit_writer = {
+        let key_store = AuditKeyStore::new(audit_key_ks);
+        match key_store.ensure_initial(&key_material).await {
+            Ok(_) => Some(AuditWriter::new(audit_ks, key_store)),
+            Err(e) => {
+                warn!("failed to derive initial audit key: {e} — audit-emitting routes disabled");
+                None
+            }
+        }
+    };
+
     // 1. DID resolver (local mode)
     let did_resolver = match DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await {
         Ok(r) => r,
         Err(e) => {
             warn!("failed to create DID resolver: {e} — auth endpoints will not work");
-            return (None, None, None, None, install_signer);
+            return (None, None, None, None, install_signer, audit_writer);
         }
     };
 
@@ -505,6 +543,7 @@ async fn init_auth(
                     None,
                     None,
                     install_signer,
+                    audit_writer,
                 );
             }
         },
@@ -518,6 +557,7 @@ async fn init_auth(
                 None,
                 None,
                 install_signer,
+                audit_writer,
             );
         }
     };
@@ -561,6 +601,7 @@ async fn init_auth(
         Some(Arc::new(jwt_keys)),
         atm,
         install_signer,
+        audit_writer,
     )
 }
 

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -1,0 +1,471 @@
+//! End-to-end coverage for `POST /v1/admin/bootstrap`.
+//!
+//! Drives the full install → claim → bootstrap chain through
+//! `Router::oneshot`, using the soft EdDSA harness for the WebAuthn
+//! ceremony. Verifies the M0.6.2 acceptance criteria:
+//!
+//! - Happy path writes an `Admin` ACL entry, an `AdminEntry`, and a
+//!   `CommunityInstalled` audit envelope; closes the install carve-out.
+//! - Bootstrap-after-bootstrap is rejected (409).
+//! - Replay of the same setup-session JWT is rejected after carve-out
+//!   closes (the JWT signature stays valid; the duplicate-admin check
+//!   catches it as 409).
+//! - Tampered / wrong-audience / expired tokens are rejected as 401.
+//! - 503 when install signer or audit writer aren't configured.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use chrono::{Duration as ChronoDuration, Utc};
+use ed25519_dalek::Signer;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use uuid::Uuid;
+use vti_common::acl::{Role, list_acl_entries};
+use vti_common::audit::{AuditEvent, AuditKeyStore, AuditWriter};
+use vti_common::auth::passkey::build_webauthn;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::acl::admin::get_admin_entry;
+use vtc_service::config::AppConfig;
+use vtc_service::install::{InstallTokenSigner, InstallTokenStore, mint_install_token};
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+use common::webauthn_harness::SoftEd25519Authenticator;
+
+const RP_ORIGIN: &str = "https://vtc.example.com";
+const START_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0";
+const FINISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0";
+const BOOTSTRAP_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    state: AppState,
+    router: axum::Router,
+    install_signer: Arc<InstallTokenSigner>,
+    install_store: InstallTokenStore,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
+    let install_signer = if with_install_signer {
+        Some(Arc::new(
+            InstallTokenSigner::from_master_seed(&[0xAB; 64]).unwrap(),
+        ))
+    } else {
+        None
+    };
+
+    let audit_writer = if with_audit {
+        let key_store = AuditKeyStore::new(audit_key_ks.clone());
+        key_store.ensure_initial(&[0xAB; 64]).await.unwrap();
+        Some(AuditWriter::new(audit_ks.clone(), key_store))
+    } else {
+        None
+    };
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks: install_ks.clone(),
+        audit_ks: audit_ks.clone(),
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: None,
+        atm: None,
+        webauthn,
+        public_url: Some(RP_ORIGIN.to_string()),
+        install_signer: install_signer.clone(),
+        install_store: install_store.clone(),
+        audit_writer,
+    };
+
+    let router = routes::router().with_state(state.clone());
+
+    Fixture {
+        state,
+        router,
+        install_signer: install_signer.unwrap_or_else(|| {
+            Arc::new(InstallTokenSigner::from_master_seed(&[0xCD; 64]).unwrap())
+        }),
+        install_store,
+        _dir: dir,
+    }
+}
+
+async fn mint_token_and_record(fix: &Fixture, ttl_seconds: u64) -> String {
+    let minted = mint_install_token(
+        &fix.install_signer,
+        "did:webvh:vtc.example.com:abc",
+        ttl_seconds,
+    )
+    .expect("mint install token");
+    let exp = Utc::now() + ChronoDuration::seconds(ttl_seconds as i64);
+    fix.install_store
+        .record_issued(
+            &minted.jti,
+            minted.cnonce_bytes,
+            *minted.ephemeral_signing_key,
+            exp,
+        )
+        .await
+        .unwrap();
+    minted.jwt
+}
+
+async fn post_json(
+    router: &axum::Router,
+    path: &str,
+    trust_task: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    let res = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/json")
+                .header("Trust-Task", trust_task)
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+fn harness_seed_for(challenge: &[u8], rp_id: &str) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(challenge);
+    h.update(rp_id.as_bytes());
+    h.update(b"soft-eddsa-seed/v1");
+    h.finalize().into()
+}
+
+/// Drive a full claim ceremony and return the setup-session JWT plus
+/// the candidate admin DID the server returned.
+async fn run_claim_ceremony(fix: &Fixture) -> (String, String) {
+    let token = mint_token_and_record(fix, 600).await;
+
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": token }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "start: {body}");
+
+    let registration_id = body["registrationId"].as_str().unwrap().to_string();
+    let challenge_b64 = body["didBindingChallenge"].as_str().unwrap();
+    let challenge: [u8; 32] = B64.decode(challenge_b64).unwrap().try_into().unwrap();
+    let ccr: webauthn_rs::prelude::CreationChallengeResponse =
+        serde_json::from_value(body["options"].clone()).unwrap();
+
+    let mut authenticator = SoftEd25519Authenticator::new();
+    let (register_cred, _ed25519_pub) = authenticator.register(&ccr, RP_ORIGIN);
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&harness_seed_for(
+        ccr.public_key.challenge.as_ref(),
+        &ccr.public_key.rp.id,
+    ));
+    let sig = B64.encode(signing_key.sign(&challenge).to_bytes());
+
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/install/claim/finish",
+        FINISH_TASK,
+        json!({
+            "install_token": token,
+            "registration_id": registration_id,
+            "webauthn_response": register_cred,
+            "did_binding_signature": sig,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "finish: {body}");
+    let session_jwt = body["setupSessionToken"].as_str().unwrap().to_string();
+    let admin_did = body["adminDid"].as_str().unwrap().to_string();
+    (session_jwt, admin_did)
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn full_install_to_bootstrap_succeeds() {
+    let fix = build_fixture(true, true).await;
+    let (session_jwt, admin_did) = run_claim_ceremony(&fix).await;
+
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/admin/bootstrap",
+        BOOTSTRAP_TASK,
+        json!({ "setup_session_token": session_jwt }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "bootstrap: {body}");
+    assert_eq!(body["adminDid"].as_str().unwrap(), admin_did);
+    let event_id = body["eventId"].as_str().unwrap();
+    let _: Uuid = event_id.parse().expect("eventId is a UUID");
+
+    // ACL: one Admin entry for our DID.
+    let acl = list_acl_entries(&fix.state.acl_ks).await.unwrap();
+    assert_eq!(acl.len(), 1);
+    assert_eq!(acl[0].did, admin_did);
+    assert_eq!(acl[0].role, Role::Admin);
+
+    // AdminEntry written with one passkey.
+    let admin_entry = get_admin_entry(&fix.state.passkey_ks, &admin_did)
+        .await
+        .unwrap()
+        .expect("admin entry persisted");
+    assert_eq!(admin_entry.passkeys.len(), 1);
+
+    // Carve-out closed.
+    assert!(fix.install_store.carveout_is_closed().await.unwrap());
+
+    // Audit envelope present and references the install jti.
+    // `envelope_storage_key` formats as `<rfc3339-timestamp>:<event_id>`
+    // — there's no fixed string prefix, so a `2` literal works for
+    // every realistic timestamp (it's the first digit of the year).
+    let raw = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(b"2".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(raw.len(), 1, "exactly one audit envelope expected");
+    let envelope: vti_common::audit::AuditEnvelope = serde_json::from_slice(&raw[0].1).unwrap();
+    match envelope.event {
+        AuditEvent::CommunityInstalled(data) => {
+            assert_eq!(data.community_did, "did:webvh:vtc.example.com:abc");
+            // install_token_jti is non-empty.
+            assert!(!data.install_token_jti.is_empty());
+        }
+        other => panic!("expected CommunityInstalled, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 409 — bootstrap-after-bootstrap
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn second_bootstrap_returns_409() {
+    let fix = build_fixture(true, true).await;
+    let (session_jwt_a, _) = run_claim_ceremony(&fix).await;
+
+    let (s1, _) = post_json(
+        &fix.router,
+        "/v1/admin/bootstrap",
+        BOOTSTRAP_TASK,
+        json!({ "setup_session_token": session_jwt_a }),
+    )
+    .await;
+    assert_eq!(s1, StatusCode::OK);
+
+    // Try to replay the same session JWT.
+    let (s2, body) = post_json(
+        &fix.router,
+        "/v1/admin/bootstrap",
+        BOOTSTRAP_TASK,
+        json!({ "setup_session_token": session_jwt_a }),
+    )
+    .await;
+    assert_eq!(
+        s2,
+        StatusCode::CONFLICT,
+        "duplicate-admin check must catch the replay: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 401 paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bootstrap_rejects_unsigned_token() {
+    let fix = build_fixture(true, true).await;
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/admin/bootstrap",
+        BOOTSTRAP_TASK,
+        json!({ "setup_session_token": "not.a.real.jwt" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn bootstrap_rejects_install_token_as_setup_token() {
+    // An attacker who intercepted the install URL still cannot drive
+    // bootstrap directly — the install JWT has `aud = "vtc-install"`,
+    // which the session decoder rejects.
+    let fix = build_fixture(true, true).await;
+    let install_jwt = mint_token_and_record(&fix, 600).await;
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/admin/bootstrap",
+        BOOTSTRAP_TASK,
+        json!({ "setup_session_token": install_jwt }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn bootstrap_rejects_when_no_passkey_user_exists() {
+    // Forge a valid setup-session JWT for a DID that never went
+    // through claim/finish. Decoder accepts the signature; the
+    // passkey-user lookup fails.
+    let fix = build_fixture(true, true).await;
+    let session_jwt = vtc_service::install::mint_install_session_token(
+        &fix.install_signer,
+        "did:webvh:vtc.example.com:abc",
+        "did:key:zNobody",
+        &Uuid::new_v4().to_string(),
+        600,
+    )
+    .unwrap();
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/admin/bootstrap",
+        BOOTSTRAP_TASK,
+        json!({ "setup_session_token": session_jwt }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// 503 paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bootstrap_returns_503_when_install_signer_missing() {
+    let fix = build_fixture(false, true).await;
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/admin/bootstrap",
+        BOOTSTRAP_TASK,
+        json!({ "setup_session_token": "x" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn bootstrap_returns_503_when_audit_writer_missing() {
+    let fix = build_fixture(true, false).await;
+    let session_jwt = vtc_service::install::mint_install_session_token(
+        &fix.install_signer,
+        "did:webvh:vtc.example.com:abc",
+        "did:key:zAnyone",
+        &Uuid::new_v4().to_string(),
+        600,
+    )
+    .unwrap();
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/admin/bootstrap",
+        BOOTSTRAP_TASK,
+        json!({ "setup_session_token": session_jwt }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+// ---------------------------------------------------------------------------
+// Trust-Task gate
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn wrong_trust_task_returns_415() {
+    let fix = build_fixture(true, true).await;
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/admin/bootstrap",
+        FINISH_TASK,
+        json!({ "setup_session_token": "x" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn missing_trust_task_returns_400() {
+    let fix = build_fixture(true, true).await;
+    let res = fix
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/admin/bootstrap")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"setup_session_token":"x"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -53,6 +53,8 @@ async fn build() -> Fixture {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -86,6 +88,9 @@ async fn build() -> Fixture {
         public_url: None,
         install_signer: None,
         install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_ks,
+        audit_key_ks,
+        audit_writer: None,
     };
 
     let router = routes::router().with_state(state.clone());

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -53,6 +53,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -86,6 +88,9 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         public_url: None,
         install_signer: None,
         install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_ks,
+        audit_key_ks,
+        audit_writer: None,
     };
 
     let router = routes::router().with_state(state);

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -54,6 +54,8 @@ async fn build() -> Fixture {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
 
     let jwt_seed = [0x42u8; 32];
     let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
@@ -87,6 +89,9 @@ async fn build() -> Fixture {
         public_url: None,
         install_signer: None,
         install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_ks,
+        audit_key_ks,
+        audit_writer: None,
     };
 
     let router = routes::router().with_state(state.clone());

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -65,6 +65,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
 
     let config: AppConfig = toml::from_str(&format!(
@@ -96,6 +98,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         config_ks,
         passkey_ks,
         install_ks: install_ks.clone(),
+        audit_ks,
+        audit_key_ks,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,
@@ -105,6 +109,7 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         public_url: public_url.map(|s| s.to_string()),
         install_signer: install_signer.clone(),
         install_store: install_store.clone(),
+        audit_writer: None,
     };
 
     let router = routes::router().with_state(state);

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -37,6 +37,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
 
     let config: AppConfig = toml::from_str(&format!(
         r#"
@@ -66,6 +68,9 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         public_url: public_url.map(|s| s.to_string()),
         install_signer: None,
         install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_ks,
+        audit_key_ks,
+        audit_writer: None,
     };
     (state, dir)
 }


### PR DESCRIPTION
## Summary

Closes the **install → bootstrap critical path**. After this PR a
fresh VTC binary can complete:

1. `vtc setup` → install URL printed (M0.4)
2. `POST /v1/install/claim/start` → WebAuthn ceremony (M0.5.2)
3. `POST /v1/install/claim/finish` → setup-session JWT (M0.5.2)
4. **`POST /v1/admin/bootstrap` → ACL admin written, carve-out
   closed, `CommunityInstalled` emitted** ← *this PR*

This is **Checkpoint D** from the plan: end-to-end first-admin
install through the test harness without M0.6.3's multi-passkey
endpoints (those land in the follow-up).

## M0.6.1 — AdminEntry sister record

Touching the shared `vti_common::acl::Role` enum would force VTA
into the VTC role taxonomy, so this PR ships the admin extension
as a **sister record** under `admin:<did>` in the existing
`passkey` keyspace, coexisting with the canonical
`acl:<did>` → `AclEntry` row. Phase 1 unifies once the shared
crate gains generic-over-Role support.

- New `vtc_service::acl::admin::{AdminEntry, RegisteredPasskey}`
  per spec §5.2/§4.3, plus CRUD helpers.
- `VtcRole` introduction deferred — Moderator / Issuer / Member
  aren't exercised by any Phase-0 endpoint.

## M0.6.2 — POST /v1/admin/bootstrap

- Consumes the M0.5.2 setup-session JWT
  (`aud = vtc-install-session`; the install token's
  `aud = vtc-install` is rejected by the session decoder).
- Lifts the install token's `jti` forward via a new
  `InstallSessionClaims.install_jti` field so the
  `CommunityInstalled` audit envelope can chain
  install URL → carve-out close → audit row.
- Writes `AdminEntry` + `AclEntry { role: Admin }` + emits
  `CommunityInstalled` + closes the install carve-out atomically.
- 409 if any `Role::Admin` ACL entry already exists
  (defence-in-depth against double-bootstrap; the carve-out
  should already block this).

## Audit infrastructure wired into AppState

- New `audit` + `audit_key` keyspaces.
- `init_auth` calls `AuditKeyStore::ensure_initial` against the
  64-byte secret material (HKDF info `vtc-audit-key/v1`) and builds
  `AuditWriter`. Idempotent across restarts.
- `audit_writer: Option<AuditWriter>` on AppState. Other endpoints
  (community profile, config patch) can adopt incrementally in
  follow-ups.

## Trust Tasks

New entry `admin/bootstrap/1.0` with `spec.md` + `schema.json`.

## Test plan

- [x] `cargo test --package vtc-service` — **128 tests pass**
  (115 before this PR):
  - 73 lib unit (incl. 4 new `acl::admin::tests`).
  - **9 new `tests/admin_bootstrap.rs` integration tests** — full
    ceremony, replay-rejected-as-409, audience separation between
    install and session JWTs, missing passkey user, 503 paths,
    Trust-Task gate.
  - 11 admin_config + 6 auth_audience + 10 community_profile +
    11 install_claim + 5 passkey_state + 3 webauthn_harness
    (unchanged).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --lib` clean.

## What's next

**M0.6.3** — multi-passkey endpoints with step-up UV reauth:
- `POST /v1/admin/passkeys/register`
- `DELETE /v1/admin/passkeys/{credential_id}` (last-passkey CAS guard)
- `GET /v1/admin/passkeys`
- New `StepUpUvAuth` extractor that requires a fresh WebAuthn UV
  assertion in the same request.

After M0.6.3 the install flow is complete. Then M0.9 (CLI setup
wizard rewrite), M0.10 (emergency-bootstrap CLI), M0.11–12
(routing/CORS + integration tests) close Phase 0.