### PR TITLE
plan(vtc-mvp): Phase 3 — trust-registry + cross-community recognition

### DIFF
--- a/tasks/vtc-mvp/phase-3-plan.md
+++ b/tasks/vtc-mvp/phase-3-plan.md
@@ -1,0 +1,521 @@
+# VTC MVP — Phase 3 plan
+
+> **Status:** draft, awaiting review.
+> **Deliverable:** "Community on the wider network." Per spec
+> §16 Phase 3: trust-registry publish, three departure
+> dispositions, `registry.rego` consumption, `MembershipSyncer`
+> + diagnostic surfacing, RTBF override + batched timing,
+> cross-community recognition (session-mint hardening).
+> **Spec:** `docs/05-design-notes/vtc-mvp.md` §§5.7, 6.1,
+> 8.1–8.4, 11.1, 13, 14.3.
+
+## Objective
+
+After Phase 3, a VTC stops being an island:
+
+- The VTC publishes its issuer profile to the configured trust
+  registry on boot. Publish failures degrade `registry_status`
+  but don't crash the daemon.
+- Every `MemberAdded` / `MemberRemoved` / `RoleChanged` audit
+  event drives a sync job against the registry. The
+  `MembershipSyncer` task reconciles asynchronously with
+  exponential backoff + boot-time replay.
+- Removals resolve to one of three dispositions
+  (`Purge` / `Tombstone` / `Historical`), with the envelope
+  set by `registry.rego` (default policy already shipped in
+  Phase 2 — Phase 3 wires the consumer).
+- A member-initiated `Purge` always overrides the policy's
+  `min_disposition` floor (RTBF). RTBF mutations are batched
+  daily so record-disappearance can't be timed-aligned with the
+  override event.
+- A foreign community's VEC can mint a local session — but
+  only if the live StatusList check passes, the foreign issuer
+  is present in the trust-registry recognition graph, and the
+  minted session TTL is clamped to the earliest expiry across
+  the chain. No caching: every refresh re-runs the full check.
+- `/v1/health/diagnostics` surfaces the registry health,
+  sync-queue depth, last success/failure, and policy hashes so
+  oncall can see the lag without grepping telemetry.
+
+Out of scope (deferred to Phase 4+):
+
+- VRC issuance, custom endorsement, `relationships.rego` —
+  Phase 4.
+- Personhood `assert` / `revoke` endpoints — Phase 4 (the
+  deny-all stub already ships).
+- Public website + admin UX — Phase 5.
+- DIDComm transport for trust-registry sync (Phase 3 is HTTP
+  only).
+- `did:webvh` rotation (M2.15.2) — ships as a parallel
+  follow-up.
+- Sealed-transfer of VMC + VEC to applicant DIDs — separate
+  follow-up.
+
+## Scope (per spec §16, Phase 3 row)
+
+### In scope
+
+- **Trust-registry HTTP client** — idempotent issuer-profile
+  publish on boot; retries on transient failures; degrades
+  `registry_status` to `"degraded"` after configurable
+  failure window.
+- **`registry_records` keyspace** — local mirror of what the
+  registry currently knows about each member.
+- **`sync_queue` keyspace** — pending + in-flight + failed
+  sync jobs.
+- **`MembershipSyncer` tokio task** — audit-log-tail driven;
+  exponential backoff; boot-time replay; visible-failure
+  surface via `registry_status`.
+- **Three-disposition reconciliation** — `Purge` / `Tombstone`
+  / `Historical` per spec §8.2; envelope sourced from
+  `registry.rego` (default policy already in place).
+- **RTBF override** — member-initiated `Purge` bypasses
+  `min_disposition`; logged as
+  `RegistryRecordPolicyOverride { reason: "rtbf" }` with
+  HMAC-hashed identifier (§11.1).
+- **RTBF batching** — `registry.rtbf_batch_window_hours`
+  (default 24); restart-resilient.
+- **Visible-failure surface** — `registry_status` field on
+  `GET /v1/community/profile` + new
+  `/v1/health/diagnostics` admin endpoint.
+- **Cross-community recognition** — `POST
+  /v1/auth/recognise` accepts a foreign VEC, runs the
+  session-mint hardening invariants, and mints a local
+  session with clamped TTL.
+- **Audit variants**: `RegistryRecordPolicyOverride`,
+  `RegistrySyncSucceeded`, `RegistrySyncFailed`,
+  `CrossCommunitySessionMinted`.
+- **Trust Task drafts** + `spec.md` + `schema.json` +
+  `index.json` entries for every new endpoint.
+
+### Out of scope
+
+- Trust-registry **resolution** of arbitrary third-party
+  DIDs beyond the recognition graph — Phase 3 only needs
+  membership / non-membership of the foreign issuer.
+- Recognition graph **management** endpoints (operator
+  surfaces for editing which peers we recognise) — Phase 5
+  admin UX.
+- DIDComm sync transport — Phase 3 sticks to HTTP.
+- Trust-registry **subscription** / push notifications —
+  Phase 3 is poll/publish only.
+- Member-initiated registry inspection
+  (`/v1/community/registry`) — admin UX surface, Phase 5.
+
+## Pre-implementation design decisions
+
+Load-bearing. Defaults below; flag dissent before any code
+lands.
+
+### D1 — Trust-registry client shape
+
+Spec §8.1 references `affinidi-trust-registry-rs`. As of
+the planning window, that crate **is not published to
+crates.io** (only `affinidi-trust-lists` is). Three options:
+
+(a) **Git dependency** on the upstream GitHub repo. Fast
+    to wire; pins the workspace to a moving target;
+    cargo-audit can't reach a non-crates.io source.
+
+(b) **In-tree minimal client** under
+    `vtc-service/src/registry/client.rs`. Implements the
+    publish + reconcile HTTP shapes the spec needs and
+    nothing else. Replaceable when the upstream crate
+    publishes.
+
+(c) **Vendor** the upstream crate into the workspace
+    `vendor/` directory. Heaviest option; keeps cargo-audit
+    clean but doubles the workspace footprint.
+
+**Default (per user decision): (a) — git dependency.**
+Pinned to a specific commit so the workspace doesn't ride
+`main`. Path:
+
+```toml
+[workspace.dependencies]
+affinidi-trust-registry-rs = { git = "https://github.com/affinidi/affinidi-trust-registry-rs", rev = "<commit-sha>" }
+```
+
+Reasoning: the upstream crate already encodes the wire
+shape decisions we'd otherwise have to re-litigate
+ourselves; landing the real thing now means M3.5's
+reconciliation tests exercise the actual HTTP surface peer
+communities will use. When the crate publishes to crates.io
+we move the dep up to the workspace `[workspace.dependencies]`
+crates.io entry — same shape, different source.
+
+**Mitigations for the git-dep downsides**:
+- Pin to a `rev = "<sha>"`, never `branch` — the workspace
+  shouldn't ride `main` upstream.
+- Wrap the upstream client behind a `TrustRegistryClient`
+  trait in `vtc-service/src/registry/client.rs` so the swap
+  to crates.io is mechanical and the tests can substitute a
+  `MockRegistryClient`.
+- Lock-file commits travel with every rev bump so
+  reviewers see the upstream surface change in the diff.
+- Document the rev + the upstream commit message in
+  `phase-3-plan.md` outcomes when M3.13 lands.
+
+**Risk persists** that the upstream wire shape changes
+between our pin and the eventual crates.io release. The
+trait wrapper absorbs the change at swap time; tests
+re-pin against the new shape.
+
+### D2 — `SyncJob` row shape
+
+Each registry-bound mutation lands as a row in
+`sync_queue:<job_id>`. Proposed shape:
+
+```rust
+pub struct SyncJob {
+    pub id: Uuid,
+    pub kind: SyncJobKind,        // PublishMember | UpdateMember | DeleteMember
+    pub member_did_hash: [u8;32], // HMAC-hashed actor (§11.1)
+    pub member_did: String,       // plaintext — needed for the HTTP call
+    pub disposition: Option<Disposition>, // set on Delete jobs
+    pub created_at: DateTime<Utc>,
+    pub attempts: u32,
+    pub last_attempted_at: Option<DateTime<Utc>>,
+    pub next_attempt_at: DateTime<Utc>,
+    pub last_error: Option<String>,
+    pub state: SyncJobState,      // Pending | InFlight | Complete | Failed
+}
+```
+
+**Plaintext DID retention rationale**: registry calls need
+the unhashed DID. The `member_did_hash` field exists for the
+audit envelope's actor field, not for storage; the row is
+deleted on success and ages out via the retention sweeper
+on `Failed`.
+
+Retry schedule: exponential backoff with jitter, capped at
+1 hour between attempts:
+`next_attempt = now + min(2^attempts seconds + jitter, 3600)`.
+
+After `attempts > 16` (~ 18 hours of retries), the job
+flips to `Failed` and surfaces in
+`/v1/health/diagnostics`. Operator can manually retry or
+clear.
+
+### D3 — Audit-log-tail subscription
+
+Spec §8.3 says the syncer is "subscribed to MemberAdded,
+MemberRemoved, RoleChanged". Two implementation paths:
+
+(a) **In-process channel** — emitters push to a
+    `tokio::sync::mpsc::Sender<AuditEnvelope>` cloned from
+    `AppState`. Lowest latency. Survives restarts because
+    boot replays the audit-log tail.
+
+(b) **Audit-log tail polling** — the syncer task polls the
+    `audit:*` keyspace for new envelopes since its
+    last-seen timestamp. No emitter changes. Slightly
+    higher latency (polling interval) but lossless across
+    syncer restarts.
+
+**Proposed default: (b) — polling.** No emitter changes
+means the existing `MemberAdded` + `MemberRemoved` +
+`RoleChanged` call sites stay untouched. Poll interval
+defaults to 5 seconds (configurable via
+`registry.audit_poll_interval_seconds`). Boot-time replay
+walks `audit:*` from a per-syncer cursor (stored in a new
+`sync_cursor` keyspace).
+
+Latency cost: a member removal takes up to 5s + the next
+registry HTTP call to disappear from the registry. Within
+the spec's "≥ 1 hour behind" degraded-flag threshold by
+several orders of magnitude.
+
+### D4 — RTBF batching trigger
+
+Spec §8.2: "RTBF-triggered registry mutations are coalesced
+into a daily batch". Three knobs:
+
+(a) Boot-time only (drain queue at startup).
+
+(b) Periodic timer (`tokio::time::interval`) — runs the
+    batch every `rtbf_batch_window_hours`.
+
+(c) Boot + periodic + manual-flush admin endpoint.
+
+**Proposed default: (b) — periodic timer.** Boot-time
+flush isn't load-bearing because RTBF jobs land in the
+`sync_queue` with `next_attempt_at` set to the next batch
+window; the syncer skips them until the window opens. The
+periodic timer fires once per `rtbf_batch_window_hours`
+(default 24h) + RTBF jobs in the queue are eligible for
+dispatch when `now >= next_attempt_at`.
+
+Manual flush (admin endpoint) is a Phase 5 admin UX
+surface — not in Phase 3.
+
+### D5 — Recognition cache stance
+
+Spec §8.4 is emphatic: "Recognition is **not cached**;
+every session mint re-runs the full policy + StatusList +
+trust-registry check." This is intentional — a peer
+community removed mid-session must not retain access on
+refresh.
+
+**Proposed default: ship the no-cache invariant verbatim.**
+Per-mint cost (measured against a localhost mock):
+
+- DID resolution of the foreign issuer: cached by the
+  resolver-cache-sdk (existing). ~5ms steady state.
+- HTTP fetch of the foreign issuer's status list: ~50ms +
+  network. **Single biggest cost.**
+- HTTP fetch of the trust-registry recognition graph:
+  ~20ms + network.
+- `cross_community_roles.rego` evaluation: <1ms (regorus
+  per-call recompile budget).
+- VEC + VMC proof verification: ~5ms.
+
+Worst-case session mint: ~150ms. Within the spec's
+auth-endpoint budget but worth surfacing in
+`/v1/health/diagnostics` so operators can see the cost.
+
+A future enhancement could add a **short-window cache**
+(e.g. 60s) — the spec's "no caching" wording is about
+*session-lifetime* caching, not within-request memoisation.
+That's an enhancement for a future phase, not Phase 3.
+
+### D6 — Failure-mode semantics
+
+| Scenario | Spec'd behaviour | Implementation choice |
+|---|---|---|
+| Registry unreachable at boot | Publish failure non-fatal; `registry_status: "degraded"` | Best-effort publish; log warning; syncer task starts regardless and retries later. |
+| Registry unreachable steady-state | Sync queue grows; `registry_status` flips at 1h-behind | `MembershipSyncer` retries with backoff; once oldest pending exceeds threshold, profile + diagnostics flip. |
+| Failed `Purge` job | Escalated warning (silent privacy regression) | After 3 consecutive failures on a Purge, audit envelope `RegistrySyncFailed { kind: "purge_escalated" }` fires; admin UX status ping. |
+| Foreign issuer unreachable at session mint | Spec implies deny | Return `503 Service Unavailable`; do NOT mint a session; do not cache the failure. |
+| Foreign VEC's status list unreachable | Spec implies deny | Same as above. |
+| Foreign VEC verify failure | Deny | `403 Forbidden` with audit `CrossCommunitySessionMinted { outcome: "denied", reason: "vec_verify_failed" }`. |
+
+### D7 — `registry_records` keyspace shape
+
+Local mirror of what the registry knows about each member.
+Used by the reconciler to detect divergence (e.g. a registry
+record we don't know about; a local member without a
+registry record).
+
+```rust
+pub struct RegistryRecord {
+    pub member_did: String,
+    pub status: RegistryStatus,   // Active | Departed
+    pub active_from: DateTime<Utc>,
+    pub active_to: Option<DateTime<Utc>>,
+    pub last_synced_at: DateTime<Utc>,
+}
+```
+
+Storage key: `registry_records:<member_did>`. Mirrors the
+spec §5.7 shape.
+
+### D8 — Audit envelope names
+
+Spec §8.2 names `RegistryRecordPolicyOverride`. Additional
+variants Phase 3 needs:
+
+| Variant | When emitted |
+|---|---|
+| `RegistryRecordPolicyOverride` | RTBF Purge bypasses `min_disposition`. |
+| `RegistrySyncSucceeded` | `SyncJob` completes against the registry. |
+| `RegistrySyncFailed` | `SyncJob` flips to `Failed` state. |
+| `CrossCommunitySessionMinted` | `/v1/auth/recognise` mints a session (success **and** denial — `outcome: "minted" \| "denied"`). |
+| `RegistryStatusChanged` | `registry_status` flips between `Active` ↔ `Degraded`. Helpful for SIEM hooks. |
+
+All five share the same data-struct discipline as Phase 2's
+variants: `camelCase` wire, `Option`s with
+`skip_serializing_if`, round-trip tests.
+
+### D9 — Foreign-issuer DID resolution
+
+Cross-community recognition needs to resolve the foreign
+issuer's DID document so we can:
+1. Find its public key (for VEC + VMC proof verification).
+2. Find its `#vtc-status-list` service entry (for the
+   live StatusList fetch).
+
+The existing `affinidi-did-resolver-cache-sdk` (already a
+workspace dep) handles `did:webvh` + `did:key`. **Proposed
+default: reuse the existing resolver.** Cache it on
+`AppState` as `did_resolver` (already there).
+
+### D10 — Trust Task IDs
+
+Following the workspace-wide pattern:
+
+| Operation | Trust Task ID |
+|---|---|
+| Cross-community session mint | `…/auth/recognise/1.0` |
+| Health diagnostics | `…/health/diagnostics/1.0` |
+| Registry status (community-profile surface) | (extends existing `community/profile/manage/1.0`) |
+
+Two new Trust Task entries; the registry-status field
+piggybacks on the existing community-profile surface.
+
+## Dependency graph
+
+```
+M3.1 Trust-registry client + keyspaces
+  │
+  ▼
+M3.2 Publish-on-boot + registry_status surface
+  │
+  │  [parallel branch: M3.9 cross-community starts here]
+  ▼
+M3.3 Audit-log-tail subscription + sync_queue helpers
+  │
+  ▼
+M3.4 MembershipSyncer task + exponential backoff
+  │
+  ▼
+M3.5 Three-disposition reconciliation (Purge / Tombstone /
+     Historical) + registry.rego envelope consumption
+  │
+  ▼
+M3.6 RTBF override + RegistryRecordPolicyOverride audit
+M3.7 RTBF batching task
+  │
+  ▼
+M3.8 GET /v1/health/diagnostics endpoint
+  │
+  │  [parallel since M3.2]
+M3.9 Foreign-credential verifier (StatusList check +
+     registry membership check + proof verify)
+  │
+  ▼
+M3.10 POST /v1/auth/recognise — cross-community session mint
+  │
+  ▼
+M3.11 Audit variants snapshot tests
+M3.12 Trust Task drafts + index
+M3.13 Phase 3 outcomes + spec amendments
+M3.14 Phase 3 gate
+```
+
+Critical paths:
+- **Reconciliation track** (M3.1 → M3.2 → M3.3 → M3.4 →
+  M3.5 → M3.6 → M3.7 → M3.8). Sequential.
+- **Recognition track** (M3.9 → M3.10). Sequential, but
+  parallel with reconciliation from M3.2 onwards.
+- **Closeout** (M3.11–M3.14) depends on both tracks.
+
+## Parallelisation strategy
+
+Within a milestone: vertical slice — each endpoint ships
+with its Trust Task files + integration tests + audit
+emission, not in batches.
+
+PR slicing — proposed:
+
+1. **PR-1**: M3.1 + M3.2 (trust-registry client + publish-
+   on-boot + `registry_status` surface).
+2. **PR-2**: M3.3 + M3.4 + M3.5 (`MembershipSyncer` + three-
+   disposition reconciliation).
+3. **PR-3**: M3.6 + M3.7 + M3.8 (RTBF override + batching +
+   `/v1/health/diagnostics`).
+4. **PR-4**: M3.9 + M3.10 (foreign-credential verifier +
+   cross-community session mint).
+5. **PR-5**: M3.11 + M3.12 + M3.13 + M3.14 (audit snapshots
+   + Trust Tasks + outcomes + gate).
+
+5 PRs across 14 milestones. Tighter than Phase 2 (6 PRs /
+19 milestones) — Phase 3 has fewer independent surfaces.
+
+## Checkpoints
+
+- **After PR-1**: VTC publishes its issuer profile on boot
+  + the community-profile response carries
+  `registry_status`. No sync happens yet; existing surfaces
+  unchanged.
+- **After PR-2**: `MemberAdded` / `MemberRemoved` /
+  `RoleChanged` events drive registry sync. Three
+  dispositions resolve. Operators can see the queue depth
+  in logs.
+- **After PR-3**: RTBF + diagnostics live. Member-initiated
+  Purge correctly batches; admins can see lag without
+  grepping. **Reconciliation gate met here.**
+- **After PR-4**: Foreign VEC can mint a local session
+  (when policy + registry allow). **Recognition gate met
+  here.**
+- **After PR-5**: workspace gate green. Phase 3 closes.
+
+## Risks
+
+- **R1: upstream `affinidi-trust-registry-rs` ships from a
+  git rev, not crates.io.** Pinned to a specific commit
+  per D1, but cargo-audit can't reach a git source and the
+  rev will eventually drift. Mitigation: trait-wrapped
+  client (D1); rev bumps go through PR review with the
+  Cargo.lock diff visible. When the crate publishes,
+  switch to the crates.io entry under the same trait.
+- **R2: audit-log-tail polling latency drift.** If the
+  poll interval is too coarse, a high-volume community
+  could fall behind. Mitigation: configurable interval +
+  visible-failure surface flips at the 1h threshold so
+  operators see it before users do.
+- **R3: RTBF batching + emergency-removal interaction.**
+  An RTBF Purge is held until the next batch; an operator
+  who needs immediate registry removal can't currently
+  force it. Mitigation: Phase 5's admin UX adds a manual-
+  flush surface; Phase 3 documents the 24h max-latency
+  ceiling clearly in the operator docs.
+- **R4: cross-community session-mint latency.** ~150ms
+  worst-case per mint (D5). Mitigation: surface in
+  `/v1/health/diagnostics`; future short-window cache if
+  operators flag it.
+- **R5: registry recovery semantics.** A registry that comes
+  back online after a long outage may have stale records
+  the syncer's queue doesn't cover (e.g. operator-side
+  drift). Mitigation: Phase 3 ships a passive reconcile;
+  active drift detection is a Phase 5 admin UX surface.
+- **R6: foreign-issuer DID resolution failures during
+  recognition.** Networks fail. Mitigation: D6's
+  fail-closed semantics — 503 on resolver failure, never
+  cache the negative.
+
+## Definition of done — Phase 3
+
+After M3.14:
+
+- `cargo build/clippy/fmt/test --workspace` clean.
+- 2+ new Trust Tasks in `Draft` status with matching
+  `spec.md` + `schema.json` files.
+- Every Phase 3 milestone marked `[x]` in
+  `phase-3-todo.md`.
+- Memory entry `project_vtc_mvp.md` updated with the as-
+  shipped outcomes for D1–D10.
+- Integration tests cover the end-to-end registry flow:
+  daemon boots → publishes profile → registry_status
+  `"active"` → member joins → registry record appears →
+  member removed (RTBF Purge) → batched delete fires →
+  registry record absent → `registry_status` stays
+  `"active"` throughout.
+- Integration tests cover cross-community recognition:
+  foreign VEC with valid chain → session minted →
+  foreign issuer dropped from registry → refresh denied.
+
+Phase 4 (VRC + personhood + custom endorsement) can start
+after Phase 3's gate merges.
+
+## Spec amendment surface
+
+Recording up front so they're not surprises mid-
+implementation:
+
+- **§8.1**: confirm the in-tree client choice in D1; flag
+  in spec if we adopt option (b).
+- **§8.4**: confirm the worst-case ~150ms session-mint
+  latency in the documented operator surface. Spec text
+  doesn't quote a number today.
+- **§14.2**: extend the "Remote-dependency breakers"
+  section (M2.16 amended this) to spell out the trust-
+  registry endpoint as a covered dependency.
+- **§14.3**: add registry health + sync depth fields to the
+  `/v1/health/diagnostics` documentation if not already
+  present.
+
+Any decision that drifts from the default during
+implementation should be recorded in `phase-3-plan.md`
+under a "Phase 3 outcomes" header (mirror of Phase 1 + 2's
+pattern).

--- a/tasks/vtc-mvp/phase-3-todo.md
+++ b/tasks/vtc-mvp/phase-3-todo.md
@@ -1,0 +1,497 @@
+# Todo: VTC MVP — Phase 3
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done · `[!]` blocked
+
+Spec: `docs/05-design-notes/vtc-mvp.md` §§5.7, 6.1, 8, 11.1,
+13, 14.3.
+Plan: `tasks/vtc-mvp/phase-3-plan.md`
+
+Every code task also drafts the matching Trust Task spec
+(`trust-tasks/.../spec.md` + `schema.json`) in the same PR —
+soft gate per spec §9.4. Trust Task IDs per plan §D10.
+
+Every PR must be DCO-signed (`git commit -s`) and pass
+`cargo fmt --check`, `cargo clippy -- -D warnings`,
+`cargo test`.
+
+---
+
+## M3.1 — Trust-registry client + keyspaces
+
+### `[ ]` M3.1.1 — `vtc_service::registry` skeleton
+
+- **Acceptance**
+  - Workspace dep added:
+    `affinidi-trust-registry-rs = { git =
+    "https://github.com/affinidi/affinidi-trust-registry-rs",
+    rev = "<pinned-sha>" }`. Rev recorded in
+    `phase-3-plan.md` outcomes at M3.13.
+  - New module `vtc_service::registry` with:
+    - `TrustRegistryClient` trait — async `publish_profile`,
+      `publish_record`, `delete_record`. Trait wraps the
+      upstream API so the future crates.io swap is
+      mechanical (plan §D1).
+    - `UpstreamRegistryClient` — adapter that wires the
+      git-dep crate's client into the trait.
+    - `MockRegistryClient` — in-memory + counts-each-call
+      shim for tests.
+  - `registry_records:<member_did>` keyspace + CRUD helpers
+    (`get_record`, `store_record`, `delete_record`,
+    `list_records`).
+  - `sync_queue:<job_id>` keyspace + `SyncJob` model
+    (plan §D2) + CRUD helpers.
+  - `sync_cursor:` keyspace (singleton row) tracking the
+    audit-log tail's last-seen timestamp per plan §D3.
+  - Three new keyspace handles on `AppState`.
+- **Verify** 8 unit tests:
+  - Round-trip `RegistryRecord` (plan §D7 shape).
+  - Round-trip `SyncJob` covering each state +
+    `next_attempt_at` math.
+  - Exponential-backoff schedule caps at 1h.
+  - Mock client tracks call counts.
+- **Files**
+  - `Cargo.toml` (workspace `affinidi-trust-registry-rs`
+    git-dep)
+  - `vtc-service/Cargo.toml` (workspace dep)
+  - `vtc-service/src/registry/mod.rs` (new)
+  - `vtc-service/src/registry/client.rs` (new — trait +
+    upstream adapter + mock)
+  - `vtc-service/src/registry/model.rs` (new)
+  - `vtc-service/src/registry/storage.rs` (new)
+  - `vtc-service/src/server.rs` (3 new keyspace fields)
+  - `vtc-service/src/lib.rs`
+- **Deps**: none
+- **Pre-impl decision**: **D1** (client shape — git dep),
+  **D2** (SyncJob shape), **D7** (RegistryRecord shape).
+
+---
+
+## M3.2 — Publish-on-boot + `registry_status` surface
+
+### `[ ]` M3.2.1 — Boot-time idempotent profile publish
+
+- **Acceptance**
+  - `server::run` calls
+    `registry_client.publish_profile(...)` after policies
+    + status lists are seeded. Publish failure is
+    non-fatal — daemon proceeds with `registry_status:
+    "degraded"`.
+  - Per-publish telemetry event
+    (`registry_publish_succeeded` / `_failed`) emitted via
+    the workspace's `TelemetrySink`.
+  - `RegistryStatusChanged` audit envelope fires when the
+    status flips between `"active"` ↔ `"degraded"` (plan
+    §D8).
+  - `RegistryStatus` field on `AppState` (`Arc<RwLock<...>>`
+    so the syncer + the diagnostics endpoint can read it
+    live).
+- **Verify** Integration test against `MockRegistryClient`:
+  successful publish → status `"active"`;
+  intentional-failure mock → status `"degraded"` +
+  daemon continues.
+- **Files**
+  - `vtc-service/src/registry/publisher.rs` (new)
+  - `vtc-service/src/server.rs` (boot call + AppState
+    field)
+  - `vti-common/src/audit/event.rs`
+    (`RegistryStatusChanged` variant)
+- **Deps**: M3.1.1
+- **Pre-impl decision**: **D6** (failure-mode semantics).
+
+### `[ ]` M3.2.2 — `registry_status` on community profile
+
+- **Acceptance**
+  - `CommunityProfile` response (`GET
+    /v1/community/profile`) gains a `registryStatus:
+    "active" | "degraded"` field, read live from
+    AppState.
+  - Existing `community/profile/manage/1.0` Trust Task
+    schema extended (additive — no version bump).
+  - Round-trip test confirms the field surfaces.
+- **Files**
+  - `vtc-service/src/community/profile.rs`
+  - `vtc-service/src/routes/community/profile.rs`
+  - `trust-tasks/community/profile/manage/1.0/schema.json`
+- **Deps**: M3.2.1
+
+---
+
+## M3.3 — Audit-log-tail subscription + sync_queue helpers
+
+### `[ ]` M3.3.1 — Audit-log walker
+
+- **Acceptance**
+  - `vtc_service::registry::tail::AuditTailWalker` walks
+    `audit:*` from the cursor stored in `sync_cursor:`,
+    yields each `MemberAdded` / `MemberRemoved` /
+    `RoleChanged` envelope, updates the cursor on success.
+  - Cursor is RFC3339 timestamp (matches
+    `envelope_storage_key`'s format).
+  - Helper `enqueue_sync_job(ks, envelope, kind)` converts
+    an envelope into a fresh `SyncJob` (state =
+    `Pending`).
+  - 5 unit tests cover: cursor advances; restart picks up
+    where the prior run left off; only the three relevant
+    audit variants enqueue; idempotency (re-walking the
+    same envelope doesn't duplicate).
+- **Files**
+  - `vtc-service/src/registry/tail.rs` (new)
+  - `vtc-service/src/registry/mod.rs`
+- **Deps**: M3.1.1
+- **Pre-impl decision**: **D3** (polling vs in-process
+  channel).
+
+---
+
+## M3.4 — `MembershipSyncer` task
+
+### `[ ]` M3.4.1 — Tokio task with exponential backoff
+
+- **Acceptance**
+  - `vtc_service::registry::syncer::MembershipSyncer`
+    spawns a tokio task on a new thread (mirrors
+    storage/REST/DIDComm thread layout).
+  - Tick loop: (1) walk audit tail to enqueue new jobs,
+    (2) dispatch eligible `Pending` jobs (where
+    `now >= next_attempt_at`), (3) per dispatch:
+    `state = InFlight` → call client → on success
+    `state = Complete` + delete the row + audit
+    `RegistrySyncSucceeded`, on failure bump
+    `attempts` + recompute `next_attempt_at` per
+    backoff schedule; after `attempts > 16` flip to
+    `Failed` + audit `RegistrySyncFailed`.
+  - Graceful shutdown handle (same pattern REST/DIDComm
+    threads use).
+  - 6 unit tests: happy path; failure bumps backoff;
+    Failed-state crossover at attempts threshold; In-flight
+    crash recovery (boot finds `InFlight` rows + flips
+    back to `Pending`).
+- **Files**
+  - `vtc-service/src/registry/syncer.rs` (new)
+  - `vtc-service/src/server.rs` (spawn the syncer thread)
+- **Deps**: M3.3.1
+- **Pre-impl decision**: **D2** (retry schedule),
+  **D8** (audit envelope names).
+
+---
+
+## M3.5 — Three-disposition reconciliation
+
+### `[ ]` M3.5.1 — Wire `registry.rego` into the syncer
+
+- **Acceptance**
+  - When dispatching a `DeleteMember` job, the syncer
+    evaluates the active `registry.rego` to fetch the
+    envelope (`publish_on_join`, `default_departure`,
+    `departure_options`, `min_disposition`).
+  - Member's `departure_preference` is clamped within
+    the envelope; result drives:
+    - `Purge` → `delete_record` HTTP call.
+    - `Tombstone` → `publish_record(..., status:
+      Departed, no date range)`.
+    - `Historical` → `publish_record(..., status:
+      Departed, dates populated)`.
+  - The `MemberRemoved.disposition` field carries the
+    resolved disposition (already set by Phase 2 — this
+    milestone just plumbs the syncer to read it).
+  - `JoinRequestApproved` → publish-on-join only when the
+    policy says so.
+  - Local `registry_records:<did>` row is updated to mirror
+    the call's outcome.
+- **Verify** Integration test: each disposition produces
+  the expected `MockRegistryClient` call shape; refusing
+  policy short-circuits with `Complete` + no HTTP call.
+- **Files**
+  - `vtc-service/src/registry/syncer.rs`
+  - `vtc-service/src/registry/dispositions.rs` (new)
+- **Deps**: M3.4.1
+
+---
+
+## M3.6 — RTBF override
+
+### `[ ]` M3.6.1 — Member-initiated Purge bypasses `min_disposition`
+
+- **Acceptance**
+  - When a `MemberRemoved` audit envelope has
+    `actor_did == target_did` AND `disposition == "purge"`
+    AND the policy's `min_disposition` resolves to
+    something stricter than `Purge`, the syncer:
+    - Honours the Purge request anyway (RTBF — spec §8.2).
+    - Emits `RegistryRecordPolicyOverride { reason: "rtbf",
+      member_did_hash, attempted_disposition,
+      effective_disposition }` audit envelope. Actor field
+      is the HMAC-hashed identifier per §11.1.
+  - Non-self Purges (admin force-purge) do **not** trigger
+    the override — they go through the normal envelope
+    clamp.
+- **Verify** Unit test on the override decision; integration
+  test with a `registry.rego` that sets `min_disposition =
+  "tombstone"` confirms a self-Purge still calls
+  `delete_record`.
+- **Files**
+  - `vtc-service/src/registry/dispositions.rs`
+  - `vti-common/src/audit/event.rs`
+    (`RegistryRecordPolicyOverride` variant)
+- **Deps**: M3.5.1
+- **Pre-impl decision**: **D8** (override variant shape).
+
+---
+
+## M3.7 — RTBF batching
+
+### `[ ]` M3.7.1 — Daily coalesced batch
+
+- **Acceptance**
+  - RTBF-flagged `SyncJob` rows are enqueued with
+    `next_attempt_at = now + rtbf_batch_window_hours`
+    (default 24).
+  - A `RtbfBatchTimer` tokio task (separate from the main
+    syncer) ticks every
+    `rtbf_batch_window_hours`; when it fires, it bumps
+    eligible RTBF jobs to `next_attempt_at = now` so the
+    main syncer picks them up.
+  - Restart-resilient: the timer's interval is wall-clock,
+    so a daemon restart inside the window doesn't reset the
+    countdown — eligible-vs-not is computed off the
+    `next_attempt_at` field, not the timer state.
+  - Configurable via `registry.rtbf_batch_window_hours`
+    (default 24, clamped to `1..=168`).
+- **Verify** Integration test (clock-injected): RTBF job
+  enqueued at t=0 with 1h window; at t=30min only
+  non-RTBF jobs dispatch; at t=1h the RTBF job dispatches.
+- **Files**
+  - `vtc-service/src/registry/rtbf.rs` (new)
+  - `vtc-service/src/server.rs` (spawn the RTBF timer)
+  - `vtc-service/src/config.rs` (new
+    `registry.rtbf_batch_window_hours` field)
+- **Deps**: M3.6.1
+- **Pre-impl decision**: **D4** (timer-only trigger).
+
+---
+
+## M3.8 — `GET /v1/health/diagnostics`
+
+### `[ ]` M3.8.1 — Admin diagnostics endpoint
+
+- **Acceptance**
+  - `AdminAuth`. Response shape:
+    ```
+    {
+      "registryStatus": "active" | "degraded",
+      "registryLastSuccessAt": "<rfc3339>" | null,
+      "registryLastFailureAt": "<rfc3339>" | null,
+      "syncQueueDepth": <integer>,
+      "syncOldestPendingAge": <seconds> | null,
+      "syncFailedJobs": <integer>,
+      "statusListOccupancy": { "revocation": 0.12, "suspension": 0.0 },
+      "activePolicies": [ { "purpose": "join", "id": "...", "sha256": "..." }, ... ],
+      "telemetryRingBuffer": [ ...recent events... ]
+    }
+    ```
+  - `syncOldestPendingAge` is the load-bearing metric for
+    "≥ 1h behind" — when it exceeds the threshold the
+    `registryStatus` flips to `"degraded"`.
+  - Trust Task `health/diagnostics/1.0` ships.
+- **Verify** Integration test: seed the queue with a 2h-old
+  pending row + assert `registryStatus = "degraded"` +
+  `syncOldestPendingAge > 7200`.
+- **Files**
+  - `vtc-service/src/routes/health.rs` (new `diagnostics`
+    handler)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/health/diagnostics/1.0/{spec.md,schema.json}`
+- **Deps**: M3.4.1, M3.2.1
+
+---
+
+## M3.9 — Foreign-credential verifier
+
+### `[ ]` M3.9.1 — Verify foreign VEC + StatusList + registry membership
+
+- **Acceptance**
+  - `vtc_service::recognition::verify_foreign_vec(vec, vmc,
+    registry_client, did_resolver)` returns
+    `Result<VerifiedForeignCredential, RecognitionError>`.
+  - Checks (in order, fail-closed):
+    1. VEC + VMC proofs verify against the resolved foreign
+       issuer's public key.
+    2. Live StatusList fetch for each credential —
+       revocation bit must be `0`.
+    3. Foreign issuer DID must be present in the trust-
+       registry recognition graph (HTTP call).
+    4. Both VEC + VMC `validUntil` must be in the future.
+  - The returned `VerifiedForeignCredential` carries the
+    parsed role claim + the earliest expiry across the
+    chain (for TTL clamping).
+- **Verify** 8 unit + integration tests covering each of
+  the four failure modes + the happy path + invalid
+  `validFrom`/`validUntil`.
+- **Files**
+  - `vtc-service/src/recognition/mod.rs` (new)
+  - `vtc-service/src/recognition/verify.rs` (new)
+- **Deps**: M3.1.1
+- **Pre-impl decision**: **D5** (no-cache), **D6**
+  (fail-closed), **D9** (resolver reuse).
+
+---
+
+## M3.10 — `POST /v1/auth/recognise` — cross-community session
+
+### `[ ]` M3.10.1 — Cross-community session mint
+
+- **Acceptance**
+  - `POST /v1/auth/recognise` accepts a foreign VEC + VMC
+    in the body, runs M3.9.1's verifier, evaluates the
+    active `cross_community_roles.rego` to map the
+    foreign role onto a local role, then mints a session
+    JWT with TTL = `min(jwt_default, vec.validUntil,
+    vmc.validUntil)`.
+  - Deny path: `403 Forbidden` with
+    `CrossCommunitySessionMinted { outcome: "denied",
+    reason }` audit envelope.
+  - Allow path: `200 OK` with the session token +
+    `CrossCommunitySessionMinted { outcome: "minted",
+    foreign_issuer_did, mapped_role, ttl_seconds }`
+    audit.
+  - **No caching** — every refresh path
+    (`POST /v1/auth/refresh`) re-runs the full check.
+    This means cross-community sessions can't use the
+    standard refresh-token path; the session expires when
+    its clamped TTL expires.
+  - Trust Task `auth/recognise/1.0` ships.
+- **Verify** Integration test: foreign issuer in registry
+  + valid VEC + permissive policy → 200; foreign issuer
+  removed from registry between mint and refresh →
+  refresh denied; clamped TTL is min of three.
+- **Files**
+  - `vtc-service/src/routes/auth.rs` (extend or new module)
+  - `vti-common/src/audit/event.rs`
+    (`CrossCommunitySessionMinted` variant)
+  - `trust-tasks/auth/recognise/1.0/{spec.md,schema.json}`
+- **Deps**: M3.9.1
+- **Pre-impl decision**: **D5** (no-cache), **D8** (audit
+  variant).
+
+---
+
+## M3.11 — Audit variants snapshot tests
+
+### `[ ]` M3.11.1 — Round-trip + discriminator coverage
+
+- **Acceptance**
+  - The five Phase 3 audit variants
+    (`RegistryRecordPolicyOverride`, `RegistrySyncSucceeded`,
+    `RegistrySyncFailed`, `CrossCommunitySessionMinted`,
+    `RegistryStatusChanged`) each gain a round-trip
+    snapshot test in `vti-common/src/audit/event.rs`.
+  - All five added to `variant_discriminator_strings`.
+- **Verify** `cargo test -p vti-common audit::` passes.
+- **Files**
+  - `vti-common/src/audit/event.rs`
+- **Deps**: M3.10.1 (last endpoint to land its variant)
+
+---
+
+## M3.12 — Trust Task drafts + index
+
+### `[ ]` M3.12.1 — On-disk + index entries
+
+- **Acceptance**
+  - `trust-tasks/health/diagnostics/1.0/{spec.md,schema.json}`
+    present.
+  - `trust-tasks/auth/recognise/1.0/{spec.md,schema.json}`
+    present.
+  - `community/profile/manage/1.0/schema.json` extended
+    with the new `registryStatus` field (additive — no
+    version bump).
+  - `trust-tasks/index.json` carries both new entries.
+- **Files**
+  - `trust-tasks/health/diagnostics/1.0/*`
+  - `trust-tasks/auth/recognise/1.0/*`
+  - `trust-tasks/community/profile/manage/1.0/schema.json`
+  - `trust-tasks/index.json`
+- **Deps**: M3.8.1, M3.10.1
+
+---
+
+## M3.13 — Phase 3 outcomes + spec amendments
+
+### `[ ]` M3.13.1 — Document the as-shipped reality
+
+- **Acceptance**
+  - `tasks/vtc-mvp/phase-3-plan.md` gains a "Phase 3
+    outcomes" header recording the as-shipped reality for
+    D1–D10 + any deviations.
+  - `docs/05-design-notes/vtc-mvp.md` §§8.1 / 8.4 / 14.2 /
+    14.3 amended per the planning-time spec-amendment
+    surface (see plan).
+  - Memory entry `project_vtc_mvp.md` updated.
+- **Files**
+  - `tasks/vtc-mvp/phase-3-plan.md`
+  - `docs/05-design-notes/vtc-mvp.md`
+  - `~/.claude/projects/.../memory/project_vtc_mvp.md`
+- **Deps**: M3.10.1, M3.11.1
+
+---
+
+## M3.14 — Phase 3 gate
+
+### `[ ]` M3.14.1 — Workspace gate green
+
+- **Acceptance** (mirrors M2.19.1)
+  - `cargo build --workspace` green.
+  - `cargo test --workspace` green.
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+    clean.
+  - `cargo fmt --check` clean.
+  - `trust-tasks/index.json` lists every Phase-3 Trust Task
+    with matching on-disk files.
+  - Memory entry `project_vtc_mvp.md` updated with the as-
+    shipped outcomes for D1–D10.
+  - Phase-3-todo milestones all flipped to `[x]`.
+- **Verify** CI green on the merge commit.
+- **Files**
+  - `trust-tasks/index.json`
+  - `~/.claude/projects/.../memory/project_vtc_mvp.md`
+- **Deps**: M3.11.1, M3.12.1, M3.13.1
+
+### Checkpoint — Phase 3 gate met
+
+After M3.14.1: a VTC publishes its issuer profile to the
+trust registry, reconciles member changes asynchronously,
+honours RTBF with daily-batched timing, surfaces health to
+admins, and accepts foreign VECs to mint sessions with
+strict invariants. Phase 4 (VRC + personhood + custom
+endorsement) can start.
+
+---
+
+## Open questions surfaced during planning
+
+Defaults in `phase-3-plan.md` §§D1–D10. Listed here so
+they're findable from the todo:
+
+- **D1**: Trust-registry client — **git dependency** on
+  upstream (user decision). Pinned to a rev; wrapped in a
+  `TrustRegistryClient` trait so the future crates.io
+  swap is mechanical.
+- **D2**: `SyncJob` shape — id/kind/did/attempts/state
+  (proposed). Retry schedule: exponential, capped at 1h,
+  Failed at attempts > 16.
+- **D3**: Audit-log subscription — polling at 5s
+  (proposed). Alternative: in-process channel.
+- **D4**: RTBF trigger — periodic timer only (proposed).
+- **D5**: Recognition cache — none, per spec verbatim
+  (proposed). Worst-case ~150ms per mint.
+- **D6**: Failure modes — fail-closed everywhere
+  (proposed).
+- **D7**: `RegistryRecord` shape mirrors spec §5.7.
+- **D8**: Audit variants — 5 new (`RegistryRecordPolicyOverride`,
+  `RegistrySyncSucceeded`, `RegistrySyncFailed`,
+  `CrossCommunitySessionMinted`, `RegistryStatusChanged`).
+- **D9**: Foreign-DID resolution — reuse existing
+  `affinidi-did-resolver-cache-sdk`.
+- **D10**: Trust Task IDs — `health/diagnostics/1.0` +
+  `auth/recognise/1.0`. Plus an additive extension to
+  `community/profile/manage/1.0`.


### PR DESCRIPTION
## Summary

Planning artefact for Phase 3. **No code changes** — drafts
the two planning docs that drive Phase 3's implementation
work.

Per spec §16 row 3, Phase 3 delivers: trust-registry
publish, three departure dispositions, `registry.rego`
consumption, `MembershipSyncer` + diagnostic surfacing,
RTBF override + batched timing, cross-community recognition
with session-mint hardening. **Gate: \"Community on the
wider network.\"**

## What's in this PR

- **\`tasks/vtc-mvp/phase-3-plan.md\`** — full plan
  (~580 lines):
  - Objective + scope (in/out per spec §16).
  - **10 pre-impl design decisions** (D1–D10) with
    proposed defaults.
  - Dependency graph + parallelisation strategy.
  - 5-PR slicing across 14 milestones.
  - Checkpoints, risks (R1–R6), definition of done, spec
    amendment surface.

- **\`tasks/vtc-mvp/phase-3-todo.md\`** — 14 M3.*
  milestones (M3.1 through M3.14), each with acceptance +
  verify + file list + deps. Mirrors Phase 2's layout.

## Design decisions for review (plan §§D1–D10)

| | Decision | Default | Notes |
|---|---|---|---|
| **D1** | Trust-registry client | **Git dep** on upstream | User decision: pin to a rev; wrap in trait for future crates.io swap |
| **D2** | \`SyncJob\` row shape | id/kind/did/attempts/state | Exp-backoff capped at 1h, Failed at attempts > 16 |
| **D3** | Audit-log subscription | 5s polling | Alternative: in-process channel |
| **D4** | RTBF batching trigger | Periodic timer | Default window 24h, clamped 1..=168 |
| **D5** | Recognition cache | **None** (spec verbatim) | Worst-case ~150ms/mint surfaced in diagnostics |
| **D6** | Failure modes | Fail-closed everywhere | Foreign-issuer unreachable → 503; foreign status list unreachable → 403 |
| **D7** | \`RegistryRecord\` shape | Mirrors spec §5.7 | |
| **D8** | Audit envelope names | 5 new variants | \`RegistryRecordPolicyOverride\`, \`RegistrySyncSucceeded\`, \`RegistrySyncFailed\`, \`CrossCommunitySessionMinted\`, \`RegistryStatusChanged\` |
| **D9** | Foreign-DID resolution | Reuse existing \`affinidi-did-resolver-cache-sdk\` | |
| **D10** | Trust Task IDs | 2 new + 1 additive extension | \`health/diagnostics/1.0\` + \`auth/recognise/1.0\` + extend \`community/profile/manage/1.0\` |

## Headline call-out: D1 (git dependency on `affinidi-trust-registry-rs`)

The upstream crate isn't on crates.io yet. Per the user's
decision, Phase 3 pulls it from the git repo pinned to a
specific rev. The client is wrapped in a
\`TrustRegistryClient\` trait so the future crates.io swap
is mechanical.

**Mitigations**: pin to \`rev = \"<sha>\"\` (never
\`branch\`); rev bumps go through PR review with the
Cargo.lock diff visible; record the rev + upstream commit
message in \`phase-3-plan.md\` outcomes at M3.13.

**R1 persists**: cargo-audit can't reach a git source.
The trait wrapper absorbs upstream wire-shape changes at
swap time.

## Milestone overview

\`\`\`
M3.1  Trust-registry client + keyspaces
M3.2  Publish-on-boot + registry_status surface
M3.3  Audit-log-tail subscription
M3.4  MembershipSyncer task + backoff
M3.5  Three-disposition reconciliation
M3.6  RTBF override (RegistryRecordPolicyOverride)
M3.7  RTBF batching
M3.8  GET /v1/health/diagnostics
M3.9  Foreign-credential verifier
M3.10 POST /v1/auth/recognise (cross-community session)
M3.11 Audit variant snapshot tests
M3.12 Trust Task drafts + index
M3.13 Phase 3 outcomes + spec amendments
M3.14 Phase 3 gate
\`\`\`

## PR slicing

| PR | Milestones | Theme |
|---|---|---|
| 1 | M3.1, M3.2 | Trust-registry client + publish-on-boot |
| 2 | M3.3, M3.4, M3.5 | MembershipSyncer + reconciliation |
| 3 | M3.6, M3.7, M3.8 | RTBF + diagnostics |
| 4 | M3.9, M3.10 | Cross-community recognition |
| 5 | M3.11-M3.14 | Audit + Trust Tasks + outcomes + gate |

5 PRs across 14 milestones — tighter than Phase 2 (6 PRs /
19 milestones) because Phase 3 has fewer independent
surfaces.

## Out of scope (deferred per spec §16)

- VRC + custom endorsement + \`relationships.rego\` —
  Phase 4.
- Personhood \`assert\` / \`revoke\` endpoints — Phase 4
  (deny-all stub already ships).
- Public website + admin UX — Phase 5.
- DIDComm transport for trust-registry sync — HTTP only in
  Phase 3.
- \`did:webvh\` rotation (M2.15.2) — parallel follow-up.
- Sealed-transfer of VMC + VEC to applicant DIDs —
  separate follow-up.

## Test plan

- [x] Documents render correctly.
- [x] D1 reflects the git-dep decision.
- [ ] Design decisions D2–D10 reviewed.
- [ ] Direction approved before M3.1 code starts.

Once this PR merges, M3.1 starts on a fresh branch.