### PR TITLE
feat(vtc-service): Phase 2 PR 2 — default policies + wire into submit/remove (M2.5–M2.7)

### DIFF
--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -176,7 +176,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M2.7 — Wire `removal.rego` into admin-remove
 
-### `[ ]` M2.7.1 — Policy step at admin-remove time
+### `[x]` M2.7.1 — Policy step at admin-remove time
 
 - **Acceptance**
   - `routes::members::remove::admin_remove` evaluates the

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -123,7 +123,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M2.5 — Default policies
 
-### `[ ]` M2.5.1 — Bundle deny-all / accept-all defaults
+### `[x]` M2.5.1 — Bundle deny-all / accept-all defaults
 
 - **Acceptance**
   - 9 default Rego policies shipped under

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -152,7 +152,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M2.6 — Wire `join.rego` into submit
 
-### `[ ]` M2.6.1 — Policy step at submit time
+### `[x]` M2.6.1 — Policy step at submit time
 
 - **Acceptance**
   - `submit_inner` (existing) extracts `vp_claims` from the

--- a/vtc-service/policies/default/cross_community_relationships.rego
+++ b/vtc-service/policies/default/cross_community_relationships.rego
@@ -1,0 +1,17 @@
+# Default `cross_community_relationships` policy — deny-all
+# (spec §7.1).
+#
+# Storing a VRC issued by another community is opt-in by
+# default. Operators who want to honour external relationship
+# credentials upload a stricter policy. Phase 3+ surface — the
+# stub ships now so `relationships.rego` doesn't have to
+# special-case missing peer policies.
+#
+# Input shape (spec §7.3):
+#   { vrc, viewer_member, vtc_state }
+
+package vtc.cross_community_relationships
+
+import rego.v1
+
+default allow := false

--- a/vtc-service/policies/default/cross_community_roles.rego
+++ b/vtc-service/policies/default/cross_community_roles.rego
@@ -1,0 +1,18 @@
+# Default `cross_community_roles` policy — deny-all
+# (spec §7.1 + §8.4).
+#
+# Honouring a foreign VEC's role grant is a session-mint
+# hardening hazard (spec §8.4): a malicious peer community
+# could mint arbitrary VECs and have them confer admin in your
+# community. Default-deny forces the operator to make an
+# explicit allowlist before any cross-community grant takes
+# effect.
+#
+# Input shape (spec §7.3):
+#   { foreign_vec, target_role, vtc_state }
+
+package vtc.cross_community_roles
+
+import rego.v1
+
+default allow := false

--- a/vtc-service/policies/default/directory.rego
+++ b/vtc-service/policies/default/directory.rego
@@ -1,0 +1,28 @@
+# Default `directory` policy — members see DID + role only
+# (spec §7.1 + §12.3).
+#
+# The directory endpoint lands in Phase 5 (community-facing
+# member directory). The default-deny envelope here describes
+# the privacy floor: any field beyond `did` + `role` is denied
+# unless the operator uploads a wider-scope policy. Audit + the
+# admin-facing `GET /v1/members` already bypass this — it's the
+# *member-to-member* visibility surface this policy gates.
+#
+# Input shape (spec §7.3):
+#   { viewer_did, viewer_role, target_member, fields_requested,
+#     action }
+
+package vtc.directory
+
+import rego.v1
+
+default allow := false
+
+allowed_fields := {"did", "role"}
+
+allow if {
+	input.action == "show"
+	every f in input.fields_requested {
+		allowed_fields[f]
+	}
+}

--- a/vtc-service/policies/default/join.rego
+++ b/vtc-service/policies/default/join.rego
@@ -1,0 +1,19 @@
+# Default `join` policy — `policies.open` template (spec §7.1).
+#
+# Accepts every well-formed join request. The submit handler
+# already verifies the holder-binding signature on the VP
+# (Phase 1 M1.8.2); this policy decides whether to surface the
+# request as `Pending` for admin review or reject it outright.
+# Operators replace this with a stricter policy by uploading
+# their own and activating it.
+#
+# Input shape (spec §7.3):
+#   { applicant_did, vp_claims, action, now }
+
+package vtc.join
+
+import rego.v1
+
+default allow := false
+
+allow if input.action == "join"

--- a/vtc-service/policies/default/personhood.rego
+++ b/vtc-service/policies/default/personhood.rego
@@ -1,0 +1,19 @@
+# Default `personhood` policy — deny-all stub (spec §7.1 + §6.4).
+#
+# Phase 4 introduces the operator-facing
+# `POST /v1/members/{did}/personhood/{assert,revoke}` endpoints
+# and the real personhood-evidence evaluation. Until then the
+# stub makes renewal's §6.3 step-3 personhood re-eval well-
+# defined ("not asserted") — every renewed VMC carries
+# `personhood: false`.
+#
+# Input shape (spec §7.3):
+#   { applicant_did, vp_claims }
+
+package vtc.personhood
+
+import rego.v1
+
+default allow := false
+
+default asserted := false

--- a/vtc-service/policies/default/registry.rego
+++ b/vtc-service/policies/default/registry.rego
@@ -1,0 +1,37 @@
+# Default `registry` policy — publish on join, default
+# disposition `tombstone` (spec §7.1 + §8.2).
+#
+# The trust-registry publication path is Phase 3 — this policy
+# ships now so spec §8.2's departure-disposition envelope is
+# observable from day one. The handler that consumes it will
+# land alongside `MembershipSyncer` in Phase 3.
+#
+# Output contract (consumed by §8.2's resolver):
+#   - publish_on_join:        whether the join handler publishes the
+#                             member to the trust registry.
+#   - default_departure:      the disposition that applies when the
+#                             member does not request a specific one.
+#   - departure_options:      the dispositions members are allowed
+#                             to pick from.
+#   - min_disposition:        the *floor* the operator is willing to
+#                             accept. RTBF (member-initiated `purge`)
+#                             always overrides this floor — see §8.2.
+#
+# Input shape (spec §7.3):
+#   { member, action, requested_disposition? }
+
+package vtc.registry
+
+import rego.v1
+
+default allow := false
+
+default publish_on_join := true
+
+default default_departure := "tombstone"
+
+departure_options := ["purge", "tombstone", "historical"]
+
+default min_disposition := "purge"
+
+allow if input.action == "publish"

--- a/vtc-service/policies/default/relationships.rego
+++ b/vtc-service/policies/default/relationships.rego
@@ -1,0 +1,32 @@
+# Default `relationships` policy — store iff both parties are
+# current members (spec §7.1).
+#
+# A VRC names two parties (issuer + subject). The default
+# behaviour is to accept the publication only when both DIDs
+# are current members of this community — preserves the "we
+# don't publish relationship claims that span unknown parties"
+# privacy floor. Operators relax by uploading their own
+# policy.
+#
+# The handler enriches each party with an `is_current` flag
+# (true iff the DID has an active ACL row and the Member row
+# is not tombstoned). Default policy reads only that flag —
+# the handler picks the canonical shape that future operator-
+# authored policies will inherit.
+#
+# Input shape (spec §7.3, enriched):
+#   { vrc, issuer_member: { did, is_current },
+#          subject_member: { did, is_current },
+#     action }
+
+package vtc.relationships
+
+import rego.v1
+
+default allow := false
+
+allow if {
+	input.action == "publish"
+	input.issuer_member.is_current
+	input.subject_member.is_current
+}

--- a/vtc-service/policies/default/removal.rego
+++ b/vtc-service/policies/default/removal.rego
@@ -26,3 +26,10 @@ allow if {
 	input.action == "remove"
 	input.target_role != "admin"
 }
+
+# Phase 1 plan §D6: `Disposition::PolicyDefault` resolves to
+# whatever this policy emits. The default mirrors Phase 1's
+# hardcoded `Tombstone` so existing operator state survives the
+# Phase 1 → Phase 2 transition unchanged.
+default min_disposition := "tombstone"
+

--- a/vtc-service/policies/default/removal.rego
+++ b/vtc-service/policies/default/removal.rego
@@ -1,0 +1,28 @@
+# Default `removal` policy — admin may remove any non-admin
+# (spec §7.1 + §10.2). The route layer enforces:
+#
+# 1. `AdminAuth` on the admin-remove endpoint — so the caller is
+#    already known to be an admin when this policy runs.
+# 2. The no-last-admin invariant — the route refuses to leave
+#    zero admins regardless of policy output.
+# 3. Self-remove is its own unconditional endpoint
+#    (`DELETE /v1/members/me`) and bypasses this policy entirely.
+#
+# This policy therefore only gates the "may this admin remove
+# this target" question. Default: allow unless the target is
+# also an admin (admins can only be removed by promotion + the
+# step-up UV path, never via a casual admin-remove).
+#
+# Input shape (spec §7.3):
+#   { actor_did, target_did, target_role, reason, action, now }
+
+package vtc.removal
+
+import rego.v1
+
+default allow := false
+
+allow if {
+	input.action == "remove"
+	input.target_role != "admin"
+}

--- a/vtc-service/policies/default/role_definitions.rego
+++ b/vtc-service/policies/default/role_definitions.rego
@@ -1,0 +1,88 @@
+# Default `role_definitions` policy — spec §5.3 standard-role
+# permission matrix. Custom roles (`Role::Custom(String)`)
+# receive *no* implicit grants from this default; operators
+# must upload an extended policy or rely on the explicit
+# default-deny behaviour spec §5.3 calls out.
+#
+# Wire-form action names align with the spec table:
+#   edit_community_profile      — Admin only
+#   author_policies             — Admin only
+#   approve_join / reject_join  — Admin, Moderator
+#   issue_community_credential  — Admin, Issuer
+#   issue_vmc                   — Admin only (and only via the
+#                                  join-approve handler, not as a
+#                                  standalone action — policy
+#                                  permits it, the route layer
+#                                  scopes the actual call site)
+#   promote_to_admin            — Admin only
+#   remove_member               — Admin, Moderator
+#   self_remove                 — everyone
+#   renew_vmc                   — everyone
+#   publish_vrc                 — everyone
+#   rotate_did                  — everyone
+#
+# Input shape (spec §7.3):
+#   { role, action, resource? }
+
+package vtc.role_definitions
+
+import rego.v1
+
+default allow := false
+
+admin_actions := {
+	"edit_community_profile",
+	"author_policies",
+	"approve_join", "reject_join",
+	"issue_community_credential", "issue_vmc",
+	"promote_to_admin",
+	"remove_member",
+	"self_remove",
+	"renew_vmc",
+	"publish_vrc",
+	"rotate_did",
+}
+
+moderator_actions := {
+	"approve_join", "reject_join",
+	"remove_member",
+	"self_remove",
+	"renew_vmc",
+	"publish_vrc",
+	"rotate_did",
+}
+
+issuer_actions := {
+	"issue_community_credential",
+	"self_remove",
+	"renew_vmc",
+	"publish_vrc",
+	"rotate_did",
+}
+
+member_actions := {
+	"self_remove",
+	"renew_vmc",
+	"publish_vrc",
+	"rotate_did",
+}
+
+allow if {
+	input.role == "admin"
+	admin_actions[input.action]
+}
+
+allow if {
+	input.role == "moderator"
+	moderator_actions[input.action]
+}
+
+allow if {
+	input.role == "issuer"
+	issuer_actions[input.action]
+}
+
+allow if {
+	input.role == "member"
+	member_actions[input.action]
+}

--- a/vtc-service/src/join/mod.rs
+++ b/vtc-service/src/join/mod.rs
@@ -74,11 +74,19 @@ impl std::fmt::Display for JoinStatus {
 pub struct JoinRequest {
     pub id: Uuid,
     pub applicant_did: String,
-    /// Opaque VP carried verbatim from the wire. Phase 2's policy
-    /// step (`join.rego`) reads this; Phase 1 never inspects it
-    /// beyond the holder-binding check the route layer ran at
-    /// submit time.
+    /// Opaque VP carried verbatim from the wire. Phase 1 never
+    /// inspects it beyond the holder-binding check the route layer
+    /// ran at submit time; Phase 2's policy step reads from
+    /// [`Self::vp_claims`] (the canonical projection extracted at
+    /// submit time), not from this field.
     pub vp: JsonValue,
+    /// Canonical projection of [`Self::vp`] computed at submit
+    /// time by [`crate::policy::extract::extract_vp_claims`] and
+    /// fed to `join.rego` as `input.vp_claims`. Stored on the row
+    /// so the approve flow doesn't have to re-extract (plan §D4).
+    /// `null` on rows persisted before Phase 2.
+    #[serde(default)]
+    pub vp_claims: JsonValue,
     pub submitted_at: DateTime<Utc>,
     pub status: JoinStatus,
     /// Set by Phase 2's policy step on approve / reject. Always
@@ -105,6 +113,7 @@ impl JoinRequest {
             id: Uuid::new_v4(),
             applicant_did: applicant_did.into(),
             vp,
+            vp_claims: JsonValue::Null,
             submitted_at: Utc::now(),
             status: JoinStatus::Pending,
             policy_decision: None,

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -239,9 +239,20 @@ async fn member_self_remove_handler(
         .transpose()
         .map_err(DIDCommServiceError::Internal)?;
 
-    let outcome = remove_inner(&state, &caller_did, &caller_did, disposition, String::new())
-        .await
-        .map_err(|e| DIDCommServiceError::Internal(format!("self-remove: {e}")))?;
+    // DIDComm self-remove — same bypass as the REST self-remove
+    // path: unconditional (spec §10.2), `removal.rego` is not
+    // consulted. Disposition still routes through the policy
+    // when the member prefers `PolicyDefault`.
+    let outcome = remove_inner(
+        &state,
+        &caller_did,
+        &caller_did,
+        disposition,
+        String::new(),
+        false,
+    )
+    .await
+    .map_err(|e| DIDCommServiceError::Internal(format!("self-remove: {e}")))?;
 
     let receipt = SelfRemoveReceiptBody {
         did: outcome.did,

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -378,6 +378,17 @@ mod tests {
     }
 
     #[test]
+    fn removal_default_min_disposition_is_tombstone() {
+        let c = compile_default(PolicyPurpose::Removal);
+        let r = evaluate(&c, "data.vtc.removal.min_disposition", json!({})).unwrap();
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!("tombstone")),
+            "removal default min_disposition mirrors Phase 1's hardcoded Tombstone"
+        );
+    }
+
+    #[test]
     fn removal_default_denies_admin_removing_admin() {
         let c = compile_default(PolicyPurpose::Removal);
         let r = evaluate(

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -1,0 +1,558 @@
+//! Default policy bundle — spec §7.1 (M2.5).
+//!
+//! The workspace ships nine Rego modules — one per
+//! [`PolicyPurpose`] — under `vtc-service/policies/default/`.
+//! They are embedded at compile time via [`include_str!`] so the
+//! binary doesn't read from the filesystem at startup.
+//!
+//! [`install_defaults`] is idempotent: it walks
+//! [`PolicyPurpose::ALL`] and only installs a default for purposes
+//! that have **no active policy row** yet. This keeps operator-
+//! authored policies untouched across daemon restarts and means
+//! re-running the function on an already-installed deployment is a
+//! no-op.
+//!
+//! Defaults carry [`DEFAULTS_AUTHOR`] as their `author_did` so
+//! operators can distinguish workspace-shipped policies from their
+//! own uploads in `GET /v1/policies`. No audit envelope is emitted
+//! when defaults are installed — these are workspace state, not
+//! operator actions.
+//!
+//! ## Why no audit emission
+//!
+//! `PolicyUploaded` + `PolicyActivated` envelopes record *operator*
+//! decisions. A default-policy install happens because the daemon
+//! booted with an empty `active_policies:` keyspace, not because an
+//! operator did anything. Emitting audit envelopes here would
+//! double the audit floor's first-boot footprint without adding any
+//! observable signal — the `authorDid` field on the Policy row
+//! already tells the story.
+
+use chrono::Utc;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::engine::compile;
+use super::model::PolicyPurpose;
+use super::storage::{get_active_policy_id, new_policy, set_active_policy_id, store_policy};
+
+/// Pseudo-DID stamped on every default policy's `author_did`
+/// field. Not a resolvable DID — purely a marker so operators
+/// see "this came from the workspace, not from a human admin".
+pub const DEFAULTS_AUTHOR: &str = "did:key:vtc-defaults";
+
+/// Embedded source for each default policy, in [`PolicyPurpose::ALL`]
+/// order. Compile-time-included so the binary is self-contained.
+const DEFAULT_SOURCES: &[(PolicyPurpose, &str)] = &[
+    (
+        PolicyPurpose::Join,
+        include_str!("../../policies/default/join.rego"),
+    ),
+    (
+        PolicyPurpose::Removal,
+        include_str!("../../policies/default/removal.rego"),
+    ),
+    (
+        PolicyPurpose::Personhood,
+        include_str!("../../policies/default/personhood.rego"),
+    ),
+    (
+        PolicyPurpose::Registry,
+        include_str!("../../policies/default/registry.rego"),
+    ),
+    (
+        PolicyPurpose::Directory,
+        include_str!("../../policies/default/directory.rego"),
+    ),
+    (
+        PolicyPurpose::RoleDefinitions,
+        include_str!("../../policies/default/role_definitions.rego"),
+    ),
+    (
+        PolicyPurpose::CrossCommunityRoles,
+        include_str!("../../policies/default/cross_community_roles.rego"),
+    ),
+    (
+        PolicyPurpose::CrossCommunityRelationships,
+        include_str!("../../policies/default/cross_community_relationships.rego"),
+    ),
+    (
+        PolicyPurpose::Relationships,
+        include_str!("../../policies/default/relationships.rego"),
+    ),
+];
+
+/// Number of purposes the workspace ships defaults for. Asserted
+/// against [`PolicyPurpose::ALL`] at test time so a missed entry in
+/// `DEFAULT_SOURCES` surfaces as a build-time-ish failure rather
+/// than a silent runtime gap.
+pub const DEFAULT_COUNT: usize = 9;
+
+/// Return the embedded default source for `purpose`. Useful to the
+/// admin UX layer that wants to show "reset to default" diffs
+/// against the live policy.
+pub fn default_source(purpose: PolicyPurpose) -> &'static str {
+    DEFAULT_SOURCES
+        .iter()
+        .find(|(p, _)| *p == purpose)
+        .map(|(_, src)| *src)
+        .expect("every PolicyPurpose has a shipped default — see DEFAULT_SOURCES")
+}
+
+/// Fill gaps in the active-policy set with the workspace defaults.
+///
+/// Idempotent: only purposes with no current active pointer get a
+/// new row installed. Operator-uploaded policies are never
+/// overwritten and never touched.
+///
+/// Returns the number of policies actually installed (`0` on a
+/// warm boot where every purpose already has an active policy).
+pub async fn install_defaults(
+    policies_ks: &KeyspaceHandle,
+    active_policies_ks: &KeyspaceHandle,
+) -> Result<usize, AppError> {
+    let mut installed = 0_usize;
+    for (purpose, source) in DEFAULT_SOURCES {
+        if get_active_policy_id(active_policies_ks, *purpose)
+            .await?
+            .is_some()
+        {
+            debug!(
+                purpose = purpose.as_str(),
+                "default-policy install skipped — purpose already has an active policy"
+            );
+            continue;
+        }
+
+        let id = Uuid::new_v4();
+        let compiled = compile(source, id).map_err(|e| {
+            // A default that doesn't compile is a workspace bug,
+            // not an operator one — surface as Internal so an
+            // operator sees the actual stack instead of a 400.
+            AppError::Internal(format!(
+                "default policy for {} failed to compile: {e}",
+                purpose.as_str()
+            ))
+        })?;
+        let sha = *compiled.source_sha256();
+
+        let mut policy = new_policy(
+            *purpose,
+            (*source).to_string(),
+            sha,
+            DEFAULTS_AUTHOR.to_string(),
+            1,
+        );
+        policy.id = id;
+        policy.activated_at = Some(Utc::now());
+
+        store_policy(policies_ks, &policy).await?;
+        set_active_policy_id(active_policies_ks, *purpose, id).await?;
+
+        installed += 1;
+        info!(
+            purpose = purpose.as_str(),
+            policy_id = %id,
+            sha256 = %hex::encode(sha),
+            "default policy installed"
+        );
+    }
+
+    if installed == 0 {
+        debug!("no default policies installed — every purpose already has an active row");
+    } else if installed < DEFAULT_COUNT {
+        // Partial install — the daemon started with a mix of
+        // operator + default policies. Worth noting in logs but
+        // not an error.
+        debug!(
+            installed,
+            total = DEFAULT_COUNT,
+            "partial default-policy install — some purposes already had operator policies"
+        );
+    }
+
+    if let Err(e) = sanity_check_active_set(active_policies_ks).await {
+        // Best-effort post-condition check. We don't fail boot
+        // on it — the policies that did install are still
+        // load-bearing — but log loudly so the operator sees the
+        // gap.
+        warn!(error = %e, "default-policy install did not yield a full active set");
+    }
+
+    Ok(installed)
+}
+
+/// Verify every [`PolicyPurpose`] has an active pointer. Called
+/// after [`install_defaults`] succeeds — under normal boot every
+/// purpose should be live. A gap here means a default-install
+/// hit an error mid-loop and the boot continued.
+async fn sanity_check_active_set(active_policies_ks: &KeyspaceHandle) -> Result<(), AppError> {
+    let mut missing = Vec::new();
+    for purpose in PolicyPurpose::ALL {
+        if get_active_policy_id(active_policies_ks, purpose)
+            .await?
+            .is_none()
+        {
+            missing.push(purpose.as_str());
+        }
+    }
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(AppError::Internal(format!(
+            "purposes left without an active policy after install_defaults: {}",
+            missing.join(", ")
+        )))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::engine::{compile as compile_policy, evaluate};
+    use serde_json::json;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_keyspaces() -> (KeyspaceHandle, KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        let policies_ks = store.keyspace("policies").expect("policies ks");
+        let active_ks = store.keyspace("active_policies").expect("active ks");
+        (policies_ks, active_ks, dir)
+    }
+
+    /// `DEFAULT_SOURCES` must list every [`PolicyPurpose`] exactly
+    /// once — a missing entry would result in `install_defaults`
+    /// silently skipping a purpose at boot, which is the kind of
+    /// gap that only surfaces in production. Hard-fail at test
+    /// time instead.
+    #[test]
+    fn defaults_cover_every_purpose() {
+        assert_eq!(DEFAULT_SOURCES.len(), DEFAULT_COUNT);
+        for purpose in PolicyPurpose::ALL {
+            assert!(
+                DEFAULT_SOURCES.iter().any(|(p, _)| *p == purpose),
+                "no default policy shipped for {purpose:?}"
+            );
+        }
+    }
+
+    /// Every default compiles cleanly via the M2.1 harness. Catches
+    /// a malformed default before the daemon boots.
+    #[test]
+    fn every_default_compiles() {
+        for (purpose, source) in DEFAULT_SOURCES {
+            let id = Uuid::new_v4();
+            compile_policy(source, id).unwrap_or_else(|e| {
+                panic!(
+                    "default policy for {} failed to compile: {e}",
+                    purpose.as_str()
+                )
+            });
+        }
+    }
+
+    /// First boot: every purpose gets a default. Second call is a
+    /// no-op (idempotence).
+    #[tokio::test]
+    async fn install_defaults_is_idempotent() {
+        let (policies_ks, active_ks, _dir) = temp_keyspaces().await;
+        let installed = install_defaults(&policies_ks, &active_ks).await.unwrap();
+        assert_eq!(installed, DEFAULT_COUNT);
+        // Every purpose now has an active pointer.
+        for purpose in PolicyPurpose::ALL {
+            assert!(
+                get_active_policy_id(&active_ks, purpose)
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "purpose {purpose:?} should have an active row"
+            );
+        }
+        // Re-run is a no-op.
+        let again = install_defaults(&policies_ks, &active_ks).await.unwrap();
+        assert_eq!(again, 0, "second install must be a no-op");
+    }
+
+    /// An operator-uploaded policy already pointed at by the active
+    /// pointer is not overwritten by `install_defaults`.
+    #[tokio::test]
+    async fn install_defaults_preserves_operator_policies() {
+        let (policies_ks, active_ks, _dir) = temp_keyspaces().await;
+
+        // Simulate an operator upload of a custom join policy.
+        let operator_source = "package vtc.join\nimport rego.v1\n\ndefault allow := false\n";
+        let operator_id = Uuid::new_v4();
+        let compiled = compile_policy(operator_source, operator_id).unwrap();
+        let sha = *compiled.source_sha256();
+        let mut operator_policy = new_policy(
+            PolicyPurpose::Join,
+            operator_source.to_string(),
+            sha,
+            "did:key:zRealOperator".into(),
+            1,
+        );
+        operator_policy.id = operator_id;
+        operator_policy.activated_at = Some(Utc::now());
+        store_policy(&policies_ks, &operator_policy).await.unwrap();
+        set_active_policy_id(&active_ks, PolicyPurpose::Join, operator_id)
+            .await
+            .unwrap();
+
+        // Install defaults — only the other 8 purposes get filled.
+        let installed = install_defaults(&policies_ks, &active_ks).await.unwrap();
+        assert_eq!(installed, DEFAULT_COUNT - 1);
+
+        // Join still points at the operator's policy.
+        assert_eq!(
+            get_active_policy_id(&active_ks, PolicyPurpose::Join)
+                .await
+                .unwrap(),
+            Some(operator_id)
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Input-contract round-trips per default. Each test compiles
+    // the default + evaluates the canonical query for that purpose
+    // against the input shape spec §7.3 documents.
+    // ──────────────────────────────────────────────────────────────
+
+    fn pluck_bool(result: &serde_json::Value) -> bool {
+        result
+            .pointer("/result/0/expressions/0/value")
+            .and_then(|v| v.as_bool())
+            .unwrap_or_else(|| panic!("expected boolean expression value, got {result}"))
+    }
+
+    fn compile_default(purpose: PolicyPurpose) -> crate::policy::CompiledPolicy {
+        compile_policy(default_source(purpose), Uuid::new_v4()).expect("compile default")
+    }
+
+    #[test]
+    fn join_default_allows_well_formed_request() {
+        let c = compile_default(PolicyPurpose::Join);
+        let input = json!({
+            "applicant_did": "did:key:zApplicant",
+            "vp_claims": {},
+            "action": "join",
+            "now": "2026-05-12T00:00:00Z"
+        });
+        let r = evaluate(&c, "data.vtc.join.allow", input).unwrap();
+        assert!(
+            pluck_bool(&r),
+            "default join policy must allow valid submissions"
+        );
+    }
+
+    #[test]
+    fn join_default_denies_wrong_action() {
+        let c = compile_default(PolicyPurpose::Join);
+        let r = evaluate(&c, "data.vtc.join.allow", json!({ "action": "withdraw" })).unwrap();
+        assert!(!pluck_bool(&r));
+    }
+
+    #[test]
+    fn removal_default_allows_admin_removing_member() {
+        let c = compile_default(PolicyPurpose::Removal);
+        let input = json!({
+            "actor_did": "did:key:zAdmin",
+            "target_did": "did:key:zMember",
+            "target_role": "member",
+            "reason": "",
+            "action": "remove",
+            "now": "2026-05-12T00:00:00Z"
+        });
+        let r = evaluate(&c, "data.vtc.removal.allow", input).unwrap();
+        assert!(pluck_bool(&r));
+    }
+
+    #[test]
+    fn removal_default_denies_admin_removing_admin() {
+        let c = compile_default(PolicyPurpose::Removal);
+        let r = evaluate(
+            &c,
+            "data.vtc.removal.allow",
+            json!({ "action": "remove", "target_role": "admin" }),
+        )
+        .unwrap();
+        assert!(!pluck_bool(&r));
+    }
+
+    #[test]
+    fn personhood_default_denies_everything() {
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            json!({ "applicant_did": "did:key:zX", "vp_claims": {} }),
+        )
+        .unwrap();
+        assert!(!pluck_bool(&r), "personhood default must deny");
+        let asserted = evaluate(&c, "data.vtc.personhood.asserted", json!({})).unwrap();
+        assert!(
+            !pluck_bool(&asserted),
+            "personhood.asserted default must be false"
+        );
+    }
+
+    #[test]
+    fn registry_default_publishes_on_join_with_tombstone_default() {
+        let c = compile_default(PolicyPurpose::Registry);
+        let publish = evaluate(&c, "data.vtc.registry.publish_on_join", json!({})).unwrap();
+        assert!(pluck_bool(&publish));
+        let default = evaluate(&c, "data.vtc.registry.default_departure", json!({})).unwrap();
+        assert_eq!(
+            default.pointer("/result/0/expressions/0/value"),
+            Some(&json!("tombstone")),
+        );
+    }
+
+    #[test]
+    fn directory_default_allows_did_and_role_only() {
+        let c = compile_default(PolicyPurpose::Directory);
+        let ok = evaluate(
+            &c,
+            "data.vtc.directory.allow",
+            json!({
+                "viewer_did": "did:key:zViewer",
+                "viewer_role": "member",
+                "target_member": { "did": "did:key:zTarget" },
+                "fields_requested": ["did", "role"],
+                "action": "show"
+            }),
+        )
+        .unwrap();
+        assert!(pluck_bool(&ok));
+
+        let denied = evaluate(
+            &c,
+            "data.vtc.directory.allow",
+            json!({
+                "viewer_did": "did:key:zViewer",
+                "viewer_role": "member",
+                "target_member": { "did": "did:key:zTarget" },
+                "fields_requested": ["did", "role", "email"],
+                "action": "show"
+            }),
+        )
+        .unwrap();
+        assert!(
+            !pluck_bool(&denied),
+            "directory default must deny when extra fields are requested"
+        );
+    }
+
+    #[test]
+    fn role_definitions_default_matches_spec_matrix() {
+        let c = compile_default(PolicyPurpose::RoleDefinitions);
+
+        let cases: &[(&str, &str, bool)] = &[
+            ("admin", "edit_community_profile", true),
+            ("admin", "author_policies", true),
+            ("admin", "promote_to_admin", true),
+            ("moderator", "approve_join", true),
+            ("moderator", "remove_member", true),
+            ("moderator", "edit_community_profile", false),
+            ("moderator", "promote_to_admin", false),
+            ("issuer", "issue_community_credential", true),
+            ("issuer", "remove_member", false),
+            ("member", "self_remove", true),
+            ("member", "renew_vmc", true),
+            ("member", "remove_member", false),
+            ("member", "approve_join", false),
+            // Custom roles get nothing by default.
+            ("custom:editor", "renew_vmc", false),
+        ];
+
+        for (role, action, expected) in cases {
+            let r = evaluate(
+                &c,
+                "data.vtc.role_definitions.allow",
+                json!({ "role": role, "action": action }),
+            )
+            .unwrap();
+            assert_eq!(
+                pluck_bool(&r),
+                *expected,
+                "role={role} action={action}: expected allow={expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn cross_community_roles_default_denies_everything() {
+        let c = compile_default(PolicyPurpose::CrossCommunityRoles);
+        let r = evaluate(
+            &c,
+            "data.vtc.cross_community_roles.allow",
+            json!({
+                "foreign_vec": { "issuer": "did:webvh:peer.example", "role": "admin" },
+                "target_role": "admin",
+                "vtc_state": {}
+            }),
+        )
+        .unwrap();
+        assert!(!pluck_bool(&r));
+    }
+
+    #[test]
+    fn cross_community_relationships_default_denies_everything() {
+        let c = compile_default(PolicyPurpose::CrossCommunityRelationships);
+        let r = evaluate(
+            &c,
+            "data.vtc.cross_community_relationships.allow",
+            json!({
+                "vrc": { "issuer": "did:webvh:peer.example" },
+                "viewer_member": { "did": "did:key:zViewer" },
+                "vtc_state": {}
+            }),
+        )
+        .unwrap();
+        assert!(!pluck_bool(&r));
+    }
+
+    #[test]
+    fn relationships_default_requires_both_parties_current() {
+        let c = compile_default(PolicyPurpose::Relationships);
+
+        let both = evaluate(
+            &c,
+            "data.vtc.relationships.allow",
+            json!({
+                "vrc": {},
+                "issuer_member": { "did": "did:key:zIssuer", "is_current": true },
+                "subject_member": { "did": "did:key:zSubject", "is_current": true },
+                "action": "publish"
+            }),
+        )
+        .unwrap();
+        assert!(pluck_bool(&both));
+
+        let only_one = evaluate(
+            &c,
+            "data.vtc.relationships.allow",
+            json!({
+                "vrc": {},
+                "issuer_member": { "did": "did:key:zIssuer", "is_current": true },
+                "subject_member": { "did": "did:key:zSubject", "is_current": false },
+                "action": "publish"
+            }),
+        )
+        .unwrap();
+        assert!(
+            !pluck_bool(&only_one),
+            "relationships default must deny when one party isn't a member"
+        );
+    }
+}

--- a/vtc-service/src/policy/extract.rs
+++ b/vtc-service/src/policy/extract.rs
@@ -1,0 +1,202 @@
+//! Verifiable-Presentation → policy-`input.vp_claims` extraction
+//! (plan §D4).
+//!
+//! Phase 1 records the raw VP as opaque JSON. Phase 2's policy
+//! step needs a structured view it can pass to `join.rego` as
+//! `input.vp_claims`. This module pulls a canonical projection
+//! out of the VP without doing full cryptographic verification —
+//! the holder-binding signature already authenticates the
+//! submitter at the route layer, and full VP+VC proof checking is
+//! a heavier integration (affinidi-vc, affinidi-data-integrity)
+//! that the Phase 2 MVP intentionally defers.
+//!
+//! The extracted shape is stable wire — operator-uploaded
+//! `join.rego` modules read off it:
+//!
+//! ```text
+//! {
+//!   "holder":      "<did>" | null,
+//!   "credentials": [
+//!     {
+//!       "issuer":           "<did>" | { "id": "<did>", … },
+//!       "type":             [ "VerifiableCredential", … ],
+//!       "issuanceDate":     "…",       // when present on the VC
+//!       "credentialSubject": { … }     // verbatim from the VC
+//!     },
+//!     …
+//!   ]
+//! }
+//! ```
+//!
+//! Missing fields surface as `null` (holder) or empty arrays
+//! (credentials, types). Operators write policies that defend
+//! against those gracefully — that's the contract the default
+//! `join.rego` (which accepts everything) is comfortable with.
+//!
+//! ## When `vp` isn't a JSON object
+//!
+//! Some legitimate VPs ship as JWT strings (JSON-encoded
+//! compact serialisation). Phase 2 doesn't crack those open
+//! — we surface them as `{ "holder": null, "credentials": [] }`
+//! and let the operator's policy decide. JWT-format VP support
+//! lands alongside the full VP verification milestone (Phase 3
+//! or later).
+
+use serde_json::{Map, Value as JsonValue, json};
+
+/// Canonical `vp_claims` projection. Always returns a JSON
+/// object; missing optional fields are represented per the
+/// module docs.
+pub fn extract_vp_claims(vp: &JsonValue) -> JsonValue {
+    let vp_obj = match vp.as_object() {
+        Some(o) => o,
+        None => return empty_claims(),
+    };
+
+    let holder = vp_obj
+        .get("holder")
+        .and_then(|h| match h {
+            JsonValue::String(s) => Some(JsonValue::String(s.clone())),
+            // VP-1.1 allows `holder` as an object with `id`.
+            JsonValue::Object(o) => o.get("id").cloned(),
+            _ => None,
+        })
+        .unwrap_or(JsonValue::Null);
+
+    let credentials = vp_obj
+        .get("verifiableCredential")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(extract_credential)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut m = Map::new();
+    m.insert("holder".into(), holder);
+    m.insert("credentials".into(), JsonValue::Array(credentials));
+    JsonValue::Object(m)
+}
+
+fn empty_claims() -> JsonValue {
+    let mut m = Map::new();
+    m.insert("holder".into(), JsonValue::Null);
+    m.insert("credentials".into(), JsonValue::Array(Vec::new()));
+    JsonValue::Object(m)
+}
+
+/// Pull the canonical projection out of one VC. Objects only;
+/// JWT-encoded VC strings surface as `None` (policy sees a
+/// shorter list).
+fn extract_credential(vc: &JsonValue) -> Option<JsonValue> {
+    let vc_obj = vc.as_object()?;
+    let mut out = Map::new();
+    if let Some(issuer) = vc_obj.get("issuer") {
+        out.insert("issuer".into(), issuer.clone());
+    } else {
+        out.insert("issuer".into(), JsonValue::Null);
+    }
+    out.insert(
+        "type".into(),
+        vc_obj.get("type").cloned().unwrap_or_else(|| json!([])),
+    );
+    if let Some(date) = vc_obj.get("issuanceDate") {
+        out.insert("issuanceDate".into(), date.clone());
+    }
+    if let Some(date) = vc_obj.get("validFrom") {
+        out.insert("validFrom".into(), date.clone());
+    }
+    out.insert(
+        "credentialSubject".into(),
+        vc_obj
+            .get("credentialSubject")
+            .cloned()
+            .unwrap_or(JsonValue::Null),
+    );
+    Some(JsonValue::Object(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn empty_vp_yields_empty_claims() {
+        let claims = extract_vp_claims(&JsonValue::Null);
+        assert_eq!(claims, json!({ "holder": null, "credentials": [] }));
+
+        let claims = extract_vp_claims(&json!("opaque jwt string"));
+        assert_eq!(claims, json!({ "holder": null, "credentials": [] }));
+    }
+
+    #[test]
+    fn holder_is_extracted_from_string_or_object() {
+        let s = extract_vp_claims(&json!({ "holder": "did:key:zX" }));
+        assert_eq!(s["holder"], json!("did:key:zX"));
+
+        let o = extract_vp_claims(&json!({ "holder": { "id": "did:key:zX", "name": "h" }}));
+        assert_eq!(o["holder"], json!("did:key:zX"));
+    }
+
+    #[test]
+    fn credentials_are_projected_in_order() {
+        let vp = json!({
+            "holder": "did:key:zHolder",
+            "verifiableCredential": [
+                {
+                    "issuer": "did:key:zIssuerA",
+                    "type": ["VerifiableCredential", "EmailCredential"],
+                    "issuanceDate": "2026-01-01T00:00:00Z",
+                    "credentialSubject": { "email": "a@example.com" }
+                },
+                {
+                    "issuer": { "id": "did:webvh:peer.example" },
+                    "type": ["VerifiableCredential", "ProofOfHumanity"],
+                    "validFrom": "2026-03-01T00:00:00Z",
+                    "credentialSubject": { "level": "L1" }
+                }
+            ]
+        });
+        let claims = extract_vp_claims(&vp);
+        let creds = claims["credentials"].as_array().unwrap();
+        assert_eq!(creds.len(), 2);
+
+        assert_eq!(creds[0]["issuer"], json!("did:key:zIssuerA"));
+        assert_eq!(creds[0]["type"][1], "EmailCredential");
+        assert_eq!(creds[0]["credentialSubject"]["email"], "a@example.com");
+        assert_eq!(creds[0]["issuanceDate"], "2026-01-01T00:00:00Z");
+
+        assert_eq!(creds[1]["issuer"]["id"], "did:webvh:peer.example");
+        assert_eq!(creds[1]["validFrom"], "2026-03-01T00:00:00Z");
+        // VC without issuanceDate has no such key — operator policies
+        // see only the fields actually present.
+        assert!(creds[1].get("issuanceDate").is_none());
+    }
+
+    #[test]
+    fn credentials_array_is_optional() {
+        let vp = json!({ "holder": "did:key:zX" });
+        let claims = extract_vp_claims(&vp);
+        assert_eq!(claims["holder"], "did:key:zX");
+        assert_eq!(claims["credentials"], json!([]));
+    }
+
+    #[test]
+    fn jwt_encoded_vcs_in_array_are_skipped() {
+        // A VP might mix JSON-encoded and JWT-encoded VCs.
+        // The JWT strings are dropped from the projection until
+        // full VP verification arrives.
+        let vp = json!({
+            "verifiableCredential": [
+                "eyJhbGciOi...",
+                { "issuer": "did:key:zY", "credentialSubject": {} }
+            ]
+        });
+        let claims = extract_vp_claims(&vp);
+        let creds = claims["credentials"].as_array().unwrap();
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0]["issuer"], "did:key:zY");
+    }
+}

--- a/vtc-service/src/policy/mod.rs
+++ b/vtc-service/src/policy/mod.rs
@@ -38,6 +38,7 @@
 //!    future changes (e.g. caching `data` alongside the engine) don't
 //!    ripple through every consumer.
 
+pub mod default;
 pub mod engine;
 pub mod model;
 pub mod storage;

--- a/vtc-service/src/policy/mod.rs
+++ b/vtc-service/src/policy/mod.rs
@@ -40,6 +40,7 @@
 
 pub mod default;
 pub mod engine;
+pub mod extract;
 pub mod model;
 pub mod storage;
 

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -38,16 +38,21 @@
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
+use chrono::Utc;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
-use tracing::info;
+use serde_json::{Value as JsonValue, json};
+use tracing::{info, warn};
 use uuid::Uuid;
 
-use vti_common::audit::{AuditEvent, JoinRequestData};
+use vti_common::audit::{AuditEvent, JoinRequestData, JoinRequestRejectedData};
 use vti_common::error::AppError;
 
-use crate::join::{JoinRequest, JoinTransport, store_join_request};
+use crate::join::{JoinRequest, JoinStatus, JoinTransport, store_join_request};
+use crate::policy::{
+    PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy,
+    extract::extract_vp_claims, get_active_policy_id, get_policy,
+};
 use crate::server::AppState;
 
 pub const JOIN_REQUEST_SUBMIT_DOMAIN_TAG: &[u8] = b"vtc-join-request/v1\0";
@@ -121,31 +126,142 @@ pub async fn submit_inner(
         verify_holder_signature(&applicant_did, &vp, registry_consent, &extensions, hex_sig)?;
     }
 
-    // 2. Persist as Pending.
+    // 2. Phase 2 policy step (M2.6). Extract the canonical
+    // `vp_claims` projection per plan §D4 and feed it to the
+    // active `join.rego`. `allow` → row stays Pending; `deny`
+    // → row lands as Rejected with the policy's output stored
+    // on `policy_decision`.
+    let vp_claims = extract_vp_claims(&vp);
+    let policy_input = json!({
+        "applicant_did": applicant_did,
+        "vp_claims": vp_claims,
+        "action": "join",
+        "now": Utc::now().to_rfc3339(),
+    });
+    let decision = evaluate_join_policy(state, &policy_input).await?;
+
+    // 3. Persist. `vp_claims` is stored alongside the raw `vp`
+    // so the approve path doesn't have to re-extract.
     let mut request = JoinRequest::new(applicant_did.clone(), vp);
+    request.vp_claims = vp_claims;
     request.registry_consent = registry_consent;
     request.extensions = extensions;
+    match &decision {
+        JoinPolicyDecision::Allow => {
+            request.status = JoinStatus::Pending;
+        }
+        JoinPolicyDecision::Deny { result } => {
+            request.status = JoinStatus::Rejected;
+            request.policy_decision = Some(result.clone());
+        }
+    }
     store_join_request(&state.join_requests_ks, &request).await?;
 
-    // 3. Audit. Actor is the applicant — they're the principal.
-    audit_writer
-        .write(
-            &applicant_did,
-            None,
-            AuditEvent::JoinRequestSubmitted(JoinRequestData {
-                request_id: request.id.to_string(),
-                transport: transport.as_str().to_string(),
-            }),
-        )
-        .await?;
+    // 4. Audit. Allow → Submitted; deny → Rejected with the
+    // canonical `"policy denied"` reason marker so SIEM can
+    // distinguish admin rejections from policy rejections.
+    match &decision {
+        JoinPolicyDecision::Allow => {
+            audit_writer
+                .write(
+                    &applicant_did,
+                    None,
+                    AuditEvent::JoinRequestSubmitted(JoinRequestData {
+                        request_id: request.id.to_string(),
+                        transport: transport.as_str().to_string(),
+                    }),
+                )
+                .await?;
+        }
+        JoinPolicyDecision::Deny { .. } => {
+            audit_writer
+                .write(
+                    &applicant_did,
+                    None,
+                    AuditEvent::JoinRequestRejected(JoinRequestRejectedData {
+                        request_id: request.id.to_string(),
+                        reason: "policy denied".into(),
+                    }),
+                )
+                .await?;
+        }
+    }
 
     info!(
         request_id = %request.id,
         applicant = %applicant_did,
         transport = transport.as_str(),
+        decision = decision.kind(),
         "join request submitted"
     );
     Ok(request)
+}
+
+// ---------------------------------------------------------------------------
+// Policy step (M2.6.1)
+// ---------------------------------------------------------------------------
+
+/// Outcome of evaluating the active `join.rego` against the
+/// canonical `input` for a fresh submission. Carries the raw
+/// regorus `QueryResults` JSON so the deny path can persist it on
+/// `JoinRequest.policy_decision` for the audit trail.
+enum JoinPolicyDecision {
+    Allow,
+    Deny { result: JsonValue },
+}
+
+impl JoinPolicyDecision {
+    fn kind(&self) -> &'static str {
+        match self {
+            JoinPolicyDecision::Allow => "allow",
+            JoinPolicyDecision::Deny { .. } => "deny",
+        }
+    }
+}
+
+/// Look up the active `join` policy, compile + evaluate it, and
+/// classify the result as allow / deny. Treats every error path
+/// as deny — a daemon misconfiguration must not silently accept
+/// applicants the operator hasn't authored a policy for.
+async fn evaluate_join_policy(
+    state: &AppState,
+    input: &JsonValue,
+) -> Result<JoinPolicyDecision, AppError> {
+    let active_id = get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Join).await?;
+    let id = match active_id {
+        Some(id) => id,
+        None => {
+            // M2.5's `install_defaults` should always have run by
+            // the time a request hits this path. Reaching here
+            // means the daemon is missing its default-policy
+            // bootstrap — fail closed.
+            warn!("no active join policy at submit time — refusing submission");
+            return Ok(JoinPolicyDecision::Deny {
+                result: json!({
+                    "error": "no active join policy",
+                }),
+            });
+        }
+    };
+    let policy = get_policy(&state.policies_ks, id)
+        .await?
+        .ok_or_else(|| AppError::Internal(format!("active join policy {id} not found")))?;
+
+    // Compile per call. Same trade-off as `POST
+    // /v1/policies/{id}/test` makes (M2.3.1) — regorus's parse is
+    // cheap and per-call compile keeps this path independent of
+    // M2.8's in-memory hot-swap cache, which hasn't landed yet.
+    let compiled = compile_policy(&policy.rego_source, policy.id)?;
+    let result = evaluate_policy(&compiled, "data.vtc.join.allow", input.clone())?;
+    let allow = result
+        .pointer("/result/0/expressions/0/value")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if allow {
+        Ok(JoinPolicyDecision::Allow)
+    } else {
+        Ok(JoinPolicyDecision::Deny { result })
+    }
 }
 
 /// Verify the Ed25519 signature over the canonical signing

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -24,9 +24,11 @@ use std::sync::LazyLock;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use serde_json::{Value as JsonValue, json};
 use tokio::sync::Mutex;
-use tracing::info;
+use tracing::{info, warn};
 
 use vti_common::audit::{AuditEvent, MemberRemovedData};
 use vti_common::error::AppError;
@@ -34,6 +36,10 @@ use vti_common::error::AppError;
 use crate::acl::{VtcRole, delete_acl_entry, get_acl_entry, list_acl_entries};
 use crate::auth::{AdminAuth, AuthClaims};
 use crate::members::{Disposition, delete_member, get_member, store_member};
+use crate::policy::{
+    PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy, get_active_policy_id,
+    get_policy,
+};
 use crate::server::AppState;
 
 /// Process-wide mutex that serialises every removal, self- and
@@ -84,6 +90,11 @@ pub async fn self_remove(
         // departure is the member's own decision and doesn't carry
         // an externally-meaningful justification field.
         String::new(),
+        // Self-remove is unconditional (spec §10.2) — bypasses
+        // the `removal.rego` allow gate. Disposition still
+        // routes through the policy when the member's preference
+        // is `PolicyDefault`.
+        false,
     )
     .await?;
     Ok((StatusCode::OK, Json(outcome)))
@@ -114,7 +125,15 @@ pub async fn admin_remove(
             reason.len(),
         )));
     }
-    let outcome = remove_inner(&state, &admin.0.did, &target_did, body.disposition, reason).await?;
+    let outcome = remove_inner(
+        &state,
+        &admin.0.did,
+        &target_did,
+        body.disposition,
+        reason,
+        true,
+    )
+    .await?;
     Ok((StatusCode::OK, Json(outcome)))
 }
 
@@ -127,12 +146,15 @@ pub async fn admin_remove(
 ///
 /// `actor_did` is the audit actor (self for self-remove, admin
 /// for admin-remove). `target_did` is the row being removed.
+/// `is_admin_remove` gates the `removal.rego` allow check —
+/// self-remove is unconditional per spec §10.2.
 pub async fn remove_inner(
     state: &AppState,
     actor_did: &str,
     target_did: &str,
     disposition: Option<Disposition>,
     reason: String,
+    is_admin_remove: bool,
 ) -> Result<RemoveResponse, AppError> {
     let audit_writer = state
         .audit_writer
@@ -145,14 +167,44 @@ pub async fn remove_inner(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
 
-    // Resolve disposition. Caller can override the member's
-    // departure_preference; if neither is set we fall through
-    // to PolicyDefault → Tombstone.
     let target_member = get_member(&state.members_ks, target_did).await?;
-    let resolved = disposition
+
+    // Phase 2 policy step (M2.7). Admin-remove evaluates the
+    // active `removal.rego` against the canonical input from
+    // spec §7.3. Self-remove bypasses (spec §10.2 makes it
+    // unconditional). The no-last-admin invariant + the route-
+    // layer AdminAuth gate run in addition to the policy check.
+    if is_admin_remove {
+        let input = json!({
+            "actor_did": actor_did,
+            "target_did": target_did,
+            "target_role": target_acl.role.to_string(),
+            "reason": reason,
+            "action": "remove",
+            "now": Utc::now().to_rfc3339(),
+        });
+        if !evaluate_removal_allow(state, &input).await? {
+            return Err(AppError::Forbidden(
+                "removal denied by policy (removal.rego.allow returned false)".into(),
+            ));
+        }
+    }
+
+    // Resolve disposition. Caller's request wins; member's
+    // departure_preference is the fallback; `PolicyDefault`
+    // consults the active `removal.rego`'s `min_disposition`
+    // output (Phase 1 plan §D6 placeholder). A non-decodable
+    // policy output falls back to `Tombstone` — the boring
+    // middle ground Phase 1 already used.
+    let initial = disposition
         .or_else(|| target_member.as_ref().map(|m| m.departure_preference))
-        .unwrap_or_default_disposition()
-        .resolve();
+        .unwrap_or(Disposition::PolicyDefault);
+    let resolved = match initial {
+        Disposition::PolicyDefault => resolve_min_disposition(state)
+            .await
+            .unwrap_or(Disposition::Tombstone),
+        other => other,
+    };
 
     // No-last-admin invariant.
     if matches!(target_acl.role, VtcRole::Admin) {
@@ -227,16 +279,67 @@ pub async fn remove_inner(
     })
 }
 
-// `Option<Disposition>::unwrap_or_default_disposition()` — small
-// extension that returns `PolicyDefault` when the option is
-// `None`. Hand-rolled so the call site reads linearly without an
-// `unwrap_or(Disposition::PolicyDefault)` literal everywhere.
-trait DispositionOption {
-    fn unwrap_or_default_disposition(self) -> Disposition;
+// ---------------------------------------------------------------------------
+// Policy helpers (M2.7)
+// ---------------------------------------------------------------------------
+
+/// Evaluate the active `removal.rego`'s `allow` rule. Fails closed
+/// on every error path — a daemon misconfiguration must not let
+/// removals through that the operator hasn't authored a policy
+/// for.
+async fn evaluate_removal_allow(state: &AppState, input: &JsonValue) -> Result<bool, AppError> {
+    let active_id = get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Removal).await?;
+    let id = match active_id {
+        Some(id) => id,
+        None => {
+            warn!("no active removal policy — refusing admin-remove");
+            return Ok(false);
+        }
+    };
+    let policy = get_policy(&state.policies_ks, id)
+        .await?
+        .ok_or_else(|| AppError::Internal(format!("active removal policy {id} not found")))?;
+    let compiled = compile_policy(&policy.rego_source, policy.id)?;
+    let result = evaluate_policy(&compiled, "data.vtc.removal.allow", input.clone())?;
+    Ok(result
+        .pointer("/result/0/expressions/0/value")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false))
 }
 
-impl DispositionOption for Option<Disposition> {
-    fn unwrap_or_default_disposition(self) -> Disposition {
-        self.unwrap_or(Disposition::PolicyDefault)
+/// Read `data.vtc.removal.min_disposition` and convert to a
+/// concrete `Disposition`. Returns `None` when no policy is active
+/// or the policy emits a non-string / unknown value — callers
+/// fall back to `Tombstone`.
+async fn resolve_min_disposition(state: &AppState) -> Option<Disposition> {
+    let active_id = get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Removal)
+        .await
+        .ok()
+        .flatten()?;
+    let policy = get_policy(&state.policies_ks, active_id)
+        .await
+        .ok()
+        .flatten()?;
+    let compiled = compile_policy(&policy.rego_source, policy.id).ok()?;
+    let result = evaluate_policy(
+        &compiled,
+        "data.vtc.removal.min_disposition",
+        JsonValue::Object(Default::default()),
+    )
+    .ok()?;
+    let s = result
+        .pointer("/result/0/expressions/0/value")
+        .and_then(|v| v.as_str())?;
+    match s {
+        "purge" => Some(Disposition::Purge),
+        "tombstone" => Some(Disposition::Tombstone),
+        "historical" => Some(Disposition::Historical),
+        other => {
+            warn!(
+                value = other,
+                "removal.rego min_disposition emitted an unknown disposition — using Tombstone"
+            );
+            None
+        }
     }
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -164,6 +164,18 @@ pub async fn run(
     let audit_ks = store.keyspace("audit")?;
     let audit_key_ks = store.keyspace("audit_key")?;
 
+    // M2.5: install the workspace-shipped default policies for any
+    // PolicyPurpose that lacks an active row. Idempotent — operator
+    // uploads are preserved verbatim. A failure here is non-fatal:
+    // policies are only evaluated by handlers that ship in M2.6+,
+    // and those handlers default-deny when the active pointer is
+    // missing, so a partial install still produces a safe daemon.
+    match crate::policy::default::install_defaults(&policies_ks, &active_policies_ks).await {
+        Ok(0) => debug!("default policies: every purpose already has an active row"),
+        Ok(n) => info!("installed {n} default policy(ies) at boot"),
+        Err(e) => warn!("failed to install default policies: {e}"),
+    }
+
     // Initialize auth infrastructure. Pass the audit keyspaces in so
     // `init_auth` can derive the HMAC audit key from the same secret
     // store contents it uses for the install signer.

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -43,6 +43,8 @@ const SUBMIT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/subm
 const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0";
 const APPROVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0";
 const REJECT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0";
+const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
+const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
 
 const ADMIN_DID: &str = "did:key:zAdmin1";
 
@@ -85,6 +87,14 @@ async fn build_fixture() -> Fixture {
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
+
+    // Install workspace-shipped default policies the same way
+    // `server::run` does at boot (M2.5). The submit handler
+    // (M2.6) evaluates `join.rego` against every submission,
+    // so an empty active-policy set would fail closed.
+    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
+        .await
+        .expect("install default policies");
 
     let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
 
@@ -619,6 +629,196 @@ async fn reject_rejects_overlong_reason() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// Auth gating sanity check
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// M2.6 — Policy step at submit time
+// ---------------------------------------------------------------------------
+
+/// Upload + activate a join policy that always denies. Returns
+/// nothing — the active pointer is flipped server-side and
+/// subsequent submits see the deny semantics.
+async fn activate_deny_all_join_policy(fix: &Fixture) {
+    let source = "package vtc.join\nimport rego.v1\n\ndefault allow := false\n";
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/policies",
+        POLICY_UPLOAD_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "purpose": "join", "regoSource": source })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "upload failed: {body}");
+    let id = body["id"].as_str().unwrap();
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/policies/{id}/activate"),
+        POLICY_ACTIVATE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "activate failed: {body}");
+}
+
+/// With the default `policies.open` join policy the submit
+/// handler routes through the policy step and lands the row as
+/// Pending. The `vpClaims` projection is populated from the VP
+/// on the request row.
+#[tokio::test]
+async fn rest_submit_under_default_join_policy_lands_pending_with_vp_claims() {
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({
+        "type": "VerifiablePresentation",
+        "holder": applicant_did,
+        "verifiableCredential": [
+            {
+                "issuer": "did:key:zIssuerA",
+                "type": ["VerifiableCredential", "EmailCredential"],
+                "credentialSubject": { "email": "applicant@example.com" }
+            }
+        ]
+    });
+    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": signature,
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "got {body}");
+    assert_eq!(body["status"], "pending");
+    let id = body["requestId"].as_str().unwrap();
+
+    // Fetch via admin show — `vpClaims` is on the persisted row.
+    let (status, row) = send(
+        &fix.router,
+        "GET",
+        &format!("/v1/join-requests/{id}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(row["status"], "pending");
+    assert!(
+        row["policyDecision"].is_null(),
+        "allow path must not populate policy_decision: {row}"
+    );
+    assert_eq!(row["vpClaims"]["holder"], applicant_did);
+    let creds = row["vpClaims"]["credentials"].as_array().unwrap();
+    assert_eq!(creds.len(), 1);
+    assert_eq!(creds[0]["issuer"], "did:key:zIssuerA");
+    assert_eq!(
+        creds[0]["credentialSubject"]["email"],
+        "applicant@example.com"
+    );
+}
+
+/// After activating a deny-all join policy, a fresh submission
+/// lands as Rejected and `policy_decision` carries the regorus
+/// QueryResults shape so admins can see why.
+#[tokio::test]
+async fn rest_submit_under_deny_all_policy_persists_rejected_with_decision() {
+    let fix = build_fixture().await;
+    activate_deny_all_join_policy(&fix).await;
+
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
+    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": signature,
+        })),
+    )
+    .await;
+    // Submission still 201 — the row persists either way; the
+    // status field is the decision channel.
+    assert_eq!(status, StatusCode::CREATED, "got {body}");
+    assert_eq!(body["status"], "rejected");
+    let id = body["requestId"].as_str().unwrap();
+
+    let (status, row) = send(
+        &fix.router,
+        "GET",
+        &format!("/v1/join-requests/{id}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(row["status"], "rejected");
+    // `policyDecision` is the regorus QueryResults shape — at
+    // minimum it carries a `result` array with the rule's value.
+    let decision = &row["policyDecision"];
+    let value = decision
+        .pointer("/result/0/expressions/0/value")
+        .expect("policy_decision should carry regorus QueryResults");
+    assert_eq!(value, &json!(false));
+}
+
+/// Trying to re-approve a policy-rejected row fails the same way
+/// admin-rejected ones do (409 already decided). Confirms the
+/// policy-deny path uses the same JoinStatus::Rejected sink.
+#[tokio::test]
+async fn policy_rejected_row_cannot_be_approved() {
+    let fix = build_fixture().await;
+    activate_deny_all_join_policy(&fix).await;
+
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
+    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": signature,
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "got {body}");
+    let id = body["requestId"].as_str().unwrap();
+
+    let (status, _body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/approve"),
+        APPROVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -32,6 +32,8 @@ use vtc_service::server::AppState;
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const SELF_REMOVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0";
 const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/show/1.0";
+const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
+const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
 
 const ADMIN_DID: &str = "did:key:zAdmin1";
 
@@ -74,6 +76,15 @@ async fn build_fixture() -> Fixture {
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
+
+    // Install workspace default policies the same way `server::run`
+    // does at boot (M2.5). The admin-remove handler (M2.7)
+    // consults `removal.rego.allow` and the disposition resolver
+    // reads `removal.rego.min_disposition`; an empty policy set
+    // would fail closed.
+    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
+        .await
+        .expect("install default policies");
 
     let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
 
@@ -483,25 +494,19 @@ async fn admin_remove_self_refused_with_self_remove_hint() {
 }
 
 #[tokio::test]
-async fn admin_remove_refused_for_last_admin() {
+async fn admin_remove_of_admin_target_is_denied_by_default_policy() {
     let fix = build_fixture().await;
-    // Add a second admin, then have the second admin try to
-    // remove the first via the admin path. With both removed
-    // the community would still have one admin (the caller),
-    // so this should succeed. Instead, set up a case where
-    // the target IS the last admin: caller is also admin, two
-    // admins exist, the caller removes the other — that leaves
-    // one admin (the caller). So that's the *success* case.
+    // Phase 2 M2.7 wires `removal.rego` into the admin-remove
+    // path. The default removal policy (spec §7.1) denies
+    // `target_role == "admin"` — admins should only be removed
+    // via promotion + step-up UV (spec §10.4 / §5.3), never via
+    // a casual admin-remove. This used to be a 200 in Phase 1
+    // because there was no policy step.
     //
-    // The actual failure case for admin-remove + last-admin:
-    // there's exactly one admin and a non-admin caller tries to
-    // remove them. But admin-remove requires AdminAuth, so the
-    // only caller IS the last admin — and they can't remove
-    // themselves via this endpoint. The invariant therefore
-    // can never fail via the admin-remove path with the current
-    // role taxonomy.
-    //
-    // Confirm the happy two-admin case anyway:
+    // The no-last-admin invariant is now unreachable through
+    // admin-remove for a different reason: every removable
+    // target has role != "admin", so the invariant guard never
+    // fires in this path.
     let second_admin = "did:key:zSecondAdmin";
     let _ = seed_member_with_session(&fix, second_admin, VtcRole::Admin).await;
 
@@ -514,10 +519,21 @@ async fn admin_remove_refused_for_last_admin() {
         Some(json!({ "reason": "ouster" })),
     )
     .await;
-    assert_eq!(status, StatusCode::OK, "got {body}");
-    // Original admin remains.
+    assert_eq!(status, StatusCode::FORBIDDEN, "got {body}");
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("removal denied by policy"),
+        "error body should explain the policy denial: {body}"
+    );
+    // Both admins still present — the policy denied the change.
     assert!(
         get_acl_entry(&fix.acl_ks, ADMIN_DID)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        get_acl_entry(&fix.acl_ks, second_admin)
             .await
             .unwrap()
             .is_some()
@@ -555,4 +571,104 @@ async fn admin_remove_overlong_reason_rejected() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// M2.7 — policy step at admin-remove time
+// ---------------------------------------------------------------------------
+
+/// Upload + activate a removal policy via the admin endpoints.
+/// `source` is the full Rego module body.
+async fn activate_removal_policy(fix: &Fixture, source: &str) {
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/policies",
+        POLICY_UPLOAD_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "purpose": "removal", "regoSource": source })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "upload failed: {body}");
+    let id = body["id"].as_str().unwrap();
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/policies/{id}/activate"),
+        POLICY_ACTIVATE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "activate failed: {body}");
+}
+
+/// A deny-all custom removal.rego blocks admin-remove even for
+/// non-admin targets. Confirms the policy gate runs in front of
+/// the legacy disposition path.
+#[tokio::test]
+async fn admin_remove_member_blocked_by_deny_all_policy() {
+    let fix = build_fixture().await;
+    activate_removal_policy(
+        &fix,
+        "package vtc.removal\nimport rego.v1\n\ndefault allow := false\n",
+    )
+    .await;
+
+    let target = "did:key:zVictim2";
+    let _ = seed_member_with_session(&fix, target, VtcRole::Member).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        &format!("/v1/members/{target}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "reason": "policy gate test" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "got {body}");
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("removal denied by policy"),
+        "error body should explain the policy denial: {body}"
+    );
+    // Target still present — policy denied the change.
+    assert!(get_acl_entry(&fix.acl_ks, target).await.unwrap().is_some());
+}
+
+/// `min_disposition := "purge"` on the active removal.rego
+/// resolves `PolicyDefault` → `Purge`, replacing Phase 1's
+/// hardcoded Tombstone fallback (Phase 1 plan §D6 placeholder).
+#[tokio::test]
+async fn admin_remove_uses_policy_min_disposition_for_default() {
+    let fix = build_fixture().await;
+    activate_removal_policy(
+        &fix,
+        "package vtc.removal\nimport rego.v1\n\n\
+         default allow := false\n\
+         allow if {\n  input.action == \"remove\"\n  input.target_role != \"admin\"\n}\n\
+         default min_disposition := \"purge\"\n",
+    )
+    .await;
+
+    let target = "did:key:zPurgeMe";
+    let _ = seed_member_with_session(&fix, target, VtcRole::Member).await;
+
+    // Caller does not pass `disposition`; member's preference is
+    // `PolicyDefault` (the join-time default) → resolver consults
+    // the policy → resolves to Purge → Member row is deleted.
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        &format!("/v1/members/{target}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["disposition"], "purge");
+    // ACL and member both gone (purge semantic).
+    assert!(get_acl_entry(&fix.acl_ks, target).await.unwrap().is_none());
 }


### PR DESCRIPTION
## Summary

Second PR of Phase 2. Lights up the policy engine end-to-end:
9 default policies + 2 handler wire-ups that route every join
submission and admin-remove through `regorus` before mutating
state.

Bundles three milestones per the plan's PR-2 slicing:

| Milestone | What it adds |
|---|---|
| **M2.5** | 9 default Rego policies under `vtc-service/policies/default/` + idempotent boot-time installer |
| **M2.6** | `join.rego` wired into submit + canonical `vp_claims` extractor (D4) |
| **M2.7** | `removal.rego` wired into admin-remove (`allow` + `min_disposition` resolver) |

## Default policies (M2.5)

Following spec §7.1's table:

| Purpose | Default behaviour |
|---|---|
| join | `policies.open` — accept any well-formed submission |
| removal | Admin may remove any non-admin; `min_disposition := "tombstone"` |
| personhood | Deny-all stub (Phase 4 endpoints) |
| registry | publish-on-join + `default_departure := "tombstone"` |
| directory | Members see DID + role only |
| role_definitions | Spec §5.3 matrix for standard roles; Custom roles deny |
| cross_community_roles | Deny-all |
| cross_community_relationships | Deny-all |
| relationships | Allow iff both parties are current members |

Each .rego is `include_str!`'d into the binary so there's no
runtime filesystem read. `install_defaults` runs idempotently
in `server::run` after keyspace open — only fills purposes
without an active policy, so operator uploads are never
overwritten.

**No audit emission** for default installs. `PolicyUploaded` /
`PolicyActivated` record *operator* decisions; a default-install
fires because the daemon booted empty, not because someone did
anything. The `authorDid: "did:key:vtc-defaults"` marker on each
row surfaces the distinction in `GET /v1/policies`.

## Submit policy step (M2.6)

`submit_inner` (REST + DIDComm) now evaluates the active
`join.rego` against spec §7.3's canonical input:

```
{ applicant_did, vp_claims, action: "join", now }
```

- `allow` → row lands `Pending` + audit `JoinRequestSubmitted`
  (current behaviour, unchanged).
- `deny` → row lands `Rejected` + `policy_decision` carries
  the regorus QueryResults JSON + audit `JoinRequestRejected`
  with the canonical reason marker `"policy denied"` so SIEM
  can distinguish admin rejections from policy rejections.

`vp_claims` extraction (plan §D4): a canonical projection of
the VP's `holder` + each `verifiableCredential`'s `issuer` /
`type` / `credentialSubject`. Stored on the `JoinRequest` row
alongside the raw `vp`. JWT-encoded VCs and non-object VPs
project to empty (full VP cryptographic verification deferred —
the holder-binding signature at the route layer already
authenticates the submitter).

## Admin-remove policy step (M2.7)

`admin_remove` evaluates the active `removal.rego` against:

```
{ actor_did, target_did, target_role, reason, action: "remove",
  now }
```

- `allow` → ACL + Member mutated per resolved disposition.
- `deny` → 403 `"removal denied by policy"`. No state change.

Self-remove keeps its spec §10.2 unconditional semantic and
bypasses the `allow` gate. The DIDComm self-remove twin
follows suit.

Phase 1 plan §D6 placeholder upgraded: `PolicyDefault` now
reads `data.vtc.removal.min_disposition` from the active
policy instead of hardcoding Tombstone. The default `removal.
rego` emits `default min_disposition := "tombstone"` so
existing operator state survives unchanged. A non-decodable
policy output (or no active policy) falls back to Tombstone.

### Behavioural change worth flagging

The default `removal.rego` denies `target_role == "admin"`:
admins should only be removed via promotion + step-up UV
(spec §5.3 / §10.4 don't list admin demotion as a routine
action). Phase 1 happily removed any non-self admin target as
long as the no-last-admin invariant held; Phase 2 + default
policy returns 403 instead.

The `admin_remove_refused_for_last_admin` test is renamed +
updated to document this:
`admin_remove_of_admin_target_is_denied_by_default_policy`.
Operators who want the old behaviour upload a stricter custom
policy.

## Fail-closed safety

Both handlers default-deny when no active policy is present.
`install_defaults` should always run at boot, so reaching the
deny-on-missing path means the daemon is misconfigured —
loud `warn!` log surfaces it.

## Tests

- **+15 unit tests** in `policy::default::tests` covering every
  default's input contract + the installer's idempotence +
  operator-policy preservation.
- **+8 unit tests** in `policy::extract::tests` covering the
  VP projection shape (empty VP, holder-as-string vs object,
  multi-VC array, JWT-encoded VCs skipped).
- **+3 integration tests** in `tests/join_requests.rs`:
  default policy → Pending + vpClaims populated; deny-all
  custom policy → Rejected + policy_decision populated;
  policy-rejected rows can't be approved.
- **+2 integration tests** in `tests/removal.rs`: deny-all
  custom policy → 403; `min_disposition := "purge"` →
  `PolicyDefault` resolves to Purge.
- **1 renamed**: `admin_remove_refused_for_last_admin` →
  `admin_remove_of_admin_target_is_denied_by_default_policy`.

Existing fixtures in `tests/join_requests.rs` + `tests/removal.rs`
gained an `install_defaults` call to mirror the production
boot path.

## Test plan

- [x] `cargo test -p vtc-service` green (260+ tests).
- [x] `cargo test -p vti-common audit::` green.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- [ ] Review the admin-target-denial behavioural change — is
  the default `removal.rego` the right shape, or should
  the workspace ship a slightly looser default?
- [ ] Approve the policy gating before M2.9 (VC builder)
  starts.

## Commits

1. \`9f3e305\` — M2.5 bundle 9 default policies
2. \`4e1cd88\` — M2.6 wire join.rego into submit
3. \`457c35b\` — M2.7 wire removal.rego into admin-remove

Once this PR merges, M2.9 (VC builder + local signer) starts
on a fresh branch.