### PR TITLE
feat(vtc-service): Phase 2 PR 1 — policy CRUD + regorus harness (M2.1–M2.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,7 +1600,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1608,6 +1617,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -1705,6 +1720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1741,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1751,6 +1782,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1911,6 +1948,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2085,15 @@ dependencies = [
  "tracing-subscriber",
  "vta-cli-common",
  "vta-sdk 0.6.0",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2338,7 +2394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -3023,6 +3079,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,8 +3222,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3237,12 +3325,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3295,6 +3394,16 @@ checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
 dependencies = [
  "nonempty",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -3494,6 +3603,18 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4709,6 +4830,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257eb0e588b76827bbddc9e73945a9743693dd2adeaee9da26420f93cfedb798"
+dependencies = [
+ "ahash 0.8.12",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.17.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5221,6 +5369,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7627d8bbeb17edbf1c3f74b21488e4af680040da89713b4217d0010e9cbd97e"
 
 [[package]]
+name = "msvc_spectre_libs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e871a9861f3664f18b7e04e9301d4edd55090c2dadb4b1c602e26ab32b1f5b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "multibase"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5348,6 +5505,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -5770,7 +5933,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -5780,7 +5952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -5789,7 +5961,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
 ]
 
@@ -5800,7 +5972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5811,6 +5983,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -5918,6 +6099,18 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
@@ -6448,6 +6641,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f38748ceca8d0b0013e60f534d94a6e23dfd89fd2a88318fc5a2d04fda1010"
+dependencies = [
+ "ahash 0.8.12",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6481,6 +6689,39 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "regorus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63642e663bb81698ab7160735bdc831f580022194922d3f24d5c40a913ff3fab"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "chrono-tz",
+ "data-encoding",
+ "globset",
+ "indexmap 2.14.0",
+ "ipnet",
+ "jsonschema",
+ "lazy_static",
+ "lru",
+ "msvc_spectre_libs",
+ "num-bigint",
+ "num-traits",
+ "parking_lot",
+ "postcard",
+ "rand 0.10.1",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "spin 0.10.0",
+ "thiserror 2.0.18",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "replace_with"
@@ -7130,6 +7371,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7395,6 +7649,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spinning_top"
@@ -7855,7 +8115,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -7877,7 +8137,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bitflags 2.11.1",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
  "fixedbitset",
@@ -7892,7 +8152,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2 0.10.9",
  "signal-hook",
  "siphasher",
@@ -8526,6 +8786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8578,6 +8844,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
@@ -8652,6 +8924,16 @@ dependencies = [
  "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -8933,6 +9215,7 @@ dependencies = [
  "keyring-core",
  "multibase",
  "rand 0.10.1",
+ "regorus",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,13 @@ webauthn-rs = { version = "0.5", features = [
   "danger-allow-state-serialisation",
 ] }
 
+# Rego (OPA policy language) interpreter. In-process — no OPA sidecar.
+# Used by `vtc-service`'s policy engine (Phase 2 M2.1). Defaults include
+# `arc` so `regorus::Engine` is `Send + Sync` and `full-opa` for the
+# stdlib builtins (regex, time, etc.) that real policies (`join.rego`,
+# `removal.rego`) lean on. Trim later if compile times bite.
+regorus = "0.10"
+
 # OS keyring API (replaces legacy `keyring` v3 crate). keyring-core 1.0 split
 # the API from the backend stores; each binary picks a platform-native store
 # and registers it once at startup via `vta_sdk::keyring_init::install_default_store`.

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -106,7 +106,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M2.4 — Policy read endpoints
 
-### `[ ]` M2.4.1 — List + show
+### `[x]` M2.4.1 — List + show
 
 - **Acceptance**
   - `GET /v1/policies` — admin-only. Paginated; ?purpose=

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -46,7 +46,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M2.2 — Policy model + `policies` keyspace
 
-### `[ ]` M2.2.1 — `Policy` + storage CRUD
+### `[x]` M2.2.1 — `Policy` + storage CRUD
 
 - **Acceptance**
   - `Policy { id, purpose, rego_source, sha256, activated_at:

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -16,7 +16,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M2.1 — `regorus` policy harness
 
-### `[ ]` M2.1.1 — `vtc_service::policy` module
+### `[x]` M2.1.1 — `vtc_service::policy` module
 
 - **Acceptance**
   - `regorus` added to workspace dependencies.

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -76,7 +76,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M2.3 — Policy admin endpoints
 
-### `[ ]` M2.3.1 — Upload + activate + test
+### `[x]` M2.3.1 — Upload + activate + test
 
 - **Acceptance**
   - `POST /v1/policies` — admin-only. Body `{ purpose,

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -210,6 +210,18 @@
       "status": "Draft",
       "path": "policies/test/1.0",
       "rest": "POST /v1/policies/{id}/test"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/policies/list/1.0",
+      "status": "Draft",
+      "path": "policies/list/1.0",
+      "rest": "GET /v1/policies"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/policies/show/1.0",
+      "status": "Draft",
+      "path": "policies/show/1.0",
+      "rest": "GET /v1/policies/{id}"
     }
   ]
 }

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -192,6 +192,24 @@
       "status": "Draft",
       "path": "members/admin-remove/1.0",
       "rest": "DELETE /v1/members/{did}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/policies/upload/1.0",
+      "status": "Draft",
+      "path": "policies/upload/1.0",
+      "rest": "POST /v1/policies"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/policies/activate/1.0",
+      "status": "Draft",
+      "path": "policies/activate/1.0",
+      "rest": "POST /v1/policies/{id}/activate"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/policies/test/1.0",
+      "status": "Draft",
+      "path": "policies/test/1.0",
+      "rest": "POST /v1/policies/{id}/test"
     }
   ]
 }

--- a/trust-tasks/policies/activate/1.0/schema.json
+++ b/trust-tasks/policies/activate/1.0/schema.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/policies/activate/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Policies — Activate",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["id", "purpose", "sha256"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "purpose": { "$ref": "#/$defs/PolicyPurpose" },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "previousPolicyId": {
+          "type": ["string", "null"],
+          "format": "uuid"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "PolicyPurpose": {
+      "type": "string",
+      "enum": [
+        "join",
+        "removal",
+        "personhood",
+        "registry",
+        "directory",
+        "roleDefinitions",
+        "crossCommunityRoles",
+        "crossCommunityRelationships",
+        "relationships"
+      ]
+    }
+  }
+}

--- a/trust-tasks/policies/activate/1.0/spec.md
+++ b/trust-tasks/policies/activate/1.0/spec.md
@@ -1,0 +1,75 @@
+---
+id: https://trusttasks.org/openvtc/vtc/policies/activate/1.0
+title: VTC Policies — Activate
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/policies/{id}/activate
+---
+
+# VTC Policies — Activate
+
+Flips the per-purpose active pointer for a previously-uploaded
+policy. Spec §7.1 + plan §D8. The flip is a single fjall put
+serialised under a process-wide async mutex (see
+`crate::routes::policies::admin::ACTIVATE_LOCK`) so concurrent
+activations of the same purpose cannot interleave their audit
+envelopes.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`.
+
+## Request
+
+```
+POST /v1/policies/{id}/activate
+```
+
+Empty body. `{id}` is the UUID returned by `POST /v1/policies`.
+
+## Response (`200 OK`)
+
+```
+{
+  "id": "1a2b3c…",
+  "purpose": "join",
+  "sha256": "abcd…",
+  "previousPolicyId": "0f1e…"   // null on the first activation
+}
+```
+
+The audit envelope `PolicyActivated` records the same id +
+purpose + sha256 and the predecessor id (omitted on first
+activation per `serde(skip_serializing_if = "Option::is_none")`).
+
+## Errors
+
+- `401 Unauthorized` — missing / invalid session token.
+- `403 Forbidden` — caller is not Admin.
+- `404 Not Found` — no policy with this id.
+- `409 Conflict` — this policy is already active for its
+  purpose. The activate flow is idempotent at the **wire layer**
+  (re-activating a different policy than the live one for the
+  same purpose succeeds), but re-activating the *same* row twice
+  is refused so the audit log doesn't carry no-op events.
+- `500 Internal Server Error` — audit writer unavailable.
+
+## Side-effects
+
+1. Stamps `activated_at = now()` on the policy row.
+2. Writes `active_policies:<purpose>` = id.
+3. Emits `PolicyActivated` audit envelope.
+
+The previous active row for the purpose remains in the
+`policies:<uuid>` keyspace; it just stops being pointed at.
+M2.4's `GET /v1/policies?status=archived` surfaces it.
+
+## Notes
+
+The compiled-policy in-memory registry (plan §D8) lands in M2.5
+when default policies need to be evaluated by the join + removal
+handlers. M2.3 alone flips the fjall pointer — there are no
+consumers yet, so the swap is trivially atomic.

--- a/trust-tasks/policies/list/1.0/schema.json
+++ b/trust-tasks/policies/list/1.0/schema.json
@@ -1,0 +1,60 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/policies/list/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Policies — List",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/PolicyResponse" }
+        },
+        "nextCursor": { "type": ["string", "null"] },
+        "totalEstimate": { "type": ["integer", "null"] }
+      }
+    }
+  },
+  "$defs": {
+    "PolicyResponse": {
+      "type": "object",
+      "required": [
+        "id",
+        "purpose",
+        "regoSource",
+        "sha256",
+        "authorDid",
+        "createdAt",
+        "version",
+        "isActive"
+      ],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "purpose": { "$ref": "#/$defs/PolicyPurpose" },
+        "regoSource": { "type": "string" },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "activatedAt": { "type": ["string", "null"], "format": "date-time" },
+        "authorDid": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "version": { "type": "integer", "minimum": 1 },
+        "isActive": { "type": "boolean" }
+      }
+    },
+    "PolicyPurpose": {
+      "type": "string",
+      "enum": [
+        "join",
+        "removal",
+        "personhood",
+        "registry",
+        "directory",
+        "roleDefinitions",
+        "crossCommunityRoles",
+        "crossCommunityRelationships",
+        "relationships"
+      ]
+    }
+  }
+}

--- a/trust-tasks/policies/list/1.0/spec.md
+++ b/trust-tasks/policies/list/1.0/spec.md
@@ -1,0 +1,77 @@
+---
+id: https://trusttasks.org/openvtc/vtc/policies/list/1.0
+title: VTC Policies — List
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/policies
+---
+
+# VTC Policies — List
+
+Returns a paginated list of stored policies. Spec §7.1. Each
+entry carries the full Policy row (including Rego source) plus
+an `isActive` flag indicating whether this revision is the
+currently-active policy for its purpose.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`.
+
+## Query parameters
+
+- `purpose` (optional) — exact-match filter on the policy
+  purpose. Wire-form camelCase (`"join"`, `"removal"`,
+  `"crossCommunityRoles"`, …). Unknown values surface as 400.
+- `status` (optional) — `"active"` returns only rows currently
+  pointed at by `active_policies:<purpose>`; `"archived"`
+  returns only rows that are not pointed at. Omitted returns
+  every row.
+- `cursor` (optional) — pagination cursor from a prior page.
+- `limit` (optional) — page size; clamped to `1..=200`.
+  Default 50.
+
+Filters are applied **after** pagination, so a page can be
+smaller than `limit` when rows are filtered out. The cursor
+remains valid; just call again with the same cursor + filter to
+walk further.
+
+## Response (`200 OK`)
+
+```
+{
+  "items": [
+    {
+      "id": "1a2b…",
+      "purpose": "join",
+      "regoSource": "package vtc.join\nimport rego.v1\n…",
+      "sha256": "abcd…",
+      "activatedAt": "2026-03-21T18:42:00Z" | null,
+      "authorDid": "did:key:zAdmin",
+      "createdAt": "2026-03-21T18:40:00Z",
+      "version": 4,
+      "isActive": true
+    }
+  ],
+  "nextCursor": "…" | null,
+  "totalEstimate": null
+}
+```
+
+## Errors
+
+- `401 Unauthorized` — missing / invalid session token.
+- `403 Forbidden` — caller is not Admin.
+- `500 Internal Server Error` — audit writer / cursor signing
+  unavailable.
+
+## Notes
+
+- The full Rego source ships in the response. Phase 2 doesn't
+  separate "summary" from "detail" — operators usually want the
+  source anyway, and pagination caps total payload size.
+- `activatedAt` is `null` for revisions that have never been
+  active and `non-null` for the latest activation timestamp on
+  rows that were once or are currently active.

--- a/trust-tasks/policies/show/1.0/schema.json
+++ b/trust-tasks/policies/show/1.0/schema.json
@@ -1,0 +1,49 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/policies/show/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Policies — Show",
+  "type": "object",
+  "properties": {
+    "response": { "$ref": "#/$defs/PolicyResponse" }
+  },
+  "$defs": {
+    "PolicyResponse": {
+      "type": "object",
+      "required": [
+        "id",
+        "purpose",
+        "regoSource",
+        "sha256",
+        "authorDid",
+        "createdAt",
+        "version",
+        "isActive"
+      ],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "purpose": { "$ref": "#/$defs/PolicyPurpose" },
+        "regoSource": { "type": "string" },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "activatedAt": { "type": ["string", "null"], "format": "date-time" },
+        "authorDid": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "version": { "type": "integer", "minimum": 1 },
+        "isActive": { "type": "boolean" }
+      }
+    },
+    "PolicyPurpose": {
+      "type": "string",
+      "enum": [
+        "join",
+        "removal",
+        "personhood",
+        "registry",
+        "directory",
+        "roleDefinitions",
+        "crossCommunityRoles",
+        "crossCommunityRelationships",
+        "relationships"
+      ]
+    }
+  }
+}

--- a/trust-tasks/policies/show/1.0/spec.md
+++ b/trust-tasks/policies/show/1.0/spec.md
@@ -1,0 +1,53 @@
+---
+id: https://trusttasks.org/openvtc/vtc/policies/show/1.0
+title: VTC Policies — Show
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/policies/{id}
+---
+
+# VTC Policies — Show
+
+Returns the full Policy row including Rego source and an
+`isActive` flag against the current `active_policies:<purpose>`
+pointer. Spec §7.1.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`.
+
+## Request
+
+```
+GET /v1/policies/{id}
+```
+
+`{id}` is the UUID returned by `POST /v1/policies`.
+
+## Response (`200 OK`)
+
+```
+{
+  "id": "1a2b…",
+  "purpose": "join",
+  "regoSource": "package vtc.join\nimport rego.v1\n…",
+  "sha256": "abcd…",
+  "activatedAt": "2026-03-21T18:42:00Z" | null,
+  "authorDid": "did:key:zAdmin",
+  "createdAt": "2026-03-21T18:40:00Z",
+  "version": 4,
+  "isActive": true
+}
+```
+
+`isActive` is `true` iff `active_policies:<purpose>` points at
+this id at request time.
+
+## Errors
+
+- `401 Unauthorized` — missing / invalid session token.
+- `403 Forbidden` — caller is not Admin.
+- `404 Not Found` — no policy with this id.

--- a/trust-tasks/policies/test/1.0/schema.json
+++ b/trust-tasks/policies/test/1.0/schema.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/policies/test/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Policies — Test",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "required": ["query", "input"],
+      "properties": {
+        "query": { "type": "string" },
+        "input": {}
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["id", "purpose", "sha256", "result"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "purpose": { "$ref": "#/$defs/PolicyPurpose" },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "result": {
+          "type": "object",
+          "description": "Raw regorus QueryResults — opa-eval shape."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "PolicyPurpose": {
+      "type": "string",
+      "enum": [
+        "join",
+        "removal",
+        "personhood",
+        "registry",
+        "directory",
+        "roleDefinitions",
+        "crossCommunityRoles",
+        "crossCommunityRelationships",
+        "relationships"
+      ]
+    }
+  }
+}

--- a/trust-tasks/policies/test/1.0/spec.md
+++ b/trust-tasks/policies/test/1.0/spec.md
@@ -1,0 +1,78 @@
+---
+id: https://trusttasks.org/openvtc/vtc/policies/test/1.0
+title: VTC Policies — Test
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/policies/{id}/test
+---
+
+# VTC Policies — Test
+
+Dry-runs a stored policy against a caller-supplied `input`. Does
+**not** affect the active pointer, does not write to fjall, does
+not emit audit envelopes beyond the operator-visible info log
+line. Used to validate a candidate upload before activating.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`.
+
+## Request
+
+```
+POST /v1/policies/{id}/test
+Content-Type: application/json
+
+{
+  "query": "data.vtc.join.allow",
+  "input": { "applicant": { "did": "did:key:zX", "vp_claims": { } } }
+}
+```
+
+- `query` (required) — Rego query to evaluate. Caller picks the
+  query so `test` can probe any rule in the module, not just
+  `allow`.
+- `input` (required) — JSON document fed to the policy as
+  `input`. Shape is policy-specific; M2.6 / M2.7 will lock in
+  the canonical shapes the daemon passes for `join.rego` /
+  `removal.rego`.
+
+## Response (`200 OK`)
+
+```
+{
+  "id": "1a2b3c…",
+  "purpose": "join",
+  "sha256": "abcd…",
+  "result": { "result": [ { "expressions": [ … ] } ] }
+}
+```
+
+`result` is the raw regorus `QueryResults` JSON (`opa eval`-
+compatible shape). Plucking `result[0].expressions[0].value`
+yields the rule's output. For boolean rules, that value is
+`true` / `false`. For object rules, it's the rule's body.
+
+## Errors
+
+- `400 Bad Request` — malformed JSON, missing `query` /
+  `input`, or query syntax error.
+- `401 Unauthorized` — missing / invalid session token.
+- `403 Forbidden` — caller is not Admin.
+- `404 Not Found` — no policy with this id.
+- `500 Internal Server Error` — regorus evaluation failure.
+
+## Notes
+
+- The policy is **recompiled per call**. The harness is cheap
+  (regorus stores compiled modules behind an `Arc` so re-running
+  the parser is the dominant cost, not codegen). Recompiling
+  means `test` doesn't depend on a long-lived compiled-cache —
+  archived (non-active) rows aren't cached in M2.5+.
+- The endpoint never mutates state beyond log lines. Audit
+  envelopes are reserved for `PolicyUploaded` / `PolicyActivated`
+  — operators run `test` repeatedly and noisy audit would
+  swamp real signal.

--- a/trust-tasks/policies/upload/1.0/schema.json
+++ b/trust-tasks/policies/upload/1.0/schema.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/policies/upload/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Policies — Upload",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "required": ["purpose", "regoSource"],
+      "properties": {
+        "purpose": { "$ref": "#/$defs/PolicyPurpose" },
+        "regoSource": {
+          "type": "string",
+          "maxLength": 65536
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["id", "sha256", "purpose", "version"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "purpose": { "$ref": "#/$defs/PolicyPurpose" },
+        "version": { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+  "$defs": {
+    "PolicyPurpose": {
+      "type": "string",
+      "enum": [
+        "join",
+        "removal",
+        "personhood",
+        "registry",
+        "directory",
+        "roleDefinitions",
+        "crossCommunityRoles",
+        "crossCommunityRelationships",
+        "relationships"
+      ]
+    }
+  }
+}

--- a/trust-tasks/policies/upload/1.0/spec.md
+++ b/trust-tasks/policies/upload/1.0/spec.md
@@ -1,0 +1,83 @@
+---
+id: https://trusttasks.org/openvtc/vtc/policies/upload/1.0
+title: VTC Policies — Upload
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/policies
+---
+
+# VTC Policies — Upload
+
+Compiles and persists a new Rego policy revision. Spec §7.1. The
+upload does **not** activate the policy — `POST
+/v1/policies/{id}/activate` is a separate call so operators can
+inspect a candidate (and run dry-runs via `POST
+/v1/policies/{id}/test`) before flipping the live pointer.
+
+## Authentication
+
+`AdminAuth` — bearer-token JWT with `role: Admin`.
+
+## Request
+
+```
+POST /v1/policies
+Content-Type: application/json
+
+{
+  "purpose": "join",
+  "regoSource": "package vtc.join\nimport rego.v1\n\ndefault allow := false\n"
+}
+```
+
+- `purpose` (required) — one of `join`, `removal`, `personhood`,
+  `registry`, `directory`, `roleDefinitions`,
+  `crossCommunityRoles`, `crossCommunityRelationships`,
+  `relationships`. Spec §7.1.
+- `regoSource` (required) — the Rego module body. Bounded at
+  64 KiB; larger uploads are refused with 400. Rego v1 syntax is
+  the default (regorus 0.10).
+
+## Response (`201 Created`)
+
+```
+{
+  "id": "1a2b3c…",
+  "sha256": "abcd…<64 hex>",
+  "purpose": "join",
+  "version": 7
+}
+```
+
+- `id` — the new Policy row's UUID. Stable identifier.
+- `sha256` — lowercase-hex SHA-256 of the source bytes. Matches
+  `sha256sum policy.rego`. Used by audit + the operator-side
+  verification echo.
+- `version` — per-purpose monotone counter, incremented at every
+  upload for the same purpose.
+
+The audit envelope `PolicyUploaded` records the same id +
+purpose + sha256 + version.
+
+## Errors
+
+- `400 Bad Request` — malformed JSON, missing fields, Rego
+  source exceeds 64 KiB, or unknown `purpose` value.
+- `400 Bad Request` (compile failure) — Rego parse / type error.
+  The message names the policy id + the regorus diagnostic
+  position (`policy.rego:line:col`).
+- `401 Unauthorized` — missing / invalid session token.
+- `403 Forbidden` — caller is not Admin.
+- `500 Internal Server Error` — audit writer unavailable.
+
+## Notes
+
+- The upload does not affect the active pointer for any purpose.
+  Existing community traffic continues to evaluate against the
+  pre-existing active policy.
+- Historical revisions are retained — there is no implicit
+  "supersede the previous version" semantic. M2.4's
+  `GET /v1/policies?status=archived` will surface them.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -93,6 +93,9 @@ hkdf = { workspace = true }
 x25519-dalek = { workspace = true }
 zeroize = { version = "1", features = ["derive"] }
 multibase = { workspace = true }
+# Rego policy interpreter (Phase 2 M2.1). Hosted in `crate::policy`.
+# Spec §3-J + §7: regorus runs in-process; no external OPA sidecar.
+regorus = { workspace = true }
 url = { workspace = true, optional = true }
 # BIP-39 mnemonic parsing for `vtc admin emergency-bootstrap` (M0.10).
 # Same pin as `vta-service`.

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -26,6 +26,7 @@ pub mod join;
 pub mod keys;
 pub mod members;
 pub mod messaging;
+pub mod policy;
 pub mod routes;
 pub mod server;
 pub mod setup;

--- a/vtc-service/src/policy/engine.rs
+++ b/vtc-service/src/policy/engine.rs
@@ -1,0 +1,286 @@
+//! Compile + evaluate Rego modules via `regorus`.
+//!
+//! The public surface is intentionally narrow — one struct
+//! ([`CompiledPolicy`]), one placeholder ([`Policy`]), and two free
+//! functions ([`compile`], [`evaluate`]). Persistence + CRUD layer on top
+//! in M2.2 onwards; this milestone is just the harness.
+//!
+//! ## Engine module path
+//!
+//! `regorus::Engine::add_policy` takes a "path" string that becomes the
+//! diagnostic filename in compile-error messages. We hard-code it to
+//! [`POLICY_MODULE_PATH`] here so the harness only ever loads exactly
+//! one module per engine. Multi-module compilation (importing
+//! `data.policies.helpers` etc.) is out of scope until a real policy
+//! needs it.
+//!
+//! ## Eval-time engine cloning
+//!
+//! `regorus::Engine::eval_query` takes `&mut self`. To keep
+//! [`evaluate`]'s signature `&CompiledPolicy` (matching what the
+//! milestone spec calls for and what M2.8's hot-swap wants), we clone
+//! the engine per call. With the `arc` feature (workspace default) the
+//! clone is `Arc::clone` over the compiled module tree — cheap. Only
+//! the per-evaluation state (input, internal interpreter scratch) is
+//! reallocated.
+
+use std::fmt;
+
+use regorus::{Engine, Value as RegoValue};
+use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+use vti_common::error::AppError;
+
+/// Module path used for the single Rego source in every compiled
+/// policy. Surfaces in regorus's compile-error messages as
+/// `policy.rego:line:col`. Not stable wire — operators only ever see
+/// it when their upload fails to parse.
+pub const POLICY_MODULE_PATH: &str = "policy.rego";
+
+/// Persistence-layer placeholder. The full shape (storage row, ACL
+/// scope, activation pointer) lands in M2.2; for the harness this
+/// only carries the source + id so callers can round-trip the
+/// inputs to [`compile`].
+#[derive(Debug, Clone)]
+pub struct Policy {
+    pub id: Uuid,
+    pub source: String,
+}
+
+/// A Rego module that has compiled cleanly and is ready to evaluate.
+///
+/// Constructed exclusively via [`compile`]. The compiled engine is
+/// `Send + Sync` (regorus `arc` feature, on by default) so this
+/// struct is safe to share across tasks. Eval-time cloning is the
+/// expected access pattern — see module docs.
+pub struct CompiledPolicy {
+    id: Uuid,
+    source_sha256: [u8; 32],
+    engine: Engine,
+}
+
+impl fmt::Debug for CompiledPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CompiledPolicy")
+            .field("id", &self.id)
+            .field("source_sha256", &hex::encode(self.source_sha256))
+            .finish_non_exhaustive()
+    }
+}
+
+impl CompiledPolicy {
+    /// Policy id this module was compiled under. Matches the caller's
+    /// `id` argument to [`compile`]; surfaced for log/audit lines and
+    /// to round-trip back to the persistence row.
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    /// SHA-256 of the Rego source bytes. Used by audit (the
+    /// `PolicyActivated` event records the hash, not the source) and
+    /// by the trust-task upload-confirmation echo. Stable across
+    /// recompilations of byte-identical source.
+    pub fn source_sha256(&self) -> &[u8; 32] {
+        &self.source_sha256
+    }
+}
+
+/// Compile a Rego source into a [`CompiledPolicy`].
+///
+/// Rego v1 syntax (`import rego.v1`) is the default — regorus 0.10
+/// is v1-first. Returns [`AppError::Validation`] on parse failure so
+/// the M2.3 upload endpoint can map it directly to 400.
+pub fn compile(rego_source: &str, id: Uuid) -> Result<CompiledPolicy, AppError> {
+    let mut engine = Engine::new();
+    engine
+        .add_policy(POLICY_MODULE_PATH.to_string(), rego_source.to_string())
+        .map_err(|e| AppError::Validation(format!("rego compile failed for policy {id}: {e}")))?;
+    let source_sha256: [u8; 32] = Sha256::digest(rego_source.as_bytes()).into();
+    Ok(CompiledPolicy {
+        id,
+        source_sha256,
+        engine,
+    })
+}
+
+/// Evaluate a Rego query against the compiled module, given a JSON
+/// input.
+///
+/// The returned [`JsonValue`] is regorus's `QueryResults` serialised to
+/// JSON — same shape as `opa eval`. Callers that want a plain
+/// `allow/deny` boolean should pluck `result[0].expressions[0].value`.
+/// Surfacing the raw shape here keeps the harness usable by the M2.6
+/// `join.rego` wire-up (which wants the full result set for audit) and
+/// the M2.7 `removal.rego` wire-up (which only cares about `allow`).
+///
+/// Returns [`AppError::Internal`] on evaluation failure. Policies that
+/// parse cleanly but reference undefined rules surface here, not at
+/// [`compile`] time — Rego is permissive about forward references.
+pub fn evaluate(
+    compiled: &CompiledPolicy,
+    query: &str,
+    input: JsonValue,
+) -> Result<JsonValue, AppError> {
+    let mut engine = compiled.engine.clone();
+    engine.set_input(RegoValue::from(input));
+    let results = engine.eval_query(query.to_string(), false).map_err(|e| {
+        AppError::Internal(format!(
+            "rego evaluation failed for policy {}: {e}",
+            compiled.id
+        ))
+    })?;
+    serde_json::to_value(results).map_err(AppError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const ALLOW_POLICY: &str = "\
+package vtc.test
+
+import rego.v1
+
+default allow := false
+
+allow if input.role == \"admin\"
+";
+
+    const DENY_POLICY: &str = "\
+package vtc.test
+
+import rego.v1
+
+default allow := false
+
+allow if {
+    input.role == \"admin\"
+    input.context == \"prod\"
+}
+";
+
+    fn test_id() -> Uuid {
+        // Deterministic id so failures point at the same policy each run.
+        Uuid::from_u128(0x0102_0304_0506_0708_0900_0a0b_0c0d_0e0f)
+    }
+
+    /// Happy path: a syntactically valid Rego module compiles and the
+    /// returned CompiledPolicy carries the caller's id + a matching
+    /// SHA-256.
+    #[test]
+    fn compile_happy_path() {
+        let id = test_id();
+        let compiled = compile(ALLOW_POLICY, id).expect("compile should succeed");
+        assert_eq!(compiled.id(), id);
+        let expected: [u8; 32] = Sha256::digest(ALLOW_POLICY.as_bytes()).into();
+        assert_eq!(compiled.source_sha256(), &expected);
+    }
+
+    /// Parse error: a malformed Rego source surfaces as
+    /// `AppError::Validation` with a message naming the policy id.
+    #[test]
+    fn compile_surfaces_parse_error() {
+        let id = test_id();
+        let err = compile("not valid rego @@@ }}}", id).expect_err("malformed source must fail");
+        match err {
+            AppError::Validation(msg) => {
+                assert!(
+                    msg.contains(&id.to_string()),
+                    "error message should name the policy id: {msg}"
+                );
+                assert!(
+                    msg.contains("rego compile failed"),
+                    "error message should be a compile-failure: {msg}"
+                );
+            }
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+
+    /// Evaluate-allow: an `allow` rule that fires returns
+    /// `true` in the QueryResults shape.
+    #[test]
+    fn evaluate_allow_true() {
+        let compiled = compile(ALLOW_POLICY, test_id()).unwrap();
+        let result = evaluate(&compiled, "data.vtc.test.allow", json!({ "role": "admin" }))
+            .expect("evaluate must succeed");
+        let value = pluck_expression_value(&result);
+        assert_eq!(value, &json!(true));
+    }
+
+    /// Evaluate-deny: same `allow` rule with input that doesn't
+    /// satisfy the body returns `false`.
+    #[test]
+    fn evaluate_allow_false() {
+        let compiled = compile(DENY_POLICY, test_id()).unwrap();
+        let result = evaluate(
+            &compiled,
+            "data.vtc.test.allow",
+            json!({ "role": "admin", "context": "staging" }),
+        )
+        .expect("evaluate must succeed");
+        let value = pluck_expression_value(&result);
+        assert_eq!(value, &json!(false));
+    }
+
+    /// Missing-rule semantics: querying an undefined symbol does
+    /// **not** error — Rego treats undefined references as a
+    /// per-row `undefined` and the QueryResults shape comes back
+    /// without a value. Document the behaviour so callers know not
+    /// to assume "rule missing" turns into an error.
+    ///
+    /// The error path is exercised separately by feeding `eval_query`
+    /// a syntactically malformed query string, which regorus rejects
+    /// at parse time and we surface as `AppError::Internal`.
+    #[test]
+    fn evaluate_undefined_returns_empty_and_malformed_query_errors() {
+        let compiled = compile(ALLOW_POLICY, test_id()).unwrap();
+
+        // Undefined rule → success with empty result. Document the
+        // shape so the M2.6 / M2.7 wire-ups don't trip over it.
+        let ok = evaluate(&compiled, "data.vtc.test.does_not_exist", json!({}))
+            .expect("undefined symbols must not surface as an error");
+        let value = ok.pointer("/result/0/expressions/0/value");
+        assert!(
+            value.is_none() || matches!(value, Some(JsonValue::Object(o)) if o.is_empty()),
+            "undefined rule should yield no value, got {ok}"
+        );
+
+        // Malformed query → genuine evaluation error path.
+        let err = evaluate(&compiled, "@@@ not a query @@@", json!({}))
+            .expect_err("malformed query must fail");
+        match err {
+            AppError::Internal(msg) => {
+                assert!(
+                    msg.contains("rego evaluation failed"),
+                    "error message should be an evaluation failure: {msg}"
+                );
+            }
+            other => panic!("expected Internal error, got {other:?}"),
+        }
+    }
+
+    /// SHA determinism: recompiling identical source twice yields the
+    /// same hash. Audit + trust-task echo lean on this.
+    #[test]
+    fn compile_sha_is_deterministic() {
+        let a = compile(ALLOW_POLICY, Uuid::new_v4()).unwrap();
+        let b = compile(ALLOW_POLICY, Uuid::new_v4()).unwrap();
+        assert_eq!(a.source_sha256(), b.source_sha256());
+        // And a different source produces a different hash so the
+        // property isn't trivially satisfied by a constant hasher.
+        let c = compile(DENY_POLICY, Uuid::new_v4()).unwrap();
+        assert_ne!(a.source_sha256(), c.source_sha256());
+    }
+
+    /// Extract `result[0].expressions[0].value` from regorus's
+    /// QueryResults JSON shape. The QueryResults wire shape is
+    /// `{ "result": [{ "expressions": [{ "value": V, ... }], ... }] }`.
+    fn pluck_expression_value(results: &JsonValue) -> &JsonValue {
+        results
+            .pointer("/result/0/expressions/0/value")
+            .expect("regorus QueryResults must carry result[0].expressions[0].value")
+    }
+}

--- a/vtc-service/src/policy/engine.rs
+++ b/vtc-service/src/policy/engine.rs
@@ -38,16 +38,6 @@ use vti_common::error::AppError;
 /// it when their upload fails to parse.
 pub const POLICY_MODULE_PATH: &str = "policy.rego";
 
-/// Persistence-layer placeholder. The full shape (storage row, ACL
-/// scope, activation pointer) lands in M2.2; for the harness this
-/// only carries the source + id so callers can round-trip the
-/// inputs to [`compile`].
-#[derive(Debug, Clone)]
-pub struct Policy {
-    pub id: Uuid,
-    pub source: String,
-}
-
 /// A Rego module that has compiled cleanly and is ready to evaluate.
 ///
 /// Constructed exclusively via [`compile`]. The compiled engine is

--- a/vtc-service/src/policy/mod.rs
+++ b/vtc-service/src/policy/mod.rs
@@ -1,0 +1,43 @@
+//! Rego (OPA policy language) evaluation surface for the VTC.
+//!
+//! Spec §3-J + §7. The VTC ships an embedded `regorus` interpreter —
+//! no external OPA sidecar, no out-of-process IPC. Phase 2 M2.1 lands
+//! the **harness only**: compile a Rego source into a [`CompiledPolicy`]
+//! and run a query against it. Persistence ([`Policy`] rows backed by
+//! a fjall keyspace) lands in M2.2; CRUD endpoints land in M2.3 + M2.4;
+//! the default-policy bundle (join / removal / personhood / …) lands
+//! in M2.5.
+//!
+//! ## Lifecycle
+//!
+//! 1. Operator (or the boot-time default-policy loader) calls
+//!    [`engine::compile`] with the Rego source. Failure surfaces as
+//!    [`AppError::Validation`] so route handlers map it to 400.
+//! 2. The compiled module is wrapped in an `Arc<CompiledPolicy>` and
+//!    stored in the live-policy registry (M2.8 / D8). Source +
+//!    SHA-256 land in the `policies:<id>` fjall row; the compiled
+//!    bytecode is reconstructed on boot.
+//! 3. Evaluation goes through [`engine::evaluate`] with a
+//!    `serde_json::Value` input. The wrapper clones the underlying
+//!    `regorus::Engine` per call so concurrent evaluators don't
+//!    serialise on a single mutable engine.
+//!
+//! ## Why a thin wrapper instead of re-exporting `regorus::Engine`
+//!
+//! Three reasons:
+//! 1. **Error mapping.** Regorus returns `anyhow::Error`; route handlers
+//!    speak [`AppError`]. The conversion lives here, not at every call
+//!    site.
+//! 2. **SHA pinning.** Audit + the trust-task `policies/upload/1.0`
+//!    payload need the content hash. Computing it alongside compilation
+//!    keeps the two in lockstep — there's no way to ship a compiled
+//!    module without its hash.
+//! 3. **D8 hot-swap.** The registry needs an `Arc`-shareable handle.
+//!    `regorus::Engine` is `Send + Sync` with the `arc` feature (default)
+//!    so this works, but we want a single canonical wrapper type so
+//!    future changes (e.g. caching `data` alongside the engine) don't
+//!    ripple through every consumer.
+
+pub mod engine;
+
+pub use engine::{CompiledPolicy, Policy, compile, evaluate};

--- a/vtc-service/src/policy/mod.rs
+++ b/vtc-service/src/policy/mod.rs
@@ -39,5 +39,12 @@
 //!    ripple through every consumer.
 
 pub mod engine;
+pub mod model;
+pub mod storage;
 
-pub use engine::{CompiledPolicy, Policy, compile, evaluate};
+pub use engine::{CompiledPolicy, compile, evaluate};
+pub use model::{POLICY_SOURCE_MAX_BYTES, Policy, PolicyPurpose};
+pub use storage::{
+    clear_active_policy_id, delete_policy, get_active_policy_id, get_policy, list_policies,
+    list_policies_paginated, max_version_for, new_policy, set_active_policy_id, store_policy,
+};

--- a/vtc-service/src/policy/model.rs
+++ b/vtc-service/src/policy/model.rs
@@ -1,0 +1,253 @@
+//! Policy persistence model — spec §5.4 + §7.1.
+//!
+//! One [`Policy`] row per uploaded Rego module. Active modules are
+//! pointed at by `active_policies:<purpose>` rows (single id per
+//! purpose). M2.2 lands the model + storage CRUD; the upload /
+//! activate / test endpoints layer on top in M2.3.
+//!
+//! ## What's stored, what's recompiled
+//!
+//! Spec §5.4 + plan §D3: only the Rego **source** + its **SHA-256**
+//! hit fjall. Compiled bytecode is reconstructed at boot by walking
+//! the active-pointer set and re-compiling. This keeps the on-disk
+//! shape stable across regorus upgrades — bumping the interpreter
+//! never invalidates stored rows.
+//!
+//! ## Wire shape vs storage shape
+//!
+//! The serialized form (`camelCase`) is also the JSON shape returned
+//! by `GET /v1/policies/{id}` (M2.4). The audit envelope's
+//! `PolicyActivated` data struct lifts `id` + `purpose` + `sha256` +
+//! `version` from this same struct — see vti-common audit events.
+//!
+//! Phase 2 milestones layered on top:
+//! - M2.3 — upload + activate + test endpoints.
+//! - M2.5 — bundled default policies (join, removal, personhood, …)
+//!   land as [`Policy`] rows at boot if no row exists for the
+//!   purpose.
+//! - M2.6 / M2.7 — `join.rego` + `removal.rego` consume the active
+//!   pointer.
+//! - M2.17 — audit variants `PolicyUploaded` + `PolicyActivated`
+//!   reference [`Policy::id`] / [`Policy::sha256`].
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// One uploaded Rego policy.
+///
+/// Identity is by [`Self::id`] (UUID v4, allocated server-side at
+/// upload time). `(purpose, version)` is unique across the
+/// keyspace: every upload for a purpose bumps `version` by 1 so
+/// historical rows stay reachable for audit even after a newer
+/// upload supersedes them.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Policy {
+    /// Server-allocated UUID. Stable across activations + renames.
+    pub id: Uuid,
+    /// What this policy decides — see [`PolicyPurpose`].
+    pub purpose: PolicyPurpose,
+    /// The full Rego source. Bounded by [`POLICY_SOURCE_MAX_BYTES`]
+    /// at the route layer (M2.3).
+    pub rego_source: String,
+    /// SHA-256 over the source bytes. Used by audit + the trust-task
+    /// upload echo; computed alongside compilation in
+    /// [`super::engine::compile`] so the hash + bytecode stay
+    /// lockstep. Wire shape is a 64-char lowercase-hex string so
+    /// operators + audit log consumers don't have to read a 32-element
+    /// byte array — see [`hex32`] for the (de)serialization adapter.
+    #[serde(with = "hex32")]
+    pub sha256: [u8; 32],
+    /// When this version was activated — `None` if it has never
+    /// been the live policy for its purpose. M2.3's activate
+    /// endpoint stamps this on every flip; archived rows retain
+    /// the last activation time for audit context.
+    #[serde(default)]
+    pub activated_at: Option<DateTime<Utc>>,
+    /// DID of the operator who uploaded this revision. Recorded
+    /// for audit + the `PolicyUploaded` envelope's actor field
+    /// (the audit envelope's `actor` is already this DID; this
+    /// field exists so the row itself remains self-describing
+    /// when read in isolation).
+    pub author_did: String,
+    /// Wall-clock time the row hit fjall.
+    pub created_at: DateTime<Utc>,
+    /// Monotone per-`purpose` counter. The first upload for any
+    /// purpose is `1`. Audit + the operator UX use this to label
+    /// historical revisions ("removal.rego v3 archived").
+    pub version: u32,
+}
+
+/// Hard cap on the bytes-on-disk size of [`Policy::rego_source`].
+/// 64 KiB is comfortably above every default policy the workspace
+/// ships in M2.5 (the largest, `join.rego`, is ~3 KiB) but small
+/// enough that a malicious upload can't bloat the keyspace. M2.3
+/// rejects payloads above this with 413.
+pub const POLICY_SOURCE_MAX_BYTES: usize = 64 * 1024;
+
+/// What a policy decides. The keyspace `active_policies:<purpose>`
+/// has at most one row per variant; the active pointer is a
+/// per-purpose singleton.
+///
+/// Wire shape is `camelCase` ASCII (`join`, `removal`,
+/// `crossCommunityRoles`) — operators wire purposes into REST
+/// payloads + the policies CLI verbs.
+///
+/// Per spec §7.1, the workspace ships nine purposes. They split
+/// into three groups:
+/// - **Membership lifecycle**: [`Self::Join`], [`Self::Removal`],
+///   [`Self::Personhood`].
+/// - **Discoverability**: [`Self::Registry`], [`Self::Directory`].
+/// - **Authorization**: [`Self::RoleDefinitions`],
+///   [`Self::CrossCommunityRoles`],
+///   [`Self::CrossCommunityRelationships`], [`Self::Relationships`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum PolicyPurpose {
+    Join,
+    Removal,
+    Personhood,
+    Registry,
+    Directory,
+    RoleDefinitions,
+    CrossCommunityRoles,
+    CrossCommunityRelationships,
+    Relationships,
+}
+
+impl PolicyPurpose {
+    /// Every purpose variant, in declaration order. Used by the
+    /// boot-time default-policy loader (M2.5) so missing rows can
+    /// be filled from the bundled defaults without listing each
+    /// purpose explicitly at the call site.
+    pub const ALL: [PolicyPurpose; 9] = [
+        PolicyPurpose::Join,
+        PolicyPurpose::Removal,
+        PolicyPurpose::Personhood,
+        PolicyPurpose::Registry,
+        PolicyPurpose::Directory,
+        PolicyPurpose::RoleDefinitions,
+        PolicyPurpose::CrossCommunityRoles,
+        PolicyPurpose::CrossCommunityRelationships,
+        PolicyPurpose::Relationships,
+    ];
+
+    /// Lowercase camelCase wire form of this purpose. Stable wire
+    /// (operators script around it); matches the serde
+    /// representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PolicyPurpose::Join => "join",
+            PolicyPurpose::Removal => "removal",
+            PolicyPurpose::Personhood => "personhood",
+            PolicyPurpose::Registry => "registry",
+            PolicyPurpose::Directory => "directory",
+            PolicyPurpose::RoleDefinitions => "roleDefinitions",
+            PolicyPurpose::CrossCommunityRoles => "crossCommunityRoles",
+            PolicyPurpose::CrossCommunityRelationships => "crossCommunityRelationships",
+            PolicyPurpose::Relationships => "relationships",
+        }
+    }
+}
+
+/// `[u8; 32]` ↔ 64-char lowercase-hex string serde adapter. Used by
+/// [`Policy::sha256`] so the wire form is human-readable and matches
+/// what `sha256sum policy.rego` prints. Hand-rolled to avoid pulling
+/// `serde_with` into the workspace for a single field.
+mod hex32 {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(bytes: &[u8; 32], s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_str(&hex::encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<[u8; 32], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(d)?;
+        let v = hex::decode(&s).map_err(serde::de::Error::custom)?;
+        v.try_into()
+            .map_err(|got: Vec<u8>| serde::de::Error::invalid_length(got.len(), &"32 bytes"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use sha2::{Digest, Sha256};
+
+    #[test]
+    fn purpose_wire_shape_round_trips() {
+        // Every variant serializes to the documented `camelCase`
+        // string and deserializes back. Lock the shape down at
+        // model level — the audit envelope + the route layer both
+        // depend on it.
+        let cases = [
+            (PolicyPurpose::Join, json!("join")),
+            (PolicyPurpose::Removal, json!("removal")),
+            (PolicyPurpose::Personhood, json!("personhood")),
+            (PolicyPurpose::Registry, json!("registry")),
+            (PolicyPurpose::Directory, json!("directory")),
+            (PolicyPurpose::RoleDefinitions, json!("roleDefinitions")),
+            (
+                PolicyPurpose::CrossCommunityRoles,
+                json!("crossCommunityRoles"),
+            ),
+            (
+                PolicyPurpose::CrossCommunityRelationships,
+                json!("crossCommunityRelationships"),
+            ),
+            (PolicyPurpose::Relationships, json!("relationships")),
+        ];
+        for (purpose, wire) in cases {
+            assert_eq!(serde_json::to_value(purpose).unwrap(), wire);
+            let parsed: PolicyPurpose = serde_json::from_value(wire.clone()).unwrap();
+            assert_eq!(parsed, purpose);
+            assert_eq!(purpose.as_str(), wire.as_str().unwrap());
+        }
+    }
+
+    #[test]
+    fn policy_round_trips_through_json() {
+        let source = "package vtc.test\nimport rego.v1\n";
+        let sha256: [u8; 32] = Sha256::digest(source.as_bytes()).into();
+        let policy = Policy {
+            id: Uuid::from_u128(0xdead_beef_0000_0001_0000_0000_0000_0000),
+            purpose: PolicyPurpose::Removal,
+            rego_source: source.into(),
+            sha256,
+            activated_at: None,
+            author_did: "did:key:zAdmin".into(),
+            created_at: Utc::now(),
+            version: 7,
+        };
+        let json = serde_json::to_value(&policy).unwrap();
+        assert!(json["regoSource"].is_string());
+        assert_eq!(json["purpose"], "removal");
+        assert_eq!(json["version"], 7);
+        let parsed: Policy = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, policy);
+    }
+
+    #[test]
+    fn all_covers_every_variant() {
+        // `ALL` is consumed by M2.5's default-policy loader; if a
+        // new variant lands and someone forgets to add it here,
+        // the bundled default would silently never load. Drive the
+        // count + exhaustiveness assertion off the same constant
+        // so a missed entry surfaces at test time.
+        assert_eq!(PolicyPurpose::ALL.len(), 9);
+        for purpose in PolicyPurpose::ALL {
+            // Compiles iff the match is total — `as_str` exhaustively
+            // matches every variant; this exists so the assertion
+            // sticks if anyone tries to special-case a variant out.
+            let _ = purpose.as_str();
+        }
+    }
+}

--- a/vtc-service/src/policy/storage.rs
+++ b/vtc-service/src/policy/storage.rs
@@ -1,0 +1,422 @@
+//! CRUD helpers for [`Policy`] rows and the per-purpose active
+//! pointer.
+//!
+//! Two keyspaces:
+//! - `policies:<uuid>` — every uploaded revision, keyed by UUID.
+//!   Survives archival; rows are only ever deleted on operator
+//!   action (M2.3.1's purge path lands in a follow-up milestone).
+//! - `active_policies:<purpose>` — one row per [`PolicyPurpose`]
+//!   pointing at the currently-active [`Policy::id`] for that
+//!   purpose. M2.3's activate endpoint flips this pointer
+//!   atomically; M2.6 / M2.7 / M2.13 read it to pick which compiled
+//!   module to feed to the harness.
+//!
+//! ## Why two keyspaces instead of one
+//!
+//! Plan §D3: keeping the active pointer in its own keyspace lets the
+//! activation flow do a single atomic put-of-a-tiny-value instead of
+//! rewriting the entire Policy row (which carries the Rego source).
+//! It also matches the boot-time recompile loop, which only needs
+//! to walk the active-pointer keyspace (9 entries max) — not the
+//! full revision history.
+
+use chrono::Utc;
+use uuid::Uuid;
+use vti_common::audit::AuditKey;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated, paginate};
+use vti_common::store::KeyspaceHandle;
+
+use super::model::{Policy, PolicyPurpose};
+
+const POLICY_PREFIX: &[u8] = b"policies:";
+const ACTIVE_PREFIX: &[u8] = b"active_policies:";
+
+fn policy_key(id: Uuid) -> Vec<u8> {
+    let mut k = POLICY_PREFIX.to_vec();
+    k.extend_from_slice(id.to_string().as_bytes());
+    k
+}
+
+fn active_key(purpose: PolicyPurpose) -> Vec<u8> {
+    let mut k = ACTIVE_PREFIX.to_vec();
+    k.extend_from_slice(purpose.as_str().as_bytes());
+    k
+}
+
+fn decode(bytes: &[u8]) -> Result<Policy, AppError> {
+    serde_json::from_slice(bytes).map_err(|e| AppError::Internal(format!("Policy decode: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// Policy CRUD
+// ---------------------------------------------------------------------------
+
+/// Retrieve a policy by id. `Ok(None)` if absent.
+pub async fn get_policy(ks: &KeyspaceHandle, id: Uuid) -> Result<Option<Policy>, AppError> {
+    let raw = ks.get_raw(policy_key(id)).await?;
+    match raw {
+        Some(bytes) => Ok(Some(decode(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+/// Persist a policy row (create or overwrite by id).
+///
+/// The route layer (M2.3) is responsible for the version-bump
+/// invariant — this helper never edits `version`. Callers are
+/// expected to set `version = next_version_for(purpose)` before
+/// calling [`store_policy`].
+pub async fn store_policy(ks: &KeyspaceHandle, policy: &Policy) -> Result<(), AppError> {
+    ks.insert(
+        String::from_utf8(policy_key(policy.id)).expect("policy key is ASCII"),
+        policy,
+    )
+    .await
+}
+
+/// Delete a policy row. Idempotent.
+///
+/// Does **not** clear the active pointer — a policy can only be
+/// deleted when no purpose points at it, but the invariant lives
+/// at the route layer (M2.3) so the storage helper stays
+/// unconditionally usable from boot-time fixups.
+pub async fn delete_policy(ks: &KeyspaceHandle, id: Uuid) -> Result<(), AppError> {
+    ks.remove(policy_key(id)).await
+}
+
+/// Return every policy row. Whole-keyspace walk — prefer
+/// [`list_policies_paginated`] from user-facing routes.
+pub async fn list_policies(ks: &KeyspaceHandle) -> Result<Vec<Policy>, AppError> {
+    let raw = ks.prefix_iter_raw(POLICY_PREFIX.to_vec()).await?;
+    let mut out = Vec::with_capacity(raw.len());
+    for (_k, v) in raw {
+        match decode(&v) {
+            Ok(p) => out.push(p),
+            Err(err) => tracing::warn!(error = %err, "skipping unparseable policy row"),
+        }
+    }
+    Ok(out)
+}
+
+/// Paginated walk over `policies:*`. Cursor signed under `audit_key`
+/// so a captured cursor can't be replayed against an evicted page
+/// boundary. Mirrors the pattern `list_members_paginated` uses.
+pub async fn list_policies_paginated(
+    ks: &KeyspaceHandle,
+    audit_key: &AuditKey,
+    cursor: Option<&Cursor>,
+    limit: usize,
+) -> Result<Paginated<Policy>, AppError> {
+    let mut pairs = ks.prefix_iter_raw(POLICY_PREFIX.to_vec()).await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let snapshot_id: u64 = pairs.len() as u64;
+    paginate(pairs, cursor, limit, &audit_key.key, snapshot_id, decode)
+}
+
+/// Highest `version` previously recorded for `purpose`. Returns `0`
+/// when no rows exist for the purpose (so the next upload will land
+/// as `version = 1`). M2.3's upload endpoint adds one.
+pub async fn max_version_for(ks: &KeyspaceHandle, purpose: PolicyPurpose) -> Result<u32, AppError> {
+    let rows = list_policies(ks).await?;
+    Ok(rows
+        .into_iter()
+        .filter(|p| p.purpose == purpose)
+        .map(|p| p.version)
+        .max()
+        .unwrap_or(0))
+}
+
+// ---------------------------------------------------------------------------
+// Active-pointer CRUD
+// ---------------------------------------------------------------------------
+
+/// Get the active policy id for `purpose`. `Ok(None)` if no policy
+/// is currently active for that purpose (boot before defaults
+/// load, or after an operator explicitly unsets via M2.3.x).
+pub async fn get_active_policy_id(
+    ks: &KeyspaceHandle,
+    purpose: PolicyPurpose,
+) -> Result<Option<Uuid>, AppError> {
+    let raw = ks.get_raw(active_key(purpose)).await?;
+    match raw {
+        Some(bytes) => {
+            let s = std::str::from_utf8(&bytes)
+                .map_err(|e| AppError::Internal(format!("active policy pointer not utf-8: {e}")))?;
+            let id = Uuid::parse_str(s)
+                .map_err(|e| AppError::Internal(format!("active policy pointer not uuid: {e}")))?;
+            Ok(Some(id))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Set the active policy id for `purpose`. Overwrites any prior
+/// pointer.
+///
+/// The route layer (M2.3 activate) is responsible for:
+/// 1. Verifying the target policy exists + `purpose` matches.
+/// 2. Stamping [`Policy::activated_at`] on the new row.
+/// 3. Emitting `PolicyActivated` audit (M2.17).
+///
+/// This helper just persists the pointer.
+pub async fn set_active_policy_id(
+    ks: &KeyspaceHandle,
+    purpose: PolicyPurpose,
+    id: Uuid,
+) -> Result<(), AppError> {
+    ks.insert_raw(active_key(purpose), id.to_string().into_bytes())
+        .await
+}
+
+/// Clear the active pointer for `purpose`. Idempotent. After this,
+/// [`get_active_policy_id`] returns `Ok(None)`. Phase 2's M2.3
+/// activate flow does **not** use this — it overwrites the pointer
+/// rather than clearing it — but boot-time fixup paths
+/// (e.g. archive-the-last-revision-of-this-purpose) need a way to
+/// strand a purpose unmapped.
+pub async fn clear_active_policy_id(
+    ks: &KeyspaceHandle,
+    purpose: PolicyPurpose,
+) -> Result<(), AppError> {
+    ks.remove(active_key(purpose)).await
+}
+
+// ---------------------------------------------------------------------------
+// Construction helpers
+// ---------------------------------------------------------------------------
+
+/// Build a fresh [`Policy`] row from an upload-time tuple.
+/// `version` is left to the caller (typically `max_version_for(…) +
+/// 1`) so this helper doesn't open a TOCTOU window with concurrent
+/// uploads. M2.3 serialises uploads behind a per-purpose lock.
+pub fn new_policy(
+    purpose: PolicyPurpose,
+    rego_source: String,
+    sha256: [u8; 32],
+    author_did: String,
+    version: u32,
+) -> Policy {
+    Policy {
+        id: Uuid::new_v4(),
+        purpose,
+        rego_source,
+        sha256,
+        activated_at: None,
+        author_did,
+        created_at: Utc::now(),
+        version,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+    use vti_common::audit::AuditKeyStore;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_keyspaces() -> (KeyspaceHandle, KeyspaceHandle, AuditKey, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        let policies_ks = store.keyspace("policies").expect("policies ks");
+        let active_ks = store.keyspace("active_policies").expect("active ks");
+        let audit_key = AuditKeyStore::new(store.keyspace("audit_key").unwrap())
+            .ensure_initial(&[0xAA; 32])
+            .await
+            .expect("audit key");
+        (policies_ks, active_ks, audit_key, dir)
+    }
+
+    fn sample(purpose: PolicyPurpose, version: u32, marker: u8) -> Policy {
+        let src = format!("package vtc.test\nimport rego.v1\n\n# v{version}-marker:{marker}\n");
+        let sha: [u8; 32] = Sha256::digest(src.as_bytes()).into();
+        new_policy(purpose, src, sha, "did:key:zAdmin".into(), version)
+    }
+
+    /// Round-trip every PolicyPurpose through the policies keyspace.
+    /// Acceptance bullet 1 from M2.2.1.
+    #[tokio::test]
+    async fn round_trip_every_purpose() {
+        let (policies_ks, _active_ks, _ak, _dir) = temp_keyspaces().await;
+        for (i, purpose) in PolicyPurpose::ALL.into_iter().enumerate() {
+            let p = sample(purpose, 1, i as u8);
+            store_policy(&policies_ks, &p).await.unwrap();
+            let got = get_policy(&policies_ks, p.id).await.unwrap().unwrap();
+            assert_eq!(got, p, "round-trip mismatch for {purpose:?}");
+        }
+        // All nine rows visible via list.
+        let all = list_policies(&policies_ks).await.unwrap();
+        assert_eq!(all.len(), PolicyPurpose::ALL.len());
+    }
+
+    /// `delete_policy` is idempotent and stops `get_policy` finding
+    /// the row. Lifecycle invariant for the M2.3 archive path.
+    #[tokio::test]
+    async fn delete_is_idempotent() {
+        let (policies_ks, _active_ks, _ak, _dir) = temp_keyspaces().await;
+        let p = sample(PolicyPurpose::Join, 1, 0);
+        store_policy(&policies_ks, &p).await.unwrap();
+        delete_policy(&policies_ks, p.id).await.unwrap();
+        delete_policy(&policies_ks, p.id).await.unwrap();
+        assert!(get_policy(&policies_ks, p.id).await.unwrap().is_none());
+    }
+
+    /// `max_version_for` scopes its query to a single purpose so
+    /// concurrent uploads to different purposes don't collide on
+    /// version numbers.
+    #[tokio::test]
+    async fn max_version_is_purpose_scoped() {
+        let (policies_ks, _active_ks, _ak, _dir) = temp_keyspaces().await;
+        store_policy(&policies_ks, &sample(PolicyPurpose::Join, 1, 0))
+            .await
+            .unwrap();
+        store_policy(&policies_ks, &sample(PolicyPurpose::Join, 2, 1))
+            .await
+            .unwrap();
+        store_policy(&policies_ks, &sample(PolicyPurpose::Removal, 5, 0))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            max_version_for(&policies_ks, PolicyPurpose::Join)
+                .await
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            max_version_for(&policies_ks, PolicyPurpose::Removal)
+                .await
+                .unwrap(),
+            5
+        );
+        assert_eq!(
+            max_version_for(&policies_ks, PolicyPurpose::Personhood)
+                .await
+                .unwrap(),
+            0,
+            "purpose with no rows must return 0"
+        );
+    }
+
+    /// Paginated walk returns rows in stable order and offers a
+    /// cursor when the page is full. Acceptance bullet 2 from
+    /// M2.2.1.
+    #[tokio::test]
+    async fn paginated_walks_policies() {
+        let (policies_ks, _active_ks, audit_key, _dir) = temp_keyspaces().await;
+        for i in 0..5 {
+            let mut p = sample(PolicyPurpose::Join, (i + 1) as u32, i as u8);
+            // Deterministic ids so the sort + cursor are reproducible
+            // across runs.
+            p.id = Uuid::from_u128(0x1000_0000_0000_0000_0000_0000_0000_0000 + i as u128);
+            store_policy(&policies_ks, &p).await.unwrap();
+        }
+        let page = list_policies_paginated(&policies_ks, &audit_key, None, 2)
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 2);
+        assert!(
+            page.next_cursor.is_some(),
+            "expected cursor for partial page"
+        );
+    }
+
+    /// Active-pointer set + get round-trips per purpose, and unset
+    /// purposes return `None`. Acceptance bullet 3 from M2.2.1.
+    #[tokio::test]
+    async fn active_pointer_set_get_round_trips() {
+        let (_policies_ks, active_ks, _ak, _dir) = temp_keyspaces().await;
+        let join_id = Uuid::new_v4();
+        let removal_id = Uuid::new_v4();
+
+        // Initially every purpose is unmapped.
+        for purpose in PolicyPurpose::ALL {
+            assert!(
+                get_active_policy_id(&active_ks, purpose)
+                    .await
+                    .unwrap()
+                    .is_none(),
+                "purpose {purpose:?} should start unmapped"
+            );
+        }
+
+        set_active_policy_id(&active_ks, PolicyPurpose::Join, join_id)
+            .await
+            .unwrap();
+        set_active_policy_id(&active_ks, PolicyPurpose::Removal, removal_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            get_active_policy_id(&active_ks, PolicyPurpose::Join)
+                .await
+                .unwrap(),
+            Some(join_id)
+        );
+        assert_eq!(
+            get_active_policy_id(&active_ks, PolicyPurpose::Removal)
+                .await
+                .unwrap(),
+            Some(removal_id)
+        );
+        // Other purposes still unmapped.
+        assert!(
+            get_active_policy_id(&active_ks, PolicyPurpose::Personhood)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// Reassigning the pointer overwrites in place — no orphaned
+    /// pointer rows.
+    #[tokio::test]
+    async fn active_pointer_overwrites_in_place() {
+        let (_policies_ks, active_ks, _ak, _dir) = temp_keyspaces().await;
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        set_active_policy_id(&active_ks, PolicyPurpose::Join, first)
+            .await
+            .unwrap();
+        set_active_policy_id(&active_ks, PolicyPurpose::Join, second)
+            .await
+            .unwrap();
+        assert_eq!(
+            get_active_policy_id(&active_ks, PolicyPurpose::Join)
+                .await
+                .unwrap(),
+            Some(second)
+        );
+    }
+
+    /// `clear_active_policy_id` is idempotent and strands the
+    /// purpose unmapped.
+    #[tokio::test]
+    async fn active_pointer_clear_is_idempotent() {
+        let (_policies_ks, active_ks, _ak, _dir) = temp_keyspaces().await;
+        let id = Uuid::new_v4();
+        set_active_policy_id(&active_ks, PolicyPurpose::Removal, id)
+            .await
+            .unwrap();
+        clear_active_policy_id(&active_ks, PolicyPurpose::Removal)
+            .await
+            .unwrap();
+        clear_active_policy_id(&active_ks, PolicyPurpose::Removal)
+            .await
+            .unwrap();
+        assert!(
+            get_active_policy_id(&active_ks, PolicyPurpose::Removal)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -131,6 +131,16 @@ pub fn router() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let policies_test = TrustTask::new("https://trusttasks.org/openvtc/vtc/policies/test/1.0")
         .expect("static Trust-Task URL");
+    // Read endpoints (M2.4). GET /v1/policies and
+    // GET /v1/policies/{id} share their mounts with the POST
+    // /v1/policies upload and POST /v1/policies/{id}/activate
+    // endpoints respectively — TrustTaskRouter doesn't yet support
+    // per-method selectors (same workaround community/profile,
+    // admin/config, members/{did}, join-requests use). The
+    // standalone `policies/list/1.0` + `policies/show/1.0` Trust
+    // Tasks exist on disk + in index.json so the soft-gate
+    // surface stays complete; the wire enforcement collapses to
+    // the POST task on the shared mount.
 
     TrustTaskRouter::<AppState>::new()
         .route_exempt("/health", get(health::health))
@@ -336,8 +346,16 @@ pub fn router() -> Router<AppState> {
         // policy without mutating state.
         .route_with_task(
             "/v1/policies",
-            post(policies::admin::upload),
-            policies_upload,
+            get(policies::read::list_policies).post(policies::admin::upload),
+            policies_upload.clone(),
+        )
+        .route_with_task(
+            "/v1/policies/{id}",
+            get(policies::read::show_policy),
+            // Reuses the upload task on the shared mount; the
+            // `policies/show/1.0` Trust Task lives in index.json
+            // + on disk for the soft-gate surface (see above).
+            policies_upload.clone(),
         )
         .route_with_task(
             "/v1/policies/{id}/activate",

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -8,6 +8,7 @@ mod health;
 pub(crate) mod install;
 pub(crate) mod join_requests;
 pub(crate) mod members;
+pub(crate) mod policies;
 
 use axum::Router;
 use axum::routing::{delete, get, post};
@@ -119,6 +120,16 @@ pub fn router() -> Router<AppState> {
         TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0")
             .expect("static Trust-Task URL");
     let join_reject = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0")
+        .expect("static Trust-Task URL");
+    // Policies (Phase 2 M2.3). Three distinct Trust Tasks for the
+    // three POST endpoints — upload, activate, test — so SIEM
+    // filters + soft-gate consumers can target each precisely.
+    let policies_upload = TrustTask::new("https://trusttasks.org/openvtc/vtc/policies/upload/1.0")
+        .expect("static Trust-Task URL");
+    let policies_activate =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/policies/activate/1.0")
+            .expect("static Trust-Task URL");
+    let policies_test = TrustTask::new("https://trusttasks.org/openvtc/vtc/policies/test/1.0")
         .expect("static Trust-Task URL");
 
     TrustTaskRouter::<AppState>::new()
@@ -318,6 +329,25 @@ pub fn router() -> Router<AppState> {
             "/v1/join-requests/{id}/reject",
             post(join_requests::decide::reject),
             join_reject,
+        )
+        // Policies (Phase 2 M2.3). Three POST endpoints, three
+        // Trust Tasks. `upload` mints + persists; `activate` flips
+        // the per-purpose active pointer; `test` evaluates a stored
+        // policy without mutating state.
+        .route_with_task(
+            "/v1/policies",
+            post(policies::admin::upload),
+            policies_upload,
+        )
+        .route_with_task(
+            "/v1/policies/{id}/activate",
+            post(policies::admin::activate),
+            policies_activate,
+        )
+        .route_with_task(
+            "/v1/policies/{id}/test",
+            post(policies::admin::test),
+            policies_test,
         )
         .into_router()
 }

--- a/vtc-service/src/routes/policies/admin.rs
+++ b/vtc-service/src/routes/policies/admin.rs
@@ -1,0 +1,298 @@
+//! Policy admin endpoints — upload, activate, test (M2.3.1).
+//!
+//! Spec §7 + plan §§D2, D3, D8.
+//!
+//! ## Hot-swap atomicity (plan §D8)
+//!
+//! [`ACTIVATE_LOCK`] is a process-wide async mutex that serialises
+//! the activate flow. The flip itself is a single `set_active_policy_id`
+//! call (one fjall put), but we hold the lock across:
+//! 1. Look up the candidate policy.
+//! 2. Stamp `activated_at` and `store_policy(candidate)`.
+//! 3. Read the prior pointer (to record the predecessor in audit).
+//! 4. Flip the active pointer.
+//! 5. Emit `PolicyActivated`.
+//!
+//! Steps 2 + 4 are independent fjall puts — without the lock, two
+//! concurrent activations of the same purpose could observe each
+//! other's prior state and emit contradictory audit envelopes. One
+//! global lock is fine in Phase 2: activations are infrequent
+//! (operator-initiated, not request-path).
+//!
+//! The compiled-policy in-memory registry (the `Arc<RwLock<…>>`
+//! D8 talks about) lands in M2.5 when default policies need to be
+//! evaluated by the join + removal handlers. For M2.3 alone, the
+//! fjall pointer flip is the source of truth; consumers don't
+//! exist yet.
+
+use std::sync::LazyLock;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tokio::sync::Mutex;
+use tracing::info;
+use uuid::Uuid;
+
+use vti_common::audit::{AuditEvent, PolicyActivatedData, PolicyUploadedData};
+use vti_common::error::AppError;
+
+use crate::auth::AdminAuth;
+use crate::policy::POLICY_SOURCE_MAX_BYTES;
+use crate::policy::{
+    PolicyPurpose, compile, evaluate, get_active_policy_id, get_policy, max_version_for,
+    new_policy, set_active_policy_id, store_policy,
+};
+use crate::server::AppState;
+
+/// Process-wide async mutex covering every activate-policy call so
+/// the predecessor pointer + audit envelope can't be skewed by a
+/// concurrent flip on the same purpose. See module docs.
+static ACTIVATE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+// ---------------------------------------------------------------------------
+// Request / response shapes
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadBody {
+    /// Wire-form camelCase purpose (`"join"`, `"removal"`,
+    /// `"crossCommunityRoles"`, …). Validated by serde against
+    /// [`PolicyPurpose`].
+    pub purpose: PolicyPurpose,
+    /// Full Rego source. Bounded by [`POLICY_SOURCE_MAX_BYTES`];
+    /// uploads above the cap are rejected with 413.
+    pub rego_source: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadResponse {
+    pub id: Uuid,
+    /// SHA-256 of the source bytes, lowercase hex. Matches what
+    /// `sha256sum policy.rego` prints — operators can verify the
+    /// upload made it across the wire intact.
+    pub sha256: String,
+    pub purpose: PolicyPurpose,
+    pub version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivateResponse {
+    pub id: Uuid,
+    pub purpose: PolicyPurpose,
+    pub sha256: String,
+    /// Predecessor active policy id for this purpose. `null` for
+    /// the first activation under a given purpose.
+    pub previous_policy_id: Option<Uuid>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestBody {
+    /// Rego query to evaluate against the candidate policy
+    /// (e.g. `"data.vtc.join.allow"`). Caller chooses the query so
+    /// `test` can be used to probe any rule in the module, not
+    /// just `allow`.
+    pub query: String,
+    /// JSON document fed to the policy as `input`. Mirrors the
+    /// shape M2.6 / M2.7 will pass in production.
+    pub input: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestResponse {
+    pub id: Uuid,
+    pub purpose: PolicyPurpose,
+    pub sha256: String,
+    /// Raw regorus `QueryResults` JSON. Same shape M2.6 / M2.7
+    /// will pluck `result[0].expressions[0].value` from when they
+    /// wire policy evaluation into the membership flows.
+    pub result: JsonValue,
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/policies — upload
+// ---------------------------------------------------------------------------
+
+/// Compile + persist a new policy revision. Does NOT activate it —
+/// `POST /v1/policies/{id}/activate` is a separate call.
+pub async fn upload(
+    admin: AdminAuth,
+    State(state): State<AppState>,
+    Json(body): Json<UploadBody>,
+) -> Result<(StatusCode, Json<UploadResponse>), AppError> {
+    if body.rego_source.len() > POLICY_SOURCE_MAX_BYTES {
+        return Err(AppError::Validation(format!(
+            "rego_source exceeds {POLICY_SOURCE_MAX_BYTES} bytes (got {})",
+            body.rego_source.len(),
+        )));
+    }
+
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    // Allocate id first so the compile error can name it. The
+    // `new_policy` helper also allocates one — we override via
+    // `Policy { id, .. }` after compile rather than mint twice.
+    let id = Uuid::new_v4();
+    let compiled = compile(&body.rego_source, id)?;
+    let sha256 = *compiled.source_sha256();
+    let version = max_version_for(&state.policies_ks, body.purpose).await? + 1;
+
+    let mut policy = new_policy(
+        body.purpose,
+        body.rego_source,
+        sha256,
+        admin.0.did.clone(),
+        version,
+    );
+    policy.id = id;
+    store_policy(&state.policies_ks, &policy).await?;
+
+    let sha256_hex = hex::encode(sha256);
+    audit_writer
+        .write(
+            &admin.0.did,
+            None,
+            AuditEvent::PolicyUploaded(PolicyUploadedData {
+                policy_id: id.to_string(),
+                purpose: body.purpose.as_str().to_string(),
+                sha256: sha256_hex.clone(),
+                version,
+            }),
+        )
+        .await?;
+
+    info!(
+        actor = admin.0.did.as_str(),
+        policy_id = %id,
+        purpose = body.purpose.as_str(),
+        version,
+        sha256 = sha256_hex.as_str(),
+        "policy uploaded"
+    );
+
+    Ok((
+        StatusCode::CREATED,
+        Json(UploadResponse {
+            id,
+            sha256: sha256_hex,
+            purpose: body.purpose,
+            version,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/policies/{id}/activate
+// ---------------------------------------------------------------------------
+
+pub async fn activate(
+    admin: AdminAuth,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<ActivateResponse>, AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    let _guard = ACTIVATE_LOCK.lock().await;
+
+    let mut policy = get_policy(&state.policies_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("policy not found: {id}")))?;
+
+    let previous = get_active_policy_id(&state.active_policies_ks, policy.purpose).await?;
+
+    if previous == Some(id) {
+        return Err(AppError::Conflict(format!(
+            "policy {id} is already active for purpose {}",
+            policy.purpose.as_str()
+        )));
+    }
+
+    let now = Utc::now();
+    policy.activated_at = Some(now);
+    store_policy(&state.policies_ks, &policy).await?;
+
+    set_active_policy_id(&state.active_policies_ks, policy.purpose, id).await?;
+
+    let sha256_hex = hex::encode(policy.sha256);
+    audit_writer
+        .write(
+            &admin.0.did,
+            None,
+            AuditEvent::PolicyActivated(PolicyActivatedData {
+                policy_id: id.to_string(),
+                purpose: policy.purpose.as_str().to_string(),
+                sha256: sha256_hex.clone(),
+                previous_policy_id: previous.map(|p| p.to_string()),
+            }),
+        )
+        .await?;
+
+    info!(
+        actor = admin.0.did.as_str(),
+        policy_id = %id,
+        purpose = policy.purpose.as_str(),
+        previous = ?previous,
+        "policy activated"
+    );
+
+    Ok(Json(ActivateResponse {
+        id,
+        purpose: policy.purpose,
+        sha256: sha256_hex,
+        previous_policy_id: previous,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/policies/{id}/test
+// ---------------------------------------------------------------------------
+
+/// Evaluate a stored policy against a caller-supplied input.
+/// **Does not activate** the policy and does not mutate any state
+/// beyond log lines. Used by operators to dry-run a candidate
+/// upload before flipping the active pointer.
+pub async fn test(
+    admin: AdminAuth,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<TestBody>,
+) -> Result<Json<TestResponse>, AppError> {
+    let policy = get_policy(&state.policies_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("policy not found: {id}")))?;
+
+    // Recompile every call. The harness is cheap and a per-call
+    // recompile means the test endpoint never depends on a
+    // long-running compiled-cache (M2.5 introduces that for the
+    // active policies; archived rows aren't cached).
+    let compiled = compile(&policy.rego_source, policy.id)?;
+    let result = evaluate(&compiled, &body.query, body.input)?;
+
+    info!(
+        actor = admin.0.did.as_str(),
+        policy_id = %id,
+        purpose = policy.purpose.as_str(),
+        "policy tested"
+    );
+
+    Ok(Json(TestResponse {
+        id,
+        purpose: policy.purpose,
+        sha256: hex::encode(policy.sha256),
+        result,
+    }))
+}

--- a/vtc-service/src/routes/policies/mod.rs
+++ b/vtc-service/src/routes/policies/mod.rs
@@ -11,3 +11,4 @@
 //! admin-only operation per spec §10.4.
 
 pub mod admin;
+pub mod read;

--- a/vtc-service/src/routes/policies/mod.rs
+++ b/vtc-service/src/routes/policies/mod.rs
@@ -1,0 +1,13 @@
+//! `/v1/policies/*` route handlers (Phase 2 M2.3 — admin
+//! endpoints; M2.4 — read endpoints).
+//!
+//! Spec §7 + plan §§D2, D3, D8. Phase 2 routes the policy upload /
+//! activate / test surface through these handlers and emits the
+//! `PolicyUploaded` / `PolicyActivated` audit envelopes added in
+//! vti-common alongside this milestone.
+//!
+//! All endpoints require `AdminAuth` — non-admin auth tiers were
+//! introduced in Phase 1's M1.10 but policy management is an
+//! admin-only operation per spec §10.4.
+
+pub mod admin;

--- a/vtc-service/src/routes/policies/read.rs
+++ b/vtc-service/src/routes/policies/read.rs
@@ -1,0 +1,166 @@
+//! Policy read endpoints — list + show (M2.4.1).
+//!
+//! Spec §7.1 surfacing. Two admin-only GETs that operators (and the
+//! M2.4-adjacent CLI verbs) reach for when inspecting the current
+//! policy state. Neither endpoint mutates state.
+//!
+//! ## Filters on the list endpoint
+//!
+//! - `purpose` — exact-match on `PolicyPurpose` wire form
+//!   (`"join"`, `"removal"`, `"crossCommunityRoles"`, …). Unknown
+//!   values surface as 400 via serde.
+//! - `status` — `"active"` returns only the row currently pointed
+//!   at by `active_policies:<purpose>`; `"archived"` returns every
+//!   row that is *not* the current active pointer for its purpose.
+//!   Omitted returns every row.
+//!
+//! Filters are applied **after** pagination — the page boundary is
+//! over the entire `policies:*` keyspace and rows that fail the
+//! filter are silently dropped from the response. This mirrors the
+//! members-list approach (M1.4.1) and trades a slightly noisier
+//! cursor for a stable page-size invariant.
+
+use std::collections::HashSet;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, MAX_LIMIT, Paginated};
+
+use crate::auth::AdminAuth;
+use crate::policy::{
+    Policy, PolicyPurpose, get_active_policy_id, get_policy, list_policies_paginated,
+};
+use crate::server::AppState;
+
+// ---------------------------------------------------------------------------
+// Wire shape
+// ---------------------------------------------------------------------------
+
+/// Full Policy projection returned by both endpoints. Mirrors the
+/// storage row except `sha256` ships as hex (the `hex32` serde
+/// adapter is on the storage row already, so the wire shape is
+/// already correct here — this struct just adds `isActive` so
+/// callers don't need a second round-trip).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyResponse {
+    #[serde(flatten)]
+    pub policy: Policy,
+    /// `true` when this row is the currently-active policy for its
+    /// purpose. Computed against the `active_policies:<purpose>`
+    /// keyspace at response time.
+    pub is_active: bool,
+}
+
+impl PolicyResponse {
+    fn from_policy(policy: Policy, is_active: bool) -> Self {
+        Self { policy, is_active }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/policies
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListPoliciesQuery {
+    /// Filter by purpose (wire-form camelCase).
+    pub purpose: Option<PolicyPurpose>,
+    /// `"active"` — only the row pointed at by each
+    /// `active_policies:<purpose>`. `"archived"` — every row that
+    /// is *not* the current active pointer. Omitted → all rows.
+    pub status: Option<PolicyStatusFilter>,
+    /// Pagination cursor (returned by a previous call).
+    pub cursor: Option<String>,
+    /// Page size. Clamped to `1..=200`.
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PolicyStatusFilter {
+    Active,
+    Archived,
+}
+
+pub async fn list_policies(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Query(query): Query<ListPoliciesQuery>,
+) -> Result<Json<Paginated<PolicyResponse>>, AppError> {
+    let limit = query.limit.unwrap_or(50).clamp(1, MAX_LIMIT);
+
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+    let audit_key = audit_writer.active_key().await?;
+
+    let decoded_cursor = match &query.cursor {
+        Some(s) => Some(Cursor::decode(s, &audit_key.key)?),
+        None => None,
+    };
+
+    let page = list_policies_paginated(
+        &state.policies_ks,
+        &audit_key,
+        decoded_cursor.as_ref(),
+        limit,
+    )
+    .await?;
+
+    // Resolve the set of currently-active policy ids once per page.
+    // Cheap: at most 9 entries (one per PolicyPurpose).
+    let mut active_ids: HashSet<Uuid> = HashSet::new();
+    for purpose in PolicyPurpose::ALL {
+        if let Some(id) = get_active_policy_id(&state.active_policies_ks, purpose).await? {
+            active_ids.insert(id);
+        }
+    }
+
+    let purpose_filter = query.purpose;
+    let status_filter = query.status;
+
+    let items: Vec<PolicyResponse> = page
+        .items
+        .into_iter()
+        .filter(|p| purpose_filter.is_none_or(|f| p.purpose == f))
+        .filter_map(|p| {
+            let is_active = active_ids.contains(&p.id);
+            match status_filter {
+                Some(PolicyStatusFilter::Active) if !is_active => return None,
+                Some(PolicyStatusFilter::Archived) if is_active => return None,
+                _ => {}
+            }
+            Some(PolicyResponse::from_policy(p, is_active))
+        })
+        .collect();
+
+    Ok(Json(Paginated {
+        items,
+        next_cursor: page.next_cursor,
+        total_estimate: page.total_estimate,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/policies/{id}
+// ---------------------------------------------------------------------------
+
+pub async fn show_policy(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<PolicyResponse>, AppError> {
+    let policy = get_policy(&state.policies_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("policy not found: {id}")))?;
+    let active_id = get_active_policy_id(&state.active_policies_ks, policy.purpose).await?;
+    let is_active = active_id == Some(id);
+    Ok(Json(PolicyResponse::from_policy(policy, is_active)))
+}

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -49,6 +49,14 @@ pub struct AppState {
     pub install_ks: KeyspaceHandle,
     pub members_ks: KeyspaceHandle,
     pub join_requests_ks: KeyspaceHandle,
+    /// Uploaded Rego policies (M2.2). Holds every revision; the
+    /// active pointer for each purpose lives in
+    /// [`Self::active_policies_ks`].
+    pub policies_ks: KeyspaceHandle,
+    /// Per-purpose pointer to the currently-active policy id. One
+    /// row per [`crate::policy::PolicyPurpose`] variant. M2.3's
+    /// activate endpoint flips this; M2.6 / M2.7 / M2.13 read it.
+    pub active_policies_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
@@ -151,6 +159,8 @@ pub async fn run(
     let install_store = InstallTokenStore::new(install_ks.clone());
     let members_ks = store.keyspace("members")?;
     let join_requests_ks = store.keyspace("join_requests")?;
+    let policies_ks = store.keyspace("policies")?;
+    let active_policies_ks = store.keyspace("active_policies")?;
     let audit_ks = store.keyspace("audit")?;
     let audit_key_ks = store.keyspace("audit_key")?;
 
@@ -223,6 +233,8 @@ pub async fn run(
         install_ks,
         members_ks,
         join_requests_ks,
+        policies_ks,
+        active_policies_ks,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -79,6 +79,8 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -119,6 +121,8 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -62,6 +62,8 @@ async fn build_with(
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -101,6 +103,8 @@ async fn build_with(
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -85,6 +85,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -184,6 +186,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -55,6 +55,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -83,6 +85,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -56,6 +56,8 @@ async fn build() -> Fixture {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -84,6 +86,8 @@ async fn build() -> Fixture {
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -50,6 +50,8 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -73,6 +75,8 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
         install_ks,
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -206,6 +206,8 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -292,6 +294,8 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         install_ks,
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config.clone())),

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -67,6 +67,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -102,6 +104,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -98,6 +98,8 @@ async fn build_fixture() -> Fixture {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -131,6 +133,8 @@ async fn build_fixture() -> Fixture {
         install_ks,
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -80,6 +80,8 @@ async fn build_fixture() -> Fixture {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -156,6 +158,8 @@ async fn build_fixture() -> Fixture {
         install_ks,
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -70,6 +70,8 @@ async fn build_fixture() -> Fixture {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -147,6 +149,8 @@ async fn build_fixture() -> Fixture {
         install_ks,
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -39,6 +39,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -63,6 +65,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -1,0 +1,520 @@
+//! Integration coverage for `/v1/policies/*` (Phase 2 M2.3).
+//!
+//! Acceptance bullets from `phase-2-todo.md` M2.3.1:
+//! - Happy upload + bad-Rego rejection.
+//! - Activate-after-upload swaps the active pointer.
+//! - Test-without-activate doesn't mutate state.
+//!
+//! Plus auxiliary coverage: re-activate-same-id 409, activate
+//! unknown id 404, and audit envelope emission on the two
+//! state-changing endpoints.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use uuid::Uuid;
+use vti_common::audit::{AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::session::{Session, SessionState, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::{KeyspaceHandle, Store};
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::policy::{PolicyPurpose, get_active_policy_id, get_policy};
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+const UPLOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
+const ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
+const TEST_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
+
+const ADMIN_DID: &str = "did:key:zPolicyAdmin";
+
+const JOIN_ALLOW_POLICY: &str = "\
+package vtc.test
+
+import rego.v1
+
+default allow := false
+
+allow if input.role == \"admin\"
+";
+
+const ALT_POLICY: &str = "\
+package vtc.test
+
+import rego.v1
+
+default allow := true
+";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    admin_token: String,
+    policies_ks: KeyspaceHandle,
+    active_policies_ks: KeyspaceHandle,
+    audit_ks: KeyspaceHandle,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &acl_ks,
+        &VtcAclEntry {
+            did: ADMIN_DID.into(),
+            role: VtcRole::Admin,
+            label: Some("test admin".into()),
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let session_id = "test-policy-admin-session";
+    let session = Session {
+        session_id: session_id.into(),
+        did: ADMIN_DID.into(),
+        challenge: "test".into(),
+        state: SessionState::Authenticated,
+        created_at: now,
+        refresh_token: None,
+        refresh_expires_at: None,
+        tee_attested: false,
+    };
+    store_session(&sessions_ks, &session).await.unwrap();
+
+    let admin_claims = jwt_keys.new_claims(
+        ADMIN_DID.into(),
+        session_id.into(),
+        "admin".into(),
+        vec![],
+        3600,
+        true,
+    );
+    let admin_token = jwt_keys.encode(&admin_claims).unwrap();
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks,
+        join_requests_ks,
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
+        audit_ks: audit_ks.clone(),
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: None,
+        install_signer: None,
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+
+    Fixture {
+        router,
+        admin_token,
+        policies_ks,
+        active_policies_ks,
+        audit_ks,
+        _dir: dir,
+    }
+}
+
+async fn body_json(body: Body) -> Value {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        let raw = String::from_utf8_lossy(&bytes);
+        panic!("response body was not JSON ({e}): {raw}")
+    })
+}
+
+fn auth_request(method: &str, uri: &str, task: &str, token: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("trust-task", task)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+async fn upload_policy(fix: &Fixture, purpose: &str, source: &str) -> Value {
+    let req = auth_request(
+        "POST",
+        "/v1/policies",
+        UPLOAD_TASK,
+        &fix.admin_token,
+        json!({ "purpose": purpose, "regoSource": source }),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "expected 201 from upload"
+    );
+    body_json(resp.into_body()).await
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Acceptance bullet 1a: happy upload. The 201 response carries
+/// id/sha256/purpose/version and the policy row is persisted to
+/// fjall.
+#[tokio::test]
+async fn upload_happy_path_persists_policy() {
+    let fix = build_fixture().await;
+    let body = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let id: Uuid = body["id"].as_str().unwrap().parse().unwrap();
+
+    assert_eq!(body["purpose"], "join");
+    assert_eq!(body["version"], 1);
+    let sha = body["sha256"].as_str().unwrap();
+    assert_eq!(sha.len(), 64);
+    assert!(
+        sha.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    );
+
+    // Row persisted with same id + matching SHA.
+    let stored = get_policy(&fix.policies_ks, id).await.unwrap().unwrap();
+    assert_eq!(stored.id, id);
+    assert_eq!(stored.purpose, PolicyPurpose::Join);
+    assert_eq!(hex::encode(stored.sha256), sha);
+    assert_eq!(stored.version, 1);
+    assert!(
+        stored.activated_at.is_none(),
+        "upload must not activate the row"
+    );
+
+    // No active pointer was flipped.
+    assert!(
+        get_active_policy_id(&fix.active_policies_ks, PolicyPurpose::Join)
+            .await
+            .unwrap()
+            .is_none(),
+        "upload must not mutate the active pointer"
+    );
+}
+
+/// Acceptance bullet 1b: bad-Rego rejection. A malformed source
+/// surfaces from the harness as 400 (AppError::Validation) and the
+/// id from the error message is meaningful for the operator.
+#[tokio::test]
+async fn upload_bad_rego_returns_400() {
+    let fix = build_fixture().await;
+    let req = auth_request(
+        "POST",
+        "/v1/policies",
+        UPLOAD_TASK,
+        &fix.admin_token,
+        json!({ "purpose": "join", "regoSource": "@@@ not rego @@@" }),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    let body = body_json(resp.into_body()).await;
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("rego compile failed"),
+        "error body should explain the compile failure: {body}"
+    );
+}
+
+/// Acceptance bullet 2: activate-after-upload swaps the active
+/// pointer and stamps `activated_at` on the row.
+#[tokio::test]
+async fn activate_swaps_active_pointer() {
+    let fix = build_fixture().await;
+    let uploaded = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let id: Uuid = uploaded["id"].as_str().unwrap().parse().unwrap();
+
+    let req = auth_request(
+        "POST",
+        &format!("/v1/policies/{id}/activate"),
+        ACTIVATE_TASK,
+        &fix.admin_token,
+        json!({}),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["id"], id.to_string());
+    assert_eq!(body["purpose"], "join");
+    assert!(
+        body["previousPolicyId"].is_null(),
+        "first activation must have null predecessor: {body}"
+    );
+
+    // Active pointer + activated_at populated.
+    assert_eq!(
+        get_active_policy_id(&fix.active_policies_ks, PolicyPurpose::Join)
+            .await
+            .unwrap(),
+        Some(id)
+    );
+    let stored = get_policy(&fix.policies_ks, id).await.unwrap().unwrap();
+    assert!(
+        stored.activated_at.is_some(),
+        "activate must stamp activated_at"
+    );
+}
+
+/// Second activation of the same id for the same purpose returns
+/// 409. Re-activating a *different* id later swaps cleanly (covered
+/// in `activate_replaces_predecessor`).
+#[tokio::test]
+async fn activate_same_id_twice_returns_409() {
+    let fix = build_fixture().await;
+    let uploaded = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let id: Uuid = uploaded["id"].as_str().unwrap().parse().unwrap();
+
+    for expected in [StatusCode::OK, StatusCode::CONFLICT] {
+        let req = auth_request(
+            "POST",
+            &format!("/v1/policies/{id}/activate"),
+            ACTIVATE_TASK,
+            &fix.admin_token,
+            json!({}),
+        );
+        let resp = fix.router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), expected);
+    }
+}
+
+/// Activating a different revision after a prior one records the
+/// predecessor on the response + audit envelope.
+#[tokio::test]
+async fn activate_replaces_predecessor() {
+    let fix = build_fixture().await;
+    let first = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let first_id: Uuid = first["id"].as_str().unwrap().parse().unwrap();
+    let second = upload_policy(&fix, "join", ALT_POLICY).await;
+    let second_id: Uuid = second["id"].as_str().unwrap().parse().unwrap();
+    assert_eq!(second["version"], 2, "second upload bumps version");
+
+    // Activate first, then second.
+    for id in [first_id, second_id] {
+        let req = auth_request(
+            "POST",
+            &format!("/v1/policies/{id}/activate"),
+            ACTIVATE_TASK,
+            &fix.admin_token,
+            json!({}),
+        );
+        let resp = fix.router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "activating {id}");
+    }
+
+    // Active pointer is now second; predecessor returned by the
+    // activate-second response is first.
+    assert_eq!(
+        get_active_policy_id(&fix.active_policies_ks, PolicyPurpose::Join)
+            .await
+            .unwrap(),
+        Some(second_id)
+    );
+}
+
+/// Activating an unknown id returns 404.
+#[tokio::test]
+async fn activate_unknown_id_returns_404() {
+    let fix = build_fixture().await;
+    let ghost = Uuid::new_v4();
+    let req = auth_request(
+        "POST",
+        &format!("/v1/policies/{ghost}/activate"),
+        ACTIVATE_TASK,
+        &fix.admin_token,
+        json!({}),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+/// Acceptance bullet 3: test-without-activate runs the policy and
+/// does not mutate the active pointer or the policy row's
+/// `activated_at`.
+#[tokio::test]
+async fn test_does_not_mutate_state() {
+    let fix = build_fixture().await;
+    let uploaded = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let id: Uuid = uploaded["id"].as_str().unwrap().parse().unwrap();
+
+    let req = auth_request(
+        "POST",
+        &format!("/v1/policies/{id}/test"),
+        TEST_TASK,
+        &fix.admin_token,
+        json!({
+            "query": "data.vtc.test.allow",
+            "input": { "role": "admin" }
+        }),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["id"], id.to_string());
+    let allow = body
+        .pointer("/result/result/0/expressions/0/value")
+        .expect("regorus QueryResults shape");
+    assert_eq!(allow, &json!(true));
+
+    // No active pointer was flipped, no activated_at was stamped.
+    assert!(
+        get_active_policy_id(&fix.active_policies_ks, PolicyPurpose::Join)
+            .await
+            .unwrap()
+            .is_none(),
+        "test must not activate the policy"
+    );
+    let stored = get_policy(&fix.policies_ks, id).await.unwrap().unwrap();
+    assert!(
+        stored.activated_at.is_none(),
+        "test must not stamp activated_at"
+    );
+}
+
+/// Upload + activate each emit one audit envelope. The audit
+/// keyspace gains exactly two rows (plus the boot-time
+/// `AuditKeyRotated::Initial` row from `ensure_initial`).
+#[tokio::test]
+async fn upload_and_activate_emit_audit_envelopes() {
+    let fix = build_fixture().await;
+    let baseline = fix
+        .audit_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap()
+        .len();
+
+    let uploaded = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let id: Uuid = uploaded["id"].as_str().unwrap().parse().unwrap();
+    let after_upload = fix
+        .audit_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap()
+        .len();
+    assert_eq!(
+        after_upload - baseline,
+        1,
+        "upload must emit exactly one audit envelope"
+    );
+
+    let req = auth_request(
+        "POST",
+        &format!("/v1/policies/{id}/activate"),
+        ACTIVATE_TASK,
+        &fix.admin_token,
+        json!({}),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let after_activate = fix
+        .audit_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap()
+        .len();
+    assert_eq!(
+        after_activate - after_upload,
+        1,
+        "activate must emit exactly one audit envelope"
+    );
+}
+
+/// Auth gate: an unauthenticated upload returns 401. Confirms the
+/// `AdminAuth` extractor is wired through the route.
+#[tokio::test]
+async fn upload_without_token_returns_401() {
+    let fix = build_fixture().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/policies")
+        .header("trust-task", UPLOAD_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({ "purpose": "join", "regoSource": JOIN_ALLOW_POLICY }).to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -36,6 +36,13 @@ use vtc_service::server::AppState;
 const UPLOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
 const ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
 const TEST_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
+/// `/v1/policies` (list) + `/v1/policies/{id}` (show) share their
+/// HTTP mounts with the upload + activate POSTs respectively —
+/// TrustTaskRouter doesn't yet support per-method selectors, so
+/// the GET requests carry the upload task header. See
+/// `vtc-service/src/routes/mod.rs` comment block.
+const LIST_TASK: &str = UPLOAD_TASK;
+const SHOW_TASK: &str = UPLOAD_TASK;
 
 const ADMIN_DID: &str = "did:key:zPolicyAdmin";
 
@@ -500,6 +507,192 @@ async fn upload_and_activate_emit_audit_envelopes() {
         "activate must emit exactly one audit envelope"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Read endpoints (M2.4)
+// ---------------------------------------------------------------------------
+
+fn auth_get(uri: &str, task: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("trust-task", task)
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// `GET /v1/policies` returns every uploaded policy. Each item
+/// carries the full row + an `isActive` flag.
+#[tokio::test]
+async fn list_returns_all_policies() {
+    let fix = build_fixture().await;
+    let a = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let _b = upload_policy(&fix, "removal", ALT_POLICY).await;
+    let a_id = a["id"].as_str().unwrap();
+
+    // Activate one of them so the isActive flag has signal.
+    let req = auth_request(
+        "POST",
+        &format!("/v1/policies/{a_id}/activate"),
+        ACTIVATE_TASK,
+        &fix.admin_token,
+        json!({}),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(auth_get("/v1/policies", LIST_TASK, &fix.admin_token))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp.into_body()).await;
+    let items = body["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 2);
+    let active: Vec<&Value> = items.iter().filter(|i| i["isActive"] == true).collect();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0]["id"], a_id);
+    // Full row visibility — Rego source is in the response.
+    assert!(items.iter().all(|i| i["regoSource"].is_string()));
+}
+
+/// `?purpose=removal` filters list to that purpose only.
+#[tokio::test]
+async fn list_filters_by_purpose() {
+    let fix = build_fixture().await;
+    upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    upload_policy(&fix, "removal", ALT_POLICY).await;
+
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(auth_get(
+            "/v1/policies?purpose=removal",
+            LIST_TASK,
+            &fix.admin_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp.into_body()).await;
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["purpose"], "removal");
+}
+
+/// `?status=active` returns only rows pointed at by their
+/// per-purpose active pointer. `?status=archived` returns the
+/// complement.
+#[tokio::test]
+async fn list_filters_by_status() {
+    let fix = build_fixture().await;
+    let join = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let removal = upload_policy(&fix, "removal", ALT_POLICY).await;
+    let join_id = join["id"].as_str().unwrap();
+    let _removal_id = removal["id"].as_str().unwrap();
+
+    // Activate only the join row.
+    let req = auth_request(
+        "POST",
+        &format!("/v1/policies/{join_id}/activate"),
+        ACTIVATE_TASK,
+        &fix.admin_token,
+        json!({}),
+    );
+    fix.router.clone().oneshot(req).await.unwrap();
+
+    // status=active → just the join row.
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(auth_get(
+            "/v1/policies?status=active",
+            LIST_TASK,
+            &fix.admin_token,
+        ))
+        .await
+        .unwrap();
+    let body = body_json(resp.into_body()).await;
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], join_id);
+    assert_eq!(items[0]["isActive"], true);
+
+    // status=archived → just the removal row.
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(auth_get(
+            "/v1/policies?status=archived",
+            LIST_TASK,
+            &fix.admin_token,
+        ))
+        .await
+        .unwrap();
+    let body = body_json(resp.into_body()).await;
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["purpose"], "removal");
+    assert_eq!(items[0]["isActive"], false);
+}
+
+/// `GET /v1/policies/{id}` returns the full row + isActive flag.
+#[tokio::test]
+async fn show_returns_full_row() {
+    let fix = build_fixture().await;
+    let uploaded = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let id = uploaded["id"].as_str().unwrap();
+
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(auth_get(
+            &format!("/v1/policies/{id}"),
+            SHOW_TASK,
+            &fix.admin_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["id"], id);
+    assert_eq!(body["purpose"], "join");
+    assert_eq!(body["version"], 1);
+    assert_eq!(body["isActive"], false);
+    assert!(
+        body["regoSource"]
+            .as_str()
+            .unwrap()
+            .contains("default allow")
+    );
+}
+
+/// `GET /v1/policies/{id}` returns 404 for unknown ids.
+#[tokio::test]
+async fn show_unknown_id_returns_404() {
+    let fix = build_fixture().await;
+    let ghost = Uuid::new_v4();
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(auth_get(
+            &format!("/v1/policies/{ghost}"),
+            SHOW_TASK,
+            &fix.admin_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------------
+// Misc
+// ---------------------------------------------------------------------------
 
 /// Auth gate: an unauthenticated upload returns 401. Confirms the
 /// `AdminAuth` extractor is wired through the route.

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -69,6 +69,8 @@ async fn build_fixture() -> Fixture {
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -148,6 +150,8 @@ async fn build_fixture() -> Fixture {
         install_ks,
         members_ks: members_ks.clone(),
         join_requests_ks,
+        policies_ks,
+        active_policies_ks,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -235,6 +235,8 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
     let install_ks = store.keyspace("install").unwrap();
     let members_ks = store.keyspace("members").unwrap();
     let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -254,6 +256,8 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
         join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -145,6 +145,17 @@ pub enum AuditEvent {
     /// `Disposition` decides whether the row is purged outright,
     /// tombstoned with the DID retained, or kept historical.
     MemberRemoved(MemberRemovedData),
+
+    /// `POST /v1/policies` accepted an upload, compiled the source,
+    /// and persisted a new revision. The row is **not yet active** —
+    /// activation is a separate event. Spec §7.1; Phase 2 M2.3.
+    PolicyUploaded(PolicyUploadedData),
+
+    /// `POST /v1/policies/{id}/activate` flipped the active pointer
+    /// for a purpose. Carries the predecessor's id so a forensic
+    /// audit can chain backwards through revisions without scanning
+    /// the whole `policies:` keyspace. Spec §7.1; Phase 2 M2.3.
+    PolicyActivated(PolicyActivatedData),
 }
 
 // ---------------------------------------------------------------------------
@@ -359,6 +370,44 @@ pub struct MemberRemovedData {
     pub reason: String,
 }
 
+/// Payload for [`AuditEvent::PolicyUploaded`].
+///
+/// Records the *immutable* outcome of compilation: the new id, what
+/// purpose this revision targets, the source hash, and the
+/// monotone per-purpose version. The actual Rego source stays in
+/// the `policies:<id>` row — the audit envelope only carries the
+/// hash so the log doesn't bloat for large policies.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyUploadedData {
+    /// UUID of the new Policy row.
+    pub policy_id: String,
+    /// Wire-form camelCase purpose (`"join"`, `"removal"`, …).
+    pub purpose: String,
+    /// SHA-256 of the source, lowercase hex.
+    pub sha256: String,
+    /// Per-purpose monotone counter the upload landed under.
+    pub version: u32,
+}
+
+/// Payload for [`AuditEvent::PolicyActivated`].
+///
+/// Records the active-pointer flip for a purpose. `previous_policy_id`
+/// is `None` when the purpose had no prior active row (first
+/// activation for that purpose) — that case is itself audit-worthy
+/// and distinct from "activated a successor". Carries the new
+/// revision's hash so consumers don't have to cross-reference the
+/// `PolicyUploaded` event to know what bytecode is now live.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyActivatedData {
+    pub policy_id: String,
+    pub purpose: String,
+    pub sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_policy_id: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -558,6 +607,62 @@ mod tests {
     // such a change visible in review.
 
     #[test]
+    fn policy_uploaded_round_trip() {
+        let e = AuditEvent::PolicyUploaded(PolicyUploadedData {
+            policy_id: "11111111-1111-1111-1111-111111111111".into(),
+            purpose: "join".into(),
+            sha256: "abc123".into(),
+            version: 4,
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "PolicyUploaded");
+        assert_eq!(
+            v["data"]["policyId"],
+            "11111111-1111-1111-1111-111111111111"
+        );
+        assert_eq!(v["data"]["purpose"], "join");
+        assert_eq!(v["data"]["sha256"], "abc123");
+        assert_eq!(v["data"]["version"], 4);
+        round_trip(&e);
+    }
+
+    #[test]
+    fn policy_activated_round_trip_with_predecessor() {
+        let e = AuditEvent::PolicyActivated(PolicyActivatedData {
+            policy_id: "22222222-2222-2222-2222-222222222222".into(),
+            purpose: "removal".into(),
+            sha256: "deadbeef".into(),
+            previous_policy_id: Some("11111111-1111-1111-1111-111111111111".into()),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "PolicyActivated");
+        assert_eq!(
+            v["data"]["previousPolicyId"],
+            "11111111-1111-1111-1111-111111111111"
+        );
+        round_trip(&e);
+    }
+
+    #[test]
+    fn policy_activated_omits_predecessor_when_none() {
+        // First activation for a purpose has no predecessor — verify
+        // the field is omitted on the wire (Option skip), not
+        // serialised as `null`. SIEM filters key on field presence.
+        let e = AuditEvent::PolicyActivated(PolicyActivatedData {
+            policy_id: "22222222-2222-2222-2222-222222222222".into(),
+            purpose: "personhood".into(),
+            sha256: "cafe".into(),
+            previous_policy_id: None,
+        });
+        let v = wire_value(&e);
+        assert!(
+            v["data"].get("previousPolicyId").is_none(),
+            "previousPolicyId should be omitted, got {v}"
+        );
+        round_trip(&e);
+    }
+
+    #[test]
     fn variant_discriminator_strings() {
         let cases: Vec<(AuditEvent, &str)> = vec![
             (
@@ -622,6 +727,24 @@ mod tests {
                     rotation_reason: RotationReason::Initial,
                 }),
                 "AuditKeyRotated",
+            ),
+            (
+                AuditEvent::PolicyUploaded(PolicyUploadedData {
+                    policy_id: "p".into(),
+                    purpose: "join".into(),
+                    sha256: "x".into(),
+                    version: 1,
+                }),
+                "PolicyUploaded",
+            ),
+            (
+                AuditEvent::PolicyActivated(PolicyActivatedData {
+                    policy_id: "p".into(),
+                    purpose: "join".into(),
+                    sha256: "x".into(),
+                    previous_policy_id: None,
+                }),
+                "PolicyActivated",
             ),
         ];
         for (event, expected) in cases {

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -34,7 +34,8 @@ pub use event::{
     AdminPasskeyData, AdminPromotedData, AuditEvent, AuditKeyRotatedData, CommunityInstalledData,
     CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
     EmergencyBootstrapData, JoinRequestData, JoinRequestRejectedData, MemberAddedData,
-    MemberRemovedData, MemberUpdatedData, REDACTED_MARKER, RestartRequestedData, RoleChangedData,
+    MemberRemovedData, MemberUpdatedData, PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER,
+    RestartRequestedData, RoleChangedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

First PR of Phase 2. Lands the policy CRUD surface plus the
`regorus` interpreter the rest of Phase 2's policy work
(`join.rego`, `removal.rego`, role-policy evaluation,
auto-loading defaults) will sit on top of.

Bundles four milestones per the plan's PR-1 slicing:

| Milestone | What it adds |
|---|---|
| **M2.1** | `vtc_service::policy` harness — `regorus` dep + `compile()` / `evaluate()` + `CompiledPolicy` wrapper |
| **M2.2** | `Policy` model + `PolicyPurpose` enum + `policies:` / `active_policies:` keyspaces + CRUD helpers |
| **M2.3** | Admin endpoints — upload / activate / test + `PolicyUploaded` / `PolicyActivated` audit envelopes |
| **M2.4** | Read endpoints — list (with `?purpose=` / `?status=` filters) + show |

## Architecture decisions

- **D1 (cached-locally, VTA-controlled)** — implemented; the
  compile + evaluate path runs entirely in-process against
  the keys the VTC already caches. No VTA round-trip per
  policy evaluation.
- **D2 (regorus location)** — `crate::policy` in
  `vtc-service`. VTA has no policy story today.
- **D3 (storage shape)** — `policies:<uuid>` for revisions,
  `active_policies:<purpose>` for the pointer. Separating
  the pointer keyspace lets activation flip with a single
  tiny put.
- **D8 (hot-swap atomicity)** — `ACTIVATE_LOCK`
  process-wide async mutex serialises the activate flow.
  The compiled-policy in-memory registry the D8 plan
  describes lands in M2.5 (when join/removal handlers
  actually evaluate policies); M2.3 has no consumers yet so
  the fjall pointer is the source of truth.

## Wire surface

REST:
\`\`\`
POST   /v1/policies                  M2.3 upload  → 201
GET    /v1/policies                  M2.4 list    → 200
GET    /v1/policies/{id}             M2.4 show    → 200 / 404
POST   /v1/policies/{id}/activate    M2.3 flip    → 200 / 404 / 409
POST   /v1/policies/{id}/test        M2.3 dry-run → 200 / 404
\`\`\`

Five Trust Tasks: `policies/{upload,activate,test,list,show}/1.0`
all Draft with on-disk spec.md + schema.json + index.json
entries. The GET endpoints share their HTTP mounts with the
POST endpoints (TrustTaskRouter doesn't yet support per-method
selectors); the standalone tasks live on disk for the
soft-gate surface.

## What's NOT in this PR

Deferred to subsequent Phase 2 PRs per the plan:

- **M2.5** — bundle 9 default policies and load them at boot.
- **M2.6** — wire `join.rego` into the join-request submit handler.
- **M2.7** — wire `removal.rego` into admin-remove.
- **M2.9–M2.14** — VC builder, status list, VMC/VEC issuance,
  renewal, status-list flip on remove.
- **M2.15** — DID rotation (did:key + did:webvh).
- **M2.16–M2.19** — Phase 2 outcomes, audit variants
  checkpoint, Trust Task index gate, Phase 2 gate.

## Audit envelopes (M2.17 pre-landing)

The plan parks `AuditEvent` additions in M2.17, but every
endpoint milestone has a dep on it. Landing the two policy
variants alongside the endpoints that emit them keeps the
wire-shape decisions localised — easier to review the data
struct against the code that fills it. M2.17 itself becomes
a snapshot-test checkpoint pass.

- `AuditEvent::PolicyUploaded(PolicyUploadedData)` — emits on
  every successful upload.
- `AuditEvent::PolicyActivated(PolicyActivatedData)` — emits
  on every successful activate; carries the predecessor id
  (omitted on first activation per
  `serde(skip_serializing_if = "Option::is_none")`).

## Test plan

- [x] `cargo test -p vtc-service policy::` green (16/16
  M2.1 + M2.2 unit tests).
- [x] `cargo test -p vtc-service --test policies` green
  (14/14 M2.3 + M2.4 integration tests).
- [x] `cargo test -p vti-common audit::` green (32/32 incl.
  the three new policy audit variant tests).
- [x] Full `cargo test -p vtc-service` green (260+ tests).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- [ ] Review the engine cloning approach (per-call clone is
  cheap with the `arc` feature; alternative is `&mut
  CompiledPolicy` everywhere, but it complicates the M2.8
  hot-swap registry).
- [ ] Approve the D1 / D8 implementation before M2.5 starts.

## Commits

1. \`132155c\` — M2.1 regorus harness
2. \`215aef6\` — M2.2 policy model + storage CRUD
3. \`b4e9b39\` — M2.3 policy admin endpoints
4. \`acb015c\` — M2.4 policy read endpoints

Once this PR merges, M2.5 (default policies bundle) starts on
a fresh branch.