### PR TITLE
fix(vta-service): release fjall lock during `vta unseal` interactive prompt

### DIFF
--- a/docs/01-concepts/security-model.md
+++ b/docs/01-concepts/security-model.md
@@ -58,6 +58,11 @@ config changes), see [TEE Enclave Security Design](tee-architecture.md).
 - Unsealing requires challenge-response proof of admin key ownership
 - In TEE mode, seal marker is AES-256-GCM encrypted in storage
 
+Operator-facing detail (when the seal is set, when it gets in the way,
+how to unseal, and the bootstrap-then-seal-last pattern that avoids
+the unseal dance) lives in
+[`02-operating/seal-and-unseal.md`](../02-operating/seal-and-unseal.md).
+
 ### Layer 7: Network Controls
 - Three vsock channels with strict purpose separation:
   - Inbound REST (port 5100): client requests to VTA

--- a/docs/02-operating/cold-start.md
+++ b/docs/02-operating/cold-start.md
@@ -226,7 +226,11 @@ vta import-did --did did:key:z6Mk... --role admin
 ```
 
 This writes a single `AclEntry` directly to the fjall store. No
-network call, no server required.
+network call, no server required. The VTA stays unsealed — the
+offline CLI remains usable for any further provisioning work
+(mediator, webvh-daemon, etc.) before you start the daemon. See
+[`seal-and-unseal.md`](seal-and-unseal.md) for when (and whether) to
+seal explicitly with `vta bootstrap-admin`.
 
 ## Phase 5: Start the VTA
 

--- a/docs/02-operating/non-interactive-setup.md
+++ b/docs/02-operating/non-interactive-setup.md
@@ -101,7 +101,7 @@ summary.
 | `vta_name` | no | `null` | Human-readable name. |
 | `public_url` | no | `null` | Used as the `VTARest` service endpoint when minting a DID. |
 | `data_dir_exists` | no | `"error"` | What to do if `data_dir` already exists. `"delete"` for CI re-runs. |
-| `admin_did` | no | `null` | If set, seeds a super-admin and seals the VTA atomically. Must start with `did:`. |
+| `admin_did` | no | `null` | If set, seeds a super-admin and seals the VTA atomically. Must start with `did:`. See [`seal-and-unseal.md`](seal-and-unseal.md) for the consequences of sealing at setup time and the recommended seal-last alternative. |
 | `admin_label` | no | `null` | Label on the seeded admin's ACL row. |
 
 ### Sections

--- a/docs/02-operating/seal-and-unseal.md
+++ b/docs/02-operating/seal-and-unseal.md
@@ -1,0 +1,204 @@
+# Sealing and Unsealing the VTA
+
+The **seal** is a single row in the VTA's fjall store (`vta:sealed` in
+the `acl` keyspace) that the offline CLI checks before any state-
+mutating command. While the seal is present, commands like `vta acl …`,
+`vta keys …`, `vta import-did`, `vta contexts create`,
+`vta contexts reprovision`, and `vta bootstrap provision-integration`
+all refuse to run. Management has to flow through the running daemon's
+REST or DIDComm API (which are gated by JWT auth, not by the seal — the
+daemon ignores the marker entirely).
+
+The seal is **not** a cryptographic lock. In non-TEE deployments anyone
+with disk access to the data directory could delete the row by hand.
+It's a deliberate "if you're here, you should be using the API, not the
+offline CLI" gate — a guard against accidental or malicious offline
+mutations after the deployment is supposed to be running through the
+API. In TEE deployments the marker is AES-256-GCM encrypted with the
+enclave's storage key, which gives the seal real teeth: an attacker on
+the parent EC2 instance can't read or modify it.
+
+## When the seal is set
+
+Two paths set the seal automatically:
+
+| Trigger | Resulting state |
+|---|---|
+| `vta setup --from <file>` **with `admin_did = "…"`** in the TOML | Setup mints DIDs, seeds the supplied DID as super-admin, then seals. |
+| `vta bootstrap-admin --did <did:…>` after `vta setup` | Seeds a super-admin and seals as a separate step. |
+
+If `admin_did` is omitted from the setup TOML (and `vta bootstrap-admin`
+isn't run), the VTA finishes setup **unsealed with an empty ACL** — the
+offline CLI remains fully usable. This is the recommended state for the
+window where you're provisioning the mediator, webvh-daemon, or any
+other integration that needs the VTA to mint keys and seal bundles.
+
+## When the seal is in your way
+
+Any of these would fail with `Error: configuration error: VTA is sealed
+(by did:… on …)`:
+
+- `vta contexts reprovision …` — sealing a bundle for the mediator's
+  Phase 2.
+- `vta bootstrap provision-integration …` — sealing a bundle for a
+  webvh-daemon or other template-driven integration.
+- `vta contexts create …`, `vta acl …`, `vta keys …`,
+  `vta import-did …` — any state-mutating offline command.
+
+The fix is either to unseal (below) or — much better — **don't seal
+yet**: defer admin seeding until after you've finished offline
+bootstrap work.
+
+## Recommended bootstrap order: seal last
+
+Set up the VTA without `admin_did`, do all the offline provisioning
+while it's still open, *then* seed the admin and seal. This avoids the
+unseal dance entirely:
+
+1. `vta setup --from vta-setup.toml` with `admin_did` **omitted**
+   → unsealed, ACL empty.
+2. Provision the mediator: `mediator-setup` Phase 1 →
+   `vta contexts reprovision …` → `mediator-setup` Phase 2.
+3. Provision the webvh-daemon: `webvh-daemon setup-offline-prepare` →
+   `vta contexts create webvh …` →
+   `vta bootstrap provision-integration …` →
+   `webvh-daemon setup-offline-complete`.
+4. Provision any other integrations the same way.
+5. Mint or import the admin identity (`pnm setup --name <slug>` is the
+   common case) and register it: `vta import-did --did <admin> --role
+   admin`. Or, if PNM lives on a different host, just `vta import-did`
+   with the externally-supplied DID.
+6. **Optionally** seal now: `vta bootstrap-admin --did <admin>`. Skip
+   this if you're happy leaving the offline CLI usable; the running
+   daemon's auth gates production work regardless of seal state.
+
+This sequence is also why `pnm setup` doesn't have to be the first step.
+PNM only matters once you want an authenticated client against the
+running VTA — it doesn't participate in offline provisioning.
+
+## If you do need to unseal
+
+`vta unseal` runs an offline challenge-response: the VTA prints a random
+32-byte challenge, the operator signs it with the super-admin's Ed25519
+private key, pastes the signature back. The VTA verifies, removes the
+marker.
+
+```bash
+cd /path/to/vta
+vta unseal
+```
+
+The prompt looks like:
+
+```
+=== VTA Unseal Challenge ===
+
+  Sealed by: did:key:z6Mk…
+  Sealed at: 2026-05-13 11:42:08 +08:00
+
+  Authorized super admin DIDs:
+    - did:key:z6Mk… (pnm-bootstrap)
+
+  Challenge (hex):
+  9f3a1c…
+
+  Sign this challenge with your super admin key. Either:
+
+    pnm auth sign-challenge 9f3a1c…                                      # online: signs with PNM's stored admin key
+    vta auth sign-challenge --did <admin-did> --challenge 9f3a1c…        # offline: signs from this VTA's local keystore
+
+  Then paste the signature (hex) and your DID below.
+
+  Admin DID:
+```
+
+Open a **second terminal** to produce the signature, paste it back into
+the prompt, and `vta unseal` removes the seal.
+
+### Which signer command to use
+
+Pick the signer that has the admin's private key:
+
+| Signer | Where the private key lives | When to use |
+|---|---|---|
+| `pnm auth sign-challenge <hex>` | PNM's OS keyring on this (or another) host. | The admin DID was minted by PNM (the common case for operator-driven setup). |
+| `vta auth sign-challenge --did <did> --challenge <hex>` | This VTA's local fjall keystore. | The admin DID was minted by the VTA itself (e.g. `vta create-did-key --admin`). |
+| Any external Ed25519 signer (Python script, `ssh-keygen -Y sign`, KMS, hardware token, …) | Wherever you keep it. | Air-gapped admin, no PNM, hardware-token deployments. |
+
+The wire format is intentionally simple: **raw Ed25519 signature over the
+32-byte challenge, hex-encoded.** No domain tag, no envelope. Any
+Ed25519 signer with access to the admin private key can produce it:
+
+```python
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+sk = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(SEED_HEX))
+print(sk.sign(bytes.fromhex(CHALLENGE_HEX)).hex())
+```
+
+### After unsealing
+
+The VTA prints `Re-seal when done: vta bootstrap-admin --did <admin>` as
+a hint. It's not mandatory — `vta bootstrap-admin` will refuse if a
+super-admin already exists, so the literal re-seal command is actually a
+different one (just clear the marker via a sealed/unseal cycle, or run
+`vta bootstrap-admin` only after first running through the rest of the
+admin lifecycle). In most production setups, once the daemon is up and
+running you never touch the offline CLI again, so the seal state stops
+mattering.
+
+## Gotchas
+
+### The admin private key has to be somewhere
+
+`vta unseal` verifies a signature; it doesn't have one to give. The
+private key for the super-admin DID has to live in PNM, in the VTA's
+local fjall (only if the VTA itself minted the admin), in a hardware
+token, or in some other signer you trust. If you sealed with an
+externally-supplied `admin_did` (S08-style) **and** then lost the PNM
+keyring on the host that minted it, the only path back is restoring
+from a backup (`vta backup import`) — that path doesn't traverse the
+seal.
+
+### `vta auth sign-challenge` only works for `did:key:` admins minted by this VTA
+
+The verifier behind `vta unseal` only accepts `did:key:` admin DIDs.
+Beyond that, `vta auth sign-challenge` reads the key record from the
+VTA's *own* fjall keystore — so it only works when the VTA was the
+mint. Admin DIDs minted by PNM (which is the default when you write
+`admin_did = "<pnm DID>"` in `vta-setup.toml`) live in PNM's keyring,
+not the VTA's, and `vta auth sign-challenge` will fail with `no key
+record found for <did> in this VTA's keystore`. Use
+`pnm auth sign-challenge` instead, on whichever host PNM lives on.
+
+### `vta unseal` and `vta auth sign-challenge` open the same data dir
+
+fjall takes an exclusive lock on the data directory per process. Until
+recently, `vta unseal` held that lock the whole time it was waiting for
+the operator to paste a signature, which meant
+`vta auth sign-challenge` in a second terminal failed immediately with
+`FjallError: Locked`. The current implementation releases the lock for
+the duration of the interactive prompt (read seal + ACL → drop → wait
+on stdin → reopen → remove seal), so the two commands now coexist
+cleanly. Older builds may still exhibit the conflict — workaround is to
+use `pnm auth sign-challenge` (which lives in a different keyring and
+never touches the VTA's fjall).
+
+### The daemon ignores the seal — don't rely on it for live security
+
+The seal only gates the *offline CLI*. While the VTA daemon is running,
+all the same mutations are available via authenticated REST/DIDComm and
+are gated by ACL roles, JWT expiry, and audit logging. Don't think of
+the seal as part of live access control — it's a setup-time guardrail.
+
+## Related
+
+- [`non-interactive-setup.md`](non-interactive-setup.md) — `vta setup
+  --from <file>`, including the `admin_did` field that triggers
+  auto-seal.
+- [`cold-start.md`](cold-start.md) — the interactive walkthrough, which
+  reaches the same end state through prompts.
+- [`provision-integration.md`](../03-integrating/provision-integration.md)
+  — the offline integration-provisioning flow whose `reprovision` /
+  `provision-integration` subcommands trip the seal.
+- [`security-model.md`](../01-concepts/security-model.md) — Layer 6 of
+  the defense-in-depth model.

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,9 @@ how to integrate with it, and where the design decisions live.
 - **[Non-interactive setup](02-operating/non-interactive-setup.md)** —
   scripted VTA provisioning via `vta setup --from <file>` for CI,
   sealed images, and unattended bootstrap.
+- **[Sealing and unsealing the VTA](02-operating/seal-and-unseal.md)** —
+  what the seal is, when it's set, how `vta unseal` works, and the
+  bootstrap-then-seal-last pattern that sidesteps it entirely.
 - **[Secret-storage backends](02-operating/secret-backends.md)** —
   AWS Secrets Manager, GCP Secret Manager, Azure Key Vault,
   HashiCorp Vault (with Kubernetes / token / AppRole auth),

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -921,8 +921,11 @@ async fn main() {
                     std::process::exit(1);
                 }
             };
-            let store = store::Store::open(&config.store).expect("failed to open store");
-            if let Err(e) = seal::run_unseal_challenge(&store).await {
+            // run_unseal_challenge opens and drops the store twice on
+            // purpose so the fjall lock is not held while the operator
+            // is pasting a signature — see the doc comment on that
+            // function. Pass the config, not an already-opened Store.
+            if let Err(e) = seal::run_unseal_challenge(&config.store).await {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             }

--- a/vta-service/src/seal.rs
+++ b/vta-service/src/seal.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::acl::{self, Role};
+use crate::config::StoreConfig;
 use crate::error::AppError;
 use crate::store::{KeyspaceHandle, Store};
 
@@ -100,26 +101,34 @@ pub async fn seal(acl_ks: &KeyspaceHandle, admin_did: &str) -> Result<SealRecord
     Ok(record)
 }
 
-/// Run the interactive unseal challenge-response protocol.
-///
-/// 1. Finds super admin DIDs in the ACL
-/// 2. Generates a random 32-byte challenge
-/// 3. Displays the challenge for the admin to sign
-/// 4. Reads back the signature
-/// 5. Verifies the Ed25519 signature against the admin's public key
-/// 6. If valid, removes the seal
-pub async fn run_unseal_challenge(store: &Store) -> Result<(), AppError> {
+/// Snapshot of what `read_unseal_state` pulls from the sealed store
+/// before releasing the fjall lock.
+#[derive(Debug)]
+pub(crate) struct UnsealChallenge {
+    pub seal: SealRecord,
+    pub super_admins: Vec<acl::AclEntry>,
+    pub challenge_bytes: [u8; 32],
+}
+
+/// Phase 1 of the unseal flow: open the store, read the seal record
+/// and the super-admin list, mint a fresh 32-byte challenge, and
+/// **drop the store before returning**. After this call the fjall
+/// directory lock is released — a sibling `vta auth sign-challenge` (or
+/// any other process) can open the same data dir while the operator is
+/// pasting their signature.
+pub(crate) async fn read_unseal_state(
+    store_config: &StoreConfig,
+) -> Result<UnsealChallenge, AppError> {
+    let store = Store::open(store_config)?;
     let acl_ks = store.keyspace("acl")?;
 
-    // Verify the VTA is actually sealed
     let seal = get_seal(&acl_ks)
         .await?
         .ok_or_else(|| AppError::Config("VTA is not sealed — nothing to unseal".into()))?;
 
-    // Find super admin DIDs
     let entries = acl::list_acl_entries(&acl_ks).await?;
-    let super_admins: Vec<_> = entries
-        .iter()
+    let super_admins: Vec<acl::AclEntry> = entries
+        .into_iter()
         .filter(|e| e.role == Role::Admin && e.allowed_contexts.is_empty())
         .collect();
 
@@ -129,9 +138,50 @@ pub async fn run_unseal_challenge(store: &Store) -> Result<(), AppError> {
         ));
     }
 
-    // Generate random challenge
     let mut challenge_bytes = [0u8; 32];
     rand::fill(&mut challenge_bytes);
+
+    Ok(UnsealChallenge {
+        seal,
+        super_admins,
+        challenge_bytes,
+    })
+    // `store` and `acl_ks` drop here — fjall lock released.
+}
+
+/// Phase 3 of the unseal flow: reopen the store, remove the seal
+/// marker if it's still there, persist. Returns `Ok(true)` if the
+/// seal was removed in this call, `Ok(false)` if it had already been
+/// removed (e.g. by a concurrent process while the operator was
+/// blocked on stdin).
+pub(crate) async fn remove_seal_marker(store_config: &StoreConfig) -> Result<bool, AppError> {
+    let store = Store::open(store_config)?;
+    let acl_ks = store.keyspace("acl")?;
+    if get_seal(&acl_ks).await?.is_none() {
+        return Ok(false);
+    }
+    acl_ks.remove(SEAL_KEY).await?;
+    store.persist().await?;
+    Ok(true)
+}
+
+/// Run the interactive unseal challenge-response protocol.
+///
+/// 1. [`read_unseal_state`] — open store, read seal + super-admins,
+///    generate a 32-byte challenge, drop store.
+/// 2. Print the challenge and read the admin DID + signature on stdin.
+///    **No fjall lock is held during this phase**, so a sibling
+///    `vta auth sign-challenge` or `pnm auth sign-challenge` invocation
+///    can open the same data dir to produce the signature.
+/// 3. Verify the Ed25519 signature; [`remove_seal_marker`] then
+///    reopens the store, removes the seal, and persists.
+pub async fn run_unseal_challenge(store_config: &StoreConfig) -> Result<(), AppError> {
+    let UnsealChallenge {
+        seal,
+        super_admins,
+        challenge_bytes,
+    } = read_unseal_state(store_config).await?;
+
     let challenge_hex = hex::encode(challenge_bytes);
 
     eprintln!();
@@ -160,7 +210,7 @@ pub async fn run_unseal_challenge(store: &Store) -> Result<(), AppError> {
     );
     eprintln!(
         "    vta auth sign-challenge --did <admin-did> --challenge {challenge_hex}   \
-         # offline: signs from this VTA's local keystore (daemon stopped)"
+         # offline: signs from this VTA's local keystore"
     );
     eprintln!();
     eprintln!("  Then paste the signature (hex) and your DID below.");
@@ -181,7 +231,7 @@ pub async fn run_unseal_challenge(store: &Store) -> Result<(), AppError> {
         .map_err(|e| AppError::Internal(format!("failed to read input: {e}")))?;
     let admin_did = did_input.trim();
 
-    // Verify the DID is a super admin
+    // Verify the DID is a super admin (against the snapshot we read in phase 1).
     let admin_entry = super_admins
         .iter()
         .find(|e| e.did == admin_did)
@@ -195,12 +245,16 @@ pub async fn run_unseal_challenge(store: &Store) -> Result<(), AppError> {
         .map_err(|e| AppError::Internal(format!("failed to read input: {e}")))?;
     let sig_hex = sig_input.trim();
 
-    // Verify the signature
+    // Verify the signature before we reacquire the lock.
     verify_challenge_signature(admin_did, &challenge_bytes, sig_hex)?;
 
-    // Signature valid — unseal
-    acl_ks.remove(SEAL_KEY).await?;
-    store.persist().await?;
+    let removed = remove_seal_marker(store_config).await?;
+    if !removed {
+        eprintln!();
+        eprintln!("  VTA was unsealed concurrently — nothing to do.");
+        eprintln!();
+        return Ok(());
+    }
 
     info!(admin = %admin_did, "VTA unsealed via challenge-response");
 
@@ -280,4 +334,139 @@ fn verify_challenge_signature(
     })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::AclEntry;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// Seal a fresh store under `data_dir` with a single super-admin
+    /// ACL entry. The store is opened, populated, and dropped — the
+    /// fjall lock is released before this helper returns.
+    async fn seal_fresh_store(data_dir: &std::path::Path, admin_did: &str) {
+        let config = StoreConfig {
+            data_dir: data_dir.to_path_buf(),
+        };
+        let store = Store::open(&config).expect("open store");
+        let acl_ks = store.keyspace("acl").expect("acl keyspace");
+
+        let entry = AclEntry {
+            did: admin_did.to_string(),
+            role: Role::Admin,
+            label: Some("test-super-admin".into()),
+            allowed_contexts: vec![],
+            created_at: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            created_by: "test".into(),
+            expires_at: None,
+        };
+        acl::store_acl_entry(&acl_ks, &entry).await.expect("acl");
+        seal(&acl_ks, admin_did).await.expect("seal");
+        store.persist().await.expect("persist");
+    }
+
+    /// Regression: `read_unseal_state` MUST drop the fjall handle
+    /// before returning. The bug it fixes was that
+    /// `run_unseal_challenge` kept the store open across the stdin
+    /// wait, so `vta auth sign-challenge` (which opens the same data
+    /// dir to sign the challenge) failed with `FjallError: Locked`.
+    ///
+    /// If this test ever starts failing with a fjall lock error on
+    /// the second `Store::open`, someone has reintroduced the bug.
+    #[tokio::test]
+    async fn read_unseal_state_releases_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        seal_fresh_store(dir.path(), "did:key:zTestAdmin").await;
+
+        let config = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+
+        // Phase 1: must return without holding the lock.
+        let challenge = read_unseal_state(&config).await.expect("read_unseal_state");
+
+        assert_eq!(challenge.seal.sealed_by, "did:key:zTestAdmin");
+        assert_eq!(challenge.super_admins.len(), 1);
+        assert_eq!(challenge.challenge_bytes.len(), 32);
+
+        // A sibling opener — mimicking `vta auth sign-challenge` — must
+        // be able to acquire the lock now. If `read_unseal_state` ever
+        // regresses to holding the store across the stdin wait, this
+        // open fails with `FjallError: Locked`.
+        let _sibling = Store::open(&config).expect(
+            "sibling Store::open after read_unseal_state must succeed — \
+             the fjall lock from phase 1 should have been released on drop",
+        );
+    }
+
+    /// `remove_seal_marker` removes the seal on first call, then is
+    /// idempotent (returns Ok(false) — useful for the "concurrent
+    /// unseal" race in the interactive flow).
+    #[tokio::test]
+    async fn remove_seal_marker_is_idempotent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        seal_fresh_store(dir.path(), "did:key:zTestAdmin").await;
+
+        let config = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+
+        let first = remove_seal_marker(&config).await.expect("first call");
+        assert!(first, "first call should report seal removed");
+
+        let second = remove_seal_marker(&config).await.expect("second call");
+        assert!(
+            !second,
+            "second call should report no-op (seal already gone)"
+        );
+
+        // Store reopens fine afterwards — lock released.
+        let _after = Store::open(&config).expect("reopen after remove");
+    }
+
+    /// Phase 1 fails cleanly when the VTA isn't sealed (no marker row).
+    #[tokio::test]
+    async fn read_unseal_state_rejects_unsealed_vta() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        // Open + drop to create the data dir but don't seal.
+        {
+            let store = Store::open(&config).expect("open");
+            store.persist().await.expect("persist");
+        }
+
+        let err = read_unseal_state(&config)
+            .await
+            .expect_err("must reject unsealed VTA");
+        assert!(matches!(err, AppError::Config(_)), "got {err:?}");
+    }
+
+    /// Phase 1 fails cleanly when sealed but no super-admin exists
+    /// (should not happen in practice — seal always follows admin
+    /// seeding — but the guard is worth keeping fenced).
+    #[tokio::test]
+    async fn read_unseal_state_rejects_missing_super_admin() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        {
+            let store = Store::open(&config).expect("open");
+            let acl_ks = store.keyspace("acl").expect("acl");
+            // Seal directly without seeding a super-admin.
+            seal(&acl_ks, "did:key:zPhantom").await.expect("seal");
+            store.persist().await.expect("persist");
+        }
+
+        let err = read_unseal_state(&config)
+            .await
+            .expect_err("must reject missing super-admin");
+        assert!(matches!(err, AppError::Config(_)), "got {err:?}");
+    }
 }


### PR DESCRIPTION
## Summary

- `vta unseal` held the fjall directory lock across the interactive challenge-response, so a sibling `vta auth sign-challenge` (the offline signer the prompt itself recommends) on the same data dir failed immediately with `FjallError: Locked`. Restructured into three phases — open/read/drop → prompt+stdin (no lock) → reopen/remove/persist — so the two commands now coexist cleanly.
- Adds a new operator doc `docs/02-operating/seal-and-unseal.md` covering what the seal is, when it's set, the recommended **seal-last bootstrap order** that avoids `vta unseal` entirely (defer admin/sealing until after mediator + webvh-daemon provisioning), how to unseal when needed, which signer to use for which admin-key location, and the historical gotchas. Cross-linked from the doc index, security model, non-interactive setup, and cold-start guide.
- Four new unit tests including `read_unseal_state_releases_lock` as a regression fence that opens a sibling `Store` after phase 1 returns.

## Context

Reported during offline-VTA + DIDComm bootstrap (vti-setup S08 scenario). The operator hits `vta unseal` between mediator Phase 1 and Phase 2 to enable `vta contexts reprovision`; the prompt suggests `vta auth sign-challenge --did <did> --challenge <hex>` as the offline signing path, but that command tried to open the same fjall data dir and was rejected by the lock held by `vta unseal` itself.

Root cause: `run_unseal_challenge` took `&Store` and the caller (`vta-service/src/main.rs:924`) opened the store before invoking it, keeping the fjall lock alive for the whole stdin wait. Fixed by giving `run_unseal_challenge` ownership of the open/close lifecycle, split into explicit phases.

## Test plan

- [x] `cargo test --package vta-service --lib` — 319 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] New regression test `read_unseal_state_releases_lock` proves a sibling `Store::open` succeeds after phase 1
- [ ] Manual verification on an actual offline VTA: seal → `vta unseal` in terminal 1 → `vta auth sign-challenge` in terminal 2 → paste signature → seal removed