### PR TITLE
plan(vtc-mvp): Phase 2 — policy engine + credentials + status list + DID rotation

### DIFF
--- a/tasks/vtc-mvp/phase-2-plan.md
+++ b/tasks/vtc-mvp/phase-2-plan.md
@@ -82,30 +82,44 @@ Out of scope (deferred to Phase 3+):
 
 Load-bearing. Defaults below; flag dissent before any code lands.
 
-### D1 — Signing surface: local vs VTA oracle
+### D1 — Signing surface: cached-locally, VTA-controlled
 
-Spec §3-A says "VTC has no key custody; every signature
-delegates to the VTA signing oracle." That predates the
-VTA-driven-keys rework (PR-A of Phase 0), which **ships the
-VTC its own `#key-0` Ed25519 private** inside the secret store
-(`VtcKeyBundle`). After PR-A, the VTC **does** hold its own
-keys — the "delegate to VTA" line is obsolete.
+Spec §3-A wording — "VTC has no key custody; every signature
+delegates to the VTA signing oracle" — is overloaded.
+**Custody** could read as "no key storage at all" or as "no
+key minting / rotation authority". The working architecture
+matches the `affinidi-messaging-mediator` +
+`affinidi-webvh-services` pattern: **the VTA is the key
+controller; the VTC caches a working copy in its secret
+store and signs locally**.
 
-**Proposed default: local signing.** The VTC signs VMCs / VECs
-/ status-list credentials directly with its own `#key-0`. Cuts
-out a network hop, removes the timeout / breaker complexity,
-and matches what the keys-already-here architecture invites.
+The post-PR-A `VtcKeyBundle` shape is correct under this
+reading — the VTA mints the integration DID's keys, seals
+them to the VTC at first-boot via the `vtc-host`
+provision-integration flow, and the VTC retains the cached
+copy in its secret store for the lifetime of the deployment.
+The VTA remains the authority for **key minting** +
+**rotation**; the VTC is just a cached signer.
 
-Implication: spec §14.2's `vta.signing_timeout_seconds` +
-`vta.circuit_breaker_threshold` config knobs become **dead
-parameters** in Phase 2. The breaker pattern still has value
-elsewhere (trust-registry publish in Phase 3, did:webvh
-resolution for member-DID-rotation), so the pattern stays in
-the codebase even though VMC issuance no longer needs it.
+**Proposed default: VTC signs locally.** Every VMC / VEC /
+status-list credential / install-token JWT / DIDComm
+outbound message is signed with the cached `#key-0` Ed25519
+already in the secret store. No per-call VTA round-trip.
 
-This is a **spec deviation** worth surfacing. The user
-approved the post-PR-A architecture explicitly; this plan
-makes the consequence concrete.
+The breaker pattern still has value for **non-VMC remote
+dependencies** — trust-registry publish in Phase 3,
+did:webvh resolution during member-DID rotation in M2.15.2.
+Those truly are remote operations. The pattern stays in the
+codebase; only the wiring to VMC issuance is dropped.
+
+**Spec clarification, not deviation** (M2.16): §3-A is
+amended to spell out the cached-locally / VTA-controlled
+model — "no key custody" was always meant as "no key minting
+/ rotation authority", not "no key storage". §14.2's
+VTA-oracle timeout + breaker parameters retain their names
+but document which operations actually use them (Phase 3
+trust-registry, M2.15.2 did:webvh resolver). VMC issuance
+is not among them.
 
 ### D2 — `regorus` location
 
@@ -345,9 +359,11 @@ surface.
   (broad change), or scope role-policy evaluation to **route
   handlers only** (narrower, defer AuthClaims rewrite to
   Phase 3+). Proposed: route-handler-only Phase 2.
-- **R6: signing-oracle spec deviation (D1).** Recording it as
-  a Phase 2 outcome — the spec's "no key custody" line gets
-  amended.
+- **R6: signing-surface spec clarification (D1).** Recording it
+  as a Phase 2 outcome — §3-A's "no key custody" line gets
+  amended to spell out the cached-locally / VTA-controlled
+  model (= no key minting / rotation authority, not no key
+  storage).
 
 ## Definition of done — Phase 2
 
@@ -371,7 +387,12 @@ start after Phase 2's gate merges.
 
 Recording up front so they're not surprises mid-implementation:
 
-- **§3-A "VTC has no key custody"** — amended per D1.
+- **§3-A "VTC has no key custody"** — amended per D1 to
+  spell out the cached-locally / VTA-controlled model: VTA
+  mints + controls the keys; VTC caches a working copy in
+  its secret store and signs locally. "No custody" was
+  always meant as "no minting / rotation authority", not
+  "no key storage" (mediator / webvh-service pattern).
 - **§14.2 "VTA signing oracle dependence"** — VTA-oracle
   timeout + breaker stay in the spec but apply to other
   remote dependencies (trust-registry, did:webvh resolver),

--- a/tasks/vtc-mvp/phase-2-plan.md
+++ b/tasks/vtc-mvp/phase-2-plan.md
@@ -1,0 +1,389 @@
+# VTC MVP — Phase 2 plan
+
+> **Status:** draft, awaiting review.
+> **Deliverable:** "Live policy + credentials." Per spec §16
+> Phase 2: `regorus`, policy upload + activate, `join.rego` +
+> `removal.rego`, VMC + VEC issuance, status-list with reserved-
+> index discipline, renewal, DID rotation.
+> **Spec:** `docs/05-design-notes/vtc-mvp.md` §§5.4, 6.1–6.3,
+> 7, 10.5, 14.2.
+
+## Objective
+
+After Phase 2, a VTC issues real credentials backed by real
+policy:
+
+- Admins upload, test, and activate `join.rego` /
+  `removal.rego` / friends. Default policies ship and apply on
+  install.
+- `POST /v1/join-requests` (existing) consults `join.rego`
+  before persisting; on `allow`, the approve path mints a VMC +
+  role VEC and seals them to the applicant. On `deny`, the
+  decision is recorded with the policy's rationale.
+- Removal (existing) consults `removal.rego` for admin-initiated
+  removals; the disposition resolver reads the policy's
+  `min_disposition` output.
+- The VTC publishes two `BitstringStatusListCredential`s
+  (revocation + suspension), allocates indices with privacy-
+  preserving decoys, never reallocates flipped slots.
+- `POST /v1/members/me/renew` re-issues a member's VMC + role
+  VEC unconditionally on ACL membership (spec §6.3).
+- DID rotation works for both `did:webvh` (native via
+  `did.jsonl` history) and `did:key` (co-signed attestation,
+  domain-tag-prefixed).
+
+Out of scope (deferred to Phase 3+):
+
+- Trust-registry publication (`MembershipSyncer`,
+  `registry.rego` consumption, three-disposition reconciliation).
+- Cross-community recognition.
+- Personhood (`personhood.rego` deny-all stub ships in §6.4 but
+  the assert/revoke endpoints land in Phase 4).
+- VRC / RCard issuance — Phase 4.
+
+## Scope (per spec §16, Phase 2 row)
+
+### In scope
+
+- **`regorus` integration** — embedded Rego compiler/evaluator
+  in vtc-service. No OPA sidecar.
+- **Policy CRUD + activation** — upload, compile, test, activate
+  endpoints. `policies:` keyspace.
+- **Bundled default policies** for `join`, `removal`,
+  `role_definitions`, plus the deny-all stubs for
+  `personhood`, `cross_community_roles`,
+  `cross_community_relationships`.
+- **VC builder** using `affinidi-vc` + `affinidi-data-integrity`
+  for VMC + VEC issuance.
+- **Local VTC signing** (per **D1** below) — VTC's `#key-0`
+  Ed25519 signs VMCs/VECs/status-list credentials directly.
+- **Status-list infrastructure** — BitstringStatusList VC build,
+  reserved-index allocator, `status_lists:` keyspace, public
+  `GET /v1/status-lists/{purpose}` route.
+- **VMC + VEC issuance on approve** — `join-requests/approve`
+  mints + seals on a policy `allow`.
+- **`POST /v1/members/me/renew`** — re-mint VMC + role VEC.
+- **Status-list flip on removal** — `MemberRemoved` writes the
+  revocation bit.
+- **DID rotation** — `did:webvh` native + `did:key` co-signed.
+- **Trust Tasks** + spec.md/schema.json for every new endpoint.
+
+### Out of scope
+
+- Trust registry — Phase 3.
+- Cross-community recognition — Phase 3.
+- VRC issuance — Phase 4.
+- Personhood `assert`/`revoke` endpoints — Phase 4 (the
+  `personhood.rego` stub ships in Phase 2 as default-deny per
+  spec §7.1; only the **assert/revoke endpoints** are deferred).
+- Reactor / chaining of status-list capacity (v2 per spec §17).
+
+## Pre-implementation design decisions
+
+Load-bearing. Defaults below; flag dissent before any code lands.
+
+### D1 — Signing surface: local vs VTA oracle
+
+Spec §3-A says "VTC has no key custody; every signature
+delegates to the VTA signing oracle." That predates the
+VTA-driven-keys rework (PR-A of Phase 0), which **ships the
+VTC its own `#key-0` Ed25519 private** inside the secret store
+(`VtcKeyBundle`). After PR-A, the VTC **does** hold its own
+keys — the "delegate to VTA" line is obsolete.
+
+**Proposed default: local signing.** The VTC signs VMCs / VECs
+/ status-list credentials directly with its own `#key-0`. Cuts
+out a network hop, removes the timeout / breaker complexity,
+and matches what the keys-already-here architecture invites.
+
+Implication: spec §14.2's `vta.signing_timeout_seconds` +
+`vta.circuit_breaker_threshold` config knobs become **dead
+parameters** in Phase 2. The breaker pattern still has value
+elsewhere (trust-registry publish in Phase 3, did:webvh
+resolution for member-DID-rotation), so the pattern stays in
+the codebase even though VMC issuance no longer needs it.
+
+This is a **spec deviation** worth surfacing. The user
+approved the post-PR-A architecture explicitly; this plan
+makes the consequence concrete.
+
+### D2 — `regorus` location
+
+- **(a)** New module `vti_common::policy` — would let VTA
+  consume it later if VTA grows policy needs.
+- **(b)** `vtc_service::policy` — VTC-only.
+
+**Proposed default: (b)**. VTA has no policy story today;
+promoting regorus into vti-common is speculative. If VTA later
+needs Rego, the move from vtc-service → vti-common is
+mechanical.
+
+### D3 — Policy storage shape
+
+`policies:<id>` rows hold the full Policy + compiled bytecode.
+`active_policies:<purpose>` rows hold a pointer to the
+currently-active id. Activation rewrites the pointer; archived
+versions retained for audit + rollback. Compiled bytecode is
+**recomputed at boot** (regorus binaries aren't versioned
+across releases) — the on-disk row carries only the Rego
+source + SHA-256.
+
+### D4 — Policy `input` extraction from a JoinRequest
+
+Phase 1 records the join VP as opaque JSON. Phase 2's policy
+step needs `vp_claims` — the verified subset of the VP's
+`verifiableCredential` array. **Proposed default**: the
+`submit_inner` path verifies the VP at submit time (Phase 2
+upgrade from Phase 1's holder-binding-only check), extracts a
+canonical `vp_claims` JsonValue, and stores it on the
+JoinRequest alongside the raw `vp`. On approve, the policy step
+reads the extracted claims directly.
+
+Phase 2 keeps did:key applicants only at the VP-verify layer;
+did:webvh applicants land in a follow-up once the
+`affinidi-did-resolver-cache-sdk` integration grows the
+member-DID hot path.
+
+### D5 — Status-list crypto
+
+The BitstringStatusList credential is itself a VC. It's signed
+by `#key-0` (same as VMCs), data-integrity proof, hosted at a
+public URL under the VTC's deployment. The DID document's
+`#vtc-status-list` service entry already advertises the URL
+(`{URL}/v1/status-lists` per the `vtc-host` template).
+
+**Proposed default**: one `BitstringStatusListCredential` per
+purpose at `GET /v1/status-lists/{purpose}`, where `purpose ∈
+{revocation, suspension}`. Capacity 131_072 (2^17) each, hardcoded
+for MVP. Re-issued lazily on every flip — there's no separate
+"sign the status list" job.
+
+### D6 — Renewal idempotency
+
+`POST /v1/members/me/renew` is non-destructive (it issues a new
+credential without flipping any state). Idempotency cache: 24h
+non-destructive class per M0.1.3. Repeated renewals within
+24h of the same `Idempotency-Key` return the cached VMC + VEC
+pair.
+
+### D7 — DID rotation path split
+
+`did:webvh` and `did:key` rotations are operationally and
+cryptographically distinct (spec §10.5). They share the **same
+external surface** (`POST /v1/members/me/rotate/challenge` +
+`POST /v1/members/me/rotate`) but the verification step
+branches on the new DID's method.
+
+**Proposed default**: ship the `did:key` path first
+(`vtc-did-rotation/v1\0` domain tag, both-keys co-signed
+attestation) since it's the simpler crypto. `did:webvh`
+rotation needs `affinidi-did-resolver-cache-sdk` to walk the
+`did.jsonl` history; that resolver is already a workspace
+dep, but the integration is non-trivial. Both paths in scope
+for Phase 2 but `did:webvh` is the riskier slice.
+
+### D8 — Policy hot-swap atomicity
+
+Spec §7.2: "atomically swaps the active policy for its purpose;
+in-flight requests against the old policy complete; new
+requests use the new."
+
+**Proposed default**: the active pointer is an `Arc<CompiledPolicy>`
+held on AppState. `activate` swaps the Arc via
+`tokio::sync::RwLock` write; in-flight evaluators hold their
+own clone. fjall's `active_policies:<purpose>` row is updated
+in the same transaction so a daemon restart picks up the new
+active without a separate apply step.
+
+### D9 — Personhood-policy default placement
+
+Spec §6.4 + §7.1: `personhood.rego` ships deny-all. The
+**stub ships in Phase 2** (so renewal's §6.3 step 3
+`personhood` re-eval has something to call), but the
+operator-facing `POST /v1/members/{did}/personhood/{assert,revoke}`
+endpoints are Phase 4 work. Phase 2's renewal pipeline just
+records `personhood: false` on every renewed VMC.
+
+### D10 — Trust Task ID naming
+
+Following the workspace-wide pattern:
+
+| Operation | Trust Task ID |
+|---|---|
+| Upload policy | `…/policies/upload/1.0` |
+| Activate policy | `…/policies/activate/1.0` |
+| Test policy | `…/policies/test/1.0` |
+| List policies | `…/policies/list/1.0` |
+| Show policy | `…/policies/show/1.0` |
+| Renew VMC | `…/members/renew/1.0` |
+| Rotation challenge | `…/members/rotate-challenge/1.0` |
+| Rotation finish | `…/members/rotate/1.0` |
+| Status-list show | `…/status-lists/show/1.0` (exempt from header check — verifier-facing) |
+
+## Dependency graph
+
+```
+M2.1 regorus harness in vtc_service::policy
+  │
+  ▼
+M2.2 Policy model + policies keyspace
+  │
+  ▼
+M2.3 POST /v1/policies (upload + activate + test)
+M2.4 GET  /v1/policies (list + show)
+  │
+  ▼  [parallel: M2.9 VC builder]
+M2.5 Bundle default policies (join, removal, role_definitions,
+     personhood deny-all, cross_community_*, relationships,
+     directory, registry)
+  │
+  ▼
+M2.6 Wire join.rego into submit_inner
+M2.7 Wire removal.rego into remove_inner
+  │
+  │  [parallel branch: M2.9 → M2.10 → M2.11]
+  ▼
+M2.9 VC builder (affinidi-vc + affinidi-data-integrity) +
+     local Ed25519 signer (D1) — `vtc_service::credentials`
+  │
+  ▼
+M2.10 Status-list keyspace + reserved-index allocator +
+      BitstringStatusList VC builder
+  │
+  ▼
+M2.11 GET /v1/status-lists/{purpose} route
+  │
+  ▼
+M2.12 VMC + VEC issuance wired into join-requests/approve
+M2.13 POST /v1/members/me/renew (D6)
+M2.16 Status-list flip on removal
+  │
+  │  [parallel: M2.15 DID rotation]
+  ▼
+M2.15a did:key rotation (D7)
+M2.15b did:webvh rotation
+  │
+  ▼
+M2.17 Phase 2 audit variants
+M2.18 Trust Task spec.md + schema.json for every new endpoint
+  │
+  ▼
+M2.19 Phase 2 gate (M2.13's workspace-green check)
+```
+
+Critical paths:
+- **Policy track** (M2.1 → M2.2 → M2.3 → M2.5 → M2.6 / M2.7).
+  Sequential.
+- **Credentials track** (M2.9 → M2.10 → M2.11). Sequential but
+  parallel with policy track.
+- **Issuance integration** (M2.12, M2.13) joins both tracks.
+- **DID rotation** (M2.15) is independent — can land in
+  parallel with M2.12.
+
+## Parallelisation strategy
+
+Within a milestone: vertical slice — each endpoint ships with
+its Trust Task files + integration tests + audit emission, not
+in batches.
+
+PR slicing — proposed:
+
+1. **PR-1**: M2.1 + M2.2 + M2.3 + M2.4 (regorus + policy
+   CRUD).
+2. **PR-2**: M2.5 + M2.6 + M2.7 (default policies + wire
+   into existing endpoints).
+3. **PR-3**: M2.9 + M2.10 + M2.11 (VC builder +
+   status-list infrastructure).
+4. **PR-4**: M2.12 + M2.13 + M2.16 (VMC/VEC on approve +
+   renew + status-list flip on remove).
+5. **PR-5**: M2.15 (DID rotation — did:key + did:webvh).
+6. **PR-6**: M2.17 + M2.18 + M2.19 (audit + Trust Tasks + gate).
+
+6 PRs across 19 milestones. Larger phase than Phase 1's
+15 milestones / 5 PRs — the credentials track adds substantial
+surface.
+
+## Checkpoints
+
+- **After PR-1**: policy admin endpoints work; no policy is
+  active by default. Existing surfaces unaffected.
+- **After PR-2**: default `join` allows; existing
+  join-request submit flow continues to work because the
+  Phase 1 path stayed authoritative until the policy step
+  formally lands. Removal flow likewise. A rejected join
+  request now carries a policy-decision payload.
+- **After PR-3**: status-list VCs publish; no VMCs reference
+  them yet.
+- **After PR-4**: approve mints VMC + role VEC; renewal works;
+  removal flips the revocation bit. **Gate "Live credentials"
+  effectively met here** — the rest is rotation polish.
+- **After PR-5**: members can rotate their DIDs.
+- **After PR-6**: workspace gate green. Phase 2 closes.
+
+## Risks
+
+- **R1: regorus version churn.** `regorus` is in active
+  development; pin a minor + plan to bump deliberately.
+- **R2: affinidi-vc API surface.** The data-integrity proof
+  shape is well-tested in vta-sdk (provision-integration uses
+  it). Reuse the same crate-feature set to minimise duplicate
+  config.
+- **R3: status-list privacy.** The reserved-index discipline
+  (spec §6.2) is load-bearing for privacy. Tests must
+  exercise: never reallocate a flipped slot; capacity warning
+  fires at 75% live+reserved; index allocation is
+  cryptographically random not sequential.
+- **R4: did:webvh rotation correctness.** Walking `did.jsonl`
+  + verifying prior-key signatures is fiddly. The
+  `affinidi-did-resolver-cache-sdk` covers it but its hot path
+  isn't well-trodden. Land did:key first to de-risk; did:webvh
+  may need its own follow-up PR.
+- **R5: policy auth-gating drift.** Once the auth layer
+  consumes `role_definitions.rego` (planned Phase 2), the
+  Phase 1 AuthClaims-vs-VtcRole degradation is no longer
+  workable. Either rewrite AuthClaims to be `VtcRole`-aware
+  (broad change), or scope role-policy evaluation to **route
+  handlers only** (narrower, defer AuthClaims rewrite to
+  Phase 3+). Proposed: route-handler-only Phase 2.
+- **R6: signing-oracle spec deviation (D1).** Recording it as
+  a Phase 2 outcome — the spec's "no key custody" line gets
+  amended.
+
+## Definition of done — Phase 2
+
+After M2.19:
+
+- `cargo build/clippy/fmt/test --workspace` clean.
+- 9+ new Trust Tasks in `Draft` status with matching `spec.md`
+  + `schema.json` files.
+- Every Phase 2 milestone marked `[x]` in `phase-2-todo.md`.
+- Memory entry `project_vtc_mvp.md` updated with the seven
+  pre-impl decisions' as-shipped outcomes.
+- Integration tests cover the end-to-end membership lifecycle:
+  applicant submits → policy allows → admin approves → VMC +
+  VEC sealed-transferred → renewal succeeds → admin removes →
+  revocation bit flipped → status-list VC reflects the flip.
+
+Phase 3 (trust-registry + cross-community recognition) can
+start after Phase 2's gate merges.
+
+## Spec amendment surface
+
+Recording up front so they're not surprises mid-implementation:
+
+- **§3-A "VTC has no key custody"** — amended per D1.
+- **§14.2 "VTA signing oracle dependence"** — VTA-oracle
+  timeout + breaker stay in the spec but apply to other
+  remote dependencies (trust-registry, did:webvh resolver),
+  not VMC issuance.
+- **§6.2 status-list URL** — confirm the URL the
+  `vtc-host` template renders into `#vtc-status-list` is the
+  one the VTC daemon serves at
+  `GET /v1/status-lists/{purpose}`. Phase 0's template
+  uses `{URL}/v1/status-lists` (substring) and the VTC routes
+  per-purpose. May need a `{purpose}` in the template's
+  service-endpoint URL — flag for M2.11.
+
+Any decision that drifts from the default during
+implementation should be recorded in `phase-2-plan.md` under a
+"Phase 2 outcome" header (mirror of Phase 1's pattern).

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -380,23 +380,29 @@ ships; assert / revoke endpoints are Phase 4.
 
 ---
 
-## M2.16 — Spec-deviation note
+## M2.16 — Spec clarifications
 
 ### `[ ]` M2.16.1 — Capture D1 + status-list URL outcomes
 
 - **Acceptance** — `tasks/vtc-mvp/phase-2-plan.md` gains a
   "Phase 2 outcomes" header listing:
-  - **D1 outcome**: VTC signs its own credentials locally.
-    Spec §3-A "no key custody" amended.
+  - **D1 outcome**: VTC signs its own credentials locally
+    against a **cached** copy of the integration DID's keys
+    (mediator / webvh-service pattern). Spec §3-A amended to
+    spell out the cached-locally / VTA-controlled model —
+    "no key custody" was always meant as "no key minting /
+    rotation authority", not "no key storage".
   - **§14.2 outcome**: VTA-oracle timeout + breaker config
-    knobs retained but only apply to non-VMC remote
-    dependencies (trust-registry in Phase 3, did:webvh
-    resolver in M2.15.2).
-  - Any other deviations discovered during implementation.
+    parameters retain their names but the spec is amended
+    to clarify they apply to **non-VMC remote dependencies**
+    only (trust-registry publish in Phase 3, did:webvh
+    resolver in M2.15.2). VMC issuance is in-process.
+  - Any other clarifications discovered during
+    implementation.
 - **Files**
   - `tasks/vtc-mvp/phase-2-plan.md`
   - `docs/05-design-notes/vtc-mvp.md` (§3-A + §14.2
-    amendments)
+    clarifications)
 
 ---
 
@@ -468,8 +474,10 @@ the flip → members can rotate their DIDs. Phase 3
 Defaults in `phase-2-plan.md` §§D1–D10. Listed here so
 they're findable from the todo:
 
-- **D1**: Signing surface — local Ed25519 (proposed).
-  **Spec deviation**.
+- **D1**: Signing surface — cached-locally, VTA-controlled
+  (mediator / webvh-service pattern). **Spec clarification**
+  of §3-A "no key custody" (= no key minting / rotation
+  authority, not no key storage).
 - **D2**: regorus location — `vtc_service::policy` (proposed).
 - **D3**: Policy storage shape — `policies:<id>` rows +
   `active_policies:<purpose>` pointer (proposed).

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -1,0 +1,492 @@
+# Todo: VTC MVP — Phase 2
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done · `[!]` blocked
+
+Spec: `docs/05-design-notes/vtc-mvp.md` §§5.4, 6.1–6.3, 7, 10.5, 14.2
+Plan: `tasks/vtc-mvp/phase-2-plan.md`
+
+Every code task also drafts the matching Trust Task spec
+(`trust-tasks/.../spec.md` + `schema.json`) in the same PR — soft
+gate per spec §9.4. Trust Task IDs per plan §D10.
+
+Every PR must be DCO-signed (`git commit -s`) and pass
+`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`.
+
+---
+
+## M2.1 — `regorus` policy harness
+
+### `[ ]` M2.1.1 — `vtc_service::policy` module
+
+- **Acceptance**
+  - `regorus` added to workspace dependencies.
+  - New module `vtc_service::policy` with:
+    - `Policy` struct (placeholder until M2.2).
+    - `CompiledPolicy` wrapping a `regorus::Engine` + the
+      source SHA-256 + the policy id.
+    - `compile(rego_source: &str, id: Uuid) -> Result<CompiledPolicy,
+      AppError>` — compiles, returns descriptive error on
+      Rego syntax errors.
+    - `evaluate(&CompiledPolicy, query: &str, input: JsonValue)
+      -> Result<JsonValue, AppError>` — evaluates a Rego query
+      under the given input.
+  - 6 unit tests cover happy compile + parse error + evaluate
+    with allow + evaluate with deny + missing-rule error +
+    deterministic SHA across recompilations.
+- **Verify** `cargo test --package vtc-service policy::` green.
+- **Files**
+  - `Cargo.toml` (workspace `regorus` dep)
+  - `vtc-service/Cargo.toml`
+  - `vtc-service/src/policy/mod.rs` (new)
+  - `vtc-service/src/policy/engine.rs` (new — compile/evaluate)
+- **Deps**: none
+- **Pre-impl decision**: **D2** (regorus location).
+
+---
+
+## M2.2 — Policy model + `policies` keyspace
+
+### `[ ]` M2.2.1 — `Policy` + storage CRUD
+
+- **Acceptance**
+  - `Policy { id, purpose, rego_source, sha256, activated_at:
+    Option<DateTime>, author_did, created_at, version: u32 }`
+    per spec §5.4.
+  - `PolicyPurpose` enum: `Join`, `Removal`, `Personhood`,
+    `Registry`, `Directory`, `RoleDefinitions`,
+    `CrossCommunityRoles`, `CrossCommunityRelationships`,
+    `Relationships` (spec §7.1).
+  - `policies:<id>` keyspace stores `Policy` rows.
+  - `active_policies:<purpose>` keyspace stores the active
+    policy id per purpose (one row per purpose).
+  - CRUD helpers: `store_policy`, `get_policy`,
+    `list_policies_paginated`, `delete_policy`,
+    `get_active_policy_id`, `set_active_policy_id`.
+- **Verify** Round-trip every PolicyPurpose; paginated list;
+  set + get active pointer.
+- **Files**
+  - `vtc-service/src/policy/model.rs` (new)
+  - `vtc-service/src/policy/storage.rs` (new)
+  - `vtc-service/src/server.rs` (AppState gains
+    `policies_ks` + `active_policies_ks`)
+- **Deps**: M2.1.1
+- **Pre-impl decision**: **D3** (storage shape).
+
+---
+
+## M2.3 — Policy admin endpoints
+
+### `[ ]` M2.3.1 — Upload + activate + test
+
+- **Acceptance**
+  - `POST /v1/policies` — admin-only. Body `{ purpose,
+    rego_source }`. Compiles via M2.1.1; persists Policy row.
+    Returns `{ id, sha256 }`. 400 with compiler error on Rego
+    parse / type failures.
+  - `POST /v1/policies/{id}/activate` — admin-only. Atomic
+    swap of the active pointer (D8). Emits `PolicyActivated`
+    audit envelope. 409 if already active.
+  - `POST /v1/policies/{id}/test` — admin-only. Evaluates the
+    candidate policy against a caller-supplied `input` JSON
+    **without activating**. Returns the policy's output.
+  - Trust Tasks: `policies/upload/1.0`,
+    `policies/activate/1.0`, `policies/test/1.0`.
+- **Verify** Integration tests cover happy upload + bad-Rego
+  rejection + activate-after-upload swaps the active pointer +
+  test-without-activate doesn't mutate state.
+- **Files**
+  - `vtc-service/src/routes/policies/mod.rs` (new)
+  - `vtc-service/src/routes/policies/admin.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/policies/{upload,activate,test}/1.0/{spec.md,schema.json}`
+- **Deps**: M2.2.1
+- **Pre-impl decision**: **D8** (hot-swap atomicity).
+
+---
+
+## M2.4 — Policy read endpoints
+
+### `[ ]` M2.4.1 — List + show
+
+- **Acceptance**
+  - `GET /v1/policies` — admin-only. Paginated; ?purpose=
+    filter, ?status=active|archived.
+  - `GET /v1/policies/{id}` — admin-only. Returns the full
+    Policy row including Rego source.
+  - Trust Tasks: `policies/list/1.0`, `policies/show/1.0`.
+- **Files**
+  - `vtc-service/src/routes/policies/read.rs` (new)
+  - `trust-tasks/policies/{list,show}/1.0/{spec.md,schema.json}`
+- **Deps**: M2.2.1
+
+---
+
+## M2.5 — Default policies
+
+### `[ ]` M2.5.1 — Bundle deny-all / accept-all defaults
+
+- **Acceptance**
+  - 9 default Rego policies shipped under
+    `vtc-service/policies/default/*.rego` per spec §7.1's table.
+  - `policies::default::install_defaults()` writes each one as a
+    Policy row + sets the active pointer at first boot. Idempotent.
+  - `join.rego` default = allow-any-signed-VP (template
+    `policies.open` per §7.1).
+  - `personhood.rego` + cross-community defaults = deny-all.
+  - `removal.rego` default = "any admin may remove any
+    non-admin".
+- **Verify** Compile each via M2.1.1 at unit-test time +
+  round-trip each input contract → expected output for each
+  default.
+- **Files**
+  - `vtc-service/policies/default/{join,removal,personhood,
+    registry,directory,role_definitions,
+    cross_community_roles,cross_community_relationships,
+    relationships}.rego`
+  - `vtc-service/src/policy/default.rs` (new)
+  - `vtc-service/src/server.rs` (call `install_defaults` at
+    init_auth time)
+- **Deps**: M2.3.1
+
+---
+
+## M2.6 — Wire `join.rego` into submit
+
+### `[ ]` M2.6.1 — Policy step at submit time
+
+- **Acceptance**
+  - `submit_inner` (existing) extracts `vp_claims` from the
+    VP (D4) and evaluates the active `join` policy with input
+    `{ applicant_did, vp_claims, action: "join", now }` per
+    spec §7.3.
+  - `allow` → row persisted with `JoinStatus::Pending` (current
+    behaviour).
+  - `deny` → row persisted with `JoinStatus::Rejected` +
+    `policy_decision` populated with the policy's output JSON.
+    Audit event `JoinRequestRejected` instead of
+    `JoinRequestSubmitted`.
+- **Files**
+  - `vtc-service/src/routes/join_requests/submit.rs`
+  - `vtc-service/src/policy/extract.rs` (new — VP → vp_claims
+    extractor per D4)
+- **Deps**: M2.5.1
+- **Pre-impl decision**: **D4** (vp_claims extraction).
+
+---
+
+## M2.7 — Wire `removal.rego` into admin-remove
+
+### `[ ]` M2.7.1 — Policy step at admin-remove time
+
+- **Acceptance**
+  - `routes::members::remove::admin_remove` evaluates the
+    active `removal` policy with input `{ actor_did, target_did,
+    target_role, reason, action: "remove", now }`.
+  - `deny` → 403 `RemovalDeniedByPolicy` with the policy's
+    rationale.
+  - `min_disposition` output (Phase 1's plan §D6 placeholder)
+    now reads from the policy when caller didn't override.
+- **Files**
+  - `vtc-service/src/routes/members/remove.rs`
+- **Deps**: M2.5.1
+
+---
+
+## M2.8 — `personhood.rego` stub install
+
+Folds into M2.5.1 — no separate milestone. The deny-all stub
+ships; assert / revoke endpoints are Phase 4.
+
+---
+
+## M2.9 — VC builder + local signer
+
+### `[ ]` M2.9.1 — `vtc_service::credentials` module
+
+- **Acceptance**
+  - `affinidi-vc` + `affinidi-data-integrity` added as
+    direct deps.
+  - `LocalSigner` wraps the `#key-0` Ed25519 private (read
+    from the same `VtcKeyBundle` via the existing secret
+    store) and signs data-integrity proofs.
+  - `build_vmc(member_did, community_did, status_list_index,
+    validity, personhood) -> VerifiableCredential` per spec
+    §6.1's VMC shape.
+  - `build_role_vec(member_did, role, community_did) ->
+    VerifiableCredential` per the §6.1 VEC shape.
+  - 8 unit tests covering: VMC happy path; VMC `validUntil`
+    pinning; VEC with each `VtcRole`; signature verifies
+    against the VTC's public key; tampering invalidates.
+- **Files**
+  - `vtc-service/src/credentials/mod.rs` (new)
+  - `vtc-service/src/credentials/vmc.rs` (new)
+  - `vtc-service/src/credentials/vec.rs` (new)
+  - `vtc-service/src/credentials/signer.rs` (new)
+- **Deps**: none (uses existing key material)
+- **Pre-impl decision**: **D1** (local signer; spec §3-A
+  amendment).
+
+---
+
+## M2.10 — Status-list infrastructure
+
+### `[ ]` M2.10.1 — `status_lists` keyspace + reserved-index allocator
+
+- **Acceptance**
+  - `StatusListState { purpose, capacity, next_random_seed,
+    occupied: BitSet, list_credential_id }` per spec §5.6.
+  - Random-with-decoys allocator (`affinidi-status-list`'s
+    privacy mode).
+  - **Flipped indices retained** as occupied so reallocation
+    can never reuse them.
+  - `StatusListOccupancyWarning` telemetry event at 75%
+    live + reserved (spec §6.2).
+  - `BitstringStatusListCredential` builder using
+    M2.9.1's signer.
+- **Verify** Allocator never returns a flipped slot;
+  occupancy warning fires at 75%; round-trip
+  BitstringStatusList VC + verify.
+- **Files**
+  - `vtc-service/src/status_list/mod.rs` (new)
+  - `vtc-service/src/status_list/storage.rs` (new)
+  - `vtc-service/src/status_list/allocator.rs` (new)
+  - `vtc-service/src/status_list/credential.rs` (new)
+- **Deps**: M2.9.1
+- **Pre-impl decision**: **D5** (status-list crypto).
+
+---
+
+## M2.11 — Status-list publication route
+
+### `[ ]` M2.11.1 — `GET /v1/status-lists/{purpose}`
+
+- **Acceptance**
+  - Public, unauthenticated, Trust-Task-exempt (verifier-
+    facing — same rationale as `/v1/{scid}/did.jsonl`).
+  - Path param `purpose ∈ {revocation, suspension}`; other
+    values → 404.
+  - Returns the latest BitstringStatusList VC as JSON-LD.
+  - `Cache-Control: no-store` (status list is live state).
+- **Verify** Integration test: route serves the seeded
+  status-list VC; unknown purpose 404s; route bypasses
+  Trust-Task header check.
+- **Files**
+  - `vtc-service/src/routes/status_lists.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/status-lists/show/1.0/{spec.md,schema.json}`
+- **Deps**: M2.10.1
+
+---
+
+## M2.12 — VMC + VEC issuance on approve
+
+### `[ ]` M2.12.1 — Wire issuance into `decide::approve`
+
+- **Acceptance**
+  - On approve: allocate a status-list index (revocation
+    purpose), mint VMC + role VEC via M2.9.1, seal-transfer
+    to applicant DID via the existing sealed-transfer path
+    (vta-sdk's `seal_payload`).
+  - Member row gains `status_list_index` + `current_vmc_id` +
+    `current_role_vec_id`.
+  - Audit emits `VmcIssued` + `VecIssued` alongside the
+    existing `JoinRequestApproved` + `MemberAdded`.
+- **Files**
+  - `vtc-service/src/routes/join_requests/decide.rs`
+  - `vti-common/src/audit/event.rs` (`VmcIssued`,
+    `VecIssued` variants)
+- **Deps**: M2.10.1, M2.5.1
+
+---
+
+## M2.13 — Renewal
+
+### `[ ]` M2.13.1 — `POST /v1/members/me/renew`
+
+- **Acceptance**
+  - Authenticated. Caller's DID is the renewal target.
+  - Verifies the caller has an active ACL row (spec §6.3 —
+    no expiry / grace window check).
+  - Re-mints VMC + role VEC via M2.9.1 with `validFrom = now`
+    + `validUntil = now + community.membership.validity`.
+  - Re-evaluates `personhood.rego` per §6.3 step 3. Phase 2
+    deny-all stub means `personhood: false` always.
+  - Status-list index reused.
+  - Audit emits `MembershipRenewed { personhood_changed }`.
+  - Trust Task: `members/renew/1.0`.
+- **Files**
+  - `vtc-service/src/routes/members/renew.rs` (new)
+  - `trust-tasks/members/renew/1.0/{spec.md,schema.json}`
+- **Deps**: M2.12.1
+- **Pre-impl decision**: **D6** (idempotency cache).
+
+---
+
+## M2.14 — Removal flips revocation bit
+
+### `[ ]` M2.14.1 — Status-list flip on `MemberRemoved`
+
+- **Acceptance**
+  - `remove_inner` flips the member's status-list bit
+    (revocation purpose) before deleting the ACL row.
+  - Re-emits the BitstringStatusList VC (M2.10.1).
+  - Audit emits `StatusListFlipped { purpose, index }`.
+- **Files**
+  - `vtc-service/src/routes/members/remove.rs`
+- **Deps**: M2.10.1
+
+---
+
+## M2.15 — DID rotation
+
+### `[ ]` M2.15.1 — `did:key` rotation (challenge + finish)
+
+- **Acceptance**
+  - `POST /v1/members/me/rotate/challenge` — auth: old DID's
+    session. Returns single-use `rotation_id` + `expires_at`
+    (10 min TTL).
+  - `POST /v1/members/me/rotate` — auth: **new DID's session**.
+    Body carries the rotation payload signed by both old and
+    new keys, domain-tag-prefixed with `vtc-did-rotation/v1\0`.
+    Atomic:
+    - Verify both signatures.
+    - Consume the `rotation_id`.
+    - Update ACL DID → new.
+    - Update Member DID → new.
+    - Revoke all sessions / refresh tokens / idempotency
+      cache rows keyed on old DID.
+    - Re-issue VMC + role VEC to new DID (status-list index
+      reused).
+    - Audit `DidRotated { old_did, new_did, method: "did:key" }`.
+  - Trust Tasks: `members/rotate-challenge/1.0`,
+    `members/rotate/1.0`.
+- **Files**
+  - `vtc-service/src/routes/members/rotate.rs` (new)
+  - `vti-common/src/audit/event.rs` (`DidRotated` variant)
+- **Deps**: M2.12.1
+- **Pre-impl decision**: **D7** (path split).
+
+### `[ ]` M2.15.2 — `did:webvh` rotation
+
+- **Acceptance**
+  - `POST /v1/members/me/rotate` (same endpoint) detects
+    new_did's method as `did:webvh`, resolves the new DID via
+    `affinidi-did-resolver-cache-sdk`, walks the `did.jsonl`
+    log, and verifies the prior-key signature on the latest
+    log entry matches the old DID's key.
+  - Same atomic effect as M2.15.1.
+- **Risk** — see R4. May ship as a separate follow-up PR.
+- **Deps**: M2.15.1
+
+---
+
+## M2.16 — Spec-deviation note
+
+### `[ ]` M2.16.1 — Capture D1 + status-list URL outcomes
+
+- **Acceptance** — `tasks/vtc-mvp/phase-2-plan.md` gains a
+  "Phase 2 outcomes" header listing:
+  - **D1 outcome**: VTC signs its own credentials locally.
+    Spec §3-A "no key custody" amended.
+  - **§14.2 outcome**: VTA-oracle timeout + breaker config
+    knobs retained but only apply to non-VMC remote
+    dependencies (trust-registry in Phase 3, did:webvh
+    resolver in M2.15.2).
+  - Any other deviations discovered during implementation.
+- **Files**
+  - `tasks/vtc-mvp/phase-2-plan.md`
+  - `docs/05-design-notes/vtc-mvp.md` (§3-A + §14.2
+    amendments)
+
+---
+
+## M2.17 — Audit variants
+
+### `[ ]` M2.17.1 — Phase 2 audit vocabulary
+
+- **Acceptance**
+  - `AuditEvent` enum gains variants:
+    `PolicyUploaded`, `PolicyActivated`, `VmcIssued`,
+    `VecIssued`, `MembershipRenewed`, `StatusListFlipped`,
+    `DidRotated`.
+  - Each variant's data struct snapshot-tested.
+- **Files**
+  - `vti-common/src/audit/event.rs`
+- **Deps**: every endpoint milestone (consumers wire after
+  variants land)
+
+---
+
+## M2.18 — Trust Task drafts + index
+
+### `[ ]` M2.18.1 — Spec + schema files for Phase 2 surface
+
+- **Acceptance**
+  - All 9 Phase 2 Trust Tasks from plan §D10 have `spec.md`
+    + `schema.json` files.
+  - `trust-tasks/index.json` extended with all 9 entries.
+- **Files**
+  - `trust-tasks/{policies,members,status-lists}/...`
+  - `trust-tasks/index.json`
+- **Deps**: M2.3, M2.4, M2.11, M2.13, M2.15
+
+---
+
+## M2.19 — Phase 2 gate
+
+### `[ ]` M2.19.1 — Workspace gate green
+
+- **Acceptance** (mirrors M0.12.3 + M1.15.1)
+  - `cargo build --workspace` green.
+  - `cargo test --workspace` green.
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+    clean.
+  - `cargo fmt --check` clean.
+  - `trust-tasks/index.json` lists every Phase-2 Trust Task
+    with matching on-disk files.
+  - Memory entry `project_vtc_mvp.md` updated with the as-
+    shipped outcomes for D1–D10.
+  - Phase-2-todo milestones all flipped to `[x]`.
+- **Verify** CI green on the merge commit.
+- **Files**
+  - `trust-tasks/index.json`
+  - `/Users/glenngore/.claude/projects/-Users-glenngore-devel-fpp-verifiable-trust-infrastructure/memory/project_vtc_mvp.md`
+- **Deps**: M2.17.1, M2.18.1
+
+### Checkpoint — Phase 2 gate met
+
+After M2.19.1: an applicant can submit → policy decides →
+admin approves → VMC + VEC sealed-transferred → renewal works
+→ removal flips the revocation bit → status list reflects
+the flip → members can rotate their DIDs. Phase 3
+(trust-registry + cross-community) can start.
+
+---
+
+## Open questions surfaced during planning
+
+Defaults in `phase-2-plan.md` §§D1–D10. Listed here so
+they're findable from the todo:
+
+- **D1**: Signing surface — local Ed25519 (proposed).
+  **Spec deviation**.
+- **D2**: regorus location — `vtc_service::policy` (proposed).
+- **D3**: Policy storage shape — `policies:<id>` rows +
+  `active_policies:<purpose>` pointer (proposed).
+- **D4**: VP → vp_claims extraction at submit time
+  (proposed).
+- **D5**: Status-list crypto — same `#key-0` signing,
+  per-purpose endpoints (proposed).
+- **D6**: Renewal idempotency — 24h non-destructive cache
+  (proposed).
+- **D7**: DID rotation — did:key first, did:webvh follows
+  (proposed).
+- **D8**: Policy hot-swap atomicity — Arc<CompiledPolicy>
+  + RwLock + fjall row in same transaction (proposed).
+- **D9**: Personhood policy stub in Phase 2; endpoints in
+  Phase 4 (proposed).
+- **D10**: Trust Task ID naming — see plan §D10.
+
+Any decision that drifts from the default during
+implementation should be recorded in `phase-2-plan.md`
+under a "Phase 2 outcome" header.


### PR DESCRIPTION
## Summary

Planning artefact for Phase 2. **No code changes** — drafts
the two planning docs that drive Phase 2's implementation work.

Per spec §16, Phase 2 delivers: `regorus`, policy upload +
activate, `join.rego` + `removal.rego`, VMC + VEC issuance via
the signing oracle, status-list with reserved-index discipline,
renewal, DID rotation (both methods, domain-tagged).
**Gate: "Live policy + credentials."**

## What's in this PR

- **`tasks/vtc-mvp/phase-2-plan.md`** — full plan (~570 lines):
  - Objective + scope (in/out per spec §16).
  - **10 pre-impl design decisions** (D1–D10) with proposed
    defaults. These are load-bearing — flag dissent before
    M2.1 code starts.
  - Dependency graph + parallelisation strategy.
  - 6-PR slicing across 19 milestones.
  - Checkpoints, risks, definition of done, **spec amendment
    surface** (§3-A + §14.2 clarifications from D1).

- **`tasks/vtc-mvp/phase-2-todo.md`** — 19 M2.* milestones
  (M2.1 through M2.19), each with acceptance + verify + file
  list + deps. Mirrors Phase 1's `phase-1-todo.md` layout.

## Design decisions for review (plan §§D1–D10)

| | Decision | Proposed default | Notes |
|---|---|---|---|
| **D1** | Signing surface | Cached-locally, VTA-controlled (`#key-0`) | **Spec clarification §3-A** — mediator / webvh-service pattern; VTA mints + controls, VTC caches + signs locally |
| **D2** | `regorus` location | `vtc_service::policy` | VTA has no policy story today |
| **D3** | Policy storage | `policies:<id>` rows + `active_policies:<purpose>` pointer | Source + SHA only on disk; bytecode recompiled at boot |
| **D4** | vp_claims extraction | At submit time (Phase 2 upgrade) | Phase 1 stored raw VP only |
| **D5** | Status-list crypto | `#key-0` signs; per-purpose endpoints | Same key as VMC |
| **D6** | Renewal idempotency | 24h non-destructive cache | Standard non-destructive class |
| **D7** | DID rotation path split | did:key first, did:webvh follows | Risk R4: did:webvh may slip to a follow-up PR |
| **D8** | Policy hot-swap | `Arc<CompiledPolicy>` + `RwLock` + fjall row in same txn | In-flight evaluators hold their own clone |
| **D9** | Personhood placement | Stub ships in Phase 2; endpoints Phase 4 | Renewal's §6.3 step 3 needs something to call |
| **D10** | Trust Task ID naming | 9 new IDs under `policies/*`, `members/*`, `status-lists/*` | See plan §D10 table |

## Headline call-out: D1 (signing surface)

Spec §3-A says "VTC has no key custody; every signature
delegates to the VTA signing oracle." That wording is
overloaded. **Custody** could read as "no key storage at all"
or as "no key minting / rotation authority". The working
architecture matches the `affinidi-messaging-mediator` +
`affinidi-webvh-services` pattern: **the VTA is the key
controller; the VTC caches a working copy in its secret store
and signs locally**.

PR-A (Phase 0) already ships this model — `VtcKeyBundle` lands
the integration DID's keys into the VTC's secret store as the
*working copy*. The VTA remains the authority that minted
them, can rotate them, and decides when they're destroyed.

Phase 2 default: **VTC signs locally** against the cached keys.
Cuts the per-call network hop, removes the timeout / circuit-
breaker complexity spec §14.2 mandated for VMC issuance, and
matches the architecture PR-A already established.

The breaker pattern still has value for non-VMC remote
dependencies (trust-registry publish in Phase 3, did:webvh
resolver for member-DID rotation in M2.15.2), so the pattern
stays in the codebase even though VMC issuance no longer
needs it. The spec §3-A + §14.2 **clarifications** land as a
Phase 2 outcome in M2.16.

**This is the single most consequential framing change in
Phase 2.** Push back here if you want the VTC to remain
without any local key storage and we'll redo PR-A's
architecture instead.

## Milestone overview

```
M2.1  regorus harness in vtc_service::policy
M2.2  Policy model + policies keyspace
M2.3  POST /v1/policies (upload + activate + test)
M2.4  GET  /v1/policies (list + show)
M2.5  Bundle 9 default policies
M2.6  Wire join.rego into submit
M2.7  Wire removal.rego into admin-remove
M2.8  [folds into M2.5 — no separate milestone]
M2.9  VC builder + local Ed25519 signer
M2.10 Status-list keyspace + reserved-index allocator
M2.11 GET /v1/status-lists/{purpose}
M2.12 VMC + VEC issuance on approve
M2.13 POST /v1/members/me/renew
M2.14 Status-list flip on remove
M2.15 DID rotation (did:key + did:webvh)
M2.16 Spec clarifications (D1 outcome)
M2.17 Phase 2 audit variants
M2.18 Trust Task drafts + index
M2.19 Phase 2 gate
```

## PR slicing

| PR | Milestones | Theme |
|---|---|---|
| 1 | M2.1, M2.2, M2.3, M2.4 | regorus + policy CRUD |
| 2 | M2.5, M2.6, M2.7 | Default policies + wire into existing endpoints |
| 3 | M2.9, M2.10, M2.11 | VC builder + status-list infrastructure |
| 4 | M2.12, M2.13, M2.14 | VMC/VEC issuance + renewal + status-list flip |
| 5 | M2.15 | DID rotation |
| 6 | M2.16, M2.17, M2.18, M2.19 | Spec clarifications + audit + Trust Tasks + gate |

6 PRs across 19 milestones. Phase 2 is larger than Phase 1
(5 PRs / 17 milestones) — the credentials track adds
substantial surface.

## Out of scope (deferred per spec §16)

- **Trust registry** + `MembershipSyncer` + three-disposition
  reconciliation — **Phase 3**.
- **Cross-community recognition** — **Phase 3**.
- **VRC** issuance — **Phase 4**.
- **Personhood assert/revoke endpoints** — **Phase 4**
  (the `personhood.rego` deny-all stub ships in M2.5).
- **Status-list chaining** when capacity exceeded — **v2**
  (spec §17).

## Test plan

- [x] Documents render correctly.
- [ ] Design decisions D1–D10 reviewed (especially **D1** —
  the §3-A clarification).
- [ ] Direction approved before M2.1 code starts.

Once this PR merges, M2.1 starts on a fresh branch.