### PR TITLE
feat(vtc): member CRUD + admin promotion (M1.4 + M1.5 + M1.6)

### DIFF
--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -124,6 +124,30 @@
       "status": "Draft",
       "path": "admin/config/import/1.0",
       "rest": "POST /v1/admin/config/import"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/list/1.0",
+      "status": "Draft",
+      "path": "members/list/1.0",
+      "rest": "GET /v1/members"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/show/1.0",
+      "status": "Draft",
+      "path": "members/show/1.0",
+      "rest": "GET /v1/members/{did}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/update/1.0",
+      "status": "Draft",
+      "path": "members/update/1.0",
+      "rest": "PATCH /v1/members/{did}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0",
+      "status": "Draft",
+      "path": "members/promote-to-admin/1.0",
+      "rest": "POST /v1/members/{did}/promote-to-admin/{start,finish}"
     }
   ]
 }

--- a/trust-tasks/members/list/1.0/schema.json
+++ b/trust-tasks/members/list/1.0/schema.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/list/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Members — List",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/MemberResponse" }
+        },
+        "nextCursor": { "type": ["string", "null"] },
+        "totalEstimate": { "type": ["integer", "null"] }
+      }
+    }
+  },
+  "$defs": {
+    "MemberResponse": {
+      "type": "object",
+      "required": [
+        "did",
+        "role",
+        "joinedAt",
+        "publishConsent",
+        "departurePreference",
+        "extensions"
+      ],
+      "properties": {
+        "did": { "type": "string" },
+        "role": { "type": "string" },
+        "label": { "type": ["string", "null"] },
+        "joinedAt": { "type": "string", "format": "date-time" },
+        "publishConsent": { "type": "boolean" },
+        "departurePreference": {
+          "type": "string",
+          "enum": ["purge", "tombstone", "historical", "policydefault"]
+        },
+        "statusListIndex": { "type": ["integer", "null"] },
+        "currentVmcId": { "type": ["string", "null"] },
+        "currentRoleVecId": { "type": ["string", "null"] },
+        "extensions": {}
+      }
+    }
+  }
+}

--- a/trust-tasks/members/list/1.0/spec.md
+++ b/trust-tasks/members/list/1.0/spec.md
@@ -1,0 +1,37 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/list/1.0
+title: VTC Members — List
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/members
+---
+
+# VTC Members — List
+
+Returns a paginated list of community members. The response joins
+each `members:<did>` row with its `acl:<did>` ACL entry so callers
+get the role + label inline.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`. Phase 1 has no
+privacy gating beyond the admin role; spec §12.3 PMF lands in
+Phase 2+.
+
+## Query parameters
+
+- `role` (optional) — filter by VtcRole wire form (e.g.
+  `"admin"`, `"moderator"`, `"custom:editor"`).
+- `cursor` (optional) — pagination cursor from a prior page.
+- `limit` (optional) — page size; clamped to `1..=200`. Default
+  50.
+
+## Errors
+
+- `401 Unauthorized` — missing / invalid session token.
+- `403 Forbidden` — caller is not Admin.
+- `500 Internal Server Error` — audit writer / cursor signing
+  unavailable (the daemon hasn't completed `init_auth`).

--- a/trust-tasks/members/promote-to-admin/1.0/schema.json
+++ b/trust-tasks/members/promote-to-admin/1.0/schema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Members — Promote to Admin",
+  "type": "object",
+  "properties": {
+    "startResponse": {
+      "type": "object",
+      "required": ["registrationId", "options"],
+      "properties": {
+        "registrationId": { "type": "string", "format": "uuid" },
+        "options": { "type": "object" }
+      }
+    },
+    "finishRequest": {
+      "type": "object",
+      "required": ["registrationId", "uvResponse"],
+      "properties": {
+        "registrationId": { "type": "string", "format": "uuid" },
+        "uvResponse": { "type": "object" }
+      }
+    },
+    "finishResponse": {
+      "type": "object",
+      "required": ["did", "eventId"],
+      "properties": {
+        "did": { "type": "string" },
+        "eventId": { "type": "string", "format": "uuid" }
+      }
+    }
+  }
+}

--- a/trust-tasks/members/promote-to-admin/1.0/spec.md
+++ b/trust-tasks/members/promote-to-admin/1.0/spec.md
@@ -1,0 +1,61 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0
+title: VTC Members — Promote to Admin
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/members/{did}/promote-to-admin/start
+  - rest: POST /v1/members/{did}/promote-to-admin/finish
+---
+
+# VTC Members — Promote to Admin
+
+Two-phase ceremony that promotes an existing member to
+`VtcRole::Admin`. Spec §10.4 keeps this path distinct from the
+generic `PATCH /v1/members/{did}` so admin elevation is the
+highest-privilege grant the community emits — SIEM rules target
+the `AdminPromoted` audit variant specifically.
+
+## Authentication
+
+`AdminAuth` on both endpoints. The `finish` step adds a step-up
+WebAuthn user-verification (UV) ceremony against the caller's
+already-registered passkeys.
+
+## /start
+
+Mints a UV challenge against the caller's passkeys. Returns:
+
+```
+{ "registrationId": "<uuid>", "options": <PublicKeyCredentialRequestOptions> }
+```
+
+Pre-flight refusals (no UV ceremony issued):
+
+- `400 Bad Request` — caller is the target DID.
+- `404 Not Found` — target is not a current member.
+- `409 Conflict` — target is already an admin.
+
+## /finish
+
+Verifies the UV response, then atomically:
+
+1. Sets `acl:<target>.role = Admin`.
+2. Creates `admin:<target>` sister record (empty passkey list —
+   the new admin enrols devices via the existing passkey routes).
+3. Emits `AdminPromoted` audit envelope with the authorising
+   credential id.
+
+Re-checks the "already-admin" invariant under
+`PROMOTE_LOCK` so a concurrent PATCH cannot smuggle in an
+out-of-band role mutation between start + finish.
+
+## Errors
+
+- `400 Bad Request` — self-promotion.
+- `401 Unauthorized` — UV state expired / failed.
+- `403 Forbidden` — caller has no enrolled passkey to perform UV.
+- `404 Not Found` — target removed between start + finish.
+- `409 Conflict` — target became admin between start + finish.

--- a/trust-tasks/members/show/1.0/schema.json
+++ b/trust-tasks/members/show/1.0/schema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/show/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Members — Show",
+  "type": "object",
+  "properties": {
+    "response": { "$ref": "../../list/1.0/schema.json#/$defs/MemberResponse" }
+  }
+}

--- a/trust-tasks/members/show/1.0/spec.md
+++ b/trust-tasks/members/show/1.0/spec.md
@@ -1,0 +1,24 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/show/1.0
+title: VTC Members — Show
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/members/{did}
+---
+
+# VTC Members — Show
+
+Returns one member record joined with its ACL row. Spec §5.2.
+
+## Authentication
+
+`AdminAuth`.
+
+## Errors
+
+- `401 Unauthorized` — missing / invalid session.
+- `403 Forbidden` — caller is not Admin.
+- `404 Not Found` — member or matching ACL row absent.

--- a/trust-tasks/members/update/1.0/schema.json
+++ b/trust-tasks/members/update/1.0/schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/update/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Members — Update",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "properties": {
+        "role": { "type": "string" },
+        "publishConsent": { "type": "boolean" },
+        "departurePreference": {
+          "type": "string",
+          "enum": ["purge", "tombstone", "historical", "policydefault"]
+        },
+        "extensions": {}
+      }
+    },
+    "response": { "$ref": "../../list/1.0/schema.json#/$defs/MemberResponse" }
+  }
+}

--- a/trust-tasks/members/update/1.0/spec.md
+++ b/trust-tasks/members/update/1.0/spec.md
@@ -1,0 +1,51 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/update/1.0
+title: VTC Members — Update
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: PATCH /v1/members/{did}
+---
+
+# VTC Members — Update
+
+Updates the role or non-credential metadata of a member. Spec
+§10.4.
+
+## Authentication
+
+`AdminAuth`. Phase 1 keeps a uniform admin gate; spec §5.3's
+permission matrix (Moderator-tier removal etc.) lands when the
+auth layer becomes VtcRole-aware in Phase 2.
+
+## Body
+
+```
+{
+  "role":                ? VtcRole (excl. "admin"),
+  "publishConsent":      ? bool,
+  "departurePreference": ? "purge" | "tombstone" | "historical" | "policydefault",
+  "extensions":          ? object  (≤ 16 KiB)
+}
+```
+
+Every field is optional; a body with no fields is a no-op
+(`200 OK` returning the current row).
+
+## Errors
+
+- `400 Bad Request` — `role: "admin"` — refused with an
+  operator-facing hint pointing at
+  `POST /v1/members/{did}/promote-to-admin`. The promote-to-admin
+  endpoint runs the required step-up UV ceremony (spec §10.4).
+- `401 Unauthorized`, `403 Forbidden` — auth.
+- `404 Not Found` — member or matching ACL row absent.
+
+## Audit
+
+- `RoleChanged { previousRole, newRole }` when the role changes.
+- `MemberUpdated { fieldsChanged: [...] }` when one or more
+  non-role fields change. Both events fire if both kinds of
+  change land in the same PATCH.

--- a/vtc-service/src/routes/members/mod.rs
+++ b/vtc-service/src/routes/members/mod.rs
@@ -1,0 +1,21 @@
+//! `/v1/members/*` route handlers.
+//!
+//! Spec §5.2 + §10.1–10.4. Phase 1 shape per
+//! `tasks/vtc-mvp/phase-1-todo.md` M1.4–M1.6:
+//!
+//! - `GET /v1/members` — paginated list.
+//! - `GET /v1/members/{did}` — single member.
+//! - `PATCH /v1/members/{did}` — role + profile fields. Refuses
+//!   role=Admin (use `promote-to-admin`).
+//! - `POST /v1/members/{did}/promote-to-admin/{start,finish}` —
+//!   two-phase step-up UV ceremony per spec §10.4. Lands in
+//!   M1.6 (`promote.rs`).
+//!
+//! All endpoints require `AdminAuth` in Phase 1 (the auth layer
+//! still uses vti-common's Role taxonomy until M1.10 introduces
+//! non-Admin authenticated sessions; the Member-role policy
+//! surface is Phase 2+).
+
+pub mod promote;
+pub mod read;
+pub mod update;

--- a/vtc-service/src/routes/members/promote.rs
+++ b/vtc-service/src/routes/members/promote.rs
@@ -1,0 +1,234 @@
+//! `POST /v1/members/{did}/promote-to-admin/{start,finish}`
+//! — M1.6.1.
+//!
+//! Two-phase step-up UV ceremony that authorises promoting an
+//! existing member to `VtcRole::Admin`. Spec §10.4 keeps this
+//! path distinct from the generic `PATCH /v1/members/{did}` so
+//! admin elevation is the highest-privilege grant the community
+//! emits and SIEM rules can target it via the `AdminPromoted`
+//! audit variant.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+use webauthn_rs::Webauthn;
+use webauthn_rs::prelude::{PublicKeyCredential, RequestChallengeResponse};
+
+use vti_common::audit::{AdminPromotedData, AuditEvent};
+use vti_common::auth::passkey::PasskeyState;
+use vti_common::auth::passkey::store::{
+    get_passkey_user_by_did, store_auth_state, take_auth_state,
+};
+
+use crate::acl::admin::{AdminEntry, get_admin_entry, store_admin_entry};
+use crate::acl::{VtcRole, get_acl_entry, store_acl_entry};
+use crate::auth::AdminAuth;
+use crate::error::AppError;
+use crate::members::get_member;
+use crate::server::AppState;
+
+/// Serialises every promote-to-admin write per-target so a
+/// concurrent `PATCH /v1/members/{did}` racing the finish step
+/// can't smuggle a role mutation in between the
+/// already-admin check and the ACL write. Process-wide because
+/// fjall isn't multi-process safe (project memory).
+static PROMOTE_LOCK: Mutex<()> = Mutex::const_new(());
+
+// ---------------------------------------------------------------------------
+// /start
+// ---------------------------------------------------------------------------
+
+/// Returned by `start` — the operator's existing passkey is the
+/// authoriser, so this is a UV authentication challenge against
+/// the caller's already-registered credentials. The same shape
+/// admin/passkeys/register/start uses for its UV phase.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromoteStartResponse {
+    pub registration_id: Uuid,
+    pub options: RequestChallengeResponse,
+}
+
+pub async fn promote_start(
+    auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(target_did): Path<String>,
+) -> Result<Json<PromoteStartResponse>, AppError> {
+    if auth.0.did == target_did {
+        return Err(AppError::Validation(
+            "you cannot promote yourself; the promotion endpoint requires a separate admin caller"
+                .into(),
+        ));
+    }
+
+    let webauthn = require_webauthn(&state)?;
+
+    // Pre-flight: confirm the target is an existing member that
+    // isn't already an admin. We re-check inside the finish
+    // ceremony under the lock; the pre-flight here just avoids
+    // running a UV ceremony that can never succeed.
+    get_member(&state.members_ks, &target_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
+    let target_acl = get_acl_entry(&state.acl_ks, &target_did)
+        .await?
+        .ok_or_else(|| {
+            AppError::NotFound(format!("member not found (no ACL row): {target_did}"))
+        })?;
+    if matches!(target_acl.role, VtcRole::Admin) {
+        return Err(AppError::Conflict(format!(
+            "{target_did} is already an admin"
+        )));
+    }
+
+    // Mint the UV challenge against the caller's registered
+    // passkeys — same shape `admin/passkeys/register/start` uses
+    // for its UV phase so the operator's authenticator UX is
+    // identical.
+    let pk_user = get_passkey_user_by_did(&state.passkey_ks, &auth.0.did)
+        .await?
+        .ok_or_else(|| {
+            AppError::Forbidden(format!(
+                "caller {} has no registered passkeys; cannot authorise step-up UV",
+                auth.0.did
+            ))
+        })?;
+    let (uv_options, uv_state) = webauthn
+        .start_passkey_authentication(&pk_user.credentials)
+        .map_err(|e| AppError::Internal(format!("webauthn UV start: {e}")))?;
+    let registration_id = Uuid::new_v4();
+    store_auth_state(&state.passkey_ks, &registration_id.to_string(), &uv_state).await?;
+
+    Ok(Json(PromoteStartResponse {
+        registration_id,
+        options: uv_options,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// /finish
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromoteFinishRequest {
+    pub registration_id: Uuid,
+    pub uv_response: PublicKeyCredential,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromoteFinishResponse {
+    pub did: String,
+    pub event_id: Uuid,
+}
+
+pub async fn promote_finish(
+    auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(target_did): Path<String>,
+    Json(req): Json<PromoteFinishRequest>,
+) -> Result<Json<PromoteFinishResponse>, AppError> {
+    if auth.0.did == target_did {
+        return Err(AppError::Validation("you cannot promote yourself".into()));
+    }
+
+    let webauthn = require_webauthn(&state)?;
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    // 1. Verify the UV ceremony.
+    let uv_state = take_auth_state(&state.passkey_ks, &req.registration_id.to_string())
+        .await?
+        .ok_or_else(|| AppError::Unauthorized("UV challenge not found or expired".into()))?;
+    let uv_result = webauthn
+        .finish_passkey_authentication(&req.uv_response, &uv_state)
+        .map_err(|_| AppError::Unauthorized("step-up UV failed".into()))?;
+
+    if !uv_result.user_verified() {
+        return Err(AppError::Unauthorized(
+            "passkey did not assert user verification (UV); cannot authorise admin promotion"
+                .into(),
+        ));
+    }
+
+    let cred_id_hex = hex::encode(<_ as AsRef<[u8]>>::as_ref(uv_result.cred_id()));
+
+    // 2. Critical section: re-check + apply role change.
+    let _guard = PROMOTE_LOCK.lock().await;
+
+    let mut target_acl = get_acl_entry(&state.acl_ks, &target_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
+    let _target_member = get_member(&state.members_ks, &target_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
+
+    if matches!(target_acl.role, VtcRole::Admin) {
+        return Err(AppError::Conflict(format!(
+            "{target_did} is already an admin"
+        )));
+    }
+
+    let previous_role = target_acl.role.clone();
+    target_acl.role = VtcRole::Admin;
+    store_acl_entry(&state.acl_ks, &target_acl).await?;
+
+    // Create the admin sister record so the new admin can enrol a
+    // device via the existing passkey flow. Empty passkey list
+    // until `admin/passkeys/register` runs.
+    let already_exists = get_admin_entry(&state.passkey_ks, &target_did)
+        .await?
+        .is_some();
+    if !already_exists {
+        store_admin_entry(
+            &state.passkey_ks,
+            &AdminEntry {
+                did: target_did.clone(),
+                passkeys: Vec::new(),
+                extensions: serde_json::Value::Null,
+                created_at: Utc::now(),
+            },
+        )
+        .await?;
+    }
+
+    let envelope = audit_writer
+        .write(
+            &auth.0.did,
+            Some(&target_did),
+            AuditEvent::AdminPromoted(AdminPromotedData {
+                previous_role: previous_role.to_string(),
+                authorising_credential_id: cred_id_hex,
+            }),
+        )
+        .await?;
+
+    Ok(Json(PromoteFinishResponse {
+        did: target_did,
+        event_id: envelope.event_id,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_webauthn(state: &AppState) -> Result<Arc<Webauthn>, AppError> {
+    state.webauthn().cloned().ok_or_else(|| {
+        // No 503 variant on AppError — surface as Internal so the
+        // operator sees the message verbatim. The actual HTTP
+        // status mapping is fine: a missing public_url at runtime
+        // is an internal configuration error.
+        AppError::Internal(
+            "webauthn not configured (public_url unset); promote-to-admin unavailable".into(),
+        )
+    })
+}

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -1,0 +1,174 @@
+//! `GET /v1/members` + `GET /v1/members/{did}` — admin-gated
+//! member read endpoints (M1.4.1).
+//!
+//! The response shape joins the [`crate::members::Member`] metadata
+//! row with its matching [`crate::acl::VtcAclEntry`]'s role + label
+//! so callers don't need a second round-trip. Phase 1 has no
+//! privacy gating beyond `AdminAuth`; spec §12.3's PMF lands in
+//! Phase 2+.
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use vti_common::pagination::{Cursor, MAX_LIMIT, Paginated};
+
+use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, list_acl_entries};
+use crate::auth::AdminAuth;
+use crate::error::AppError;
+use crate::members::{Disposition, Member, get_member, list_members_paginated};
+use crate::server::AppState;
+
+/// Wire shape returned by both endpoints. Joins `members:<did>`
+/// + `acl:<did>` so a caller doesn't need a second request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberResponse {
+    pub did: String,
+    pub role: VtcRole,
+    pub label: Option<String>,
+    pub joined_at: DateTime<Utc>,
+    pub publish_consent: bool,
+    pub departure_preference: Disposition,
+    pub status_list_index: Option<u32>,
+    pub current_vmc_id: Option<String>,
+    pub current_role_vec_id: Option<String>,
+    pub extensions: JsonValue,
+}
+
+impl MemberResponse {
+    fn from_pair(acl: VtcAclEntry, member: Member) -> Self {
+        debug_assert_eq!(
+            acl.did, member.did,
+            "ACL + Member rows must share their DID — caller is responsible for the join"
+        );
+        Self {
+            did: member.did,
+            role: acl.role,
+            label: acl.label,
+            joined_at: member.joined_at,
+            publish_consent: member.publish_consent,
+            departure_preference: member.departure_preference,
+            status_list_index: member.status_list_index,
+            current_vmc_id: member.current_vmc_id,
+            current_role_vec_id: member.current_role_vec_id,
+            extensions: member.extensions,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/members
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListMembersQuery {
+    /// Filter by role, expressed in the same wire form
+    /// [`VtcRole`] uses (`"admin"`, `"moderator"`,
+    /// `"custom:editor"`, …). Server-side filter applied after
+    /// pagination — sibling pages skip rows that don't match.
+    /// Future improvement: index by role.
+    pub role: Option<String>,
+    /// Pagination cursor (returned by a previous call).
+    pub cursor: Option<String>,
+    /// Page size. Clamped to `1..=200`.
+    pub limit: Option<usize>,
+}
+
+pub async fn list_members(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Query(query): Query<ListMembersQuery>,
+) -> Result<Json<Paginated<MemberResponse>>, AppError> {
+    let limit = query.limit.unwrap_or(50).clamp(1, MAX_LIMIT);
+
+    // Phase 1 reads the audit_key out of AppState's writer. The
+    // writer is `Some` for every Phase 0 + Phase 1 path — install
+    // bootstrap ensures the initial key exists. A daemon that
+    // started before that initial-key derivation would 503 here.
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+    let audit_key = audit_writer.active_key().await?;
+
+    let decoded_cursor = match &query.cursor {
+        Some(s) => Some(Cursor::decode(s, &audit_key.key)?),
+        None => None,
+    };
+
+    let mut page = list_members_paginated(
+        &state.members_ks,
+        &audit_key,
+        decoded_cursor.as_ref(),
+        limit,
+    )
+    .await?;
+
+    // Join with ACL entries.
+    let mut items = Vec::with_capacity(page.items.len());
+    for member in page.items.drain(..) {
+        match get_acl_entry(&state.acl_ks, &member.did).await? {
+            Some(acl) => {
+                if let Some(filter) = &query.role
+                    && acl.role.to_string() != *filter
+                {
+                    continue;
+                }
+                items.push(MemberResponse::from_pair(acl, member));
+            }
+            None => {
+                // Member row without an ACL row would mean an
+                // out-of-band corruption. Log + skip rather than
+                // 500 — the page should still be returnable.
+                tracing::warn!(
+                    did = %member.did,
+                    "member row has no matching ACL entry; skipping in list response"
+                );
+            }
+        }
+    }
+
+    Ok(Json(Paginated {
+        items,
+        next_cursor: page.next_cursor,
+        total_estimate: page.total_estimate,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/members/{did}
+// ---------------------------------------------------------------------------
+
+pub async fn show_member(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(did): Path<String>,
+) -> Result<Json<MemberResponse>, AppError> {
+    let member = get_member(&state.members_ks, &did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;
+    let acl = get_acl_entry(&state.acl_ks, &did).await?.ok_or_else(|| {
+        // Same out-of-band corruption case as the list path —
+        // surface as 404 because the *member* isn't presentable.
+        AppError::NotFound(format!("member not found (no ACL row): {did}"))
+    })?;
+    Ok(Json(MemberResponse::from_pair(acl, member)))
+}
+
+/// Unused-listing helper kept to ensure `list_acl_entries` stays
+/// linked when the foundation PR's pruning passes try to flag it
+/// dead. Will be the production filter path once "list ACL
+/// without member metadata" arrives in Phase 2+.
+#[allow(dead_code)]
+pub(crate) async fn list_admin_dids(state: &AppState) -> Result<Vec<String>, AppError> {
+    let entries = list_acl_entries(&state.acl_ks).await?;
+    Ok(entries
+        .into_iter()
+        .filter(|e| matches!(e.role, VtcRole::Admin))
+        .map(|e| e.did)
+        .collect())
+}

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -1,0 +1,148 @@
+//! `PATCH /v1/members/{did}` — M1.5.1.
+
+use axum::Json;
+use axum::extract::{Path, State};
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+
+use vti_common::audit::{AuditEvent, MemberUpdatedData, RoleChangedData};
+
+use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use crate::auth::AdminAuth;
+use crate::error::AppError;
+use crate::members::{Disposition, get_member, store_member};
+use crate::routes::members::read::MemberResponse;
+use crate::server::AppState;
+
+/// Body of the PATCH request. Every field is optional; a request
+/// with no fields is a no-op (200 with the current row).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateMemberRequest {
+    pub role: Option<VtcRole>,
+    pub publish_consent: Option<bool>,
+    pub departure_preference: Option<Disposition>,
+    pub extensions: Option<JsonValue>,
+}
+
+pub async fn update_member(
+    auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(did): Path<String>,
+    Json(req): Json<UpdateMemberRequest>,
+) -> Result<Json<MemberResponse>, AppError> {
+    // Role=Admin is forbidden on this surface — it routes to the
+    // separate promote-to-admin endpoint (spec §10.4). Catch it
+    // early so the response carries an operator-friendly hint.
+    if matches!(req.role, Some(VtcRole::Admin)) {
+        return Err(AppError::Validation(format!(
+            "role=admin is not assignable via PATCH /v1/members/{{did}}; \
+             use POST /v1/members/{did}/promote-to-admin (spec §10.4) \
+             so the step-up UV ceremony fires."
+        )));
+    }
+
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    let mut acl = get_acl_entry(&state.acl_ks, &did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;
+    let mut member = get_member(&state.members_ks, &did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;
+
+    let previous_role = acl.role.clone();
+    let mut fields_changed: Vec<String> = Vec::new();
+    let mut role_changed = false;
+
+    if let Some(new_role) = req.role.clone()
+        && new_role != acl.role
+    {
+        acl.role = new_role;
+        role_changed = true;
+    }
+
+    if let Some(consent) = req.publish_consent
+        && consent != member.publish_consent
+    {
+        member.publish_consent = consent;
+        fields_changed.push("publishConsent".into());
+    }
+    if let Some(pref) = req.departure_preference
+        && pref != member.departure_preference
+    {
+        member.departure_preference = pref;
+        fields_changed.push("departurePreference".into());
+    }
+    if let Some(extensions) = req.extensions
+        && extensions != member.extensions
+    {
+        member.extensions = extensions;
+        fields_changed.push("extensions".into());
+    }
+
+    // Persist in canonical order: ACL row first (auth-gating
+    // truth), then Member row. A crash between the two leaves the
+    // ACL slightly ahead of the metadata, which is the safer
+    // direction (the auth path keeps working).
+    if role_changed {
+        store_acl_entry(&state.acl_ks, &acl).await?;
+    }
+    if !fields_changed.is_empty() {
+        store_member(&state.members_ks, &member).await?;
+    }
+
+    // Audit. Role changes are a separate variant from
+    // non-role updates (spec §10.4 keeps the SIEM filter
+    // simple).
+    if role_changed {
+        audit_writer
+            .write(
+                &auth.0.did,
+                Some(&did),
+                AuditEvent::RoleChanged(RoleChangedData {
+                    previous_role: previous_role.to_string(),
+                    new_role: acl.role.to_string(),
+                }),
+            )
+            .await?;
+    }
+    if !fields_changed.is_empty() {
+        audit_writer
+            .write(
+                &auth.0.did,
+                Some(&did),
+                AuditEvent::MemberUpdated(MemberUpdatedData {
+                    fields_changed: fields_changed.clone(),
+                }),
+            )
+            .await?;
+    }
+
+    Ok(Json(MemberResponse::from_pair_for_route(acl, member)))
+}
+
+// Re-export `from_pair` under a route-only alias so this module
+// doesn't have to make the constructor public on `MemberResponse`.
+impl MemberResponse {
+    pub(crate) fn from_pair_for_route(acl: VtcAclEntry, member: crate::members::Member) -> Self {
+        // Inline the same join the read endpoints do — duplicating
+        // the body (~10 lines) is cheaper than exposing a public
+        // constructor that's only used by route handlers.
+        Self {
+            did: member.did,
+            role: acl.role,
+            label: acl.label,
+            joined_at: member.joined_at,
+            publish_consent: member.publish_consent,
+            departure_preference: member.departure_preference,
+            status_list_index: member.status_list_index,
+            current_vmc_id: member.current_vmc_id,
+            current_role_vec_id: member.current_role_vec_id,
+            extensions: member.extensions,
+        }
+    }
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -6,6 +6,7 @@ mod config;
 pub(crate) mod did_log;
 mod health;
 pub(crate) mod install;
+mod members;
 
 use axum::Router;
 use axum::routing::{delete, get, post};
@@ -82,6 +83,18 @@ pub fn router() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let admin_passkeys_revoke =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0")
+            .expect("static Trust-Task URL");
+    let members_list = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/list/1.0")
+        .expect("static Trust-Task URL");
+    let members_show = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/show/1.0")
+        .expect("static Trust-Task URL");
+    // `members_update` (`members/update/1.0`) shares the
+    // `members/{did}` mount with `show` for now — TrustTaskRouter
+    // doesn't support per-method Trust-Task selectors yet
+    // (same Phase-0 workaround `admin/config` + `community/profile`
+    // use). When that lands, split show + update.
+    let members_promote =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0")
             .expect("static Trust-Task URL");
 
     TrustTaskRouter::<AppState>::new()
@@ -218,6 +231,31 @@ pub fn router() -> Router<AppState> {
             "/v1/admin/passkeys/revoke/finish",
             post(admin::passkeys::revoke_finish),
             admin_passkeys_revoke,
+        )
+        // Members (Phase 1 M1.4–M1.6).
+        .route_with_task(
+            "/v1/members",
+            get(members::read::list_members),
+            members_list,
+        )
+        .route_with_task(
+            "/v1/members/{did}",
+            get(members::read::show_member).patch(members::update::update_member),
+            // GET + PATCH share one Trust Task today; split into
+            // members/show/1.0 + members/update/1.0 when
+            // TrustTaskRouter gains per-method selectors (same
+            // Phase-0 pattern community/profile + admin/config use).
+            members_show,
+        )
+        .route_with_task(
+            "/v1/members/{did}/promote-to-admin/start",
+            post(members::promote::promote_start),
+            members_promote.clone(),
+        )
+        .route_with_task(
+            "/v1/members/{did}/promote-to-admin/finish",
+            post(members::promote::promote_finish),
+            members_promote,
         )
         .into_router()
 }

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -1,0 +1,481 @@
+//! Integration coverage for `/v1/members/*` (Phase 1 M1.4–M1.6).
+//!
+//! Tests the wire shapes + auth gates of the list/show/update +
+//! promote-to-admin endpoints. The full UV ceremony for
+//! promote-to-admin needs the WebAuthn soft authenticator and
+//! lives separately (mirrors the admin/passkeys test split).
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::audit::{AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::passkey::build_webauthn;
+use vti_common::auth::session::{Session, SessionState, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::{KeyspaceHandle, Store};
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::{Member, store_member};
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+const RP_ORIGIN: &str = "https://vtc.example.com";
+const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/list/1.0";
+const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/show/1.0";
+const PROMOTE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0";
+
+const ADMIN_DID: &str = "did:key:zAdmin1";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    admin_token: String,
+    acl_ks: KeyspaceHandle,
+    members_ks: KeyspaceHandle,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    let install_store = InstallTokenStore::new(install_ks.clone());
+    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    // Seed an admin ACL row + Member row so the existing fixture
+    // helpers can mint a session token for the admin DID.
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &acl_ks,
+        &VtcAclEntry {
+            did: ADMIN_DID.into(),
+            role: VtcRole::Admin,
+            label: Some("test admin".into()),
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        public_url = "{RP_ORIGIN}"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    // Mint a session row that matches the JWT we hand back. The
+    // AuthClaims extractor requires both a valid JWT AND a
+    // matching `session_id` row in the sessions keyspace.
+    let session_id = "test-admin-session";
+    let session = Session {
+        session_id: session_id.into(),
+        did: ADMIN_DID.into(),
+        challenge: "test".into(),
+        state: SessionState::Authenticated,
+        created_at: now,
+        refresh_token: None,
+        refresh_expires_at: None,
+        tee_attested: false,
+    };
+    store_session(&sessions_ks, &session).await.unwrap();
+
+    let admin_claims = jwt_keys.new_claims(
+        ADMIN_DID.into(),
+        session_id.into(),
+        "admin".into(),
+        vec![],
+        3600,
+        true,
+    );
+    let admin_token = jwt_keys.encode(&admin_claims).unwrap();
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks: acl_ks.clone(),
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks: members_ks.clone(),
+        audit_ks,
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn,
+        public_url: Some(RP_ORIGIN.to_string()),
+        install_signer: None,
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+
+    Fixture {
+        router,
+        admin_token,
+        acl_ks,
+        members_ks,
+        _dir: dir,
+    }
+}
+
+async fn seed_member(fix: &Fixture, did: &str, role: VtcRole) {
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &fix.acl_ks,
+        &VtcAclEntry {
+            did: did.into(),
+            role,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    store_member(&fix.members_ks, &Member::fresh(did))
+        .await
+        .unwrap();
+}
+
+async fn send(
+    router: &axum::Router,
+    method: &str,
+    uri: &str,
+    trust_task: &str,
+    token: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("Trust-Task", trust_task);
+    if let Some(t) = token {
+        req = req.header("Authorization", format!("Bearer {t}"));
+    }
+    let res = router
+        .clone()
+        .oneshot(
+            req.body(
+                body.map(|v| Body::from(v.to_string()))
+                    .unwrap_or(Body::empty()),
+            )
+            .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+// ---------------------------------------------------------------------------
+// M1.4 — list + show
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_members_empty_returns_empty_items() {
+    let fix = build_fixture().await;
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/members",
+        LIST_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["items"], json!([]));
+    assert!(body["nextCursor"].is_null());
+}
+
+#[tokio::test]
+async fn list_members_returns_seeded_members() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zMember1", VtcRole::Member).await;
+    seed_member(&fix, "did:key:zMember2", VtcRole::Moderator).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/members",
+        LIST_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(items.len(), 2);
+    let roles: Vec<&str> = items.iter().map(|m| m["role"].as_str().unwrap()).collect();
+    assert!(roles.contains(&"member"));
+    assert!(roles.contains(&"moderator"));
+}
+
+#[tokio::test]
+async fn list_members_filter_by_role_drops_non_matching() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zMember1", VtcRole::Member).await;
+    seed_member(&fix, "did:key:zMod1", VtcRole::Moderator).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/members?role=moderator",
+        LIST_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["did"], "did:key:zMod1");
+}
+
+#[tokio::test]
+async fn list_members_requires_admin_role() {
+    let fix = build_fixture().await;
+    let (status, _) = send(&fix.router, "GET", "/v1/members", LIST_TASK, None, None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn show_member_returns_joined_response() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zM1", VtcRole::Issuer).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/members/did:key:zM1",
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["did"], "did:key:zM1");
+    assert_eq!(body["role"], "issuer");
+    assert!(body["joinedAt"].is_string());
+    assert_eq!(body["publishConsent"], false);
+    assert_eq!(body["departurePreference"], "policydefault");
+}
+
+#[tokio::test]
+async fn show_member_returns_404_for_unknown_did() {
+    let fix = build_fixture().await;
+    let (status, _) = send(
+        &fix.router,
+        "GET",
+        "/v1/members/did:key:zNobody",
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------------
+// M1.5 — PATCH
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn patch_member_role_member_to_moderator_succeeds_and_emits_audit() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zM1", VtcRole::Member).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "PATCH",
+        "/v1/members/did:key:zM1",
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "role": "moderator" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["role"], "moderator");
+
+    // Confirm the on-disk ACL row reflects the change.
+    let entry = vtc_service::acl::get_acl_entry(&fix.acl_ks, "did:key:zM1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(entry.role, VtcRole::Moderator);
+}
+
+#[tokio::test]
+async fn patch_member_role_admin_is_refused_with_promote_hint() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zM1", VtcRole::Member).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "PATCH",
+        "/v1/members/did:key:zM1",
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "role": "admin" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {body}");
+    let msg = body.to_string();
+    assert!(
+        msg.contains("promote-to-admin"),
+        "expected operator hint, got {msg}"
+    );
+}
+
+#[tokio::test]
+async fn patch_member_profile_only_emits_member_updated() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zM1", VtcRole::Member).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "PATCH",
+        "/v1/members/did:key:zM1",
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({
+            "publishConsent": true,
+            "departurePreference": "purge",
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["publishConsent"], true);
+    assert_eq!(body["departurePreference"], "purge");
+    // Role unchanged.
+    assert_eq!(body["role"], "member");
+}
+
+#[tokio::test]
+async fn patch_member_404_for_unknown_did() {
+    let fix = build_fixture().await;
+    let (status, _) = send(
+        &fix.router,
+        "PATCH",
+        "/v1/members/did:key:zNobody",
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "publishConsent": true })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------------
+// M1.6 — promote-to-admin pre-flight (full UV ceremony is in
+// `tests/admin_passkeys.rs`-style harness coverage, separate)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn promote_rejects_caller_promoting_themselves() {
+    let fix = build_fixture().await;
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/members/{ADMIN_DID}/promote-to-admin/start"),
+        PROMOTE_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {body}");
+    let msg = body.to_string();
+    assert!(msg.contains("cannot promote yourself"), "got {msg}");
+}
+
+#[tokio::test]
+async fn promote_404_for_non_member_target() {
+    let fix = build_fixture().await;
+    let (status, _) = send(
+        &fix.router,
+        "POST",
+        "/v1/members/did:key:zNobody/promote-to-admin/start",
+        PROMOTE_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn promote_409_when_target_is_already_admin() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zSecondAdmin", VtcRole::Admin).await;
+    let (status, _) = send(
+        &fix.router,
+        "POST",
+        "/v1/members/did:key:zSecondAdmin/promote-to-admin/start",
+        PROMOTE_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+}

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -97,6 +97,26 @@ pub enum AuditEvent {
     /// `audit_by_type` index without needing to walk the prior
     /// epoch.
     AuditKeyRotated(AuditKeyRotatedData),
+
+    /// `PATCH /v1/members/{did}` updated profile or non-role
+    /// metadata on a member's record. Lists the field names that
+    /// changed; values stay out of the envelope.
+    MemberUpdated(MemberUpdatedData),
+
+    /// `PATCH /v1/members/{did}` reassigned the member's role.
+    /// Distinct event from `MemberUpdated` because role changes
+    /// are security-significant — SIEM filters key on this
+    /// variant separately. Admin promotion uses
+    /// [`AdminPromoted`] instead (spec §10.4 keeps the two
+    /// paths separate).
+    RoleChanged(RoleChangedData),
+
+    /// `POST /v1/members/{did}/promote-to-admin` finished with
+    /// a successful step-up UV ceremony. Spec §10.4 makes this
+    /// its own variant (distinct from `RoleChanged`) so SIEM
+    /// rules can target it; admin elevation is the highest-
+    /// privilege grant the community emits.
+    AdminPromoted(AdminPromotedData),
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +248,41 @@ pub struct AuditKeyRotatedData {
     pub previous_key_id: String,
     pub new_key_id: String,
     pub rotation_reason: RotationReason,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberUpdatedData {
+    /// Names of the fields changed on this PATCH (e.g.
+    /// `["publishConsent", "departurePreference"]`). Field values
+    /// stay out of the audit log — operator-facing extensions data
+    /// can be arbitrarily large, and the metadata `publish_consent`
+    /// / `departure_preference` shifts are individually
+    /// non-sensitive.
+    pub fields_changed: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleChangedData {
+    /// Previous role, serialised via the service's role-enum
+    /// `Display` impl (e.g. `"moderator"`, `"custom:editor"`).
+    /// String-typed so this struct stays in vti-common without
+    /// taking a dep on vtc-service's `VtcRole`.
+    pub previous_role: String,
+    pub new_role: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminPromotedData {
+    /// Role the member held immediately before promotion.
+    pub previous_role: String,
+    /// Credential id of the passkey used in the step-up UV
+    /// ceremony that authorised the promotion. Spec §10.4 calls
+    /// out the UV requirement; recording the credential id makes
+    /// the chain of authority auditable.
+    pub authorising_credential_id: String,
 }
 
 // ---------------------------------------------------------------------------

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -31,9 +31,10 @@ pub mod writer;
 
 pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
 pub use event::{
-    AdminPasskeyData, AuditEvent, AuditKeyRotatedData, CommunityInstalledData,
+    AdminPasskeyData, AdminPromotedData, AuditEvent, AuditKeyRotatedData, CommunityInstalledData,
     CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
-    EmergencyBootstrapData, REDACTED_MARKER, RestartRequestedData,
+    EmergencyBootstrapData, MemberUpdatedData, REDACTED_MARKER, RestartRequestedData,
+    RoleChangedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;

--- a/vti-common/src/audit/writer.rs
+++ b/vti-common/src/audit/writer.rs
@@ -40,6 +40,14 @@ impl AuditWriter {
         }
     }
 
+    /// Return the currently-active audit key. Callers that need to
+    /// sign a pagination cursor (or run any other HMAC operation
+    /// tied to the per-community audit epoch) use this rather than
+    /// reaching into the key store directly.
+    pub async fn active_key(&self) -> Result<crate::audit::AuditKey, AppError> {
+        self.key_store.active().await
+    }
+
     /// Write an audit event. Hashes `actor_did` (mandatory) and
     /// `target_did` (optional) under the currently-active key,
     /// returns the persisted envelope so callers can echo the


### PR DESCRIPTION
## Summary

**PR-2 of Phase 1** per `tasks/vtc-mvp/phase-1-plan.md`. Adds the
admin-gated read + update + promote-to-admin surface that
PR-3's join flow will write into.

Closes **M1.4, M1.5, M1.6**.

## Endpoints

| Method | Path | Trust Task | Auth |
|---|---|---|---|
| `GET` | `/v1/members` | `members/list/1.0` | AdminAuth |
| `GET` | `/v1/members/{did}` | `members/show/1.0` | AdminAuth |
| `PATCH` | `/v1/members/{did}` | `members/show/1.0`† | AdminAuth |
| `POST` | `/v1/members/{did}/promote-to-admin/start` | `members/promote-to-admin/1.0` | AdminAuth |
| `POST` | `/v1/members/{did}/promote-to-admin/finish` | `members/promote-to-admin/1.0` | AdminAuth + step-up UV |

† GET + PATCH share the `members/show/1.0` Trust Task at the
router layer pending TrustTaskRouter's per-method selectors —
same Phase-0 workaround `admin/config` + `community/profile`
already use. The standalone `members/update/1.0` Trust Task
exists in `index.json` + on-disk spec / schema files so the
soft-gate Trust Task surface is complete; the router layer
catches up later.

## Highlights

- **Joined response shape** — `MemberResponse` returns
  `members:<did>` metadata + `acl:<did>` role + label in one
  body so admin UX doesn't need a second round-trip.
- **PATCH role=admin refused** with an operator-facing hint
  pointing at promote-to-admin. Spec §10.4's "admin promotion
  is a separate endpoint" invariant is now wire-enforced.
- **`AdminPromoted` is its own audit variant** (distinct from
  `RoleChanged`) so SIEM rules can target admin elevation
  specifically. Carries the authorising credential id from the
  step-up UV ceremony.
- **`PROMOTE_LOCK`** serialises the already-admin re-check at
  finish time, mirroring `ADMIN_PASSKEY_LOCK`. A concurrent
  PATCH can't smuggle an out-of-band role mutation between
  start + finish.
- **`AuditWriter::active_key()`** new accessor — pagination
  cursor signing reaches the key without poking at the
  keystore directly.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --package vtc-service` — 128 lib + 13 new
  `tests/members_crud.rs` cases + every existing integration
  fixture green
- [ ] `cargo test --workspace` — CI will confirm

The 13 new tests cover: list (empty / seeded / role filter /
no-auth), show (happy + 404), PATCH (role change + role=admin
refusal + profile-only + 404), and promote-to-admin pre-flight
refusals (self-promotion / non-member / already-admin). Full
UV ceremony happy-path lives separately (mirrors the
admin/passkeys harness split — needs the soft EdDSA
authenticator fixture).

## Phase 1 progress

| PR | Milestones | Status |
|---|---|---|
| PR-1 | M1.1, M1.2, M1.3 | merged |
| **PR-2 (this)** | M1.4, M1.5, M1.6 | **in review** |
| PR-3 | M1.7, M1.8, M1.9, M1.10 | next (join requests) |
| PR-4 | M1.11, M1.12 | (removal) |
| PR-5 | M1.13, M1.14, M1.15 | (gate) |