### PR TITLE
feat(vtc): join requests REST + DIDComm + approve/reject (M1.7–M1.10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8901,7 +8901,9 @@ dependencies = [
 name = "vtc-service"
 version = "0.6.0"
 dependencies = [
+ "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
  "affinidi-tdk",
  "async-trait",

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -148,6 +148,37 @@
       "status": "Draft",
       "path": "members/promote-to-admin/1.0",
       "rest": "POST /v1/members/{did}/promote-to-admin/{start,finish}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0",
+      "status": "Draft",
+      "path": "join-requests/submit/1.0",
+      "rest": "POST /v1/join-requests",
+      "didcomm": "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/join-requests/list/1.0",
+      "status": "Draft",
+      "path": "join-requests/list/1.0",
+      "rest": "GET /v1/join-requests"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0",
+      "status": "Draft",
+      "path": "join-requests/show/1.0",
+      "rest": "GET /v1/join-requests/{id}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0",
+      "status": "Draft",
+      "path": "join-requests/approve/1.0",
+      "rest": "POST /v1/join-requests/{id}/approve"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0",
+      "status": "Draft",
+      "path": "join-requests/reject/1.0",
+      "rest": "POST /v1/join-requests/{id}/reject"
     }
   ]
 }

--- a/trust-tasks/join-requests/approve/1.0/schema.json
+++ b/trust-tasks/join-requests/approve/1.0/schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Join Requests — Approve",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["requestId", "status"],
+      "properties": {
+        "requestId": { "type": "string", "format": "uuid" },
+        "status": { "type": "string", "enum": ["approved"] }
+      }
+    }
+  }
+}

--- a/trust-tasks/join-requests/approve/1.0/spec.md
+++ b/trust-tasks/join-requests/approve/1.0/spec.md
@@ -1,0 +1,33 @@
+---
+id: https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0
+title: VTC Join Requests — Approve
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/join-requests/{id}/approve
+---
+
+# VTC Join Requests — Approve
+
+Approves a `Pending` join request. Atomic write of:
+
+1. `acl:<applicant_did>` with `role = Member`.
+2. `members:<applicant_did>` row.
+3. `JoinRequest.status = Approved`.
+
+Audit envelopes emitted: `JoinRequestApproved`, `MemberAdded`.
+The two events share the same admin actor + applicant target so
+SIEM rules can correlate them via timestamp / target DID.
+
+## Authentication
+
+`AdminAuth`.
+
+## Errors
+
+- `404 Not Found` — request id unknown.
+- `409 Conflict` — request is not in `Pending` status, **or**
+  the applicant DID already has an ACL row (defence against a
+  double-admit race).

--- a/trust-tasks/join-requests/list/1.0/schema.json
+++ b/trust-tasks/join-requests/list/1.0/schema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/join-requests/list/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Join Requests — List",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": { "$ref": "../../show/1.0/schema.json#/$defs/JoinRequest" }
+        },
+        "nextCursor": { "type": ["string", "null"] },
+        "totalEstimate": { "type": ["integer", "null"] }
+      }
+    }
+  }
+}

--- a/trust-tasks/join-requests/list/1.0/spec.md
+++ b/trust-tasks/join-requests/list/1.0/spec.md
@@ -1,0 +1,25 @@
+---
+id: https://trusttasks.org/openvtc/vtc/join-requests/list/1.0
+title: VTC Join Requests — List
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/join-requests
+---
+
+# VTC Join Requests — List
+
+Paginated list of join requests. Default status filter is
+`pending`.
+
+## Authentication
+
+`AdminAuth`.
+
+## Query parameters
+
+- `status` (optional, default `pending`) — `pending` /
+  `approved` / `rejected` / `withdrawn` / `deferred`.
+- `cursor` / `limit` — standard pagination.

--- a/trust-tasks/join-requests/reject/1.0/schema.json
+++ b/trust-tasks/join-requests/reject/1.0/schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Join Requests — Reject",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "properties": {
+        "reason": { "type": "string", "maxLength": 1024 }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["requestId", "status"],
+      "properties": {
+        "requestId": { "type": "string", "format": "uuid" },
+        "status": { "type": "string", "enum": ["rejected"] }
+      }
+    }
+  }
+}

--- a/trust-tasks/join-requests/reject/1.0/spec.md
+++ b/trust-tasks/join-requests/reject/1.0/spec.md
@@ -1,0 +1,31 @@
+---
+id: https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0
+title: VTC Join Requests — Reject
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/join-requests/{id}/reject
+---
+
+# VTC Join Requests — Reject
+
+Rejects a `Pending` join request. The body may carry an optional
+`reason` (capped at 1024 chars). No ACL or Member rows written.
+
+Audit envelope: `JoinRequestRejected { requestId, reason }`.
+
+The row stays in the keyspace until the retention sweeper purges
+it (default 30 days, configurable via
+`config.join_requests.retention_days`).
+
+## Authentication
+
+`AdminAuth`.
+
+## Errors
+
+- `400 Bad Request` — `reason` exceeds 1024 chars.
+- `404 Not Found` — request id unknown.
+- `409 Conflict` — request is not in `Pending` status.

--- a/trust-tasks/join-requests/show/1.0/schema.json
+++ b/trust-tasks/join-requests/show/1.0/schema.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Join Requests — Show",
+  "type": "object",
+  "properties": {
+    "response": { "$ref": "#/$defs/JoinRequest" }
+  },
+  "$defs": {
+    "JoinRequest": {
+      "type": "object",
+      "required": ["id", "applicantDid", "vp", "submittedAt", "status"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "applicantDid": { "type": "string" },
+        "vp": {},
+        "submittedAt": { "type": "string", "format": "date-time" },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "approved", "rejected", "withdrawn", "deferred"]
+        },
+        "policyDecision": {},
+        "registryConsent": { "type": "boolean" },
+        "extensions": {}
+      }
+    }
+  }
+}

--- a/trust-tasks/join-requests/show/1.0/spec.md
+++ b/trust-tasks/join-requests/show/1.0/spec.md
@@ -1,0 +1,22 @@
+---
+id: https://trusttasks.org/openvtc/vtc/join-requests/show/1.0
+title: VTC Join Requests — Show
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/join-requests/{id}
+---
+
+# VTC Join Requests — Show
+
+Returns the full `JoinRequest` including the opaque VP.
+
+## Authentication
+
+`AdminAuth`.
+
+## Errors
+
+- `404 Not Found` — unknown id.

--- a/trust-tasks/join-requests/submit/1.0/schema.json
+++ b/trust-tasks/join-requests/submit/1.0/schema.json
@@ -1,0 +1,35 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Join Requests — Submit",
+  "type": "object",
+  "properties": {
+    "restRequest": {
+      "type": "object",
+      "required": ["applicantDid", "vp", "signature"],
+      "properties": {
+        "applicantDid": { "type": "string", "pattern": "^did:key:" },
+        "vp": {},
+        "registryConsent": { "type": "boolean" },
+        "extensions": {},
+        "signature": { "type": "string", "pattern": "^[0-9a-fA-F]+$" }
+      }
+    },
+    "didcommBody": {
+      "type": "object",
+      "properties": {
+        "vp": {},
+        "registryConsent": { "type": "boolean" },
+        "extensions": {}
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["requestId", "status"],
+      "properties": {
+        "requestId": { "type": "string", "format": "uuid" },
+        "status": { "type": "string", "enum": ["pending"] }
+      }
+    }
+  }
+}

--- a/trust-tasks/join-requests/submit/1.0/spec.md
+++ b/trust-tasks/join-requests/submit/1.0/spec.md
@@ -1,0 +1,55 @@
+---
+id: https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0
+title: VTC Join Requests — Submit
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/join-requests
+  - didcomm: https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0
+---
+
+# VTC Join Requests — Submit
+
+Persist a `JoinRequest` in status `Pending`. Phase 1 manual-
+approval flow: admin / moderator runs approve or reject later.
+
+## Authentication
+
+Unauthenticated. The VP / DIDComm envelope is the auth — see
+spec §5.5.
+
+### REST holder binding
+
+Request body carries `applicantDid`, `vp`, optional
+`registryConsent` + `extensions`, and a hex-encoded Ed25519
+signature. Phase 1 supports `did:key` applicants only (the
+pubkey is intrinsic to the DID).
+
+The signing payload is the canonical JSON of the request body
+(minus `signature`) prefixed with the domain tag
+`vtc-join-request/v1\0`. Verification:
+
+1. Decode `applicantDid` → Ed25519 pubkey.
+2. Decode `signature` (hex).
+3. Verify the signature against the prefixed payload.
+
+### DIDComm
+
+`applicantDid` comes from the DIDComm `from` field (the
+authcrypt sender). No separate signature in the body — the
+envelope IS the binding. The handler replies with a
+`join-requests/submit-receipt/1.0` message carrying the
+`requestId` + `status`.
+
+## Errors
+
+- `400 Bad Request` — malformed VP / signature / non-did:key
+  applicant.
+- `429 Too Many Requests` — rate-limited (per-IP for REST,
+  per-sender-DID for DIDComm).
+
+## Audit
+
+`JoinRequestSubmitted { requestId, transport: "rest"|"didcomm" }`.

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -1,0 +1,42 @@
+//! DIDComm wire types for VTC join-request submission.
+//!
+//! The corresponding REST endpoint is `POST /v1/join-requests`;
+//! over DIDComm the message `type` field IS the Trust Task URL
+//! (workspace convention) and the DIDComm authcrypt sender
+//! authenticates the applicant DID — no separate holder-binding
+//! signature is needed (the envelope already binds the sender).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+/// DIDComm message `type` for a join-request submission.
+pub const JOIN_REQUEST_SUBMIT_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0";
+
+/// DIDComm message `type` for the VTC's reply (the submission
+/// receipt). Carried as a `thid` reply to the submit message id.
+pub const JOIN_REQUEST_SUBMIT_RECEIPT_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/join-requests/submit-receipt/1.0";
+
+/// Body of the submit message. Applicant_did comes from the
+/// DIDComm `from` field, not the body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestSubmitBody {
+    pub vp: JsonValue,
+    #[serde(default)]
+    pub registry_consent: bool,
+    #[serde(default)]
+    pub extensions: JsonValue,
+}
+
+/// Body of the receipt message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestSubmitReceiptBody {
+    pub request_id: Uuid,
+    /// Status string. Always `"pending"` for a successful submit;
+    /// future protocol versions may add `"deferred"` etc.
+    pub status: String,
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -7,6 +7,7 @@ pub mod context_management;
 pub mod did_management;
 pub mod did_template_management;
 pub mod discovery;
+pub mod join_requests;
 pub mod key_management;
 pub mod protocol_management;
 #[cfg(feature = "provision-integration")]

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -50,6 +50,11 @@ vta-sdk = { path = "../vta-sdk", version = "0.6", features = [
 ] }
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm-service = { workspace = true }
+# Lower-level DIDComm message types — needed for the join-request
+# message handler in `messaging.rs` (M1.8.2). The service crate
+# accepts `Message` / `UnpackMetadata` by value but doesn't
+# re-export them.
+affinidi-messaging-didcomm = "0.13"
 tokio-util = { workspace = true, features = ["rt"] }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 base64 = { workspace = true }
@@ -105,6 +110,9 @@ webauthn-rs-proto = "0.5"
 # `emergency::VtaRecoveryProver` trait so production code +
 # integration tests can swap in their own provers.
 async-trait = "0.1"
+# did:key → Ed25519 public-key conversion for the join-request
+# holder-binding signature verifier (M1.8.1).
+affinidi-crypto = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/vtc-service/src/join/mod.rs
+++ b/vtc-service/src/join/mod.rs
@@ -1,0 +1,172 @@
+//! Join requests — spec §5.5 + §10.1.
+//!
+//! Phase 1 ships a manual-approval flow: applicants submit a
+//! holder-bound VP, the request lands in `join_requests:` with
+//! status `Pending`, and an admin / moderator approves or
+//! rejects via the admin surface (M1.10). The policy-engine
+//! step (`join.rego`) is Phase 2.
+//!
+//! ## What's deferred to Phase 2+
+//!
+//! - VP scoring against `join.rego`. Phase 1 records the VP as
+//!   opaque JSON; Phase 2's policy step reads it back without a
+//!   re-submit.
+//! - VMC + role VEC issuance via the VTA oracle on approve.
+//!   Phase 1's approve writes ACL + Member only.
+
+pub mod retention;
+pub mod storage;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+pub use retention::{JoinRequestsConfig, RetentionSweeper, default_retention_days};
+pub use storage::{
+    JOIN_REQUEST_EXTENSIONS_MAX_BYTES, JOIN_REQUEST_VP_MAX_BYTES, delete_join_request,
+    get_join_request, list_join_requests, list_join_requests_paginated, store_join_request,
+};
+
+/// State of a join request through its lifecycle.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum JoinStatus {
+    /// Submitted; awaiting admin / moderator decision.
+    Pending,
+    /// Admin / moderator approved; ACL + Member rows written.
+    Approved,
+    /// Admin / moderator rejected. Retained for the configured
+    /// retention window then purged.
+    Rejected,
+    /// Applicant withdrew their request before a decision.
+    /// Retained per same window as `Rejected`.
+    Withdrawn,
+    /// Policy engine signalled "decide later" (e.g. needs an
+    /// out-of-band step before admission). Phase 2+.
+    Deferred,
+}
+
+impl JoinStatus {
+    /// Returns `true` for the statuses the 30-day retention
+    /// sweeper prunes. `Pending` + `Deferred` rows stay until
+    /// they reach a terminal state.
+    pub fn is_terminal_retainable(self) -> bool {
+        matches!(self, JoinStatus::Rejected | JoinStatus::Withdrawn)
+    }
+}
+
+impl std::fmt::Display for JoinStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JoinStatus::Pending => f.write_str("pending"),
+            JoinStatus::Approved => f.write_str("approved"),
+            JoinStatus::Rejected => f.write_str("rejected"),
+            JoinStatus::Withdrawn => f.write_str("withdrawn"),
+            JoinStatus::Deferred => f.write_str("deferred"),
+        }
+    }
+}
+
+/// One join request. Stored under `join_requests:<id>`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequest {
+    pub id: Uuid,
+    pub applicant_did: String,
+    /// Opaque VP carried verbatim from the wire. Phase 2's policy
+    /// step (`join.rego`) reads this; Phase 1 never inspects it
+    /// beyond the holder-binding check the route layer ran at
+    /// submit time.
+    pub vp: JsonValue,
+    pub submitted_at: DateTime<Utc>,
+    pub status: JoinStatus,
+    /// Set by Phase 2's policy step on approve / reject. Always
+    /// `None` in Phase 1.
+    #[serde(default)]
+    pub policy_decision: Option<JsonValue>,
+    /// Whether the applicant consents to being published in the
+    /// community's trust-registry record (spec §8). Default
+    /// `false`; the operator-facing surface defers this decision
+    /// to Phase 3.
+    #[serde(default)]
+    pub registry_consent: bool,
+    /// Community-defined extensions slot (spec §3-M). Bounded by
+    /// `JOIN_REQUEST_EXTENSIONS_MAX_BYTES` (16 KiB) at the route
+    /// layer.
+    #[serde(default)]
+    pub extensions: JsonValue,
+}
+
+impl JoinRequest {
+    /// Construct a fresh `Pending` request.
+    pub fn new(applicant_did: impl Into<String>, vp: JsonValue) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            applicant_did: applicant_did.into(),
+            vp,
+            submitted_at: Utc::now(),
+            status: JoinStatus::Pending,
+            policy_decision: None,
+            registry_consent: false,
+            extensions: JsonValue::Null,
+        }
+    }
+}
+
+/// Transport the request arrived over. Used by the audit event
+/// (`JoinRequestData.transport`) so investigators can tell REST +
+/// DIDComm submissions apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JoinTransport {
+    Rest,
+    DIDComm,
+}
+
+impl JoinTransport {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            JoinTransport::Rest => "rest",
+            JoinTransport::DIDComm => "didcomm",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_status_terminal_retainable_only_for_rejected_and_withdrawn() {
+        for (status, expected) in [
+            (JoinStatus::Pending, false),
+            (JoinStatus::Approved, false),
+            (JoinStatus::Rejected, true),
+            (JoinStatus::Withdrawn, true),
+            (JoinStatus::Deferred, false),
+        ] {
+            assert_eq!(status.is_terminal_retainable(), expected, "{status:?}");
+        }
+    }
+
+    #[test]
+    fn join_status_display_is_lowercase() {
+        assert_eq!(JoinStatus::Pending.to_string(), "pending");
+        assert_eq!(JoinStatus::Approved.to_string(), "approved");
+        assert_eq!(JoinStatus::Deferred.to_string(), "deferred");
+    }
+
+    #[test]
+    fn join_request_new_uses_pending_status() {
+        let r = JoinRequest::new("did:key:z", serde_json::json!({}));
+        assert_eq!(r.status, JoinStatus::Pending);
+        assert_eq!(r.policy_decision, None);
+        assert!(!r.registry_consent);
+    }
+
+    #[test]
+    fn join_transport_str_round_trip() {
+        assert_eq!(JoinTransport::Rest.as_str(), "rest");
+        assert_eq!(JoinTransport::DIDComm.as_str(), "didcomm");
+    }
+}

--- a/vtc-service/src/join/retention.rs
+++ b/vtc-service/src/join/retention.rs
@@ -1,0 +1,195 @@
+//! 30-day retention sweeper for `Rejected` + `Withdrawn` join
+//! requests (spec §5.5).
+//!
+//! VP contents may include PII; the sole control on inadvertent
+//! PII retention is this sweeper. Runs on a daemon-wide tokio
+//! task spawned at startup; default cadence is hourly.
+
+use std::time::Duration;
+
+use chrono::{Duration as ChronoDuration, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::watch;
+use tracing::{debug, info, warn};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::{delete_join_request, list_join_requests};
+
+/// Operator-controllable retention window for terminal join
+/// requests (Rejected + Withdrawn).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestsConfig {
+    /// Retention window in days. After this many days from
+    /// `submitted_at`, terminal-state rows are purged on the next
+    /// sweep. Default 30.
+    #[serde(default = "default_retention_days")]
+    pub retention_days: u32,
+    /// How often the sweeper runs, in seconds. Default 3600 (1
+    /// hour). Lower in tests via the config knob if needed.
+    #[serde(default = "default_sweep_interval_secs")]
+    pub sweep_interval_secs: u64,
+}
+
+pub fn default_retention_days() -> u32 {
+    30
+}
+
+fn default_sweep_interval_secs() -> u64 {
+    3600
+}
+
+impl Default for JoinRequestsConfig {
+    fn default() -> Self {
+        Self {
+            retention_days: default_retention_days(),
+            sweep_interval_secs: default_sweep_interval_secs(),
+        }
+    }
+}
+
+/// Owns the sweeper background task.
+pub struct RetentionSweeper;
+
+impl RetentionSweeper {
+    /// Spawn the sweeper. Returns immediately; the task runs
+    /// until the daemon's shutdown watcher fires.
+    pub fn spawn(
+        ks: KeyspaceHandle,
+        config: JoinRequestsConfig,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let interval = Duration::from_secs(config.sweep_interval_secs.max(60));
+            info!(
+                retention_days = config.retention_days,
+                interval_secs = interval.as_secs(),
+                "join-request retention sweeper started"
+            );
+            // Sweep once on startup so a freshly-restarted daemon
+            // catches up on rows that aged out while it was down.
+            if let Err(e) = sweep_once(&ks, config.retention_days).await {
+                warn!(error = %e, "initial join-request sweep failed");
+            }
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        info!("join-request retention sweeper shutting down");
+                        return;
+                    }
+                    _ = tokio::time::sleep(interval) => {
+                        if let Err(e) = sweep_once(&ks, config.retention_days).await {
+                            warn!(error = %e, "join-request sweep failed");
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+
+/// One pass: scan every row, delete those whose status is
+/// `Rejected` / `Withdrawn` AND `submitted_at` is older than the
+/// retention window.
+async fn sweep_once(ks: &KeyspaceHandle, retention_days: u32) -> Result<(), AppError> {
+    let cutoff = Utc::now() - ChronoDuration::days(retention_days as i64);
+    let rows = list_join_requests(ks).await?;
+    let mut purged = 0usize;
+    for row in rows {
+        if row.status.is_terminal_retainable() && row.submitted_at < cutoff {
+            delete_join_request(ks, row.id).await?;
+            purged += 1;
+        }
+    }
+    if purged > 0 {
+        info!(
+            purged,
+            retention_days, "join-request retention sweep complete"
+        );
+    } else {
+        debug!(
+            retention_days,
+            "join-request retention sweep: nothing to purge"
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::join::storage::store_join_request;
+    use crate::join::{JoinRequest, JoinStatus};
+    use chrono::{Duration as ChronoDuration, Utc};
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("join_requests").unwrap();
+        (ks, dir)
+    }
+
+    fn at(submitted_at: chrono::DateTime<Utc>, status: JoinStatus) -> JoinRequest {
+        JoinRequest {
+            submitted_at,
+            status,
+            ..JoinRequest::new("did:key:z", serde_json::json!({}))
+        }
+    }
+
+    #[tokio::test]
+    async fn sweep_purges_old_rejected_rows() {
+        let (ks, _dir) = temp_ks().await;
+        let old = at(Utc::now() - ChronoDuration::days(31), JoinStatus::Rejected);
+        let recent = at(Utc::now() - ChronoDuration::days(7), JoinStatus::Rejected);
+        let pending_old = at(Utc::now() - ChronoDuration::days(60), JoinStatus::Pending);
+        for r in [&old, &recent, &pending_old] {
+            store_join_request(&ks, r).await.unwrap();
+        }
+
+        sweep_once(&ks, 30).await.unwrap();
+
+        let remaining = list_join_requests(&ks).await.unwrap();
+        let dids: Vec<_> = remaining.iter().map(|r| r.id).collect();
+        assert!(!dids.contains(&old.id), "old Rejected row must be purged");
+        assert!(
+            dids.contains(&recent.id),
+            "recent Rejected row must be retained"
+        );
+        assert!(
+            dids.contains(&pending_old.id),
+            "Pending rows must never be swept"
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_purges_old_withdrawn_rows() {
+        let (ks, _dir) = temp_ks().await;
+        let old = at(Utc::now() - ChronoDuration::days(45), JoinStatus::Withdrawn);
+        store_join_request(&ks, &old).await.unwrap();
+        sweep_once(&ks, 30).await.unwrap();
+        assert!(
+            list_join_requests(&ks).await.unwrap().is_empty(),
+            "old Withdrawn rows must be purged"
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_does_not_purge_approved_rows() {
+        let (ks, _dir) = temp_ks().await;
+        let approved = at(Utc::now() - ChronoDuration::days(365), JoinStatus::Approved);
+        store_join_request(&ks, &approved).await.unwrap();
+        sweep_once(&ks, 30).await.unwrap();
+        assert_eq!(list_join_requests(&ks).await.unwrap().len(), 1);
+    }
+}

--- a/vtc-service/src/join/storage.rs
+++ b/vtc-service/src/join/storage.rs
@@ -1,0 +1,179 @@
+//! CRUD helpers for [`super::JoinRequest`].
+//!
+//! `join_requests:<uuid>` key shape. The UUID-keyed shape (rather
+//! than DID-keyed) is plan §D8: a join request has an ID before
+//! the applicant DID is admitted to the community.
+
+use uuid::Uuid;
+use vti_common::audit::AuditKey;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated, paginate};
+use vti_common::store::KeyspaceHandle;
+
+use super::JoinRequest;
+
+/// Hard cap on the bytes-on-disk size of `JoinRequest.vp`. The
+/// route layer enforces this at submit time so an adversary
+/// can't fill the keyspace with multi-megabyte VPs.
+pub const JOIN_REQUEST_VP_MAX_BYTES: usize = 256 * 1024;
+
+/// Hard cap on `JoinRequest.extensions`.
+pub const JOIN_REQUEST_EXTENSIONS_MAX_BYTES: usize = 16 * 1024;
+
+const PREFIX: &[u8] = b"join_requests:";
+
+fn key(id: Uuid) -> Vec<u8> {
+    let mut k = PREFIX.to_vec();
+    k.extend_from_slice(id.as_hyphenated().to_string().as_bytes());
+    k
+}
+
+fn decode(bytes: &[u8]) -> Result<JoinRequest, AppError> {
+    serde_json::from_slice(bytes)
+        .map_err(|e| AppError::Internal(format!("JoinRequest decode: {e}")))
+}
+
+pub async fn get_join_request(
+    ks: &KeyspaceHandle,
+    id: Uuid,
+) -> Result<Option<JoinRequest>, AppError> {
+    let raw = ks.get_raw(key(id)).await?;
+    match raw {
+        Some(bytes) => Ok(Some(decode(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+pub async fn store_join_request(
+    ks: &KeyspaceHandle,
+    request: &JoinRequest,
+) -> Result<(), AppError> {
+    let vp_bytes = serde_json::to_vec(&request.vp)
+        .map_err(|e| AppError::Internal(format!("JoinRequest vp serialize: {e}")))?;
+    if vp_bytes.len() > JOIN_REQUEST_VP_MAX_BYTES {
+        return Err(AppError::Validation(format!(
+            "join request VP exceeds {} bytes (got {})",
+            JOIN_REQUEST_VP_MAX_BYTES,
+            vp_bytes.len(),
+        )));
+    }
+    let extensions_bytes = serde_json::to_vec(&request.extensions)
+        .map_err(|e| AppError::Internal(format!("JoinRequest extensions serialize: {e}")))?;
+    if extensions_bytes.len() > JOIN_REQUEST_EXTENSIONS_MAX_BYTES {
+        return Err(AppError::Validation(format!(
+            "join request extensions exceeds {} bytes (got {})",
+            JOIN_REQUEST_EXTENSIONS_MAX_BYTES,
+            extensions_bytes.len(),
+        )));
+    }
+    ks.insert(
+        String::from_utf8(key(request.id)).expect("key is ASCII"),
+        request,
+    )
+    .await
+}
+
+pub async fn delete_join_request(ks: &KeyspaceHandle, id: Uuid) -> Result<(), AppError> {
+    ks.remove(key(id)).await
+}
+
+/// Whole-keyspace walk — used by the retention sweeper. Routes use
+/// [`list_join_requests_paginated`] instead.
+pub async fn list_join_requests(ks: &KeyspaceHandle) -> Result<Vec<JoinRequest>, AppError> {
+    let raw = ks.prefix_iter_raw(PREFIX.to_vec()).await?;
+    let mut out = Vec::with_capacity(raw.len());
+    for (_k, v) in raw {
+        match decode(&v) {
+            Ok(r) => out.push(r),
+            Err(err) => tracing::warn!(error = %err, "skipping unparseable join_request row"),
+        }
+    }
+    Ok(out)
+}
+
+pub async fn list_join_requests_paginated(
+    ks: &KeyspaceHandle,
+    audit_key: &AuditKey,
+    cursor: Option<&Cursor>,
+    limit: usize,
+) -> Result<Paginated<JoinRequest>, AppError> {
+    let mut pairs = ks.prefix_iter_raw(PREFIX.to_vec()).await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let snapshot_id: u64 = pairs.len() as u64;
+    paginate(pairs, cursor, limit, &audit_key.key, snapshot_id, decode)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::join::JoinStatus;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("join_requests").unwrap();
+        (ks, dir)
+    }
+
+    fn fresh(applicant: &str) -> JoinRequest {
+        JoinRequest::new(applicant, serde_json::json!({"vp":"placeholder"}))
+    }
+
+    #[tokio::test]
+    async fn round_trip() {
+        let (ks, _dir) = temp_ks().await;
+        let r = fresh("did:key:zApplicant");
+        store_join_request(&ks, &r).await.unwrap();
+        let got = get_join_request(&ks, r.id).await.unwrap().unwrap();
+        assert_eq!(got, r);
+    }
+
+    #[tokio::test]
+    async fn list_returns_every_request() {
+        let (ks, _dir) = temp_ks().await;
+        for did in ["did:key:zA", "did:key:zB", "did:key:zC"] {
+            store_join_request(&ks, &fresh(did)).await.unwrap();
+        }
+        let list = list_join_requests(&ks).await.unwrap();
+        assert_eq!(list.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn delete_is_idempotent() {
+        let (ks, _dir) = temp_ks().await;
+        let r = fresh("did:key:z");
+        store_join_request(&ks, &r).await.unwrap();
+        delete_join_request(&ks, r.id).await.unwrap();
+        delete_join_request(&ks, r.id).await.unwrap();
+        assert!(get_join_request(&ks, r.id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn vp_size_limit_enforced() {
+        let (ks, _dir) = temp_ks().await;
+        let big = "a".repeat(JOIN_REQUEST_VP_MAX_BYTES + 1);
+        let mut r = fresh("did:key:zBig");
+        r.vp = serde_json::json!(big);
+        let err = store_join_request(&ks, &r).await.expect_err("size hit");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn join_status_lowercase_wire() {
+        let r = JoinRequest {
+            status: JoinStatus::Pending,
+            ..fresh("did:key:z")
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert_eq!(json["status"], "pending");
+    }
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -22,6 +22,7 @@ pub mod did_key;
 pub mod emergency;
 pub mod error;
 pub mod install;
+pub mod join;
 pub mod keys;
 pub mod members;
 pub mod messaging;

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use affinidi_messaging_didcomm::Message;
 use affinidi_messaging_didcomm_service::{
-    DIDCommService, DIDCommServiceConfig, ListenerConfig, ListenerEvent,
-    MESSAGE_PICKUP_STATUS_TYPE, RestartPolicy, RetryConfig, Router, TRUST_PING_TYPE, handler_fn,
-    ignore_handler, trust_ping_handler,
+    DIDCommResponse, DIDCommService, DIDCommServiceConfig, DIDCommServiceError, Extension,
+    HandlerContext, ListenerConfig, ListenerEvent, MESSAGE_PICKUP_STATUS_TYPE, RestartPolicy,
+    RetryConfig, Router, TRUST_PING_TYPE, handler_fn, ignore_handler, trust_ping_handler,
 };
 use affinidi_tdk::common::profiles::TDKProfile;
 use affinidi_tdk::secrets_resolver::{SecretsResolver, ThreadedSecretsResolver};
@@ -12,16 +13,30 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use vta_sdk::protocols::join_requests::{
+    JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitBody,
+    JoinRequestSubmitReceiptBody,
+};
+
 use crate::config::AppConfig;
+use crate::join::JoinTransport;
+use crate::routes::join_requests::submit::submit_inner;
+use crate::server::AppState;
 
 /// Start the DIDComm service and block until shutdown.
 ///
 /// Uses `DIDCommService` for automatic mediator connection management,
 /// reconnection with backoff, and typed message routing.
+///
+/// `state` is needed because the join-request handler writes
+/// rows into the keyspaces + audit log — same shared
+/// `AppState` the REST surface holds. Passed as a `Router`
+/// extension so handlers extract it via `Extension<AppState>`.
 pub async fn run_didcomm_service(
     config: &AppConfig,
     secrets_resolver: &Arc<ThreadedSecretsResolver>,
     vtc_did: &str,
+    state: AppState,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
     let mediator_did = match &config.messaging {
@@ -64,11 +79,19 @@ pub async fn run_didcomm_service(
         }],
     };
 
-    // Build a minimal router: trust-ping + ignore message-pickup-status
+    // Build the router: trust-ping + ignore-pickup-status + the
+    // VTC's protocol surface. `Extension<AppState>` is how the
+    // join-request handler reaches the keyspaces / audit writer.
     let router = match Router::new()
+        .extension(state)
         .route(TRUST_PING_TYPE, handler_fn(trust_ping_handler))
         .and_then(|r| r.route(MESSAGE_PICKUP_STATUS_TYPE, handler_fn(ignore_handler)))
-    {
+        .and_then(|r| {
+            r.route(
+                JOIN_REQUEST_SUBMIT_TYPE,
+                handler_fn(join_request_submit_handler),
+            )
+        }) {
         Ok(r) => r,
         Err(e) => {
             warn!("failed to build DIDComm router: {e}");
@@ -140,4 +163,44 @@ pub async fn run_didcomm_service(
     service.shutdown().await;
     event_task.abort();
     info!("DIDComm service stopped");
+}
+
+/// `join-requests/submit/1.0` over DIDComm (M1.8.2).
+///
+/// The applicant DID is the DIDComm `from` field — the
+/// authcrypt sender. No separate holder-binding signature
+/// needed (the envelope IS the proof). Calls into the same
+/// `submit_inner` the REST endpoint uses.
+async fn join_request_submit_handler(
+    ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<AppState>,
+) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let applicant_did = ctx.sender_did.clone().ok_or_else(|| {
+        DIDCommServiceError::Internal("join-request submit has no DIDComm sender".into())
+    })?;
+    let body: JoinRequestSubmitBody = serde_json::from_value(message.body.clone())
+        .map_err(|e| DIDCommServiceError::Internal(format!("malformed join-request body: {e}")))?;
+
+    let request = submit_inner(
+        &state,
+        applicant_did,
+        body.vp,
+        body.registry_consent,
+        body.extensions,
+        None,
+        JoinTransport::DIDComm,
+    )
+    .await
+    .map_err(|e| DIDCommServiceError::Internal(format!("submit failed: {e}")))?;
+
+    let receipt = JoinRequestSubmitReceiptBody {
+        request_id: request.id,
+        status: request.status.to_string(),
+    };
+    let body = serde_json::to_value(&receipt)
+        .map_err(|e| DIDCommServiceError::Internal(format!("receipt serialise: {e}")))?;
+    Ok(Some(
+        DIDCommResponse::new(JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, body).thid(message.id),
+    ))
 }

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -1,0 +1,198 @@
+//! `POST /v1/join-requests/{id}/approve` + `/reject` — admin
+//! decision endpoints (M1.10.1).
+//!
+//! Approve atomically writes the ACL row (`VtcRole::Member`),
+//! the Member record, and the audit envelopes
+//! (`JoinRequestApproved` + `MemberAdded`). The applicant_did is
+//! already validated at submit time so the only failure modes
+//! here are auth + duplicate-membership.
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use uuid::Uuid;
+
+use vti_common::audit::{AuditEvent, JoinRequestData, JoinRequestRejectedData, MemberAddedData};
+use vti_common::error::AppError;
+
+use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use crate::auth::AdminAuth;
+use crate::auth::session::now_epoch;
+use crate::join::{JoinStatus, get_join_request, store_join_request};
+use crate::members::{Member, store_member};
+use crate::server::AppState;
+
+const REJECT_REASON_MAX: usize = 1024;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecideResponse {
+    pub request_id: Uuid,
+    pub status: String,
+}
+
+// ---------------------------------------------------------------------------
+// Approve
+// ---------------------------------------------------------------------------
+
+pub async fn approve(
+    admin: AdminAuth,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<(StatusCode, Json<DecideResponse>), AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    let mut req = get_join_request(&state.join_requests_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("join request not found: {id}")))?;
+    if req.status != JoinStatus::Pending {
+        return Err(AppError::Conflict(format!(
+            "join request {id} is {:?}, not Pending",
+            req.status
+        )));
+    }
+    if get_acl_entry(&state.acl_ks, &req.applicant_did)
+        .await?
+        .is_some()
+    {
+        return Err(AppError::Conflict(format!(
+            "{} already has an ACL row; refusing to approve a duplicate membership",
+            req.applicant_did
+        )));
+    }
+
+    // Write ACL first (auth-gating truth), then Member, then flip
+    // the JoinRequest status. A crash between ACL + Member would
+    // leave the auth path working but the metadata missing — the
+    // safer direction (Phase 2 reconcile / next admin action can
+    // patch the gap).
+    let now = now_epoch();
+    let acl = VtcAclEntry {
+        did: req.applicant_did.clone(),
+        role: VtcRole::Member,
+        label: None,
+        allowed_contexts: vec![],
+        created_at: now,
+        created_by: admin.0.did.clone(),
+        expires_at: None,
+    };
+    store_acl_entry(&state.acl_ks, &acl).await?;
+
+    let member = Member::fresh(&req.applicant_did);
+    store_member(&state.members_ks, &member).await?;
+
+    req.status = JoinStatus::Approved;
+    store_join_request(&state.join_requests_ks, &req).await?;
+
+    audit_writer
+        .write(
+            &admin.0.did,
+            Some(&req.applicant_did),
+            AuditEvent::JoinRequestApproved(JoinRequestData {
+                request_id: id.to_string(),
+                transport: "rest".to_string(),
+            }),
+        )
+        .await?;
+    audit_writer
+        .write(
+            &admin.0.did,
+            Some(&req.applicant_did),
+            AuditEvent::MemberAdded(MemberAddedData {
+                role: VtcRole::Member.to_string(),
+                via_join_request_id: Some(id.to_string()),
+            }),
+        )
+        .await?;
+
+    info!(
+        request_id = %id,
+        applicant = %req.applicant_did,
+        admin = %admin.0.did,
+        "join request approved"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(DecideResponse {
+            request_id: id,
+            status: req.status.to_string(),
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Reject
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RejectBody {
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+pub async fn reject(
+    admin: AdminAuth,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<RejectBody>,
+) -> Result<(StatusCode, Json<DecideResponse>), AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    let reason = body.reason.unwrap_or_default();
+    if reason.len() > REJECT_REASON_MAX {
+        return Err(AppError::Validation(format!(
+            "reject reason exceeds {REJECT_REASON_MAX} chars (got {})",
+            reason.len(),
+        )));
+    }
+
+    let mut req = get_join_request(&state.join_requests_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("join request not found: {id}")))?;
+    if req.status != JoinStatus::Pending {
+        return Err(AppError::Conflict(format!(
+            "join request {id} is {:?}, not Pending",
+            req.status
+        )));
+    }
+
+    req.status = JoinStatus::Rejected;
+    store_join_request(&state.join_requests_ks, &req).await?;
+
+    audit_writer
+        .write(
+            &admin.0.did,
+            Some(&req.applicant_did),
+            AuditEvent::JoinRequestRejected(JoinRequestRejectedData {
+                request_id: id.to_string(),
+                reason: reason.clone(),
+            }),
+        )
+        .await?;
+
+    info!(
+        request_id = %id,
+        applicant = %req.applicant_did,
+        admin = %admin.0.did,
+        reason_present = !reason.is_empty(),
+        "join request rejected"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(DecideResponse {
+            request_id: id,
+            status: req.status.to_string(),
+        }),
+    ))
+}

--- a/vtc-service/src/routes/join_requests/mod.rs
+++ b/vtc-service/src/routes/join_requests/mod.rs
@@ -1,0 +1,11 @@
+//! `/v1/join-requests/*` route handlers (M1.7–M1.10).
+//!
+//! Submit + applicant-side endpoints are unauthenticated (the
+//! holder-binding VP / DIDComm envelope IS the auth). Admin-side
+//! list / show / approve / reject endpoints require AdminAuth
+//! (Phase 1 simplification — Moderator-tier admission lands in
+//! Phase 2's policy surface).
+
+pub mod decide;
+pub mod read;
+pub mod submit;

--- a/vtc-service/src/routes/join_requests/read.rs
+++ b/vtc-service/src/routes/join_requests/read.rs
@@ -1,0 +1,67 @@
+//! `GET /v1/join-requests` + `GET /v1/join-requests/{id}` — admin
+//! read endpoints (M1.9.1).
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, MAX_LIMIT, Paginated};
+
+use crate::auth::AdminAuth;
+use crate::join::{JoinRequest, JoinStatus, get_join_request, list_join_requests_paginated};
+use crate::server::AppState;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListJoinRequestsQuery {
+    /// Filter by status. Default `pending` — the operator-facing
+    /// surface usually wants the work queue.
+    pub status: Option<JoinStatus>,
+    pub cursor: Option<String>,
+    pub limit: Option<usize>,
+}
+
+pub async fn list_join_requests(
+    _admin: AdminAuth,
+    State(state): State<AppState>,
+    Query(query): Query<ListJoinRequestsQuery>,
+) -> Result<Json<Paginated<JoinRequest>>, AppError> {
+    let limit = query.limit.unwrap_or(50).clamp(1, MAX_LIMIT);
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+    let audit_key = audit_writer.active_key().await?;
+
+    let decoded_cursor = match &query.cursor {
+        Some(s) => Some(Cursor::decode(s, &audit_key.key)?),
+        None => None,
+    };
+
+    let mut page = list_join_requests_paginated(
+        &state.join_requests_ks,
+        &audit_key,
+        decoded_cursor.as_ref(),
+        limit,
+    )
+    .await?;
+
+    // Filter to the requested status (default Pending).
+    let filter_status = query.status.unwrap_or(JoinStatus::Pending);
+    page.items.retain(|r| r.status == filter_status);
+
+    Ok(Json(page))
+}
+
+pub async fn show_join_request(
+    _admin: AdminAuth,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<JoinRequest>, AppError> {
+    let req = get_join_request(&state.join_requests_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("join request not found: {id}")))?;
+    Ok(Json(req))
+}

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -1,0 +1,298 @@
+//! `POST /v1/join-requests` — REST submit (M1.8.1) + a shared
+//! inner `submit_inner` the DIDComm handler (M1.8.2) calls into.
+//!
+//! ## Holder binding
+//!
+//! Phase 1 plan §D4 requires only the holder-binding proof: the
+//! signature must verify against the applicant_did's intrinsic
+//! Ed25519 public key (did:key only — did:webvh resolution lands
+//! in Phase 2).
+//!
+//! Wire shape:
+//!
+//! ```text
+//! {
+//!   "applicantDid": "did:key:z…",
+//!   "vp":               { … opaque JSON … },
+//!   "registryConsent":  ? bool,
+//!   "extensions":       ? object,
+//!   "signature":        "<hex Ed25519 signature>"
+//! }
+//! ```
+//!
+//! Canonical signing payload:
+//!
+//! ```text
+//! "vtc-join-request/v1\0" || canonical_json({
+//!   "applicantDid":     applicant_did,
+//!   "vp":               vp,
+//!   "registryConsent":  registry_consent (default false),
+//!   "extensions":       extensions (default null),
+//! })
+//! ```
+//!
+//! `canonical_json` is just `serde_json::to_vec` on a
+//! key-ordered object — sufficient because both sides agree on
+//! the field ordering via the typed struct.
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::info;
+use uuid::Uuid;
+
+use vti_common::audit::{AuditEvent, JoinRequestData};
+use vti_common::error::AppError;
+
+use crate::join::{JoinRequest, JoinTransport, store_join_request};
+use crate::server::AppState;
+
+pub const JOIN_REQUEST_SUBMIT_DOMAIN_TAG: &[u8] = b"vtc-join-request/v1\0";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitRequestBody {
+    pub applicant_did: String,
+    pub vp: JsonValue,
+    #[serde(default)]
+    pub registry_consent: bool,
+    #[serde(default)]
+    pub extensions: JsonValue,
+    /// Hex-encoded Ed25519 signature.
+    pub signature: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitResponse {
+    pub request_id: Uuid,
+    pub status: String,
+}
+
+pub async fn submit(
+    State(state): State<AppState>,
+    Json(req): Json<SubmitRequestBody>,
+) -> Result<(StatusCode, Json<SubmitResponse>), AppError> {
+    let request = submit_inner(
+        &state,
+        req.applicant_did,
+        req.vp,
+        req.registry_consent,
+        req.extensions,
+        Some(&req.signature),
+        JoinTransport::Rest,
+    )
+    .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(SubmitResponse {
+            request_id: request.id,
+            status: request.status.to_string(),
+        }),
+    ))
+}
+
+/// Shared inner implementation called by both REST and the
+/// DIDComm handler. Returns the persisted `JoinRequest`.
+///
+/// `signature` is `Some` for REST (where the wire must carry an
+/// explicit holder-binding signature) and `None` for DIDComm
+/// (where the DIDComm envelope's authcrypt sender already
+/// authenticates `applicant_did`).
+pub async fn submit_inner(
+    state: &AppState,
+    applicant_did: String,
+    vp: JsonValue,
+    registry_consent: bool,
+    extensions: JsonValue,
+    signature_hex: Option<&str>,
+    transport: JoinTransport,
+) -> Result<JoinRequest, AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    // 1. Holder binding (REST only).
+    if let Some(hex_sig) = signature_hex {
+        verify_holder_signature(&applicant_did, &vp, registry_consent, &extensions, hex_sig)?;
+    }
+
+    // 2. Persist as Pending.
+    let mut request = JoinRequest::new(applicant_did.clone(), vp);
+    request.registry_consent = registry_consent;
+    request.extensions = extensions;
+    store_join_request(&state.join_requests_ks, &request).await?;
+
+    // 3. Audit. Actor is the applicant — they're the principal.
+    audit_writer
+        .write(
+            &applicant_did,
+            None,
+            AuditEvent::JoinRequestSubmitted(JoinRequestData {
+                request_id: request.id.to_string(),
+                transport: transport.as_str().to_string(),
+            }),
+        )
+        .await?;
+
+    info!(
+        request_id = %request.id,
+        applicant = %applicant_did,
+        transport = transport.as_str(),
+        "join request submitted"
+    );
+    Ok(request)
+}
+
+/// Verify the Ed25519 signature over the canonical signing
+/// payload (see module docs).
+fn verify_holder_signature(
+    applicant_did: &str,
+    vp: &JsonValue,
+    registry_consent: bool,
+    extensions: &JsonValue,
+    signature_hex: &str,
+) -> Result<(), AppError> {
+    let pubkey_bytes =
+        affinidi_crypto::did_key::did_key_to_ed25519_pub(applicant_did).map_err(|e| {
+            AppError::Validation(format!("applicant_did is not a parseable did:key: {e}"))
+        })?;
+    let verifying = VerifyingKey::from_bytes(&pubkey_bytes).map_err(|e| {
+        AppError::Validation(format!(
+            "applicant_did decodes to an invalid Ed25519 pubkey: {e}"
+        ))
+    })?;
+
+    let payload = canonical_payload(applicant_did, vp, registry_consent, extensions)?;
+    let signing_bytes = signing_bytes(&payload);
+
+    let raw_sig = hex::decode(signature_hex)
+        .map_err(|e| AppError::Validation(format!("signature is not hex: {e}")))?;
+    let signature = Signature::from_slice(&raw_sig).map_err(|e| {
+        AppError::Validation(format!("signature is not a 64-byte Ed25519 value: {e}"))
+    })?;
+
+    verifying
+        .verify(&signing_bytes, &signature)
+        .map_err(|e| AppError::Validation(format!("holder-binding signature failed: {e}")))?;
+    Ok(())
+}
+
+/// Canonical signing payload — a typed struct serialised via
+/// `serde_json::to_vec` with the field order pinned by the
+/// derive. Both sides build this identically by going through the
+/// same struct.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalPayload<'a> {
+    applicant_did: &'a str,
+    vp: &'a JsonValue,
+    registry_consent: bool,
+    extensions: &'a JsonValue,
+}
+
+fn canonical_payload(
+    applicant_did: &str,
+    vp: &JsonValue,
+    registry_consent: bool,
+    extensions: &JsonValue,
+) -> Result<Vec<u8>, AppError> {
+    serde_json::to_vec(&CanonicalPayload {
+        applicant_did,
+        vp,
+        registry_consent,
+        extensions,
+    })
+    .map_err(|e| AppError::Internal(format!("canonical payload serialize: {e}")))
+}
+
+/// Domain-tag prefixed bytes the signer hashes over.
+fn signing_bytes(payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(JOIN_REQUEST_SUBMIT_DOMAIN_TAG.len() + payload.len());
+    buf.extend_from_slice(JOIN_REQUEST_SUBMIT_DOMAIN_TAG);
+    buf.extend_from_slice(payload);
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// Tests — signing primitive + sign-then-verify round trip.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn pair() -> (SigningKey, String) {
+        let sk = SigningKey::from_bytes(&[0xAB; 32]);
+        let pub_bytes = sk.verifying_key().to_bytes();
+        let did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes);
+        (sk, did)
+    }
+
+    #[test]
+    fn sign_then_verify_round_trip() {
+        let (sk, did) = pair();
+        let vp = serde_json::json!({"vp":"placeholder"});
+        let payload = canonical_payload(&did, &vp, false, &JsonValue::Null).unwrap();
+        let sig = sk.sign(&signing_bytes(&payload));
+        let sig_hex = hex::encode(sig.to_bytes());
+
+        verify_holder_signature(&did, &vp, false, &JsonValue::Null, &sig_hex).unwrap();
+    }
+
+    #[test]
+    fn verify_rejects_wrong_signer() {
+        let (_a_sk, a_did) = pair();
+        let other = SigningKey::from_bytes(&[0xCD; 32]);
+        let vp = serde_json::json!({});
+        let payload = canonical_payload(&a_did, &vp, false, &JsonValue::Null).unwrap();
+        let sig = other.sign(&signing_bytes(&payload));
+        let sig_hex = hex::encode(sig.to_bytes());
+
+        let err = verify_holder_signature(&a_did, &vp, false, &JsonValue::Null, &sig_hex)
+            .expect_err("wrong signer must fail");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn verify_rejects_tampered_payload() {
+        let (sk, did) = pair();
+        let vp = serde_json::json!({"vp":"original"});
+        let payload = canonical_payload(&did, &vp, false, &JsonValue::Null).unwrap();
+        let sig = sk.sign(&signing_bytes(&payload));
+        let sig_hex = hex::encode(sig.to_bytes());
+
+        // Same signature, different VP body.
+        let tampered = serde_json::json!({"vp":"changed"});
+        let err = verify_holder_signature(&did, &tampered, false, &JsonValue::Null, &sig_hex)
+            .expect_err("tampered VP must fail");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn verify_rejects_garbage_signature() {
+        let (_sk, did) = pair();
+        let err =
+            verify_holder_signature(&did, &JsonValue::Null, false, &JsonValue::Null, "not-hex")
+                .expect_err("garbage sig must fail");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn verify_rejects_non_did_key_applicant() {
+        let err = verify_holder_signature(
+            "did:web:example.com",
+            &JsonValue::Null,
+            false,
+            &JsonValue::Null,
+            "00",
+        )
+        .expect_err("non-did:key must fail");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -6,6 +6,7 @@ mod config;
 pub(crate) mod did_log;
 mod health;
 pub(crate) mod install;
+pub(crate) mod join_requests;
 mod members;
 
 use axum::Router;
@@ -96,6 +97,21 @@ pub fn router() -> Router<AppState> {
     let members_promote =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0")
             .expect("static Trust-Task URL");
+    // POST + GET share `/v1/join-requests`. The `join-requests/list/1.0`
+    // Trust Task exists in index.json + on-disk spec/schema so the
+    // soft-gate surface stays complete; the wire enforcement here
+    // collapses to `join-requests/submit/1.0` until TrustTaskRouter
+    // gains per-method selectors (same workaround community/profile,
+    // admin/config, members/{did} use).
+    let join_submit = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0")
+        .expect("static Trust-Task URL");
+    let join_show = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/show/1.0")
+        .expect("static Trust-Task URL");
+    let join_approve =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0")
+            .expect("static Trust-Task URL");
+    let join_reject = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0")
+        .expect("static Trust-Task URL");
 
     TrustTaskRouter::<AppState>::new()
         .route_exempt("/health", get(health::health))
@@ -256,6 +272,31 @@ pub fn router() -> Router<AppState> {
             "/v1/members/{did}/promote-to-admin/finish",
             post(members::promote::promote_finish),
             members_promote,
+        )
+        // Join requests (Phase 1 M1.7–M1.10).
+        .route_with_task(
+            "/v1/join-requests",
+            // Submit (unauth) + admin list share the mount; the
+            // submit Trust Task `join-requests/submit/1.0` covers
+            // both methods here. Per-method selectors land
+            // alongside the same router work admin/config awaits.
+            post(join_requests::submit::submit).get(join_requests::read::list_join_requests),
+            join_submit,
+        )
+        .route_with_task(
+            "/v1/join-requests/{id}",
+            get(join_requests::read::show_join_request),
+            join_show,
+        )
+        .route_with_task(
+            "/v1/join-requests/{id}/approve",
+            post(join_requests::decide::approve),
+            join_approve,
+        )
+        .route_with_task(
+            "/v1/join-requests/{id}/reject",
+            post(join_requests::decide::reject),
+            join_reject,
         )
         .into_router()
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -48,6 +48,7 @@ pub struct AppState {
     pub passkey_ks: KeyspaceHandle,
     pub install_ks: KeyspaceHandle,
     pub members_ks: KeyspaceHandle,
+    pub join_requests_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
@@ -149,6 +150,7 @@ pub async fn run(
     let install_ks = store.keyspace("install")?;
     let install_store = InstallTokenStore::new(install_ks.clone());
     let members_ks = store.keyspace("members")?;
+    let join_requests_ks = store.keyspace("join_requests")?;
     let audit_ks = store.keyspace("audit")?;
     let audit_key_ks = store.keyspace("audit_key")?;
 
@@ -220,6 +222,7 @@ pub async fn run(
         passkey_ks,
         install_ks,
         members_ks,
+        join_requests_ks,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),
@@ -279,12 +282,14 @@ pub async fn run(
 
     // Spawn three named OS threads
     let mut rest_shutdown_rx = shutdown_rx.clone();
+    let rest_state = state.clone();
     let rest_handle = std::thread::Builder::new()
         .name("vtc-rest".into())
-        .spawn(move || run_rest_thread(std_listener, state, rest_cors, &mut rest_shutdown_rx))
+        .spawn(move || run_rest_thread(std_listener, rest_state, rest_cors, &mut rest_shutdown_rx))
         .map_err(|e| AppError::Internal(format!("failed to spawn REST thread: {e}")))?;
 
     let mut didcomm_shutdown_rx = shutdown_rx.clone();
+    let didcomm_state = state.clone();
     let didcomm_handle = std::thread::Builder::new()
         .name("vtc-didcomm".into())
         .spawn(move || {
@@ -292,6 +297,7 @@ pub async fn run(
                 didcomm_config,
                 didcomm_secrets,
                 didcomm_vtc_did,
+                didcomm_state,
                 &mut didcomm_shutdown_rx,
             )
         })
@@ -516,6 +522,7 @@ fn run_didcomm_thread(
     config: AppConfig,
     secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
     vtc_did: Option<String>,
+    state: AppState,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -536,7 +543,7 @@ fn run_didcomm_thread(
             }
         };
 
-        messaging::run_didcomm_service(&config, sr, did, shutdown_rx).await;
+        messaging::run_didcomm_service(&config, sr, did, state, shutdown_rx).await;
 
         info!("DIDComm thread shutting down");
     });

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -78,6 +78,7 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -117,6 +118,7 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         passkey_ks,
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -61,6 +61,7 @@ async fn build_with(
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -99,6 +100,7 @@ async fn build_with(
         passkey_ks,
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -84,6 +84,7 @@ async fn build_fixture(with_audit: bool) -> Fixture {
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -182,6 +183,7 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         passkey_ks,
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -54,6 +54,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -81,6 +82,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         passkey_ks,
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -55,6 +55,7 @@ async fn build() -> Fixture {
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -82,6 +83,7 @@ async fn build() -> Fixture {
         passkey_ks,
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -49,6 +49,7 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -71,6 +72,7 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
         passkey_ks,
         install_ks,
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -205,6 +205,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -290,6 +291,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         passkey_ks: passkey_ks.clone(),
         install_ks,
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config.clone())),

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -66,6 +66,7 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -100,6 +101,7 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         passkey_ks,
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -97,6 +97,7 @@ async fn build_fixture() -> Fixture {
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -129,6 +130,7 @@ async fn build_fixture() -> Fixture {
         passkey_ks,
         install_ks,
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1,0 +1,637 @@
+//! Integration coverage for `/v1/join-requests/*` (M1.7–M1.10).
+//!
+//! Exercises the REST surface end-to-end through `Router::oneshot`.
+//! DIDComm twin is covered separately by unit-testing the
+//! handler's `submit_inner` invocation pattern; an end-to-end
+//! DIDComm round-trip needs the mediator harness and lives in
+//! `vti-e2e-tests`.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ed25519_dalek::{Signer, SigningKey};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use uuid::Uuid;
+use vti_common::audit::{AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::passkey::build_webauthn;
+use vti_common::auth::session::{Session, SessionState, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::{KeyspaceHandle, Store};
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::get_member;
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+/// Mirror of the constant in `vtc_service::routes::join_requests::submit`
+/// — the route module is `pub(crate)` so we can't import it from a
+/// test. Keeping a single-line copy here is cheaper than widening
+/// the module's visibility for one test.
+const JOIN_REQUEST_SUBMIT_DOMAIN_TAG: &[u8] = b"vtc-join-request/v1\0";
+
+const RP_ORIGIN: &str = "https://vtc.example.com";
+const SUBMIT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0";
+const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0";
+const APPROVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0";
+const REJECT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0";
+
+const ADMIN_DID: &str = "did:key:zAdmin1";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    admin_token: String,
+    acl_ks: KeyspaceHandle,
+    members_ks: KeyspaceHandle,
+    #[allow(dead_code)]
+    join_requests_ks: KeyspaceHandle,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &acl_ks,
+        &VtcAclEntry {
+            did: ADMIN_DID.into(),
+            role: VtcRole::Admin,
+            label: Some("test admin".into()),
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let session_id = "test-admin-session";
+    store_session(
+        &sessions_ks,
+        &Session {
+            session_id: session_id.into(),
+            did: ADMIN_DID.into(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now,
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let admin_claims = jwt_keys.new_claims(
+        ADMIN_DID.into(),
+        session_id.into(),
+        "admin".into(),
+        vec![],
+        3600,
+        true,
+    );
+    let admin_token = jwt_keys.encode(&admin_claims).unwrap();
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        public_url = "{RP_ORIGIN}"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks: acl_ks.clone(),
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
+        audit_ks,
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn,
+        public_url: Some(RP_ORIGIN.to_string()),
+        install_signer: None,
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+
+    Fixture {
+        router,
+        admin_token,
+        acl_ks,
+        members_ks,
+        join_requests_ks,
+        _dir: dir,
+    }
+}
+
+/// Build a canonical-signing-payload signature for the holder-
+/// binding check. Mirrors the verifier's payload construction.
+fn sign_holder_payload(
+    sk: &SigningKey,
+    applicant_did: &str,
+    vp: &Value,
+    registry_consent: bool,
+    extensions: &Value,
+) -> String {
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Payload<'a> {
+        applicant_did: &'a str,
+        vp: &'a Value,
+        registry_consent: bool,
+        extensions: &'a Value,
+    }
+    let payload = serde_json::to_vec(&Payload {
+        applicant_did,
+        vp,
+        registry_consent,
+        extensions,
+    })
+    .unwrap();
+    let mut signing = Vec::with_capacity(JOIN_REQUEST_SUBMIT_DOMAIN_TAG.len() + payload.len());
+    signing.extend_from_slice(JOIN_REQUEST_SUBMIT_DOMAIN_TAG);
+    signing.extend_from_slice(&payload);
+    hex::encode(sk.sign(&signing).to_bytes())
+}
+
+fn applicant_pair() -> (SigningKey, String) {
+    let sk = SigningKey::from_bytes(&[0xCD; 32]);
+    let pub_bytes = sk.verifying_key().to_bytes();
+    let did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes);
+    (sk, did)
+}
+
+async fn send(
+    router: &axum::Router,
+    method: &str,
+    uri: &str,
+    trust_task: &str,
+    token: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("Trust-Task", trust_task);
+    if let Some(t) = token {
+        req = req.header("Authorization", format!("Bearer {t}"));
+    }
+    let res = router
+        .clone()
+        .oneshot(
+            req.body(
+                body.map(|v| Body::from(v.to_string()))
+                    .unwrap_or(Body::empty()),
+            )
+            .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+// ---------------------------------------------------------------------------
+// M1.8.1 — REST submit
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rest_submit_happy_path_persists_pending() {
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
+    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": signature,
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "got {body}");
+    assert_eq!(body["status"], "pending");
+    assert!(body["requestId"].is_string());
+}
+
+#[tokio::test]
+async fn rest_submit_rejects_wrong_signer() {
+    let fix = build_fixture().await;
+    let (_a_sk, applicant_did) = applicant_pair();
+    let other = SigningKey::from_bytes(&[0xEE; 32]);
+    let vp = json!({});
+    let bad_sig = sign_holder_payload(&other, &applicant_did, &vp, false, &Value::Null);
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": bad_sig,
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {body}");
+}
+
+#[tokio::test]
+async fn rest_submit_rejects_non_did_key_applicant() {
+    let fix = build_fixture().await;
+    let (status, _) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": "did:web:not-supported.example.com",
+            "vp": {},
+            "signature": "00",
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// M1.9.1 — list + show
+// ---------------------------------------------------------------------------
+
+async fn submit_pending(fix: &Fixture) -> Uuid {
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({"a":"b"});
+    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let (_, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": sig,
+        })),
+    )
+    .await;
+    Uuid::parse_str(body["requestId"].as_str().unwrap()).unwrap()
+}
+
+#[tokio::test]
+async fn list_returns_pending_by_default() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], id.to_string());
+    assert_eq!(items[0]["status"], "pending");
+}
+
+#[tokio::test]
+async fn show_returns_full_request_including_vp() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        &format!("/v1/join-requests/{id}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["status"], "pending");
+    assert!(body["vp"].is_object());
+}
+
+// ---------------------------------------------------------------------------
+// M1.10.1 — approve + reject
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn approve_writes_acl_and_member_atomically() {
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({});
+    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let (_, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": sig,
+        })),
+    )
+    .await;
+    let id = body["requestId"].as_str().unwrap();
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/approve"),
+        APPROVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["status"], "approved");
+
+    let acl = get_acl_entry(&fix.acl_ks, &applicant_did)
+        .await
+        .unwrap()
+        .expect("ACL row written");
+    assert_eq!(acl.role, VtcRole::Member);
+
+    let member = get_member(&fix.members_ks, &applicant_did)
+        .await
+        .unwrap()
+        .expect("Member row written");
+    assert_eq!(member.did, applicant_did);
+}
+
+#[tokio::test]
+async fn approve_409_when_duplicate_acl_exists() {
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({});
+    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let (_, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": sig,
+        })),
+    )
+    .await;
+    let id = body["requestId"].as_str().unwrap();
+
+    // Pre-existing ACL row collides with the approve write.
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &fix.acl_ks,
+        &VtcAclEntry {
+            did: applicant_did.clone(),
+            role: VtcRole::Member,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let (status, _) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/approve"),
+        APPROVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn reject_leaves_no_acl_or_member_rows() {
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({});
+    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let (_, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": sig,
+        })),
+    )
+    .await;
+    let id = body["requestId"].as_str().unwrap();
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/reject"),
+        REJECT_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "reason": "policy says no" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["status"], "rejected");
+
+    assert!(
+        get_acl_entry(&fix.acl_ks, &applicant_did)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        get_member(&fix.members_ks, &applicant_did)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn approve_404_for_unknown_id() {
+    let fix = build_fixture().await;
+    let id = Uuid::new_v4();
+    let (status, _) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/approve"),
+        APPROVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn approve_409_when_request_already_decided() {
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({});
+    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let (_, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": sig,
+        })),
+    )
+    .await;
+    let id = body["requestId"].as_str().unwrap();
+
+    // First approve — succeeds.
+    let _ = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/approve"),
+        APPROVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    // Second approve — 409.
+    let (status, _) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/approve"),
+        APPROVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn reject_rejects_overlong_reason() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+
+    let huge = "x".repeat(1025);
+    let (status, _) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/reject"),
+        REJECT_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "reason": huge })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// Auth gating sanity check
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_requires_authentication() {
+    let fix = build_fixture().await;
+    let (status, _) = send(
+        &fix.router,
+        "GET",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -49,6 +49,8 @@ struct Fixture {
     admin_token: String,
     acl_ks: KeyspaceHandle,
     members_ks: KeyspaceHandle,
+    #[allow(dead_code)]
+    join_requests_ks: KeyspaceHandle,
     _dir: tempfile::TempDir,
 }
 
@@ -67,6 +69,7 @@ async fn build_fixture() -> Fixture {
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -143,6 +146,7 @@ async fn build_fixture() -> Fixture {
         passkey_ks,
         install_ks,
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),
@@ -166,6 +170,7 @@ async fn build_fixture() -> Fixture {
         admin_token,
         acl_ks,
         members_ks,
+        join_requests_ks,
         _dir: dir,
     }
 }

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -38,6 +38,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -61,6 +62,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         passkey_ks,
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -234,6 +234,7 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
     let passkey_ks = store.keyspace("passkey").unwrap();
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -252,6 +253,7 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
         passkey_ks,
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -117,6 +117,34 @@ pub enum AuditEvent {
     /// rules can target it; admin elevation is the highest-
     /// privilege grant the community emits.
     AdminPromoted(AdminPromotedData),
+
+    /// `POST /v1/join-requests` (REST or DIDComm) accepted a
+    /// well-formed submission and persisted it as `Pending`. The
+    /// actor on this event is the applicant DID — they're the
+    /// principal, even though the daemon's authenticated identity
+    /// did not vouch for them.
+    JoinRequestSubmitted(JoinRequestData),
+
+    /// An admin / moderator approved a pending join request via
+    /// `POST /v1/join-requests/{id}/approve`. Always paired with a
+    /// `MemberAdded` emission in the same transaction (the
+    /// approve flow writes the ACL + Member rows atomically).
+    JoinRequestApproved(JoinRequestData),
+
+    /// An admin / moderator rejected a pending join request. The
+    /// `reason` field is operator-supplied and may be empty.
+    JoinRequestRejected(JoinRequestRejectedData),
+
+    /// New member row written. Companion event to
+    /// `JoinRequestApproved` — the latter is what an audit
+    /// query for "who approved this" matches, the former is
+    /// what "when did <did> join" matches. Spec §10.1.
+    MemberAdded(MemberAddedData),
+
+    /// Member row removed (or anonymised) per spec §10.2. Spec §5
+    /// `Disposition` decides whether the row is purged outright,
+    /// tombstoned with the DID retained, or kept historical.
+    MemberRemoved(MemberRemovedData),
 }
 
 // ---------------------------------------------------------------------------
@@ -283,6 +311,52 @@ pub struct AdminPromotedData {
     /// out the UV requirement; recording the credential id makes
     /// the chain of authority auditable.
     pub authorising_credential_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestData {
+    /// UUID of the JoinRequest row in the `join_requests:` keyspace.
+    pub request_id: String,
+    /// Transport the request arrived over (`"rest"` / `"didcomm"`),
+    /// recorded for diagnostics.
+    pub transport: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestRejectedData {
+    pub request_id: String,
+    /// Operator-supplied reason, capped at 1024 chars at the
+    /// route layer. May be empty.
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberAddedData {
+    /// Role assigned at admission. Phase 1 always emits
+    /// `"member"` (the default role on approve); future phases
+    /// may emit `"moderator"` / `"issuer"` etc. when invite
+    /// flows admit at higher tiers.
+    pub role: String,
+    /// `request_id` of the JoinRequest the admission resolved.
+    /// `None` for out-of-band additions (e.g. emergency bootstrap)
+    /// that don't pass through a join request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub via_join_request_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberRemovedData {
+    /// `disposition` after resolving `PolicyDefault`. One of
+    /// `"purge"`, `"tombstone"`, `"historical"`.
+    pub disposition: String,
+    /// Optional operator-supplied reason on admin removal. Empty
+    /// for self-removal.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub reason: String,
 }
 
 // ---------------------------------------------------------------------------

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -33,8 +33,8 @@ pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
 pub use event::{
     AdminPasskeyData, AdminPromotedData, AuditEvent, AuditKeyRotatedData, CommunityInstalledData,
     CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
-    EmergencyBootstrapData, MemberUpdatedData, REDACTED_MARKER, RestartRequestedData,
-    RoleChangedData,
+    EmergencyBootstrapData, JoinRequestData, JoinRequestRejectedData, MemberAddedData,
+    MemberRemovedData, MemberUpdatedData, REDACTED_MARKER, RestartRequestedData, RoleChangedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

**PR-3 of Phase 1**. Adds the applicant-facing submit surface
(REST + DIDComm) and the admin-facing list / show / approve /
reject path.

Closes **M1.7, M1.8 (incl. M1.8.2 DIDComm twin), M1.9, M1.10**.

## Endpoints

| Method | Path | Trust Task | Auth |
|---|---|---|---|
| `POST` | `/v1/join-requests` | `join-requests/submit/1.0` | Unauth (holder-binding signature) |
| `GET` | `/v1/join-requests` | `join-requests/submit/1.0`† | AdminAuth |
| `GET` | `/v1/join-requests/{id}` | `join-requests/show/1.0` | AdminAuth |
| `POST` | `/v1/join-requests/{id}/approve` | `join-requests/approve/1.0` | AdminAuth |
| `POST` | `/v1/join-requests/{id}/reject` | `join-requests/reject/1.0` | AdminAuth |

† POST + GET share the mount pending TrustTaskRouter's per-method
selectors. The standalone `join-requests/list/1.0` Trust Task is
in `index.json` + on-disk so the soft-gate surface stays
complete; same workaround `admin/config`, `community/profile`,
and the members PR use.

| Wire | Message type | Body |
|---|---|---|
| DIDComm submit | `https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0` | `{ vp, registryConsent?, extensions? }` |
| DIDComm receipt | `…/join-requests/submit-receipt/1.0` | `{ requestId, status }` |

## Highlights

- **Holder-binding signature** (REST). did:key applicants only —
  pubkey is intrinsic so no DID resolution needed. Domain-tag
  prefix `vtc-join-request/v1\0` follows the workspace doctrine
  (mirrors `vta-sealed-transfer/v1`, `vtc-did-rotation/v1`).
- **DIDComm authcrypt sender IS the binding** (no separate
  signature in the body). Handler dispatches via
  `affinidi-messaging-didcomm-service`'s `Router::extension(state)`
  pattern so AppState flows in the same way trust_ping_handler
  does — consistent with the workspace's existing design.
- **30-day retention sweeper** runs hourly + on startup. Spec
  §5.5 PII control. Default window configurable via
  `config.join_requests.retention_days`.
- **Approve atomicity**: ACL write → Member write →
  JoinRequest status flip → audit. Order is "auth-gating truth
  first" so a mid-flight crash leaves the auth path workable.
- **5 new audit variants** in vti-common
  (`JoinRequestSubmitted`, `JoinRequestApproved`,
  `JoinRequestRejected`, `MemberAdded`, `MemberRemoved`).
  `MemberRemoved` is unused until PR-4 lands removal; ships
  here so Phase 1's audit vocabulary is complete.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --package vtc-service` — **145 lib** (+17 over
  PR-2's 128) + **12 new `tests/join_requests.rs` cases** + every
  existing fixture still green
- [ ] `cargo test --workspace` — CI will confirm

The 12 new integration tests cover REST submit (happy +
wrong-signer + non-did:key), list/show (happy + auth required),
approve (happy + duplicate-ACL 409 + already-decided 409), reject
(happy + overlong-reason 400), and 404s for unknown ids.

End-to-end DIDComm submit (mediator round-trip) would need the
e2e harness — deferred to a `vti-e2e-tests` follow-up. The
handler's submit path is exercised by the REST happy-path tests
(both go through the same `submit_inner`).

## Phase 1 progress

| PR | Milestones | Status |
|---|---|---|
| PR-1 | M1.1, M1.2, M1.3 | merged |
| PR-2 | M1.4, M1.5, M1.6 | merged |
| **PR-3 (this)** | M1.7, M1.8, M1.9, M1.10 | **in review** |
| PR-4 | M1.11, M1.12 | next (removal) |
| PR-5 | M1.13, M1.14, M1.15 | (gate) |