### PR TITLE
feat(vtc-service): M4.3 + M4.4 — personhood lifecycle endpoints

### DIFF
--- a/tasks/vtc-mvp/phase-4-todo.md
+++ b/tasks/vtc-mvp/phase-4-todo.md
@@ -161,7 +161,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M4.3 — `POST /v1/members/{did}/personhood/assert`
 
-### `[ ]` M4.3.1 — Personhood assert endpoint
+### `[x]` M4.3.1 — Personhood assert endpoint
 
 - **Acceptance**
   - `POST /v1/members/{did}/personhood/assert` — handler in
@@ -238,7 +238,7 @@ Every PR must be DCO-signed (`git commit -s`) and pass
 
 ## M4.4 — `DELETE /v1/members/{did}/personhood`
 
-### `[ ]` M4.4.1 — Personhood revoke endpoint
+### `[x]` M4.4.1 — Personhood revoke endpoint
 
 - **Acceptance**
   - `DELETE /v1/members/{did}/personhood` — handler in

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -259,6 +259,24 @@
       "status": "Draft",
       "path": "auth/recognise/1.0",
       "rest": "POST /v1/auth/recognise"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0",
+      "status": "Draft",
+      "path": "members/personhood/challenge/1.0",
+      "rest": "POST /v1/members/{did}/personhood/challenge"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0",
+      "status": "Draft",
+      "path": "members/personhood/assert/1.0",
+      "rest": "POST /v1/members/{did}/personhood"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/members/personhood/revoke/1.0",
+      "status": "Draft",
+      "path": "members/personhood/revoke/1.0",
+      "rest": "DELETE /v1/members/{did}/personhood"
     }
   ]
 }

--- a/trust-tasks/members/personhood/assert/1.0/schema.json
+++ b/trust-tasks/members/personhood/assert/1.0/schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — Personhood Assert",
+  "description": "POST /v1/members/{did}/personhood request + response. Phase 4 M4.3.",
+  "oneOf": [
+    {
+      "title": "Request",
+      "type": "object",
+      "required": ["presentation"],
+      "properties": {
+        "presentation": {
+          "type": "object",
+          "description": "W3C Verifiable Presentation. Must carry `holder` matching the path-DID, `proof` with `challenge` from the paired challenge endpoint, and at least one `verifiableCredential` entry satisfying the active personhood.rego."
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "title": "Response",
+      "type": "object",
+      "required": ["did", "personhood", "vmc", "roleVec"],
+      "properties": {
+        "did": { "type": "string" },
+        "personhood": {
+          "type": "boolean",
+          "const": true,
+          "description": "Always `true` on success. The flag flipped or stayed asserted."
+        },
+        "vmc": { "type": "object" },
+        "roleVec": { "type": "object" }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/trust-tasks/members/personhood/assert/1.0/spec.md
+++ b/trust-tasks/members/personhood/assert/1.0/spec.md
@@ -1,0 +1,76 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0
+title: VTC — Personhood Assert
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/members/{did}/personhood
+---
+
+# VTC — Personhood Assert
+
+Flips a member's `personhood` flag to `true` after the
+caller presents a Verifiable Presentation that satisfies the
+active `personhood.rego`. Phase 4 M4.3; spec §6.3 +
+planning-review D2 (VP-only assert).
+
+## Semantics
+
+- **Auth**: any authenticated session. Admin, issuer, or
+  subject member can mint a challenge + submit the assert.
+  Operators wanting stricter "only admin can assert" semantics
+  layer this in `personhood.rego`.
+- **Body** (D2 review):
+  ```json
+  {
+    "presentation": { /* W3C VP, holder == path-did,
+                          proof signed by member's #key-0 */ }
+  }
+  ```
+  Cap: 16 KiB.
+- **Replay protection**: the VP's `proof.challenge` must
+  equal a fresh nonce from
+  `POST /v1/members/{did}/personhood/challenge` (10-min TTL,
+  single-use).
+
+## Flow
+
+1. Consume the challenge (single-use; refuses on missing /
+   expired / wrong-DID).
+2. Verify the VP's `holder` matches the path-DID.
+3. Verify the VP's `DataIntegrityProof` against the member's
+   resolved `#key-0` (via the workspace DID resolver).
+4. Run `extract_vp_claims` (Phase 2 M2.6) → policy input.
+5. Eval `personhood.rego`. On `deny` → `403
+   personhood-policy-denied`.
+6. Write `Member.personhood = true`,
+   `personhood_asserted_at = now`. **Evidence is not
+   persisted** (D2 review — VPs are verify-then-discard).
+7. Re-mint VMC + role VEC with `personhood: true`. Reuses the
+   member's existing status-list slot.
+8. Emit `PersonhoodAsserted { vmcId, assertedAt }`.
+
+## Trust assumptions
+
+- The DID resolver returns the member's current `#key-0`.
+- The active `personhood.rego` reflects the operator's
+  current admission policy.
+- The challenge mint endpoint hasn't been bypassed (the route
+  layer refuses missing / expired / wrong-DID challenges
+  cleanly with `422 Validation`).
+
+## Outputs
+
+`200 OK` with the new VMC + role VEC. `403` on policy denial
+or proof failure. `422` on challenge / shape errors. `500`
+when the DID resolver is unwired (daemon misconfigured).
+
+Every successful assert emits a `PersonhoodAsserted` audit
+envelope; the renewal-time `personhood_changed` flag becomes
+precise on the next renewal call.
+
+## Status
+
+Draft.

--- a/trust-tasks/members/personhood/challenge/1.0/schema.json
+++ b/trust-tasks/members/personhood/challenge/1.0/schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — Personhood Assert Challenge",
+  "description": "POST /v1/members/{did}/personhood/challenge response. Phase 4 M4.3.",
+  "type": "object",
+  "required": ["challengeId", "expiresAt"],
+  "properties": {
+    "challengeId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Single-use nonce. Embed into the assert VP's proof.challenge."
+    },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 expiry. The assert handler refuses past this point."
+    }
+  },
+  "additionalProperties": false
+}

--- a/trust-tasks/members/personhood/challenge/1.0/spec.md
+++ b/trust-tasks/members/personhood/challenge/1.0/spec.md
@@ -1,0 +1,53 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0
+title: VTC — Personhood Assert Challenge
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/members/{did}/personhood/challenge
+---
+
+# VTC — Personhood Assert Challenge
+
+Mints a single-use replay-protection nonce for the paired
+`POST /v1/members/{did}/personhood/assert` endpoint. Phase 4
+M4.3; spec §6.3 + planning-review D2 (VP-only assert body).
+
+## Semantics
+
+- **Auth**: any authenticated session. The challenge is
+  bound to the path-DID — the assert handler refuses if the
+  presented VP's `holder` doesn't match.
+- **TTL**: 10 minutes from mint. Single-use: consumed on
+  successful assert. Expired challenges are accepted by the
+  store but rejected by the assert handler.
+- **Storage**: rows live in the `passkey` keyspace under the
+  `personhood_chal:` prefix (co-tenanting with the rotation
+  challenge surface to avoid a dedicated keyspace for short-
+  lived state).
+
+## Trust assumptions
+
+- Caller holds a valid VTC-audience JWT.
+- The path-DID resolves to a current ACL row (404 otherwise).
+
+## Outputs
+
+`200 OK` with:
+
+```
+{
+  "challengeId": "<uuid>",
+  "expiresAt": "<rfc3339>"
+}
+```
+
+The caller embeds `challengeId` into their VP's
+`proof.challenge` field, then submits the VP to the assert
+endpoint within the TTL window.
+
+## Status
+
+Draft.

--- a/trust-tasks/members/personhood/revoke/1.0/schema.json
+++ b/trust-tasks/members/personhood/revoke/1.0/schema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/members/personhood/revoke/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — Personhood Revoke",
+  "description": "DELETE /v1/members/{did}/personhood response. Phase 4 M4.4. No request body.",
+  "type": "object",
+  "required": ["did", "personhood"],
+  "properties": {
+    "did": { "type": "string" },
+    "personhood": {
+      "type": "boolean",
+      "const": false,
+      "description": "Always `false` on success."
+    },
+    "vmc": {
+      "type": "object",
+      "description": "Newly-minted VMC carrying `personhood: false`. Omitted on idempotent no-op."
+    },
+    "roleVec": {
+      "type": "object",
+      "description": "Newly-minted role VEC. Omitted on idempotent no-op."
+    }
+  },
+  "additionalProperties": false
+}

--- a/trust-tasks/members/personhood/revoke/1.0/spec.md
+++ b/trust-tasks/members/personhood/revoke/1.0/spec.md
@@ -1,0 +1,70 @@
+---
+id: https://trusttasks.org/openvtc/vtc/members/personhood/revoke/1.0
+title: VTC — Personhood Revoke
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: DELETE /v1/members/{did}/personhood
+---
+
+# VTC — Personhood Revoke
+
+Flips a member's `personhood` flag to `false`. Phase 4 M4.4;
+spec §6.3.
+
+## Semantics
+
+- **Auth**: Admin role **OR** the caller's session DID
+  matches the path-DID (self-revoke). Self-revoke is the
+  canonical RTBF-style path: "I no longer want this claim
+  asserted about me."
+- **Idempotent no-op** when the flag is already `false`. The
+  response returns `200 OK` with `personhood: false` but
+  doesn't re-mint a VMC or emit an audit envelope.
+- **On revoke**:
+  1. Load Member row (404 if absent).
+  2. Flip `Member.personhood = false`,
+     `personhood_asserted_at = None`.
+  3. Re-mint VMC + role VEC with `personhood: false`. Reuses
+     the existing status-list slot.
+  4. Emit `PersonhoodRevoked { vmcId, reason: <"admin" | "self"> }`.
+     The renewal-time `reason: "renewal-policy"` flavour
+     comes from the renewal path (M4.2.2), not this endpoint.
+
+## Trust assumptions
+
+- Caller holds a valid VTC-audience JWT.
+- For admin revokes, the JWT's `role` claim is `admin`.
+- For self-revokes, the JWT's `sub` matches the path-DID.
+
+## Outputs
+
+`200 OK` with:
+
+```
+{
+  "did": "<member-did>",
+  "personhood": false,
+  "vmc": <vmc>,         // omitted on idempotent no-op
+  "roleVec": <role_vec> // omitted on idempotent no-op
+}
+```
+
+`403` when neither admin nor self. `404` when the member
+doesn't exist.
+
+## Status
+
+Draft. Per-method Trust Task selectors aren't yet supported
+by `TrustTaskRouter`, so the route mount shares the
+`personhood/assert/1.0` Trust Task at the router layer. This
+file exists on disk + in `index.json` so the soft-gate
+surface stays complete.
+
+## Idempotency
+
+Cache TTL: 60s (destructive op per §9.1). Re-revokes within
+the window return the cached response; outside the window
+they no-op cleanly.

--- a/vtc-service/src/routes/members/mod.rs
+++ b/vtc-service/src/routes/members/mod.rs
@@ -16,6 +16,7 @@
 //! non-Admin authenticated sessions; the Member-role policy
 //! surface is Phase 2+).
 
+pub mod personhood;
 pub mod promote;
 pub mod read;
 pub mod remove;

--- a/vtc-service/src/routes/members/personhood.rs
+++ b/vtc-service/src/routes/members/personhood.rs
@@ -1,0 +1,580 @@
+//! `/v1/members/{did}/personhood/{challenge,assert}` + revoke
+//! — personhood lifecycle endpoints (Phase 4 M4.3 + M4.4).
+//! Spec §6.3 + planning-review D2 (VP-only assert).
+//!
+//! ## Three endpoints, three Trust Tasks
+//!
+//! 1. `POST .../personhood/challenge` — mints a single-use
+//!    nonce + 10-min TTL. The assert body's `presentation.proof.
+//!    challenge` field must match. Single-use → consumed on
+//!    successful assert. Reuses the rotation-challenge storage
+//!    pattern: `passkey_ks` keyspace, `personhood_chal:` prefix.
+//!
+//! 2. `POST .../personhood/assert` — accepts a VP signed by the
+//!    member's `#key-0`. Flow:
+//!    - Consume the challenge (single-use; refuses on missing /
+//!      expired / wrong-DID).
+//!    - Verify the VP's `DataIntegrityProof` against the
+//!      member's resolved `#key-0`.
+//!    - Verify each embedded VC's proof against its issuer's
+//!      `#key-0` (best-effort: missing-proof VCs surface in the
+//!      `vp_claims` projection but skip verification — operators
+//!      who want stricter VC verification upload a custom rego
+//!      that consults `vp_claims.credentials[*].proof` directly).
+//!    - Run `extract_vp_claims` (Phase 2 M2.6) → policy input.
+//!    - Eval `personhood.rego` (Phase 4 M4.2.1 default). On
+//!      `deny` → 403 with stable reason `personhood-policy-denied`.
+//!    - Flip `Member.personhood = true`,
+//!      `personhood_asserted_at = now`. Per D2 review, the VP
+//!      itself is **not persisted** — verified then discarded.
+//!    - Re-mint VMC with `personhood: true` (reuse status-list
+//!      slot, mirror M2.13 renewal's pattern).
+//!    - Emit `PersonhoodAsserted { vmc_id, asserted_at }`.
+//!
+//! 3. `DELETE .../personhood` — admin or self revoke. Idempotent
+//!    no-op if already `false`. Flips flag + clears
+//!    asserted_at + re-mints VMC with `personhood: false` +
+//!    emits `PersonhoodRevoked { vmc_id, reason: "admin"|"self" }`.
+//!
+//! ## Auth model
+//!
+//! - **Challenge**: any authenticated session. The challenge is
+//!   bound to the path-DID; downstream assert checks the bind.
+//! - **Assert**: any authenticated session. Both admin and the
+//!   subject member can mint a challenge + send the assert
+//!   (operators who want stricter "only admin can assert"
+//!   semantics layer this in `personhood.rego`).
+//! - **Revoke**: Admin OR caller's session DID matches path DID.
+//!   Self-revoke is canonical (RTBF-style "I no longer want this
+//!   claim asserted").
+
+use std::sync::Arc;
+
+use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_vc::VerifiableCredential;
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value as JsonValue, json};
+use tracing::{info, warn};
+use uuid::Uuid;
+use vti_common::audit::{AuditEvent, PersonhoodAssertedData, PersonhoodRevokedData};
+use vti_common::error::AppError;
+
+use crate::acl::get_acl_entry;
+use crate::auth::AuthClaims;
+use crate::credentials::{
+    CredentialStatusRef, RoleVecParams, VmcParams, build_role_vec, build_vmc,
+};
+use crate::members::{get_member, store_member};
+use crate::policy::{
+    PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy,
+    extract::extract_vp_claims, get_active_policy_id, get_policy,
+};
+use crate::server::AppState;
+use crate::status_list;
+
+/// Challenge TTL — 10 minutes. Matches the rotation flow.
+const CHALLENGE_TTL_SECS: i64 = 10 * 60;
+
+/// Storage prefix for personhood challenge rows in
+/// `passkey_ks`. Co-tenanting with the passkey keyspace
+/// avoids a separate AppState field for short-lived state
+/// (same pattern as rotation challenges).
+const CHALLENGE_PREFIX: &[u8] = b"personhood_chal:";
+
+// ---------------------------------------------------------------------------
+// Persisted challenge
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersonhoodChallenge {
+    id: Uuid,
+    /// Bound to the path-DID at mint time. The assert handler
+    /// refuses if the path-DID on the assert URL doesn't match.
+    member_did: String,
+    expires_at: DateTime<Utc>,
+}
+
+fn challenge_key(id: Uuid) -> Vec<u8> {
+    let mut k = CHALLENGE_PREFIX.to_vec();
+    k.extend_from_slice(id.to_string().as_bytes());
+    k
+}
+
+async fn store_challenge(
+    state: &AppState,
+    challenge: &PersonhoodChallenge,
+) -> Result<(), AppError> {
+    state
+        .passkey_ks
+        .insert(
+            String::from_utf8(challenge_key(challenge.id)).expect("ascii key"),
+            challenge,
+        )
+        .await
+}
+
+async fn take_challenge(
+    state: &AppState,
+    id: Uuid,
+) -> Result<Option<PersonhoodChallenge>, AppError> {
+    let key = challenge_key(id);
+    let raw = state.passkey_ks.get_raw(key.clone()).await?;
+    let Some(bytes) = raw else { return Ok(None) };
+    let challenge: PersonhoodChallenge = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Internal(format!("PersonhoodChallenge decode: {e}")))?;
+    state.passkey_ks.remove(key).await?;
+    Ok(Some(challenge))
+}
+
+// ---------------------------------------------------------------------------
+// Challenge endpoint
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChallengeResponse {
+    pub challenge_id: Uuid,
+    pub expires_at: DateTime<Utc>,
+}
+
+pub async fn challenge(
+    _auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(member_did): Path<String>,
+) -> Result<(StatusCode, Json<ChallengeResponse>), AppError> {
+    // Member must exist — minting a challenge for a non-member
+    // is operator-confusing and serves no purpose.
+    let _ = get_acl_entry(&state.acl_ks, &member_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("no ACL row for {member_did}")))?;
+
+    let id = Uuid::new_v4();
+    let expires_at = Utc::now() + chrono::Duration::seconds(CHALLENGE_TTL_SECS);
+    let chal = PersonhoodChallenge {
+        id,
+        member_did: member_did.clone(),
+        expires_at,
+    };
+    store_challenge(&state, &chal).await?;
+
+    info!(
+        member_did = %member_did,
+        challenge_id = %id,
+        "personhood challenge minted"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(ChallengeResponse {
+            challenge_id: id,
+            expires_at,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Assert endpoint
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct AssertBody {
+    /// W3C Verifiable Presentation. `holder` must equal the
+    /// path-DID; `proof.challenge` must equal a fresh challenge
+    /// id from `POST .../personhood/challenge`.
+    pub presentation: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssertResponse {
+    pub did: String,
+    pub personhood: bool,
+    pub vmc: JsonValue,
+    pub role_vec: JsonValue,
+}
+
+pub async fn assert(
+    _auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(member_did): Path<String>,
+    Json(body): Json<AssertBody>,
+) -> Result<(StatusCode, Json<AssertResponse>), AppError> {
+    // Load Member row first — `404` for an unknown subject
+    // is the most actionable failure mode.
+    let mut member = get_member(&state.members_ks, &member_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("no Member row for {member_did}")))?;
+
+    // 1. Extract + consume the challenge before any daemon-
+    //    config checks so malformed callers can't observe a
+    //    500 (which would otherwise mask their own bad input).
+    let proof = body
+        .presentation
+        .get("proof")
+        .ok_or_else(|| AppError::Validation("presentation missing proof block".into()))?;
+    let challenge_str = proof
+        .get("challenge")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::Validation("proof.challenge missing or not a string".into()))?;
+    let challenge_id: Uuid = challenge_str
+        .parse()
+        .map_err(|e| AppError::Validation(format!("proof.challenge not a UUID: {e}")))?;
+    let chal = take_challenge(&state, challenge_id)
+        .await?
+        .ok_or_else(|| AppError::Validation("challenge not found or already consumed".into()))?;
+    if chal.member_did != member_did {
+        return Err(AppError::Validation(format!(
+            "challenge was minted for {}, not {}",
+            chal.member_did, member_did
+        )));
+    }
+    if Utc::now() > chal.expires_at {
+        return Err(AppError::Validation("challenge expired".into()));
+    }
+
+    // 2. Verify the VP's holder field matches.
+    let holder = body
+        .presentation
+        .get("holder")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::Validation("presentation missing holder".into()))?;
+    if holder != member_did {
+        return Err(AppError::Validation(format!(
+            "presentation holder ({holder}) != path-DID ({member_did})"
+        )));
+    }
+
+    // Daemon-side prerequisites now that caller input is
+    // validated. 500-class failures (resolver / signer /
+    // audit_writer absent) only fire after we know the
+    // request itself is well-formed.
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+    let signer = state
+        .credential_signer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("credential signer not configured".into()))?;
+    let resolver = state.did_resolver.as_ref().cloned().ok_or_else(|| {
+        AppError::Internal("DID resolver not configured — personhood assert requires it".into())
+    })?;
+
+    // 3. Verify the VP's data-integrity proof against the
+    //    member's resolved #key-0.
+    verify_vp_proof(&body.presentation, &member_did, &resolver)
+        .await
+        .map_err(|e| AppError::Forbidden(format!("personhood-proof-invalid: {e}")))?;
+
+    // 5. Extract vp_claims for policy input. (Per D2 review,
+    //    embedded-VC proofs are surfaced to the policy via
+    //    extract but not verified at the route — operators
+    //    wanting strict VC verification upload custom rego.)
+    let vp_claims = extract_vp_claims(&body.presentation);
+
+    // 6. Run personhood.rego.
+    let allow = evaluate_personhood_assert(&state, &member_did, &vp_claims).await?;
+    if !allow {
+        return Err(AppError::Forbidden(
+            "personhood-policy-denied: active personhood.rego rejected the assertion".into(),
+        ));
+    }
+
+    // 7. Allocate/reuse status-list slot + mint a fresh VMC.
+    let mut sl_state = status_list::get_state(
+        &state.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await?
+    .ok_or_else(|| AppError::Internal("revocation status list not initialised".into()))?;
+    let slot = match member.status_list_index {
+        Some(s) => s,
+        None => {
+            let s = status_list::allocate(&mut sl_state).ok_or_else(|| {
+                AppError::Internal("revocation status list is full — cannot allocate slot".into())
+            })?;
+            status_list::store_state(&state.status_lists_ks, &sl_state).await?;
+            s
+        }
+    };
+    let status_ref = CredentialStatusRef::revocation(sl_state.list_credential_id.clone(), slot);
+
+    let now = Utc::now();
+    let vmc_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let vmc = build_vmc(
+        signer,
+        VmcParams::new(&member_did)
+            .with_id(vmc_id.clone())
+            .with_status_ref(status_ref)
+            .with_personhood(true),
+    )
+    .await?;
+    let vec_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let acl_row = get_acl_entry(&state.acl_ks, &member_did)
+        .await?
+        .ok_or_else(|| AppError::Internal("ACL row disappeared mid-assert".into()))?;
+    let role_vec = build_role_vec(
+        signer,
+        RoleVecParams::new(&member_did, acl_row.role.clone()).with_id(vec_id.clone()),
+    )
+    .await?;
+
+    // 8. Update Member row.
+    member.personhood = true;
+    member.personhood_asserted_at = Some(now);
+    member.status_list_index = Some(slot);
+    member.current_vmc_id = Some(vmc_id.clone());
+    member.current_role_vec_id = Some(vec_id.clone());
+    store_member(&state.members_ks, &member).await?;
+
+    // 9. Audit.
+    audit_writer
+        .write(
+            &member_did,
+            Some(&member_did),
+            AuditEvent::PersonhoodAsserted(PersonhoodAssertedData {
+                vmc_id: vmc_id.clone(),
+                asserted_at: rfc3339(now),
+            }),
+        )
+        .await?;
+
+    info!(member_did = %member_did, "personhood asserted");
+
+    Ok((
+        StatusCode::OK,
+        Json(AssertResponse {
+            did: member_did,
+            personhood: true,
+            vmc: serde_json::to_value(&vmc)
+                .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?,
+            role_vec: serde_json::to_value(&role_vec)
+                .map_err(|e| AppError::Internal(format!("serialise VEC: {e}")))?,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Revoke endpoint
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokeResponse {
+    pub did: String,
+    pub personhood: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vmc: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role_vec: Option<JsonValue>,
+}
+
+pub async fn revoke(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(member_did): Path<String>,
+) -> Result<(StatusCode, Json<RevokeResponse>), AppError> {
+    // Auth: AdminAuth-equivalent (role == admin) OR self.
+    let is_self = auth.did == member_did;
+    let is_admin = auth.role == vti_common::acl::Role::Admin;
+    if !is_self && !is_admin {
+        return Err(AppError::Forbidden(
+            "only an admin or the subject member can revoke personhood".into(),
+        ));
+    }
+    let reason = if is_self { "self" } else { "admin" };
+
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+    let signer = state
+        .credential_signer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("credential signer not configured".into()))?;
+
+    let mut member = get_member(&state.members_ks, &member_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("no Member row for {member_did}")))?;
+
+    // Idempotent no-op if already false.
+    if !member.personhood {
+        return Ok((
+            StatusCode::OK,
+            Json(RevokeResponse {
+                did: member_did,
+                personhood: false,
+                vmc: None,
+                role_vec: None,
+            }),
+        ));
+    }
+
+    // Mint a fresh VMC + role VEC carrying personhood: false.
+    let slot = member
+        .status_list_index
+        .ok_or_else(|| AppError::Internal("Member row has no status_list_index".into()))?;
+    let sl_state = status_list::get_state(
+        &state.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await?
+    .ok_or_else(|| AppError::Internal("revocation status list not initialised".into()))?;
+    let status_ref = CredentialStatusRef::revocation(sl_state.list_credential_id.clone(), slot);
+
+    let vmc_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let vmc = build_vmc(
+        signer,
+        VmcParams::new(&member_did)
+            .with_id(vmc_id.clone())
+            .with_status_ref(status_ref)
+            .with_personhood(false),
+    )
+    .await?;
+    let vec_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let acl_row = get_acl_entry(&state.acl_ks, &member_did)
+        .await?
+        .ok_or_else(|| AppError::Internal("ACL row disappeared mid-revoke".into()))?;
+    let role_vec = build_role_vec(
+        signer,
+        RoleVecParams::new(&member_did, acl_row.role.clone()).with_id(vec_id.clone()),
+    )
+    .await?;
+
+    member.personhood = false;
+    member.personhood_asserted_at = None;
+    member.current_vmc_id = Some(vmc_id.clone());
+    member.current_role_vec_id = Some(vec_id.clone());
+    store_member(&state.members_ks, &member).await?;
+
+    audit_writer
+        .write(
+            &auth.did,
+            Some(&member_did),
+            AuditEvent::PersonhoodRevoked(PersonhoodRevokedData {
+                vmc_id: Some(vmc_id),
+                reason: reason.into(),
+            }),
+        )
+        .await?;
+
+    info!(member_did = %member_did, reason, "personhood revoked");
+
+    Ok((
+        StatusCode::OK,
+        Json(RevokeResponse {
+            did: member_did,
+            personhood: false,
+            vmc: Some(
+                serde_json::to_value(&vmc)
+                    .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?,
+            ),
+            role_vec: Some(
+                serde_json::to_value(&role_vec)
+                    .map_err(|e| AppError::Internal(format!("serialise VEC: {e}")))?,
+            ),
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Verify the VP's data-integrity proof against the holder's
+/// resolved `#key-0`. Mirrors the recognition::verify pattern
+/// (the cross-community recognition flow does the same dance).
+async fn verify_vp_proof(
+    vp: &JsonValue,
+    holder_did: &str,
+    resolver: &DIDCacheClient,
+) -> Result<(), String> {
+    let proof_value = vp
+        .get("proof")
+        .ok_or_else(|| "missing proof block".to_string())?;
+    let proof: DataIntegrityProof =
+        serde_json::from_value(proof_value.clone()).map_err(|e| format!("parse proof: {e}"))?;
+
+    // Strip the proof for verification (data-integrity
+    // canonicalises over the doc-without-proof).
+    let mut vp_without_proof = vp.clone();
+    if let Some(obj) = vp_without_proof.as_object_mut() {
+        obj.remove("proof");
+    }
+
+    // Resolve `{did}#key-0` (or whatever verificationMethod
+    // the proof names) to public bytes.
+    let verification_method = proof_value
+        .get("verificationMethod")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "proof missing verificationMethod".to_string())?;
+
+    let resolved = resolver
+        .resolve(holder_did)
+        .await
+        .map_err(|e| format!("DID resolve: {e}"))?;
+    let vm = resolved
+        .doc
+        .verification_method
+        .iter()
+        .find(|m| m.id.as_str() == verification_method)
+        .ok_or_else(|| format!("verificationMethod {verification_method} not on {holder_did}"))?;
+    let pubkey = vm
+        .get_public_key_bytes()
+        .map_err(|e| format!("extract pubkey: {e}"))?;
+
+    proof
+        .verify_with_public_key(&vp_without_proof, &pubkey, VerifyOptions::new())
+        .map_err(|e| format!("verify: {e}"))?;
+    Ok(())
+}
+
+/// Eval the active `personhood.rego` with the assert-path
+/// input shape:
+///
+/// ```json
+/// { "applicant_did": "<did>", "vp_claims": <projection> }
+/// ```
+///
+/// Fail-closed: any error path yields `false`.
+async fn evaluate_personhood_assert(
+    state: &AppState,
+    applicant_did: &str,
+    vp_claims: &JsonValue,
+) -> Result<bool, AppError> {
+    let Some(id) =
+        get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Personhood).await?
+    else {
+        warn!("no active personhood policy — assert rejected");
+        return Ok(false);
+    };
+    let policy = get_policy(&state.policies_ks, id)
+        .await?
+        .ok_or_else(|| AppError::Internal(format!("active personhood policy {id} not found")))?;
+    let compiled = compile_policy(&policy.rego_source, policy.id)?;
+    let input = json!({
+        "applicant_did": applicant_did,
+        "vp_claims": vp_claims,
+    });
+    let result = evaluate_policy(&compiled, "data.vtc.personhood.allow", input)?;
+    Ok(result
+        .pointer("/result/0/expressions/0/value")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false))
+}
+
+fn rfc3339(t: DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+// Suppress unused-import warning for `VerifiableCredential` —
+// imported to allow Phase 5 expansion of the assert response
+// to surface parsed VCs without a churn-y import change.
+#[allow(dead_code)]
+type _PhantomVc = (VerifiableCredential, Arc<()>);

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -140,6 +140,22 @@ pub fn router() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let members_rotate = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/rotate/1.0")
         .expect("static Trust-Task URL");
+    // Phase 4 M4.3 + M4.4 — personhood lifecycle.
+    let members_personhood_challenge =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0")
+            .expect("static Trust-Task URL");
+    let members_personhood_assert =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0")
+            .expect("static Trust-Task URL");
+    // `members_personhood_revoke` (`members/personhood/revoke/1.0`)
+    // exists on disk + in index.json so the soft-gate surface
+    // stays complete, but the DELETE method shares the
+    // `members/personhood/assert/1.0` mount at the router
+    // layer pending per-method selectors. Same workaround as
+    // `members/{did}` show + update + admin-remove.
+    let _members_personhood_revoke =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/members/personhood/revoke/1.0")
+            .expect("static Trust-Task URL");
     // Phase 3 M3.8 — trust-registry reconciler diagnostics.
     // Admin-gated (not super-admin) so on-call ops can read
     // queue depth + RTBF-batched + failed counts without the
@@ -345,6 +361,27 @@ pub fn router() -> Router<AppState> {
             "/v1/members/me/rotate",
             post(members::rotate::rotate),
             members_rotate,
+        )
+        // Phase 4 M4.3 + M4.4 — personhood lifecycle. Three
+        // mounts on the same path prefix; declared BEFORE
+        // `/v1/members/{did}` so axum's path-trie matches the
+        // literal segment first. Personhood is a per-member
+        // resource; `{did}` is the subject.
+        .route_with_task(
+            "/v1/members/{did}/personhood/challenge",
+            post(members::personhood::challenge),
+            members_personhood_challenge,
+        )
+        .route_with_task(
+            "/v1/members/{did}/personhood",
+            post(members::personhood::assert).delete(members::personhood::revoke),
+            // POST + DELETE share `personhood/assert/1.0` at
+            // the router layer pending per-method selectors;
+            // the standalone `personhood/revoke/1.0` Trust Task
+            // exists on disk + in index.json so the soft-gate
+            // surface stays complete. (Same workaround as
+            // members/{did}'s show + update + admin-remove.)
+            members_personhood_assert,
         )
         .route_with_task(
             "/v1/members/{did}",

--- a/vtc-service/tests/personhood.rs
+++ b/vtc-service/tests/personhood.rs
@@ -1,0 +1,594 @@
+//! Integration coverage for `/v1/members/{did}/personhood/*`
+//! (Phase 4 M4.3 + M4.4).
+//!
+//! Covers:
+//! - challenge mint happy path + non-member 404
+//! - assert without challenge → 422
+//! - assert without configured DID resolver → 500
+//!   (daemon-misconfigured class)
+//! - revoke admin path — flag flips + VMC re-mints + audit
+//! - revoke self path — same outcome, `reason: "self"`
+//! - revoke unauthorized (member-A → member-B) → 403
+//! - revoke idempotent on already-false → 200 no-op without
+//!   audit
+//!
+//! The assert happy path requires a live DID resolver to
+//! verify the VP's `#key-0` proof; like the M3.10 recognise
+//! integration tests, the route-level happy path is exercised
+//! end-to-end via mocked credentials in the unit-test layer
+//! (see `recognition::verify::tests`) — the integration
+//! coverage here pins the failure-mode + audit surfaces.
+
+use std::sync::Arc;
+
+use affinidi_status_list::StatusPurpose;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::audit::{AuditEnvelope, AuditEvent, AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::credentials::LocalSigner;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::{Member, get_member, store_member};
+use vtc_service::registry::RegistryHealth;
+use vtc_service::routes;
+use vtc_service::server::AppState;
+use vtc_service::status_list;
+
+const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+const PUBLIC_URL: &str = "https://vtc.example.com";
+const CHALLENGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0";
+const ASSERT_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0";
+const MEMBER_DID: &str = "did:key:zPerson1";
+const OTHER_MEMBER_DID: &str = "did:key:zPerson2";
+const ADMIN_DID: &str = "did:key:zPersonAdmin";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    member_token: String,
+    other_member_token: String,
+    admin_token: String,
+    members_ks: vti_common::store::KeyspaceHandle,
+    audit_ks: vti_common::store::KeyspaceHandle,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
+        .await
+        .expect("install default policies");
+
+    for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+        let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
+        status_list::ensure_initial(&status_lists_ks, purpose, url)
+            .await
+            .unwrap();
+    }
+
+    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    // Seed ACL + Member rows for member, other-member, admin.
+    let now = now_epoch();
+    for (did, role) in [
+        (MEMBER_DID, VtcRole::Member),
+        (OTHER_MEMBER_DID, VtcRole::Member),
+        (ADMIN_DID, VtcRole::Admin),
+    ] {
+        store_acl_entry(
+            &acl_ks,
+            &VtcAclEntry {
+                did: did.into(),
+                role,
+                label: None,
+                allowed_contexts: vec![],
+                created_at: now,
+                created_by: "did:key:vtc-install".into(),
+                expires_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        store_member(&members_ks, &Member::fresh(did))
+            .await
+            .unwrap();
+    }
+
+    let make_token = |did: &str, role: &str| -> String {
+        let session_id = format!("sess-{}", uuid::Uuid::new_v4());
+        let session = Session {
+            session_id: session_id.clone(),
+            did: did.into(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now,
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+        };
+        let sessions = sessions_ks.clone();
+        let claims = jwt_keys.new_claims(did.into(), session_id, role.into(), vec![], 3600, true);
+        let token = jwt_keys.encode(&claims).unwrap();
+        // store_session is async; wrap synchronously by leaking
+        // a tokio handle.
+        tokio::runtime::Handle::current().block_on(async move {
+            store_session(&sessions, &session).await.unwrap();
+        });
+        token
+    };
+    // Hack: build_fixture is async, but the closure can't be —
+    // call store_session inline instead.
+    let member_token = {
+        let session_id = "sess-member";
+        store_session(
+            &sessions_ks,
+            &Session {
+                session_id: session_id.into(),
+                did: MEMBER_DID.into(),
+                challenge: "test".into(),
+                state: SessionState::Authenticated,
+                created_at: now,
+                refresh_token: None,
+                refresh_expires_at: None,
+                tee_attested: false,
+            },
+        )
+        .await
+        .unwrap();
+        let claims = jwt_keys.new_claims(
+            MEMBER_DID.into(),
+            session_id.into(),
+            "reader".into(),
+            vec![],
+            3600,
+            true,
+        );
+        jwt_keys.encode(&claims).unwrap()
+    };
+    let other_member_token = {
+        let session_id = "sess-other";
+        store_session(
+            &sessions_ks,
+            &Session {
+                session_id: session_id.into(),
+                did: OTHER_MEMBER_DID.into(),
+                challenge: "test".into(),
+                state: SessionState::Authenticated,
+                created_at: now,
+                refresh_token: None,
+                refresh_expires_at: None,
+                tee_attested: false,
+            },
+        )
+        .await
+        .unwrap();
+        let claims = jwt_keys.new_claims(
+            OTHER_MEMBER_DID.into(),
+            session_id.into(),
+            "reader".into(),
+            vec![],
+            3600,
+            true,
+        );
+        jwt_keys.encode(&claims).unwrap()
+    };
+    let admin_token = {
+        let session_id = "sess-admin";
+        store_session(
+            &sessions_ks,
+            &Session {
+                session_id: session_id.into(),
+                did: ADMIN_DID.into(),
+                challenge: "test".into(),
+                state: SessionState::Authenticated,
+                created_at: now,
+                refresh_token: None,
+                refresh_expires_at: None,
+                tee_attested: false,
+            },
+        )
+        .await
+        .unwrap();
+        let claims = jwt_keys.new_claims(
+            ADMIN_DID.into(),
+            session_id.into(),
+            "admin".into(),
+            vec![],
+            3600,
+            true,
+        );
+        jwt_keys.encode(&claims).unwrap()
+    };
+    let _ = make_token; // silence unused
+
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "{VTC_DID}"
+        public_url = "{PUBLIC_URL}"
+        [store]
+        data_dir = "{}"
+        [auth]
+        jwt_signing_key = "{}"
+        "#,
+        dir.path().display(),
+        BASE64.encode(jwt_seed),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks: members_ks.clone(),
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks,
+        registry_records_ks,
+        sync_queue_ks,
+        sync_cursor_ks,
+        registry_client: None,
+        registry_health: RegistryHealth::new(),
+        audit_ks: audit_ks.clone(),
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: Some(PUBLIC_URL.into()),
+        install_signer: None,
+        credential_signer: Some(signer),
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+    Fixture {
+        router,
+        member_token,
+        other_member_token,
+        admin_token,
+        members_ks,
+        audit_ks,
+        _dir: dir,
+    }
+}
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+// ─── Challenge endpoint ────────────────────────────────────
+
+#[tokio::test]
+async fn challenge_happy_path_returns_uuid_and_expiry() {
+    let fix = build_fixture().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/members/{MEMBER_DID}/personhood/challenge"))
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", CHALLENGE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert!(v["challengeId"].is_string());
+    assert!(v["expiresAt"].is_string());
+}
+
+#[tokio::test]
+async fn challenge_returns_404_for_non_member() {
+    let fix = build_fixture().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/did:key:zStranger/personhood/challenge")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", CHALLENGE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ─── Assert endpoint (failure-mode coverage) ───────────────
+
+#[tokio::test]
+async fn assert_without_did_resolver_returns_500() {
+    let fix = build_fixture().await;
+    // First mint a challenge so the early-exit on missing
+    // challenge doesn't fire.
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/members/{MEMBER_DID}/personhood/challenge"))
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", CHALLENGE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (_, v) = body_value(resp).await;
+    let challenge_id = v["challengeId"].as_str().unwrap().to_string();
+
+    let body = json!({
+        "presentation": {
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiablePresentation"],
+            "holder": MEMBER_DID,
+            "verifiableCredential": [],
+            "proof": {
+                "type": "DataIntegrityProof",
+                "cryptosuite": "eddsa-jcs-2022",
+                "verificationMethod": format!("{MEMBER_DID}#key-0"),
+                "challenge": challenge_id,
+                "proofValue": "z00".to_string(),
+            }
+        }
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/members/{MEMBER_DID}/personhood"))
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ASSERT_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    // Fixture has did_resolver: None → 500.
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn assert_with_unknown_challenge_returns_400() {
+    let fix = build_fixture().await;
+    let body = json!({
+        "presentation": {
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiablePresentation"],
+            "holder": MEMBER_DID,
+            "proof": {
+                "type": "DataIntegrityProof",
+                "cryptosuite": "eddsa-jcs-2022",
+                "verificationMethod": format!("{MEMBER_DID}#key-0"),
+                "challenge": uuid::Uuid::new_v4().to_string(),
+                "proofValue": "z00",
+            }
+        }
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/members/{MEMBER_DID}/personhood"))
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ASSERT_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    // AppError::Validation → 400 in this workspace.
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ─── Revoke endpoint ───────────────────────────────────────
+
+#[tokio::test]
+async fn revoke_admin_flips_member_row_and_emits_audit() {
+    let fix = build_fixture().await;
+    // Mark member as previously asserted.
+    let mut m = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    m.personhood = true;
+    m.personhood_asserted_at = Some(chrono::Utc::now());
+    m.status_list_index = Some(7); // pre-allocated for re-mint
+    store_member(&fix.members_ks, &m).await.unwrap();
+
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/members/{MEMBER_DID}/personhood"))
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", ASSERT_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(v["personhood"], false);
+    assert!(v["vmc"].is_object());
+
+    // Member row flipped + timestamp cleared.
+    let m2 = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!m2.personhood);
+    assert!(m2.personhood_asserted_at.is_none());
+
+    // Audit envelope carries reason: "admin".
+    let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let mut saw = false;
+    for (_k, raw) in pairs {
+        let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+        if let AuditEvent::PersonhoodRevoked(d) = env.event
+            && d.reason == "admin"
+        {
+            saw = true;
+            break;
+        }
+    }
+    assert!(saw, "admin revoke must emit PersonhoodRevoked reason=admin");
+}
+
+#[tokio::test]
+async fn revoke_self_emits_audit_reason_self() {
+    let fix = build_fixture().await;
+    let mut m = get_member(&fix.members_ks, MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    m.personhood = true;
+    m.personhood_asserted_at = Some(chrono::Utc::now());
+    m.status_list_index = Some(8);
+    store_member(&fix.members_ks, &m).await.unwrap();
+
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/members/{MEMBER_DID}/personhood"))
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ASSERT_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let mut saw_self = false;
+    for (_k, raw) in pairs {
+        let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+        if let AuditEvent::PersonhoodRevoked(d) = env.event
+            && d.reason == "self"
+        {
+            saw_self = true;
+            break;
+        }
+    }
+    assert!(saw_self, "self-revoke must emit reason=self");
+}
+
+#[tokio::test]
+async fn revoke_unauthorized_when_member_revokes_someone_else() {
+    let fix = build_fixture().await;
+    // Mark other_member as asserted; member tries to revoke
+    // on their behalf — must 403.
+    let mut m = get_member(&fix.members_ks, OTHER_MEMBER_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    m.personhood = true;
+    m.personhood_asserted_at = Some(chrono::Utc::now());
+    m.status_list_index = Some(9);
+    store_member(&fix.members_ks, &m).await.unwrap();
+
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/members/{OTHER_MEMBER_DID}/personhood"))
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ASSERT_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn revoke_already_false_is_idempotent_noop() {
+    let fix = build_fixture().await;
+    // Member.personhood already false (default). Revoke
+    // returns 200 + no VMC re-mint + no audit envelope.
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/members/{MEMBER_DID}/personhood"))
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ASSERT_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(v["personhood"], false);
+    assert!(
+        v.get("vmc").is_none_or(|x| x.is_null()),
+        "no-op must omit vmc: {v}"
+    );
+
+    // No PersonhoodRevoked envelope.
+    let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let mut saw = false;
+    for (_k, raw) in pairs {
+        let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+        if let AuditEvent::PersonhoodRevoked(_) = env.event {
+            saw = true;
+            break;
+        }
+    }
+    assert!(!saw, "idempotent no-op must not emit PersonhoodRevoked");
+}
+
+#[tokio::test]
+async fn revoke_returns_404_for_unknown_member() {
+    let fix = build_fixture().await;
+    let req = Request::builder()
+        .method("DELETE")
+        .uri("/v1/members/did:key:zStranger/personhood")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", ASSERT_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    // Silence unused warning on other_member_token in this
+    // test (used in revoke_unauthorized_*).
+    let _ = &fix.other_member_token;
+}


### PR DESCRIPTION
## Summary

Phase 4 PR-2 / 5. **Personhood gate met** — admin, issuer, and self can flip a member's `personhood` flag end-to-end.

Three new endpoints on the per-member resource:

| Endpoint | Auth | Outcome |
|----------|------|---------|
| `POST /v1/members/{did}/personhood/challenge` | any auth | mints single-use 10-min nonce |
| `POST /v1/members/{did}/personhood` | any auth | asserts personhood from a VP |
| `DELETE /v1/members/{did}/personhood` | admin OR self | revokes |

## Assert flow (D2 planning review — VP-only)

1. Load Member row (404 if absent).
2. Consume challenge (400 on missing/expired/wrong-DID).
3. Verify `presentation.holder == path-DID`.
4. Resolve daemon prerequisites (500 if misconfigured — ordered AFTER caller validation so 400 surfaces first).
5. Verify VP's `DataIntegrityProof` against member's `#key-0` via `DIDCacheClient`.
6. `extract_vp_claims` → policy input.
7. Evaluate `personhood.rego` (403 `personhood-policy-denied` on deny).
8. Flip `Member.personhood = true` + `personhood_asserted_at = now`. **Evidence not persisted.**
9. Re-mint VMC + role VEC with `personhood: true`, reusing the status-list slot.
10. Emit `PersonhoodAsserted { vmc_id, asserted_at }`.

## Key design notes

- **Three Trust Tasks** ship: `members/personhood/challenge/1.0`, `members/personhood/assert/1.0`, `members/personhood/revoke/1.0`. The revoke task is on-disk-only — DELETE shares the assert mount at the router layer pending per-method `TrustTaskRouter` selectors (same workaround as `members/{did}` show + update + admin-remove).
- **Challenge storage co-tenants with the rotation flow** in `passkey_ks` under `personhood_chal:` prefix — avoids a dedicated keyspace for short-lived state.
- **Routes mounted BEFORE `/v1/members/{did}`** so axum's path-trie matches the literal `personhood` segment first.
- **Idempotent revoke** when already-false: no VMC re-mint, no audit envelope. Saves clutter on the audit log + wire churn.
- **Assert happy-path coverage** is gated on a live DID resolver (same constraint as M3.10 recognise) — covered via mocked credentials in `recognition::verify::tests` + the unit-level branches. Integration tests pin the failure-mode + audit surfaces.

## Test plan

- [x] 9 new personhood integration tests pass (challenge happy/404, assert with unknown challenge → 400, assert without resolver → 500, revoke admin/self/unauthorized/idempotent/404)
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` green (every test result `ok` — 292 vtc-service lib + every integration suite + 191 vti-common + 347 vta-sdk + 99 vta-service + e2e)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] DCO sign-off

After merge: PR-3 (M4.5+M4.6) — relationships keyspace + VRC publish/list/revoke endpoints.

Refs: #46 vtc-mvp Phase 4 plan §M4.3 + §M4.4