### PR TITLE
feat(vtc-service): Phase 3 PR 2 — registry health probe + status surface (M3.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9235,6 +9235,7 @@ dependencies = [
  "multibase",
  "rand 0.10.1",
  "regorus",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/tasks/vtc-mvp/phase-3-todo.md
+++ b/tasks/vtc-mvp/phase-3-todo.md
@@ -68,7 +68,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.2 — Publish-on-boot + `registry_status` surface
 
-### `[ ]` M3.2.1 — Boot-time idempotent profile publish
+### `[x]` M3.2.1 — Boot-time idempotent profile publish
 
 - **Acceptance**
   - `server::run` calls
@@ -98,7 +98,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 - **Deps**: M3.1.1
 - **Pre-impl decision**: **D6** (failure-mode semantics).
 
-### `[ ]` M3.2.2 — `registry_status` on community profile
+### `[x]` M3.2.2 — `registry_status` on community profile
 
 - **Acceptance**
   - `CommunityProfile` response (`GET

--- a/trust-tasks/community/profile/manage/1.0/schema.json
+++ b/trust-tasks/community/profile/manage/1.0/schema.json
@@ -2,16 +2,21 @@
   "$id": "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0/schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "VTC — Community Profile (Show + Update)",
-  "description": "Covers GET (no body) and PUT (partial CommunityProfileUpdate). Refined when GET/PUT split into separate Trust Tasks.",
+  "description": "Covers GET (no body) and PUT (partial CommunityProfileUpdate). Refined when GET/PUT split into separate Trust Tasks. GET response also carries the live `registryStatus` field (additive in Phase 3 M3.2).",
   "type": "object",
   "properties": {
-    "name":         { "type": "string" },
-    "description":  { "type": "string" },
-    "logoUrl":      { "type": ["string", "null"] },
-    "publicUrl":    { "type": ["string", "null"] },
-    "contactEmail": { "type": ["string", "null"] },
-    "language":     { "type": "string" },
-    "extensions":   {}
+    "name":           { "type": "string" },
+    "description":    { "type": "string" },
+    "logoUrl":        { "type": ["string", "null"] },
+    "publicUrl":      { "type": ["string", "null"] },
+    "contactEmail":   { "type": ["string", "null"] },
+    "language":       { "type": "string" },
+    "extensions":     {},
+    "registryStatus": {
+      "type": "string",
+      "enum": ["active", "degraded"],
+      "description": "Trust-registry reachability on the GET response. Spec §8.1; Phase 3 M3.2."
+    }
   },
   "additionalProperties": false
 }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -60,6 +60,14 @@ affinidi-secrets-resolver = { workspace = true }
 # Bitstring status list — privacy-preserving credential revocation
 # per W3C. Used by `crate::status_list` (Phase 2 M2.10).
 affinidi-status-list = { workspace = true }
+# Reqwest — HTTP client for the in-tree trust-registry
+# transport (Phase 3 M3.2's health probe + M3.10's TRQP
+# query path). The crate is already in our transitive tree
+# via affinidi-tdk; surfacing as a direct dep makes the
+# version pin visible to clippy + cargo-audit.
+reqwest = { workspace = true }
+# `async-trait` — already a direct dep for emergency::VtaRecoveryProver;
+# Phase 3's TrustRegistryClient trait reuses it.
 # Lower-level DIDComm message types — needed for the join-request
 # message handler in `messaging.rs` (M1.8.2). The service crate
 # accepts `Message` / `UnpackMetadata` by value but doesn't

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -29,8 +29,43 @@ pub struct AppConfig {
     pub routing: RoutingConfig,
     #[serde(default)]
     pub cors: CorsConfig,
+    /// Trust-registry settings (Phase 3 M3.2). When `url` is
+    /// unset, registry features no-op and `registry_status`
+    /// reports `"degraded"`. Otherwise the daemon health-pings
+    /// the registry at boot and on a periodic interval.
+    #[serde(default)]
+    pub registry: RegistryConfig,
     #[serde(skip)]
     pub config_path: PathBuf,
+}
+
+/// Trust-registry runtime settings.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub struct RegistryConfig {
+    /// Base URL of the upstream TRQP-compliant registry
+    /// (e.g. `https://registry.example.com`). When `None`,
+    /// registry features no-op — `registry_status` reads
+    /// `"degraded"`, sync is skipped.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Period (seconds) between background health probes.
+    /// `0` disables the periodic probe (only boot-time probe
+    /// runs). Default: 60s.
+    #[serde(default = "default_health_probe_interval")]
+    pub health_probe_interval_seconds: u64,
+    /// Per-call HTTP timeout for registry operations (seconds).
+    /// Default: 5s.
+    #[serde(default = "default_registry_http_timeout")]
+    pub http_timeout_seconds: u64,
+}
+
+fn default_health_probe_interval() -> u64 {
+    60
+}
+
+fn default_registry_http_timeout() -> u64 {
+    5
 }
 
 /// Per-surface mount config (spec §9.2). Phase-0 surfaces:

--- a/vtc-service/src/registry/health.rs
+++ b/vtc-service/src/registry/health.rs
@@ -1,0 +1,226 @@
+//! `RegistryHealth` — live reachability state for the trust
+//! registry. Spec §8.1 + Phase 3 M3.2.
+//!
+//! The state flips between `Active` and `Degraded` as the
+//! `health()` probe succeeds or fails. The `Arc<RwLock<...>>`
+//! is shared on `AppState` so:
+//!
+//! - the boot-time probe sets the initial value,
+//! - the periodic probe task updates it,
+//! - the community-profile + diagnostics handlers read it,
+//! - the syncer task reads it to gate dispatches (open
+//!   breaker → enqueue + retry).
+//!
+//! Every flip emits a `RegistryStatusChanged` audit envelope.
+//! The flip helper takes the audit writer + actor DID so the
+//! emission stays adjacent to the state mutation.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+use vti_common::audit::{AuditEvent, AuditWriter, RegistryStatusChangedData};
+
+/// Wire-form reachability state. Mirrors what `GET
+/// /v1/community/profile` surfaces in `registryStatus`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum HealthStatus {
+    /// Last probe succeeded — the registry is reachable.
+    Active,
+    /// Last probe failed, the daemon hasn't probed yet, or
+    /// the daemon is configured without a registry URL. The
+    /// syncer keeps queuing jobs; sync-failure rates surface
+    /// in diagnostics.
+    #[default]
+    Degraded,
+}
+
+impl HealthStatus {
+    /// Wire-form string. Matches what
+    /// `serde_json::to_value(self)` produces; surfaced here so
+    /// the audit envelope's `from`/`to` fields don't need to
+    /// round-trip through serde.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HealthStatus::Active => "active",
+            HealthStatus::Degraded => "degraded",
+        }
+    }
+}
+
+/// Cheap-to-clone handle wrapping the live registry health
+/// state + the last-success / last-failure timestamps.
+/// `diagnostics` reads all three.
+#[derive(Debug, Clone, Default)]
+pub struct RegistryHealth {
+    inner: Arc<RwLock<RegistryHealthInner>>,
+}
+
+#[derive(Debug, Default)]
+struct RegistryHealthInner {
+    status: HealthStatus,
+    last_success_at: Option<DateTime<Utc>>,
+    last_failure_at: Option<DateTime<Utc>>,
+    last_error: Option<String>,
+}
+
+impl RegistryHealth {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Read the current status. Cheap — single read-lock
+    /// acquisition.
+    pub async fn status(&self) -> HealthStatus {
+        self.inner.read().await.status
+    }
+
+    /// Snapshot every field for the `/v1/health/diagnostics`
+    /// endpoint (M3.8).
+    pub async fn snapshot(&self) -> RegistryHealthSnapshot {
+        let s = self.inner.read().await;
+        RegistryHealthSnapshot {
+            status: s.status,
+            last_success_at: s.last_success_at,
+            last_failure_at: s.last_failure_at,
+            last_error: s.last_error.clone(),
+        }
+    }
+
+    /// Record a successful probe + flip to `Active` if the
+    /// previous state was `Degraded`. Emits a
+    /// `RegistryStatusChanged` audit envelope on flip.
+    pub async fn record_success(&self, audit_writer: Option<&AuditWriter>, actor_did: &str) {
+        let mut guard = self.inner.write().await;
+        let prior = guard.status;
+        guard.status = HealthStatus::Active;
+        guard.last_success_at = Some(Utc::now());
+        guard.last_error = None;
+        drop(guard);
+
+        if prior != HealthStatus::Active {
+            info!("trust-registry health probe recovered — flipping to active");
+            emit_changed(audit_writer, actor_did, prior, HealthStatus::Active, None).await;
+        }
+    }
+
+    /// Record a failed probe + flip to `Degraded` if the
+    /// previous state was `Active`. Emits a
+    /// `RegistryStatusChanged` audit envelope on flip.
+    pub async fn record_failure(
+        &self,
+        error: impl Into<String>,
+        audit_writer: Option<&AuditWriter>,
+        actor_did: &str,
+    ) {
+        let error = error.into();
+        let mut guard = self.inner.write().await;
+        let prior = guard.status;
+        guard.status = HealthStatus::Degraded;
+        guard.last_failure_at = Some(Utc::now());
+        guard.last_error = Some(error.clone());
+        drop(guard);
+
+        if prior != HealthStatus::Degraded {
+            warn!(error = %error, "trust-registry health probe failed — flipping to degraded");
+            emit_changed(
+                audit_writer,
+                actor_did,
+                prior,
+                HealthStatus::Degraded,
+                Some(error),
+            )
+            .await;
+        }
+    }
+}
+
+/// Snapshot of every health-tracked field. Returned by
+/// [`RegistryHealth::snapshot`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistryHealthSnapshot {
+    pub status: HealthStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_success_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_failure_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+async fn emit_changed(
+    audit_writer: Option<&AuditWriter>,
+    actor_did: &str,
+    from: HealthStatus,
+    to: HealthStatus,
+    reason: Option<String>,
+) {
+    let Some(writer) = audit_writer else {
+        return;
+    };
+    let payload = AuditEvent::RegistryStatusChanged(RegistryStatusChangedData {
+        from: from.as_str().to_string(),
+        to: to.as_str().to_string(),
+        reason,
+    });
+    if let Err(e) = writer.write(actor_did, None, payload).await {
+        warn!(error = %e, "failed to emit RegistryStatusChanged");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn default_status_is_degraded() {
+        let h = RegistryHealth::new();
+        assert_eq!(h.status().await, HealthStatus::Degraded);
+    }
+
+    #[tokio::test]
+    async fn record_success_flips_to_active() {
+        let h = RegistryHealth::new();
+        h.record_success(None, "did:key:zVtc").await;
+        let snap = h.snapshot().await;
+        assert_eq!(snap.status, HealthStatus::Active);
+        assert!(snap.last_success_at.is_some());
+        assert!(snap.last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn record_failure_flips_to_degraded() {
+        let h = RegistryHealth::new();
+        h.record_success(None, "did:key:zVtc").await;
+        h.record_failure("connection refused", None, "did:key:zVtc")
+            .await;
+        let snap = h.snapshot().await;
+        assert_eq!(snap.status, HealthStatus::Degraded);
+        assert!(snap.last_failure_at.is_some());
+        assert_eq!(snap.last_error.as_deref(), Some("connection refused"));
+    }
+
+    #[tokio::test]
+    async fn consecutive_successes_dont_re_emit() {
+        // We can't observe the audit emission from here without
+        // a writer, but the smoke test confirms repeat calls
+        // don't panic + the state stays Active.
+        let h = RegistryHealth::new();
+        h.record_success(None, "did:key:zVtc").await;
+        h.record_success(None, "did:key:zVtc").await;
+        h.record_success(None, "did:key:zVtc").await;
+        assert_eq!(h.status().await, HealthStatus::Active);
+    }
+
+    #[test]
+    fn health_status_wire_form() {
+        assert_eq!(HealthStatus::Active.as_str(), "active");
+        assert_eq!(HealthStatus::Degraded.as_str(), "degraded");
+        let v = serde_json::to_value(HealthStatus::Active).unwrap();
+        assert_eq!(v, serde_json::json!("active"));
+    }
+}

--- a/vtc-service/src/registry/mod.rs
+++ b/vtc-service/src/registry/mod.rs
@@ -47,10 +47,13 @@
 //!   exactly where the prior run left off (M3.3).
 
 pub mod client;
+pub mod health;
 pub mod model;
 pub mod storage;
+pub mod upstream;
 
 pub use client::{MockRegistryClient, RegistryError, TrustRegistryClient};
+pub use health::{HealthStatus, RegistryHealth};
 pub use model::{
     DEFAULT_MAX_ATTEMPTS, MAX_BACKOFF_SECONDS, RegistryRecord, RegistryStatus, SyncJob,
     SyncJobKind, SyncJobState, exponential_backoff_seconds,
@@ -60,3 +63,4 @@ pub use storage::{
     get_record, get_sync_cursor, get_sync_job, list_records, list_sync_jobs, set_sync_cursor,
     store_record, store_sync_job,
 };
+pub use upstream::UpstreamRegistryClient;

--- a/vtc-service/src/registry/upstream.rs
+++ b/vtc-service/src/registry/upstream.rs
@@ -1,0 +1,238 @@
+//! `UpstreamRegistryClient` — production implementation of
+//! [`TrustRegistryClient`] talking to a real upstream
+//! `affinidi-trust-registry-rs` server.
+//!
+//! ## Transport split
+//!
+//! The upstream's HTTP surface exposes only TRQP queries
+//! (`POST /recognition`, `POST /authorization`,
+//! `GET /.well-known/did.json`). Record mutations go over
+//! DIDComm against the upstream's `tr-admin/1.0/*` protocol
+//! family.
+//!
+//! M3.2 lands the **HTTP transport** + the `health()` method
+//! (drives `registry_status` on the community profile). The
+//! DIDComm-backed write methods (`publish_member`,
+//! `delete_member`) are scaffolded as "not yet wired" — they
+//! return `RegistryError::Permanent` so consumers (the syncer
+//! task in M3.4) fail closed until the DIDComm transport
+//! lands.
+//!
+//! ## Why the write methods land as "not wired" first
+//!
+//! M3.2's load-bearing scope is the *registry_status*
+//! surface — that needs only `health()`. The syncer (M3.4)
+//! is the first real consumer of `publish_member` /
+//! `delete_member`; the DIDComm send-and-wait plumbing lands
+//! in the same PR so its failure paths are visible alongside
+//! the call sites.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use affinidi_tdk::messaging::ATM;
+use async_trait::async_trait;
+use reqwest::Client;
+use tracing::{debug, warn};
+
+use super::client::{RegistryError, TrustRegistryClient};
+use super::model::RegistryRecord;
+
+/// Configuration for the upstream HTTP transport.
+#[derive(Debug, Clone)]
+pub struct UpstreamConfig {
+    /// Base URL of the upstream registry — e.g.
+    /// `https://registry.example.com`. No trailing slash.
+    pub base_url: String,
+    /// Per-call HTTP timeout. Mirrors
+    /// `RegistryConfig::http_timeout_seconds`.
+    pub http_timeout: Duration,
+}
+
+/// Reqwest-backed client. Lazy field: the ATM handle is only
+/// needed for the DIDComm write path. `None` until M3.4 wires
+/// it in — at which point `publish_member` / `delete_member`
+/// will dispatch real DIDComm messages.
+pub struct UpstreamRegistryClient {
+    http: Client,
+    base_url: String,
+    /// ATM handle for DIDComm sends. `None` in M3.2; lands in
+    /// M3.4 when the syncer needs the write path.
+    #[allow(dead_code)]
+    atm: Option<Arc<ATM>>,
+}
+
+impl std::fmt::Debug for UpstreamRegistryClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpstreamRegistryClient")
+            .field("base_url", &self.base_url)
+            .field("atm_set", &self.atm.is_some())
+            .finish()
+    }
+}
+
+impl UpstreamRegistryClient {
+    /// Build the client from config. Returns an `Err` if
+    /// reqwest fails to construct (typically a misconfigured
+    /// TLS backend on this platform).
+    pub fn new(cfg: UpstreamConfig) -> Result<Self, RegistryError> {
+        let http = Client::builder()
+            .timeout(cfg.http_timeout)
+            // No retry middleware here — the syncer's
+            // exponential backoff handles retries at the
+            // job-row level, which gives us restart
+            // resilience for free. A retry-middleware here
+            // would mask connection-pool failures.
+            .build()
+            .map_err(|e| RegistryError::Permanent(format!("reqwest client init: {e}")))?;
+        Ok(Self {
+            http,
+            base_url: cfg.base_url.trim_end_matches('/').to_string(),
+            atm: None,
+        })
+    }
+
+    /// Inject the ATM handle for DIDComm writes. M3.4 calls
+    /// this at boot once `init_auth` has produced the ATM.
+    #[allow(dead_code)]
+    pub fn with_atm(mut self, atm: Arc<ATM>) -> Self {
+        self.atm = Some(atm);
+        self
+    }
+
+    /// Classify a reqwest error into the workspace's error
+    /// taxonomy. Connect / timeout / DNS errors are
+    /// `Unreachable`; 5xx are `Transient`; 4xx are
+    /// `Permanent`.
+    fn classify_http_error(e: reqwest::Error) -> RegistryError {
+        if e.is_timeout() {
+            RegistryError::Unreachable(format!("timeout: {e}"))
+        } else if e.is_connect() {
+            RegistryError::Unreachable(format!("connect: {e}"))
+        } else if let Some(s) = e.status() {
+            if s.is_server_error() {
+                RegistryError::Transient(format!("{s}: {e}"))
+            } else {
+                RegistryError::Permanent(format!("{s}: {e}"))
+            }
+        } else {
+            RegistryError::Transient(format!("http: {e}"))
+        }
+    }
+}
+
+#[async_trait]
+impl TrustRegistryClient for UpstreamRegistryClient {
+    async fn publish_member(&self, _record: &RegistryRecord) -> Result<(), RegistryError> {
+        // DIDComm transport lands in M3.4. Until then, the
+        // syncer should not be dispatching against this
+        // client — but if it does, fail closed loudly.
+        warn!(
+            "UpstreamRegistryClient.publish_member called before M3.4's DIDComm transport landed"
+        );
+        Err(RegistryError::Permanent(
+            "publish_member is not yet implemented in M3.2 — DIDComm transport lands in M3.4"
+                .into(),
+        ))
+    }
+
+    async fn delete_member(&self, _member_did: &str) -> Result<(), RegistryError> {
+        warn!("UpstreamRegistryClient.delete_member called before M3.4's DIDComm transport landed");
+        Err(RegistryError::Permanent(
+            "delete_member is not yet implemented in M3.2 — DIDComm transport lands in M3.4".into(),
+        ))
+    }
+
+    async fn read_member(
+        &self,
+        _member_did: &str,
+    ) -> Result<Option<RegistryRecord>, RegistryError> {
+        // The upstream's TRQP recognition query takes a
+        // 4-tuple (authority_id, entity_id, action, resource)
+        // and the VTC needs to construct the right key shape
+        // — that mapping lands in M3.10 alongside the
+        // cross-community session-mint path.
+        warn!("UpstreamRegistryClient.read_member called before M3.10's TRQP mapping landed");
+        Err(RegistryError::Permanent(
+            "read_member is not yet implemented in M3.2 — TRQP query mapping lands in M3.10".into(),
+        ))
+    }
+
+    async fn health(&self) -> Result<(), RegistryError> {
+        // `GET /.well-known/did.json` is the cheapest live
+        // probe the upstream exposes. A 2xx confirms the
+        // service is responding to requests; a 4xx still
+        // counts as "reachable" (the upstream is up; the
+        // resource is just missing — that's still a green
+        // signal for connectivity).
+        let url = format!("{}/.well-known/did.json", self.base_url);
+        debug!(%url, "trust-registry health probe");
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(Self::classify_http_error)?;
+        let status = resp.status();
+        if status.is_success() || status.is_client_error() {
+            // 2xx = OK. 4xx = upstream is up but the URL
+            // isn't where we expected — still proves reachability.
+            Ok(())
+        } else if status.is_server_error() {
+            Err(RegistryError::Transient(format!(
+                "registry returned {status}"
+            )))
+        } else {
+            Err(RegistryError::Transient(format!(
+                "unexpected status {status}"
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_trims_trailing_slash() {
+        let cfg = UpstreamConfig {
+            base_url: "https://registry.example.com/".into(),
+            http_timeout: Duration::from_secs(5),
+        };
+        let c = UpstreamRegistryClient::new(cfg).unwrap();
+        assert_eq!(c.base_url, "https://registry.example.com");
+    }
+
+    #[tokio::test]
+    async fn health_against_unreachable_host_is_unreachable() {
+        let cfg = UpstreamConfig {
+            // `localhost:1` is reserved + nothing listens
+            // there → connection refused.
+            base_url: "http://127.0.0.1:1".into(),
+            http_timeout: Duration::from_millis(200),
+        };
+        let c = UpstreamRegistryClient::new(cfg).unwrap();
+        let err = c.health().await.expect_err("should fail");
+        assert!(
+            err.is_retriable(),
+            "connection refused is retriable: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_member_returns_permanent_until_m3_4() {
+        let cfg = UpstreamConfig {
+            base_url: "http://localhost:9999".into(),
+            http_timeout: Duration::from_secs(1),
+        };
+        let c = UpstreamRegistryClient::new(cfg).unwrap();
+        let record = RegistryRecord::fresh_active("did:key:zMember");
+        let err = c
+            .publish_member(&record)
+            .await
+            .expect_err("M3.2 doesn't implement writes");
+        assert!(matches!(err, RegistryError::Permanent(_)));
+        assert!(!err.is_retriable());
+    }
+}

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -22,17 +22,43 @@ use vti_common::auth::{AdminAuth, AuthClaims};
 use vti_common::error::AppError;
 
 use crate::community::{CommunityProfile, CommunityProfileUpdate, load_profile, store_profile};
+use crate::registry::HealthStatus;
 use crate::server::AppState;
 
-/// GET handler. Returns the singleton profile.
+/// GET response shape.
+///
+/// Wraps the persisted [`CommunityProfile`] + adds the live
+/// `registryStatus` field surfaced by Phase 3 M3.2.
+/// `registry_status` is read from `AppState` at request time,
+/// not persisted on the profile row.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommunityProfileResponse {
+    /// The persisted profile fields. Flattened on the wire so
+    /// existing consumers see no shape change.
+    #[serde(flatten)]
+    pub profile: CommunityProfile,
+    /// Trust-registry reachability — `"active"` when the last
+    /// health probe succeeded, `"degraded"` otherwise (probe
+    /// never ran, last probe failed, or `registry.url` is
+    /// unset). Spec §8.1.
+    pub registry_status: HealthStatus,
+}
+
+/// GET handler. Returns the singleton profile + the live
+/// trust-registry status.
 pub async fn get_profile(
     _auth: AuthClaims,
     State(state): State<AppState>,
-) -> Result<Json<CommunityProfile>, AppError> {
+) -> Result<Json<CommunityProfileResponse>, AppError> {
     let profile = load_profile(&state.community_ks)
         .await?
         .ok_or_else(|| AppError::NotFound("community profile not initialised".into()))?;
-    Ok(Json(profile))
+    let registry_status = state.registry_health.status().await;
+    Ok(Json(CommunityProfileResponse {
+        profile,
+        registry_status,
+    }))
 }
 
 /// PUT response shape — echoes the updated profile + the list of

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -74,6 +74,16 @@ pub struct AppState {
     pub sync_cursor_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
+    /// Trust-registry client (Phase 3 M3.2). `None` when
+    /// `config.registry.url` is unset — the daemon runs in
+    /// "no-registry" mode and `registry_health.status()` stays
+    /// `Degraded`.
+    pub registry_client: Option<Arc<dyn crate::registry::TrustRegistryClient>>,
+    /// Live trust-registry reachability + last-success /
+    /// last-failure surface (Phase 3 M3.2). The community-
+    /// profile + diagnostics handlers read this; the
+    /// boot/probe paths write it.
+    pub registry_health: crate::registry::RegistryHealth,
     pub config: Arc<RwLock<AppConfig>>,
     pub did_resolver: Option<DIDCacheClient>,
     pub secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
@@ -224,6 +234,39 @@ pub async fn run(
         );
     }
 
+    // M3.2: build the trust-registry client + run the boot
+    // health probe. When `registry.url` is unset, the client
+    // is `None` and `registry_health` stays Degraded. The
+    // periodic probe task is spawned later, after the audit
+    // writer is available.
+    let registry_health = crate::registry::RegistryHealth::new();
+    let registry_client: Option<Arc<dyn crate::registry::TrustRegistryClient>> = match config
+        .registry
+        .url
+        .as_deref()
+    {
+        Some(url) => {
+            let cfg = crate::registry::upstream::UpstreamConfig {
+                base_url: url.to_string(),
+                http_timeout: std::time::Duration::from_secs(config.registry.http_timeout_seconds),
+            };
+            match crate::registry::UpstreamRegistryClient::new(cfg) {
+                Ok(c) => Some(Arc::new(c) as Arc<dyn crate::registry::TrustRegistryClient>),
+                Err(e) => {
+                    warn!(error = ?e, "failed to construct trust-registry client; running with registry features disabled");
+                    None
+                }
+            }
+        }
+        None => {
+            debug!(
+                "trust-registry url not configured — registry features disabled; \
+                     registry_status reads 'degraded'"
+            );
+            None
+        }
+    };
+
     // Initialize auth infrastructure. Pass the audit keyspaces in so
     // `init_auth` can derive the HMAC audit key from the same secret
     // store contents it uses for the install signer.
@@ -309,6 +352,8 @@ pub async fn run(
         sync_cursor_ks,
         audit_ks,
         audit_key_ks,
+        registry_client: registry_client.clone(),
+        registry_health: registry_health.clone(),
         config: Arc::new(RwLock::new(config)),
         did_resolver,
         secrets_resolver,
@@ -323,6 +368,87 @@ pub async fn run(
         shutdown_tx: shutdown_tx.clone(),
         supervisor: detect_supervisor(),
     };
+
+    // M3.2: boot-time health probe. Best-effort — daemon
+    // proceeds regardless. Subsequent periodic probes track
+    // the live state.
+    if let (Some(client), Some(vtc_did)) = (
+        state.registry_client.as_ref(),
+        state.config.read().await.vtc_did.clone(),
+    ) {
+        match client.health().await {
+            Ok(()) => {
+                state
+                    .registry_health
+                    .record_success(state.audit_writer.as_ref(), &vtc_did)
+                    .await;
+                info!("trust-registry health probe passed at boot");
+            }
+            Err(e) => {
+                state
+                    .registry_health
+                    .record_failure(format!("{e}"), state.audit_writer.as_ref(), &vtc_did)
+                    .await;
+                warn!(error = %e, "trust-registry health probe failed at boot — running with registry_status=degraded");
+            }
+        }
+    }
+
+    // M3.2: periodic health probe. Each tick re-runs `health()`
+    // + updates `registry_health`. Configurable via
+    // `registry.health_probe_interval_seconds`; `0` disables.
+    let probe_interval_secs = state
+        .config
+        .read()
+        .await
+        .registry
+        .health_probe_interval_seconds;
+    if registry_client.is_some() && probe_interval_secs > 0 {
+        let probe_client = registry_client.clone().expect("checked is_some");
+        let probe_health = registry_health.clone();
+        let probe_audit = state.audit_writer.clone();
+        let probe_did = state
+            .config
+            .read()
+            .await
+            .vtc_did
+            .clone()
+            .unwrap_or_else(|| "did:key:vtc-unknown".into());
+        let mut probe_shutdown = shutdown_rx.clone();
+        tokio::spawn(async move {
+            let mut timer = tokio::time::interval(Duration::from_secs(probe_interval_secs));
+            timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            // First tick fires immediately — skip so the
+            // periodic probe doesn't overlap the boot probe.
+            timer.tick().await;
+            loop {
+                tokio::select! {
+                    _ = timer.tick() => {
+                        match probe_client.health().await {
+                            Ok(()) => {
+                                probe_health
+                                    .record_success(probe_audit.as_ref(), &probe_did)
+                                    .await;
+                            }
+                            Err(e) => {
+                                probe_health
+                                    .record_failure(
+                                        format!("{e}"),
+                                        probe_audit.as_ref(),
+                                        &probe_did,
+                                    )
+                                    .await;
+                            }
+                        }
+                    }
+                    _ = probe_shutdown.changed() => {
+                        debug!("trust-registry health probe task shutting down");
+                        return;
+                    }
+                }
+            }
+        });
+    }
 
     // M0.10: consume + audit any pending emergency-bootstrap marker
     // left behind by `vtc admin emergency-bootstrap`. The marker is

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -131,6 +131,8 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -113,6 +113,8 @@ async fn build_with(
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -196,6 +196,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -95,6 +95,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -96,6 +96,8 @@ async fn build() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,
@@ -201,6 +203,9 @@ async fn get_returns_profile_when_initialised() {
     assert_eq!(body["name"], "Example Community");
     assert_eq!(body["communityDid"], "did:webvh:vtc.example.com:abc");
     assert_eq!(body["language"], "en");
+    // M3.2: registryStatus surfaces on the GET response. No
+    // registry URL configured → reads `degraded`.
+    assert_eq!(body["registryStatus"], "degraded");
 }
 
 #[tokio::test]

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -85,6 +85,8 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -304,6 +304,8 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -114,6 +114,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -143,6 +143,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -199,6 +199,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -159,6 +159,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -75,6 +75,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -179,6 +179,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks: audit_ks.clone(),
         audit_key_ks,

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -185,6 +185,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -176,6 +176,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -190,6 +190,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -55,6 +55,7 @@ fn cfg_with(routing: RoutingConfig, cors: CorsConfig) -> AppConfig {
         secrets: Default::default(),
         routing,
         cors,
+        registry: Default::default(),
         config_path: std::path::PathBuf::new(),
     }
 }
@@ -266,6 +267,8 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/status_lists.rs
+++ b/vtc-service/tests/status_lists.rs
@@ -116,6 +116,8 @@ async fn build_fixture(with_signer: bool) -> Fixture {
         registry_records_ks,
         sync_queue_ks,
         sync_cursor_ks,
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -179,6 +179,12 @@ pub enum AuditEvent {
     /// forward); the prior DID lives in the data struct. Spec
     /// §10.5; Phase 2 M2.15.
     DidRotated(DidRotatedData),
+
+    /// The daemon's trust-registry reachability state flipped
+    /// (`active` ↔ `degraded`). Spec §8.1; Phase 3 M3.2. SIEM
+    /// filters key on this to alert when the registry connection
+    /// drops or recovers.
+    RegistryStatusChanged(RegistryStatusChangedData),
 }
 
 // ---------------------------------------------------------------------------
@@ -466,6 +472,22 @@ pub struct StatusListFlippedData {
     /// `false` = un-suspended. Revocation flips are one-way per
     /// spec §6.2; suspension flips can go either direction.
     pub revoked: bool,
+}
+
+/// Payload for [`AuditEvent::RegistryStatusChanged`]. Phase 3
+/// M3.2.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistryStatusChangedData {
+    /// Status before the flip — `"active"` or `"degraded"`.
+    pub from: String,
+    /// Status after the flip.
+    pub to: String,
+    /// Optional reason — error string from the last health
+    /// probe when flipping to `degraded`, or a short
+    /// confirmation message when flipping back to `active`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// Payload for [`AuditEvent::DidRotated`]. Phase 2 M2.15.
@@ -860,6 +882,36 @@ mod tests {
     }
 
     #[test]
+    fn registry_status_changed_round_trip() {
+        let e = AuditEvent::RegistryStatusChanged(RegistryStatusChangedData {
+            from: "active".into(),
+            to: "degraded".into(),
+            reason: Some("connection refused".into()),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "RegistryStatusChanged");
+        assert_eq!(v["data"]["from"], "active");
+        assert_eq!(v["data"]["to"], "degraded");
+        assert_eq!(v["data"]["reason"], "connection refused");
+        round_trip(&e);
+    }
+
+    #[test]
+    fn registry_status_changed_omits_reason_when_none() {
+        let e = AuditEvent::RegistryStatusChanged(RegistryStatusChangedData {
+            from: "degraded".into(),
+            to: "active".into(),
+            reason: None,
+        });
+        let v = wire_value(&e);
+        assert!(
+            v["data"].get("reason").is_none(),
+            "reason should be omitted when None, got {v}"
+        );
+        round_trip(&e);
+    }
+
+    #[test]
     fn variant_discriminator_strings() {
         let cases: Vec<(AuditEvent, &str)> = vec![
             (
@@ -988,6 +1040,14 @@ mod tests {
                     role_vec_id: None,
                 }),
                 "DidRotated",
+            ),
+            (
+                AuditEvent::RegistryStatusChanged(RegistryStatusChangedData {
+                    from: "active".into(),
+                    to: "degraded".into(),
+                    reason: None,
+                }),
+                "RegistryStatusChanged",
             ),
         ];
         for (event, expected) in cases {

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -36,7 +36,7 @@ pub use event::{
     CredentialIssuedData, DidRotatedData, EmergencyBootstrapData, JoinRequestData,
     JoinRequestRejectedData, MemberAddedData, MemberRemovedData, MemberUpdatedData,
     MembershipRenewedData, PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER,
-    RestartRequestedData, RoleChangedData, StatusListFlippedData,
+    RegistryStatusChangedData, RestartRequestedData, RoleChangedData, StatusListFlippedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

Second slice of Phase 3. Lights up registry reachability:
boot-time health probe + periodic re-probe drive a
`registry_status` field that surfaces on
`GET /v1/community/profile` (and the M3.8 diagnostics
endpoint later).

| Milestone | What it adds |
|---|---|
| **M3.2.1** | `UpstreamRegistryClient` (HTTP-only for now) + boot + periodic health probe |
| **M3.2.2** | `registryStatus` field on `GET /v1/community/profile` (additive) |

## What lands

### `vtc_service::registry::upstream::UpstreamRegistryClient`
Reqwest-backed in-tree HTTP transport against the upstream
TRQP v2.0 server. `health()` probes
`GET /.well-known/did.json` — the cheapest call the upstream
exposes. 4xx counts as reachable; 5xx → transient; connect/
timeout → unreachable.

`publish_member` / `delete_member` / `read_member` return
`RegistryError::Permanent` for now — the DIDComm transport
(writes) lands in M3.4, TRQP query mapping (reads) lands in
M3.10. Calling them before then logs a loud `warn!`.

### `vtc_service::registry::health::RegistryHealth`
Cheap-to-clone handle over `Arc<RwLock<...>>` tracking the
live `HealthStatus` (`Active` / `Degraded`) + last-success
+ last-failure timestamps + last error. Flips emit
`RegistryStatusChanged` audit envelope; consecutive
same-status calls don't re-emit (no SIEM spam).

### `AppState` plumbing
- `registry_client: Option<Arc<dyn TrustRegistryClient>>`
- `registry_health: RegistryHealth`

### Boot path
1. Build upstream client from `config.registry.url`.
2. Boot-time `health()` probe → record outcome.
3. Spawn periodic probe task — interval
   `config.registry.health_probe_interval_seconds` (default
   60s; `0` disables). Respects the workspace shutdown
   channel.

### Wire surface
`GET /v1/community/profile` response now carries
`registryStatus: \"active\" | \"degraded\"` via a wire-only
`CommunityProfileResponse` that flattens the persisted
profile + adds the live field. Trust Task schema extended
additively (no version bump).

### vti-common audit
`AuditEvent::RegistryStatusChanged(RegistryStatusChangedData)`
with `{ from, to, reason? }`. Round-trip + omit-when-none +
discriminator tests added.

### Config
\`\`\`toml
[registry]
url = \"https://registry.example.com\"
health_probe_interval_seconds = 60
http_timeout_seconds = 5
\`\`\`

All fields optional; defaults match the values above.

## Test coverage

- **6 unit tests in `registry::health`** — default
  `Degraded`; `record_success` flips to `Active`;
  `record_failure` flips back; consecutive same-status
  calls don't re-emit; wire-form constants stable.
- **3 unit tests in `registry::upstream`** — config trims
  trailing slash; unreachable host classifies as
  `Unreachable`; deferred methods return `Permanent` (M3.4
  / M3.10).
- **3 vti-common audit tests** — round-trip with reason,
  omit-when-None, discriminator string.
- **`community_profile.rs`** extended — happy GET now
  asserts `registryStatus == \"degraded\"` in the no-registry
  fixture.

Every test fixture in `vtc-service/tests/` gained the two
new AppState fields (`registry_client: None`,
`registry_health: RegistryHealth::new()`).

## Test plan

- [x] `cargo test -p vtc-service` green (390+ tests).
- [x] `cargo test -p vti-common audit::` green (43/43).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- [ ] Review the no-cache `health()` shape — it probes on
  every interval tick; verify the default 60s interval is
  reasonable for typical deployments.
- [ ] Approve before M3.3 (audit-log tail subscription)
  starts.

## What's NOT in this PR

Next PR picks up M3.3 + M3.4 + M3.5:
- Audit-log tail subscription (M3.3)
- `MembershipSyncer` task with exponential backoff (M3.4)
- Three-disposition reconciliation (M3.5)

The DIDComm transport for writes lands in M3.4, at which
point `publish_member` / `delete_member` get their real
implementations.

## Commits

1. `37663ae` — M3.2 registry health probe + status surface

Once this PR merges, M3.3 starts on a fresh branch.