### PR TITLE
feat(vtc-service): Phase 2 PR 4 — VMC/VEC issuance + renewal + flip-on-removal (M2.12–M2.14)

### DIFF
--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -280,7 +280,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.12 — VMC + VEC issuance on approve
 
-### `[ ]` M2.12.1 — Wire issuance into `decide::approve`
+### `[x]` M2.12.1 — Wire issuance into `decide::approve`
 
 - **Acceptance**
   - On approve: allocate a status-list index (revocation

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -301,7 +301,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.13 — Renewal
 
-### `[ ]` M2.13.1 — `POST /v1/members/me/renew`
+### `[x]` M2.13.1 — `POST /v1/members/me/renew`
 
 - **Acceptance**
   - Authenticated. Caller's DID is the renewal target.
@@ -324,7 +324,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.14 — Removal flips revocation bit
 
-### `[ ]` M2.14.1 — Status-list flip on `MemberRemoved`
+### `[x]` M2.14.1 — Status-list flip on `MemberRemoved`
 
 - **Acceptance**
   - `remove_inner` flips the member's status-list bit

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -224,6 +224,12 @@
       "rest": "GET /v1/policies/{id}"
     },
     {
+      "id": "https://trusttasks.org/openvtc/vtc/members/renew/1.0",
+      "status": "Draft",
+      "path": "members/renew/1.0",
+      "rest": "POST /v1/members/me/renew"
+    },
+    {
       "id": "https://trusttasks.org/openvtc/vtc/status-lists/show/1.0",
       "status": "Draft",
       "path": "status-lists/show/1.0",

--- a/trust-tasks/members/renew/1.0/schema.json
+++ b/trust-tasks/members/renew/1.0/schema.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/renew/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Members — Renew",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["did", "vmc", "roleVec", "personhood", "personhoodChanged"],
+      "properties": {
+        "did": { "type": "string" },
+        "vmc": { "type": "object" },
+        "roleVec": { "type": "object" },
+        "personhood": { "type": "boolean" },
+        "personhoodChanged": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/trust-tasks/members/renew/1.0/spec.md
+++ b/trust-tasks/members/renew/1.0/spec.md
@@ -1,0 +1,67 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/renew/1.0
+title: VTC Members — Renew
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/members/me/renew
+---
+
+# VTC Members — Renew
+
+Re-mints the caller's VMC + role VEC. Spec §6.3.
+
+## Authentication
+
+Bearer-token JWT for the member. No expiry or grace-window
+check on the caller's session is added beyond the standard
+session validation — the spec calls renewal "unconditional on
+ACL membership", and an expired session is a different issue.
+
+## Side-effects
+
+1. Verifies the caller has an active ACL row (404 if not a
+   member).
+2. Re-evaluates `personhood.rego` (spec §6.3 step 3). Phase 2
+   ships the deny-all stub so the new VMC's `personhood` flag
+   is always `false`.
+3. Re-uses the same status-list slot the member was allocated
+   at join time. A member without a slot (a grandfathered
+   pre-M2.12 row) gets a fresh allocation as a one-time
+   reconcile.
+4. Mints a fresh VMC + role VEC (`validFrom = now`,
+   `validUntil = now + community.membership.validity`).
+5. Updates `Member.current_vmc_id` + `current_role_vec_id`
+   to the new ids.
+6. Emits `MembershipRenewed` audit envelope with
+   `personhood_changed` set when the new flag differs from
+   the prior VMC's.
+
+## Response (`200 OK`)
+
+```
+{
+  "did": "did:key:zMember",
+  "vmc": { ... signed VC ... },
+  "roleVec": { ... signed VC ... },
+  "personhood": false,
+  "personhoodChanged": false
+}
+```
+
+## Errors
+
+- `401 Unauthorized` — missing / invalid session token.
+- `404 Not Found` — caller has no ACL or Member row.
+- `500 Internal Server Error` — credential signer unavailable,
+  status list not provisioned, etc.
+
+## Idempotency
+
+Phase 2 plan §D6 classifies renewal as non-destructive: the
+ACL row is unchanged, only fresh VC ids are minted. Repeated
+renewal calls within a 24h window are safe; the workspace's
+idempotency cache lands separately as part of the M0.1.3
+plumbing.

--- a/vtc-service/src/credentials/vec.rs
+++ b/vtc-service/src/credentials/vec.rs
@@ -47,6 +47,10 @@ pub const DEFAULT_ROLE_VEC_VALIDITY: Duration = Duration::days(30);
 pub struct RoleVecParams {
     /// Subject DID — the member receiving the role grant.
     pub member_did: String,
+    /// Optional top-level `id` URI for the VC (typically
+    /// `urn:uuid:<server-allocated>`). Mirrors
+    /// [`super::vmc::VmcParams::id`].
+    pub id: Option<String>,
     /// The role being granted. Spec §5.3 names four standard
     /// roles + `Custom(String)`; all five surface here via
     /// [`VtcRole::to_string`].
@@ -59,9 +63,15 @@ impl RoleVecParams {
     pub fn new(member_did: impl Into<String>, role: VtcRole) -> Self {
         Self {
             member_did: member_did.into(),
+            id: None,
             role,
             validity: DEFAULT_ROLE_VEC_VALIDITY,
         }
+    }
+
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
     }
 
     pub fn with_validity(mut self, validity: Duration) -> Self {
@@ -98,8 +108,26 @@ pub async fn build_role_vec(
         .build()
         .map_err(|e| AppError::Internal(format!("VEC build: {e}")))?;
 
+    if let Some(id) = &params.id {
+        attach_top_level_id(&mut vc, id)?;
+    }
+
     signer.sign(&mut vc).await?;
     Ok(vc)
+}
+
+/// Splice a top-level `id` onto the VC. Same JSON-round-trip
+/// trick the VMC builder uses for `credentialStatus`.
+fn attach_top_level_id(vc: &mut VerifiableCredential, id: &str) -> Result<(), AppError> {
+    let mut as_value =
+        serde_json::to_value(&*vc).map_err(|e| AppError::Internal(format!("VEC -> value: {e}")))?;
+    as_value
+        .as_object_mut()
+        .ok_or_else(|| AppError::Internal("VEC not an object".into()))?
+        .insert("id".into(), JsonValue::String(id.into()));
+    *vc = serde_json::from_value(as_value)
+        .map_err(|e| AppError::Internal(format!("value -> VEC: {e}")))?;
+    Ok(())
 }
 
 fn rfc3339(t: chrono::DateTime<Utc>) -> String {

--- a/vtc-service/src/credentials/vmc.rs
+++ b/vtc-service/src/credentials/vmc.rs
@@ -90,6 +90,14 @@ impl CredentialStatusRef {
 pub struct VmcParams {
     /// Subject DID — the member receiving the VMC.
     pub member_did: String,
+    /// Optional top-level `id` URI for the VC. When `Some`, the
+    /// builder splices it into the credential after construction
+    /// (the upstream typed VC doesn't expose `id` as a builder
+    /// method). M2.12's issuance flow uses
+    /// `urn:uuid:<server-allocated>` so the audit trail + the
+    /// `Member.current_vmc_id` pointer can reference the same
+    /// stable id.
+    pub id: Option<String>,
     /// Status-list reference, or `None` to omit `credentialStatus`
     /// entirely (used by tests + the M2.9-only path before
     /// M2.10/M2.11 wire in live status lists).
@@ -108,10 +116,16 @@ impl VmcParams {
     pub fn new(member_did: impl Into<String>) -> Self {
         Self {
             member_did: member_did.into(),
+            id: None,
             status_ref: None,
             validity: super::DEFAULT_VMC_VALIDITY,
             personhood: false,
         }
+    }
+
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
     }
 
     pub fn with_status_ref(mut self, status_ref: CredentialStatusRef) -> Self {
@@ -154,6 +168,10 @@ pub async fn build_vmc(
         .build()
         .map_err(|e| AppError::Internal(format!("VMC build: {e}")))?;
 
+    if let Some(id) = &params.id {
+        attach_top_level_field(&mut vc, "id", JsonValue::String(id.clone()))?;
+    }
+
     if let Some(status_ref) = &params.status_ref {
         // `affinidi-vc` 0.1's typed VC doesn't expose a public
         // `credentialStatus` setter (the type carries common
@@ -174,14 +192,25 @@ fn attach_credential_status(
     vc: &mut VerifiableCredential,
     status_ref: &CredentialStatusRef,
 ) -> Result<(), AppError> {
-    let mut as_value =
-        serde_json::to_value(&*vc).map_err(|e| AppError::Internal(format!("VMC -> value: {e}")))?;
     let status = serde_json::to_value(status_ref)
         .map_err(|e| AppError::Internal(format!("credentialStatus -> value: {e}")))?;
+    attach_top_level_field(vc, "credentialStatus", status)
+}
+
+/// Splice an arbitrary top-level field onto the VC. Same
+/// JSON-round-trip trick used for `credentialStatus`; shared so
+/// the `id` setter doesn't duplicate the round-trip dance.
+fn attach_top_level_field(
+    vc: &mut VerifiableCredential,
+    key: &str,
+    value: JsonValue,
+) -> Result<(), AppError> {
+    let mut as_value =
+        serde_json::to_value(&*vc).map_err(|e| AppError::Internal(format!("VMC -> value: {e}")))?;
     as_value
         .as_object_mut()
         .ok_or_else(|| AppError::Internal("VMC not an object".into()))?
-        .insert("credentialStatus".into(), status);
+        .insert(key.to_string(), value);
     *vc = serde_json::from_value(as_value)
         .map_err(|e| AppError::Internal(format!("value -> VMC: {e}")))?;
     Ok(())

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -7,22 +7,33 @@
 //! already validated at submit time so the only failure modes
 //! here are auth + duplicate-membership.
 
+use affinidi_status_list::StatusPurpose;
+use affinidi_vc::VerifiableCredential;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use tracing::info;
 use uuid::Uuid;
 
-use vti_common::audit::{AuditEvent, JoinRequestData, JoinRequestRejectedData, MemberAddedData};
+use vti_common::audit::{
+    AuditEvent, CredentialIssuedData, JoinRequestData, JoinRequestRejectedData, MemberAddedData,
+};
 use vti_common::error::AppError;
 
 use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
 use crate::auth::AdminAuth;
 use crate::auth::session::now_epoch;
+use crate::credentials::vec::VEC_TYPE;
+use crate::credentials::vmc::VMC_TYPE;
+use crate::credentials::{
+    CredentialStatusRef, RoleVecParams, VmcParams, build_role_vec, build_vmc,
+};
 use crate::join::{JoinStatus, get_join_request, store_join_request};
 use crate::members::{Member, store_member};
 use crate::server::AppState;
+use crate::status_list;
 
 const REJECT_REASON_MAX: usize = 1024;
 
@@ -31,6 +42,15 @@ const REJECT_REASON_MAX: usize = 1024;
 pub struct DecideResponse {
     pub request_id: Uuid,
     pub status: String,
+    /// Issued VMC (M2.12). Inline so the admin caller can hand
+    /// it to the applicant out-of-band; sealed-transfer to the
+    /// applicant's DID lands in a follow-up milestone. `None` on
+    /// the reject path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vmc: Option<JsonValue>,
+    /// Issued role VEC. Same delivery story as `vmc`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_vec: Option<JsonValue>,
 }
 
 // ---------------------------------------------------------------------------
@@ -83,7 +103,20 @@ pub async fn approve(
     };
     store_acl_entry(&state.acl_ks, &acl).await?;
 
-    let member = Member::fresh(&req.applicant_did);
+    let mut member = Member::fresh(&req.applicant_did);
+    store_member(&state.members_ks, &member).await?;
+
+    // M2.12: issue VMC + role VEC + flip status-list slot. Done
+    // after the ACL + Member rows are persisted so the credential
+    // pointers reference a row that exists. A failure here
+    // surfaces as 500 — the ACL + Member rows remain, so the
+    // operator can retry via the M2.13 renewal endpoint once the
+    // underlying issue is fixed.
+    let (vmc, role_vec, status_list_index) =
+        issue_join_credentials(&state, &req.applicant_did).await?;
+    member.status_list_index = Some(status_list_index);
+    member.current_vmc_id = top_level_id(&vmc);
+    member.current_role_vec_id = top_level_id(&role_vec);
     store_member(&state.members_ks, &member).await?;
 
     req.status = JoinStatus::Approved;
@@ -109,11 +142,26 @@ pub async fn approve(
             }),
         )
         .await?;
+    audit_writer
+        .write(
+            &admin.0.did,
+            Some(&req.applicant_did),
+            AuditEvent::VmcIssued(credential_issued_data(&vmc, Some(status_list_index))?),
+        )
+        .await?;
+    audit_writer
+        .write(
+            &admin.0.did,
+            Some(&req.applicant_did),
+            AuditEvent::VecIssued(credential_issued_data(&role_vec, None)?),
+        )
+        .await?;
 
     info!(
         request_id = %id,
         applicant = %req.applicant_did,
         admin = %admin.0.did,
+        status_list_index,
         "join request approved"
     );
 
@@ -122,8 +170,117 @@ pub async fn approve(
         Json(DecideResponse {
             request_id: id,
             status: req.status.to_string(),
+            vmc: Some(serde_json::to_value(&vmc).map_err(|e| {
+                AppError::Internal(format!("serialise VMC for response: {e}"))
+            })?),
+            role_vec: Some(serde_json::to_value(&role_vec).map_err(|e| {
+                AppError::Internal(format!("serialise VEC for response: {e}"))
+            })?),
         }),
     ))
+}
+
+/// Allocate a revocation-list slot, mint the VMC + role VEC,
+/// persist the updated status-list state. Returns the signed
+/// VCs + the allocated index for the audit trail.
+///
+/// Sealed-transfer to the applicant's DID is deferred — for
+/// M2.12 the credentials are returned inline in the approve
+/// response and the admin caller hands them off out-of-band.
+async fn issue_join_credentials(
+    state: &AppState,
+    applicant_did: &str,
+) -> Result<(VerifiableCredential, VerifiableCredential, u32), AppError> {
+    let signer = state.credential_signer.as_ref().ok_or_else(|| {
+        AppError::Internal(
+            "credential signer not initialised — cannot mint VMC (run setup first)".into(),
+        )
+    })?;
+
+    let mut row = status_list::get_state(&state.status_lists_ks, StatusPurpose::Revocation)
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal(
+                "revocation status list not provisioned — set `public_url` + restart".into(),
+            )
+        })?;
+
+    let slot = status_list::allocate(&mut row).ok_or_else(|| {
+        AppError::Internal(format!(
+            "revocation status list exhausted (capacity = {})",
+            row.capacity
+        ))
+    })?;
+
+    let status_ref =
+        CredentialStatusRef::revocation(row.list_credential_id.clone(), slot);
+
+    let vmc_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let vmc = build_vmc(
+        signer,
+        VmcParams::new(applicant_did)
+            .with_id(vmc_id)
+            .with_status_ref(status_ref)
+            .with_personhood(false),
+    )
+    .await?;
+
+    let vec_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let role_vec = build_role_vec(
+        signer,
+        RoleVecParams::new(applicant_did, VtcRole::Member).with_id(vec_id),
+    )
+    .await?;
+
+    // Persist the status-list state *after* both VCs build
+    // successfully — if either build fails we don't permanently
+    // burn a slot. (The state lives only in this function's
+    // local copy until the store_state call.)
+    status_list::store_state(&state.status_lists_ks, &row).await?;
+    status_list::maybe_emit_occupancy_warning(&row);
+
+    Ok((vmc, role_vec, slot))
+}
+
+/// Pull the top-level `id` field off a signed VC. The
+/// upstream `VerifiableCredential` type doesn't expose it
+/// directly — we splice it onto the wire form via JSON, so
+/// reading it back requires a JSON round-trip.
+fn top_level_id(vc: &VerifiableCredential) -> Option<String> {
+    serde_json::to_value(vc)
+        .ok()
+        .and_then(|v| v.get("id").and_then(|i| i.as_str().map(str::to_string)))
+}
+
+/// Build a [`CredentialIssuedData`] payload from a signed VC.
+fn credential_issued_data(
+    vc: &VerifiableCredential,
+    status_list_index: Option<u32>,
+) -> Result<CredentialIssuedData, AppError> {
+    let id = top_level_id(vc).ok_or_else(|| {
+        AppError::Internal("credential is missing top-level `id` — issuance dropped it".into())
+    })?;
+    let credential_type = vc
+        .types
+        .iter()
+        .find(|t| *t == VMC_TYPE || *t == VEC_TYPE)
+        .cloned()
+        .ok_or_else(|| AppError::Internal("credential carries neither VMC nor VEC type".into()))?;
+    let valid_from = vc
+        .valid_from
+        .clone()
+        .ok_or_else(|| AppError::Internal("credential missing validFrom".into()))?;
+    let valid_until = vc
+        .valid_until
+        .clone()
+        .ok_or_else(|| AppError::Internal("credential missing validUntil".into()))?;
+    Ok(CredentialIssuedData {
+        credential_id: id,
+        credential_type,
+        valid_from,
+        valid_until,
+        status_list_index,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -193,6 +350,8 @@ pub async fn reject(
         Json(DecideResponse {
             request_id: id,
             status: req.status.to_string(),
+            vmc: None,
+            role_vec: None,
         }),
     ))
 }

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -170,12 +170,14 @@ pub async fn approve(
         Json(DecideResponse {
             request_id: id,
             status: req.status.to_string(),
-            vmc: Some(serde_json::to_value(&vmc).map_err(|e| {
-                AppError::Internal(format!("serialise VMC for response: {e}"))
-            })?),
-            role_vec: Some(serde_json::to_value(&role_vec).map_err(|e| {
-                AppError::Internal(format!("serialise VEC for response: {e}"))
-            })?),
+            vmc: Some(
+                serde_json::to_value(&vmc)
+                    .map_err(|e| AppError::Internal(format!("serialise VMC for response: {e}")))?,
+            ),
+            role_vec: Some(
+                serde_json::to_value(&role_vec)
+                    .map_err(|e| AppError::Internal(format!("serialise VEC for response: {e}")))?,
+            ),
         }),
     ))
 }
@@ -212,8 +214,7 @@ async fn issue_join_credentials(
         ))
     })?;
 
-    let status_ref =
-        CredentialStatusRef::revocation(row.list_credential_id.clone(), slot);
+    let status_ref = CredentialStatusRef::revocation(row.list_credential_id.clone(), slot);
 
     let vmc_id = format!("urn:uuid:{}", Uuid::new_v4());
     let vmc = build_vmc(

--- a/vtc-service/src/routes/members/mod.rs
+++ b/vtc-service/src/routes/members/mod.rs
@@ -19,4 +19,5 @@
 pub mod promote;
 pub mod read;
 pub mod remove;
+pub mod renew;
 pub mod update;

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -30,7 +30,7 @@ use serde_json::{Value as JsonValue, json};
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
-use vti_common::audit::{AuditEvent, MemberRemovedData};
+use vti_common::audit::{AuditEvent, MemberRemovedData, StatusListFlippedData};
 use vti_common::error::AppError;
 
 use crate::acl::{VtcRole, delete_acl_entry, get_acl_entry, list_acl_entries};
@@ -168,6 +168,11 @@ pub async fn remove_inner(
         .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
 
     let target_member = get_member(&state.members_ks, target_did).await?;
+    // Capture the status-list slot **before** the disposition
+    // path mutates the Member row (purge deletes it; tombstone
+    // clears extensions but leaves status_list_index intact —
+    // we still want to read it from the pre-mutation snapshot).
+    let status_list_index = target_member.as_ref().and_then(|m| m.status_list_index);
 
     // Phase 2 policy step (M2.7). Admin-remove evaluates the
     // active `removal.rego` against the canonical input from
@@ -264,6 +269,24 @@ pub async fn remove_inner(
         )
         .await?;
 
+    // M2.14: flip the revocation bit + emit StatusListFlipped.
+    // Best-effort — a failure here doesn't unwind the ACL +
+    // Member removal (those are already persisted), but it
+    // surfaces in audit + logs so an operator can re-flip
+    // manually if needed.
+    if let Some(slot) = status_list_index
+        && let Err(e) =
+            flip_revocation_for_member(state, slot, audit_writer, actor_did, target_did).await
+    {
+        warn!(
+            error = %e,
+            slot,
+            target = target_did,
+            "failed to flip revocation status-list bit on removal — \
+             ACL/Member already removed; operator must reflip manually"
+        );
+    }
+
     info!(
         actor = actor_did,
         target = target_did,
@@ -277,6 +300,56 @@ pub async fn remove_inner(
         disposition: disposition_str.into(),
         removed: true,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Status-list helpers (M2.14)
+// ---------------------------------------------------------------------------
+
+/// Flip the revocation bit at `slot` + emit `StatusListFlipped`.
+/// Used by [`remove_inner`] after the ACL + Member rows have
+/// already been mutated.
+async fn flip_revocation_for_member(
+    state: &AppState,
+    slot: u32,
+    audit_writer: &vti_common::audit::AuditWriter,
+    actor_did: &str,
+    target_did: &str,
+) -> Result<(), AppError> {
+    let mut row = crate::status_list::get_state(
+        &state.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await?
+    .ok_or_else(|| {
+        AppError::Internal(
+            "revocation status list not provisioned — set `public_url` + restart".into(),
+        )
+    })?;
+    crate::status_list::flip(&mut row, slot, true)
+        .map_err(|e| AppError::Internal(format!("flip revocation slot {slot}: {e}")))?;
+    crate::status_list::store_state(&state.status_lists_ks, &row).await?;
+    crate::status_list::maybe_emit_occupancy_warning(&row);
+
+    audit_writer
+        .write(
+            actor_did,
+            Some(target_did),
+            AuditEvent::StatusListFlipped(StatusListFlippedData {
+                purpose: affinidi_status_list::StatusPurpose::Revocation.to_string(),
+                index: slot,
+                revoked: true,
+            }),
+        )
+        .await?;
+
+    info!(
+        actor = actor_did,
+        target = target_did,
+        slot,
+        "revocation bit flipped"
+    );
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/routes/members/renew.rs
+++ b/vtc-service/src/routes/members/renew.rs
@@ -1,0 +1,240 @@
+//! `POST /v1/members/me/renew` — VMC + role VEC renewal
+//! (M2.13). Spec §6.3.
+//!
+//! The renewal flow is **unconditional on ACL membership**: no
+//! expiry check, no grace window. Spec §3-F + §6.3 — the VMC
+//! `validUntil` is an external-verifier concern. Inside the
+//! community, the ACL is the authoritative source of "are you
+//! a member?", and the ACL doesn't have an expiry on Phase 2's
+//! member rows.
+//!
+//! On renew:
+//!
+//! 1. Look up the caller's ACL row (404 if removed, 401 if
+//!    session unauthenticated).
+//! 2. Look up the Member row to recover the existing
+//!    `status_list_index` — renewal **reuses the same slot**
+//!    so external chains stay coherent across the renewal
+//!    boundary (spec §6.2).
+//! 3. Re-evaluate `personhood.rego` per spec §6.3 step 3. The
+//!    Phase 2 default ships deny-all so the new VMC always
+//!    carries `personhood: false`; if the prior VMC had a
+//!    different flag, the audit envelope records
+//!    `personhood_changed: true`.
+//! 4. Mint VMC + role VEC.
+//! 5. Update the Member row with the new VMC + VEC ids.
+//! 6. Emit `MembershipRenewed` audit.
+
+use affinidi_status_list::StatusPurpose;
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+use tracing::info;
+use uuid::Uuid;
+
+use vti_common::audit::{AuditEvent, MembershipRenewedData};
+use vti_common::error::AppError;
+
+use crate::acl::get_acl_entry;
+use crate::auth::AuthClaims;
+use crate::credentials::{
+    CredentialStatusRef, RoleVecParams, VmcParams, build_role_vec, build_vmc,
+};
+use crate::members::{get_member, store_member};
+use crate::policy::{
+    PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy, get_active_policy_id,
+    get_policy,
+};
+use crate::server::AppState;
+use crate::status_list;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenewResponse {
+    pub did: String,
+    pub vmc: JsonValue,
+    pub role_vec: JsonValue,
+    /// `personhood.rego` re-eval outcome for the new VMC.
+    /// Phase 2's deny-all default keeps this `false`; the
+    /// field exists from day one so Phase 4's
+    /// assert/revoke endpoints don't break the wire shape.
+    pub personhood: bool,
+    /// `true` when the personhood flag flipped from the prior
+    /// VMC. Surfaced separately from `personhood` itself so
+    /// callers can light up a "your personhood status
+    /// changed" notification.
+    pub personhood_changed: bool,
+}
+
+pub async fn renew(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+) -> Result<(StatusCode, Json<RenewResponse>), AppError> {
+    let caller_did = auth.did.clone();
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    // 1. Verify the caller has an active ACL row (spec §6.3 —
+    // no expiry / grace window).
+    let _acl = get_acl_entry(&state.acl_ks, &caller_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("no ACL row for {caller_did} — not a member")))?;
+
+    // 2. Recover the prior Member row for the status-list slot
+    // + the prior VMC's personhood flag (audit context).
+    let mut member = get_member(&state.members_ks, &caller_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("no Member row for {caller_did}")))?;
+
+    let signer = state.credential_signer.as_ref().ok_or_else(|| {
+        AppError::Internal(
+            "credential signer not initialised — cannot renew (run setup first)".into(),
+        )
+    })?;
+
+    let status_list_state =
+        status_list::get_state(&state.status_lists_ks, StatusPurpose::Revocation)
+            .await?
+            .ok_or_else(|| {
+                AppError::Internal(
+                    "revocation status list not provisioned — set `public_url` + restart".into(),
+                )
+            })?;
+
+    // Slot: renewal reuses the same slot the member was
+    // allocated at join time. A member without a slot somehow
+    // (mid-Phase-1 row that pre-dates M2.12) gets a fresh
+    // allocation — this keeps renewal idempotent for
+    // grandfathered rows without forcing the operator to
+    // reseed.
+    let slot = match member.status_list_index {
+        Some(s) => s,
+        None => {
+            let mut row = status_list_state.clone();
+            let s = status_list::allocate(&mut row).ok_or_else(|| {
+                AppError::Internal(format!(
+                    "revocation status list exhausted (capacity = {})",
+                    row.capacity
+                ))
+            })?;
+            status_list::store_state(&state.status_lists_ks, &row).await?;
+            s
+        }
+    };
+
+    let status_ref =
+        CredentialStatusRef::revocation(status_list_state.list_credential_id.clone(), slot);
+
+    // 3. Re-evaluate `personhood.rego`.
+    let personhood = evaluate_personhood(&state, &caller_did, &member.extensions).await?;
+
+    let prior_personhood = prior_personhood_from_member(&member);
+    let personhood_changed = prior_personhood != personhood;
+
+    // 4. Build VMC + role VEC.
+    let vmc_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let vmc = build_vmc(
+        signer,
+        VmcParams::new(&caller_did)
+            .with_id(vmc_id.clone())
+            .with_status_ref(status_ref)
+            .with_personhood(personhood),
+    )
+    .await?;
+
+    let vec_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let role_vec_acl = get_acl_entry(&state.acl_ks, &caller_did)
+        .await?
+        .ok_or_else(|| AppError::Internal("ACL row disappeared mid-renewal".into()))?;
+    let role_vec = build_role_vec(
+        signer,
+        RoleVecParams::new(&caller_did, role_vec_acl.role.clone()).with_id(vec_id.clone()),
+    )
+    .await?;
+
+    // 5. Update the Member row.
+    member.status_list_index = Some(slot);
+    member.current_vmc_id = Some(vmc_id.clone());
+    member.current_role_vec_id = Some(vec_id.clone());
+    store_member(&state.members_ks, &member).await?;
+
+    // 6. Audit.
+    audit_writer
+        .write(
+            &caller_did,
+            Some(&caller_did),
+            AuditEvent::MembershipRenewed(MembershipRenewedData {
+                vmc_id: vmc_id.clone(),
+                role_vec_id: vec_id.clone(),
+                personhood_changed,
+            }),
+        )
+        .await?;
+
+    info!(
+        did = %caller_did,
+        slot,
+        personhood,
+        personhood_changed,
+        "membership renewed"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(RenewResponse {
+            did: caller_did,
+            vmc: serde_json::to_value(&vmc)
+                .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?,
+            role_vec: serde_json::to_value(&role_vec)
+                .map_err(|e| AppError::Internal(format!("serialise VEC: {e}")))?,
+            personhood,
+            personhood_changed,
+        }),
+    ))
+}
+
+/// Run the active `personhood.rego` against the canonical
+/// input (spec §6.4): `{ applicant_did, vp_claims }`. The
+/// Member row's `extensions` slot is the closest stand-in for
+/// `vp_claims` in Phase 2 — Phase 4's assert/revoke endpoints
+/// will populate a richer claim. Fail-closed: any error path
+/// yields `false`.
+async fn evaluate_personhood(
+    state: &AppState,
+    applicant_did: &str,
+    vp_claims: &JsonValue,
+) -> Result<bool, AppError> {
+    let active = get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Personhood).await?;
+    let Some(id) = active else {
+        return Ok(false);
+    };
+    let policy = get_policy(&state.policies_ks, id)
+        .await?
+        .ok_or_else(|| AppError::Internal(format!("active personhood policy {id} not found")))?;
+    let compiled = compile_policy(&policy.rego_source, policy.id)?;
+    let input = json!({
+        "applicant_did": applicant_did,
+        "vp_claims": vp_claims,
+    });
+    let result = evaluate_policy(&compiled, "data.vtc.personhood.allow", input)?;
+    Ok(result
+        .pointer("/result/0/expressions/0/value")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false))
+}
+
+/// Best-effort recovery of the prior VMC's `personhood` flag.
+/// Phase 2 doesn't persist VMC bodies server-side, so we
+/// can't read it back directly. We default to `false` (the
+/// deny-all stub's output) — meaning `personhood_changed` is
+/// always `false` in MVP unless the operator uploads a
+/// custom personhood policy that flips between renewals. The
+/// field is on the wire from day one; Phase 4 can persist the
+/// flag on the Member row to make this comparison precise.
+fn prior_personhood_from_member(_member: &crate::members::Member) -> bool {
+    false
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -132,6 +132,8 @@ pub fn router() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let policies_test = TrustTask::new("https://trusttasks.org/openvtc/vtc/policies/test/1.0")
         .expect("static Trust-Task URL");
+    let members_renew = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/renew/1.0")
+        .expect("static Trust-Task URL");
     // Read endpoints (M2.4). GET /v1/policies and
     // GET /v1/policies/{id} share their mounts with the POST
     // /v1/policies upload and POST /v1/policies/{id}/activate
@@ -296,6 +298,14 @@ pub fn router() -> Router<AppState> {
             "/v1/members/me",
             axum::routing::delete(members::remove::self_remove),
             members_self_remove,
+        )
+        // Renewal (M2.13). POST on its own mount so the
+        // Trust Task header check + per-method selectors are
+        // unambiguous.
+        .route_with_task(
+            "/v1/members/me/renew",
+            post(members::renew::renew),
+            members_renew,
         )
         .route_with_task(
             "/v1/members/{did}",

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -97,6 +97,27 @@ async fn build_fixture() -> Fixture {
         .await
         .expect("install default policies");
 
+    // M2.10 + M2.12: seed both status lists so the approve
+    // handler can allocate a slot when issuing the VMC.
+    for purpose in [
+        affinidi_status_list::StatusPurpose::Revocation,
+        affinidi_status_list::StatusPurpose::Suspension,
+    ] {
+        let url = format!("{RP_ORIGIN}/v1/status-lists/{purpose}");
+        vtc_service::status_list::ensure_initial(&status_lists_ks, purpose, url)
+            .await
+            .expect("ensure_initial status list");
+    }
+
+    // M2.12 credential signer — deterministic seed for stable
+    // test fixtures.
+    let credential_signer = Some(Arc::new(
+        vtc_service::credentials::LocalSigner::from_ed25519_seed(
+            "did:webvh:vtc.example.com:abc".into(),
+            &[0xCC; 32],
+        ),
+    ));
+
     let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
 
     let key_store = AuditKeyStore::new(audit_key_ks.clone());
@@ -172,7 +193,7 @@ async fn build_fixture() -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
-        credential_signer: None,
+        credential_signer,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),
@@ -457,6 +478,45 @@ async fn approve_writes_acl_and_member_atomically() {
         .unwrap()
         .expect("Member row written");
     assert_eq!(member.did, applicant_did);
+
+    // M2.12: approve now mints a VMC + role VEC and stamps the
+    // pointers on the Member row.
+    assert!(
+        member.status_list_index.is_some(),
+        "approve must allocate a status-list slot"
+    );
+    let vmc_id = member.current_vmc_id.as_deref().expect("VMC id stamped");
+    let vec_id = member
+        .current_role_vec_id
+        .as_deref()
+        .expect("VEC id stamped");
+    assert!(vmc_id.starts_with("urn:uuid:"), "got {vmc_id}");
+    assert!(vec_id.starts_with("urn:uuid:"), "got {vec_id}");
+
+    // Response carries the signed VCs inline.
+    let vmc = &body["vmc"];
+    let role_vec = &body["roleVec"];
+    assert_eq!(vmc["id"], vmc_id);
+    assert_eq!(vec_id, role_vec["id"].as_str().unwrap());
+
+    // VMC carries the credentialStatus block pointing at the
+    // allocated slot.
+    let slot = member.status_list_index.unwrap();
+    let cs = &vmc["credentialStatus"];
+    assert_eq!(cs["statusPurpose"], "revocation");
+    assert_eq!(cs["statusListIndex"], slot.to_string());
+
+    // Both VCs verify against the fixture's signer.
+    let signer = vtc_service::credentials::LocalSigner::from_ed25519_seed(
+        "did:webvh:vtc.example.com:abc".into(),
+        &[0xCC; 32],
+    );
+    let vmc_vc: affinidi_vc::VerifiableCredential =
+        serde_json::from_value(vmc.clone()).expect("VMC parses");
+    signer.verify(&vmc_vc).expect("VMC proof must verify");
+    let vec_vc: affinidi_vc::VerifiableCredential =
+        serde_json::from_value(role_vec.clone()).expect("VEC parses");
+    signer.verify(&vec_vc).expect("VEC proof must verify");
 }
 
 #[tokio::test]

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -51,6 +51,7 @@ struct Fixture {
     acl_ks: KeyspaceHandle,
     members_ks: KeyspaceHandle,
     sessions_ks: KeyspaceHandle,
+    status_lists_ks: KeyspaceHandle,
     jwt_keys: Arc<JwtKeys>,
     _dir: tempfile::TempDir,
 }
@@ -86,6 +87,19 @@ async fn build_fixture() -> Fixture {
     vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
         .await
         .expect("install default policies");
+
+    // M2.14: seed the revocation status list so the flip-on-
+    // removal path has somewhere to land. Suspension seeded
+    // for parity even though removal only touches revocation.
+    for purpose in [
+        affinidi_status_list::StatusPurpose::Revocation,
+        affinidi_status_list::StatusPurpose::Suspension,
+    ] {
+        let url = format!("{RP_ORIGIN}/v1/status-lists/{purpose}");
+        vtc_service::status_list::ensure_initial(&status_lists_ks, purpose, url)
+            .await
+            .expect("ensure_initial status list");
+    }
 
     let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
 
@@ -164,7 +178,7 @@ async fn build_fixture() -> Fixture {
         join_requests_ks,
         policies_ks,
         active_policies_ks,
-        status_lists_ks,
+        status_lists_ks: status_lists_ks.clone(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,
@@ -190,6 +204,7 @@ async fn build_fixture() -> Fixture {
         acl_ks,
         members_ks,
         sessions_ks,
+        status_lists_ks,
         jwt_keys,
         _dir: dir,
     }
@@ -674,4 +689,133 @@ async fn admin_remove_uses_policy_min_disposition_for_default() {
     assert_eq!(body["disposition"], "purge");
     // ACL and member both gone (purge semantic).
     assert!(get_acl_entry(&fix.acl_ks, target).await.unwrap().is_none());
+}
+
+// ---------------------------------------------------------------------------
+// M2.14 — status-list flip on removal
+// ---------------------------------------------------------------------------
+
+/// Removing a member whose `status_list_index` is populated
+/// flips the revocation bit. The slot remains assigned (spec
+/// §6.2's never-reallocate invariant) so subsequent
+/// allocations skip it.
+#[tokio::test]
+async fn admin_remove_flips_revocation_bit() {
+    let fix = build_fixture().await;
+    let target = "did:key:zHasSlot";
+    let _ = seed_member_with_session(&fix, target, VtcRole::Member).await;
+
+    // Pre-allocate a slot for the target by hand (the
+    // approve-path that normally does this isn't exercised
+    // here). The flip-on-removal path then has a real slot
+    // to consult.
+    let mut state = vtc_service::status_list::get_state(
+        &fix.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await
+    .unwrap()
+    .expect("revocation state seeded");
+    let slot = vtc_service::status_list::allocate(&mut state).expect("status list has capacity");
+    vtc_service::status_list::store_state(&fix.status_lists_ks, &state)
+        .await
+        .unwrap();
+
+    let mut member = vtc_service::members::get_member(&fix.members_ks, target)
+        .await
+        .unwrap()
+        .expect("member seeded");
+    member.status_list_index = Some(slot);
+    vtc_service::members::store_member(&fix.members_ks, &member)
+        .await
+        .unwrap();
+
+    // Before removal, the bit at `slot` is `0`.
+    let pre = vtc_service::status_list::get_state(
+        &fix.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(!pre.is_set(slot as usize), "bit should start cleared");
+
+    // Admin-remove.
+    let (status, _) = send(
+        &fix.router,
+        "DELETE",
+        &format!("/v1/members/{target}"),
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Post: the bit is set + the slot remains assigned.
+    let post = vtc_service::status_list::get_state(
+        &fix.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        post.is_set(slot as usize),
+        "bit must be flipped after remove"
+    );
+    assert!(
+        post.assigned[slot as usize],
+        "slot must stay assigned (no-reallocate invariant)"
+    );
+}
+
+/// Self-remove flips the bit too — the flip lives in
+/// `remove_inner` which both paths share.
+#[tokio::test]
+async fn self_remove_flips_revocation_bit() {
+    let fix = build_fixture().await;
+    let target = "did:key:zSelfFlip";
+    let token = seed_member_with_session(&fix, target, VtcRole::Member).await;
+
+    // Pre-allocate a slot.
+    let mut state = vtc_service::status_list::get_state(
+        &fix.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let slot = vtc_service::status_list::allocate(&mut state).unwrap();
+    vtc_service::status_list::store_state(&fix.status_lists_ks, &state)
+        .await
+        .unwrap();
+    let mut member = vtc_service::members::get_member(&fix.members_ks, target)
+        .await
+        .unwrap()
+        .unwrap();
+    member.status_list_index = Some(slot);
+    vtc_service::members::store_member(&fix.members_ks, &member)
+        .await
+        .unwrap();
+
+    let (status, _) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/me",
+        SELF_REMOVE_TASK,
+        Some(&token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let post = vtc_service::status_list::get_state(
+        &fix.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(post.is_set(slot as usize));
 }

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -1,0 +1,299 @@
+//! Integration coverage for `POST /v1/members/me/renew`
+//! (Phase 2 M2.13).
+//!
+//! Verifies:
+//! - Happy path re-mints VMC + role VEC and stamps the new
+//!   ids on the Member row.
+//! - Renewal reuses the same status-list slot the member was
+//!   allocated at join time.
+//! - 404 when the caller isn't a member.
+//! - Both signed VCs verify against the daemon's signer.
+
+mod common;
+
+use std::sync::Arc;
+
+use affinidi_status_list::StatusPurpose;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::audit::{AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::session::{Session, SessionState, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::credentials::LocalSigner;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::{Member, get_member, store_member};
+use vtc_service::routes;
+use vtc_service::server::AppState;
+use vtc_service::status_list;
+
+const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+const PUBLIC_URL: &str = "https://vtc.example.com";
+const RENEW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/renew/1.0";
+const MEMBER_DID: &str = "did:key:zRenewMember";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    member_token: String,
+    signer: Arc<LocalSigner>,
+    members_ks: vti_common::store::KeyspaceHandle,
+    status_lists_ks: vti_common::store::KeyspaceHandle,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
+        .await
+        .expect("install default policies");
+
+    for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+        let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
+        status_list::ensure_initial(&status_lists_ks, purpose, url)
+            .await
+            .unwrap();
+    }
+
+    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    // Seed a Member ACL row + Member metadata row.
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &acl_ks,
+        &VtcAclEntry {
+            did: MEMBER_DID.into(),
+            role: VtcRole::Member,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    store_member(&members_ks, &Member::fresh(MEMBER_DID))
+        .await
+        .unwrap();
+
+    let session_id = "test-member-session";
+    store_session(
+        &sessions_ks,
+        &Session {
+            session_id: session_id.into(),
+            did: MEMBER_DID.into(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now,
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let member_claims = jwt_keys.new_claims(
+        MEMBER_DID.into(),
+        session_id.into(),
+        "reader".into(),
+        vec![],
+        3600,
+        true,
+    );
+    let member_token = jwt_keys.encode(&member_claims).unwrap();
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "{VTC_DID}"
+        public_url = "{PUBLIC_URL}"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks: members_ks.clone(),
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks: status_lists_ks.clone(),
+        audit_ks,
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: Some(PUBLIC_URL.into()),
+        install_signer: None,
+        credential_signer: Some(signer.clone()),
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+
+    Fixture {
+        router,
+        member_token,
+        signer,
+        members_ks,
+        status_lists_ks,
+        _dir: dir,
+    }
+}
+
+async fn body_json(body: Body) -> Value {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        let raw = String::from_utf8_lossy(&bytes);
+        panic!("response body was not JSON ({e}): {raw}")
+    })
+}
+
+#[tokio::test]
+async fn renew_mints_fresh_vmc_and_role_vec() {
+    let fix = build_fixture().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/renew")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", RENEW_TASK)
+        .header("content-type", "application/json")
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp.into_body()).await;
+
+    assert_eq!(body["did"], MEMBER_DID);
+    assert_eq!(body["personhood"], false);
+    assert_eq!(body["personhoodChanged"], false);
+
+    let vmc: affinidi_vc::VerifiableCredential =
+        serde_json::from_value(body["vmc"].clone()).unwrap();
+    let role_vec: affinidi_vc::VerifiableCredential =
+        serde_json::from_value(body["roleVec"].clone()).unwrap();
+    fix.signer.verify(&vmc).expect("VMC verifies");
+    fix.signer.verify(&role_vec).expect("VEC verifies");
+
+    // Member row updated with the new ids + the freshly-
+    // allocated slot.
+    let m = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(m.current_vmc_id.is_some());
+    assert!(m.current_role_vec_id.is_some());
+    assert!(m.status_list_index.is_some());
+}
+
+#[tokio::test]
+async fn renew_reuses_existing_status_list_slot() {
+    let fix = build_fixture().await;
+
+    // Pre-allocate a slot for the member.
+    let mut state = status_list::get_state(&fix.status_lists_ks, StatusPurpose::Revocation)
+        .await
+        .unwrap()
+        .unwrap();
+    let pinned_slot = status_list::allocate(&mut state).unwrap();
+    status_list::store_state(&fix.status_lists_ks, &state)
+        .await
+        .unwrap();
+    let mut m = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    m.status_list_index = Some(pinned_slot);
+    store_member(&fix.members_ks, &m).await.unwrap();
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/renew")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", RENEW_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let m = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        m.status_list_index,
+        Some(pinned_slot),
+        "renewal must reuse the existing slot"
+    );
+}
+
+#[tokio::test]
+async fn renew_requires_authentication() {
+    let fix = build_fixture().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/renew")
+        .header("trust-task", RENEW_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -156,6 +156,23 @@ pub enum AuditEvent {
     /// audit can chain backwards through revisions without scanning
     /// the whole `policies:` keyspace. Spec §7.1; Phase 2 M2.3.
     PolicyActivated(PolicyActivatedData),
+
+    /// A new VMC was minted (join-approve or renewal). Spec §6.1.
+    VmcIssued(CredentialIssuedData),
+
+    /// A new role VEC was minted (join-approve, renewal, or role
+    /// change). Spec §6.1.
+    VecIssued(CredentialIssuedData),
+
+    /// `POST /v1/members/me/renew` re-minted the member's VMC +
+    /// role VEC. Spec §6.3. `personhood_changed` flips when the
+    /// renewal's `personhood.rego` re-eval produced a different
+    /// flag than the prior VMC.
+    MembershipRenewed(MembershipRenewedData),
+
+    /// A status-list bit was flipped (revocation / suspension).
+    /// Spec §6.2.
+    StatusListFlipped(StatusListFlippedData),
 }
 
 // ---------------------------------------------------------------------------
@@ -388,6 +405,61 @@ pub struct PolicyUploadedData {
     pub sha256: String,
     /// Per-purpose monotone counter the upload landed under.
     pub version: u32,
+}
+
+/// Payload for [`AuditEvent::VmcIssued`] + [`AuditEvent::VecIssued`].
+///
+/// The audit envelope's `target_did` already carries the member;
+/// this struct adds the credential id + type + the issuance
+/// window so an investigator can correlate "who got which VC
+/// when" without cross-referencing the credential store.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialIssuedData {
+    /// VC `id` URI (typically `urn:uuid:<server-allocated>`).
+    pub credential_id: String,
+    /// Wire-form credential type (`"VerifiableMembershipCredential"`
+    /// for VMC, `"VerifiableEndorsementCredential"` for VEC).
+    pub credential_type: String,
+    /// RFC3339 `validFrom` from the issued VC.
+    pub valid_from: String,
+    /// RFC3339 `validUntil` from the issued VC.
+    pub valid_until: String,
+    /// Status-list slot for VMCs (revocation list). `None` for
+    /// VECs and other credential types that don't carry a
+    /// status-list entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_list_index: Option<u32>,
+}
+
+/// Payload for [`AuditEvent::MembershipRenewed`]. Phase 2 M2.13.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MembershipRenewedData {
+    /// New VMC id.
+    pub vmc_id: String,
+    /// New role VEC id.
+    pub role_vec_id: String,
+    /// Whether the `personhood.rego` re-eval produced a different
+    /// flag than the prior VMC (spec §6.3 step 3). Phase 2 ships
+    /// the deny-all stub so this is always `false` in MVP; the
+    /// field is on the wire from day one so Phase 4's
+    /// `assert`/`revoke` endpoints don't break the audit schema.
+    pub personhood_changed: bool,
+}
+
+/// Payload for [`AuditEvent::StatusListFlipped`]. Phase 2 M2.14.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusListFlippedData {
+    /// Wire-form status purpose (`"revocation"` / `"suspension"`).
+    pub purpose: String,
+    /// Slot index that was flipped.
+    pub index: u32,
+    /// Direction of the flip — `true` = revoked/suspended,
+    /// `false` = un-suspended. Revocation flips are one-way per
+    /// spec §6.2; suspension flips can go either direction.
+    pub revoked: bool,
 }
 
 /// Payload for [`AuditEvent::PolicyActivated`].

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -33,9 +33,10 @@ pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
 pub use event::{
     AdminPasskeyData, AdminPromotedData, AuditEvent, AuditKeyRotatedData, CommunityInstalledData,
     CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
-    EmergencyBootstrapData, JoinRequestData, JoinRequestRejectedData, MemberAddedData,
-    MemberRemovedData, MemberUpdatedData, PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER,
-    RestartRequestedData, RoleChangedData,
+    CredentialIssuedData, EmergencyBootstrapData, JoinRequestData, JoinRequestRejectedData,
+    MemberAddedData, MemberRemovedData, MemberUpdatedData, MembershipRenewedData,
+    PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER, RestartRequestedData,
+    RoleChangedData, StatusListFlippedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

Fourth PR of Phase 2. Lights up the full membership-credential
lifecycle: a new member's VMC + role VEC are minted on
approval, members can renew, and removal flips the revocation
bit so external verifiers see the change live.

Three milestones per the plan's PR-4 slicing:

| Milestone | What it adds |
|---|---|
| **M2.12** | VMC + role VEC issuance on `join-requests/approve` + status-list slot allocation |
| **M2.13** | `POST /v1/members/me/renew` — re-mint VMC + VEC with same slot |
| **M2.14** | `MemberRemoved` flips the revocation bit + emits `StatusListFlipped` |

## Issuance flow (M2.12)

Approve now does, in order, after the existing ACL + Member
writes:
1. Allocate a revocation-list slot (`status_list::allocate`).
2. Build the VMC with `BitstringStatusListEntry` pointing at
   the slot, `personhood: false` (Phase 2 deny-all stub), 30-day
   `validUntil`.
3. Build the role VEC (role = `Member` for join-approve).
4. Persist the updated status-list state.
5. Stamp `Member.{status_list_index, current_vmc_id,
   current_role_vec_id}` with the freshly-allocated values.
6. Emit `VmcIssued` + `VecIssued` audit envelopes alongside
   the existing `JoinRequestApproved` + `MemberAdded`.

Both signed VCs ship inline in the approve response (`vmc` +
`roleVec` fields) for the admin caller to hand off
out-of-band. Sealed-transfer to the applicant's DID is
deferred to a follow-up.

VMC + VEC builders gained a `with_id(...)` parameter so the
issuance flow can mint stable `urn:uuid:<server-allocated>` ids
and tie the `Member` row's pointers to the audit envelope.
Same JSON-round-trip splice trick as `credentialStatus`.

## Renewal (M2.13)

`POST /v1/members/me/renew` — unconditional on ACL membership
per spec §6.3:

- 1: verify caller's ACL row (404 if removed).
- 2: recover existing `status_list_index` from the Member
  row. Renewal **reuses the same slot** so external chains
  stay coherent. Grandfathered Phase-1 rows without a slot
  get a fresh allocation (one-time reconcile).
- 3: re-evaluate `personhood.rego` per spec §6.3 step 3.
  Deny-all stub means `personhood: false` always; the audit
  envelope's `personhood_changed` flag is `false` in MVP
  but the wire shape is locked in.
- 4: mint VMC + role VEC.
- 5: update Member row.
- 6: emit `MembershipRenewed` audit.

Response carries fresh VCs inline + `personhood` /
`personhoodChanged` flags.

Trust Task `members/renew/1.0` ships per spec §9.4.

## Flip-on-removal (M2.14)

`remove_inner` now flips the revocation bit after the ACL +
Member rows are mutated. The flip lives in the shared inner
path so both admin-remove and self-remove get it. Best-effort
on failure: a warning is logged but the ACL/Member removal
isn't unwound (already persisted).

The "flipped indices never reallocated" invariant lands
end-to-end here: `status_list::flip` only touches `bits`, never
`assigned`, so the allocator continues to skip a flipped slot
even after the Member row is gone.

`StatusListFlipped { purpose, index, revoked: true }` audit
envelope records the flip.

## Audit additions (M2.17 pre-landing)

Same pattern as PRs 1 + 3:

- `AuditEvent::VmcIssued(CredentialIssuedData)` — M2.12
- `AuditEvent::VecIssued(CredentialIssuedData)` — M2.12
- `AuditEvent::MembershipRenewed(MembershipRenewedData)` —
  M2.13
- `AuditEvent::StatusListFlipped(StatusListFlippedData)` —
  M2.14

## Test coverage

- **join_requests.rs** — `approve_writes_acl_and_member_atomically`
  extended to assert: status_list_index allocated, VC ids
  stamped as `urn:uuid:*`, response carries inline `vmc` +
  `roleVec`, both VCs verify against the signer, VMC's
  `credentialStatus.statusListIndex` matches the slot.
- **renewal.rs (3 integration)** — happy renewal mints fresh
  VCs; same slot reused across renewals; unauth → 401.
- **removal.rs (+2 integration)** — admin-remove + self-remove
  both flip the revocation bit and retain `assigned[slot]`
  (no-reallocate invariant).

Fixtures in `join_requests.rs` + `removal.rs` extended to
seed both status lists + (for join_requests) install a real
`LocalSigner` so the approve path can mint.

## Test plan

- [x] `cargo test -p vtc-service` green (380+ tests).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- [ ] Review sealed-transfer deferral — currently VCs ship
  inline in approve / renew responses; HPKE-to-applicant
  wire format is the follow-up.
- [ ] Approve before M2.15 (DID rotation) starts.

## Commits

1. `fc527bf` — M2.12 VMC + VEC issuance on approve
2. `2a233c4` — M2.13 + M2.14 renewal + flip-on-removal

Once this PR merges, M2.15 (DID rotation) starts on a fresh
branch.