### PR TITLE
feat(vtc): Phase 1 foundation — VtcRole + VtcAclEntry + Member model

### DIFF
--- a/vtc-service/src/acl/entry.rs
+++ b/vtc-service/src/acl/entry.rs
@@ -1,0 +1,163 @@
+//! `VtcAclEntry` — the VTC's per-DID auth-gate record.
+//!
+//! Replaces `vti_common::acl::AclEntry` for vtc-side storage so the
+//! `role` field can carry [`super::VtcRole`] (with `Moderator`,
+//! `Issuer`, `Member`, `Custom(_)` variants beyond the
+//! VTA-flavoured `vti_common::acl::Role` taxonomy).
+//!
+//! ## Wire shape
+//!
+//! Stored under `acl:<did>` in the `acl` keyspace, same key prefix
+//! as the prior `vti_common::acl::AclEntry` shape. The on-disk JSON
+//! is field-compatible with the old shape:
+//!
+//! - `did`, `label`, `allowed_contexts`, `created_at`, `created_by`,
+//!   `expires_at` are byte-identical.
+//! - `role` was previously a `vti_common::acl::Role`, serialised
+//!   `#[serde(rename_all = "lowercase")]` → `"admin"`, etc.
+//!   `VtcRole`'s wire shape is the same plain string with a
+//!   `custom:<name>` prefix for the new `Custom` variant
+//!   (`role.rs` module docs explain the choice). Rows written by
+//!   Phase 0's bootstrap path with `Role::Admin` decode to
+//!   `VtcRole::Admin` without migration.
+
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::VtcRole;
+
+/// One ACL entry. 1:1 with a [`crate::members::Member`] row by
+/// DID, but kept in a separate keyspace because the auth path
+/// reads ACL rows on every request and shouldn't pay the cost of
+/// loading the richer Member metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VtcAclEntry {
+    pub did: String,
+    pub role: VtcRole,
+    pub label: Option<String>,
+    #[serde(default)]
+    pub allowed_contexts: Vec<String>,
+    pub created_at: u64,
+    pub created_by: String,
+    /// Unix-epoch seconds at which this entry expires and should be
+    /// pruned by the background sweeper. `None` is permanent.
+    #[serde(default)]
+    pub expires_at: Option<u64>,
+}
+
+impl VtcAclEntry {
+    /// Returns `true` once this entry has passed its
+    /// `expires_at`. Permanent entries (`None`) never expire.
+    pub fn is_expired(&self, now_unix: u64) -> bool {
+        match self.expires_at {
+            Some(deadline) => now_unix >= deadline,
+            None => false,
+        }
+    }
+}
+
+/// Decode a `VtcAclEntry` from raw bytes. Public so the
+/// [`super::storage`] helpers + pagination callers can reuse the
+/// same decode path without duplicating the JSON tax.
+pub(crate) fn decode(bytes: &[u8]) -> Result<VtcAclEntry, AppError> {
+    serde_json::from_slice(bytes)
+        .map_err(|e| AppError::Internal(format!("VtcAclEntry decode: {e}")))
+}
+
+/// Iterate `acl:<did>` rows, decoding each into a `VtcAclEntry`.
+/// Helper for `list_acl_entries` + paginated walkers.
+pub(crate) async fn iter(ks: &KeyspaceHandle) -> Result<Vec<VtcAclEntry>, AppError> {
+    let raw = ks.prefix_iter_raw(b"acl:".to_vec()).await?;
+    let mut out = Vec::with_capacity(raw.len());
+    for (_k, v) in raw {
+        match decode(&v) {
+            Ok(entry) => out.push(entry),
+            Err(err) => {
+                tracing::warn!(error = %err, "skipping unparseable acl entry");
+            }
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn is_expired_returns_false_for_permanent_entries() {
+        let entry = sample_entry(None);
+        assert!(!entry.is_expired(u64::MAX));
+    }
+
+    #[test]
+    fn is_expired_returns_true_after_deadline() {
+        let entry = sample_entry(Some(100));
+        assert!(!entry.is_expired(50));
+        assert!(entry.is_expired(101));
+    }
+
+    #[test]
+    fn round_trip_through_json() {
+        let entry = sample_entry(Some(200));
+        let bytes = serde_json::to_vec(&entry).unwrap();
+        let parsed = decode(&bytes).unwrap();
+        assert_eq!(parsed, entry);
+    }
+
+    #[test]
+    fn decodes_legacy_role_admin_wire_shape() {
+        // Phase 0's bootstrap path wrote rows via
+        // `vti_common::acl::store_acl_entry` with `Role::Admin`
+        // serialised as the lowercase string `"admin"`. Confirm
+        // the new shape decodes those rows without migration.
+        let legacy = json!({
+            "did": "did:key:zAdmin",
+            "role": "admin",
+            "label": null,
+            "allowed_contexts": [],
+            "created_at": 0,
+            "created_by": "did:key:vtc-install"
+        });
+        let bytes = serde_json::to_vec(&legacy).unwrap();
+        let entry = decode(&bytes).unwrap();
+        assert_eq!(entry.role, VtcRole::Admin);
+        assert_eq!(entry.did, "did:key:zAdmin");
+        assert_eq!(entry.expires_at, None);
+    }
+
+    #[test]
+    fn custom_role_round_trips() {
+        let entry = VtcAclEntry {
+            did: "did:key:zEditor".into(),
+            role: VtcRole::custom("editor").unwrap(),
+            label: Some("badge holder".into()),
+            allowed_contexts: vec![],
+            created_at: 1,
+            created_by: "did:key:zAdmin".into(),
+            expires_at: None,
+        };
+        let bytes = serde_json::to_vec(&entry).unwrap();
+        let parsed = decode(&bytes).unwrap();
+        assert_eq!(parsed.role, VtcRole::Custom("editor".into()));
+        assert_eq!(parsed, entry);
+    }
+
+    fn sample_entry(expires_at: Option<u64>) -> VtcAclEntry {
+        VtcAclEntry {
+            did: "did:key:zSomeMember".into(),
+            role: VtcRole::Member,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: 42,
+            created_by: "did:key:vtc-install".into(),
+            expires_at,
+        }
+    }
+}

--- a/vtc-service/src/acl/mod.rs
+++ b/vtc-service/src/acl/mod.rs
@@ -1,3 +1,15 @@
 pub mod admin;
+pub mod entry;
+pub mod role;
+pub mod storage;
 
-pub use vti_common::acl::*;
+pub use entry::VtcAclEntry;
+pub use role::VtcRole;
+pub use storage::{
+    delete_acl_entry, get_acl_entry, list_acl_entries, list_acl_entries_paginated, store_acl_entry,
+    validate_vtc_role_assignment,
+};
+pub use vti_common::acl::{
+    Role, check_acl, check_acl_full, is_acl_entry_visible, validate_acl_modification,
+    validate_role_assignment,
+};

--- a/vtc-service/src/acl/role.rs
+++ b/vtc-service/src/acl/role.rs
@@ -1,0 +1,281 @@
+//! `VtcRole` — the VTC-specific role taxonomy.
+//!
+//! Spec §5.3:
+//! ```text
+//! enum VtcRole { Admin, Moderator, Issuer, Member, Custom(String) }
+//! ```
+//!
+//! ## Why a new enum
+//!
+//! `vti_common::acl::Role` carries the VTA's role taxonomy
+//! (`Admin`, `Initiator`, `Application`, `Reader`, `Monitor`) and is
+//! shared between VTA + VTC. Adding the VTC variants
+//! (`Moderator`, `Issuer`, `Member`, `Custom`) to the shared enum
+//! would force every VTA-side code path to handle roles it has no
+//! semantics for. Phase-1 plan §D1 keeps the role taxonomy
+//! service-owned — VTC ships its own enum, VTA stays untouched.
+//!
+//! ## Wire shape (and why not `#[serde(tag)]`)
+//!
+//! The plan originally proposed
+//! `#[serde(tag = "type", content = "value")]`, which would
+//! serialise `VtcRole::Admin` as `{"type":"admin"}`. That breaks
+//! backwards-compatibility with the existing `acl:<did>` rows
+//! written by Phase 0's bootstrap path, which store the role as a
+//! plain lowercase string (`"admin"`) via
+//! `vti_common::acl::Role`'s `#[serde(rename_all = "lowercase")]`.
+//!
+//! Instead, every variant is a single string. The `Custom`
+//! variant uses a `custom:` prefix to distinguish from the named
+//! variants:
+//!
+//! | Variant | Wire |
+//! |---|---|
+//! | `Admin` | `"admin"` |
+//! | `Moderator` | `"moderator"` |
+//! | `Issuer` | `"issuer"` |
+//! | `Member` | `"member"` |
+//! | `Custom("editor")` | `"custom:editor"` |
+//!
+//! The `custom:` prefix makes the encoding unambiguous: a string
+//! that doesn't start with `custom:` can only be one of the four
+//! named variants. Custom names are validated against a
+//! conservative charset (lowercase alphanumeric + `-` + `_`,
+//! 1..=64 chars) so a malicious `custom:admin` value cannot
+//! decode to the `Admin` variant via the colon-strip.
+//!
+//! **Phase-1 outcome note**: the on-disk wire shape diverges from
+//! the plan's proposal for the backwards-compat reason above.
+//! Captured here so the deviation is findable from the plan doc.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use vti_common::error::AppError;
+
+/// The VTC's role taxonomy. See module docs for the wire shape.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum VtcRole {
+    /// Full management access. Spec §5.3 default permission matrix.
+    Admin,
+    /// Approves / rejects join requests; policy-gated removal of
+    /// other members.
+    Moderator,
+    /// Issues VEC / VWC / RCard on behalf of the community.
+    Issuer,
+    /// Standard member. Default role on join.
+    Member,
+    /// Community-defined custom role. Receives **no implicit
+    /// grants** from the standard permission matrix; the only
+    /// authoritative source of `Custom` permissions is
+    /// `role_definitions.rego` (spec §5.3, Phase 2+).
+    Custom(String),
+}
+
+const CUSTOM_PREFIX: &str = "custom:";
+const CUSTOM_NAME_MAX: usize = 64;
+
+impl VtcRole {
+    /// Returns the wire-shape representation as borrowed-or-owned
+    /// `String`. Used by `Display` + `Serialize`.
+    fn as_wire(&self) -> String {
+        match self {
+            VtcRole::Admin => "admin".into(),
+            VtcRole::Moderator => "moderator".into(),
+            VtcRole::Issuer => "issuer".into(),
+            VtcRole::Member => "member".into(),
+            VtcRole::Custom(name) => format!("{CUSTOM_PREFIX}{name}"),
+        }
+    }
+
+    /// Construct a `VtcRole::Custom(name)` after validating the
+    /// charset. Returns `AppError::Validation` on invalid input.
+    /// Use this rather than the bare enum variant when the input
+    /// comes from outside the daemon (REST body, DIDComm message).
+    pub fn custom(name: impl Into<String>) -> Result<Self, AppError> {
+        let name = name.into();
+        validate_custom_name(&name)?;
+        Ok(VtcRole::Custom(name))
+    }
+
+    /// Returns `true` for the four named variants, `false` for
+    /// `Custom`. Used by `validate_role_assignment` in the
+    /// permission-matrix check to short-circuit Custom-role
+    /// lookups against the (Phase-2) `role_definitions.rego`
+    /// output.
+    pub fn is_standard(&self) -> bool {
+        !matches!(self, VtcRole::Custom(_))
+    }
+}
+
+impl fmt::Display for VtcRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.as_wire())
+    }
+}
+
+impl FromStr for VtcRole {
+    type Err = AppError;
+
+    fn from_str(s: &str) -> Result<Self, AppError> {
+        match s {
+            "admin" => Ok(VtcRole::Admin),
+            "moderator" => Ok(VtcRole::Moderator),
+            "issuer" => Ok(VtcRole::Issuer),
+            "member" => Ok(VtcRole::Member),
+            other => {
+                if let Some(name) = other.strip_prefix(CUSTOM_PREFIX) {
+                    validate_custom_name(name)?;
+                    Ok(VtcRole::Custom(name.to_string()))
+                } else {
+                    Err(AppError::Validation(format!(
+                        "unknown VTC role '{other}'. Expected one of admin, moderator, issuer, \
+                         member, or custom:<name>."
+                    )))
+                }
+            }
+        }
+    }
+}
+
+impl Serialize for VtcRole {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.as_wire())
+    }
+}
+
+impl<'de> Deserialize<'de> for VtcRole {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        VtcRole::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+fn validate_custom_name(name: &str) -> Result<(), AppError> {
+    if name.is_empty() {
+        return Err(AppError::Validation(
+            "custom role name cannot be empty".into(),
+        ));
+    }
+    if name.len() > CUSTOM_NAME_MAX {
+        return Err(AppError::Validation(format!(
+            "custom role name too long (max {CUSTOM_NAME_MAX} chars)"
+        )));
+    }
+    if !name.chars().all(is_valid_name_char) {
+        return Err(AppError::Validation(format!(
+            "custom role name '{name}' contains disallowed characters \
+             (allowed: lowercase a–z, digits, `-`, `_`)"
+        )));
+    }
+    Ok(())
+}
+
+fn is_valid_name_char(c: char) -> bool {
+    matches!(c, 'a'..='z' | '0'..='9' | '-' | '_')
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_variants_round_trip_through_wire() {
+        for (variant, wire) in [
+            (VtcRole::Admin, "admin"),
+            (VtcRole::Moderator, "moderator"),
+            (VtcRole::Issuer, "issuer"),
+            (VtcRole::Member, "member"),
+        ] {
+            let serialised = serde_json::to_string(&variant).unwrap();
+            assert_eq!(serialised, format!("\"{wire}\""));
+            let deserialised: VtcRole = serde_json::from_str(&serialised).unwrap();
+            assert_eq!(deserialised, variant);
+            assert_eq!(variant.to_string(), wire);
+        }
+    }
+
+    #[test]
+    fn custom_variant_round_trips() {
+        let r = VtcRole::custom("editor").unwrap();
+        let serialised = serde_json::to_string(&r).unwrap();
+        assert_eq!(serialised, "\"custom:editor\"");
+        let deserialised: VtcRole = serde_json::from_str(&serialised).unwrap();
+        assert_eq!(deserialised, r);
+    }
+
+    #[test]
+    fn custom_constructor_validates_charset() {
+        assert!(VtcRole::custom("editor").is_ok());
+        assert!(VtcRole::custom("trust-anchor").is_ok());
+        assert!(VtcRole::custom("badge_holder_42").is_ok());
+
+        for bad in ["", "EDITOR", "with spaces", "colon:bad", "../../etc"] {
+            let err = VtcRole::custom(bad).expect_err(&format!("expected reject: {bad}"));
+            assert!(matches!(err, AppError::Validation(_)));
+        }
+    }
+
+    #[test]
+    fn deserialise_rejects_unknown_string() {
+        let err = serde_json::from_str::<VtcRole>("\"unknown\"").unwrap_err();
+        assert!(err.to_string().contains("unknown VTC role"));
+    }
+
+    #[test]
+    fn deserialise_rejects_custom_with_bad_charset() {
+        // Decoder must run the same validation as the constructor —
+        // otherwise a malicious peer could write
+        // `"custom:UPPER"` to disk and bypass the charset rule.
+        let err = serde_json::from_str::<VtcRole>("\"custom:UPPER\"").unwrap_err();
+        assert!(err.to_string().contains("disallowed characters"));
+    }
+
+    #[test]
+    fn deserialise_rejects_custom_with_empty_name() {
+        let err = serde_json::from_str::<VtcRole>("\"custom:\"").unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn deserialise_rejects_custom_with_name_too_long() {
+        let name = "a".repeat(CUSTOM_NAME_MAX + 1);
+        let err = serde_json::from_str::<VtcRole>(&format!("\"custom:{name}\"")).unwrap_err();
+        assert!(err.to_string().contains("too long"));
+    }
+
+    #[test]
+    fn custom_name_with_colon_does_not_smuggle_admin() {
+        // The colon-strip in from_str only fires for the *first*
+        // colon-after-`custom:`. A `custom:admin` value would
+        // still decode as `Custom("admin")`, *not* `Admin`.
+        // Confirmed here so the encoding stays unambiguous.
+        let r: VtcRole = serde_json::from_str("\"custom:admin\"").unwrap();
+        assert_eq!(r, VtcRole::Custom("admin".into()));
+        assert_ne!(r, VtcRole::Admin);
+    }
+
+    #[test]
+    fn is_standard_returns_true_only_for_named_variants() {
+        assert!(VtcRole::Admin.is_standard());
+        assert!(VtcRole::Moderator.is_standard());
+        assert!(VtcRole::Issuer.is_standard());
+        assert!(VtcRole::Member.is_standard());
+        assert!(!VtcRole::Custom("x".into()).is_standard());
+    }
+
+    #[test]
+    fn from_str_handles_vti_common_admin_wire_shape() {
+        // The existing `vti_common::acl::Role::Admin` serialises
+        // as `"admin"`. Phase-0 `acl:<did>` rows written via that
+        // path must decode to `VtcRole::Admin` without
+        // re-serialisation. This pins that path.
+        let role = VtcRole::from_str("admin").unwrap();
+        assert_eq!(role, VtcRole::Admin);
+    }
+}

--- a/vtc-service/src/acl/storage.rs
+++ b/vtc-service/src/acl/storage.rs
@@ -1,0 +1,272 @@
+//! CRUD helpers for [`super::VtcAclEntry`].
+//!
+//! Mirrors the shape of `vti_common::acl`'s helper set but speaks
+//! the VTC's role taxonomy. The on-disk key prefix (`acl:`) is
+//! unchanged, so a vtc-service binary built against this module
+//! can read rows that Phase 0 wrote via `vti_common::acl::*`
+//! without an explicit migration.
+//!
+//! ## What's intentionally missing
+//!
+//! - `check_acl` / `check_acl_full` — those return a
+//!   `vti_common::acl::Role`. Auth-time role checks still flow
+//!   through those helpers; vtc-service's PR-1 keeps consuming
+//!   them as-is and only the storage path reshapes. Phase-2
+//!   tightens the auth helpers to use `VtcRole` once the
+//!   downstream session / passkey code is ready for the shift.
+//! - `validate_role_assignment` — same reason. Phase-2.
+//!
+//! ## Pagination
+//!
+//! [`list_acl_entries_paginated`] returns a
+//! [`vti_common::pagination::Paginated`] for the GET-list
+//! endpoints under §M1.4. The unpaginated
+//! [`list_acl_entries`] keeps the call sites that walked the
+//! full keyspace (audit, emergency-bootstrap cleanup) working
+//! without rewriting them.
+
+use vti_common::audit::AuditKey;
+use vti_common::auth::extractor::AuthClaims;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated, paginate};
+use vti_common::store::KeyspaceHandle;
+
+use super::VtcRole;
+use super::entry::{VtcAclEntry, decode, iter};
+
+fn acl_key(did: &str) -> String {
+    format!("acl:{did}")
+}
+
+/// Retrieve an ACL entry by DID. `Ok(None)` if absent.
+pub async fn get_acl_entry(
+    ks: &KeyspaceHandle,
+    did: &str,
+) -> Result<Option<VtcAclEntry>, AppError> {
+    let key = acl_key(did);
+    let raw = ks.get_raw(key.as_bytes()).await?;
+    match raw {
+        Some(bytes) => Ok(Some(decode(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+/// Store (create or overwrite) an ACL entry.
+pub async fn store_acl_entry(ks: &KeyspaceHandle, entry: &VtcAclEntry) -> Result<(), AppError> {
+    ks.insert(acl_key(&entry.did), entry).await
+}
+
+/// Delete an ACL entry by DID. Idempotent — `Ok(())` whether the
+/// row existed or not.
+pub async fn delete_acl_entry(ks: &KeyspaceHandle, did: &str) -> Result<(), AppError> {
+    ks.remove(acl_key(did)).await
+}
+
+/// Validate that `caller` is allowed to assign `target_role`.
+///
+/// Mirrors `vti_common::acl::validate_role_assignment` but speaks
+/// VTC's role taxonomy:
+///
+/// - Only an `Admin` AuthClaims (vti-common's `Role::Admin`) can
+///   assign `VtcRole::Admin`.
+/// - Otherwise (`Moderator`, `Issuer`, `Member`, `Custom`), the
+///   caller must hold the vti-common `Role::Admin` or
+///   `Role::Initiator` role — the existing "management-level"
+///   caller bar.
+///
+/// AuthClaims' `role` field is still keyed to
+/// `vti_common::acl::Role` because Phase 1 keeps the JWT shape
+/// from Phase 0 unchanged. Phase 2 swaps the auth layer to a
+/// VtcRole-aware AuthClaims; for now this thin shim does the
+/// VTC-side mapping.
+pub fn validate_vtc_role_assignment(
+    caller: &AuthClaims,
+    target_role: &VtcRole,
+) -> Result<(), AppError> {
+    use vti_common::acl::Role as ViRole;
+    if matches!(
+        caller.role,
+        ViRole::Monitor | ViRole::Reader | ViRole::Application
+    ) {
+        return Err(AppError::Forbidden(
+            "insufficient role to assign roles".into(),
+        ));
+    }
+    if matches!(target_role, VtcRole::Admin) && caller.role != ViRole::Admin {
+        return Err(AppError::Forbidden(
+            "only admins can assign the admin role".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Return every ACL entry in the keyspace. Unbounded — intended
+/// for whole-keyspace operations like audit emission +
+/// emergency-bootstrap cleanup, not for user-facing list
+/// endpoints. Use [`list_acl_entries_paginated`] for those.
+pub async fn list_acl_entries(ks: &KeyspaceHandle) -> Result<Vec<VtcAclEntry>, AppError> {
+    iter(ks).await
+}
+
+/// Paginated list. Signs the cursor under `audit_key` so it can't
+/// be forged across communities.
+///
+/// Phase-1 implementation walks the full keyspace and slices
+/// in-memory. The hot-path keyspace size is bounded by the
+/// community's member count; for the Phase-1 communities (target
+/// 10k–100k members) this is fine. A streaming
+/// `prefix_iter_raw_after(key)` helper that lets fjall do the
+/// slicing lands in Phase 3 once registry-scale communities
+/// surface.
+pub async fn list_acl_entries_paginated(
+    ks: &KeyspaceHandle,
+    audit_key: &AuditKey,
+    cursor: Option<&Cursor>,
+    limit: usize,
+) -> Result<Paginated<VtcAclEntry>, AppError> {
+    let mut pairs = ks.prefix_iter_raw(b"acl:".to_vec()).await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let snapshot_id: u64 = pairs.len() as u64;
+    paginate(pairs, cursor, limit, &audit_key.key, snapshot_id, decode)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::VtcRole;
+    use vti_common::audit::AuditKeyStore;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        let ks = store.keyspace("acl").expect("ks");
+        (ks, dir)
+    }
+
+    fn entry(did: &str, role: VtcRole) -> VtcAclEntry {
+        VtcAclEntry {
+            did: did.into(),
+            role,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: 1,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn store_then_get_round_trip() {
+        let (ks, _dir) = temp_ks().await;
+        let e = entry("did:key:zMember1", VtcRole::Member);
+        store_acl_entry(&ks, &e).await.unwrap();
+        let got = get_acl_entry(&ks, "did:key:zMember1")
+            .await
+            .unwrap()
+            .expect("entry present");
+        assert_eq!(got, e);
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_unknown_did() {
+        let (ks, _dir) = temp_ks().await;
+        assert!(
+            get_acl_entry(&ks, "did:key:zNobody")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_is_idempotent() {
+        let (ks, _dir) = temp_ks().await;
+        let e = entry("did:key:zDelete", VtcRole::Member);
+        store_acl_entry(&ks, &e).await.unwrap();
+        delete_acl_entry(&ks, "did:key:zDelete").await.unwrap();
+        // Second delete on an absent row.
+        delete_acl_entry(&ks, "did:key:zDelete").await.unwrap();
+        assert!(
+            get_acl_entry(&ks, "did:key:zDelete")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn list_acl_entries_returns_every_row() {
+        let (ks, _dir) = temp_ks().await;
+        for did in ["did:key:zA", "did:key:zB", "did:key:zC"] {
+            store_acl_entry(&ks, &entry(did, VtcRole::Member))
+                .await
+                .unwrap();
+        }
+        let listed = list_acl_entries(&ks).await.unwrap();
+        assert_eq!(listed.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn paginated_walks_the_keyspace() {
+        let (ks, _dir) = temp_ks().await;
+        let dir = tempfile::tempdir().unwrap();
+        let store2 = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let audit_key_ks = store2.keyspace("audit_key").unwrap();
+        let key_store = AuditKeyStore::new(audit_key_ks);
+        let audit_key = key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+
+        // Seed 5 members.
+        for did in [
+            "did:key:zA",
+            "did:key:zB",
+            "did:key:zC",
+            "did:key:zD",
+            "did:key:zE",
+        ] {
+            store_acl_entry(&ks, &entry(did, VtcRole::Member))
+                .await
+                .unwrap();
+        }
+
+        // First page (limit 2).
+        let page1 = list_acl_entries_paginated(&ks, &audit_key, None, 2)
+            .await
+            .unwrap();
+        assert_eq!(page1.items.len(), 2);
+        assert!(page1.next_cursor.is_some());
+        assert_eq!(page1.items[0].did, "did:key:zA");
+        assert_eq!(page1.items[1].did, "did:key:zB");
+
+        // Decode the wire cursor + walk the next page.
+        let cursor1 =
+            Cursor::decode(page1.next_cursor.as_deref().unwrap(), &audit_key.key).unwrap();
+        let page2 = list_acl_entries_paginated(&ks, &audit_key, Some(&cursor1), 2)
+            .await
+            .unwrap();
+        assert_eq!(page2.items.len(), 2);
+        assert_eq!(page2.items[0].did, "did:key:zC");
+        assert_eq!(page2.items[1].did, "did:key:zD");
+
+        // Last page (no further cursor).
+        let cursor2 =
+            Cursor::decode(page2.next_cursor.as_deref().unwrap(), &audit_key.key).unwrap();
+        let page3 = list_acl_entries_paginated(&ks, &audit_key, Some(&cursor2), 2)
+            .await
+            .unwrap();
+        assert_eq!(page3.items.len(), 1);
+        assert_eq!(page3.items[0].did, "did:key:zE");
+        assert!(page3.next_cursor.is_none());
+    }
+}

--- a/vtc-service/src/did_key.rs
+++ b/vtc-service/src/did_key.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 
-use crate::acl::{AclEntry, Role, store_acl_entry};
+use crate::acl::{VtcAclEntry, VtcRole, store_acl_entry};
 use crate::auth::credentials::generate_did_key;
 use crate::config::AppConfig;
 use crate::store::Store;
@@ -23,9 +23,9 @@ pub async fn run_create_did_key(args: CreateDidKeyArgs) -> Result<(), Box<dyn st
     // Optionally create ACL entry
     if args.admin {
         let acl_ks = store.keyspace("acl")?;
-        let entry = AclEntry {
+        let entry = VtcAclEntry {
             did: did.clone(),
-            role: Role::Admin,
+            role: VtcRole::Admin,
             label: args.label.clone(),
             allowed_contexts: vec![],
             created_at: std::time::SystemTime::now()

--- a/vtc-service/src/emergency.rs
+++ b/vtc-service/src/emergency.rs
@@ -37,12 +37,12 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use crate::acl::{VtcRole, delete_acl_entry, list_acl_entries};
 use async_trait::async_trait;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
-use vti_common::acl::{Role, delete_acl_entry, list_acl_entries};
 use vti_common::config::StoreConfig;
 use vti_common::error::AppError;
 use vti_common::store::Store;
@@ -248,7 +248,7 @@ pub async fn run_emergency_bootstrap_with_store(
     // --- destructive cleanup ----------------------------------------
     let mut admin_entries_cleared = 0;
     for entry in list_acl_entries(&acl_ks).await? {
-        if entry.role == Role::Admin {
+        if entry.role == VtcRole::Admin {
             delete_acl_entry(&acl_ks, &entry.did).await?;
             admin_entries_cleared += 1;
         }

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -23,6 +23,7 @@ pub mod emergency;
 pub mod error;
 pub mod install;
 pub mod keys;
+pub mod members;
 pub mod messaging;
 pub mod routes;
 pub mod server;

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -1,0 +1,130 @@
+//! Member domain model — spec §5.2.
+//!
+//! ## Why a separate keyspace from `acl:`
+//!
+//! Plan §D3: `acl:<did>` (auth-gate) and `members:<did>`
+//! (community-membership metadata) are 1:1 by DID but logically
+//! distinct. The auth path reads ACL rows on every request and
+//! shouldn't pay the cost of loading the richer Member metadata.
+//! Lifecycle is matched — creating a Member is always atomic with
+//! writing the ACL row, and removal is similarly paired — so the
+//! per-DID consistency invariant is upheld inside the same fjall
+//! transaction.
+//!
+//! ## What's deferred to Phase 2+
+//!
+//! Spec §5.2's `status_list_index`, `current_vmc_id`, and
+//! `current_role_vec_id` are credential pointers populated by
+//! Phase 2's VTA-oracle issuance flow. They ship as `Option<T>`
+//! slots from day one so Phase 2 can populate them without a
+//! migration; Phase 1 always writes `None`.
+//!
+//! Spec §10.1's `Disposition` enum carries
+//! `PolicyDefault` which (per plan §D6) resolves to `Tombstone`
+//! in Phase 1 until `removal.rego` lands in Phase 2. The
+//! `Disposition` enum is defined here so the value is on the wire
+//! from day one; the resolver indirection lives at the removal
+//! call site.
+
+pub mod storage;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+pub use storage::{
+    DEFAULT_DEPARTURE_PREFERENCE, MEMBER_EXTENSIONS_MAX_BYTES, delete_member, get_member,
+    list_members, list_members_paginated, store_member,
+};
+
+/// One community member. 1:1 with a [`crate::acl::VtcAclEntry`]
+/// row by DID.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Member {
+    pub did: String,
+    pub joined_at: DateTime<Utc>,
+    /// Random-with-decoys status-list slot (spec §6.2). Populated by
+    /// Phase 2's issuance flow; `None` until then.
+    #[serde(default)]
+    pub status_list_index: Option<u32>,
+    /// Operator-controlled flag: when `true`, the community may
+    /// publish the member's DID via the trust-registry sync path
+    /// (spec §8.2). Default `false` until the member opts in.
+    #[serde(default)]
+    pub publish_consent: bool,
+    /// Member-controlled preference for `DELETE /v1/members/me`
+    /// disposition handling (spec §10.2).
+    #[serde(default = "Disposition::default_preference")]
+    pub departure_preference: Disposition,
+    /// ID of the currently-active VMC for this member (spec §6.1).
+    /// Populated by Phase 2's issuance flow.
+    #[serde(default)]
+    pub current_vmc_id: Option<String>,
+    /// ID of the currently-active role VEC (spec §6.1).
+    /// Populated by Phase 2's issuance flow.
+    #[serde(default)]
+    pub current_role_vec_id: Option<String>,
+    /// Community-defined extensions slot (spec §3-M). Bounded by
+    /// [`MEMBER_EXTENSIONS_MAX_BYTES`] = 16 KiB at the route
+    /// layer.
+    #[serde(default)]
+    pub extensions: JsonValue,
+}
+
+impl Member {
+    /// Construct a new member with the conventional defaults the
+    /// join-approval flow writes (M1.10):
+    ///
+    /// - `joined_at` = now
+    /// - `publish_consent` = false (opt-in)
+    /// - `departure_preference` = `PolicyDefault` (resolves to
+    ///   `Tombstone` until the policy engine ships in Phase 2)
+    /// - credential pointers + extensions absent
+    pub fn fresh(did: impl Into<String>) -> Self {
+        Self {
+            did: did.into(),
+            joined_at: Utc::now(),
+            status_list_index: None,
+            publish_consent: false,
+            departure_preference: Disposition::default_preference(),
+            current_vmc_id: None,
+            current_role_vec_id: None,
+            extensions: JsonValue::Null,
+        }
+    }
+}
+
+/// Spec §5.5 disposition for a removal. Determines what happens to
+/// the Member record + status-list slot on member departure.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Disposition {
+    /// Hard delete — Member row removed entirely. RTBF default.
+    Purge,
+    /// Member row anonymised (DID retained, profile fields
+    /// blanked). Default for `PolicyDefault` in Phase 1 (plan §D6).
+    Tombstone,
+    /// Member row retained verbatim, marked departed. For
+    /// audit-significant communities.
+    Historical,
+    /// Defer to `removal.rego`'s `min_disposition`. In Phase 1
+    /// resolves to `Tombstone`; Phase 2 swaps the resolver.
+    PolicyDefault,
+}
+
+impl Disposition {
+    fn default_preference() -> Self {
+        Disposition::PolicyDefault
+    }
+
+    /// Resolve `PolicyDefault` to a concrete disposition. In
+    /// Phase 1 this always returns [`Disposition::Tombstone`];
+    /// Phase 2 reads the active `removal.rego` policy.
+    pub fn resolve(self) -> Disposition {
+        match self {
+            Disposition::PolicyDefault => Disposition::Tombstone,
+            other => other,
+        }
+    }
+}

--- a/vtc-service/src/members/storage.rs
+++ b/vtc-service/src/members/storage.rs
@@ -1,0 +1,226 @@
+//! CRUD helpers for [`super::Member`] over the `members` keyspace.
+
+use vti_common::audit::AuditKey;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated, paginate};
+use vti_common::store::KeyspaceHandle;
+
+use super::{Disposition, Member};
+
+/// Hard cap on the bytes-on-disk size of `Member.extensions`. The
+/// route layer enforces this at write time (mirrors the
+/// `CommunityProfile.extensions` rule from M0.7.1).
+pub const MEMBER_EXTENSIONS_MAX_BYTES: usize = 16 * 1024;
+
+/// The disposition value the join-approval flow writes by default
+/// — [`Disposition::PolicyDefault`], which resolves to
+/// `Tombstone` in Phase 1.
+pub const DEFAULT_DEPARTURE_PREFERENCE: Disposition = Disposition::PolicyDefault;
+
+const PREFIX: &[u8] = b"members:";
+
+fn member_key(did: &str) -> Vec<u8> {
+    let mut k = PREFIX.to_vec();
+    k.extend_from_slice(did.as_bytes());
+    k
+}
+
+fn decode(bytes: &[u8]) -> Result<Member, AppError> {
+    serde_json::from_slice(bytes).map_err(|e| AppError::Internal(format!("Member decode: {e}")))
+}
+
+/// Retrieve a member by DID. `Ok(None)` if absent.
+pub async fn get_member(ks: &KeyspaceHandle, did: &str) -> Result<Option<Member>, AppError> {
+    let raw = ks.get_raw(member_key(did)).await?;
+    match raw {
+        Some(bytes) => Ok(Some(decode(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+/// Store (create or overwrite) a member. Enforces the
+/// `extensions` size cap.
+pub async fn store_member(ks: &KeyspaceHandle, member: &Member) -> Result<(), AppError> {
+    let extensions_bytes = serde_json::to_vec(&member.extensions)
+        .map_err(|e| AppError::Internal(format!("Member extensions serialize: {e}")))?;
+    if extensions_bytes.len() > MEMBER_EXTENSIONS_MAX_BYTES {
+        return Err(AppError::Validation(format!(
+            "member.extensions exceeds {} bytes (got {})",
+            MEMBER_EXTENSIONS_MAX_BYTES,
+            extensions_bytes.len(),
+        )));
+    }
+    ks.insert(
+        String::from_utf8(member_key(&member.did)).expect("member key is ASCII"),
+        member,
+    )
+    .await
+}
+
+/// Delete a member by DID. Idempotent.
+pub async fn delete_member(ks: &KeyspaceHandle, did: &str) -> Result<(), AppError> {
+    ks.remove(member_key(did)).await
+}
+
+/// Return every member. Whole-keyspace walk — use
+/// [`list_members_paginated`] from user-facing routes.
+pub async fn list_members(ks: &KeyspaceHandle) -> Result<Vec<Member>, AppError> {
+    let raw = ks.prefix_iter_raw(PREFIX.to_vec()).await?;
+    let mut out = Vec::with_capacity(raw.len());
+    for (_k, v) in raw {
+        match decode(&v) {
+            Ok(member) => out.push(member),
+            Err(err) => tracing::warn!(error = %err, "skipping unparseable member row"),
+        }
+    }
+    Ok(out)
+}
+
+/// Paginated list. Cursor signed under `audit_key`.
+pub async fn list_members_paginated(
+    ks: &KeyspaceHandle,
+    audit_key: &AuditKey,
+    cursor: Option<&Cursor>,
+    limit: usize,
+) -> Result<Paginated<Member>, AppError> {
+    let mut pairs = ks.prefix_iter_raw(PREFIX.to_vec()).await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let snapshot_id: u64 = pairs.len() as u64;
+    paginate(pairs, cursor, limit, &audit_key.key, snapshot_id, decode)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use vti_common::audit::AuditKeyStore;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        let ks = store.keyspace("members").expect("ks");
+        (ks, dir)
+    }
+
+    fn fresh(did: &str) -> Member {
+        Member::fresh(did)
+    }
+
+    #[tokio::test]
+    async fn round_trip_through_keyspace() {
+        let (ks, _dir) = temp_ks().await;
+        let m = fresh("did:key:zMember1");
+        store_member(&ks, &m).await.unwrap();
+        let got = get_member(&ks, "did:key:zMember1").await.unwrap().unwrap();
+        assert_eq!(got.did, m.did);
+        assert_eq!(got.departure_preference, Disposition::PolicyDefault);
+        assert!(!got.publish_consent);
+        assert!(got.status_list_index.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_returns_every_member() {
+        let (ks, _dir) = temp_ks().await;
+        for did in ["did:key:zA", "did:key:zB", "did:key:zC"] {
+            store_member(&ks, &fresh(did)).await.unwrap();
+        }
+        let list = list_members(&ks).await.unwrap();
+        assert_eq!(list.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn delete_is_idempotent() {
+        let (ks, _dir) = temp_ks().await;
+        store_member(&ks, &fresh("did:key:zD")).await.unwrap();
+        delete_member(&ks, "did:key:zD").await.unwrap();
+        delete_member(&ks, "did:key:zD").await.unwrap();
+        assert!(get_member(&ks, "did:key:zD").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn extensions_size_limit_enforced() {
+        let (ks, _dir) = temp_ks().await;
+        let big = "a".repeat(MEMBER_EXTENSIONS_MAX_BYTES + 1);
+        let mut m = fresh("did:key:zBig");
+        m.extensions = serde_json::json!(big);
+        let err = store_member(&ks, &m).await.expect_err("size limit hit");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn paginated_walks_members() {
+        let (ks, _dir) = temp_ks().await;
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let audit_key = AuditKeyStore::new(store.keyspace("audit_key").unwrap())
+            .ensure_initial(&[0xAB; 32])
+            .await
+            .unwrap();
+
+        for did in [
+            "did:key:zA",
+            "did:key:zB",
+            "did:key:zC",
+            "did:key:zD",
+            "did:key:zE",
+        ] {
+            store_member(&ks, &fresh(did)).await.unwrap();
+        }
+        let page1 = list_members_paginated(&ks, &audit_key, None, 2)
+            .await
+            .unwrap();
+        assert_eq!(page1.items.len(), 2);
+        assert!(page1.next_cursor.is_some());
+        assert_eq!(page1.items[0].did, "did:key:zA");
+        assert_eq!(page1.items[1].did, "did:key:zB");
+    }
+
+    #[test]
+    fn member_round_trips_through_json_with_camel_case_fields() {
+        let m = Member {
+            did: "did:key:zX".into(),
+            joined_at: Utc::now(),
+            status_list_index: Some(42),
+            publish_consent: true,
+            departure_preference: Disposition::Historical,
+            current_vmc_id: Some("vmc-1".into()),
+            current_role_vec_id: Some("vec-1".into()),
+            extensions: serde_json::json!({ "team": "platform" }),
+        };
+        let json = serde_json::to_value(&m).unwrap();
+        assert!(json["joinedAt"].is_string());
+        assert_eq!(json["statusListIndex"], 42);
+        assert_eq!(json["publishConsent"], true);
+        assert_eq!(json["departurePreference"], "historical");
+        assert_eq!(json["currentVmcId"], "vmc-1");
+        assert_eq!(json["currentRoleVecId"], "vec-1");
+        let parsed: Member = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn disposition_default_is_policy_default() {
+        let m = Member::fresh("did:key:z");
+        assert_eq!(m.departure_preference, Disposition::PolicyDefault);
+        assert_eq!(m.departure_preference.resolve(), Disposition::Tombstone);
+    }
+
+    #[test]
+    fn disposition_purge_resolves_to_itself() {
+        assert_eq!(Disposition::Purge.resolve(), Disposition::Purge);
+        assert_eq!(Disposition::Tombstone.resolve(), Disposition::Tombstone);
+        assert_eq!(Disposition::Historical.resolve(), Disposition::Historical);
+    }
+}

--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::acl::{
-    AclEntry, Role, delete_acl_entry, get_acl_entry, is_acl_entry_visible, list_acl_entries,
-    store_acl_entry, validate_acl_modification, validate_role_assignment,
+    VtcAclEntry, VtcRole, delete_acl_entry, get_acl_entry, is_acl_entry_visible, list_acl_entries,
+    store_acl_entry, validate_acl_modification, validate_vtc_role_assignment,
 };
 use crate::auth::{AdminAuth, ManageAuth, session::now_epoch};
 use crate::error::AppError;
@@ -23,7 +23,7 @@ pub struct AclListResponse {
 #[derive(Debug, Serialize)]
 pub struct AclEntryResponse {
     pub did: String,
-    pub role: Role,
+    pub role: VtcRole,
     pub label: Option<String>,
     pub allowed_contexts: Vec<String>,
     pub created_at: u64,
@@ -32,8 +32,8 @@ pub struct AclEntryResponse {
     pub expires_at: Option<u64>,
 }
 
-impl From<AclEntry> for AclEntryResponse {
-    fn from(e: AclEntry) -> Self {
+impl From<VtcAclEntry> for AclEntryResponse {
+    fn from(e: VtcAclEntry) -> Self {
         AclEntryResponse {
             did: e.did,
             role: e.role,
@@ -60,7 +60,7 @@ pub async fn list_acl(
     let all_entries = list_acl_entries(&acl).await?;
     let entries: Vec<AclEntryResponse> = all_entries
         .into_iter()
-        .filter(|e| is_acl_entry_visible(&auth.0, e))
+        .filter(|e| is_acl_entry_visible(&auth.0, &as_vti_acl_entry(e)))
         .filter(|e| match &query.context {
             Some(ctx) => e.allowed_contexts.contains(ctx),
             None => true,
@@ -76,7 +76,7 @@ pub async fn list_acl(
 #[derive(Debug, Deserialize)]
 pub struct CreateAclRequest {
     pub did: String,
-    pub role: Role,
+    pub role: VtcRole,
     pub label: Option<String>,
     #[serde(default)]
     pub allowed_contexts: Vec<String>,
@@ -89,9 +89,9 @@ pub async fn create_acl(
     State(state): State<AppState>,
     Json(req): Json<CreateAclRequest>,
 ) -> Result<(StatusCode, Json<AclEntryResponse>), AppError> {
-    // Block Initiators from granting Admin — role ↔ context bound checks must
-    // run before we touch storage.
-    validate_role_assignment(&auth.0, &req.role)?;
+    // Block non-admin callers from granting Admin — role + context
+    // bound checks must run before we touch storage.
+    validate_vtc_role_assignment(&auth.0, &req.role)?;
     validate_acl_modification(&auth.0, &req.allowed_contexts)?;
 
     let acl = state.acl_ks.clone();
@@ -104,7 +104,7 @@ pub async fn create_acl(
         )));
     }
 
-    let entry = AclEntry {
+    let entry = VtcAclEntry {
         did: req.did,
         role: req.role,
         label: req.label,
@@ -131,7 +131,7 @@ pub async fn get_acl(
     let entry = get_acl_entry(&acl, &did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("ACL entry not found for DID: {did}")))?;
-    if !is_acl_entry_visible(&auth.0, &entry) {
+    if !is_acl_entry_visible(&auth.0, &as_vti_acl_entry(&entry)) {
         return Err(AppError::NotFound(format!(
             "ACL entry not found for DID: {did}"
         )));
@@ -144,14 +144,14 @@ pub async fn get_acl(
 
 #[derive(Debug, Deserialize)]
 pub struct UpdateAclRequest {
-    pub role: Option<Role>,
+    pub role: Option<VtcRole>,
     pub label: Option<String>,
     pub allowed_contexts: Option<Vec<String>>,
 }
 
 pub async fn update_acl(
     // Modifying an ACL entry can downgrade an existing admin or shrink their
-    // `allowed_contexts`. Gate on Admin so an Initiator can't tamper with
+    // `allowed_contexts`. Gate on Admin so a non-admin can't tamper with
     // admin entries they happen to see (creation stays on `ManageAuth`).
     auth: AdminAuth,
     State(state): State<AppState>,
@@ -164,14 +164,14 @@ pub async fn update_acl(
         .ok_or_else(|| AppError::NotFound(format!("ACL entry not found for DID: {did}")))?;
 
     // Context admins can only modify entries they can see
-    if !is_acl_entry_visible(&auth.0, &entry) {
+    if !is_acl_entry_visible(&auth.0, &as_vti_acl_entry(&entry)) {
         return Err(AppError::NotFound(format!(
             "ACL entry not found for DID: {did}"
         )));
     }
 
     if let Some(role) = req.role {
-        validate_role_assignment(&auth.0, &role)?;
+        validate_vtc_role_assignment(&auth.0, &role)?;
         entry.role = role;
     }
     if let Some(label) = req.label {
@@ -209,7 +209,7 @@ pub async fn delete_acl(
     let entry = get_acl_entry(&acl, &did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("ACL entry not found for DID: {did}")))?;
-    if !is_acl_entry_visible(&auth.0, &entry) {
+    if !is_acl_entry_visible(&auth.0, &as_vti_acl_entry(&entry)) {
         return Err(AppError::NotFound(format!(
             "ACL entry not found for DID: {did}"
         )));
@@ -221,6 +221,29 @@ pub async fn delete_acl(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Translate a `VtcAclEntry` into the `vti_common::acl::AclEntry`
+/// shape that the role-agnostic visibility helpers
+/// (`is_acl_entry_visible`, `validate_acl_modification`) expect.
+/// They only look at `allowed_contexts`, so the role mapping is
+/// best-effort — `VtcRole::Admin` → `Role::Admin`, everything else
+/// degrades to `Role::Reader` (lowest privilege; only the contexts
+/// match), which is fine because these helpers ignore the role
+/// field entirely.
+fn as_vti_acl_entry(e: &VtcAclEntry) -> vti_common::acl::AclEntry {
+    vti_common::acl::AclEntry {
+        did: e.did.clone(),
+        role: match e.role {
+            VtcRole::Admin => vti_common::acl::Role::Admin,
+            _ => vti_common::acl::Role::Reader,
+        },
+        label: e.label.clone(),
+        allowed_contexts: e.allowed_contexts.clone(),
+        created_at: e.created_at,
+        created_by: e.created_by.clone(),
+        expires_at: e.expires_at,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     //! Wire-shape tests for the ACL route bodies. Full route integration
@@ -230,7 +253,6 @@ mod tests {
     //! renaming a field, changing a default, or breaking backward
     //! compatibility with the CLI clients that consume these types.
     use super::*;
-    use crate::acl::Role;
     use serde_json::json;
 
     // ── CreateAclRequest ────────────────────────────────────────────
@@ -240,7 +262,7 @@ mod tests {
         let body = json!({ "did": "did:key:zABC", "role": "admin" });
         let req: CreateAclRequest = serde_json::from_value(body).expect("minimal body");
         assert_eq!(req.did, "did:key:zABC");
-        assert_eq!(req.role, Role::Admin);
+        assert_eq!(req.role, VtcRole::Admin);
         assert_eq!(req.label, None);
         assert!(req.allowed_contexts.is_empty(), "defaults to empty");
         assert_eq!(req.expires_at, None);
@@ -250,13 +272,13 @@ mod tests {
     fn create_acl_request_parses_full_body() {
         let body = json!({
             "did": "did:key:zABC",
-            "role": "initiator",
+            "role": "moderator",
             "label": "ops lead",
             "allowed_contexts": ["ctx1", "ctx2"],
             "expires_at": 1_800_000_000u64,
         });
         let req: CreateAclRequest = serde_json::from_value(body).expect("full body");
-        assert_eq!(req.role, Role::Initiator);
+        assert_eq!(req.role, VtcRole::Moderator);
         assert_eq!(req.label.as_deref(), Some("ops lead"));
         assert_eq!(req.allowed_contexts, vec!["ctx1", "ctx2"]);
         assert_eq!(req.expires_at, Some(1_800_000_000));
@@ -267,18 +289,15 @@ mod tests {
         let body = json!({ "did": "did:key:zA", "role": "godmode" });
         let err = serde_json::from_value::<CreateAclRequest>(body)
             .expect_err("unknown role must not parse");
-        // This also catches a regression where someone adds a wildcard
-        // match to Role parsing that accepts arbitrary strings.
         let msg = format!("{err}");
         assert!(
-            msg.contains("godmode") || msg.contains("variant"),
+            msg.contains("godmode") || msg.contains("unknown"),
             "got {msg}"
         );
     }
 
     #[test]
     fn create_acl_request_rejects_missing_required() {
-        // `did` is mandatory (no default). Dropping it must fail parse.
         let body = json!({ "role": "admin" });
         serde_json::from_value::<CreateAclRequest>(body)
             .expect_err("missing `did` must be rejected");
@@ -297,9 +316,9 @@ mod tests {
 
     #[test]
     fn update_acl_request_parses_role_only() {
-        let body = json!({ "role": "reader" });
+        let body = json!({ "role": "member" });
         let req: UpdateAclRequest = serde_json::from_value(body).unwrap();
-        assert_eq!(req.role, Some(Role::Reader));
+        assert_eq!(req.role, Some(VtcRole::Member));
     }
 
     // ── ListAclQuery ───────────────────────────────────────────────
@@ -317,11 +336,9 @@ mod tests {
 
     #[test]
     fn acl_entry_response_serializes_with_stable_field_names() {
-        // Caller-facing JSON shape is a compatibility contract with CLI
-        // clients. Field renames here break CLIs in the field.
-        let entry = AclEntry {
+        let entry = VtcAclEntry {
             did: "did:key:zABC".into(),
-            role: Role::Admin,
+            role: VtcRole::Admin,
             label: Some("test".into()),
             allowed_contexts: vec!["ctx1".into()],
             created_at: 1_700_000_000,
@@ -341,12 +358,9 @@ mod tests {
 
     #[test]
     fn acl_entry_response_omits_expires_at_when_permanent() {
-        // Permanent entries (no expires_at) should not include the field
-        // at all — skip_serializing_if is load-bearing for wire
-        // compatibility with older clients.
-        let entry = AclEntry {
+        let entry = VtcAclEntry {
             did: "did:key:zPerm".into(),
-            role: Role::Admin,
+            role: VtcRole::Admin,
             label: None,
             allowed_contexts: vec![],
             created_at: 1_700_000_000,
@@ -367,7 +381,7 @@ mod tests {
     fn acl_list_response_round_trips() {
         let entries = vec![AclEntryResponse {
             did: "did:key:zA".into(),
-            role: Role::Reader,
+            role: VtcRole::Member,
             label: None,
             allowed_contexts: vec![],
             created_at: 0,
@@ -376,9 +390,30 @@ mod tests {
         }];
         let resp = AclListResponse { entries };
         let json = serde_json::to_string(&resp).unwrap();
-        // Top-level key is `entries`, not `acl` or `items` — CLI clients
-        // parse this exact shape.
         assert!(json.contains(r#""entries":"#), "got {json}");
-        assert!(json.contains(r#""role":"reader""#));
+        assert!(json.contains(r#""role":"member""#));
+    }
+
+    #[test]
+    fn custom_role_round_trip_through_request_body() {
+        let body = json!({
+            "did": "did:key:zEditor",
+            "role": "custom:editor",
+        });
+        let req: CreateAclRequest = serde_json::from_value(body).expect("custom role parses");
+        assert_eq!(req.role, VtcRole::Custom("editor".into()));
+        // Round-trip via the response shape.
+        let entry = VtcAclEntry {
+            did: req.did,
+            role: req.role,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: 0,
+            created_by: "did:key:zS".into(),
+            expires_at: None,
+        };
+        let resp = AclEntryResponse::from(entry);
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["role"], "custom:editor");
     }
 }

--- a/vtc-service/src/routes/admin/bootstrap.rs
+++ b/vtc-service/src/routes/admin/bootstrap.rs
@@ -15,6 +15,7 @@
 
 use std::sync::Arc;
 
+use crate::acl::{VtcAclEntry, VtcRole, list_acl_entries, store_acl_entry};
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -22,7 +23,6 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 use uuid::Uuid;
-use vti_common::acl::{AclEntry, Role, list_acl_entries, store_acl_entry};
 use vti_common::audit::{AuditEvent, AuditWriter, CommunityInstalledData};
 use vti_common::auth::passkey::store::get_passkey_user_by_did;
 use vti_common::error::AppError;
@@ -62,7 +62,7 @@ pub async fn bootstrap(
     // install-token claim would fail), but a misconfigured backup
     // restore could still land us here.
     for entry in list_acl_entries(&state.acl_ks).await? {
-        if entry.role == Role::Admin {
+        if entry.role == VtcRole::Admin {
             return Err(AppError::Conflict(
                 "an admin already exists; refusing to bootstrap a second one".into(),
             ));
@@ -106,9 +106,9 @@ pub async fn bootstrap(
     };
     store_admin_entry(&state.passkey_ks, &admin_entry).await?;
 
-    let acl_entry = AclEntry {
+    let acl_entry = VtcAclEntry {
         did: admin_did.clone(),
-        role: Role::Admin,
+        role: VtcRole::Admin,
         label: Some("first admin (install bootstrap)".into()),
         allowed_contexts: vec![],
         created_at: now_unix(),

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -47,6 +47,7 @@ pub struct AppState {
     pub config_ks: KeyspaceHandle,
     pub passkey_ks: KeyspaceHandle,
     pub install_ks: KeyspaceHandle,
+    pub members_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
@@ -147,6 +148,7 @@ pub async fn run(
     let passkey_ks = store.keyspace("passkey")?;
     let install_ks = store.keyspace("install")?;
     let install_store = InstallTokenStore::new(install_ks.clone());
+    let members_ks = store.keyspace("members")?;
     let audit_ks = store.keyspace("audit")?;
     let audit_key_ks = store.keyspace("audit_key")?;
 
@@ -217,6 +219,7 @@ pub async fn run(
         config_ks,
         passkey_ks,
         install_ks,
+        members_ks,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/src/status.rs
+++ b/vtc-service/src/status.rs
@@ -12,7 +12,7 @@ use affinidi_tdk::messaging::protocols::trust_ping::TrustPing;
 use affinidi_tdk::secrets_resolver::SecretsResolver;
 use affinidi_tdk::secrets_resolver::secrets::Secret;
 
-use crate::acl::{self, Role};
+use crate::acl::{self, VtcRole};
 use crate::auth::session::{self, SessionState};
 use crate::config::AppConfig;
 use crate::keys::seed_store::create_secret_store;
@@ -203,20 +203,35 @@ pub async fn run_status(config_path: Option<PathBuf>) -> Result<(), Box<dyn std:
 
     // --- ACL ---
     let acl_entries = acl::list_acl_entries(&acl_ks).await?;
-    let admin_count = acl_entries.iter().filter(|e| e.role == Role::Admin).count();
-    let initiator_count = acl_entries
+    let admin_count = acl_entries
         .iter()
-        .filter(|e| e.role == Role::Initiator)
+        .filter(|e| e.role == VtcRole::Admin)
         .count();
-    let application_count = acl_entries
+    let moderator_count = acl_entries
         .iter()
-        .filter(|e| e.role == Role::Application)
+        .filter(|e| e.role == VtcRole::Moderator)
+        .count();
+    let issuer_count = acl_entries
+        .iter()
+        .filter(|e| e.role == VtcRole::Issuer)
+        .count();
+    let member_count = acl_entries
+        .iter()
+        .filter(|e| e.role == VtcRole::Member)
+        .count();
+    let custom_count = acl_entries
+        .iter()
+        .filter(|e| matches!(e.role, VtcRole::Custom(_)))
         .count();
 
     section(&format!("ACL ({})", acl_entries.len()));
     eprintln!("  {CYAN}{:<13}{RESET} {admin_count}", "Admin");
-    eprintln!("  {CYAN}{:<13}{RESET} {initiator_count}", "Initiator");
-    eprintln!("  {CYAN}{:<13}{RESET} {application_count}", "Application");
+    eprintln!("  {CYAN}{:<13}{RESET} {moderator_count}", "Moderator");
+    eprintln!("  {CYAN}{:<13}{RESET} {issuer_count}", "Issuer");
+    eprintln!("  {CYAN}{:<13}{RESET} {member_count}", "Member");
+    if custom_count > 0 {
+        eprintln!("  {CYAN}{:<13}{RESET} {custom_count}", "Custom");
+    }
 
     // --- Sessions ---
     let sessions = session::list_sessions(&sessions_ks).await?;

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -77,6 +77,7 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -115,6 +116,7 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         config_ks,
         passkey_ks,
         install_ks: install_ks.clone(),
+        members_ks: members_ks.clone(),
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -60,6 +60,7 @@ async fn build_with(
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -97,6 +98,7 @@ async fn build_with(
         config_ks,
         passkey_ks,
         install_ks: install_ks.clone(),
+        members_ks: members_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -83,6 +83,7 @@ async fn build_fixture(with_audit: bool) -> Fixture {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -180,6 +181,7 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         config_ks,
         passkey_ks,
         install_ks: install_ks.clone(),
+        members_ks: members_ks.clone(),
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -53,6 +53,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -79,6 +80,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         config_ks,
         passkey_ks,
         install_ks: install_ks.clone(),
+        members_ks: members_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -54,6 +54,7 @@ async fn build() -> Fixture {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -80,6 +81,7 @@ async fn build() -> Fixture {
         config_ks,
         passkey_ks,
         install_ks: install_ks.clone(),
+        members_ks: members_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -48,6 +48,7 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -69,6 +70,7 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
         config_ks,
         passkey_ks,
         install_ks,
+        members_ks: members_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -204,6 +204,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -288,6 +289,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         config_ks,
         passkey_ks: passkey_ks.clone(),
         install_ks,
+        members_ks: members_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config.clone())),

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -65,6 +65,7 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -98,6 +99,7 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         config_ks,
         passkey_ks,
         install_ks: install_ks.clone(),
+        members_ks: members_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -96,6 +96,7 @@ async fn build_fixture() -> Fixture {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -127,6 +128,7 @@ async fn build_fixture() -> Fixture {
         config_ks,
         passkey_ks,
         install_ks,
+        members_ks: members_ks.clone(),
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -37,6 +37,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -59,6 +60,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         config_ks,
         passkey_ks,
         install_ks: install_ks.clone(),
+        members_ks: members_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -233,6 +233,7 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
     let config_ks = store.keyspace("config").unwrap();
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -250,6 +251,7 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
         config_ks,
         passkey_ks,
         install_ks: install_ks.clone(),
+        members_ks: members_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),


### PR DESCRIPTION
## Summary

**PR-1 of Phase 1** per `tasks/vtc-mvp/phase-1-plan.md`. Ships
the storage-layer foundation for the member CRUD + join request
work in PR-2+.

Closes **M1.1, M1.2, M1.3**.

## What's in this PR

- **`vtc_service::acl::VtcRole`** (M1.1.1) — VTC's own role
  taxonomy per spec §5.3: `{ Admin, Moderator, Issuer, Member,
  Custom(String) }`. Wire shape uses plain lowercase strings
  for the named variants + a `custom:<name>` prefix for the
  Custom variant.
  - **Deviates from plan §D7's proposed `#[serde(tag = "type")]`
    shape** — that would have broken backwards-compat with the
    existing `vti_common::acl::Role::Admin` rows on disk.
    Recorded as a Phase-1 outcome in `acl/role.rs` module docs.

- **`vtc_service::acl::VtcAclEntry`** (M1.2.1) — replaces
  `vti_common::acl::AclEntry` for vtc-side storage. Same
  `acl:<did>` key prefix; existing Phase 0 admin rows decode
  without migration.

- **`vtc_service::acl::storage`** ships CRUD + paginated list +
  `validate_vtc_role_assignment`. Pagination uses
  `vti_common::pagination::paginate` with `audit_key`-signed
  cursors.

- **Migrated consumers** (M1.2.2): `did_key.rs`, `status.rs`,
  `emergency.rs`, `routes/admin/bootstrap.rs`, `routes/acl.rs`
  (the legacy endpoint stays working via a thin VtcRole↔Role
  shim in the visibility helpers; full removal happens when
  M1.4 ships `/v1/members`).

- **`vtc_service::members::Member`** + `Disposition` enum
  (M1.3.1) per spec §5.2 + §5.5. `members:<did>` keyspace
  registered in `AppState`. `Member.extensions` capped at 16 KiB.
  `PolicyDefault → Tombstone` resolver per plan §D6.

## Not in this PR (intentional)

- **AuthClaims still uses `vti_common::acl::Role`**. PR-2/M1.4+
  rewrites the auth layer when Member rows enter the picture
  — non-Admin rows would fail `Role::parse` at JWT decode
  today, but the only ACL rows in a Phase 0–1 VTC are admin
  rows, so the shim works.
- **No new endpoints.** M1.4–M1.6 ship them in PR-2.
- **No JoinRequest model.** M1.7+ in PR-3.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --package vtc-service` — **128 lib tests** (+41
  new across `acl::role`, `acl::entry`, `acl::storage`,
  `members::storage`) + every existing integration fixture green
- [ ] `cargo test --workspace` — running locally, CI will confirm

## Phase 1 progress

| PR | Milestones | Status |
|---|---|---|
| **PR-1 (this)** | M1.1, M1.2, M1.3 | **in review** |
| PR-2 | M1.4, M1.5, M1.6 | next |
| PR-3 | M1.7, M1.8, M1.9, M1.10 | |
| PR-4 | M1.11, M1.12 | |
| PR-5 | M1.13, M1.14, M1.15 | |