### PR TITLE
feat(vtc-service): M4.1 + M4.2 — personhood foundation

### DIFF
--- a/tasks/vtc-mvp/phase-4-todo.md
+++ b/tasks/vtc-mvp/phase-4-todo.md
@@ -18,7 +18,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M4.1 — Member row personhood persistence + audit variant stubs
 
-### `[ ]` M4.1.1 — Extend `Member` with personhood state
+### `[x]` M4.1.1 — Extend `Member` with personhood state
 
 - **Acceptance**
   - `vtc_service::members::Member` gains **two** fields, both
@@ -48,7 +48,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 - **Deps**: none
 - **Pre-impl decision**: **D2** (planning-review VP-only assert).
 
-### `[ ]` M4.1.2 — Audit variant stubs (no emitters yet)
+### `[x]` M4.1.2 — Audit variant stubs (no emitters yet)
 
 - **Acceptance**
   - **Eight** new variants added to
@@ -75,7 +75,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M4.2 — Default `personhood.rego` rewrite + renewal hook fix
 
-### `[ ]` M4.2.1 — Replace deny-all stub with minimal-allow default
+### `[x]` M4.2.1 — Replace deny-all stub with minimal-allow default
 
 - **Acceptance**
   - `vtc-service/policies/default/personhood.rego` is
@@ -99,7 +99,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 - **Deps**: M4.1.1
 - **Pre-impl decision**: **D10** (default policy shape).
 
-### `[ ]` M4.2.2 — Renewal hook reads Member.personhood
+### `[x]` M4.2.2 — Renewal hook reads Member.personhood
 
 - **Acceptance**
   - `routes/members/renew.rs::evaluate_personhood` feeds

--- a/vtc-service/policies/default/personhood.rego
+++ b/vtc-service/policies/default/personhood.rego
@@ -1,19 +1,72 @@
-# Default `personhood` policy — deny-all stub (spec §7.1 + §6.4).
+# Default `personhood` policy — minimal-allow (Phase 4 M4.2).
 #
-# Phase 4 introduces the operator-facing
-# `POST /v1/members/{did}/personhood/{assert,revoke}` endpoints
-# and the real personhood-evidence evaluation. Until then the
-# stub makes renewal's §6.3 step-3 personhood re-eval well-
-# defined ("not asserted") — every renewed VMC carries
-# `personhood: false`.
+# This is the **default** personhood evaluator. Operators
+# replace it via `POST /v1/policies` + `POST /v1/policies/{id}/activate`
+# to express richer evidence requirements (proof-of-personhood,
+# multi-witness, biometric attestation, etc).
 #
-# Input shape (spec §7.3):
-#   { applicant_did, vp_claims }
+# ## Minimal-allow semantics
+#
+# The policy returns `allow == true` when the applicant's VP
+# carries at least one `WitnessCredential` from a non-empty
+# issuer. This is intentionally permissive — operators with
+# stricter requirements upload a custom rego. The default lets
+# the workspace's integration tests exercise the assert flow
+# without operator setup.
+#
+# ## Input shape
+#
+# Driven from two call sites:
+#
+# 1. **Assert endpoint** (M4.3):
+#    {
+#      "applicant_did": "<member-did>",
+#      "vp_claims": {
+#        "holder": "<member-did>",
+#        "credentials": [ { "type": [...], "issuer": "<did>", ... }, ... ]
+#      }
+#    }
+#
+# 2. **Renewal-time re-evaluation** (M4.2.2):
+#    {
+#      "applicant_did": "<did>",
+#      "current_personhood": <bool>,
+#      "asserted_at_seconds_ago": <int | null>,
+#      "vp_claims": { "holder": "<did>", "credentials": [] }
+#    }
+#
+#    The default re-evaluator preserves an existing
+#    `current_personhood == true` — assertions don't lapse on
+#    renewal under the default policy. Operators wanting
+#    time-based expiry override `asserted_within_max_age`.
 
 package vtc.personhood
 
 import rego.v1
 
+# Default-deny when no rule below fires.
 default allow := false
 
-default asserted := false
+# `asserted` mirrors `allow` for legacy call sites that read
+# the old name.
+asserted if allow
+
+# ── Assert path (default minimal-allow) ────────────────────
+
+# Allow when the applicant presents at least one
+# `WitnessCredential` from a non-empty issuer.
+allow if {
+	some i
+	cred := input.vp_claims.credentials[i]
+	"WitnessCredential" in cred.type
+	cred.issuer != ""
+}
+
+# ── Renewal-time re-eval (preserve existing assertion) ─────
+
+# When renewal sees a member whose flag is already `true`,
+# preserve it. Operators wanting time-based expiry override
+# this rule with their own age check.
+allow if {
+	input.current_personhood == true
+}

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -35,8 +35,49 @@ pub struct AppConfig {
     /// the registry at boot and on a periodic interval.
     #[serde(default)]
     pub registry: RegistryConfig,
+    /// Renewal-path settings (Phase 4 M4.2.2). Currently
+    /// gates the renewal-time behaviour when `personhood.rego`
+    /// flips a previously-asserted member's flag to `false`.
+    #[serde(default)]
+    pub renewal: RenewalConfig,
     #[serde(skip)]
     pub config_path: PathBuf,
+}
+
+/// Renewal-path settings. Phase 4 M4.2.2.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub struct RenewalConfig {
+    /// What to do when the active `personhood.rego` returns
+    /// `false` for a member whose current `personhood` flag
+    /// is `true` (spec §6.3 step 3 + Phase 4 plan D5 review).
+    ///
+    /// - [`PersonhoodFailMode::Downgrade`] (default): flip the
+    ///   Member row's flag to `false`, re-mint the VMC with
+    ///   `personhood: false`, audit a `PersonhoodRevoked
+    ///   { reason: "renewal-policy" }` envelope, **succeed**.
+    ///   Preserves §3-B "ACL is authoritative" — membership
+    ///   lifecycle is decoupled from personhood lifecycle.
+    /// - [`PersonhoodFailMode::Refuse`]: return `422
+    ///   Unprocessable Entity` with stable reason
+    ///   `personhood-renewal-refused`. Member row stays
+    ///   `true`; no VMC re-mint; no audit envelope. Caller
+    ///   re-asserts via the assert endpoint before retrying.
+    #[serde(default)]
+    pub on_personhood_fail: PersonhoodFailMode,
+}
+
+/// What renewal does when `personhood.rego` drops a previously-
+/// asserted member's flag to `false`. See [`RenewalConfig`].
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PersonhoodFailMode {
+    /// Re-mint with `personhood: false`. Default. Recommended
+    /// for most deployments.
+    #[default]
+    Downgrade,
+    /// Return `422`. Stricter privacy posture.
+    Refuse,
 }
 
 /// Trust-registry runtime settings.

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -80,6 +80,23 @@ pub struct Member {
     /// reconciler hasn't yet caught up on.
     #[serde(default)]
     pub removed_at: Option<DateTime<Utc>>,
+    /// Personhood flag (spec §6.3 + Phase 4 M4.1). `true` after a
+    /// successful `POST /v1/members/{did}/personhood/assert`
+    /// (M4.3); flipped back to `false` on revoke (M4.4) or
+    /// renewal-time policy downgrade (M4.2.2). Surfaced on the
+    /// member's VMC `credentialSubject.personhood` field — every
+    /// renewed VMC re-evaluates this against `personhood.rego`.
+    #[serde(default)]
+    pub personhood: bool,
+    /// Timestamp of the most recent successful personhood assert
+    /// (Phase 4 M4.1). `None` when personhood was never asserted
+    /// or has been revoked. The default `personhood.rego` (M4.2)
+    /// reads this to compute an "age" input for time-based
+    /// expiry policies. Per planning-review D2: the *evidence*
+    /// VP is verified at assert time and discarded — only this
+    /// timestamp persists.
+    #[serde(default)]
+    pub personhood_asserted_at: Option<DateTime<Utc>>,
 }
 
 impl Member {
@@ -102,6 +119,8 @@ impl Member {
             current_role_vec_id: None,
             extensions: JsonValue::Null,
             removed_at: None,
+            personhood: false,
+            personhood_asserted_at: None,
         }
     }
 
@@ -123,6 +142,13 @@ impl Member {
         self.current_role_vec_id = None;
         self.extensions = JsonValue::Null;
         self.removed_at = Some(Utc::now());
+        // Tombstone wipes personhood — it's a PII-bearing
+        // assertion (timestamps reveal when the operator
+        // performed the assert ceremony). Members reasserting
+        // after un-tombstone would have to re-present
+        // evidence.
+        self.personhood = false;
+        self.personhood_asserted_at = None;
     }
 
     /// Mark the row historical — keep all fields verbatim, just

--- a/vtc-service/src/members/storage.rs
+++ b/vtc-service/src/members/storage.rs
@@ -199,6 +199,8 @@ mod tests {
             current_role_vec_id: Some("vec-1".into()),
             extensions: serde_json::json!({ "team": "platform" }),
             removed_at: None,
+            personhood: false,
+            personhood_asserted_at: None,
         };
         let json = serde_json::to_value(&m).unwrap();
         assert!(json["joinedAt"].is_string());
@@ -207,8 +209,51 @@ mod tests {
         assert_eq!(json["departurePreference"], "historical");
         assert_eq!(json["currentVmcId"], "vmc-1");
         assert_eq!(json["currentRoleVecId"], "vec-1");
+        assert_eq!(json["personhood"], false);
+        assert!(json["personhoodAssertedAt"].is_null());
         let parsed: Member = serde_json::from_value(json).unwrap();
         assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn member_round_trips_with_personhood_asserted() {
+        let now = Utc::now();
+        let m = Member {
+            did: "did:key:zPerson".into(),
+            joined_at: now,
+            status_list_index: None,
+            publish_consent: false,
+            departure_preference: Disposition::PolicyDefault,
+            current_vmc_id: None,
+            current_role_vec_id: None,
+            extensions: serde_json::Value::Null,
+            removed_at: None,
+            personhood: true,
+            personhood_asserted_at: Some(now),
+        };
+        let json = serde_json::to_value(&m).unwrap();
+        assert_eq!(json["personhood"], true);
+        assert!(json["personhoodAssertedAt"].is_string());
+        let parsed: Member = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn member_backward_compat_pre_phase4_row_deserialises() {
+        // Hand-crafted JSON from before M4.1 — no `personhood`
+        // or `personhoodAssertedAt` keys. Round-trips with the
+        // new fields defaulted (`false`, `None`).
+        let raw = serde_json::json!({
+            "did": "did:key:zLegacy",
+            "joinedAt": "2026-01-15T00:00:00Z",
+            "publishConsent": false,
+            "departurePreference": "tombstone",
+            "extensions": null
+        });
+        let parsed: Member = serde_json::from_value(raw).expect("legacy row deserialises");
+        assert_eq!(parsed.did, "did:key:zLegacy");
+        assert!(!parsed.personhood);
+        assert!(parsed.personhood_asserted_at.is_none());
     }
 
     #[test]

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -401,7 +401,7 @@ mod tests {
     }
 
     #[test]
-    fn personhood_default_denies_everything() {
+    fn personhood_default_denies_empty_input() {
         let c = compile_default(PolicyPurpose::Personhood);
         let r = evaluate(
             &c,
@@ -409,11 +409,126 @@ mod tests {
             json!({ "applicant_did": "did:key:zX", "vp_claims": {} }),
         )
         .unwrap();
-        assert!(!pluck_bool(&r), "personhood default must deny");
-        let asserted = evaluate(&c, "data.vtc.personhood.asserted", json!({})).unwrap();
         assert!(
-            !pluck_bool(&asserted),
-            "personhood.asserted default must be false"
+            !pluck_bool(&r),
+            "empty input must deny — no WitnessCredential present"
+        );
+    }
+
+    #[test]
+    fn personhood_default_denies_vp_without_witness_credential() {
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            json!({
+                "applicant_did": "did:key:zX",
+                "vp_claims": {
+                    "holder": "did:key:zX",
+                    "credentials": [
+                        { "type": ["VerifiableCredential"], "issuer": "did:key:zIss" }
+                    ]
+                }
+            }),
+        )
+        .unwrap();
+        assert!(
+            !pluck_bool(&r),
+            "VC without WitnessCredential type must deny"
+        );
+    }
+
+    #[test]
+    fn personhood_default_denies_witness_credential_with_empty_issuer() {
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            json!({
+                "applicant_did": "did:key:zX",
+                "vp_claims": {
+                    "holder": "did:key:zX",
+                    "credentials": [
+                        { "type": ["VerifiableCredential", "WitnessCredential"], "issuer": "" }
+                    ]
+                }
+            }),
+        )
+        .unwrap();
+        assert!(
+            !pluck_bool(&r),
+            "WitnessCredential with empty issuer must deny"
+        );
+    }
+
+    #[test]
+    fn personhood_default_allows_witness_credential_with_issuer() {
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            json!({
+                "applicant_did": "did:key:zX",
+                "vp_claims": {
+                    "holder": "did:key:zX",
+                    "credentials": [
+                        {
+                            "type": ["VerifiableCredential", "WitnessCredential"],
+                            "issuer": "did:key:zWitness"
+                        }
+                    ]
+                }
+            }),
+        )
+        .unwrap();
+        assert!(
+            pluck_bool(&r),
+            "WitnessCredential with non-empty issuer must allow"
+        );
+    }
+
+    #[test]
+    fn personhood_default_preserves_current_true_on_renewal() {
+        // Renewal-time re-eval: when current_personhood is
+        // already true, the default policy preserves it
+        // even with empty vp_claims.
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            json!({
+                "applicant_did": "did:key:zX",
+                "current_personhood": true,
+                "asserted_at_seconds_ago": 3600,
+                "vp_claims": { "holder": "did:key:zX", "credentials": [] }
+            }),
+        )
+        .unwrap();
+        assert!(
+            pluck_bool(&r),
+            "renewal must preserve current_personhood=true under default policy"
+        );
+    }
+
+    #[test]
+    fn personhood_default_renewal_denies_when_current_false_no_evidence() {
+        // Renewal-time re-eval: current=false + no witness
+        // credentials → still deny. Operators wanting allow-
+        // by-stale-state upload their own rego.
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            json!({
+                "applicant_did": "did:key:zX",
+                "current_personhood": false,
+                "vp_claims": { "holder": "did:key:zX", "credentials": [] }
+            }),
+        )
+        .unwrap();
+        assert!(
+            !pluck_bool(&r),
+            "renewal with no evidence + current=false must deny"
         );
     }
 

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -36,6 +36,19 @@ pub struct MemberResponse {
     pub current_vmc_id: Option<String>,
     pub current_role_vec_id: Option<String>,
     pub extensions: JsonValue,
+    /// Personhood flag (Phase 4 M4.1). Surfaces the Member row's
+    /// `personhood` field. Read-only on this response —
+    /// `POST /v1/members/{did}/personhood/assert` flips it (M4.3),
+    /// `DELETE /v1/members/{did}/personhood` clears it (M4.4),
+    /// and renewal-policy downgrade clears it (M4.2.2).
+    pub personhood: bool,
+    /// Timestamp of the most recent assert. Operator-private —
+    /// the value is included on Admin-gated responses (this
+    /// route is `AdminAuth`) so operators can audit; the
+    /// public member-facing renewal response carries only the
+    /// `personhood` flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personhood_asserted_at: Option<DateTime<Utc>>,
 }
 
 impl MemberResponse {
@@ -55,6 +68,8 @@ impl MemberResponse {
             current_vmc_id: member.current_vmc_id,
             current_role_vec_id: member.current_role_vec_id,
             extensions: member.extensions,
+            personhood: member.personhood,
+            personhood_asserted_at: member.personhood_asserted_at,
         }
     }
 }

--- a/vtc-service/src/routes/members/renew.rs
+++ b/vtc-service/src/routes/members/renew.rs
@@ -129,10 +129,33 @@ pub async fn renew(
     let status_ref =
         CredentialStatusRef::revocation(status_list_state.list_credential_id.clone(), slot);
 
-    // 3. Re-evaluate `personhood.rego`.
-    let personhood = evaluate_personhood(&state, &caller_did, &member.extensions).await?;
+    // 3. Re-evaluate `personhood.rego` against the Member's
+    //    persisted state (Phase 4 M4.2.2).
+    let prior_personhood = member.personhood;
+    let policy_allow = evaluate_personhood(&state, &member).await?;
 
-    let prior_personhood = prior_personhood_from_member(&member);
+    // M4.2.2: when the policy flips a previously-asserted
+    // member's flag to `false`, branch on the operator's
+    // configured `on_personhood_fail` mode.
+    let fail_mode = state.config.read().await.renewal.on_personhood_fail;
+    let (personhood, downgrade_audit) = if prior_personhood && !policy_allow {
+        match fail_mode {
+            crate::config::PersonhoodFailMode::Refuse => {
+                // No state change, no audit, no VMC re-mint.
+                return Err(AppError::Validation(
+                    "personhood-renewal-refused: active personhood.rego \
+                         no longer permits this member; re-assert via \
+                         POST /v1/members/{did}/personhood/assert before \
+                         retrying renewal"
+                        .into(),
+                ));
+            }
+            crate::config::PersonhoodFailMode::Downgrade => (false, true),
+        }
+    } else {
+        (policy_allow, false)
+    };
+
     let personhood_changed = prior_personhood != personhood;
 
     // 4. Build VMC + role VEC.
@@ -160,9 +183,18 @@ pub async fn renew(
     member.status_list_index = Some(slot);
     member.current_vmc_id = Some(vmc_id.clone());
     member.current_role_vec_id = Some(vec_id.clone());
+    if downgrade_audit {
+        // Renewal-policy downgrade clears the asserted-at
+        // timestamp alongside the flag. The member must
+        // re-assert (M4.3) to reinstate.
+        member.personhood = false;
+        member.personhood_asserted_at = None;
+    }
     store_member(&state.members_ks, &member).await?;
 
-    // 6. Audit.
+    // 6. Audit. `MembershipRenewed` always fires; paired
+    //    `PersonhoodRevoked { reason: "renewal-policy" }` only
+    //    on the downgrade arm.
     audit_writer
         .write(
             &caller_did,
@@ -174,6 +206,25 @@ pub async fn renew(
             }),
         )
         .await?;
+    if downgrade_audit {
+        let vtc_did = state
+            .config
+            .read()
+            .await
+            .vtc_did
+            .clone()
+            .unwrap_or_else(|| "did:key:vtc-unknown".into());
+        audit_writer
+            .write(
+                &vtc_did,
+                Some(&caller_did),
+                AuditEvent::PersonhoodRevoked(vti_common::audit::PersonhoodRevokedData {
+                    vmc_id: Some(vmc_id.clone()),
+                    reason: "renewal-policy".into(),
+                }),
+            )
+            .await?;
+    }
 
     info!(
         did = %caller_did,
@@ -197,16 +248,28 @@ pub async fn renew(
     ))
 }
 
-/// Run the active `personhood.rego` against the canonical
-/// input (spec §6.4): `{ applicant_did, vp_claims }`. The
-/// Member row's `extensions` slot is the closest stand-in for
-/// `vp_claims` in Phase 2 — Phase 4's assert/revoke endpoints
-/// will populate a richer claim. Fail-closed: any error path
-/// yields `false`.
+/// Run the active `personhood.rego` against the renewal-time
+/// canonical input (Phase 4 M4.2.2):
+///
+/// ```json
+/// {
+///   "applicant_did": "<did>",
+///   "current_personhood": <bool>,
+///   "asserted_at_seconds_ago": <int | null>,
+///   "vp_claims": { "holder": "<did>", "credentials": [] }
+/// }
+/// ```
+///
+/// Evidence (the VP) is **not persisted** on the Member row
+/// per planning-review D2 — the policy sees the current
+/// flag + the assert age, not the original evidence. Operators
+/// wanting richer renewal-time eval upload a custom rego that
+/// consults additional inputs (e.g. live trust-registry).
+///
+/// Fail-closed: any error path yields `false`.
 async fn evaluate_personhood(
     state: &AppState,
-    applicant_did: &str,
-    vp_claims: &JsonValue,
+    member: &crate::members::Member,
 ) -> Result<bool, AppError> {
     let active = get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Personhood).await?;
     let Some(id) = active else {
@@ -216,25 +279,19 @@ async fn evaluate_personhood(
         .await?
         .ok_or_else(|| AppError::Internal(format!("active personhood policy {id} not found")))?;
     let compiled = compile_policy(&policy.rego_source, policy.id)?;
+    let asserted_at_seconds_ago: JsonValue = match member.personhood_asserted_at {
+        Some(t) => json!((chrono::Utc::now() - t).num_seconds().max(0)),
+        None => JsonValue::Null,
+    };
     let input = json!({
-        "applicant_did": applicant_did,
-        "vp_claims": vp_claims,
+        "applicant_did": member.did,
+        "current_personhood": member.personhood,
+        "asserted_at_seconds_ago": asserted_at_seconds_ago,
+        "vp_claims": { "holder": member.did, "credentials": [] },
     });
     let result = evaluate_policy(&compiled, "data.vtc.personhood.allow", input)?;
     Ok(result
         .pointer("/result/0/expressions/0/value")
         .and_then(|v| v.as_bool())
         .unwrap_or(false))
-}
-
-/// Best-effort recovery of the prior VMC's `personhood` flag.
-/// Phase 2 doesn't persist VMC bodies server-side, so we
-/// can't read it back directly. We default to `false` (the
-/// deny-all stub's output) — meaning `personhood_changed` is
-/// always `false` in MVP unless the operator uploads a
-/// custom personhood policy that flips between renewals. The
-/// field is on the wire from day one; Phase 4 can persist the
-/// flag on the Member row to make this comparison precise.
-fn prior_personhood_from_member(_member: &crate::members::Member) -> bool {
-    false
 }

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -143,6 +143,8 @@ impl MemberResponse {
             current_vmc_id: member.current_vmc_id,
             current_role_vec_id: member.current_role_vec_id,
             extensions: member.extensions,
+            personhood: member.personhood,
+            personhood_asserted_at: member.personhood_asserted_at,
         }
     }
 }

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -54,6 +54,9 @@ struct Fixture {
     signer: Arc<LocalSigner>,
     members_ks: vti_common::store::KeyspaceHandle,
     status_lists_ks: vti_common::store::KeyspaceHandle,
+    policies_ks: vti_common::store::KeyspaceHandle,
+    active_policies_ks: vti_common::store::KeyspaceHandle,
+    audit_ks: vti_common::store::KeyspaceHandle,
     _dir: tempfile::TempDir,
 }
 
@@ -195,7 +198,7 @@ async fn build_fixture() -> Fixture {
         supervisor: None,
     };
 
-    let router = routes::router().with_state(state);
+    let router = routes::router().with_state(state.clone());
 
     Fixture {
         router,
@@ -203,6 +206,9 @@ async fn build_fixture() -> Fixture {
         signer,
         members_ks,
         status_lists_ks,
+        policies_ks: state.policies_ks,
+        active_policies_ks: state.active_policies_ks,
+        audit_ks: state.audit_ks,
         _dir: dir,
     }
 }
@@ -304,4 +310,132 @@ async fn renew_requires_authentication() {
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ─── Phase 4 M4.2.2: renewal personhood eval ─────────────
+
+#[tokio::test]
+async fn renew_preserves_personhood_when_already_asserted() {
+    // Member.personhood = true, default policy preserves on
+    // renewal. The new VMC should carry personhood: true.
+    let fix = build_fixture().await;
+    let mut m = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    m.personhood = true;
+    m.personhood_asserted_at = Some(chrono::Utc::now());
+    store_member(&fix.members_ks, &m).await.unwrap();
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/renew")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", RENEW_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["personhood"], true);
+    assert_eq!(body["personhoodChanged"], false);
+
+    let m2 = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(m2.personhood);
+    assert!(m2.personhood_asserted_at.is_some());
+}
+
+#[tokio::test]
+async fn renew_default_downgrades_when_policy_drops_flag() {
+    // Member.personhood = true but we activate a strict
+    // policy that denies for everyone. With default
+    // on_personhood_fail = Downgrade, renewal succeeds with
+    // personhood: false; Member row flips + paired
+    // PersonhoodRevoked envelope is emitted.
+    //
+    // The Refuse-mode arm is exercised by a Fixture variant
+    // that takes a PersonhoodFailMode parameter — deferred
+    // to PR-2 alongside the assert/revoke endpoints.
+    use vti_common::audit::AuditEvent;
+
+    let fix = build_fixture().await;
+
+    let mut m = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    m.personhood = true;
+    m.personhood_asserted_at = Some(chrono::Utc::now());
+    store_member(&fix.members_ks, &m).await.unwrap();
+
+    // Activate a strict deny-all personhood policy via the
+    // fixture's already-open keyspace handles (fjall is
+    // single-process-locked; can't re-open the dir).
+    let src = "package vtc.personhood\nimport rego.v1\ndefault allow := false\n";
+    use sha2::{Digest, Sha256};
+    let sha: [u8; 32] = Sha256::digest(src.as_bytes()).into();
+    let id = uuid::Uuid::new_v4();
+    let strict = vtc_service::policy::Policy {
+        id,
+        purpose: vtc_service::policy::PolicyPurpose::Personhood,
+        rego_source: src.into(),
+        sha256: sha,
+        activated_at: Some(chrono::Utc::now()),
+        author_did: "did:key:test".into(),
+        created_at: chrono::Utc::now(),
+        version: 1,
+    };
+    vtc_service::policy::store_policy(&fix.policies_ks, &strict)
+        .await
+        .unwrap();
+    vtc_service::policy::set_active_policy_id(
+        &fix.active_policies_ks,
+        vtc_service::policy::PolicyPurpose::Personhood,
+        id,
+    )
+    .await
+    .unwrap();
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/renew")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", RENEW_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "downgrade must succeed");
+
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["personhood"], false, "downgraded");
+    assert_eq!(body["personhoodChanged"], true);
+
+    let m2 = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!m2.personhood);
+    assert!(m2.personhood_asserted_at.is_none());
+
+    let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let mut saw_revoked = false;
+    for (_k, v) in pairs {
+        let env: vti_common::audit::AuditEnvelope = serde_json::from_slice(&v).unwrap();
+        if let AuditEvent::PersonhoodRevoked(data) = env.event
+            && data.reason == "renewal-policy"
+        {
+            saw_revoked = true;
+            break;
+        }
+    }
+    assert!(
+        saw_revoked,
+        "downgrade path must emit PersonhoodRevoked with reason=renewal-policy"
+    );
 }

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -56,6 +56,7 @@ fn cfg_with(routing: RoutingConfig, cors: CorsConfig) -> AppConfig {
         routing,
         cors,
         registry: Default::default(),
+        renewal: Default::default(),
         config_path: std::path::PathBuf::new(),
     }
 }

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -215,6 +215,63 @@ pub enum AuditEvent {
     /// `registry-unreachable` / `validity-window` / `malformed`
     /// / `role-mapping-denied`).
     CrossCommunitySessionMinted(CrossCommunitySessionMintedData),
+
+    // ─── Phase 4 lifecycle ─────────────────────────────────
+    /// A member published a self-issued Verifiable Recognition
+    /// Credential (VRC) — a trust edge `issuer-member → subject-
+    /// member` per spec §5.4 + §6.1. Phase 4 M4.6. The actor is
+    /// the issuer; the target is the subject DID.
+    VrcPublished(VrcPublishedData),
+
+    /// A VRC was revoked — either by the original issuer or by
+    /// an admin acting on behalf of the community. Phase 4 M4.6.
+    /// Per D7, VRCs carry no `credentialStatus`; revocation is
+    /// row deletion in the local `relationships:` keyspace.
+    VrcRevoked(VrcRevokedData),
+
+    /// A member's personhood flag was asserted true via
+    /// `POST /v1/members/{did}/personhood/assert`. Phase 4
+    /// M4.3. The actor is the asserter (admin or issuer); the
+    /// target is the member. Per D2 review (VP-only assert),
+    /// the presented evidence is verified at assert time and
+    /// discarded — no `evidence_sha256` field on this envelope.
+    PersonhoodAsserted(PersonhoodAssertedData),
+
+    /// A member's personhood flag was revoked. Phase 4 M4.4 +
+    /// M4.2.2. The `reason` discriminator pins which of the
+    /// three triggers fired: `"admin"` (admin `DELETE`),
+    /// `"self"` (member `DELETE`), or `"renewal-policy"`
+    /// (renewal-time policy downgrade per D5 review's
+    /// `downgrade` arm).
+    PersonhoodRevoked(PersonhoodRevokedData),
+
+    /// A custom (non-role) endorsement credential was issued
+    /// by an issuer or admin. Phase 4 M4.8. Per D8 review, the
+    /// credential carries a `credentialStatus` entry on the
+    /// shared `Revocation` status list — `status_list_index`
+    /// records the allocated slot.
+    CustomEndorsementIssued(CustomEndorsementIssuedData),
+
+    /// A custom endorsement was revoked. Phase 4 M4.8. Flips
+    /// the `Revocation` status-list bit at the credential's
+    /// `status_list_index`. Paired with a
+    /// `StatusListFlipped { purpose: "revocation", index,
+    /// revoked: true }` envelope (existing variant) so the
+    /// status-list audit surface stays uniform.
+    CustomEndorsementRevoked(CustomEndorsementRevokedData),
+
+    /// An operator registered a new custom endorsement type
+    /// via `POST /v1/endorsement-types`. Phase 4 M4.8.1 (D4
+    /// review). The actor is the admin; the `type_uri` field
+    /// records what was registered.
+    EndorsementTypeRegistered(EndorsementTypeRegisteredData),
+
+    /// An operator deleted a custom endorsement type via
+    /// `DELETE /v1/endorsement-types/{uri}`. Phase 4 M4.8.1.
+    /// The registry refuses deletion when at least one live
+    /// endorsement of this type still exists; this envelope
+    /// only fires after a successful delete.
+    EndorsementTypeDeleted(EndorsementTypeDeletedData),
 }
 
 // ---------------------------------------------------------------------------
@@ -582,6 +639,121 @@ pub struct CrossCommunitySessionMintedData {
     /// `"role-mapping-denied"` for the policy-rejection arm.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+}
+
+// ─── Phase 4 payload structs ──────────────────────────────
+
+/// Payload for [`AuditEvent::VrcPublished`]. Phase 4 M4.6.
+/// Self-issued trust edge from one member to another.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VrcPublishedData {
+    /// Server-allocated id (UUID) of the relationship row.
+    /// The wire-form `id` lives at `urn:uuid:<vrc_id>` on the
+    /// VRC's top-level `id` field.
+    pub vrc_id: String,
+    /// Subject DID — the *other* member the edge points at.
+    /// HMAC-hashed in `target_did_hash` on the envelope; the
+    /// raw value lives here only when operator policy allows
+    /// (default: omitted).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_did: Option<String>,
+    /// Free-form trust-relationship type tag from the VRC's
+    /// `endorsement.type`. Examples: `"endorses"`, `"reports-to"`,
+    /// `"collaborates-with"` — operator-defined.
+    pub edge_type: String,
+}
+
+/// Payload for [`AuditEvent::VrcRevoked`]. Phase 4 M4.6.
+/// Issued whether the original issuer or an admin performed
+/// the revocation; the envelope's `actor_did` distinguishes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VrcRevokedData {
+    pub vrc_id: String,
+    /// `"issuer"` (the original member revoked their own VRC)
+    /// or `"admin"` (an admin revoked on behalf of the
+    /// community).
+    pub revoked_by: String,
+}
+
+/// Payload for [`AuditEvent::PersonhoodAsserted`]. Phase 4
+/// M4.3. The envelope's `actor_did` is the asserter (admin or
+/// issuer); `target_did_hash` is the member.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PersonhoodAssertedData {
+    /// VMC id minted with the new `personhood: true` flag.
+    /// Empty when the assert ran inside an idempotent retry
+    /// that didn't mint a fresh credential.
+    pub vmc_id: String,
+    /// `now` at assert time, in RFC3339. Persisted on the
+    /// Member row as `personhood_asserted_at` (per D2 review,
+    /// only the timestamp persists — not the VP itself).
+    pub asserted_at: String,
+}
+
+/// Payload for [`AuditEvent::PersonhoodRevoked`]. Phase 4
+/// M4.4 / M4.2.2.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PersonhoodRevokedData {
+    /// VMC id minted with the new `personhood: false` flag.
+    /// `None` on the `refuse` arm of `on_personhood_fail`
+    /// (no VMC re-mint).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vmc_id: Option<String>,
+    /// Discriminator for the three triggers: `"admin"`,
+    /// `"self"`, or `"renewal-policy"`.
+    pub reason: String,
+}
+
+/// Payload for [`AuditEvent::CustomEndorsementIssued`]. Phase 4
+/// M4.8.2. The envelope's `actor_did` is the issuer (issuer-
+/// role member or admin); `target_did_hash` is the subject.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomEndorsementIssuedData {
+    /// Server-allocated id (UUID) of the endorsement row.
+    pub endorsement_id: String,
+    /// The registered endorsement type URI.
+    pub endorsement_type: String,
+    /// Allocated slot index on the shared `Revocation` status
+    /// list (D8 review). Paired with the credential's
+    /// `credentialStatus.statusListIndex` field.
+    pub status_list_index: u32,
+}
+
+/// Payload for [`AuditEvent::CustomEndorsementRevoked`]. Phase 4
+/// M4.8.4. Paired with the existing `StatusListFlipped` envelope
+/// so the bit-flip is independently auditable.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomEndorsementRevokedData {
+    pub endorsement_id: String,
+    pub endorsement_type: String,
+}
+
+/// Payload for [`AuditEvent::EndorsementTypeRegistered`].
+/// Phase 4 M4.8.1 (D4 review).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EndorsementTypeRegisteredData {
+    /// The newly-registered type URI. Operators use this on
+    /// the issuance path's `body.type` field.
+    pub type_uri: String,
+    /// Optional human-readable description supplied at
+    /// registration time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Payload for [`AuditEvent::EndorsementTypeDeleted`]. Phase 4
+/// M4.8.1.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EndorsementTypeDeletedData {
+    pub type_uri: String,
 }
 
 /// Payload for [`AuditEvent::RegistryStatusChanged`]. Phase 3
@@ -1115,6 +1287,149 @@ mod tests {
         round_trip(&e);
     }
 
+    // ─── Phase 4 round-trip coverage ───────────────────
+
+    #[test]
+    fn vrc_published_round_trip() {
+        let e = AuditEvent::VrcPublished(VrcPublishedData {
+            vrc_id: "11111111-1111-1111-1111-111111111111".into(),
+            subject_did: Some("did:key:zSubject".into()),
+            edge_type: "endorses".into(),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "VrcPublished");
+        assert_eq!(v["data"]["vrcId"], "11111111-1111-1111-1111-111111111111");
+        assert_eq!(v["data"]["subjectDid"], "did:key:zSubject");
+        assert_eq!(v["data"]["edgeType"], "endorses");
+        round_trip(&e);
+    }
+
+    #[test]
+    fn vrc_published_omits_subject_did_when_none() {
+        let e = AuditEvent::VrcPublished(VrcPublishedData {
+            vrc_id: "id".into(),
+            subject_did: None,
+            edge_type: "reports-to".into(),
+        });
+        let v = wire_value(&e);
+        assert!(v["data"].get("subjectDid").is_none());
+        round_trip(&e);
+    }
+
+    #[test]
+    fn vrc_revoked_round_trip() {
+        let e = AuditEvent::VrcRevoked(VrcRevokedData {
+            vrc_id: "id".into(),
+            revoked_by: "issuer".into(),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "VrcRevoked");
+        assert_eq!(v["data"]["revokedBy"], "issuer");
+        round_trip(&e);
+    }
+
+    #[test]
+    fn personhood_asserted_round_trip() {
+        let e = AuditEvent::PersonhoodAsserted(PersonhoodAssertedData {
+            vmc_id: "vmc-7".into(),
+            asserted_at: "2026-05-14T10:00:00Z".into(),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "PersonhoodAsserted");
+        assert_eq!(v["data"]["vmcId"], "vmc-7");
+        assert_eq!(v["data"]["assertedAt"], "2026-05-14T10:00:00Z");
+        round_trip(&e);
+    }
+
+    #[test]
+    fn personhood_revoked_round_trip() {
+        let e = AuditEvent::PersonhoodRevoked(PersonhoodRevokedData {
+            vmc_id: Some("vmc-8".into()),
+            reason: "admin".into(),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "PersonhoodRevoked");
+        assert_eq!(v["data"]["vmcId"], "vmc-8");
+        assert_eq!(v["data"]["reason"], "admin");
+        round_trip(&e);
+    }
+
+    #[test]
+    fn personhood_revoked_omits_vmc_id_when_refuse_arm() {
+        // `refuse` arm of on_personhood_fail doesn't re-mint
+        // a VMC, so vmc_id is None.
+        let e = AuditEvent::PersonhoodRevoked(PersonhoodRevokedData {
+            vmc_id: None,
+            reason: "renewal-policy".into(),
+        });
+        let v = wire_value(&e);
+        assert!(v["data"].get("vmcId").is_none());
+        assert_eq!(v["data"]["reason"], "renewal-policy");
+        round_trip(&e);
+    }
+
+    #[test]
+    fn custom_endorsement_issued_round_trip() {
+        let e = AuditEvent::CustomEndorsementIssued(CustomEndorsementIssuedData {
+            endorsement_id: "end-1".into(),
+            endorsement_type: "https://example.com/v1/skills/rust".into(),
+            status_list_index: 42,
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "CustomEndorsementIssued");
+        assert_eq!(
+            v["data"]["endorsementType"],
+            "https://example.com/v1/skills/rust"
+        );
+        assert_eq!(v["data"]["statusListIndex"], 42);
+        round_trip(&e);
+    }
+
+    #[test]
+    fn custom_endorsement_revoked_round_trip() {
+        let e = AuditEvent::CustomEndorsementRevoked(CustomEndorsementRevokedData {
+            endorsement_id: "end-1".into(),
+            endorsement_type: "https://example.com/v1/skills/rust".into(),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "CustomEndorsementRevoked");
+        round_trip(&e);
+    }
+
+    #[test]
+    fn endorsement_type_registered_round_trip() {
+        let e = AuditEvent::EndorsementTypeRegistered(EndorsementTypeRegisteredData {
+            type_uri: "https://example.com/v1/skills/rust".into(),
+            description: Some("Rust proficiency endorsement".into()),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "EndorsementTypeRegistered");
+        assert_eq!(v["data"]["typeUri"], "https://example.com/v1/skills/rust");
+        assert_eq!(v["data"]["description"], "Rust proficiency endorsement");
+        round_trip(&e);
+    }
+
+    #[test]
+    fn endorsement_type_registered_omits_description_when_none() {
+        let e = AuditEvent::EndorsementTypeRegistered(EndorsementTypeRegisteredData {
+            type_uri: "https://example.com/v1/x".into(),
+            description: None,
+        });
+        let v = wire_value(&e);
+        assert!(v["data"].get("description").is_none());
+        round_trip(&e);
+    }
+
+    #[test]
+    fn endorsement_type_deleted_round_trip() {
+        let e = AuditEvent::EndorsementTypeDeleted(EndorsementTypeDeletedData {
+            type_uri: "https://example.com/v1/skills/rust".into(),
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "EndorsementTypeDeleted");
+        round_trip(&e);
+    }
+
     #[test]
     fn variant_discriminator_strings() {
         let cases: Vec<(AuditEvent, &str)> = vec![
@@ -1289,6 +1604,63 @@ mod tests {
                     reason: None,
                 }),
                 "CrossCommunitySessionMinted",
+            ),
+            (
+                AuditEvent::VrcPublished(VrcPublishedData {
+                    vrc_id: "id".into(),
+                    subject_did: Some("did:key:zX".into()),
+                    edge_type: "endorses".into(),
+                }),
+                "VrcPublished",
+            ),
+            (
+                AuditEvent::VrcRevoked(VrcRevokedData {
+                    vrc_id: "id".into(),
+                    revoked_by: "admin".into(),
+                }),
+                "VrcRevoked",
+            ),
+            (
+                AuditEvent::PersonhoodAsserted(PersonhoodAssertedData {
+                    vmc_id: "v".into(),
+                    asserted_at: "2026-05-14T10:00:00Z".into(),
+                }),
+                "PersonhoodAsserted",
+            ),
+            (
+                AuditEvent::PersonhoodRevoked(PersonhoodRevokedData {
+                    vmc_id: Some("v".into()),
+                    reason: "self".into(),
+                }),
+                "PersonhoodRevoked",
+            ),
+            (
+                AuditEvent::CustomEndorsementIssued(CustomEndorsementIssuedData {
+                    endorsement_id: "end".into(),
+                    endorsement_type: "https://x/v1/t".into(),
+                    status_list_index: 0,
+                }),
+                "CustomEndorsementIssued",
+            ),
+            (
+                AuditEvent::CustomEndorsementRevoked(CustomEndorsementRevokedData {
+                    endorsement_id: "end".into(),
+                    endorsement_type: "https://x/v1/t".into(),
+                }),
+                "CustomEndorsementRevoked",
+            ),
+            (
+                AuditEvent::EndorsementTypeRegistered(EndorsementTypeRegisteredData {
+                    type_uri: "https://x/v1/t".into(),
+                    description: None,
+                }),
+                "EndorsementTypeRegistered",
+            ),
+            (
+                AuditEvent::EndorsementTypeDeleted(EndorsementTypeDeletedData {
+                    type_uri: "https://x/v1/t".into(),
+                }),
+                "EndorsementTypeDeleted",
             ),
         ];
         for (event, expected) in cases {

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -33,11 +33,14 @@ pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
 pub use event::{
     AdminPasskeyData, AdminPromotedData, AuditEvent, AuditKeyRotatedData, CommunityInstalledData,
     CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
-    CredentialIssuedData, CrossCommunitySessionMintedData, DidRotatedData, EmergencyBootstrapData,
-    JoinRequestData, JoinRequestRejectedData, MemberAddedData, MemberRemovedData,
-    MemberUpdatedData, MembershipRenewedData, PolicyActivatedData, PolicyUploadedData,
-    REDACTED_MARKER, RegistryRecordPolicyOverrideData, RegistryStatusChangedData,
-    RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData, StatusListFlippedData,
+    CredentialIssuedData, CrossCommunitySessionMintedData, CustomEndorsementIssuedData,
+    CustomEndorsementRevokedData, DidRotatedData, EmergencyBootstrapData,
+    EndorsementTypeDeletedData, EndorsementTypeRegisteredData, JoinRequestData,
+    JoinRequestRejectedData, MemberAddedData, MemberRemovedData, MemberUpdatedData,
+    MembershipRenewedData, PersonhoodAssertedData, PersonhoodRevokedData, PolicyActivatedData,
+    PolicyUploadedData, REDACTED_MARKER, RegistryRecordPolicyOverrideData,
+    RegistryStatusChangedData, RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData,
+    StatusListFlippedData, VrcPublishedData, VrcRevokedData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

Phase 4 PR-1 / 5. The personhood-track foundation — no new wire surfaces yet, derisks the renewal-path change in isolation before assert/revoke endpoints land in PR-2.

- **M4.1.1** — `Member` gains two new fields (per D2 review): `personhood: bool` + `personhood_asserted_at: Option<DateTime<Utc>>`. Evidence is **not persisted** on the row (planning-review decision — VPs are verify-then-discard). Backward-compat: pre-Phase-4 JSON rows still deserialise; tombstone clears the new fields alongside the existing PII wipe.
- **M4.1.2** — 8 new audit variant stubs in vti-common (D6 + D4 review). 11 new round-trip + discriminator-table tests. No emitters yet — wired up by subsequent PRs.
- **M4.2.1** — `personhood.rego` flipped from deny-all stub to a minimal-allow default. Two allow paths: WitnessCredential presence on assert + `current_personhood == true` preservation on renewal. 6 unit tests cover deny + allow + renewal-preserve.
- **M4.2.2** — Renewal hook reads the new Member fields; new `RenewalConfig.on_personhood_fail` knob (`downgrade` default | `refuse`). Downgrade path emits paired `PersonhoodRevoked { reason: "renewal-policy" }` so the audit log captures the flip. 5 renewal integration tests (was 3).

### Key design notes

- **Refuse-mode integration coverage deferred to PR-2.** The fixture builder doesn't expose a `PersonhoodFailMode` parameter yet — both branches are exercised at the route layer and via policy unit tests, but the full HTTP refuse path lands when assert/revoke endpoints arrive.
- **Renewal fixture now exposes policy + audit keyspaces** so integration tests can install strict policies + inspect the audit log without re-opening the fjall-locked store.
- **Audit envelope discipline**: the `PersonhoodRevoked` emitter ships with the renewal-downgrade path even though the assert/revoke routes haven't landed — keeps the audit trail complete for the M4.2 closeout.

## Test plan

- [x] 11 new audit round-trip + discriminator tests pass
- [x] 6 personhood.rego unit tests pass
- [x] 5 renewal integration tests pass (was 3 — added preserve + downgrade paths with audit verification)
- [x] Backward-compat test: pre-Phase-4 Member JSON deserialises
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` green (292 vtc-service lib + every integration suite + 191 vti-common)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] DCO sign-off

Refs: #46 vtc-mvp Phase 4 plan §M4.1 + §M4.2