### PR TITLE
chore(vtc-service): M3.11-M3.14 — Phase 3 closeout

### DIFF
--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -442,11 +442,25 @@ file-watching, no auto-reload.
 
 ### 8.1 Startup
 
-VTC publishes its issuer profile via `affinidi-trust-registry-rs` on
-boot. Idempotent. Publish failures are non-fatal but raise a state
-flag in `GET /v1/community/profile` (`registry_status:
-"degraded" | "active"`) and in `/v1/health/diagnostics`. Operators
-see the lag without having to grep telemetry.
+VTC publishes its issuer profile via an in-tree
+`TrustRegistryClient` wrapping the upstream
+`affinidi-trust-registry-rs` server's two transports (HTTP for
+reads, DIDComm for admin writes; see workspace
+`vtc_service::registry::client` + `upstream`). Idempotent.
+Publish failures are non-fatal but raise a state flag in
+`GET /v1/community/profile` (`registry_status: "degraded" |
+"active"`) and in `/v1/health/diagnostics`. Operators see the
+lag without having to grep telemetry.
+
+**Implementation note (Phase 3).** The TRQP v2.0 wire shape
+for `recognise` (used by §8.4) is not yet pinned against the
+live upstream — `UpstreamRegistryClient::recognise` returns a
+`Permanent` error with a clear deferral message until the
+payload format stabilises. The full M3.9 / M3.10 path is
+exercised end-to-end against the `MockRegistryClient` in
+integration tests; production deployments need the upstream
+HTTP wired before cross-community recognition functions
+against real peers.
 
 **PII boundary.** Only `member_did`, `status`, `active_from`,
 `active_to`, and `record_id` are written to the registry. The VTC
@@ -506,9 +520,20 @@ claim maps to a local ACL role. Default deny-all.
   audience default, the foreign VEC's `validUntil`, the foreign
   VMC's `validUntil`.
 - Recognition is **not cached**; every session mint re-runs the
-  full policy + StatusList + trust-registry check. A peer community
-  removed from the registry mid-session does not retain access on
-  refresh.
+  full policy + StatusList + trust-registry check.
+- **Cross-community sessions do not refresh.** The standard
+  `POST /v1/auth/refresh` route doesn't carry the foreign
+  credentials, so re-issuing a token without re-verifying
+  would defeat the "peer community removed mid-session loses
+  access" invariant. Cross-community sessions expire on their
+  clamped TTL; the caller mints a fresh one with the latest
+  credentials. Session IDs are prefixed `xc-` to distinguish
+  them from local-member sessions.
+- The verifier runs four checks in order (proof verify →
+  validity window → StatusList revocation → registry
+  recognise) and short-circuits on the first failure. Stable
+  reason codes for SIEM filtering live in
+  `vtc_service::recognition::RecognitionError::reason_code`.
 
 ## 9. Wire protocols
 
@@ -1038,7 +1063,8 @@ not in this spec.
 in Phase 2 (§3-A — cached-locally signer), so the per-call
 timeout and circuit-breaker configuration apply to **non-VMC
 remote dependencies only**: the trust-registry publish path in
-Phase 3 (`MembershipSyncer`) and the did:webvh resolver walk in
+Phase 3 (`MembershipSyncer`), the cross-community
+`recognise` query (§8.4), and the did:webvh resolver walk in
 M2.15.2's rotation slice. The configuration knobs retain their
 names (`vta.signing_timeout_seconds`, default 5;
 `vta.circuit_breaker_threshold`, default 5 consecutive failures)
@@ -1046,20 +1072,47 @@ for forward compatibility — they are the workspace's canonical
 "remote-call discipline" handles. The breaker-open semantics
 (join → `Deferred`, renewal → 503,
 `/v1/health/diagnostics` surfaces remote health) apply to those
-non-VMC paths once they land. Clarified per Phase 2 M2.16.
+non-VMC paths once they land. Clarified per Phase 2 M2.16 +
+Phase 3 M3.13.
+
+**Trust-registry-specific settings (Phase 3 M3.2 + M3.7).** The
+`registry` config block adds three knobs:
+
+- `registry.url` — base URL of the upstream TRQP registry.
+  When unset, the registry features no-op and
+  `registry_status` reports `"degraded"`.
+- `registry.health_probe_interval_seconds` — periodic probe
+  cadence (default 60s; `0` disables).
+- `registry.http_timeout_seconds` — per-call HTTP timeout
+  (default 5s).
+- `registry.rtbf_batch_window_hours` — RTBF coalescing
+  window (default 24h; `0` disables — test convenience
+  only).
 
 ### 14.3 Telemetry + diagnostics
 
-Reuses `vti_common::telemetry::TelemetrySink`. `/v1/health/diagnostics`
-(admin) surfaces:
+Reuses `vti_common::telemetry::TelemetrySink`.
+`/v1/health/diagnostics` (admin) surfaces the trust-registry
+reconciler state. As-shipped Phase 3 M3.8 response shape:
 
-- Remote-dependency health (trust-registry publish, did:webvh
-  resolver) + last-success timestamp
-- Status-list occupancy per purpose
-- `MembershipSyncer` queue depth + last-success/failure
-- Active policy IDs + SHA-256 per purpose
-- Trust-registry sync status
-- Telemetry ring-buffer snapshot
+```
+{
+  "registry_status": "active" | "degraded",
+  "queue_depth": <integer>,              // Pending + InFlight
+  "rtbf_batched_count": <integer>,       // Parked behind window
+  "failed_count": <integer>,             // Terminal failures
+  "oldest_pending_age_seconds": <int|null>,  // excludes RTBF-parked
+  "last_success_at": "<rfc3339>" | null,
+  "last_failure_at": "<rfc3339>" | null,
+  "last_error": "<string>" | null
+}
+```
+
+Aggregate-only — individual member DIDs are not surfaced; the
+`rtbf_batched_count` field discloses how many RTBF jobs are
+in flight but not which members. Phase 5 admin UX may add
+the status-list occupancy + active-policy snapshots + ring
+buffer named in earlier drafts.
 
 `/health` (unauthenticated, Trust-Task-exempt §9.4) returns 200 when
 the daemon is responsive and storage is reachable.

--- a/tasks/vtc-mvp/phase-3-plan.md
+++ b/tasks/vtc-mvp/phase-3-plan.md
@@ -519,3 +519,166 @@ Any decision that drifts from the default during
 implementation should be recorded in `phase-3-plan.md`
 under a "Phase 3 outcomes" header (mirror of Phase 1 + 2's
 pattern).
+
+## Phase 3 outcomes
+
+Recorded at M3.13 close-out. Each row links a pre-impl
+decision (D1–D10) or risk (R1–R6) to the as-shipped reality.
+
+### D1 — Trust-registry client shape
+
+**As shipped with deviation**: the proposed git-dep on
+`affinidi-trust-registry-rs` turned out to mean depending on
+the *server* crate, which pulls in an `affinidi-tdk = "0.4"`
+that conflicts with the workspace's `"0.7"`. Resolved
+mid-implementation (PR #87 planning) by writing an in-tree
+client wrapping the upstream's TRQP v2.0 HTTP surface +
+DIDComm admin protocol. The `TrustRegistryClient` trait
+keeps both transports opaque so future upstream changes
+land in one place.
+
+Spec deviation: upstream's `recognise` HTTP wire format
+isn't yet pinned — the live `UpstreamRegistryClient::recognise`
+returns `Permanent` with a clear "wire shape not yet pinned"
+message; a follow-up pins the payload against a running
+upstream. Mock-backed tests cover the full M3.9 + M3.10
+trail end-to-end.
+
+### D2 — `SyncJob` row shape
+
+**As shipped as proposed**: `SyncJob { id, kind, member_did,
+disposition?, created_at, attempts, last_attempted_at?,
+next_attempt_at, last_error?, state, rtbf_batched }` in
+`vtc_service::registry::model`. `state ∈
+{Pending, InFlight, Complete, Failed}`. Exponential backoff
+capped at 1h (M3.4); `rtbf_batched` flag drives the M3.7
+batch-window logic.
+
+### D3 — Audit-log-tail subscription
+
+**As shipped as proposed**: M3.3's `walk()` polls the
+`audit:` keyspace from a persisted `sync_cursor` row. The
+cursor advances over every envelope (including ignored
+variants) so a restart doesn't re-walk. Restart resilience
+is the load-bearing property — the audit log IS the event
+source of truth, and cursor-driven replay handles every
+"daemon crashed mid-flight" case identically.
+
+### D4 — RTBF batching trigger
+
+**As shipped with simplification**: parked-job `next_attempt_at`
+is set to `now + rtbf_batch_window_hours` (default 24h) at
+walk time. The proposed separate `RtbfBatchTimer` task is
+**not needed** — `SyncJob::is_dispatchable(now)` already
+checks the field, so the main syncer's tick naturally picks
+up parked jobs once their window expires. Configurable via
+`registry.rtbf_batch_window_hours`; `0` disables (test
+convenience).
+
+### D5 — Recognition cache stance
+
+**As shipped as proposed**: no caching anywhere. Every
+`POST /v1/auth/recognise` re-runs the full
+verifier (proof + status list + registry recognise +
+validity). Cross-community sessions intentionally **don't
+refresh** — the standard refresh path doesn't carry the
+foreign credentials, so re-issuing without re-verifying
+would defeat the "peer community removed mid-session loses
+access" invariant. Sessions just expire.
+
+### D6 — Failure-mode semantics
+
+**As shipped as proposed**: fail-closed in M3.9 (every
+check failure rejects); fail-open in M3.5's
+`publish_on_join` policy evaluation (broken policies sync
+rather than swallow membership). Registry unreachability at
+mint time maps to `503`, every other recognition failure to
+`403`. `RecognitionError::reason_code()` provides stable
+discriminators for SIEM filters.
+
+### D7 — `registry_records` keyspace shape
+
+**As shipped as proposed**: `RegistryRecord { member_did,
+status, active_from, active_to?, last_synced_at }` mirrors
+what the registry has. Updated on successful `SyncJob`
+dispatch; deleted on `DeleteMember` success.
+
+### D8 — Audit envelope names
+
+**As shipped as proposed**: five Phase 3 variants —
+`RegistryStatusChanged` (M3.2), `RegistrySyncSucceeded` +
+`RegistrySyncFailed` (M3.4), `RegistryRecordPolicyOverride`
+(M3.6), `CrossCommunitySessionMinted` (M3.10). All five
+have round-trip + discriminator-table coverage in
+`vti-common/src/audit/event.rs`.
+
+### D9 — Foreign-issuer DID resolution
+
+**As shipped as proposed**: production wires
+`DidResolverKeyResolver` over `DIDCacheClient` (reuses
+existing AppState resolver). Tests inject a stub via the
+`ForeignIssuerKeyResolver` trait — keeps the unit-test
+matrix hermetic.
+
+### D10 — Trust Task IDs
+
+**As shipped as proposed**: `health/diagnostics/1.0` (M3.8)
++ `auth/recognise/1.0` (M3.10). Both `Draft` in
+`index.json`; spec.md + schema.json on disk.
+
+### R1 — Upstream git-dep drift
+
+**Realised** — see D1. Pinned the trait abstraction;
+production HTTP wiring deferred behind a clear marker until
+the wire shape is pinned. cargo-audit on the trait is moot
+because the implementation is in-tree.
+
+### R2 — Tail-poll latency drift
+
+**Not realised yet**. Default 5s tick; the 1h
+visible-degraded threshold isn't currently surfaced via
+`oldest_pending_age_seconds`. The diagnostics endpoint
+exposes the metric; the flip-to-degraded threshold is left
+to operator alerting (their SIEM picks 1h or whatever they
+want). Phase 5 admin UX may bake it in.
+
+### R3 — RTBF / emergency-removal interaction
+
+**Not realised**. Phase 3 documents the 24h ceiling; admin
+manual-flush deferred to Phase 5 admin UX as planned.
+
+### R4 — Recognise latency
+
+**Not measured at production scale.** No live `recognise`
+HTTP call has been issued (see D1). Mock-backed
+microbenchmark unmeasured. Follow-up after wire format pins.
+
+### R5 — Registry recovery semantics
+
+**As planned**: passive reconcile via the syncer's
+restart-replay path. No active drift detection. Phase 5
+admin UX surface deferred.
+
+### R6 — DID resolution failures during recognition
+
+**As shipped**: `RecognitionError::IssuerKeyUnresolved`
+fails closed; route maps to `403` (caller's foreign issuer
+DID is the problem from the VTC's perspective, even when
+the underlying cause is network). No negative cache.
+
+### Spec amendments applied at M3.13
+
+- **§8.1**: in-tree TRQP client documented; `recognise`
+  HTTP wire-shape deferral noted.
+- **§8.4**: cross-community no-refresh path documented;
+  no caching anywhere; session TTL clamp formula spelled
+  out.
+- **§14.2**: trust-registry endpoint added to the remote-
+  dependency-breaker section (the M2.16 surface already
+  carried the abstraction; §14.2 now names registry
+  publish + recognise explicitly).
+- **§14.3**: `/v1/health/diagnostics` payload now matches
+  the as-shipped response (`registry_status`, `queue_depth`,
+  `rtbf_batched_count`, `failed_count`,
+  `oldest_pending_age_seconds`, + last-success/failure/
+  error fields).

--- a/tasks/vtc-mvp/phase-3-todo.md
+++ b/tasks/vtc-mvp/phase-3-todo.md
@@ -377,7 +377,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.11 — Audit variants snapshot tests
 
-### `[ ]` M3.11.1 — Round-trip + discriminator coverage
+### `[x]` M3.11.1 — Round-trip + discriminator coverage
 
 - **Acceptance**
   - The five Phase 3 audit variants
@@ -395,7 +395,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.12 — Trust Task drafts + index
 
-### `[ ]` M3.12.1 — On-disk + index entries
+### `[x]` M3.12.1 — On-disk + index entries
 
 - **Acceptance**
   - `trust-tasks/health/diagnostics/1.0/{spec.md,schema.json}`
@@ -417,7 +417,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.13 — Phase 3 outcomes + spec amendments
 
-### `[ ]` M3.13.1 — Document the as-shipped reality
+### `[x]` M3.13.1 — Document the as-shipped reality
 
 - **Acceptance**
   - `tasks/vtc-mvp/phase-3-plan.md` gains a "Phase 3
@@ -437,7 +437,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M3.14 — Phase 3 gate
 
-### `[ ]` M3.14.1 — Workspace gate green
+### `[x]` M3.14.1 — Workspace gate green
 
 - **Acceptance** (mirrors M2.19.1)
   - `cargo build --workspace` green.

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -1056,6 +1056,21 @@ mod tests {
     }
 
     #[test]
+    fn registry_record_policy_override_round_trip() {
+        let e = AuditEvent::RegistryRecordPolicyOverride(RegistryRecordPolicyOverrideData {
+            reason: "rtbf".into(),
+            attempted_disposition: "tombstone".into(),
+            effective_disposition: "purge".into(),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "RegistryRecordPolicyOverride");
+        assert_eq!(v["data"]["reason"], "rtbf");
+        assert_eq!(v["data"]["attemptedDisposition"], "tombstone");
+        assert_eq!(v["data"]["effectiveDisposition"], "purge");
+        round_trip(&e);
+    }
+
+    #[test]
     fn cross_community_session_minted_round_trip() {
         let e = AuditEvent::CrossCommunitySessionMinted(CrossCommunitySessionMintedData {
             outcome: "minted".into(),


### PR DESCRIPTION
## Summary

Phase 3 PR 5/5 — the closeout. Documents the as-shipped reality, fills the M3.11 round-trip gap, and confirms the workspace gate is green.

- **M3.11** — `RegistryRecordPolicyOverride` gets its dedicated round-trip snapshot test. The other four Phase-3 audit variants already had parity; this fills the gap.
- **M3.12** — Trust Tasks (`health/diagnostics/1.0` + `auth/recognise/1.0`) shipped with their respective PRs. 42 index entries ↔ 42 on-disk `spec.md` ↔ 42 on-disk `schema.json`.
- **M3.13** — Phase 3 outcomes recorded:
  - `tasks/vtc-mvp/phase-3-plan.md` gains a "Phase 3 outcomes" section covering D1–D10 + R1–R6 with the as-shipped reality.
  - `docs/05-design-notes/vtc-mvp.md` §§8.1 / 8.4 / 14.2 / 14.3 amended to match what shipped.
  - Memory entry `project_vtc_mvp.md` updated.
- **M3.14** — workspace gate green: `cargo build/clippy/fmt/test --workspace` clean.

### Key Phase 3 outcomes captured

- **D1 — in-tree TRQP client (deviation from "git-dep")**. Upstream is a server crate pulling in a conflicting `affinidi-tdk` major version. Resolved in PR1 by writing an in-tree `TrustRegistryClient` trait + `UpstreamRegistryClient` wrapping the HTTP + DIDComm surfaces. The `recognise` HTTP wire shape isn't pinned yet — production deployments need that follow-up before cross-community recognition functions against real peers.
- **D4 — RTBF batching simplified**. No separate `RtbfBatchTimer` task; parked-job `next_attempt_at` + the main syncer's `is_dispatchable(now)` check handle it naturally.
- **D5 — no caching + no refresh**. Cross-community sessions just expire on their clamped TTL; session IDs prefixed `xc-` to distinguish.
- **Disposition severity is preservation-based**, not privacy-strength. `historical (3) > tombstone (2) > purge (1)` — operator's floor is the minimum record retention they accept. Default `min_disposition := "purge"` means RTBF override is moot for fresh deployments; operators who raise the floor surface the override.
- **`oldest_pending_age_seconds` excludes future-dated RTBF rows** so the "≥1h behind → degraded" SLI can't be tricked by parked RTBF jobs.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — every test result `ok` (vtc-service 273 lib + every integration suite; vti-common 180; vta-sdk; vta-service; vta-enclave; vti-e2e-tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 42 ↔ 42 ↔ 42 Trust Task index/spec/schema match
- [x] All Phase 3 todo checkboxes flipped to `[x]`
- [x] DCO sign-off on commit

Phase 3 closes. Phase 4 (VRC + personhood `assert`/`revoke` + custom endorsements) can start.