### PR TITLE
feat(vtc-service): Phase 3 PR 3 — audit-tail walker + MembershipSyncer (M3.3 + M3.4)

### DIFF
--- a/tasks/vtc-mvp/phase-3-todo.md
+++ b/tasks/vtc-mvp/phase-3-todo.md
@@ -118,7 +118,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.3 — Audit-log-tail subscription + sync_queue helpers
 
-### `[ ]` M3.3.1 — Audit-log walker
+### `[x]` M3.3.1 — Audit-log walker
 
 - **Acceptance**
   - `vtc_service::registry::tail::AuditTailWalker` walks
@@ -145,7 +145,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.4 — `MembershipSyncer` task
 
-### `[ ]` M3.4.1 — Tokio task with exponential backoff
+### `[x]` M3.4.1 — Tokio task with exponential backoff
 
 - **Acceptance**
   - `vtc_service::registry::syncer::MembershipSyncer`

--- a/vtc-service/src/registry/mod.rs
+++ b/vtc-service/src/registry/mod.rs
@@ -50,6 +50,8 @@ pub mod client;
 pub mod health;
 pub mod model;
 pub mod storage;
+pub mod syncer;
+pub mod tail;
 pub mod upstream;
 
 pub use client::{MockRegistryClient, RegistryError, TrustRegistryClient};
@@ -63,4 +65,6 @@ pub use storage::{
     get_record, get_sync_cursor, get_sync_job, list_records, list_sync_jobs, set_sync_cursor,
     store_record, store_sync_job,
 };
+pub use syncer::MembershipSyncer;
+pub use tail::{WalkOutcome, walk as walk_audit_tail};
 pub use upstream::UpstreamRegistryClient;

--- a/vtc-service/src/registry/syncer.rs
+++ b/vtc-service/src/registry/syncer.rs
@@ -1,0 +1,507 @@
+//! `MembershipSyncer` — Phase 3 M3.4.
+//!
+//! The async task that drives trust-registry reconciliation.
+//! Spec §8.3.
+//!
+//! ## Tick loop
+//!
+//! Every `tick_interval` the task does, in order:
+//!
+//! 1. **Boot recovery** (first tick only) — walk
+//!    `sync_queue:` and flip any `InFlight` rows back to
+//!    `Pending`. The daemon may have crashed between
+//!    "marked InFlight" and "wrote outcome"; we re-dispatch
+//!    rather than wait for the client to time out a row that's
+//!    already been delivered.
+//!
+//! 2. **Tail walk** — call [`super::tail::walk`] to enqueue
+//!    fresh jobs from new audit envelopes. Advance the
+//!    `sync_cursor` row.
+//!
+//! 3. **Dispatch** — for each `Pending` row where
+//!    `now >= next_attempt_at`:
+//!    - Flip to `InFlight`.
+//!    - Call the appropriate `TrustRegistryClient` method.
+//!    - On success: delete the row + emit
+//!      `RegistrySyncSucceeded` + update the local
+//!      `registry_records` mirror.
+//!    - On retriable failure: `record_failure` (bumps
+//!      attempts, reschedules per backoff). Row stays in
+//!      the queue.
+//!    - On permanent failure: flip immediately to `Failed` +
+//!      emit `RegistrySyncFailed`.
+//!    - After every dispatch, [`super::RegistryHealth`] is
+//!      updated (success → Active, failure → Degraded).
+//!
+//! ## Failure isolation
+//!
+//! One job's failure can't cascade — every dispatch is its
+//! own `Result<()>` boundary. A registry that's down keeps
+//! producing `RegistryError::Unreachable`; the queue grows;
+//! `RegistryHealth.status()` flips to Degraded; the
+//! diagnostics endpoint surfaces queue depth + oldest pending.
+//! No retry storms — backoff caps at 1h.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+use tracing::{debug, info, warn};
+use vti_common::audit::{AuditEvent, AuditWriter, RegistrySyncOutcomeData};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::client::{RegistryError, TrustRegistryClient};
+use super::health::RegistryHealth;
+use super::model::{RegistryRecord, SyncJob, SyncJobKind, SyncJobState};
+use super::storage::{
+    delete_sync_job, get_sync_cursor, list_sync_jobs, set_sync_cursor, store_record, store_sync_job,
+};
+use super::tail::walk;
+
+/// Default tick interval. Mirrors the spec §8.3 ≥-1h-behind
+/// threshold by being well under it.
+pub const DEFAULT_TICK_INTERVAL_SECONDS: u64 = 5;
+
+/// Owned handle to the syncer task. Spawn via [`Self::run`];
+/// shutdown via the workspace's `watch::Receiver<bool>`
+/// channel (same pattern the REST/DIDComm threads use).
+pub struct MembershipSyncer {
+    audit_ks: KeyspaceHandle,
+    sync_queue_ks: KeyspaceHandle,
+    sync_cursor_ks: KeyspaceHandle,
+    registry_records_ks: KeyspaceHandle,
+    client: Arc<dyn TrustRegistryClient>,
+    health: RegistryHealth,
+    audit_writer: Option<AuditWriter>,
+    actor_did: String,
+    tick_interval: Duration,
+}
+
+impl MembershipSyncer {
+    /// Construct a fresh syncer. `actor_did` is the VTC's
+    /// own DID — used as the `actor_did` on
+    /// `RegistrySyncSucceeded` / `RegistrySyncFailed` audit
+    /// envelopes.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        audit_ks: KeyspaceHandle,
+        sync_queue_ks: KeyspaceHandle,
+        sync_cursor_ks: KeyspaceHandle,
+        registry_records_ks: KeyspaceHandle,
+        client: Arc<dyn TrustRegistryClient>,
+        health: RegistryHealth,
+        audit_writer: Option<AuditWriter>,
+        actor_did: impl Into<String>,
+    ) -> Self {
+        Self {
+            audit_ks,
+            sync_queue_ks,
+            sync_cursor_ks,
+            registry_records_ks,
+            client,
+            health,
+            audit_writer,
+            actor_did: actor_did.into(),
+            tick_interval: Duration::from_secs(DEFAULT_TICK_INTERVAL_SECONDS),
+        }
+    }
+
+    /// Override the tick interval (default 5s). Lower in tests
+    /// so async-driven assertions resolve quickly.
+    pub fn with_tick_interval(mut self, interval: Duration) -> Self {
+        self.tick_interval = interval;
+        self
+    }
+
+    /// Run the syncer's tick loop. Returns when `shutdown`
+    /// flips to `true`. Spawn via `tokio::spawn` in the
+    /// daemon's boot path.
+    pub async fn run(self, mut shutdown: watch::Receiver<bool>) {
+        info!(
+            tick_interval_secs = self.tick_interval.as_secs(),
+            "membership-syncer task starting"
+        );
+        // Boot recovery — flip any InFlight rows back to
+        // Pending. The daemon may have died between "set
+        // InFlight" and "record outcome"; we re-dispatch.
+        if let Err(e) = self.recover_in_flight().await {
+            warn!(error = %e, "in-flight recovery failed at syncer boot");
+        }
+
+        let mut timer = tokio::time::interval(self.tick_interval);
+        timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // First tick fires immediately — skip so we don't
+        // overlap the recovery scan above.
+        timer.tick().await;
+        loop {
+            tokio::select! {
+                _ = timer.tick() => {
+                    if let Err(e) = self.tick().await {
+                        warn!(error = %e, "syncer tick failed");
+                    }
+                }
+                _ = shutdown.changed() => {
+                    debug!("membership-syncer task shutting down");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// One tick: walk audit tail + dispatch every eligible
+    /// pending job. Exposed for tests.
+    pub async fn tick(&self) -> Result<(), AppError> {
+        let cursor = get_sync_cursor(&self.sync_cursor_ks).await?;
+        let outcome = walk(&self.audit_ks, &self.sync_queue_ks, cursor).await?;
+        if let Some(new) = outcome.new_cursor
+            && Some(new) != cursor
+        {
+            set_sync_cursor(&self.sync_cursor_ks, new).await?;
+        }
+        if outcome.jobs_enqueued > 0 {
+            debug!(jobs = outcome.jobs_enqueued, "tail walk enqueued jobs");
+        }
+
+        let jobs = list_sync_jobs(&self.sync_queue_ks).await?;
+        let now = chrono::Utc::now();
+        for job in jobs.into_iter().filter(|j| j.is_dispatchable(now)) {
+            self.dispatch_one(job).await;
+        }
+        Ok(())
+    }
+
+    /// Boot-time recovery: flip any `InFlight` rows back to
+    /// `Pending`. Exposed for tests.
+    pub async fn recover_in_flight(&self) -> Result<usize, AppError> {
+        let jobs = list_sync_jobs(&self.sync_queue_ks).await?;
+        let mut recovered = 0_usize;
+        for mut job in jobs {
+            if job.state == SyncJobState::InFlight {
+                job.state = SyncJobState::Pending;
+                store_sync_job(&self.sync_queue_ks, &job).await?;
+                recovered += 1;
+                debug!(
+                    job_id = %job.id,
+                    did = %job.member_did,
+                    "recovered InFlight job → Pending after restart"
+                );
+            }
+        }
+        if recovered > 0 {
+            info!(
+                recovered,
+                "membership-syncer recovered InFlight jobs at boot"
+            );
+        }
+        Ok(recovered)
+    }
+
+    /// Dispatch one job. All failure paths land here so the
+    /// caller stays simple; the `Result` is `()` because we
+    /// never propagate — every error is captured on the job
+    /// row + the audit envelope.
+    async fn dispatch_one(&self, mut job: SyncJob) {
+        // Flip to InFlight + persist before the network call
+        // so a crash mid-flight leaves a row the recovery
+        // path will see.
+        job.state = SyncJobState::InFlight;
+        if let Err(e) = store_sync_job(&self.sync_queue_ks, &job).await {
+            warn!(error = %e, job_id = %job.id, "failed to persist InFlight transition");
+            return;
+        }
+
+        let outcome = self.run_call(&job).await;
+        match outcome {
+            Ok(()) => {
+                job.record_success();
+                // Mirror update: PublishMember + UpdateMember
+                // land as Active records; MarkDeparted lands
+                // as Departed; DeleteMember removes the row.
+                self.update_mirror(&job).await;
+                self.health
+                    .record_success(self.audit_writer.as_ref(), &self.actor_did)
+                    .await;
+                self.emit_outcome(&job, true);
+                if let Err(e) = delete_sync_job(&self.sync_queue_ks, job.id).await {
+                    warn!(error = %e, job_id = %job.id, "failed to delete completed job row");
+                }
+            }
+            Err(e) => {
+                if e.is_retriable() {
+                    job.record_failure(format!("{e}"));
+                    self.health
+                        .record_failure(format!("{e}"), self.audit_writer.as_ref(), &self.actor_did)
+                        .await;
+                    if let Err(s) = store_sync_job(&self.sync_queue_ks, &job).await {
+                        warn!(error = %s, job_id = %job.id, "failed to persist retry state");
+                    }
+                    if job.state == SyncJobState::Failed {
+                        // record_failure flipped to Failed (hit
+                        // max attempts).
+                        self.emit_outcome(&job, false);
+                    }
+                } else {
+                    // Permanent — flip to Failed immediately.
+                    job.attempts += 1;
+                    job.last_attempted_at = Some(chrono::Utc::now());
+                    job.last_error = Some(format!("{e}"));
+                    job.state = SyncJobState::Failed;
+                    if let Err(s) = store_sync_job(&self.sync_queue_ks, &job).await {
+                        warn!(error = %s, job_id = %job.id, "failed to persist Failed state");
+                    }
+                    self.emit_outcome(&job, false);
+                    warn!(
+                        job_id = %job.id,
+                        did = %job.member_did,
+                        kind = job.kind.as_str(),
+                        error = %e,
+                        "registry rejected sync job permanently — operator intervention required"
+                    );
+                }
+            }
+        }
+    }
+
+    async fn run_call(&self, job: &SyncJob) -> Result<(), RegistryError> {
+        match job.kind {
+            SyncJobKind::PublishMember | SyncJobKind::UpdateMember => {
+                let record = RegistryRecord::fresh_active(&job.member_did);
+                self.client.publish_member(&record).await
+            }
+            SyncJobKind::MarkDeparted => {
+                let now = chrono::Utc::now();
+                let active_to = if job.disposition.as_deref() == Some("historical") {
+                    Some(now)
+                } else {
+                    None
+                };
+                let record = RegistryRecord::departed(&job.member_did, now, active_to);
+                self.client.publish_member(&record).await
+            }
+            SyncJobKind::DeleteMember => self.client.delete_member(&job.member_did).await,
+        }
+    }
+
+    async fn update_mirror(&self, job: &SyncJob) {
+        match job.kind {
+            SyncJobKind::PublishMember | SyncJobKind::UpdateMember => {
+                let record = RegistryRecord::fresh_active(&job.member_did);
+                if let Err(e) = store_record(&self.registry_records_ks, &record).await {
+                    warn!(error = %e, did = %job.member_did, "failed to update registry_records mirror");
+                }
+            }
+            SyncJobKind::MarkDeparted => {
+                let now = chrono::Utc::now();
+                let active_to = if job.disposition.as_deref() == Some("historical") {
+                    Some(now)
+                } else {
+                    None
+                };
+                let record = RegistryRecord::departed(&job.member_did, now, active_to);
+                if let Err(e) = store_record(&self.registry_records_ks, &record).await {
+                    warn!(error = %e, did = %job.member_did, "failed to update registry_records mirror");
+                }
+            }
+            SyncJobKind::DeleteMember => {
+                if let Err(e) =
+                    super::storage::delete_record(&self.registry_records_ks, &job.member_did).await
+                {
+                    warn!(error = %e, did = %job.member_did, "failed to delete registry_records mirror row");
+                }
+            }
+        }
+    }
+
+    fn emit_outcome(&self, job: &SyncJob, succeeded: bool) {
+        let Some(writer) = self.audit_writer.as_ref() else {
+            return;
+        };
+        let payload = RegistrySyncOutcomeData {
+            job_id: job.id.to_string(),
+            kind: job.kind.as_str().to_string(),
+            attempts: job.attempts,
+            last_error: if succeeded {
+                None
+            } else {
+                job.last_error.clone()
+            },
+        };
+        let event = if succeeded {
+            AuditEvent::RegistrySyncSucceeded(payload)
+        } else {
+            AuditEvent::RegistrySyncFailed(payload)
+        };
+        let actor_did = self.actor_did.clone();
+        let target_did = job.member_did.clone();
+        let writer = writer.clone();
+        // Fire-and-forget — the audit emission failing
+        // shouldn't surface back to the syncer's hot path,
+        // and the audit writer's own logging covers the
+        // failure mode.
+        tokio::spawn(async move {
+            if let Err(e) = writer.write(&actor_did, Some(&target_did), event).await {
+                warn!(error = %e, "failed to emit RegistrySync outcome");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::client::MockRegistryClient;
+    use crate::registry::model::{SyncJob, SyncJobKind};
+    use crate::registry::storage::{get_record, store_sync_job};
+    use vti_common::audit::{AuditEvent, AuditKeyStore, AuditWriter, MemberAddedData};
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn fixture() -> (MembershipSyncer, MockRegistryClient, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let audit_ks = store.keyspace("audit").unwrap();
+        let audit_key_ks = store.keyspace("audit_key").unwrap();
+        let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+        let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+        let registry_records_ks = store.keyspace("registry_records").unwrap();
+        let key_store = AuditKeyStore::new(audit_key_ks);
+        key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+        let audit_writer = AuditWriter::new(audit_ks.clone(), key_store);
+        let mock = MockRegistryClient::new();
+        let client: Arc<dyn TrustRegistryClient> = Arc::new(mock.clone());
+        let syncer = MembershipSyncer::new(
+            audit_ks,
+            sync_queue_ks,
+            sync_cursor_ks,
+            registry_records_ks,
+            client,
+            RegistryHealth::new(),
+            Some(audit_writer),
+            "did:webvh:vtc.example",
+        );
+        (syncer, mock, dir)
+    }
+
+    async fn write_member_added(audit_ks: &KeyspaceHandle, target: &str) {
+        let audit_key_ks_dir = tempfile::tempdir().unwrap();
+        let key_store_for_test = Store::open(&StoreConfig {
+            data_dir: audit_key_ks_dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let aks = AuditKeyStore::new(key_store_for_test.keyspace("audit_key").unwrap());
+        aks.ensure_initial(&[0xAB; 32]).await.unwrap();
+        let w = AuditWriter::new(audit_ks.clone(), aks);
+        w.write(
+            "did:webvh:vtc.example",
+            Some(target),
+            AuditEvent::MemberAdded(MemberAddedData {
+                role: "member".into(),
+                via_join_request_id: None,
+            }),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn happy_path_drains_one_publish_job() {
+        let (syncer, mock, _dir) = fixture().await;
+        write_member_added(&syncer.audit_ks, "did:key:zA").await;
+
+        syncer.tick().await.unwrap();
+
+        assert_eq!(mock.call_counts().await.publish, 1);
+        let snap = mock.snapshot().await;
+        assert!(snap.contains_key("did:key:zA"));
+
+        // Job row deleted; mirror updated.
+        let jobs = list_sync_jobs(&syncer.sync_queue_ks).await.unwrap();
+        assert!(jobs.is_empty(), "completed jobs should be deleted");
+        let mirror = get_record(&syncer.registry_records_ks, "did:key:zA")
+            .await
+            .unwrap();
+        assert!(
+            mirror.is_some(),
+            "registry_records mirror should reflect the publish"
+        );
+
+        // Health flipped to Active.
+        assert_eq!(
+            syncer.health.status().await,
+            crate::registry::HealthStatus::Active
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_failure_bumps_attempts_and_keeps_job_pending() {
+        let (syncer, mock, _dir) = fixture().await;
+        write_member_added(&syncer.audit_ks, "did:key:zA").await;
+        mock.fail_next_publish(RegistryError::Transient("flaky".into()))
+            .await;
+
+        syncer.tick().await.unwrap();
+
+        let jobs = list_sync_jobs(&syncer.sync_queue_ks).await.unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].state, SyncJobState::Pending);
+        assert_eq!(jobs[0].attempts, 1);
+        assert!(jobs[0].last_error.as_deref().unwrap().contains("flaky"));
+    }
+
+    #[tokio::test]
+    async fn permanent_failure_flips_to_failed_immediately() {
+        let (syncer, mock, _dir) = fixture().await;
+        write_member_added(&syncer.audit_ks, "did:key:zA").await;
+        mock.fail_next_publish(RegistryError::Permanent("bad input".into()))
+            .await;
+
+        syncer.tick().await.unwrap();
+
+        let jobs = list_sync_jobs(&syncer.sync_queue_ks).await.unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].state, SyncJobState::Failed);
+        assert_eq!(jobs[0].attempts, 1, "single attempt then Failed");
+    }
+
+    #[tokio::test]
+    async fn in_flight_rows_recover_to_pending_on_boot() {
+        let (syncer, _mock, _dir) = fixture().await;
+        // Seed an InFlight row by hand (simulates a crash mid-
+        // dispatch).
+        let mut job = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zStranded");
+        job.state = SyncJobState::InFlight;
+        store_sync_job(&syncer.sync_queue_ks, &job).await.unwrap();
+
+        let recovered = syncer.recover_in_flight().await.unwrap();
+        assert_eq!(recovered, 1);
+
+        let jobs = list_sync_jobs(&syncer.sync_queue_ks).await.unwrap();
+        assert_eq!(jobs[0].state, SyncJobState::Pending);
+    }
+
+    #[tokio::test]
+    async fn delete_member_job_drops_mirror_row() {
+        let (syncer, _mock, _dir) = fixture().await;
+        // Seed the mirror so the delete path has something to
+        // remove.
+        store_record(
+            &syncer.registry_records_ks,
+            &RegistryRecord::fresh_active("did:key:zDrop"),
+        )
+        .await
+        .unwrap();
+        let job = SyncJob::fresh(SyncJobKind::DeleteMember, "did:key:zDrop");
+        store_sync_job(&syncer.sync_queue_ks, &job).await.unwrap();
+
+        syncer.tick().await.unwrap();
+
+        let mirror = get_record(&syncer.registry_records_ks, "did:key:zDrop")
+            .await
+            .unwrap();
+        assert!(mirror.is_none(), "mirror row should be deleted");
+    }
+}

--- a/vtc-service/src/registry/tail.rs
+++ b/vtc-service/src/registry/tail.rs
@@ -1,0 +1,337 @@
+//! Audit-log tail walker — Phase 3 M3.3.
+//!
+//! Walks the `audit:` keyspace from a persisted cursor and
+//! converts membership-affecting envelopes into [`SyncJob`]
+//! rows. The cursor is the RFC3339 timestamp of the
+//! last-processed envelope; a daemon restart picks up
+//! exactly where the prior run left off (no double-enqueue,
+//! no missed event).
+//!
+//! ## Why poll, not subscribe
+//!
+//! Plan §D3 traded latency for a clean separation: emitters
+//! (the route handlers + the syncer task) never know about
+//! each other. A future architecture could plumb an in-process
+//! channel to drop tail latency below the audit-row write
+//! latency, but the polling design wins on restart resilience
+//! — the audit log IS the event source of truth, so cursor-
+//! driven replay handles every "daemon crashed mid-flight"
+//! scenario the same way.
+//!
+//! ## Which audit variants enqueue jobs
+//!
+//! - `MemberAdded` → `SyncJobKind::PublishMember`
+//! - `MemberRemoved` → `SyncJobKind::DeleteMember` when
+//!   disposition is `Purge`; `SyncJobKind::MarkDeparted`
+//!   when `Tombstone` / `Historical`. (Disposition resolves
+//!   at the emitter; we trust the `MemberRemovedData.disposition`
+//!   field.)
+//! - `RoleChanged` → `SyncJobKind::UpdateMember`. The role
+//!   itself doesn't propagate to the registry record shape
+//!   today — the registry-record `status` flips between
+//!   `Active`/`Departed` only — but the `UpdateMember` job
+//!   keeps the local mirror's `last_synced_at` fresh so drift
+//!   detection has something to anchor against.
+//!
+//! Every other audit variant is ignored. Operator-action
+//! envelopes (`ConfigChanged`, `AdminPasskeyRegistered`, etc.)
+//! never reach the registry.
+
+use chrono::{DateTime, Utc};
+use tracing::{debug, warn};
+use vti_common::audit::{AuditEnvelope, AuditEvent, MemberRemovedData};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::model::{SyncJob, SyncJobKind};
+use super::storage::store_sync_job;
+
+/// Outcome of one walk pass. `new_cursor` is the RFC3339
+/// timestamp of the latest envelope inspected (Some unless the
+/// audit log is empty); `jobs_enqueued` counts how many fresh
+/// `SyncJob` rows landed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalkOutcome {
+    pub new_cursor: Option<DateTime<Utc>>,
+    pub jobs_enqueued: usize,
+}
+
+/// Walk audit envelopes since `cursor`. Returns the new cursor
+/// + the number of jobs enqueued.
+///
+/// `cursor = None` walks from the start of the audit log
+/// (first-boot path). Subsequent calls pass the previous
+/// `new_cursor` back in.
+///
+/// The function is idempotent under concurrent runs only when
+/// the caller serializes calls (typically the syncer's tick
+/// loop holds exclusive access). A racy double-call could
+/// enqueue duplicate jobs; the syncer's tick loop never runs
+/// concurrently with itself, so this isn't a hazard in
+/// production.
+pub async fn walk(
+    audit_ks: &KeyspaceHandle,
+    sync_queue_ks: &KeyspaceHandle,
+    cursor: Option<DateTime<Utc>>,
+) -> Result<WalkOutcome, AppError> {
+    let pairs = audit_ks.prefix_iter_raw(Vec::new()).await?;
+    let mut jobs_enqueued = 0_usize;
+    let mut latest_seen = cursor;
+
+    for (key, value) in pairs {
+        let envelope: AuditEnvelope = match serde_json::from_slice(&value) {
+            Ok(e) => e,
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    key = %String::from_utf8_lossy(&key),
+                    "skipping unparseable audit envelope during tail walk"
+                );
+                continue;
+            }
+        };
+        // Skip envelopes at-or-before the cursor. The cursor
+        // semantic is "everything up to and including this
+        // timestamp has been processed", so equality also
+        // skips.
+        if let Some(c) = cursor
+            && envelope.timestamp <= c
+        {
+            continue;
+        }
+        // Track the latest-seen timestamp regardless of
+        // whether we enqueue — cursor advances over rows we
+        // chose not to enqueue (other audit variants), so a
+        // future restart doesn't re-walk them.
+        if latest_seen.is_none_or(|prev| envelope.timestamp > prev) {
+            latest_seen = Some(envelope.timestamp);
+        }
+        if let Some(job) = audit_to_sync_job(&envelope) {
+            store_sync_job(sync_queue_ks, &job).await?;
+            jobs_enqueued += 1;
+            debug!(
+                job_id = %job.id,
+                kind = job.kind.as_str(),
+                did = %job.member_did,
+                "enqueued sync job from audit envelope"
+            );
+        }
+    }
+
+    Ok(WalkOutcome {
+        new_cursor: latest_seen,
+        jobs_enqueued,
+    })
+}
+
+/// Convert an audit envelope into a `SyncJob`. Returns `None`
+/// for variants that don't drive registry mutations.
+fn audit_to_sync_job(envelope: &AuditEnvelope) -> Option<SyncJob> {
+    match &envelope.event {
+        AuditEvent::MemberAdded(_data) => {
+            let target = envelope.target_did_plain.as_deref()?;
+            Some(SyncJob::fresh(SyncJobKind::PublishMember, target))
+        }
+        AuditEvent::MemberRemoved(MemberRemovedData { disposition, .. }) => {
+            let target = envelope.target_did_plain.as_deref()?;
+            let mut job = match disposition.as_str() {
+                "purge" => SyncJob::fresh(SyncJobKind::DeleteMember, target),
+                "tombstone" | "historical" => SyncJob::fresh(SyncJobKind::MarkDeparted, target),
+                other => {
+                    warn!(
+                        disposition = other,
+                        target = target,
+                        "MemberRemoved with unknown disposition — defaulting to MarkDeparted"
+                    );
+                    SyncJob::fresh(SyncJobKind::MarkDeparted, target)
+                }
+            };
+            job.disposition = Some(disposition.clone());
+            Some(job)
+        }
+        AuditEvent::RoleChanged(_data) => {
+            let target = envelope.target_did_plain.as_deref()?;
+            Some(SyncJob::fresh(SyncJobKind::UpdateMember, target))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::model::SyncJobState;
+    use crate::registry::storage::list_sync_jobs;
+    use vti_common::audit::{
+        AuditKeyStore, AuditWriter, JoinRequestData, MemberAddedData, MemberRemovedData,
+        RoleChangedData,
+    };
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_keyspaces() -> (
+        KeyspaceHandle,
+        KeyspaceHandle,
+        AuditWriter,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        let audit_ks = store.keyspace("audit").unwrap();
+        let audit_key_ks = store.keyspace("audit_key").unwrap();
+        let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+        let key_store = AuditKeyStore::new(audit_key_ks);
+        key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+        let writer = AuditWriter::new(audit_ks.clone(), key_store);
+        (audit_ks, sync_queue_ks, writer, dir)
+    }
+
+    async fn write_member_added(writer: &AuditWriter, target: &str) {
+        writer
+            .write(
+                "did:webvh:vtc.example",
+                Some(target),
+                AuditEvent::MemberAdded(MemberAddedData {
+                    role: "member".into(),
+                    via_join_request_id: None,
+                }),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn write_member_removed(writer: &AuditWriter, target: &str, disposition: &str) {
+        writer
+            .write(
+                "did:webvh:vtc.example",
+                Some(target),
+                AuditEvent::MemberRemoved(MemberRemovedData {
+                    disposition: disposition.into(),
+                    reason: String::new(),
+                }),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn write_role_changed(writer: &AuditWriter, target: &str) {
+        writer
+            .write(
+                "did:webvh:vtc.example",
+                Some(target),
+                AuditEvent::RoleChanged(RoleChangedData {
+                    previous_role: "member".into(),
+                    new_role: "moderator".into(),
+                }),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn write_unrelated_envelope(writer: &AuditWriter) {
+        writer
+            .write(
+                "did:webvh:vtc.example",
+                None,
+                AuditEvent::JoinRequestSubmitted(JoinRequestData {
+                    request_id: "ignored".into(),
+                    transport: "rest".into(),
+                }),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn enqueues_publish_for_member_added() {
+        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
+        write_member_added(&writer, "did:key:zA").await;
+
+        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        assert_eq!(outcome.jobs_enqueued, 1);
+        let jobs = list_sync_jobs(&queue_ks).await.unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].kind, SyncJobKind::PublishMember);
+        assert_eq!(jobs[0].member_did, "did:key:zA");
+        assert_eq!(jobs[0].state, SyncJobState::Pending);
+    }
+
+    #[tokio::test]
+    async fn member_removed_dispositions_map_to_correct_kinds() {
+        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
+        write_member_removed(&writer, "did:key:zPurge", "purge").await;
+        write_member_removed(&writer, "did:key:zTomb", "tombstone").await;
+        write_member_removed(&writer, "did:key:zHist", "historical").await;
+
+        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        assert_eq!(outcome.jobs_enqueued, 3);
+        let mut jobs = list_sync_jobs(&queue_ks).await.unwrap();
+        jobs.sort_by(|a, b| a.member_did.cmp(&b.member_did));
+        let by_did: std::collections::HashMap<_, _> = jobs
+            .into_iter()
+            .map(|j| (j.member_did.clone(), j))
+            .collect();
+        assert_eq!(by_did["did:key:zPurge"].kind, SyncJobKind::DeleteMember);
+        assert_eq!(
+            by_did["did:key:zPurge"].disposition.as_deref(),
+            Some("purge")
+        );
+        assert_eq!(by_did["did:key:zTomb"].kind, SyncJobKind::MarkDeparted);
+        assert_eq!(by_did["did:key:zHist"].kind, SyncJobKind::MarkDeparted);
+    }
+
+    #[tokio::test]
+    async fn role_changed_enqueues_update_member() {
+        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
+        write_role_changed(&writer, "did:key:zRole").await;
+
+        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        assert_eq!(outcome.jobs_enqueued, 1);
+        let jobs = list_sync_jobs(&queue_ks).await.unwrap();
+        assert_eq!(jobs[0].kind, SyncJobKind::UpdateMember);
+    }
+
+    #[tokio::test]
+    async fn unrelated_envelopes_are_ignored() {
+        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
+        write_unrelated_envelope(&writer).await;
+        write_member_added(&writer, "did:key:zA").await;
+        write_unrelated_envelope(&writer).await;
+
+        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        assert_eq!(outcome.jobs_enqueued, 1);
+        // Cursor still advances over the unrelated rows so a
+        // subsequent walk doesn't re-process them.
+        assert!(outcome.new_cursor.is_some());
+    }
+
+    #[tokio::test]
+    async fn cursor_advances_so_restart_is_idempotent() {
+        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
+        write_member_added(&writer, "did:key:zA").await;
+        let first = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        assert_eq!(first.jobs_enqueued, 1);
+
+        // Second walk with the prior cursor enqueues nothing.
+        let second = walk(&audit_ks, &queue_ks, first.new_cursor).await.unwrap();
+        assert_eq!(second.jobs_enqueued, 0);
+
+        // New event after the cursor lands as a fresh job.
+        write_member_added(&writer, "did:key:zB").await;
+        let third = walk(&audit_ks, &queue_ks, first.new_cursor).await.unwrap();
+        assert_eq!(third.jobs_enqueued, 1);
+        let jobs = list_sync_jobs(&queue_ks).await.unwrap();
+        assert_eq!(jobs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn empty_audit_log_yields_no_cursor() {
+        let (audit_ks, queue_ks, _writer, _dir) = temp_keyspaces().await;
+        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        assert_eq!(outcome.jobs_enqueued, 0);
+        assert!(outcome.new_cursor.is_none());
+    }
+}

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -450,6 +450,36 @@ pub async fn run(
         });
     }
 
+    // M3.4: spawn the MembershipSyncer task. Drains the
+    // sync_queue against the trust-registry client with
+    // exponential backoff + boot-time InFlight recovery.
+    // Only runs when a registry is configured — without
+    // one, the queue grows visibly via /v1/health/diagnostics
+    // but no dispatch happens.
+    if let Some(client) = state.registry_client.clone() {
+        let actor_did = state
+            .config
+            .read()
+            .await
+            .vtc_did
+            .clone()
+            .unwrap_or_else(|| "did:key:vtc-unknown".into());
+        let syncer = crate::registry::MembershipSyncer::new(
+            state.audit_ks.clone(),
+            state.sync_queue_ks.clone(),
+            state.sync_cursor_ks.clone(),
+            state.registry_records_ks.clone(),
+            client,
+            state.registry_health.clone(),
+            state.audit_writer.clone(),
+            actor_did,
+        );
+        let syncer_shutdown = shutdown_rx.clone();
+        tokio::spawn(async move {
+            syncer.run(syncer_shutdown).await;
+        });
+    }
+
     // M0.10: consume + audit any pending emergency-bootstrap marker
     // left behind by `vtc admin emergency-bootstrap`. The marker is
     // **one-shot**: `take_pending_emergency` deletes it as part of

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -185,6 +185,16 @@ pub enum AuditEvent {
     /// filters key on this to alert when the registry connection
     /// drops or recovers.
     RegistryStatusChanged(RegistryStatusChangedData),
+
+    /// A `MembershipSyncer` job completed successfully against
+    /// the registry. Spec §8.3; Phase 3 M3.4.
+    RegistrySyncSucceeded(RegistrySyncOutcomeData),
+
+    /// A `MembershipSyncer` job flipped to the `Failed` state
+    /// after exhausting its retry budget. Spec §8.3 calls these
+    /// out for operator attention — failed `Purge` jobs are
+    /// silent privacy regressions. Phase 3 M3.4.
+    RegistrySyncFailed(RegistrySyncOutcomeData),
 }
 
 // ---------------------------------------------------------------------------
@@ -472,6 +482,28 @@ pub struct StatusListFlippedData {
     /// `false` = un-suspended. Revocation flips are one-way per
     /// spec §6.2; suspension flips can go either direction.
     pub revoked: bool,
+}
+
+/// Payload for [`AuditEvent::RegistrySyncSucceeded`] +
+/// [`AuditEvent::RegistrySyncFailed`]. Phase 3 M3.4. The
+/// `actor_did` on the envelope is the VTC's own DID; the
+/// `target_did` is the member being synced.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistrySyncOutcomeData {
+    /// UUID of the `SyncJob` row.
+    pub job_id: String,
+    /// Wire-form `SyncJobKind` — `"publishMember"`,
+    /// `"updateMember"`, `"deleteMember"`, or
+    /// `"markDeparted"`.
+    pub kind: String,
+    /// Number of attempts the job made (1 for happy-path
+    /// succeed-on-first-try, higher when retries fired).
+    pub attempts: u32,
+    /// On failure: the last error message. On success:
+    /// `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 /// Payload for [`AuditEvent::RegistryStatusChanged`]. Phase 3
@@ -882,6 +914,40 @@ mod tests {
     }
 
     #[test]
+    fn registry_sync_succeeded_round_trip() {
+        let e = AuditEvent::RegistrySyncSucceeded(RegistrySyncOutcomeData {
+            job_id: "11111111-1111-1111-1111-111111111111".into(),
+            kind: "publishMember".into(),
+            attempts: 1,
+            last_error: None,
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "RegistrySyncSucceeded");
+        assert_eq!(v["data"]["kind"], "publishMember");
+        assert_eq!(v["data"]["attempts"], 1);
+        assert!(
+            v["data"].get("lastError").is_none(),
+            "lastError should be omitted on success: {v}"
+        );
+        round_trip(&e);
+    }
+
+    #[test]
+    fn registry_sync_failed_round_trip_carries_last_error() {
+        let e = AuditEvent::RegistrySyncFailed(RegistrySyncOutcomeData {
+            job_id: "22222222-2222-2222-2222-222222222222".into(),
+            kind: "deleteMember".into(),
+            attempts: 17,
+            last_error: Some("permanent: bad input".into()),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "RegistrySyncFailed");
+        assert_eq!(v["data"]["attempts"], 17);
+        assert_eq!(v["data"]["lastError"], "permanent: bad input");
+        round_trip(&e);
+    }
+
+    #[test]
     fn registry_status_changed_round_trip() {
         let e = AuditEvent::RegistryStatusChanged(RegistryStatusChangedData {
             from: "active".into(),
@@ -1048,6 +1114,24 @@ mod tests {
                     reason: None,
                 }),
                 "RegistryStatusChanged",
+            ),
+            (
+                AuditEvent::RegistrySyncSucceeded(RegistrySyncOutcomeData {
+                    job_id: "j".into(),
+                    kind: "publishMember".into(),
+                    attempts: 1,
+                    last_error: None,
+                }),
+                "RegistrySyncSucceeded",
+            ),
+            (
+                AuditEvent::RegistrySyncFailed(RegistrySyncOutcomeData {
+                    job_id: "j".into(),
+                    kind: "deleteMember".into(),
+                    attempts: 1,
+                    last_error: Some("x".into()),
+                }),
+                "RegistrySyncFailed",
             ),
         ];
         for (event, expected) in cases {

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -36,7 +36,8 @@ pub use event::{
     CredentialIssuedData, DidRotatedData, EmergencyBootstrapData, JoinRequestData,
     JoinRequestRejectedData, MemberAddedData, MemberRemovedData, MemberUpdatedData,
     MembershipRenewedData, PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER,
-    RegistryStatusChangedData, RestartRequestedData, RoleChangedData, StatusListFlippedData,
+    RegistryStatusChangedData, RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData,
+    StatusListFlippedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

Third slice of Phase 3. Lights up the reconciliation track.
Every `MemberAdded` / `MemberRemoved` / `RoleChanged` audit
envelope now drives a `SyncJob` against the trust registry,
with exponential backoff + boot-time replay + crash recovery.

| Milestone | What it adds |
|---|---|
| **M3.3** | `registry::tail::walk` — audit-log → SyncJob enqueue |
| **M3.4** | `registry::syncer::MembershipSyncer` — tokio task with backoff, recovery, dispatch |

## M3.3 — Audit-tail walker

Polls the `audit:` keyspace from a persisted cursor and
enqueues `SyncJob` rows:

- `MemberAdded` → `PublishMember`
- `MemberRemoved` (disposition `"purge"`) → `DeleteMember`
- `MemberRemoved` (disposition `"tombstone"` / `"historical"`)
  → `MarkDeparted`
- `RoleChanged` → `UpdateMember`

Cursor advances over *every* envelope, not just enqueued
ones — unrelated audit variants get walked once and never
re-walked.

Plan §D3's polling-over-channel decision lands as-shipped:
emitters never know about the syncer. The audit log IS the
event source of truth; cursor-driven replay handles
"daemon crashed mid-flight" identically to a fresh boot.

## M3.4 — `MembershipSyncer`

The tokio task that drains `sync_queue:`. Tick loop, every
5s (configurable). Spawned from `server::run` only when a
registry is configured. Same shutdown channel as REST /
DIDComm / storage threads.

Per-tick:
1. **Boot recovery** (first tick) — flip `InFlight` →
   `Pending`. Crash recovery for the dispatched-but-not-
   recorded window.
2. **Tail walk** — `tail::walk` + cursor advance.
3. **Dispatch** for each eligible `Pending`:
   - InFlight → call client → success/failure paths.
   - Success: delete row + emit `RegistrySyncSucceeded`
     + update local mirror.
   - Retriable failure: `record_failure` bumps attempts
     per backoff. Health flips to Degraded.
   - Permanent: flip to `Failed` immediately + emit
     `RegistrySyncFailed`. Operator-visible in
     diagnostics.

Audit emission is fire-and-forget (`tokio::spawn`) so a
writer failure can't surface on the syncer hot path.

## New audit variants

- `AuditEvent::RegistrySyncSucceeded(RegistrySyncOutcomeData)`
- `AuditEvent::RegistrySyncFailed(RegistrySyncOutcomeData)`

Shared payload: `job_id` + `kind` + `attempts` + optional
`last_error`.

## Test coverage (12 new)

- **5 in `registry::tail`** — happy publish; all three
  removal dispositions; role-change → UpdateMember;
  unrelated envelopes ignored (cursor still advances);
  empty audit log; cursor idempotence across restarts.
- **5 in `registry::syncer`** — happy publish drains row
  + updates mirror + flips health to Active; transient
  failure bumps attempts + keeps Pending; permanent
  failure flips to Failed in one attempt; InFlight rows
  recover at boot; DeleteMember drops the mirror row.
- **2 in vti-common audit** — `RegistrySyncSucceeded` +
  `RegistrySyncFailed` round-trip + discriminator
  coverage.

## Test plan

- [x] `cargo test -p vtc-service` green (430+).
- [x] `cargo test -p vti-common audit::` green (44/44).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- [ ] Review the tick-interval default (5s); a slower
  default would reduce idle wake-ups but might cross the
  spec §8.3 ≥-1h-behind threshold under load.
- [ ] Approve before M3.5+ starts (next PR is RTBF /
  diagnostics).

## What's NOT in this PR

Next PR picks up M3.5 + M3.6 + M3.7 + M3.8:

- M3.5: wire `registry.rego.publish_on_join` into the
  syncer's dispatch decision.
- M3.6: RTBF override (member-initiated Purge bypasses
  `min_disposition`) + `RegistryRecordPolicyOverride`
  audit envelope.
- M3.7: RTBF batching
  (`registry.rtbf_batch_window_hours`).
- M3.8: `GET /v1/health/diagnostics` endpoint.

The DIDComm transport for `UpstreamRegistryClient`'s
`publish_member` / `delete_member` is still deferred (PR
#88's "Permanent: not yet implemented" stubs). Lands
alongside M3.5–M3.8 or as its own follow-up.

## Commits

1. `32112b7` — M3.3 + M3.4 audit-tail walker + MembershipSyncer

Once this PR merges, M3.5+ starts on a fresh branch.