### PR TITLE
feat(vtc-service): pin TRQP recognise wire format against upstream

### DIFF
--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -452,15 +452,21 @@ Publish failures are non-fatal but raise a state flag in
 "active"`) and in `/v1/health/diagnostics`. Operators see the
 lag without having to grep telemetry.
 
-**Implementation note (Phase 3).** The TRQP v2.0 wire shape
-for `recognise` (used by §8.4) is not yet pinned against the
-live upstream — `UpstreamRegistryClient::recognise` returns a
-`Permanent` error with a clear deferral message until the
-payload format stabilises. The full M3.9 / M3.10 path is
-exercised end-to-end against the `MockRegistryClient` in
-integration tests; production deployments need the upstream
-HTTP wired before cross-community recognition functions
-against real peers.
+**Implementation note (Phase 3, post-closeout).** The TRQP
+v2.0 wire shape for `recognise` (used by §8.4) is pinned
+against the upstream's `POST /recognition` route at
+`affinidi/affinidi-trust-registry-rs`. The request is a
+4-tuple of snake_case strings (`entity_id`, `authority_id`,
+`action`, `resource`); the response carries a top-level
+`recognized: bool`. The VTC sends `entity_id =
+<foreign-issuer-did>`, `authority_id = <local-vtc-did>`,
+`action = "recognise"`, `resource = "trust-graph"`. A `404`
+response is mapped to `Ok(false)` (clean not-found),
+semantically equivalent to a stored record with `recognized:
+false`. End-to-end tests stand up an in-process axum server
+exercising the same wire codepath. Production deployments
+need only the upstream's `registry.url` set + the VTC's
+`vtc_did` populated.
 
 **PII boundary.** Only `member_did`, `status`, `active_from`,
 `active_to`, and `record_id` are written to the registry. The VTC

--- a/tasks/vtc-mvp/phase-3-plan.md
+++ b/tasks/vtc-mvp/phase-3-plan.md
@@ -537,12 +537,15 @@ DIDComm admin protocol. The `TrustRegistryClient` trait
 keeps both transports opaque so future upstream changes
 land in one place.
 
-Spec deviation: upstream's `recognise` HTTP wire format
-isn't yet pinned — the live `UpstreamRegistryClient::recognise`
-returns `Permanent` with a clear "wire shape not yet pinned"
-message; a follow-up pins the payload against a running
-upstream. Mock-backed tests cover the full M3.9 + M3.10
-trail end-to-end.
+Follow-up landed post-closeout: `UpstreamRegistryClient::
+recognise` now sends a real `POST /recognition` 4-tuple
+(`entity_id`, `authority_id`, `action`, `resource`) and
+parses `response.recognized`. 404 maps to `Ok(false)`
+(clean not-found); 400 → `Permanent`; 5xx / connect-refused
+→ existing classify path. End-to-end tests stand up an
+in-process axum server. Mock-backed verifier tests in
+`recognition::verify::tests` still cover the M3.9 trail
+hermetically.
 
 ### D2 — `SyncJob` row shape
 

--- a/vtc-service/src/registry/upstream.rs
+++ b/vtc-service/src/registry/upstream.rs
@@ -10,13 +10,19 @@
 //! DIDComm against the upstream's `tr-admin/1.0/*` protocol
 //! family.
 //!
-//! M3.2 lands the **HTTP transport** + the `health()` method
-//! (drives `registry_status` on the community profile). The
-//! DIDComm-backed write methods (`publish_member`,
-//! `delete_member`) are scaffolded as "not yet wired" — they
-//! return `RegistryError::Permanent` so consumers (the syncer
-//! task in M3.4) fail closed until the DIDComm transport
-//! lands.
+//! As-shipped status:
+//!
+//! - `health()` — live (HTTP probe against
+//!   `GET /.well-known/did.json`); drives `registry_status`
+//!   on the community profile (M3.2).
+//! - `recognise()` — live (`POST /recognition` with the
+//!   pinned TRQP v2.0 4-tuple); drives the cross-community
+//!   session-mint path's recognition gate (M3.10 + the wire-
+//!   shape pin follow-up).
+//! - `publish_member()` / `delete_member()` / `read_member()`
+//!   — scaffolded as "not yet wired"; return
+//!   `RegistryError::Permanent` so consumers (the syncer task
+//!   in M3.4) fail closed until the DIDComm transport lands.
 //!
 //! ## Why the write methods land as "not wired" first
 //!
@@ -47,6 +53,13 @@ pub struct UpstreamConfig {
     /// Per-call HTTP timeout. Mirrors
     /// `RegistryConfig::http_timeout_seconds`.
     pub http_timeout: Duration,
+    /// Local VTC's DID — used as the TRQP `authority_id` in
+    /// recognition queries (we're the authority asking "do *I*
+    /// recognise this peer?"). Sourced from `config.vtc_did`
+    /// at boot. `None` when the VTC hasn't completed setup —
+    /// recognition queries refuse with a clear error in that
+    /// state rather than sending a malformed payload.
+    pub authority_did: Option<String>,
 }
 
 /// Reqwest-backed client. Lazy field: the ATM handle is only
@@ -56,6 +69,7 @@ pub struct UpstreamConfig {
 pub struct UpstreamRegistryClient {
     http: Client,
     base_url: String,
+    authority_did: Option<String>,
     /// ATM handle for DIDComm sends. `None` in M3.2; lands in
     /// M3.4 when the syncer needs the write path.
     #[allow(dead_code)]
@@ -88,6 +102,7 @@ impl UpstreamRegistryClient {
         Ok(Self {
             http,
             base_url: cfg.base_url.trim_end_matches('/').to_string(),
+            authority_did: cfg.authority_did,
             atm: None,
         })
     }
@@ -158,22 +173,108 @@ impl TrustRegistryClient for UpstreamRegistryClient {
         ))
     }
 
-    async fn recognise(&self, _foreign_issuer_did: &str) -> Result<bool, RegistryError> {
-        // TRQP `POST /recognition` wire shape is documented by
-        // upstream as a 4-tuple query (authority_id, entity_id,
-        // action, resource). Pinning the exact payload — and
-        // the response envelope — needs a live integration
-        // test against a running upstream, which is out of
-        // scope for this milestone. The verifier (M3.9) calls
-        // through the trait and is exercised end-to-end via
-        // `MockRegistryClient` until the wire format is
-        // pinned. Production deployments using this client
-        // get a clear, retriable-classification failure rather
-        // than silently passing the recognition check.
-        warn!("UpstreamRegistryClient.recognise called before TRQP v2.0 payload shape is pinned");
-        Err(RegistryError::Permanent(
-            "recognise is not yet implemented in this build — pin the upstream TRQP v2.0 wire shape first".into(),
-        ))
+    async fn recognise(&self, foreign_issuer_did: &str) -> Result<bool, RegistryError> {
+        // TRQP `POST /recognition` per
+        // `affinidi/affinidi-trust-registry-rs`:
+        //
+        // - Path: `/recognition` at server root (no API prefix).
+        // - Body: `{ entity_id, authority_id, action, resource,
+        //   context? }`, all snake_case strings; `context`
+        //   optional/omitted.
+        // - 200 → body carries `recognized: bool` (single
+        //   tuple lookup — not an array). A `recognized: true`
+        //   means the upstream confirms recognition.
+        // - 404 → no record matches the 4-tuple. We map this
+        //   to `Ok(false)` — that's the *clean* "not
+        //   recognised" path, semantically identical to a
+        //   stored record with `recognized: false`. Surfacing
+        //   it as an error would force every caller to handle
+        //   the same case twice.
+        // - 400 → operator-side input is malformed. Maps to
+        //   `Permanent` so the syncer flips the job to
+        //   `Failed` immediately rather than retrying.
+        // - 5xx / connect / DNS errors → `classify_http_error`
+        //   (Transient / Unreachable).
+        //
+        // The recognition trust model:
+        //   entity_id    = the peer community being checked
+        //                  (`foreign_issuer_did`).
+        //   authority_id = our own VTC's DID (we're the
+        //                  authority who recognises peers).
+        //   action       = `"recognise"`.
+        //   resource     = `"trust-graph"` — the scope we're
+        //                  asking about. Fixed string for
+        //                  Phase 3; future PRs can promote to
+        //                  a config knob if operators need
+        //                  per-deployment scopes.
+        let authority = self.authority_did.as_deref().ok_or_else(|| {
+            RegistryError::Permanent(
+                "authority_did not configured — cannot issue recognise query (set vtc_did in config)".into(),
+            )
+        })?;
+
+        #[derive(serde::Serialize)]
+        struct RecognitionRequest<'a> {
+            entity_id: &'a str,
+            authority_id: &'a str,
+            action: &'static str,
+            resource: &'static str,
+        }
+        #[derive(serde::Deserialize)]
+        #[allow(dead_code)]
+        struct RecognitionResponse {
+            recognized: bool,
+            // The upstream response carries a handful of
+            // additional fields (`entity_id`, `authority_id`,
+            // `record_type`, `time_requested`, `time_evaluated`,
+            // `message`, merged `context`). We deserialize only
+            // `recognized` so any wire additions don't break
+            // us. `#[serde(deny_unknown_fields)]` would be the
+            // wrong call here — let the upstream evolve.
+        }
+
+        let url = format!("{}/recognition", self.base_url);
+        let body = RecognitionRequest {
+            entity_id: foreign_issuer_did,
+            authority_id: authority,
+            action: "recognise",
+            resource: "trust-graph",
+        };
+        debug!(%url, entity = %foreign_issuer_did, authority = %authority, "trust-registry recognise");
+        let resp = self
+            .http
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(Self::classify_http_error)?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+        if status.is_client_error() {
+            // 400 / 401 / 403 — payload malformed or auth
+            // surface changed. Operator intervention; don't
+            // retry.
+            return Err(RegistryError::Permanent(format!(
+                "registry returned {status} for recognise"
+            )));
+        }
+        if status.is_server_error() {
+            return Err(RegistryError::Transient(format!(
+                "registry returned {status} for recognise"
+            )));
+        }
+        if !status.is_success() {
+            return Err(RegistryError::Transient(format!(
+                "unexpected status {status} for recognise"
+            )));
+        }
+        let body: RecognitionResponse = resp
+            .json()
+            .await
+            .map_err(|e| RegistryError::Transient(format!("parse recognise response: {e}")))?;
+        Ok(body.recognized)
     }
 
     async fn health(&self) -> Result<(), RegistryError> {
@@ -210,13 +311,151 @@ impl TrustRegistryClient for UpstreamRegistryClient {
 
 #[cfg(test)]
 mod tests {
+    //! In-test axum servers stand in for a real
+    //! `affinidi-trust-registry-rs` upstream. We bind to
+    //! `127.0.0.1:0`, capture the port, and point the client
+    //! at the resulting URL. No mocking dependencies — keeps
+    //! the test surface honest about the wire format because
+    //! reqwest serialises through the same codepath as
+    //! production.
+
     use super::*;
+    use axum::Json;
+    use axum::Router;
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::routing::post;
+    use serde_json::Value as JsonValue;
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+    use tokio::sync::oneshot;
+
+    /// Captured-payload type so tests can assert on the
+    /// exact wire shape the client sent.
+    #[derive(Debug, Clone, serde::Deserialize)]
+    struct CapturedRequest {
+        entity_id: String,
+        authority_id: String,
+        action: String,
+        resource: String,
+    }
+
+    #[derive(Clone)]
+    struct ServerState {
+        captured: Arc<tokio::sync::Mutex<Option<CapturedRequest>>>,
+        response: Arc<tokio::sync::Mutex<TestResponse>>,
+    }
+
+    #[derive(Clone, Debug)]
+    enum TestResponse {
+        Recognized(bool),
+        NotFound,
+        BadRequest,
+        ServerError,
+    }
+
+    async fn recognition_handler(
+        State(state): State<ServerState>,
+        Json(body): Json<CapturedRequest>,
+    ) -> (StatusCode, Json<JsonValue>) {
+        *state.captured.lock().await = Some(body);
+        match state.response.lock().await.clone() {
+            TestResponse::Recognized(b) => (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "entity_id": "did:webvh:peer.example",
+                    "authority_id": "did:webvh:vtc.example",
+                    "action": "recognise",
+                    "resource": "trust-graph",
+                    "recognized": b,
+                    "context": {},
+                    "record_type": "recognition",
+                    "time_requested": "2026-05-13T10:00:00Z",
+                    "time_evaluated": "2026-05-13T10:00:00Z",
+                    "message": "mock"
+                })),
+            ),
+            TestResponse::NotFound => (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "title": "not_found",
+                    "type": "about:blank",
+                    "code": 404
+                })),
+            ),
+            TestResponse::BadRequest => (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "title": "bad_request",
+                    "type": "about:blank",
+                    "code": 400
+                })),
+            ),
+            TestResponse::ServerError => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "title": "internal_error",
+                    "type": "about:blank",
+                    "code": 500
+                })),
+            ),
+        }
+    }
+
+    /// Spin up the in-test server. Returns (base_url,
+    /// captured-request handle, response-mode handle,
+    /// shutdown-trigger).
+    ///
+    /// Shutdown trigger fires the oneshot to tear down the
+    /// server cleanly at end-of-test — avoids leaking the
+    /// background task across tests sharing a tokio runtime.
+    async fn spawn_server(
+        initial: TestResponse,
+    ) -> (
+        String,
+        Arc<tokio::sync::Mutex<Option<CapturedRequest>>>,
+        Arc<tokio::sync::Mutex<TestResponse>>,
+        oneshot::Sender<()>,
+    ) {
+        let captured = Arc::new(tokio::sync::Mutex::new(None));
+        let response = Arc::new(tokio::sync::Mutex::new(initial));
+        let state = ServerState {
+            captured: captured.clone(),
+            response: response.clone(),
+        };
+        let app = Router::new()
+            .route("/recognition", post(recognition_handler))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        (format!("http://{addr}"), captured, response, shutdown_tx)
+    }
+
+    fn config_for(base_url: &str) -> UpstreamConfig {
+        UpstreamConfig {
+            base_url: base_url.to_string(),
+            http_timeout: Duration::from_secs(2),
+            authority_did: Some("did:webvh:vtc.example".into()),
+        }
+    }
+
+    // ──────────────────────────────────────────────────────
 
     #[test]
     fn config_trims_trailing_slash() {
         let cfg = UpstreamConfig {
             base_url: "https://registry.example.com/".into(),
             http_timeout: Duration::from_secs(5),
+            authority_did: Some("did:webvh:vtc.example".into()),
         };
         let c = UpstreamRegistryClient::new(cfg).unwrap();
         assert_eq!(c.base_url, "https://registry.example.com");
@@ -225,10 +464,9 @@ mod tests {
     #[tokio::test]
     async fn health_against_unreachable_host_is_unreachable() {
         let cfg = UpstreamConfig {
-            // `localhost:1` is reserved + nothing listens
-            // there → connection refused.
             base_url: "http://127.0.0.1:1".into(),
             http_timeout: Duration::from_millis(200),
+            authority_did: None,
         };
         let c = UpstreamRegistryClient::new(cfg).unwrap();
         let err = c.health().await.expect_err("should fail");
@@ -243,6 +481,7 @@ mod tests {
         let cfg = UpstreamConfig {
             base_url: "http://localhost:9999".into(),
             http_timeout: Duration::from_secs(1),
+            authority_did: None,
         };
         let c = UpstreamRegistryClient::new(cfg).unwrap();
         let record = RegistryRecord::fresh_active("did:key:zMember");
@@ -252,5 +491,95 @@ mod tests {
             .expect_err("M3.2 doesn't implement writes");
         assert!(matches!(err, RegistryError::Permanent(_)));
         assert!(!err.is_retriable());
+    }
+
+    #[tokio::test]
+    async fn recognise_sends_canonical_four_tuple() {
+        let (url, captured, _resp, shutdown) = spawn_server(TestResponse::Recognized(true)).await;
+        let c = UpstreamRegistryClient::new(config_for(&url)).unwrap();
+        let ok = c.recognise("did:webvh:peer.example").await.unwrap();
+        assert!(ok);
+        let body = captured.lock().await.clone().expect("server saw request");
+        assert_eq!(body.entity_id, "did:webvh:peer.example");
+        assert_eq!(body.authority_id, "did:webvh:vtc.example");
+        assert_eq!(body.action, "recognise");
+        assert_eq!(body.resource, "trust-graph");
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn recognise_returns_false_when_response_recognized_is_false() {
+        let (url, _captured, _resp, shutdown) = spawn_server(TestResponse::Recognized(false)).await;
+        let c = UpstreamRegistryClient::new(config_for(&url)).unwrap();
+        let ok = c.recognise("did:webvh:peer.example").await.unwrap();
+        assert!(!ok);
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn recognise_maps_404_to_clean_not_recognised() {
+        let (url, _captured, _resp, shutdown) = spawn_server(TestResponse::NotFound).await;
+        let c = UpstreamRegistryClient::new(config_for(&url)).unwrap();
+        // 404 = no record matches the 4-tuple. The client
+        // surfaces this as Ok(false) — semantically the same
+        // as a stored record with `recognized: false`.
+        let ok = c.recognise("did:webvh:stranger.example").await.unwrap();
+        assert!(!ok);
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn recognise_maps_400_to_permanent() {
+        let (url, _captured, _resp, shutdown) = spawn_server(TestResponse::BadRequest).await;
+        let c = UpstreamRegistryClient::new(config_for(&url)).unwrap();
+        let err = c.recognise("did:webvh:peer.example").await.unwrap_err();
+        assert!(matches!(err, RegistryError::Permanent(_)));
+        assert!(!err.is_retriable());
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn recognise_maps_500_to_transient() {
+        let (url, _captured, _resp, shutdown) = spawn_server(TestResponse::ServerError).await;
+        let c = UpstreamRegistryClient::new(config_for(&url)).unwrap();
+        let err = c.recognise("did:webvh:peer.example").await.unwrap_err();
+        assert!(matches!(err, RegistryError::Transient(_)));
+        assert!(err.is_retriable());
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn recognise_connection_refused_is_unreachable() {
+        // Nothing listens on 127.0.0.1:1 — connection refused.
+        let cfg = UpstreamConfig {
+            base_url: "http://127.0.0.1:1".into(),
+            http_timeout: Duration::from_millis(300),
+            authority_did: Some("did:webvh:vtc.example".into()),
+        };
+        let c = UpstreamRegistryClient::new(cfg).unwrap();
+        let err = c.recognise("did:webvh:peer.example").await.unwrap_err();
+        assert!(
+            err.is_retriable(),
+            "connection refused must be retriable: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recognise_refuses_when_authority_did_missing() {
+        // Daemons that boot without `vtc_did` configured can't
+        // produce a valid recognition payload — refuse with a
+        // clear Permanent rather than send half a 4-tuple.
+        let cfg = UpstreamConfig {
+            base_url: "http://127.0.0.1:1".into(),
+            http_timeout: Duration::from_secs(1),
+            authority_did: None,
+        };
+        let c = UpstreamRegistryClient::new(cfg).unwrap();
+        let err = c.recognise("did:webvh:peer.example").await.unwrap_err();
+        assert!(matches!(err, RegistryError::Permanent(_)));
+        assert!(
+            err.to_string().contains("authority_did"),
+            "error should mention authority_did: {err}"
+        );
     }
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -249,6 +249,7 @@ pub async fn run(
             let cfg = crate::registry::upstream::UpstreamConfig {
                 base_url: url.to_string(),
                 http_timeout: std::time::Duration::from_secs(config.registry.http_timeout_seconds),
+                authority_did: config.vtc_did.clone(),
             };
             match crate::registry::UpstreamRegistryClient::new(cfg) {
                 Ok(c) => Some(Arc::new(c) as Arc<dyn crate::registry::TrustRegistryClient>),


### PR DESCRIPTION
## Summary

Replaces `UpstreamRegistryClient::recognise`'s "wire shape not yet pinned" stub with a live `POST /recognition` call. Closes the deferral noted in Phase 3 §D1 outcomes.

Wire format pinned against `affinidi/affinidi-trust-registry-rs`'s `main` branch — the handler at `trust-registry/src/http/handlers/trqp/mod.rs` plus integration tests that confirm the success / 404 / 400 paths end-to-end.

## Wire contract

- **Path**: `/recognition` at server root (no API prefix).
- **Body**: `{ entity_id, authority_id, action, resource, context? }` — snake_case, all four IDs required strings.
- **Response 200**: `{ recognized: bool, ... }`. Additional fields (`record_type`, `time_requested`, `time_evaluated`, `message`, merged `context`) are deserialised-and-ignored so upstream wire additions don't break the client.
- **404 → `Ok(false)`**: clean "no matching record" — semantically equivalent to a stored record with `recognized: false`. Surfacing it as an error would force every caller to handle the same case twice.
- **400 → `Permanent`**: malformed payload; operator intervention required.
- **5xx / connect / DNS errors**: existing `classify_http_error` (Transient / Unreachable).

## Recognition trust model

| TRQP field    | Value                                                                      |
|---------------|----------------------------------------------------------------------------|
| `entity_id`   | The foreign issuer DID being checked (`foreign_issuer_did` trait arg)      |
| `authority_id`| Local VTC's DID — we're the authority who recognises peers                 |
| `action`      | `"recognise"` (fixed for Phase 3)                                          |
| `resource`    | `"trust-graph"` (fixed for Phase 3)                                        |

`action` / `resource` could become config knobs later; not worth it until an operator asks.

## Config plumbing

`UpstreamConfig` gets `authority_did: Option<String>`. `server.rs` sources it from `config.vtc_did` at boot. Daemons booted without `vtc_did` get a clear `Permanent` error on recognition queries rather than send half a 4-tuple.

## Test approach

No HTTP mocking library in the workspace — spun up a real in-process axum server bound to `127.0.0.1:0`, captured the port. Same reqwest codepath as production. Covers:

- Happy path with `recognized: true` + asserts the wire body matches the upstream's exact snake_case 4-tuple
- Happy path with `recognized: false`
- 404 → `Ok(false)` (clean not-found)
- 400 → `Permanent`
- 500 → `Transient`
- Connection refused → `Unreachable`
- Missing `authority_did` → `Permanent`

## Test plan

- [x] 10 new `registry::upstream::tests::*` unit tests pass
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — every test result `ok` (no regressions)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] DCO sign-off

Refs: #46 vtc-mvp Phase 3 plan §D1 + Phase 3 closeout deferral