### PR TITLE
docs(vtc-mvp): close Phase 1 gate (M1.13 + M1.14 + M1.15)

### DIFF
--- a/tasks/vtc-mvp/phase-1-todo.md
+++ b/tasks/vtc-mvp/phase-1-todo.md
@@ -21,7 +21,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.1 — Role enum extension (`vtc-service::acl::VtcRole`)
 
-### `[ ]` M1.1.1 — Introduce `VtcRole`
+### `[x]` M1.1.1 — Introduce `VtcRole`
 
 - **Acceptance**
   - New enum `vtc_service::acl::VtcRole { Admin, Moderator, Issuer,
@@ -45,7 +45,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.2 — ACL unification
 
-### `[ ]` M1.2.1 — `VtcAclEntry` + storage CRUD
+### `[x]` M1.2.1 — `VtcAclEntry` + storage CRUD
 
 - **Acceptance**
   - New struct `vtc_service::acl::VtcAclEntry { did, role: VtcRole,
@@ -73,7 +73,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 - **Pre-impl decision**: **D2** (admin sister record loses role
   field; passkeys stay where they are).
 
-### `[ ]` M1.2.2 — Wire `VtcAclEntry` everywhere
+### `[x]` M1.2.2 — Wire `VtcAclEntry` everywhere
 
 - **Acceptance**
   - Every consumer of `vti_common::acl::store_acl_entry`,
@@ -98,7 +98,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.3 — Member model + keyspace
 
-### `[ ]` M1.3.1 — `Member` struct + `members` keyspace
+### `[x]` M1.3.1 — `Member` struct + `members` keyspace
 
 - **Acceptance**
   - `vtc_service::members::Member { did, joined_at, status_list_index:
@@ -123,7 +123,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.4 — Member read endpoints
 
-### `[ ]` M1.4.1 — `GET /v1/members` + `GET /v1/members/{did}`
+### `[x]` M1.4.1 — `GET /v1/members` + `GET /v1/members/{did}`
 
 - **Acceptance**
   - List endpoint returns a `Paginated<Member>` using the cursor
@@ -150,7 +150,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.5 — Member update
 
-### `[ ]` M1.5.1 — `PATCH /v1/members/{did}` (role + profile)
+### `[x]` M1.5.1 — `PATCH /v1/members/{did}` (role + profile)
 
 - **Acceptance**
   - Body shape: `{ role?: VtcRole, publish_consent?: bool,
@@ -177,7 +177,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.6 — Admin promotion (step-up UV)
 
-### `[ ]` M1.6.1 — `POST /v1/members/{did}/promote-to-admin`
+### `[x]` M1.6.1 — `POST /v1/members/{did}/promote-to-admin`
 
 - **Acceptance**
   - Two-phase ceremony mirroring `admin/passkeys/register/{start,finish}`:
@@ -206,7 +206,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.7 — JoinRequest model + retention
 
-### `[ ]` M1.7.1 — `JoinRequest` struct + `join_requests` keyspace
+### `[x]` M1.7.1 — `JoinRequest` struct + `join_requests` keyspace
 
 - **Acceptance**
   - `vtc_service::join::JoinRequest { id: Uuid, applicant_did, vp:
@@ -236,7 +236,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.8 — Submit join request
 
-### `[ ]` M1.8.1 — `POST /v1/join-requests` (REST)
+### `[x]` M1.8.1 — `POST /v1/join-requests` (REST)
 
 - **Acceptance**
   - Unauthenticated (rate-limited per spec §9 unauth-route policy).
@@ -259,7 +259,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
   - `trust-tasks/join-requests/submit/1.0/{spec.md,schema.json}`
 - **Deps**: M1.7.1, M1.4.1
 
-### `[ ]` M1.8.2 — DIDComm twin for submit
+### `[x]` M1.8.2 — DIDComm twin for submit
 
 - **Acceptance**
   - DIDComm message `type` =
@@ -283,7 +283,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.9 — Join request read endpoints (admin)
 
-### `[ ]` M1.9.1 — `GET /v1/join-requests` + `/v1/join-requests/{id}`
+### `[x]` M1.9.1 — `GET /v1/join-requests` + `/v1/join-requests/{id}`
 
 - **Acceptance**
   - List endpoint requires admin or moderator role; returns
@@ -306,7 +306,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.10 — Join request decision
 
-### `[ ]` M1.10.1 — `POST /v1/join-requests/{id}/{approve,reject}`
+### `[x]` M1.10.1 — `POST /v1/join-requests/{id}/{approve,reject}`
 
 - **Acceptance**
   - Admin or moderator role required.
@@ -335,7 +335,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.11 — Self-removal
 
-### `[ ]` M1.11.1 — `DELETE /v1/members/me` (REST + DIDComm)
+### `[x]` M1.11.1 — `DELETE /v1/members/me` (REST + DIDComm)
 
 - **Acceptance**
   - Authenticated caller's `did` is the target. Body shape:
@@ -366,7 +366,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.12 — Admin removal
 
-### `[ ]` M1.12.1 — `DELETE /v1/members/{did}` (REST only)
+### `[x]` M1.12.1 — `DELETE /v1/members/{did}` (REST only)
 
 - **Acceptance**
   - Admin role required.
@@ -390,7 +390,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.13 — Audit event variants
 
-### `[ ]` M1.13.1 — Phase 1 audit event vocabulary
+### `[x]` M1.13.1 — Phase 1 audit event vocabulary
 
 - **Acceptance**
   - `AuditEvent` enum (`vti_common::audit::envelope`) gains
@@ -412,7 +412,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.14 — Trust Task drafts + index
 
-### `[ ]` M1.14.1 — Spec + schema files for Phase 1 surface
+### `[x]` M1.14.1 — Spec + schema files for Phase 1 surface
 
 - **Acceptance**
   - All 11 Trust Tasks from plan §D7 have `spec.md` (request +
@@ -432,24 +432,28 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M1.15 — Phase 1 gate green
 
-### `[ ]` M1.15.1 — Workspace gate
+### `[x]` M1.15.1 — Workspace gate
 
-- **Acceptance** (mirrors M0.12.3)
-  - `cargo build --workspace` green.
-  - `cargo test --workspace` green (all new tests passing).
-  - `cargo clippy --workspace --all-targets -- -D warnings` clean.
-  - `cargo fmt --check` clean.
-  - `trust-tasks/index.json` lists every Phase-1 Trust Task with
-    matching `spec.md` + `schema.json` on disk.
-  - Memory entry `project_vtc_mvp.md` updated with any
-    implementation-time tweaks (Role enum shape, AdminEntry
-    collapse, removal disposition default, etc.).
-  - Phase-1-todo.md milestones all flipped to `[x]`.
-- **Verify** CI green on the merge commit.
-- **Files**
-  - `trust-tasks/index.json`
-  - `/Users/glenngore/.claude/projects/-Users-glenngore-devel-fpp-verifiable-trust-infrastructure/memory/project_vtc_mvp.md`
-- **Deps**: M1.13.1, M1.14.1
+Closed 2026-05-12.
+
+- `cargo build --workspace` green ✓
+- `cargo test --workspace` green ✓ (>200 vtc-service tests; full
+  workspace passes)
+- `cargo clippy --workspace --all-targets -- -D warnings` clean ✓
+- `cargo fmt --check` clean ✓
+- `trust-tasks/index.json` lists **31** Trust Tasks in `Draft`;
+  each has matching `spec.md` + `schema.json` on disk (1:1).
+  Phase 1's 11 new tasks: `members/{list,show,update,
+  promote-to-admin,self-remove,admin-remove}/1.0` +
+  `join-requests/{submit,list,show,approve,reject}/1.0`.
+- 8 Phase 1 audit variants
+  (`JoinRequestSubmitted`, `JoinRequestApproved`,
+  `JoinRequestRejected`, `MemberAdded`, `MemberRemoved`,
+  `MemberUpdated`, `RoleChanged`, `AdminPromoted`) each have a
+  live emit site in vtc-service.
+- Memory entry `project_vtc_mvp.md` updated with the Phase 1
+  closure note + implementation-time deviations (VtcRole wire
+  shape, M1.8.2 DIDComm routing, no-last-admin lock).
 
 ### Checkpoint — Phase 1 gate met
 


### PR DESCRIPTION
## Summary

Closes the Phase 1 gate. **Phase 1 closes with this PR.**

No code changes — pure gate-closure PR audits the surface
and flips every M1 milestone to `[x]`.

## Gate verification

All four cargo gates pass on `main` after PRs #74–#77:

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — **47 test-result lines, 0 failures**
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Trust Task surface:
- **31 entries** in `trust-tasks/index.json` (Phase 0's 20 + Phase 1's 11)
- **31 spec.md + 31 schema.json** on disk — 1:1 match
- Phase 1's 11 new tasks:
  - `members/{list, show, update, promote-to-admin, self-remove, admin-remove}/1.0`
  - `join-requests/{submit, list, show, approve, reject}/1.0`

Audit vocabulary (M1.13 check) — all 8 Phase-1 variants live + emitted:

| Variant | Emit site |
|---|---|
| `JoinRequestSubmitted` | `routes::join_requests::submit::submit_inner` |
| `JoinRequestApproved` | `routes::join_requests::decide::approve` |
| `JoinRequestRejected` | `routes::join_requests::decide::reject` |
| `MemberAdded` | `routes::join_requests::decide::approve` |
| `MemberRemoved` | `routes::members::remove::remove_inner` |
| `MemberUpdated` | `routes::members::update::update_member` |
| `RoleChanged` | `routes::members::update::update_member` |
| `AdminPromoted` | `routes::members::promote::promote_finish` |

## Memory entry

`project_vtc_mvp.md` updated with the Phase 1 closure note +
implementation-time deviations captured so Phase 2 doesn't
re-litigate them:

- **`VtcRole` wire shape** — plain lowercase strings + `custom:<name>` prefix (not `#[serde(tag = "type")]`). Backwards-compat with the existing `Role::Admin → "admin"` rows on disk drove the call.
- **`AuthClaims` still uses vti-common's `Role`**. Non-Admin VtcRole variants degrade to `Role::Reader` at the JWT boundary. Phase 2 rewrites the auth layer. For Phase 1, only Admin is privileged at the auth path, so the degradation is invisible at runtime.
- **DIDComm twins** (join-submit + self-remove) use the `affinidi-messaging-didcomm-service` `Router::extension(state)` pattern. Pin this for any future DIDComm endpoints.
- **`LAST_ADMIN_LOCK`** process-wide async mutex serialises every removal. Multi-process out-of-scope per workspace doctrine.
- **`Member.removed_at`** is the tombstone marker. Phase 2's renewal + VMC issuance paths should consult it.
- **`Disposition::PolicyDefault → Tombstone`** in Phase 1 (plan §D6). Phase 2's `removal.rego` swaps the resolver.
- **Per-method Trust-Task selectors** still missing from `TrustTaskRouter`. Some Phase 1 mounts share a single Trust Task across methods; the standalone files exist on disk so the soft-gate surface stays complete. Same workaround `community/profile` + `admin/config` already use.

## Phase 1 retrospective

| PR | Milestones | Status |
|---|---|---|
| #74 (PR-1) | M1.1, M1.2, M1.3 | merged |
| #75 (PR-2) | M1.4, M1.5, M1.6 | merged |
| #76 (PR-3) | M1.7, M1.8, M1.9, M1.10 | merged |
| #77 (PR-4) | M1.11, M1.12 | merged |
| **#? (PR-5, this)** | M1.13, M1.14, M1.15 | **in review** |

All 17 M1.* milestones shipped across 5 PRs.

## What Phase 1 delivered

After this merges, a freshly-bootstrapped VTC can:

- Accept VP-framed `POST /v1/join-requests` (REST + DIDComm).
- Persist requests; admins list / show / approve / reject.
- Surface `GET / PATCH /v1/members[/{did}]` for admin CRUD.
- Promote members to Admin via separate step-up UV endpoint.
- Process self-removal + admin removal with the no-last-admin
  invariant under `LAST_ADMIN_LOCK`.
- Emit the full Phase 1 audit vocabulary (8 new variants).
- Sweep terminal-state join requests on a 30-day window.

## Test plan

- [x] All four cargo gates pass locally
- [ ] CI green on the merge commit

## What's next

Phase 2 per spec §16:

> `regorus`, policy upload + activate, `join.rego` + `removal.rego`, VMC + VEC issuance via VTA oracle (with timeout + breaker), status-list with reserved-index discipline, renewal, DID rotation (both methods, domain-tagged).

That's a sizeable phase. The natural follow-up after this gate
merges is a Phase 2 planning artefact (mirrors the Phase 1 plan
PR #73 — read the spec sections, draft `phase-2-plan.md` +
`phase-2-todo.md`, surface design questions before code lands).