### PR TITLE
docs(vtc-mvp): close out M0.12.3 — Phase 0 gate green

### DIFF
--- a/tasks/vtc-mvp/todo.md
+++ b/tasks/vtc-mvp/todo.md
@@ -1104,23 +1104,22 @@ everything the new path replaces.
     driver test doesn't need OS keyring access.
 - **Deps**: M0.10.1, M0.12.1
 
-### `[ ]` M0.12.3 — Workspace gate green
+### `[x]` M0.12.3 — Workspace gate green
 
-- **Acceptance**
-  - `cargo build --workspace` green
-  - `cargo test --workspace` green
-  - `cargo clippy --workspace -- -D warnings` clean
-  - `cargo fmt --check` clean
-  - `trust-tasks/index.json` lists every Phase-0 Trust Task in
-    `Draft` status with corresponding `spec.md` + `schema.json` on
-    disk
-  - Memory entry `project_vtc_mvp.md` updated with any tweaks
-    discovered during implementation
-- **Verify** CI green on the merge commit
-- **Files**
-  - `trust-tasks/index.json`
-  - `/Users/glenngore/.claude/projects/-Users-glenngore-devel-fpp-verifiable-trust-infrastructure/memory/project_vtc_mvp.md`
-- **Deps**: M0.12.1, M0.12.2
+Closed 2026-05-12.
+
+- `cargo build --workspace` green ✓
+- `cargo test --workspace` green ✓ (>500 tests across the
+  workspace; no failures)
+- `cargo clippy --workspace --all-targets -- -D warnings` clean ✓
+- `cargo fmt --check` clean ✓
+- `trust-tasks/index.json` lists 20 Phase-0 Trust Tasks in
+  `Draft` status; each has matching `spec.md` + `schema.json`
+  files on disk ✓ (the new `did:webvh` log route `GET
+  /v1/{scid}/did.jsonl` is intentionally Trust-Task-exempt
+  following the same pattern as `/health`).
+- Memory entry `project_vtc_mvp.md` updated with the
+  VTA-driven-keys rework + Phase 0 completion note ✓.
 
 ### Checkpoint E — Phase 0 gate met
 After M0.12.1–M0.12.3: full install flow runs through


### PR DESCRIPTION
## Summary

Closes **M0.12.3** — the final Phase 0 milestone. Verifies the
workspace gate, flips the todo, captures the implementation
notes that landed in the memory entry.

**Phase 0 closes with this PR.**

## Gate verification

All four cargo gates pass on `main` after PRs #67–#71:

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 44 test-result lines, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Trust Task surface:
- 20 entries in `trust-tasks/index.json`, all `Draft`.
- 20 directories under `trust-tasks/<task>/1.0/` on disk, each
  with `spec.md` + `schema.json`.
- 1:1 match between the index and on-disk files.
- The new `GET /v1/{scid}/did.jsonl` did-log route is
  intentionally Trust-Task-exempt (same pattern as `/health` —
  DID resolvers don't carry our extension header).

## Memory entry

`project_vtc_mvp.md` updated outside the repo (lives under
`~/.claude/projects/...`):
- Emergency bootstrap invariant rewritten to reflect the
  VTA-`AdminRotated`-based recovery from PR-B (was: "requires
  the master seed mnemonic"; now: gated on the operator's
  VTA-side admin credential).
- New implementation-notes bullets covering VTA-as-sole-key-
  authority, did:webvh log publication on the VTC, the 5-prompt
  wizard, and the `vti-common::setup::secrets_prompt` helper.
- Phase 0 completion note at the bottom.

## Phase 0 retrospective

Milestones that landed in this Phase 0:

| Milestone | Status |
|---|---|
| M0.1.* hygiene primitives (`vti-common`) | shipped |
| M0.2.* vtc-host DID template | shipped |
| M0.3.* `/v1/` migration + Trust-Task wiring | shipped |
| M0.4.* install token + carve-out | shipped |
| M0.5.* WebAuthn claim flow | shipped |
| M0.6.* admin bootstrap + multi-passkey | shipped |
| M0.7.* community profile | shipped |
| M0.8.* config plumbing + supervisor | shipped |
| M0.9.* CLI setup wizard rewrite | shipped (PRs A + B) |
| M0.10 emergency bootstrap | reworked (VTA-credential-based) |
| M0.11.* routing + CORS | shipped |
| M0.12.* install-flow gate tests + workspace gate | shipped |

Spec amendments during implementation captured in
`tasks/vtc-mvp/vta-driven-keys.md`.

Phase 1 (IAM + member lifecycle — manual approval, no-last-admin,
admin promotion separate path) can start.

## Test plan

- [x] All four cargo gates pass locally
- [ ] CI green on the merge commit