### PR TITLE
plan(vtc-mvp): Phase 1 — IAM + member lifecycle (planning artefact)

### DIFF
--- a/tasks/vtc-mvp/phase-1-plan.md
+++ b/tasks/vtc-mvp/phase-1-plan.md
@@ -1,0 +1,337 @@
+# VTC MVP — Phase 1 plan
+
+> **Status:** draft, awaiting review.
+> **Deliverable:** "Members can exist." Per spec §16 Phase 1:
+> Role enum + custom roles, ACL extension, member CRUD with manual
+> approval, self/admin removal (no-last-admin), audit envelope
+> events for the new surface.
+> **Spec:** `docs/05-design-notes/vtc-mvp.md` §§5.2–5.5, §10.1–10.4.
+
+## Objective
+
+After Phase 1, a freshly-bootstrapped VTC daemon can:
+
+- Accept VP-framed `POST /v1/join-requests` from an applicant DID.
+- Persist the request; an admin lists pending requests, approves
+  or rejects, and on approval the applicant's DID is admitted to
+  the ACL with the default `Member` role and a `members:<did>`
+  metadata row.
+- Surface `GET / PATCH /v1/members[/{did}]` so admins can read +
+  edit member metadata, with role changes (except to `Admin`)
+  applied via PATCH.
+- Promote an existing member to `Admin` via the separate
+  `POST /v1/members/{did}/promote-to-admin` endpoint, gated by
+  a step-up WebAuthn UV ceremony.
+- Process self-removal (`DELETE /v1/members/me`) and admin removal
+  (`DELETE /v1/members/{did}`), with the no-last-admin invariant
+  enforced under fjall CAS.
+- Emit `JoinRequestSubmitted`, `JoinRequestApproved`,
+  `JoinRequestRejected`, `MemberAdded`, `MemberRemoved`,
+  `AdminPromoted`, `RoleChanged` audit envelopes.
+
+Out of scope (deferred to Phase 2+):
+
+- `regorus` policy engine, `join.rego` / `removal.rego` evaluation.
+  Phase 1 join is **manual admin approval**; the VP's claims are
+  recorded as opaque JSON on the JoinRequest for Phase 2 to score.
+- VMC + role VEC issuance via the VTA oracle.
+- Status-list allocation + flipping.
+- DID rotation (both methods).
+- Personhood; cross-community recognition; trust-registry sync.
+
+## Scope (per spec §16, Phase 1 row)
+
+### In scope
+
+- **Role enum extension.** `vti_common::acl::Role` cannot grow VTC-
+  specific variants without leaking into VTA — see **D1**. Per
+  service, the role taxonomy is service-owned; vtc-service gets a
+  `VtcRole` enum mirrored on the AclEntry shape it stores under
+  `acl:<did>`.
+- **ACL extension.** Phase 0's M0.6.1 stored admin metadata in a
+  **sister record** under `admin:<did>` (since the shared
+  `AclEntry.role` field was a `vti_common::acl::Role` and couldn't
+  carry VTC-specific values). Phase 1 collapses that — see **D2**.
+- **Member model** (`members:<did>`) — fields per spec §5.2 minus
+  the Phase 2 credential pointers (`status_list_index`,
+  `current_vmc_id`, `current_role_vec_id` ship as `Option<T>` slots
+  populated by Phase 2 work).
+- **JoinRequest model** (`join_requests:<id>`) + 30-day retention
+  sweeper.
+- **REST surface** for member CRUD + join requests + removal +
+  admin promotion.
+- **DIDComm twin** for the applicant-facing join-request submit
+  endpoint — see **D5**.
+- **Audit envelope events** for every state mutation on this
+  surface.
+- **Trust Task** stable IDs + `spec.md` + `schema.json` for every
+  new endpoint.
+
+### Out of scope
+
+Everything in spec §16 Phase 2 and later. The Phase 0 hygiene
+items the §16 table parks under Phase 1 (audit envelope, HMAC,
+idempotency, `/v1/` versioning, cursor pagination) **already
+shipped** in Phase 0 as M0.1.* and don't re-land here.
+
+## Pre-implementation design decisions
+
+These are **load-bearing** — Phase 1's whole shape depends on
+them. Proposed defaults below. Flag dissent before any code lands.
+
+### D1 — Role enum location
+
+Two options for extending the role taxonomy:
+
+- **(a)** Move VTC-specific variants into `vtc-service`. The shared
+  `vti_common::acl::AclEntry` becomes generic over a service-owned
+  role type (or vtc-service stops using vti_common's AclEntry and
+  ships its own). VTA-side roles stay where they are.
+- **(b)** Add `Moderator`, `Issuer`, `Member`, `Custom(String)`
+  to the shared `vti_common::acl::Role` enum. VTA ignores those
+  variants by documentation.
+
+**Proposed default: (a).** Cleanest separation; VTA doesn't
+inherit roles it has no semantics for; the `Role::Custom(String)`
+variant is genuinely community-specific and shouldn't pollute
+VTA. Implementation: vtc-service gets `vtc_service::acl::VtcRole`
+and a parallel `VtcAclEntry` that wraps it, replacing the
+vti-common-rooted `AclEntry` for VTC-facing storage. VTA-side
+storage uses vti-common as before.
+
+### D2 — AdminEntry → AclEntry unification
+
+Phase 0 shipped `AdminEntry` as a sister record under
+`admin:<did>` in the passkey keyspace because the shared
+`AclEntry.role` couldn't carry VTC-specific values. After D1, the
+VTC's AclEntry can grow `passkeys: Vec<RegisteredPasskey>`
+directly — at which point `admin:<did>` is dead weight.
+
+**Proposed default: collapse, but only at the role level.** Move
+the role enum into the unified `VtcAclEntry`. **Keep passkeys in
+their own sister record** — they're admin-only metadata with
+distinct ownership (the passkey routes manage them, not the
+member-CRUD routes) and bloating every `AclEntry` lookup with
+a passkey list is wasteful when most rows aren't admins. The
+sister record stays under `admin:<did>` but loses its role field
+(role is now canonically on the AclEntry).
+
+### D3 — Member vs AclEntry
+
+Spec §5.2's `Member` carries `joined_at`, `status_list_index`,
+`publish_consent`, `departure_preference`, etc. — much richer than
+`AclEntry`'s auth-gate role + label.
+
+**Proposed default: separate keyspaces.** `acl:<did>` (auth) and
+`members:<did>` (community-membership metadata) are 1:1 by DID
+but logically distinct. Hash-only joins via the DID. Creating
+the Member record is one atomic transaction with the ACL row
+write; deletion is the same — `MemberRemoved` audit fires on the
+last delete of the pair.
+
+### D4 — JoinRequest VP shape
+
+Without `regorus` (Phase 2), the join VP can carry whatever the
+applicant wants — Phase 1 has no policy to score it against.
+
+**Proposed default: Phase 1 requires only the holder-binding
+proof.** The VP's `holder` must match `applicant_did`; the VP
+signature must verify. Any additional VC content the VP includes
+is recorded **verbatim as opaque JSON** on the JoinRequest record
+so Phase 2's policy step has the input it needs without an
+intermediate re-submit. PII concern noted (spec §5.5) — same
+30-day retention rule applies regardless of VP content shape.
+
+### D5 — DIDComm vs REST surface
+
+The §16 Phase 1 row implicitly asks for DIDComm parity. Spec §4.3
+explicitly forbids passkey ops over DIDComm; the rest of the
+surface is open.
+
+**Proposed default: DIDComm only for applicant-facing endpoints.**
+
+| Endpoint | REST | DIDComm |
+|---|---|---|
+| `POST /v1/join-requests` | ✓ | ✓ |
+| `GET / PATCH / DELETE /v1/members[/{did}]` | ✓ | — |
+| `POST /v1/members/{did}/promote-to-admin` | ✓ | — |
+| `GET / POST /v1/join-requests/{id}/{approve,reject}` | ✓ | — |
+| `DELETE /v1/members/me` | ✓ | ✓ |
+
+Rationale: admins typically operate via the admin UX (web/REST);
+applicants and self-removing members frequently come from
+wallets (DIDComm). The asymmetric scope avoids building DIDComm
+admin twins that nobody actually uses in Phase 1.
+
+### D6 — Removal disposition default
+
+Spec §5 lists `Purge | Tombstone | Historical | PolicyDefault`.
+`PolicyDefault` resolves via `removal.rego`'s
+`min_disposition` output — Phase 2.
+
+**Proposed default: `PolicyDefault → Tombstone` in Phase 1.** The
+boring middle ground (member record anonymised, audit retained).
+Operators explicitly picking `Purge` or `Historical` get that
+behavior. Phase 2 swaps the resolver to read
+`removal.rego.min_disposition`.
+
+### D7 — Trust Task ID naming for the new surface
+
+Following the Phase 0 pattern (stable IDs from day one, soft gate
+on the `Draft` status):
+
+| Operation | Trust Task ID |
+|---|---|
+| Submit join request | `https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0` |
+| List join requests (admin) | `…/join-requests/list/1.0` |
+| Show join request | `…/join-requests/show/1.0` |
+| Approve | `…/join-requests/approve/1.0` |
+| Reject | `…/join-requests/reject/1.0` |
+| List members | `…/members/list/1.0` |
+| Show member | `…/members/show/1.0` |
+| Update member | `…/members/update/1.0` |
+| Self-remove | `…/members/self-remove/1.0` |
+| Admin remove | `…/members/admin-remove/1.0` |
+| Promote to admin | `…/members/promote-to-admin/1.0` |
+
+### D8 — Member ID — DID vs UUID
+
+Spec §5.2 doesn't pin this. PR-A of Phase 0 used DIDs as primary
+keys throughout (`acl:<did>`, `admin:<did>`). Phase 1's
+JoinRequest needs an ID before the DID is admitted; that ID has
+to be a UUID (or similar opaque token).
+
+**Proposed default**: DIDs as primary keys for `members:` (the
+DID is the stable identifier); UUIDs for `join_requests:` (no DID
+binding until approval). The applicant_did **does** appear inside
+the JoinRequest payload, but the row's key stays UUID-shaped.
+
+## Dependency graph
+
+```
+M1.1 Role enum extension (vtc_service::acl::VtcRole)
+  │
+  ▼
+M1.2 ACL unification (drop AdminEntry sister role field)
+  │     [parallel: M1.3 Member model]
+  ▼
+M1.3 Member model + members keyspace + CRUD primitives
+  │
+  ▼
+M1.4 GET /v1/members + /v1/members/{did}
+M1.5 PATCH /v1/members/{did} (role change, profile edit)
+M1.6 POST /v1/members/{did}/promote-to-admin (step-up UV)
+  │
+  │     [parallel: M1.7 JoinRequest model]
+  ▼
+M1.7 JoinRequest model + keyspace + retention sweeper
+  │
+  ▼
+M1.8 POST /v1/join-requests (REST + DIDComm)
+M1.9 GET /v1/join-requests + /v1/join-requests/{id}
+M1.10 POST /v1/join-requests/{id}/{approve,reject}
+  │
+  ▼
+M1.11 DELETE /v1/members/me (REST + DIDComm, no-last-admin)
+M1.12 DELETE /v1/members/{did} (REST only, no-last-admin)
+  │
+  ▼
+M1.13 Audit event variants for Phase 1 surface
+M1.14 Trust Task spec.md + schema.json for every new endpoint
+  │
+  ▼
+M1.15 Phase 1 gate (workspace green + memory updated)
+```
+
+Strict dependency order: M1.1 → M1.2 (both touch ACL). M1.3 can
+start in parallel with M1.2 (separate keyspace). The member-CRUD
+endpoints (M1.4–M1.6) need M1.2 + M1.3 done. JoinRequest
+endpoints (M1.7–M1.10) need M1.3 done for the approval path. The
+removal endpoints (M1.11–M1.12) need M1.4–M1.6 in tree (they
+share the member-CRUD primitives). Audit + Trust Task work
+trails behind the endpoints.
+
+## Parallelisation strategy
+
+Within a milestone, vertical slice — each endpoint ships with its
+trust task files + integration tests + audit emission, not in
+batches.
+
+Cross-milestone parallel tracks:
+- **M1.2 + M1.3** can run in parallel after M1.1.
+- **M1.5 + M1.6** can run in parallel after M1.4.
+- **M1.8 + M1.9 + M1.10** can run in parallel after M1.7.
+- **M1.11 + M1.12** can run in parallel after M1.6 (different
+  no-last-admin CAS shapes, but same primitive).
+- **M1.13 + M1.14** can run in parallel after every endpoint is
+  in tree.
+
+Phase 1 splits cleanly into ~3 PR batches:
+1. **PR-1**: M1.1 + M1.2 + M1.3 (foundation — Role + ACL + Member).
+2. **PR-2**: M1.4–M1.6 (member CRUD + admin promotion).
+3. **PR-3**: M1.7–M1.10 (join requests).
+4. **PR-4**: M1.11 + M1.12 (removal).
+5. **PR-5**: M1.13 + M1.14 + M1.15 (audit + trust tasks + gate).
+
+5 PRs feels about right for the scope. Phase 0 was 12 PRs across
+12 milestones; Phase 1's 15 milestones bundle more cleanly because
+the dependency graph is shallower.
+
+## Checkpoints
+
+After each PR batch, a "smoke" sanity check that doesn't require
+the next batch to land:
+
+- **After PR-1**: `cargo test -p vtc-service` green. AdminEntry's
+  role field gone; passkey routes still pass. No new endpoint.
+- **After PR-2**: list/show/update + admin promotion green;
+  step-up UV works against the existing passkey state.
+- **After PR-3**: applicant can submit (REST + DIDComm); admin
+  can approve → ACL row + Member row + audit envelope all land.
+- **After PR-4**: no-last-admin invariant tested under
+  concurrent removal attempts (mutex shape mirrors
+  ADMIN_PASSKEY_LOCK).
+- **After PR-5**: M1.15 workspace gate identical to M0.12.3's
+  pattern. Phase 1 closes.
+
+## Risks
+
+- **R1: AclEntry migration breaks Phase 0 fixtures.** Every
+  integration test in vtc-service stages an AclEntry today. M1.2
+  changes the shape. Need a migration helper + fixture flip in
+  the same PR (PR-1).
+- **R2: DIDComm twin scope creep.** Spec §16 Phase 1 says "member
+  CRUD" without specifying transport. D5 restricts DIDComm to
+  applicant-facing endpoints. Operator UX may push for DIDComm
+  admin variants — defer to Phase 1.5 if surfaced.
+- **R3: No-last-admin CAS correctness.** Mutex covers single-
+  process; fjall isn't multi-process-safe (architectural
+  invariant per project memory). Single-process is fine but
+  document the assumption.
+- **R4: VP verification dep choice.** JoinRequest VP signatures
+  need a verifier. PR-A of Phase 0 used `affinidi-data-integrity`
+  via vta-sdk's provision-integration path. Phase 1 should reuse
+  the same verifier rather than introduce a parallel one — pin
+  this in M1.8 implementation.
+- **R5: `audit_key` rotation under member churn.** Phase 0
+  baseline rotates on RTBF. Phase 1's removal paths trigger that;
+  make sure the rotation hook actually fires when removal
+  disposition is `Purge`.
+
+## Definition of done — Phase 1
+
+After M1.15:
+
+- `cargo build/clippy/fmt/test --workspace` clean.
+- 11 new Trust Tasks (D7) in `Draft` status with matching
+  `spec.md` + `schema.json` files.
+- Every Phase 1 milestone marked `[x]` in `phase-1-todo.md`.
+- Memory entry `project_vtc_mvp.md` updated with any
+  implementation-time tweaks discovered along the way (mirrors
+  Phase 0's pattern).
+- Integration tests cover: applicant join → admin approve → ACL +
+  Member row written → self-remove with no-last-admin protection
+  → admin promotion with step-up UV.
+
+Phase 2 (policy engine + VMC/VEC issuance + status list) can
+start after Phase 1's gate merges.

--- a/tasks/vtc-mvp/phase-1-todo.md
+++ b/tasks/vtc-mvp/phase-1-todo.md
@@ -1,0 +1,485 @@
+# Todo: VTC MVP — Phase 1
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done · `[!]` blocked
+
+Each task lists: **acceptance** (what must be true), **verify** (how
+to prove it), **files** (what's touched), **deps** (which task IDs
+must land first). Tasks within a milestone that share `deps` can run
+in parallel.
+
+Spec: `docs/05-design-notes/vtc-mvp.md` §§5.2–5.5, §10.1–10.4
+Plan: `tasks/vtc-mvp/phase-1-plan.md`
+
+Every code task also drafts the matching Trust Task spec
+(`trust-tasks/.../spec.md` + `schema.json`) in the same PR — soft
+gate per spec §9.4. Trust Task IDs per phase-1-plan §D7.
+
+Every PR must be DCO-signed (`git commit -s`) and pass
+`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`.
+
+---
+
+## M1.1 — Role enum extension (`vtc-service::acl::VtcRole`)
+
+### `[ ]` M1.1.1 — Introduce `VtcRole`
+
+- **Acceptance**
+  - New enum `vtc_service::acl::VtcRole { Admin, Moderator, Issuer,
+    Member, Custom(String) }`. `Serialize`/`Deserialize` use
+    `#[serde(tag = "type", content = "value")]` so custom values
+    don't collide with the named variants on the wire.
+  - `From<vti_common::acl::Role>` + `TryInto<vti_common::acl::Role>`
+    helpers so the existing ACL helpers can keep working during the
+    PR-1 transition.
+  - 100% unit coverage on every variant + a snapshot test of the
+    wire shape.
+- **Verify** `cargo test --package vtc-service acl::role::` green.
+- **Files**
+  - `vtc-service/src/acl/role.rs` (new)
+  - `vtc-service/src/acl/mod.rs` (re-export `VtcRole`)
+- **Deps**: none
+- **Pre-impl decision**: **D1** (role enum location — vtc-service-
+  owned per the plan).
+
+---
+
+## M1.2 — ACL unification
+
+### `[ ]` M1.2.1 — `VtcAclEntry` + storage CRUD
+
+- **Acceptance**
+  - New struct `vtc_service::acl::VtcAclEntry { did, role: VtcRole,
+    label, allowed_contexts, created_at, created_by, expires_at }`
+    replacing `vti_common::acl::AclEntry` for vtc-side storage.
+  - Helpers: `store_acl_entry`, `get_acl_entry`, `list_acl_entries`,
+    `delete_acl_entry` (per-DID CRUD over `acl:<did>` key shape).
+  - Pagination via `vti_common::pagination::Cursor`.
+  - Backwards-compat decode: existing on-disk rows that carry a
+    `vti_common::acl::Role::Admin` value continue to decode to
+    `VtcRole::Admin` without migration. Other variants
+    (`Initiator`, `Application`, `Reader`) currently don't appear
+    in VTC ACL rows, but the decoder rejects them with a clear
+    error pointing at the spec.
+- **Verify**
+  - Round-trip every `VtcRole` variant through store + list.
+  - A row written by the Phase 0 `vti_common::acl::store_acl_entry`
+    (with `Role::Admin`) decodes via the new
+    `get_acl_entry` without panic.
+- **Files**
+  - `vtc-service/src/acl/entry.rs` (new — `VtcAclEntry`)
+  - `vtc-service/src/acl/storage.rs` (new — CRUD over the new shape)
+  - `vtc-service/src/acl/mod.rs`
+- **Deps**: M1.1.1
+- **Pre-impl decision**: **D2** (admin sister record loses role
+  field; passkeys stay where they are).
+
+### `[ ]` M1.2.2 — Wire `VtcAclEntry` everywhere
+
+- **Acceptance**
+  - Every consumer of `vti_common::acl::store_acl_entry`,
+    `get_acl_entry`, `list_acl_entries`, `delete_acl_entry` in
+    `vtc-service` switches to the new `vtc_service::acl::storage::*`
+    helpers.
+  - `admin/passkeys/*` keeps its sister-record lookups; just stops
+    treating the sister record's role as authoritative.
+  - All admin bootstrap tests + admin passkey tests + emergency
+    bootstrap tests stage `VtcAclEntry` instead of
+    `vti_common::acl::AclEntry`.
+- **Verify** Existing vtc-service tests green after the swap.
+- **Files**
+  - `vtc-service/src/routes/install.rs`
+  - `vtc-service/src/routes/admin/bootstrap.rs`
+  - `vtc-service/src/routes/admin/passkeys.rs`
+  - `vtc-service/src/emergency.rs`
+  - Every `vtc-service/tests/*.rs` fixture
+- **Deps**: M1.2.1
+
+---
+
+## M1.3 — Member model + keyspace
+
+### `[ ]` M1.3.1 — `Member` struct + `members` keyspace
+
+- **Acceptance**
+  - `vtc_service::members::Member { did, joined_at, status_list_index:
+    Option<u32>, publish_consent: bool, departure_preference:
+    Disposition, current_vmc_id: Option<String>, current_role_vec_id:
+    Option<String>, extensions: JsonValue }` per spec §5.2.
+  - `extensions` capped at 16 KiB (D4 from M0.7.1).
+  - New `members` keyspace registered in `AppState`.
+  - CRUD helpers: `store_member`, `get_member`, `list_members`
+    (paginated), `delete_member`.
+  - `Disposition` enum: `{ Purge, Tombstone, Historical, PolicyDefault }`.
+- **Verify** Round-trip every disposition + `extensions` size-limit test.
+- **Files**
+  - `vtc-service/src/members/mod.rs` (new)
+  - `vtc-service/src/members/storage.rs` (new)
+  - `vtc-service/src/server.rs` (AppState gains `members_ks`)
+  - `vtc-service/src/store/mod.rs` (register keyspace)
+- **Deps**: M1.1.1 (uses `VtcRole`)
+- **Pre-impl decision**: **D3** (separate keyspaces from ACL).
+
+---
+
+## M1.4 — Member read endpoints
+
+### `[ ]` M1.4.1 — `GET /v1/members` + `GET /v1/members/{did}`
+
+- **Acceptance**
+  - List endpoint returns a `Paginated<Member>` using the cursor
+    primitive. Filter params: `?role=Admin|Moderator|...` (server-
+    side filter against the ACL join), `?cursor=...`, `?limit=...`
+    (1..200 clamp).
+  - Show endpoint returns the `Member` row + the matching
+    `VtcAclEntry` for the same DID (joined response shape).
+  - Auth: any authenticated session can list/show. Phase 1 has no
+    privacy gating beyond auth; spec §12.3 PMF lands in Phase 2+.
+  - Trust Task IDs: `members/list/1.0`, `members/show/1.0`.
+- **Verify**
+  - Integration tests: list returns seeded members, cursor walks
+    correctly, show returns 404 for non-members.
+- **Files**
+  - `vtc-service/src/routes/members/mod.rs` (new)
+  - `vtc-service/src/routes/members/read.rs` (new)
+  - `vtc-service/src/routes/mod.rs` (mount + Trust Tasks)
+  - `trust-tasks/members/list/1.0/{spec.md,schema.json}`
+  - `trust-tasks/members/show/1.0/{spec.md,schema.json}`
+- **Deps**: M1.3.1
+
+---
+
+## M1.5 — Member update
+
+### `[ ]` M1.5.1 — `PATCH /v1/members/{did}` (role + profile)
+
+- **Acceptance**
+  - Body shape: `{ role?: VtcRole, publish_consent?: bool,
+    departure_preference?: Disposition, extensions?: JsonValue }`.
+  - Refuses any `role` patch where the requested value is
+    `VtcRole::Admin` — return 422 `AdminPromotionRequiresStepUp`
+    with a hint pointing at `POST /v1/members/{did}/promote-to-admin`.
+  - Auth: caller role ≥ `Moderator` for role changes; caller role ≥
+    `Moderator` or `caller_did == did` for profile-only patches.
+  - On success: ACL row + Member row updated under a single fjall
+    transaction; emits `RoleChanged` (if role changed) or
+    `MemberUpdated` (profile-only). 
+  - Trust Task ID: `members/update/1.0`.
+- **Verify** Integration tests cover happy path + role=Admin
+  refusal + non-self profile patch from a non-admin (403) + concurrent
+  PATCH under the per-DID CAS lock.
+- **Files**
+  - `vtc-service/src/routes/members/update.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/members/update/1.0/{spec.md,schema.json}`
+- **Deps**: M1.4.1
+
+---
+
+## M1.6 — Admin promotion (step-up UV)
+
+### `[ ]` M1.6.1 — `POST /v1/members/{did}/promote-to-admin`
+
+- **Acceptance**
+  - Two-phase ceremony mirroring `admin/passkeys/register/{start,finish}`:
+    - `start` returns a UV challenge against the caller's existing
+      passkey.
+    - `finish` verifies UV → atomically promotes the target DID's
+      ACL role to `VtcRole::Admin`, copies the new admin DID into
+      the passkey keyspace's sister record (empty `passkeys` list
+      so the new admin enrols their device next), emits
+      `AdminPromoted`.
+  - Refused if the caller is not already an admin (403).
+  - Refused if the target is not a current Member (404).
+  - Refused if the target is already an admin (409).
+  - Trust Task ID: `members/promote-to-admin/1.0`.
+- **Verify**
+  - Integration tests: happy path with step-up UV; refusals for
+    non-admin caller, non-member target, already-admin target;
+    audit envelope shape verified.
+- **Files**
+  - `vtc-service/src/routes/members/promote.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/members/promote-to-admin/1.0/{spec.md,schema.json}`
+- **Deps**: M1.4.1, M1.2.2 (touches AclEntry + passkey sister record)
+
+---
+
+## M1.7 — JoinRequest model + retention
+
+### `[ ]` M1.7.1 — `JoinRequest` struct + `join_requests` keyspace
+
+- **Acceptance**
+  - `vtc_service::join::JoinRequest { id: Uuid, applicant_did, vp:
+    JsonValue, submitted_at: DateTime<Utc>, status: JoinStatus,
+    policy_decision: Option<JsonValue>, registry_consent: bool,
+    extensions: JsonValue }` per spec §5.5.
+  - `JoinStatus`: `{ Pending, Approved, Rejected, Withdrawn, Deferred }`.
+  - CRUD helpers + paginated list with status filter.
+  - Retention sweeper task that prunes `Rejected` + `Withdrawn` rows
+    older than `config.join_requests.retention_days` (default 30).
+    Sweeper runs hourly on the daemon's tokio runtime.
+- **Verify**
+  - Round-trip every status variant.
+  - Retention sweeper test with seeded rows + clock injection.
+- **Files**
+  - `vtc-service/src/join/mod.rs` (new)
+  - `vtc-service/src/join/storage.rs` (new)
+  - `vtc-service/src/join/retention.rs` (new)
+  - `vtc-service/src/server.rs` (AppState gains `join_requests_ks`,
+    sweeper spawned at startup)
+  - `vtc-service/src/config.rs` (`JoinRequestsConfig` with
+    `retention_days`)
+- **Deps**: M1.3.1
+- **Pre-impl decision**: **D4** (VP shape — opaque JSON for Phase 1).
+
+---
+
+## M1.8 — Submit join request
+
+### `[ ]` M1.8.1 — `POST /v1/join-requests` (REST)
+
+- **Acceptance**
+  - Unauthenticated (rate-limited per spec §9 unauth-route policy).
+  - Body shape: `{ applicant_did, vp: JsonValue, registry_consent?:
+    bool, extensions?: JsonValue }`.
+  - Verifies the VP signature + that the VP's `holder` equals
+    `applicant_did` (D4 — holder-binding is the only check).
+  - Persists as `JoinStatus::Pending`; emits `JoinRequestSubmitted`
+    audit envelope.
+  - Idempotency-Key header honoured (24h cache for the non-
+    destructive request, per M0.1.3).
+  - Trust Task ID: `join-requests/submit/1.0`.
+- **Verify**
+  - Happy path; malformed VP rejected with 400; mismatched holder
+    rejected with 422.
+- **Files**
+  - `vtc-service/src/routes/join_requests/mod.rs` (new)
+  - `vtc-service/src/routes/join_requests/submit.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/join-requests/submit/1.0/{spec.md,schema.json}`
+- **Deps**: M1.7.1, M1.4.1
+
+### `[ ]` M1.8.2 — DIDComm twin for submit
+
+- **Acceptance**
+  - DIDComm message `type` =
+    `https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0`.
+  - Wallet sends an anoncrypt-packed envelope addressed to the
+    VTC DID; the VTC unpacks, runs the same handler shape as
+    REST, and replies with a `join-request-receipt` message
+    carrying the request UUID + status.
+  - The applicant_did MUST be the DIDComm `from` field (no
+    separate VP holder field needed — the DIDComm envelope
+    already binds the sender).
+- **Verify** End-to-end test against the existing DIDComm test
+  responder fixture (mirrors `vti-e2e-tests` pattern).
+- **Files**
+  - `vtc-service/src/messaging.rs` (handler dispatch)
+  - `vta-sdk/src/protocols/join_requests/mod.rs` (new wire types)
+- **Deps**: M1.8.1
+- **Pre-impl decision**: **D5** (DIDComm scope per-endpoint).
+
+---
+
+## M1.9 — Join request read endpoints (admin)
+
+### `[ ]` M1.9.1 — `GET /v1/join-requests` + `/v1/join-requests/{id}`
+
+- **Acceptance**
+  - List endpoint requires admin or moderator role; returns
+    `Paginated<JoinRequest>` filtered by `?status=Pending`
+    (default), other statuses available.
+  - Show endpoint requires admin or moderator role; returns the
+    full JoinRequest including the opaque VP.
+  - Trust Task IDs: `join-requests/list/1.0`,
+    `join-requests/show/1.0`.
+- **Verify** Integration tests: list filters by status, show 404s
+  for unknown ids, non-admin/mod returns 403.
+- **Files**
+  - `vtc-service/src/routes/join_requests/read.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/join-requests/list/1.0/{spec.md,schema.json}`
+  - `trust-tasks/join-requests/show/1.0/{spec.md,schema.json}`
+- **Deps**: M1.7.1
+
+---
+
+## M1.10 — Join request decision
+
+### `[ ]` M1.10.1 — `POST /v1/join-requests/{id}/{approve,reject}`
+
+- **Acceptance**
+  - Admin or moderator role required.
+  - **Approve**: atomically transitions JoinRequest status to
+    `Approved`, writes ACL row (`VtcRole::Member` default), writes
+    Member row, emits `JoinRequestApproved` + `MemberAdded`.
+    Refuses if the `applicant_did` already has an ACL row (409).
+  - **Reject**: transitions to `Rejected` with optional reason in
+    body; emits `JoinRequestRejected`.
+  - Idempotency-Key honoured (60s destructive-class TTL per M0.1.3).
+  - Trust Task IDs: `join-requests/approve/1.0`,
+    `join-requests/reject/1.0`.
+- **Verify**
+  - Happy path: pending → approved + ACL + Member written.
+  - Approve a request whose `applicant_did` already has an ACL
+    row → 409.
+  - Reject is a clean state transition with no ACL/Member writes.
+- **Files**
+  - `vtc-service/src/routes/join_requests/decide.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/join-requests/approve/1.0/{spec.md,schema.json}`
+  - `trust-tasks/join-requests/reject/1.0/{spec.md,schema.json}`
+- **Deps**: M1.9.1, M1.4.1
+
+---
+
+## M1.11 — Self-removal
+
+### `[ ]` M1.11.1 — `DELETE /v1/members/me` (REST + DIDComm)
+
+- **Acceptance**
+  - Authenticated caller's `did` is the target. Body shape:
+    `{ disposition: Purge | Tombstone | Historical | PolicyDefault }`
+    — default `PolicyDefault` which resolves to `Tombstone` in
+    Phase 1 per **D6**.
+  - **No-last-admin invariant**: if the caller is the sole
+    remaining admin, return 409 `LastAdminProtected`. Check inside
+    a fjall transaction protected by a process-wide
+    `LAST_ADMIN_LOCK` mutex (same shape as `ADMIN_PASSKEY_LOCK`).
+  - Atomic: ACL row deleted, Member row anonymised (Tombstone) or
+    purged (Purge) or retained (Historical); audit emits
+    `MemberRemoved`. Status-list index flipping is Phase 2 — for
+    now log a `TODO` line on the audit envelope.
+  - Trust Task ID: `members/self-remove/1.0`.
+- **Verify**
+  - Integration tests: happy paths for each disposition; sole-admin
+    self-removal returns 409; concurrent self-remove attempts
+    under the mutex.
+- **Files**
+  - `vtc-service/src/routes/members/remove.rs` (new)
+  - `vtc-service/src/messaging.rs` (DIDComm twin handler)
+  - `trust-tasks/members/self-remove/1.0/{spec.md,schema.json}`
+- **Deps**: M1.4.1
+- **Pre-impl decision**: **D6** (disposition default).
+
+---
+
+## M1.12 — Admin removal
+
+### `[ ]` M1.12.1 — `DELETE /v1/members/{did}` (REST only)
+
+- **Acceptance**
+  - Admin role required.
+  - Caller cannot remove themselves via this endpoint (use
+    `/members/me` for that — refused with 422 pointing there).
+  - Same no-last-admin invariant under the same `LAST_ADMIN_LOCK`.
+  - Body shape: `{ disposition?: Disposition, reason?: String }`.
+  - Effects identical to self-removal; audit envelope carries the
+    `admin_did` as actor + the target DID as resource.
+  - Trust Task ID: `members/admin-remove/1.0`.
+- **Verify**
+  - Happy path; remove-self refused; remove-last-admin refused;
+    audit envelope distinguishes admin removal from self-removal
+    via the `actor` vs `target` distinction.
+- **Files**
+  - `vtc-service/src/routes/members/remove.rs` (extended)
+  - `trust-tasks/members/admin-remove/1.0/{spec.md,schema.json}`
+- **Deps**: M1.11.1
+
+---
+
+## M1.13 — Audit event variants
+
+### `[ ]` M1.13.1 — Phase 1 audit event vocabulary
+
+- **Acceptance**
+  - `AuditEvent` enum (`vti_common::audit::envelope`) gains
+    variants: `JoinRequestSubmitted`, `JoinRequestApproved`,
+    `JoinRequestRejected`, `MemberAdded`, `MemberRemoved`,
+    `MemberUpdated`, `RoleChanged`, `AdminPromoted`.
+  - Each variant's `data` payload schema captured as a `data:
+    JsonValue` per Phase 0's convention; per-variant snapshot test
+    pins the wire shape.
+  - Existing audit emitters (M1.5–M1.12) wire to the new variants.
+- **Verify** Snapshot test per variant + round-trip every variant
+  through `AuditWriter`.
+- **Files**
+  - `vti-common/src/audit/envelope.rs`
+- **Deps**: every endpoint milestone (consumers wire after
+  variants land)
+
+---
+
+## M1.14 — Trust Task drafts + index
+
+### `[ ]` M1.14.1 — Spec + schema files for Phase 1 surface
+
+- **Acceptance**
+  - All 11 Trust Tasks from plan §D7 have `spec.md` (request +
+    response + error semantics) and `schema.json` (request +
+    response shape) files.
+  - `trust-tasks/index.json` extended with all 11 entries in
+    `Draft` status.
+- **Verify** `cargo test` validates Trust Task files (extant
+  framework from M0.3); index.json round-trips through serde.
+- **Files**
+  - `trust-tasks/{join-requests,members}/...`
+  - `trust-tasks/index.json`
+- **Deps**: M1.8, M1.9, M1.10, M1.11, M1.12 (every endpoint must
+  exist before its Trust Task file is non-stub)
+
+---
+
+## M1.15 — Phase 1 gate green
+
+### `[ ]` M1.15.1 — Workspace gate
+
+- **Acceptance** (mirrors M0.12.3)
+  - `cargo build --workspace` green.
+  - `cargo test --workspace` green (all new tests passing).
+  - `cargo clippy --workspace --all-targets -- -D warnings` clean.
+  - `cargo fmt --check` clean.
+  - `trust-tasks/index.json` lists every Phase-1 Trust Task with
+    matching `spec.md` + `schema.json` on disk.
+  - Memory entry `project_vtc_mvp.md` updated with any
+    implementation-time tweaks (Role enum shape, AdminEntry
+    collapse, removal disposition default, etc.).
+  - Phase-1-todo.md milestones all flipped to `[x]`.
+- **Verify** CI green on the merge commit.
+- **Files**
+  - `trust-tasks/index.json`
+  - `/Users/glenngore/.claude/projects/-Users-glenngore-devel-fpp-verifiable-trust-infrastructure/memory/project_vtc_mvp.md`
+- **Deps**: M1.13.1, M1.14.1
+
+### Checkpoint — Phase 1 gate met
+
+After M1.15.1: applicants can submit join requests (REST +
+DIDComm); admins can list, approve, reject; members can self-
+remove with no-last-admin protection; admin promotion uses
+step-up UV. Phase 2 (policy engine + VMC/VEC) can start.
+
+---
+
+## Open questions surfaced during planning
+
+Defaults in `phase-1-plan.md` §§D1–D8. Listed here so they're
+findable from the todo:
+
+- **D1**: Role enum location — vtc-service-owned (proposed).
+- **D2**: AdminEntry → AclEntry — role merges, passkeys stay
+  sister-record (proposed).
+- **D3**: Member vs AclEntry — separate keyspaces (proposed).
+- **D4**: JoinRequest VP shape — holder-binding only,
+  additional VC content opaque (proposed).
+- **D5**: DIDComm scope — applicant-facing endpoints only
+  (proposed).
+- **D6**: Removal disposition default — `PolicyDefault →
+  Tombstone` in Phase 1 (proposed).
+- **D7**: Trust Task ID naming — see plan §D7.
+- **D8**: Member ID — DIDs for `members:`, UUIDs for
+  `join_requests:` (proposed).
+
+Any decision that drifts from the default during implementation
+should be recorded in `phase-1-plan.md` under a "Phase 1
+outcome" header (mirrors Phase 0's
+`vta-driven-keys.md` `Resolution` pattern).


### PR DESCRIPTION
## Summary

Planning artefact for Phase 1. **No code changes** — drafts the
two planning documents that drive Phase 1's implementation work.

Per spec §16, Phase 1 delivers: Role enum + custom roles, ACL
extension, member CRUD with manual approval, self/admin removal
(no-last-admin). Gate: **"Members can exist."**

## What's in this PR

- **`tasks/vtc-mvp/phase-1-plan.md`** — full plan (mirrors
  `plan.md`'s Phase 0 layout):
  - Objective + scope (in/out per spec §16).
  - **8 pre-impl design decisions** (D1–D8) with proposed
    defaults. These are load-bearing — every Phase 1 milestone
    depends on at least one. Validate before code lands.
  - Dependency graph + parallelisation strategy.
  - PR slicing (≈5 PRs across 15 milestones).
  - Checkpoints, risks, definition of done.

- **`tasks/vtc-mvp/phase-1-todo.md`** — 15 M1.* milestones
  (M1.1 through M1.15), each with acceptance + verify steps +
  file list + deps. Mirrors Phase 0's `todo.md` layout.

## Design decisions for review (plan §§D1–D8)

These shape the whole phase. Proposed defaults are noted; flag
any disagreement here so we course-correct before M1.1 lands.

| | Decision | Proposed default |
|---|---|---|
| **D1** | Role enum location | vtc-service-owned `VtcRole` enum (clean separation from VTA) |
| **D2** | AdminEntry → AclEntry | role merges; passkeys stay in sister record |
| **D3** | Member vs AclEntry | separate keyspaces (`acl:` + `members:`) |
| **D4** | JoinRequest VP shape | holder-binding only; additional VC content opaque |
| **D5** | DIDComm scope | applicant-facing endpoints only (REST-only for admin ops) |
| **D6** | Removal disposition default | `PolicyDefault → Tombstone` in Phase 1 |
| **D7** | Trust Task naming | 11 new Trust Tasks under `members/*` + `join-requests/*` |
| **D8** | Member ID | DIDs for `members:`; UUIDs for `join_requests:` |

## Milestone overview

```
M1.1  Role enum extension (VtcRole)
M1.2  ACL unification (drop AdminEntry sister role field)
M1.3  Member model + keyspace
M1.4  GET members (list + show)
M1.5  PATCH /v1/members/{did} (role + profile)
M1.6  POST /v1/members/{did}/promote-to-admin (step-up UV)
M1.7  JoinRequest model + keyspace + 30-day retention sweeper
M1.8  POST /v1/join-requests (REST + DIDComm)
M1.9  GET /v1/join-requests (admin list + show)
M1.10 POST /v1/join-requests/{id}/{approve,reject}
M1.11 DELETE /v1/members/me (REST + DIDComm, no-last-admin)
M1.12 DELETE /v1/members/{did} (admin remove, no-last-admin)
M1.13 Audit event variants (Phase 1 vocabulary)
M1.14 Trust Task spec.md + schema.json files
M1.15 Phase 1 gate green
```

## Out of scope (deferred per spec §16)

- `regorus` policy engine, `join.rego` / `removal.rego` — **Phase 2**.
- VMC + VEC issuance via VTA oracle — **Phase 2**.
- Status-list allocation — **Phase 2**.
- DID rotation (both methods) — **Phase 2**.
- Trust registry, cross-community recognition — **Phase 3**.
- Personhood, VRC — **Phase 4**.

Hygiene items the §16 table parks under Phase 1 (audit
envelope + HMAC, idempotency, `/v1/` versioning, cursor
pagination) already shipped in Phase 0 as M0.1.* — they don't
re-land here.

## Test plan

- [x] Documents render correctly in markdown.
- [ ] Design decisions reviewed (D1–D8).
- [ ] Direction approved before M1.1 code starts.

Once this PR merges, M1.1 starts on a fresh branch. The 5-PR
slicing in plan §"Parallelisation" is the proposed cadence.