### PR TITLE
docs(vtc-mvp): Phase 2 PR 6 — closeout (M2.16–M2.19)

### DIFF
--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -47,7 +47,7 @@ do not restate.
 
 | | Decision | Rationale |
 |---|---|---|
-| **A** | **1 VTC ⇄ 1 VTA** | The VTC has no key custody; every signature delegates to the VTA signing oracle. |
+| **A** | **1 VTC ⇄ 1 VTA**; **VTA mints + controls keys, VTC caches + signs locally** | The VTA is the canonical issuer of the integration DID's keys: it mints them at first-boot via the existing provision-integration flow and remains the only party authorised to mint or rotate them. The VTC retains a cached working copy of those keys in its own secret store (mediator / webvh-service pattern) and signs locally — every VMC, VEC, status-list credential, install-token JWT, and DIDComm outbound message is signed in-process. "No key custody" in earlier drafts meant "no key minting / rotation authority", not "no key storage" — clarified per Phase 2 M2.16. |
 | **B** | **VTC is always authoritative for its own state** | ACL + keyspaces are truth. VMC/VEC are *projections* useful only when the member operates outside the VTC. VTC authz never reads its own issued VCs. |
 | **C** | **Credentials limited to the DTG catalog** | New credential needs go upstream into `dtg-credentials`, not local extensions. |
 | **D** | **Embedded `regorus`, no OPA sidecar** | Single artefact, lower latency. Policy activation is explicit; no hot-reload watchers. |
@@ -377,7 +377,8 @@ inside the community, ACL is truth.
 Issuance steps:
 
 1. Mint new VMC (`validFrom = now`, `validUntil = now + community.membership.validity`)
-   via the VTA signing oracle. Same status-list index.
+   via the VTC's local signer (§3-A — cached integration-DID keys).
+   Same status-list index.
 2. Re-issue role VEC (always — both for ACL/role drift and to keep
    external chains current).
 3. Re-evaluate `personhood.rego` (§6.4) and surface the resulting
@@ -730,7 +731,7 @@ VTC:
   2. Run join.rego with input.vp_claims
   3. allow:
      a. Allocate status-list index (random; flipped slots excluded)
-     b. Mint VMC + role VEC via VTA oracle (§14.2 for VTA timeout)
+     b. Mint VMC + role VEC via the VTC's local signer (§3-A; in-process)
      c. Write ACL + Member, enqueue registry.rego decision
      d. Sealed-transfer credentials to applicant_did
      e. Audit: JoinRequestApproved + MemberAdded
@@ -1033,20 +1034,27 @@ Full config taxonomy (which key reloads, which restarts, which is
 UX-settable, sensitive-flag) lives in `docs/04-reference/vtc-config.md`,
 not in this spec.
 
-**VTA oracle dependence.** Every VMC / VEC issuance blocks on the
-paired VTA's signing oracle. The VTC enforces a per-call timeout
-(`vta.signing_timeout_seconds`, default 5) and a circuit breaker
-(`vta.circuit_breaker_threshold`, default 5 consecutive failures).
-On breaker-open: join requests are queued (returned as `Deferred`
-instead of 500), renewals return 503, and `/v1/health/diagnostics`
-surfaces VTA health.
+**Remote-dependency breakers.** VMC + VEC issuance is in-process
+in Phase 2 (§3-A — cached-locally signer), so the per-call
+timeout and circuit-breaker configuration apply to **non-VMC
+remote dependencies only**: the trust-registry publish path in
+Phase 3 (`MembershipSyncer`) and the did:webvh resolver walk in
+M2.15.2's rotation slice. The configuration knobs retain their
+names (`vta.signing_timeout_seconds`, default 5;
+`vta.circuit_breaker_threshold`, default 5 consecutive failures)
+for forward compatibility — they are the workspace's canonical
+"remote-call discipline" handles. The breaker-open semantics
+(join → `Deferred`, renewal → 503,
+`/v1/health/diagnostics` surfaces remote health) apply to those
+non-VMC paths once they land. Clarified per Phase 2 M2.16.
 
 ### 14.3 Telemetry + diagnostics
 
 Reuses `vti_common::telemetry::TelemetrySink`. `/v1/health/diagnostics`
 (admin) surfaces:
 
-- VTA oracle health + last-success timestamp
+- Remote-dependency health (trust-registry publish, did:webvh
+  resolver) + last-success timestamp
 - Status-list occupancy per purpose
 - `MembershipSyncer` queue depth + last-success/failure
 - Active policy IDs + SHA-256 per purpose
@@ -1085,7 +1093,7 @@ workspace doctrine. Detailed verb list lives in
 |---|---|---|
 | **0** | `vtc-host` template, install wizard, WebAuthn install flow, multi-passkey admin DID, community profile, config plumbing | DID + auth foundation. |
 | **1** | Role enum + custom roles, ACL extension, member CRUD with manual approval, self/admin removal (no-last-admin), audit envelope + HMAC, idempotency, `/v1/` versioning, cursor pagination | Members can exist. |
-| **2** | `regorus`, policy upload + activate, `join.rego` + `removal.rego`, VMC + VEC issuance via VTA oracle (with timeout + breaker), status-list with reserved-index discipline, renewal, DID rotation (both methods, domain-tagged) | Live policy + credentials. |
+| **2** | `regorus`, policy upload + activate, `join.rego` + `removal.rego`, **in-process VMC + VEC issuance** (cached-locally signer per §3-A), status-list with reserved-index discipline, renewal, DID rotation (`did:key` + `did:webvh`, domain-tagged) | Live policy + credentials. |
 | **3** | Trust-registry publish, three departure dispositions, `registry.rego`, `MembershipSyncer` + diagnostic surfacing, RTBF override + batched timing, cross-community recognition (session-mint hardening) | Community on the wider network. |
 | **4** | VRC self-issuance + `relationships.rego`, `personhood.rego` (deny-all stub) + assert/revoke + renewal re-eval, custom endorsement issuance (issuer role) | Graph + personhood live. |
 | **5** | Public website (filesystem-backed, CSP, path safety), admin UX consumed via `build.rs` (release-key-signed tarball), path-prefix routing default + subdomain support | MVP complete. |

--- a/tasks/vtc-mvp/phase-2-plan.md
+++ b/tasks/vtc-mvp/phase-2-plan.md
@@ -408,3 +408,156 @@ Recording up front so they're not surprises mid-implementation:
 Any decision that drifts from the default during
 implementation should be recorded in `phase-2-plan.md` under a
 "Phase 2 outcome" header (mirror of Phase 1's pattern).
+
+## Phase 2 outcomes
+
+Recorded at M2.16 close-out. Each row links a pre-impl
+decision (D1–D10) or risk (R1–R6) to the as-shipped reality.
+
+### D1 — Signing surface (§3-A clarification)
+
+**As shipped**: VTC signs every credential locally against a
+cached working copy of the integration DID's keys. The VTA
+remains the canonical minter + rotator; the VTC's secret
+store carries the live signing key for the lifetime of the
+deployment. Lands as
+`vtc_service::credentials::LocalSigner` (M2.9) consumed by
+VMC + VEC builders + status-list-credential builder.
+
+Spec §3-A row A amended at M2.16: "No key custody" now reads
+as "no key minting / rotation authority", not "no key
+storage" — see the docs/05-design-notes/vtc-mvp.md change in
+this PR.
+
+### §14.2 — Remote-dependency breaker scope
+
+**As shipped**: configuration parameters
+`vta.signing_timeout_seconds` + `vta.circuit_breaker_threshold`
+retain their names but apply to **non-VMC remote dependencies
+only** (trust-registry publish in Phase 3, did:webvh resolver
+walk in M2.15.2). VMC + VEC + status-list issuance is fully
+in-process and never trips the breaker. Spec §14.2 amended at
+M2.16.
+
+### D2 — `regorus` location
+
+**As shipped as proposed**: `vtc_service::policy::engine`
+hosts the harness; `vtc_service::policy::default` ships nine
+embedded `.rego` modules; the M2.3 admin endpoints sit on top.
+
+### D3 — Policy storage shape
+
+**As shipped as proposed**: `policies:<uuid>` rows carry the
+source + SHA + author; `active_policies:<purpose>` carries
+the pointer. Split keyspaces let activation flip with a
+single put.
+
+### D4 — `vp_claims` extraction (M2.6)
+
+**As shipped as proposed**: `submit_inner` extracts the
+canonical projection at submit time via
+`policy::extract::extract_vp_claims`; stored on
+`JoinRequest.vp_claims` alongside the raw VP. Full VP
+cryptographic verification deferred to a follow-up — the
+holder-binding signature at the route layer already
+authenticates the submitter.
+
+### D5 — Status-list crypto
+
+**As shipped as proposed**: same `#key-0` Ed25519 signs the
+status-list credential as the VMCs/VECs (`LocalSigner` is
+shared). Per-purpose endpoints under `GET
+/v1/status-lists/{purpose}`. Capacity 131,072.
+
+### D6 — Removal disposition resolver
+
+**As shipped as proposed**: `Disposition::PolicyDefault`
+resolves via `removal.rego.min_disposition`. Default policy
+emits `"tombstone"` so existing operator state survives the
+Phase 1 → Phase 2 transition. Unknown / missing values fall
+back to `Tombstone`.
+
+### D7 — DID rotation path split
+
+**As shipped with deferral**: M2.15.1 lands the `did:key`
+slice; M2.15.2 (`did:webvh` resolver walk) is deferred to a
+follow-up PR per R4. Endpoint accepts non-`did:key` new-DID
+values with a clear 400 + pointer to the follow-up.
+
+**Spec deviation (documented)**: rotation `/finish` is
+authenticated by the OLD DID's session, not the new DID's.
+The new DID has no ACL row, so the standard `AuthClaims`
+extractor wouldn't accept it. The body's `newSignature`
+provides the equivalent "new key holder is in control"
+guarantee. Module-level comment in
+`routes/members/rotate.rs` documents this.
+
+### D8 — Policy hot-swap atomicity
+
+**As shipped partially**: `ACTIVATE_LOCK` process-wide async
+mutex serialises every activate-policy call so the audit
+envelope's `previousPolicyId` field can't be skewed by a
+concurrent flip. The in-memory `Arc<CompiledPolicy>` registry
+the plan describes is **deferred** — Phase 2's consumers
+(M2.6 / M2.7 / M2.13) recompile per call (same pattern as
+the M2.3 `test` endpoint). Acceptable for Phase 2 because
+regorus's parse is cheap; the registry lands when policy
+evaluation becomes hot-path enough to matter.
+
+### D9 — Personhood policy placement
+
+**As shipped as proposed**: deny-all `personhood.rego` ships
+with the M2.5 bundle. M2.13 renewal evaluates the policy
+during step 3 (§6.3); the deny-all default means every
+renewed VMC carries `personhood: false`. The
+`MembershipRenewed.personhood_changed` audit field is on
+the wire from day one — Phase 4's assert/revoke endpoints
+will flip it when the real policy lands.
+
+### D10 — Trust Task IDs
+
+**As shipped as proposed**: nine Phase-2 Trust Tasks land
+under `policies/*`, `members/*`, and `status-lists/*`.
+`status-lists/show/1.0` carries
+`trust_task_header_exempt: true` in both frontmatter and
+index.json (verifier-facing, same as `did.jsonl`).
+
+### Sealed-transfer deferral
+
+**Across M2.12 + M2.13 + M2.15**: VMC + VEC sealed-transfer
+(vta-sdk's `seal_payload` HPKE-to-applicant path) is
+**deferred** to a follow-up. For Phase 2 MVP the credentials
+ship inline in the approve / renew / rotate responses; the
+admin caller hands them off out-of-band. The wire shape for
+sealed delivery lands when the cross-VTA deliveries
+materialise in Phase 3+.
+
+### M2.15.2 — did:webvh rotation
+
+**Deferred** to a follow-up PR per R4. The
+`affinidi-did-resolver-cache-sdk` integration + `did.jsonl`
+walk is the riskier slice; M2.15.1 ships the `did:key`
+slice and the endpoint method-detection step 400s
+non-`did:key` new-DIDs with a clear pointer to the
+follow-up.
+
+### M2.16 audit pre-landing pattern
+
+**As shipped across PRs 1–5**: every audit variant
+(`PolicyUploaded`, `PolicyActivated`, `VmcIssued`, `VecIssued`,
+`MembershipRenewed`, `StatusListFlipped`, `DidRotated`)
+landed alongside its emitting endpoint, not in a single
+M2.17 batch. Reasoning in
+`vti-common/src/audit/event.rs` doc-comments: wire-shape
+decisions stay localised to the code that fills them. M2.17
+becomes a snapshot-test checkpoint that confirms the seven
+variants are present + serialise to their canonical wire
+form.
+
+### M2.18 Trust Task pre-landing
+
+**As shipped across PRs 1–5**: every Trust Task draft landed
+alongside its endpoint. M2.18 confirms the on-disk
+`spec.md` + `schema.json` + `index.json` entries match the
+endpoint surface — no separate batch of files to author at
+close-out.

--- a/tasks/vtc-mvp/phase-2-todo.md
+++ b/tasks/vtc-mvp/phase-2-todo.md
@@ -382,7 +382,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.16 — Spec clarifications
 
-### `[ ]` M2.16.1 — Capture D1 + status-list URL outcomes
+### `[x]` M2.16.1 — Capture D1 + status-list URL outcomes
 
 - **Acceptance** — `tasks/vtc-mvp/phase-2-plan.md` gains a
   "Phase 2 outcomes" header listing:
@@ -408,7 +408,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.17 — Audit variants
 
-### `[ ]` M2.17.1 — Phase 2 audit vocabulary
+### `[x]` M2.17.1 — Phase 2 audit vocabulary
 
 - **Acceptance**
   - `AuditEvent` enum gains variants:
@@ -425,7 +425,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.18 — Trust Task drafts + index
 
-### `[ ]` M2.18.1 — Spec + schema files for Phase 2 surface
+### `[x]` M2.18.1 — Spec + schema files for Phase 2 surface
 
 - **Acceptance**
   - All 9 Phase 2 Trust Tasks from plan §D10 have `spec.md`
@@ -440,7 +440,7 @@ ships; assert / revoke endpoints are Phase 4.
 
 ## M2.19 — Phase 2 gate
 
-### `[ ]` M2.19.1 — Workspace gate green
+### `[x]` M2.19.1 — Workspace gate green
 
 - **Acceptance** (mirrors M0.12.3 + M1.15.1)
   - `cargo build --workspace` green.

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -762,6 +762,104 @@ mod tests {
     }
 
     #[test]
+    fn vmc_issued_round_trip() {
+        let e = AuditEvent::VmcIssued(CredentialIssuedData {
+            credential_id: "urn:uuid:11111111-1111-1111-1111-111111111111".into(),
+            credential_type: "VerifiableMembershipCredential".into(),
+            valid_from: "2026-05-12T00:00:00Z".into(),
+            valid_until: "2026-06-11T00:00:00Z".into(),
+            status_list_index: Some(42),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "VmcIssued");
+        assert_eq!(
+            v["data"]["credentialType"],
+            "VerifiableMembershipCredential"
+        );
+        assert_eq!(v["data"]["statusListIndex"], 42);
+        round_trip(&e);
+    }
+
+    #[test]
+    fn vec_issued_round_trip_omits_status_list_index_when_none() {
+        let e = AuditEvent::VecIssued(CredentialIssuedData {
+            credential_id: "urn:uuid:22222222-2222-2222-2222-222222222222".into(),
+            credential_type: "VerifiableEndorsementCredential".into(),
+            valid_from: "2026-05-12T00:00:00Z".into(),
+            valid_until: "2026-06-11T00:00:00Z".into(),
+            status_list_index: None,
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "VecIssued");
+        assert!(
+            v["data"].get("statusListIndex").is_none(),
+            "statusListIndex should be omitted when None, got {v}"
+        );
+        round_trip(&e);
+    }
+
+    #[test]
+    fn membership_renewed_round_trip() {
+        let e = AuditEvent::MembershipRenewed(MembershipRenewedData {
+            vmc_id: "urn:uuid:vmc-1".into(),
+            role_vec_id: "urn:uuid:vec-1".into(),
+            personhood_changed: true,
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "MembershipRenewed");
+        assert_eq!(v["data"]["personhoodChanged"], true);
+        round_trip(&e);
+    }
+
+    #[test]
+    fn status_list_flipped_round_trip() {
+        let e = AuditEvent::StatusListFlipped(StatusListFlippedData {
+            purpose: "revocation".into(),
+            index: 7,
+            revoked: true,
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "StatusListFlipped");
+        assert_eq!(v["data"]["purpose"], "revocation");
+        assert_eq!(v["data"]["index"], 7);
+        assert_eq!(v["data"]["revoked"], true);
+        round_trip(&e);
+    }
+
+    #[test]
+    fn did_rotated_round_trip_with_credential_ids() {
+        let e = AuditEvent::DidRotated(DidRotatedData {
+            old_did: "did:key:zOld".into(),
+            new_did: "did:key:zNew".into(),
+            method: "did:key".into(),
+            vmc_id: Some("urn:uuid:vmc-2".into()),
+            role_vec_id: Some("urn:uuid:vec-2".into()),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "DidRotated");
+        assert_eq!(v["data"]["method"], "did:key");
+        assert_eq!(v["data"]["oldDid"], "did:key:zOld");
+        assert_eq!(v["data"]["newDid"], "did:key:zNew");
+        assert_eq!(v["data"]["vmcId"], "urn:uuid:vmc-2");
+        round_trip(&e);
+    }
+
+    #[test]
+    fn did_rotated_omits_credential_ids_when_none() {
+        let e = AuditEvent::DidRotated(DidRotatedData {
+            old_did: "did:key:zOld".into(),
+            new_did: "did:key:zNew".into(),
+            method: "did:key".into(),
+            vmc_id: None,
+            role_vec_id: None,
+        });
+        let v = wire_value(&e);
+        assert!(v["data"].get("vmcId").is_none());
+        assert!(v["data"].get("roleVecId").is_none());
+        round_trip(&e);
+    }
+
+    #[test]
     fn variant_discriminator_strings() {
         let cases: Vec<(AuditEvent, &str)> = vec![
             (
@@ -844,6 +942,52 @@ mod tests {
                     previous_policy_id: None,
                 }),
                 "PolicyActivated",
+            ),
+            (
+                AuditEvent::VmcIssued(CredentialIssuedData {
+                    credential_id: "id".into(),
+                    credential_type: "VerifiableMembershipCredential".into(),
+                    valid_from: "vf".into(),
+                    valid_until: "vu".into(),
+                    status_list_index: None,
+                }),
+                "VmcIssued",
+            ),
+            (
+                AuditEvent::VecIssued(CredentialIssuedData {
+                    credential_id: "id".into(),
+                    credential_type: "VerifiableEndorsementCredential".into(),
+                    valid_from: "vf".into(),
+                    valid_until: "vu".into(),
+                    status_list_index: None,
+                }),
+                "VecIssued",
+            ),
+            (
+                AuditEvent::MembershipRenewed(MembershipRenewedData {
+                    vmc_id: "v".into(),
+                    role_vec_id: "r".into(),
+                    personhood_changed: false,
+                }),
+                "MembershipRenewed",
+            ),
+            (
+                AuditEvent::StatusListFlipped(StatusListFlippedData {
+                    purpose: "revocation".into(),
+                    index: 0,
+                    revoked: true,
+                }),
+                "StatusListFlipped",
+            ),
+            (
+                AuditEvent::DidRotated(DidRotatedData {
+                    old_did: "o".into(),
+                    new_did: "n".into(),
+                    method: "did:key".into(),
+                    vmc_id: None,
+                    role_vec_id: None,
+                }),
+                "DidRotated",
             ),
         ];
         for (event, expected) in cases {


### PR DESCRIPTION
## Summary

Closes out Phase 2 of the VTC MVP. Four milestones bundled:
spec amendments, audit-variant snapshot coverage, Trust Task
index cross-check, workspace gate.

| Milestone | What it does |
|---|---|
| **M2.16** | Amends spec §3-A + §14.2 to reflect D1's as-shipped cached-locally / VTA-controlled model + records D1–D10 outcomes in `phase-2-plan.md` |
| **M2.17** | Snapshot tests for the five audit variants that pre-landed across PRs 1–5 (`VmcIssued`, `VecIssued`, `MembershipRenewed`, `StatusListFlipped`, `DidRotated`) |
| **M2.18** | Cross-check confirms 9 Phase-2 Trust Task drafts + matching `index.json` entries (all pre-landed) |
| **M2.19** | Workspace gate green; memory updated; phase-2-todo flipped |

No new endpoints, no new business logic — this PR is the
documentation + test-coverage close-out.

## Spec amendments (M2.16)

`docs/05-design-notes/vtc-mvp.md`:

- **§3-A row A** rewritten:
  > VTA mints + controls keys, VTC caches + signs locally —
  > the VTC retains a cached working copy of the integration
  > DID's keys in its own secret store (mediator /
  > webvh-service pattern) and signs locally. "No key
  > custody" in earlier drafts meant "no key minting /
  > rotation authority", not "no key storage" — clarified
  > per Phase 2 M2.16.
- **§14.2 retitled** "Remote-dependency breakers":
  > `vta.signing_timeout_seconds` +
  > `vta.circuit_breaker_threshold` retain their names but
  > apply to **non-VMC remote dependencies only**
  > (trust-registry publish in Phase 3, did:webvh resolver
  > in M2.15.2). VMC + VEC + status-list issuance is fully
  > in-process and never trips the breaker.
- §6.3 step 1, §10.4 step 3b, §14.3 telemetry, §16 Phase 2
  row all updated to reflect in-process issuance.

`tasks/vtc-mvp/phase-2-plan.md` grows a "Phase 2 outcomes"
section recording the as-shipped reality for D1–D10 + the
documented deviations (sealed-transfer deferred to a
follow-up, rotation `/finish` auth is old-DID's session not
new-DID's, did:webvh rotation deferred).

## Audit snapshot tests (M2.17)

vti-common audit suite: **32 → 38 tests**.

Six new round-trip tests for the Phase 2 variants that
pre-landed in earlier PRs:

- `vmc_issued_round_trip`
- `vec_issued_round_trip_omits_status_list_index_when_none`
- `membership_renewed_round_trip`
- `status_list_flipped_round_trip`
- `did_rotated_round_trip_with_credential_ids`
- `did_rotated_omits_credential_ids_when_none`

All five new discriminator entries added to
`variant_discriminator_strings`.

## Trust Task cross-check (M2.18)

40 entries total in `trust-tasks/index.json` (31 Phase 0+1 +
9 Phase 2). Every entry has matching `spec.md` +
`schema.json` files on disk:

```
policies/upload/1.0
policies/activate/1.0
policies/test/1.0
policies/list/1.0
policies/show/1.0
status-lists/show/1.0     (trust_task_header_exempt)
members/renew/1.0
members/rotate-challenge/1.0
members/rotate/1.0
```

## Workspace gate (M2.19)

- ✅ `cargo build --workspace`
- ✅ `cargo test --workspace` — 25 test binaries, ~390 tests
  in vtc-service plus the broader workspace
- ✅ `cargo clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo fmt --all -- --check`

Phase-2-todo: every M2.x milestone flipped to `[x]` except
M2.15.2 (`did:webvh` rotation) which is deferred to a
follow-up PR per plan §R4.

## Definition of done (spec §16 Phase 2 row)

**Live policy + credentials.** End-to-end lifecycle
exercised by integration tests:

```
applicant submits
  → join.rego decides
  → admin approves
  → VMC + VEC minted (inline)
  → renewal mints fresh VCs
  → admin/self removes
  → revocation bit flipped
  → status-list VC reflects the flip
  → member rotates DID (did:key path)
```

Phase 3 (trust-registry + cross-community) can start after
this merges. The M2.15.2 follow-up (`did:webvh` rotation
via `affinidi-did-resolver-cache-sdk`'s `did.jsonl` walk)
can ship in parallel — it touches only the rotation
route's method-detection branch.

## Test plan

- [x] `cargo build --workspace` green.
- [x] `cargo test --workspace` green (25 binaries).
- [x] `cargo clippy --workspace --all-targets -- -D
  warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Memory `project_vtc_mvp.md` updated with Phase 2
  outcomes.
- [x] phase-2-todo all `[x]` except deferred M2.15.2.
- [ ] Review spec amendments for tone + framing.
- [ ] Confirm we're ready to start Phase 3.

## Commits

1. `df8b2cf` — Phase 2 closeout (M2.16–M2.19)