### PR TITLE
feat(vtc): config export + import with diff-and-confirm (M0.8.4)

### DIFF
--- a/trust-tasks/admin/config/export/1.0/schema.json
+++ b/trust-tasks/admin/config/export/1.0/schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/admin/config/export/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Admin — Export Config",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["schemaVersion", "exportedAt", "configOverrides"],
+      "properties": {
+        "schemaVersion": { "type": "integer", "const": 1 },
+        "exportedAt": { "type": "string", "format": "date-time" },
+        "communityProfile": { "type": ["object", "null"] },
+        "configOverrides": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/admin/config/export/1.0/spec.md
+++ b/trust-tasks/admin/config/export/1.0/spec.md
@@ -1,0 +1,40 @@
+---
+id: https://trusttasks.org/openvtc/vtc/admin/config/export/1.0
+title: VTC Admin — Export Config
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/admin/config/export
+---
+
+# VTC Admin — Export Config
+
+Returns the portable subset of a VTC's configuration: the community
+profile + the db-layer config overrides. Env-layer and toml-layer
+values are deliberately excluded — those carry per-host secrets
+(JWT signing key, secret-store credentials, TLS cert paths) that
+must not travel with an export.
+
+The result is plain JSON shaped as `ConfigExport`:
+
+```json
+{
+  "schemaVersion": 1,
+  "exportedAt": "2026-05-12T03:42:00Z",
+  "communityProfile": { ... },
+  "configOverrides": { "log.level": "debug" }
+}
+```
+
+A subsequent `POST /v1/admin/config/import` of this payload against
+a fresh VTC (or the same one, idempotently) restores both.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`.
+
+## Errors
+
+- `401 Unauthorized` / `403 Forbidden` — auth + role gates.

--- a/trust-tasks/admin/config/import/1.0/schema.json
+++ b/trust-tasks/admin/config/import/1.0/schema.json
@@ -1,0 +1,76 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/admin/config/import/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Admin — Import Config",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "required": ["schemaVersion", "exportedAt", "configOverrides"],
+      "properties": {
+        "schemaVersion": { "type": "integer", "const": 1 },
+        "exportedAt": { "type": "string", "format": "date-time" },
+        "communityProfile": { "type": ["object", "null"] },
+        "configOverrides": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "query": {
+      "type": "object",
+      "properties": {
+        "confirm": { "type": "boolean", "default": false }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": [
+        "confirmed",
+        "communityProfileDiff",
+        "configOverridesDiff",
+        "communityProfileApplied",
+        "configOverridesApplied",
+        "rejected"
+      ],
+      "properties": {
+        "confirmed": { "type": "boolean" },
+        "communityProfileDiff": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["key"],
+            "properties": {
+              "key": { "type": "string" },
+              "oldValue": {},
+              "newValue": {}
+            }
+          }
+        },
+        "configOverridesDiff": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "communityProfileApplied": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "configOverridesApplied": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "rejected": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["key", "reason"],
+            "properties": {
+              "key": { "type": "string" },
+              "reason": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/admin/config/import/1.0/spec.md
+++ b/trust-tasks/admin/config/import/1.0/spec.md
@@ -1,0 +1,59 @@
+---
+id: https://trusttasks.org/openvtc/vtc/admin/config/import/1.0
+title: VTC Admin — Import Config
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/admin/config/import
+---
+
+# VTC Admin — Import Config
+
+Diff-and-confirm import of the `ConfigExport` shape produced by
+`POST /v1/admin/config/export`. Default `?confirm=false` returns
+the diff without persisting anything; `?confirm=true` applies.
+
+## Diff phase (`?confirm=false`, default)
+
+Computes per-field diffs:
+
+- **`communityProfileDiff`** — every profile field that would
+  change (`oldValue` is `null` when no profile exists yet;
+  `community_did` is included so the operator can spot a mismatched
+  source).
+- **`configOverridesDiff`** — every db-layer key that would change.
+- **`rejected`** — keys the import carries that aren't in the
+  registry, or whose values fail validation.
+
+## Apply phase (`?confirm=true`)
+
+Persists:
+1. The community profile (if `communityProfile` is present in the
+   import). Goes through the existing `CommunityProfileUpdate::apply`
+   path, including the 16 KiB `extensions` cap.
+2. Each validated config override (`ConfigStore::put`).
+
+Emits `CommunityProfileUpdated { fieldsChanged }` and `ConfigChanged
+{ changes, requiresRestart }` to the audit log (sensitive values
+redacted via `ConfigChange::redact_if`).
+
+## Community-DID safety
+
+Refuses (`409 Conflict`) when the existing profile's
+`community_did` differs from the import's — protects against
+clobbering a different community's profile by mistake. A
+freshly-installed VTC with no profile accepts any `community_did`.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`.
+
+## Errors
+
+- `400 Bad Request` — wrong `schemaVersion`.
+- `401 Unauthorized` / `403 Forbidden` — auth + role gates.
+- `409 Conflict` — `community_did` mismatch.
+- `503 Service Unavailable` — audit writer not configured (apply
+  path only; dry-run works without audit).

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -112,6 +112,18 @@
       "status": "Draft",
       "path": "admin/config/restart/1.0",
       "rest": "POST /v1/admin/config/restart"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/admin/config/export/1.0",
+      "status": "Draft",
+      "path": "admin/config/export/1.0",
+      "rest": "POST /v1/admin/config/export"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/admin/config/import/1.0",
+      "status": "Draft",
+      "path": "admin/config/import/1.0",
+      "rest": "POST /v1/admin/config/import"
     }
   ]
 }

--- a/vtc-service/src/routes/admin/config.rs
+++ b/vtc-service/src/routes/admin/config.rs
@@ -18,21 +18,26 @@
 use std::collections::HashMap;
 
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::info;
 use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
 
+use crate::community::{CommunityProfile, CommunityProfileUpdate, load_profile, store_profile};
 use crate::config_store::{
     ConfigStore, EffectiveConfig, compute_effective_config, lookup, validate_value,
 };
 use crate::server::AppState;
 #[allow(unused_imports)]
 use crate::supervisor::SupervisorKind;
-use vti_common::audit::{AuditEvent, AuditWriter, ConfigReloadedData, RestartRequestedData};
+use vti_common::audit::{
+    AuditEvent, AuditWriter, CommunityProfileUpdatedData, ConfigChange, ConfigChangedData,
+    ConfigReloadedData, ConfigSource, RestartRequestedData,
+};
 
 /// PATCH request body: arbitrary `key → value` map. Keys not in
 /// [`crate::config_store::REGISTRY`] are reported back under
@@ -340,6 +345,397 @@ fn apply_to_live(cfg: &mut crate::config::AppConfig, key: &str, value: &Value) -
         return true;
     }
     false
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+/// Schema version for the export/import envelope. Bumped on any
+/// breaking shape change so the import handler can refuse old
+/// exports cleanly. Phase 0 ships v1.
+pub const EXPORT_SCHEMA_VERSION: u32 = 1;
+
+/// Wire payload for `POST /v1/admin/config/{export,import}`.
+///
+/// `community_profile` is `None` when the community hasn't been
+/// initialised yet (pre-bootstrap). `config_overrides` carries
+/// *only* the db-layer keys — env-layer and toml-layer values stay
+/// per-host and aren't portable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigExport {
+    pub schema_version: u32,
+    pub exported_at: DateTime<Utc>,
+    pub community_profile: Option<CommunityProfile>,
+    pub config_overrides: HashMap<String, Value>,
+}
+
+pub async fn export_config(
+    _admin: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<ConfigExport>, AppError> {
+    let community_profile = load_profile(&state.community_ks).await?;
+    let store = ConfigStore::new(state.config_ks.clone());
+    let config_overrides = store.snapshot().await?;
+
+    Ok(Json(ConfigExport {
+        schema_version: EXPORT_SCHEMA_VERSION,
+        exported_at: Utc::now(),
+        community_profile,
+        config_overrides,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Import (diff-and-confirm)
+// ---------------------------------------------------------------------------
+
+/// Query string for `POST /v1/admin/config/import`. Default is
+/// `confirm=false` (dry-run / diff). The operator UX shows the diff,
+/// then re-submits with `?confirm=true` to apply.
+#[derive(Debug, Deserialize)]
+pub struct ImportQuery {
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+/// A single field's worth of import diff. `oldValue` is `None`
+/// when the key isn't currently set (either no profile yet, or no
+/// db-layer override). `newValue` is `None` when the import omits
+/// the field — which `import` interprets as "leave the live value
+/// alone", not "clear it".
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldDiff {
+    pub key: String,
+    pub old_value: Option<Value>,
+    pub new_value: Option<Value>,
+}
+
+/// `POST /v1/admin/config/import` response. The shape is the same
+/// regardless of `confirm`: `applied` is empty on dry-run; on
+/// confirm it lists the keys that actually persisted.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportResponse {
+    /// Was the request a dry-run? Mirrors the inbound `?confirm`
+    /// flag so an admin UX caching the response can render the
+    /// banner correctly.
+    pub confirmed: bool,
+    /// Profile-field-level diffs against the current profile.
+    /// Empty when import omits `communityProfile` or when no
+    /// fields differ.
+    pub community_profile_diff: Vec<FieldDiff>,
+    /// Config-override-level diffs. One entry per registry key
+    /// that the import would change.
+    pub config_overrides_diff: Vec<FieldDiff>,
+    /// On apply: the profile fields that were written. Empty on
+    /// dry-run or when no change.
+    pub community_profile_applied: Vec<String>,
+    /// On apply: the override keys that were written. Empty on
+    /// dry-run.
+    pub config_overrides_applied: Vec<String>,
+    /// Keys rejected by validation (unknown registry key, type
+    /// mismatch, value-out-of-range, oversized extensions blob).
+    pub rejected: Vec<RejectedKey>,
+}
+
+pub async fn import_config(
+    _admin: AdminAuth,
+    State(state): State<AppState>,
+    Query(query): Query<ImportQuery>,
+    Json(req): Json<ConfigExport>,
+) -> Result<(StatusCode, Json<ImportResponse>), AppError> {
+    if req.schema_version != EXPORT_SCHEMA_VERSION {
+        return Err(AppError::Validation(format!(
+            "unsupported export schemaVersion: got {}, expected {EXPORT_SCHEMA_VERSION}",
+            req.schema_version
+        )));
+    }
+
+    // community_did mismatch is a 409 — refuse to clobber a
+    // different community's profile with this import. A
+    // freshly-installed VTC with no profile accepts any
+    // community_did from the import.
+    let current_profile = load_profile(&state.community_ks).await?;
+    if let (Some(current), Some(incoming)) = (&current_profile, &req.community_profile)
+        && current.community_did != incoming.community_did
+    {
+        return Err(AppError::Conflict(format!(
+            "communityDid mismatch: current is {}, import carries {}",
+            current.community_did, incoming.community_did
+        )));
+    }
+
+    let store = ConfigStore::new(state.config_ks.clone());
+    let current_overrides = store.snapshot().await?;
+
+    // --- diff ---------------------------------------------------------
+    let mut profile_diff: Vec<FieldDiff> = Vec::new();
+    let mut overrides_diff: Vec<FieldDiff> = Vec::new();
+    let mut rejected: Vec<RejectedKey> = Vec::new();
+
+    if let Some(incoming) = &req.community_profile {
+        for (key, old, new) in profile_field_pairs(current_profile.as_ref(), incoming) {
+            if old != new {
+                profile_diff.push(FieldDiff {
+                    key: key.into(),
+                    old_value: old,
+                    new_value: new,
+                });
+            }
+        }
+    }
+
+    for (key, new_value) in &req.config_overrides {
+        let Some(def) = lookup(key) else {
+            rejected.push(RejectedKey {
+                key: key.clone(),
+                reason: "unknown config key (not in registry)".into(),
+            });
+            continue;
+        };
+        if let Err(e) = validate_value(def, new_value) {
+            rejected.push(RejectedKey {
+                key: key.clone(),
+                reason: format!("validation failed: {e}"),
+            });
+            continue;
+        }
+        let old = current_overrides.get(key).cloned();
+        if old.as_ref() != Some(new_value) {
+            overrides_diff.push(FieldDiff {
+                key: key.clone(),
+                old_value: old,
+                new_value: Some(new_value.clone()),
+            });
+        }
+    }
+
+    // --- dry-run? -----------------------------------------------------
+    if !query.confirm {
+        return Ok((
+            StatusCode::OK,
+            Json(ImportResponse {
+                confirmed: false,
+                community_profile_diff: profile_diff,
+                config_overrides_diff: overrides_diff,
+                community_profile_applied: Vec::new(),
+                config_overrides_applied: Vec::new(),
+                rejected,
+            }),
+        ));
+    }
+
+    // --- apply --------------------------------------------------------
+    // Profile first so a partial failure on overrides doesn't leave
+    // half a profile applied. Overrides are persisted one key at a
+    // time, so a fjall-side error mid-loop reports back via
+    // `rejected` rather than aborting.
+    let audit_writer = require_audit_writer(&state)?;
+
+    let community_profile_applied = if let Some(incoming) = req.community_profile.clone() {
+        apply_profile_import(&state, incoming, current_profile.as_ref()).await?
+    } else {
+        Vec::new()
+    };
+
+    let mut config_overrides_applied: Vec<String> = Vec::new();
+    let mut audit_changes: Vec<ConfigChange> = Vec::new();
+    let mut requires_restart = false;
+    for FieldDiff {
+        key,
+        old_value,
+        new_value,
+    } in &overrides_diff
+    {
+        let Some(def) = lookup(key) else { continue };
+        let new_value = match new_value {
+            Some(v) => v.clone(),
+            None => continue,
+        };
+        if let Err(e) = store.put(key, &new_value).await {
+            rejected.push(RejectedKey {
+                key: key.clone(),
+                reason: format!("persistence failed: {e}"),
+            });
+            continue;
+        }
+        config_overrides_applied.push(key.clone());
+        let mut change = ConfigChange {
+            key: key.clone(),
+            old_value: old_value.clone(),
+            new_value,
+            source_before: if old_value.is_some() {
+                ConfigSource::Db
+            } else {
+                ConfigSource::Default
+            },
+        };
+        change.redact_if(|k| matches!(lookup(k), Some(d) if d.sensitive));
+        audit_changes.push(change);
+        if def.requires_restart {
+            requires_restart = true;
+        }
+    }
+
+    if !audit_changes.is_empty() {
+        audit_writer
+            .write(
+                "did:key:vtc-admin",
+                None,
+                AuditEvent::ConfigChanged(ConfigChangedData {
+                    changes: audit_changes,
+                    requires_restart,
+                }),
+            )
+            .await?;
+    }
+    if !community_profile_applied.is_empty() {
+        audit_writer
+            .write(
+                "did:key:vtc-admin",
+                None,
+                AuditEvent::CommunityProfileUpdated(CommunityProfileUpdatedData {
+                    fields_changed: community_profile_applied.clone(),
+                }),
+            )
+            .await?;
+    }
+
+    info!(
+        profile_changed = community_profile_applied.len(),
+        overrides_applied = config_overrides_applied.len(),
+        rejected = rejected.len(),
+        "config imported"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(ImportResponse {
+            confirmed: true,
+            community_profile_diff: profile_diff,
+            config_overrides_diff: overrides_diff,
+            community_profile_applied,
+            config_overrides_applied,
+            rejected,
+        }),
+    ))
+}
+
+/// Apply the incoming profile to `community_ks`. Returns the list of
+/// field names that changed (driving the
+/// `CommunityProfileUpdated.fieldsChanged` audit payload).
+///
+/// If no profile exists yet the incoming profile is stored as-is
+/// (and **all** populated fields are reported as changed, matching
+/// `CommunityProfileUpdate::apply`'s contract).
+async fn apply_profile_import(
+    state: &AppState,
+    incoming: CommunityProfile,
+    current: Option<&CommunityProfile>,
+) -> Result<Vec<String>, AppError> {
+    let Some(current) = current else {
+        // Fresh install — store the import verbatim and report every
+        // non-default-shaped field as changed.
+        let mut changed = Vec::new();
+        if !incoming.name.is_empty() {
+            changed.push("name".into());
+        }
+        if !incoming.description.is_empty() {
+            changed.push("description".into());
+        }
+        if incoming.logo_url.is_some() {
+            changed.push("logoUrl".into());
+        }
+        if incoming.public_url.is_some() {
+            changed.push("publicUrl".into());
+        }
+        if incoming.contact_email.is_some() {
+            changed.push("contactEmail".into());
+        }
+        if incoming.language != "en" {
+            changed.push("language".into());
+        }
+        if !incoming.extensions.is_null() {
+            changed.push("extensions".into());
+        }
+        store_profile(&state.community_ks, &incoming).await?;
+        return Ok(changed);
+    };
+
+    // Existing profile — build a `CommunityProfileUpdate` from the
+    // import and let it diff + apply. This reuses the existing
+    // extension-size guard.
+    let patch = CommunityProfileUpdate {
+        name: Some(incoming.name),
+        description: Some(incoming.description),
+        logo_url: Some(incoming.logo_url),
+        public_url: Some(incoming.public_url),
+        contact_email: Some(incoming.contact_email),
+        language: Some(incoming.language),
+        extensions: Some(incoming.extensions),
+    };
+    let mut updated = current.clone();
+    let changed = patch.apply(&mut updated)?;
+    if !changed.is_empty() {
+        store_profile(&state.community_ks, &updated).await?;
+    }
+    Ok(changed)
+}
+
+/// Iterate profile fields as `(key, old_value, new_value)` triples.
+/// Includes `community_did` so a mismatched-but-allowed (i.e.,
+/// fresh-install) import surfaces it in the diff for the operator's
+/// review.
+fn profile_field_pairs(
+    current: Option<&CommunityProfile>,
+    incoming: &CommunityProfile,
+) -> Vec<(&'static str, Option<Value>, Option<Value>)> {
+    let s = |v: &str| Value::String(v.to_string());
+    let opt_s = |v: &Option<String>| match v {
+        Some(s) => Value::String(s.clone()),
+        None => Value::Null,
+    };
+    vec![
+        (
+            "communityDid",
+            current.map(|p| s(&p.community_did)),
+            Some(s(&incoming.community_did)),
+        ),
+        ("name", current.map(|p| s(&p.name)), Some(s(&incoming.name))),
+        (
+            "description",
+            current.map(|p| s(&p.description)),
+            Some(s(&incoming.description)),
+        ),
+        (
+            "logoUrl",
+            current.map(|p| opt_s(&p.logo_url)),
+            Some(opt_s(&incoming.logo_url)),
+        ),
+        (
+            "publicUrl",
+            current.map(|p| opt_s(&p.public_url)),
+            Some(opt_s(&incoming.public_url)),
+        ),
+        (
+            "contactEmail",
+            current.map(|p| opt_s(&p.contact_email)),
+            Some(opt_s(&incoming.contact_email)),
+        ),
+        (
+            "language",
+            current.map(|p| s(&p.language)),
+            Some(s(&incoming.language)),
+        ),
+        (
+            "extensions",
+            current.map(|p| p.extensions.clone()),
+            Some(incoming.extensions.clone()),
+        ),
+    ]
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -59,6 +59,12 @@ pub fn router() -> Router<AppState> {
     let admin_config_restart =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/config/restart/1.0")
             .expect("static Trust-Task URL");
+    let admin_config_export =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/config/export/1.0")
+            .expect("static Trust-Task URL");
+    let admin_config_import =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/config/import/1.0")
+            .expect("static Trust-Task URL");
     let install_claim_start =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/start/1.0")
             .expect("static Trust-Task URL");
@@ -141,6 +147,19 @@ pub fn router() -> Router<AppState> {
             "/v1/admin/config/restart",
             post(admin::config::restart_config),
             admin_config_restart,
+        )
+        // Export / import (M0.8.4). Export returns the portable
+        // (db-layer overrides + community profile) JSON; import runs
+        // diff-and-confirm via `?confirm=true|false`.
+        .route_with_task(
+            "/v1/admin/config/export",
+            post(admin::config::export_config),
+            admin_config_export,
+        )
+        .route_with_task(
+            "/v1/admin/config/import",
+            post(admin::config::import_config),
+            admin_config_import,
         )
         // Install claim (M0.5.2) — distinct Trust Tasks because the
         // two phases of the WebAuthn ceremony have different

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -618,3 +618,377 @@ async fn restart_wrong_trust_task_returns_415() {
     let (status, _) = body_value(resp).await;
     assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
 }
+
+// ──────────────────────── Export / Import ────────────────────────
+
+const EXPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/config/export/1.0";
+const IMPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/config/import/1.0";
+
+async fn export_post(fix: &Fixture, token: &str) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/admin/config/export")
+        .header("Trust-Task", EXPORT_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    body_value(resp).await
+}
+
+async fn import_post(
+    fix: &Fixture,
+    token: &str,
+    confirm: bool,
+    body: Value,
+) -> (StatusCode, Value) {
+    let uri = if confirm {
+        "/v1/admin/config/import?confirm=true"
+    } else {
+        "/v1/admin/config/import"
+    };
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("Trust-Task", IMPORT_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    body_value(resp).await
+}
+
+async fn seed_profile(fix: &Fixture) -> vtc_service::community::CommunityProfile {
+    use vtc_service::community::CommunityProfile;
+    let mut p = CommunityProfile::new("did:webvh:vtc.example.com:abc", "Example");
+    p.description = "the original".to_string();
+    vtc_service::community::store_profile(&fix.state.community_ks, &p)
+        .await
+        .unwrap();
+    p
+}
+
+#[tokio::test]
+async fn export_empty_fresh_install_returns_v1_schema_no_profile_no_overrides() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let (status, body) = export_post(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["schemaVersion"], 1);
+    assert!(body["communityProfile"].is_null());
+    assert_eq!(body["configOverrides"], json!({}));
+    assert!(body["exportedAt"].as_str().unwrap().contains("T"));
+}
+
+#[tokio::test]
+async fn export_includes_profile_and_db_overrides() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    seed_profile(&fix).await;
+
+    // Seed a db-layer override via PATCH so the export reflects it.
+    let req = Request::builder()
+        .method("PATCH")
+        .uri("/v1/admin/config")
+        .header("Trust-Task", CONFIG_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"log.level":"debug"}"#))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let (status, body) = export_post(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["communityProfile"]["name"], "Example");
+    assert_eq!(body["communityProfile"]["description"], "the original");
+    assert_eq!(body["configOverrides"]["log.level"], "debug");
+}
+
+#[tokio::test]
+async fn export_requires_admin_role() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "reader").await;
+    let (status, _) = export_post(&fix, &token).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn import_dry_run_returns_diff_without_persisting() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    seed_profile(&fix).await;
+
+    let payload = json!({
+        "schemaVersion": 1,
+        "exportedAt": "2026-05-12T03:42:00Z",
+        "communityProfile": {
+            "communityDid": "did:webvh:vtc.example.com:abc",
+            "name": "Renamed",
+            "description": "the original",
+            "logoUrl": null,
+            "publicUrl": null,
+            "contactEmail": null,
+            "language": "en",
+            "createdAt": "2026-05-12T00:00:00Z",
+            "extensions": null
+        },
+        "configOverrides": { "log.level": "debug" }
+    });
+    let (status, body) = import_post(&fix, &token, false, payload).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["confirmed"], false);
+
+    // Diff lists the changed name + the new db-layer override.
+    let profile_keys: Vec<_> = body["communityProfileDiff"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["key"].as_str().unwrap().to_string())
+        .collect();
+    assert!(profile_keys.contains(&"name".to_string()));
+    let overrides_keys: Vec<_> = body["configOverridesDiff"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["key"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(overrides_keys, vec!["log.level"]);
+
+    // Nothing applied.
+    assert_eq!(body["communityProfileApplied"], json!([]));
+    assert_eq!(body["configOverridesApplied"], json!([]));
+
+    // Live profile unchanged.
+    let live = vtc_service::community::load_profile(&fix.state.community_ks)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live.name, "Example");
+}
+
+#[tokio::test]
+async fn import_confirm_applies_profile_and_overrides() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    seed_profile(&fix).await;
+
+    let payload = json!({
+        "schemaVersion": 1,
+        "exportedAt": "2026-05-12T03:42:00Z",
+        "communityProfile": {
+            "communityDid": "did:webvh:vtc.example.com:abc",
+            "name": "Renamed",
+            "description": "the original",
+            "logoUrl": null,
+            "publicUrl": null,
+            "contactEmail": null,
+            "language": "fr",
+            "createdAt": "2026-05-12T00:00:00Z",
+            "extensions": null
+        },
+        "configOverrides": { "log.level": "debug" }
+    });
+    let (status, body) = import_post(&fix, &token, true, payload).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["confirmed"], true);
+
+    let applied: Vec<_> = body["communityProfileApplied"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(applied.contains(&"name".to_string()));
+    assert!(applied.contains(&"language".to_string()));
+    assert_eq!(body["configOverridesApplied"], json!(["log.level"]));
+
+    // Live profile reflects the import.
+    let live = vtc_service::community::load_profile(&fix.state.community_ks)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live.name, "Renamed");
+    assert_eq!(live.language, "fr");
+
+    // Both audit events landed.
+    let raw = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(b"2".to_vec())
+        .await
+        .unwrap();
+    let envelopes: Vec<vti_common::audit::AuditEnvelope> = raw
+        .iter()
+        .map(|(_, v)| serde_json::from_slice(v).unwrap())
+        .collect();
+    let mut saw_profile = false;
+    let mut saw_config = false;
+    for env in &envelopes {
+        match &env.event {
+            vti_common::audit::AuditEvent::CommunityProfileUpdated(_) => saw_profile = true,
+            vti_common::audit::AuditEvent::ConfigChanged(_) => saw_config = true,
+            _ => {}
+        }
+    }
+    assert!(saw_profile, "CommunityProfileUpdated missing");
+    assert!(saw_config, "ConfigChanged missing");
+}
+
+#[tokio::test]
+async fn import_refuses_mismatched_community_did_with_409() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    seed_profile(&fix).await;
+
+    let payload = json!({
+        "schemaVersion": 1,
+        "exportedAt": "2026-05-12T03:42:00Z",
+        "communityProfile": {
+            "communityDid": "did:webvh:OTHER.example.com:xyz",
+            "name": "Foreign",
+            "description": "",
+            "logoUrl": null,
+            "publicUrl": null,
+            "contactEmail": null,
+            "language": "en",
+            "createdAt": "2026-05-12T00:00:00Z",
+            "extensions": null
+        },
+        "configOverrides": {}
+    });
+    let (status, body) = import_post(&fix, &token, true, payload).await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(body["error"].as_str().unwrap().contains("communityDid"));
+}
+
+#[tokio::test]
+async fn import_round_trip_export_then_import_equivalence() {
+    // Set up source VTC with profile + override, export.
+    let src = build_with(true, None).await;
+    let token = token_for(&src, "admin").await;
+    seed_profile(&src).await;
+
+    let req = Request::builder()
+        .method("PATCH")
+        .uri("/v1/admin/config")
+        .header("Trust-Task", CONFIG_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"log.level":"debug"}"#))
+        .unwrap();
+    let _ = src.router.clone().oneshot(req).await.unwrap();
+
+    let (_, exported) = export_post(&src, &token).await;
+
+    // Fresh VTC: import the export, confirm.
+    let dst = build_with(true, None).await;
+    let dst_token = token_for(&dst, "admin").await;
+    let (status, body) = import_post(&dst, &dst_token, true, exported.clone()).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    // Export the destination and confirm it round-trips.
+    let (_, dst_exported) = export_post(&dst, &dst_token).await;
+
+    // Compare semantically — `exportedAt` differs, but
+    // `communityProfile` (minus `createdAt`, which we accept varying
+    // across instances) and `configOverrides` must match.
+    let strip_volatile = |mut v: Value| -> Value {
+        v["exportedAt"] = json!("<stripped>");
+        if let Some(p) = v.get_mut("communityProfile")
+            && let Some(o) = p.as_object_mut()
+        {
+            o.insert("createdAt".to_string(), json!("<stripped>"));
+        }
+        v
+    };
+    assert_eq!(strip_volatile(exported), strip_volatile(dst_exported));
+}
+
+#[tokio::test]
+async fn import_rejects_unknown_config_key() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let payload = json!({
+        "schemaVersion": 1,
+        "exportedAt": "2026-05-12T03:42:00Z",
+        "communityProfile": null,
+        "configOverrides": { "godmode.enable": true }
+    });
+    let (status, body) = import_post(&fix, &token, true, payload).await;
+    assert_eq!(status, StatusCode::OK);
+    let rejected = body["rejected"].as_array().unwrap();
+    assert_eq!(rejected.len(), 1);
+    assert_eq!(rejected[0]["key"], "godmode.enable");
+}
+
+#[tokio::test]
+async fn import_rejects_invalid_value_with_reason() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let payload = json!({
+        "schemaVersion": 1,
+        "exportedAt": "2026-05-12T03:42:00Z",
+        "communityProfile": null,
+        "configOverrides": { "log.level": "shouting" }
+    });
+    let (status, body) = import_post(&fix, &token, true, payload).await;
+    assert_eq!(status, StatusCode::OK);
+    let rejected = body["rejected"].as_array().unwrap();
+    assert_eq!(rejected.len(), 1);
+    assert_eq!(rejected[0]["key"], "log.level");
+    assert!(
+        rejected[0]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("validation failed"),
+        "got {}",
+        rejected[0]["reason"]
+    );
+}
+
+#[tokio::test]
+async fn import_wrong_schema_version_returns_400() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let payload = json!({
+        "schemaVersion": 99,
+        "exportedAt": "2026-05-12T03:42:00Z",
+        "communityProfile": null,
+        "configOverrides": {}
+    });
+    let (status, _) = import_post(&fix, &token, false, payload).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn import_apply_503_when_audit_writer_missing() {
+    let fix = build_with(false, None).await;
+    let token = token_for(&fix, "admin").await;
+    let payload = json!({
+        "schemaVersion": 1,
+        "exportedAt": "2026-05-12T03:42:00Z",
+        "communityProfile": null,
+        "configOverrides": { "log.level": "debug" }
+    });
+    let (status, _) = import_post(&fix, &token, true, payload).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn import_dry_run_works_without_audit_writer() {
+    // Pure dry-run never emits an audit event, so 503 is the wrong
+    // answer — we should return 200 with the diff.
+    let fix = build_with(false, None).await;
+    let token = token_for(&fix, "admin").await;
+    let payload = json!({
+        "schemaVersion": 1,
+        "exportedAt": "2026-05-12T03:42:00Z",
+        "communityProfile": null,
+        "configOverrides": { "log.level": "debug" }
+    });
+    let (status, body) = import_post(&fix, &token, false, payload).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["confirmed"], false);
+}


### PR DESCRIPTION
## Summary

Closes the **M0.8 family**. After this PR the Phase-0 admin config
surface is feature-complete on the daemon side.

## Export

`POST /v1/admin/config/export` returns the portable subset of a
VTC's configuration as `ConfigExport`:

```json
{
  "schemaVersion": 1,
  "exportedAt": "...",
  "communityProfile": { ... },
  "configOverrides": { "log.level": "debug" }
}
```

Env-layer + toml-layer values are deliberately excluded — those
carry per-host secrets (JWT signing key, secret-store credentials,
TLS cert paths) that must not travel with an export.

## Import (diff-and-confirm)

`POST /v1/admin/config/import?confirm=true|false`:

- **Dry-run** (default) returns per-field `FieldDiff`s for both
  `communityProfileDiff` and `configOverridesDiff`, plus a
  `rejected` list for unknown keys or validation failures.
- **Confirm** applies via `store_profile` + `ConfigStore::put`,
  emits `CommunityProfileUpdated` + `ConfigChanged` audit events
  (sensitive values redacted via `ConfigChange::redact_if`).

### Safety

- **409 Conflict** if the existing profile's `community_did`
  differs from the import. Fresh installs (no profile yet) accept
  any incoming `community_did`.
- **400 Bad Request** on `schemaVersion` mismatch.
- **503 Service Unavailable** on apply path when audit writer not
  configured. Dry-run still works (it never emits an event).
- Apply ordering: profile first, then overrides one-key-at-a-time.
  A persistence failure mid-loop reports back via `rejected`
  rather than aborting.

## Trust Tasks

Two new entries with `spec.md` + `schema.json`:
- `admin/config/export/1.0`
- `admin/config/import/1.0`

## Test plan

- [x] `cargo test --package vtc-service` — **169 tests pass**
  (157 before this PR). 12 new integration tests in
  `tests/admin_config.rs`:
  - export × 3 (fresh install, with profile + overrides, admin gate)
  - import dry-run × 2 (returns diff, works without audit writer)
  - import confirm × 2 (applies + emits both audit events,
    round-trip equivalence across a fresh-VTC export → import →
    re-export cycle)
  - `import_refuses_mismatched_community_did_with_409`
  - rejected keys × 2 (unknown key, invalid value)
  - `import_wrong_schema_version_returns_400`
  - `import_apply_503_when_audit_writer_missing`
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --lib` clean.

## Phase 0 status

| | Milestone | Status |
|---|---|---|
| | M0.1.*, M0.2, M0.3, M0.4, M0.5.*, M0.6.*, M0.7, M0.8.1–3 | All merged |
| | **M0.8.4 — export/import** | **PR #65 (in review)** |
| | M0.9 — CLI setup wizard rewrite | Not started |
| | M0.10 — emergency bootstrap CLI | Not started |
| | M0.11 — routing + CORS + cookie scope | Not started |
| | M0.12 — install-flow integration tests | Not started |

The daemon-side Phase-0 wire surface is now complete. Remaining
Phase-0 work is operator UX (CLI rewrites + emergency bootstrap),
routing/CORS hardening, and the final end-to-end integration test.