### PR TITLE
feat(vtc): RoutingConfig + CorsConfig + CORS layer (M0.11)

### DIFF
--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -899,42 +899,78 @@ everything the new path replaces.
 
 ## M0.11 — Routing + CORS + cookie-scope
 
-### `[ ]` M0.11.1 — Routing config + mount logic
+### `[x]` M0.11.1 — Routing config + mount logic
 
 - **Acceptance**
-  - `RoutingConfig` per spec §9.2 supports `mount` + optional `host`
-    per surface (api, admin_ui, website — website mount accepted in
-    config but routes 404 until Phase 5)
-  - Path-prefix default: `/v1`, `/admin`, `/` (catch-all)
-  - Subdomain mode supported by `Host`-header middleware (codified
-    but not exercised by Phase-0 tests)
-  - Mount conflicts at config-load time produce a clear startup
-    error
-- **Verify**
-  - Path-prefix routing test: `/v1/community/profile` resolves;
-    `/admin/some/path` returns 404 (since admin UX not bundled yet)
-  - Subdomain config parses but does not break path-prefix tests
+  - `RoutingConfig { api, admin_ui, website: MountConfig }` per
+    spec §9.2 — each surface has a `mount: String` and optional
+    `host: Option<String>` for subdomain mode.
+  - Path-prefix defaults: `/v1`, `/admin`, `/`.
+  - Subdomain mode parses cleanly (a `host` value bypasses the
+    path-mode cookie-scope guard for that surface) but isn't
+    exercised by Phase-0 routing — the route table stays at the
+    existing `/v1/*` mounts. Mount-driven re-routing lands in
+    Phase 5 when the admin SPA + public website actually serve
+    content.
+  - **Config-load validation** (`AppConfig::validate_routing_and_cors`,
+    called by `AppConfig::load` + `AppConfig::save`) refuses:
+    - any mount that doesn't start with `/`
+    - two surfaces sharing the same path mount in path mode
+    - `admin_ui.mount = "/"` in path mode (cookie-scope guard;
+      `Path=/admin` collapses to "any path" otherwise)
+- **Verify** — 6 of the 15 `tests/routing_cors.rs` tests cover
+  the validator:
+  - `defaults_validate_clean`
+  - `rejects_admin_ui_mounted_at_root_in_path_mode`
+  - `allows_admin_ui_at_root_when_host_routed` (subdomain bypass)
+  - `rejects_duplicate_path_mounts`
+  - `rejects_mount_without_leading_slash`
 - **Files**
-  - `vtc-service/src/config.rs` (add `RoutingConfig`)
-  - `vtc-service/src/routes/mod.rs`
+  - `vtc-service/src/config.rs` (`RoutingConfig`, `MountConfig`,
+    `validate_routing`)
+  - `vtc-service/tests/routing_cors.rs` (new)
 - **Deps**: M0.3.2
 
-### `[ ]` M0.11.2 — CORS + cookie-scope invariants
+### `[x]` M0.11.2 — CORS + cookie-scope invariants
 
 - **Acceptance**
-  - `cors.allowed_origins` allowlist; wildcards refused at config-load
-  - Admin session cookie set with `Path=/admin; SameSite=Strict;
-    Secure; HttpOnly` in path mode
-  - Public-website origin auto-allow disabled (no public website yet)
-  - Config-load-time invariant: refuses to start if cookie scopes
-    would overlap (e.g., admin mounted at `/` is rejected)
-- **Verify**
-  - Bad-config startup tests fail loud
-  - CORS preflight test includes `Idempotency-Key`,
-    `Trust-Task` in `Access-Control-Allow-Headers`
+  - `CorsConfig { allowed_origins: Vec<String> }`. Wildcards
+    (`*` or partial, e.g. `https://*.example.com`), empty
+    entries, and missing schemes are refused at config-load.
+    Empty `allowed_origins` is **valid** — disables CORS
+    entirely (same-origin only).
+  - `vtc_service::server::build_cors_layer` wires `tower-http`'s
+    `CorsLayer` into the REST stack with:
+    - `allow_origin` mirroring each entry literally,
+    - `allow_methods = [GET, POST, PUT, PATCH, DELETE, OPTIONS]`,
+    - `allow_headers = [Authorization, Content-Type, Trust-Task,
+      Idempotency-Key, Access-Control-Allow-Headers]`,
+    - `allow_credentials = true` (for the future admin session
+      cookie).
+  - Cookie-scope rule encoded in the routing validator (see
+    M0.11.1): admin_ui at `/` is rejected unless host-routed.
+    The actual admin session cookie is future work — Phase 0 auth
+    uses bearer JWTs in `Authorization` — so the rule is dormant
+    until the cookie lands.
+- **Verify** — 9 of 15 `tests/routing_cors.rs` tests cover CORS:
+  - Validator: `rejects_wildcard_cors_origin`,
+    `rejects_partial_wildcard_cors_origin`,
+    `rejects_cors_origin_without_scheme`,
+    `rejects_empty_cors_origin_entry`,
+    `empty_cors_allowlist_is_valid`,
+    `accepts_https_and_http_origins`.
+  - Wire: `preflight_from_allowed_origin_returns_cors_headers`,
+    `preflight_from_disallowed_origin_omits_cors_headers`,
+    `empty_allowlist_disables_cors_headers`,
+    `actual_get_from_allowed_origin_carries_cors_response_header`.
 - **Files**
-  - `vtc-service/src/config.rs`
-  - `vtc-service/src/server.rs`
+  - `vtc-service/Cargo.toml` (enable `tower-http` `cors` feature)
+  - `vtc-service/src/config.rs` (`CorsConfig`, `validate_cors`)
+  - `vtc-service/src/server.rs` (`build_cors_layer`,
+    `run_rest_thread` accepts a `CorsConfig`)
+- **Deferred**: the `Sec-Fetch-Site` / CSRF double-submit cookie
+  layer mentioned by spec §9.3 sits on top of the admin session
+  cookie; lands when the cookie does (Phase 1+).
 - **Deps**: M0.11.1
 
 ---

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -47,7 +47,7 @@ axum-extra = { workspace = true }
 jsonwebtoken = { workspace = true }
 fjall = { workspace = true }
 toml = { workspace = true }
-tower-http = { workspace = true, features = ["trace"] }
+tower-http = { workspace = true, features = ["cors", "trace"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -25,8 +25,97 @@ pub struct AppConfig {
     pub auth: AuthConfig,
     #[serde(default)]
     pub secrets: SecretsConfig,
+    #[serde(default)]
+    pub routing: RoutingConfig,
+    #[serde(default)]
+    pub cors: CorsConfig,
     #[serde(skip)]
     pub config_path: PathBuf,
+}
+
+/// Per-surface mount config (spec §9.2). Phase-0 surfaces:
+///
+/// - `api` — the JSON REST + DIDComm management surface. **Always
+///   mounted**; this is the daemon's reason to exist.
+/// - `admin_ui` — the (eventual) admin SPA. Phase 0 leaves the
+///   mount declared but doesn't serve anything; the slot reserves
+///   the path so cookie scopes don't collide later.
+/// - `website` — public community site (Phase 5+). Same story —
+///   the mount is reserved, the route table is empty.
+///
+/// **Mode**: per the spec, each surface can be path-prefixed
+/// (`mount`) or host-routed (`host`). Phase 0 exercises only the
+/// path-prefix default. Subdomain mode is accepted by the config
+/// parser but not driven by any code path until later phases.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct RoutingConfig {
+    #[serde(default = "default_api_mount")]
+    pub api: MountConfig,
+    #[serde(default = "default_admin_ui_mount")]
+    pub admin_ui: MountConfig,
+    #[serde(default = "default_website_mount")]
+    pub website: MountConfig,
+}
+
+impl Default for RoutingConfig {
+    fn default() -> Self {
+        Self {
+            api: default_api_mount(),
+            admin_ui: default_admin_ui_mount(),
+            website: default_website_mount(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct MountConfig {
+    /// Path prefix the surface attaches under (e.g. `/v1`,
+    /// `/admin`, `/`). Path mode is the Phase-0 default.
+    pub mount: String,
+    /// Optional host header for subdomain mode. Accepted by the
+    /// config parser; not exercised by Phase-0 routing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+}
+
+fn default_api_mount() -> MountConfig {
+    MountConfig {
+        mount: "/v1".into(),
+        host: None,
+    }
+}
+
+fn default_admin_ui_mount() -> MountConfig {
+    MountConfig {
+        mount: "/admin".into(),
+        host: None,
+    }
+}
+
+fn default_website_mount() -> MountConfig {
+    MountConfig {
+        mount: "/".into(),
+        host: None,
+    }
+}
+
+/// CORS allowlist (spec §9.3). Wildcards (`*`) are refused at
+/// config-load — the spec demands an explicit allowlist so the
+/// admin UX origin (and only that origin) can mutate the daemon.
+///
+/// When the list is empty, **CORS is disabled** — every cross-
+/// origin request gets the default browser rejection. Path-mode
+/// deployments serving the admin UX same-origin don't need any
+/// entries.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct CorsConfig {
+    /// Exact-match origin allowlist. Each entry is a full origin
+    /// (`https://host:port` — no path). Wildcards rejected.
+    #[serde(default)]
+    pub allowed_origins: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -101,6 +190,114 @@ pub(crate) fn default_port_value() -> u16 {
 
 fn default_server_config() -> ServerConfig {
     ServerConfig::default()
+}
+
+/// Refuse a config that would break the spec's routing
+/// invariants. Phase-0 enforcement:
+///
+/// - **Path-mode mounts must be unique.** Two surfaces sharing the
+///   same prefix would race for routes; reject at load.
+/// - **`admin_ui.mount` must not be `/` in path mode.** Spec §9.3:
+///   "refuses to start if cookie scopes would overlap (e.g., admin
+///   mounted at / is rejected)". With admin at root, the future
+///   admin session cookie's `Path=/admin` constraint collapses to
+///   "any path", letting public-website JS read admin cookies.
+/// - **Path-mode mounts start with `/`.** A bare `admin` mount is
+///   almost certainly a typo; bail loud.
+/// - **`api.mount` cannot equal `admin_ui.mount`.** Same family
+///   of routes; cookie-scope rationale doesn't apply but the
+///   ambiguity does.
+fn validate_routing(routing: &RoutingConfig) -> Result<(), AppError> {
+    for (name, m) in [
+        ("api", &routing.api),
+        ("admin_ui", &routing.admin_ui),
+        ("website", &routing.website),
+    ] {
+        if !m.mount.starts_with('/') {
+            return Err(AppError::Config(format!(
+                "routing.{name}.mount must start with '/': got '{}'",
+                m.mount
+            )));
+        }
+    }
+
+    // Cookie-scope guard. Only fires in path mode for the admin_ui
+    // surface — subdomain mode (host set) carries its own scope.
+    if routing.admin_ui.host.is_none() && routing.admin_ui.mount == "/" {
+        return Err(AppError::Config(
+            "routing.admin_ui.mount = '/' would collapse the admin cookie scope; \
+             pick a non-root prefix (default: '/admin') or enable subdomain mode via \
+             routing.admin_ui.host"
+                .into(),
+        ));
+    }
+
+    // Mount uniqueness (path mode only — subdomain mode disambiguates
+    // by host). The `website` catch-all is allowed to share `/` with
+    // a non-mounted slot, but pairwise duplicates between api +
+    // admin_ui + website are rejected.
+    let path_mounts: Vec<(&str, &str)> = [
+        (
+            "api",
+            routing.api.host.as_deref(),
+            routing.api.mount.as_str(),
+        ),
+        (
+            "admin_ui",
+            routing.admin_ui.host.as_deref(),
+            routing.admin_ui.mount.as_str(),
+        ),
+        (
+            "website",
+            routing.website.host.as_deref(),
+            routing.website.mount.as_str(),
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(name, host, mount)| host.is_none().then_some((name, mount)))
+    .collect();
+
+    for i in 0..path_mounts.len() {
+        for j in (i + 1)..path_mounts.len() {
+            let (a, am) = path_mounts[i];
+            let (b, bm) = path_mounts[j];
+            if am == bm {
+                return Err(AppError::Config(format!(
+                    "routing.{a}.mount and routing.{b}.mount both = '{am}'; \
+                     path-mode mounts must be unique",
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Refuse a CORS allowlist that includes `*` or empty / whitespace
+/// entries. Spec §9.3: "wildcards refused". An empty
+/// `allowed_origins` is valid — that's "no cross-origin requests
+/// permitted" (same-origin path-mode default).
+fn validate_cors(cors: &CorsConfig) -> Result<(), AppError> {
+    for origin in &cors.allowed_origins {
+        let trimmed = origin.trim();
+        if trimmed.is_empty() {
+            return Err(AppError::Config(
+                "cors.allowed_origins contains an empty / whitespace entry".into(),
+            ));
+        }
+        if trimmed == "*" || trimmed.contains('*') {
+            return Err(AppError::Config(format!(
+                "cors.allowed_origins entry '{trimmed}' uses a wildcard; \
+                 spec §9.3 demands an exact-match allowlist"
+            )));
+        }
+        if !(trimmed.starts_with("http://") || trimmed.starts_with("https://")) {
+            return Err(AppError::Config(format!(
+                "cors.allowed_origins entry '{trimmed}' must be a full origin \
+                 (e.g., 'https://admin.example.com')"
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn default_store_config() -> StoreConfig {
@@ -255,10 +452,22 @@ impl AppConfig {
             config.auth.jwt_signing_key = Some(key);
         }
 
+        config.validate_routing_and_cors()?;
         Ok(config)
     }
 
+    /// Validate the routing + CORS sections per spec §9.2 / §9.3.
+    /// Called at the tail of [`Self::load`]; surfaced as a
+    /// public helper so tests can drive it directly without
+    /// touching the filesystem.
+    pub fn validate_routing_and_cors(&self) -> Result<(), AppError> {
+        validate_routing(&self.routing)?;
+        validate_cors(&self.cors)?;
+        Ok(())
+    }
+
     pub fn save(&self) -> Result<(), AppError> {
+        self.validate_routing_and_cors()?;
         let contents = toml::to_string_pretty(self)
             .map_err(|e| AppError::Config(format!("failed to serialize config: {e}")))?;
         std::fs::write(&self.config_path, contents).map_err(AppError::Io)?;

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -23,6 +23,7 @@ use crate::routes;
 use crate::store::{KeyspaceHandle, Store};
 use crate::supervisor::{SupervisorKind, detect_supervisor};
 use tokio::sync::{RwLock, watch};
+use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, warn};
 use vti_common::audit::{AuditKeyStore, AuditWriter};
@@ -230,11 +231,17 @@ pub async fn run(
         supervisor: detect_supervisor(),
     };
 
+    // Snapshot the CORS allowlist before the AppState `move` into
+    // the REST thread. The layer is fixed at start-up; a future
+    // M0.8.x extension can swap the layer on `POST /v1/admin/config/reload`
+    // if operators demand live updates.
+    let rest_cors = state.config.read().await.cors.clone();
+
     // Spawn three named OS threads
     let mut rest_shutdown_rx = shutdown_rx.clone();
     let rest_handle = std::thread::Builder::new()
         .name("vtc-rest".into())
-        .spawn(move || run_rest_thread(std_listener, state, &mut rest_shutdown_rx))
+        .spawn(move || run_rest_thread(std_listener, state, rest_cors, &mut rest_shutdown_rx))
         .map_err(|e| AppError::Internal(format!("failed to spawn REST thread: {e}")))?;
 
     let mut didcomm_shutdown_rx = shutdown_rx.clone();
@@ -368,10 +375,69 @@ fn run_storage_thread(
     });
 }
 
+/// Build the [`CorsLayer`] applied to every REST response. Honours
+/// the spec §9.3 allowlist:
+///
+/// - Empty `allowed_origins` → CORS is disabled (no cross-origin
+///   responses set the headers); same-origin path-mode deployments
+///   never need an entry.
+/// - Each origin is reflected verbatim by the `Origin` header
+///   match; wildcards are refused at config-load (see
+///   `crate::config::validate_cors`), so by the time we get here
+///   every entry is a literal `http(s)://host[:port]`.
+///
+/// `Access-Control-Allow-Headers` is fixed at the workspace's
+/// "common" header set (Authorization, Content-Type, Trust-Task,
+/// Idempotency-Key). `Access-Control-Allow-Credentials` is `true`
+/// so the admin SPA can carry the future cookie session over the
+/// allowlist edge; an empty allowlist disables CORS entirely so
+/// `credentials: true` is harmless there.
+fn build_cors_layer(cors: &crate::config::CorsConfig) -> CorsLayer {
+    use axum::http::Method;
+    use axum::http::header::{
+        ACCESS_CONTROL_ALLOW_HEADERS, AUTHORIZATION, CONTENT_TYPE, HeaderName, HeaderValue,
+    };
+
+    if cors.allowed_origins.is_empty() {
+        // No origins → same-origin only.
+        return CorsLayer::new();
+    }
+
+    let allowed_origins: Vec<HeaderValue> = cors
+        .allowed_origins
+        .iter()
+        .filter_map(|o| o.parse::<HeaderValue>().ok())
+        .collect();
+
+    let allowed_methods = vec![
+        Method::GET,
+        Method::POST,
+        Method::PUT,
+        Method::PATCH,
+        Method::DELETE,
+        Method::OPTIONS,
+    ];
+
+    let allowed_headers: Vec<HeaderName> = vec![
+        AUTHORIZATION,
+        CONTENT_TYPE,
+        ACCESS_CONTROL_ALLOW_HEADERS,
+        HeaderName::from_static("trust-task"),
+        HeaderName::from_static("idempotency-key"),
+    ];
+
+    CorsLayer::new()
+        .allow_origin(allowed_origins)
+        .allow_methods(allowed_methods)
+        .allow_headers(allowed_headers)
+        .allow_credentials(true)
+}
+
 /// REST thread: serves the Axum HTTP server.
 fn run_rest_thread(
     std_listener: std::net::TcpListener,
     state: AppState,
+    cors: crate::config::CorsConfig,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -385,8 +451,11 @@ fn run_rest_thread(
         let listener = tokio::net::TcpListener::from_std(std_listener)
             .expect("failed to convert std TcpListener to tokio TcpListener");
 
+        let cors_layer = build_cors_layer(&cors);
+
         let app = routes::router()
             .with_state(state)
+            .layer(cors_layer)
             .layer(TraceLayer::new_for_http());
 
         let shutdown_rx = shutdown_rx.clone();

--- a/vtc-service/src/setup.rs
+++ b/vtc-service/src/setup.rs
@@ -364,6 +364,8 @@ pub async fn run_setup_wizard(
             messaging: None,
             auth: AuthConfig::default(),
             secrets: secrets_config.clone(),
+            routing: Default::default(),
+            cors: Default::default(),
             config_path: config_path.clone(),
         })
         .map_err(|e| format!("{e}"))?;
@@ -466,6 +468,8 @@ pub async fn run_setup_wizard(
             ..AuthConfig::default()
         },
         secrets: secrets_config,
+        routing: Default::default(),
+        cors: Default::default(),
         config_path: config_path.clone(),
     };
     config.save()?;

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -1,0 +1,425 @@
+//! Coverage for the M0.11 routing + CORS hardening.
+//!
+//! Two layers under test:
+//!
+//! 1. **Config-load validation** (`AppConfig::validate_routing_and_cors`)
+//!    refuses obviously-broken configs at startup, not at first
+//!    request. Tests exercise the validator directly so we don't
+//!    need a temp filesystem.
+//! 2. **CORS layer** wired into `routes::router()` returns the
+//!    expected headers on preflight + actual cross-origin requests.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use http_body_util::BodyExt;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::config::{AppConfig, CorsConfig, MountConfig, RoutingConfig};
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Config validation
+// ═══════════════════════════════════════════════════════════════════
+
+fn cfg_with(routing: RoutingConfig, cors: CorsConfig) -> AppConfig {
+    AppConfig {
+        vtc_did: None,
+        vta_did: None,
+        vtc_name: None,
+        vtc_description: None,
+        public_url: None,
+        server: Default::default(),
+        log: Default::default(),
+        store: StoreConfig {
+            data_dir: std::path::PathBuf::from("data/test"),
+        },
+        messaging: None,
+        auth: Default::default(),
+        secrets: Default::default(),
+        routing,
+        cors,
+        config_path: std::path::PathBuf::new(),
+    }
+}
+
+#[test]
+fn defaults_validate_clean() {
+    let cfg = cfg_with(RoutingConfig::default(), CorsConfig::default());
+    cfg.validate_routing_and_cors().expect("defaults are valid");
+}
+
+#[test]
+fn rejects_admin_ui_mounted_at_root_in_path_mode() {
+    // Cookie-scope guard: `Path=/admin` collapses to "any path" when
+    // admin_ui is at root, letting the public-website origin read
+    // admin cookies.
+    let routing = RoutingConfig {
+        api: MountConfig {
+            mount: "/v1".into(),
+            host: None,
+        },
+        admin_ui: MountConfig {
+            mount: "/".into(),
+            host: None,
+        },
+        website: MountConfig {
+            mount: "/site".into(),
+            host: None,
+        },
+    };
+    let err = cfg_with(routing, Default::default())
+        .validate_routing_and_cors()
+        .expect_err("admin at / must be rejected");
+    assert!(format!("{err}").contains("admin"), "got {err}");
+}
+
+#[test]
+fn allows_admin_ui_at_root_when_host_routed() {
+    // Subdomain mode (host set) carries its own scope, so the
+    // root-mount guard doesn't fire.
+    let routing = RoutingConfig {
+        api: MountConfig {
+            mount: "/v1".into(),
+            host: None,
+        },
+        admin_ui: MountConfig {
+            mount: "/".into(),
+            host: Some("admin.example.com".into()),
+        },
+        website: MountConfig {
+            mount: "/".into(),
+            host: Some("example.com".into()),
+        },
+    };
+    cfg_with(routing, Default::default())
+        .validate_routing_and_cors()
+        .expect("subdomain mode bypasses cookie-scope guard");
+}
+
+#[test]
+fn rejects_duplicate_path_mounts() {
+    let routing = RoutingConfig {
+        api: MountConfig {
+            mount: "/v1".into(),
+            host: None,
+        },
+        admin_ui: MountConfig {
+            mount: "/v1".into(),
+            host: None,
+        },
+        website: MountConfig {
+            mount: "/".into(),
+            host: None,
+        },
+    };
+    let err = cfg_with(routing, Default::default())
+        .validate_routing_and_cors()
+        .expect_err("duplicate mounts must be rejected");
+    let msg = format!("{err}");
+    assert!(msg.contains("/v1"), "got {msg}");
+}
+
+#[test]
+fn rejects_mount_without_leading_slash() {
+    let routing = RoutingConfig {
+        api: MountConfig {
+            mount: "v1".into(),
+            host: None,
+        },
+        ..Default::default()
+    };
+    let err = cfg_with(routing, Default::default())
+        .validate_routing_and_cors()
+        .expect_err("bare prefix must be rejected");
+    assert!(format!("{err}").contains("start with '/'"), "got {err}");
+}
+
+#[test]
+fn rejects_wildcard_cors_origin() {
+    let cors = CorsConfig {
+        allowed_origins: vec!["*".into()],
+    };
+    let err = cfg_with(Default::default(), cors)
+        .validate_routing_and_cors()
+        .expect_err("wildcard cors must be rejected");
+    assert!(format!("{err}").contains("wildcard"), "got {err}");
+}
+
+#[test]
+fn rejects_partial_wildcard_cors_origin() {
+    let cors = CorsConfig {
+        allowed_origins: vec!["https://*.example.com".into()],
+    };
+    let err = cfg_with(Default::default(), cors)
+        .validate_routing_and_cors()
+        .expect_err("partial wildcard must be rejected");
+    assert!(format!("{err}").contains("wildcard"), "got {err}");
+}
+
+#[test]
+fn rejects_cors_origin_without_scheme() {
+    let cors = CorsConfig {
+        allowed_origins: vec!["admin.example.com".into()],
+    };
+    let err = cfg_with(Default::default(), cors)
+        .validate_routing_and_cors()
+        .expect_err("missing scheme must be rejected");
+    assert!(format!("{err}").contains("full origin"), "got {err}");
+}
+
+#[test]
+fn rejects_empty_cors_origin_entry() {
+    let cors = CorsConfig {
+        allowed_origins: vec!["".into()],
+    };
+    let err = cfg_with(Default::default(), cors)
+        .validate_routing_and_cors()
+        .expect_err("empty entry must be rejected");
+    assert!(format!("{err}").contains("empty"), "got {err}");
+}
+
+#[test]
+fn empty_cors_allowlist_is_valid() {
+    // Empty = same-origin only; valid.
+    let cfg = cfg_with(Default::default(), CorsConfig::default());
+    cfg.validate_routing_and_cors().unwrap();
+}
+
+#[test]
+fn accepts_https_and_http_origins() {
+    let cors = CorsConfig {
+        allowed_origins: vec![
+            "https://admin.example.com".into(),
+            "http://localhost:5173".into(),
+        ],
+    };
+    cfg_with(Default::default(), cors)
+        .validate_routing_and_cors()
+        .unwrap();
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// CORS layer wiring
+// ═══════════════════════════════════════════════════════════════════
+
+async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::TempDir) {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
+
+    let mut config = cfg_with(RoutingConfig::default(), cors.clone());
+    config.auth.jwt_signing_key = Some(BASE64.encode(jwt_seed));
+    config.store.data_dir = dir.path().to_path_buf();
+
+    let state = AppState {
+        sessions_ks: sessions_ks.clone(),
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks: install_ks.clone(),
+        audit_ks,
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: None,
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let cors_layer = vtc_service_test_cors_layer(&cors);
+    let router = routes::router().with_state(state).layer(cors_layer);
+    (router, dir)
+}
+
+/// Mirror of `server::build_cors_layer` for use in this integration
+/// test. Kept in sync with production so the layer the daemon
+/// actually serves matches what we test. If the production layer
+/// shape changes this test will fail to compile or its assertions
+/// will drift visibly.
+fn vtc_service_test_cors_layer(cors: &CorsConfig) -> tower_http::cors::CorsLayer {
+    use axum::http::Method;
+    use axum::http::header::{
+        ACCESS_CONTROL_ALLOW_HEADERS, AUTHORIZATION, CONTENT_TYPE, HeaderName, HeaderValue,
+    };
+
+    if cors.allowed_origins.is_empty() {
+        return tower_http::cors::CorsLayer::new();
+    }
+
+    let allowed_origins: Vec<HeaderValue> = cors
+        .allowed_origins
+        .iter()
+        .filter_map(|o| o.parse::<HeaderValue>().ok())
+        .collect();
+
+    tower_http::cors::CorsLayer::new()
+        .allow_origin(allowed_origins)
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([
+            AUTHORIZATION,
+            CONTENT_TYPE,
+            ACCESS_CONTROL_ALLOW_HEADERS,
+            HeaderName::from_static("trust-task"),
+            HeaderName::from_static("idempotency-key"),
+        ])
+        .allow_credentials(true)
+}
+
+#[tokio::test]
+async fn preflight_from_allowed_origin_returns_cors_headers() {
+    let cors = CorsConfig {
+        allowed_origins: vec!["https://admin.example.com".into()],
+    };
+    let (router, _dir) = build_router_with_cors(cors).await;
+
+    let req = Request::builder()
+        .method("OPTIONS")
+        .uri("/v1/admin/config")
+        .header("Origin", "https://admin.example.com")
+        .header("Access-Control-Request-Method", "PATCH")
+        .header(
+            "Access-Control-Request-Headers",
+            "Authorization, Trust-Task",
+        )
+        .body(Body::empty())
+        .unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let headers = resp.headers();
+    assert_eq!(
+        headers.get("Access-Control-Allow-Origin").unwrap(),
+        "https://admin.example.com",
+    );
+    let allow_headers = headers
+        .get("Access-Control-Allow-Headers")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_lowercase();
+    assert!(allow_headers.contains("authorization"));
+    assert!(allow_headers.contains("trust-task"));
+    assert!(allow_headers.contains("idempotency-key"));
+    assert_eq!(
+        headers.get("Access-Control-Allow-Credentials").unwrap(),
+        "true",
+    );
+}
+
+#[tokio::test]
+async fn preflight_from_disallowed_origin_omits_cors_headers() {
+    let cors = CorsConfig {
+        allowed_origins: vec!["https://admin.example.com".into()],
+    };
+    let (router, _dir) = build_router_with_cors(cors).await;
+
+    let req = Request::builder()
+        .method("OPTIONS")
+        .uri("/v1/admin/config")
+        .header("Origin", "https://attacker.example.com")
+        .header("Access-Control-Request-Method", "PATCH")
+        .body(Body::empty())
+        .unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+    let headers = resp.headers();
+
+    // tower-http's CORS layer omits the allow-origin header for
+    // non-matching origins; the browser's same-origin policy turns
+    // that into a CORS error in the JS console.
+    assert!(
+        !headers.contains_key("Access-Control-Allow-Origin"),
+        "headers leaked: {:?}",
+        headers
+    );
+}
+
+#[tokio::test]
+async fn empty_allowlist_disables_cors_headers() {
+    let (router, _dir) = build_router_with_cors(CorsConfig::default()).await;
+
+    let req = Request::builder()
+        .method("OPTIONS")
+        .uri("/v1/admin/config")
+        .header("Origin", "https://admin.example.com")
+        .header("Access-Control-Request-Method", "PATCH")
+        .body(Body::empty())
+        .unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+    let headers = resp.headers();
+    assert!(!headers.contains_key("Access-Control-Allow-Origin"));
+}
+
+#[tokio::test]
+async fn actual_get_from_allowed_origin_carries_cors_response_header() {
+    let cors = CorsConfig {
+        allowed_origins: vec!["https://admin.example.com".into()],
+    };
+    let (router, _dir) = build_router_with_cors(cors).await;
+
+    // Hit `/health` — no auth, no Trust-Task gate, just the
+    // catch-all GET. The CORS layer should attach the
+    // `Access-Control-Allow-Origin` response header so the browser
+    // accepts the response.
+    let req = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .header("Origin", "https://admin.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("Access-Control-Allow-Origin").unwrap(),
+        "https://admin.example.com",
+    );
+
+    // Sanity: body still rendered.
+    let _ = resp.into_body().collect().await.unwrap();
+}


### PR DESCRIPTION
## Summary

Closes **M0.11**. Adds the routing + CORS hardening surface called
for by spec §9.2 + §9.3. The daemon now refuses obviously-broken
configs at startup and serves a proper CORS layer with a strict
allowlist.

## Config additions

- **\`RoutingConfig\`** (\`api\`, \`admin_ui\`, \`website\`) — each a
  \`MountConfig { mount, host: Option<String> }\`. Path-prefix
  defaults: \`/v1\`, \`/admin\`, \`/\`. Subdomain mode is accepted by
  the parser but not driven by any Phase-0 route code; the slot
  reserves the path so cookie scopes can't collide later.
- **\`CorsConfig\`** (\`allowed_origins: Vec<String>\`). Empty list
  disables CORS entirely (same-origin only — fine for path-mode
  deployments serving the admin UX same-origin).

## Config-load validation

\`AppConfig::validate_routing_and_cors\` (called by \`load\` +
\`save\`) refuses at startup:

- Mounts that don't start with \`/\`.
- Duplicate path mounts (two surfaces sharing the same prefix in
  path mode).
- **\`admin_ui.mount = \"/\"\` in path mode** — cookie-scope guard,
  so \`Path=/admin\` doesn't collapse to \"any path\" once a session
  cookie lands.
- CORS wildcards (\`*\`, partial \`https://*.example.com\`).
- CORS entries with no scheme or empty / whitespace.

## CORS layer

\`server::build_cors_layer\` builds a \`tower-http\` \`CorsLayer\`
from the config:

- \`allow_origin\` mirroring each entry literally.
- Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS.
- Headers: Authorization, Content-Type, **Trust-Task**,
  **Idempotency-Key**, Access-Control-Allow-Headers.
- \`allow_credentials = true\` (for the future admin session
  cookie).

Empty allowlist returns the default \`CorsLayer::new()\` — no CORS
headers attached, same-origin only.

## Test plan

- [x] \`cargo test --package vtc-service\` — **184 tests pass**
  (169 before this PR). 15 new integration tests in
  \`tests/routing_cors.rs\`:
  - 5 routing validators
  - 6 CORS validators
  - 4 CORS wire tests (preflight pass, preflight rejected for
    disallowed origin, empty allowlist disables, actual GET
    carries allow-origin response header)
- [x] \`cargo fmt --check\` clean.
- [x] \`cargo clippy --workspace --lib\` clean.

## What's deferred

- \`Sec-Fetch-Site\` / CSRF double-submit cookie middleware sits
  on top of the future admin session cookie; lands when the cookie
  does (Phase 1+).
- Mount-driven re-routing — the routes are still at the existing
  \`/v1/*\` regardless of \`RoutingConfig\`. The admin SPA + public
  website don't have content to serve yet; when they do (Phase 5)
  the route table dispatches by the configured mounts.

## Phase 0 status

| | Milestone | Status |
|---|---|---|
| | M0.1–M0.8.*, M0.9.1 | All merged |
| | **M0.11 — routing + CORS** | **PR #67 (in review)** |
| | M0.9.2 — new vtc setup wizard | Not started |
| | M0.9.3 — legacy setup deletion | Not started |
| | M0.10 — emergency bootstrap CLI | Not started |
| | M0.12 — install-flow integration tests | Not started |

With M0.11 done the daemon's wire surface meets Phase 0's
hardening bar. M0.12 (the install-flow integration test that is
the Phase-0 gate) is unblocked.