### PR TITLE
feat(vtc-service): Phase 3 PR 1 (revised) — trust-registry client skeleton (M3.1)

### DIFF
--- a/tasks/vtc-mvp/phase-3-todo.md
+++ b/tasks/vtc-mvp/phase-3-todo.md
@@ -18,7 +18,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.1 — Trust-registry client + keyspaces
 
-### `[ ]` M3.1.1 — `vtc_service::registry` skeleton
+### `[x]` M3.1.1 — `vtc_service::registry` skeleton
 
 - **Acceptance**
   - Workspace dep added:

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -28,6 +28,7 @@ pub mod keys;
 pub mod members;
 pub mod messaging;
 pub mod policy;
+pub mod registry;
 pub mod routes;
 pub mod server;
 pub mod setup;

--- a/vtc-service/src/registry/client.rs
+++ b/vtc-service/src/registry/client.rs
@@ -1,0 +1,295 @@
+//! `TrustRegistryClient` trait + in-memory mock.
+//!
+//! The trait covers both transports the upstream
+//! `affinidi-trust-registry-rs` exposes:
+//!
+//! - **Reads** — TRQP v2.0 queries (`recognise`, `authorize`) go
+//!   over HTTP. Used by M3.10's cross-community session-mint
+//!   path.
+//! - **Writes** — admin operations (publish / update / delete
+//!   member record) go over DIDComm against the upstream's
+//!   `tr-admin/1.0/*` message types. Used by M3.4's
+//!   `MembershipSyncer`.
+//!
+//! M3.1 lands the **trait shape + `MockRegistryClient`** for
+//! tests; the live HTTP / DIDComm wiring lands alongside its
+//! consumers (M3.2 + M3.4 for writes, M3.10 for reads).
+//!
+//! ## Why one trait, two transports
+//!
+//! The transports are opaque to consumers — the syncer never
+//! asks "should this go over HTTP or DIDComm?", it just calls
+//! `publish_member()`. Keeping that abstraction means future
+//! upstream changes (e.g. an HTTP admin API materialising)
+//! land in one place, not at every call site.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+use super::model::RegistryRecord;
+
+/// Errors the trust-registry client surfaces. Mapped to
+/// [`vti_common::error::AppError::Internal`] at the call site
+/// — the registry is a downstream dependency, never operator
+/// input.
+#[derive(Debug, Clone, Error)]
+pub enum RegistryError {
+    /// Transient — the next retry will likely succeed. The
+    /// syncer's backoff schedule kicks in.
+    #[error("transient registry failure: {0}")]
+    Transient(String),
+    /// Permanent — the registry rejected the request shape.
+    /// Manual operator intervention required; the syncer flips
+    /// the job to `Failed` immediately rather than retrying.
+    #[error("permanent registry failure: {0}")]
+    Permanent(String),
+    /// The registry is unreachable. Caller's circuit breaker
+    /// should open after enough of these in a row.
+    #[error("registry unreachable: {0}")]
+    Unreachable(String),
+}
+
+impl RegistryError {
+    /// `true` when the error is worth retrying. Used by the
+    /// syncer to distinguish "back off + retry" from "give up
+    /// immediately".
+    pub fn is_retriable(&self) -> bool {
+        matches!(self, Self::Transient(_) | Self::Unreachable(_))
+    }
+}
+
+/// Abstraction over the upstream trust-registry transport.
+/// Production binds [`UpstreamTrustRegistryClient`] (lands in
+/// M3.2 + M3.10); tests bind [`MockRegistryClient`].
+#[async_trait]
+pub trait TrustRegistryClient: Send + Sync {
+    /// Publish (or republish) a member record. Maps onto the
+    /// upstream's `tr-admin/1.0/create-record` (M3.4) or
+    /// `update-record` DIDComm message — the trait doesn't
+    /// distinguish; the implementation chooses based on
+    /// whether the record already exists. Phase-3 sentry:
+    /// every call is idempotent.
+    async fn publish_member(&self, record: &RegistryRecord) -> Result<(), RegistryError>;
+
+    /// Delete a member record (RTBF / Purge disposition).
+    /// Maps onto `tr-admin/1.0/delete-record`.
+    async fn delete_member(&self, member_did: &str) -> Result<(), RegistryError>;
+
+    /// Read a member's current record. `Ok(None)` when the
+    /// registry has no row for this DID. Used by the syncer
+    /// at boot to reconcile drift, and by M3.10 to check that
+    /// a foreign issuer is recognised.
+    async fn read_member(&self, member_did: &str) -> Result<Option<RegistryRecord>, RegistryError>;
+
+    /// Connectivity probe. Returns `Ok(())` iff the registry
+    /// is reachable. Drives the `registry_status` flip on
+    /// `GET /v1/community/profile` (M3.2).
+    async fn health(&self) -> Result<(), RegistryError>;
+}
+
+// ---------------------------------------------------------------------------
+// MockRegistryClient — in-memory test double
+// ---------------------------------------------------------------------------
+
+/// In-memory `TrustRegistryClient` for tests. Tracks per-call
+/// counts so tests can assert against the upstream surface
+/// without needing a docker-backed registry.
+///
+/// Cheap to clone — the inner state is an `Arc<Mutex<...>>`.
+#[derive(Debug, Clone, Default)]
+pub struct MockRegistryClient {
+    inner: Arc<Mutex<MockState>>,
+}
+
+#[derive(Debug, Default)]
+struct MockState {
+    pub records: std::collections::HashMap<String, RegistryRecord>,
+    pub publish_calls: usize,
+    pub delete_calls: usize,
+    pub read_calls: usize,
+    pub health_calls: usize,
+    /// When set, the next call of the matching kind returns
+    /// the queued error instead of succeeding. Tests inject
+    /// these to exercise the failure branches.
+    pub next_publish_error: Option<RegistryError>,
+    pub next_delete_error: Option<RegistryError>,
+    pub next_read_error: Option<RegistryError>,
+    pub next_health_error: Option<RegistryError>,
+}
+
+impl MockRegistryClient {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot the call counts. Useful for `assert_eq!` in
+    /// tests without cloning the full state.
+    pub async fn call_counts(&self) -> MockCallCounts {
+        let s = self.inner.lock().await;
+        MockCallCounts {
+            publish: s.publish_calls,
+            delete: s.delete_calls,
+            read: s.read_calls,
+            health: s.health_calls,
+        }
+    }
+
+    /// Queue an error for the next `publish_member` call.
+    pub async fn fail_next_publish(&self, err: RegistryError) {
+        self.inner.lock().await.next_publish_error = Some(err);
+    }
+
+    /// Queue an error for the next `delete_member` call.
+    pub async fn fail_next_delete(&self, err: RegistryError) {
+        self.inner.lock().await.next_delete_error = Some(err);
+    }
+
+    /// Queue an error for the next `read_member` call.
+    pub async fn fail_next_read(&self, err: RegistryError) {
+        self.inner.lock().await.next_read_error = Some(err);
+    }
+
+    /// Queue an error for the next `health` call.
+    pub async fn fail_next_health(&self, err: RegistryError) {
+        self.inner.lock().await.next_health_error = Some(err);
+    }
+
+    /// Read the upstream state directly. Tests assert against
+    /// this to confirm a call landed.
+    pub async fn snapshot(&self) -> std::collections::HashMap<String, RegistryRecord> {
+        self.inner.lock().await.records.clone()
+    }
+}
+
+/// Per-call counters surfaced by [`MockRegistryClient::call_counts`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MockCallCounts {
+    pub publish: usize,
+    pub delete: usize,
+    pub read: usize,
+    pub health: usize,
+}
+
+#[async_trait]
+impl TrustRegistryClient for MockRegistryClient {
+    async fn publish_member(&self, record: &RegistryRecord) -> Result<(), RegistryError> {
+        let mut s = self.inner.lock().await;
+        s.publish_calls += 1;
+        if let Some(err) = s.next_publish_error.take() {
+            return Err(err);
+        }
+        s.records.insert(record.member_did.clone(), record.clone());
+        Ok(())
+    }
+
+    async fn delete_member(&self, member_did: &str) -> Result<(), RegistryError> {
+        let mut s = self.inner.lock().await;
+        s.delete_calls += 1;
+        if let Some(err) = s.next_delete_error.take() {
+            return Err(err);
+        }
+        s.records.remove(member_did);
+        Ok(())
+    }
+
+    async fn read_member(&self, member_did: &str) -> Result<Option<RegistryRecord>, RegistryError> {
+        let mut s = self.inner.lock().await;
+        s.read_calls += 1;
+        if let Some(err) = s.next_read_error.take() {
+            return Err(err);
+        }
+        Ok(s.records.get(member_did).cloned())
+    }
+
+    async fn health(&self) -> Result<(), RegistryError> {
+        let mut s = self.inner.lock().await;
+        s.health_calls += 1;
+        if let Some(err) = s.next_health_error.take() {
+            return Err(err);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::model::RegistryStatus;
+    use chrono::Utc;
+
+    fn fresh_record(did: &str) -> RegistryRecord {
+        RegistryRecord {
+            member_did: did.into(),
+            status: RegistryStatus::Active,
+            active_from: Utc::now(),
+            active_to: None,
+            last_synced_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_tracks_call_counts() {
+        let m = MockRegistryClient::new();
+        m.publish_member(&fresh_record("did:key:zA")).await.unwrap();
+        m.publish_member(&fresh_record("did:key:zB")).await.unwrap();
+        m.read_member("did:key:zA").await.unwrap();
+        m.delete_member("did:key:zB").await.unwrap();
+        m.health().await.unwrap();
+
+        let counts = m.call_counts().await;
+        assert_eq!(counts.publish, 2);
+        assert_eq!(counts.read, 1);
+        assert_eq!(counts.delete, 1);
+        assert_eq!(counts.health, 1);
+    }
+
+    #[tokio::test]
+    async fn mock_persists_published_records() {
+        let m = MockRegistryClient::new();
+        m.publish_member(&fresh_record("did:key:zX")).await.unwrap();
+        let got = m.read_member("did:key:zX").await.unwrap().expect("present");
+        assert_eq!(got.member_did, "did:key:zX");
+        // Absent DID returns None.
+        let none = m.read_member("did:key:zMissing").await.unwrap();
+        assert!(none.is_none());
+    }
+
+    #[tokio::test]
+    async fn fail_next_publish_consumes_a_single_call() {
+        let m = MockRegistryClient::new();
+        m.fail_next_publish(RegistryError::Transient("flaky".into()))
+            .await;
+        let err = m
+            .publish_member(&fresh_record("did:key:zA"))
+            .await
+            .expect_err("queued error must surface");
+        assert!(err.is_retriable());
+        // Second call succeeds — error queue is one-shot.
+        m.publish_member(&fresh_record("did:key:zA")).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_removes_from_snapshot() {
+        let m = MockRegistryClient::new();
+        m.publish_member(&fresh_record("did:key:zKeep"))
+            .await
+            .unwrap();
+        m.publish_member(&fresh_record("did:key:zDrop"))
+            .await
+            .unwrap();
+        m.delete_member("did:key:zDrop").await.unwrap();
+        let snap = m.snapshot().await;
+        assert!(snap.contains_key("did:key:zKeep"));
+        assert!(!snap.contains_key("did:key:zDrop"));
+    }
+
+    #[test]
+    fn registry_error_retriable_classification() {
+        assert!(RegistryError::Transient("x".into()).is_retriable());
+        assert!(RegistryError::Unreachable("x".into()).is_retriable());
+        assert!(!RegistryError::Permanent("x".into()).is_retriable());
+    }
+}

--- a/vtc-service/src/registry/mod.rs
+++ b/vtc-service/src/registry/mod.rs
@@ -1,0 +1,62 @@
+//! Trust-registry integration surface — Phase 3 M3.1.
+//!
+//! Spec §8 + §13. The VTC publishes member records to the
+//! configured trust registry asynchronously: every
+//! `MemberAdded` / `MemberRemoved` / `RoleChanged` audit event
+//! drives a `SyncJob` against the registry, with exponential
+//! backoff and boot-time replay.
+//!
+//! ## Transport split (planning outcome)
+//!
+//! The upstream `affinidi-trust-registry-rs` ships a server +
+//! a TRQP-v2.0-compliant HTTP query surface (`POST
+//! /recognition`, `POST /authorization`) **plus** a DIDComm-only
+//! admin protocol for record mutations (URIs under
+//! `https://affinidi.com/didcomm/protocols/tr-admin/1.0/`). The
+//! upstream does **not** publish a Rust client crate.
+//!
+//! Phase 3 D1 originally proposed a git-dep on the upstream;
+//! that turned out to mean depending on the server crate, which
+//! pulls in an `affinidi-tdk = "0.4"` that conflicts with our
+//! workspace's `0.7`. Decision (per user, this PR) is to write
+//! an in-tree client wrapping both transports:
+//!
+//! - **Reads** (cross-community recognition / authorization
+//!   queries) → HTTP via `reqwest`. Lands in M3.10.
+//! - **Writes** (create / update / delete record) → DIDComm
+//!   against the upstream's `tr-admin/1.0/*` message types.
+//!   Lands in M3.2 + M3.4.
+//!
+//! [`TrustRegistryClient`] is the trait both transports route
+//! through. M3.1 lands the trait + the in-memory
+//! [`MockRegistryClient`] for tests; the live HTTP +
+//! DIDComm clients land alongside their consumers.
+//!
+//! ## Storage shape
+//!
+//! Three new keyspaces (spec §13):
+//!
+//! - `registry_records:<member_did>` — local mirror of what
+//!   the registry knows about each member. Updated when a
+//!   `SyncJob` completes successfully so the daemon can detect
+//!   divergence at boot.
+//! - `sync_queue:<job_id>` — pending / in-flight / failed
+//!   sync jobs. Drained by `MembershipSyncer` (M3.4).
+//! - `sync_cursor` — singleton row tracking the audit-log
+//!   tail's last-seen timestamp so a daemon restart picks up
+//!   exactly where the prior run left off (M3.3).
+
+pub mod client;
+pub mod model;
+pub mod storage;
+
+pub use client::{MockRegistryClient, RegistryError, TrustRegistryClient};
+pub use model::{
+    DEFAULT_MAX_ATTEMPTS, MAX_BACKOFF_SECONDS, RegistryRecord, RegistryStatus, SyncJob,
+    SyncJobKind, SyncJobState, exponential_backoff_seconds,
+};
+pub use storage::{
+    REGISTRY_RECORDS_PREFIX, SYNC_QUEUE_PREFIX, clear_sync_cursor, delete_record, delete_sync_job,
+    get_record, get_sync_cursor, get_sync_job, list_records, list_sync_jobs, set_sync_cursor,
+    store_record, store_sync_job,
+};

--- a/vtc-service/src/registry/model.rs
+++ b/vtc-service/src/registry/model.rs
@@ -1,0 +1,338 @@
+//! Trust-registry persistence model.
+//!
+//! Two row shapes:
+//!
+//! - [`RegistryRecord`] (one per member) — mirrors spec §5.7.
+//!   Captures what the registry knows about each member +
+//!   when the local view was last synced.
+//! - [`SyncJob`] (one per outstanding mutation) — pending /
+//!   in-flight / failed reconciliation jobs. Drained by
+//!   `MembershipSyncer` (M3.4).
+//!
+//! Plus [`exponential_backoff_seconds`] — the canonical
+//! retry-schedule helper. Lives here so it can be unit-tested
+//! independently of the syncer task.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Wire-form status for [`RegistryRecord::status`]. Mirrors the
+/// `status ∈ { Active, Departed }` enumeration in spec §5.7.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum RegistryStatus {
+    Active,
+    Departed,
+}
+
+/// Local mirror of a registry record. Updated when a
+/// [`SyncJob`] completes successfully so the daemon can detect
+/// drift at boot (e.g. registry contains a record we don't
+/// know about, or vice versa).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistryRecord {
+    pub member_did: String,
+    pub status: RegistryStatus,
+    pub active_from: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_to: Option<DateTime<Utc>>,
+    pub last_synced_at: DateTime<Utc>,
+}
+
+impl RegistryRecord {
+    /// Convenience constructor for an Active record being
+    /// freshly published.
+    pub fn fresh_active(member_did: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            member_did: member_did.into(),
+            status: RegistryStatus::Active,
+            active_from: now,
+            active_to: None,
+            last_synced_at: now,
+        }
+    }
+
+    /// Convenience constructor for a Departed record (post-
+    /// removal). Caller decides whether to populate
+    /// `active_to` based on the disposition (Tombstone leaves
+    /// it `None`; Historical fills it).
+    pub fn departed(
+        member_did: impl Into<String>,
+        active_from: DateTime<Utc>,
+        active_to: Option<DateTime<Utc>>,
+    ) -> Self {
+        Self {
+            member_did: member_did.into(),
+            status: RegistryStatus::Departed,
+            active_from,
+            active_to,
+            last_synced_at: Utc::now(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SyncJob
+// ---------------------------------------------------------------------------
+
+/// Kind of mutation a [`SyncJob`] dispatches against the
+/// registry. The reconciler maps `MemberAdded` → `PublishMember`,
+/// `MemberRemoved` → `DeleteMember` (or `MarkDeparted`,
+/// depending on disposition resolution), `RoleChanged` →
+/// `UpdateMember`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SyncJobKind {
+    /// First-time publish — `MemberAdded` audit event.
+    PublishMember,
+    /// Role / metadata change — `RoleChanged` /
+    /// `MemberUpdated`. Re-publishes the record verbatim.
+    UpdateMember,
+    /// Removal — `MemberRemoved` with disposition `Purge`.
+    DeleteMember,
+    /// Removal — `MemberRemoved` with disposition `Tombstone`
+    /// or `Historical`. Re-publishes the record with
+    /// `status: Departed`.
+    MarkDeparted,
+}
+
+impl SyncJobKind {
+    /// Wire-form name (camelCase). Stable; used by audit
+    /// envelopes + telemetry.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SyncJobKind::PublishMember => "publishMember",
+            SyncJobKind::UpdateMember => "updateMember",
+            SyncJobKind::DeleteMember => "deleteMember",
+            SyncJobKind::MarkDeparted => "markDeparted",
+        }
+    }
+}
+
+/// Lifecycle state of a [`SyncJob`]. Boot-time recovery flips
+/// any `InFlight` rows back to `Pending` (the daemon may have
+/// crashed between dispatch and storage update).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SyncJobState {
+    Pending,
+    InFlight,
+    Complete,
+    Failed,
+}
+
+/// Default cap on retry attempts before a job flips to
+/// `Failed`. ~18 hours of retries at the exponential schedule
+/// in [`exponential_backoff_seconds`]. After that, the row
+/// surfaces in `/v1/health/diagnostics` for operator
+/// intervention.
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 16;
+
+/// Hard cap on the per-retry sleep. Spec §8.3 implies
+/// reconciliation should never lag by more than an hour
+/// untouched.
+pub const MAX_BACKOFF_SECONDS: i64 = 3600;
+
+/// One outstanding reconciliation job.
+///
+/// `member_did` is stored in plaintext because the registry
+/// HTTP / DIDComm call needs the unhashed DID. The hashed
+/// form lives only on the audit envelope's actor field (per
+/// §11.1). Rows are deleted on `Complete` and age out via
+/// the retention sweeper on `Failed`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncJob {
+    pub id: Uuid,
+    pub kind: SyncJobKind,
+    pub member_did: String,
+    /// Pre-resolved disposition for the `DeleteMember` /
+    /// `MarkDeparted` path. `None` on publish / update jobs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub attempts: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_attempted_at: Option<DateTime<Utc>>,
+    pub next_attempt_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    pub state: SyncJobState,
+    /// `true` when this job's `next_attempt_at` was set by an
+    /// RTBF batch trigger rather than a normal retry. Lets the
+    /// RTBF timer (M3.7) identify its own jobs without
+    /// re-scanning every disposition.
+    #[serde(default)]
+    pub rtbf_batched: bool,
+}
+
+impl SyncJob {
+    /// Construct a fresh job, eligible for immediate dispatch.
+    pub fn fresh(kind: SyncJobKind, member_did: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            kind,
+            member_did: member_did.into(),
+            disposition: None,
+            created_at: now,
+            attempts: 0,
+            last_attempted_at: None,
+            next_attempt_at: now,
+            last_error: None,
+            state: SyncJobState::Pending,
+            rtbf_batched: false,
+        }
+    }
+
+    /// `true` when the job is ready to dispatch (state is
+    /// `Pending` and `next_attempt_at <= now`).
+    pub fn is_dispatchable(&self, now: DateTime<Utc>) -> bool {
+        matches!(self.state, SyncJobState::Pending) && self.next_attempt_at <= now
+    }
+
+    /// Record a failed attempt. Bumps `attempts`, sets
+    /// `next_attempt_at` per the backoff schedule, retains the
+    /// error message. Flips to `Failed` when `attempts >
+    /// DEFAULT_MAX_ATTEMPTS`.
+    pub fn record_failure(&mut self, error: impl Into<String>) {
+        self.attempts += 1;
+        self.last_attempted_at = Some(Utc::now());
+        self.last_error = Some(error.into());
+        if self.attempts > DEFAULT_MAX_ATTEMPTS {
+            self.state = SyncJobState::Failed;
+            return;
+        }
+        let backoff = exponential_backoff_seconds(self.attempts);
+        self.next_attempt_at = Utc::now() + chrono::Duration::seconds(backoff);
+        self.state = SyncJobState::Pending;
+    }
+
+    /// Record a successful dispatch. Caller is responsible for
+    /// deleting the row from `sync_queue:` after marking
+    /// complete — the audit envelope + the row deletion both
+    /// happen inside the syncer.
+    pub fn record_success(&mut self) {
+        self.last_attempted_at = Some(Utc::now());
+        self.last_error = None;
+        self.state = SyncJobState::Complete;
+    }
+}
+
+/// Exponential backoff with jitter, capped at
+/// [`MAX_BACKOFF_SECONDS`]. Schedule:
+///
+/// `next_attempt = now + min(2^attempts + jitter, 3600)`
+///
+/// `attempts = 1` → ~2-4 seconds. `attempts = 10` → ~17 min.
+/// `attempts = 12+` → 1 hour (cap). The jitter is `0..=attempts`
+/// seconds so collocated daemons don't synchronise their
+/// retry storms.
+pub fn exponential_backoff_seconds(attempts: u32) -> i64 {
+    use rand::RngExt;
+    let base = 2_i64.saturating_pow(attempts.min(20));
+    let jitter = rand::rng().random_range(0..=attempts as i64);
+    (base + jitter).min(MAX_BACKOFF_SECONDS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_is_monotonic_until_cap() {
+        // Run many trials so jitter doesn't dominate the
+        // monotonicity check.
+        for _ in 0..20 {
+            let prev = exponential_backoff_seconds(1);
+            let later = exponential_backoff_seconds(8);
+            assert!(later >= prev, "expected backoff to grow with attempts");
+        }
+    }
+
+    #[test]
+    fn backoff_caps_at_one_hour() {
+        for attempts in [12u32, 15, 20, 64] {
+            let b = exponential_backoff_seconds(attempts);
+            assert!(
+                b <= MAX_BACKOFF_SECONDS,
+                "backoff for attempts={attempts} exceeds cap: {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn fresh_job_is_immediately_dispatchable() {
+        let job = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zX");
+        assert!(job.is_dispatchable(Utc::now() + chrono::Duration::seconds(1)));
+        assert_eq!(job.attempts, 0);
+        assert_eq!(job.state, SyncJobState::Pending);
+    }
+
+    #[test]
+    fn failure_bumps_attempts_and_schedules_retry() {
+        let mut job = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zX");
+        let before = job.next_attempt_at;
+        // First failure.
+        job.record_failure("transient");
+        assert_eq!(job.attempts, 1);
+        assert_eq!(job.state, SyncJobState::Pending);
+        assert!(job.next_attempt_at > before);
+        assert_eq!(job.last_error.as_deref(), Some("transient"));
+    }
+
+    #[test]
+    fn failure_flips_to_failed_after_max_attempts() {
+        let mut job = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zX");
+        for _ in 0..=DEFAULT_MAX_ATTEMPTS {
+            job.record_failure("nope");
+        }
+        assert_eq!(job.state, SyncJobState::Failed);
+        assert!(job.attempts > DEFAULT_MAX_ATTEMPTS);
+    }
+
+    #[test]
+    fn success_marks_complete_and_clears_error() {
+        let mut job = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zX");
+        job.record_failure("first try");
+        assert!(job.last_error.is_some());
+        job.record_success();
+        assert_eq!(job.state, SyncJobState::Complete);
+        assert!(job.last_error.is_none());
+    }
+
+    #[test]
+    fn job_wire_round_trips() {
+        let job = SyncJob::fresh(SyncJobKind::MarkDeparted, "did:key:zMember");
+        let json = serde_json::to_string(&job).unwrap();
+        let back: SyncJob = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, job);
+        // Field names are camelCase wire form.
+        assert!(json.contains("\"memberDid\""));
+        assert!(json.contains("\"kind\":\"markDeparted\""));
+        assert!(json.contains("\"state\":\"pending\""));
+    }
+
+    #[test]
+    fn registry_record_wire_round_trips() {
+        let rec = RegistryRecord::fresh_active("did:key:zMember");
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: RegistryRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, rec);
+        assert!(json.contains("\"status\":\"active\""));
+    }
+
+    #[test]
+    fn departed_omits_active_to_when_none() {
+        let from = Utc::now();
+        let rec = RegistryRecord::departed("did:key:zMember", from, None);
+        let v = serde_json::to_value(&rec).unwrap();
+        assert!(
+            v.get("activeTo").is_none(),
+            "activeTo should be omitted, got {v}"
+        );
+    }
+}

--- a/vtc-service/src/registry/storage.rs
+++ b/vtc-service/src/registry/storage.rs
@@ -1,0 +1,261 @@
+//! CRUD helpers for the three Phase-3 registry keyspaces.
+//!
+//! - `registry_records:<member_did>` — local mirror of what
+//!   the registry knows.
+//! - `sync_queue:<job_id>` — pending sync jobs.
+//! - `sync_cursor` (singleton, key `cursor`) — audit-log
+//!   tail position.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::model::{RegistryRecord, SyncJob};
+
+/// Prefix every registry-record row sits under.
+pub const REGISTRY_RECORDS_PREFIX: &[u8] = b"registry_records:";
+
+/// Prefix every sync-job row sits under.
+pub const SYNC_QUEUE_PREFIX: &[u8] = b"sync_queue:";
+
+/// Singleton row key inside the `sync_cursor` keyspace.
+const SYNC_CURSOR_KEY: &[u8] = b"cursor";
+
+// ---------------------------------------------------------------------------
+// registry_records
+// ---------------------------------------------------------------------------
+
+fn registry_record_key(member_did: &str) -> Vec<u8> {
+    let mut k = REGISTRY_RECORDS_PREFIX.to_vec();
+    k.extend_from_slice(member_did.as_bytes());
+    k
+}
+
+pub async fn get_record(
+    ks: &KeyspaceHandle,
+    member_did: &str,
+) -> Result<Option<RegistryRecord>, AppError> {
+    let raw = ks.get_raw(registry_record_key(member_did)).await?;
+    match raw {
+        Some(bytes) => {
+            Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Internal(format!("RegistryRecord decode: {e}"))
+            })?))
+        }
+        None => Ok(None),
+    }
+}
+
+pub async fn store_record(ks: &KeyspaceHandle, record: &RegistryRecord) -> Result<(), AppError> {
+    ks.insert(
+        String::from_utf8(registry_record_key(&record.member_did))
+            .expect("registry_record key is ASCII"),
+        record,
+    )
+    .await
+}
+
+pub async fn delete_record(ks: &KeyspaceHandle, member_did: &str) -> Result<(), AppError> {
+    ks.remove(registry_record_key(member_did)).await
+}
+
+pub async fn list_records(ks: &KeyspaceHandle) -> Result<Vec<RegistryRecord>, AppError> {
+    let pairs = ks.prefix_iter_raw(REGISTRY_RECORDS_PREFIX.to_vec()).await?;
+    let mut out = Vec::with_capacity(pairs.len());
+    for (_k, v) in pairs {
+        match serde_json::from_slice::<RegistryRecord>(&v) {
+            Ok(r) => out.push(r),
+            Err(err) => tracing::warn!(error = %err, "skipping unparseable registry_record row"),
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// sync_queue
+// ---------------------------------------------------------------------------
+
+fn sync_job_key(id: Uuid) -> Vec<u8> {
+    let mut k = SYNC_QUEUE_PREFIX.to_vec();
+    k.extend_from_slice(id.to_string().as_bytes());
+    k
+}
+
+pub async fn get_sync_job(ks: &KeyspaceHandle, id: Uuid) -> Result<Option<SyncJob>, AppError> {
+    let raw = ks.get_raw(sync_job_key(id)).await?;
+    match raw {
+        Some(bytes) => {
+            Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Internal(format!("SyncJob decode: {e}"))
+            })?))
+        }
+        None => Ok(None),
+    }
+}
+
+pub async fn store_sync_job(ks: &KeyspaceHandle, job: &SyncJob) -> Result<(), AppError> {
+    ks.insert(
+        String::from_utf8(sync_job_key(job.id)).expect("sync_job key is ASCII"),
+        job,
+    )
+    .await
+}
+
+pub async fn delete_sync_job(ks: &KeyspaceHandle, id: Uuid) -> Result<(), AppError> {
+    ks.remove(sync_job_key(id)).await
+}
+
+pub async fn list_sync_jobs(ks: &KeyspaceHandle) -> Result<Vec<SyncJob>, AppError> {
+    let pairs = ks.prefix_iter_raw(SYNC_QUEUE_PREFIX.to_vec()).await?;
+    let mut out = Vec::with_capacity(pairs.len());
+    for (_k, v) in pairs {
+        match serde_json::from_slice::<SyncJob>(&v) {
+            Ok(j) => out.push(j),
+            Err(err) => tracing::warn!(error = %err, "skipping unparseable sync_job row"),
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// sync_cursor — singleton
+// ---------------------------------------------------------------------------
+
+/// Read the audit-log tail's last-seen timestamp. `None` on
+/// first boot (the syncer walks from the start of the audit log).
+pub async fn get_sync_cursor(ks: &KeyspaceHandle) -> Result<Option<DateTime<Utc>>, AppError> {
+    let raw = ks.get_raw(SYNC_CURSOR_KEY.to_vec()).await?;
+    let Some(bytes) = raw else { return Ok(None) };
+    let s = std::str::from_utf8(&bytes)
+        .map_err(|e| AppError::Internal(format!("sync_cursor not utf-8: {e}")))?;
+    let ts = DateTime::parse_from_rfc3339(s)
+        .map_err(|e| AppError::Internal(format!("sync_cursor not rfc3339: {e}")))?
+        .with_timezone(&Utc);
+    Ok(Some(ts))
+}
+
+/// Persist the audit-log tail's last-seen timestamp. Called
+/// after the syncer has enqueued every job from the audit
+/// envelopes up to (and including) this timestamp.
+pub async fn set_sync_cursor(ks: &KeyspaceHandle, ts: DateTime<Utc>) -> Result<(), AppError> {
+    ks.insert_raw(SYNC_CURSOR_KEY.to_vec(), ts.to_rfc3339().into_bytes())
+        .await
+}
+
+/// Reset the cursor — useful for diagnostic tools that want a
+/// full audit-log replay. Not exposed on any production
+/// endpoint.
+pub async fn clear_sync_cursor(ks: &KeyspaceHandle) -> Result<(), AppError> {
+    ks.remove(SYNC_CURSOR_KEY.to_vec()).await
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::model::{
+        RegistryRecord, RegistryStatus, SyncJob, SyncJobKind, SyncJobState,
+    };
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_keyspaces() -> (
+        KeyspaceHandle,
+        KeyspaceHandle,
+        KeyspaceHandle,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        let records = store.keyspace("registry_records").unwrap();
+        let queue = store.keyspace("sync_queue").unwrap();
+        let cursor = store.keyspace("sync_cursor").unwrap();
+        (records, queue, cursor, dir)
+    }
+
+    #[tokio::test]
+    async fn registry_record_round_trip() {
+        let (records, _q, _c, _dir) = temp_keyspaces().await;
+        let rec = RegistryRecord::fresh_active("did:key:zMember");
+        store_record(&records, &rec).await.unwrap();
+        let got = get_record(&records, "did:key:zMember")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.member_did, "did:key:zMember");
+        assert_eq!(got.status, RegistryStatus::Active);
+
+        delete_record(&records, "did:key:zMember").await.unwrap();
+        assert!(
+            get_record(&records, "did:key:zMember")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn list_records_walks_keyspace() {
+        let (records, _q, _c, _dir) = temp_keyspaces().await;
+        for did in ["did:key:zA", "did:key:zB", "did:key:zC"] {
+            store_record(&records, &RegistryRecord::fresh_active(did))
+                .await
+                .unwrap();
+        }
+        let all = list_records(&records).await.unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn sync_job_round_trip_across_each_state() {
+        let (_r, queue, _c, _dir) = temp_keyspaces().await;
+        for kind in [
+            SyncJobKind::PublishMember,
+            SyncJobKind::UpdateMember,
+            SyncJobKind::DeleteMember,
+            SyncJobKind::MarkDeparted,
+        ] {
+            let job = SyncJob::fresh(kind, "did:key:zMember");
+            store_sync_job(&queue, &job).await.unwrap();
+            let got = get_sync_job(&queue, job.id).await.unwrap().unwrap();
+            assert_eq!(got.kind, kind);
+            assert_eq!(got.state, SyncJobState::Pending);
+            delete_sync_job(&queue, job.id).await.unwrap();
+            assert!(get_sync_job(&queue, job.id).await.unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn list_sync_jobs_returns_all_pending() {
+        let (_r, queue, _c, _dir) = temp_keyspaces().await;
+        for did in ["did:key:zA", "did:key:zB"] {
+            let job = SyncJob::fresh(SyncJobKind::PublishMember, did);
+            store_sync_job(&queue, &job).await.unwrap();
+        }
+        let all = list_sync_jobs(&queue).await.unwrap();
+        assert_eq!(all.len(), 2);
+        for j in all {
+            assert_eq!(j.state, SyncJobState::Pending);
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_cursor_round_trip() {
+        let (_r, _q, cursor, _dir) = temp_keyspaces().await;
+        assert!(get_sync_cursor(&cursor).await.unwrap().is_none());
+        let ts = Utc::now();
+        set_sync_cursor(&cursor, ts).await.unwrap();
+        let got = get_sync_cursor(&cursor).await.unwrap().unwrap();
+        // RFC3339 round-trip can lose sub-second precision; compare to the second.
+        assert_eq!(got.timestamp(), ts.timestamp());
+        clear_sync_cursor(&cursor).await.unwrap();
+        assert!(get_sync_cursor(&cursor).await.unwrap().is_none());
+    }
+}

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -62,6 +62,16 @@ pub struct AppState {
     /// public route reads from it; M2.14's flip-on-removal path
     /// writes.
     pub status_lists_ks: KeyspaceHandle,
+    /// Local mirror of trust-registry records (Phase 3 M3.1).
+    /// Updated when a `SyncJob` completes successfully so the
+    /// daemon can detect drift at boot.
+    pub registry_records_ks: KeyspaceHandle,
+    /// Pending / in-flight / failed trust-registry sync jobs
+    /// (Phase 3 M3.1). Drained by `MembershipSyncer` (M3.4).
+    pub sync_queue_ks: KeyspaceHandle,
+    /// Singleton row tracking the audit-log tail's last-seen
+    /// timestamp for boot-time replay (Phase 3 M3.3).
+    pub sync_cursor_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
     pub config: Arc<RwLock<AppConfig>>,
@@ -172,6 +182,9 @@ pub async fn run(
     let policies_ks = store.keyspace("policies")?;
     let active_policies_ks = store.keyspace("active_policies")?;
     let status_lists_ks = store.keyspace("status_lists")?;
+    let registry_records_ks = store.keyspace("registry_records")?;
+    let sync_queue_ks = store.keyspace("sync_queue")?;
+    let sync_cursor_ks = store.keyspace("sync_cursor")?;
     let audit_ks = store.keyspace("audit")?;
     let audit_key_ks = store.keyspace("audit_key")?;
 
@@ -291,6 +304,9 @@ pub async fn run(
         policies_ks,
         active_policies_ks,
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks,
+        sync_queue_ks,
+        sync_cursor_ks,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -82,6 +82,9 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -125,6 +128,9 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -65,6 +65,9 @@ async fn build_with(
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -107,6 +110,9 @@ async fn build_with(
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -88,6 +88,9 @@ async fn build_fixture(with_audit: bool) -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -190,6 +193,9 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -58,6 +58,9 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -89,6 +92,9 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -59,6 +59,9 @@ async fn build() -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -90,6 +93,9 @@ async fn build() -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -53,6 +53,9 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -79,6 +82,9 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -209,6 +209,9 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -298,6 +301,9 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -70,6 +70,9 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -108,6 +111,9 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -101,6 +101,9 @@ async fn build_fixture() -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -137,6 +140,9 @@ async fn build_fixture() -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -85,6 +85,9 @@ async fn build_fixture() -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -193,6 +196,9 @@ async fn build_fixture() -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -73,6 +73,9 @@ async fn build_fixture() -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -153,6 +156,9 @@ async fn build_fixture() -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -42,6 +42,9 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -69,6 +72,9 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -100,6 +100,9 @@ async fn build_fixture() -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -173,6 +176,9 @@ async fn build_fixture() -> Fixture {
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -75,6 +75,9 @@ async fn build_fixture() -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -179,6 +182,9 @@ async fn build_fixture() -> Fixture {
         policies_ks,
         active_policies_ks,
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -76,6 +76,9 @@ async fn build_fixture() -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -170,6 +173,9 @@ async fn build_fixture() -> Fixture {
         policies_ks,
         active_policies_ks,
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -77,6 +77,9 @@ async fn build_fixture() -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -184,6 +187,9 @@ async fn build_fixture() -> Fixture {
         policies_ks,
         active_policies_ks,
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -238,6 +238,9 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -260,6 +263,9 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),
         status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/status_lists.rs
+++ b/vtc-service/tests/status_lists.rs
@@ -67,6 +67,9 @@ async fn build_fixture(with_signer: bool) -> Fixture {
     let policies_ks = store.keyspace("policies").unwrap();
     let active_policies_ks = store.keyspace("active_policies").unwrap();
     let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -110,6 +113,9 @@ async fn build_fixture(with_signer: bool) -> Fixture {
         policies_ks,
         active_policies_ks,
         status_lists_ks,
+        registry_records_ks,
+        sync_queue_ks,
+        sync_cursor_ks,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),


### PR DESCRIPTION
## Summary

First slice of Phase 3 implementation. Lands the abstraction
layer the reconciliation + recognition tracks will sit on
top of.

**Scope deviation from PR-1 plan**: M3.2 has been split out
of this PR. The trait abstraction needs to land first, and
M3.2's scope (live HTTP/DIDComm clients + `registry_status`
field + boot-time publish) expanded once the upstream's
actual transport split was visible. M3.2 ships in the next
PR.

| Milestone | What it adds |
|---|---|
| **M3.1** | `vtc_service::registry` skeleton — trait + mock + model + storage |

## Two decision changes worth surfacing — read before reviewing

The plan was written before I'd actually inspected the
upstream `affinidi-trust-registry-rs` repo. Two assumptions
in the plan turned out to be wrong:

### 1. D1 revised: in-tree client, not git-dep

The upstream is a **server crate**, not a client library:

- `trust-registry` (the only `publish = true` member) is the
  axum-based TRQP v2.0 server. Depends on AWS SDK / DynamoDB
  / Redis. Pulls in `affinidi-tdk = "0.4"` — conflicts with
  our `"0.7"`.
- `test-client` is an internal test harness (`publish = false`).
- `trqp` + `trql-client` are empty `Hello, world!` placeholders.

There is no Rust client crate to depend on. Per the
follow-up user decision, this PR writes an in-tree client
behind a `TrustRegistryClient` trait; the upstream server
becomes a black-box dep (docker for integration tests when
those land), not a Rust dep.

### 2. Transport split: writes go over DIDComm

The upstream HTTP API exposes only TRQP queries (`POST
/recognition`, `POST /authorization`,
`GET /.well-known/did.json`). All record mutations
(create / update / delete) are **DIDComm-only** using
`https://affinidi.com/didcomm/protocols/tr-admin/1.0/*`.
The plan's "HTTP only in Phase 3" scope guard is dropped.

The trait covers both transports — implementations choose
which based on the operation. Reads → HTTP (M3.10). Writes →
DIDComm (M3.2 + M3.4).

M3.13 (Phase 3 outcomes) will record the full decision set
at closeout.

## What lands

`vtc_service::registry` with four files:

- **`client.rs`** — `TrustRegistryClient` trait (4 methods:
  `publish_member`, `delete_member`, `read_member`, `health`)
  + `RegistryError` with transient / permanent / unreachable
  classification + `is_retriable()` + `MockRegistryClient`
  (per-call counters, queued-error API, snapshot accessor).
- **`model.rs`** — `RegistryRecord` (mirrors spec §5.7),
  `SyncJob` (id/kind/did/attempts/state/backoff), four
  `SyncJobKind` variants (`PublishMember` / `UpdateMember` /
  `DeleteMember` / `MarkDeparted`), four `SyncJobState`
  variants. Plus `exponential_backoff_seconds(attempts) -> i64`
  with jitter, capped at 1h; `DEFAULT_MAX_ATTEMPTS = 16` (~18h
  before flipping to `Failed`).
- **`storage.rs`** — CRUD helpers for the three new
  keyspaces.
- **`mod.rs`** — module index + re-exports.

AppState gains three new fields:

- `registry_records_ks` — local member-record mirror.
- `sync_queue_ks` — pending sync jobs.
- `sync_cursor_ks` — singleton row for the audit-log tail
  position (M3.3 prep).

Every test fixture in `vtc-service/tests/` updated.

## Test coverage (19 unit tests)

- Backoff schedule is monotonic up to the cap, never exceeds
  1h.
- Fresh `SyncJob` is immediately dispatchable; `record_failure`
  bumps attempts + reschedules; flips to `Failed` after
  `DEFAULT_MAX_ATTEMPTS`; `record_success` clears
  `last_error`.
- Wire round-trip for `SyncJob` (camelCase, every state +
  kind variant) and `RegistryRecord` (with `activeTo`
  omit-when-None).
- `MockRegistryClient` tracks per-call counts; one-shot
  queued-error API for transient / permanent / unreachable
  scenarios; snapshot reflects published / deleted state.
- Storage round-trip per kind; keyspace prefix-walks return
  every persisted row; cursor round-trip preserves
  timestamp to the second; clear is idempotent.

## Test plan

- [x] `cargo test -p vtc-service` green (390+ tests across
  17 test binaries).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- [ ] Review the D1 + transport-split decision changes
  before M3.2 starts (next PR adds live transports).
- [ ] Approve before M3.2 picks up the live HTTP/DIDComm
  clients.

## Commits

1. `c489f74` — M3.1 trust-registry client skeleton

Once this PR merges, the next PR picks up M3.2 (live HTTP +
DIDComm clients + boot-time `health()` ping +
`registry_status` field on `GET /v1/community/profile` +
`RegistryStatusChanged` audit envelope).