### PR TITLE
feat(vtc-service): M3.5-M3.8 — policy clamp, RTBF override + batch, diagnostics

### DIFF
--- a/tasks/vtc-mvp/phase-3-todo.md
+++ b/tasks/vtc-mvp/phase-3-todo.md
@@ -177,7 +177,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.5 — Three-disposition reconciliation
 
-### `[ ]` M3.5.1 — Wire `registry.rego` into the syncer
+### `[x]` M3.5.1 — Wire `registry.rego` into the syncer
 
 - **Acceptance**
   - When dispatching a `DeleteMember` job, the syncer
@@ -210,7 +210,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.6 — RTBF override
 
-### `[ ]` M3.6.1 — Member-initiated Purge bypasses `min_disposition`
+### `[x]` M3.6.1 — Member-initiated Purge bypasses `min_disposition`
 
 - **Acceptance**
   - When a `MemberRemoved` audit envelope has
@@ -240,7 +240,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.7 — RTBF batching
 
-### `[ ]` M3.7.1 — Daily coalesced batch
+### `[x]` M3.7.1 — Daily coalesced batch
 
 - **Acceptance**
   - RTBF-flagged `SyncJob` rows are enqueued with
@@ -272,7 +272,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.8 — `GET /v1/health/diagnostics`
 
-### `[ ]` M3.8.1 — Admin diagnostics endpoint
+### `[x]` M3.8.1 — Admin diagnostics endpoint
 
 - **Acceptance**
   - `AdminAuth`. Response shape:

--- a/trust-tasks/health/diagnostics/1.0/schema.json
+++ b/trust-tasks/health/diagnostics/1.0/schema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — Trust-Registry Reconciler Diagnostics",
+  "description": "GET /v1/health/diagnostics response. Aggregate-only — no per-member DIDs. Phase 3 M3.8.",
+  "type": "object",
+  "required": [
+    "registry_status",
+    "queue_depth",
+    "rtbf_batched_count",
+    "failed_count"
+  ],
+  "properties": {
+    "registry_status": {
+      "type": "string",
+      "enum": ["active", "degraded"],
+      "description": "Trust-registry reachability. Spec §8.1."
+    },
+    "queue_depth": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Pending + InFlight SyncJob rows."
+    },
+    "rtbf_batched_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Pending jobs parked behind the RTBF batch window."
+    },
+    "failed_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Terminal-failure rows awaiting operator triage."
+    },
+    "oldest_pending_age_seconds": {
+      "type": ["integer", "null"],
+      "description": "Seconds since the oldest dispatchable pending job's creation. Excludes RTBF-parked rows. `null` when queue is empty."
+    },
+    "last_success_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "RFC3339 timestamp of the most recent successful registry probe / dispatch. `null` when none has succeeded yet."
+    },
+    "last_failure_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "RFC3339 timestamp of the most recent registry failure. `null` when none has failed."
+    },
+    "last_error": {
+      "type": ["string", "null"],
+      "description": "Error string from the last registry failure. May include upstream URLs / codes — operators should treat it as potentially sensitive."
+    }
+  },
+  "additionalProperties": false
+}

--- a/trust-tasks/health/diagnostics/1.0/spec.md
+++ b/trust-tasks/health/diagnostics/1.0/spec.md
@@ -1,0 +1,66 @@
+---
+id: https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0
+title: VTC — Trust-Registry Reconciler Diagnostics
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/health/diagnostics
+---
+
+# VTC — Trust-Registry Reconciler Diagnostics
+
+Admin-gated view of the `MembershipSyncer` task's internal state.
+Lets operators answer "is registry sync stuck?" without shelling
+onto the host. Pairs with the `registry_status` field on
+`GET /v1/community/profile`: the profile says *whether* the
+registry looks reachable; this endpoint says *how stuck* the
+reconciler is. Spec §8.3.
+
+## Semantics
+
+- **GET** — requires `Admin` role.
+- Reads:
+  - `registry_status` — `"active"` or `"degraded"`. Mirrors
+    the `RegistryHealth` state machine (M3.2).
+  - `queue_depth` — count of jobs in `Pending` + `InFlight`.
+    A monotonically rising number means the registry is
+    refusing dispatch.
+  - `oldest_pending_age_seconds` — staleness of the
+    longest-waiting *dispatchable* job (excludes
+    `rtbf_batched` rows whose `next_attempt_at` is still
+    future-dated). Drives the "≥1h behind → degraded" SLI.
+  - `rtbf_batched_count` — pending jobs parked behind the
+    RTBF batch window (M3.7). Confirms batch protection is
+    active without inspecting fjall.
+  - `failed_count` — terminal-failure rows. Need operator
+    triage; the syncer won't retry them.
+  - `last_success_at` / `last_failure_at` / `last_error` —
+    the most recent registry probe state.
+
+## Trust assumptions
+
+- Caller holds a valid VTC-audience JWT.
+- JWT's `role` claim is `admin` (super-admin is not required —
+  this endpoint is intended for on-call ops without privileged
+  permissions).
+
+## Outputs
+
+`200 OK` with [`DiagnosticsResponse`](https://github.com/OpenVTC/verifiable-trust-infrastructure/blob/main/vtc-service/src/routes/health.rs).
+No state changes — read-only.
+
+## Privacy
+
+The endpoint exposes **aggregate counts only**. Individual
+member DIDs are not surfaced; `rtbf_batched_count` discloses how
+many RTBF jobs are in-flight but not which members they refer
+to. The `last_error` field carries a string from the upstream
+registry — operators reviewing diagnostics should treat it as
+potentially sensitive (it may include URLs or error codes that
+identify the upstream).
+
+## Status
+
+Draft.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -247,6 +247,12 @@
       "path": "status-lists/show/1.0",
       "rest": "GET /v1/status-lists/{purpose}",
       "trust_task_header_exempt": true
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0",
+      "status": "Draft",
+      "path": "health/diagnostics/1.0",
+      "rest": "GET /v1/health/diagnostics"
     }
   ]
 }

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -40,7 +40,7 @@ pub struct AppConfig {
 }
 
 /// Trust-registry runtime settings.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct RegistryConfig {
     /// Base URL of the upstream TRQP-compliant registry
@@ -58,6 +58,19 @@ pub struct RegistryConfig {
     /// Default: 5s.
     #[serde(default = "default_registry_http_timeout")]
     pub http_timeout_seconds: u64,
+    /// RTBF-batch coalescing window (hours) — spec §8.2 +
+    /// M3.7. When the syncer's walker fires an RTBF override,
+    /// the resulting `DeleteMember` job is parked for at
+    /// least this many hours before the registry call goes
+    /// out. The window de-correlates the override audit
+    /// envelope's timestamp from the registry record's
+    /// disappearance so an external observer can't time-align
+    /// the two and re-identify the RTBF requester. Set to `0`
+    /// to disable batching (RTBF jobs dispatch immediately —
+    /// useful in tests; **not recommended in production**).
+    /// Default: 24h.
+    #[serde(default = "default_rtbf_batch_window_hours")]
+    pub rtbf_batch_window_hours: u64,
 }
 
 fn default_health_probe_interval() -> u64 {
@@ -66,6 +79,26 @@ fn default_health_probe_interval() -> u64 {
 
 fn default_registry_http_timeout() -> u64 {
     5
+}
+
+fn default_rtbf_batch_window_hours() -> u64 {
+    24
+}
+
+impl Default for RegistryConfig {
+    fn default() -> Self {
+        // Production defaults — match the serde-default
+        // values. Deriving Default would zero every numeric
+        // field, silently disabling the periodic probe + the
+        // RTBF batch protection. Keep the two in sync by
+        // construction.
+        Self {
+            url: None,
+            health_probe_interval_seconds: default_health_probe_interval(),
+            http_timeout_seconds: default_registry_http_timeout(),
+            rtbf_batch_window_hours: default_rtbf_batch_window_hours(),
+        }
+    }
 }
 
 /// Per-surface mount config (spec §9.2). Phase-0 surfaces:

--- a/vtc-service/src/registry/mod.rs
+++ b/vtc-service/src/registry/mod.rs
@@ -49,6 +49,7 @@
 pub mod client;
 pub mod health;
 pub mod model;
+pub mod policy;
 pub mod storage;
 pub mod syncer;
 pub mod tail;
@@ -59,6 +60,10 @@ pub use health::{HealthStatus, RegistryHealth};
 pub use model::{
     DEFAULT_MAX_ATTEMPTS, MAX_BACKOFF_SECONDS, RegistryRecord, RegistryStatus, SyncJob,
     SyncJobKind, SyncJobState, exponential_backoff_seconds,
+};
+pub use policy::{
+    ClampOutcome, PublishOnJoinDecision, clamp_disposition, evaluate_publish_on_join,
+    is_rtbf_purge, read_min_disposition,
 };
 pub use storage::{
     REGISTRY_RECORDS_PREFIX, SYNC_QUEUE_PREFIX, clear_sync_cursor, delete_record, delete_sync_job,

--- a/vtc-service/src/registry/policy.rs
+++ b/vtc-service/src/registry/policy.rs
@@ -1,0 +1,369 @@
+//! `registry.rego` consultation helpers — Phase 3 M3.5 + M3.6.
+//!
+//! The default `registry.rego` (shipped from M2.5) emits four
+//! rules the reconciliation flow needs:
+//!
+//! - `publish_on_join: bool` — whether a `MemberAdded` event
+//!   should produce a `PublishMember` job at all. Operators
+//!   can opt out of publish-on-join entirely by overriding
+//!   this rule to `false`.
+//! - `default_departure: string` — the disposition the
+//!   reconciler defaults to when the member didn't pick one.
+//! - `departure_options: [string]` — the set the member's
+//!   preference must clamp to.
+//! - `min_disposition: string` — the floor the operator is
+//!   willing to accept. RTBF (`actor == target` Purge)
+//!   **always** overrides this floor per spec §8.2.
+//!
+//! Phase 3 M3.5 wires the `publish_on_join` rule. Phase 3
+//! M3.6 wires `min_disposition` clamping + the RTBF override.
+
+use serde_json::{Value as JsonValue, json};
+use tracing::warn;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use crate::policy::{
+    PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy, get_active_policy_id,
+    get_policy,
+};
+
+/// Outcome of evaluating `registry.rego` for an incoming
+/// `MemberAdded` event. `PublishOnJoin` is the default
+/// (the default policy emits `true`); `SkipPublishOnJoin`
+/// surfaces only when an operator-uploaded policy explicitly
+/// flips the rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishOnJoinDecision {
+    PublishOnJoin,
+    SkipPublishOnJoin,
+}
+
+/// Evaluate the active `registry.rego.publish_on_join`. Fails
+/// open — any error path (no active policy, compile failure,
+/// missing rule) returns `PublishOnJoin`. The rationale: if
+/// the policy is broken, we'd rather sync (the default
+/// behaviour) than silently swallow member additions. The
+/// alternative (fail closed) would let a buggy policy upload
+/// hide the entire membership graph from the registry — a
+/// silent privacy regression.
+pub async fn evaluate_publish_on_join(
+    policies_ks: &KeyspaceHandle,
+    active_policies_ks: &KeyspaceHandle,
+) -> Result<PublishOnJoinDecision, AppError> {
+    let Some(id) = get_active_policy_id(active_policies_ks, PolicyPurpose::Registry).await? else {
+        // No active policy → fall back to the spec default
+        // (`publish_on_join: true`). M2.5's installer should
+        // always have run by the time the syncer is live, so
+        // this is a "daemon misconfigured" path.
+        warn!("no active registry.rego — defaulting to publish_on_join=true");
+        return Ok(PublishOnJoinDecision::PublishOnJoin);
+    };
+    let policy = get_policy(policies_ks, id)
+        .await?
+        .ok_or_else(|| AppError::Internal(format!("active registry policy {id} not found")))?;
+    let compiled = compile_policy(&policy.rego_source, policy.id)?;
+    let result = evaluate_policy(
+        &compiled,
+        "data.vtc.registry.publish_on_join",
+        JsonValue::Object(Default::default()),
+    )?;
+    let publish = result
+        .pointer("/result/0/expressions/0/value")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    Ok(if publish {
+        PublishOnJoinDecision::PublishOnJoin
+    } else {
+        PublishOnJoinDecision::SkipPublishOnJoin
+    })
+}
+
+/// Read `data.vtc.registry.min_disposition` from the active
+/// `registry.rego`. Returns `None` when the policy is missing
+/// / malformed / emits a non-string. Callers (the reconciler)
+/// treat `None` as "fall back to the disposition the member
+/// asked for".
+pub async fn read_min_disposition(
+    policies_ks: &KeyspaceHandle,
+    active_policies_ks: &KeyspaceHandle,
+) -> Option<String> {
+    let active_id = get_active_policy_id(active_policies_ks, PolicyPurpose::Registry)
+        .await
+        .ok()
+        .flatten()?;
+    let policy = get_policy(policies_ks, active_id).await.ok().flatten()?;
+    let compiled = compile_policy(&policy.rego_source, policy.id).ok()?;
+    let result = evaluate_policy(
+        &compiled,
+        "data.vtc.registry.min_disposition",
+        JsonValue::Object(Default::default()),
+    )
+    .ok()?;
+    result
+        .pointer("/result/0/expressions/0/value")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// Disposition preservation level. Used by
+/// [`clamp_disposition`] to decide whether a member-requested
+/// disposition meets the policy floor. **Higher number =
+/// more record preservation**:
+///
+/// - `purge` (1) — no record kept; row physically gone.
+/// - `tombstone` (2) — minimal marker kept ("existed once,
+///   now departed"); not visible in active member views.
+/// - `historical` (3) — full record kept, flagged inactive;
+///   still visible in historical views.
+///
+/// `min_disposition` is the *operator's preservation floor*
+/// — the minimum record retention the operator is willing to
+/// publish to the registry. If a member-requested disposition
+/// has lower preservation than the floor, [`clamp_disposition`]
+/// bumps it up to the floor. RTBF (`actor == target` + `purge`)
+/// bypasses this clamp per spec §8.2 — a member's right-to-
+/// forget overrides the operator's retention preference.
+fn severity(s: &str) -> u8 {
+    match s {
+        "historical" => 3,
+        "tombstone" => 2,
+        "purge" => 1,
+        _ => 1,
+    }
+}
+
+/// Result of clamping a member's requested disposition against
+/// the policy floor. Returns the effective disposition the
+/// reconciler should apply, plus a flag indicating whether the
+/// policy floor actually overrode the request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClampOutcome {
+    pub effective: String,
+    pub clamped: bool,
+    pub min_floor: Option<String>,
+}
+
+/// Clamp a member's requested disposition against the
+/// `min_disposition` preservation floor. The floor is the
+/// **minimum record retention** the operator is willing to
+/// publish; if the member requested less retention than the
+/// floor (e.g. `purge` against a `tombstone` floor), bump the
+/// effective disposition up to the floor.
+///
+/// **RTBF doesn't go through here.** A member-initiated
+/// `Purge` bypasses the floor entirely (spec §8.2 + M3.6's
+/// override path). Use [`is_rtbf_purge`] before calling this.
+pub fn clamp_disposition(requested: &str, floor: Option<&str>) -> ClampOutcome {
+    let Some(floor) = floor else {
+        return ClampOutcome {
+            effective: requested.to_string(),
+            clamped: false,
+            min_floor: None,
+        };
+    };
+    if severity(requested) >= severity(floor) {
+        ClampOutcome {
+            effective: requested.to_string(),
+            clamped: false,
+            min_floor: Some(floor.to_string()),
+        }
+    } else {
+        ClampOutcome {
+            effective: floor.to_string(),
+            clamped: true,
+            min_floor: Some(floor.to_string()),
+        }
+    }
+}
+
+/// Detect a member-initiated RTBF Purge. The audit envelope's
+/// `actor_did == target_did` (the member ran their own
+/// removal) combined with `disposition == "purge"` identifies
+/// the RTBF case. Admin-force-purge (different actor)
+/// **does not** trigger the override; it goes through the
+/// normal clamp.
+pub fn is_rtbf_purge(actor_did: &str, target_did: &str, disposition: &str) -> bool {
+    actor_did == target_did && disposition == "purge"
+}
+
+/// Construct the canonical [`json`] payload for evaluating
+/// the rego rule. Exposed for the syncer's tests.
+pub fn registry_input(member_did: &str, action: &str) -> JsonValue {
+    json!({
+        "member": { "did": member_did },
+        "action": action,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::{Policy, PolicyPurpose, set_active_policy_id, store_policy};
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_keyspaces() -> (KeyspaceHandle, KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let policies = store.keyspace("policies").unwrap();
+        let active = store.keyspace("active_policies").unwrap();
+        (policies, active, dir)
+    }
+
+    async fn install_registry_policy(
+        policies: &KeyspaceHandle,
+        active: &KeyspaceHandle,
+        source: &str,
+    ) {
+        use sha2::{Digest, Sha256};
+        let sha: [u8; 32] = Sha256::digest(source.as_bytes()).into();
+        let id = uuid::Uuid::new_v4();
+        let policy = Policy {
+            id,
+            purpose: PolicyPurpose::Registry,
+            rego_source: source.into(),
+            sha256: sha,
+            activated_at: Some(chrono::Utc::now()),
+            author_did: "did:key:test".into(),
+            created_at: chrono::Utc::now(),
+            version: 1,
+        };
+        store_policy(policies, &policy).await.unwrap();
+        set_active_policy_id(active, PolicyPurpose::Registry, id)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_on_join_defaults_to_publish_when_no_policy() {
+        let (policies, active, _dir) = temp_keyspaces().await;
+        let outcome = evaluate_publish_on_join(&policies, &active).await.unwrap();
+        assert_eq!(outcome, PublishOnJoinDecision::PublishOnJoin);
+    }
+
+    #[tokio::test]
+    async fn publish_on_join_reads_true_from_default_policy() {
+        let (policies, active, _dir) = temp_keyspaces().await;
+        let src = "\
+package vtc.registry
+import rego.v1
+default publish_on_join := true
+";
+        install_registry_policy(&policies, &active, src).await;
+        let outcome = evaluate_publish_on_join(&policies, &active).await.unwrap();
+        assert_eq!(outcome, PublishOnJoinDecision::PublishOnJoin);
+    }
+
+    #[tokio::test]
+    async fn publish_on_join_returns_skip_when_policy_says_false() {
+        let (policies, active, _dir) = temp_keyspaces().await;
+        let src = "\
+package vtc.registry
+import rego.v1
+default publish_on_join := false
+";
+        install_registry_policy(&policies, &active, src).await;
+        let outcome = evaluate_publish_on_join(&policies, &active).await.unwrap();
+        assert_eq!(outcome, PublishOnJoinDecision::SkipPublishOnJoin);
+    }
+
+    #[tokio::test]
+    async fn min_disposition_returns_none_when_no_policy() {
+        let (policies, active, _dir) = temp_keyspaces().await;
+        let got = read_min_disposition(&policies, &active).await;
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn min_disposition_reads_from_policy() {
+        let (policies, active, _dir) = temp_keyspaces().await;
+        let src = "\
+package vtc.registry
+import rego.v1
+default min_disposition := \"tombstone\"
+";
+        install_registry_policy(&policies, &active, src).await;
+        let got = read_min_disposition(&policies, &active).await;
+        assert_eq!(got.as_deref(), Some("tombstone"));
+    }
+
+    #[test]
+    fn clamp_disposition_below_floor_bumps_up_to_floor() {
+        // purge (preservation 1) below tombstone floor (2) →
+        // clamp UP to tombstone. Operator wanted at least a
+        // marker preserved.
+        let out = clamp_disposition("purge", Some("tombstone"));
+        assert_eq!(out.effective, "tombstone");
+        assert!(out.clamped);
+
+        // purge (1) below historical floor (3) — clamp to
+        // historical. Operator wanted full preservation.
+        let out = clamp_disposition("purge", Some("historical"));
+        assert_eq!(out.effective, "historical");
+        assert!(out.clamped);
+
+        // tombstone (2) below historical floor (3) — clamp UP.
+        let out = clamp_disposition("tombstone", Some("historical"));
+        assert_eq!(out.effective, "historical");
+        assert!(out.clamped);
+    }
+
+    #[test]
+    fn clamp_disposition_at_or_above_floor_passes_through() {
+        // tombstone (2) == tombstone (2) — no clamp.
+        let out = clamp_disposition("tombstone", Some("tombstone"));
+        assert_eq!(out.effective, "tombstone");
+        assert!(!out.clamped);
+
+        // historical (3) > tombstone floor (2) — more
+        // preservation than the floor demands, passes verbatim.
+        let out = clamp_disposition("historical", Some("tombstone"));
+        assert_eq!(out.effective, "historical");
+        assert!(!out.clamped);
+
+        // Default registry.rego ships with floor "purge" (1)
+        // — every disposition is at-or-above floor, no clamp.
+        let out = clamp_disposition("purge", Some("purge"));
+        assert_eq!(out.effective, "purge");
+        assert!(!out.clamped);
+        let out = clamp_disposition("tombstone", Some("purge"));
+        assert_eq!(out.effective, "tombstone");
+        assert!(!out.clamped);
+    }
+
+    #[test]
+    fn clamp_with_no_floor_returns_requested_verbatim() {
+        let out = clamp_disposition("purge", None);
+        assert_eq!(out.effective, "purge");
+        assert!(!out.clamped);
+        assert!(out.min_floor.is_none());
+    }
+
+    #[test]
+    fn is_rtbf_purge_detects_self_purge() {
+        assert!(is_rtbf_purge("did:key:zMember", "did:key:zMember", "purge"));
+    }
+
+    #[test]
+    fn is_rtbf_purge_rejects_admin_force_purge() {
+        assert!(!is_rtbf_purge("did:key:zAdmin", "did:key:zMember", "purge"));
+    }
+
+    #[test]
+    fn is_rtbf_purge_rejects_non_purge_dispositions() {
+        assert!(!is_rtbf_purge(
+            "did:key:zMember",
+            "did:key:zMember",
+            "tombstone"
+        ));
+        assert!(!is_rtbf_purge(
+            "did:key:zMember",
+            "did:key:zMember",
+            "historical"
+        ));
+    }
+}

--- a/vtc-service/src/registry/syncer.rs
+++ b/vtc-service/src/registry/syncer.rs
@@ -47,13 +47,16 @@ use std::time::Duration;
 
 use tokio::sync::watch;
 use tracing::{debug, info, warn};
-use vti_common::audit::{AuditEvent, AuditWriter, RegistrySyncOutcomeData};
+use vti_common::audit::{
+    AuditEvent, AuditWriter, RegistryRecordPolicyOverrideData, RegistrySyncOutcomeData,
+};
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
 use super::client::{RegistryError, TrustRegistryClient};
 use super::health::RegistryHealth;
 use super::model::{RegistryRecord, SyncJob, SyncJobKind, SyncJobState};
+use super::policy::{PublishOnJoinDecision, evaluate_publish_on_join};
 use super::storage::{
     delete_sync_job, get_sync_cursor, list_sync_jobs, set_sync_cursor, store_record, store_sync_job,
 };
@@ -71,24 +74,37 @@ pub struct MembershipSyncer {
     sync_queue_ks: KeyspaceHandle,
     sync_cursor_ks: KeyspaceHandle,
     registry_records_ks: KeyspaceHandle,
+    policies_ks: KeyspaceHandle,
+    active_policies_ks: KeyspaceHandle,
     client: Arc<dyn TrustRegistryClient>,
     health: RegistryHealth,
     audit_writer: Option<AuditWriter>,
     actor_did: String,
     tick_interval: Duration,
+    /// RTBF batch coalescing window (hours). Sourced from
+    /// [`crate::config::RegistryConfig::rtbf_batch_window_hours`]
+    /// at construction. `0` disables batching (RTBF jobs
+    /// dispatch immediately — test convenience only).
+    rtbf_batch_window_hours: u64,
 }
 
 impl MembershipSyncer {
     /// Construct a fresh syncer. `actor_did` is the VTC's
     /// own DID — used as the `actor_did` on
     /// `RegistrySyncSucceeded` / `RegistrySyncFailed` audit
-    /// envelopes.
+    /// envelopes. `policies_ks` + `active_policies_ks` are the
+    /// `vtc_service::policy` storage keyspaces — the syncer
+    /// re-resolves the active `registry.rego` on every dispatch
+    /// so a freshly-uploaded policy takes effect on the next
+    /// tick (no warm-up required, no stale cache).
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         audit_ks: KeyspaceHandle,
         sync_queue_ks: KeyspaceHandle,
         sync_cursor_ks: KeyspaceHandle,
         registry_records_ks: KeyspaceHandle,
+        policies_ks: KeyspaceHandle,
+        active_policies_ks: KeyspaceHandle,
         client: Arc<dyn TrustRegistryClient>,
         health: RegistryHealth,
         audit_writer: Option<AuditWriter>,
@@ -99,11 +115,14 @@ impl MembershipSyncer {
             sync_queue_ks,
             sync_cursor_ks,
             registry_records_ks,
+            policies_ks,
+            active_policies_ks,
             client,
             health,
             audit_writer,
             actor_did: actor_did.into(),
             tick_interval: Duration::from_secs(DEFAULT_TICK_INTERVAL_SECONDS),
+            rtbf_batch_window_hours: 24,
         }
     }
 
@@ -111,6 +130,15 @@ impl MembershipSyncer {
     /// so async-driven assertions resolve quickly.
     pub fn with_tick_interval(mut self, interval: Duration) -> Self {
         self.tick_interval = interval;
+        self
+    }
+
+    /// Override the RTBF batch window (default 24h). Sourced
+    /// from [`crate::config::RegistryConfig::rtbf_batch_window_hours`]
+    /// at boot. Set to `0` in tests to disable batching so
+    /// RTBF dispatches deterministically on the next tick.
+    pub fn with_rtbf_batch_window_hours(mut self, hours: u64) -> Self {
+        self.rtbf_batch_window_hours = hours;
         self
     }
 
@@ -153,7 +181,15 @@ impl MembershipSyncer {
     /// pending job. Exposed for tests.
     pub async fn tick(&self) -> Result<(), AppError> {
         let cursor = get_sync_cursor(&self.sync_cursor_ks).await?;
-        let outcome = walk(&self.audit_ks, &self.sync_queue_ks, cursor).await?;
+        let outcome = walk(
+            &self.audit_ks,
+            &self.sync_queue_ks,
+            &self.policies_ks,
+            &self.active_policies_ks,
+            self.rtbf_batch_window_hours,
+            cursor,
+        )
+        .await?;
         if let Some(new) = outcome.new_cursor
             && Some(new) != cursor
         {
@@ -162,6 +198,18 @@ impl MembershipSyncer {
         if outcome.jobs_enqueued > 0 {
             debug!(jobs = outcome.jobs_enqueued, "tail walk enqueued jobs");
         }
+        // M3.6: emit `RegistryRecordPolicyOverride` envelopes
+        // for any RTBF override the walker resolved. The audit
+        // emission happens *after* the SyncJob is durably
+        // enqueued — if the daemon crashes between enqueue
+        // and audit-emit, the next boot's tail walk re-runs
+        // the override path on the same MemberRemoved
+        // envelope (cursor hasn't advanced past it yet) and
+        // re-emits. A duplicate override envelope is a less
+        // bad failure mode than a silent override.
+        for ov in &outcome.overrides {
+            self.emit_override(ov);
+        }
 
         let jobs = list_sync_jobs(&self.sync_queue_ks).await?;
         let now = chrono::Utc::now();
@@ -169,6 +217,32 @@ impl MembershipSyncer {
             self.dispatch_one(job).await;
         }
         Ok(())
+    }
+
+    fn emit_override(&self, ov: &super::tail::OverrideEvent) {
+        let Some(writer) = self.audit_writer.as_ref() else {
+            return;
+        };
+        let payload = RegistryRecordPolicyOverrideData {
+            reason: ov.reason.clone(),
+            attempted_disposition: ov.attempted_disposition.clone(),
+            effective_disposition: ov.effective_disposition.clone(),
+        };
+        let actor = ov.actor_did.clone();
+        let target = ov.target_did.clone();
+        let writer = writer.clone();
+        tokio::spawn(async move {
+            if let Err(e) = writer
+                .write(
+                    &actor,
+                    Some(&target),
+                    AuditEvent::RegistryRecordPolicyOverride(payload),
+                )
+                .await
+            {
+                warn!(error = %e, "failed to emit RegistryRecordPolicyOverride envelope");
+            }
+        });
     }
 
     /// Boot-time recovery: flip any `InFlight` rows back to
@@ -202,6 +276,33 @@ impl MembershipSyncer {
     /// never propagate — every error is captured on the job
     /// row + the audit envelope.
     async fn dispatch_one(&self, mut job: SyncJob) {
+        // M3.5: consult `registry.rego.publish_on_join` for
+        // PublishMember jobs *at dispatch time* — the operator
+        // may have flipped the policy between enqueue and tick.
+        // Resolving here means a fresh policy upload takes
+        // effect on the next tick without bouncing the daemon
+        // or draining the queue manually. Other job kinds
+        // (UpdateMember, MarkDeparted, DeleteMember) bypass the
+        // gate: `publish_on_join` only governs new-member
+        // publication, not lifecycle updates / departures.
+        if job.kind == SyncJobKind::PublishMember && self.policy_skips_publish().await {
+            job.record_success();
+            self.emit_outcome(&job, true);
+            if let Err(e) = delete_sync_job(&self.sync_queue_ks, job.id).await {
+                warn!(
+                    error = %e,
+                    job_id = %job.id,
+                    "failed to delete policy-skipped PublishMember job"
+                );
+            }
+            debug!(
+                job_id = %job.id,
+                did = %job.member_did,
+                "registry.rego.publish_on_join=false — skipping PublishMember"
+            );
+            return;
+        }
+
         // Flip to InFlight + persist before the network call
         // so a crash mid-flight leaves a row the recovery
         // path will see.
@@ -259,6 +360,24 @@ impl MembershipSyncer {
                         "registry rejected sync job permanently — operator intervention required"
                     );
                 }
+            }
+        }
+    }
+
+    /// Resolve `data.vtc.registry.publish_on_join` against the
+    /// currently-active `registry.rego`. Returns `true` only
+    /// when the policy explicitly emits `false`; any other
+    /// outcome (no policy, compile error, rule missing) returns
+    /// `false` so we default to publishing. See
+    /// [`super::policy::evaluate_publish_on_join`] for the
+    /// failure-mode rationale.
+    async fn policy_skips_publish(&self) -> bool {
+        match evaluate_publish_on_join(&self.policies_ks, &self.active_policies_ks).await {
+            Ok(PublishOnJoinDecision::SkipPublishOnJoin) => true,
+            Ok(PublishOnJoinDecision::PublishOnJoin) => false,
+            Err(e) => {
+                warn!(error = %e, "publish_on_join evaluation failed — defaulting to publish");
+                false
             }
         }
     }
@@ -368,6 +487,8 @@ mod tests {
         let sync_queue_ks = store.keyspace("sync_queue").unwrap();
         let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
         let registry_records_ks = store.keyspace("registry_records").unwrap();
+        let policies_ks = store.keyspace("policies").unwrap();
+        let active_policies_ks = store.keyspace("active_policies").unwrap();
         let key_store = AuditKeyStore::new(audit_key_ks);
         key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
         let audit_writer = AuditWriter::new(audit_ks.clone(), key_store);
@@ -378,6 +499,8 @@ mod tests {
             sync_queue_ks,
             sync_cursor_ks,
             registry_records_ks,
+            policies_ks,
+            active_policies_ks,
             client,
             RegistryHealth::new(),
             Some(audit_writer),
@@ -481,6 +604,44 @@ mod tests {
 
         let jobs = list_sync_jobs(&syncer.sync_queue_ks).await.unwrap();
         assert_eq!(jobs[0].state, SyncJobState::Pending);
+    }
+
+    #[tokio::test]
+    async fn publish_on_join_false_skips_dispatch() {
+        use crate::policy::{Policy, PolicyPurpose, set_active_policy_id, store_policy};
+        let (syncer, mock, _dir) = fixture().await;
+        // Install a registry policy that disables publish-on-join.
+        let src = "\
+package vtc.registry
+import rego.v1
+default publish_on_join := false
+";
+        use sha2::{Digest, Sha256};
+        let sha: [u8; 32] = Sha256::digest(src.as_bytes()).into();
+        let id = uuid::Uuid::new_v4();
+        let policy = Policy {
+            id,
+            purpose: PolicyPurpose::Registry,
+            rego_source: src.into(),
+            sha256: sha,
+            activated_at: Some(chrono::Utc::now()),
+            author_did: "did:key:test".into(),
+            created_at: chrono::Utc::now(),
+            version: 1,
+        };
+        store_policy(&syncer.policies_ks, &policy).await.unwrap();
+        set_active_policy_id(&syncer.active_policies_ks, PolicyPurpose::Registry, id)
+            .await
+            .unwrap();
+
+        write_member_added(&syncer.audit_ks, "did:key:zSkip").await;
+        syncer.tick().await.unwrap();
+
+        // Registry never got called.
+        assert_eq!(mock.call_counts().await.publish, 0);
+        // Job row deleted (policy-skip is a success state).
+        let jobs = list_sync_jobs(&syncer.sync_queue_ks).await.unwrap();
+        assert!(jobs.is_empty());
     }
 
     #[tokio::test]

--- a/vtc-service/src/registry/tail.rs
+++ b/vtc-service/src/registry/tail.rs
@@ -44,16 +44,50 @@ use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
 use super::model::{SyncJob, SyncJobKind};
+use super::policy::{clamp_disposition, is_rtbf_purge, read_min_disposition};
 use super::storage::store_sync_job;
+
+/// Captured policy-override decision the walker discovered for
+/// a single `MemberRemoved` envelope. The syncer turns each one
+/// into a `RegistryRecordPolicyOverride` audit envelope after
+/// the walk completes — keeping audit emission out of the
+/// walker means the walker doesn't need the `AuditWriter`
+/// directly, which keeps its async surface narrow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OverrideEvent {
+    /// Member-DID acting on themselves; this is also the
+    /// `target_did` of the envelope by RTBF construction
+    /// (`actor == target`).
+    pub actor_did: String,
+    /// Same as `actor_did` for RTBF — the target the override
+    /// applies to. Carried explicitly so future override
+    /// reasons (Phase 4 legal-hold) can populate distinct
+    /// actor/target pairs.
+    pub target_did: String,
+    /// Reason code for the override. Phase 3 only emits
+    /// `"rtbf"`.
+    pub reason: String,
+    /// The disposition the active `registry.rego.min_disposition`
+    /// would have clamped to. Captured so operators can audit
+    /// the gap between "what policy said" and "what RTBF
+    /// produced".
+    pub attempted_disposition: String,
+    /// The disposition the override actually applied. Always
+    /// `"purge"` for RTBF in Phase 3.
+    pub effective_disposition: String,
+}
 
 /// Outcome of one walk pass. `new_cursor` is the RFC3339
 /// timestamp of the latest envelope inspected (Some unless the
 /// audit log is empty); `jobs_enqueued` counts how many fresh
-/// `SyncJob` rows landed.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// `SyncJob` rows landed; `overrides` enumerates RTBF override
+/// events the syncer should turn into
+/// `RegistryRecordPolicyOverride` audit envelopes.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct WalkOutcome {
     pub new_cursor: Option<DateTime<Utc>>,
     pub jobs_enqueued: usize,
+    pub overrides: Vec<OverrideEvent>,
 }
 
 /// Walk audit envelopes since `cursor`. Returns the new cursor
@@ -72,11 +106,19 @@ pub struct WalkOutcome {
 pub async fn walk(
     audit_ks: &KeyspaceHandle,
     sync_queue_ks: &KeyspaceHandle,
+    policies_ks: &KeyspaceHandle,
+    active_policies_ks: &KeyspaceHandle,
+    rtbf_batch_window_hours: u64,
     cursor: Option<DateTime<Utc>>,
 ) -> Result<WalkOutcome, AppError> {
     let pairs = audit_ks.prefix_iter_raw(Vec::new()).await?;
     let mut jobs_enqueued = 0_usize;
     let mut latest_seen = cursor;
+    let mut overrides: Vec<OverrideEvent> = Vec::new();
+    // Resolve once per walk — a policy upload between walks
+    // takes effect on the next tick, which is the same
+    // freshness `dispatch_one` gets for `publish_on_join`.
+    let floor = read_min_disposition(policies_ks, active_policies_ks).await;
 
     for (key, value) in pairs {
         let envelope: AuditEnvelope = match serde_json::from_slice(&value) {
@@ -106,7 +148,18 @@ pub async fn walk(
         if latest_seen.is_none_or(|prev| envelope.timestamp > prev) {
             latest_seen = Some(envelope.timestamp);
         }
-        if let Some(job) = audit_to_sync_job(&envelope) {
+        if let Some((mut job, override_event)) = audit_to_sync_job(&envelope, floor.as_deref()) {
+            // M3.7: park RTBF DeleteMember jobs by the batch
+            // window. A non-RTBF DeleteMember (admin force-
+            // purge) dispatches immediately — only RTBF gets
+            // the de-correlation delay. Identified by the
+            // walker having produced an OverrideEvent (the
+            // only override reason in Phase 3 is RTBF).
+            if override_event.is_some() && rtbf_batch_window_hours > 0 {
+                job.next_attempt_at =
+                    chrono::Utc::now() + chrono::Duration::hours(rtbf_batch_window_hours as i64);
+                job.rtbf_batched = true;
+            }
             store_sync_job(sync_queue_ks, &job).await?;
             jobs_enqueued += 1;
             debug!(
@@ -115,43 +168,96 @@ pub async fn walk(
                 did = %job.member_did,
                 "enqueued sync job from audit envelope"
             );
+            if let Some(ov) = override_event {
+                overrides.push(ov);
+            }
         }
     }
 
     Ok(WalkOutcome {
         new_cursor: latest_seen,
         jobs_enqueued,
+        overrides,
     })
 }
 
-/// Convert an audit envelope into a `SyncJob`. Returns `None`
-/// for variants that don't drive registry mutations.
-fn audit_to_sync_job(envelope: &AuditEnvelope) -> Option<SyncJob> {
+/// Convert an audit envelope into a `SyncJob` + an optional
+/// `OverrideEvent` (RTBF). Returns `None` for variants that
+/// don't drive registry mutations.
+///
+/// For `MemberRemoved`:
+/// - Reads the envelope's `disposition`.
+/// - Detects RTBF (`actor == target` + `purge`); if the
+///   active `registry.rego.min_disposition` floor would
+///   have clamped the purge to something with more
+///   preservation, emits an `OverrideEvent` and keeps
+///   `effective = "purge"`.
+/// - Otherwise, applies [`clamp_disposition`] against the
+///   floor and produces a SyncJob carrying the *effective*
+///   (post-clamp) disposition. The `MemberRemovedData` audit
+///   envelope itself retains the as-requested disposition;
+///   the SyncJob carries the resolved one.
+fn audit_to_sync_job(
+    envelope: &AuditEnvelope,
+    floor: Option<&str>,
+) -> Option<(SyncJob, Option<OverrideEvent>)> {
     match &envelope.event {
         AuditEvent::MemberAdded(_data) => {
             let target = envelope.target_did_plain.as_deref()?;
-            Some(SyncJob::fresh(SyncJobKind::PublishMember, target))
+            Some((SyncJob::fresh(SyncJobKind::PublishMember, target), None))
         }
         AuditEvent::MemberRemoved(MemberRemovedData { disposition, .. }) => {
             let target = envelope.target_did_plain.as_deref()?;
-            let mut job = match disposition.as_str() {
+            let actor = envelope.actor_did_plain.as_deref().unwrap_or("");
+            let requested = disposition.as_str();
+
+            // RTBF override path: member self-purge bypasses
+            // the min_disposition clamp. We only emit the
+            // override audit envelope when the floor *would*
+            // have clamped — otherwise the override is
+            // semantically a no-op and emitting noise would
+            // pollute the audit log.
+            let is_rtbf = is_rtbf_purge(actor, target, requested);
+            let (effective_disposition, override_event) = if is_rtbf {
+                let clamp = clamp_disposition(requested, floor);
+                if clamp.clamped {
+                    let ov = OverrideEvent {
+                        actor_did: actor.to_string(),
+                        target_did: target.to_string(),
+                        reason: "rtbf".to_string(),
+                        attempted_disposition: clamp.effective.clone(),
+                        effective_disposition: "purge".to_string(),
+                    };
+                    ("purge".to_string(), Some(ov))
+                } else {
+                    // RTBF + purge but the floor didn't clamp
+                    // — just publish purge, no override
+                    // envelope needed.
+                    ("purge".to_string(), None)
+                }
+            } else {
+                let clamp = clamp_disposition(requested, floor);
+                (clamp.effective, None)
+            };
+
+            let mut job = match effective_disposition.as_str() {
                 "purge" => SyncJob::fresh(SyncJobKind::DeleteMember, target),
                 "tombstone" | "historical" => SyncJob::fresh(SyncJobKind::MarkDeparted, target),
                 other => {
                     warn!(
                         disposition = other,
                         target = target,
-                        "MemberRemoved with unknown disposition — defaulting to MarkDeparted"
+                        "MemberRemoved with unknown effective disposition — defaulting to MarkDeparted"
                     );
                     SyncJob::fresh(SyncJobKind::MarkDeparted, target)
                 }
             };
-            job.disposition = Some(disposition.clone());
-            Some(job)
+            job.disposition = Some(effective_disposition);
+            Some((job, override_event))
         }
         AuditEvent::RoleChanged(_data) => {
             let target = envelope.target_did_plain.as_deref()?;
-            Some(SyncJob::fresh(SyncJobKind::UpdateMember, target))
+            Some((SyncJob::fresh(SyncJobKind::UpdateMember, target), None))
         }
         _ => None,
     }
@@ -169,12 +275,16 @@ mod tests {
     use vti_common::config::StoreConfig;
     use vti_common::store::Store;
 
-    async fn temp_keyspaces() -> (
-        KeyspaceHandle,
-        KeyspaceHandle,
-        AuditWriter,
-        tempfile::TempDir,
-    ) {
+    struct TestKs {
+        audit: KeyspaceHandle,
+        queue: KeyspaceHandle,
+        policies: KeyspaceHandle,
+        active_policies: KeyspaceHandle,
+        writer: AuditWriter,
+        _dir: tempfile::TempDir,
+    }
+
+    async fn temp_keyspaces() -> TestKs {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open(&StoreConfig {
             data_dir: dir.path().to_path_buf(),
@@ -183,10 +293,66 @@ mod tests {
         let audit_ks = store.keyspace("audit").unwrap();
         let audit_key_ks = store.keyspace("audit_key").unwrap();
         let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+        let policies_ks = store.keyspace("policies").unwrap();
+        let active_policies_ks = store.keyspace("active_policies").unwrap();
         let key_store = AuditKeyStore::new(audit_key_ks);
         key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
         let writer = AuditWriter::new(audit_ks.clone(), key_store);
-        (audit_ks, sync_queue_ks, writer, dir)
+        TestKs {
+            audit: audit_ks,
+            queue: sync_queue_ks,
+            policies: policies_ks,
+            active_policies: active_policies_ks,
+            writer,
+            _dir: dir,
+        }
+    }
+
+    async fn install_registry_policy_with_floor(
+        policies: &KeyspaceHandle,
+        active: &KeyspaceHandle,
+        floor: &str,
+    ) {
+        use crate::policy::{Policy, PolicyPurpose, set_active_policy_id, store_policy};
+        use sha2::{Digest, Sha256};
+        let src = format!(
+            "package vtc.registry\nimport rego.v1\ndefault min_disposition := \"{floor}\"\n"
+        );
+        let sha: [u8; 32] = Sha256::digest(src.as_bytes()).into();
+        let id = uuid::Uuid::new_v4();
+        let policy = Policy {
+            id,
+            purpose: PolicyPurpose::Registry,
+            rego_source: src,
+            sha256: sha,
+            activated_at: Some(chrono::Utc::now()),
+            author_did: "did:key:test".into(),
+            created_at: chrono::Utc::now(),
+            version: 1,
+        };
+        store_policy(policies, &policy).await.unwrap();
+        set_active_policy_id(active, PolicyPurpose::Registry, id)
+            .await
+            .unwrap();
+    }
+
+    async fn write_member_removed_by_self(
+        writer: &AuditWriter,
+        member_did: &str,
+        disposition: &str,
+    ) {
+        // RTBF construction: actor == target.
+        writer
+            .write(
+                member_did,
+                Some(member_did),
+                AuditEvent::MemberRemoved(MemberRemovedData {
+                    disposition: disposition.into(),
+                    reason: String::new(),
+                }),
+            )
+            .await
+            .unwrap();
     }
 
     async fn write_member_added(writer: &AuditWriter, target: &str) {
@@ -247,12 +413,14 @@ mod tests {
 
     #[tokio::test]
     async fn enqueues_publish_for_member_added() {
-        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
-        write_member_added(&writer, "did:key:zA").await;
+        let t = temp_keyspaces().await;
+        write_member_added(&t.writer, "did:key:zA").await;
 
-        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        let outcome = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
         assert_eq!(outcome.jobs_enqueued, 1);
-        let jobs = list_sync_jobs(&queue_ks).await.unwrap();
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0].kind, SyncJobKind::PublishMember);
         assert_eq!(jobs[0].member_did, "did:key:zA");
@@ -261,14 +429,21 @@ mod tests {
 
     #[tokio::test]
     async fn member_removed_dispositions_map_to_correct_kinds() {
-        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
-        write_member_removed(&writer, "did:key:zPurge", "purge").await;
-        write_member_removed(&writer, "did:key:zTomb", "tombstone").await;
-        write_member_removed(&writer, "did:key:zHist", "historical").await;
+        let t = temp_keyspaces().await;
+        // No registry policy installed → no floor → no clamp.
+        write_member_removed(&t.writer, "did:key:zPurge", "purge").await;
+        write_member_removed(&t.writer, "did:key:zTomb", "tombstone").await;
+        write_member_removed(&t.writer, "did:key:zHist", "historical").await;
 
-        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        let outcome = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
         assert_eq!(outcome.jobs_enqueued, 3);
-        let mut jobs = list_sync_jobs(&queue_ks).await.unwrap();
+        assert!(
+            outcome.overrides.is_empty(),
+            "no policy → no clamp → no overrides"
+        );
+        let mut jobs = list_sync_jobs(&t.queue).await.unwrap();
         jobs.sort_by(|a, b| a.member_did.cmp(&b.member_did));
         let by_did: std::collections::HashMap<_, _> = jobs
             .into_iter()
@@ -285,23 +460,27 @@ mod tests {
 
     #[tokio::test]
     async fn role_changed_enqueues_update_member() {
-        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
-        write_role_changed(&writer, "did:key:zRole").await;
+        let t = temp_keyspaces().await;
+        write_role_changed(&t.writer, "did:key:zRole").await;
 
-        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        let outcome = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
         assert_eq!(outcome.jobs_enqueued, 1);
-        let jobs = list_sync_jobs(&queue_ks).await.unwrap();
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
         assert_eq!(jobs[0].kind, SyncJobKind::UpdateMember);
     }
 
     #[tokio::test]
     async fn unrelated_envelopes_are_ignored() {
-        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
-        write_unrelated_envelope(&writer).await;
-        write_member_added(&writer, "did:key:zA").await;
-        write_unrelated_envelope(&writer).await;
+        let t = temp_keyspaces().await;
+        write_unrelated_envelope(&t.writer).await;
+        write_member_added(&t.writer, "did:key:zA").await;
+        write_unrelated_envelope(&t.writer).await;
 
-        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        let outcome = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
         assert_eq!(outcome.jobs_enqueued, 1);
         // Cursor still advances over the unrelated rows so a
         // subsequent walk doesn't re-process them.
@@ -310,28 +489,227 @@ mod tests {
 
     #[tokio::test]
     async fn cursor_advances_so_restart_is_idempotent() {
-        let (audit_ks, queue_ks, writer, _dir) = temp_keyspaces().await;
-        write_member_added(&writer, "did:key:zA").await;
-        let first = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        let t = temp_keyspaces().await;
+        write_member_added(&t.writer, "did:key:zA").await;
+        let first = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
         assert_eq!(first.jobs_enqueued, 1);
 
         // Second walk with the prior cursor enqueues nothing.
-        let second = walk(&audit_ks, &queue_ks, first.new_cursor).await.unwrap();
+        let second = walk(
+            &t.audit,
+            &t.queue,
+            &t.policies,
+            &t.active_policies,
+            0,
+            first.new_cursor,
+        )
+        .await
+        .unwrap();
         assert_eq!(second.jobs_enqueued, 0);
 
         // New event after the cursor lands as a fresh job.
-        write_member_added(&writer, "did:key:zB").await;
-        let third = walk(&audit_ks, &queue_ks, first.new_cursor).await.unwrap();
+        write_member_added(&t.writer, "did:key:zB").await;
+        let third = walk(
+            &t.audit,
+            &t.queue,
+            &t.policies,
+            &t.active_policies,
+            0,
+            first.new_cursor,
+        )
+        .await
+        .unwrap();
         assert_eq!(third.jobs_enqueued, 1);
-        let jobs = list_sync_jobs(&queue_ks).await.unwrap();
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
         assert_eq!(jobs.len(), 2);
     }
 
     #[tokio::test]
     async fn empty_audit_log_yields_no_cursor() {
-        let (audit_ks, queue_ks, _writer, _dir) = temp_keyspaces().await;
-        let outcome = walk(&audit_ks, &queue_ks, None).await.unwrap();
+        let t = temp_keyspaces().await;
+        let outcome = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
         assert_eq!(outcome.jobs_enqueued, 0);
         assert!(outcome.new_cursor.is_none());
+    }
+
+    // ─── M3.6: RTBF override + min_disposition clamp ───────
+
+    #[tokio::test]
+    async fn min_disposition_clamps_non_rtbf_purge_up_to_floor() {
+        let t = temp_keyspaces().await;
+        install_registry_policy_with_floor(&t.policies, &t.active_policies, "tombstone").await;
+        // Admin removes member with purge — not RTBF (admin
+        // didn't ask for their own removal). Floor "tombstone"
+        // (preservation 2) > purge (1) → clamp UP to tombstone.
+        write_member_removed(&t.writer, "did:key:zMember", "purge").await;
+
+        let outcome = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
+        assert!(
+            outcome.overrides.is_empty(),
+            "non-RTBF clamp must not produce overrides"
+        );
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
+        assert_eq!(
+            jobs[0].kind,
+            SyncJobKind::MarkDeparted,
+            "purge clamped UP to tombstone → MarkDeparted job"
+        );
+        assert_eq!(jobs[0].disposition.as_deref(), Some("tombstone"));
+    }
+
+    #[tokio::test]
+    async fn rtbf_purge_overrides_min_disposition_floor() {
+        let t = temp_keyspaces().await;
+        install_registry_policy_with_floor(&t.policies, &t.active_policies, "tombstone").await;
+        // Member purges themselves. RTBF construction
+        // (actor == target + purge) → bypass floor.
+        write_member_removed_by_self(&t.writer, "did:key:zSelf", "purge").await;
+
+        let outcome = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
+        assert_eq!(outcome.overrides.len(), 1);
+        let ov = &outcome.overrides[0];
+        assert_eq!(ov.actor_did, "did:key:zSelf");
+        assert_eq!(ov.target_did, "did:key:zSelf");
+        assert_eq!(ov.reason, "rtbf");
+        assert_eq!(ov.attempted_disposition, "tombstone");
+        assert_eq!(ov.effective_disposition, "purge");
+
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
+        assert_eq!(
+            jobs[0].kind,
+            SyncJobKind::DeleteMember,
+            "RTBF override → DeleteMember, not MarkDeparted"
+        );
+        assert_eq!(jobs[0].disposition.as_deref(), Some("purge"));
+    }
+
+    #[tokio::test]
+    async fn rtbf_purge_without_clamp_emits_no_override_envelope() {
+        let t = temp_keyspaces().await;
+        // Floor is purge (the default-policy value) — no
+        // clamp would happen, so the override is moot.
+        install_registry_policy_with_floor(&t.policies, &t.active_policies, "purge").await;
+        write_member_removed_by_self(&t.writer, "did:key:zSelf", "purge").await;
+
+        let outcome = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
+        assert!(
+            outcome.overrides.is_empty(),
+            "no clamp → no override envelope (avoid audit noise)"
+        );
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
+        assert_eq!(jobs[0].kind, SyncJobKind::DeleteMember);
+    }
+
+    #[tokio::test]
+    async fn rtbf_batching_window_defers_dispatch() {
+        let t = temp_keyspaces().await;
+        install_registry_policy_with_floor(&t.policies, &t.active_policies, "tombstone").await;
+        write_member_removed_by_self(&t.writer, "did:key:zSelf", "purge").await;
+
+        // 24h batch window: the RTBF DeleteMember job lands with
+        // next_attempt_at in the future and rtbf_batched=true.
+        let outcome = walk(
+            &t.audit,
+            &t.queue,
+            &t.policies,
+            &t.active_policies,
+            24,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcome.overrides.len(), 1);
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert!(jobs[0].rtbf_batched, "RTBF job must be marked batched");
+        // next_attempt_at should be ~24h out — assert it's
+        // beyond 23h to avoid clock-skew flake.
+        let delta = jobs[0].next_attempt_at - chrono::Utc::now();
+        assert!(
+            delta.num_hours() >= 23,
+            "next_attempt_at must be at least ~24h in the future, got {delta:?}"
+        );
+        assert!(
+            !jobs[0].is_dispatchable(chrono::Utc::now()),
+            "RTBF job must not be dispatchable until the window expires"
+        );
+        assert!(
+            jobs[0].is_dispatchable(chrono::Utc::now() + chrono::Duration::hours(25)),
+            "RTBF job must dispatch once the window expires"
+        );
+    }
+
+    #[tokio::test]
+    async fn rtbf_batching_window_zero_dispatches_immediately() {
+        let t = temp_keyspaces().await;
+        install_registry_policy_with_floor(&t.policies, &t.active_policies, "tombstone").await;
+        write_member_removed_by_self(&t.writer, "did:key:zSelf", "purge").await;
+
+        let _ = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
+        assert!(!jobs[0].rtbf_batched);
+        assert!(
+            jobs[0].is_dispatchable(chrono::Utc::now()),
+            "with batching disabled, RTBF dispatches on the next tick"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_rtbf_delete_is_not_batched() {
+        let t = temp_keyspaces().await;
+        // No policy → no clamp → non-RTBF purge stays purge,
+        // no override event → walker doesn't apply the batch
+        // delay even when batch_window > 0.
+        write_member_removed(&t.writer, "did:key:zMember", "purge").await;
+
+        let outcome = walk(
+            &t.audit,
+            &t.queue,
+            &t.policies,
+            &t.active_policies,
+            24,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(outcome.overrides.is_empty());
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
+        assert!(
+            !jobs[0].rtbf_batched,
+            "admin-initiated purge must not be subject to the RTBF batch delay"
+        );
+        assert!(
+            jobs[0].is_dispatchable(chrono::Utc::now()),
+            "non-RTBF DeleteMember must dispatch immediately"
+        );
+    }
+
+    #[tokio::test]
+    async fn member_self_tombstone_request_is_not_rtbf() {
+        let t = temp_keyspaces().await;
+        install_registry_policy_with_floor(&t.policies, &t.active_policies, "historical").await;
+        // Member self-removes with tombstone (not purge) →
+        // NOT an RTBF case. Clamp UP to historical.
+        write_member_removed_by_self(&t.writer, "did:key:zSelf", "tombstone").await;
+
+        let outcome = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
+        assert!(outcome.overrides.is_empty());
+        let jobs = list_sync_jobs(&t.queue).await.unwrap();
+        assert_eq!(jobs[0].kind, SyncJobKind::MarkDeparted);
+        assert_eq!(jobs[0].disposition.as_deref(), Some("historical"));
     }
 }

--- a/vtc-service/src/routes/health.rs
+++ b/vtc-service/src/routes/health.rs
@@ -1,8 +1,12 @@
 use axum::Json;
 use axum::extract::State;
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tracing::debug;
+use vti_common::error::AppError;
 
+use crate::auth::AdminAuth;
+use crate::registry::{HealthStatus, list_sync_jobs};
 use crate::server::AppState;
 
 #[derive(Serialize)]
@@ -29,4 +33,108 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         mediator_url,
         mediator_did,
     })
+}
+
+/// Phase 3 M3.8 — admin-gated diagnostics view.
+///
+/// Surfaces enough of the trust-registry reconciler's internal
+/// state to debug "is sync stuck?" without shelling onto the
+/// host. The fields are picked for *operator action*, not raw
+/// metrics dump:
+///
+/// - `registry_status` — does the daemon think the registry
+///   is reachable right now? Mirrors the same flag on
+///   `GET /v1/community/profile` (M3.2).
+/// - `queue_depth` — count of pending+InFlight rows. A
+///   monotonically rising number means the registry is
+///   refusing dispatch.
+/// - `oldest_pending_age_seconds` — staleness of the
+///   longest-waiting job. Drives the "≥1h behind →
+///   degraded" SLI per spec §8.3.
+/// - `rtbf_batched_count` — how many jobs are parked behind
+///   the RTBF window. Lets operators verify the batch
+///   protection is active without inspecting fjall.
+/// - `failed_count` — terminal-failure rows the syncer gave
+///   up on (`attempts > max_attempts` or
+///   `RegistryError::Permanent`). These need operator
+///   triage; the syncer won't retry them.
+/// - `last_success_at` / `last_failure_at` / `last_error` —
+///   replayed verbatim from the health probe state.
+///
+/// Diagnostics is **admin-gated**, not super-admin: ops staff
+/// running on-call should be able to read this without
+/// holding the super-admin role.
+#[derive(Serialize)]
+pub struct DiagnosticsResponse {
+    pub registry_status: String,
+    pub queue_depth: u64,
+    pub rtbf_batched_count: u64,
+    pub failed_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_pending_age_seconds: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_success_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_failure_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+pub async fn diagnostics(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+) -> Result<Json<DiagnosticsResponse>, AppError> {
+    let jobs = list_sync_jobs(&state.sync_queue_ks).await?;
+    let now = Utc::now();
+    let queue_depth = jobs
+        .iter()
+        .filter(|j| {
+            matches!(
+                j.state,
+                crate::registry::SyncJobState::Pending | crate::registry::SyncJobState::InFlight
+            )
+        })
+        .count() as u64;
+    let rtbf_batched_count = jobs
+        .iter()
+        .filter(|j| j.rtbf_batched && j.state == crate::registry::SyncJobState::Pending)
+        .count() as u64;
+    let failed_count = jobs
+        .iter()
+        .filter(|j| j.state == crate::registry::SyncJobState::Failed)
+        .count() as u64;
+    // Oldest *dispatchable* pending job — RTBF-parked rows are
+    // intentionally future-dated so they shouldn't count
+    // against the "stuck" SLI.
+    let oldest_pending_age_seconds = jobs
+        .iter()
+        .filter(|j| j.state == crate::registry::SyncJobState::Pending && j.next_attempt_at <= now)
+        .map(|j| (now - j.created_at).num_seconds())
+        .max();
+
+    let snapshot = state.registry_health.snapshot().await;
+    let registry_status = match snapshot.status {
+        HealthStatus::Active => "active",
+        HealthStatus::Degraded => "degraded",
+    }
+    .to_string();
+
+    debug!(
+        queue_depth,
+        rtbf_batched_count,
+        failed_count,
+        registry_status = %registry_status,
+        "diagnostics queried"
+    );
+
+    Ok(Json(DiagnosticsResponse {
+        registry_status,
+        queue_depth,
+        rtbf_batched_count,
+        failed_count,
+        oldest_pending_age_seconds,
+        last_success_at: snapshot.last_success_at,
+        last_failure_at: snapshot.last_failure_at,
+        last_error: snapshot.last_error,
+    }))
 }

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -139,6 +139,13 @@ pub fn router() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let members_rotate = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/rotate/1.0")
         .expect("static Trust-Task URL");
+    // Phase 3 M3.8 — trust-registry reconciler diagnostics.
+    // Admin-gated (not super-admin) so on-call ops can read
+    // queue depth + RTBF-batched + failed counts without the
+    // super-admin role.
+    let health_diagnostics =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0")
+            .expect("static Trust-Task URL");
     // Read endpoints (M2.4). GET /v1/policies and
     // GET /v1/policies/{id} share their mounts with the POST
     // /v1/policies upload and POST /v1/policies/{id}/activate
@@ -152,6 +159,11 @@ pub fn router() -> Router<AppState> {
 
     TrustTaskRouter::<AppState>::new()
         .route_exempt("/health", get(health::health))
+        .route_with_task(
+            "/v1/health/diagnostics",
+            get(health::diagnostics),
+            health_diagnostics,
+        )
         // `did:webvh` log publication (Trust-Task-exempt — DID
         // resolvers don't carry our extension header). The VTC is
         // not a general-purpose did:webvh host: the handler matches

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -464,16 +464,20 @@ pub async fn run(
             .vtc_did
             .clone()
             .unwrap_or_else(|| "did:key:vtc-unknown".into());
+        let rtbf_batch_window_hours = state.config.read().await.registry.rtbf_batch_window_hours;
         let syncer = crate::registry::MembershipSyncer::new(
             state.audit_ks.clone(),
             state.sync_queue_ks.clone(),
             state.sync_cursor_ks.clone(),
             state.registry_records_ks.clone(),
+            state.policies_ks.clone(),
+            state.active_policies_ks.clone(),
             client,
             state.registry_health.clone(),
             state.audit_writer.clone(),
             actor_did,
-        );
+        )
+        .with_rtbf_batch_window_hours(rtbf_batch_window_hours);
         let syncer_shutdown = shutdown_rx.clone();
         tokio::spawn(async move {
             syncer.run(syncer_shutdown).await;

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -1,0 +1,286 @@
+//! Integration coverage for `GET /v1/health/diagnostics`.
+//!
+//! Exercises the full router stack — Trust-Task header → auth
+//! extractor → handler → registry storage — through
+//! `Router::oneshot`.
+//!
+//! Phase 3 M3.8.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::config::AppConfig;
+use vtc_service::registry::{RegistryHealth, SyncJob, SyncJobKind, SyncJobState, store_sync_job};
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+const DIAGNOSTICS_TASK: &str = "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    jwt_keys: Arc<JwtKeys>,
+    state: AppState,
+    _dir: tempfile::TempDir,
+}
+
+async fn build() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        [store]
+        data_dir = "{}"
+        [auth]
+        jwt_signing_key = "{}"
+        "#,
+        dir.path().display(),
+        BASE64.encode(jwt_seed),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks: sessions_ks.clone(),
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks: install_ks.clone(),
+        members_ks,
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks,
+        registry_records_ks,
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks,
+        registry_client: None,
+        registry_health: RegistryHealth::new(),
+        credential_signer: None,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys.clone()),
+        atm: None,
+        webauthn: None,
+        public_url: None,
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_ks,
+        audit_key_ks,
+        audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state.clone());
+    Fixture {
+        router,
+        jwt_keys,
+        state,
+        _dir: dir,
+    }
+}
+
+async fn token_for(fix: &Fixture, role: &str) -> String {
+    use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+    let session_id = format!("sess-{}", uuid::Uuid::new_v4());
+    let session = Session {
+        session_id: session_id.clone(),
+        did: "did:key:z6MkAdmin".into(),
+        challenge: "test".into(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: None,
+        tee_attested: false,
+    };
+    store_session(&fix.state.sessions_ks, &session)
+        .await
+        .unwrap();
+    let claims = fix.jwt_keys.new_claims(
+        "did:key:z6MkAdmin".to_string(),
+        session_id,
+        role.to_string(),
+        vec![],
+        900,
+        false,
+    );
+    fix.jwt_keys.encode(&claims).expect("encode")
+}
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+fn get(uri: &str, task: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("Trust-Task", task)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+#[tokio::test]
+async fn diagnostics_empty_queue_reports_zero_counts() {
+    let fix = build().await;
+    let token = token_for(&fix, "admin").await;
+
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(get("/v1/health/diagnostics", DIAGNOSTICS_TASK, &token))
+        .await
+        .unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(v["queue_depth"], 0);
+    assert_eq!(v["rtbf_batched_count"], 0);
+    assert_eq!(v["failed_count"], 0);
+    // Default RegistryHealth state is "degraded" (no successful
+    // probe yet).
+    assert_eq!(v["registry_status"], "degraded");
+    assert!(
+        v.get("oldest_pending_age_seconds")
+            .is_none_or(|x| x.is_null()),
+        "empty queue → no oldest_pending_age"
+    );
+}
+
+#[tokio::test]
+async fn diagnostics_reports_pending_rtbf_and_failed_counts() {
+    let fix = build().await;
+    let token = token_for(&fix, "admin").await;
+
+    // Pending dispatchable.
+    let pending = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zP");
+    store_sync_job(&fix.state.sync_queue_ks, &pending)
+        .await
+        .unwrap();
+
+    // RTBF-batched (future-dated next_attempt_at).
+    let mut rtbf = SyncJob::fresh(SyncJobKind::DeleteMember, "did:key:zR");
+    rtbf.next_attempt_at = chrono::Utc::now() + chrono::Duration::hours(20);
+    rtbf.rtbf_batched = true;
+    store_sync_job(&fix.state.sync_queue_ks, &rtbf)
+        .await
+        .unwrap();
+
+    // Failed (terminal).
+    let mut failed = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zF");
+    failed.state = SyncJobState::Failed;
+    failed.last_error = Some("permanent error from upstream".into());
+    store_sync_job(&fix.state.sync_queue_ks, &failed)
+        .await
+        .unwrap();
+
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(get("/v1/health/diagnostics", DIAGNOSTICS_TASK, &token))
+        .await
+        .unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    // Pending (1) + RTBF-pending (1) = queue_depth 2; Failed
+    // sits outside the active queue.
+    assert_eq!(v["queue_depth"], 2);
+    assert_eq!(v["rtbf_batched_count"], 1);
+    assert_eq!(v["failed_count"], 1);
+    // Pending (dispatchable) job's age is surfaced; RTBF row
+    // doesn't count toward "stuck" SLI.
+    assert!(v["oldest_pending_age_seconds"].is_number());
+}
+
+#[tokio::test]
+async fn diagnostics_requires_admin_role() {
+    let fix = build().await;
+    // `reader` is a valid VTC ACL role but not admin —
+    // AdminAuth must reject.
+    let reader_token = token_for(&fix, "reader").await;
+
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(get(
+            "/v1/health/diagnostics",
+            DIAGNOSTICS_TASK,
+            &reader_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "non-admin must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn diagnostics_requires_trust_task_header() {
+    let fix = build().await;
+    let token = token_for(&fix, "admin").await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/health/diagnostics")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "missing Trust-Task header must 400"
+    );
+}

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -195,6 +195,15 @@ pub enum AuditEvent {
     /// out for operator attention — failed `Purge` jobs are
     /// silent privacy regressions. Phase 3 M3.4.
     RegistrySyncFailed(RegistrySyncOutcomeData),
+
+    /// A member-initiated `Purge` (RTBF) bypassed the active
+    /// `registry.rego.min_disposition` floor. Spec §8.2 calls
+    /// these out: RTBF always overrides the policy envelope.
+    /// The audit envelope's `actor_did_hash` is the HMAC-hashed
+    /// identifier per §11.1; the `actor_did_plain` field is
+    /// `None` for these envelopes (privacy-preserving by
+    /// construction). Phase 3 M3.6.
+    RegistryRecordPolicyOverride(RegistryRecordPolicyOverrideData),
 }
 
 // ---------------------------------------------------------------------------
@@ -482,6 +491,28 @@ pub struct StatusListFlippedData {
     /// `false` = un-suspended. Revocation flips are one-way per
     /// spec §6.2; suspension flips can go either direction.
     pub revoked: bool,
+}
+
+/// Payload for [`AuditEvent::RegistryRecordPolicyOverride`].
+/// Phase 3 M3.6. Carries `reason` (always `"rtbf"` in Phase 3
+/// — future overrides could land additional reason codes),
+/// the attempted disposition the policy would have enforced,
+/// and the effective disposition the override produced.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistryRecordPolicyOverrideData {
+    /// Short reason code. Phase 3 only emits `"rtbf"`; the
+    /// field is shaped as a free string so Phase 4+ can
+    /// introduce additional codes (`"legal-hold"`, etc.)
+    /// without bumping the envelope version.
+    pub reason: String,
+    /// The disposition the active `registry.rego.min_disposition`
+    /// would have enforced (e.g. `"tombstone"`).
+    pub attempted_disposition: String,
+    /// The disposition the override applied (always `"purge"`
+    /// for RTBF overrides; Phase 4+ may add new effective
+    /// dispositions for legal-hold paths).
+    pub effective_disposition: String,
 }
 
 /// Payload for [`AuditEvent::RegistrySyncSucceeded`] +

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -36,8 +36,8 @@ pub use event::{
     CredentialIssuedData, DidRotatedData, EmergencyBootstrapData, JoinRequestData,
     JoinRequestRejectedData, MemberAddedData, MemberRemovedData, MemberUpdatedData,
     MembershipRenewedData, PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER,
-    RegistryStatusChangedData, RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData,
-    StatusListFlippedData,
+    RegistryRecordPolicyOverrideData, RegistryStatusChangedData, RegistrySyncOutcomeData,
+    RestartRequestedData, RoleChangedData, StatusListFlippedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

Phase 3 PR 3/5. Lands the trust-registry reconciler's policy-aware behaviour:

- **M3.5** — `MembershipSyncer` consults `registry.rego.publish_on_join` at dispatch time. PublishMember jobs short-circuit to `Complete` (no HTTP call) when the active policy returns `false`.
- **M3.6** — `min_disposition` floor clamps non-RTBF removals up to the operator's preservation floor. Member-initiated `Purge` (actor == target) bypasses the clamp per spec §8.2 and emits `RegistryRecordPolicyOverride` audit envelopes. No override envelope when the clamp wouldn't have fired — keeps the audit log focused on actionable signals.
- **M3.7** — RTBF-flagged jobs are parked with `next_attempt_at = now + rtbf_batch_window_hours` (default 24h) so the registry record's disappearance can't be timed-aligned with the override event. Configurable via `registry.rtbf_batch_window_hours`; `0` disables batching (test convenience).
- **M3.8** — `GET /v1/health/diagnostics` (AdminAuth) surfaces queue_depth, rtbf_batched_count, failed_count, oldest_pending_age_seconds (excludes future-dated RTBF rows), plus registry_status / last_success / last_failure / last_error from `RegistryHealth`. Trust Task `health/diagnostics/1.0` ships with spec.md + schema.json + index entry.

### Key design notes

- **Severity is preservation-based.** `historical > tombstone > purge` — the operator's floor is the minimum record retention they'll accept, not the privacy strength. Matches the default `registry.rego` shipping `min_disposition := "purge"` (no clamp) and makes the RTBF override semantically meaningful when operators raise the floor.
- **Policy resolution happens at the walker / dispatch boundary.** A freshly-uploaded policy takes effect on the next tick without bouncing the daemon — no warm-up, no cache invalidation surface.
- **Override audit envelope emission is fire-and-forget after the SyncJob is durably enqueued.** A daemon crash between enqueue and audit-emit re-walks the same `MemberRemoved` envelope on next boot (cursor hasn't advanced past it yet) and re-emits. Duplicate override envelope is a less-bad failure mode than a silent override.
- **`RegistryConfig` gets an explicit `Default` impl** so the derived zeros don't silently disable batching / the periodic probe in code paths that hit the default.

## Test plan

- [x] 54 registry unit tests pass (`registry::policy`, `registry::tail`, `registry::syncer`, `registry::upstream`, `registry::storage`, `registry::model`)
- [x] 4 diagnostics integration tests pass (empty queue, populated queue with pending+RTBF+failed, role gating, Trust-Task gating)
- [x] Full `cargo test --package vtc-service` green (262 lib + every integration suite)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --package vtc-service --all-targets -- -D warnings` clean
- [x] DCO sign-off on commit

## Out of scope

- M3.9 (foreign-credential verifier) — next PR
- M3.10 (cross-community session-mint hardening) — next PR
- DIDComm transport for `UpstreamRegistryClient::{publish_member,delete_member}` — deferred to M3.10 follow-up