### PR TITLE
docs(vtc-mvp): Phase 4 plan + todo

### DIFF
--- a/tasks/vtc-mvp/phase-4-plan.md
+++ b/tasks/vtc-mvp/phase-4-plan.md
@@ -1,0 +1,704 @@
+# VTC MVP — Phase 4 plan
+
+> **Status:** draft, awaiting review.
+> **Deliverable:** "Graph + personhood live." Per spec §16 Phase 4:
+> VRC self-issuance + `relationships.rego`, `personhood.rego`
+> (deny-all stub) + assert/revoke + renewal re-eval, custom
+> endorsement issuance (issuer role).
+> **Spec:** `docs/05-design-notes/vtc-mvp.md` §§5.4, 6.1, 6.3, 6.4,
+> 7.1, 11.1, 12.3, 14.2, 14.3.
+
+## Objective
+
+After Phase 4, the VTC issues the relationship + personhood +
+custom-endorsement credentials the spec promises, with the policy
+hooks wired:
+
+- A member publishes a **self-issued VRC** trust edge via
+  `POST /v1/relationships`. The VTC verifies the caller's
+  signature against their resolved DID, runs `relationships.rego`
+  (default: store iff both parties are current members), persists
+  the row in a new `relationships:` keyspace, and emits an audit
+  variant. `GET /v1/members/{did}/relationships` paginates the
+  graph for one party.
+- An admin / issuer **asserts personhood** for a member via
+  `POST /v1/members/{did}/personhood/assert`, supplying an evidence
+  payload. The new `personhood.rego` (replacing the deny-all stub)
+  consumes the canonical input shape; on `allow`, the Member row
+  flips `personhood = true` and a fresh VMC is minted with the new
+  flag. Revoke goes through `DELETE /v1/members/{did}/personhood`
+  (admin / self-revoke). The existing M2.13 renewal flow already
+  re-evaluates `personhood.rego` on every renewal — Phase 4 makes
+  that reachable by giving the policy a real allow path and
+  persisting the prior flag on the Member row so
+  `personhood_changed` becomes precise.
+- An **issuer role member** mints **custom endorsements** (VECs
+  with a community-defined `endorsement.type`) via
+  `POST /v1/credentials/endorsements`. The custom-endorsement row
+  is tracked in a new `endorsements:` keyspace, carries its own
+  status-list slot for revocation, and can be revoked via
+  `DELETE /v1/credentials/endorsements/{id}` — the slot flips
+  immediately.
+- New audit variants — `VrcPublished`, `VrcRevoked`,
+  `PersonhoodAsserted`, `PersonhoodRevoked`,
+  `CustomEndorsementIssued`, `CustomEndorsementRevoked` — and the
+  Trust Tasks behind every endpoint.
+
+Out of scope (deferred):
+
+- **Bilateral / counter-signed VRC** — spec §3, §12.3 pin this
+  as v2. Phase 4 ships self-issued only.
+- **Public website + admin UX** — Phase 5.
+- **WASM / plugin extensions** — workspace memory.
+- **DIDComm transport for VRC publication** — spec §17.6 calls
+  it out as a UX option; Phase 4 sticks to REST. The DIDComm
+  twin can follow once the REST shape stabilises (Phase 5 or v2).
+- **New trust-registry surfaces** — the M3 surfaces stay as-is.
+  Custom endorsements + VRCs are local-only credentials; they
+  are not published to the trust registry.
+- **`witness` / `RCard` credential routes** — spec §9.5 lists
+  `POST /v1/credentials/{endorsements,witnesses,rcards}` as a
+  group, but §6.1 reserves `VWC` to *external* issuance (VTC
+  doesn't issue) and `RCard` is a contact-card primitive (no
+  policy hook). Phase 4 ships endorsements only; witnesses +
+  RCards are a follow-up.
+- **VPC (Persona credentials)** — explicitly v2 per §18.
+
+## Scope (per spec §16, Phase 4 row)
+
+### In scope
+
+- **VRC self-issuance graph**
+  - `POST /v1/relationships` — caller submits a VRC they signed
+    against the issuer DID. VTC verifies signature against the
+    resolved DID, runs `relationships.rego`, stores. Spec §12.3.
+  - `GET /v1/members/{did}/relationships` — paginated list of
+    VRCs where `did` is issuer OR subject; respects the
+    departure-handling rule (spec §12.3) that strips VRCs
+    naming a `Purge`d member.
+  - `DELETE /v1/relationships/{id}` — issuer-only retraction
+    (member self-cleanup). Emits `VrcRevoked`.
+  - New `relationships:` keyspace + storage helpers.
+- **Personhood lifecycle**
+  - `POST /v1/members/{did}/personhood/assert` — accepts
+    evidence body; runs the new `personhood.rego`; on `allow`
+    flips `Member.personhood = true`, re-mints VMC with the
+    new flag, emits `PersonhoodAsserted`.
+  - `DELETE /v1/members/{did}/personhood` — admin or self
+    revocation; flips `Member.personhood = false`, re-mints
+    VMC, emits `PersonhoodRevoked`.
+  - **Default `personhood.rego` replacement** — flip from
+    deny-all to a real (but minimal) policy consuming the
+    canonical evidence shape. Operator-replaceable as today.
+  - **Member row** gains two new fields:
+    - `personhood: bool` — current state, default `false`.
+    - `personhood_asserted_at: Option<DateTime<Utc>>` —
+      timestamp of the most recent successful assert.
+    Per planning-review D2: evidence is **not** persisted on
+    the Member row. The assert path verifies the presented
+    VP, evaluates `personhood.rego` against the policy input
+    derived from the verified credentials, and flips the
+    flag. Renewal re-eval reads only `personhood` +
+    `personhood_asserted_at` + the configured age threshold —
+    operators wanting richer renewal-time evaluation upload a
+    custom rego that consults additional inputs.
+  - **Renewal-time outcome is operator-configurable** —
+    config knob `vtc.renewal.on_personhood_fail` with values
+    `downgrade` (default) and `refuse`:
+    - `downgrade` (default, per D5 review): when renewal-time
+      `personhood.rego` fails for a member who was previously
+      `true`, the Member row flips to `false`, the new VMC
+      carries `false`, the audit envelope records
+      `personhood_changed: true`. Renewal itself does **not**
+      refuse — preserves §3-B "ACL is authoritative".
+    - `refuse`: renewal returns `422` until an admin re-asserts.
+      Stricter privacy posture for operators that want
+      personhood-aware membership.
+- **Custom endorsement issuance** (D4 review: operator-uploaded
+  type registry — bundled into M4.8 per planning review)
+  - **Type registry** (new, per D4 review):
+    - `POST /v1/endorsement-types` (Admin role) — register a new
+      endorsement type by URI. Body:
+      `{ type_uri, claim_schema?, description? }`. Refuses the
+      workspace-reserved `"CommunityRole"` type (that's VEC-managed).
+    - `GET /v1/endorsement-types` — paginated list.
+    - `DELETE /v1/endorsement-types/{uri}` — admin teardown.
+      Refuses if any endorsement of this type is still live.
+    - New `endorsement_types:` keyspace.
+    - Emits `EndorsementTypeRegistered` / `EndorsementTypeDeleted`
+      audit envelopes.
+  - **Endorsement issuance** consults the type registry:
+    - `POST /v1/credentials/endorsements` (Issuer / Admin role) —
+      accepts `(subject_did, type, claim, validity?)`. **Refuses
+      if `type` isn't in the registry**. Mints a VEC with the
+      community-defined `endorsement` payload, allocates a
+      status-list slot, persists in `endorsements:`, emits
+      `CustomEndorsementIssued`.
+    - `GET /v1/credentials/endorsements` — paginated list (admin
+      + issuer scoped).
+    - `GET /v1/credentials/endorsements/{id}` — show.
+    - `DELETE /v1/credentials/endorsements/{id}` — admin /
+      issuing-issuer revocation; flips the status-list bit,
+      emits `CustomEndorsementRevoked`.
+  - New `endorsements:` keyspace.
+  - Custom endorsements **reuse the existing `Revocation`
+    status list** (D8 review confirmed); per the spec §6.2
+    reserved-slot discipline, the slot is permanently
+    reserved on flip.
+- **Audit variants** (8 new total per D6 + D4 review):
+  `VrcPublished`, `VrcRevoked`, `PersonhoodAsserted`,
+  `PersonhoodRevoked`, `CustomEndorsementIssued`,
+  `CustomEndorsementRevoked`, `EndorsementTypeRegistered`,
+  `EndorsementTypeDeleted`.
+- **Trust Task drafts** — `relationships/publish/1.0`,
+  `relationships/list/1.0`, `relationships/revoke/1.0`,
+  `members/personhood/assert/1.0`,
+  `members/personhood/revoke/1.0`,
+  `credentials/endorsements/issue/1.0`,
+  `credentials/endorsements/list/1.0`,
+  `credentials/endorsements/show/1.0`,
+  `credentials/endorsements/revoke/1.0`,
+  `endorsement-types/register/1.0`,
+  `endorsement-types/list/1.0`,
+  `endorsement-types/delete/1.0`. Spec.md + schema.json
+  per endpoint + `index.json` entries.
+- **Renewal hook fix** — `routes/members/renew.rs::evaluate_personhood`
+  now reads `Member.personhood` + `Member.personhood_asserted_at`
+  (no evidence persisted — see D2 review) and writes back to
+  `Member.personhood` per the configured `on_personhood_fail`
+  policy. The `prior_personhood_from_member` helper becomes
+  precise.
+
+### Out of scope
+
+- VRC issuance over DIDComm transport — spec §17.6 lists as
+  open. Wire the REST path first; DIDComm twin is a follow-up.
+- VRC bilateral / counter-signing — spec §3, §12.3 (v2).
+- `witness` / `RCard` credentials — Phase 4 ships endorsements
+  only (see scope notes above).
+- Public reference personhood policy (`docs/04-reference/
+  personhood-templates.md`) — spec §17.1 lists as a post-Phase-4
+  doc; the spec amendment surface flags it.
+- Admin UX for the new surfaces — Phase 5.
+- StatusList **purpose extension** for endorsements (would
+  need an upstream `affinidi-status-list` PR for a new
+  `StatusPurpose::Endorsement` variant) — D8 keeps Phase 4
+  within the existing `Revocation` / `Suspension` purposes.
+
+## Pre-implementation design decisions
+
+Load-bearing. Defaults below; flag dissent before any code lands.
+
+### D1 — VRC issuance authority
+
+Spec §5.4 / §6.1: VRC is "member DID" → "other member DID",
+self-issued. The credential's `issuer` is the asserting
+**member** (not the community), and that's what's verified at
+publication time.
+
+**Default:** the VTC accepts only VRCs whose `issuer` resolves
+to a current ACL member, and whose proof verifies against the
+issuer's resolved `#key-0`. The community **never** mints a
+VRC — the `LocalSigner` is not invoked. This keeps "self-issued"
+clean and avoids a confused-deputy attack where the VTC could
+be tricked into endorsing a relationship the member never
+authored.
+
+The `relationships.rego` input gets `issuer_member` and
+`subject_member` shapes enriched with `is_current: bool` (live
+ACL check), mirroring how M3.9 enriches foreign credentials.
+
+### D2 — Personhood evidence shape
+
+**Decision (planning review): VP-only assert body.** The
+`POST /v1/members/{did}/personhood/assert` body carries a
+single Verifiable Presentation signed by the member:
+
+```json
+{
+  "presentation": { /* W3C VP, with proof signed by member's #key-0 */ }
+}
+```
+
+The VP must include:
+- `holder` matching the path-DID (the member asserting personhood).
+- One or more `verifiableCredential` entries (witness credentials,
+  proof-of-personhood VCs, vouches — operator-defined types).
+- A `proof` block over `vp.proof.challenge` (a fresh
+  server-issued nonce) so the assert is replay-protected.
+
+The route layer (M4.3):
+
+1. Verifies the VP proof against the member's `#key-0`.
+2. Verifies each embedded VC's proof against its issuer's
+   `#key-0` (resolved via the workspace DID resolver).
+3. Runs `extract_vp_claims` from M2.6's extract module to
+   produce the canonical projection.
+4. Feeds the projection into `personhood.rego` as
+   `{ applicant_did, vp_claims }` — spec §6.4 input contract
+   unchanged.
+
+**Evidence is not persisted on the Member row** (per planning
+review): the assert path verifies the VP, evaluates the policy,
+flips `personhood = true` + sets `personhood_asserted_at`. The
+VP itself is discarded after the assert succeeds. Renewal re-eval
+reads only the persisted flag + timestamp (see D5 + the
+Member-row schema below) — operators wanting policy-driven
+renewal eval against richer state upload a custom rego that
+consults additional inputs (e.g. live trust-registry queries).
+
+Body cap: 16 KiB (mirrors `MEMBER_EXTENSIONS_MAX_BYTES`).
+
+### D3 — Personhood revoke trigger
+
+Spec §6.4: "Personhood is asserted via a dedicated
+`POST /v1/members/{did}/personhood/assert` (re-mints VMC with
+`personhood: true`), and revoked via `DELETE` (re-mints with
+`false`). The policy re-evaluates on every renewal."
+
+Three triggers, all spec'd:
+
+1. **Active admin revocation** — `DELETE` endpoint. Admin role
+   (issuer role does **not** suffice — personhood is a higher-
+   trust signal). Audit: `PersonhoodRevoked { actor_did,
+   reason: "admin" }`.
+2. **Self-revocation** — same `DELETE` endpoint when caller's
+   DID == path DID. RTBF-style "I no longer want this claim
+   asserted about me." Audit: `PersonhoodRevoked { actor_did,
+   reason: "self" }`.
+3. **Renewal-time policy downgrade** — when renewal evaluates
+   `personhood.rego` and gets `false` for a member who was
+   previously `true`. Spec §6.3 step 3 makes this load-bearing:
+   "losing personhood is not gated on operator action." Audit:
+   `PersonhoodRevoked { actor_did: <vtc-did>, reason:
+   "renewal-policy" }`.
+
+**Default:** all three implemented. Trigger #3 piggybacks on
+the existing M2.13 renewal call site — it's a one-line flip
+once the Member row carries the flag.
+
+### D4 — Custom endorsement type registry
+
+Spec §6.1 row "Custom endorsement (badges, attestations)":
+issuer-role member mints a VEC with a community-defined
+`endorsement.type`. Spec gives no validation rule.
+
+**Decision (planning review): operator-uploaded type registry.**
+Phase 4 ships a CRUD surface for endorsement types — only
+registered types are issuable. **Bundled into M4.8** per the
+planning review (single endorsements PR covers both type
+registry + endorsement issuance).
+
+- New `endorsement_types:` keyspace.
+- New endpoints (all Admin-gated, all carry their own Trust Tasks):
+  - `POST /v1/endorsement-types` — register. Body
+    `{ type_uri, claim_schema?, description? }`.
+  - `GET /v1/endorsement-types` — list (cursor paginated).
+  - `GET /v1/endorsement-types/{uri}` — show.
+  - `DELETE /v1/endorsement-types/{uri}` — delete. Refuses
+    when at least one live endorsement of this type exists
+    (prevents dangling references; `409 Conflict`).
+- `endorsement.type` validation on the issuance path:
+  - The supplied `type` URI must be registered.
+  - The workspace-reserved `"CommunityRole"` type is refused
+    *at registration time* (the registrar route 409s).
+  - `claim` is a JSON object, max 8 KiB; optional
+    `claim_schema` on the type row can validate the shape
+    (Phase 4 ships the registry — schema validation runtime
+    can lag to a follow-up if the JSON Schema library
+    integration is heavy).
+- Audit envelopes: `EndorsementTypeRegistered` /
+  `EndorsementTypeDeleted` (paired with the standard
+  `EndorsementIssued` / `EndorsementRevoked` for the actual
+  credentials).
+
+### D5 — Renewal re-evaluation semantics
+
+Spec §6.3 step 3: "Re-evaluate `personhood.rego` and surface
+the resulting `personhood` flag on the new VMC. If the flag
+changes from the prior VMC, the audit event
+`MembershipRenewed` records `personhood_changed: true`."
+
+**Decision (planning review): operator-configurable via
+`vtc.renewal.on_personhood_fail`.** Two values:
+
+- **`downgrade` (default)**: when renewal evaluates
+  `personhood.rego` and gets `false` for a member who was
+  previously `true`, the Member row flips to `false`, the new
+  VMC carries `false`, audit envelope records
+  `personhood_changed: true` + paired `PersonhoodRevoked
+  { reason: "renewal-policy" }`. Renewal **does not refuse** —
+  preserves §3-B "ACL is authoritative". Recommended for
+  most deployments.
+- **`refuse`**: renewal returns `422 Unprocessable Entity`
+  with a clear error pointing the caller at the assert
+  endpoint. The Member row stays `true` (no silent flip),
+  the VMC isn't re-minted, no audit envelope. Stricter
+  privacy posture; couples renewal to personhood state.
+
+Config knob lives in `RenewalConfig` (new struct in
+`vtc_service::config`), serde-default `"downgrade"`. Audit
+envelope for renewal-refused case lands as a new
+`MembershipRenewed { outcome: "personhood-refused" }` flavour
+— planner notes this slightly expands M2.13's audit shape.
+
+This keeps the "ACL is authoritative inside the community"
+invariant intact (§3-B) — losing personhood doesn't lock a
+member out of community auth.
+
+### D6 — Audit envelope shape for VRC
+
+Six new variants:
+
+| Variant | Fields |
+|---|---|
+| `VrcPublished` | `vrc_id`, `issuer_did_hash`, `subject_did_hash` (HMAC-hashed per §11.1; plain DIDs stay in the envelope's `actor_did_plain` / `target_did_plain` since they're community-internal) |
+| `VrcRevoked` | `vrc_id` |
+| `PersonhoodAsserted` | `member_did_hash`, `evidence_sha256` (hex), `vmc_id` |
+| `PersonhoodRevoked` | `member_did_hash`, `vmc_id`, `reason` ∈ `"admin" \| "self" \| "renewal-policy"` |
+| `CustomEndorsementIssued` | `endorsement_id`, `endorsement_type`, `subject_did_hash`, `issuer_did_hash`, `status_list_index` |
+| `CustomEndorsementRevoked` | `endorsement_id`, `endorsement_type` |
+
+All six follow the discipline of Phases 1–3: round-trip test +
+`variant_discriminator_strings` entry + `camelCase` wire +
+`Option`s with `skip_serializing_if`.
+
+### D7 — Status-list slot allocation for VRCs
+
+Spec §5.4 / §12.3 don't name a status-list entry for VRCs. A
+self-issued credential has no community-issued revocation
+authority — the issuer is a member, and member-driven
+retraction is the canonical RTBF.
+
+**Default:** **VRCs do not carry `credentialStatus`.**
+`DELETE /v1/relationships/{id}` removes the row from the
+`relationships:` keyspace; there's no bit to flip externally.
+The departure-handling rule (§12.3) strips VRCs naming
+`Purge`d members from list responses; storage retains them
+referenced by issuer until the issuer departs.
+
+This keeps the reserved-slot space (131K) for community-
+issued credentials only (VMC + VEC + custom endorsements).
+
+### D8 — Custom endorsement revocation
+
+Spec §6.1 names custom endorsements as VECs issued by the
+community in `issuer` role. Communities will want to revoke
+("the badge was awarded in error"). External verifiers expect
+a `credentialStatus`.
+
+**Default:** custom endorsements **reuse the existing
+`Revocation` status list**, allocating a slot from the same
+2^17-capacity bitstring as VMCs. The reserved-slot discipline
+(§6.2) still holds — flipped slots never reallocate.
+
+A future `StatusPurpose::Endorsement` variant would need an
+upstream PR to `affinidi-status-list` and is **explicitly
+not** Phase 4 work. The shared-`Revocation`-list approach has
+one downside: external verifiers checking a member's VMC can
+trace which slots belong to "live members" vs "revoked
+endorsements" only via the per-slot decoy distribution.
+Random-with-decoys allocation already mitigates correlation
+attacks on this list.
+
+### D9 — Trust Task IDs
+
+Standard convention. Each endpoint gets its own task:
+
+| Endpoint | Trust Task ID |
+|---|---|
+| `POST /v1/relationships` | `…/relationships/publish/1.0` |
+| `GET /v1/members/{did}/relationships` | `…/relationships/list/1.0` |
+| `DELETE /v1/relationships/{id}` | `…/relationships/revoke/1.0` |
+| `POST /v1/members/{did}/personhood/assert` | `…/members/personhood/assert/1.0` |
+| `DELETE /v1/members/{did}/personhood` | `…/members/personhood/revoke/1.0` |
+| `POST /v1/credentials/endorsements` | `…/credentials/endorsements/issue/1.0` |
+| `GET /v1/credentials/endorsements` | `…/credentials/endorsements/list/1.0` |
+| `GET /v1/credentials/endorsements/{id}` | `…/credentials/endorsements/show/1.0` |
+| `DELETE /v1/credentials/endorsements/{id}` | `…/credentials/endorsements/revoke/1.0` |
+
+Nine new Trust Tasks; `index.json` extends accordingly. The
+existing per-method-collapse workaround (multiple HTTP methods
+on one mount share one Trust Task at the router layer) applies
+to `/v1/credentials/endorsements` (POST + GET) and to
+`/v1/credentials/endorsements/{id}` (GET + DELETE) — same
+pattern Phase 1 + Phase 3 use; on-disk tasks all exist for
+soft-gate completeness.
+
+### D10 — Personhood Rego input shape (default policy)
+
+Spec §6.4 / §7.3 pin the policy input as `{ applicant_did,
+vp_claims }`. The new default `personhood.rego` reads only
+those two fields. Proposed minimal allow path:
+
+```rego
+package vtc.personhood
+import rego.v1
+
+default allow := false
+default asserted := false
+
+# Accept assertion when:
+#  1. vp_claims.credentials has at least one credential whose
+#     type array contains "WitnessCredential", AND
+#  2. the credential's issuer DID is non-empty.
+#
+# Operators override with stricter rules (e.g. multiple
+# witnesses, specific issuer DIDs, validity windows).
+allow if {
+    some i
+    cred := input.vp_claims.credentials[i]
+    "WitnessCredential" in cred.type
+    cred.issuer != ""
+}
+
+# "asserted" mirrors "allow" — the spec §6.4 distinction
+# exists so a future policy can split "evidence is acceptable"
+# from "evidence sufficient to *assert*"; in MVP they collapse.
+asserted := allow
+```
+
+This default is **minimal but not deny-all** — the post-Phase-4
+"reference templates" doc (§17.1) is where operators should
+look for production-grade policies. The default is
+deliberately permissive enough that workspace integration
+tests can exercise the assert flow without operator-supplied
+policy uploads.
+
+## Dependency graph
+
+```
+M4.1 Member row personhood persistence + audit variants stub
+  │
+  ▼
+M4.2 Default personhood.rego replacement + renewal hook fix
+  │
+  │  [parallel branch from M4.1: M4.5, M4.7 start independently]
+  ▼
+M4.3 Personhood assert endpoint + Trust Task
+  │
+  ▼
+M4.4 Personhood revoke endpoint (admin + self + renewal-driven)
+  │
+  ▼                                                  M4.5 relationships keyspace + storage helpers
+                                                          │
+                                                          ▼
+                                                       M4.6 VRC publish + list + revoke endpoints + Trust Tasks
+                                                          │
+M4.7 endorsements keyspace + custom-endorsement builder
+  │
+  ▼
+M4.8 Custom endorsement issue + list + show + revoke endpoints + Trust Tasks
+  │
+  ▼
+M4.9 Audit variants round-trip snapshot tests
+M4.10 Trust Task on-disk + index.json batch
+M4.11 Phase 4 outcomes + spec amendments
+M4.12 Phase 4 gate
+```
+
+Critical paths:
+
+- **Personhood track** (M4.1 → M4.2 → M4.3 → M4.4). Sequential.
+- **VRC track** (M4.5 → M4.6). Sequential. Parallel with
+  personhood from M4.1's end.
+- **Endorsement track** (M4.7 → M4.8). Sequential. Parallel
+  with both other tracks.
+- **Closeout** (M4.9–M4.12) depends on all three tracks.
+
+## Parallelisation strategy
+
+Within a milestone: vertical slice — each endpoint ships with
+its Trust Task files + integration tests + audit emission, not
+in batches.
+
+PR slicing — proposed:
+
+1. **PR-1**: M4.1 + M4.2 (Member-row persistence + default
+   `personhood.rego` rewrite + renewal hook fix). No new
+   wire surfaces; preconditions for the personhood track.
+2. **PR-2**: M4.3 + M4.4 (personhood assert + revoke
+   endpoints + Trust Tasks). **Personhood gate met here.**
+3. **PR-3**: M4.5 + M4.6 (VRC keyspace + publish + list +
+   revoke endpoints + Trust Tasks). **VRC gate met here.**
+4. **PR-4**: M4.7 + M4.8 (endorsement keyspace + builder +
+   endorsement-type registry + endorsement-issuance CRUD +
+   Trust Tasks). **Endorsement gate met here.** Per
+   planning review's D4 bundle decision, this PR covers
+   ~800-1000 LoC across the type registry (M4.8.0 +
+   M4.8.1) and the endorsement CRUD (M4.8.2 + M4.8.3 +
+   M4.8.4); reviewers see the registry + issuance surface
+   atomically.
+5. **PR-5**: M4.9 + M4.10 + M4.11 + M4.12 (audit snapshots +
+   index.json batch + outcomes + gate).
+
+5 PRs across 12 milestones — tighter than Phase 2 (6 PRs / 19
+milestones), matches Phase 3 (5 PRs / 14 milestones). PR-4 is
+the heaviest (CRUD on two new resources + status-list
+integration + 8 endpoints + 7 Trust Tasks); PR-1 is
+intentionally light to derisk the renewal-hook change in
+isolation.
+
+## Checkpoints
+
+- **After PR-1**: Member row carries `personhood` +
+  `personhood_asserted_at` fields. Renewal correctly
+  downgrades / refuses per the `on_personhood_fail` config
+  knob when policy says so.
+  No new wire endpoints yet. **Renewal `personhood_changed`
+  becomes precise here** (M2.13 follow-up retroactively
+  resolved).
+- **After PR-2**: Admin can assert + revoke personhood on
+  any member. Self-revoke works. Renewal-driven downgrade
+  emits the paired audit. **Personhood lifecycle gate met.**
+- **After PR-3**: Members publish + revoke VRCs. The
+  `relationships.rego` default consumes its enriched input.
+  Member-page relationships endpoint paginates. **VRC graph
+  gate met.**
+- **After PR-4**: Issuer role mints + revokes custom
+  endorsements with status-list backing. **Custom endorsement
+  gate met.**
+- **After PR-5**: workspace gate green. Phase 4 closes.
+
+## Risks
+
+- **R1: Member-row migration on existing data.** PR-1 adds
+  three fields to `Member`. Existing rows lack them. fjall
+  stores serde JSON, so `#[serde(default)]` covers the
+  read-side; tests must hit the path that reads a Phase-3
+  row + roundtrips it. **Mitigation:** every new field is
+  `#[serde(default)]` + a one-time boot pass is NOT needed
+  (the existing M2.13 renewal path already tolerates older
+  rows via the `Option<>` discipline). Add a regression
+  test that loads a hand-crafted pre-Phase-4 row.
+- **R2: Personhood policy downgrade racing renewal.** A
+  member's renewal could fire concurrently with an admin
+  assert. **Mitigation:** the Member row's CAS update
+  serialises writes; the renewal handler reads the row,
+  evaluates the policy, then re-reads at write time. If the
+  flag flipped under us, the audit envelope still records
+  the right `personhood_changed` (the value the renewal
+  policy decided vs the value the admin wrote).
+- **R3: VRC issuer DID resolution failures.** Spec §12.3
+  doesn't pin the resolver. **Mitigation:** reuse the
+  existing `did_resolver` on `AppState` (same one M3.9 uses).
+  Failure to resolve → 422 with stable reason code; not 503,
+  because the caller could fix it by waiting + retrying.
+- **R4: Custom endorsement status-list slot exhaustion.**
+  Sharing the `Revocation` list with VMCs means heavy
+  endorsement issuance could trip the 75% occupancy warning
+  faster than expected. **Mitigation:** Phase 4 documents
+  the shared discipline; the M2.14 occupancy telemetry
+  already fires; a future `StatusPurpose::Endorsement`
+  upstream change is the v2 escape.
+- **R5: Custom endorsement type collision with workspace
+  reserved types.** Operators picking `"CommunityRole"`
+  would shadow the role-VEC discrimination. **Mitigation:**
+  D4 review's type registry rejects `"CommunityRole"` at
+  registration time (the registrar route 409s); the
+  issuance path can only consume registered types, so the
+  rejection is unbypassable.
+- **R6: `personhood.rego` default too permissive.** The D10
+  proposal accepts any single witness credential. A
+  hostile applicant could mint their own
+  `WitnessCredential` and self-witness. **Mitigation:** the
+  spec §17.1 note tells operators to upload a real policy
+  in production; integration tests use the default to
+  exercise the assert flow but the reference docs (post-
+  Phase-4) point to a stricter template. The default is
+  deliberately a starting point, not a security-grade
+  policy.
+- **R7: Renewal-driven `PersonhoodRevoked` audit
+  duplication.** The renewal flow already emits
+  `MembershipRenewed { personhood_changed: true }`. Adding
+  a paired `PersonhoodRevoked { reason: "renewal-policy" }`
+  could look like double-counting. **Mitigation:** the two
+  variants encode different SIEM filters — `MembershipRenewed`
+  is "credential was re-issued"; `PersonhoodRevoked` is
+  "this principal lost personhood". Operators want both for
+  retention + alerting. Document the pairing in the spec
+  amendment surface.
+
+## Definition of done — Phase 4
+
+After M4.12:
+
+- `cargo build/clippy/fmt/test --workspace` clean.
+- 9 new Trust Tasks in `Draft` status with matching
+  `spec.md` + `schema.json` files.
+- Every Phase 4 milestone marked `[x]` in
+  `phase-4-todo.md`.
+- Memory entry `project_vtc_mvp.md` updated with the as-
+  shipped outcomes for D1–D10.
+- Integration tests cover:
+  - End-to-end personhood: admin asserts → Member row
+    flipped → next renewal carries `personhood: true` →
+    admin uploads stricter policy → renewal flips back to
+    `false` + emits `PersonhoodRevoked { reason: "renewal-policy" }`.
+  - End-to-end VRC: member A publishes VRC naming member
+    B → `GET /v1/members/{B}/relationships` returns it →
+    member A self-removes with `Purge` → list returns
+    empty (the departure-handling strip).
+  - End-to-end endorsement: issuer mints custom
+    endorsement → status-list slot allocated → admin
+    revokes → slot flipped → endorsement row marked
+    revoked.
+
+Phase 5 (public website + admin UX) can start; the work
+parallelises with Phase 4 per spec §16 ("Phase 5 sub-tasks
+parallelise with phases 3–4").
+
+## Spec amendment surface
+
+Recording up front so they're not surprises mid-implementation:
+
+- **§5.2**: add two new fields to the `Member` schema —
+  `personhood: bool`, `personhood_asserted_at:
+  Option<DateTime<Utc>>` (per planning review). Evidence is
+  not persisted on the row (see D2 review). Currently the
+  schema reads "(no personhood field)"; Phase 4 makes it
+  explicit.
+- **§5.4 / §12.3**: confirm "VRCs do not carry
+  `credentialStatus`" (D7). Spec is currently silent; pin the
+  decision.
+- **§6.1**: custom endorsement row — document the
+  **operator-uploaded type registry** (D4 review). Replaces
+  the prior allow-list-by-regex draft. New endpoints under
+  `/v1/endorsement-types/*`; only registered types are
+  issuable.
+- **§6.2**: confirm custom endorsements share the
+  `Revocation` status list (D8 review); document the future
+  `StatusPurpose::Endorsement` v2 path.
+- **§6.3 step 3**: document the **operator-configurable
+  renewal-time outcome** (D5 review) — config knob
+  `vtc.renewal.on_personhood_fail: downgrade | refuse`,
+  default `downgrade`. Note the `refuse` flavour returns
+  `422` and skips the VMC re-mint.
+- **§6.4**: rewrite the personhood evidence section per the
+  **VP-only assert body** (D2 review). The assert body
+  carries a single Verifiable Presentation; evidence is
+  evaluated at assert time and discarded.
+- **§7.1**: update the "Default-ship" column for `personhood`
+  from "Deny-all stub" to a minimal allow on `WitnessCredential`
+  presence. Note operator-replacement remains the standard
+  pattern.
+- **§11.4**: extend the audit catalogue with the eight new
+  variants from D6 + D4 review: `VrcPublished`, `VrcRevoked`,
+  `PersonhoodAsserted`, `PersonhoodRevoked`,
+  `CustomEndorsementIssued`, `CustomEndorsementRevoked`,
+  `EndorsementTypeRegistered`, `EndorsementTypeDeleted`.
+- **§17.1**: now a Phase 4 outcomes follow-up — the reference
+  policy templates doc becomes the gating deliverable for
+  Open Question #1.
+
+Any decision that drifts from the default during
+implementation should be recorded in `phase-4-plan.md` under
+a "Phase 4 outcomes" header (mirror of Phase 1 + 2 + 3's
+pattern).
+
+## Phase 4 outcomes
+
+Recorded at M4.11 close-out. Each row links a pre-impl
+decision (D1–D10) or risk (R1–R7) to the as-shipped reality.
+
+(Filled in at M4.11.)

--- a/tasks/vtc-mvp/phase-4-todo.md
+++ b/tasks/vtc-mvp/phase-4-todo.md
@@ -1,0 +1,802 @@
+# Todo: VTC MVP — Phase 4
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done · `[!]` blocked
+
+Spec: `docs/05-design-notes/vtc-mvp.md` §§5.2, 5.4, 6.1, 6.3, 6.4,
+7.1, 11.1, 12.3, 14.2, 14.3.
+Plan: `tasks/vtc-mvp/phase-4-plan.md`
+
+Every code task also drafts the matching Trust Task spec
+(`trust-tasks/.../spec.md` + `schema.json`) in the same PR —
+soft gate per spec §9.4. Trust Task IDs per plan §D9.
+
+Every PR must be DCO-signed (`git commit -s`) and pass
+`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
+`cargo test --workspace`.
+
+---
+
+## M4.1 — Member row personhood persistence + audit variant stubs
+
+### `[ ]` M4.1.1 — Extend `Member` with personhood state
+
+- **Acceptance**
+  - `vtc_service::members::Member` gains **two** fields, both
+    `#[serde(default)]` (per planning review of D2):
+    - `personhood: bool` (default `false`).
+    - `personhood_asserted_at: Option<DateTime<Utc>>` (default
+      `None`).
+  - **Evidence is not persisted on the Member row** (D2 review:
+    VP-only assert body; evidence is verified at assert time
+    and discarded).
+  - `Member::fresh` writes the new fields with defaults
+    (`false`, `None`).
+  - `routes/members/read.rs::MemberSummary` surfaces
+    `personhood` (only) in the response — `personhood_asserted_at`
+    is operator-private.
+  - Regression test: load a hand-crafted JSON row from
+    pre-Phase-4 (no `personhood` field) → round-trips +
+    field reads as `false`.
+- **Verify** 4 unit tests:
+  - `Member::fresh()` carries defaults.
+  - Round-trip serialise/deserialise.
+  - Backward-compat: hand-crafted pre-Phase-4 JSON deserialises.
+  - `MemberSummary` exposes `personhood` but not asserted-at.
+- **Files**
+  - `vtc-service/src/members/mod.rs`
+  - `vtc-service/src/routes/members/read.rs`
+- **Deps**: none
+- **Pre-impl decision**: **D2** (planning-review VP-only assert).
+
+### `[ ]` M4.1.2 — Audit variant stubs (no emitters yet)
+
+- **Acceptance**
+  - **Eight** new variants added to
+    `vti_common::audit::event::AuditEvent` (D6 + D4 review):
+    `VrcPublished`, `VrcRevoked`, `PersonhoodAsserted`,
+    `PersonhoodRevoked`, `CustomEndorsementIssued`,
+    `CustomEndorsementRevoked`, `EndorsementTypeRegistered`,
+    `EndorsementTypeDeleted`.
+  - Per-variant data structs (`VrcPublishedData`, etc.) with
+    `#[serde(rename_all = "camelCase")]`,
+    `Option<T> + skip_serializing_if`. Eight structs total.
+  - **No call sites yet** — emitters land alongside their
+    endpoints (M4.3, M4.4, M4.6, M4.8).
+  - Variants added to `variant_discriminator_strings` table
+    so the discriminator panic-test catches typos.
+- **Verify** 8 round-trip snapshot tests + the discriminator
+  table extension.
+- **Files**
+  - `vti-common/src/audit/event.rs`
+- **Deps**: none
+- **Pre-impl decision**: **D6** + **D4** review.
+
+---
+
+## M4.2 — Default `personhood.rego` rewrite + renewal hook fix
+
+### `[ ]` M4.2.1 — Replace deny-all stub with minimal-allow default
+
+- **Acceptance**
+  - `vtc-service/policies/default/personhood.rego` is
+    replaced per plan §D10. New default:
+    - `allow := true` iff `input.vp_claims.credentials[_]`
+      contains a credential with `"WitnessCredential" in cred.type`
+      AND non-empty `issuer`.
+    - `asserted := allow`.
+  - `policy::default::install_defaults` still ships this
+    purpose (existing M2.5 path; no changes needed there).
+  - The 4 input contract round-trips in `policy/default.rs`
+    `personhood_default_*` tests are **rewritten**:
+    - Empty input → deny.
+    - VP with no `WitnessCredential` → deny.
+    - VP with `WitnessCredential` + empty issuer → deny.
+    - VP with `WitnessCredential` + non-empty issuer → allow.
+- **Verify** 4 rewritten unit tests in `policy/default.rs`.
+- **Files**
+  - `vtc-service/policies/default/personhood.rego`
+  - `vtc-service/src/policy/default.rs` (test rewrites)
+- **Deps**: M4.1.1
+- **Pre-impl decision**: **D10** (default policy shape).
+
+### `[ ]` M4.2.2 — Renewal hook reads Member.personhood
+
+- **Acceptance**
+  - `routes/members/renew.rs::evaluate_personhood` feeds
+    `personhood.rego` an input drawn from the Member's
+    current state (per D2 review: evidence is not persisted):
+    ```json
+    { "applicant_did": "<did>",
+      "current_personhood": <member.personhood>,
+      "asserted_at_seconds_ago": <now - member.personhood_asserted_at | null>,
+      "vp_claims": { "holder": "<did>", "credentials": [] } }
+    ```
+    The `vp_claims` block is empty by default — operators
+    needing richer renewal-time eval upload a custom rego.
+  - `prior_personhood_from_member` reads
+    `member.personhood` (now precise, not always-`false`).
+  - New config knob `vtc.renewal.on_personhood_fail`
+    (`downgrade` | `refuse`, default `downgrade`) gates the
+    failure arm (D5 review).
+  - When `personhood_changed` flips `true → false` at
+    renewal time:
+    - **`downgrade` (default)**: `member.personhood = false`,
+      `member.personhood_asserted_at = None`. Re-mint VMC
+      with `personhood: false`. Paired `PersonhoodRevoked
+      { actor_did: <vtc-did>, reason: "renewal-policy", vmc_id }`
+      audit alongside the existing `MembershipRenewed`.
+    - **`refuse`**: return `422 Unprocessable Entity` with
+      stable reason `personhood-renewal-refused`. Member row
+      stays `true`; no VMC re-mint; no audit envelope (the
+      operator chose this path; not surprising). Caller
+      retries via `POST .../personhood/assert`.
+  - When `personhood_changed` flips `false → true` at
+    renewal time (rare — the policy allows on a stale
+    state): **no paired** `PersonhoodAsserted` emitted. The
+    renewal path doesn't carry an actor intent; the
+    existing `MembershipRenewed { personhood_changed: true }`
+    is sufficient. (Documented in code comment.)
+- **Verify** 6 integration tests:
+  - Renewal with `personhood: false` → flag stays `false`.
+  - Renewal with `personhood: true` matching new default →
+    flag stays `true`.
+  - Renewal under a stricter operator policy + default
+    `downgrade` → flag flips to `false` + paired
+    `PersonhoodRevoked` audit + renewal succeeds.
+  - Renewal under stricter policy + `refuse` config →
+    `422 personhood-renewal-refused` + Member row unchanged
+    + no audit envelope.
+  - Renewal preserves `personhood_asserted_at` when flag
+    stays `true`.
+  - Renewal clears `personhood_asserted_at` when flag flips
+    to `false` (downgrade arm).
+- **Files**
+  - `vtc-service/src/routes/members/renew.rs`
+  - `vtc-service/src/config.rs` (new `RenewalConfig`)
+- **Deps**: M4.1.1, M4.1.2, M4.2.1
+- **Pre-impl decision**: **D3** (renewal-policy revoke
+  trigger), **D5** review (operator-configurable outcome).
+
+---
+
+## M4.3 — `POST /v1/members/{did}/personhood/assert`
+
+### `[ ]` M4.3.1 — Personhood assert endpoint
+
+- **Acceptance**
+  - `POST /v1/members/{did}/personhood/assert` — handler in
+    `vtc-service/src/routes/members/personhood.rs` (new).
+  - **Auth**: `AdminAuth` OR `IssuerAuth` (admin + issuer
+    roles per spec §5.3 "Issue VEC / VWC / RCard"). The
+    spec's permission matrix doesn't list personhood
+    explicitly — plan §D3 maps it to the issuer tier.
+  - **Body** (D2 review — VP-only):
+    ```json
+    {
+      "presentation": { /* W3C VP, holder == path-did,
+                            proof signed by member's #key-0 */ }
+    }
+    ```
+    Cap 16 KiB; reject larger bodies with 413.
+  - **Challenge requirement**: the VP's
+    `proof.challenge` must equal a fresh server-issued
+    nonce from a paired `POST /v1/members/{did}/personhood/challenge`
+    endpoint (10-minute TTL, single-use). Refuses replay.
+  - **Flow**:
+    1. Resolve target DID → load Member row (404 if absent).
+    2. Consume + verify the challenge.
+    3. Verify the VP proof against the member's `#key-0`
+       (resolved via the workspace DID resolver). Refuse on
+       proof failure with `403 personhood-proof-invalid`.
+    4. For each embedded `verifiableCredential`, verify its
+       proof against the issuer's `#key-0`. Refuse on any
+       failure with `403 personhood-evidence-invalid`.
+    5. Run `extract_vp_claims` (M2.6's extractor) to produce
+       the canonical projection.
+    6. Run `personhood.rego` with
+       `{ applicant_did: target, vp_claims: <projection> }`.
+       On `deny` → `403 personhood-policy-denied`.
+    7. Write Member row: `personhood = true`,
+       `personhood_asserted_at = now`.
+       **Evidence (the VP itself) is not persisted** per
+       D2 review — discarded after the verify+evaluate.
+    8. Re-mint VMC + role VEC (same status-list slot;
+       reuse `evaluate_personhood` output `true`).
+    9. Emit `PersonhoodAsserted { member_did_hash,
+       vmc_id, asserted_at }`. Actor on the envelope is
+       the caller; target is the member. (No
+       `evidence_sha256` field — there's nothing persisted
+       to hash, and surfacing a hash from the discarded
+       VP would imply persistence.)
+  - **Trust Task** `members/personhood/assert/1.0` ships.
+    Paired `members/personhood/challenge/1.0` for the
+    nonce mint.
+  - **Idempotency**: standard `Idempotency-Key` per §9.1;
+    same-body retries return the cached response. Note the
+    challenge is single-use, so a true retry needs a fresh
+    challenge — the idempotency cache provides the
+    server-side dedup within the cache TTL.
+- **Verify** 6 integration tests:
+  - Happy path: admin asserts → Member flag flips → new VMC
+    has `personhood: true` → audit envelope emitted.
+  - Default policy denial → 403 + no Member-row write.
+  - Body too large → 413.
+  - Target not found → 404.
+  - Idempotent re-assert with same evidence → 200 with the
+    same vmc_id (no new VMC minted).
+  - Non-admin / non-issuer caller → 403.
+- **Files**
+  - `vtc-service/src/routes/members/personhood.rs` (new)
+  - `vtc-service/src/routes/members/mod.rs`
+  - `vtc-service/src/routes/mod.rs` (route attach)
+  - `trust-tasks/members/personhood/assert/1.0/{spec.md,schema.json}`
+- **Deps**: M4.2.2
+- **Pre-impl decision**: **D2** (evidence shape), **D3**
+  (admin/issuer auth).
+
+---
+
+## M4.4 — `DELETE /v1/members/{did}/personhood`
+
+### `[ ]` M4.4.1 — Personhood revoke endpoint
+
+- **Acceptance**
+  - `DELETE /v1/members/{did}/personhood` — handler in
+    same `routes/members/personhood.rs`.
+  - **Auth**: `AdminAuth` OR caller's session DID matches
+    path DID (self-revoke).
+  - **Flow**:
+    1. Load Member row (404 if absent; 200 no-op if already
+       `personhood: false` — idempotent, mirrors
+       `Member-not-asserted`).
+    2. Write Member row: `personhood = false`,
+       `personhood_asserted_at = None`.
+    3. Re-mint VMC + role VEC with `personhood: false`.
+    4. Emit `PersonhoodRevoked { member_did_hash, vmc_id,
+       reason: <"admin" | "self"> }`.
+  - **Trust Task** `members/personhood/revoke/1.0` ships.
+  - **Idempotency cache TTL**: 60s (destructive op per §9.1).
+- **Verify** 4 integration tests:
+  - Admin revokes asserted member → flag flips → audit
+    `reason: "admin"`.
+  - Self-revoke (member calls on own DID) → flag flips →
+    audit `reason: "self"`.
+  - Revoke when already `false` → 200 no-op.
+  - Non-admin revoke of someone else's personhood → 403.
+- **Files**
+  - `vtc-service/src/routes/members/personhood.rs`
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/members/personhood/revoke/1.0/{spec.md,schema.json}`
+- **Deps**: M4.3.1
+- **Pre-impl decision**: **D3** (revoke triggers).
+
+### Checkpoint — Personhood gate met
+
+After M4.4.1: admin + self + renewal-driven revocation all
+work; assert flips the flag + re-mints; renewal downgrades.
+
+---
+
+## M4.5 — `relationships:` keyspace + storage helpers
+
+### `[ ]` M4.5.1 — Relationships keyspace + Relationship model
+
+- **Acceptance**
+  - New keyspace `relationships` registered in
+    `server::run` alongside `members_ks`.
+  - New module `vtc_service::relationships` with:
+    - `Relationship` struct: `id` (Uuid), `issuer_did`,
+      `subject_did`, `vrc_jsonld` (the verified VC body),
+      `vrc_sha256` (hex), `created_at: DateTime<Utc>`.
+    - Storage helpers: `store_relationship`, `get_relationship`,
+      `delete_relationship`, `list_for_did(did, cursor, limit)`
+      (paginated; returns rows where issuer OR subject = did).
+    - Optional secondary index keyspace
+      `relationships_by_did:<did>:<id>` for the per-DID
+      list query (CAS-paired writes with the primary row).
+  - 4 unit tests: round-trip, list-by-issuer, list-by-subject,
+    cursor pagination across 10 rows.
+- **Files**
+  - `vtc-service/src/relationships/mod.rs` (new)
+  - `vtc-service/src/relationships/storage.rs` (new)
+  - `vtc-service/src/server.rs` (1 new keyspace field +
+    boot wiring)
+- **Deps**: none (parallel with M4.1+)
+- **Pre-impl decision**: **D1** (issuer is the member, not
+  the community).
+
+---
+
+## M4.6 — VRC publish + list + revoke endpoints
+
+### `[ ]` M4.6.1 — `POST /v1/relationships`
+
+- **Acceptance**
+  - Handler in `vtc-service/src/routes/relationships.rs` (new).
+  - **Auth**: `AuthClaims` (any authenticated member).
+  - **Body**: `{ vrc: <signed VC body> }`.
+  - **Flow**:
+    1. Parse the VC; reject malformed bodies (422
+       `MalformedVrc`).
+    2. Caller's session DID **must equal** the VC's `issuer`
+       (self-issued only, per plan §D1). Otherwise 403.
+    3. Resolve `issuer_did` via the existing
+       `did_resolver`; verify the VC's data-integrity proof
+       against the resolved `#key-0`. Failure → 422
+       `VrcProofInvalid`.
+    4. Look up `is_current` for both issuer + subject (live
+       ACL row + non-tombstoned Member row). Build the
+       enriched policy input.
+    5. Run `relationships.rego` (existing default already
+       reads `is_current`). Deny → 403 `RelationshipPolicyDenied`.
+    6. Compute `vrc_sha256 = sha256(canonical_json(vrc))`.
+       Idempotent: if a relationship with the same hash
+       already exists, return its id (200).
+    7. Store the row.
+    8. Emit `VrcPublished { vrc_id, issuer_did_hash,
+       subject_did_hash }`.
+  - **Trust Task** `relationships/publish/1.0` ships.
+- **Verify** 6 integration tests:
+  - Happy path: member A publishes VRC naming member B →
+    row stored → audit emitted.
+  - Caller != issuer → 403.
+  - Tampered proof → 422.
+  - One party not a current member → 403 (default policy).
+  - Idempotent same-hash re-publish → 200 with same id.
+  - Subject DID unresolvable → 422.
+- **Files**
+  - `vtc-service/src/routes/relationships.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/relationships/publish/1.0/{spec.md,schema.json}`
+- **Deps**: M4.5.1, M4.1.2
+- **Pre-impl decision**: **D1** (member-as-issuer).
+
+### `[ ]` M4.6.2 — `GET /v1/members/{did}/relationships`
+
+- **Acceptance**
+  - Handler in `routes/members/relationships.rs` (new).
+  - Cursor pagination per §9.1 (`?cursor=&limit=` clamped
+    1..=200).
+  - **Departure-handling strip per §12.3**: the response
+    excludes any VRC where one party is `Purge`d (i.e., the
+    Member row is absent AND the ACL row is absent —
+    `Purge` is the only disposition that deletes both).
+    Tombstoned + Historical members still appear.
+  - **Auth**: any authenticated session can list (matches
+    the spec §12.3 "optionally published" + the
+    directory.rego default of "DID + role only"); operator
+    can tighten via `directory.rego`.
+  - **Trust Task** `relationships/list/1.0` ships.
+- **Verify** 4 integration tests:
+  - List for an issuer → returns issued VRCs.
+  - List for a subject → returns received VRCs.
+  - List after one party Purge-removes → that VRC stripped.
+  - Pagination with 10 rows + limit 3 → 4 pages, last
+    `next_cursor: null`.
+- **Files**
+  - `vtc-service/src/routes/members/relationships.rs` (new)
+  - `vtc-service/src/routes/members/mod.rs`
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/relationships/list/1.0/{spec.md,schema.json}`
+- **Deps**: M4.6.1
+- **Pre-impl decision**: **D1**.
+
+### `[ ]` M4.6.3 — `DELETE /v1/relationships/{id}`
+
+- **Acceptance**
+  - Handler in `routes/relationships.rs`.
+  - **Auth**: caller's session DID must equal the row's
+    `issuer_did` (issuer-only retraction). Admins can also
+    revoke (for moderation).
+  - **Flow**:
+    1. Load the row (404 if absent).
+    2. Auth check.
+    3. Delete row + secondary-index entries (CAS).
+    4. Emit `VrcRevoked { vrc_id }`.
+  - **Trust Task** `relationships/revoke/1.0` ships.
+- **Verify** 3 integration tests:
+  - Issuer revokes own VRC → row gone + audit.
+  - Subject (non-admin) attempts revoke → 403.
+  - Admin revokes any VRC → row gone + audit.
+- **Files**
+  - `vtc-service/src/routes/relationships.rs`
+  - `trust-tasks/relationships/revoke/1.0/{spec.md,schema.json}`
+- **Deps**: M4.6.1
+- **Pre-impl decision**: **D1**.
+
+### Checkpoint — VRC graph gate met
+
+After M4.6.3: members publish + list + revoke VRCs; the
+default policy + departure-strip both work.
+
+---
+
+## M4.7 — `endorsements:` keyspace + custom-endorsement builder
+
+### `[ ]` M4.7.1 — Endorsements keyspace + Endorsement model
+
+- **Acceptance**
+  - New keyspace `endorsements` registered in `server::run`.
+  - New module `vtc_service::endorsements` with:
+    - `Endorsement` struct: `id` (Uuid), `endorsement_type`,
+      `issuer_did` (community DID), `subject_did`,
+      `claim: JsonValue`, `status_list_index: u32`,
+      `vec_id`, `created_at`, `revoked_at:
+      Option<DateTime<Utc>>`.
+    - Storage helpers: `store_endorsement`,
+      `get_endorsement`, `list_endorsements(cursor, limit)`,
+      `mark_revoked(id, now)`.
+  - 3 unit tests: round-trip, list pagination, mark_revoked
+    sets timestamp without deleting the row.
+- **Files**
+  - `vtc-service/src/endorsements/mod.rs` (new)
+  - `vtc-service/src/endorsements/storage.rs` (new)
+  - `vtc-service/src/server.rs` (1 new keyspace field)
+- **Deps**: none (parallel with other tracks)
+- **Pre-impl decision**: **D4** review (operator-uploaded
+  type registry), **D8** review (shared revocation list).
+
+### `[ ]` M4.7.2 — Custom endorsement VC builder
+
+- **Acceptance**
+  - `vtc_service::credentials` extends with
+    `custom_endorsement.rs`:
+    - `CustomEndorsementParams { subject_did, type,
+      claim, status_ref, validity }`.
+    - `build_custom_endorsement(signer, params) ->
+      VerifiableCredential`.
+    - VC `type` array carries `VerifiableEndorsementCredential`
+      (same VEC type) — wire-compatible with role VECs.
+    - `endorsement` payload: `{ type: <registered>,
+      claim: <object>, communityDid: <signer.issuer_did> }`.
+  - **Type validation deferred to the route layer** (D4
+    review — type registry consultation happens at the
+    REST handler, not in the builder, so the builder
+    stays a pure transformer). Builder still enforces:
+    - `claim` is a JSON object, ≤ 8 KiB.
+    - `type` is a non-empty string.
+- **Verify** 4 unit tests:
+  - Builds + signs + verifies for a sample type.
+  - `claim` too large rejected.
+  - `claim` not an object rejected.
+  - `claim` body present in the credential subject.
+- **Files**
+  - `vtc-service/src/credentials/custom_endorsement.rs` (new)
+  - `vtc-service/src/credentials/mod.rs`
+- **Deps**: M4.7.1
+- **Pre-impl decision**: **D4** review (type validation in
+  route layer via registry).
+
+---
+
+## M4.8 — Endorsement type registry + custom endorsement REST surface
+
+> **Bundled per planning review (D4):** M4.8 covers both the
+> operator-uploaded endorsement-type registry **and** the
+> endorsement issuance / list / show / revoke endpoints. The
+> issuance endpoint consults the registry. ~800-1000 LoC total,
+> reviewed atomically.
+
+### `[ ]` M4.8.0 — `endorsement_types:` keyspace + storage
+
+- **Acceptance**
+  - New keyspace `endorsement_types` registered in `server::run`.
+  - New module `vtc_service::endorsement_types` with:
+    - `EndorsementType` struct: `type_uri` (String, primary
+      key — URL-encoded into the keyspace key),
+      `claim_schema: Option<JsonValue>` (reserved for
+      future per-type validation),
+      `description: Option<String>`, `created_at`,
+      `created_by_did: String`.
+    - Storage helpers: `store_type`, `get_type`,
+      `list_types(cursor, limit)`, `delete_type`,
+      `type_exists` (used by M4.8.2 issuance path).
+  - 3 unit tests: round-trip, list pagination, delete.
+- **Files**
+  - `vtc-service/src/endorsement_types/mod.rs` (new)
+  - `vtc-service/src/endorsement_types/storage.rs` (new)
+  - `vtc-service/src/server.rs` (new keyspace field)
+- **Deps**: none (parallel with other tracks)
+- **Pre-impl decision**: **D4** review.
+
+### `[ ]` M4.8.1 — Endorsement type registry endpoints
+
+- **Acceptance** — three endpoints under
+  `/v1/endorsement-types`:
+  - `POST /v1/endorsement-types` (Admin) — body
+    `{ type_uri, claim_schema?, description? }`. Refuses:
+    - The workspace-reserved `"CommunityRole"` URI
+      (409 `endorsement-type-reserved`).
+    - Already-registered URIs (409 `endorsement-type-exists`).
+    - Empty / oversized URI (422).
+    Emits `EndorsementTypeRegistered`.
+  - `GET /v1/endorsement-types` (Admin / Issuer) — cursor
+    paginated.
+  - `DELETE /v1/endorsement-types/{uri}` (Admin) — refuses
+    when at least one **live** endorsement (not yet
+    revoked) of this type exists in the `endorsements:`
+    keyspace (409 `endorsement-type-in-use`). Emits
+    `EndorsementTypeDeleted`.
+  - **Trust Tasks** ship: `endorsement-types/register/1.0`,
+    `endorsement-types/list/1.0`,
+    `endorsement-types/delete/1.0`.
+- **Verify** 7 integration tests:
+  - Happy register → row persisted + audit.
+  - Reserved `"CommunityRole"` rejected.
+  - Duplicate URI rejected.
+  - Oversized URI rejected.
+  - List paginated.
+  - Delete with live endorsement → 409.
+  - Delete with no live endorsements → row gone + audit.
+- **Files**
+  - `vtc-service/src/routes/endorsement_types.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/endorsement-types/{register,list,delete}/1.0/...`
+- **Deps**: M4.7.1, M4.8.0, M4.1.2
+- **Pre-impl decision**: **D4** review.
+
+### `[ ]` M4.8.2 — `POST /v1/credentials/endorsements`
+
+- **Acceptance**
+  - Handler in `routes/credentials/endorsements.rs` (new).
+  - **Auth**: `AdminAuth` OR caller's ACL role is `Issuer`.
+  - **Body**:
+    ```json
+    {
+      "subject_did": "<did>",
+      "type": "<community-defined>",
+      "claim": { … <= 8 KiB JSON object … },
+      "validity_seconds": <optional, default 30d>
+    }
+    ```
+  - **Flow**:
+    1. Look up `body.type` in the `endorsement_types:`
+       keyspace via `type_exists`. Refuse with `422
+       endorsement-type-not-registered` when missing (D4
+       review).
+    2. Validate `claim` is a JSON object ≤ 8 KiB.
+    3. Allocate a slot from the `Revocation` status list
+       (shared with VMC slots — D8 review).
+    4. Build + sign the custom-endorsement VEC via
+       `build_custom_endorsement`.
+    5. Persist `Endorsement` row.
+    6. Emit `CustomEndorsementIssued { endorsement_id,
+       endorsement_type, subject_did_hash, issuer_did_hash,
+       status_list_index }`.
+    7. **Also emit** `VecIssued` (re-using the existing
+       Phase 2 variant) so credential-issuance accounting
+       stays uniform.
+  - **Trust Task** `credentials/endorsements/issue/1.0`
+    ships.
+- **Verify** 5 integration tests:
+  - Happy path issuer (type registered) → endorsement
+    persisted + slot allocated + audit emitted.
+  - Admin can issue (auth check).
+  - Non-issuer / non-admin → 403.
+  - Type NOT registered → 422
+    `endorsement-type-not-registered`.
+  - Subject DID unresolvable → 422.
+- **Files**
+  - `vtc-service/src/routes/credentials/mod.rs` (new module)
+  - `vtc-service/src/routes/credentials/endorsements.rs` (new)
+  - `vtc-service/src/routes/mod.rs`
+  - `trust-tasks/credentials/endorsements/issue/1.0/{spec.md,schema.json}`
+- **Deps**: M4.7.2, M4.8.1
+- **Pre-impl decision**: **D4** review, **D8** review.
+
+### `[ ]` M4.8.3 — `GET /v1/credentials/endorsements` + `GET /{id}`
+
+- **Acceptance**
+  - List handler: `AdminAuth` OR `IssuerAuth`. Cursor
+    pagination per §9.1.
+  - Show handler: same auth.
+  - List response includes `revoked: bool` (computed from
+    `revoked_at.is_some()`); show response includes the
+    full `claim`.
+  - **Trust Tasks** `credentials/endorsements/list/1.0`
+    and `credentials/endorsements/show/1.0` ship.
+- **Verify** 3 integration tests:
+  - List 10, paginated by 3.
+  - Show by id.
+  - Show 404 on unknown id.
+- **Files**
+  - `vtc-service/src/routes/credentials/endorsements.rs`
+  - `trust-tasks/credentials/endorsements/list/1.0/{spec.md,schema.json}`
+  - `trust-tasks/credentials/endorsements/show/1.0/{spec.md,schema.json}`
+- **Deps**: M4.8.2
+
+### `[ ]` M4.8.4 — `DELETE /v1/credentials/endorsements/{id}`
+
+- **Acceptance**
+  - **Auth**: `AdminAuth` OR the original issuer's DID
+    (per audit envelope's `actor_did_plain`). Issuer
+    self-revocation is the canonical "I awarded this in
+    error" path.
+  - **Flow**:
+    1. Load the row (404 if absent; 200 no-op if already
+       revoked).
+    2. Flip the `Revocation` status-list bit at
+       `row.status_list_index` (immediate, locally — same
+       primitive M2.14 uses).
+    3. `mark_revoked(id, now)`.
+    4. Emit `CustomEndorsementRevoked { endorsement_id,
+       endorsement_type }`.
+    5. Also emit `StatusListFlipped { purpose: "revocation",
+       index, revoked: true }` (reuses existing variant).
+  - Idempotency cache TTL: 60s (destructive op).
+  - **Trust Task** `credentials/endorsements/revoke/1.0`
+    ships.
+- **Verify** 4 integration tests:
+  - Admin revokes → bit flipped + row marked revoked +
+    audit emitted.
+  - Issuer self-revokes own endorsement → same outcome.
+  - Non-admin / non-original-issuer → 403.
+  - Re-revoke already-revoked → 200 no-op (idempotent).
+- **Files**
+  - `vtc-service/src/routes/credentials/endorsements.rs`
+  - `trust-tasks/credentials/endorsements/revoke/1.0/{spec.md,schema.json}`
+- **Deps**: M4.8.2, M4.8.3
+
+### Checkpoint — Custom endorsement gate met
+
+After M4.8.4: type registry, issuer issuance, admin/issuer
+revocation, status-list backing all live.
+
+---
+
+## M4.9 — Audit variants snapshot tests
+
+### `[ ]` M4.9.1 — Round-trip + discriminator coverage
+
+- **Acceptance**
+  - The **eight** Phase 4 audit variants (D6 + D4 review:
+    `VrcPublished`, `VrcRevoked`, `PersonhoodAsserted`,
+    `PersonhoodRevoked`, `CustomEndorsementIssued`,
+    `CustomEndorsementRevoked`,
+    `EndorsementTypeRegistered`,
+    `EndorsementTypeDeleted`) each gain a round-trip
+    snapshot test in `vti-common/src/audit/event.rs`.
+  - All eight added to `variant_discriminator_strings`
+    coverage table.
+- **Verify** `cargo test -p vti-common audit::` passes.
+- **Files**
+  - `vti-common/src/audit/event.rs`
+- **Deps**: M4.3.1, M4.4.1, M4.6.3, M4.8.1, M4.8.4 (last
+  endpoints to land their variants)
+
+---
+
+## M4.10 — Trust Task drafts + index
+
+### `[ ]` M4.10.1 — On-disk + index entries
+
+- **Acceptance**
+  - **Thirteen** new Trust Task directories per plan §D9 +
+    D4 review (added the three `endorsement-types/*` +
+    the `members/personhood/challenge/1.0`) with `spec.md`
+    + `schema.json`:
+    - `relationships/publish/1.0`
+    - `relationships/list/1.0`
+    - `relationships/revoke/1.0`
+    - `members/personhood/challenge/1.0`
+    - `members/personhood/assert/1.0`
+    - `members/personhood/revoke/1.0`
+    - `endorsement-types/register/1.0`
+    - `endorsement-types/list/1.0`
+    - `endorsement-types/delete/1.0`
+    - `credentials/endorsements/issue/1.0`
+    - `credentials/endorsements/list/1.0`
+    - `credentials/endorsements/show/1.0`
+    - `credentials/endorsements/revoke/1.0`
+  - `trust-tasks/index.json` carries all thirteen new
+    entries.
+  - Each Trust Task ID is `exact_matched` at route attach
+    in `routes/mod.rs`.
+- **Files**
+  - All `trust-tasks/{...}/1.0/*` directories above.
+  - `trust-tasks/index.json`
+- **Deps**: M4.3.1, M4.4.1, M4.6.1, M4.6.2, M4.6.3, M4.8.1,
+  M4.8.2, M4.8.3, M4.8.4
+
+---
+
+## M4.11 — Phase 4 outcomes + spec amendments
+
+### `[ ]` M4.11.1 — Document the as-shipped reality
+
+- **Acceptance**
+  - `tasks/vtc-mvp/phase-4-plan.md` gains a "Phase 4
+    outcomes" header recording the as-shipped reality for
+    D1–D10 + any deviations + R1–R7 realisation status.
+  - `docs/05-design-notes/vtc-mvp.md` §§5.2 / 5.4 / 6.1 /
+    6.2 / 6.3 / 6.4 / 7.1 / 11.4 / 17.1 amended per the
+    planning-time spec-amendment surface (see plan).
+  - Memory entry `project_vtc_mvp.md` updated.
+- **Files**
+  - `tasks/vtc-mvp/phase-4-plan.md`
+  - `docs/05-design-notes/vtc-mvp.md`
+  - `~/.claude/projects/.../memory/project_vtc_mvp.md`
+- **Deps**: M4.8.4, M4.9.1, M4.10.1
+
+---
+
+## M4.12 — Phase 4 gate
+
+### `[ ]` M4.12.1 — Workspace gate green
+
+- **Acceptance** (mirrors M3.14.1)
+  - `cargo build --workspace` green.
+  - `cargo test --workspace` green.
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+    clean.
+  - `cargo fmt --check` clean.
+  - `trust-tasks/index.json` lists every Phase 4 Trust Task
+    with matching on-disk files.
+  - Memory entry `project_vtc_mvp.md` updated with the as-
+    shipped outcomes for D1–D10.
+  - Phase-4-todo milestones all flipped to `[x]`.
+- **Verify** CI green on the merge commit.
+- **Files**
+  - `trust-tasks/index.json`
+  - `~/.claude/projects/.../memory/project_vtc_mvp.md`
+- **Deps**: M4.9.1, M4.10.1, M4.11.1
+
+### Checkpoint — Phase 4 gate met
+
+After M4.12.1: members publish + revoke VRC trust edges,
+admin / issuer / self assert + revoke personhood,
+issuer-role members mint + revoke custom endorsements with
+status-list backing, renewal precisely tracks personhood
+state. Phase 5 (public website + admin UX) can proceed
+fully (the M3-onwards parallel branch lands its final
+sequential dependency here).
+
+---
+
+## Resolved decisions (planning review)
+
+All decisions confirmed before plan PR was opened. Listed
+here so they're findable from the todo:
+
+- **D1**: VRC issuer is the asserting *member*, not the
+  community. VTC verifies the member's signature against
+  the resolved DID; never mints VRCs itself.
+- **D2** (planning review): **VP-only assert body**. The
+  assert endpoint accepts a single W3C Verifiable
+  Presentation signed by the member's `#key-0` with a
+  fresh server-issued challenge. Embedded VC proofs are
+  verified before policy evaluation. **Evidence is NOT
+  persisted** on the Member row — verify-then-discard.
+- **D3**: Personhood revoke triggers — three: admin-driven
+  `DELETE`, self-`DELETE`, renewal-policy downgrade. All
+  three emit `PersonhoodRevoked` with stable `reason`
+  discriminators.
+- **D4** (planning review): **Operator-uploaded type
+  registry**, bundled into M4.8. Only registered types are
+  issuable. New CRUD surface under
+  `/v1/endorsement-types`. Workspace-reserved
+  `"CommunityRole"` URI is refused at registration time.
+- **D5** (planning review): Renewal-time personhood
+  failure is **operator-configurable** via
+  `vtc.renewal.on_personhood_fail` (`downgrade` |
+  `refuse`, default `downgrade`). `downgrade` preserves
+  §3-B "ACL is authoritative"; `refuse` returns `422` and
+  the member must re-assert.
+- **D6** (+ D4 review): **Eight** new audit variants
+  (`VrcPublished`, `VrcRevoked`, `PersonhoodAsserted`,
+  `PersonhoodRevoked`, `CustomEndorsementIssued`,
+  `CustomEndorsementRevoked`, `EndorsementTypeRegistered`,
+  `EndorsementTypeDeleted`).
+- **D7**: VRCs carry **no** `credentialStatus`. Revocation
+  is row-deletion via `DELETE /v1/relationships/{id}`.
+- **D8** (review confirmed): Custom endorsements reuse the
+  existing `Revocation` status list. No upstream
+  `affinidi-status-list` PR in MVP.
+- **D9**: 13 new Trust Task IDs (D9's 9 + 3 endorsement-
+  types + 1 personhood/challenge).
+- **D10**: Default `personhood.rego` allows on any VC with
+  `"WitnessCredential" in type` + non-empty issuer.
+  Reference templates ship post-Phase-4.
+- **Member schema** (planning review): two new fields only
+  — `personhood: bool`, `personhood_asserted_at:
+  Option<DateTime<Utc>>`. No `personhood_evidence` field.


### PR DESCRIPTION
## Summary

Phase 4 entry: planning artifact only — no code changes. Mirrors the Phase 1-3 planning structure.

**Deliverable** (spec §16 row 4): VRC (self-issued only), personhood assert/revoke + renewal re-evaluation, custom endorsement issuance.

**12 milestones, 5 PRs:**
1. PR-1 (M4.1+M4.2): Member-row personhood persistence + default `personhood.rego` rewrite + renewal hook fix.
2. PR-2 (M4.3+M4.4): personhood assert + revoke endpoints. **Personhood gate met.**
3. PR-3 (M4.5+M4.6): relationships keyspace + VRC publish/list/revoke. **VRC gate met.**
4. PR-4 (M4.7+M4.8): endorsements keyspace + builder + type registry + endorsement CRUD. **Endorsement gate met.** Heaviest PR (~800-1000 LoC).
5. PR-5 (M4.9-M4.12): audit snapshots + Trust Task index batch + outcomes + gate.

## Resolved design decisions (planning review)

All ambiguities pinned before implementation starts:

| Decision | Outcome |
|----------|---------|
| **D1** VRC issuer | Member, never the community |
| **D2** Personhood evidence shape | **VP-only assert body**. Evidence is verify-then-discard; not persisted on Member row |
| **D3** Revoke triggers | Three: admin `DELETE`, self `DELETE`, renewal-policy downgrade |
| **D4** Custom endorsement type validation | **Operator-uploaded type registry** bundled into M4.8; only registered types issuable |
| **D5** Renewal-time personhood failure | **Operator-configurable** via `vtc.renewal.on_personhood_fail: downgrade \| refuse` (default `downgrade`) |
| **D6** + D4 review: Audit variants | 8 new (added `EndorsementTypeRegistered`/`Deleted`) |
| **D7** VRC `credentialStatus` | None; revocation = row deletion |
| **D8** Endorsement status list | Shares Revocation list |
| **D9** Trust Task IDs | 13 new (9 + 3 endorsement-types + 1 personhood/challenge) |
| **D10** Default personhood.rego | Allows on `WitnessCredential` presence |
| **Member schema** | Two new fields only: `personhood`, `personhood_asserted_at` |

## Spec amendments queued for M4.11

§§5.2, 5.4, 6.1, 6.2, 6.3, 6.4, 7.1, 11.4, 17.1 — listed in the plan's "Spec amendment surface" section.

## Test plan

- [x] `tasks/vtc-mvp/phase-4-plan.md` + `phase-4-todo.md` saved
- [x] All design ambiguities resolved via AskUserQuestion before PR opened
- [x] Plan structure mirrors Phase 1-3 (objective / scope / D1-D10 / dependency graph / parallelisation / PR slicing / checkpoints / risks / definition of done / spec amendment surface / outcomes-template)
- [x] DCO sign-off