### PR TITLE
feat(vtc): config reload + restart endpoints with supervisor handshake (M0.8.3)

### DIFF
--- a/trust-tasks/admin/config/reload/1.0/schema.json
+++ b/trust-tasks/admin/config/reload/1.0/schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/admin/config/reload/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Admin — Reload Config",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["keysReloaded"],
+      "properties": {
+        "keysReloaded": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/admin/config/reload/1.0/spec.md
+++ b/trust-tasks/admin/config/reload/1.0/spec.md
@@ -1,0 +1,40 @@
+---
+id: https://trusttasks.org/openvtc/vtc/admin/config/reload/1.0
+title: VTC Admin — Reload Config
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/admin/config/reload
+---
+
+# VTC Admin — Reload Config
+
+Re-applies hot-reloadable settings to the running daemon without a
+process restart. Diffs the four-layer `EffectiveConfig` against the
+live in-memory `AppConfig`; for every key flagged
+`requires_restart = false` whose effective value differs, the
+in-memory config is updated and the key name is added to
+`keysReloaded`. Keys whose new value already equals the live value
+(no-op) are absent.
+
+Emits `ConfigReloaded { keysReloaded }` to the audit log.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`.
+
+## Phase 0 limitation
+
+The Phase-0 config registry covers `server.host`, `server.port`
+(both `requires_restart = true`) and `log.level` (hot-reloadable).
+`log.level` updates land in the in-memory `AppConfig` but do not
+yet propagate to the running `tracing-subscriber` filter — a
+Phase-1 follow-up wires the subscriber's reload handle. Restart-
+gated keys re-apply on the next daemon start regardless.
+
+## Errors
+
+- `401 Unauthorized` / `403 Forbidden` — auth + role gates.
+- `503 Service Unavailable` — audit writer not configured.

--- a/trust-tasks/admin/config/restart/1.0/schema.json
+++ b/trust-tasks/admin/config/restart/1.0/schema.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/admin/config/restart/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Admin — Restart Daemon",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["supervisor", "drainTimeoutSeconds"],
+      "properties": {
+        "supervisor": {
+          "type": "string",
+          "enum": ["manual", "systemd", "kubernetes"]
+        },
+        "drainTimeoutSeconds": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/trust-tasks/admin/config/restart/1.0/spec.md
+++ b/trust-tasks/admin/config/restart/1.0/spec.md
@@ -1,0 +1,51 @@
+---
+id: https://trusttasks.org/openvtc/vtc/admin/config/restart/1.0
+title: VTC Admin — Restart Daemon
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/admin/config/restart
+---
+
+# VTC Admin — Restart Daemon
+
+Triggers a graceful shutdown so a process supervisor can bring the
+daemon back up with `requires_restart`-flagged config changes
+applied. Refuses unless a supervisor is detected — without one,
+"restart" is just "kill the process".
+
+## Supervisor detection
+
+Probed in priority order (`crate::supervisor`):
+
+1. **`VTC_SUPERVISED=1`** env var — explicit operator opt-in.
+2. **`NOTIFY_SOCKET`** — set by systemd `Type=notify` units.
+3. **`KUBERNETES_SERVICE_HOST`** — running inside a pod; kubelet
+   honours `restartPolicy`.
+
+The detected kind is echoed back on the response so the admin UX
+can render "restarting under systemd…" or similar.
+
+## Flow
+
+1. Validate supervisor detection — `412 PRECONDITION_FAILED` with
+   `SupervisorRequired` if none found.
+2. Emit `RestartRequested { drainTimeoutSeconds }` to the audit
+   log *before* signalling shutdown — guarantees the row survives a
+   wedged drain.
+3. Flip the daemon's shared graceful-shutdown channel
+   (`AppState.shutdown_tx`). The REST thread stops accepting new
+   connections via `axum::serve::with_graceful_shutdown`; the
+   storage thread flushes; supervisor brings the process back.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`.
+
+## Errors
+
+- `401 Unauthorized` / `403 Forbidden` — auth + role gates.
+- `412 Precondition Failed` — `SupervisorRequired`.
+- `503 Service Unavailable` — audit writer not configured.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -100,6 +100,18 @@
       "status": "Draft",
       "path": "admin/passkeys/revoke/1.0",
       "rest": "POST /v1/admin/passkeys/revoke/{start,finish}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/admin/config/reload/1.0",
+      "status": "Draft",
+      "path": "admin/config/reload/1.0",
+      "rest": "POST /v1/admin/config/reload"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/admin/config/restart/1.0",
+      "status": "Draft",
+      "path": "admin/config/restart/1.0",
+      "rest": "POST /v1/admin/config/restart"
     }
   ]
 }

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -32,4 +32,5 @@ pub mod server;
 pub mod setup;
 pub mod status;
 pub mod store;
+pub mod supervisor;
 pub mod webauthn;

--- a/vtc-service/src/routes/admin/config.rs
+++ b/vtc-service/src/routes/admin/config.rs
@@ -30,6 +30,9 @@ use crate::config_store::{
     ConfigStore, EffectiveConfig, compute_effective_config, lookup, validate_value,
 };
 use crate::server::AppState;
+#[allow(unused_imports)]
+use crate::supervisor::SupervisorKind;
+use vti_common::audit::{AuditEvent, AuditWriter, ConfigReloadedData, RestartRequestedData};
 
 /// PATCH request body: arbitrary `key → value` map. Keys not in
 /// [`crate::config_store::REGISTRY`] are reported back under
@@ -131,6 +134,212 @@ pub async fn patch_config(
             rejected,
         }),
     ))
+}
+
+// ---------------------------------------------------------------------------
+// Reload
+// ---------------------------------------------------------------------------
+
+/// `restart.drain_timeout` default (seconds). Hardcoded for Phase 0
+/// — surfaces in the `RestartRequested` audit event and bounds the
+/// graceful-shutdown wait in `run_rest_thread`. A future
+/// `restart.drain_timeout` config key plugs in here.
+const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 30;
+
+/// `POST /v1/admin/config/reload` response. Lists the keys whose
+/// **db-layer** values were applied in-memory by this call. Keys
+/// flagged `requires_restart` never appear here — they re-apply on
+/// the next restart.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReloadResponse {
+    pub keys_reloaded: Vec<String>,
+}
+
+/// `POST /v1/admin/config/reload` handler. Re-reads the
+/// `EffectiveConfig` and diffs against the live in-memory config;
+/// for each hot-reloadable key whose effective value differs, the
+/// in-memory `AppConfig` is updated. Emits `ConfigReloaded` listing
+/// the keys that actually changed.
+///
+/// **Phase 0 limitation**: only the Phase-0 registry's
+/// hot-reloadable keys (`log.level` today) are propagated. Future
+/// runtime-state subscribers (tracing subscriber filter handle,
+/// session-cleanup interval, etc.) will plug into the same diff
+/// loop.
+pub async fn reload_config(
+    _admin: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<ReloadResponse>, AppError> {
+    let audit_writer = require_audit_writer(&state)?;
+
+    let store = ConfigStore::new(state.config_ks.clone());
+
+    // Snapshot the live in-memory config so we can diff against what
+    // the four-layer overlay currently says. Read the latest
+    // effective view first, then mutate the in-memory copy under a
+    // write lock so concurrent reads see a single atomic flip per
+    // key.
+    let new_effective = {
+        let cfg = state.config.read().await;
+        compute_effective_config(&cfg, &store).await?
+    };
+
+    // Compare per-key effective values against `EffectiveConfig`'s
+    // serialised snapshot of the same `AppConfig` shape. For Phase 0
+    // the registry has three keys (`server.host`, `server.port`,
+    // `log.level`). Server keys are `requires_restart` so they
+    // never re-apply here.
+    let mut keys_reloaded = Vec::new();
+    {
+        let mut cfg = state.config.write().await;
+        for def in crate::config_store::REGISTRY {
+            if def.requires_restart {
+                continue;
+            }
+            let new_value = new_effective
+                .fields
+                .iter()
+                .find(|f| f.key == def.key)
+                .map(|f| f.value.clone())
+                .unwrap_or(Value::Null);
+            let live_value = lookup_live(&cfg, def.key);
+            if new_value != live_value && apply_to_live(&mut cfg, def.key, &new_value) {
+                keys_reloaded.push(def.key.to_string());
+            }
+        }
+    }
+
+    audit_writer
+        .write(
+            "did:key:vtc-admin", // M0.6.2 will swap this for the real admin DID once
+            // the audit-actor plumbing wires `AdminAuth` through.
+            None,
+            AuditEvent::ConfigReloaded(ConfigReloadedData {
+                keys_reloaded: keys_reloaded.clone(),
+            }),
+        )
+        .await?;
+
+    info!(?keys_reloaded, "config reloaded");
+
+    Ok(Json(ReloadResponse { keys_reloaded }))
+}
+
+// ---------------------------------------------------------------------------
+// Restart
+// ---------------------------------------------------------------------------
+
+/// `POST /v1/admin/config/restart` response when the supervisor
+/// check passes.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RestartResponse {
+    /// Which supervisor the daemon detected (so the operator's
+    /// admin UX can echo it back).
+    pub supervisor: SupervisorKind,
+    /// `drain_timeout` (seconds) the daemon will use for graceful
+    /// shutdown. Mirrors `RestartRequestedData.drain_timeout_seconds`.
+    pub drain_timeout_seconds: u64,
+}
+
+/// `POST /v1/admin/config/restart` handler.
+///
+/// Refuses (`412 Precondition Failed`,
+/// `SupervisorRequired`) unless a supervisor is detected — restart
+/// without an external supervisor is just "kill the process" and a
+/// caller asking for `restart` likely means "have the daemon come
+/// back up afterwards". Detection lives in
+/// [`crate::supervisor::detect_supervisor`].
+///
+/// On success the handler emits `RestartRequested` to the audit
+/// log *before* signalling shutdown — so the row survives even if
+/// the drain wedges.
+pub async fn restart_config(
+    _admin: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<RestartResponse>, AppError> {
+    let audit_writer = require_audit_writer(&state)?;
+
+    let supervisor = state.supervisor.ok_or_else(|| AppError::ServiceError {
+        status: StatusCode::PRECONDITION_FAILED,
+        message: "SupervisorRequired: refusing to restart without a process supervisor \
+            (set VTC_SUPERVISED=1 or run under systemd / kubernetes)"
+            .into(),
+    })?;
+
+    audit_writer
+        .write(
+            "did:key:vtc-admin",
+            None,
+            AuditEvent::RestartRequested(RestartRequestedData {
+                drain_timeout_seconds: DEFAULT_DRAIN_TIMEOUT_SECS,
+            }),
+        )
+        .await?;
+
+    info!(?supervisor, "restart requested");
+
+    // Flip the shared graceful-shutdown channel. The REST thread
+    // observes this via `with_graceful_shutdown` and stops accepting
+    // new connections; the storage thread flushes; supervisor
+    // restarts the process. We send AFTER audit emission so a wedged
+    // drain still leaves the row behind.
+    let _ = state.shutdown_tx.send(true);
+
+    Ok(Json(RestartResponse {
+        supervisor,
+        drain_timeout_seconds: DEFAULT_DRAIN_TIMEOUT_SECS,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_audit_writer(state: &AppState) -> Result<&AuditWriter, AppError> {
+    state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::ServiceError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: "audit writer not configured".into(),
+        })
+}
+
+/// Read the live in-memory value for `key` out of an `AppConfig`.
+/// Phase-0 keys only; unknown keys return `Value::Null`.
+fn lookup_live(cfg: &crate::config::AppConfig, key: &str) -> Value {
+    match key {
+        "server.host" => Value::String(cfg.server.host.clone()),
+        "server.port" => Value::Number(cfg.server.port.into()),
+        "log.level" => Value::String(cfg.log.level.clone()),
+        _ => Value::Null,
+    }
+}
+
+/// Apply `value` to the live in-memory `AppConfig` for `key`.
+/// Returns `true` if the field changed (it should; the caller has
+/// already diffed). Phase-0 keys only; unknown keys are a no-op.
+///
+/// **Phase 0 limitation**: this updates the field but does NOT
+/// notify downstream subscribers (e.g., `tracing-subscriber`'s
+/// reload Handle for `log.level`). Plumbing those subscribers is
+/// a Phase-1 follow-up; for now the new value sticks for any
+/// future reads of `state.config`, and `requires_restart`-flagged
+/// keys (`server.*`) keep behaving correctly because they're never
+/// touched here.
+fn apply_to_live(cfg: &mut crate::config::AppConfig, key: &str, value: &Value) -> bool {
+    // server.host / server.port are requires_restart and never reach
+    // this function. Future hot-reloadable keys plug in alongside
+    // `log.level` with their own arms.
+    if key == "log.level"
+        && let Some(s) = value.as_str()
+    {
+        cfg.log.level = s.to_string();
+        return true;
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -53,6 +53,12 @@ pub fn router() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let admin_config = TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/config/manage/1.0")
         .expect("static Trust-Task URL");
+    let admin_config_reload =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/config/reload/1.0")
+            .expect("static Trust-Task URL");
+    let admin_config_restart =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/config/restart/1.0")
+            .expect("static Trust-Task URL");
     let install_claim_start =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/start/1.0")
             .expect("static Trust-Task URL");
@@ -122,6 +128,19 @@ pub fn router() -> Router<AppState> {
             "/v1/admin/config",
             get(admin::config::get_config).patch(admin::config::patch_config),
             admin_config,
+        )
+        // Reload + restart (M0.8.3). Reload applies hot-reloadable
+        // settings in-place; restart requires a supervisor (412
+        // `SupervisorRequired` otherwise).
+        .route_with_task(
+            "/v1/admin/config/reload",
+            post(admin::config::reload_config),
+            admin_config_reload,
+        )
+        .route_with_task(
+            "/v1/admin/config/restart",
+            post(admin::config::restart_config),
+            admin_config_restart,
         )
         // Install claim (M0.5.2) — distinct Trust Tasks because the
         // two phases of the WebAuthn ceremony have different

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -21,6 +21,7 @@ use crate::keys::seed_store::SecretStore;
 use crate::messaging;
 use crate::routes;
 use crate::store::{KeyspaceHandle, Store};
+use crate::supervisor::{SupervisorKind, detect_supervisor};
 use tokio::sync::{RwLock, watch};
 use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, warn};
@@ -70,6 +71,16 @@ pub struct AppState {
     /// derived from the master seed). Endpoints that emit audit
     /// events 503 in that case.
     pub audit_writer: Option<AuditWriter>,
+    /// Sender half of the shared graceful-shutdown channel.
+    /// `POST /v1/admin/config/restart` flips this to `true` to
+    /// trigger the same drain path SIGINT/SIGTERM use.
+    pub shutdown_tx: watch::Sender<bool>,
+    /// Cached supervisor probe (M0.8.3). Computed once at startup
+    /// — process supervisors don't change during the daemon's
+    /// lifetime, and a cached value lets tests inject
+    /// `Some(Manual)` / `None` without racing other tests on the
+    /// shared `std::env`.
+    pub supervisor: Option<SupervisorKind>,
 }
 
 impl AuthState for AppState {
@@ -215,6 +226,8 @@ pub async fn run(
         install_signer,
         install_store,
         audit_writer,
+        shutdown_tx: shutdown_tx.clone(),
+        supervisor: detect_supervisor(),
     };
 
     // Spawn three named OS threads

--- a/vtc-service/src/supervisor.rs
+++ b/vtc-service/src/supervisor.rs
@@ -1,0 +1,146 @@
+//! Supervisor-handshake detection for `POST /v1/admin/config/restart`.
+//!
+//! Implements **M0.8.3** of the VTC MVP Phase 0 plan. The restart
+//! endpoint refuses to trigger graceful shutdown unless the daemon
+//! is running under a process supervisor that will start it back up
+//! — without that, "restart" is just "kill the only process".
+//!
+//! ## Detection sources
+//!
+//! Probed in priority order. The first match wins; the result is
+//! reported back so the audit log records *why* the restart was
+//! allowed.
+//!
+//! 1. **`VTC_SUPERVISED=1`** — explicit operator opt-in. Use when
+//!    the daemon is wrapped by something this module doesn't natively
+//!    recognise (e.g., a custom shell loop, an init system without a
+//!    notify socket, a process-supervisor harness in tests).
+//! 2. **`NOTIFY_SOCKET`** — set by systemd for `Type=notify` units.
+//!    Presence is sufficient; we don't need to actually talk to
+//!    the socket for the supervisor check.
+//! 3. **`KUBERNETES_SERVICE_HOST`** — Kubernetes injects this into
+//!    every pod; if it's present we trust kubelet to restart the
+//!    container per its `restartPolicy`.
+//!
+//! ## What this module deliberately does NOT do
+//!
+//! - We don't probe for the kubelet downward-API marker file
+//!   (`/etc/podinfo/...`). Operators wanting that pattern can set
+//!   `VTC_SUPERVISED=1` via the downward API instead — keeps the
+//!   detection surface tiny.
+//! - We don't authenticate the supervisor. The env var family is an
+//!   inherited-from-launcher fact; an attacker who can set
+//!   `VTC_SUPERVISED=1` already has process-level control.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SupervisorKind {
+    /// `VTC_SUPERVISED=1` env var present.
+    Manual,
+    /// `NOTIFY_SOCKET` env var present (systemd Type=notify or
+    /// any shim that sets the same variable).
+    Systemd,
+    /// `KUBERNETES_SERVICE_HOST` env var present (running in a pod).
+    Kubernetes,
+}
+
+/// Probe the process environment. Returns `Some(SupervisorKind)` if
+/// any supported supervisor is detected; `None` otherwise.
+pub fn detect_supervisor() -> Option<SupervisorKind> {
+    detect_supervisor_in(&std::env::vars().collect::<std::collections::HashMap<_, _>>())
+}
+
+/// Same as [`detect_supervisor`] but reads from a caller-supplied
+/// env map. Lets tests drive every branch deterministically without
+/// mutating the process-wide env, which would race other tests.
+pub fn detect_supervisor_in(
+    env: &std::collections::HashMap<String, String>,
+) -> Option<SupervisorKind> {
+    if env.get("VTC_SUPERVISED").map(|v| v.as_str()) == Some("1") {
+        return Some(SupervisorKind::Manual);
+    }
+    if env.get("NOTIFY_SOCKET").is_some_and(|v| !v.is_empty()) {
+        return Some(SupervisorKind::Systemd);
+    }
+    if env
+        .get("KUBERNETES_SERVICE_HOST")
+        .is_some_and(|v| !v.is_empty())
+    {
+        return Some(SupervisorKind::Kubernetes);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn env_with(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn empty_env_returns_none() {
+        assert_eq!(detect_supervisor_in(&HashMap::new()), None);
+    }
+
+    #[test]
+    fn vtc_supervised_1_wins_first() {
+        let env = env_with(&[
+            ("VTC_SUPERVISED", "1"),
+            ("NOTIFY_SOCKET", "/run/systemd/notify"),
+            ("KUBERNETES_SERVICE_HOST", "10.0.0.1"),
+        ]);
+        assert_eq!(detect_supervisor_in(&env), Some(SupervisorKind::Manual));
+    }
+
+    #[test]
+    fn vtc_supervised_other_values_dont_match() {
+        // We require the literal string "1". "true", "yes", "0" all
+        // miss — operators who fat-finger the value shouldn't get a
+        // surprise-restart capability.
+        for v in ["0", "true", "yes", "TRUE", " 1", "1 "] {
+            let env = env_with(&[("VTC_SUPERVISED", v)]);
+            assert_eq!(
+                detect_supervisor_in(&env),
+                None,
+                "VTC_SUPERVISED={v:?} must not enable",
+            );
+        }
+    }
+
+    #[test]
+    fn notify_socket_detects_systemd() {
+        let env = env_with(&[("NOTIFY_SOCKET", "/run/systemd/notify")]);
+        assert_eq!(detect_supervisor_in(&env), Some(SupervisorKind::Systemd));
+    }
+
+    #[test]
+    fn empty_notify_socket_does_not_match() {
+        // systemd never sets it to empty; a stale shell export could,
+        // and we treat that as "no supervisor".
+        let env = env_with(&[("NOTIFY_SOCKET", "")]);
+        assert_eq!(detect_supervisor_in(&env), None);
+    }
+
+    #[test]
+    fn kubernetes_service_host_detects_pod() {
+        let env = env_with(&[("KUBERNETES_SERVICE_HOST", "10.0.0.1")]);
+        assert_eq!(detect_supervisor_in(&env), Some(SupervisorKind::Kubernetes));
+    }
+
+    #[test]
+    fn detection_priority_systemd_over_kubernetes() {
+        let env = env_with(&[
+            ("NOTIFY_SOCKET", "/run/systemd/notify"),
+            ("KUBERNETES_SERVICE_HOST", "10.0.0.1"),
+        ]);
+        assert_eq!(detect_supervisor_in(&env), Some(SupervisorKind::Systemd));
+    }
+}

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -127,6 +127,8 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         install_signer: install_signer.clone(),
         install_store: install_store.clone(),
         audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
     };
 
     let router = routes::router().with_state(state.clone());

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -40,6 +40,13 @@ struct Fixture {
 }
 
 async fn build() -> Fixture {
+    build_with(false, None).await
+}
+
+async fn build_with(
+    with_audit: bool,
+    supervisor: Option<vtc_service::supervisor::SupervisorKind>,
+) -> Fixture {
     init_jwt_provider();
     let dir = tempfile::tempdir().expect("tempdir");
     let store = Store::open(&StoreConfig {
@@ -72,6 +79,17 @@ async fn build() -> Fixture {
     ))
     .expect("parse config");
 
+    let audit_writer = if with_audit {
+        let key_store = vti_common::audit::AuditKeyStore::new(audit_key_ks.clone());
+        key_store.ensure_initial(&[0xAB; 64]).await.unwrap();
+        Some(vti_common::audit::AuditWriter::new(
+            audit_ks.clone(),
+            key_store,
+        ))
+    } else {
+        None
+    };
+
     let state = AppState {
         sessions_ks: sessions_ks.clone(),
         acl_ks,
@@ -90,7 +108,9 @@ async fn build() -> Fixture {
         install_store: vtc_service::install::InstallTokenStore::new(install_ks),
         audit_ks,
         audit_key_ks,
-        audit_writer: None,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor,
     };
 
     let router = routes::router().with_state(state.clone());
@@ -405,5 +425,196 @@ async fn get_with_wrong_trust_task_returns_415() {
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+// ──────────────────────── Reload ────────────────────────
+
+const RELOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/config/reload/1.0";
+const RESTART_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/config/restart/1.0";
+
+async fn reload(fix: &Fixture, token: &str) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/admin/config/reload")
+        .header("Trust-Task", RELOAD_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    body_value(resp).await
+}
+
+async fn restart(fix: &Fixture, token: &str) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/admin/config/restart")
+        .header("Trust-Task", RESTART_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    body_value(resp).await
+}
+
+#[tokio::test]
+async fn reload_no_diff_returns_empty_keys_reloaded() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let (status, body) = reload(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["keysReloaded"], json!([]));
+}
+
+#[tokio::test]
+async fn reload_applies_hot_reloadable_diff() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+
+    // Write `log.level = "debug"` via PATCH so the db-layer differs
+    // from the live in-memory `info`. reload must pick up the
+    // delta.
+    let req = Request::builder()
+        .method("PATCH")
+        .uri("/v1/admin/config")
+        .header(
+            "Trust-Task",
+            "https://trusttasks.org/openvtc/vtc/admin/config/manage/1.0",
+        )
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"log.level":"debug"}"#))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, body) = reload(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["keysReloaded"], json!(["log.level"]));
+
+    // In-memory `AppConfig.log.level` now reflects the new value.
+    assert_eq!(fix.state.config.read().await.log.level, "debug");
+
+    // Second reload is a no-op (no diff left).
+    let (_, body) = reload(&fix, &token).await;
+    assert_eq!(body["keysReloaded"], json!([]));
+}
+
+#[tokio::test]
+async fn reload_requires_admin_role() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "reader").await;
+    let (status, _) = reload(&fix, &token).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn reload_503_when_audit_writer_missing() {
+    let fix = build_with(false, None).await;
+    let token = token_for(&fix, "admin").await;
+    let (status, _) = reload(&fix, &token).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+// ──────────────────────── Restart ────────────────────────
+
+#[tokio::test]
+async fn restart_without_supervisor_returns_412() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let (status, body) = restart(&fix, &token).await;
+    assert_eq!(status, StatusCode::PRECONDITION_FAILED);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("SupervisorRequired"),
+        "got {body}",
+    );
+}
+
+#[tokio::test]
+async fn restart_with_supervisor_triggers_shutdown() {
+    use vtc_service::supervisor::SupervisorKind;
+    let fix = build_with(true, Some(SupervisorKind::Manual)).await;
+    let token = token_for(&fix, "admin").await;
+
+    // Subscribe to the shutdown channel BEFORE the request so we
+    // can assert the flip.
+    let mut rx = fix.state.shutdown_tx.subscribe();
+    assert!(!*rx.borrow_and_update());
+
+    let (status, body) = restart(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["supervisor"], "manual");
+    assert!(body["drainTimeoutSeconds"].as_u64().unwrap() > 0);
+
+    // Shutdown was signalled.
+    assert!(*rx.borrow_and_update());
+}
+
+#[tokio::test]
+async fn restart_emits_audit_event_before_signal() {
+    use vtc_service::supervisor::SupervisorKind;
+    let fix = build_with(true, Some(SupervisorKind::Systemd)).await;
+    let token = token_for(&fix, "admin").await;
+
+    let (status, _) = restart(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Confirm exactly one RestartRequested envelope landed.
+    let raw = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(b"2".to_vec())
+        .await
+        .unwrap();
+    let envelopes: Vec<vti_common::audit::AuditEnvelope> = raw
+        .iter()
+        .map(|(_, v)| serde_json::from_slice(v).unwrap())
+        .collect();
+    let restart_events: Vec<_> = envelopes
+        .iter()
+        .filter(|e| matches!(e.event, vti_common::audit::AuditEvent::RestartRequested(_)))
+        .collect();
+    assert_eq!(restart_events.len(), 1);
+}
+
+#[tokio::test]
+async fn restart_requires_admin_role() {
+    use vtc_service::supervisor::SupervisorKind;
+    let fix = build_with(true, Some(SupervisorKind::Manual)).await;
+    let token = token_for(&fix, "reader").await;
+    let (status, _) = restart(&fix, &token).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn restart_503_when_audit_writer_missing() {
+    use vtc_service::supervisor::SupervisorKind;
+    let fix = build_with(false, Some(SupervisorKind::Manual)).await;
+    let token = token_for(&fix, "admin").await;
+    let (status, _) = restart(&fix, &token).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn restart_wrong_trust_task_returns_415() {
+    use vtc_service::supervisor::SupervisorKind;
+    let fix = build_with(true, Some(SupervisorKind::Manual)).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/admin/config/restart")
+        .header("Trust-Task", RELOAD_TASK) // wrong
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _) = body_value(resp).await;
     assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
 }

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -194,6 +194,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         )),
         install_store,
         audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
     };
 
     let router = routes::router().with_state(state.clone());

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -91,6 +91,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         audit_ks,
         audit_key_ks,
         audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
     };
 
     let router = routes::router().with_state(state);

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -92,6 +92,8 @@ async fn build() -> Fixture {
         audit_ks,
         audit_key_ks,
         audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
     };
 
     let router = routes::router().with_state(state.clone());

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -110,6 +110,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         install_signer: install_signer.clone(),
         install_store: install_store.clone(),
         audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
     };
 
     let router = routes::router().with_state(state);

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -71,6 +71,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         audit_ks,
         audit_key_ks,
         audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
     };
     (state, dir)
 }


### PR DESCRIPTION
## Summary

Adds `POST /v1/admin/config/{reload,restart}` and the supervisor-
detection primitive that gates restart. Completes the M0.8 family
(overlay + show/patch + reload + restart); only export/import
(M0.8.4) remains.

## Reload

- Re-reads the four-layer `EffectiveConfig`, diffs against the live
  in-memory `AppConfig`, applies hot-reloadable keys whose values
  changed.
- Emits `ConfigReloaded { keysReloaded }`.
- Phase-0 limitation: in-memory `log.level` flips immediately but
  doesn't yet propagate to `tracing-subscriber`'s reload handle —
  Phase 1 follow-up. Future hot-reloadable keys plug into the same
  diff loop.

## Restart

- Consults `AppState.supervisor`, cached at startup via
  `crate::supervisor::detect_supervisor`:
  - `VTC_SUPERVISED=1` → `Manual`
  - `NOTIFY_SOCKET` → `Systemd`
  - `KUBERNETES_SERVICE_HOST` → `Kubernetes`
- Returns **`412 SupervisorRequired`** if none match — without a
  supervisor 'restart' is just 'kill the only process'.
- On success, emits `RestartRequested { drainTimeoutSeconds: 30 }`
  *before* signalling shutdown via the shared `shutdown_tx` watch
  channel — so the audit row survives a wedged drain.

## Why cache supervisor detection

Process supervisors don't change during a daemon's lifetime, and a
cached value lets tests inject `Some(SupervisorKind::Manual)` or
`None` deterministically — no `std::env` mutation, no race between
parallel tests.

## Trust Tasks

Two new entries with `spec.md` + `schema.json`:
- `admin/config/reload/1.0`
- `admin/config/restart/1.0`

## Test plan

- [x] `cargo test --package vtc-service` — **157 tests pass**
  (140 before this PR):
  - **7 new unit tests** in `supervisor::tests::*` covering env-
    detection priority + empty-value rejection
    (`VTC_SUPERVISED` only matches the literal `'1'`; empty
    `NOTIFY_SOCKET` does NOT match).
  - **10 new integration tests** in `tests/admin_config.rs`:
    - reload × 4 (no-diff no-op, log.level diff applies, admin gate,
      503 path)
    - restart × 6 (412 without supervisor, shutdown_tx flips with
      supervisor, audit envelope persists, admin gate, 503 path,
      wrong Trust-Task)
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --lib` clean.

## Phase 0 status

| | Milestone | Status |
|---|---|---|
| | M0.1.*, M0.2, M0.3, M0.4, M0.5.*, M0.6.*, M0.7, M0.8.1+2 | All merged |
| | **M0.8.3 — config reload + restart** | **PR #64 (in review)** |
| | M0.8.4 — config export/import | Not started |
| | M0.9 — CLI setup wizard rewrite | Not started |
| | M0.10 — emergency bootstrap CLI | Not started |
| | M0.11 — routing + CORS + cookie scope | Not started |
| | M0.12 — install-flow integration tests | Not started |

The Phase-0 wire surface is now feature-complete on the daemon
side. Remaining work is operator-experience (CLI rewrites,
emergency bootstrap) plus routing/CORS hardening and the final
end-to-end integration test.