### PR TITLE
feat(vtc): member removal — self + admin + no-last-admin (M1.11 + M1.12)

### DIFF
--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -179,6 +179,19 @@
       "status": "Draft",
       "path": "join-requests/reject/1.0",
       "rest": "POST /v1/join-requests/{id}/reject"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0",
+      "status": "Draft",
+      "path": "members/self-remove/1.0",
+      "rest": "DELETE /v1/members/me",
+      "didcomm": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/admin-remove/1.0",
+      "status": "Draft",
+      "path": "members/admin-remove/1.0",
+      "rest": "DELETE /v1/members/{did}"
     }
   ]
 }

--- a/trust-tasks/members/admin-remove/1.0/schema.json
+++ b/trust-tasks/members/admin-remove/1.0/schema.json
@@ -1,0 +1,30 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/admin-remove/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Members — Admin Remove",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "properties": {
+        "disposition": {
+          "type": "string",
+          "enum": ["purge", "tombstone", "historical", "policydefault"]
+        },
+        "reason": { "type": "string", "maxLength": 1024 }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["did", "disposition", "removed"],
+      "properties": {
+        "did": { "type": "string" },
+        "disposition": {
+          "type": "string",
+          "enum": ["purge", "tombstone", "historical"]
+        },
+        "removed": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/trust-tasks/members/admin-remove/1.0/spec.md
+++ b/trust-tasks/members/admin-remove/1.0/spec.md
@@ -1,0 +1,53 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/admin-remove/1.0
+title: VTC Members — Admin Remove
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: DELETE /v1/members/{did}
+---
+
+# VTC Members — Admin Remove
+
+Spec §10.2. An admin removes another member. Distinct path from
+self-remove so `MemberRemoved` audit envelopes carry the
+admin's DID as the actor and the target as the resource — SIEM
+rules can tell self-departures and admin actions apart.
+
+## Authentication
+
+`AdminAuth`. The caller MUST NOT be the target — use
+`DELETE /v1/members/me` for that. Phase 2 may grant
+`Moderator` callers a policy-gated path; Phase 1 keeps the
+gate on `Admin` only.
+
+## Body
+
+```text
+{
+  "disposition": ? "purge" | "tombstone" | "historical" | "policydefault",
+  "reason":      ? string (≤ 1024 chars)
+}
+```
+
+`reason` is operator-supplied and lands in the audit envelope.
+May be empty.
+
+## No-last-admin invariant
+
+Refused with **409 `LastAdminProtected`** if the target is the
+last `Admin` in the ACL. Promote another member to admin
+before removing the current sole admin.
+
+## Refusals
+
+- `400 Bad Request` — caller is the target.
+- `404 Not Found` — target has no ACL row.
+- `409 Conflict` — last-admin invariant.
+
+## Audit
+
+`MemberRemoved { disposition, reason }` with the admin DID as
+`actor` and the target DID as `resource`.

--- a/trust-tasks/members/self-remove/1.0/schema.json
+++ b/trust-tasks/members/self-remove/1.0/schema.json
@@ -1,0 +1,29 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Members — Self-Remove",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "properties": {
+        "disposition": {
+          "type": "string",
+          "enum": ["purge", "tombstone", "historical", "policydefault"]
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["did", "disposition", "removed"],
+      "properties": {
+        "did": { "type": "string" },
+        "disposition": {
+          "type": "string",
+          "enum": ["purge", "tombstone", "historical"]
+        },
+        "removed": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/trust-tasks/members/self-remove/1.0/spec.md
+++ b/trust-tasks/members/self-remove/1.0/spec.md
@@ -1,0 +1,63 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/self-remove/1.0
+title: VTC Members — Self-Remove
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: DELETE /v1/members/me
+  - didcomm: https://trusttasks.org/openvtc/vtc/members/self-remove/1.0
+---
+
+# VTC Members — Self-Remove
+
+Spec §10.2. A member departs the community. The caller's DID
+is the only target.
+
+## Authentication
+
+REST: any authenticated session (the caller IS the target).
+DIDComm: the message's `from` field — authcrypt sender — IS the
+target DID.
+
+## Body
+
+```text
+{
+  "disposition": ? "purge" | "tombstone" | "historical" | "policydefault"
+}
+```
+
+Empty body is accepted; defaults to the Member's stored
+`departure_preference`, falling back to
+`PolicyDefault → Tombstone` (plan §D6).
+
+## Atomicity
+
+ACL row deleted → Member row handled per disposition → audit
+`MemberRemoved` emitted. Step order is auth-gating truth first
+(so a mid-flight crash leaves the auth path workable).
+
+## No-last-admin invariant
+
+Caller is refused with **409 `LastAdminProtected`** if their
+removal would leave the community with zero admins. The check
+runs inside the same critical section as the ACL delete
+(process-wide `LAST_ADMIN_LOCK` mutex). Promote another member
+to admin first.
+
+## Dispositions
+
+- `purge` — ACL deleted, Member row deleted outright.
+- `tombstone` — ACL deleted, Member row retained with
+  `did` + `joinedAt` + `removedAt`; every PII / credential
+  field is cleared.
+- `historical` — ACL deleted, Member row retained verbatim
+  with `removedAt` stamped.
+- `policydefault` — resolves to `tombstone` in Phase 1; Phase 2
+  swaps in `removal.rego`'s `min_disposition`.
+
+## Audit
+
+`MemberRemoved { disposition, reason: "" }`.

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -40,3 +40,37 @@ pub struct JoinRequestSubmitReceiptBody {
     /// future protocol versions may add `"deferred"` etc.
     pub status: String,
 }
+
+// ---------------------------------------------------------------------------
+// Self-remove (M1.11.1 DIDComm twin)
+// ---------------------------------------------------------------------------
+
+/// DIDComm `type` for a member-side self-removal.
+pub const MEMBER_SELF_REMOVE_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0";
+
+/// VTC's reply with the resolved disposition + audit hint.
+pub const MEMBER_SELF_REMOVE_RECEIPT_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/members/self-remove-receipt/1.0";
+
+/// Body of the self-remove message. `did` comes from the DIDComm
+/// `from` field — the caller's authcrypt sender authenticates
+/// them. Disposition optional; falls back to the Member's stored
+/// `departure_preference` and then to PolicyDefault→Tombstone.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SelfRemoveBody {
+    #[serde(default)]
+    pub disposition: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelfRemoveReceiptBody {
+    pub did: String,
+    /// Resolved disposition (`"purge"` | `"tombstone"` |
+    /// `"historical"`). `policydefault` is never returned —
+    /// the daemon resolves it before responding.
+    pub disposition: String,
+    pub removed: bool,
+}

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -70,6 +70,16 @@ pub struct Member {
     /// layer.
     #[serde(default)]
     pub extensions: JsonValue,
+    /// Set when the member departs (spec §10.2). `None` for live
+    /// members; `Some(_)` distinguishes a Tombstoned or Historical
+    /// row from an active one. `Purge` deletes the Member row
+    /// outright — those rows never carry `removed_at`.
+    ///
+    /// Phase 2's renewal + VMC issuance paths consult this so they
+    /// don't mint a credential for a departed member that the
+    /// reconciler hasn't yet caught up on.
+    #[serde(default)]
+    pub removed_at: Option<DateTime<Utc>>,
 }
 
 impl Member {
@@ -91,7 +101,34 @@ impl Member {
             current_vmc_id: None,
             current_role_vec_id: None,
             extensions: JsonValue::Null,
+            removed_at: None,
         }
+    }
+
+    /// Returns `true` if this Member has been tombstoned or marked
+    /// historical. Always `false` immediately after [`Self::fresh`].
+    pub fn is_removed(&self) -> bool {
+        self.removed_at.is_some()
+    }
+
+    /// Convert the live row to a tombstone: clear every
+    /// PII-bearing / credential-bearing field, leave `did` +
+    /// `joined_at` intact, stamp `removed_at`. Tombstoned rows
+    /// retain enough metadata for "who was a member" queries
+    /// but carry no live profile data.
+    pub fn tombstone(&mut self) {
+        self.publish_consent = false;
+        self.departure_preference = Disposition::default_preference();
+        self.current_vmc_id = None;
+        self.current_role_vec_id = None;
+        self.extensions = JsonValue::Null;
+        self.removed_at = Some(Utc::now());
+    }
+
+    /// Mark the row historical — keep all fields verbatim, just
+    /// stamp `removed_at`.
+    pub fn mark_historical(&mut self) {
+        self.removed_at = Some(Utc::now());
     }
 }
 

--- a/vtc-service/src/members/storage.rs
+++ b/vtc-service/src/members/storage.rs
@@ -198,6 +198,7 @@ mod tests {
             current_vmc_id: Some("vmc-1".into()),
             current_role_vec_id: Some("vec-1".into()),
             extensions: serde_json::json!({ "team": "platform" }),
+            removed_at: None,
         };
         let json = serde_json::to_value(&m).unwrap();
         assert!(json["joinedAt"].is_string());

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -15,12 +15,15 @@ use tracing::{info, warn};
 
 use vta_sdk::protocols::join_requests::{
     JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitBody,
-    JoinRequestSubmitReceiptBody,
+    JoinRequestSubmitReceiptBody, MEMBER_SELF_REMOVE_RECEIPT_TYPE, MEMBER_SELF_REMOVE_TYPE,
+    SelfRemoveBody, SelfRemoveReceiptBody,
 };
 
 use crate::config::AppConfig;
 use crate::join::JoinTransport;
+use crate::members::Disposition;
 use crate::routes::join_requests::submit::submit_inner;
+use crate::routes::members::remove::remove_inner;
 use crate::server::AppState;
 
 /// Start the DIDComm service and block until shutdown.
@@ -90,6 +93,12 @@ pub async fn run_didcomm_service(
             r.route(
                 JOIN_REQUEST_SUBMIT_TYPE,
                 handler_fn(join_request_submit_handler),
+            )
+        })
+        .and_then(|r| {
+            r.route(
+                MEMBER_SELF_REMOVE_TYPE,
+                handler_fn(member_self_remove_handler),
             )
         }) {
         Ok(r) => r,
@@ -203,4 +212,57 @@ async fn join_request_submit_handler(
     Ok(Some(
         DIDCommResponse::new(JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, body).thid(message.id),
     ))
+}
+
+/// `members/self-remove/1.0` over DIDComm (M1.11.1 twin).
+///
+/// Caller's DID = the DIDComm `from` field. Body optionally
+/// carries the disposition; defaults match REST (Member's
+/// stored `departure_preference`, then PolicyDefault→Tombstone).
+async fn member_self_remove_handler(
+    ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<AppState>,
+) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let caller_did = ctx
+        .sender_did
+        .clone()
+        .ok_or_else(|| DIDCommServiceError::Internal("self-remove has no DIDComm sender".into()))?;
+
+    let body: SelfRemoveBody = serde_json::from_value(message.body.clone())
+        .map_err(|e| DIDCommServiceError::Internal(format!("malformed self-remove body: {e}")))?;
+
+    let disposition = body
+        .disposition
+        .as_deref()
+        .map(parse_disposition)
+        .transpose()
+        .map_err(DIDCommServiceError::Internal)?;
+
+    let outcome = remove_inner(&state, &caller_did, &caller_did, disposition, String::new())
+        .await
+        .map_err(|e| DIDCommServiceError::Internal(format!("self-remove: {e}")))?;
+
+    let receipt = SelfRemoveReceiptBody {
+        did: outcome.did,
+        disposition: outcome.disposition,
+        removed: outcome.removed,
+    };
+    let body = serde_json::to_value(&receipt)
+        .map_err(|e| DIDCommServiceError::Internal(format!("receipt serialise: {e}")))?;
+    Ok(Some(
+        DIDCommResponse::new(MEMBER_SELF_REMOVE_RECEIPT_TYPE, body).thid(message.id),
+    ))
+}
+
+fn parse_disposition(s: &str) -> Result<Disposition, String> {
+    match s.to_ascii_lowercase().as_str() {
+        "purge" => Ok(Disposition::Purge),
+        "tombstone" => Ok(Disposition::Tombstone),
+        "historical" => Ok(Disposition::Historical),
+        "policydefault" => Ok(Disposition::PolicyDefault),
+        other => Err(format!(
+            "unknown disposition '{other}' (expected purge|tombstone|historical|policydefault)"
+        )),
+    }
 }

--- a/vtc-service/src/routes/members/mod.rs
+++ b/vtc-service/src/routes/members/mod.rs
@@ -18,4 +18,5 @@
 
 pub mod promote;
 pub mod read;
+pub mod remove;
 pub mod update;

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -1,0 +1,242 @@
+//! `DELETE /v1/members/me` (M1.11.1) + `DELETE /v1/members/{did}`
+//! (M1.12.1).
+//!
+//! Both paths converge on `remove_inner` so the no-last-admin
+//! invariant + disposition resolution + audit emission live in
+//! exactly one place.
+//!
+//! ## No-last-admin invariant
+//!
+//! Spec §10.2: a removal that would leave the community with
+//! zero admins is refused with 409 `LastAdminProtected`. The
+//! check + ACL delete run inside the same critical section
+//! guarded by [`LAST_ADMIN_LOCK`] so concurrent removals can't
+//! race past each other.
+//!
+//! Phase 1 implementation: snapshot every ACL row inside the
+//! lock, count Admin rows after removing the target, refuse if
+//! the count would hit zero. Fjall walks are O(n) but
+//! Phase-1 communities are small; Phase 2+ can swap in an
+//! admin-count index.
+
+use std::sync::LazyLock;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tracing::info;
+
+use vti_common::audit::{AuditEvent, MemberRemovedData};
+use vti_common::error::AppError;
+
+use crate::acl::{VtcRole, delete_acl_entry, get_acl_entry, list_acl_entries};
+use crate::auth::{AdminAuth, AuthClaims};
+use crate::members::{Disposition, delete_member, get_member, store_member};
+use crate::server::AppState;
+
+/// Process-wide mutex that serialises every removal, self- and
+/// admin- alike, so the "would this leave zero admins?" check is
+/// not racy. Cannot defend against multi-process — fjall isn't
+/// multi-process safe to begin with (project memory).
+static LAST_ADMIN_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveBody {
+    #[serde(default)]
+    pub disposition: Option<Disposition>,
+    /// Optional admin-only reason. Self-remove ignores this (the
+    /// member doesn't need to justify their own departure). Capped
+    /// at 1024 chars at the route layer.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveResponse {
+    pub did: String,
+    pub disposition: String,
+    pub removed: bool,
+}
+
+const REASON_MAX: usize = 1024;
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/members/me — M1.11.1
+// ---------------------------------------------------------------------------
+
+pub async fn self_remove(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    body: Option<Json<RemoveBody>>,
+) -> Result<(StatusCode, Json<RemoveResponse>), AppError> {
+    let body = body.map(|Json(b)| b).unwrap_or_default();
+    let target_did = auth.did.clone();
+    let outcome = remove_inner(
+        &state,
+        &auth.did,
+        &target_did,
+        body.disposition,
+        // Self-remove ignores any caller-supplied reason — the
+        // departure is the member's own decision and doesn't carry
+        // an externally-meaningful justification field.
+        String::new(),
+    )
+    .await?;
+    Ok((StatusCode::OK, Json(outcome)))
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/members/{did} — M1.12.1 (REST only)
+// ---------------------------------------------------------------------------
+
+pub async fn admin_remove(
+    admin: AdminAuth,
+    State(state): State<AppState>,
+    Path(target_did): Path<String>,
+    body: Option<Json<RemoveBody>>,
+) -> Result<(StatusCode, Json<RemoveResponse>), AppError> {
+    if admin.0.did == target_did {
+        return Err(AppError::Validation(
+            "use DELETE /v1/members/me to remove yourself — \
+             DELETE /v1/members/{did} is for admins removing other members"
+                .to_string(),
+        ));
+    }
+    let body = body.map(|Json(b)| b).unwrap_or_default();
+    let reason = body.reason.unwrap_or_default();
+    if reason.len() > REASON_MAX {
+        return Err(AppError::Validation(format!(
+            "reason exceeds {REASON_MAX} chars (got {})",
+            reason.len(),
+        )));
+    }
+    let outcome = remove_inner(&state, &admin.0.did, &target_did, body.disposition, reason).await?;
+    Ok((StatusCode::OK, Json(outcome)))
+}
+
+// ---------------------------------------------------------------------------
+// Shared inner removal
+// ---------------------------------------------------------------------------
+
+/// Returns `Ok(RemoveResponse)` on success or
+/// `Err(AppError::Conflict)` for the no-last-admin invariant.
+///
+/// `actor_did` is the audit actor (self for self-remove, admin
+/// for admin-remove). `target_did` is the row being removed.
+pub async fn remove_inner(
+    state: &AppState,
+    actor_did: &str,
+    target_did: &str,
+    disposition: Option<Disposition>,
+    reason: String,
+) -> Result<RemoveResponse, AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    let _guard = LAST_ADMIN_LOCK.lock().await;
+
+    let target_acl = get_acl_entry(&state.acl_ks, target_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
+
+    // Resolve disposition. Caller can override the member's
+    // departure_preference; if neither is set we fall through
+    // to PolicyDefault → Tombstone.
+    let target_member = get_member(&state.members_ks, target_did).await?;
+    let resolved = disposition
+        .or_else(|| target_member.as_ref().map(|m| m.departure_preference))
+        .unwrap_or_default_disposition()
+        .resolve();
+
+    // No-last-admin invariant.
+    if matches!(target_acl.role, VtcRole::Admin) {
+        let acl_rows = list_acl_entries(&state.acl_ks).await?;
+        let other_admins = acl_rows
+            .iter()
+            .filter(|e| e.did != target_did && matches!(e.role, VtcRole::Admin))
+            .count();
+        if other_admins == 0 {
+            return Err(AppError::Conflict(format!(
+                "refusing to remove the last admin ({target_did}) — promote another \
+                 member to admin first"
+            )));
+        }
+    }
+
+    // Apply the disposition.
+    delete_acl_entry(&state.acl_ks, target_did).await?;
+    match (resolved, target_member) {
+        (Disposition::Purge, _) => {
+            delete_member(&state.members_ks, target_did).await?;
+        }
+        (Disposition::Tombstone, Some(mut m)) => {
+            m.tombstone();
+            store_member(&state.members_ks, &m).await?;
+        }
+        (Disposition::Historical, Some(mut m)) => {
+            m.mark_historical();
+            store_member(&state.members_ks, &m).await?;
+        }
+        // No Member row to operate on — Tombstone/Historical
+        // semantics are trivially satisfied (nothing to keep).
+        (Disposition::Tombstone | Disposition::Historical, None) => {}
+        (Disposition::PolicyDefault, _) => {
+            // resolve() collapsed this to Tombstone above; this
+            // arm is unreachable but stays here so the match
+            // remains total.
+            unreachable!("PolicyDefault must resolve before dispatch");
+        }
+    }
+
+    let disposition_str = match resolved {
+        Disposition::Purge => "purge",
+        Disposition::Tombstone => "tombstone",
+        Disposition::Historical => "historical",
+        Disposition::PolicyDefault => "policydefault",
+    };
+
+    audit_writer
+        .write(
+            actor_did,
+            Some(target_did),
+            AuditEvent::MemberRemoved(MemberRemovedData {
+                disposition: disposition_str.into(),
+                reason: reason.clone(),
+            }),
+        )
+        .await?;
+
+    info!(
+        actor = actor_did,
+        target = target_did,
+        disposition = disposition_str,
+        reason_present = !reason.is_empty(),
+        "member removed"
+    );
+
+    Ok(RemoveResponse {
+        did: target_did.to_string(),
+        disposition: disposition_str.into(),
+        removed: true,
+    })
+}
+
+// `Option<Disposition>::unwrap_or_default_disposition()` — small
+// extension that returns `PolicyDefault` when the option is
+// `None`. Hand-rolled so the call site reads linearly without an
+// `unwrap_or(Disposition::PolicyDefault)` literal everywhere.
+trait DispositionOption {
+    fn unwrap_or_default_disposition(self) -> Disposition;
+}
+
+impl DispositionOption for Option<Disposition> {
+    fn unwrap_or_default_disposition(self) -> Disposition {
+        self.unwrap_or(Disposition::PolicyDefault)
+    }
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod did_log;
 mod health;
 pub(crate) mod install;
 pub(crate) mod join_requests;
-mod members;
+pub(crate) mod members;
 
 use axum::Router;
 use axum::routing::{delete, get, post};
@@ -97,6 +97,14 @@ pub fn router() -> Router<AppState> {
     let members_promote =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0")
             .expect("static Trust-Task URL");
+    let members_self_remove =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/members/self-remove/1.0")
+            .expect("static Trust-Task URL");
+    // `members_admin_remove` (`members/admin-remove/1.0`) shares
+    // the `members/{did}` mount with show + update for now —
+    // TrustTaskRouter doesn't support per-method Trust-Task
+    // selectors yet. The standalone task exists on disk +
+    // index.json so the soft-gate surface stays complete.
     // POST + GET share `/v1/join-requests`. The `join-requests/list/1.0`
     // Trust Task exists in index.json + on-disk spec/schema so the
     // soft-gate surface stays complete; the wire enforcement here
@@ -254,13 +262,26 @@ pub fn router() -> Router<AppState> {
             get(members::read::list_members),
             members_list,
         )
+        // `/v1/members/me` for self-remove (M1.11.1). Must be
+        // declared BEFORE the `/v1/members/{did}` mount otherwise
+        // axum's path-trie picks the parameterised route first
+        // and routes "me" as a literal DID.
+        .route_with_task(
+            "/v1/members/me",
+            axum::routing::delete(members::remove::self_remove),
+            members_self_remove,
+        )
         .route_with_task(
             "/v1/members/{did}",
-            get(members::read::show_member).patch(members::update::update_member),
-            // GET + PATCH share one Trust Task today; split into
-            // members/show/1.0 + members/update/1.0 when
-            // TrustTaskRouter gains per-method selectors (same
-            // Phase-0 pattern community/profile + admin/config use).
+            get(members::read::show_member)
+                .patch(members::update::update_member)
+                .delete(members::remove::admin_remove),
+            // GET + PATCH + DELETE share `members/show/1.0` at the
+            // router layer pending per-method selectors; the
+            // standalone `members/update/1.0` and
+            // `members/admin-remove/1.0` Trust Tasks exist on
+            // disk + in index.json so the soft-gate surface stays
+            // complete.
             members_show,
         )
         .route_with_task(

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -1,0 +1,554 @@
+//! Integration coverage for the M1.11 + M1.12 removal endpoints.
+//!
+//! - `DELETE /v1/members/me` (self-remove): happy path per
+//!   disposition, sole-admin protection, missing-member 404.
+//! - `DELETE /v1/members/{did}` (admin-remove): admin auth,
+//!   self-target refused, last-admin protection.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::audit::{AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::passkey::build_webauthn;
+use vti_common::auth::session::{Session, SessionState, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::{KeyspaceHandle, Store};
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::{Member, get_member, store_member};
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+const RP_ORIGIN: &str = "https://vtc.example.com";
+const SELF_REMOVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0";
+const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/show/1.0";
+
+const ADMIN_DID: &str = "did:key:zAdmin1";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    admin_token: String,
+    acl_ks: KeyspaceHandle,
+    members_ks: KeyspaceHandle,
+    sessions_ks: KeyspaceHandle,
+    jwt_keys: Arc<JwtKeys>,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &acl_ks,
+        &VtcAclEntry {
+            did: ADMIN_DID.into(),
+            role: VtcRole::Admin,
+            label: Some("primary admin".into()),
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    store_member(&members_ks, &Member::fresh(ADMIN_DID))
+        .await
+        .unwrap();
+
+    let session_id = "test-admin-session";
+    store_session(
+        &sessions_ks,
+        &Session {
+            session_id: session_id.into(),
+            did: ADMIN_DID.into(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now,
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let admin_claims = jwt_keys.new_claims(
+        ADMIN_DID.into(),
+        session_id.into(),
+        "admin".into(),
+        vec![],
+        3600,
+        true,
+    );
+    let admin_token = jwt_keys.encode(&admin_claims).unwrap();
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        public_url = "{RP_ORIGIN}"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks: sessions_ks.clone(),
+        acl_ks: acl_ks.clone(),
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks: members_ks.clone(),
+        join_requests_ks,
+        audit_ks,
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys.clone()),
+        atm: None,
+        webauthn,
+        public_url: Some(RP_ORIGIN.to_string()),
+        install_signer: None,
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+
+    Fixture {
+        router,
+        admin_token,
+        acl_ks,
+        members_ks,
+        sessions_ks,
+        jwt_keys,
+        _dir: dir,
+    }
+}
+
+/// Mint a `Member`-role session token for a freshly-seeded
+/// member. The auth layer still uses vti-common's Role taxonomy
+/// (PR-1's M1.2 plumbing note), so the token's `role` claim is
+/// the lowercase Role string the JWT decoder accepts —
+/// `"reader"` maps to the lowest privilege bucket, which lets
+/// the AuthClaims extractor populate `auth.did` without
+/// gating-by-role at the route layer. Self-remove only checks
+/// auth.did, so this is sufficient for the wire test.
+async fn seed_member_with_session(fix: &Fixture, did: &str, role: VtcRole) -> String {
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &fix.acl_ks,
+        &VtcAclEntry {
+            did: did.into(),
+            role: role.clone(),
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    store_member(&fix.members_ks, &Member::fresh(did))
+        .await
+        .unwrap();
+
+    let session_id = format!("session-{}", did.replace([':', '/'], "-"));
+    store_session(
+        &fix.sessions_ks,
+        &Session {
+            session_id: session_id.clone(),
+            did: did.into(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now,
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Map VtcRole → vti-common's Role string for the JWT.
+    let vti_role = match role {
+        VtcRole::Admin => "admin",
+        // Every non-Admin VtcRole degrades to vti-common's
+        // `reader` for the JWT — AuthClaims uses vti-common Role
+        // until the auth layer is rewritten. Self-remove doesn't
+        // gate on role beyond "authenticated" so this is fine.
+        _ => "reader",
+    };
+    let claims =
+        fix.jwt_keys
+            .new_claims(did.into(), session_id, vti_role.into(), vec![], 3600, true);
+    fix.jwt_keys.encode(&claims).unwrap()
+}
+
+async fn send(
+    router: &axum::Router,
+    method: &str,
+    uri: &str,
+    trust_task: &str,
+    token: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("Trust-Task", trust_task);
+    if let Some(t) = token {
+        req = req.header("Authorization", format!("Bearer {t}"));
+    }
+    let res = router
+        .clone()
+        .oneshot(
+            req.body(
+                body.map(|v| Body::from(v.to_string()))
+                    .unwrap_or(Body::empty()),
+            )
+            .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+// ---------------------------------------------------------------------------
+// M1.11.1 — DELETE /v1/members/me
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn self_remove_tombstones_member_by_default() {
+    let fix = build_fixture().await;
+    let member_did = "did:key:zMember1";
+    let token = seed_member_with_session(&fix, member_did, VtcRole::Member).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/me",
+        SELF_REMOVE_TASK,
+        Some(&token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["disposition"], "tombstone");
+    assert_eq!(body["removed"], true);
+
+    assert!(
+        get_acl_entry(&fix.acl_ks, member_did)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let tomb = get_member(&fix.members_ks, member_did)
+        .await
+        .unwrap()
+        .expect("Tombstone Member row retained");
+    assert!(tomb.removed_at.is_some());
+    assert!(tomb.current_vmc_id.is_none());
+}
+
+#[tokio::test]
+async fn self_remove_with_purge_deletes_member_row() {
+    let fix = build_fixture().await;
+    let member_did = "did:key:zMember2";
+    let token = seed_member_with_session(&fix, member_did, VtcRole::Member).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/me",
+        SELF_REMOVE_TASK,
+        Some(&token),
+        Some(json!({ "disposition": "purge" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["disposition"], "purge");
+
+    assert!(
+        get_acl_entry(&fix.acl_ks, member_did)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        get_member(&fix.members_ks, member_did)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn self_remove_with_historical_keeps_row_verbatim() {
+    let fix = build_fixture().await;
+    let member_did = "did:key:zMember3";
+    let token = seed_member_with_session(&fix, member_did, VtcRole::Member).await;
+    // Stamp a credential pointer so we can confirm Historical
+    // retains it.
+    let mut m = get_member(&fix.members_ks, member_did)
+        .await
+        .unwrap()
+        .unwrap();
+    m.current_vmc_id = Some("vmc-test".into());
+    store_member(&fix.members_ks, &m).await.unwrap();
+
+    let (status, _) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/me",
+        SELF_REMOVE_TASK,
+        Some(&token),
+        Some(json!({ "disposition": "historical" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let kept = get_member(&fix.members_ks, member_did)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(kept.removed_at.is_some());
+    assert_eq!(kept.current_vmc_id.as_deref(), Some("vmc-test"));
+}
+
+#[tokio::test]
+async fn self_remove_refused_for_sole_admin() {
+    let fix = build_fixture().await;
+    // The fixture's sole admin is ADMIN_DID — try to remove them.
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/me",
+        SELF_REMOVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "got {body}");
+    assert!(
+        get_acl_entry(&fix.acl_ks, ADMIN_DID)
+            .await
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn self_remove_works_when_second_admin_exists() {
+    let fix = build_fixture().await;
+    // Promote a second admin so the no-last-admin invariant is
+    // satisfied.
+    let _other_token = seed_member_with_session(&fix, "did:key:zSecondAdmin", VtcRole::Admin).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/me",
+        SELF_REMOVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert!(
+        get_acl_entry(&fix.acl_ks, ADMIN_DID)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn self_remove_requires_authentication() {
+    let fix = build_fixture().await;
+    let (status, _) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/me",
+        SELF_REMOVE_TASK,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// M1.12.1 — DELETE /v1/members/{did}
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn admin_remove_member_works() {
+    let fix = build_fixture().await;
+    let target = "did:key:zVictim";
+    let _ = seed_member_with_session(&fix, target, VtcRole::Member).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        &format!("/v1/members/{target}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "reason": "policy violation" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["disposition"], "tombstone");
+    assert!(get_acl_entry(&fix.acl_ks, target).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn admin_remove_self_refused_with_self_remove_hint() {
+    let fix = build_fixture().await;
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        &format!("/v1/members/{ADMIN_DID}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let msg = body.to_string();
+    assert!(msg.contains("/v1/members/me"), "got {msg}");
+}
+
+#[tokio::test]
+async fn admin_remove_refused_for_last_admin() {
+    let fix = build_fixture().await;
+    // Add a second admin, then have the second admin try to
+    // remove the first via the admin path. With both removed
+    // the community would still have one admin (the caller),
+    // so this should succeed. Instead, set up a case where
+    // the target IS the last admin: caller is also admin, two
+    // admins exist, the caller removes the other — that leaves
+    // one admin (the caller). So that's the *success* case.
+    //
+    // The actual failure case for admin-remove + last-admin:
+    // there's exactly one admin and a non-admin caller tries to
+    // remove them. But admin-remove requires AdminAuth, so the
+    // only caller IS the last admin — and they can't remove
+    // themselves via this endpoint. The invariant therefore
+    // can never fail via the admin-remove path with the current
+    // role taxonomy.
+    //
+    // Confirm the happy two-admin case anyway:
+    let second_admin = "did:key:zSecondAdmin";
+    let _ = seed_member_with_session(&fix, second_admin, VtcRole::Admin).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        &format!("/v1/members/{second_admin}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "reason": "ouster" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    // Original admin remains.
+    assert!(
+        get_acl_entry(&fix.acl_ks, ADMIN_DID)
+            .await
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn admin_remove_404_for_unknown_did() {
+    let fix = build_fixture().await;
+    let (status, _) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/did:key:zNobody",
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn admin_remove_overlong_reason_rejected() {
+    let fix = build_fixture().await;
+    let target = "did:key:zV";
+    let _ = seed_member_with_session(&fix, target, VtcRole::Member).await;
+
+    let (status, _) = send(
+        &fix.router,
+        "DELETE",
+        &format!("/v1/members/{target}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "reason": "x".repeat(1025) })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## Summary

**PR-4 of Phase 1.** Closes the member lifecycle loop with
self- and admin-initiated removal.

**Closes M1.11 (self-remove REST + DIDComm), M1.12 (admin-remove REST).**

## Endpoints

| Method | Path | Trust Task | Auth |
|---|---|---|---|
| `DELETE` | `/v1/members/me` | `members/self-remove/1.0` | Any authenticated session |
| DIDComm | `members/self-remove/1.0` | same | DIDComm `from` is the target |
| `DELETE` | `/v1/members/{did}` | `members/show/1.0`† | AdminAuth |

† Admin-remove shares the `members/{did}` mount with show + update at the router layer pending TrustTaskRouter's per-method selectors. The standalone `members/admin-remove/1.0` Trust Task is on disk + in index.json.

## Highlights

- **No-last-admin invariant** under `LAST_ADMIN_LOCK`. The "would this leave zero admins?" check + the ACL delete share a critical section so concurrent removals can't race past each other. 409 `LastAdminProtected` if violation.

- **Disposition resolution** (spec §10.2, plan §D6):
  - `purge` → ACL + Member deleted outright.
  - `tombstone` → ACL deleted; Member retains `did` + `joined_at` + new `removed_at` stamp; every PII / credential field cleared.
  - `historical` → ACL deleted; Member retained verbatim with `removed_at`.
  - `policydefault` → `tombstone` in Phase 1; Phase 2 swaps in `removal.rego`'s `min_disposition`.

- **`Member::removed_at`** new optional field with `#[serde(default)]` so older rows decode cleanly. Helpers `tombstone()` + `mark_historical()` keep the disposition transitions in one place.

- **Self-target guard** on admin-remove: 400 with an operator-facing hint pointing at `/v1/members/me`. The self-remove path enforces the no-last-admin invariant for that case.

- **DIDComm twin** wires through the same `Router::extension(state)` pattern PR-3 introduced for join-requests. Handler dispatches into the shared `remove_inner`.

- **Route ordering**: `/v1/members/me` declared BEFORE `/v1/members/{did}` so axum's path-trie picks the literal route first (otherwise "me" routes as a literal DID).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --package vtc-service` — 145 lib + **11 new `tests/removal.rs`** cases + every existing integration suite still green
- [ ] `cargo test --workspace` — CI will confirm

The 11 new tests cover self-remove (default tombstone, purge, historical, sole-admin protection, second-admin success, auth required) and admin-remove (happy, self-target refusal, second-admin removal, 404, overlong-reason 400).

## Phase 1 progress

| PR | Milestones | Status |
|---|---|---|
| PR-1 | M1.1, M1.2, M1.3 | merged |
| PR-2 | M1.4, M1.5, M1.6 | merged |
| PR-3 | M1.7, M1.8, M1.9, M1.10 | merged |
| **PR-4 (this)** | M1.11, M1.12 | **in review** |
| PR-5 | M1.13, M1.14, M1.15 | next (gate) |

Phase 1's wire surface is feature-complete after this. PR-5 closes the Phase 1 gate per `tasks/vtc-mvp/phase-1-todo.md` M1.13–M1.15:
- Audit vocabulary sanity check (the variants already added are real — M1.13 verifies they're wired into the right emit sites).
- Trust Task index pass + on-disk completeness check.
- Workspace gate green + memory entry updated + phase-1-todo.md `[x]`s.