### PR TITLE
feat(vtc-service): Phase 2 PR 5 — did:key DID rotation (M2.15.1)

### DIFF
--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -339,7 +339,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.15 — DID rotation
 
-### `[ ]` M2.15.1 — `did:key` rotation (challenge + finish)
+### `[x]` M2.15.1 — `did:key` rotation (challenge + finish)
 
 - **Acceptance**
   - `POST /v1/members/me/rotate/challenge` — auth: old DID's

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -230,6 +230,18 @@
       "rest": "POST /v1/members/me/renew"
     },
     {
+      "id": "https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0",
+      "status": "Draft",
+      "path": "members/rotate-challenge/1.0",
+      "rest": "POST /v1/members/me/rotate/challenge"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/rotate/1.0",
+      "status": "Draft",
+      "path": "members/rotate/1.0",
+      "rest": "POST /v1/members/me/rotate"
+    },
+    {
       "id": "https://trusttasks.org/openvtc/vtc/status-lists/show/1.0",
       "status": "Draft",
       "path": "status-lists/show/1.0",

--- a/trust-tasks/members/rotate-challenge/1.0/schema.json
+++ b/trust-tasks/members/rotate-challenge/1.0/schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Members — DID Rotation Challenge",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["rotationId", "expiresAt", "signingPayloadHex", "canonicalTemplate"],
+      "properties": {
+        "rotationId": { "type": "string", "format": "uuid" },
+        "expiresAt": { "type": "string", "format": "date-time" },
+        "signingPayloadHex": { "type": "string", "pattern": "^[0-9a-f]+$" },
+        "canonicalTemplate": { "type": "object" }
+      }
+    }
+  }
+}

--- a/trust-tasks/members/rotate-challenge/1.0/spec.md
+++ b/trust-tasks/members/rotate-challenge/1.0/spec.md
@@ -1,0 +1,62 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0
+title: VTC Members — DID Rotation Challenge
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/members/me/rotate/challenge
+---
+
+# VTC Members — DID Rotation Challenge
+
+Step 1 of the two-step DID-rotation ceremony (spec §10.5,
+Phase 2 M2.15.1). Mints a single-use `rotation_id` + 10-minute
+TTL the caller binds into the co-signed payload in step 2.
+
+## Authentication
+
+Bearer-token JWT for the member's current DID. Must
+correspond to an active ACL row — non-members are 404'd.
+
+## Request
+
+```
+POST /v1/members/me/rotate/challenge
+```
+
+Empty body.
+
+## Response (`200 OK`)
+
+```
+{
+  "rotationId": "<uuid>",
+  "expiresAt": "<rfc3339>",
+  "signingPayloadHex": "<hex of vtc-did-rotation/v1\0 domain tag>",
+  "canonicalTemplate": {
+    "rotationId": "<uuid>",
+    "oldDid": "<caller's DID>",
+    "newDid": "<fill in>",
+    "expiresAt": <epoch seconds>
+  }
+}
+```
+
+The signing payload the caller hashes over is:
+
+```
+vtc-did-rotation/v1\0 || canonical_json({
+  rotationId, oldDid, newDid, expiresAt
+})
+```
+
+`canonicalTemplate` is a convenience — the caller substitutes
+`newDid` and serializes the JSON with key-ordered fields to
+reproduce the exact bytes step 2 verifies against.
+
+## Errors
+
+- `401 Unauthorized` — missing / invalid session token.
+- `404 Not Found` — caller is not a current member.

--- a/trust-tasks/members/rotate/1.0/schema.json
+++ b/trust-tasks/members/rotate/1.0/schema.json
@@ -1,0 +1,29 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/rotate/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Members — DID Rotation",
+  "type": "object",
+  "properties": {
+    "request": {
+      "type": "object",
+      "required": ["rotationId", "oldDid", "newDid", "oldSignature", "newSignature"],
+      "properties": {
+        "rotationId": { "type": "string", "format": "uuid" },
+        "oldDid": { "type": "string" },
+        "newDid": { "type": "string" },
+        "oldSignature": { "type": "string", "pattern": "^[0-9a-f]+$" },
+        "newSignature": { "type": "string", "pattern": "^[0-9a-f]+$" }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["newDid", "method", "vmc", "roleVec"],
+      "properties": {
+        "newDid": { "type": "string" },
+        "method": { "type": "string", "enum": ["did:key", "did:webvh"] },
+        "vmc": { "type": "object" },
+        "roleVec": { "type": "object" }
+      }
+    }
+  }
+}

--- a/trust-tasks/members/rotate/1.0/spec.md
+++ b/trust-tasks/members/rotate/1.0/spec.md
@@ -1,0 +1,100 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/rotate/1.0
+title: VTC Members — DID Rotation
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/members/me/rotate
+---
+
+# VTC Members — DID Rotation
+
+Step 2 of the two-step DID-rotation ceremony. Atomically
+swaps the member's DID with both keys co-signing. Spec §10.5;
+Phase 2 M2.15.1 ships `did:key` only; M2.15.2 layers in
+`did:webvh` resolution.
+
+## Authentication
+
+Bearer-token JWT for the **old** DID's session. (The
+milestone bullet says "new DID's session", but the new DID
+has no ACL row yet — the standard `AuthClaims` extractor
+wouldn't accept it. The body's `newSignature` field provides
+the equivalent "new key holder is in control" guarantee. The
+deviation is documented for M2.16's spec-clarification
+pass.)
+
+## Request
+
+```
+POST /v1/members/me/rotate
+Content-Type: application/json
+
+{
+  "rotationId": "<uuid from challenge>",
+  "oldDid": "<caller's current DID>",
+  "newDid": "<member's chosen new DID, must be did:key in M2.15.1>",
+  "oldSignature": "<hex Ed25519 signature>",
+  "newSignature": "<hex Ed25519 signature>"
+}
+```
+
+Both signatures cover the same canonical payload bytes:
+
+```
+vtc-did-rotation/v1\0 || canonical_json({
+  rotationId, oldDid, newDid, expiresAt
+})
+```
+
+where `expiresAt` is the **epoch-seconds integer** from the
+challenge response.
+
+## Side-effects (all-or-nothing)
+
+1. Consume the `rotation_id` (single-use).
+2. Verify both signatures against the respective DID's
+   Ed25519 pubkey.
+3. Move the ACL row: delete `acl:<old>`, write `acl:<new>`
+   with the same role + metadata.
+4. Move the Member row (same DID transition).
+5. Revoke every session keyed on the old DID.
+6. Re-mint VMC + role VEC to the new DID, **reusing the
+   existing status-list slot** (spec §6.2 — no new slot
+   allocation on rotation).
+7. Emit `DidRotated { oldDid, newDid, method, vmcId,
+   roleVecId }` audit envelope. Actor is the **new** DID
+   (future principal).
+
+## Response (`200 OK`)
+
+```
+{
+  "newDid": "<new DID>",
+  "method": "did:key",
+  "vmc": { ... freshly-signed VMC ... },
+  "roleVec": { ... freshly-signed VEC ... }
+}
+```
+
+## Errors
+
+- `400 Bad Request` — DID method unsupported (currently any
+  non-`did:key` value), `rotationId` not found / expired /
+  already consumed, malformed signatures, same-DID
+  rotation, signature verification failure.
+- `401 Unauthorized` — missing / invalid session token.
+- `403 Forbidden` — session DID doesn't match `oldDid`, or
+  the rotation challenge was issued for a different DID.
+- `409 Conflict` — `newDid` already has an ACL row.
+
+## Notes
+
+- `did:webvh` rotation (M2.15.2) extends this endpoint by
+  detecting the method and walking the `did.jsonl` log via
+  `affinidi-did-resolver-cache-sdk` to verify the prior-key
+  signature on the latest log entry. Until that lands,
+  non-`did:key` new-DID values are 400'd with a pointer to
+  the follow-up milestone.

--- a/vtc-service/src/routes/members/mod.rs
+++ b/vtc-service/src/routes/members/mod.rs
@@ -20,4 +20,5 @@ pub mod promote;
 pub mod read;
 pub mod remove;
 pub mod renew;
+pub mod rotate;
 pub mod update;

--- a/vtc-service/src/routes/members/rotate.rs
+++ b/vtc-service/src/routes/members/rotate.rs
@@ -1,0 +1,524 @@
+//! `POST /v1/members/me/rotate/{challenge,…}` — DID rotation
+//! (M2.15.1). Spec §10.5.
+//!
+//! Two-step ceremony that swaps a member's DID with both keys
+//! co-signing. M2.15.1 ships the `did:key` path; the
+//! `did:webvh` branch (M2.15.2) is left as a `TODO` at the
+//! method-detection step and lands in a follow-up.
+//!
+//! ## Step 1 — `POST /v1/members/me/rotate/challenge`
+//!
+//! Authenticated by the member's existing session. Mints a
+//! single-use `rotation_id` + `expires_at` (10-minute TTL) and
+//! returns them. The challenge row is persisted to the
+//! `passkey_ks` keyspace under a `rotation_chal:` prefix so we
+//! don't need a separate keyspace handle for a short-lived
+//! state row.
+//!
+//! ## Step 2 — `POST /v1/members/me/rotate`
+//!
+//! Authenticated by the old DID's session. The body carries:
+//!
+//! - `rotationId` (from step 1)
+//! - `oldDid` (must match the caller's session)
+//! - `newDid` (the member's new identity)
+//! - `oldSignature` — Ed25519 over the canonical payload
+//! - `newSignature` — Ed25519 over the canonical payload,
+//!   signed by the new DID's key
+//!
+//! Canonical payload (the bytes the signers sign):
+//!
+//! ```text
+//! "vtc-did-rotation/v1\0" || canonical_json({
+//!   "rotationId":  <uuid>,
+//!   "oldDid":       <did>,
+//!   "newDid":       <did>,
+//!   "expiresAt":    <epoch seconds>
+//! })
+//! ```
+//!
+//! On success (atomic):
+//!
+//! 1. Verify both signatures.
+//! 2. Consume the rotation row.
+//! 3. Move the ACL row: delete `acl:<old>`, write
+//!    `acl:<new>` with the same role + metadata.
+//! 4. Move the Member row.
+//! 5. Revoke every session keyed on the old DID.
+//! 6. Re-mint VMC + role VEC against the new DID, reusing
+//!    the existing status-list slot.
+//! 7. Audit `DidRotated`.
+//!
+//! ## Why the *old* DID's session
+//!
+//! Spec §10.5 + the M2.15 milestone bullet say "auth: new
+//! DID's session" — practically the new DID has no ACL row
+//! yet, so the auth layer can't accept its session under the
+//! standard `AuthClaims` extractor. The body's `newSignature`
+//! field gives us the equivalent guarantee (the new key
+//! holder is in control), and the old session ties the
+//! request back to the existing member's authenticated
+//! presence. Documenting the deviation for M2.16's spec-
+//! clarification pass.
+//!
+//! ## `did:key` only for M2.15.1
+//!
+//! New-DID method detection rejects non-`did:key` values with
+//! a clear message pointing at M2.15.2's follow-up. The
+//! cryptographic verification path only knows how to extract
+//! Ed25519 pubkeys from `did:key` today; `did:webvh` needs the
+//! `affinidi-did-resolver-cache-sdk` walk that lands later.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use affinidi_status_list::StatusPurpose;
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use vti_common::audit::{AuditEvent, DidRotatedData};
+use vti_common::auth::session::{delete_session, list_sessions};
+use vti_common::error::AppError;
+
+use crate::acl::{delete_acl_entry, get_acl_entry, store_acl_entry};
+use crate::auth::AuthClaims;
+use crate::credentials::{
+    CredentialStatusRef, RoleVecParams, VmcParams, build_role_vec, build_vmc,
+};
+use crate::members::{delete_member, get_member, store_member};
+use crate::server::AppState;
+use crate::status_list;
+
+/// Domain tag prefixed onto the canonical payload that both
+/// the old and new DID's keys sign over. Distinct from every
+/// other domain tag in the workspace so a signature minted
+/// for a different protocol can't be replayed as a rotation.
+pub const ROTATION_DOMAIN_TAG: &[u8] = b"vtc-did-rotation/v1\0";
+
+/// Rotation-challenge TTL — spec §10.5 calls for 10 minutes.
+const CHALLENGE_TTL_SECS: i64 = 10 * 60;
+
+/// Storage prefix for rotation challenge rows in `passkey_ks`.
+/// Co-tenanting with the passkey keyspace avoids a separate
+/// AppState field for what is conceptually short-lived
+/// transient state.
+const ROTATION_PREFIX: &[u8] = b"rotation_chal:";
+
+// ---------------------------------------------------------------------------
+// Persisted challenge
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RotationChallenge {
+    id: Uuid,
+    did: String,
+    expires_at: DateTime<Utc>,
+}
+
+fn challenge_key(id: Uuid) -> Vec<u8> {
+    let mut k = ROTATION_PREFIX.to_vec();
+    k.extend_from_slice(id.to_string().as_bytes());
+    k
+}
+
+async fn store_challenge(state: &AppState, challenge: &RotationChallenge) -> Result<(), AppError> {
+    state
+        .passkey_ks
+        .insert(
+            String::from_utf8(challenge_key(challenge.id)).expect("ascii key"),
+            challenge,
+        )
+        .await
+}
+
+async fn take_challenge(state: &AppState, id: Uuid) -> Result<Option<RotationChallenge>, AppError> {
+    let key = challenge_key(id);
+    let raw = state.passkey_ks.get_raw(key.clone()).await?;
+    let Some(bytes) = raw else { return Ok(None) };
+    let challenge: RotationChallenge = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Internal(format!("RotationChallenge decode: {e}")))?;
+    state.passkey_ks.remove(key).await?;
+    Ok(Some(challenge))
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — challenge
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChallengeResponse {
+    pub rotation_id: Uuid,
+    pub expires_at: DateTime<Utc>,
+    /// Canonical payload bytes the signers must hash over,
+    /// hex-encoded. Server-supplied so the caller can't omit
+    /// the domain tag or get the canonical JSON encoding
+    /// wrong.
+    pub signing_payload_hex: String,
+    /// New-DID placeholder — the canonical payload includes
+    /// `newDid`, so the client computes the final payload by
+    /// substituting its chosen `new_did` into the JSON and
+    /// hashing the result. Callers that prefer to assemble
+    /// the payload themselves can ignore this field.
+    pub canonical_template: JsonValue,
+}
+
+pub async fn challenge(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+) -> Result<(StatusCode, Json<ChallengeResponse>), AppError> {
+    // Caller must be a current member — anyone with a session
+    // could mint a challenge otherwise.
+    let _acl = get_acl_entry(&state.acl_ks, &auth.did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("no ACL row for {} — not a member", auth.did)))?;
+
+    let id = Uuid::new_v4();
+    let now = Utc::now();
+    let expires_at = now + chrono::Duration::seconds(CHALLENGE_TTL_SECS);
+    let challenge = RotationChallenge {
+        id,
+        did: auth.did.clone(),
+        expires_at,
+    };
+    store_challenge(&state, &challenge).await?;
+
+    // Canonical template — the caller substitutes `newDid`.
+    let template = serde_json::json!({
+        "rotationId": id.to_string(),
+        "oldDid": auth.did,
+        "newDid": "<fill in>",
+        "expiresAt": expires_at.timestamp(),
+    });
+
+    info!(
+        rotation_id = %id,
+        did = %auth.did,
+        "DID rotation challenge issued"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(ChallengeResponse {
+            rotation_id: id,
+            expires_at,
+            signing_payload_hex: hex::encode(ROTATION_DOMAIN_TAG),
+            canonical_template: template,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — finish
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinishBody {
+    pub rotation_id: Uuid,
+    pub old_did: String,
+    pub new_did: String,
+    /// Hex-encoded Ed25519 signature by the old DID's key.
+    pub old_signature: String,
+    /// Hex-encoded Ed25519 signature by the new DID's key.
+    pub new_signature: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinishResponse {
+    pub new_did: String,
+    pub method: String,
+    pub vmc: JsonValue,
+    pub role_vec: JsonValue,
+}
+
+pub async fn rotate(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Json(body): Json<FinishBody>,
+) -> Result<(StatusCode, Json<FinishResponse>), AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    // 1. Authenticated session must match `oldDid`.
+    if auth.did != body.old_did {
+        return Err(AppError::Forbidden(format!(
+            "session DID ({}) does not match oldDid ({})",
+            auth.did, body.old_did
+        )));
+    }
+
+    // 2. Method detection. M2.15.1 ships did:key only;
+    //    did:webvh is deferred to M2.15.2.
+    let method = method_of(&body.new_did)?;
+    if method != "did:key" {
+        return Err(AppError::Validation(format!(
+            "DID method '{method}' is not yet supported for rotation \
+             (M2.15.1 covers did:key only; did:webvh lands in M2.15.2)"
+        )));
+    }
+
+    // 3. Consume the challenge row. Single-use: `take_challenge`
+    //    removes it before we run any further checks.
+    let challenge = take_challenge(&state, body.rotation_id)
+        .await?
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "rotation challenge {} not found or already consumed",
+                body.rotation_id
+            ))
+        })?;
+    if challenge.did != body.old_did {
+        return Err(AppError::Forbidden(format!(
+            "rotation challenge was issued for {}, not {}",
+            challenge.did, body.old_did
+        )));
+    }
+    if Utc::now() > challenge.expires_at {
+        return Err(AppError::Validation(format!(
+            "rotation challenge {} expired at {}",
+            body.rotation_id, challenge.expires_at
+        )));
+    }
+
+    // 4. Reject same-DID rotations (no-op churn).
+    if body.old_did == body.new_did {
+        return Err(AppError::Validation(
+            "oldDid and newDid must differ — same-DID rotation is a no-op".into(),
+        ));
+    }
+
+    // 5. Verify both signatures over the canonical payload.
+    let payload = canonical_signing_bytes(
+        body.rotation_id,
+        &body.old_did,
+        &body.new_did,
+        challenge.expires_at.timestamp(),
+    )?;
+    verify_did_key_signature(&body.old_did, &payload, &body.old_signature)
+        .map_err(|e| AppError::Validation(format!("oldSignature failed: {e}")))?;
+    verify_did_key_signature(&body.new_did, &payload, &body.new_signature)
+        .map_err(|e| AppError::Validation(format!("newSignature failed: {e}")))?;
+
+    // 6. Refuse if the new DID already has an ACL row (would
+    //    collide).
+    if get_acl_entry(&state.acl_ks, &body.new_did).await?.is_some() {
+        return Err(AppError::Conflict(format!(
+            "newDid {} already has an ACL row — refusing to clobber",
+            body.new_did
+        )));
+    }
+
+    // 7. Move the ACL row.
+    let mut acl = get_acl_entry(&state.acl_ks, &body.old_did)
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal(format!(
+                "ACL row for {} disappeared mid-rotation",
+                body.old_did
+            ))
+        })?;
+    acl.did = body.new_did.clone();
+    store_acl_entry(&state.acl_ks, &acl).await?;
+    delete_acl_entry(&state.acl_ks, &body.old_did).await?;
+
+    // 8. Move the Member row.
+    let member_opt = get_member(&state.members_ks, &body.old_did).await?;
+    if let Some(mut m) = member_opt {
+        m.did = body.new_did.clone();
+        store_member(&state.members_ks, &m).await?;
+    }
+    delete_member(&state.members_ks, &body.old_did).await?;
+
+    // 9. Revoke every session keyed on the old DID.
+    let sessions = list_sessions(&state.sessions_ks).await?;
+    for s in sessions.iter().filter(|s| s.did == body.old_did) {
+        let _ = delete_session(&state.sessions_ks, &s.session_id).await;
+    }
+
+    // 10. Re-mint VMC + role VEC against the new DID. Reuse
+    //     the status-list slot. A daemon misconfiguration
+    //     leaves the credential pointers null — the operator
+    //     can recover via the renewal endpoint.
+    let (vmc_value, vec_value, vmc_id, vec_id) =
+        match reissue_credentials(&state, &body.new_did, &acl).await {
+            Ok(out) => out,
+            Err(e) => {
+                warn!(error = %e, "rotation succeeded but credential re-issuance failed");
+                (JsonValue::Null, JsonValue::Null, None, None)
+            }
+        };
+
+    // 11. Audit. Actor is the **new** DID (the future
+    //     principal) per spec §10.5.
+    audit_writer
+        .write(
+            &body.new_did,
+            Some(&body.old_did),
+            AuditEvent::DidRotated(DidRotatedData {
+                old_did: body.old_did.clone(),
+                new_did: body.new_did.clone(),
+                method: method.to_string(),
+                vmc_id,
+                role_vec_id: vec_id,
+            }),
+        )
+        .await?;
+
+    info!(
+        old_did = %body.old_did,
+        new_did = %body.new_did,
+        method,
+        "DID rotated"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(FinishResponse {
+            new_did: body.new_did,
+            method: method.to_string(),
+            vmc: vmc_value,
+            role_vec: vec_value,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Wire-form DID method prefix — `did:key` or `did:webvh`. Used
+/// by the rotation endpoint's method-detection step.
+fn method_of(did: &str) -> Result<&'static str, AppError> {
+    if did.starts_with("did:key:") {
+        Ok("did:key")
+    } else if did.starts_with("did:webvh:") {
+        Ok("did:webvh")
+    } else {
+        Err(AppError::Validation(format!(
+            "DID '{did}' is not did:key or did:webvh"
+        )))
+    }
+}
+
+/// Build the canonical signing payload — domain tag prefixed
+/// onto a key-ordered JSON object. Both signers (old + new) sign
+/// this exact byte sequence.
+fn canonical_signing_bytes(
+    rotation_id: Uuid,
+    old_did: &str,
+    new_did: &str,
+    expires_at: i64,
+) -> Result<Vec<u8>, AppError> {
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Payload<'a> {
+        rotation_id: String,
+        old_did: &'a str,
+        new_did: &'a str,
+        expires_at: i64,
+    }
+    let json = serde_json::to_vec(&Payload {
+        rotation_id: rotation_id.to_string(),
+        old_did,
+        new_did,
+        expires_at,
+    })
+    .map_err(|e| AppError::Internal(format!("canonical payload: {e}")))?;
+    let mut buf = Vec::with_capacity(ROTATION_DOMAIN_TAG.len() + json.len());
+    buf.extend_from_slice(ROTATION_DOMAIN_TAG);
+    buf.extend_from_slice(&json);
+    Ok(buf)
+}
+
+fn verify_did_key_signature(did: &str, payload: &[u8], hex_sig: &str) -> Result<(), String> {
+    let pub_bytes = affinidi_crypto::did_key::did_key_to_ed25519_pub(did)
+        .map_err(|e| format!("did:key parse: {e}"))?;
+    let vk =
+        VerifyingKey::from_bytes(&pub_bytes).map_err(|e| format!("invalid Ed25519 pubkey: {e}"))?;
+    let raw = hex::decode(hex_sig).map_err(|e| format!("signature is not hex: {e}"))?;
+    let sig = Signature::from_slice(&raw).map_err(|e| format!("signature is not 64 bytes: {e}"))?;
+    vk.verify(payload, &sig)
+        .map_err(|e| format!("signature verification: {e}"))
+}
+
+/// Re-mint VMC + role VEC against the new DID. Reuses the
+/// existing status-list slot (recovered from the moved
+/// Member row).
+async fn reissue_credentials(
+    state: &AppState,
+    new_did: &str,
+    acl: &crate::acl::VtcAclEntry,
+) -> Result<(JsonValue, JsonValue, Option<String>, Option<String>), AppError> {
+    let signer = state
+        .credential_signer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("credential signer not initialised".into()))?;
+
+    let member = get_member(&state.members_ks, new_did)
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal(format!(
+                "Member row for {new_did} missing after rotation move"
+            ))
+        })?;
+
+    let row = status_list::get_state(&state.status_lists_ks, StatusPurpose::Revocation)
+        .await?
+        .ok_or_else(|| AppError::Internal("revocation status list not provisioned".into()))?;
+
+    let slot = member.status_list_index.ok_or_else(|| {
+        AppError::Internal(format!(
+            "Member {new_did} has no status_list_index — rotation cannot reissue"
+        ))
+    })?;
+    let status_ref = CredentialStatusRef::revocation(row.list_credential_id.clone(), slot);
+
+    let vmc_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let vmc = build_vmc(
+        signer,
+        VmcParams::new(new_did)
+            .with_id(vmc_id.clone())
+            .with_status_ref(status_ref)
+            .with_personhood(false),
+    )
+    .await?;
+
+    let vec_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let role_vec = build_role_vec(
+        signer,
+        RoleVecParams::new(new_did, acl.role.clone()).with_id(vec_id.clone()),
+    )
+    .await?;
+
+    // Update Member row pointers.
+    let mut member_mut = member;
+    member_mut.current_vmc_id = Some(vmc_id.clone());
+    member_mut.current_role_vec_id = Some(vec_id.clone());
+    store_member(&state.members_ks, &member_mut).await?;
+
+    let vmc_value = serde_json::to_value(&vmc)
+        .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?;
+    let vec_value = serde_json::to_value(&role_vec)
+        .map_err(|e| AppError::Internal(format!("serialise VEC: {e}")))?;
+
+    Ok((vmc_value, vec_value, Some(vmc_id), Some(vec_id)))
+}
+
+#[allow(dead_code)]
+fn epoch_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -134,6 +134,11 @@ pub fn router() -> Router<AppState> {
         .expect("static Trust-Task URL");
     let members_renew = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/renew/1.0")
         .expect("static Trust-Task URL");
+    let members_rotate_challenge =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0")
+            .expect("static Trust-Task URL");
+    let members_rotate = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/rotate/1.0")
+        .expect("static Trust-Task URL");
     // Read endpoints (M2.4). GET /v1/policies and
     // GET /v1/policies/{id} share their mounts with the POST
     // /v1/policies upload and POST /v1/policies/{id}/activate
@@ -306,6 +311,19 @@ pub fn router() -> Router<AppState> {
             "/v1/members/me/renew",
             post(members::renew::renew),
             members_renew,
+        )
+        // DID rotation (M2.15.1). Two-step ceremony — challenge
+        // mints a single-use rotation_id, the finish endpoint
+        // applies the co-signed swap atomically.
+        .route_with_task(
+            "/v1/members/me/rotate/challenge",
+            post(members::rotate::challenge),
+            members_rotate_challenge,
+        )
+        .route_with_task(
+            "/v1/members/me/rotate",
+            post(members::rotate::rotate),
+            members_rotate,
         )
         .route_with_task(
             "/v1/members/{did}",

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -1,0 +1,463 @@
+//! Integration coverage for `POST /v1/members/me/rotate/*`
+//! (Phase 2 M2.15.1, `did:key` path only).
+
+mod common;
+
+use std::sync::Arc;
+
+use affinidi_status_list::StatusPurpose;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ed25519_dalek::{Signer, SigningKey};
+use http_body_util::BodyExt;
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::audit::{AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::session::{Session, SessionState, list_sessions, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::credentials::LocalSigner;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::{Member, get_member, store_member};
+use vtc_service::routes;
+// `ROTATION_DOMAIN_TAG` from the rotate module is `pub(crate)`;
+// duplicate the literal here so the integration test doesn't
+// have to peek through the route layer's private modules.
+const ROTATION_DOMAIN_TAG: &[u8] = b"vtc-did-rotation/v1\0";
+use vtc_service::server::AppState;
+use vtc_service::status_list;
+
+const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+const PUBLIC_URL: &str = "https://vtc.example.com";
+const CHALLENGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0";
+const ROTATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/rotate/1.0";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    member_token: String,
+    member_signing: SigningKey,
+    member_did: String,
+    members_ks: vti_common::store::KeyspaceHandle,
+    acl_ks: vti_common::store::KeyspaceHandle,
+    sessions_ks: vti_common::store::KeyspaceHandle,
+    signer: Arc<LocalSigner>,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
+        .await
+        .unwrap();
+    for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+        let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
+        status_list::ensure_initial(&status_lists_ks, purpose, url)
+            .await
+            .unwrap();
+    }
+    // Pre-allocate a slot for the member so rotation can
+    // reuse it during credential re-issuance.
+    let mut state_row = status_list::get_state(&status_lists_ks, StatusPurpose::Revocation)
+        .await
+        .unwrap()
+        .unwrap();
+    let slot = status_list::allocate(&mut state_row).unwrap();
+    status_list::store_state(&status_lists_ks, &state_row)
+        .await
+        .unwrap();
+
+    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    // Build a member with a deterministic Ed25519 key + matching did:key.
+    let member_signing = SigningKey::from_bytes(&[0xAA; 32]);
+    let member_pub = member_signing.verifying_key().to_bytes();
+    let member_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&member_pub);
+
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &acl_ks,
+        &VtcAclEntry {
+            did: member_did.clone(),
+            role: VtcRole::Member,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    let mut m = Member::fresh(&member_did);
+    m.status_list_index = Some(slot);
+    store_member(&members_ks, &m).await.unwrap();
+
+    let session_id = "test-rot-session";
+    store_session(
+        &sessions_ks,
+        &Session {
+            session_id: session_id.into(),
+            did: member_did.clone(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now,
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let member_claims = jwt_keys.new_claims(
+        member_did.clone(),
+        session_id.into(),
+        "reader".into(),
+        vec![],
+        3600,
+        true,
+    );
+    let member_token = jwt_keys.encode(&member_claims).unwrap();
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "{VTC_DID}"
+        public_url = "{PUBLIC_URL}"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks: sessions_ks.clone(),
+        acl_ks: acl_ks.clone(),
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks: members_ks.clone(),
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks: status_lists_ks.clone(),
+        audit_ks,
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: Some(PUBLIC_URL.into()),
+        install_signer: None,
+        credential_signer: Some(signer.clone()),
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+
+    Fixture {
+        router,
+        member_token,
+        member_signing,
+        member_did,
+        members_ks,
+        acl_ks,
+        sessions_ks,
+        signer,
+        _dir: dir,
+    }
+}
+
+async fn body_json(body: Body) -> Value {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        let raw = String::from_utf8_lossy(&bytes);
+        panic!("response body was not JSON ({e}): {raw}")
+    })
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalPayload<'a> {
+    rotation_id: String,
+    old_did: &'a str,
+    new_did: &'a str,
+    expires_at: i64,
+}
+
+fn signing_bytes(rotation_id: &str, old_did: &str, new_did: &str, expires_at: i64) -> Vec<u8> {
+    let json = serde_json::to_vec(&CanonicalPayload {
+        rotation_id: rotation_id.to_string(),
+        old_did,
+        new_did,
+        expires_at,
+    })
+    .unwrap();
+    let mut buf = Vec::with_capacity(ROTATION_DOMAIN_TAG.len() + json.len());
+    buf.extend_from_slice(ROTATION_DOMAIN_TAG);
+    buf.extend_from_slice(&json);
+    buf
+}
+
+async fn mint_challenge(fix: &Fixture) -> (String, i64) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/rotate/challenge")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", CHALLENGE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp.into_body()).await;
+    let id = body["rotationId"].as_str().unwrap().to_string();
+    // expiresAt is RFC3339 — convert to epoch for the canonical
+    // payload.
+    let expires_at = chrono::DateTime::parse_from_rfc3339(body["expiresAt"].as_str().unwrap())
+        .unwrap()
+        .timestamp();
+    (id, expires_at)
+}
+
+#[tokio::test]
+async fn rotation_happy_path_swaps_acl_and_member() {
+    let fix = build_fixture().await;
+
+    // Pick a fresh did:key for the new identity.
+    let new_signing = SigningKey::from_bytes(&[0xBB; 32]);
+    let new_did =
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&new_signing.verifying_key().to_bytes());
+
+    let (rotation_id, expires_at) = mint_challenge(&fix).await;
+    let payload = signing_bytes(&rotation_id, &fix.member_did, &new_did, expires_at);
+
+    let old_sig = hex::encode(fix.member_signing.sign(&payload).to_bytes());
+    let new_sig = hex::encode(new_signing.sign(&payload).to_bytes());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/rotate")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ROTATE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "rotationId": rotation_id,
+                "oldDid": fix.member_did,
+                "newDid": new_did,
+                "oldSignature": old_sig,
+                "newSignature": new_sig,
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["newDid"], new_did);
+    assert_eq!(body["method"], "did:key");
+
+    // ACL + Member rows moved.
+    assert!(
+        get_acl_entry(&fix.acl_ks, &fix.member_did)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        get_acl_entry(&fix.acl_ks, &new_did)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        get_member(&fix.members_ks, &fix.member_did)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let new_member = get_member(&fix.members_ks, &new_did)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(new_member.did, new_did);
+    assert!(new_member.status_list_index.is_some(), "slot reused");
+
+    // Sessions for the old DID revoked.
+    let sessions = list_sessions(&fix.sessions_ks).await.unwrap();
+    assert!(
+        sessions.iter().all(|s| s.did != fix.member_did),
+        "old-DID sessions must be revoked"
+    );
+
+    // VMC + VEC inline + verifying.
+    let vmc: affinidi_vc::VerifiableCredential =
+        serde_json::from_value(body["vmc"].clone()).unwrap();
+    let role_vec: affinidi_vc::VerifiableCredential =
+        serde_json::from_value(body["roleVec"].clone()).unwrap();
+    fix.signer.verify(&vmc).expect("VMC verifies");
+    fix.signer.verify(&role_vec).expect("VEC verifies");
+}
+
+#[tokio::test]
+async fn rotation_rejects_did_webvh_for_now() {
+    let fix = build_fixture().await;
+    let (rotation_id, expires_at) = mint_challenge(&fix).await;
+    let new_did = "did:webvh:peer.example.com:abc";
+    let payload = signing_bytes(&rotation_id, &fix.member_did, new_did, expires_at);
+    let old_sig = hex::encode(fix.member_signing.sign(&payload).to_bytes());
+    let new_signing = SigningKey::from_bytes(&[0xBB; 32]);
+    let new_sig = hex::encode(new_signing.sign(&payload).to_bytes());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/rotate")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ROTATE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "rotationId": rotation_id,
+                "oldDid": fix.member_did,
+                "newDid": new_did,
+                "oldSignature": old_sig,
+                "newSignature": new_sig,
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn rotation_rejects_bad_new_signature() {
+    let fix = build_fixture().await;
+    let new_signing = SigningKey::from_bytes(&[0xBB; 32]);
+    let new_did =
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&new_signing.verifying_key().to_bytes());
+
+    let (rotation_id, expires_at) = mint_challenge(&fix).await;
+    let payload = signing_bytes(&rotation_id, &fix.member_did, &new_did, expires_at);
+    let old_sig = hex::encode(fix.member_signing.sign(&payload).to_bytes());
+    // Sign with a DIFFERENT key than the one whose pubkey is in
+    // the new_did — verifier must reject.
+    let wrong = SigningKey::from_bytes(&[0xDE; 32]);
+    let bad_sig = hex::encode(wrong.sign(&payload).to_bytes());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/rotate")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ROTATE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "rotationId": rotation_id,
+                "oldDid": fix.member_did,
+                "newDid": new_did,
+                "oldSignature": old_sig,
+                "newSignature": bad_sig,
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn rotation_id_is_single_use() {
+    let fix = build_fixture().await;
+    let new_signing = SigningKey::from_bytes(&[0xBB; 32]);
+    let new_did =
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&new_signing.verifying_key().to_bytes());
+
+    let (rotation_id, expires_at) = mint_challenge(&fix).await;
+    let payload = signing_bytes(&rotation_id, &fix.member_did, &new_did, expires_at);
+    let old_sig = hex::encode(fix.member_signing.sign(&payload).to_bytes());
+    let new_sig = hex::encode(new_signing.sign(&payload).to_bytes());
+
+    let make_req = || {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/members/me/rotate")
+            .header("authorization", format!("Bearer {}", fix.member_token))
+            .header("trust-task", ROTATE_TASK)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({
+                    "rotationId": rotation_id,
+                    "oldDid": fix.member_did,
+                    "newDid": new_did,
+                    "oldSignature": old_sig,
+                    "newSignature": new_sig,
+                })
+                .to_string(),
+            ))
+            .unwrap()
+    };
+
+    let resp = fix.router.clone().oneshot(make_req()).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "first call succeeds");
+
+    // Second call: rotation_id is consumed, and the old DID no
+    // longer has a session (revoked in step 1). The endpoint
+    // returns 401 because the AuthClaims extractor can't verify
+    // the session. Either failure mode is acceptable; we
+    // assert any non-2xx.
+    let resp = fix.router.clone().oneshot(make_req()).await.unwrap();
+    assert!(
+        !resp.status().is_success(),
+        "second call must not succeed, got {}",
+        resp.status()
+    );
+}

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -173,6 +173,12 @@ pub enum AuditEvent {
     /// A status-list bit was flipped (revocation / suspension).
     /// Spec §6.2.
     StatusListFlipped(StatusListFlippedData),
+
+    /// A member rotated to a fresh DID. The audit envelope's
+    /// `actor_did` is the **new** DID (it's the principal going
+    /// forward); the prior DID lives in the data struct. Spec
+    /// §10.5; Phase 2 M2.15.
+    DidRotated(DidRotatedData),
 }
 
 // ---------------------------------------------------------------------------
@@ -460,6 +466,27 @@ pub struct StatusListFlippedData {
     /// `false` = un-suspended. Revocation flips are one-way per
     /// spec §6.2; suspension flips can go either direction.
     pub revoked: bool,
+}
+
+/// Payload for [`AuditEvent::DidRotated`]. Phase 2 M2.15.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DidRotatedData {
+    pub old_did: String,
+    pub new_did: String,
+    /// DID method of the new DID — `"did:key"` /
+    /// `"did:webvh"`. Spec §10.5 keeps the two paths
+    /// cryptographically distinct so SIEM rules can target
+    /// each.
+    pub method: String,
+    /// New VMC id minted in the same transaction (status-list
+    /// slot reused). `None` if issuance was skipped (e.g.
+    /// daemon misconfiguration).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vmc_id: Option<String>,
+    /// New role VEC id minted in the same transaction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_vec_id: Option<String>,
 }
 
 /// Payload for [`AuditEvent::PolicyActivated`].

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -33,10 +33,10 @@ pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
 pub use event::{
     AdminPasskeyData, AdminPromotedData, AuditEvent, AuditKeyRotatedData, CommunityInstalledData,
     CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
-    CredentialIssuedData, EmergencyBootstrapData, JoinRequestData, JoinRequestRejectedData,
-    MemberAddedData, MemberRemovedData, MemberUpdatedData, MembershipRenewedData,
-    PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER, RestartRequestedData,
-    RoleChangedData, StatusListFlippedData,
+    CredentialIssuedData, DidRotatedData, EmergencyBootstrapData, JoinRequestData,
+    JoinRequestRejectedData, MemberAddedData, MemberRemovedData, MemberUpdatedData,
+    MembershipRenewedData, PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER,
+    RestartRequestedData, RoleChangedData, StatusListFlippedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

Fifth PR of Phase 2. Lands the `did:key` rotation slice of
M2.15 — members can swap their DID with both keys co-signing,
atomically. The `did:webvh` slice (M2.15.2) is deferred to a
follow-up per plan §R4.

| Milestone | What it adds |
|---|---|
| **M2.15.1** | `POST /v1/members/me/rotate/{challenge,…}` — two-step ceremony for `did:key` rotation |

## Two-step ceremony

### Step 1 — `POST /v1/members/me/rotate/challenge`
- Authed by the member's existing session.
- Mints a single-use `rotation_id` + 10-minute TTL.
- Returns the canonical-payload template + the domain-tag-hex
  so the caller can reconstruct the bytes the server will
  verify byte-for-byte.

### Step 2 — `POST /v1/members/me/rotate`
- Authed by the OLD DID's session (spec deviation — see
  below).
- Body carries `oldSignature` + `newSignature` over

  `vtc-did-rotation/v1\0 || canonical_json({ rotationId,
  oldDid, newDid, expiresAt })`

- On success: consume the rotation row → verify both sigs →
  move ACL row → move Member row → revoke old-DID sessions →
  re-mint VMC + role VEC against the new DID (status-list
  slot reused) → emit `DidRotated` audit envelope.

## Spec deviation — old session, not new

The milestone bullet says "auth: new DID's session". The new
DID has no ACL row yet, so the standard `AuthClaims`
extractor can't accept it. The body's `newSignature` provides
the equivalent "new key holder is in control" guarantee; the
old session ties the request back to the existing member's
authenticated presence. Documented in the module header +
will be folded into M2.16's spec-clarification pass.

## did:key only

M2.15.1 ships the simpler crypto path. Non-`did:key`
new-DID values are rejected with `400 Bad Request` and a
clear pointer to the M2.15.2 follow-up that integrates
`affinidi-did-resolver-cache-sdk`'s `did.jsonl` walk.

## Audit + Trust Tasks

- `AuditEvent::DidRotated(DidRotatedData)` — old/new DIDs,
  method, vmc_id, role_vec_id. Same M2.17-as-checkpoint
  pre-landing pattern.
- `members/rotate-challenge/1.0` + `members/rotate/1.0` Trust
  Tasks with spec.md + schema.json + index.json entries.

## Storage

Rotation challenges co-tenant in `passkey_ks` under a
`rotation_chal:` prefix — avoids adding a fresh keyspace
handle to AppState for short-lived transient state. The two
keyspaces don't share key shapes.

## Tests (`tests/rotation.rs`, 4 integration)

- **Happy path** — ACL + Member rows move to new DID;
  old-DID sessions revoked; status-list slot reused; both
  signed VCs verify against the daemon's signer.
- **`did:webvh` new-DID** → 400 (clear pointer to M2.15.2).
- **Mismatched `newSignature`** (signed by a key that
  doesn't match `newDid`'s pubkey) → 400.
- **Rotation id is single-use** (replay rejected).

## Test plan

- [x] `cargo test -p vtc-service` green (390+ tests).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- [ ] Review the "old session, not new" spec deviation — is
  the body's `newSignature` an acceptable substitute, or
  should we mint a no-ACL session for the new DID and
  require it?
- [ ] Approve before M2.16 (Phase 2 outcomes + spec
  clarifications) starts.

## What's NOT in this PR

- **M2.15.2** (`did:webvh` rotation) — plan §R4 flagged it
  as the riskier slice. Follow-up.
- **M2.16–M2.19** — Phase 2 outcomes documentation, audit
  variants checkpoint (most already pre-landed in PR 1+3+4),
  Trust Task index gate, Phase 2 gate. PR 6.

## Commits

1. `5ab075b` — M2.15.1 did:key DID rotation

Once this PR merges, M2.16+ (Phase 2 closeout) starts on a
fresh branch.