### PR TITLE
feat(vtc-service): M3.9 + M3.10 — foreign-credential verifier + cross-community session mint

### DIFF
--- a/tasks/vtc-mvp/phase-3-todo.md
+++ b/tasks/vtc-mvp/phase-3-todo.md
@@ -307,7 +307,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.9 — Foreign-credential verifier
 
-### `[ ]` M3.9.1 — Verify foreign VEC + StatusList + registry membership
+### `[x]` M3.9.1 — Verify foreign VEC + StatusList + registry membership
 
 - **Acceptance**
   - `vtc_service::recognition::verify_foreign_vec(vec, vmc,
@@ -338,7 +338,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.10 — `POST /v1/auth/recognise` — cross-community session
 
-### `[ ]` M3.10.1 — Cross-community session mint
+### `[x]` M3.10.1 — Cross-community session mint
 
 - **Acceptance**
   - `POST /v1/auth/recognise` accepts a foreign VEC + VMC

--- a/trust-tasks/auth/recognise/1.0/schema.json
+++ b/trust-tasks/auth/recognise/1.0/schema.json
@@ -1,0 +1,55 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/auth/recognise/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — Cross-Community Session Mint",
+  "description": "POST /v1/auth/recognise request + response. Phase 3 M3.10; spec §8.4.",
+  "oneOf": [
+    {
+      "title": "Request",
+      "type": "object",
+      "required": ["vec", "vmc"],
+      "properties": {
+        "vec": {
+          "type": "object",
+          "description": "Foreign-issued VerifiableEndorsementCredential. Carries the role grant. Must include a DataIntegrityProof eddsa-jcs-2022 signature."
+        },
+        "vmc": {
+          "type": "object",
+          "description": "Foreign-issued VerifiableMembershipCredential. Carries the membership proof + optional credentialStatus for live revocation."
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "title": "Response",
+      "type": "object",
+      "required": ["sessionId", "data"],
+      "properties": {
+        "sessionId": {
+          "type": "string",
+          "pattern": "^xc-",
+          "description": "`xc-<uuid>` to distinguish cross-community sessions from local-member ones."
+        },
+        "data": {
+          "type": "object",
+          "required": ["accessToken", "accessExpiresAt", "foreignIssuerDid", "mappedRole"],
+          "properties": {
+            "accessToken": { "type": "string" },
+            "accessExpiresAt": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Unix-seconds expiry. Clamped to min(jwt_default, earliest(vec.validUntil, vmc.validUntil))."
+            },
+            "foreignIssuerDid": { "type": "string" },
+            "mappedRole": {
+              "type": "string",
+              "description": "Local role from cross_community_roles.rego — NOT the foreign role."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/trust-tasks/auth/recognise/1.0/spec.md
+++ b/trust-tasks/auth/recognise/1.0/spec.md
@@ -1,0 +1,83 @@
+---
+id: https://trusttasks.org/openvtc/vtc/auth/recognise/1.0
+title: VTC — Cross-Community Session Mint
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/auth/recognise
+---
+
+# VTC — Cross-Community Session Mint
+
+Mints a session JWT for a holder presenting a foreign
+community's `VerifiableEndorsementCredential` + `Verifiable
+MembershipCredential` pair. Phase 3 M3.10; spec §8.4.
+
+## Semantics
+
+- **No prior session** required — the foreign credentials *are*
+  the authentication proof. Replaces the
+  challenge/response/authenticate dance used by local-member
+  flows.
+- **Fail-closed.** Four hardening checks run in order, each
+  short-circuiting on failure:
+  1. Both VEC + VMC proofs verify against the foreign issuer's
+     `#key-0`.
+  2. Each credential's `credentialStatus.statusListCredential`
+     fetches; the bit at `statusListIndex` must be `0`.
+  3. The foreign issuer DID is present in the trust-registry
+     recognition graph (live `recognise` query).
+  4. Both `validFrom <= now <= validUntil`.
+- **Role mapping** via `cross_community_roles.rego` (spec
+  §7.1). The default policy denies every cross-community
+  mapping; operators must upload an allowlist before any
+  foreign role confers local access.
+- **TTL clamp.** Session expires at
+  `now + min(jwt_default, earliest(vec.validUntil,
+  vmc.validUntil) - now)`. Per spec §8.4.
+- **No refresh.** Cross-community sessions never refresh. The
+  standard `POST /v1/auth/refresh` route would re-issue
+  without re-running recognition — defeating the "peer
+  community removed mid-session loses access" invariant. The
+  session simply expires.
+
+## Trust assumptions
+
+- The trust registry's `recognise` query is the source of
+  truth for "is this peer community recognised?". A registry
+  outage during the call surfaces as `503 Service
+  Unavailable`, never as a silent accept.
+- The DID resolver returns the foreign issuer's current
+  `#key-0`. A peer community rotating their key without
+  updating their `did:webvh` log invalidates every outstanding
+  foreign-issued credential — by design.
+
+## Outputs
+
+`200 OK` with:
+
+```
+{
+  "sessionId": "xc-<uuid>",
+  "data": {
+    "accessToken": "<jwt>",
+    "accessExpiresAt": <unix-seconds>,
+    "foreignIssuerDid": "<did>",
+    "mappedRole": "<local-role-string>"
+  }
+}
+```
+
+`403 Forbidden` on any verification failure or policy denial.
+`500/503` only when the registry / DID resolver is
+unreachable.
+
+Every call (allow or deny) emits a
+`CrossCommunitySessionMinted` audit envelope with a stable
+`reason` discriminator.
+
+## Status
+
+Draft.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -253,6 +253,12 @@
       "status": "Draft",
       "path": "health/diagnostics/1.0",
       "rest": "GET /v1/health/diagnostics"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/auth/recognise/1.0",
+      "status": "Draft",
+      "path": "auth/recognise/1.0",
+      "rest": "POST /v1/auth/recognise"
     }
   ]
 }

--- a/vtc-service/policies/default/cross_community_roles.rego
+++ b/vtc-service/policies/default/cross_community_roles.rego
@@ -8,11 +8,32 @@
 # explicit allowlist before any cross-community grant takes
 # effect.
 #
-# Input shape (spec §7.3):
-#   { foreign_vec, target_role, vtc_state }
+# Input shape (spec §7.3 + M3.10):
+#   {
+#     "foreign_vec": {
+#       "issuer": "<did>",
+#       "role": "<foreign role string>",
+#       "subject_did": "<did>"
+#     },
+#     "action": "mint_session"
+#   }
+#
+# Output contract:
+#   - `allow: bool`         — gate for "should we mint anything?".
+#   - `mapped_role: string` — the local role to embed in the JWT.
+#                             Only consulted when `allow` is true.
+#                             Operators uploading custom policies
+#                             can return e.g. "monitor" for any
+#                             foreign role to grant read-only
+#                             access regardless of foreign rank.
 
 package vtc.cross_community_roles
 
 import rego.v1
 
 default allow := false
+
+# `mapped_role` has no `default` rule by design: the route layer
+# treats a missing value as "deny" even when `allow` is true. An
+# operator upload that flips `allow := true` but forgets to set
+# `mapped_role` therefore still denies — fail-closed.

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -28,6 +28,7 @@ pub mod keys;
 pub mod members;
 pub mod messaging;
 pub mod policy;
+pub mod recognition;
 pub mod registry;
 pub mod routes;
 pub mod server;

--- a/vtc-service/src/recognition/mod.rs
+++ b/vtc-service/src/recognition/mod.rs
@@ -1,0 +1,57 @@
+//! Cross-community foreign-credential recognition — Phase 3 M3.9 + M3.10.
+//!
+//! Spec §8.4. The `MembershipSyncer` publishes our community's
+//! members to the trust registry; this module is the **inverse**
+//! path — taking a foreign community's
+//! `VerifiableEndorsementCredential` +
+//! `VerifiableMembershipCredential` and deciding whether the
+//! local VTC should mint a session for the bearer.
+//!
+//! ## Session-mint hardening (fail-closed)
+//!
+//! [`verify::verify_foreign_vec`] runs four checks **in order**;
+//! the first failure short-circuits with a typed
+//! [`RecognitionError`]. Order matters — proof verification is
+//! cheap (one signature + JCS canonicalisation), while the
+//! status-list fetch + registry recognition query both hit the
+//! network. We want the most disqualifying check (a malformed
+//! credential) to surface before any HTTP call lands.
+//!
+//! 1. **Proof verification.** Both VEC + VMC carry
+//!    `DataIntegrityProof::eddsa-jcs-2022` signatures over the
+//!    foreign issuer's `#key-0`. Resolves via the workspace's
+//!    [`ForeignIssuerKeyResolver`] trait — production wires
+//!    `DIDCacheClient`, tests inject a stub.
+//! 2. **StatusList revocation.** Fetches the credential's
+//!    `credentialStatus.statusListCredential` URL, decodes the
+//!    bitstring, and checks `statusListIndex`. A set bit
+//!    rejects the credential. Production wires
+//!    `HttpStatusListFetcher`; tests inject a stub.
+//! 3. **Registry recognition.** Calls the
+//!    `TrustRegistryClient`'s `recognise()` query for the
+//!    foreign issuer DID. A negative result rejects regardless
+//!    of how the credentials verify. This is the "operator
+//!    forgot to add the foreign community to the recognition
+//!    graph" failsafe.
+//! 4. **Validity window.** Both `validFrom` ≤ now ≤ `validUntil`
+//!    must hold for both credentials. The returned
+//!    `VerifiedForeignCredential` carries the **earliest**
+//!    `validUntil` across the pair, which the route layer
+//!    clamps the session TTL to (spec §8.4).
+//!
+//! ## No caching
+//!
+//! Plan D5. Every mint and every refresh re-runs the full
+//! check — a peer community removed from the recognition graph
+//! mid-session loses access on the next refresh, not on a TTL
+//! boundary. The latency tax is acceptable because the
+//! cross-community session lifetime is intentionally short
+//! (min of three TTLs) and refresh paths are rare relative to
+//! "regular member" sessions.
+
+pub mod verify;
+
+pub use verify::{
+    DidResolverKeyResolver, ForeignIssuerKeyResolver, HttpStatusListFetcher, RecognitionError,
+    StatusListFetcher, VerifiedForeignCredential, verify_foreign_vec,
+};

--- a/vtc-service/src/recognition/verify.rs
+++ b/vtc-service/src/recognition/verify.rs
@@ -1,0 +1,843 @@
+//! `verify_foreign_vec` — the load-bearing M3.9 entry point.
+//!
+//! Verifies a foreign-issued (VEC, VMC) pair against four
+//! invariants (in order, fail-closed):
+//!
+//! 1. Both proofs verify against the foreign issuer's
+//!    `#key-0` public key.
+//! 2. Each credential's `credentialStatus.statusListCredential`
+//!    fetches, decodes, and the bit at `statusListIndex` is
+//!    `0`.
+//! 3. The foreign issuer DID is present in the trust-registry
+//!    recognition graph (via the `TrustRegistryClient` trait).
+//! 4. Both `validFrom <= now <= validUntil` hold.
+//!
+//! The returned [`VerifiedForeignCredential`] carries the
+//! parsed role claim + the earliest `validUntil` across the
+//! pair — the route layer (`POST /v1/auth/recognise`) clamps
+//! the session TTL to that earliest expiry.
+//!
+//! ## Why traits for key resolution + status fetch
+//!
+//! Both surfaces are heavy: DID resolution can hit external
+//! HTTPS, status-list fetching is unconditionally HTTP. Hiding
+//! them behind small traits keeps `verify_foreign_vec` unit-
+//! testable without a live DID resolver or status-list host,
+//! and isolates the M3.9 logic from upstream API churn.
+
+use std::sync::Arc;
+
+use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
+use affinidi_vc::VerifiableCredential;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+
+use crate::registry::{RegistryError, TrustRegistryClient};
+
+/// Failure modes the verifier surfaces. Mapped to HTTP 403
+/// (Forbidden) at the route layer — never operator input,
+/// always a foreign-credential property the caller couldn't
+/// have predicted from their own state. The discriminator
+/// drives the `denied` audit envelope's `reason` field.
+#[derive(Debug, Clone, Error)]
+pub enum RecognitionError {
+    /// The foreign issuer's DID didn't resolve or the
+    /// `#key-0` verification method couldn't be located.
+    #[error("issuer DID resolution failed: {0}")]
+    IssuerKeyUnresolved(String),
+    /// VEC or VMC proof failed signature verification.
+    #[error("foreign credential proof verification failed: {0}")]
+    ProofInvalid(String),
+    /// Status-list fetch / decode / status-bit check failed.
+    /// Either the URL was unreachable, the response didn't
+    /// parse, or the bit at `statusListIndex` was `1`.
+    #[error("status-list check failed: {0}")]
+    StatusListFailed(String),
+    /// Foreign issuer is not in the trust-registry recognition
+    /// graph. This is the "operator forgot to add the peer
+    /// community" path — fail-closed by construction (plan
+    /// D6).
+    #[error("foreign issuer {0} is not recognised by this VTC")]
+    IssuerNotRecognised(String),
+    /// Trust-registry was unreachable during the recognise
+    /// check. Distinct from `IssuerNotRecognised` so the
+    /// route layer can map to 503 vs 403.
+    #[error("trust registry unreachable: {0}")]
+    RegistryUnreachable(String),
+    /// `validFrom` is in the future or `validUntil` is in the
+    /// past. Carries which credential failed for diagnostics.
+    #[error("credential validity window: {0}")]
+    ValidityWindow(String),
+    /// Malformed credential shape — missing required field,
+    /// unparsable RFC3339, etc. Distinct from `ProofInvalid`
+    /// (which means the signature didn't match a valid shape).
+    #[error("credential shape invalid: {0}")]
+    Malformed(String),
+}
+
+impl RecognitionError {
+    /// Short reason code for the audit envelope's `reason`
+    /// field. Stable across releases — operators may build
+    /// SIEM filters keyed on these strings.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::IssuerKeyUnresolved(_) => "issuer-key-unresolved",
+            Self::ProofInvalid(_) => "proof-invalid",
+            Self::StatusListFailed(_) => "status-list-failed",
+            Self::IssuerNotRecognised(_) => "issuer-not-recognised",
+            Self::RegistryUnreachable(_) => "registry-unreachable",
+            Self::ValidityWindow(_) => "validity-window",
+            Self::Malformed(_) => "malformed",
+        }
+    }
+}
+
+/// Resolves a foreign issuer's `#key-0` public bytes from
+/// their DID. The verifier consults this once per credential
+/// (VEC + VMC — usually the same issuer, so production wires
+/// a per-mint memoising layer in the route handler if needed).
+#[async_trait]
+pub trait ForeignIssuerKeyResolver: Send + Sync {
+    /// Resolve the issuer's `#key-0` Ed25519 public key bytes.
+    /// `verification_method` is the proof's
+    /// `verificationMethod` URI — typically `{issuer_did}#key-0`,
+    /// but the resolver decides which key to return based on
+    /// the URI fragment.
+    async fn resolve_key(
+        &self,
+        issuer_did: &str,
+        verification_method: &str,
+    ) -> Result<Vec<u8>, RecognitionError>;
+}
+
+/// Fetches + decodes a status-list credential. Production
+/// wires [`HttpStatusListFetcher`] (reqwest + JSON parse +
+/// bitstring decode); tests inject a stub returning a known
+/// bit value.
+#[async_trait]
+pub trait StatusListFetcher: Send + Sync {
+    /// Fetch the status-list credential at `url` and return the
+    /// status bit at `index`. `Ok(false)` = not revoked.
+    async fn check_status_bit(&self, url: &str, index: usize) -> Result<bool, RecognitionError>;
+}
+
+/// Post-verification view of a (VEC, VMC) pair. Only
+/// constructible by [`verify_foreign_vec`] — the route layer
+/// taking this type as input is guaranteed to be looking at a
+/// fully-verified pair (typestate discipline per workspace
+/// CLAUDE.md).
+#[derive(Debug, Clone)]
+pub struct VerifiedForeignCredential {
+    /// The foreign community's issuer DID — `vec.issuer ==
+    /// vmc.issuer` by spec §6.1.
+    pub foreign_issuer_did: String,
+    /// The bearer's DID — the `credentialSubject.id` field on
+    /// the VEC. The session is minted *to* this DID.
+    pub subject_did: String,
+    /// The role claim from the VEC's `credentialSubject.role`
+    /// field. Fed into `cross_community_roles.rego` for local
+    /// role mapping.
+    pub foreign_role: String,
+    /// The **earliest** `validUntil` across VEC + VMC. The
+    /// route layer clamps session TTL to `min(jwt_default,
+    /// this)` per spec §8.4.
+    pub earliest_valid_until: DateTime<Utc>,
+}
+
+/// Run the four-step verification. See module docs for the
+/// rationale on ordering + fail-closed semantics.
+pub async fn verify_foreign_vec(
+    vec: &VerifiableCredential,
+    vmc: &VerifiableCredential,
+    key_resolver: &dyn ForeignIssuerKeyResolver,
+    status_fetcher: &dyn StatusListFetcher,
+    registry: Arc<dyn TrustRegistryClient>,
+    now: DateTime<Utc>,
+) -> Result<VerifiedForeignCredential, RecognitionError> {
+    // Spec §6.1 requires both credentials share an issuer.
+    let issuer = vec.issuer.id();
+    if issuer != vmc.issuer.id() {
+        return Err(RecognitionError::Malformed(format!(
+            "VEC issuer ({}) != VMC issuer ({})",
+            issuer,
+            vmc.issuer.id()
+        )));
+    }
+    let issuer = issuer.to_string();
+
+    // Step 1: proof verification. Cheap; runs first so a
+    // malformed pair short-circuits before any network call.
+    verify_proof(vec, &issuer, key_resolver, "VEC").await?;
+    verify_proof(vmc, &issuer, key_resolver, "VMC").await?;
+
+    // Step 4 (early): validity windows. Cheap RFC3339 parse +
+    // comparison. Bumped before the network calls so an
+    // expired credential doesn't waste a status-list fetch.
+    let vec_until = parse_valid_until(vec, "VEC")?;
+    let vmc_until = parse_valid_until(vmc, "VMC")?;
+    if let Some(vf) = vec.valid_from.as_deref() {
+        let vf = parse_rfc3339(vf)
+            .map_err(|e| RecognitionError::ValidityWindow(format!("VEC validFrom: {e}")))?;
+        if vf > now {
+            return Err(RecognitionError::ValidityWindow(format!(
+                "VEC validFrom {vf} is in the future"
+            )));
+        }
+    }
+    if let Some(vf) = vmc.valid_from.as_deref() {
+        let vf = parse_rfc3339(vf)
+            .map_err(|e| RecognitionError::ValidityWindow(format!("VMC validFrom: {e}")))?;
+        if vf > now {
+            return Err(RecognitionError::ValidityWindow(format!(
+                "VMC validFrom {vf} is in the future"
+            )));
+        }
+    }
+    if vec_until <= now {
+        return Err(RecognitionError::ValidityWindow(format!(
+            "VEC validUntil {vec_until} is in the past"
+        )));
+    }
+    if vmc_until <= now {
+        return Err(RecognitionError::ValidityWindow(format!(
+            "VMC validUntil {vmc_until} is in the past"
+        )));
+    }
+
+    // Step 2: status-list revocation. Per-credential; either
+    // a missing `credentialStatus` is treated as "no
+    // revocation surface" (the credential never opted into
+    // BitstringStatusList). A *present* status block whose
+    // bit is set rejects the credential.
+    check_status_list(vec, status_fetcher, "VEC").await?;
+    check_status_list(vmc, status_fetcher, "VMC").await?;
+
+    // Step 3: registry recognition. The most operator-visible
+    // failure mode — fails when the operator hasn't added the
+    // peer community to their recognition graph.
+    let recognised = registry.recognise(&issuer).await.map_err(|e| match e {
+        RegistryError::Unreachable(msg) | RegistryError::Transient(msg) => {
+            RecognitionError::RegistryUnreachable(msg)
+        }
+        RegistryError::Permanent(msg) => {
+            RecognitionError::IssuerNotRecognised(format!("registry rejected query: {msg}"))
+        }
+    })?;
+    if !recognised {
+        return Err(RecognitionError::IssuerNotRecognised(issuer));
+    }
+
+    // Extract bearer subject + role from the VEC.
+    let (subject_did, foreign_role) = extract_role_claim(vec)?;
+
+    Ok(VerifiedForeignCredential {
+        foreign_issuer_did: issuer,
+        subject_did,
+        foreign_role,
+        earliest_valid_until: vec_until.min(vmc_until),
+    })
+}
+
+async fn verify_proof(
+    vc: &VerifiableCredential,
+    issuer_did: &str,
+    key_resolver: &dyn ForeignIssuerKeyResolver,
+    label: &str,
+) -> Result<(), RecognitionError> {
+    let proof_value = vc
+        .proof
+        .as_ref()
+        .ok_or_else(|| RecognitionError::ProofInvalid(format!("{label} has no proof")))?;
+    let proof: DataIntegrityProof = serde_json::from_value(proof_value.clone())
+        .map_err(|e| RecognitionError::ProofInvalid(format!("{label} parse proof: {e}")))?;
+
+    let verification_method = proof_value
+        .get("verificationMethod")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            RecognitionError::ProofInvalid(format!("{label} proof missing verificationMethod"))
+        })?;
+
+    let pubkey = key_resolver
+        .resolve_key(issuer_did, verification_method)
+        .await?;
+
+    let mut vc_without_proof = vc.clone();
+    vc_without_proof.proof = None;
+
+    proof
+        .verify_with_public_key(&vc_without_proof, &pubkey, VerifyOptions::new())
+        .map_err(|e| RecognitionError::ProofInvalid(format!("{label}: {e}")))?;
+    Ok(())
+}
+
+async fn check_status_list(
+    vc: &VerifiableCredential,
+    fetcher: &dyn StatusListFetcher,
+    label: &str,
+) -> Result<(), RecognitionError> {
+    let Some(status) = vc.credential_status.as_ref() else {
+        // No status block → credential never opted into
+        // BitstringStatusList. Treat as "not revocable" — a
+        // foreign community that issues without a status list
+        // is making an implicit "we don't revoke" claim.
+        return Ok(());
+    };
+    let url = status.status_list_credential.as_deref().ok_or_else(|| {
+        RecognitionError::Malformed(format!(
+            "{label} credentialStatus has no statusListCredential URL"
+        ))
+    })?;
+    let index_str = status.status_list_index.as_deref().ok_or_else(|| {
+        RecognitionError::Malformed(format!("{label} credentialStatus has no statusListIndex"))
+    })?;
+    let index: usize = index_str.parse().map_err(|e| {
+        RecognitionError::Malformed(format!("{label} statusListIndex {index_str}: {e}"))
+    })?;
+    let bit_set = fetcher.check_status_bit(url, index).await?;
+    if bit_set {
+        return Err(RecognitionError::StatusListFailed(format!(
+            "{label} status bit at {index} is set (revoked/suspended)"
+        )));
+    }
+    Ok(())
+}
+
+fn parse_valid_until(
+    vc: &VerifiableCredential,
+    label: &str,
+) -> Result<DateTime<Utc>, RecognitionError> {
+    let raw = vc
+        .valid_until
+        .as_deref()
+        .ok_or_else(|| RecognitionError::Malformed(format!("{label} has no validUntil")))?;
+    parse_rfc3339(raw)
+        .map_err(|e| RecognitionError::ValidityWindow(format!("{label} validUntil: {e}")))
+}
+
+fn parse_rfc3339(raw: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("parse RFC3339 {raw}: {e}"))
+}
+
+fn extract_role_claim(vec: &VerifiableCredential) -> Result<(String, String), RecognitionError> {
+    use affinidi_vc::SubjectValue;
+    let subject_map = match &vec.credential_subject {
+        SubjectValue::Single(m) => m.clone(),
+        SubjectValue::Multiple(v) => v
+            .first()
+            .cloned()
+            .ok_or_else(|| RecognitionError::Malformed("VEC credentialSubject is empty".into()))?,
+    };
+    let subject_did = subject_map
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            RecognitionError::Malformed("VEC credentialSubject.id missing or not a string".into())
+        })?;
+    // VEC shape per `build_role_vec`:
+    // credentialSubject = { id, endorsement: { type, role, communityDid } }
+    // The role lives under `endorsement.role`, not at the top level
+    // of `credentialSubject`.
+    let role = subject_map
+        .get("endorsement")
+        .and_then(|v| v.as_object())
+        .and_then(|m| m.get("role"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            RecognitionError::Malformed(
+                "VEC credentialSubject.endorsement.role missing or not a string".into(),
+            )
+        })?;
+    Ok((subject_did, role))
+}
+
+// ---------------------------------------------------------------------------
+// Production trait impls
+// ---------------------------------------------------------------------------
+
+/// `ForeignIssuerKeyResolver` backed by the workspace's
+/// [`affinidi_did_resolver_cache_sdk::DIDCacheClient`]. Walks
+/// the resolved DID Document's `verificationMethod` array for
+/// an entry matching the proof's verificationMethod URI and
+/// extracts the Ed25519 public bytes from
+/// `publicKeyMultibase`.
+///
+/// Production deployments inject this; tests stub
+/// [`ForeignIssuerKeyResolver`] directly.
+pub struct DidResolverKeyResolver {
+    resolver: affinidi_did_resolver_cache_sdk::DIDCacheClient,
+}
+
+impl DidResolverKeyResolver {
+    pub fn new(resolver: affinidi_did_resolver_cache_sdk::DIDCacheClient) -> Self {
+        Self { resolver }
+    }
+}
+
+#[async_trait]
+impl ForeignIssuerKeyResolver for DidResolverKeyResolver {
+    async fn resolve_key(
+        &self,
+        issuer_did: &str,
+        verification_method: &str,
+    ) -> Result<Vec<u8>, RecognitionError> {
+        let resolved = self
+            .resolver
+            .resolve(issuer_did)
+            .await
+            .map_err(|e| RecognitionError::IssuerKeyUnresolved(format!("{issuer_did}: {e}")))?;
+        // Match the verificationMethod URI exactly. The
+        // foreign issuer's proof references something like
+        // `did:webvh:peer.example#key-0`; the resolved doc's
+        // `verification_method` array carries entries with the
+        // same `id` field.
+        let vm = resolved
+            .doc
+            .verification_method
+            .iter()
+            .find(|m| m.id.as_str() == verification_method)
+            .ok_or_else(|| {
+                RecognitionError::IssuerKeyUnresolved(format!(
+                    "verificationMethod {verification_method} not present on {issuer_did}"
+                ))
+            })?;
+        // Use the upstream's built-in extractor — handles
+        // Multikey + Ed25519VerificationKey2020 + publicKeyJwk
+        // shapes uniformly.
+        vm.get_public_key_bytes()
+            .map_err(|e| RecognitionError::IssuerKeyUnresolved(format!("extract pubkey: {e}")))
+    }
+}
+
+/// HTTP `StatusListFetcher` — fetches a BitstringStatusList
+/// credential by URL, parses out the encoded list, and tests
+/// the bit at `index`. Used by production deployments; tests
+/// inject a stub.
+pub struct HttpStatusListFetcher {
+    client: reqwest::Client,
+}
+
+impl HttpStatusListFetcher {
+    pub fn new(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl StatusListFetcher for HttpStatusListFetcher {
+    async fn check_status_bit(&self, url: &str, index: usize) -> Result<bool, RecognitionError> {
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| RecognitionError::StatusListFailed(format!("fetch {url}: {e}")))?;
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(RecognitionError::StatusListFailed(format!(
+                "fetch {url} returned {status}"
+            )));
+        }
+        let body: JsonValue = resp
+            .json()
+            .await
+            .map_err(|e| RecognitionError::StatusListFailed(format!("parse {url}: {e}")))?;
+
+        // BitstringStatusList encoding: the status-list
+        // credential's `credentialSubject.encodedList` carries
+        // a base64url-encoded GZIP'd bitstring. Capacity +
+        // purpose are also in the subject; we infer capacity
+        // from the encoded bytes.
+        let encoded = body
+            .pointer("/credentialSubject/encodedList")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                RecognitionError::StatusListFailed(format!(
+                    "status-list at {url} missing credentialSubject.encodedList"
+                ))
+            })?;
+        let purpose_str = body
+            .pointer("/credentialSubject/statusPurpose")
+            .and_then(|v| v.as_str())
+            .unwrap_or("revocation");
+        let purpose = match purpose_str {
+            "revocation" => affinidi_status_list::StatusPurpose::Revocation,
+            "suspension" => affinidi_status_list::StatusPurpose::Suspension,
+            other => {
+                return Err(RecognitionError::StatusListFailed(format!(
+                    "unsupported statusPurpose {other}"
+                )));
+            }
+        };
+        // Capacity defaults to 131,072 (16 KiB compressed) —
+        // the spec-mandated minimum. Foreign status lists may
+        // be larger; the decoder fails closed if the actual
+        // bitstring is shorter than `index`.
+        let capacity = body
+            .pointer("/credentialSubject/statusSize")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as usize)
+            .unwrap_or(131_072);
+
+        let decoded = affinidi_status_list::BitstringStatusList::decode(encoded, capacity, purpose)
+            .map_err(|e| RecognitionError::StatusListFailed(format!("decode {url}: {e}")))?;
+        if index >= capacity {
+            return Err(RecognitionError::StatusListFailed(format!(
+                "index {index} exceeds capacity {capacity} for {url}"
+            )));
+        }
+        decoded
+            .get(index)
+            .map_err(|e| RecognitionError::StatusListFailed(format!("get {index}: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::VtcRole;
+    use crate::credentials::{
+        CredentialStatusRef, LocalSigner, RoleVecParams, VmcParams, build_role_vec, build_vmc,
+    };
+    use crate::registry::client::MockRegistryClient;
+    use affinidi_vc::IssuerValue;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// In-memory key resolver. Tests seed the bytes they
+    /// expect the verifier to use.
+    struct StubKeyResolver {
+        keys: HashMap<String, Vec<u8>>,
+    }
+
+    impl StubKeyResolver {
+        fn new() -> Self {
+            Self {
+                keys: HashMap::new(),
+            }
+        }
+        fn with(mut self, did: &str, key: Vec<u8>) -> Self {
+            self.keys.insert(did.to_string(), key);
+            self
+        }
+    }
+
+    #[async_trait]
+    impl ForeignIssuerKeyResolver for StubKeyResolver {
+        async fn resolve_key(
+            &self,
+            issuer_did: &str,
+            _verification_method: &str,
+        ) -> Result<Vec<u8>, RecognitionError> {
+            self.keys
+                .get(issuer_did)
+                .cloned()
+                .ok_or_else(|| RecognitionError::IssuerKeyUnresolved(issuer_did.into()))
+        }
+    }
+
+    /// In-memory status-list stub. Tests seed bits per URL.
+    #[derive(Default)]
+    struct StubStatusFetcher {
+        bits: Mutex<HashMap<(String, usize), bool>>,
+        next_error: Mutex<Option<RecognitionError>>,
+    }
+
+    impl StubStatusFetcher {
+        fn new() -> Self {
+            Default::default()
+        }
+        fn set_bit(&self, url: &str, index: usize, set: bool) {
+            self.bits.lock().unwrap().insert((url.into(), index), set);
+        }
+        #[allow(dead_code)]
+        fn fail_next(&self, err: RecognitionError) {
+            *self.next_error.lock().unwrap() = Some(err);
+        }
+    }
+
+    #[async_trait]
+    impl StatusListFetcher for StubStatusFetcher {
+        async fn check_status_bit(
+            &self,
+            url: &str,
+            index: usize,
+        ) -> Result<bool, RecognitionError> {
+            if let Some(e) = self.next_error.lock().unwrap().take() {
+                return Err(e);
+            }
+            Ok(*self
+                .bits
+                .lock()
+                .unwrap()
+                .get(&(url.to_string(), index))
+                .unwrap_or(&false))
+        }
+    }
+
+    /// Build a signed (VEC, VMC) pair issued by a fresh
+    /// `LocalSigner` with a fixed DID. Returns the signer's
+    /// public bytes alongside so the test can seed the
+    /// resolver.
+    async fn fresh_pair(
+        issuer_did: &str,
+        subject_did: &str,
+        role: VtcRole,
+        validity_secs: i64,
+    ) -> (VerifiableCredential, VerifiableCredential, Vec<u8>) {
+        let seed = [0xCDu8; 32];
+        let signer = LocalSigner::from_ed25519_seed(issuer_did.into(), &seed);
+        let pubkey = signer.public_bytes().to_vec();
+
+        let vec_params = RoleVecParams::new(subject_did, role)
+            .with_validity(chrono::Duration::seconds(validity_secs))
+            .with_id("urn:vec:test");
+        let vec_vc = build_role_vec(&signer, vec_params)
+            .await
+            .expect("build vec");
+
+        let vmc_params = VmcParams::new(subject_did)
+            .with_validity(chrono::Duration::seconds(validity_secs))
+            .with_id("urn:vmc:test");
+        let vmc_vc = build_vmc(&signer, vmc_params).await.expect("build vmc");
+
+        (vec_vc, vmc_vc, pubkey)
+    }
+
+    #[tokio::test]
+    async fn happy_path_verifies_and_returns_earliest_expiry() {
+        let issuer = "did:webvh:peer.example.com:abc";
+        let subject = "did:key:zSubject";
+        let (vec, vmc, pubkey) = fresh_pair(issuer, subject, VtcRole::Moderator, 3600).await;
+
+        let resolver = StubKeyResolver::new().with(issuer, pubkey);
+        let fetcher = StubStatusFetcher::new();
+        let mock_reg = MockRegistryClient::new();
+        mock_reg.set_recognised(issuer).await;
+        let reg: Arc<dyn TrustRegistryClient> = Arc::new(mock_reg);
+
+        let verified = verify_foreign_vec(&vec, &vmc, &resolver, &fetcher, reg, Utc::now())
+            .await
+            .expect("happy path");
+        assert_eq!(verified.foreign_issuer_did, issuer);
+        assert_eq!(verified.subject_did, subject);
+        assert_eq!(verified.foreign_role, "moderator");
+        assert!(verified.earliest_valid_until > Utc::now());
+    }
+
+    #[tokio::test]
+    async fn unrecognised_issuer_is_rejected_even_with_valid_proofs() {
+        let issuer = "did:webvh:stranger.example";
+        let (vec, vmc, pubkey) =
+            fresh_pair(issuer, "did:key:zSubject", VtcRole::Member, 3600).await;
+
+        let resolver = StubKeyResolver::new().with(issuer, pubkey);
+        let fetcher = StubStatusFetcher::new();
+        // Mock registry: NO recognised issuers.
+        let reg: Arc<dyn TrustRegistryClient> = Arc::new(MockRegistryClient::new());
+
+        let err = verify_foreign_vec(&vec, &vmc, &resolver, &fetcher, reg, Utc::now())
+            .await
+            .expect_err("must reject");
+        assert!(matches!(err, RecognitionError::IssuerNotRecognised(_)));
+        assert_eq!(err.reason_code(), "issuer-not-recognised");
+    }
+
+    #[tokio::test]
+    async fn proof_mismatch_rejected_before_network_calls() {
+        let issuer = "did:webvh:peer.example";
+        let (vec, vmc, _pubkey) =
+            fresh_pair(issuer, "did:key:zSubject", VtcRole::Member, 3600).await;
+
+        // Wrong pubkey → proof verify fails.
+        let resolver = StubKeyResolver::new().with(issuer, vec![0u8; 32]);
+        let fetcher = StubStatusFetcher::new();
+        let mock_reg = MockRegistryClient::new();
+        mock_reg.set_recognised(issuer).await;
+        let reg: Arc<dyn TrustRegistryClient> = Arc::new(mock_reg.clone());
+
+        let err = verify_foreign_vec(&vec, &vmc, &resolver, &fetcher, reg, Utc::now())
+            .await
+            .expect_err("must reject");
+        assert!(matches!(err, RecognitionError::ProofInvalid(_)));
+        assert_eq!(
+            mock_reg.call_counts().await.recognise,
+            0,
+            "recognise must not be called when proof fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoked_credential_is_rejected() {
+        // Build a VMC with a credentialStatus pointing at our
+        // stub fetcher. (RoleVecParams doesn't currently
+        // accept a status ref — the VMC carries the status
+        // block in the workspace today, and that's where the
+        // revocation surface lives in steady state.)
+        let issuer = "did:webvh:peer.example";
+        let subject = "did:key:zSubject";
+        let seed = [0xCDu8; 32];
+        let signer = LocalSigner::from_ed25519_seed(issuer.into(), &seed);
+        let pubkey = signer.public_bytes().to_vec();
+
+        let vec_vc = build_role_vec(
+            &signer,
+            RoleVecParams::new(subject, VtcRole::Member)
+                .with_validity(chrono::Duration::seconds(3600))
+                .with_id("urn:vec:fresh"),
+        )
+        .await
+        .expect("build vec");
+
+        let status_url = "https://peer.example/status-lists/revocation";
+        let status_ref = CredentialStatusRef::revocation(status_url, 42);
+        let vmc_vc = build_vmc(
+            &signer,
+            VmcParams::new(subject)
+                .with_validity(chrono::Duration::seconds(3600))
+                .with_id("urn:vmc:revoked")
+                .with_status_ref(status_ref),
+        )
+        .await
+        .expect("build vmc");
+
+        let resolver = StubKeyResolver::new().with(issuer, pubkey);
+        let fetcher = StubStatusFetcher::new();
+        fetcher.set_bit(status_url, 42, true);
+        let mock_reg = MockRegistryClient::new();
+        mock_reg.set_recognised(issuer).await;
+        let reg: Arc<dyn TrustRegistryClient> = Arc::new(mock_reg);
+
+        let err = verify_foreign_vec(&vec_vc, &vmc_vc, &resolver, &fetcher, reg, Utc::now())
+            .await
+            .expect_err("must reject");
+        assert!(matches!(err, RecognitionError::StatusListFailed(_)));
+        assert_eq!(err.reason_code(), "status-list-failed");
+    }
+
+    #[tokio::test]
+    async fn expired_credential_is_rejected_before_network() {
+        let issuer = "did:webvh:peer.example";
+        // Issue with a 1-second window so it expires by `now`.
+        let (vec, vmc, pubkey) = fresh_pair(issuer, "did:key:zSubject", VtcRole::Member, 1).await;
+        let resolver = StubKeyResolver::new().with(issuer, pubkey);
+        let fetcher = StubStatusFetcher::new();
+        let mock_reg = MockRegistryClient::new();
+        mock_reg.set_recognised(issuer).await;
+        let reg: Arc<dyn TrustRegistryClient> = Arc::new(mock_reg.clone());
+
+        // Verify 10 minutes in the future → both expired.
+        let now = Utc::now() + chrono::Duration::minutes(10);
+        let err = verify_foreign_vec(&vec, &vmc, &resolver, &fetcher, reg, now)
+            .await
+            .expect_err("must reject");
+        assert!(matches!(err, RecognitionError::ValidityWindow(_)));
+        assert_eq!(
+            mock_reg.call_counts().await.recognise,
+            0,
+            "validity check should short-circuit before recognise"
+        );
+    }
+
+    #[tokio::test]
+    async fn issuer_mismatch_between_vec_and_vmc_rejected() {
+        let issuer_a = "did:webvh:peer-a.example";
+        let issuer_b = "did:webvh:peer-b.example";
+        let (vec, _vmc_a, _pk_a) =
+            fresh_pair(issuer_a, "did:key:zSubject", VtcRole::Member, 3600).await;
+        let (_vec_b, vmc, _pk_b) =
+            fresh_pair(issuer_b, "did:key:zSubject", VtcRole::Member, 3600).await;
+
+        let resolver = StubKeyResolver::new();
+        let fetcher = StubStatusFetcher::new();
+        let reg: Arc<dyn TrustRegistryClient> = Arc::new(MockRegistryClient::new());
+
+        let err = verify_foreign_vec(&vec, &vmc, &resolver, &fetcher, reg, Utc::now())
+            .await
+            .expect_err("must reject");
+        assert!(matches!(err, RecognitionError::Malformed(_)));
+    }
+
+    #[tokio::test]
+    async fn registry_unreachable_maps_to_distinct_error_variant() {
+        let issuer = "did:webvh:peer.example";
+        let (vec, vmc, pubkey) =
+            fresh_pair(issuer, "did:key:zSubject", VtcRole::Member, 3600).await;
+        let resolver = StubKeyResolver::new().with(issuer, pubkey);
+        let fetcher = StubStatusFetcher::new();
+        let mock_reg = MockRegistryClient::new();
+        mock_reg
+            .fail_next_recognise(crate::registry::RegistryError::Unreachable("dns".into()))
+            .await;
+        let reg: Arc<dyn TrustRegistryClient> = Arc::new(mock_reg);
+
+        let err = verify_foreign_vec(&vec, &vmc, &resolver, &fetcher, reg, Utc::now())
+            .await
+            .expect_err("must reject");
+        assert!(matches!(err, RecognitionError::RegistryUnreachable(_)));
+        assert_eq!(err.reason_code(), "registry-unreachable");
+    }
+
+    #[tokio::test]
+    async fn earliest_valid_until_picks_the_shorter_window() {
+        let issuer = "did:webvh:peer.example";
+        let subject = "did:key:zSubject";
+        let seed = [0xCDu8; 32];
+        let signer = LocalSigner::from_ed25519_seed(issuer.into(), &seed);
+        let pubkey = signer.public_bytes().to_vec();
+
+        // VEC valid 1h, VMC valid 30min — expected earliest =
+        // VMC's window.
+        let vec_vc = build_role_vec(
+            &signer,
+            RoleVecParams::new(subject, VtcRole::Member)
+                .with_validity(chrono::Duration::hours(1))
+                .with_id("urn:vec:long"),
+        )
+        .await
+        .unwrap();
+        let vmc_vc = build_vmc(
+            &signer,
+            VmcParams::new(subject)
+                .with_validity(chrono::Duration::minutes(30))
+                .with_id("urn:vmc:short"),
+        )
+        .await
+        .unwrap();
+
+        let resolver = StubKeyResolver::new().with(issuer, pubkey);
+        let fetcher = StubStatusFetcher::new();
+        let mock_reg = MockRegistryClient::new();
+        mock_reg.set_recognised(issuer).await;
+        let reg: Arc<dyn TrustRegistryClient> = Arc::new(mock_reg);
+
+        let now = Utc::now();
+        let verified = verify_foreign_vec(&vec_vc, &vmc_vc, &resolver, &fetcher, reg, now)
+            .await
+            .unwrap();
+
+        // Earliest expiry is the VMC's 30-min window.
+        let delta_minutes = (verified.earliest_valid_until - now).num_minutes();
+        assert!(
+            (28..=32).contains(&delta_minutes),
+            "earliest valid_until ({delta_minutes} min) should be around 30",
+        );
+    }
+
+    #[test]
+    fn issuer_id_extraction_handles_both_value_shapes() {
+        let uri = IssuerValue::Uri("did:webvh:a".into());
+        assert_eq!(uri.id(), "did:webvh:a");
+        let obj = IssuerValue::Object {
+            id: "did:webvh:b".into(),
+            properties: serde_json::Map::new(),
+        };
+        assert_eq!(obj.id(), "did:webvh:b");
+    }
+}

--- a/vtc-service/src/registry/client.rs
+++ b/vtc-service/src/registry/client.rs
@@ -88,6 +88,18 @@ pub trait TrustRegistryClient: Send + Sync {
     /// is reachable. Drives the `registry_status` flip on
     /// `GET /v1/community/profile` (M3.2).
     async fn health(&self) -> Result<(), RegistryError>;
+
+    /// TRQP `recognise` query (M3.9 + M3.10): "is this foreign
+    /// community's issuer DID present in the recognition
+    /// graph?". Returns `Ok(true)` when the registry confirms
+    /// the issuer is recognised, `Ok(false)` for a clean
+    /// not-found, and `Err` for transport / parse failures.
+    ///
+    /// **Called per-mint, never cached** (spec §8.4 + plan
+    /// D5): a peer community removed from the recognition
+    /// graph mid-session loses access on the next mint /
+    /// refresh, not when a TTL elapses.
+    async fn recognise(&self, foreign_issuer_did: &str) -> Result<bool, RegistryError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -107,10 +119,15 @@ pub struct MockRegistryClient {
 #[derive(Debug, Default)]
 struct MockState {
     pub records: std::collections::HashMap<String, RegistryRecord>,
+    /// Set of foreign-issuer DIDs the mock will return
+    /// `Ok(true)` for on `recognise`. Tests seed this directly
+    /// via [`MockRegistryClient::set_recognised`].
+    pub recognised_issuers: std::collections::HashSet<String>,
     pub publish_calls: usize,
     pub delete_calls: usize,
     pub read_calls: usize,
     pub health_calls: usize,
+    pub recognise_calls: usize,
     /// When set, the next call of the matching kind returns
     /// the queued error instead of succeeding. Tests inject
     /// these to exercise the failure branches.
@@ -118,6 +135,7 @@ struct MockState {
     pub next_delete_error: Option<RegistryError>,
     pub next_read_error: Option<RegistryError>,
     pub next_health_error: Option<RegistryError>,
+    pub next_recognise_error: Option<RegistryError>,
 }
 
 impl MockRegistryClient {
@@ -134,6 +152,7 @@ impl MockRegistryClient {
             delete: s.delete_calls,
             read: s.read_calls,
             health: s.health_calls,
+            recognise: s.recognise_calls,
         }
     }
 
@@ -157,6 +176,21 @@ impl MockRegistryClient {
         self.inner.lock().await.next_health_error = Some(err);
     }
 
+    /// Mark `foreign_issuer_did` as recognised — the next
+    /// `recognise` call returns `Ok(true)` for it.
+    pub async fn set_recognised(&self, foreign_issuer_did: impl Into<String>) {
+        self.inner
+            .lock()
+            .await
+            .recognised_issuers
+            .insert(foreign_issuer_did.into());
+    }
+
+    /// Queue an error for the next `recognise` call.
+    pub async fn fail_next_recognise(&self, err: RegistryError) {
+        self.inner.lock().await.next_recognise_error = Some(err);
+    }
+
     /// Read the upstream state directly. Tests assert against
     /// this to confirm a call landed.
     pub async fn snapshot(&self) -> std::collections::HashMap<String, RegistryRecord> {
@@ -171,6 +205,7 @@ pub struct MockCallCounts {
     pub delete: usize,
     pub read: usize,
     pub health: usize,
+    pub recognise: usize,
 }
 
 #[async_trait]
@@ -211,6 +246,15 @@ impl TrustRegistryClient for MockRegistryClient {
             return Err(err);
         }
         Ok(())
+    }
+
+    async fn recognise(&self, foreign_issuer_did: &str) -> Result<bool, RegistryError> {
+        let mut s = self.inner.lock().await;
+        s.recognise_calls += 1;
+        if let Some(err) = s.next_recognise_error.take() {
+            return Err(err);
+        }
+        Ok(s.recognised_issuers.contains(foreign_issuer_did))
     }
 }
 
@@ -284,6 +328,28 @@ mod tests {
         let snap = m.snapshot().await;
         assert!(snap.contains_key("did:key:zKeep"));
         assert!(!snap.contains_key("did:key:zDrop"));
+    }
+
+    #[tokio::test]
+    async fn recognise_returns_true_for_seeded_issuer() {
+        let m = MockRegistryClient::new();
+        m.set_recognised("did:webvh:peer.example.com:abc").await;
+        assert!(m.recognise("did:webvh:peer.example.com:abc").await.unwrap());
+        // Unseeded DID returns false (clean not-found).
+        assert!(!m.recognise("did:webvh:stranger.example").await.unwrap());
+        assert_eq!(m.call_counts().await.recognise, 2);
+    }
+
+    #[tokio::test]
+    async fn recognise_propagates_transport_errors() {
+        let m = MockRegistryClient::new();
+        m.fail_next_recognise(RegistryError::Unreachable("dns".into()))
+            .await;
+        let err = m
+            .recognise("did:webvh:peer.example")
+            .await
+            .expect_err("queued error must surface");
+        assert!(err.is_retriable());
     }
 
     #[test]

--- a/vtc-service/src/registry/upstream.rs
+++ b/vtc-service/src/registry/upstream.rs
@@ -158,6 +158,24 @@ impl TrustRegistryClient for UpstreamRegistryClient {
         ))
     }
 
+    async fn recognise(&self, _foreign_issuer_did: &str) -> Result<bool, RegistryError> {
+        // TRQP `POST /recognition` wire shape is documented by
+        // upstream as a 4-tuple query (authority_id, entity_id,
+        // action, resource). Pinning the exact payload — and
+        // the response envelope — needs a live integration
+        // test against a running upstream, which is out of
+        // scope for this milestone. The verifier (M3.9) calls
+        // through the trait and is exercised end-to-end via
+        // `MockRegistryClient` until the wire format is
+        // pinned. Production deployments using this client
+        // get a clear, retriable-classification failure rather
+        // than silently passing the recognition check.
+        warn!("UpstreamRegistryClient.recognise called before TRQP v2.0 payload shape is pinned");
+        Err(RegistryError::Permanent(
+            "recognise is not yet implemented in this build — pin the upstream TRQP v2.0 wire shape first".into(),
+        ))
+    }
+
     async fn health(&self) -> Result<(), RegistryError> {
         // `GET /.well-known/did.json` is the cheapest live
         // probe the upstream exposes. A 2xx confirms the

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod install;
 pub(crate) mod join_requests;
 pub(crate) mod members;
 pub(crate) mod policies;
+pub mod recognise;
 pub(crate) mod status_lists;
 
 use axum::Router;
@@ -146,6 +147,9 @@ pub fn router() -> Router<AppState> {
     let health_diagnostics =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0")
             .expect("static Trust-Task URL");
+    // Phase 3 M3.10 — cross-community session mint.
+    let auth_recognise = TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/recognise/1.0")
+        .expect("static Trust-Task URL");
     // Read endpoints (M2.4). GET /v1/policies and
     // GET /v1/policies/{id} share their mounts with the POST
     // /v1/policies upload and POST /v1/policies/{id}/activate
@@ -163,6 +167,11 @@ pub fn router() -> Router<AppState> {
             "/v1/health/diagnostics",
             get(health::diagnostics),
             health_diagnostics,
+        )
+        .route_with_task(
+            "/v1/auth/recognise",
+            post(recognise::recognise),
+            auth_recognise,
         )
         // `did:webvh` log publication (Trust-Task-exempt — DID
         // resolvers don't carry our extension header). The VTC is

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -1,0 +1,396 @@
+//! `POST /v1/auth/recognise` — cross-community session mint.
+//!
+//! Phase 3 M3.10. Spec §8.4.
+//!
+//! The route accepts a foreign community's (`VEC`, `VMC`) pair,
+//! runs the M3.9 verifier, evaluates `cross_community_roles.rego`
+//! to map the foreign role onto a local role, and mints a session
+//! JWT with TTL clamped to
+//! `min(jwt_default, vec.validUntil - now, vmc.validUntil - now)`.
+//!
+//! ## No refresh path
+//!
+//! Spec §8.4 + plan D5: cross-community sessions **never**
+//! refresh. The standard `POST /v1/auth/refresh` route doesn't
+//! carry the foreign credentials needed to re-run the
+//! recognition check, so re-issuing a token without
+//! re-verifying would defeat the "peer community removed
+//! mid-session loses access" invariant. The session simply
+//! expires when its clamped TTL elapses; the caller mints a
+//! fresh one with the latest credentials.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::{info, warn};
+use uuid::Uuid;
+use vti_common::audit::{AuditEvent, CrossCommunitySessionMintedData};
+
+use crate::auth::session::{Session, SessionState, now_epoch, store_session};
+use crate::error::AppError;
+use crate::policy::{
+    PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy, get_active_policy_id,
+    get_policy,
+};
+use crate::recognition::{
+    DidResolverKeyResolver, HttpStatusListFetcher, RecognitionError, VerifiedForeignCredential,
+    verify_foreign_vec,
+};
+use crate::server::AppState;
+use affinidi_vc::VerifiableCredential;
+
+/// Request body for `POST /v1/auth/recognise`. The caller
+/// supplies the foreign VEC + VMC verbatim — the route
+/// resolves the issuer's key + status list itself.
+#[derive(Debug, Deserialize)]
+pub struct RecogniseRequest {
+    pub vec: VerifiableCredential,
+    pub vmc: VerifiableCredential,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecogniseResponse {
+    pub session_id: String,
+    pub data: RecogniseData,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecogniseData {
+    /// Minted JWT. Carries the *mapped local* role, not the
+    /// foreign one.
+    pub access_token: String,
+    pub access_expires_at: u64,
+    /// Foreign issuer DID, surfaced so the caller can correlate
+    /// the response with their request (the route doesn't echo
+    /// the credentials).
+    pub foreign_issuer_did: String,
+    /// Local role the foreign role mapped to.
+    pub mapped_role: String,
+}
+
+pub async fn recognise(
+    State(state): State<AppState>,
+    Json(req): Json<RecogniseRequest>,
+) -> Result<Json<RecogniseResponse>, AppError> {
+    // Pre-flight: the route depends on three pieces of optional
+    // state. Refuse cleanly when any is missing rather than
+    // 500ing inside the handler.
+    let registry = state.registry_client.as_ref().cloned().ok_or_else(|| {
+        AppError::Validation("trust-registry client not configured on this VTC".into())
+    })?;
+    let resolver = state
+        .did_resolver
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| AppError::Internal("DID resolver not configured".into()))?;
+    // JWT-keys availability is re-checked inside
+    // `mint_recognised_session` — but bail early when the
+    // verifier hasn't been wired either, so the response is
+    // shaped by config issues rather than running a real
+    // verification first.
+    state
+        .jwt_keys
+        .as_ref()
+        .ok_or_else(|| AppError::Authentication("JWT keys not configured".into()))?;
+
+    let key_resolver = DidResolverKeyResolver::new(resolver);
+    let status_fetcher = HttpStatusListFetcher::new(reqwest::Client::new());
+
+    let actor_did_for_audit = req.vec.credential_subject_id_for_audit();
+
+    // Run the M3.9 verifier. Failures are mapped to `denied`
+    // audit envelopes + a 403 response.
+    let verified = match verify_foreign_vec(
+        &req.vec,
+        &req.vmc,
+        &key_resolver,
+        &status_fetcher,
+        Arc::clone(&registry),
+        Utc::now(),
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            emit_denied_audit(
+                &state,
+                &actor_did_for_audit,
+                None,
+                e.reason_code(),
+                None,
+                &e,
+            )
+            .await;
+            return Err(map_recognition_error(e));
+        }
+    };
+
+    mint_recognised_session(&state, verified).await
+}
+
+/// Post-verification half of the recognise flow — exposed at
+/// `pub(crate)` so integration tests can exercise it without
+/// faking a DID resolver. Production goes through
+/// [`recognise`] which runs the verifier first; tests
+/// hand-build a [`VerifiedForeignCredential`] (typestate
+/// proof of "this credential passed the four checks") and
+/// drive only the route-level concerns: role-mapping policy,
+/// TTL clamp, session mint, audit emission.
+pub async fn mint_recognised_session(
+    state: &AppState,
+    verified: VerifiedForeignCredential,
+) -> Result<Json<RecogniseResponse>, AppError> {
+    let jwt_keys = state
+        .jwt_keys
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| AppError::Authentication("JWT keys not configured".into()))?;
+
+    // Run cross_community_roles.rego to map the foreign role
+    // onto a local role. Deny is encoded as either:
+    //   - `data.vtc.cross_community_roles.allow = false`, or
+    //   - missing/null `mapped_role`.
+    let mapped_role = match map_foreign_role(state, &verified).await? {
+        Some(r) => r,
+        None => {
+            emit_denied_audit(
+                state,
+                &verified.subject_did,
+                Some(verified.foreign_issuer_did.as_str()),
+                "role-mapping-denied",
+                Some(verified.foreign_role.as_str()),
+                &RecognitionError::Malformed("policy denied role mapping".into()),
+            )
+            .await;
+            return Err(AppError::Forbidden(format!(
+                "cross_community_roles.rego denied mapping for foreign role '{}'",
+                verified.foreign_role
+            )));
+        }
+    };
+
+    // Clamp the TTL to `min(jwt_default, vec.validUntil - now,
+    // vmc.validUntil - now)`. The verifier already exposed the
+    // *earliest* validUntil; we just compare to the configured
+    // access-token TTL.
+    let config = state.config.read().await;
+    let jwt_default = config.auth.access_token_expiry;
+    drop(config);
+
+    let now = Utc::now();
+    let creds_window_secs = (verified.earliest_valid_until - now).num_seconds().max(0) as u64;
+    let access_expiry = jwt_default.min(creds_window_secs);
+    if access_expiry == 0 {
+        // Credentials expire before the next clock tick. Treat
+        // as denied — minting a JWT that expires the same
+        // instant it's issued is operator-hostile.
+        emit_denied_audit(
+            state,
+            &verified.subject_did,
+            Some(verified.foreign_issuer_did.as_str()),
+            "validity-window",
+            Some(verified.foreign_role.as_str()),
+            &RecognitionError::ValidityWindow("credentials expire immediately".into()),
+        )
+        .await;
+        return Err(AppError::Forbidden(
+            "foreign credentials expire too soon to mint a session".into(),
+        ));
+    }
+
+    // Mint the session. Mirror the existing
+    // `authenticate` path: store a Session row + emit a JWT.
+    // Skip the refresh token (cross-community sessions don't
+    // refresh — see module docs).
+    let session_id = format!("xc-{}", Uuid::new_v4());
+    let session = Session {
+        session_id: session_id.clone(),
+        did: verified.subject_did.clone(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: None,
+        tee_attested: false,
+    };
+    store_session(&state.sessions_ks, &session).await?;
+
+    let claims = jwt_keys.new_claims(
+        verified.subject_did.clone(),
+        session_id.clone(),
+        mapped_role.clone(),
+        Vec::new(),
+        access_expiry,
+        false,
+    );
+    let access_expires_at = claims.exp;
+    let access_token = jwt_keys.encode(&claims)?;
+
+    // Audit: minted.
+    if let Some(writer) = state.audit_writer.as_ref() {
+        let payload = CrossCommunitySessionMintedData {
+            outcome: "minted".into(),
+            foreign_issuer_did: verified.foreign_issuer_did.clone(),
+            foreign_role: Some(verified.foreign_role.clone()),
+            mapped_role: Some(mapped_role.clone()),
+            ttl_seconds: Some(access_expiry),
+            reason: None,
+        };
+        if let Err(e) = writer
+            .write(
+                &verified.subject_did,
+                Some(&verified.subject_did),
+                AuditEvent::CrossCommunitySessionMinted(payload),
+            )
+            .await
+        {
+            warn!(error = %e, "failed to emit CrossCommunitySessionMinted (minted) envelope");
+        }
+    }
+
+    info!(
+        subject = %verified.subject_did,
+        issuer = %verified.foreign_issuer_did,
+        mapped_role = %mapped_role,
+        ttl = access_expiry,
+        "cross-community session minted"
+    );
+
+    Ok(Json(RecogniseResponse {
+        session_id,
+        data: RecogniseData {
+            access_token,
+            access_expires_at,
+            foreign_issuer_did: verified.foreign_issuer_did,
+            mapped_role,
+        },
+    }))
+}
+
+/// Run `cross_community_roles.rego` against the verified
+/// credential pair. Returns `Ok(Some(mapped_role))` on policy
+/// allow, `Ok(None)` on deny. Errors propagate as
+/// `AppError::Internal` because they indicate a workspace bug
+/// (no policy, compile failure, etc.) — the operator has the
+/// fallback "default deny" stub from M2.5.
+async fn map_foreign_role(
+    state: &AppState,
+    verified: &VerifiedForeignCredential,
+) -> Result<Option<String>, AppError> {
+    let active_id = get_active_policy_id(
+        &state.active_policies_ks,
+        PolicyPurpose::CrossCommunityRoles,
+    )
+    .await?
+    .ok_or_else(|| AppError::Internal("no active cross_community_roles policy".into()))?;
+    let policy = get_policy(&state.policies_ks, active_id)
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal(format!(
+                "active cross_community_roles policy {active_id} not found"
+            ))
+        })?;
+    let compiled = compile_policy(&policy.rego_source, policy.id)?;
+
+    let input = serde_json::json!({
+        "foreign_vec": {
+            "issuer": verified.foreign_issuer_did,
+            "role": verified.foreign_role,
+            "subject_did": verified.subject_did,
+        },
+        "action": "mint_session",
+    });
+
+    let allow = evaluate_policy(
+        &compiled,
+        "data.vtc.cross_community_roles.allow",
+        input.clone(),
+    )?;
+    let allow = allow
+        .pointer("/result/0/expressions/0/value")
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(false);
+    if !allow {
+        return Ok(None);
+    }
+
+    // Policy passed the allow gate; now read mapped_role.
+    let mapped = evaluate_policy(
+        &compiled,
+        "data.vtc.cross_community_roles.mapped_role",
+        input,
+    )?;
+    let mapped = mapped
+        .pointer("/result/0/expressions/0/value")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    Ok(mapped)
+}
+
+fn map_recognition_error(e: RecognitionError) -> AppError {
+    match e {
+        RecognitionError::RegistryUnreachable(msg) => {
+            AppError::Internal(format!("trust registry unreachable: {msg}"))
+        }
+        // All other variants are caller-driven rejection
+        // signals → 403 Forbidden.
+        other => AppError::Forbidden(other.to_string()),
+    }
+}
+
+async fn emit_denied_audit(
+    state: &AppState,
+    actor_did: &str,
+    foreign_issuer_did: Option<&str>,
+    reason: &str,
+    foreign_role: Option<&str>,
+    _err: &RecognitionError,
+) {
+    let Some(writer) = state.audit_writer.as_ref() else {
+        return;
+    };
+    let payload = CrossCommunitySessionMintedData {
+        outcome: "denied".into(),
+        foreign_issuer_did: foreign_issuer_did.unwrap_or("<unknown>").to_string(),
+        foreign_role: foreign_role.map(str::to_string),
+        mapped_role: None,
+        ttl_seconds: None,
+        reason: Some(reason.to_string()),
+    };
+    if let Err(e) = writer
+        .write(
+            actor_did,
+            None,
+            AuditEvent::CrossCommunitySessionMinted(payload),
+        )
+        .await
+    {
+        warn!(error = %e, "failed to emit CrossCommunitySessionMinted (denied) envelope");
+    }
+}
+
+// Helper trait — extracts the subject DID from the VEC even
+// when verification hasn't run yet, so audit envelopes for the
+// `denied` arm can still name an actor when possible.
+trait CredentialSubjectIdAccessor {
+    fn credential_subject_id_for_audit(&self) -> String;
+}
+
+impl CredentialSubjectIdAccessor for VerifiableCredential {
+    fn credential_subject_id_for_audit(&self) -> String {
+        use affinidi_vc::SubjectValue;
+        let subj_map = match &self.credential_subject {
+            SubjectValue::Single(m) => Some(m.clone()),
+            SubjectValue::Multiple(v) => v.first().cloned(),
+        };
+        subj_map
+            .and_then(|m| m.get("id").and_then(|v| v.as_str()).map(str::to_string))
+            .unwrap_or_else(|| "<unknown-subject>".into())
+    }
+}

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -1,0 +1,361 @@
+//! Integration coverage for the cross-community recognise flow.
+//!
+//! The HTTP `/v1/auth/recognise` route hard-wires a live
+//! `DIDCacheClient` for foreign-issuer key resolution, which
+//! is impractical to fake in a unit test. We exercise
+//! `routes::recognise::mint_recognised_session` directly —
+//! it takes an already-`VerifiedForeignCredential` (typestate
+//! proof of "this passed the four hardening checks") and is
+//! the load-bearing route-level surface. The M3.9 verifier
+//! itself has 9 unit tests in `recognition::verify::tests` that
+//! cover the four fail-closed checks against
+//! mock/stub-backed credentials.
+//!
+//! Phase 3 M3.10.
+
+use std::sync::Arc;
+
+use axum::Json;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use chrono::{Duration, Utc};
+use http_body_util::BodyExt;
+use tokio::sync::RwLock;
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::config::AppConfig;
+use vtc_service::policy::{Policy, PolicyPurpose, set_active_policy_id, store_policy};
+use vtc_service::recognition::VerifiedForeignCredential;
+use vtc_service::registry::RegistryHealth;
+use vtc_service::routes::recognise::{RecogniseResponse, mint_recognised_session};
+use vtc_service::server::AppState;
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    state: AppState,
+    _dir: tempfile::TempDir,
+}
+
+async fn build() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        [store]
+        data_dir = "{}"
+        [auth]
+        jwt_signing_key = "{}"
+        access_token_expiry = 900
+        "#,
+        dir.path().display(),
+        BASE64.encode(jwt_seed),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks: sessions_ks.clone(),
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks: install_ks.clone(),
+        members_ks,
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks,
+        registry_records_ks,
+        sync_queue_ks,
+        sync_cursor_ks,
+        registry_client: None,
+        registry_health: RegistryHealth::new(),
+        credential_signer: None,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: None,
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_ks,
+        audit_key_ks,
+        audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    Fixture { state, _dir: dir }
+}
+
+async fn install_cross_community_policy(state: &AppState, source: &str) {
+    use sha2::{Digest, Sha256};
+    let sha: [u8; 32] = Sha256::digest(source.as_bytes()).into();
+    let id = uuid::Uuid::new_v4();
+    let policy = Policy {
+        id,
+        purpose: PolicyPurpose::CrossCommunityRoles,
+        rego_source: source.into(),
+        sha256: sha,
+        activated_at: Some(Utc::now()),
+        author_did: "did:key:test".into(),
+        created_at: Utc::now(),
+        version: 1,
+    };
+    store_policy(&state.policies_ks, &policy).await.unwrap();
+    set_active_policy_id(
+        &state.active_policies_ks,
+        PolicyPurpose::CrossCommunityRoles,
+        id,
+    )
+    .await
+    .unwrap();
+}
+
+fn verified(
+    issuer: &str,
+    subject: &str,
+    foreign_role: &str,
+    valid_minutes: i64,
+) -> VerifiedForeignCredential {
+    VerifiedForeignCredential {
+        foreign_issuer_did: issuer.into(),
+        subject_did: subject.into(),
+        foreign_role: foreign_role.into(),
+        earliest_valid_until: Utc::now() + Duration::minutes(valid_minutes),
+    }
+}
+
+async fn body_value(resp: Json<RecogniseResponse>) -> RecogniseResponse {
+    resp.0
+}
+
+#[tokio::test]
+async fn default_deny_policy_rejects_every_mapping() {
+    let fix = build().await;
+    // Default policy: allow := false, no mapped_role rule.
+    let src = "\
+package vtc.cross_community_roles
+import rego.v1
+default allow := false
+";
+    install_cross_community_policy(&fix.state, src).await;
+
+    let v = verified("did:webvh:peer.example", "did:key:zSub", "moderator", 60);
+    let err = mint_recognised_session(&fix.state, v)
+        .await
+        .expect_err("default deny must reject");
+    let resp = err.into_response();
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    let resp = resp.into_response();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn permissive_policy_mints_session_with_mapped_role() {
+    let fix = build().await;
+    // Map every foreign role to local `monitor`.
+    let src = r#"
+package vtc.cross_community_roles
+import rego.v1
+default allow := true
+mapped_role := "monitor"
+"#;
+    install_cross_community_policy(&fix.state, src).await;
+
+    let v = verified("did:webvh:peer.example", "did:key:zSub", "admin", 60);
+    let resp = mint_recognised_session(&fix.state, v).await.expect("mint");
+    let resp = body_value(resp).await;
+    assert!(resp.session_id.starts_with("xc-"));
+    assert_eq!(resp.data.mapped_role, "monitor");
+    assert_eq!(resp.data.foreign_issuer_did, "did:webvh:peer.example");
+    assert!(!resp.data.access_token.is_empty());
+}
+
+#[tokio::test]
+async fn ttl_clamps_to_credentials_when_shorter_than_default() {
+    let fix = build().await;
+    let src = r#"
+package vtc.cross_community_roles
+import rego.v1
+default allow := true
+mapped_role := "monitor"
+"#;
+    install_cross_community_policy(&fix.state, src).await;
+
+    // Default access_token_expiry = 900s (15m); credentials
+    // only valid for 5 more minutes → clamp to credentials.
+    let v = verified("did:webvh:peer.example", "did:key:zSub", "moderator", 5);
+    let resp = mint_recognised_session(&fix.state, v).await.expect("mint");
+    let resp = body_value(resp).await;
+    let now_secs = chrono::Utc::now().timestamp() as u64;
+    let ttl = resp.data.access_expires_at - now_secs;
+    assert!(
+        (260..=305).contains(&ttl),
+        "TTL ({ttl}s) should be ~300s (clamped to 5-min credential window)"
+    );
+}
+
+#[tokio::test]
+async fn ttl_clamps_to_default_when_credentials_longer() {
+    let fix = build().await;
+    let src = r#"
+package vtc.cross_community_roles
+import rego.v1
+default allow := true
+mapped_role := "monitor"
+"#;
+    install_cross_community_policy(&fix.state, src).await;
+
+    // Credentials valid 1 hour; default expiry 15 min →
+    // clamp to default.
+    let v = verified("did:webvh:peer.example", "did:key:zSub", "moderator", 60);
+    let resp = mint_recognised_session(&fix.state, v).await.expect("mint");
+    let resp = body_value(resp).await;
+    let now_secs = chrono::Utc::now().timestamp() as u64;
+    let ttl = resp.data.access_expires_at - now_secs;
+    assert!(
+        (880..=905).contains(&ttl),
+        "TTL ({ttl}s) should be ~900s (default access_token_expiry)"
+    );
+}
+
+#[tokio::test]
+async fn expired_credentials_rejected_with_zero_window() {
+    let fix = build().await;
+    let src = r#"
+package vtc.cross_community_roles
+import rego.v1
+default allow := true
+mapped_role := "monitor"
+"#;
+    install_cross_community_policy(&fix.state, src).await;
+
+    // earliest_valid_until in the past → 0 window → reject.
+    let v = VerifiedForeignCredential {
+        foreign_issuer_did: "did:webvh:peer.example".into(),
+        subject_did: "did:key:zSub".into(),
+        foreign_role: "moderator".into(),
+        earliest_valid_until: Utc::now() - Duration::seconds(1),
+    };
+    let err = mint_recognised_session(&fix.state, v)
+        .await
+        .expect_err("expired credentials must reject");
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    let resp = err.into_response();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body = String::from_utf8_lossy(&bytes);
+    assert!(
+        body.contains("expire") || body.contains("validity"),
+        "error body should mention expiry: {body}"
+    );
+}
+
+#[tokio::test]
+async fn allow_true_but_no_mapped_role_is_treated_as_deny() {
+    let fix = build().await;
+    // Operator typo: allows but forgets to set mapped_role.
+    // Fail-closed per spec wording.
+    let src = "\
+package vtc.cross_community_roles
+import rego.v1
+default allow := true
+";
+    install_cross_community_policy(&fix.state, src).await;
+
+    let v = verified("did:webvh:peer.example", "did:key:zSub", "moderator", 60);
+    let err = mint_recognised_session(&fix.state, v)
+        .await
+        .expect_err("missing mapped_role must reject even when allow=true");
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    let resp = err.into_response();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn session_row_is_persisted_with_xc_prefix() {
+    use vti_common::auth::session::{get_session, list_sessions};
+    let fix = build().await;
+    let src = r#"
+package vtc.cross_community_roles
+import rego.v1
+default allow := true
+mapped_role := "monitor"
+"#;
+    install_cross_community_policy(&fix.state, src).await;
+
+    let subject = "did:key:zSessionTest";
+    let v = verified("did:webvh:peer.example", subject, "moderator", 60);
+    let resp = mint_recognised_session(&fix.state, v).await.expect("mint");
+    let resp = body_value(resp).await;
+
+    // Direct read-back: confirm the session row landed in fjall
+    // with the xc- prefix and no refresh token.
+    let session = get_session(&fix.state.sessions_ks, &resp.session_id)
+        .await
+        .unwrap()
+        .expect("session row");
+    assert_eq!(session.did, subject);
+    assert!(session.session_id.starts_with("xc-"));
+    assert!(session.refresh_token.is_none(), "no refresh token");
+    // Total sessions in the keyspace should also be 1.
+    let all = list_sessions(&fix.state.sessions_ks).await.unwrap();
+    assert_eq!(all.len(), 1);
+}
+
+#[tokio::test]
+async fn missing_active_policy_surfaces_as_internal_error() {
+    // No cross_community_roles policy installed at all.
+    let fix = build().await;
+    let v = verified("did:webvh:peer.example", "did:key:zSub", "moderator", 60);
+    let err = mint_recognised_session(&fix.state, v)
+        .await
+        .expect_err("no active policy must reject");
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    let resp = err.into_response();
+    // No active policy = 500: this is a misconfigured-daemon
+    // path (M2.5 should have installed the default), not a
+    // caller-fixable input.
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -204,6 +204,17 @@ pub enum AuditEvent {
     /// `None` for these envelopes (privacy-preserving by
     /// construction). Phase 3 M3.6.
     RegistryRecordPolicyOverride(RegistryRecordPolicyOverrideData),
+
+    /// A cross-community session was minted (or denied). Spec
+    /// §8.4; Phase 3 M3.10. The `outcome` field discriminates
+    /// `minted` from `denied`; the `reason` is populated only
+    /// on `denied` and carries one of [`RecognitionError`]'s
+    /// stable reason codes
+    /// (`issuer-key-unresolved` / `proof-invalid` /
+    /// `status-list-failed` / `issuer-not-recognised` /
+    /// `registry-unreachable` / `validity-window` / `malformed`
+    /// / `role-mapping-denied`).
+    CrossCommunitySessionMinted(CrossCommunitySessionMintedData),
 }
 
 // ---------------------------------------------------------------------------
@@ -535,6 +546,42 @@ pub struct RegistrySyncOutcomeData {
     /// `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
+}
+
+/// Payload for [`AuditEvent::CrossCommunitySessionMinted`].
+/// Phase 3 M3.10. The envelope's `actor_did` (HMAC-hashed per
+/// §11.1) is the bearer of the foreign credentials — i.e. the
+/// caller of `POST /v1/auth/recognise`. The envelope's
+/// `target_did` is the local subject DID the session was minted
+/// to (same value on `minted`; absent on `denied` because no
+/// local subject was established).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CrossCommunitySessionMintedData {
+    /// `"minted"` or `"denied"`. Stable wire form so SIEM
+    /// rules can key on it.
+    pub outcome: String,
+    /// Foreign community's issuer DID (e.g.
+    /// `did:webvh:peer.example.com:abc`).
+    pub foreign_issuer_did: String,
+    /// Role claim from the foreign VEC — present even on
+    /// `denied` so operators can see what was attempted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreign_role: Option<String>,
+    /// Local role the foreign role mapped onto. Populated on
+    /// `minted` only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mapped_role: Option<String>,
+    /// Clamped session TTL in seconds. `min(jwt_default,
+    /// vec.validUntil - now, vmc.validUntil - now)`. Populated
+    /// on `minted` only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_seconds: Option<u64>,
+    /// On `denied`: a short reason code from
+    /// [`RecognitionError::reason_code`] or
+    /// `"role-mapping-denied"` for the policy-rejection arm.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// Payload for [`AuditEvent::RegistryStatusChanged`]. Phase 3
@@ -1009,6 +1056,51 @@ mod tests {
     }
 
     #[test]
+    fn cross_community_session_minted_round_trip() {
+        let e = AuditEvent::CrossCommunitySessionMinted(CrossCommunitySessionMintedData {
+            outcome: "minted".into(),
+            foreign_issuer_did: "did:webvh:peer.example.com:abc".into(),
+            foreign_role: Some("moderator".into()),
+            mapped_role: Some("monitor".into()),
+            ttl_seconds: Some(900),
+            reason: None,
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "CrossCommunitySessionMinted");
+        assert_eq!(v["data"]["outcome"], "minted");
+        assert_eq!(
+            v["data"]["foreignIssuerDid"],
+            "did:webvh:peer.example.com:abc"
+        );
+        assert_eq!(v["data"]["foreignRole"], "moderator");
+        assert_eq!(v["data"]["mappedRole"], "monitor");
+        assert_eq!(v["data"]["ttlSeconds"], 900);
+        assert!(
+            v["data"].get("reason").is_none(),
+            "reason should be omitted on minted: {v}"
+        );
+        round_trip(&e);
+    }
+
+    #[test]
+    fn cross_community_session_minted_denied_carries_reason() {
+        let e = AuditEvent::CrossCommunitySessionMinted(CrossCommunitySessionMintedData {
+            outcome: "denied".into(),
+            foreign_issuer_did: "did:webvh:peer.example.com:abc".into(),
+            foreign_role: Some("admin".into()),
+            mapped_role: None,
+            ttl_seconds: None,
+            reason: Some("issuer-not-recognised".into()),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["data"]["outcome"], "denied");
+        assert_eq!(v["data"]["reason"], "issuer-not-recognised");
+        assert!(v["data"].get("mappedRole").is_none());
+        assert!(v["data"].get("ttlSeconds").is_none());
+        round_trip(&e);
+    }
+
+    #[test]
     fn variant_discriminator_strings() {
         let cases: Vec<(AuditEvent, &str)> = vec![
             (
@@ -1163,6 +1255,25 @@ mod tests {
                     last_error: Some("x".into()),
                 }),
                 "RegistrySyncFailed",
+            ),
+            (
+                AuditEvent::RegistryRecordPolicyOverride(RegistryRecordPolicyOverrideData {
+                    reason: "rtbf".into(),
+                    attempted_disposition: "tombstone".into(),
+                    effective_disposition: "purge".into(),
+                }),
+                "RegistryRecordPolicyOverride",
+            ),
+            (
+                AuditEvent::CrossCommunitySessionMinted(CrossCommunitySessionMintedData {
+                    outcome: "minted".into(),
+                    foreign_issuer_did: "did:webvh:peer".into(),
+                    foreign_role: Some("moderator".into()),
+                    mapped_role: Some("monitor".into()),
+                    ttl_seconds: Some(900),
+                    reason: None,
+                }),
+                "CrossCommunitySessionMinted",
             ),
         ];
         for (event, expected) in cases {

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -33,11 +33,11 @@ pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
 pub use event::{
     AdminPasskeyData, AdminPromotedData, AuditEvent, AuditKeyRotatedData, CommunityInstalledData,
     CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
-    CredentialIssuedData, DidRotatedData, EmergencyBootstrapData, JoinRequestData,
-    JoinRequestRejectedData, MemberAddedData, MemberRemovedData, MemberUpdatedData,
-    MembershipRenewedData, PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER,
-    RegistryRecordPolicyOverrideData, RegistryStatusChangedData, RegistrySyncOutcomeData,
-    RestartRequestedData, RoleChangedData, StatusListFlippedData,
+    CredentialIssuedData, CrossCommunitySessionMintedData, DidRotatedData, EmergencyBootstrapData,
+    JoinRequestData, JoinRequestRejectedData, MemberAddedData, MemberRemovedData,
+    MemberUpdatedData, MembershipRenewedData, PolicyActivatedData, PolicyUploadedData,
+    REDACTED_MARKER, RegistryRecordPolicyOverrideData, RegistryStatusChangedData,
+    RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData, StatusListFlippedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

Phase 3 PR 4/5. Lights up cross-community recognition end-to-end:

- **M3.9** — `vtc_service::recognition::verify_foreign_vec` runs four fail-closed checks (proof verify → validity window → status-list revocation → trust-registry recognise). Returns a typestate `VerifiedForeignCredential` — route layers can only take this type, so a forgotten verification step is a compile error.
- **M3.10** — `POST /v1/auth/recognise` wraps the verifier, evaluates `cross_community_roles.rego` for role mapping, and mints a session JWT with TTL = `min(jwt_default, earliest(vec.validUntil, vmc.validUntil))`. **No refresh path** — every mint re-runs the full check, so a peer community removed mid-session loses access on the next call.

### Key design notes

- **Trait-based extension points.** `ForeignIssuerKeyResolver` + `StatusListFetcher` are the testability seams — production binds `DidResolverKeyResolver` (over `DIDCacheClient`) + `HttpStatusListFetcher` (over `reqwest`); tests stub both for hermetic, no-network runs.
- **Severity ordering is preservation-based.** The route surfaces a clear typed `RecognitionError` with stable `reason_code()` values that SIEM filters can key on (`issuer-key-unresolved` / `proof-invalid` / `status-list-failed` / `issuer-not-recognised` / `registry-unreachable` / `validity-window` / `malformed` / `role-mapping-denied`).
- **Default `cross_community_roles.rego` updated** to document the allow + `mapped_role` contract — missing `mapped_role` denies even when `allow := true`. Fail-closed by construction.
- **`mint_recognised_session` is `pub`** so integration tests exercise the route-level concerns (policy mapping, TTL clamp, session mint, audit emission) without faking a live DID resolver. The verifier itself is exercised separately via 9 unit tests on stub-backed credentials.
- **`TrustRegistryClient.recognise()` upstream HTTP wiring deferred** — the trait + Mock are live, the production HTTP returns `Permanent` with a clear "TRQP v2.0 wire shape not yet pinned" message. A follow-up will land the live `POST /recognition` payload once the upstream's surface stabilises.

## Test plan

- [x] 9 recognition unit tests (every fail-closed path + happy path + earliest-expiry selection)
- [x] 8 recognise integration tests (deny-all, permissive, both TTL clamps, expired creds, missing mapped_role, session persistence, no policy → 500)
- [x] 44 vti-common audit tests (`CrossCommunitySessionMinted` round-trip + discriminator + `RegistryRecordPolicyOverride` discriminator gap-fill)
- [x] Full `cargo test --package vtc-service --package vti-common` green (273 lib + every integration suite + 173 vti-common)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] DCO sign-off on commit

## Out of scope

- Live TRQP v2.0 HTTP wire format for `recognise` — Permanent stub until the upstream surface is pinned
- M3.11 (audit snapshot round-trip coverage for all five Phase 3 variants) — most of it is already done in this PR; the remainder lands with the closeout PR
- M3.12 (Trust Task drafts batch) — both `health/diagnostics/1.0` and `auth/recognise/1.0` shipped with their respective PRs
- M3.13 (Phase 3 outcomes amendments + spec text) — closeout PR