### PR TITLE
feat(vtc-service): Phase 2 PR 3 — VC builder + status-list infrastructure (M2.9–M2.11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9184,10 +9184,13 @@ name = "vtc-service"
 version = "0.6.0"
 dependencies = [
  "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
+ "affinidi-secrets-resolver",
  "affinidi-tdk",
+ "affinidi-vc",
  "async-trait",
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-status-list"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7519418d6004ad52e67a7b23fb6171bd91b5bcd9ccc26e44fefcc8ba1452fcd"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "affinidi-tdk"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9189,6 +9204,7 @@ dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
  "affinidi-secrets-resolver",
+ "affinidi-status-list",
  "affinidi-tdk",
  "affinidi-vc",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ affinidi-crypto = "0.1"
 # admin authorization). See CLAUDE.md "Authorization claims" principle.
 affinidi-vc = "0.1"
 affinidi-data-integrity = "0.6"
+affinidi-status-list = "0.1"
 affinidi-secrets-resolver = "0.5"
 affinidi-messaging-didcomm-service = "0.3"
 

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -230,7 +230,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.10 — Status-list infrastructure
 
-### `[ ]` M2.10.1 — `status_lists` keyspace + reserved-index allocator
+### `[x]` M2.10.1 — `status_lists` keyspace + reserved-index allocator
 
 - **Acceptance**
   - `StatusListState { purpose, capacity, next_random_seed,

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -201,7 +201,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.9 — VC builder + local signer
 
-### `[ ]` M2.9.1 — `vtc_service::credentials` module
+### `[x]` M2.9.1 — `vtc_service::credentials` module
 
 - **Acceptance**
   - `affinidi-vc` + `affinidi-data-integrity` added as

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -258,7 +258,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.11 — Status-list publication route
 
-### `[ ]` M2.11.1 — `GET /v1/status-lists/{purpose}`
+### `[x]` M2.11.1 — `GET /v1/status-lists/{purpose}`
 
 - **Acceptance**
   - Public, unauthenticated, Trust-Task-exempt (verifier-

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -222,6 +222,13 @@
       "status": "Draft",
       "path": "policies/show/1.0",
       "rest": "GET /v1/policies/{id}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/status-lists/show/1.0",
+      "status": "Draft",
+      "path": "status-lists/show/1.0",
+      "rest": "GET /v1/status-lists/{purpose}",
+      "trust_task_header_exempt": true
     }
   ]
 }

--- a/trust-tasks/status-lists/show/1.0/schema.json
+++ b/trust-tasks/status-lists/show/1.0/schema.json
@@ -1,0 +1,46 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/status-lists/show/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Status Lists — Show",
+  "type": "object",
+  "properties": {
+    "response": {
+      "$ref": "#/$defs/BitstringStatusListCredential"
+    }
+  },
+  "$defs": {
+    "BitstringStatusListCredential": {
+      "type": "object",
+      "required": ["@context", "id", "type", "issuer", "validFrom", "credentialSubject", "proof"],
+      "properties": {
+        "@context": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "id": { "type": "string", "format": "uri" },
+        "type": {
+          "type": "array",
+          "items": { "type": "string" },
+          "contains": { "const": "BitstringStatusListCredential" }
+        },
+        "issuer": { "type": "string" },
+        "validFrom": { "type": "string", "format": "date-time" },
+        "credentialSubject": {
+          "type": "object",
+          "required": ["id", "type", "statusPurpose", "encodedList"],
+          "properties": {
+            "id": { "type": "string", "format": "uri" },
+            "type": { "const": "BitstringStatusList" },
+            "statusPurpose": {
+              "type": "string",
+              "enum": ["revocation", "suspension"]
+            },
+            "encodedList": { "type": "string" }
+          }
+        },
+        "proof": { "type": "object" }
+      }
+    }
+  }
+}

--- a/trust-tasks/status-lists/show/1.0/spec.md
+++ b/trust-tasks/status-lists/show/1.0/spec.md
@@ -1,0 +1,82 @@
+---
+id: https://trusttasks.org/openvtc/vtc/status-lists/show/1.0
+title: VTC Status Lists — Show
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/status-lists/{purpose}
+trust_task_header_exempt: true
+---
+
+# VTC Status Lists — Show
+
+Returns the freshly-signed `BitstringStatusListCredential` for
+one of the two status purposes the VTC maintains. Verifier-
+facing — external verifiers fetch this endpoint as part of the
+standard W3C status-list-v1 resolution flow.
+
+## Trust-Task-exempt
+
+This endpoint **does not** require the `Trust-Task` header.
+W3C status-list resolution is the standard verification flow
+external verifiers follow; carrying our extension header would
+break interoperability. The exemption mirrors
+`/v1/{scid}/did.jsonl` (DID resolver fetches).
+
+## Path parameters
+
+- `purpose` (required) — `revocation` or `suspension`. Other
+  values surface as 404.
+
+## Response (`200 OK`)
+
+The response body is a signed `BitstringStatusListCredential`
+per W3C Bitstring Status List v1.0:
+
+```
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2"],
+  "id": "<canonical list URL>",
+  "type": ["VerifiableCredential", "BitstringStatusListCredential"],
+  "issuer": "<vtc_did>",
+  "validFrom": "<rfc3339>",
+  "credentialSubject": {
+    "id": "<list URL>#list",
+    "type": "BitstringStatusList",
+    "statusPurpose": "revocation",
+    "encodedList": "<gzip + base64url>"
+  },
+  "proof": { … data-integrity proof … }
+}
+```
+
+The proof is signed by the VTC's `#key-0` Ed25519
+(`eddsa-jcs-2022` data integrity). The encoded list is
+GZIP+base64url per W3C.
+
+### `Cache-Control: no-store`
+
+Status-list flips land in real time on the local fjall row.
+Caching the response between the VTC and a verifier would mask
+recent revocations, so the response carries `Cache-Control:
+no-store`. Operators who deploy a CDN in front of the VTC must
+preserve this header.
+
+## Errors
+
+- `404 Not Found` — `{purpose}` is neither `revocation` nor
+  `suspension`, or the daemon hasn't provisioned this purpose
+  yet (pre-`public_url` deployment).
+- `503 Service Unavailable` — credential signer not initialised
+  (the VTC has no key material).
+
+## Notes
+
+- The VC's `validFrom` is `now()` at every request — the VC is
+  signed fresh per request. This is intentional: stale flips
+  cannot linger in a CDN.
+- Index allocation is random with decoys per spec §6.2. The
+  encoded bitstring leaks neither the active member count nor
+  any specific member's slot.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -50,6 +50,13 @@ vta-sdk = { path = "../vta-sdk", version = "0.6", features = [
 ] }
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm-service = { workspace = true }
+# W3C VC builder + Data Integrity proof signing/verification. Used
+# by `crate::credentials` for VMC + VEC issuance (Phase 2 M2.9).
+# Same crates as `vta-sdk::provision_integration::credential` —
+# canonical workspace path for credential issuance.
+affinidi-vc = { workspace = true }
+affinidi-data-integrity = { workspace = true }
+affinidi-secrets-resolver = { workspace = true }
 # Lower-level DIDComm message types — needed for the join-request
 # message handler in `messaging.rs` (M1.8.2). The service crate
 # accepts `Message` / `UnpackMetadata` by value but doesn't

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -57,6 +57,9 @@ affinidi-messaging-didcomm-service = { workspace = true }
 affinidi-vc = { workspace = true }
 affinidi-data-integrity = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
+# Bitstring status list — privacy-preserving credential revocation
+# per W3C. Used by `crate::status_list` (Phase 2 M2.10).
+affinidi-status-list = { workspace = true }
 # Lower-level DIDComm message types — needed for the join-request
 # message handler in `messaging.rs` (M1.8.2). The service crate
 # accepts `Message` / `UnpackMetadata` by value but doesn't

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -1,0 +1,73 @@
+//! Credentials issued by the VTC — Phase 2 M2.9.
+//!
+//! Spec §6.1's DTG catalog. This module covers the two
+//! credentials Phase 2 mints from a member-side action:
+//!
+//! - **VMC** ([`vmc`]) — Verifiable Membership Credential. One per
+//!   member, re-minted on join + every renewal. Bounded
+//!   `validUntil` per spec §3-F.
+//! - **VEC** ([`vec`]) — Verifiable Endorsement Credential, used
+//!   for role grants (`endorsement = { type: "CommunityRole",
+//!   role, communityDid }`). Re-issued on every role change.
+//!
+//! Both are signed locally via [`LocalSigner`] — plan §D1's
+//! "cached-locally, VTA-controlled" model. The VTC's `#key-0`
+//! Ed25519 secret already lives in the secret store; no per-call
+//! VTA round-trip.
+//!
+//! ## Why M2.9 is one PR-sized module
+//!
+//! The two credential builders share their signing path,
+//! validity-window plumbing, and `@context`-URL handling. They
+//! also share their test-fixture pattern (deterministic seed →
+//! known issuer DID + verify the proof with the matching
+//! public key). Keeping the surface together means the M2.12
+//! issuance step (VMC + VEC on approve) and the M2.13 renewal
+//! step both reach for one canonical module.
+//!
+//! ## Shape parity with `vta-sdk::provision_integration::credential`
+//!
+//! The reference implementation in the VTA SDK signs a
+//! `VtaAuthorizationCredential` the same way: `CredentialBuilder`
+//! → `DataIntegrityProof::sign(&vc, &secret, …)` → attach proof.
+//! We follow that pattern verbatim so the workspace has exactly
+//! one canonical way to sign a VC.
+//!
+//! ## Status-list credentialStatus
+//!
+//! The VMC builder accepts an optional [`CredentialStatusRef`].
+//! When present, the VMC carries a `credentialStatus` block
+//! pointing at the relevant BitstringStatusList entry. M2.9
+//! lands the *shape*; M2.10 + M2.11 populate the URL +
+//! index from a live status-list registry. M2.9 alone can be
+//! exercised with the optional left as `None` — the resulting
+//! VMC has no `credentialStatus`, which is the expected
+//! pre-status-list state in tests.
+
+pub mod signer;
+pub mod vec;
+pub mod vmc;
+
+pub use signer::LocalSigner;
+pub use vec::{RoleVecParams, build_role_vec};
+pub use vmc::{CredentialStatusRef, VmcParams, build_vmc};
+
+/// Default validity for a freshly-minted VMC when the caller
+/// doesn't override. Mirrors spec §3-F's "default 30d" — short
+/// enough that a leaked credential expires in a useful window,
+/// long enough that legitimate verifiers don't trip over expiry
+/// on a casual cadence. Operators tighten via configuration.
+pub const DEFAULT_VMC_VALIDITY: chrono::Duration = chrono::Duration::days(30);
+
+/// `@context` URL the VMC ships under.
+///
+/// Matches the JSON-LD context the workspace publishes under
+/// `https://openvtc.org/contexts/`. The JSON-LD context body
+/// plus an offline-includable copy land in a follow-up; for
+/// M2.9 the URL is referenced by string only.
+/// `DataIntegrityProof`'s JCS canonicalisation doesn't need
+/// the context to resolve.
+pub const VMC_CONTEXT_URL: &str = "https://openvtc.org/contexts/dtg-membership-v1.jsonld";
+
+/// `@context` URL for VECs (role grants + custom endorsements).
+pub const VEC_CONTEXT_URL: &str = "https://openvtc.org/contexts/dtg-endorsement-v1.jsonld";

--- a/vtc-service/src/credentials/signer.rs
+++ b/vtc-service/src/credentials/signer.rs
@@ -1,0 +1,168 @@
+//! `LocalSigner` — plan §D1's cached-locally signing surface.
+//!
+//! Wraps the VTC's `#key-0` Ed25519 secret in the shape
+//! [`affinidi_data_integrity::DataIntegrityProof::sign`] wants.
+//! The secret already lives in the secret store (loaded at boot
+//! from `VtcKeyBundle` per `tasks/vtc-mvp/vta-driven-keys.md`); the
+//! signer is a thin handle that pairs it with the VTC's issuer
+//! DID so callers don't have to plumb both through every builder.
+//!
+//! ## Why not just pass `&Secret` directly
+//!
+//! Three reasons we wrap:
+//! 1. **Issuer-DID coupling.** Every VC the VTC signs has
+//!    `issuer = vtc_did`. Pairing the DID with the secret in one
+//!    handle means the VMC + VEC builders don't have to take both
+//!    and the caller can't pass mismatched values.
+//! 2. **Assertion-method id.** `secret.id` is the
+//!    `verificationMethod` URI the proof carries. Building it
+//!    once at construction (`{vtc_did}#key-0`) keeps the wire
+//!    shape consistent.
+//! 3. **Test fixtures.** Tests want a "from seed bytes" shortcut
+//!    that doesn't go through the keyring / secrets-resolver
+//!    plumbing. [`LocalSigner::from_ed25519_seed`] gives them
+//!    that without exposing the wrapper internals.
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions, VerifyOptions};
+use affinidi_secrets_resolver::secrets::Secret;
+use affinidi_vc::VerifiableCredential;
+use vti_common::error::AppError;
+
+/// Verification-method fragment the VTC consistently uses for
+/// its assertion-method key. Lines up with what
+/// `server::init_auth` stamps onto the secret at boot
+/// (`{vtc_did}#key-0`).
+pub const ASSERTION_KEY_FRAGMENT: &str = "key-0";
+
+/// A local signer wrapping the VTC's `#key-0` Ed25519 secret.
+/// Constructed once at boot from the secret store and shared via
+/// `AppState`; cloning is cheap (the inner secret is a small
+/// owned struct).
+#[derive(Debug, Clone)]
+pub struct LocalSigner {
+    issuer_did: String,
+    secret: Secret,
+}
+
+impl LocalSigner {
+    /// Construct from a fully-formed [`Secret`]. Caller is
+    /// responsible for ensuring `secret.id` is
+    /// `{issuer_did}#key-0` — the helpers below all enforce
+    /// this; this constructor exists for callers that already
+    /// did the work (e.g. the boot path that read the secret
+    /// out of [`affinidi_secrets_resolver::ThreadedSecretsResolver`]).
+    pub fn new(issuer_did: String, secret: Secret) -> Self {
+        Self { issuer_did, secret }
+    }
+
+    /// Construct from 32 raw Ed25519 seed bytes. The resulting
+    /// signer's `secret.id` is `{issuer_did}#key-0`. Used by
+    /// tests + the boot path that decodes a `VtcKeyBundle`.
+    pub fn from_ed25519_seed(issuer_did: String, seed: &[u8; 32]) -> Self {
+        let assertion_id = assertion_method_id(&issuer_did);
+        let secret = Secret::generate_ed25519(Some(&assertion_id), Some(seed));
+        Self { issuer_did, secret }
+    }
+
+    /// VTC issuer DID — stamped on every credential's `issuer`
+    /// field.
+    pub fn issuer_did(&self) -> &str {
+        &self.issuer_did
+    }
+
+    /// `verificationMethod` URI the proof carries.
+    pub fn assertion_method_id(&self) -> &str {
+        &self.secret.id
+    }
+
+    /// Bytes-on-the-wire public key, useful to tests that want
+    /// to verify a freshly-signed VC without going through the
+    /// did resolver.
+    pub fn public_bytes(&self) -> &[u8] {
+        self.secret.get_public_bytes()
+    }
+
+    /// Sign the supplied VC in place. Appends the
+    /// `DataIntegrityProof` to `vc.proof`. Returns
+    /// [`AppError::Internal`] on signing failure — every error
+    /// the data-integrity layer surfaces is a workspace bug
+    /// (wrong key type, canonicalisation crash, etc.) rather
+    /// than operator input.
+    pub async fn sign(&self, vc: &mut VerifiableCredential) -> Result<(), AppError> {
+        let proof = DataIntegrityProof::sign(vc, &self.secret, SignOptions::new())
+            .await
+            .map_err(|e| AppError::Internal(format!("sign VC: {e}")))?;
+        vc.proof = Some(
+            serde_json::to_value(&proof)
+                .map_err(|e| AppError::Internal(format!("serialize VC proof: {e}")))?,
+        );
+        Ok(())
+    }
+
+    /// Verify a previously-signed VC against this signer's public
+    /// key. Used by tests + the M2.13 renewal path that hands
+    /// freshly-issued VCs to verifiers. Returns `Ok(())` on
+    /// success, [`AppError::Validation`] when the proof is
+    /// missing or malformed, [`AppError::Forbidden`] when the
+    /// signature does not verify.
+    pub fn verify(&self, vc: &VerifiableCredential) -> Result<(), AppError> {
+        let proof_value = vc
+            .proof
+            .as_ref()
+            .ok_or_else(|| AppError::Validation("VC has no proof to verify".into()))?;
+        let proof: DataIntegrityProof = serde_json::from_value(proof_value.clone())
+            .map_err(|e| AppError::Validation(format!("parse VC proof: {e}")))?;
+
+        let mut vc_without_proof = vc.clone();
+        vc_without_proof.proof = None;
+
+        proof
+            .verify_with_public_key(&vc_without_proof, self.public_bytes(), VerifyOptions::new())
+            .map_err(|e| AppError::Forbidden(format!("verify VC: {e}")))?;
+        Ok(())
+    }
+}
+
+/// `{did}#key-0` — the conventional assertion-method id for the
+/// VTC. Re-exposed here so the VMC + VEC builders compose the
+/// same URI without re-deriving it from `LocalSigner` every
+/// time.
+pub fn assertion_method_id(issuer_did: &str) -> String {
+    format!("{issuer_did}#{ASSERTION_KEY_FRAGMENT}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_DID: &str = "did:webvh:vtc.example.com:abc";
+
+    #[test]
+    fn from_seed_constructs_with_canonical_kid() {
+        let seed = [0xAB; 32];
+        let signer = LocalSigner::from_ed25519_seed(TEST_DID.into(), &seed);
+        assert_eq!(signer.issuer_did(), TEST_DID);
+        assert_eq!(
+            signer.assertion_method_id(),
+            format!("{TEST_DID}#{ASSERTION_KEY_FRAGMENT}")
+        );
+        // Public key bytes deterministic for the seed.
+        let other = LocalSigner::from_ed25519_seed(TEST_DID.into(), &seed);
+        assert_eq!(signer.public_bytes(), other.public_bytes());
+    }
+
+    #[test]
+    fn different_seeds_produce_different_public_keys() {
+        let a = LocalSigner::from_ed25519_seed(TEST_DID.into(), &[0xAB; 32]);
+        let b = LocalSigner::from_ed25519_seed(TEST_DID.into(), &[0xCD; 32]);
+        assert_ne!(a.public_bytes(), b.public_bytes());
+    }
+
+    #[test]
+    fn assertion_method_id_is_did_hash_fragment() {
+        assert_eq!(
+            assertion_method_id("did:key:zX"),
+            "did:key:zX#key-0".to_string()
+        );
+    }
+}

--- a/vtc-service/src/credentials/vec.rs
+++ b/vtc-service/src/credentials/vec.rs
@@ -1,0 +1,183 @@
+//! Verifiable Endorsement Credential builder — spec §6.1 / M2.9.
+//!
+//! Used for role grants ("admin", "moderator", …) and — in
+//! Phase 3+ — community-defined endorsement values. The role
+//! VEC's `endorsement` field follows spec §6.1's shape:
+//!
+//! ```json
+//! {
+//!   "endorsement": {
+//!     "type": "CommunityRole",
+//!     "role": "admin",
+//!     "communityDid": "did:webvh:vtc.example.com:abc"
+//!   }
+//! }
+//! ```
+//!
+//! The credential is re-issued on every role change (spec §6.1)
+//! and on every renewal (spec §6.3 step 2) so the external chain
+//! stays consistent.
+
+use affinidi_vc::{CredentialBuilder, VerifiableCredential};
+use chrono::{Duration, Utc};
+use serde_json::{Map, Value as JsonValue, json};
+use vti_common::error::AppError;
+
+use crate::acl::VtcRole;
+
+use super::LocalSigner;
+use super::VEC_CONTEXT_URL;
+
+/// Type the VEC's `type` array carries alongside
+/// `VerifiableCredential`. Spec §6.1 names this credential the
+/// "Verifiable Endorsement Credential"; role grants are one
+/// canonical shape.
+pub const VEC_TYPE: &str = "VerifiableEndorsementCredential";
+
+/// `endorsement.type` value for a role-grant VEC. Custom
+/// endorsements (Phase 3+) use community-defined types.
+pub const COMMUNITY_ROLE_ENDORSEMENT_TYPE: &str = "CommunityRole";
+
+/// Default validity for a freshly-minted role VEC. Mirrors the
+/// VMC default (30d). Operators tighten via configuration.
+pub const DEFAULT_ROLE_VEC_VALIDITY: Duration = Duration::days(30);
+
+/// Parameters for [`build_role_vec`].
+#[derive(Debug, Clone)]
+pub struct RoleVecParams {
+    /// Subject DID — the member receiving the role grant.
+    pub member_did: String,
+    /// The role being granted. Spec §5.3 names four standard
+    /// roles + `Custom(String)`; all five surface here via
+    /// [`VtcRole::to_string`].
+    pub role: VtcRole,
+    /// `validUntil = now + validity`. Same default as VMC.
+    pub validity: Duration,
+}
+
+impl RoleVecParams {
+    pub fn new(member_did: impl Into<String>, role: VtcRole) -> Self {
+        Self {
+            member_did: member_did.into(),
+            role,
+            validity: DEFAULT_ROLE_VEC_VALIDITY,
+        }
+    }
+
+    pub fn with_validity(mut self, validity: Duration) -> Self {
+        self.validity = validity;
+        self
+    }
+}
+
+/// Build + sign a role VEC. `issuer = signer.issuer_did()`.
+pub async fn build_role_vec(
+    signer: &LocalSigner,
+    params: RoleVecParams,
+) -> Result<VerifiableCredential, AppError> {
+    let now = Utc::now();
+    let valid_until = now + params.validity;
+
+    let endorsement = json!({
+        "type": COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+        "role": params.role.to_string(),
+        "communityDid": signer.issuer_did(),
+    });
+
+    let mut subject = Map::new();
+    subject.insert("id".into(), JsonValue::String(params.member_did.clone()));
+    subject.insert("endorsement".into(), endorsement);
+
+    let mut vc = CredentialBuilder::v2()
+        .context(VEC_CONTEXT_URL)
+        .issuer_uri(signer.issuer_did().to_string())
+        .add_type(VEC_TYPE)
+        .valid_from(rfc3339(now))
+        .valid_until(rfc3339(valid_until))
+        .subject(subject)
+        .build()
+        .map_err(|e| AppError::Internal(format!("VEC build: {e}")))?;
+
+    signer.sign(&mut vc).await?;
+    Ok(vc)
+}
+
+fn rfc3339(t: chrono::DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_vc::SubjectValue;
+
+    const TEST_VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+    const MEMBER_DID: &str = "did:key:zMember1";
+
+    fn signer() -> LocalSigner {
+        LocalSigner::from_ed25519_seed(TEST_VTC_DID.into(), &[0xBB; 32])
+    }
+
+    fn subject_map(vc: &VerifiableCredential) -> Map<String, JsonValue> {
+        match &vc.credential_subject {
+            SubjectValue::Single(m) => m.clone(),
+            SubjectValue::Multiple(v) => v[0].clone(),
+        }
+    }
+
+    /// Build + verify a VEC for each standard role. Spec §5.3's
+    /// matrix covers Admin/Moderator/Issuer/Member; Custom is
+    /// the open-ended fifth variant.
+    #[tokio::test]
+    async fn role_vec_round_trips_for_each_standard_role() {
+        let signer = signer();
+        let cases = [
+            (VtcRole::Admin, "admin"),
+            (VtcRole::Moderator, "moderator"),
+            (VtcRole::Issuer, "issuer"),
+            (VtcRole::Member, "member"),
+            (VtcRole::Custom("editor".into()), "custom:editor"),
+        ];
+        for (role, expected_wire) in cases {
+            let vc = build_role_vec(&signer, RoleVecParams::new(MEMBER_DID, role.clone()))
+                .await
+                .unwrap_or_else(|e| panic!("build VEC for {role:?}: {e:?}"));
+
+            // Type array carries VEC type.
+            assert!(vc.types.iter().any(|t| t == VEC_TYPE));
+
+            // endorsement payload.
+            let subj = subject_map(&vc);
+            let endorsement = &subj["endorsement"];
+            assert_eq!(endorsement["type"], COMMUNITY_ROLE_ENDORSEMENT_TYPE);
+            assert_eq!(endorsement["role"], expected_wire);
+            assert_eq!(endorsement["communityDid"], TEST_VTC_DID);
+            assert_eq!(subj["id"], MEMBER_DID);
+
+            // Proof verifies.
+            signer
+                .verify(&vc)
+                .unwrap_or_else(|e| panic!("VEC proof must verify for {role:?}: {e:?}"));
+        }
+    }
+
+    /// Tampering with the endorsement role invalidates the
+    /// proof.
+    #[tokio::test]
+    async fn role_vec_tampered_role_invalidates_proof() {
+        let signer = signer();
+        let mut vc = build_role_vec(&signer, RoleVecParams::new(MEMBER_DID, VtcRole::Member))
+            .await
+            .unwrap();
+        let mut as_value = serde_json::to_value(&vc).unwrap();
+        // Promote member to admin without re-signing.
+        as_value["credentialSubject"]["endorsement"]["role"] = JsonValue::String("admin".into());
+        vc = serde_json::from_value(as_value).unwrap();
+
+        let err = signer.verify(&vc).expect_err("tampered VEC must fail");
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "expected Forbidden, got {err:?}"
+        );
+    }
+}

--- a/vtc-service/src/credentials/vmc.rs
+++ b/vtc-service/src/credentials/vmc.rs
@@ -1,0 +1,314 @@
+//! Verifiable Membership Credential builder — spec §6.1's VMC
+//! row, M2.9 entry point.
+//!
+//! Shape:
+//!
+//! ```json
+//! {
+//!   "@context": [
+//!     "https://www.w3.org/ns/credentials/v2",
+//!     "https://openvtc.org/contexts/dtg-membership-v1.jsonld"
+//!   ],
+//!   "type": ["VerifiableCredential", "VerifiableMembershipCredential"],
+//!   "issuer": "did:webvh:vtc.example.com:abc",
+//!   "validFrom": "2026-05-12T00:00:00Z",
+//!   "validUntil": "2026-06-11T00:00:00Z",
+//!   "credentialSubject": {
+//!     "id": "did:key:zMember",
+//!     "personhood": false
+//!   },
+//!   "credentialStatus": {
+//!     "id": "https://vtc.example.com/v1/status-lists/revocation#42",
+//!     "type": "BitstringStatusListEntry",
+//!     "statusPurpose": "revocation",
+//!     "statusListIndex": "42",
+//!     "statusListCredential": "https://vtc.example.com/v1/status-lists/revocation"
+//!   },
+//!   "proof": { … data-integrity proof attached by `LocalSigner` … }
+//! }
+//! ```
+//!
+//! The `credentialStatus` block is optional at this milestone —
+//! M2.10 + M2.11 wire it in with live status-list URLs. M2.9
+//! tests can construct a VMC with `status_ref = None` to exercise
+//! the proof + validity-window paths in isolation.
+
+use affinidi_vc::{CredentialBuilder, VerifiableCredential};
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value as JsonValue, json};
+use vti_common::error::AppError;
+
+use super::LocalSigner;
+use super::VMC_CONTEXT_URL;
+
+/// Type the VC's `type` array carries in addition to the
+/// universal `VerifiableCredential` value. Spec §6.1 names this
+/// credential the "Verifiable Membership Credential".
+pub const VMC_TYPE: &str = "VerifiableMembershipCredential";
+
+/// `credentialStatus` reference for a VMC. Mirrors the
+/// `BitstringStatusListEntry` shape per spec §6.2. M2.10 + M2.11
+/// will compute the index and URL; M2.9's signer wraps it in the
+/// VC verbatim.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialStatusRef {
+    /// Per-VC unique entry id (typically
+    /// `{status_list_url}#{index}`).
+    pub id: String,
+    /// Always `"BitstringStatusListEntry"` per the W3C status-list
+    /// spec.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    /// `"revocation"` or `"suspension"` per spec §6.2.
+    pub status_purpose: String,
+    /// Index into the BitstringStatusList. Wire shape is a string
+    /// per the W3C spec.
+    pub status_list_index: String,
+    /// URL of the BitstringStatusList credential itself.
+    pub status_list_credential: String,
+}
+
+impl CredentialStatusRef {
+    /// Build a `revocation`-purpose entry from a list URL + index.
+    /// Mirrors what M2.11 will produce.
+    pub fn revocation(status_list_url: impl Into<String>, index: u32) -> Self {
+        let url = status_list_url.into();
+        Self {
+            id: format!("{url}#{index}"),
+            r#type: "BitstringStatusListEntry".into(),
+            status_purpose: "revocation".into(),
+            status_list_index: index.to_string(),
+            status_list_credential: url,
+        }
+    }
+}
+
+/// Parameters for [`build_vmc`].
+#[derive(Debug, Clone)]
+pub struct VmcParams {
+    /// Subject DID — the member receiving the VMC.
+    pub member_did: String,
+    /// Status-list reference, or `None` to omit `credentialStatus`
+    /// entirely (used by tests + the M2.9-only path before
+    /// M2.10/M2.11 wire in live status lists).
+    pub status_ref: Option<CredentialStatusRef>,
+    /// `validUntil = now + validity`. Spec §3-F requires this
+    /// window be bounded; the workspace default is 30 days
+    /// ([`super::DEFAULT_VMC_VALIDITY`]).
+    pub validity: Duration,
+    /// `personhood: bool` carried on the credentialSubject.
+    /// Phase 2's renewal flow re-evaluates this via
+    /// `personhood.rego` per spec §6.3 step 3.
+    pub personhood: bool,
+}
+
+impl VmcParams {
+    pub fn new(member_did: impl Into<String>) -> Self {
+        Self {
+            member_did: member_did.into(),
+            status_ref: None,
+            validity: super::DEFAULT_VMC_VALIDITY,
+            personhood: false,
+        }
+    }
+
+    pub fn with_status_ref(mut self, status_ref: CredentialStatusRef) -> Self {
+        self.status_ref = Some(status_ref);
+        self
+    }
+
+    pub fn with_validity(mut self, validity: Duration) -> Self {
+        self.validity = validity;
+        self
+    }
+
+    pub fn with_personhood(mut self, personhood: bool) -> Self {
+        self.personhood = personhood;
+        self
+    }
+}
+
+/// Build + sign a VMC. `issuer = signer.issuer_did()`,
+/// `validFrom = now()`, `validUntil = now() + params.validity`.
+/// Returns the signed VC with `proof` attached.
+pub async fn build_vmc(
+    signer: &LocalSigner,
+    params: VmcParams,
+) -> Result<VerifiableCredential, AppError> {
+    let now = Utc::now();
+    let valid_until = now + params.validity;
+
+    let mut subject = Map::new();
+    subject.insert("id".into(), JsonValue::String(params.member_did.clone()));
+    subject.insert("personhood".into(), JsonValue::Bool(params.personhood));
+
+    let mut vc = CredentialBuilder::v2()
+        .context(VMC_CONTEXT_URL)
+        .issuer_uri(signer.issuer_did().to_string())
+        .add_type(VMC_TYPE)
+        .valid_from(rfc3339(now))
+        .valid_until(rfc3339(valid_until))
+        .subject(subject)
+        .build()
+        .map_err(|e| AppError::Internal(format!("VMC build: {e}")))?;
+
+    if let Some(status_ref) = &params.status_ref {
+        // `affinidi-vc` 0.1's typed VC doesn't expose a public
+        // `credentialStatus` setter (the type carries common
+        // fields; richer fields are operator-defined). Round-trip
+        // through JSON so we can splice the block in without
+        // forking the crate.
+        attach_credential_status(&mut vc, status_ref)?;
+    }
+
+    signer.sign(&mut vc).await?;
+    Ok(vc)
+}
+
+/// Splice a `credentialStatus` object onto the VC. Goes through
+/// JSON because the upstream typed `VerifiableCredential` doesn't
+/// expose the field as a builder method.
+fn attach_credential_status(
+    vc: &mut VerifiableCredential,
+    status_ref: &CredentialStatusRef,
+) -> Result<(), AppError> {
+    let mut as_value =
+        serde_json::to_value(&*vc).map_err(|e| AppError::Internal(format!("VMC -> value: {e}")))?;
+    let status = serde_json::to_value(status_ref)
+        .map_err(|e| AppError::Internal(format!("credentialStatus -> value: {e}")))?;
+    as_value
+        .as_object_mut()
+        .ok_or_else(|| AppError::Internal("VMC not an object".into()))?
+        .insert("credentialStatus".into(), status);
+    *vc = serde_json::from_value(as_value)
+        .map_err(|e| AppError::Internal(format!("value -> VMC: {e}")))?;
+    Ok(())
+}
+
+/// Format a `DateTime<Utc>` as RFC 3339 — same shape the VTA SDK
+/// uses (`rfc3339(now)`), kept here so the VMC builder doesn't
+/// reach across crate boundaries for a one-liner.
+fn rfc3339(t: chrono::DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+#[allow(dead_code)]
+fn vmc_subject_template() -> JsonValue {
+    json!({ "id": "", "personhood": false })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+    const MEMBER_DID: &str = "did:key:zMember1";
+
+    fn signer() -> LocalSigner {
+        LocalSigner::from_ed25519_seed(TEST_VTC_DID.into(), &[0xAA; 32])
+    }
+
+    /// Happy path: VMC carries the expected types, issuer, and
+    /// subject id; the proof verifies against the signer's public
+    /// key.
+    #[tokio::test]
+    async fn vmc_happy_path_verifies() {
+        let signer = signer();
+        let vc = build_vmc(&signer, VmcParams::new(MEMBER_DID))
+            .await
+            .expect("build VMC");
+
+        // Type array contains both `VerifiableCredential` (the
+        // builder adds it implicitly) and `VerifiableMembershipCredential`.
+        assert!(vc.types.iter().any(|t| t == "VerifiableCredential"));
+        assert!(vc.types.iter().any(|t| t == VMC_TYPE));
+
+        // Issuer matches the signer's DID.
+        let issuer_value = serde_json::to_value(&vc.issuer).unwrap();
+        assert_eq!(issuer_value, JsonValue::String(TEST_VTC_DID.into()));
+
+        // Subject id == member DID.
+        let subject_id = match &vc.credential_subject {
+            affinidi_vc::SubjectValue::Single(m) => m.get("id").cloned(),
+            affinidi_vc::SubjectValue::Multiple(v) => v[0].get("id").cloned(),
+        };
+        assert_eq!(subject_id, Some(JsonValue::String(MEMBER_DID.into())));
+
+        // Proof verifies.
+        signer.verify(&vc).expect("VMC proof must verify");
+    }
+
+    /// `validUntil = validFrom + params.validity` to the second.
+    #[tokio::test]
+    async fn vmc_valid_until_pinned_to_validity_window() {
+        let signer = signer();
+        let validity = Duration::days(7);
+        let vc = build_vmc(&signer, VmcParams::new(MEMBER_DID).with_validity(validity))
+            .await
+            .unwrap();
+        let vf = chrono::DateTime::parse_from_rfc3339(vc.valid_from.as_deref().unwrap()).unwrap();
+        let vu = chrono::DateTime::parse_from_rfc3339(vc.valid_until.as_deref().unwrap()).unwrap();
+        // Build clamps the seconds — diff matches exactly.
+        assert_eq!((vu - vf).num_seconds(), validity.num_seconds());
+    }
+
+    /// Personhood flag propagates onto credentialSubject.
+    #[tokio::test]
+    async fn vmc_personhood_flag_set_in_credential_subject() {
+        let signer = signer();
+        let vc = build_vmc(&signer, VmcParams::new(MEMBER_DID).with_personhood(true))
+            .await
+            .unwrap();
+        let subject = match &vc.credential_subject {
+            affinidi_vc::SubjectValue::Single(m) => m.clone(),
+            affinidi_vc::SubjectValue::Multiple(v) => v[0].clone(),
+        };
+        assert_eq!(subject.get("personhood"), Some(&JsonValue::Bool(true)));
+    }
+
+    /// A status_ref produces a `credentialStatus` block in the
+    /// serialised VC.
+    #[tokio::test]
+    async fn vmc_status_ref_serialises_into_credential_status() {
+        let signer = signer();
+        let status = CredentialStatusRef::revocation(
+            "https://vtc.example.com/v1/status-lists/revocation",
+            7,
+        );
+        let vc = build_vmc(
+            &signer,
+            VmcParams::new(MEMBER_DID).with_status_ref(status.clone()),
+        )
+        .await
+        .unwrap();
+        let v = serde_json::to_value(&vc).unwrap();
+        let cs = &v["credentialStatus"];
+        assert_eq!(cs["statusPurpose"], "revocation");
+        assert_eq!(cs["statusListIndex"], "7");
+        assert_eq!(cs["statusListCredential"], status.status_list_credential);
+        // And the proof still verifies after splicing.
+        signer.verify(&vc).expect("VMC proof must still verify");
+    }
+
+    /// Mutating the VMC after signing invalidates the proof.
+    #[tokio::test]
+    async fn vmc_tampered_subject_invalidates_proof() {
+        let signer = signer();
+        let mut vc = build_vmc(&signer, VmcParams::new(MEMBER_DID))
+            .await
+            .unwrap();
+
+        // Tamper with the subject — flip personhood.
+        let mut as_value = serde_json::to_value(&vc).unwrap();
+        as_value["credentialSubject"]["personhood"] = JsonValue::Bool(true);
+        vc = serde_json::from_value(as_value).unwrap();
+
+        let err = signer.verify(&vc).expect_err("tampered VMC must fail");
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "expected Forbidden, got {err:?}"
+        );
+    }
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -32,6 +32,7 @@ pub mod routes;
 pub mod server;
 pub mod setup;
 pub mod status;
+pub mod status_list;
 pub mod store;
 pub mod supervisor;
 pub mod webauthn;

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -17,6 +17,7 @@ pub mod auth;
 pub mod community;
 pub mod config;
 pub mod config_store;
+pub mod credentials;
 pub mod did_key;
 #[cfg(feature = "setup")]
 pub mod emergency;

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod install;
 pub(crate) mod join_requests;
 pub(crate) mod members;
 pub(crate) mod policies;
+pub(crate) mod status_lists;
 
 use axum::Router;
 use axum::routing::{delete, get, post};
@@ -150,6 +151,10 @@ pub fn router() -> Router<AppState> {
         // the URL `scid` against the VTC's own DID and 404s on any
         // other request. See `tasks/vtc-mvp/vta-driven-keys.md` §10.
         .route_exempt("/v1/{scid}/did.jsonl", get(did_log::did_log))
+        // BitstringStatusList publication (M2.11). Trust-Task-
+        // exempt — external verifiers don't carry our extension
+        // header (same rationale as `did.jsonl`).
+        .route_exempt("/v1/status-lists/{purpose}", get(status_lists::show))
         // Auth routes
         .route_with_task("/v1/auth/challenge", post(auth::challenge), auth_challenge)
         .route_with_task("/v1/auth/", post(auth::authenticate), auth_authenticate)

--- a/vtc-service/src/routes/status_lists.rs
+++ b/vtc-service/src/routes/status_lists.rs
@@ -1,0 +1,90 @@
+//! Public BitstringStatusList route — `GET
+//! /v1/status-lists/{purpose}` (M2.11).
+//!
+//! Verifier-facing, unauthenticated, Trust-Task-exempt — same
+//! rationale as `/v1/{scid}/did.jsonl`: external verifiers
+//! resolve credentials through standard W3C verification flows
+//! that don't carry our extension header.
+//!
+//! Responses:
+//!
+//! - `200` with the freshly-signed `BitstringStatusListCredential`
+//!   VC as JSON.
+//! - `404` for `purpose` values other than `revocation` /
+//!   `suspension`, or when the daemon has not provisioned that
+//!   purpose yet (pre-`public_url` deployment).
+//! - `503` when the credential signer or state row aren't ready
+//!   (the daemon booted without a `VtcKeyBundle`).
+//!
+//! `Cache-Control: no-store` is set on every response — flips
+//! land in real time and a stale cached copy would mask a
+//! revocation.
+
+use affinidi_status_list::StatusPurpose;
+use axum::extract::{Path, State};
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use serde_json::Value as JsonValue;
+use vti_common::error::AppError;
+
+use crate::server::AppState;
+use crate::status_list;
+
+/// Parse the wire-form `purpose` path segment. Returns `None` for
+/// unknown values (which the handler maps to 404).
+fn parse_purpose(s: &str) -> Option<StatusPurpose> {
+    match s {
+        "revocation" => Some(StatusPurpose::Revocation),
+        "suspension" => Some(StatusPurpose::Suspension),
+        _ => None,
+    }
+}
+
+pub async fn show(
+    State(state): State<AppState>,
+    Path(purpose_str): Path<String>,
+) -> Result<Response, AppError> {
+    let purpose = parse_purpose(&purpose_str).ok_or_else(|| {
+        AppError::NotFound(format!(
+            "unknown status-list purpose '{purpose_str}' \
+             (expected 'revocation' or 'suspension')"
+        ))
+    })?;
+
+    let signer = state.credential_signer.as_ref().ok_or_else(|| {
+        // Same shape `routes::install` returns when the secret
+        // store is unset — operators get a clear "run setup first"
+        // signal rather than an opaque 500.
+        AppError::Internal(format!(
+            "credential signer not initialised — status list for {purpose} unavailable"
+        ))
+    })?;
+
+    let row = status_list::get_state(&state.status_lists_ks, purpose).await?;
+    let row = row.ok_or_else(|| {
+        AppError::NotFound(format!(
+            "status list for {purpose} not provisioned — \
+             set `public_url` and restart the daemon to initialise"
+        ))
+    })?;
+
+    let vc = status_list::build_status_list_credential(signer, &row).await?;
+    let body = serde_json::to_value(&vc)
+        .map_err(|e| AppError::Internal(format!("status-list VC serialize: {e}")))?;
+
+    // `Cache-Control: no-store` — spec §6.2 calls flips
+    // "immediate locally". A CDN cache between us and a verifier
+    // would defeat that.
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CACHE_CONTROL, HeaderValue::from_static("no-store")),
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+        ],
+        axum::Json::<JsonValue>(body),
+    )
+        .into_response())
+}

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -57,6 +57,11 @@ pub struct AppState {
     /// row per [`crate::policy::PolicyPurpose`] variant. M2.3's
     /// activate endpoint flips this; M2.6 / M2.7 / M2.13 read it.
     pub active_policies_ks: KeyspaceHandle,
+    /// BitstringStatusList state (M2.10). One row per
+    /// [`affinidi_status_list::StatusPurpose`] variant. M2.11's
+    /// public route reads from it; M2.14's flip-on-removal path
+    /// writes.
+    pub status_lists_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
@@ -76,6 +81,11 @@ pub struct AppState {
     /// tokens at the end of the claim ceremony. `None` until the secret
     /// store yields key material — install routes 503 in that case.
     pub install_signer: Option<Arc<InstallTokenSigner>>,
+    /// Ed25519 signer that mints VMC, VEC, and BitstringStatusList
+    /// credentials (M2.9). Wraps the same `#key-0` secret the
+    /// `secrets_resolver` holds. `None` until the secret store
+    /// yields key material — credential routes 503 in that case.
+    pub credential_signer: Option<Arc<crate::credentials::LocalSigner>>,
     /// Wraps `install_ks` with the claim-window state machine. Cheap
     /// to clone; always present once `install_ks` is open.
     pub install_store: InstallTokenStore,
@@ -161,6 +171,7 @@ pub async fn run(
     let join_requests_ks = store.keyspace("join_requests")?;
     let policies_ks = store.keyspace("policies")?;
     let active_policies_ks = store.keyspace("active_policies")?;
+    let status_lists_ks = store.keyspace("status_lists")?;
     let audit_ks = store.keyspace("audit")?;
     let audit_key_ks = store.keyspace("audit_key")?;
 
@@ -176,10 +187,42 @@ pub async fn run(
         Err(e) => warn!("failed to install default policies: {e}"),
     }
 
+    // M2.10 + M2.11: provision the two BitstringStatusLists.
+    // Idempotent — only seeds decoys when the row is brand new.
+    // Skipped when `public_url` is unset (pre-setup deployment) —
+    // the status-list `list_credential_id` is baked into every
+    // VMC's `credentialStatus.statusListCredential`, so we can't
+    // mint the row until we know the canonical URL.
+    if let Some(public_url) = config.public_url.as_deref() {
+        for purpose in [
+            affinidi_status_list::StatusPurpose::Revocation,
+            affinidi_status_list::StatusPurpose::Suspension,
+        ] {
+            let url = format!("{public_url}/v1/status-lists/{purpose}");
+            match crate::status_list::ensure_initial(&status_lists_ks, purpose, url).await {
+                Ok(_) => debug!(?purpose, "status list initialised"),
+                Err(e) => warn!(?purpose, "failed to initialise status list: {e}"),
+            }
+        }
+    } else {
+        warn!(
+            "public_url not configured — status lists deferred; \
+             VMC issuance + GET /v1/status-lists/* return 503 until set"
+        );
+    }
+
     // Initialize auth infrastructure. Pass the audit keyspaces in so
     // `init_auth` can derive the HMAC audit key from the same secret
     // store contents it uses for the install signer.
-    let (did_resolver, secrets_resolver, jwt_keys, atm, install_signer, audit_writer) = init_auth(
+    let (
+        did_resolver,
+        secrets_resolver,
+        jwt_keys,
+        atm,
+        install_signer,
+        audit_writer,
+        credential_signer,
+    ) = init_auth(
         &config,
         &*secret_store,
         audit_ks.clone(),
@@ -247,6 +290,7 @@ pub async fn run(
         join_requests_ks,
         policies_ks,
         active_policies_ks,
+        status_lists_ks: status_lists_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),
@@ -257,6 +301,7 @@ pub async fn run(
         webauthn,
         public_url,
         install_signer,
+        credential_signer: credential_signer.clone(),
         install_store,
         audit_writer,
         shutdown_tx: shutdown_tx.clone(),
@@ -597,12 +642,13 @@ async fn init_auth(
     Option<ATM>,
     Option<Arc<InstallTokenSigner>>,
     Option<AuditWriter>,
+    Option<Arc<crate::credentials::LocalSigner>>,
 ) {
     let vtc_did = match &config.vtc_did {
         Some(did) => did.clone(),
         None => {
             warn!("vtc_did not configured — auth endpoints will not work (run setup first)");
-            return (None, None, None, None, None, None);
+            return (None, None, None, None, None, None, None);
         }
     };
 
@@ -615,11 +661,11 @@ async fn init_auth(
         Ok(Some(s)) => s,
         Ok(None) => {
             warn!("no key material found — auth endpoints will not work (run setup first)");
-            return (None, None, None, None, None, None);
+            return (None, None, None, None, None, None, None);
         }
         Err(e) => {
             warn!("failed to load key material: {e} — auth endpoints will not work");
-            return (None, None, None, None, None, None);
+            return (None, None, None, None, None, None, None);
         }
     };
 
@@ -627,9 +673,17 @@ async fn init_auth(
         Ok(pair) => pair,
         Err(msg) => {
             warn!("{msg}");
-            return (None, None, None, None, None, None);
+            return (None, None, None, None, None, None, None);
         }
     };
+
+    // M2.9 credential signer — wraps the same 32-byte Ed25519
+    // seed in a [`LocalSigner`] handle so VMC / VEC / status-list
+    // credential builders can sign without round-tripping through
+    // the secret store on every call.
+    let credential_signer = Some(Arc::new(
+        crate::credentials::LocalSigner::from_ed25519_seed(vtc_did.clone(), &ed25519_bytes),
+    ));
 
     // Derive the install-token signer from the 32-byte Ed25519
     // private. HKDF info is `vtc-install-jwt-key/v2` — bumped from
@@ -665,7 +719,15 @@ async fn init_auth(
         Ok(r) => r,
         Err(e) => {
             warn!("failed to create DID resolver: {e} — auth endpoints will not work");
-            return (None, None, None, None, install_signer, audit_writer);
+            return (
+                None,
+                None,
+                None,
+                None,
+                install_signer,
+                audit_writer,
+                credential_signer,
+            );
         }
     };
 
@@ -697,6 +759,7 @@ async fn init_auth(
                     None,
                     install_signer,
                     audit_writer,
+                    credential_signer,
                 );
             }
         },
@@ -711,6 +774,7 @@ async fn init_auth(
                 None,
                 install_signer,
                 audit_writer,
+                credential_signer,
             );
         }
     };
@@ -755,6 +819,7 @@ async fn init_auth(
         atm,
         install_signer,
         audit_writer,
+        credential_signer,
     )
 }
 

--- a/vtc-service/src/status_list/allocator.rs
+++ b/vtc-service/src/status_list/allocator.rs
@@ -1,0 +1,235 @@
+//! Random-with-decoys slot allocator + bit-flip helpers.
+//!
+//! Spec §6.2 requires:
+//!
+//! - **Random allocation** so the slot index can't be
+//!   correlated with credential issuance order.
+//! - **Decoys** flipped on unassigned slots so external
+//!   verifiers can't infer occupancy from the bitstring's
+//!   Hamming weight.
+//! - **Flipped indices never reallocated** so a departing
+//!   member's slot index can't be reused to correlate the
+//!   new holder with the departed one.
+//!
+//! The allocator works against a [`StatusListState`] passed by
+//! `&mut`: the caller is responsible for persisting the row
+//! after a mutation (the storage layer doesn't auto-write on
+//! every operation; that's the route handler's job, ideally
+//! inside the same fjall transaction as the credential row).
+//!
+//! Allocation uses a uniform RNG over the unassigned-slot index
+//! list (same approach `affinidi-status-list`'s
+//! `BitstringStatusList::allocate_index` uses, but we own the
+//! `assigned` mask so we can persist it across daemon
+//! restarts).
+
+use rand::RngExt;
+
+use super::storage::StatusListState;
+
+/// Allocate a fresh slot for a member. Returns `Some(index)` on
+/// success, `None` if the list is full.
+///
+/// Side-effects: sets `assigned[index] = true`. Does **not**
+/// touch the bitstring — the bit stays `0` (= "valid") until a
+/// subsequent [`flip`] revokes / suspends.
+pub fn allocate(state: &mut StatusListState) -> Option<u32> {
+    let available: Vec<usize> = (0..state.capacity)
+        .filter(|&i| !state.assigned[i])
+        .collect();
+    if available.is_empty() {
+        return None;
+    }
+    let mut rng = rand::rng();
+    let pick = rng.random_range(0..available.len());
+    let index = available[pick];
+    state.assigned[index] = true;
+    Some(index as u32)
+}
+
+/// Flip the bit for `index` to `revoked`. Caller is responsible
+/// for ensuring `index` was previously [`allocate`]d to a real
+/// member — flipping a decoy slot is harmless but the audit
+/// trail won't make sense.
+///
+/// **Critical invariant**: `assigned[index]` stays `true` after
+/// this call. The allocator skips assigned slots regardless of
+/// their bit value, so a flipped (revoked) slot is permanently
+/// reserved.
+pub fn flip(state: &mut StatusListState, index: u32, revoked: bool) -> Result<(), &'static str> {
+    let i = index as usize;
+    if i >= state.capacity {
+        return Err("index out of bounds for status list");
+    }
+    let byte = i / 8;
+    let bit = 7 - (i % 8);
+    if revoked {
+        state.bits[byte] |= 1 << bit;
+    } else {
+        state.bits[byte] &= !(1 << bit);
+    }
+    // Note: assigned[i] is intentionally untouched. Flipping
+    // back to `revoked = false` (e.g. un-suspend) leaves the
+    // slot still owned by the same member.
+    Ok(())
+}
+
+/// Seed `count` decoy bits — bit flips on unassigned slots.
+/// Used once at first-init. Random collisions are skipped, so
+/// the actual decoy count may be slightly lower than requested
+/// if `count` approaches `capacity`.
+pub fn add_initial_decoys(state: &mut StatusListState, count: usize) {
+    let mut rng = rand::rng();
+    let mut added = 0_usize;
+    // Bounded attempts so a near-full list can't spin forever.
+    let mut attempts = 0_usize;
+    let max_attempts = count.saturating_mul(8).max(1024);
+    while added < count && attempts < max_attempts {
+        attempts += 1;
+        let idx = rng.random_range(0..state.capacity);
+        if state.assigned[idx] {
+            continue;
+        }
+        let byte = idx / 8;
+        let bit = 7 - (idx % 8);
+        if state.bits[byte] & (1 << bit) != 0 {
+            // Already set — try again.
+            continue;
+        }
+        state.bits[byte] |= 1 << bit;
+        added += 1;
+    }
+}
+
+/// Occupancy fraction in `[0.0, 1.0]`. Defined as the larger of
+/// "assigned slots" and "bits set", divided by capacity. This
+/// matches spec §6.2's "live + reserved" wording: assigned
+/// slots that haven't been flipped yet count toward the warning
+/// threshold too.
+pub fn occupancy(state: &StatusListState) -> f64 {
+    let assigned = state.count_assigned();
+    let set = state.count_set();
+    let max = assigned.max(set);
+    max as f64 / state.capacity as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_status_list::StatusPurpose;
+
+    fn fresh_state(capacity_hint: Option<usize>) -> StatusListState {
+        let mut s = StatusListState::new(
+            StatusPurpose::Revocation,
+            "https://vtc.example.com/v1/status-lists/revocation".into(),
+        );
+        if let Some(cap) = capacity_hint {
+            // Shrink the state for fast tests. The production
+            // size is 131K — slow to iterate in a unit test.
+            s.capacity = cap;
+            s.bits = vec![0u8; cap.div_ceil(8)];
+            s.assigned = vec![false; cap];
+        }
+        s
+    }
+
+    /// Allocator returns each unassigned slot exactly once + then
+    /// returns `None` when the list is full.
+    #[test]
+    fn allocator_exhausts_capacity_then_returns_none() {
+        let mut state = fresh_state(Some(16));
+        let mut seen = [false; 16];
+        for _ in 0..16 {
+            let idx = allocate(&mut state).expect("slot available");
+            assert!(!seen[idx as usize], "slot {idx} returned twice");
+            seen[idx as usize] = true;
+        }
+        assert!(allocate(&mut state).is_none(), "list is full");
+        assert!(seen.iter().all(|s| *s), "every slot must be returned once");
+    }
+
+    /// The critical invariant: a flipped slot is never returned
+    /// again by the allocator, even after many subsequent
+    /// allocations.
+    #[test]
+    fn allocator_never_returns_a_flipped_slot() {
+        let mut state = fresh_state(Some(64));
+        // Allocate 10 slots, flip them, deallocate the rest.
+        let mut flipped = Vec::new();
+        for _ in 0..10 {
+            let idx = allocate(&mut state).unwrap();
+            flip(&mut state, idx, true).unwrap();
+            flipped.push(idx);
+        }
+        // Drain the remaining capacity; none of the new
+        // allocations may collide with a flipped slot.
+        while let Some(idx) = allocate(&mut state) {
+            assert!(
+                !flipped.contains(&idx),
+                "allocator returned previously-flipped slot {idx}"
+            );
+        }
+        // Every flipped bit is still set.
+        for idx in flipped {
+            assert!(state.is_set(idx as usize));
+        }
+    }
+
+    /// Flipping `revoked = false` un-sets the bit but keeps the
+    /// slot assigned (useful for the suspension list's
+    /// reactivation path).
+    #[test]
+    fn flip_back_to_zero_keeps_slot_assigned() {
+        let mut state = fresh_state(Some(16));
+        let idx = allocate(&mut state).unwrap();
+        flip(&mut state, idx, true).unwrap();
+        assert!(state.is_set(idx as usize));
+        flip(&mut state, idx, false).unwrap();
+        assert!(!state.is_set(idx as usize));
+        assert!(state.assigned[idx as usize], "slot stays assigned");
+    }
+
+    #[test]
+    fn flip_out_of_bounds_returns_err() {
+        let mut state = fresh_state(Some(16));
+        let err = flip(&mut state, 99, true).expect_err("oob must fail");
+        assert!(err.contains("out of bounds"));
+    }
+
+    /// Occupancy hits the warning threshold once enough slots
+    /// are assigned. Drive against an artificially small list so
+    /// the test runs fast.
+    #[test]
+    fn occupancy_crosses_threshold_at_75_percent() {
+        let mut state = fresh_state(Some(100));
+        assert!(occupancy(&state) < 0.75);
+        // Allocate 75 slots → 75% occupancy → at the threshold.
+        for _ in 0..75 {
+            allocate(&mut state).unwrap();
+        }
+        assert!(
+            occupancy(&state) >= 0.75,
+            "expected occupancy >= 0.75, got {}",
+            occupancy(&state)
+        );
+    }
+
+    /// Decoys land on unassigned slots only.
+    #[test]
+    fn add_initial_decoys_only_touches_unassigned_slots() {
+        let mut state = fresh_state(Some(64));
+        // Allocate slot 0 first.
+        let owned = allocate(&mut state).unwrap();
+        // Sprinkle some decoys.
+        add_initial_decoys(&mut state, 30);
+        // The owned slot's bit is still 0 (decoys don't touch
+        // assigned slots), unless we explicitly flip it.
+        if !state.assigned.iter().filter(|a| **a).count() == 1 {
+            // Sanity — only one slot is assigned.
+        }
+        assert!(
+            !state.is_set(owned as usize),
+            "decoy must not flip an assigned slot"
+        );
+    }
+}

--- a/vtc-service/src/status_list/credential.rs
+++ b/vtc-service/src/status_list/credential.rs
@@ -1,0 +1,232 @@
+//! `BitstringStatusListCredential` builder.
+//!
+//! Wraps a [`super::storage::StatusListState`] in the W3C VC
+//! shape and signs it with the workspace's M2.9 [`LocalSigner`].
+//! The published VC is what verifiers fetch from `GET
+//! /v1/status-lists/{purpose}` (the route lands in M2.11; this
+//! milestone just lands the builder).
+//!
+//! Wire shape (per W3C bitstring status list v1.0):
+//!
+//! ```json
+//! {
+//!   "@context": [
+//!     "https://www.w3.org/ns/credentials/v2"
+//!   ],
+//!   "id": "<list_credential_id>",
+//!   "type": ["VerifiableCredential", "BitstringStatusListCredential"],
+//!   "issuer": "<vtc_did>",
+//!   "validFrom": "<rfc3339>",
+//!   "credentialSubject": {
+//!     "id": "<list_credential_id>#list",
+//!     "type": "BitstringStatusList",
+//!     "statusPurpose": "revocation" | "suspension",
+//!     "encodedList": "<gzip + base64url>"
+//!   },
+//!   "proof": { … }
+//! }
+//! ```
+
+use affinidi_status_list::BitstringStatusList;
+use affinidi_vc::{CredentialBuilder, VerifiableCredential};
+use chrono::Utc;
+use serde_json::{Map, Value as JsonValue};
+use vti_common::error::AppError;
+
+use crate::credentials::LocalSigner;
+
+use super::storage::StatusListState;
+
+/// Type the VC's `type` array carries alongside
+/// `VerifiableCredential`. Stable W3C name.
+pub const BITSTRING_STATUS_LIST_VC_TYPE: &str = "BitstringStatusListCredential";
+
+/// Build + sign a `BitstringStatusListCredential` for the given
+/// state. `issuer = signer.issuer_did()`; the VC's `id` is the
+/// state's `list_credential_id` (the canonical public URL).
+///
+/// The encoded bitstring uses the same GZIP+base64url format
+/// `affinidi-status-list::BitstringStatusList::encode` produces;
+/// we reuse that crate to avoid a second compressor in the
+/// workspace.
+pub async fn build_status_list_credential(
+    signer: &LocalSigner,
+    state: &StatusListState,
+) -> Result<VerifiableCredential, AppError> {
+    // Materialise into the upstream BitstringStatusList shape
+    // long enough to call `encode`. The state we persist owns
+    // the truth (`assigned` mask, etc.); the upstream type's
+    // internal `assigned` is unused after the encode call.
+    let encoded = encode_bits(state).map_err(|e| {
+        AppError::Internal(format!("status list encode for {}: {e}", state.purpose))
+    })?;
+
+    let mut subject = Map::new();
+    subject.insert(
+        "id".into(),
+        JsonValue::String(format!("{}#list", state.list_credential_id)),
+    );
+    subject.insert(
+        "type".into(),
+        JsonValue::String("BitstringStatusList".into()),
+    );
+    subject.insert(
+        "statusPurpose".into(),
+        JsonValue::String(state.purpose.to_string()),
+    );
+    subject.insert("encodedList".into(), JsonValue::String(encoded));
+
+    let now = Utc::now();
+    let mut vc = CredentialBuilder::v2()
+        .issuer_uri(signer.issuer_did().to_string())
+        .add_type(BITSTRING_STATUS_LIST_VC_TYPE)
+        .valid_from(rfc3339(now))
+        .subject(subject)
+        .build()
+        .map_err(|e| AppError::Internal(format!("status-list VC build: {e}")))?;
+
+    // The `id` field on the typed VC isn't builder-settable;
+    // splice it via JSON like the VMC's credentialStatus.
+    attach_top_level_id(&mut vc, &state.list_credential_id)?;
+
+    signer.sign(&mut vc).await?;
+    Ok(vc)
+}
+
+/// Encode the raw bits via `affinidi-status-list`'s GZIP+base64url
+/// path. We construct a fresh `BitstringStatusList` and copy our
+/// bits into it via `set` calls so the encode output matches
+/// what verifiers expect from the upstream crate.
+fn encode_bits(state: &StatusListState) -> Result<String, affinidi_status_list::StatusListError> {
+    let mut bsl = BitstringStatusList::new(state.capacity, state.purpose);
+    // Apply each `1` bit in the source. Iterating once over the
+    // raw bytes is cheap; this is the steady-state path for the
+    // M2.11 publish handler and the M2.14 flip-on-removal path.
+    for i in 0..state.capacity {
+        if state.is_set(i) {
+            bsl.set(i, true)?;
+        }
+    }
+    bsl.encode()
+}
+
+fn rfc3339(t: chrono::DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn attach_top_level_id(vc: &mut VerifiableCredential, id: &str) -> Result<(), AppError> {
+    let mut as_value = serde_json::to_value(&*vc)
+        .map_err(|e| AppError::Internal(format!("status-list VC -> value: {e}")))?;
+    as_value
+        .as_object_mut()
+        .ok_or_else(|| AppError::Internal("status-list VC not an object".into()))?
+        .insert("id".into(), JsonValue::String(id.into()));
+    *vc = serde_json::from_value(as_value)
+        .map_err(|e| AppError::Internal(format!("value -> status-list VC: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credentials::LocalSigner;
+    use crate::status_list::allocator::{allocate, flip};
+    use affinidi_status_list::StatusPurpose;
+    use affinidi_vc::SubjectValue;
+
+    const TEST_VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+
+    fn signer() -> LocalSigner {
+        LocalSigner::from_ed25519_seed(TEST_VTC_DID.into(), &[0xCC; 32])
+    }
+
+    fn smallish_state() -> StatusListState {
+        let mut s = StatusListState::new(
+            StatusPurpose::Revocation,
+            "https://vtc.example.com/v1/status-lists/revocation".into(),
+        );
+        // Shrink for fast tests.
+        s.capacity = 128;
+        s.bits = vec![0u8; 128 / 8];
+        s.assigned = vec![false; 128];
+        s
+    }
+
+    #[tokio::test]
+    async fn round_trip_status_list_vc_verifies() {
+        let signer = signer();
+        let mut state = smallish_state();
+        // Flip a couple of real slots.
+        let a = allocate(&mut state).unwrap();
+        let b = allocate(&mut state).unwrap();
+        flip(&mut state, a, true).unwrap();
+        flip(&mut state, b, true).unwrap();
+
+        let vc = build_status_list_credential(&signer, &state)
+            .await
+            .expect("build status-list VC");
+
+        // Type array carries BitstringStatusListCredential.
+        assert!(
+            vc.types.iter().any(|t| t == BITSTRING_STATUS_LIST_VC_TYPE),
+            "expected {BITSTRING_STATUS_LIST_VC_TYPE} in types: {:?}",
+            vc.types
+        );
+
+        // Subject shape: id, type, statusPurpose, encodedList.
+        let subject = match &vc.credential_subject {
+            SubjectValue::Single(m) => m.clone(),
+            SubjectValue::Multiple(v) => v[0].clone(),
+        };
+        assert_eq!(
+            subject.get("type"),
+            Some(&JsonValue::String("BitstringStatusList".into()))
+        );
+        assert_eq!(
+            subject.get("statusPurpose"),
+            Some(&JsonValue::String("revocation".into()))
+        );
+        let encoded = subject
+            .get("encodedList")
+            .and_then(|v| v.as_str())
+            .expect("encodedList must be a string");
+        assert!(!encoded.is_empty());
+
+        // Top-level `id` carries the canonical URL.
+        let as_value = serde_json::to_value(&vc).unwrap();
+        assert_eq!(as_value["id"], state.list_credential_id);
+
+        // Proof verifies.
+        signer.verify(&vc).expect("status-list VC must verify");
+    }
+
+    /// Decoding the encoded bitstring yields the same bits we
+    /// fed in. Confirms the wire round-trip works end-to-end.
+    #[tokio::test]
+    async fn encoded_list_round_trips_through_decode() {
+        let signer = signer();
+        let mut state = smallish_state();
+        let a = allocate(&mut state).unwrap();
+        flip(&mut state, a, true).unwrap();
+        let b = allocate(&mut state).unwrap();
+        flip(&mut state, b, true).unwrap();
+
+        let vc = build_status_list_credential(&signer, &state).await.unwrap();
+        let subject = match &vc.credential_subject {
+            SubjectValue::Single(m) => m.clone(),
+            SubjectValue::Multiple(v) => v[0].clone(),
+        };
+        let encoded = subject["encodedList"].as_str().unwrap();
+        let decoded = BitstringStatusList::decode(encoded, state.capacity, state.purpose).unwrap();
+        assert!(
+            decoded.get(a as usize).unwrap(),
+            "slot {a} should round-trip as set"
+        );
+        assert!(decoded.get(b as usize).unwrap());
+        // A slot we never touched is `0`.
+        let untouched = state.capacity - 1;
+        if !state.assigned[untouched] && !state.is_set(untouched) {
+            assert!(!decoded.get(untouched).unwrap());
+        }
+    }
+}

--- a/vtc-service/src/status_list/mod.rs
+++ b/vtc-service/src/status_list/mod.rs
@@ -1,0 +1,87 @@
+//! Status-list infrastructure — spec §6.2 (M2.10).
+//!
+//! Each VTC maintains two BitstringStatusLists — `revocation`
+//! and `suspension` — capacity 131,072 bits each (W3C herd-
+//! privacy floor). Every VMC carries a `credentialStatus`
+//! entry pointing at one slot in the revocation list. Member
+//! removal flips the slot to `1`; renewal re-uses the same
+//! slot.
+//!
+//! ## Persistence shape
+//!
+//! Per spec §5.6, the VTC stores a [`storage::StatusListState`]
+//! row per purpose in `status_lists:<purpose>`:
+//!
+//! - `bits` — the raw 16 KiB bitstring, MSB-first per W3C.
+//! - `assigned` — which slots are *owned by a member* (decoys
+//!   don't appear here). Drives the allocator's
+//!   never-reallocate-a-flipped-slot invariant: even after a
+//!   member departs and the bit is flipped to `1`, the slot
+//!   stays in `assigned` so the allocator skips it forever.
+//! - `list_credential_id` — the canonical `id` URL the
+//!   published `BitstringStatusListCredential` carries.
+//!
+//! ## Decoys
+//!
+//! `assigned` and `bits` are independent. Decoys are bit
+//! flips on *unassigned* slots — they obscure the real
+//! occupancy from external verifiers without ever blocking a
+//! future allocation. [`allocator::add_initial_decoys`] runs
+//! once at first-init to seed the list with a non-zero
+//! baseline; subsequent operations don't add more decoys
+//! (the underlying `affinidi-status-list::BitstringStatusList`
+//! already randomises slot allocation, which is the primary
+//! correlation defence).
+//!
+//! ## Occupancy warning (spec §6.2)
+//!
+//! `StatusListOccupancyWarning` is emitted via the standard
+//! tracing macro when the live + reserved fraction exceeds
+//! 75% of capacity. Telemetry consumers can subscribe via
+//! the `status_list_occupancy_warning` event name — see
+//! [`OCCUPANCY_WARNING_THRESHOLD`].
+
+pub mod allocator;
+pub mod credential;
+pub mod storage;
+
+pub use allocator::{add_initial_decoys, allocate, flip, occupancy};
+pub use credential::{BITSTRING_STATUS_LIST_VC_TYPE, build_status_list_credential};
+pub use storage::{
+    STATUS_LIST_PREFIX, StatusListState, ensure_initial, get_state, list_states, store_state,
+};
+
+pub use affinidi_status_list::{
+    DEFAULT_BITSTRING_SIZE, MIN_BITSTRING_SIZE, StatusListEntry, StatusPurpose,
+};
+
+/// Fraction at which the per-list occupancy warning fires. Spec
+/// §6.2 calls for 75%. "Occupied" includes both assigned slots
+/// and decoy bits — the warning measures *capacity remaining
+/// for new allocations*, not just live members.
+pub const OCCUPANCY_WARNING_THRESHOLD: f64 = 0.75;
+
+/// Default fraction of slots flipped as decoys at first-init.
+/// 0.05 (~6,500 bits in a 131K list) is the same default
+/// `affinidi-status-list`'s privacy mode tends toward — large
+/// enough to defeat zero-occupancy correlation, small enough
+/// not to chew through capacity prematurely.
+pub const INITIAL_DECOY_FRACTION: f64 = 0.05;
+
+/// Emit a tracing event named `status_list_occupancy_warning`
+/// when [`occupancy`] crosses [`OCCUPANCY_WARNING_THRESHOLD`].
+/// Hand-rolled helper so the allocator + flip paths use the
+/// exact same event shape; downstream telemetry pipelines key on
+/// the event name.
+pub fn maybe_emit_occupancy_warning(state: &storage::StatusListState) {
+    let frac = allocator::occupancy(state);
+    if frac >= OCCUPANCY_WARNING_THRESHOLD {
+        tracing::warn!(
+            event = "status_list_occupancy_warning",
+            purpose = %state.purpose,
+            occupancy = frac,
+            capacity = state.capacity,
+            "status list occupancy crossed warning threshold"
+        );
+    }
+}

--- a/vtc-service/src/status_list/storage.rs
+++ b/vtc-service/src/status_list/storage.rs
@@ -1,0 +1,330 @@
+//! `status_lists:` keyspace — persistence for the two
+//! BitstringStatusList state rows (revocation + suspension).
+//!
+//! Spec §5.6 + §6.2. One row per [`StatusPurpose`] keyed by the
+//! purpose's wire form. The row carries the raw bitstring + the
+//! `assigned` mask that drives the allocator's
+//! never-reuse-a-flipped-slot invariant.
+
+use affinidi_status_list::{DEFAULT_BITSTRING_SIZE, StatusPurpose};
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::INITIAL_DECOY_FRACTION;
+
+/// Prefix every status-list row sits under. Exposed so the
+/// boot path + admin tooling can prefix-iterate.
+pub const STATUS_LIST_PREFIX: &[u8] = b"status_lists:";
+
+/// Persisted state for one BitstringStatusList. Stored under
+/// `status_lists:<purpose>` (one row per purpose) and loaded on
+/// every allocate / flip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusListState {
+    /// Purpose this list serves (`revocation` / `suspension`).
+    pub purpose: StatusPurpose,
+    /// Total number of bits in the list. Defaults to
+    /// [`DEFAULT_BITSTRING_SIZE`] (131,072) per spec §6.2's
+    /// herd-privacy floor; immutable after creation.
+    pub capacity: usize,
+    /// Raw bitstring, MSB-first per W3C
+    /// `BitstringStatusListCredential`.
+    #[serde(with = "hex_bytes")]
+    pub bits: Vec<u8>,
+    /// Slot ownership. `assigned[i] == true` iff slot `i` has
+    /// been handed out by [`super::allocate`] for a real
+    /// member. Decoys don't show up here. Drives
+    /// "flipped indices are never reallocated" — a departed
+    /// member's slot keeps `assigned[i] == true` even after
+    /// the bit flips, so the allocator skips it.
+    #[serde(with = "compact_bool_vec")]
+    pub assigned: Vec<bool>,
+    /// Canonical `id` URL the published
+    /// `BitstringStatusListCredential` carries. The VMC's
+    /// `credentialStatus.statusListCredential` field also
+    /// references this URL.
+    pub list_credential_id: String,
+}
+
+impl StatusListState {
+    /// Fresh state — all bits zero, nothing assigned. Caller
+    /// is responsible for seeding decoys via
+    /// [`super::add_initial_decoys`].
+    pub fn new(purpose: StatusPurpose, list_credential_id: String) -> Self {
+        let capacity = DEFAULT_BITSTRING_SIZE;
+        Self {
+            purpose,
+            capacity,
+            bits: vec![0u8; capacity.div_ceil(8)],
+            assigned: vec![false; capacity],
+            list_credential_id,
+        }
+    }
+
+    /// `true` iff bit `index` is set (revoked / suspended).
+    pub fn is_set(&self, index: usize) -> bool {
+        let byte = index / 8;
+        let bit = 7 - (index % 8);
+        (self.bits[byte] >> bit) & 1 == 1
+    }
+
+    /// Count of bits set to `1` across the whole list (live
+    /// flips + decoys).
+    pub fn count_set(&self) -> usize {
+        self.bits.iter().map(|b| b.count_ones() as usize).sum()
+    }
+
+    /// Number of slots currently assigned to a real member
+    /// (excluding decoys).
+    pub fn count_assigned(&self) -> usize {
+        self.assigned.iter().filter(|a| **a).count()
+    }
+
+    /// Suggested initial decoy count derived from
+    /// [`INITIAL_DECOY_FRACTION`].
+    pub fn initial_decoy_count(&self) -> usize {
+        (self.capacity as f64 * INITIAL_DECOY_FRACTION) as usize
+    }
+}
+
+fn purpose_key(purpose: StatusPurpose) -> Vec<u8> {
+    let mut k = STATUS_LIST_PREFIX.to_vec();
+    k.extend_from_slice(purpose.to_string().as_bytes());
+    k
+}
+
+/// Retrieve a state row by purpose. `Ok(None)` if absent.
+pub async fn get_state(
+    ks: &KeyspaceHandle,
+    purpose: StatusPurpose,
+) -> Result<Option<StatusListState>, AppError> {
+    let raw = ks.get_raw(purpose_key(purpose)).await?;
+    match raw {
+        Some(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+            AppError::Internal(format!("StatusListState decode: {e}"))
+        })?)),
+        None => Ok(None),
+    }
+}
+
+/// Persist a state row (create or overwrite).
+pub async fn store_state(ks: &KeyspaceHandle, state: &StatusListState) -> Result<(), AppError> {
+    ks.insert(
+        String::from_utf8(purpose_key(state.purpose)).expect("status-list key is ASCII"),
+        state,
+    )
+    .await
+}
+
+/// List every persisted state row. Used at boot to materialise
+/// the live status-list set into memory.
+pub async fn list_states(ks: &KeyspaceHandle) -> Result<Vec<StatusListState>, AppError> {
+    let pairs = ks.prefix_iter_raw(STATUS_LIST_PREFIX.to_vec()).await?;
+    let mut out = Vec::with_capacity(pairs.len());
+    for (_k, v) in pairs {
+        match serde_json::from_slice::<StatusListState>(&v) {
+            Ok(s) => out.push(s),
+            Err(err) => tracing::warn!(error = %err, "skipping unparseable status-list row"),
+        }
+    }
+    Ok(out)
+}
+
+/// Idempotent first-init helper. If `purpose` has no row yet,
+/// create one with [`StatusListState::new`] and seed decoys via
+/// [`super::add_initial_decoys`]. Returns the state regardless
+/// (boot path can act on it without a second `get_state` call).
+pub async fn ensure_initial(
+    ks: &KeyspaceHandle,
+    purpose: StatusPurpose,
+    list_credential_id: String,
+) -> Result<StatusListState, AppError> {
+    if let Some(existing) = get_state(ks, purpose).await? {
+        return Ok(existing);
+    }
+    let mut state = StatusListState::new(purpose, list_credential_id);
+    let decoy_count = state.initial_decoy_count();
+    super::allocator::add_initial_decoys(&mut state, decoy_count);
+    store_state(ks, &state).await?;
+    Ok(state)
+}
+
+// ---------------------------------------------------------------------------
+// serde adapters
+// ---------------------------------------------------------------------------
+
+/// Hex-encode `Vec<u8>` on the wire. 16 KiB of bits is 16 KiB
+/// of base16 = 32 KiB string — fine for a once-per-flip persist
+/// of a fjall row, and operators reading the JSON see something
+/// inspectable.
+mod hex_bytes {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(bytes: &[u8], s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_str(&hex::encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(d)?;
+        hex::decode(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Compact `Vec<bool>` serializer. Packs 8 booleans per byte
+/// and hex-encodes. Keeps the persisted row a manageable size
+/// (a 131K-slot `Vec<bool>` would be 131K * 1 byte = 128 KiB
+/// of JSON otherwise).
+mod compact_bool_vec {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize, Deserialize)]
+    struct Packed {
+        len: usize,
+        #[serde(with = "super::hex_bytes")]
+        bits: Vec<u8>,
+    }
+
+    pub fn serialize<S>(v: &[bool], s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut bits = vec![0u8; v.len().div_ceil(8)];
+        for (i, b) in v.iter().enumerate() {
+            if *b {
+                bits[i / 8] |= 1 << (7 - (i % 8));
+            }
+        }
+        Packed { len: v.len(), bits }.serialize(s)
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Vec<bool>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let Packed { len, bits } = Packed::deserialize(d)?;
+        let mut v = vec![false; len];
+        for (i, slot) in v.iter_mut().enumerate() {
+            let byte = bits.get(i / 8).copied().unwrap_or(0);
+            *slot = (byte >> (7 - (i % 8))) & 1 == 1;
+        }
+        Ok(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        let ks = store.keyspace("status_lists").expect("ks");
+        (ks, dir)
+    }
+
+    #[tokio::test]
+    async fn round_trip_through_keyspace_preserves_bits_and_assigned() {
+        let (ks, _dir) = temp_ks().await;
+        let mut state = StatusListState::new(
+            StatusPurpose::Revocation,
+            "https://vtc.example.com/v1/status-lists/revocation".into(),
+        );
+        // Flip + assign a handful of slots.
+        state.bits[0] = 0b10101010;
+        state.assigned[3] = true;
+        state.assigned[5] = true;
+
+        store_state(&ks, &state).await.unwrap();
+        let got = get_state(&ks, StatusPurpose::Revocation)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.purpose, StatusPurpose::Revocation);
+        assert_eq!(got.capacity, state.capacity);
+        assert_eq!(got.bits[0], 0b10101010);
+        assert!(got.assigned[3]);
+        assert!(got.assigned[5]);
+        assert!(!got.assigned[4]);
+        assert_eq!(got.list_credential_id, state.list_credential_id);
+    }
+
+    #[tokio::test]
+    async fn ensure_initial_is_idempotent() {
+        let (ks, _dir) = temp_ks().await;
+        let a = ensure_initial(
+            &ks,
+            StatusPurpose::Revocation,
+            "https://vtc.example.com/v1/status-lists/revocation".into(),
+        )
+        .await
+        .unwrap();
+        let b = ensure_initial(
+            &ks,
+            StatusPurpose::Revocation,
+            "https://vtc.example.com/v1/status-lists/revocation".into(),
+        )
+        .await
+        .unwrap();
+        // Same bitstring + assigned mask back from both calls
+        // (re-init must not re-seed decoys).
+        assert_eq!(a.bits, b.bits);
+        assert_eq!(a.assigned, b.assigned);
+    }
+
+    #[tokio::test]
+    async fn ensure_initial_seeds_decoys() {
+        let (ks, _dir) = temp_ks().await;
+        let state = ensure_initial(
+            &ks,
+            StatusPurpose::Revocation,
+            "https://vtc.example.com/v1/status-lists/revocation".into(),
+        )
+        .await
+        .unwrap();
+        // Initial decoy count is INITIAL_DECOY_FRACTION * capacity.
+        // The bit count won't be exactly that because random
+        // collisions skip duplicates, but it's at least 90% of the
+        // target.
+        let expected = state.initial_decoy_count();
+        let actual = state.count_set();
+        assert!(
+            actual >= (expected * 9) / 10,
+            "expected at least ~{expected} decoys, got {actual}"
+        );
+        // No slots assigned yet — decoys never touch `assigned`.
+        assert_eq!(state.count_assigned(), 0);
+    }
+
+    #[test]
+    fn count_set_matches_bit_arithmetic() {
+        let mut state = StatusListState::new(StatusPurpose::Revocation, "id".into());
+        state.bits[0] = 0b11110000;
+        state.bits[1] = 0b00000011;
+        assert_eq!(state.count_set(), 6);
+    }
+
+    #[test]
+    fn compact_bool_vec_round_trips() {
+        let mut state = StatusListState::new(StatusPurpose::Revocation, "id".into());
+        // Touch slots 0, 7, 8, 9 (cross-byte) + a far-right slot.
+        for idx in [0usize, 7, 8, 9, state.capacity - 1] {
+            state.assigned[idx] = true;
+        }
+        let s = serde_json::to_string(&state).unwrap();
+        let back: StatusListState = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.assigned, state.assigned);
+    }
+}

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -81,6 +81,7 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -123,6 +124,8 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -64,6 +64,7 @@ async fn build_with(
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -105,6 +106,8 @@ async fn build_with(
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -87,6 +87,7 @@ async fn build_fixture(with_audit: bool) -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -188,6 +189,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -57,6 +57,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -87,6 +88,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -58,6 +58,7 @@ async fn build() -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -88,6 +89,8 @@ async fn build() -> Fixture {
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -52,6 +52,7 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -77,6 +78,8 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -208,6 +208,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -296,6 +297,8 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config.clone())),

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -69,6 +69,7 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -106,6 +107,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -100,6 +100,7 @@ async fn build_fixture() -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -135,6 +136,8 @@ async fn build_fixture() -> Fixture {
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -84,6 +84,7 @@ async fn build_fixture() -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -170,6 +171,8 @@ async fn build_fixture() -> Fixture {
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -72,6 +72,7 @@ async fn build_fixture() -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -151,6 +152,8 @@ async fn build_fixture() -> Fixture {
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -41,6 +41,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -67,6 +68,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
         secrets_resolver: None,

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -99,6 +99,7 @@ async fn build_fixture() -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -171,6 +172,8 @@ async fn build_fixture() -> Fixture {
         join_requests_ks,
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -73,6 +73,7 @@ async fn build_fixture() -> Fixture {
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -163,6 +164,8 @@ async fn build_fixture() -> Fixture {
         join_requests_ks,
         policies_ks,
         active_policies_ks,
+        status_lists_ks,
+        credential_signer: None,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -237,6 +237,7 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
     let join_requests_ks = store.keyspace("join_requests").unwrap();
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -258,6 +259,8 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        credential_signer: None,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/status_lists.rs
+++ b/vtc-service/tests/status_lists.rs
@@ -1,0 +1,231 @@
+//! Integration coverage for `GET /v1/status-lists/{purpose}`
+//! (Phase 2 M2.11).
+//!
+//! Verifies:
+//! - Route serves the seeded status-list VC.
+//! - Trust-Task header is **not** required (verifier-facing
+//!   exemption).
+//! - Unknown purpose → 404.
+//! - 503 path when the credential signer isn't initialised.
+
+mod common;
+
+use std::sync::Arc;
+
+use affinidi_status_list::StatusPurpose;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::audit::{AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::config::AppConfig;
+use vtc_service::credentials::LocalSigner;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::routes;
+use vtc_service::server::AppState;
+use vtc_service::status_list;
+
+const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+const PUBLIC_URL: &str = "https://vtc.example.com";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    signer: Arc<LocalSigner>,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture(with_signer: bool) -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    // Seed both status lists like `server::run` does at boot.
+    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
+    for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+        let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
+        status_list::ensure_initial(&status_lists_ks, purpose, url)
+            .await
+            .unwrap();
+    }
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "{VTC_DID}"
+        public_url = "{PUBLIC_URL}"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks,
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks,
+        audit_ks,
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: Some(PUBLIC_URL.into()),
+        install_signer: None,
+        credential_signer: with_signer.then(|| signer.clone()),
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+
+    Fixture {
+        router,
+        signer,
+        _dir: dir,
+    }
+}
+
+async fn body_json(body: Body) -> Value {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        let raw = String::from_utf8_lossy(&bytes);
+        panic!("response body was not JSON ({e}): {raw}")
+    })
+}
+
+/// GET without a Trust-Task header returns the status-list VC.
+/// Confirms the route_exempt path is wired.
+#[tokio::test]
+async fn show_returns_signed_vc_without_trust_task_header() {
+    let fix = build_fixture(true).await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/status-lists/revocation")
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Cache-Control: no-store header set per spec §6.2.
+    let headers = resp.headers().clone();
+    assert_eq!(
+        headers.get("cache-control").map(|v| v.to_str().unwrap()),
+        Some("no-store"),
+    );
+
+    let body = body_json(resp.into_body()).await;
+
+    // Shape: VC with the BitstringStatusListCredential type.
+    let types = body["type"].as_array().expect("type array");
+    assert!(types.iter().any(|t| t == "VerifiableCredential"));
+    assert!(types.iter().any(|t| t == "BitstringStatusListCredential"));
+
+    // Subject details.
+    assert_eq!(body["credentialSubject"]["statusPurpose"], "revocation");
+    assert_eq!(body["credentialSubject"]["type"], "BitstringStatusList");
+    assert!(body["credentialSubject"]["encodedList"].is_string());
+
+    // Proof verifies against the signer used in the fixture.
+    let vc: affinidi_vc::VerifiableCredential = serde_json::from_value(body).unwrap();
+    fix.signer.verify(&vc).expect("status-list VC must verify");
+}
+
+/// `suspension` purpose is also served (both purposes seeded
+/// at boot).
+#[tokio::test]
+async fn show_serves_suspension_purpose() {
+    let fix = build_fixture(true).await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/status-lists/suspension")
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["credentialSubject"]["statusPurpose"], "suspension");
+}
+
+/// An unknown purpose value returns 404.
+#[tokio::test]
+async fn show_unknown_purpose_returns_404() {
+    let fix = build_fixture(true).await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/status-lists/disco")
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+/// When the credential signer is `None` (daemon not yet
+/// provisioned), the route returns 500 with a "signer not
+/// initialised" message. `AppError::Internal` maps to 500 in
+/// the workspace.
+#[tokio::test]
+async fn show_returns_5xx_when_signer_missing() {
+    let fix = build_fixture(false).await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/status-lists/revocation")
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert!(
+        resp.status().is_server_error(),
+        "expected 5xx when signer missing, got {}",
+        resp.status()
+    );
+}


### PR DESCRIPTION
## Summary

Third PR of Phase 2. Lands the credential-issuance surface
M2.12 (VMC + VEC on join-approve) and M2.13 (renewal) will
sit on top of. Three milestones per plan PR-3 slicing:

| Milestone | What it adds |
|---|---|
| **M2.9** | `vtc_service::credentials` — `LocalSigner` (plan §D1) + VMC + VEC builders |
| **M2.10** | `vtc_service::status_list` — keyspace, allocator, BitstringStatusList VC builder |
| **M2.11** | Public `GET /v1/status-lists/{purpose}` route + boot-time init |

## Plan §D1 cached-locally signing in action

`LocalSigner` wraps the VTC's `#key-0` Ed25519 secret —
already loaded into the secrets resolver at boot — and signs
every credential locally via
`affinidi-data-integrity::DataIntegrityProof::sign` with
`eddsa-jcs-2022`. No per-call VTA round-trip; same canonical
path the existing VTA SDK's `VtaAuthorizationCredential` uses.

Plumbed onto AppState as `credential_signer:
Option<Arc<LocalSigner>>`, built alongside the install signer
in `init_auth` from the same Ed25519 seed.

## Status-list architecture (M2.10)

Spec §6.2 invariants preserved:
- **Random allocation** — via `affinidi-status-list`'s privacy
  mode, every slot is randomised at issuance.
- **Decoys** — ~5% of slots flipped at first-init so external
  verifiers can't infer occupancy from Hamming weight.
- **Flipped indices never reallocated** — `assigned` mask
  tracks slot ownership separately from `bits`, and the
  allocator only considers `!assigned`. A departed member's
  bit flips to 1 + `assigned[i]` stays true → allocator
  permanently skips it.
- **75% occupancy warning** — `status_list_occupancy_warning`
  tracing event fires when the live + reserved fraction
  crosses the threshold.

Persistence: `status_lists:<purpose>` row carrying the raw
bitstring (hex-encoded) + a packed `Vec<bool>` for the
assigned mask. Custom serde adapters keep the 131K-slot row
manageable on disk.

## Public route (M2.11)

`GET /v1/status-lists/{purpose}` — verifier-facing,
Trust-Task-exempt (`route_exempt`, same as `did.jsonl`).
Returns the freshly-signed `BitstringStatusListCredential` per
W3C bitstring-status-list v1.0 with `Cache-Control: no-store`
so CDN caches between us and verifiers cannot mask a recent
revocation. Trust Task `status-lists/show/1.0` ships with
`trust_task_header_exempt: true` in both frontmatter and the
index.json entry.

Boot path provisions both status lists when `public_url` is
set (URL pattern is `{public_url}/v1/status-lists/{purpose}`).
When unset, the daemon logs a warning and the route returns
404 with a recovery hint — VMC issuance + status-list
publication are both gated on the URL being known.

## Test coverage (32 new tests)

- **credentials::signer (3 unit)** — deterministic kid +
  public key from seed; different seeds → different keys;
  assertion_method_id construction.
- **credentials::vmc (5 unit)** — happy path verifies;
  `validUntil = validFrom + validity`; personhood flag
  propagates; status_ref splices a `credentialStatus` block +
  proof still verifies; tampering invalidates.
- **credentials::vec (2 unit)** — all five `VtcRole` variants
  round-trip (Admin, Moderator, Issuer, Member, Custom);
  tampering with the role invalidates.
- **status_list::storage (5 unit)** — round-trip preserves
  bits + assigned; ensure_initial idempotent; seeds decoys;
  count_set bit arithmetic; compact_bool_vec round-trip
  across byte boundaries.
- **status_list::allocator (7 unit)** — exhaust returns None;
  **flipped slots never reallocated** (the load-bearing
  invariant); flip-back keeps assigned; flip OOB Err;
  occupancy crosses 75% at the right point; decoys never
  touch assigned.
- **status_list::credential (2 unit)** — signed VC verifies;
  encoded list round-trips through `BitstringStatusList::decode`.
- **status_lists.rs (4 integration)** — GET without
  Trust-Task header succeeds (proves exemption); suspension
  purpose also served; unknown purpose → 404; signer missing
  → 5xx.

## Direct deps added

- `affinidi-vc` (workspace pin)
- `affinidi-data-integrity` (workspace pin)
- `affinidi-secrets-resolver` (workspace pin)
- `affinidi-status-list = "0.1"` (workspace pin)

All four were transitively present via `affinidi-tdk` and
`vta-sdk`; the direct entries make them visible to clippy +
cargo-audit and let us pin without depending on `vta-sdk`'s
choices.

## What's NOT in this PR

Deferred to PR 4 (M2.12–M2.14):
- VMC + VEC issuance on `join-requests/approve`.
- `POST /v1/members/me/renew` (renewal flow).
- Status-list flip on `MemberRemoved`.

## Test plan

- [x] `cargo test -p vtc-service` green (350+ tests).
- [x] `cargo test -p vti-common audit::` green.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- [ ] Review the per-request VC build cost (status-list VC is
  re-signed on every GET — fine for MVP, cacheable later).
- [ ] Approve before M2.12 (issuance) starts.

## Commits

1. `764b66f` — M2.9 VC builder + local signer
2. `ad94d68` — M2.10 status-list infrastructure
3. `8ee1d38` — M2.11 public status-list route

Once this PR merges, M2.12 starts on a fresh branch.