### PR TITLE
feat(vtc-service): M4.5 + M4.6 — VRC trust-graph endpoints

### DIFF
--- a/tasks/vtc-mvp/phase-4-todo.md
+++ b/tasks/vtc-mvp/phase-4-todo.md
@@ -279,7 +279,7 @@ work; assert flips the flag + re-mints; renewal downgrades.
 
 ## M4.5 — `relationships:` keyspace + storage helpers
 
-### `[ ]` M4.5.1 — Relationships keyspace + Relationship model
+### `[x]` M4.5.1 — Relationships keyspace + Relationship model
 
 - **Acceptance**
   - New keyspace `relationships` registered in
@@ -309,7 +309,7 @@ work; assert flips the flag + re-mints; renewal downgrades.
 
 ## M4.6 — VRC publish + list + revoke endpoints
 
-### `[ ]` M4.6.1 — `POST /v1/relationships`
+### `[x]` M4.6.1 — `POST /v1/relationships`
 
 - **Acceptance**
   - Handler in `vtc-service/src/routes/relationships.rs` (new).
@@ -351,7 +351,7 @@ work; assert flips the flag + re-mints; renewal downgrades.
 - **Deps**: M4.5.1, M4.1.2
 - **Pre-impl decision**: **D1** (member-as-issuer).
 
-### `[ ]` M4.6.2 — `GET /v1/members/{did}/relationships`
+### `[x]` M4.6.2 — `GET /v1/members/{did}/relationships`
 
 - **Acceptance**
   - Handler in `routes/members/relationships.rs` (new).
@@ -381,7 +381,7 @@ work; assert flips the flag + re-mints; renewal downgrades.
 - **Deps**: M4.6.1
 - **Pre-impl decision**: **D1**.
 
-### `[ ]` M4.6.3 — `DELETE /v1/relationships/{id}`
+### `[x]` M4.6.3 — `DELETE /v1/relationships/{id}`
 
 - **Acceptance**
   - Handler in `routes/relationships.rs`.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -277,6 +277,24 @@
       "status": "Draft",
       "path": "members/personhood/revoke/1.0",
       "rest": "DELETE /v1/members/{did}/personhood"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/relationships/publish/1.0",
+      "status": "Draft",
+      "path": "relationships/publish/1.0",
+      "rest": "POST /v1/relationships"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/relationships/list/1.0",
+      "status": "Draft",
+      "path": "relationships/list/1.0",
+      "rest": "GET /v1/members/{did}/relationships"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0",
+      "status": "Draft",
+      "path": "relationships/revoke/1.0",
+      "rest": "DELETE /v1/relationships/{id}"
     }
   ]
 }

--- a/trust-tasks/relationships/list/1.0/schema.json
+++ b/trust-tasks/relationships/list/1.0/schema.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/relationships/list/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — VRC List per Member",
+  "description": "GET /v1/members/{did}/relationships response. Phase 4 M4.6.2.",
+  "type": "object",
+  "required": ["items"],
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "issuerDid", "subjectDid", "vrcJsonld", "vrcSha256", "createdAt"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "issuerDid": { "type": "string" },
+          "subjectDid": { "type": "string" },
+          "vrcJsonld": { "type": "object" },
+          "vrcSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+          "createdAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    "nextCursor": { "type": ["string", "null"] },
+    "totalEstimate": { "type": ["integer", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/trust-tasks/relationships/list/1.0/spec.md
+++ b/trust-tasks/relationships/list/1.0/spec.md
@@ -1,0 +1,58 @@
+---
+id: https://trusttasks.org/openvtc/vtc/relationships/list/1.0
+title: VTC — VRC List per Member
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/members/{did}/relationships
+---
+
+# VTC — VRC List per Member
+
+Paginated list of VRCs naming `{did}` as either issuer or
+subject. Phase 4 M4.6.2; spec §6.1 + §12.3.
+
+## Semantics
+
+- **Auth**: any authenticated session. Operators wanting
+  stricter visibility (e.g. issuer-only listing) layer
+  `directory.rego` (Phase 4 follow-up).
+- **Pagination**: cursor-based per §9.1.
+  `?cursor=&limit=` clamped to `1..=200`. The cursor is
+  HMAC-signed under the audit key; replay rejects with `400
+  invalid cursor`.
+- **§12.3 departure strip**: rows where the *other* party
+  (not the path-DID) is **Purge**-removed are stripped
+  from the response. `Tombstone` + `Historical` members
+  remain visible — they keep their Member row and the
+  trust edge remains a legitimate historical claim.
+
+## Trust assumptions
+
+- Caller holds a valid VTC-audience JWT.
+
+## Outputs
+
+```
+{
+  "items": [
+    {
+      "id": "<uuid>",
+      "issuerDid": "<did>",
+      "subjectDid": "<did>",
+      "vrcJsonld": { ... full VC body ... },
+      "vrcSha256": "<hex>",
+      "createdAt": "<rfc3339>"
+    },
+    ...
+  ],
+  "nextCursor": "<base64-signed>" | null,
+  "totalEstimate": null
+}
+```
+
+## Status
+
+Draft.

--- a/trust-tasks/relationships/publish/1.0/schema.json
+++ b/trust-tasks/relationships/publish/1.0/schema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/relationships/publish/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — VRC Publish",
+  "description": "POST /v1/relationships request + response. Phase 4 M4.6.1.",
+  "oneOf": [
+    {
+      "title": "Request",
+      "type": "object",
+      "required": ["vrc"],
+      "properties": {
+        "vrc": {
+          "type": "object",
+          "description": "Signed W3C VC body. issuer must match the caller's session DID; credentialSubject.id names the subject member; proof must be a DataIntegrityProof over the issuer's #key-0."
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "title": "Response",
+      "type": "object",
+      "required": ["id", "issuerDid", "subjectDid", "vrcSha256"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "issuerDid": { "type": "string" },
+        "subjectDid": { "type": "string" },
+        "vrcSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/trust-tasks/relationships/publish/1.0/spec.md
+++ b/trust-tasks/relationships/publish/1.0/spec.md
@@ -1,0 +1,78 @@
+---
+id: https://trusttasks.org/openvtc/vtc/relationships/publish/1.0
+title: VTC — VRC Publish
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/relationships
+---
+
+# VTC — VRC Publish
+
+Publishes a member-issued Verifiable Recognition Credential
+(VRC) — a self-asserted trust edge from the caller to another
+member. Phase 4 M4.6; spec §5.4 + §6.1; planning-review D1
+(issuer is the *member*, not the community).
+
+## Semantics
+
+- **Auth**: any authenticated session. The caller's session
+  DID **must equal** the VC's `issuer` field — VRCs are
+  self-issued by construction. The VTC never mints VRCs.
+- **Body**: `{ vrc: <signed VC body> }`. The VC must include:
+  - `issuer` (string or `{ id, ... }`) matching the caller.
+  - `credentialSubject.id` naming the subject member.
+  - A `DataIntegrityProof` signed by the issuer's `#key-0`.
+- **Idempotent re-publish**: a second publish of the same
+  canonicalised VRC body returns `200 OK` with the existing
+  row's id (vs a fresh `201 Created`).
+
+## Flow
+
+1. Parse `issuer` + `subject_did`.
+2. Caller == issuer (else `403`).
+3. Resolve the issuer's `#key-0` via the DID resolver +
+   verify the data-integrity proof. Failure → `422
+   VrcProofInvalid`.
+4. Enrich both parties with `is_current` (live ACL + non-
+   tombstoned Member). Subject absent → `422`.
+5. Evaluate `relationships.rego`. Default policy: allow iff
+   both parties are current members. Deny → `403
+   RelationshipPolicyDenied`.
+6. Compute SHA-256 of the canonicalised VRC. If a row with
+   that hash exists, return its id (`200 OK`).
+7. Allocate a new UUID, persist the row + secondary-index
+   entries, emit `VrcPublished { vrc_id, subject_did,
+   edge_type }`.
+
+Per D7, VRCs carry **no `credentialStatus`** — revocation is
+row deletion, not a status-list bit flip.
+
+## Trust assumptions
+
+- DID resolver returns the issuer's current `#key-0`.
+- `relationships.rego` reflects the operator's current
+  publishing policy.
+
+## Outputs
+
+`201 Created` on first publish, `200 OK` on idempotent
+re-publish, with:
+
+```
+{
+  "id": "<uuid>",
+  "issuerDid": "<did>",
+  "subjectDid": "<did>",
+  "vrcSha256": "<hex>"
+}
+```
+
+`403` on auth / policy failure. `422` on proof / shape
+errors. `500` on misconfigured daemon (resolver absent).
+
+## Status
+
+Draft.

--- a/trust-tasks/relationships/revoke/1.0/schema.json
+++ b/trust-tasks/relationships/revoke/1.0/schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — VRC Revoke",
+  "description": "DELETE /v1/relationships/{id} response. No request body. Phase 4 M4.6.3.",
+  "type": "object",
+  "required": ["id"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" }
+  },
+  "additionalProperties": false
+}

--- a/trust-tasks/relationships/revoke/1.0/spec.md
+++ b/trust-tasks/relationships/revoke/1.0/spec.md
@@ -1,0 +1,48 @@
+---
+id: https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0
+title: VTC — VRC Revoke
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: DELETE /v1/relationships/{id}
+---
+
+# VTC — VRC Revoke
+
+Revokes a previously-published VRC. Phase 4 M4.6.3; spec
+§6.1; planning-review D7 (no `credentialStatus`, revocation
+= row deletion).
+
+## Semantics
+
+- **Auth**: the caller's session DID **must equal** the
+  row's `issuerDid` (issuer self-retraction) OR the caller
+  is an admin (moderation). Subject-only revocation is
+  explicitly **not** allowed — the subject can't unilaterally
+  drop a claim someone else made about them; they can ask
+  an admin to moderate.
+- **Effect**: deletes the primary row + both secondary-index
+  entries. Idempotent: re-revoking a missing row returns
+  `404`.
+- **Audit**: emits `VrcRevoked { vrc_id, revoked_by:
+  "issuer"|"admin" }`.
+
+## Trust assumptions
+
+- Caller holds a valid VTC-audience JWT.
+- For admin revoke, the JWT's `role` claim is `admin`.
+
+## Outputs
+
+`200 OK` with `{ "id": "<uuid>" }`. `403` on auth failure;
+`404` on missing row.
+
+## Idempotency
+
+Cache TTL: 60s (destructive op per §9.1).
+
+## Status
+
+Draft.

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -30,6 +30,7 @@ pub mod messaging;
 pub mod policy;
 pub mod recognition;
 pub mod registry;
+pub mod relationships;
 pub mod routes;
 pub mod server;
 pub mod setup;

--- a/vtc-service/src/relationships/mod.rs
+++ b/vtc-service/src/relationships/mod.rs
@@ -1,0 +1,85 @@
+//! VRC (Verifiable Recognition Credential) trust-graph
+//! storage — Phase 4 M4.5. Spec §5.4 + §6.1.
+//!
+//! ## What this module owns
+//!
+//! - The `relationships:` keyspace: one row per VRC, keyed by
+//!   `relationships:<uuid>`. The row stores the verified VC
+//!   JSON-LD body verbatim plus metadata for list / revoke
+//!   surfaces.
+//! - The `relationships_by_did:` secondary-index keyspace: one
+//!   row per (DID, VRC-id) pair, written for BOTH the issuer
+//!   and the subject so per-DID list queries are O(prefix-scan)
+//!   instead of O(full-table). Keys are
+//!   `relationships_by_did:<did>:<vrc-id>` so a `prefix_iter`
+//!   on `relationships_by_did:<did>:` returns just that DID's
+//!   edges.
+//!
+//! ## Why two keyspaces
+//!
+//! The natural per-DID query is "list all VRCs where I'm
+//! issuer OR subject". A single keyspace + filter would walk
+//! every row. The secondary index keeps the per-DID list
+//! pageable in O(matched-rows) — the same trade-off the
+//! audit log uses for its actor index.
+//!
+//! Writes are CAS-paired: store the primary row, then both
+//! secondary-index rows. Delete is the inverse. A crash
+//! between the primary write and the index writes is
+//! self-healing on the next list-for-did call (it walks the
+//! index and the primary is fjall-durable; the index entries
+//! are tolerant of an orphan). A crash between the index
+//! writes is similarly recoverable — list-for-did returns
+//! whatever index entries are present + the route layer
+//! deals with the primary-row absent case (404 on subsequent
+//! ops).
+//!
+//! ## Issuer = the member, not the community
+//!
+//! Per planning-review D1, the VTC never *mints* VRCs. The
+//! issuer of every stored row is a current community member
+//! (the route layer verifies caller-DID == VC.issuer + the
+//! VC's data-integrity proof verifies against the member's
+//! `#key-0`). The community signer is uninvolved.
+
+pub mod storage;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+pub use storage::{
+    RELATIONSHIPS_BY_DID_PREFIX, RELATIONSHIPS_PREFIX, delete_relationship, find_by_hash,
+    get_relationship, list_for_did, store_relationship,
+};
+
+/// A stored, verified VRC. Field order matches the spec §5.4
+/// surface (issuer/subject DIDs + the credential body).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Relationship {
+    /// Server-allocated UUID. Surfaced as `urn:uuid:<id>` on
+    /// the VRC's top-level `id` field at publish time when
+    /// the caller didn't supply one.
+    pub id: Uuid,
+    /// The asserting member. By the publish-time auth check,
+    /// this equals the caller's session DID.
+    pub issuer_did: String,
+    /// The other party the VRC names. Need not be a current
+    /// community member at *list* time (the list path strips
+    /// Purge-removed rows per §12.3) but must be a current
+    /// member at *publish* time (default `relationships.rego`).
+    pub subject_did: String,
+    /// The VRC body verbatim — JSON-LD, including the
+    /// data-integrity proof. Stored as `JsonValue` rather
+    /// than a typed `VerifiableCredential` so future VRC
+    /// shape extensions don't require a storage migration.
+    pub vrc_jsonld: JsonValue,
+    /// SHA-256 of `canonical_json(vrc_jsonld)`, hex-encoded.
+    /// Used for idempotency: a second publish of an
+    /// already-stored VRC returns the existing id (200)
+    /// rather than creating a duplicate row.
+    pub vrc_sha256: String,
+    pub created_at: DateTime<Utc>,
+}

--- a/vtc-service/src/relationships/storage.rs
+++ b/vtc-service/src/relationships/storage.rs
@@ -1,0 +1,335 @@
+//! CRUD helpers for [`super::Relationship`] over the
+//! `relationships:` + `relationships_by_did:` keyspaces.
+
+use uuid::Uuid;
+use vti_common::audit::AuditKey;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated, paginate};
+use vti_common::store::KeyspaceHandle;
+
+use super::Relationship;
+
+/// Primary keyspace prefix. Each VRC lives at
+/// `relationships:<uuid>`.
+pub const RELATIONSHIPS_PREFIX: &[u8] = b"relationships:";
+
+/// Secondary-index prefix. Each `(did, vrc-id)` pair lives at
+/// `relationships_by_did:<did>:<vrc-id>` so a `prefix_iter` on
+/// `relationships_by_did:<did>:` lists only that DID's edges.
+pub const RELATIONSHIPS_BY_DID_PREFIX: &[u8] = b"relationships_by_did:";
+
+fn primary_key(id: Uuid) -> Vec<u8> {
+    let mut k = RELATIONSHIPS_PREFIX.to_vec();
+    k.extend_from_slice(id.to_string().as_bytes());
+    k
+}
+
+fn index_key(did: &str, id: Uuid) -> Vec<u8> {
+    let mut k = RELATIONSHIPS_BY_DID_PREFIX.to_vec();
+    k.extend_from_slice(did.as_bytes());
+    k.push(b':');
+    k.extend_from_slice(id.to_string().as_bytes());
+    k
+}
+
+fn decode(bytes: &[u8]) -> Result<Relationship, AppError> {
+    serde_json::from_slice(bytes)
+        .map_err(|e| AppError::Internal(format!("Relationship decode: {e}")))
+}
+
+/// Retrieve a relationship by id. `Ok(None)` if absent.
+pub async fn get_relationship(
+    primary: &KeyspaceHandle,
+    id: Uuid,
+) -> Result<Option<Relationship>, AppError> {
+    let raw = primary.get_raw(primary_key(id)).await?;
+    match raw {
+        Some(bytes) => Ok(Some(decode(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+/// Store the row + write both secondary-index entries
+/// (issuer + subject). Writes are best-effort-CAS-paired —
+/// a crash between the primary write and the index writes
+/// leaves the primary row visible to `get_relationship` and
+/// invisible to per-DID list queries; the next list call's
+/// orphan-tolerant walk handles this without operator
+/// intervention.
+pub async fn store_relationship(
+    primary: &KeyspaceHandle,
+    index: &KeyspaceHandle,
+    rel: &Relationship,
+) -> Result<(), AppError> {
+    primary
+        .insert(
+            String::from_utf8(primary_key(rel.id)).expect("ascii key"),
+            rel,
+        )
+        .await?;
+    // Index entries store just the relationship id as the
+    // value — the primary keyspace holds the body. Storing
+    // the id explicitly (rather than relying on the key
+    // suffix) keeps the value self-describing for tooling.
+    let id_value = serde_json::json!({ "id": rel.id.to_string() });
+    index
+        .insert(
+            String::from_utf8(index_key(&rel.issuer_did, rel.id)).expect("ascii key"),
+            &id_value,
+        )
+        .await?;
+    if rel.subject_did != rel.issuer_did {
+        index
+            .insert(
+                String::from_utf8(index_key(&rel.subject_did, rel.id)).expect("ascii key"),
+                &id_value,
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+/// Delete the row + both index entries. Idempotent: deleting
+/// an absent row is a no-op (matches the rest of the
+/// workspace's storage helpers).
+pub async fn delete_relationship(
+    primary: &KeyspaceHandle,
+    index: &KeyspaceHandle,
+    id: Uuid,
+) -> Result<(), AppError> {
+    // Look up the row first so we know which index entries
+    // to clear. If the primary row is absent the caller
+    // path (route layer) should have 404'd already; we
+    // still walk best-effort to clean up any orphan index
+    // rows.
+    if let Some(rel) = get_relationship(primary, id).await? {
+        primary.remove(primary_key(id)).await?;
+        index.remove(index_key(&rel.issuer_did, id)).await?;
+        if rel.subject_did != rel.issuer_did {
+            index.remove(index_key(&rel.subject_did, id)).await?;
+        }
+    } else {
+        primary.remove(primary_key(id)).await?;
+    }
+    Ok(())
+}
+
+/// Find an existing relationship by VRC SHA-256 hash. Walks
+/// the primary keyspace; small VTCs are fine (a Phase 5
+/// scaling pass adds a hash-keyed secondary index if
+/// needed). Used for idempotent publish: a second publish
+/// of the same VRC body returns the existing id.
+pub async fn find_by_hash(
+    primary: &KeyspaceHandle,
+    vrc_sha256: &str,
+) -> Result<Option<Relationship>, AppError> {
+    let pairs = primary
+        .prefix_iter_raw(RELATIONSHIPS_PREFIX.to_vec())
+        .await?;
+    for (_k, v) in pairs {
+        if let Ok(rel) = decode(&v)
+            && rel.vrc_sha256 == vrc_sha256
+        {
+            return Ok(Some(rel));
+        }
+    }
+    Ok(None)
+}
+
+/// Paginated list of relationships where `did` is either
+/// issuer or subject. Walks the secondary index, then loads
+/// the primary rows lazily — orphan index entries (where the
+/// primary row is missing) are silently skipped. Cursor signed
+/// under `audit_key`, same pattern as other paginated listers.
+pub async fn list_for_did(
+    primary: &KeyspaceHandle,
+    index: &KeyspaceHandle,
+    audit_key: &AuditKey,
+    did: &str,
+    cursor: Option<&Cursor>,
+    limit: usize,
+) -> Result<Paginated<Relationship>, AppError> {
+    let mut index_prefix = RELATIONSHIPS_BY_DID_PREFIX.to_vec();
+    index_prefix.extend_from_slice(did.as_bytes());
+    index_prefix.push(b':');
+    let mut idx_pairs = index.prefix_iter_raw(index_prefix).await?;
+    idx_pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    // Resolve each index entry to its primary row, dropping
+    // orphans. The paginate helper expects `(key, bytes)`
+    // pairs of the same shape it would see from a direct
+    // prefix scan of the primary keyspace; we synthesise
+    // that by re-using the index key (sortable by id) and
+    // packing the primary row's bytes.
+    let mut hydrated: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(idx_pairs.len());
+    for (idx_key, _idx_val) in idx_pairs {
+        // Extract the trailing UUID segment from the index key
+        // — last `:`-delimited piece.
+        let key_str = match std::str::from_utf8(&idx_key) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let Some(id_str) = key_str.rsplit(':').next() else {
+            continue;
+        };
+        let Ok(id) = Uuid::parse_str(id_str) else {
+            continue;
+        };
+        if let Some(raw) = primary.get_raw(primary_key(id)).await? {
+            hydrated.push((idx_key, raw));
+        }
+    }
+
+    let snapshot_id: u64 = hydrated.len() as u64;
+    paginate(hydrated, cursor, limit, &audit_key.key, snapshot_id, decode)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use vti_common::audit::AuditKeyStore;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_kss() -> (KeyspaceHandle, KeyspaceHandle, AuditKey, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let primary = store.keyspace("relationships").unwrap();
+        let index = store.keyspace("relationships_by_did").unwrap();
+        let audit_key_ks = store.keyspace("audit_key").unwrap();
+        let key_store = AuditKeyStore::new(audit_key_ks);
+        key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+        let audit_key = key_store.active().await.unwrap();
+        (primary, index, audit_key, dir)
+    }
+
+    fn fresh(issuer: &str, subject: &str) -> Relationship {
+        let id = Uuid::new_v4();
+        Relationship {
+            id,
+            issuer_did: issuer.into(),
+            subject_did: subject.into(),
+            vrc_jsonld: serde_json::json!({
+                "type": ["VerifiableCredential", "VerifiableRecognitionCredential"],
+                "issuer": issuer,
+                "credentialSubject": { "id": subject, "endorsement": { "type": "endorses" } }
+            }),
+            vrc_sha256: format!("{:x}", id.as_u128()),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip() {
+        let (primary, index, _audit, _dir) = temp_kss().await;
+        let rel = fresh("did:key:zA", "did:key:zB");
+        store_relationship(&primary, &index, &rel).await.unwrap();
+        let got = get_relationship(&primary, rel.id).await.unwrap().unwrap();
+        assert_eq!(got, rel);
+    }
+
+    #[tokio::test]
+    async fn delete_clears_primary_and_index() {
+        let (primary, index, _audit, _dir) = temp_kss().await;
+        let rel = fresh("did:key:zA", "did:key:zB");
+        store_relationship(&primary, &index, &rel).await.unwrap();
+        delete_relationship(&primary, &index, rel.id).await.unwrap();
+        assert!(get_relationship(&primary, rel.id).await.unwrap().is_none());
+        // Index entries gone too.
+        let pairs = index
+            .prefix_iter_raw(RELATIONSHIPS_BY_DID_PREFIX.to_vec())
+            .await
+            .unwrap();
+        assert!(pairs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_for_issuer_returns_issued() {
+        let (primary, index, audit, _dir) = temp_kss().await;
+        let r1 = fresh("did:key:zA", "did:key:zB");
+        let r2 = fresh("did:key:zA", "did:key:zC");
+        let r3 = fresh("did:key:zX", "did:key:zY"); // unrelated
+        for r in [&r1, &r2, &r3] {
+            store_relationship(&primary, &index, r).await.unwrap();
+        }
+        let page = list_for_did(&primary, &index, &audit, "did:key:zA", None, 10)
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 2);
+        let dids: Vec<_> = page.items.iter().map(|r| r.id).collect();
+        assert!(dids.contains(&r1.id));
+        assert!(dids.contains(&r2.id));
+    }
+
+    #[tokio::test]
+    async fn list_for_subject_returns_received() {
+        let (primary, index, audit, _dir) = temp_kss().await;
+        let r1 = fresh("did:key:zA", "did:key:zSubject");
+        let r2 = fresh("did:key:zB", "did:key:zSubject");
+        let r3 = fresh("did:key:zC", "did:key:zOther");
+        for r in [&r1, &r2, &r3] {
+            store_relationship(&primary, &index, r).await.unwrap();
+        }
+        let page = list_for_did(&primary, &index, &audit, "did:key:zSubject", None, 10)
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn list_paginates_with_cursor() {
+        let (primary, index, audit, _dir) = temp_kss().await;
+        for _ in 0..10 {
+            let rel = fresh("did:key:zHub", &format!("did:key:z{}", Uuid::new_v4()));
+            store_relationship(&primary, &index, &rel).await.unwrap();
+        }
+        let page1 = list_for_did(&primary, &index, &audit, "did:key:zHub", None, 3)
+            .await
+            .unwrap();
+        assert_eq!(page1.items.len(), 3);
+        let cursor_str = page1.next_cursor.as_ref().expect("more pages");
+        let cursor = Cursor::decode(cursor_str, &audit.key).expect("decode cursor");
+        let page2 = list_for_did(&primary, &index, &audit, "did:key:zHub", Some(&cursor), 3)
+            .await
+            .unwrap();
+        assert_eq!(page2.items.len(), 3);
+        // No overlap between pages.
+        let ids1: std::collections::HashSet<_> = page1.items.iter().map(|r| r.id).collect();
+        for r in &page2.items {
+            assert!(!ids1.contains(&r.id));
+        }
+    }
+
+    #[tokio::test]
+    async fn find_by_hash_returns_existing_row() {
+        let (primary, index, _audit, _dir) = temp_kss().await;
+        let mut rel = fresh("did:key:zA", "did:key:zB");
+        rel.vrc_sha256 = "deadbeef".into();
+        store_relationship(&primary, &index, &rel).await.unwrap();
+        let got = find_by_hash(&primary, "deadbeef").await.unwrap();
+        assert_eq!(got.map(|r| r.id), Some(rel.id));
+        let miss = find_by_hash(&primary, "feedface").await.unwrap();
+        assert!(miss.is_none());
+    }
+
+    #[tokio::test]
+    async fn self_loop_writes_one_index_entry() {
+        // Edge case: issuer == subject. We only write one
+        // index entry so list_for_did returns the row once.
+        let (primary, index, audit, _dir) = temp_kss().await;
+        let rel = fresh("did:key:zSelf", "did:key:zSelf");
+        store_relationship(&primary, &index, &rel).await.unwrap();
+        let page = list_for_did(&primary, &index, &audit, "did:key:zSelf", None, 10)
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 1, "self-edge must list once, not twice");
+    }
+}

--- a/vtc-service/src/routes/members/mod.rs
+++ b/vtc-service/src/routes/members/mod.rs
@@ -19,6 +19,7 @@
 pub mod personhood;
 pub mod promote;
 pub mod read;
+pub mod relationships;
 pub mod remove;
 pub mod renew;
 pub mod rotate;

--- a/vtc-service/src/routes/members/relationships.rs
+++ b/vtc-service/src/routes/members/relationships.rs
@@ -1,0 +1,94 @@
+//! `GET /v1/members/{did}/relationships` — paginated VRC
+//! list per member. Phase 4 M4.6.2. Spec §6.1 + §12.3.
+//!
+//! ## §12.3 departure-handling strip
+//!
+//! When a community member is **Purge**-removed, their ACL
+//! row and Member row are both deleted. VRCs naming a
+//! purged party are stripped from this list so the response
+//! doesn't surface dangling references to identifiers that
+//! no longer exist in the community.
+//!
+//! `Tombstone` and `Historical` members keep their Member
+//! rows (with `removed_at: Some(_)`), so VRCs naming them
+//! remain visible. The list path doesn't filter on
+//! `removed_at` — operator-uploaded directory policies can
+//! layer that if they want.
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use serde::Deserialize;
+use vti_common::auth::extractor::AuthClaims;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated};
+
+use crate::acl::get_acl_entry;
+use crate::members::get_member;
+use crate::relationships::{Relationship, list_for_did};
+use crate::server::AppState;
+
+const MAX_LIMIT: usize = 200;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListQuery {
+    pub cursor: Option<String>,
+    pub limit: Option<usize>,
+}
+
+pub async fn list(
+    _auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(did): Path<String>,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<Paginated<Relationship>>, AppError> {
+    let limit = query.limit.unwrap_or(50).clamp(1, MAX_LIMIT);
+    let audit_key = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?
+        .active_key()
+        .await?;
+
+    let cursor = query
+        .cursor
+        .as_deref()
+        .map(|c| Cursor::decode(c, &audit_key.key))
+        .transpose()
+        .map_err(|e| AppError::Validation(format!("invalid cursor: {e}")))?;
+
+    let page = list_for_did(
+        &state.relationships_ks,
+        &state.relationships_by_did_ks,
+        &audit_key,
+        &did,
+        cursor.as_ref(),
+        limit,
+    )
+    .await?;
+
+    // §12.3 strip: drop rows where the OTHER party (not the
+    // path-DID) has been Purge-removed (ACL absent AND Member
+    // absent). The path-DID itself is whoever the caller
+    // asked about — they're inherently part of the
+    // relationship, so we don't strip on their state.
+    let mut filtered: Vec<Relationship> = Vec::with_capacity(page.items.len());
+    for rel in page.items {
+        let other = if rel.issuer_did == did {
+            &rel.subject_did
+        } else {
+            &rel.issuer_did
+        };
+        let other_purged = get_acl_entry(&state.acl_ks, other).await?.is_none()
+            && get_member(&state.members_ks, other).await?.is_none();
+        if !other_purged {
+            filtered.push(rel);
+        }
+    }
+
+    Ok(Json(Paginated {
+        items: filtered,
+        next_cursor: page.next_cursor,
+        total_estimate: page.total_estimate,
+    }))
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod join_requests;
 pub(crate) mod members;
 pub(crate) mod policies;
 pub mod recognise;
+mod relationships;
 pub(crate) mod status_lists;
 
 use axum::Router;
@@ -155,6 +156,16 @@ pub fn router() -> Router<AppState> {
     // `members/{did}` show + update + admin-remove.
     let _members_personhood_revoke =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/members/personhood/revoke/1.0")
+            .expect("static Trust-Task URL");
+    // Phase 4 M4.6 — VRC trust-graph endpoints.
+    let relationships_publish =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/relationships/publish/1.0")
+            .expect("static Trust-Task URL");
+    let relationships_list =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/relationships/list/1.0")
+            .expect("static Trust-Task URL");
+    let relationships_revoke =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0")
             .expect("static Trust-Task URL");
     // Phase 3 M3.8 — trust-registry reconciler diagnostics.
     // Admin-gated (not super-admin) so on-call ops can read
@@ -382,6 +393,25 @@ pub fn router() -> Router<AppState> {
             // surface stays complete. (Same workaround as
             // members/{did}'s show + update + admin-remove.)
             members_personhood_assert,
+        )
+        // Phase 4 M4.6 — VRC trust-graph endpoints. The
+        // per-member list mounts under /v1/members/{did}/
+        // and must precede the catchall `/v1/members/{did}`
+        // (same path-trie precedence as personhood).
+        .route_with_task(
+            "/v1/members/{did}/relationships",
+            get(members::relationships::list),
+            relationships_list,
+        )
+        .route_with_task(
+            "/v1/relationships",
+            post(relationships::publish),
+            relationships_publish,
+        )
+        .route_with_task(
+            "/v1/relationships/{id}",
+            delete(relationships::revoke),
+            relationships_revoke,
         )
         .route_with_task(
             "/v1/members/{did}",

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -1,0 +1,425 @@
+//! VRC (Verifiable Recognition Credential) graph endpoints
+//! — Phase 4 M4.6. Spec §5.4 + §6.1; planning-review D1
+//! (issuer is the *member*, not the community).
+//!
+//! ## Three endpoints
+//!
+//! 1. `POST /v1/relationships` — publish a self-issued VRC.
+//!    Caller's session DID must equal the VC's `issuer`
+//!    field. The VTC verifies the data-integrity proof
+//!    against the member's resolved `#key-0`, runs
+//!    `relationships.rego` against an enriched input
+//!    (`{ vrc, issuer_member: { did, is_current },
+//!        subject_member: { did, is_current }, action }`),
+//!    persists the row + secondary-index entries on allow,
+//!    emits `VrcPublished`.
+//!
+//! 2. `GET /v1/members/{did}/relationships` — see
+//!    `src/routes/members/relationships.rs`. Owns its own
+//!    file because the URL is rooted under `/v1/members/`.
+//!
+//! 3. `DELETE /v1/relationships/{id}` — issuer-only retraction
+//!    (admin can also revoke for moderation). Deletes the row
+//!    plus secondary-index entries; emits `VrcRevoked`. Per
+//!    D7, VRCs carry no `credentialStatus`; revocation is row
+//!    deletion, not a status-list bit flip.
+
+use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value as JsonValue, json};
+use sha2::{Digest, Sha256};
+use tracing::info;
+use uuid::Uuid;
+use vti_common::audit::{AuditEvent, VrcPublishedData, VrcRevokedData};
+use vti_common::error::AppError;
+
+use crate::acl::get_acl_entry;
+use crate::auth::AuthClaims;
+use crate::members::get_member;
+use crate::policy::{
+    PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy, get_active_policy_id,
+    get_policy,
+};
+use crate::relationships::{
+    Relationship, delete_relationship, find_by_hash, get_relationship, store_relationship,
+};
+use crate::server::AppState;
+
+// ─── Publish ─────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct PublishBody {
+    /// The self-issued VRC. Must be a JSON-LD VC body with
+    /// `type` array including `VerifiableRecognitionCredential`,
+    /// an `issuer` field matching the caller's session DID,
+    /// `credentialSubject.id` naming the subject, and a
+    /// data-integrity proof.
+    pub vrc: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishResponse {
+    pub id: Uuid,
+    pub issuer_did: String,
+    pub subject_did: String,
+    pub vrc_sha256: String,
+}
+
+pub async fn publish(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Json(body): Json<PublishBody>,
+) -> Result<(StatusCode, Json<PublishResponse>), AppError> {
+    // 1. Parse the VC's core fields without going through the
+    //    typed `VerifiableCredential` — VRCs carry a few
+    //    extensions the typed parser doesn't know about, and
+    //    we want to store the JSON-LD verbatim either way.
+    let vrc = &body.vrc;
+    let issuer_did = extract_did_field(vrc, "issuer")?;
+    let subject_did = extract_subject_id(vrc)?;
+
+    // 2. Caller == issuer check (D1: self-issued only).
+    if auth.did != issuer_did {
+        return Err(AppError::Forbidden(format!(
+            "session DID ({}) does not match VRC issuer ({issuer_did}) — \
+             VRCs are self-issued; the VTC never mints them on a member's behalf",
+            auth.did
+        )));
+    }
+
+    // 3. Verify the VC's data-integrity proof against the
+    //    issuer's resolved #key-0. Daemon-config prerequisites
+    //    surface after caller validation.
+    let resolver = state.did_resolver.as_ref().cloned().ok_or_else(|| {
+        AppError::Internal("DID resolver not configured — VRC publish requires it".into())
+    })?;
+    verify_vc_proof(vrc, &issuer_did, &resolver)
+        .await
+        .map_err(|e| AppError::Validation(format!("VrcProofInvalid: {e}")))?;
+
+    // 4. Enrich both parties with `is_current` for the policy
+    //    input. A member is `current` iff they have a live ACL
+    //    row + a non-tombstoned Member row.
+    let issuer_current = is_current_member(&state, &issuer_did).await?;
+    let subject_current = is_current_member(&state, &subject_did).await?;
+    if !subject_current {
+        // Subject must at least exist (resolvable); the default
+        // policy refuses if either party isn't current, but
+        // we surface the more specific "subject unknown" 422
+        // before falling through to the generic policy 403.
+        if get_acl_entry(&state.acl_ks, &subject_did).await?.is_none() {
+            return Err(AppError::Validation(format!(
+                "subject DID {subject_did} is not a current community member"
+            )));
+        }
+    }
+
+    let policy_input = json!({
+        "vrc": vrc,
+        "issuer_member": { "did": issuer_did, "is_current": issuer_current },
+        "subject_member": { "did": subject_did, "is_current": subject_current },
+        "action": "publish",
+    });
+    let allow = evaluate_relationships_policy(&state, &policy_input).await?;
+    if !allow {
+        return Err(AppError::Forbidden(
+            "RelationshipPolicyDenied: active relationships.rego rejected the publish".into(),
+        ));
+    }
+
+    // 5. Compute hash for idempotent re-publish.
+    let canon = canonicalise(vrc);
+    let digest = Sha256::digest(canon.as_bytes());
+    let vrc_sha256 = hex::encode(digest);
+
+    // 6. Idempotency: same hash → same id.
+    if let Some(existing) = find_by_hash(&state.relationships_ks, &vrc_sha256).await? {
+        return Ok((
+            StatusCode::OK,
+            Json(PublishResponse {
+                id: existing.id,
+                issuer_did: existing.issuer_did,
+                subject_did: existing.subject_did,
+                vrc_sha256: existing.vrc_sha256,
+            }),
+        ));
+    }
+
+    // 7. Store the row + secondary-index entries.
+    let id = Uuid::new_v4();
+    let rel = Relationship {
+        id,
+        issuer_did: issuer_did.clone(),
+        subject_did: subject_did.clone(),
+        vrc_jsonld: vrc.clone(),
+        vrc_sha256: vrc_sha256.clone(),
+        created_at: Utc::now(),
+    };
+    store_relationship(
+        &state.relationships_ks,
+        &state.relationships_by_did_ks,
+        &rel,
+    )
+    .await?;
+
+    // 8. Audit.
+    let edge_type = vrc
+        .pointer("/credentialSubject/endorsement/type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("recognition")
+        .to_string();
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &issuer_did,
+                Some(&subject_did),
+                AuditEvent::VrcPublished(VrcPublishedData {
+                    vrc_id: id.to_string(),
+                    subject_did: Some(subject_did.clone()),
+                    edge_type,
+                }),
+            )
+            .await?;
+    }
+
+    info!(
+        vrc_id = %id,
+        issuer = %issuer_did,
+        subject = %subject_did,
+        "VRC published"
+    );
+
+    Ok((
+        StatusCode::CREATED,
+        Json(PublishResponse {
+            id,
+            issuer_did,
+            subject_did,
+            vrc_sha256,
+        }),
+    ))
+}
+
+// ─── Revoke ──────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokeResponse {
+    pub id: String,
+}
+
+pub async fn revoke(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<(StatusCode, Json<RevokeResponse>), AppError> {
+    let rel = get_relationship(&state.relationships_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("VRC {id} not found")))?;
+
+    // Auth: issuer of the row OR admin.
+    let is_issuer = auth.did == rel.issuer_did;
+    let is_admin = auth.role == vti_common::acl::Role::Admin;
+    if !is_issuer && !is_admin {
+        return Err(AppError::Forbidden(
+            "only the issuer or an admin can revoke a VRC".into(),
+        ));
+    }
+
+    delete_relationship(&state.relationships_ks, &state.relationships_by_did_ks, id).await?;
+
+    let revoked_by = if is_issuer { "issuer" } else { "admin" };
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.did,
+                Some(&rel.subject_did),
+                AuditEvent::VrcRevoked(VrcRevokedData {
+                    vrc_id: id.to_string(),
+                    revoked_by: revoked_by.into(),
+                }),
+            )
+            .await?;
+    }
+
+    info!(vrc_id = %id, revoked_by, "VRC revoked");
+
+    Ok((StatusCode::OK, Json(RevokeResponse { id: id.to_string() })))
+}
+
+// ─── Helpers ─────────────────────────────────────────────
+
+/// Extract a DID from a JSON-LD VC field that may be either a
+/// string or an object with an `id` member (W3C spec allows
+/// both shapes for `issuer`).
+fn extract_did_field(vrc: &JsonValue, field: &str) -> Result<String, AppError> {
+    let v = vrc
+        .get(field)
+        .ok_or_else(|| AppError::Validation(format!("VRC missing {field}")))?;
+    match v {
+        JsonValue::String(s) => Ok(s.clone()),
+        JsonValue::Object(o) => o
+            .get("id")
+            .and_then(|x| x.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| AppError::Validation(format!("VRC.{field}.id missing or not a string"))),
+        _ => Err(AppError::Validation(format!(
+            "VRC.{field} is neither a string nor an object"
+        ))),
+    }
+}
+
+fn extract_subject_id(vrc: &JsonValue) -> Result<String, AppError> {
+    vrc.pointer("/credentialSubject/id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            AppError::Validation("VRC.credentialSubject.id missing or not a string".into())
+        })
+}
+
+/// Verify a VC's data-integrity proof against the issuer's
+/// resolved `#key-0`. Mirrors the personhood + recognition
+/// verifiers; same upstream `get_public_key_bytes()` helper.
+async fn verify_vc_proof(
+    vrc: &JsonValue,
+    issuer_did: &str,
+    resolver: &DIDCacheClient,
+) -> Result<(), String> {
+    let proof_value = vrc
+        .get("proof")
+        .ok_or_else(|| "VRC missing proof".to_string())?;
+    let proof: DataIntegrityProof =
+        serde_json::from_value(proof_value.clone()).map_err(|e| format!("parse proof: {e}"))?;
+
+    let mut vrc_without_proof = vrc.clone();
+    if let Some(obj) = vrc_without_proof.as_object_mut() {
+        obj.remove("proof");
+    }
+
+    let verification_method = proof_value
+        .get("verificationMethod")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "proof missing verificationMethod".to_string())?;
+
+    let resolved = resolver
+        .resolve(issuer_did)
+        .await
+        .map_err(|e| format!("resolve {issuer_did}: {e}"))?;
+    let vm = resolved
+        .doc
+        .verification_method
+        .iter()
+        .find(|m| m.id.as_str() == verification_method)
+        .ok_or_else(|| format!("verificationMethod {verification_method} not on {issuer_did}"))?;
+    let pubkey = vm
+        .get_public_key_bytes()
+        .map_err(|e| format!("extract pubkey: {e}"))?;
+
+    proof
+        .verify_with_public_key(&vrc_without_proof, &pubkey, VerifyOptions::new())
+        .map_err(|e| format!("verify: {e}"))?;
+    Ok(())
+}
+
+/// A member is `is_current` iff they have a live ACL row +
+/// the Member row exists and isn't tombstoned. Either
+/// missing → false.
+async fn is_current_member(state: &AppState, did: &str) -> Result<bool, AppError> {
+    let acl = get_acl_entry(&state.acl_ks, did).await?;
+    if acl.is_none() {
+        return Ok(false);
+    }
+    let member = get_member(&state.members_ks, did).await?;
+    Ok(member.is_some_and(|m| !m.is_removed()))
+}
+
+/// Evaluate `relationships.rego.allow`. Fail-closed.
+async fn evaluate_relationships_policy(
+    state: &AppState,
+    input: &JsonValue,
+) -> Result<bool, AppError> {
+    let Some(id) =
+        get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Relationships).await?
+    else {
+        return Ok(false);
+    };
+    let policy = get_policy(&state.policies_ks, id)
+        .await?
+        .ok_or_else(|| AppError::Internal(format!("active relationships policy {id} not found")))?;
+    let compiled = compile_policy(&policy.rego_source, policy.id)?;
+    let result = evaluate_policy(&compiled, "data.vtc.relationships.allow", input.clone())?;
+    Ok(result
+        .pointer("/result/0/expressions/0/value")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false))
+}
+
+/// Canonicalise the VRC JSON for the SHA-256 hash. JCS
+/// (RFC 8785) is the W3C-standard canonical form for VC
+/// signing, but the data-integrity layer already canonicalises
+/// during proof verification; for our local idempotency check
+/// we only need a *deterministic* form, not a *standard* one.
+/// `serde_json` sorts keys lexicographically when serialising
+/// from a `BTreeMap` — we convert + serialise to get that.
+fn canonicalise(v: &JsonValue) -> String {
+    fn into_sorted(v: JsonValue) -> JsonValue {
+        match v {
+            JsonValue::Object(m) => {
+                let mut sorted: std::collections::BTreeMap<String, JsonValue> =
+                    std::collections::BTreeMap::new();
+                for (k, val) in m {
+                    sorted.insert(k, into_sorted(val));
+                }
+                serde_json::to_value(sorted).expect("sorted object is JSON-able")
+            }
+            JsonValue::Array(arr) => JsonValue::Array(arr.into_iter().map(into_sorted).collect()),
+            other => other,
+        }
+    }
+    serde_json::to_string(&into_sorted(v.clone())).unwrap_or_else(|_| "{}".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_did_field_handles_string_form() {
+        let vrc = json!({ "issuer": "did:key:zA" });
+        assert_eq!(extract_did_field(&vrc, "issuer").unwrap(), "did:key:zA");
+    }
+
+    #[test]
+    fn extract_did_field_handles_object_form() {
+        let vrc = json!({ "issuer": { "id": "did:key:zA", "name": "x" } });
+        assert_eq!(extract_did_field(&vrc, "issuer").unwrap(), "did:key:zA");
+    }
+
+    #[test]
+    fn extract_did_field_rejects_missing() {
+        let vrc = json!({});
+        assert!(extract_did_field(&vrc, "issuer").is_err());
+    }
+
+    #[test]
+    fn extract_subject_id_extracts_nested() {
+        let vrc = json!({
+            "credentialSubject": { "id": "did:key:zSubject", "role": "member" }
+        });
+        assert_eq!(extract_subject_id(&vrc).unwrap(), "did:key:zSubject");
+    }
+
+    #[test]
+    fn canonicalise_is_key_order_stable() {
+        let a = json!({ "b": 1, "a": 2, "c": { "y": 5, "x": 4 } });
+        let b = json!({ "a": 2, "c": { "x": 4, "y": 5 }, "b": 1 });
+        assert_eq!(canonicalise(&a), canonicalise(&b));
+    }
+}

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -72,6 +72,12 @@ pub struct AppState {
     /// Singleton row tracking the audit-log tail's last-seen
     /// timestamp for boot-time replay (Phase 3 M3.3).
     pub sync_cursor_ks: KeyspaceHandle,
+    /// VRC trust-edge rows (Phase 4 M4.5). Primary keyspace.
+    pub relationships_ks: KeyspaceHandle,
+    /// VRC per-DID secondary index (Phase 4 M4.5). Keyed by
+    /// `<did>:<vrc-id>` so per-DID list queries are O(matched
+    /// rows). CAS-paired with `relationships_ks`.
+    pub relationships_by_did_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
     /// Trust-registry client (Phase 3 M3.2). `None` when
@@ -195,6 +201,8 @@ pub async fn run(
     let registry_records_ks = store.keyspace("registry_records")?;
     let sync_queue_ks = store.keyspace("sync_queue")?;
     let sync_cursor_ks = store.keyspace("sync_cursor")?;
+    let relationships_ks = store.keyspace("relationships")?;
+    let relationships_by_did_ks = store.keyspace("relationships_by_did")?;
     let audit_ks = store.keyspace("audit")?;
     let audit_key_ks = store.keyspace("audit_key")?;
 
@@ -351,6 +359,8 @@ pub async fn run(
         registry_records_ks,
         sync_queue_ks,
         sync_cursor_ks,
+        relationships_ks,
+        relationships_by_did_ks,
         audit_ks,
         audit_key_ks,
         registry_client: registry_client.clone(),

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -85,6 +85,8 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -131,6 +133,8 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -68,6 +68,8 @@ async fn build_with(
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -113,6 +115,8 @@ async fn build_with(
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -91,6 +91,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -196,6 +198,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -61,6 +61,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -95,6 +97,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -62,6 +62,8 @@ async fn build() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -96,6 +98,8 @@ async fn build() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -64,6 +64,8 @@ async fn build() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -98,6 +100,8 @@ async fn build() -> Fixture {
         registry_records_ks,
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks,
+        relationships_ks,
+        relationships_by_did_ks,
         registry_client: None,
         registry_health: RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -56,6 +56,8 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -85,6 +87,8 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -212,6 +212,8 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -304,6 +306,8 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -73,6 +73,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -114,6 +116,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -104,6 +104,8 @@ async fn build_fixture() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -143,6 +145,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -88,6 +88,8 @@ async fn build_fixture() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -199,6 +201,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer,

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -76,6 +76,8 @@ async fn build_fixture() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -159,6 +161,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -45,6 +45,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -75,6 +77,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/personhood.rs
+++ b/vtc-service/tests/personhood.rs
@@ -94,6 +94,8 @@ async fn build_fixture() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -281,6 +283,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks,
         sync_queue_ks,
         sync_cursor_ks,
+        relationships_ks,
+        relationships_by_did_ks,
         registry_client: None,
         registry_health: RegistryHealth::new(),
         audit_ks: audit_ks.clone(),

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -103,6 +103,8 @@ async fn build_fixture() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -179,6 +181,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -67,6 +67,8 @@ async fn build() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -102,6 +104,8 @@ async fn build() -> Fixture {
         registry_records_ks,
         sync_queue_ks,
         sync_cursor_ks,
+        relationships_ks,
+        relationships_by_did_ks,
         registry_client: None,
         registry_health: RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -1,0 +1,541 @@
+//! Integration coverage for `/v1/relationships*` (Phase 4
+//! M4.6).
+//!
+//! The publish happy path needs a live DID resolver to verify
+//! the VRC's data-integrity proof — same constraint as M3.10
+//! recognise + M4.3 personhood assert. Integration tests here
+//! cover:
+//! - publish: caller != issuer → 403
+//! - publish: missing resolver → 500
+//! - revoke: issuer revokes own row (with hand-seeded state)
+//! - revoke: subject (non-issuer) → 403
+//! - revoke: admin revokes any row
+//! - revoke: 404 on unknown id
+//! - list: pagination + §12.3 strip on Purge-removed party
+
+use std::sync::Arc;
+
+use affinidi_status_list::StatusPurpose;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use uuid::Uuid;
+use vti_common::audit::{AuditEnvelope, AuditEvent, AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, delete_acl_entry, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::credentials::LocalSigner;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::{Member, delete_member, store_member};
+use vtc_service::registry::RegistryHealth;
+use vtc_service::relationships::{Relationship, store_relationship};
+use vtc_service::routes;
+use vtc_service::server::AppState;
+use vtc_service::status_list;
+
+const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+const PUBLIC_URL: &str = "https://vtc.example.com";
+const PUBLISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/relationships/publish/1.0";
+const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/relationships/list/1.0";
+const REVOKE_TASK: &str = "https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0";
+const ISSUER_DID: &str = "did:key:zVrcIssuer";
+const SUBJECT_DID: &str = "did:key:zVrcSubject";
+const STRANGER_DID: &str = "did:key:zStranger";
+const ADMIN_DID: &str = "did:key:zVrcAdmin";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    issuer_token: String,
+    subject_token: String,
+    admin_token: String,
+    relationships_ks: vti_common::store::KeyspaceHandle,
+    relationships_by_did_ks: vti_common::store::KeyspaceHandle,
+    acl_ks: vti_common::store::KeyspaceHandle,
+    members_ks: vti_common::store::KeyspaceHandle,
+    audit_ks: vti_common::store::KeyspaceHandle,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
+        .await
+        .expect("install default policies");
+
+    for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+        let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
+        status_list::ensure_initial(&status_lists_ks, purpose, url)
+            .await
+            .unwrap();
+    }
+
+    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    // Seed ACL + Member rows for issuer, subject, admin.
+    let now = now_epoch();
+    for (did, role) in [
+        (ISSUER_DID, VtcRole::Member),
+        (SUBJECT_DID, VtcRole::Member),
+        (ADMIN_DID, VtcRole::Admin),
+    ] {
+        store_acl_entry(
+            &acl_ks,
+            &VtcAclEntry {
+                did: did.into(),
+                role,
+                label: None,
+                allowed_contexts: vec![],
+                created_at: now,
+                created_by: "did:key:vtc-install".into(),
+                expires_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        store_member(&members_ks, &Member::fresh(did))
+            .await
+            .unwrap();
+    }
+
+    async fn mint(
+        sessions: &vti_common::store::KeyspaceHandle,
+        jwt_keys: &Arc<JwtKeys>,
+        did: &str,
+        role: &str,
+        now: u64,
+    ) -> String {
+        let session_id = format!("sess-{}", Uuid::new_v4());
+        store_session(
+            sessions,
+            &Session {
+                session_id: session_id.clone(),
+                did: did.into(),
+                challenge: "test".into(),
+                state: SessionState::Authenticated,
+                created_at: now,
+                refresh_token: None,
+                refresh_expires_at: None,
+                tee_attested: false,
+            },
+        )
+        .await
+        .unwrap();
+        let claims = jwt_keys.new_claims(did.into(), session_id, role.into(), vec![], 3600, true);
+        jwt_keys.encode(&claims).unwrap()
+    }
+
+    let issuer_token = mint(&sessions_ks, &jwt_keys, ISSUER_DID, "reader", now).await;
+    let subject_token = mint(&sessions_ks, &jwt_keys, SUBJECT_DID, "reader", now).await;
+    let admin_token = mint(&sessions_ks, &jwt_keys, ADMIN_DID, "admin", now).await;
+
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "{VTC_DID}"
+        public_url = "{PUBLIC_URL}"
+        [store]
+        data_dir = "{}"
+        [auth]
+        jwt_signing_key = "{}"
+        "#,
+        dir.path().display(),
+        BASE64.encode(jwt_seed),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks: acl_ks.clone(),
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks: members_ks.clone(),
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks,
+        registry_records_ks,
+        sync_queue_ks,
+        sync_cursor_ks,
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
+        registry_client: None,
+        registry_health: RegistryHealth::new(),
+        audit_ks: audit_ks.clone(),
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: Some(PUBLIC_URL.into()),
+        install_signer: None,
+        credential_signer: Some(signer),
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+    Fixture {
+        router,
+        issuer_token,
+        subject_token,
+        admin_token,
+        relationships_ks,
+        relationships_by_did_ks,
+        acl_ks,
+        members_ks,
+        audit_ks,
+        _dir: dir,
+    }
+}
+
+fn fake_vrc(issuer: &str, subject: &str) -> Value {
+    json!({
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
+        "type": ["VerifiableCredential", "VerifiableRecognitionCredential"],
+        "issuer": issuer,
+        "credentialSubject": {
+            "id": subject,
+            "endorsement": { "type": "endorses" }
+        },
+        "proof": {
+            "type": "DataIntegrityProof",
+            "cryptosuite": "eddsa-jcs-2022",
+            "verificationMethod": format!("{issuer}#key-0"),
+            "proofValue": "z00"
+        }
+    })
+}
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+// ─── Publish ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn publish_rejects_caller_not_issuer() {
+    let fix = build_fixture().await;
+    // Subject member tries to publish a VRC issued by someone else.
+    let vrc = fake_vrc(ISSUER_DID, SUBJECT_DID);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/relationships")
+        .header("authorization", format!("Bearer {}", fix.subject_token))
+        .header("trust-task", PUBLISH_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(json!({ "vrc": vrc }).to_string()))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn publish_returns_500_when_resolver_unconfigured() {
+    let fix = build_fixture().await;
+    let vrc = fake_vrc(ISSUER_DID, SUBJECT_DID);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/relationships")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", PUBLISH_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(json!({ "vrc": vrc }).to_string()))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    // Caller passes the issuer == VC.issuer gate; resolver
+    // path is next + the fixture has did_resolver: None.
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn publish_rejects_malformed_vrc() {
+    let fix = build_fixture().await;
+    // No `issuer` field → 400 (Validation).
+    let vrc = json!({
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
+        "credentialSubject": { "id": SUBJECT_DID }
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/relationships")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", PUBLISH_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(json!({ "vrc": vrc }).to_string()))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ─── Revoke ──────────────────────────────────────────────
+
+async fn seed_relationship(fix: &Fixture, issuer: &str, subject: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let rel = Relationship {
+        id,
+        issuer_did: issuer.into(),
+        subject_did: subject.into(),
+        vrc_jsonld: fake_vrc(issuer, subject),
+        vrc_sha256: format!("seed-{id}"),
+        created_at: chrono::Utc::now(),
+    };
+    store_relationship(&fix.relationships_ks, &fix.relationships_by_did_ks, &rel)
+        .await
+        .unwrap();
+    id
+}
+
+#[tokio::test]
+async fn revoke_issuer_can_retract_own() {
+    let fix = build_fixture().await;
+    let id = seed_relationship(&fix, ISSUER_DID, SUBJECT_DID).await;
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/relationships/{id}"))
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", REVOKE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Row gone.
+    let got = vtc_service::relationships::get_relationship(&fix.relationships_ks, id)
+        .await
+        .unwrap();
+    assert!(got.is_none());
+
+    // Audit envelope carries revoked_by: "issuer".
+    let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let mut saw = false;
+    for (_k, raw) in pairs {
+        let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+        if let AuditEvent::VrcRevoked(d) = env.event
+            && d.revoked_by == "issuer"
+        {
+            saw = true;
+        }
+    }
+    assert!(saw, "issuer revoke must emit revoked_by=issuer");
+}
+
+#[tokio::test]
+async fn revoke_subject_is_forbidden() {
+    let fix = build_fixture().await;
+    let id = seed_relationship(&fix, ISSUER_DID, SUBJECT_DID).await;
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/relationships/{id}"))
+        .header("authorization", format!("Bearer {}", fix.subject_token))
+        .header("trust-task", REVOKE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn revoke_admin_can_revoke_any() {
+    let fix = build_fixture().await;
+    let id = seed_relationship(&fix, ISSUER_DID, SUBJECT_DID).await;
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/relationships/{id}"))
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", REVOKE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    // Audit reason = "admin".
+    let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let mut saw_admin = false;
+    for (_k, raw) in pairs {
+        let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+        if let AuditEvent::VrcRevoked(d) = env.event
+            && d.revoked_by == "admin"
+        {
+            saw_admin = true;
+        }
+    }
+    assert!(saw_admin);
+}
+
+#[tokio::test]
+async fn revoke_404_on_unknown() {
+    let fix = build_fixture().await;
+    let id = Uuid::new_v4();
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/relationships/{id}"))
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", REVOKE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ─── List ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_returns_issued_and_received_edges() {
+    let fix = build_fixture().await;
+    let r1 = seed_relationship(&fix, ISSUER_DID, SUBJECT_DID).await;
+    let r2 = seed_relationship(&fix, SUBJECT_DID, ISSUER_DID).await; // reverse
+    // Stranger row that shouldn't appear for the issuer's list.
+    store_acl_entry(
+        &fix.acl_ks,
+        &VtcAclEntry {
+            did: STRANGER_DID.into(),
+            role: VtcRole::Member,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now_epoch(),
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    store_member(&fix.members_ks, &Member::fresh(STRANGER_DID))
+        .await
+        .unwrap();
+    let _r3 = seed_relationship(&fix, STRANGER_DID, SUBJECT_DID).await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/v1/members/{ISSUER_DID}/relationships"))
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", LIST_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    let items = v["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 2, "issuer's list = own issued + received");
+    let ids: Vec<_> = items
+        .iter()
+        .map(|x| x["id"].as_str().unwrap().to_string())
+        .collect();
+    assert!(ids.contains(&r1.to_string()));
+    assert!(ids.contains(&r2.to_string()));
+}
+
+#[tokio::test]
+async fn list_strips_rows_where_other_party_purged() {
+    let fix = build_fixture().await;
+    let _r = seed_relationship(&fix, ISSUER_DID, SUBJECT_DID).await;
+
+    // Purge SUBJECT: delete ACL row + Member row.
+    delete_acl_entry(&fix.acl_ks, SUBJECT_DID).await.unwrap();
+    delete_member(&fix.members_ks, SUBJECT_DID).await.unwrap();
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/v1/members/{ISSUER_DID}/relationships"))
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", LIST_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    let items = v["items"].as_array().unwrap();
+    assert!(
+        items.is_empty(),
+        "Purge-removed subject must strip the edge: {v}"
+    );
+}
+
+#[tokio::test]
+async fn list_keeps_rows_for_tombstoned_other_party() {
+    let fix = build_fixture().await;
+    let _r = seed_relationship(&fix, ISSUER_DID, SUBJECT_DID).await;
+
+    // Tombstone SUBJECT: stamp removed_at on the Member row.
+    let mut m = vtc_service::members::get_member(&fix.members_ks, SUBJECT_DID)
+        .await
+        .unwrap()
+        .unwrap();
+    m.tombstone();
+    store_member(&fix.members_ks, &m).await.unwrap();
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/v1/members/{ISSUER_DID}/relationships"))
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", LIST_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    let items = v["items"].as_array().unwrap();
+    assert_eq!(
+        items.len(),
+        1,
+        "Tombstoned subject keeps the edge visible: {v}"
+    );
+}

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -78,6 +78,8 @@ async fn build_fixture() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -185,6 +187,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -82,6 +82,8 @@ async fn build_fixture() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -179,6 +181,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         audit_ks,

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -80,6 +80,8 @@ async fn build_fixture() -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -190,6 +192,8 @@ async fn build_fixture() -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         audit_ks,

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -243,6 +243,8 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -268,6 +270,8 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/status_lists.rs
+++ b/vtc-service/tests/status_lists.rs
@@ -70,6 +70,8 @@ async fn build_fixture(with_signer: bool) -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -116,6 +118,8 @@ async fn build_fixture(with_signer: bool) -> Fixture {
         registry_records_ks,
         sync_queue_ks,
         sync_cursor_ks,
+        relationships_ks,
+        relationships_by_did_ks,
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         audit_ks,


### PR DESCRIPTION
## Summary

Phase 4 PR-3 / 5. **VRC gate met** — members publish + list + revoke self-issued trust edges. Per planning-review D1, VRCs are issued BY the member, not by the community; the VTC verifies proofs but never mints.

### Three new endpoints

| Endpoint | Auth | Outcome |
|----------|------|---------|
| `POST /v1/relationships` | any auth, caller == VC.issuer | publish row, emit `VrcPublished` |
| `GET /v1/members/{did}/relationships` | any auth | paginated list with §12.3 strip |
| `DELETE /v1/relationships/{id}` | issuer OR admin | delete row, emit `VrcRevoked` |

### Storage

- New `relationships:` keyspace (primary).
- New `relationships_by_did:` secondary index keyed `<did>:<vrc-id>` so per-DID list queries are O(matched-rows). CAS-paired with the primary; orphan entries self-heal on next list call.
- `Relationship { id, issuer_did, subject_did, vrc_jsonld, vrc_sha256, created_at }`.
- Idempotent publish via `find_by_hash` — second POST of the same canonicalised body returns the existing row's id.

### Key design notes

- **§12.3 departure strip** in the list path: rows where the *other* party (not the path-DID) is **Purge**-removed are excluded. `Tombstone` + `Historical` members remain visible — they keep their Member row and the trust edge is a legitimate historical claim.
- **No `credentialStatus`** (D7): revocation = row deletion, not a status-list bit flip.
- **Subject can't unilaterally revoke** a claim someone else made about them — they can ask an admin to moderate. Issuer + admin are the two retraction paths.
- **Routes mounted BEFORE `/v1/members/{did}`** so axum's path-trie matches the literal `relationships` segment first (same workaround as M4.3 personhood).
- **21 test fixtures bulk-patched** with the two new AppState keyspace fields.

## Test plan

- [x] 7 storage unit tests pass (round-trip, list-by-issuer, list-by-subject, cursor pagination, delete clears both keyspaces, find-by-hash, self-loop)
- [x] 10 relationships integration tests pass (publish: caller != issuer / missing resolver / malformed; revoke: issuer / admin / subject-forbidden / 404; list: issued + received / Purge strip / Tombstone keep)
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` green (304 vtc-service lib + every integration suite + 191 vti-common + 347 vta-sdk + 99 vta-service + e2e)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] DCO sign-off

After merge: PR-4 (M4.7+M4.8) — endorsements keyspace + builder + endorsement-type registry + endorsement-issuance CRUD. Custom endorsement gate.

Refs: #46 vtc-mvp Phase 4 plan §M4.5 + §M4.6