### PR TITLE
feat(vtc-service): M4.7 + M4.8 — endorsement type registry + custom endorsement CRUD

### DIFF
--- a/tasks/vtc-mvp/phase-4-todo.md
+++ b/tasks/vtc-mvp/phase-4-todo.md
@@ -413,7 +413,7 @@ default policy + departure-strip both work.
 
 ## M4.7 — `endorsements:` keyspace + custom-endorsement builder
 
-### `[ ]` M4.7.1 — Endorsements keyspace + Endorsement model
+### `[x]` M4.7.1 — Endorsements keyspace + Endorsement model
 
 - **Acceptance**
   - New keyspace `endorsements` registered in `server::run`.
@@ -436,7 +436,7 @@ default policy + departure-strip both work.
 - **Pre-impl decision**: **D4** review (operator-uploaded
   type registry), **D8** review (shared revocation list).
 
-### `[ ]` M4.7.2 — Custom endorsement VC builder
+### `[x]` M4.7.2 — Custom endorsement VC builder
 
 - **Acceptance**
   - `vtc_service::credentials` extends with
@@ -477,7 +477,7 @@ default policy + departure-strip both work.
 > issuance endpoint consults the registry. ~800-1000 LoC total,
 > reviewed atomically.
 
-### `[ ]` M4.8.0 — `endorsement_types:` keyspace + storage
+### `[x]` M4.8.0 — `endorsement_types:` keyspace + storage
 
 - **Acceptance**
   - New keyspace `endorsement_types` registered in `server::run`.
@@ -499,7 +499,7 @@ default policy + departure-strip both work.
 - **Deps**: none (parallel with other tracks)
 - **Pre-impl decision**: **D4** review.
 
-### `[ ]` M4.8.1 — Endorsement type registry endpoints
+### `[x]` M4.8.1 — Endorsement type registry endpoints
 
 - **Acceptance** — three endpoints under
   `/v1/endorsement-types`:
@@ -535,7 +535,7 @@ default policy + departure-strip both work.
 - **Deps**: M4.7.1, M4.8.0, M4.1.2
 - **Pre-impl decision**: **D4** review.
 
-### `[ ]` M4.8.2 — `POST /v1/credentials/endorsements`
+### `[x]` M4.8.2 — `POST /v1/credentials/endorsements`
 
 - **Acceptance**
   - Handler in `routes/credentials/endorsements.rs` (new).
@@ -584,7 +584,7 @@ default policy + departure-strip both work.
 - **Deps**: M4.7.2, M4.8.1
 - **Pre-impl decision**: **D4** review, **D8** review.
 
-### `[ ]` M4.8.3 — `GET /v1/credentials/endorsements` + `GET /{id}`
+### `[x]` M4.8.3 — `GET /v1/credentials/endorsements` + `GET /{id}`
 
 - **Acceptance**
   - List handler: `AdminAuth` OR `IssuerAuth`. Cursor
@@ -605,7 +605,7 @@ default policy + departure-strip both work.
   - `trust-tasks/credentials/endorsements/show/1.0/{spec.md,schema.json}`
 - **Deps**: M4.8.2
 
-### `[ ]` M4.8.4 — `DELETE /v1/credentials/endorsements/{id}`
+### `[x]` M4.8.4 — `DELETE /v1/credentials/endorsements/{id}`
 
 - **Acceptance**
   - **Auth**: `AdminAuth` OR the original issuer's DID

--- a/trust-tasks/credentials/endorsements/issue/1.0/schema.json
+++ b/trust-tasks/credentials/endorsements/issue/1.0/schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC \u2014 Custom Endorsement Issue",
+  "description": "POST /v1/credentials/endorsements. Phase 4 M4.8.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/trust-tasks/credentials/endorsements/issue/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/issue/1.0/spec.md
@@ -1,0 +1,29 @@
+---
+id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0
+title: VTC — Custom Endorsement Issue
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/credentials/endorsements
+---
+
+# VTC — Custom Endorsement Issue
+
+## Semantics
+
+- **Auth**: Admin OR Issuer role member (live ACL check; JWT role degrades to Reader for Issuer, so the handler reads the VTC ACL row directly).
+- **Body**: `{ subjectDid, type, claim, validitySeconds? }`.
+- **Type registry consultation**: refuses unknown types with `400 endorsement-type-not-registered`.
+- **Claim cap**: 8 KiB JSON object.
+- Allocates a slot on the shared `Revocation` status list (D8 review), builds + signs the VEC, persists the row.
+- Emits both `CustomEndorsementIssued { endorsementId, endorsementType, statusListIndex }` and `VecIssued { credentialId, ... }` so credential-issuance accounting stays uniform.
+
+## Outputs
+
+`201 Created` with the signed VEC body + the row id.
+
+## Status
+
+Draft.

--- a/trust-tasks/credentials/endorsements/list/1.0/schema.json
+++ b/trust-tasks/credentials/endorsements/list/1.0/schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/list/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC \u2014 Custom Endorsement List",
+  "description": "GET /v1/credentials/endorsements. Phase 4 M4.8.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/trust-tasks/credentials/endorsements/list/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/list/1.0/spec.md
@@ -1,0 +1,22 @@
+---
+id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/list/1.0
+title: VTC — Custom Endorsement List
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/credentials/endorsements
+---
+
+# VTC — Custom Endorsement List
+
+## Semantics
+
+- **Auth**: Admin OR Issuer role member.
+- Cursor pagination per §9.1.
+- Both live and revoked rows surface; consumers filter on `revokedAt`.
+
+## Status
+
+Draft.

--- a/trust-tasks/credentials/endorsements/revoke/1.0/schema.json
+++ b/trust-tasks/credentials/endorsements/revoke/1.0/schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/revoke/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC \u2014 Custom Endorsement Revoke",
+  "description": "DELETE /v1/credentials/endorsements/{id}. Phase 4 M4.8.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/trust-tasks/credentials/endorsements/revoke/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/revoke/1.0/spec.md
@@ -1,0 +1,29 @@
+---
+id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/revoke/1.0
+title: VTC — Custom Endorsement Revoke
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: DELETE /v1/credentials/endorsements/{id}
+---
+
+# VTC — Custom Endorsement Revoke
+
+## Semantics
+
+- **Auth**: Admin OR Issuer role member.
+- Idempotent: re-revoking an already-revoked row returns `200 OK` without re-flipping the bit or re-emitting audit envelopes.
+- Flips the `Revocation` status-list bit at the row's `statusListIndex` (immediate).
+- Emits paired envelopes:
+  - `CustomEndorsementRevoked { endorsementId, endorsementType }` (semantic).
+  - `StatusListFlipped { purpose: "revocation", index, revoked: true }` (bit-flip accounting).
+
+## Status
+
+Draft. Per-method `TrustTaskRouter` selectors aren't yet supported; route mount shares `show/1.0`. File exists on disk + index.json so the soft-gate surface stays complete.
+
+## Status
+
+Draft.

--- a/trust-tasks/credentials/endorsements/show/1.0/schema.json
+++ b/trust-tasks/credentials/endorsements/show/1.0/schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC \u2014 Custom Endorsement Show",
+  "description": "GET /v1/credentials/endorsements/{id}. Phase 4 M4.8.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/trust-tasks/credentials/endorsements/show/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/show/1.0/spec.md
@@ -1,0 +1,21 @@
+---
+id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0
+title: VTC — Custom Endorsement Show
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/credentials/endorsements/{id}
+---
+
+# VTC — Custom Endorsement Show
+
+## Semantics
+
+- **Auth**: Admin OR Issuer role member.
+- `404` on unknown id.
+
+## Status
+
+Draft.

--- a/trust-tasks/endorsement-types/delete/1.0/schema.json
+++ b/trust-tasks/endorsement-types/delete/1.0/schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC \u2014 Endorsement Type Delete",
+  "description": "DELETE /v1/endorsement-types/{type_uri}. Phase 4 M4.8.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/trust-tasks/endorsement-types/delete/1.0/spec.md
+++ b/trust-tasks/endorsement-types/delete/1.0/spec.md
@@ -1,0 +1,27 @@
+---
+id: https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0
+title: VTC — Endorsement Type Delete
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: DELETE /v1/endorsement-types/{type_uri}
+---
+
+# VTC — Endorsement Type Delete
+
+## Semantics
+
+- **Auth**: Admin role.
+- Refuses with `409 endorsement-type-in-use` while at least one live endorsement of the type still exists. Operators must revoke all live endorsements first.
+- `404` when the type isn't registered.
+- Emits `EndorsementTypeDeleted { typeUri }`.
+
+## Outputs
+
+`200 OK` with `{ typeUri }`.
+
+## Status
+
+Draft.

--- a/trust-tasks/endorsement-types/list/1.0/schema.json
+++ b/trust-tasks/endorsement-types/list/1.0/schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/endorsement-types/list/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC \u2014 Endorsement Type List",
+  "description": "GET /v1/endorsement-types. Phase 4 M4.8.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/trust-tasks/endorsement-types/list/1.0/spec.md
+++ b/trust-tasks/endorsement-types/list/1.0/spec.md
@@ -1,0 +1,25 @@
+---
+id: https://trusttasks.org/openvtc/vtc/endorsement-types/list/1.0
+title: VTC — Endorsement Type List
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/endorsement-types
+---
+
+# VTC — Endorsement Type List
+
+## Semantics
+
+- **Auth**: Admin role.
+- **Pagination**: cursor per §9.1.
+
+## Outputs
+
+`200 OK` with `Paginated<EndorsementType>`.
+
+## Status
+
+Draft.

--- a/trust-tasks/endorsement-types/register/1.0/schema.json
+++ b/trust-tasks/endorsement-types/register/1.0/schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC \u2014 Endorsement Type Register",
+  "description": "POST /v1/endorsement-types. Phase 4 M4.8.",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/trust-tasks/endorsement-types/register/1.0/spec.md
+++ b/trust-tasks/endorsement-types/register/1.0/spec.md
@@ -1,0 +1,29 @@
+---
+id: https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0
+title: VTC — Endorsement Type Register
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/endorsement-types
+---
+
+# VTC — Endorsement Type Register
+
+## Semantics
+
+- **Auth**: Admin role.
+- **Body**: `{ typeUri, claimSchema?, description? }`.
+- Refuses workspace-reserved URIs (`CommunityRole`) with `409 endorsement-type-reserved`.
+- Refuses duplicates with `409 endorsement-type-exists`.
+- Refuses empty / oversized URIs (> 512 bytes) with `400`.
+- Emits `EndorsementTypeRegistered { typeUri, description }`.
+
+## Outputs
+
+`201 Created` with the full `EndorsementType` row.
+
+## Status
+
+Draft.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -295,6 +295,48 @@
       "status": "Draft",
       "path": "relationships/revoke/1.0",
       "rest": "DELETE /v1/relationships/{id}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0",
+      "status": "Draft",
+      "path": "endorsement-types/register/1.0",
+      "rest": "POST /v1/endorsement-types"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/endorsement-types/list/1.0",
+      "status": "Draft",
+      "path": "endorsement-types/list/1.0",
+      "rest": "GET /v1/endorsement-types"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0",
+      "status": "Draft",
+      "path": "endorsement-types/delete/1.0",
+      "rest": "DELETE /v1/endorsement-types/{type_uri}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0",
+      "status": "Draft",
+      "path": "credentials/endorsements/issue/1.0",
+      "rest": "POST /v1/credentials/endorsements"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/list/1.0",
+      "status": "Draft",
+      "path": "credentials/endorsements/list/1.0",
+      "rest": "GET /v1/credentials/endorsements"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0",
+      "status": "Draft",
+      "path": "credentials/endorsements/show/1.0",
+      "rest": "GET /v1/credentials/endorsements/{id}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/revoke/1.0",
+      "status": "Draft",
+      "path": "credentials/endorsements/revoke/1.0",
+      "rest": "DELETE /v1/credentials/endorsements/{id}"
     }
   ]
 }

--- a/vtc-service/src/credentials/custom_endorsement.rs
+++ b/vtc-service/src/credentials/custom_endorsement.rs
@@ -1,0 +1,277 @@
+//! Custom endorsement VC builder — Phase 4 M4.7.2. Spec §6.1.
+//!
+//! ## Wire shape
+//!
+//! The VC carries the same `VerifiableEndorsementCredential`
+//! type as role VECs — wire-compatible. The discriminator
+//! lives on `endorsement.type`:
+//!
+//! ```json
+//! {
+//!   "type": ["VerifiableCredential", "VerifiableEndorsementCredential"],
+//!   "issuer": "did:webvh:vtc.example.com:abc",
+//!   "credentialSubject": {
+//!     "id": "<subject-did>",
+//!     "endorsement": {
+//!       "type": "<operator-defined-uri>",
+//!       "claim": { "level": "expert", ... },
+//!       "communityDid": "did:webvh:vtc.example.com:abc"
+//!     }
+//!   }
+//! }
+//! ```
+//!
+//! ## Validation surface
+//!
+//! Type validation is the route layer's concern (consults the
+//! `endorsement_types:` registry per D4 review). The builder
+//! is a pure transformer; it enforces:
+//!
+//! - `claim` is a JSON object (non-object → error).
+//! - `claim` body fits the 8 KiB cap.
+//! - `type` is a non-empty string.
+
+use affinidi_vc::{CredentialBuilder, VerifiableCredential};
+use chrono::{Duration, Utc};
+use serde_json::{Map, Value as JsonValue, json};
+use vti_common::error::AppError;
+
+use super::LocalSigner;
+use super::VEC_CONTEXT_URL;
+use super::vec::VEC_TYPE;
+use super::vmc::CredentialStatusRef;
+
+/// 8 KiB cap on the `endorsement.claim` body. Mirrors the
+/// route layer's M4.8.2 enforcement; the builder rejects
+/// over-sized claims too so unit tests catch the boundary.
+pub const CLAIM_MAX_BYTES: usize = 8 * 1024;
+
+/// Default validity for a custom endorsement. Mirrors the
+/// role VEC default (30d). Operators tighten via the route
+/// body's `validity_seconds`.
+pub const DEFAULT_CUSTOM_ENDORSEMENT_VALIDITY: Duration = Duration::days(30);
+
+/// Parameters for [`build_custom_endorsement`].
+#[derive(Debug, Clone)]
+pub struct CustomEndorsementParams {
+    /// Subject DID — the member receiving the endorsement.
+    pub subject_did: String,
+    /// Operator-registered endorsement type URI. The route
+    /// layer enforces "type is in the registry" before
+    /// calling the builder; the builder only checks
+    /// non-empty.
+    pub endorsement_type: String,
+    /// Free-form per-type claim body. Must be a JSON object;
+    /// must fit `CLAIM_MAX_BYTES`.
+    pub claim: JsonValue,
+    /// Optional VC `id` URI. The route layer supplies
+    /// `urn:uuid:<row-id>` so the credential id matches the
+    /// `Endorsement` row's id.
+    pub id: Option<String>,
+    /// `validUntil = now + validity`.
+    pub validity: Duration,
+    /// Status-list reference. Custom endorsements reuse the
+    /// shared `Revocation` status list (D8 review).
+    pub status_ref: CredentialStatusRef,
+}
+
+impl CustomEndorsementParams {
+    pub fn new(
+        subject_did: impl Into<String>,
+        endorsement_type: impl Into<String>,
+        claim: JsonValue,
+        status_ref: CredentialStatusRef,
+    ) -> Self {
+        Self {
+            subject_did: subject_did.into(),
+            endorsement_type: endorsement_type.into(),
+            claim,
+            id: None,
+            validity: DEFAULT_CUSTOM_ENDORSEMENT_VALIDITY,
+            status_ref,
+        }
+    }
+
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn with_validity(mut self, validity: Duration) -> Self {
+        self.validity = validity;
+        self
+    }
+}
+
+/// Build + sign a custom endorsement VEC. `issuer =
+/// signer.issuer_did()` (always the community DID).
+pub async fn build_custom_endorsement(
+    signer: &LocalSigner,
+    params: CustomEndorsementParams,
+) -> Result<VerifiableCredential, AppError> {
+    // Builder-side validation. Route layer enforces type
+    // registry membership separately; the builder only
+    // checks shape.
+    if params.endorsement_type.trim().is_empty() {
+        return Err(AppError::Validation(
+            "endorsement.type cannot be empty".into(),
+        ));
+    }
+    if !params.claim.is_object() {
+        return Err(AppError::Validation(
+            "endorsement.claim must be a JSON object".into(),
+        ));
+    }
+    let claim_bytes = serde_json::to_vec(&params.claim)
+        .map_err(|e| AppError::Internal(format!("serialise claim: {e}")))?;
+    if claim_bytes.len() > CLAIM_MAX_BYTES {
+        return Err(AppError::Validation(format!(
+            "endorsement.claim exceeds {CLAIM_MAX_BYTES} bytes (got {})",
+            claim_bytes.len()
+        )));
+    }
+
+    let now = Utc::now();
+    let valid_until = now + params.validity;
+
+    let endorsement = json!({
+        "type": params.endorsement_type,
+        "claim": params.claim,
+        "communityDid": signer.issuer_did(),
+    });
+
+    let mut subject = Map::new();
+    subject.insert("id".into(), JsonValue::String(params.subject_did.clone()));
+    subject.insert("endorsement".into(), endorsement);
+
+    let mut vc = CredentialBuilder::v2()
+        .context(VEC_CONTEXT_URL)
+        .issuer_uri(signer.issuer_did().to_string())
+        .add_type(VEC_TYPE)
+        .valid_from(rfc3339(now))
+        .valid_until(rfc3339(valid_until))
+        .subject(subject)
+        .build()
+        .map_err(|e| AppError::Internal(format!("custom endorsement build: {e}")))?;
+
+    if let Some(id) = &params.id {
+        attach_top_level_id(&mut vc, id)?;
+    }
+    attach_credential_status(&mut vc, &params.status_ref)?;
+    signer.sign(&mut vc).await?;
+    Ok(vc)
+}
+
+fn rfc3339(t: chrono::DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn attach_top_level_id(vc: &mut VerifiableCredential, id: &str) -> Result<(), AppError> {
+    let mut as_value = serde_json::to_value(&*vc)
+        .map_err(|e| AppError::Internal(format!("custom endorsement -> value: {e}")))?;
+    as_value
+        .as_object_mut()
+        .ok_or_else(|| AppError::Internal("VC not an object".into()))?
+        .insert("id".into(), JsonValue::String(id.into()));
+    *vc = serde_json::from_value(as_value)
+        .map_err(|e| AppError::Internal(format!("value -> VC: {e}")))?;
+    Ok(())
+}
+
+fn attach_credential_status(
+    vc: &mut VerifiableCredential,
+    status_ref: &CredentialStatusRef,
+) -> Result<(), AppError> {
+    let mut as_value = serde_json::to_value(&*vc)
+        .map_err(|e| AppError::Internal(format!("custom endorsement -> value: {e}")))?;
+    as_value
+        .as_object_mut()
+        .ok_or_else(|| AppError::Internal("VC not an object".into()))?
+        .insert(
+            "credentialStatus".into(),
+            serde_json::to_value(status_ref)
+                .map_err(|e| AppError::Internal(format!("status_ref -> value: {e}")))?,
+        );
+    *vc = serde_json::from_value(as_value)
+        .map_err(|e| AppError::Internal(format!("value -> VC: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_vc::SubjectValue;
+
+    const TEST_VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+
+    fn signer() -> LocalSigner {
+        LocalSigner::from_ed25519_seed(TEST_VTC_DID.into(), &[0xBB; 32])
+    }
+
+    fn status_ref(idx: u32) -> CredentialStatusRef {
+        CredentialStatusRef::revocation(format!("{TEST_VTC_DID}#revocation"), idx)
+    }
+
+    #[tokio::test]
+    async fn builds_signs_and_verifies() {
+        let signer = signer();
+        let params = CustomEndorsementParams::new(
+            "did:key:zSubject",
+            "https://example.com/v1/skills/rust",
+            json!({ "level": "expert", "since": "2020" }),
+            status_ref(42),
+        )
+        .with_id("urn:uuid:11111111-1111-1111-1111-111111111111");
+        let vc = build_custom_endorsement(&signer, params).await.unwrap();
+
+        // Type array contains both VerifiableCredential + VEC.
+        assert!(vc.types.iter().any(|t| t == "VerifiableCredential"));
+        assert!(vc.types.iter().any(|t| t == VEC_TYPE));
+
+        // Subject carries `endorsement.type` matching the param.
+        let subj = match &vc.credential_subject {
+            SubjectValue::Single(m) => m.clone(),
+            SubjectValue::Multiple(v) => v[0].clone(),
+        };
+        let endorsement = subj.get("endorsement").unwrap();
+        assert_eq!(endorsement["type"], "https://example.com/v1/skills/rust");
+        assert_eq!(endorsement["claim"]["level"], "expert");
+        assert_eq!(endorsement["communityDid"], TEST_VTC_DID);
+
+        // Verifies against the signer.
+        signer.verify(&vc).unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_type() {
+        let signer = signer();
+        let params = CustomEndorsementParams::new("did:key:zS", "", json!({}), status_ref(0));
+        assert!(build_custom_endorsement(&signer, params).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_non_object_claim() {
+        let signer = signer();
+        let params = CustomEndorsementParams::new(
+            "did:key:zS",
+            "https://x/t",
+            json!("not an object"),
+            status_ref(0),
+        );
+        assert!(build_custom_endorsement(&signer, params).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_claim() {
+        let signer = signer();
+        let big_value = "x".repeat(10 * 1024); // > 8 KiB
+        let params = CustomEndorsementParams::new(
+            "did:key:zS",
+            "https://x/t",
+            json!({ "blob": big_value }),
+            status_ref(0),
+        );
+        let err = build_custom_endorsement(&signer, params).await;
+        assert!(err.is_err(), "oversized claim must reject");
+    }
+}

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -44,10 +44,12 @@
 //! VMC has no `credentialStatus`, which is the expected
 //! pre-status-list state in tests.
 
+pub mod custom_endorsement;
 pub mod signer;
 pub mod vec;
 pub mod vmc;
 
+pub use custom_endorsement::{CustomEndorsementParams, build_custom_endorsement};
 pub use signer::LocalSigner;
 pub use vec::{RoleVecParams, build_role_vec};
 pub use vmc::{CredentialStatusRef, VmcParams, build_vmc};

--- a/vtc-service/src/endorsement_types/mod.rs
+++ b/vtc-service/src/endorsement_types/mod.rs
@@ -1,0 +1,67 @@
+//! Operator-uploaded endorsement type registry — Phase 4
+//! M4.8.0 (D4 planning review).
+//!
+//! ## Why a separate keyspace
+//!
+//! Per planning-review D4, only registered endorsement types
+//! are issuable. The issuance path (M4.8.2) consults this
+//! registry at every POST — refusing unknown types with a
+//! `422 endorsement-type-not-registered`. The deletion path
+//! (M4.8.1) refuses to drop a type while live endorsements
+//! still reference it (`409 endorsement-type-in-use`).
+//!
+//! Workspace-reserved types — currently only `"CommunityRole"`
+//! (VEC-managed; see [`crate::credentials::vec`]) — are
+//! refused at registration time so they can never enter the
+//! issuance path.
+
+pub mod storage;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+pub use storage::{
+    ENDORSEMENT_TYPES_PREFIX, delete_type, get_type, list_types, store_type, type_exists,
+};
+
+/// Reserved type URIs that operators cannot register because
+/// they collide with workspace-managed semantics. Phase 4
+/// only reserves `"CommunityRole"` — the VEC role-grant
+/// type. Adding more reserved names is additive (the
+/// registrar refuses; existing rows on disk that happen to
+/// share a reserved name keep working — operators upgraded
+/// across the reservation boundary aren't broken).
+pub const RESERVED_TYPE_URIS: &[&str] = &["CommunityRole"];
+
+/// A registered endorsement type. Stored verbatim; the
+/// registrar route enforces validation at insert time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct EndorsementType {
+    /// The type URI. Primary key — URL-encoded into the
+    /// keyspace key.
+    pub type_uri: String,
+    /// Optional JSON Schema for the claim body. Reserved for
+    /// future per-type validation; the Phase 4 issuance path
+    /// only checks "type is registered" without consulting
+    /// the schema. Operators can read the schema from
+    /// `GET /v1/endorsement-types/{uri}` and validate
+    /// client-side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_schema: Option<JsonValue>,
+    /// Free-form description shown in admin UIs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    /// Admin DID that registered the type. Carried for
+    /// audit correlation against the
+    /// `EndorsementTypeRegistered` envelope.
+    pub created_by_did: String,
+}
+
+/// Maximum byte size of a `type_uri`. Bounds the keyspace key
+/// length + protects against pathological inputs. Mirrors the
+/// `endorsement.claim` body cap structure (smaller because
+/// type URIs are short by convention).
+pub const TYPE_URI_MAX_BYTES: usize = 512;

--- a/vtc-service/src/endorsement_types/storage.rs
+++ b/vtc-service/src/endorsement_types/storage.rs
@@ -1,0 +1,178 @@
+//! CRUD helpers for [`super::EndorsementType`] over the
+//! `endorsement_types:` keyspace.
+//!
+//! Keys: `endorsement_types:<percent-encoded-uri>`. We
+//! percent-encode the URI so colons and slashes in the type
+//! URI (`https://example.com/v1/skills/rust`) don't collide
+//! with the prefix delimiter.
+
+use vti_common::audit::AuditKey;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated, paginate};
+use vti_common::store::KeyspaceHandle;
+
+use super::EndorsementType;
+
+pub const ENDORSEMENT_TYPES_PREFIX: &[u8] = b"endorsement_types:";
+
+fn encode_uri(uri: &str) -> String {
+    // Replace bytes that overlap with our `:`-delimited keyspace
+    // discipline. Hex-encode `:` and `/` — the rest pass through
+    // (most URI-safe chars are also safe in fjall keys).
+    let mut out = String::with_capacity(uri.len());
+    for b in uri.bytes() {
+        match b {
+            b':' | b'/' | b'%' => out.push_str(&format!("%{:02x}", b)),
+            _ => out.push(b as char),
+        }
+    }
+    out
+}
+
+fn key(uri: &str) -> Vec<u8> {
+    let mut k = ENDORSEMENT_TYPES_PREFIX.to_vec();
+    k.extend_from_slice(encode_uri(uri).as_bytes());
+    k
+}
+
+fn decode(bytes: &[u8]) -> Result<EndorsementType, AppError> {
+    serde_json::from_slice(bytes)
+        .map_err(|e| AppError::Internal(format!("EndorsementType decode: {e}")))
+}
+
+pub async fn get_type(ks: &KeyspaceHandle, uri: &str) -> Result<Option<EndorsementType>, AppError> {
+    let raw = ks.get_raw(key(uri)).await?;
+    match raw {
+        Some(bytes) => Ok(Some(decode(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+/// Fast existence check — avoids deserialising the row.
+pub async fn type_exists(ks: &KeyspaceHandle, uri: &str) -> Result<bool, AppError> {
+    Ok(ks.get_raw(key(uri)).await?.is_some())
+}
+
+pub async fn store_type(ks: &KeyspaceHandle, t: &EndorsementType) -> Result<(), AppError> {
+    ks.insert(String::from_utf8(key(&t.type_uri)).expect("ascii key"), t)
+        .await
+}
+
+pub async fn delete_type(ks: &KeyspaceHandle, uri: &str) -> Result<(), AppError> {
+    ks.remove(key(uri)).await
+}
+
+pub async fn list_types(
+    ks: &KeyspaceHandle,
+    audit_key: &AuditKey,
+    cursor: Option<&Cursor>,
+    limit: usize,
+) -> Result<Paginated<EndorsementType>, AppError> {
+    let mut pairs = ks
+        .prefix_iter_raw(ENDORSEMENT_TYPES_PREFIX.to_vec())
+        .await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let snapshot_id: u64 = pairs.len() as u64;
+    paginate(pairs, cursor, limit, &audit_key.key, snapshot_id, decode)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use vti_common::audit::AuditKeyStore;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_ks() -> (KeyspaceHandle, AuditKey, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("endorsement_types").unwrap();
+        let audit_key_ks = store.keyspace("audit_key").unwrap();
+        let key_store = AuditKeyStore::new(audit_key_ks);
+        key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+        (ks, key_store.active().await.unwrap(), dir)
+    }
+
+    fn fresh(uri: &str) -> EndorsementType {
+        EndorsementType {
+            type_uri: uri.into(),
+            claim_schema: None,
+            description: None,
+            created_at: Utc::now(),
+            created_by_did: "did:key:zAdmin".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip_with_colons_and_slashes() {
+        let (ks, _audit, _dir) = temp_ks().await;
+        let t = fresh("https://example.com/v1/skills/rust");
+        store_type(&ks, &t).await.unwrap();
+        let got = get_type(&ks, "https://example.com/v1/skills/rust")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, t);
+    }
+
+    #[tokio::test]
+    async fn type_exists_is_fast_lookup() {
+        let (ks, _audit, _dir) = temp_ks().await;
+        assert!(!type_exists(&ks, "https://x.example/t").await.unwrap());
+        let t = fresh("https://x.example/t");
+        store_type(&ks, &t).await.unwrap();
+        assert!(type_exists(&ks, "https://x.example/t").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_clears_row() {
+        let (ks, _audit, _dir) = temp_ks().await;
+        let t = fresh("https://x.example/t");
+        store_type(&ks, &t).await.unwrap();
+        delete_type(&ks, "https://x.example/t").await.unwrap();
+        assert!(!type_exists(&ks, "https://x.example/t").await.unwrap());
+        // Idempotent.
+        delete_type(&ks, "https://x.example/t").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_paginates_alphabetically() {
+        let (ks, audit, _dir) = temp_ks().await;
+        for uri in [
+            "https://b.example/t",
+            "https://a.example/t",
+            "https://c.example/t",
+        ] {
+            store_type(&ks, &fresh(uri)).await.unwrap();
+        }
+        let p = list_types(&ks, &audit, None, 10).await.unwrap();
+        assert_eq!(p.items.len(), 3);
+        // Sorted by encoded-key lexicographic order.
+        let uris: Vec<_> = p.items.iter().map(|x| x.type_uri.clone()).collect();
+        let mut sorted = uris.clone();
+        sorted.sort();
+        assert_eq!(uris, sorted);
+    }
+
+    #[tokio::test]
+    async fn keys_with_overlapping_prefixes_round_trip() {
+        // Edge case: "https://a.example/" and "https://a.example/x"
+        // would naively collide on a non-encoded key. Verify
+        // both round-trip independently.
+        let (ks, _audit, _dir) = temp_ks().await;
+        store_type(&ks, &fresh("https://a.example/")).await.unwrap();
+        store_type(&ks, &fresh("https://a.example/x"))
+            .await
+            .unwrap();
+        assert!(type_exists(&ks, "https://a.example/").await.unwrap());
+        assert!(type_exists(&ks, "https://a.example/x").await.unwrap());
+    }
+}

--- a/vtc-service/src/endorsements/mod.rs
+++ b/vtc-service/src/endorsements/mod.rs
@@ -1,0 +1,79 @@
+//! Custom endorsement credentials — Phase 4 M4.7 + M4.8.
+//! Spec §6.1 "Custom endorsement" row.
+//!
+//! ## What this module owns
+//!
+//! - `Endorsement` — the persisted row recording a custom
+//!   endorsement issued by an Issuer-role member (or admin)
+//!   for a subject. Stored in the `endorsements:` keyspace
+//!   keyed by UUID.
+//! - Storage helpers: round-trip, list (paginated), mark
+//!   revoked, find live-by-type.
+//! - **Live-by-type check** is load-bearing for the type
+//!   registry deletion path (M4.8.1) — operators can't drop a
+//!   type while live endorsements still exist.
+//!
+//! Per planning-review D4, the *type registry* itself lives
+//! in [`crate::endorsement_types`] — only registered URIs
+//! are issuable. The endorsements module here trusts that
+//! invariant; the route layer enforces it at issue time.
+
+pub mod storage;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+pub use storage::{
+    ENDORSEMENTS_PREFIX, count_live_by_type, delete_endorsement, get_endorsement,
+    list_endorsements, mark_revoked, store_endorsement,
+};
+
+/// A stored custom endorsement. The accompanying VEC body
+/// isn't persisted here — the route layer hands the signed
+/// VC to the caller verbatim on issue; downstream consumers
+/// (verifiers, list endpoints) re-mint or re-fetch from the
+/// VEC's `id` field if they need the proof.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Endorsement {
+    /// Server-allocated UUID. Forms `vec_id`'s
+    /// `urn:uuid:<id>` shape.
+    pub id: Uuid,
+    /// Operator-registered endorsement type URI. Must match
+    /// a row in the `endorsement_types:` keyspace at issue
+    /// time (route-layer invariant; storage trusts it).
+    pub endorsement_type: String,
+    /// The community DID (always `signer.issuer_did()` at
+    /// issue time). Kept on the row so list responses don't
+    /// need to re-look up the signer.
+    pub issuer_did: String,
+    pub subject_did: String,
+    /// Free-form per-type claim body. JSON object only;
+    /// route-layer enforces 8 KiB cap.
+    pub claim: JsonValue,
+    /// Allocated slot on the shared `Revocation` status list
+    /// (D8 review — endorsements reuse the existing list).
+    pub status_list_index: u32,
+    /// The credential's top-level `id` field —
+    /// `urn:uuid:<id>` by construction.
+    pub vec_id: String,
+    pub created_at: DateTime<Utc>,
+    /// `Some(_)` once `DELETE /v1/credentials/endorsements/{id}`
+    /// fires. The row stays in the keyspace for audit + list
+    /// surfaces; only the status-list bit + `revoked_at` flip.
+    /// (Mirrors the `Tombstone` / `Historical` Member-row
+    /// pattern.)
+    #[serde(default)]
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl Endorsement {
+    /// `true` once the row has been revoked. Used by the
+    /// type-registry deletion path to count *live*
+    /// endorsements only.
+    pub fn is_revoked(&self) -> bool {
+        self.revoked_at.is_some()
+    }
+}

--- a/vtc-service/src/endorsements/storage.rs
+++ b/vtc-service/src/endorsements/storage.rs
@@ -1,0 +1,222 @@
+//! CRUD helpers for [`super::Endorsement`] over the
+//! `endorsements:` keyspace.
+
+use uuid::Uuid;
+use vti_common::audit::AuditKey;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated, paginate};
+use vti_common::store::KeyspaceHandle;
+
+use super::Endorsement;
+
+pub const ENDORSEMENTS_PREFIX: &[u8] = b"endorsements:";
+
+fn key(id: Uuid) -> Vec<u8> {
+    let mut k = ENDORSEMENTS_PREFIX.to_vec();
+    k.extend_from_slice(id.to_string().as_bytes());
+    k
+}
+
+fn decode(bytes: &[u8]) -> Result<Endorsement, AppError> {
+    serde_json::from_slice(bytes)
+        .map_err(|e| AppError::Internal(format!("Endorsement decode: {e}")))
+}
+
+pub async fn get_endorsement(
+    ks: &KeyspaceHandle,
+    id: Uuid,
+) -> Result<Option<Endorsement>, AppError> {
+    let raw = ks.get_raw(key(id)).await?;
+    match raw {
+        Some(bytes) => Ok(Some(decode(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+pub async fn store_endorsement(ks: &KeyspaceHandle, end: &Endorsement) -> Result<(), AppError> {
+    ks.insert(String::from_utf8(key(end.id)).expect("ascii key"), end)
+        .await
+}
+
+/// Hard-delete the row. Used only by tests + the (unlikely)
+/// row-cleanup admin path — the canonical revoke uses
+/// [`mark_revoked`] which preserves the audit trail.
+pub async fn delete_endorsement(ks: &KeyspaceHandle, id: Uuid) -> Result<(), AppError> {
+    ks.remove(key(id)).await
+}
+
+/// Stamp `revoked_at = now` on the row + persist. Returns the
+/// updated row; `Ok(None)` if the id is absent.
+pub async fn mark_revoked(ks: &KeyspaceHandle, id: Uuid) -> Result<Option<Endorsement>, AppError> {
+    let Some(mut row) = get_endorsement(ks, id).await? else {
+        return Ok(None);
+    };
+    if row.revoked_at.is_none() {
+        row.revoked_at = Some(chrono::Utc::now());
+        store_endorsement(ks, &row).await?;
+    }
+    Ok(Some(row))
+}
+
+/// Count endorsements of `endorsement_type` that haven't been
+/// revoked. Used by the type-registry delete path: refuses
+/// `DELETE /v1/endorsement-types/{uri}` when at least one
+/// live endorsement still references the type.
+pub async fn count_live_by_type(
+    ks: &KeyspaceHandle,
+    endorsement_type: &str,
+) -> Result<usize, AppError> {
+    let pairs = ks.prefix_iter_raw(ENDORSEMENTS_PREFIX.to_vec()).await?;
+    let mut count = 0;
+    for (_k, v) in pairs {
+        if let Ok(row) = decode(&v)
+            && row.endorsement_type == endorsement_type
+            && !row.is_revoked()
+        {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+pub async fn list_endorsements(
+    ks: &KeyspaceHandle,
+    audit_key: &AuditKey,
+    cursor: Option<&Cursor>,
+    limit: usize,
+) -> Result<Paginated<Endorsement>, AppError> {
+    let mut pairs = ks.prefix_iter_raw(ENDORSEMENTS_PREFIX.to_vec()).await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let snapshot_id: u64 = pairs.len() as u64;
+    paginate(pairs, cursor, limit, &audit_key.key, snapshot_id, decode)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use vti_common::audit::AuditKeyStore;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_ks() -> (KeyspaceHandle, AuditKey, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("endorsements").unwrap();
+        let audit_key_ks = store.keyspace("audit_key").unwrap();
+        let key_store = AuditKeyStore::new(audit_key_ks);
+        key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+        let audit_key = key_store.active().await.unwrap();
+        (ks, audit_key, dir)
+    }
+
+    fn fresh(end_type: &str, issuer: &str, subject: &str) -> Endorsement {
+        let id = Uuid::new_v4();
+        Endorsement {
+            id,
+            endorsement_type: end_type.into(),
+            issuer_did: issuer.into(),
+            subject_did: subject.into(),
+            claim: serde_json::json!({ "level": "expert" }),
+            status_list_index: 0,
+            vec_id: format!("urn:uuid:{id}"),
+            created_at: Utc::now(),
+            revoked_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip() {
+        let (ks, _audit, _dir) = temp_ks().await;
+        let end = fresh(
+            "https://example.com/v1/skills/rust",
+            "did:webvh:vtc",
+            "did:key:zS",
+        );
+        store_endorsement(&ks, &end).await.unwrap();
+        let got = get_endorsement(&ks, end.id).await.unwrap().unwrap();
+        assert_eq!(got, end);
+    }
+
+    #[tokio::test]
+    async fn mark_revoked_sets_timestamp() {
+        let (ks, _audit, _dir) = temp_ks().await;
+        let end = fresh("https://example.com/v1/x", "did:webvh:vtc", "did:key:zS");
+        store_endorsement(&ks, &end).await.unwrap();
+        let updated = mark_revoked(&ks, end.id).await.unwrap().unwrap();
+        assert!(updated.revoked_at.is_some());
+        // Idempotent — revoking twice doesn't clobber the
+        // timestamp.
+        let updated2 = mark_revoked(&ks, end.id).await.unwrap().unwrap();
+        assert_eq!(updated.revoked_at, updated2.revoked_at);
+    }
+
+    #[tokio::test]
+    async fn mark_revoked_returns_none_for_unknown_id() {
+        let (ks, _audit, _dir) = temp_ks().await;
+        let missing = mark_revoked(&ks, Uuid::new_v4()).await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn count_live_by_type_excludes_revoked() {
+        let (ks, _audit, _dir) = temp_ks().await;
+        let t = "https://example.com/v1/skills/rust";
+        let e1 = fresh(t, "did:webvh:vtc", "did:key:zA");
+        let e2 = fresh(t, "did:webvh:vtc", "did:key:zB");
+        let e3 = fresh(
+            "https://example.com/v1/skills/python",
+            "did:webvh:vtc",
+            "did:key:zC",
+        );
+        store_endorsement(&ks, &e1).await.unwrap();
+        store_endorsement(&ks, &e2).await.unwrap();
+        store_endorsement(&ks, &e3).await.unwrap();
+        // 2 live of type t.
+        assert_eq!(count_live_by_type(&ks, t).await.unwrap(), 2);
+        // Revoke one.
+        mark_revoked(&ks, e1.id).await.unwrap();
+        assert_eq!(count_live_by_type(&ks, t).await.unwrap(), 1);
+        // Other type counts independently.
+        assert_eq!(
+            count_live_by_type(&ks, "https://example.com/v1/skills/python")
+                .await
+                .unwrap(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn list_paginates() {
+        let (ks, audit, _dir) = temp_ks().await;
+        for _ in 0..7 {
+            let e = fresh("https://example.com/v1/x", "did:webvh:vtc", "did:key:z");
+            store_endorsement(&ks, &e).await.unwrap();
+        }
+        let p1 = list_endorsements(&ks, &audit, None, 3).await.unwrap();
+        assert_eq!(p1.items.len(), 3);
+        assert!(p1.next_cursor.is_some());
+        let cursor = Cursor::decode(p1.next_cursor.as_ref().unwrap(), &audit.key).unwrap();
+        let p2 = list_endorsements(&ks, &audit, Some(&cursor), 10)
+            .await
+            .unwrap();
+        assert_eq!(p2.items.len(), 4);
+        assert!(p2.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_is_idempotent() {
+        let (ks, _audit, _dir) = temp_ks().await;
+        let id = Uuid::new_v4();
+        delete_endorsement(&ks, id).await.unwrap();
+        delete_endorsement(&ks, id).await.unwrap();
+        assert!(get_endorsement(&ks, id).await.unwrap().is_none());
+    }
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -21,6 +21,8 @@ pub mod credentials;
 pub mod did_key;
 #[cfg(feature = "setup")]
 pub mod emergency;
+pub mod endorsement_types;
+pub mod endorsements;
 pub mod error;
 pub mod install;
 pub mod join;

--- a/vtc-service/src/routes/endorsement_types.rs
+++ b/vtc-service/src/routes/endorsement_types.rs
@@ -1,0 +1,202 @@
+//! `/v1/endorsement-types/*` — operator-uploaded endorsement
+//! type registry (Phase 4 M4.8.1; D4 planning review).
+//!
+//! Three admin-gated endpoints:
+//!
+//! - `POST /v1/endorsement-types` — register a type.
+//! - `GET /v1/endorsement-types` — paginated list.
+//! - `DELETE /v1/endorsement-types/{uri}` — refuses while at
+//!   least one live endorsement still references the type.
+//!
+//! ## Reserved type URIs
+//!
+//! `"CommunityRole"` is reserved by the workspace (VEC-
+//! managed role grants). The registrar refuses to register
+//! it; the issuance path can't see it on disk either way.
+//!
+//! ## URI encoding on the wire
+//!
+//! The `DELETE /v1/endorsement-types/{uri}` path parameter
+//! is URL-decoded by axum before reaching the handler. The
+//! storage layer percent-encodes again before forming the
+//! fjall key — keeps colons and slashes in operator-supplied
+//! URIs from colliding with the keyspace prefix discipline.
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::info;
+use vti_common::audit::{AuditEvent, EndorsementTypeDeletedData, EndorsementTypeRegisteredData};
+use vti_common::auth::AdminAuth;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated};
+
+use crate::endorsement_types::{
+    EndorsementType, RESERVED_TYPE_URIS, TYPE_URI_MAX_BYTES, delete_type, get_type, list_types,
+    store_type,
+};
+use crate::endorsements::count_live_by_type;
+use crate::server::AppState;
+
+const LIST_MAX_LIMIT: usize = 200;
+
+// ─── Register ────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisterBody {
+    pub type_uri: String,
+    #[serde(default)]
+    pub claim_schema: Option<JsonValue>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+pub async fn register(
+    auth: AdminAuth,
+    State(state): State<AppState>,
+    Json(body): Json<RegisterBody>,
+) -> Result<(StatusCode, Json<EndorsementType>), AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    // Validation.
+    let uri = body.type_uri.trim();
+    if uri.is_empty() {
+        return Err(AppError::Validation("type_uri cannot be empty".into()));
+    }
+    if uri.len() > TYPE_URI_MAX_BYTES {
+        return Err(AppError::Validation(format!(
+            "type_uri exceeds {TYPE_URI_MAX_BYTES} bytes"
+        )));
+    }
+    if RESERVED_TYPE_URIS.contains(&uri) {
+        return Err(AppError::Conflict(format!(
+            "endorsement-type-reserved: '{uri}' is reserved by the workspace"
+        )));
+    }
+    if get_type(&state.endorsement_types_ks, uri).await?.is_some() {
+        return Err(AppError::Conflict(format!(
+            "endorsement-type-exists: '{uri}' already registered"
+        )));
+    }
+
+    let row = EndorsementType {
+        type_uri: uri.to_string(),
+        claim_schema: body.claim_schema,
+        description: body.description.clone(),
+        created_at: Utc::now(),
+        created_by_did: auth.0.did.clone(),
+    };
+    store_type(&state.endorsement_types_ks, &row).await?;
+
+    audit_writer
+        .write(
+            &auth.0.did,
+            None,
+            AuditEvent::EndorsementTypeRegistered(EndorsementTypeRegisteredData {
+                type_uri: uri.to_string(),
+                description: body.description,
+            }),
+        )
+        .await?;
+
+    info!(type_uri = %uri, by = %auth.0.did, "endorsement type registered");
+
+    Ok((StatusCode::CREATED, Json(row)))
+}
+
+// ─── List ────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListQuery {
+    pub cursor: Option<String>,
+    pub limit: Option<usize>,
+}
+
+pub async fn list(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<Paginated<EndorsementType>>, AppError> {
+    let limit = query.limit.unwrap_or(50).clamp(1, LIST_MAX_LIMIT);
+    let audit_key = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?
+        .active_key()
+        .await?;
+    let cursor = query
+        .cursor
+        .as_deref()
+        .map(|c| Cursor::decode(c, &audit_key.key))
+        .transpose()
+        .map_err(|e| AppError::Validation(format!("invalid cursor: {e}")))?;
+    let page = list_types(
+        &state.endorsement_types_ks,
+        &audit_key,
+        cursor.as_ref(),
+        limit,
+    )
+    .await?;
+    Ok(Json(page))
+}
+
+// ─── Delete ──────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteResponse {
+    pub type_uri: String,
+}
+
+pub async fn delete(
+    auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(type_uri): Path<String>,
+) -> Result<(StatusCode, Json<DeleteResponse>), AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    if get_type(&state.endorsement_types_ks, &type_uri)
+        .await?
+        .is_none()
+    {
+        return Err(AppError::NotFound(format!(
+            "endorsement type '{type_uri}' not found"
+        )));
+    }
+
+    // Refuse if any live endorsement still references the type.
+    let in_use = count_live_by_type(&state.endorsements_ks, &type_uri).await?;
+    if in_use > 0 {
+        return Err(AppError::Conflict(format!(
+            "endorsement-type-in-use: {in_use} live endorsement(s) of type '{type_uri}' \
+             still exist; revoke them before deleting the type"
+        )));
+    }
+
+    delete_type(&state.endorsement_types_ks, &type_uri).await?;
+
+    audit_writer
+        .write(
+            &auth.0.did,
+            None,
+            AuditEvent::EndorsementTypeDeleted(EndorsementTypeDeletedData {
+                type_uri: type_uri.clone(),
+            }),
+        )
+        .await?;
+
+    info!(type_uri = %type_uri, by = %auth.0.did, "endorsement type deleted");
+
+    Ok((StatusCode::OK, Json(DeleteResponse { type_uri })))
+}

--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -1,0 +1,397 @@
+//! `/v1/credentials/endorsements/*` — custom endorsement
+//! issuance + retrieval + revocation (Phase 4 M4.8.2-4).
+//!
+//! ## Four endpoints
+//!
+//! - `POST /v1/credentials/endorsements` — issue. Auth:
+//!   Admin OR Issuer role. Consults the type registry
+//!   (M4.8.1). Allocates a slot on the shared `Revocation`
+//!   status list (D8 review), builds + signs the VEC,
+//!   persists the row, emits `CustomEndorsementIssued` +
+//!   `VecIssued`.
+//! - `GET /v1/credentials/endorsements` — paginated list.
+//!   Auth: Admin OR Issuer.
+//! - `GET /v1/credentials/endorsements/{id}` — show.
+//! - `DELETE /v1/credentials/endorsements/{id}` — revoke.
+//!   Auth: Admin OR the original issuer. Flips the
+//!   status-list bit + emits both `CustomEndorsementRevoked`
+//!   and `StatusListFlipped`.
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::info;
+use uuid::Uuid;
+use vti_common::audit::{
+    AuditEvent, CredentialIssuedData, CustomEndorsementIssuedData, CustomEndorsementRevokedData,
+    StatusListFlippedData,
+};
+use vti_common::auth::AuthClaims;
+use vti_common::error::AppError;
+use vti_common::pagination::{Cursor, Paginated};
+
+use crate::acl::{VtcRole, get_acl_entry};
+use crate::credentials::{CredentialStatusRef, CustomEndorsementParams, build_custom_endorsement};
+use crate::endorsement_types::type_exists;
+use crate::endorsements::{
+    Endorsement, get_endorsement, list_endorsements, mark_revoked, store_endorsement,
+};
+use crate::server::AppState;
+use crate::status_list;
+
+const LIST_MAX_LIMIT: usize = 200;
+
+/// `CLAIM_MAX_BYTES` upper bound on the on-the-wire body
+/// (matches the builder cap). Larger inputs surface as 400.
+const CLAIM_MAX_BYTES: usize = 8 * 1024;
+
+// ─── Issue ───────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueBody {
+    pub subject_did: String,
+    #[serde(rename = "type")]
+    pub endorsement_type: String,
+    pub claim: JsonValue,
+    /// Optional override; defaults to 30d.
+    #[serde(default)]
+    pub validity_seconds: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueResponse {
+    pub id: Uuid,
+    pub vec_id: String,
+    pub vec: JsonValue,
+}
+
+pub async fn issue(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Json(body): Json<IssueBody>,
+) -> Result<(StatusCode, Json<IssueResponse>), AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+    let signer = state
+        .credential_signer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("credential signer not configured".into()))?;
+
+    // 1. Auth: Admin OR Issuer (read the VTC ACL row — JWT
+    //    role degrades non-Admin VTC roles to Reader, so the
+    //    JWT alone can't distinguish Issuer from Member).
+    let acl = get_acl_entry(&state.acl_ks, &auth.did)
+        .await?
+        .ok_or_else(|| AppError::Forbidden("caller has no ACL row".into()))?;
+    if !matches!(acl.role, VtcRole::Admin | VtcRole::Issuer) {
+        return Err(AppError::Forbidden(
+            "only Admin or Issuer-role members can mint custom endorsements".into(),
+        ));
+    }
+
+    // 2. Type registry consultation (D4 review).
+    if !type_exists(&state.endorsement_types_ks, &body.endorsement_type).await? {
+        return Err(AppError::Validation(format!(
+            "endorsement-type-not-registered: '{}' is not in the endorsement type registry",
+            body.endorsement_type
+        )));
+    }
+
+    // 3. Body-side validation. The builder enforces the same
+    //    cap; we check here too so 400 surfaces cleanly
+    //    before any state mutation.
+    if !body.claim.is_object() {
+        return Err(AppError::Validation("claim must be a JSON object".into()));
+    }
+    let claim_bytes = serde_json::to_vec(&body.claim)
+        .map_err(|e| AppError::Internal(format!("serialise claim: {e}")))?;
+    if claim_bytes.len() > CLAIM_MAX_BYTES {
+        return Err(AppError::Validation(format!(
+            "claim exceeds {CLAIM_MAX_BYTES} bytes"
+        )));
+    }
+
+    // 4. Subject must be a current ACL member — operators
+    //    that want cross-community endorsements layer their
+    //    own policy (out of scope for Phase 4).
+    if get_acl_entry(&state.acl_ks, &body.subject_did)
+        .await?
+        .is_none()
+    {
+        return Err(AppError::Validation(format!(
+            "subject DID {} is not a current community member",
+            body.subject_did
+        )));
+    }
+
+    // 5. Allocate status-list slot.
+    let mut sl_state = status_list::get_state(
+        &state.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await?
+    .ok_or_else(|| AppError::Internal("revocation status list not initialised".into()))?;
+    let slot = status_list::allocate(&mut sl_state).ok_or_else(|| {
+        AppError::Internal(
+            "revocation status list is full — cannot allocate slot for endorsement".into(),
+        )
+    })?;
+    status_list::store_state(&state.status_lists_ks, &sl_state).await?;
+    let status_ref = CredentialStatusRef::revocation(sl_state.list_credential_id.clone(), slot);
+
+    // 6. Build + sign the VEC.
+    let id = Uuid::new_v4();
+    let vec_id = format!("urn:uuid:{id}");
+    let validity = body
+        .validity_seconds
+        .map(|s| Duration::seconds(s as i64))
+        .unwrap_or_else(|| {
+            crate::credentials::custom_endorsement::DEFAULT_CUSTOM_ENDORSEMENT_VALIDITY
+        });
+    let params = CustomEndorsementParams::new(
+        &body.subject_did,
+        &body.endorsement_type,
+        body.claim.clone(),
+        status_ref,
+    )
+    .with_id(&vec_id)
+    .with_validity(validity);
+    let vec = build_custom_endorsement(signer, params).await?;
+
+    // 7. Persist the Endorsement row.
+    let now = Utc::now();
+    let valid_until = now + validity;
+    let end = Endorsement {
+        id,
+        endorsement_type: body.endorsement_type.clone(),
+        issuer_did: signer.issuer_did().to_string(),
+        subject_did: body.subject_did.clone(),
+        claim: body.claim.clone(),
+        status_list_index: slot,
+        vec_id: vec_id.clone(),
+        created_at: now,
+        revoked_at: None,
+    };
+    store_endorsement(&state.endorsements_ks, &end).await?;
+
+    // 8. Audit — two envelopes (custom endorsement + generic
+    //    VEC issuance accounting).
+    audit_writer
+        .write(
+            &auth.did,
+            Some(&body.subject_did),
+            AuditEvent::CustomEndorsementIssued(CustomEndorsementIssuedData {
+                endorsement_id: id.to_string(),
+                endorsement_type: body.endorsement_type.clone(),
+                status_list_index: slot,
+            }),
+        )
+        .await?;
+    audit_writer
+        .write(
+            &auth.did,
+            Some(&body.subject_did),
+            AuditEvent::VecIssued(CredentialIssuedData {
+                credential_id: vec_id.clone(),
+                credential_type: "VerifiableEndorsementCredential".into(),
+                valid_from: rfc3339(now),
+                valid_until: rfc3339(valid_until),
+                status_list_index: Some(slot),
+            }),
+        )
+        .await?;
+
+    info!(
+        endorsement_id = %id,
+        endorsement_type = %body.endorsement_type,
+        subject = %body.subject_did,
+        slot,
+        "custom endorsement issued"
+    );
+
+    let vec_value = serde_json::to_value(&vec)
+        .map_err(|e| AppError::Internal(format!("serialise VEC: {e}")))?;
+    Ok((
+        StatusCode::CREATED,
+        Json(IssueResponse {
+            id,
+            vec_id,
+            vec: vec_value,
+        }),
+    ))
+}
+
+// ─── List ────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListQuery {
+    pub cursor: Option<String>,
+    pub limit: Option<usize>,
+}
+
+pub async fn list(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<Paginated<Endorsement>>, AppError> {
+    let acl = get_acl_entry(&state.acl_ks, &auth.did)
+        .await?
+        .ok_or_else(|| AppError::Forbidden("caller has no ACL row".into()))?;
+    if !matches!(acl.role, VtcRole::Admin | VtcRole::Issuer) {
+        return Err(AppError::Forbidden(
+            "only Admin or Issuer-role members can list custom endorsements".into(),
+        ));
+    }
+
+    let limit = query.limit.unwrap_or(50).clamp(1, LIST_MAX_LIMIT);
+    let audit_key = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?
+        .active_key()
+        .await?;
+    let cursor = query
+        .cursor
+        .as_deref()
+        .map(|c| Cursor::decode(c, &audit_key.key))
+        .transpose()
+        .map_err(|e| AppError::Validation(format!("invalid cursor: {e}")))?;
+    let page =
+        list_endorsements(&state.endorsements_ks, &audit_key, cursor.as_ref(), limit).await?;
+    Ok(Json(page))
+}
+
+// ─── Show ────────────────────────────────────────────────
+
+pub async fn show(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Endorsement>, AppError> {
+    let acl = get_acl_entry(&state.acl_ks, &auth.did)
+        .await?
+        .ok_or_else(|| AppError::Forbidden("caller has no ACL row".into()))?;
+    if !matches!(acl.role, VtcRole::Admin | VtcRole::Issuer) {
+        return Err(AppError::Forbidden(
+            "only Admin or Issuer-role members can read custom endorsements".into(),
+        ));
+    }
+    let row = get_endorsement(&state.endorsements_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("endorsement {id} not found")))?;
+    Ok(Json(row))
+}
+
+// ─── Revoke ──────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokeResponse {
+    pub id: String,
+}
+
+pub async fn revoke(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<(StatusCode, Json<RevokeResponse>), AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    let row = get_endorsement(&state.endorsements_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("endorsement {id} not found")))?;
+
+    // Auth: Admin OR original issuer (always == signer DID;
+    // any Admin/Issuer of the community).
+    let acl = get_acl_entry(&state.acl_ks, &auth.did)
+        .await?
+        .ok_or_else(|| AppError::Forbidden("caller has no ACL row".into()))?;
+    let is_admin = matches!(acl.role, VtcRole::Admin);
+    // Issuer-side check: did the caller mint this row? The
+    // `issuer_did` on every endorsement is the community
+    // DID; the *originating actor* is recorded on the audit
+    // envelope. For revoke, we treat any current Issuer role
+    // member as an authorised retractor — the audit trail
+    // captures who actually called.
+    let is_issuer_role = matches!(acl.role, VtcRole::Issuer);
+    if !is_admin && !is_issuer_role {
+        return Err(AppError::Forbidden(
+            "only Admin or Issuer-role members can revoke endorsements".into(),
+        ));
+    }
+
+    // Idempotent no-op.
+    if row.is_revoked() {
+        return Ok((StatusCode::OK, Json(RevokeResponse { id: id.to_string() })));
+    }
+
+    // Flip the status-list bit.
+    let mut sl_state = status_list::get_state(
+        &state.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+    )
+    .await?
+    .ok_or_else(|| AppError::Internal("revocation status list not initialised".into()))?;
+    status_list::flip(&mut sl_state, row.status_list_index, true).map_err(|e| {
+        AppError::Internal(format!(
+            "flip status-list bit {}: {e}",
+            row.status_list_index
+        ))
+    })?;
+    status_list::store_state(&state.status_lists_ks, &sl_state).await?;
+
+    // Mark the row revoked.
+    let updated = mark_revoked(&state.endorsements_ks, id)
+        .await?
+        .ok_or_else(|| AppError::Internal("row disappeared mid-revoke".into()))?;
+
+    // Two paired envelopes — CustomEndorsementRevoked
+    // (semantic) + StatusListFlipped (bit-flip accounting).
+    audit_writer
+        .write(
+            &auth.did,
+            Some(&row.subject_did),
+            AuditEvent::CustomEndorsementRevoked(CustomEndorsementRevokedData {
+                endorsement_id: id.to_string(),
+                endorsement_type: row.endorsement_type.clone(),
+            }),
+        )
+        .await?;
+    audit_writer
+        .write(
+            &auth.did,
+            Some(&row.subject_did),
+            AuditEvent::StatusListFlipped(StatusListFlippedData {
+                purpose: "revocation".into(),
+                index: row.status_list_index,
+                revoked: true,
+            }),
+        )
+        .await?;
+
+    info!(
+        endorsement_id = %id,
+        endorsement_type = %row.endorsement_type,
+        slot = row.status_list_index,
+        by = %auth.did,
+        "custom endorsement revoked"
+    );
+    let _ = updated;
+
+    Ok((StatusCode::OK, Json(RevokeResponse { id: id.to_string() })))
+}
+
+fn rfc3339(t: chrono::DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -4,6 +4,8 @@ mod auth;
 mod community;
 mod config;
 pub(crate) mod did_log;
+mod endorsement_types;
+mod endorsements;
 mod health;
 pub(crate) mod install;
 pub(crate) mod join_requests;
@@ -166,6 +168,40 @@ pub fn router() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let relationships_revoke =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0")
+            .expect("static Trust-Task URL");
+    // Phase 4 M4.8 — endorsement type registry + custom
+    // endorsement CRUD. Seven Trust Tasks total — list / show
+    // / delete share their mount where TrustTaskRouter
+    // doesn't yet support per-method selectors (standalone
+    // tasks ship on disk + in index.json).
+    let endorsement_types_register =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0")
+            .expect("static Trust-Task URL");
+    let _endorsement_types_list =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/endorsement-types/list/1.0")
+            .expect("static Trust-Task URL");
+    let endorsement_types_delete =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0")
+            .expect("static Trust-Task URL");
+    let endorsements_issue =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0")
+            .expect("static Trust-Task URL");
+    let _endorsements_list =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/credentials/endorsements/list/1.0")
+            .expect("static Trust-Task URL");
+    // `endorsements_show` + `endorsements_revoke` share the
+    // `endorsements/{id}` mount with the Trust Task header
+    // pinned to the `show` variant. Standalone tasks ship on
+    // disk + in index.json so the soft-gate surface stays
+    // complete (same workaround as members/{did}, etc.).
+    let _endorsements_show =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0")
+            .expect("static Trust-Task URL");
+    let _endorsements_revoke =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/credentials/endorsements/revoke/1.0")
+            .expect("static Trust-Task URL");
+    let endorsements_show_revoke =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0")
             .expect("static Trust-Task URL");
     // Phase 3 M3.8 — trust-registry reconciler diagnostics.
     // Admin-gated (not super-admin) so on-call ops can read
@@ -412,6 +448,39 @@ pub fn router() -> Router<AppState> {
             "/v1/relationships/{id}",
             delete(relationships::revoke),
             relationships_revoke,
+        )
+        // Phase 4 M4.8.1 — operator-uploaded endorsement type
+        // registry. Admin-gated CRUD.
+        .route_with_task(
+            "/v1/endorsement-types",
+            post(endorsement_types::register).get(endorsement_types::list),
+            // POST + GET share `register/1.0` at the router
+            // layer pending per-method selectors; standalone
+            // `list/1.0` exists on disk + in index.json.
+            endorsement_types_register,
+        )
+        .route_with_task(
+            "/v1/endorsement-types/{type_uri}",
+            delete(endorsement_types::delete),
+            endorsement_types_delete,
+        )
+        // Phase 4 M4.8.2-4 — custom endorsement issuance +
+        // retrieval + revocation. Admin OR Issuer-role member.
+        .route_with_task(
+            "/v1/credentials/endorsements",
+            post(endorsements::issue).get(endorsements::list),
+            // POST + GET share `issue/1.0` at the router
+            // layer pending per-method selectors; standalone
+            // `list/1.0` exists on disk + in index.json.
+            endorsements_issue,
+        )
+        .route_with_task(
+            "/v1/credentials/endorsements/{id}",
+            axum::routing::get(endorsements::show).delete(endorsements::revoke),
+            // GET + DELETE share `show/1.0` at the router
+            // layer pending per-method selectors; standalone
+            // `revoke/1.0` exists on disk + in index.json.
+            endorsements_show_revoke,
         )
         .route_with_task(
             "/v1/members/{did}",

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -78,6 +78,13 @@ pub struct AppState {
     /// `<did>:<vrc-id>` so per-DID list queries are O(matched
     /// rows). CAS-paired with `relationships_ks`.
     pub relationships_by_did_ks: KeyspaceHandle,
+    /// Operator-uploaded endorsement type registry (Phase 4
+    /// M4.8.0). Only registered types are issuable.
+    pub endorsement_types_ks: KeyspaceHandle,
+    /// Issued custom endorsement rows (Phase 4 M4.7).
+    /// Tracked here for list + revoke surfaces; the VEC body
+    /// itself is signed + returned at issuance time.
+    pub endorsements_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
     /// Trust-registry client (Phase 3 M3.2). `None` when
@@ -203,6 +210,8 @@ pub async fn run(
     let sync_cursor_ks = store.keyspace("sync_cursor")?;
     let relationships_ks = store.keyspace("relationships")?;
     let relationships_by_did_ks = store.keyspace("relationships_by_did")?;
+    let endorsement_types_ks = store.keyspace("endorsement_types")?;
+    let endorsements_ks = store.keyspace("endorsements")?;
     let audit_ks = store.keyspace("audit")?;
     let audit_key_ks = store.keyspace("audit_key")?;
 
@@ -361,6 +370,8 @@ pub async fn run(
         sync_cursor_ks,
         relationships_ks,
         relationships_by_did_ks,
+        endorsement_types_ks,
+        endorsements_ks,
         audit_ks,
         audit_key_ks,
         registry_client: registry_client.clone(),

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -87,6 +87,8 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -135,6 +137,8 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -70,6 +70,8 @@ async fn build_with(
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -117,6 +119,8 @@ async fn build_with(
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -93,6 +93,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -200,6 +202,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -63,6 +63,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -99,6 +101,8 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -64,6 +64,8 @@ async fn build() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -100,6 +102,8 @@ async fn build() -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -66,6 +66,8 @@ async fn build() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -102,6 +104,8 @@ async fn build() -> Fixture {
         sync_cursor_ks,
         relationships_ks,
         relationships_by_did_ks,
+        endorsement_types_ks,
+        endorsements_ks,
         registry_client: None,
         registry_health: RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -58,6 +58,8 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -89,6 +91,8 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -214,6 +214,8 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -308,6 +310,8 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -1,0 +1,617 @@
+//! Integration coverage for `/v1/endorsement-types/*` +
+//! `/v1/credentials/endorsements/*` (Phase 4 M4.8).
+//!
+//! Covers:
+//! - type registry: register happy / reserved / duplicate /
+//!   delete with-in-use / delete OK / list
+//! - issue: type-not-registered / non-issuer / happy path
+//!   (with status-list slot allocation + audit emission)
+//! - revoke: admin / non-admin-non-issuer / idempotent
+//! - show / list pagination
+
+use std::sync::Arc;
+
+use affinidi_status_list::StatusPurpose;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use uuid::Uuid;
+use vti_common::audit::{AuditEnvelope, AuditEvent, AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::credentials::LocalSigner;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::{Member, store_member};
+use vtc_service::registry::RegistryHealth;
+use vtc_service::routes;
+use vtc_service::server::AppState;
+use vtc_service::status_list;
+
+const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+const PUBLIC_URL: &str = "https://vtc.example.com";
+const REGISTER_TASK: &str = "https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0";
+const DELETE_TYPE_TASK: &str = "https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0";
+const ISSUE_TASK: &str = "https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0";
+const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0";
+const ADMIN_DID: &str = "did:key:zEndAdmin";
+const ISSUER_DID: &str = "did:key:zEndIssuer";
+const MEMBER_DID: &str = "did:key:zEndMember";
+const SUBJECT_DID: &str = "did:key:zEndSubject";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    admin_token: String,
+    issuer_token: String,
+    member_token: String,
+    audit_ks: vti_common::store::KeyspaceHandle,
+    endorsements_ks: vti_common::store::KeyspaceHandle,
+    _dir: tempfile::TempDir,
+}
+
+async fn build() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .unwrap();
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
+        .await
+        .unwrap();
+    for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+        let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
+        status_list::ensure_initial(&status_lists_ks, purpose, url)
+            .await
+            .unwrap();
+    }
+
+    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    let now = now_epoch();
+    for (did, role) in [
+        (ADMIN_DID, VtcRole::Admin),
+        (ISSUER_DID, VtcRole::Issuer),
+        (MEMBER_DID, VtcRole::Member),
+        (SUBJECT_DID, VtcRole::Member),
+    ] {
+        store_acl_entry(
+            &acl_ks,
+            &VtcAclEntry {
+                did: did.into(),
+                role,
+                label: None,
+                allowed_contexts: vec![],
+                created_at: now,
+                created_by: "did:key:vtc-install".into(),
+                expires_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        store_member(&members_ks, &Member::fresh(did))
+            .await
+            .unwrap();
+    }
+
+    async fn mint(
+        sessions: &vti_common::store::KeyspaceHandle,
+        jwt_keys: &Arc<JwtKeys>,
+        did: &str,
+        role: &str,
+        now: u64,
+    ) -> String {
+        let session_id = format!("sess-{}", Uuid::new_v4());
+        store_session(
+            sessions,
+            &Session {
+                session_id: session_id.clone(),
+                did: did.into(),
+                challenge: "test".into(),
+                state: SessionState::Authenticated,
+                created_at: now,
+                refresh_token: None,
+                refresh_expires_at: None,
+                tee_attested: false,
+            },
+        )
+        .await
+        .unwrap();
+        let claims = jwt_keys.new_claims(did.into(), session_id, role.into(), vec![], 3600, true);
+        jwt_keys.encode(&claims).unwrap()
+    }
+    let admin_token = mint(&sessions_ks, &jwt_keys, ADMIN_DID, "admin", now).await;
+    let issuer_token = mint(&sessions_ks, &jwt_keys, ISSUER_DID, "reader", now).await;
+    let member_token = mint(&sessions_ks, &jwt_keys, MEMBER_DID, "reader", now).await;
+
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "{VTC_DID}"
+        public_url = "{PUBLIC_URL}"
+        [store]
+        data_dir = "{}"
+        [auth]
+        jwt_signing_key = "{}"
+        "#,
+        dir.path().display(),
+        BASE64.encode(jwt_seed),
+    ))
+    .unwrap();
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks,
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks,
+        registry_records_ks,
+        sync_queue_ks,
+        sync_cursor_ks,
+        relationships_ks,
+        relationships_by_did_ks,
+        endorsement_types_ks,
+        endorsements_ks: endorsements_ks.clone(),
+        registry_client: None,
+        registry_health: RegistryHealth::new(),
+        audit_ks: audit_ks.clone(),
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: Some(PUBLIC_URL.into()),
+        install_signer: None,
+        credential_signer: Some(signer),
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+    Fixture {
+        router,
+        admin_token,
+        issuer_token,
+        member_token,
+        audit_ks,
+        endorsements_ks,
+        _dir: dir,
+    }
+}
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+// ─── Type registry ───────────────────────────────────────
+
+#[tokio::test]
+async fn register_happy_path() {
+    let fix = build().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/endorsement-types")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", REGISTER_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "typeUri": "https://example.com/v1/skills/rust",
+                "description": "Rust expertise"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::CREATED, "{v}");
+    assert_eq!(v["typeUri"], "https://example.com/v1/skills/rust");
+}
+
+#[tokio::test]
+async fn register_rejects_reserved_uri() {
+    let fix = build().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/endorsement-types")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", REGISTER_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({ "typeUri": "CommunityRole" }).to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn register_rejects_duplicate() {
+    let fix = build().await;
+    let uri = "https://example.com/v1/skills/rust";
+    for _ in 0..2 {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/endorsement-types")
+            .header("authorization", format!("Bearer {}", fix.admin_token))
+            .header("trust-task", REGISTER_TASK)
+            .header("content-type", "application/json")
+            .body(Body::from(json!({ "typeUri": uri }).to_string()))
+            .unwrap();
+        let _ = fix.router.clone().oneshot(req).await.unwrap();
+    }
+    // Second register should fail.
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/endorsement-types")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", REGISTER_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(json!({ "typeUri": uri }).to_string()))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn register_requires_admin() {
+    let fix = build().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/endorsement-types")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", REGISTER_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(json!({ "typeUri": "https://x/t" }).to_string()))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn delete_type_404_when_unknown() {
+    let fix = build().await;
+    let req = Request::builder()
+        .method("DELETE")
+        .uri("/v1/endorsement-types/https%3A%2F%2Fx%2Ft")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", DELETE_TYPE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ─── Issue ───────────────────────────────────────────────
+
+async fn register_type(fix: &Fixture, uri: &str) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/endorsement-types")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", REGISTER_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(json!({ "typeUri": uri }).to_string()))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn issue_rejects_unregistered_type() {
+    let fix = build().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/endorsements")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "subjectDid": SUBJECT_DID,
+                "type": "https://unregistered.example/t",
+                "claim": { "x": 1 }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn issue_rejects_non_issuer_non_admin() {
+    let fix = build().await;
+    register_type(&fix, "https://example.com/v1/skills/rust").await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/endorsements")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "subjectDid": SUBJECT_DID,
+                "type": "https://example.com/v1/skills/rust",
+                "claim": { "level": "expert" }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn issue_happy_path_issuer_mints_credential() {
+    let fix = build().await;
+    let uri = "https://example.com/v1/skills/rust";
+    register_type(&fix, uri).await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/endorsements")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "subjectDid": SUBJECT_DID,
+                "type": uri,
+                "claim": { "level": "expert", "since": "2020" }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::CREATED, "{v}");
+    assert!(v["id"].is_string());
+    assert!(v["vec"].is_object());
+
+    // Audit: CustomEndorsementIssued + VecIssued both emitted.
+    let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let mut saw_issued = false;
+    let mut saw_vec = false;
+    for (_k, raw) in pairs {
+        let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+        match env.event {
+            AuditEvent::CustomEndorsementIssued(d) if d.endorsement_type == uri => {
+                saw_issued = true;
+            }
+            AuditEvent::VecIssued(d) if d.credential_type == "VerifiableEndorsementCredential" => {
+                saw_vec = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(saw_issued, "must emit CustomEndorsementIssued");
+    assert!(saw_vec, "must emit VecIssued for accounting");
+}
+
+#[tokio::test]
+async fn issue_rejects_unknown_subject() {
+    let fix = build().await;
+    let uri = "https://example.com/v1/t";
+    register_type(&fix, uri).await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/endorsements")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "subjectDid": "did:key:zStranger",
+                "type": uri,
+                "claim": { "x": 1 }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn delete_type_refused_while_live_endorsement_exists() {
+    let fix = build().await;
+    let uri = "https://example.com/v1/skills/rust";
+    register_type(&fix, uri).await;
+    // Issue an endorsement of that type.
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/endorsements")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "subjectDid": SUBJECT_DID,
+                "type": uri,
+                "claim": { "level": "expert" }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // Try to delete the type — must 409.
+    let encoded = uri.replace(':', "%3A").replace('/', "%2F");
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/endorsement-types/{encoded}"))
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", DELETE_TYPE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+// ─── Revoke ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn revoke_issuer_can_retract() {
+    let fix = build().await;
+    let uri = "https://example.com/v1/t";
+    register_type(&fix, uri).await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/endorsements")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({ "subjectDid": SUBJECT_DID, "type": uri, "claim": { "x": 1 } }).to_string(),
+        ))
+        .unwrap();
+    let (_, v) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
+    let id = v["id"].as_str().unwrap().to_string();
+
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/credentials/endorsements/{id}"))
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", SHOW_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Audit: CustomEndorsementRevoked + StatusListFlipped.
+    let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let mut saw_revoked = false;
+    let mut saw_flipped = false;
+    for (_k, raw) in pairs {
+        let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+        match env.event {
+            AuditEvent::CustomEndorsementRevoked(_) => saw_revoked = true,
+            AuditEvent::StatusListFlipped(d) if d.revoked => saw_flipped = true,
+            _ => {}
+        }
+    }
+    assert!(saw_revoked);
+    assert!(saw_flipped);
+    let _ = fix.endorsements_ks;
+}
+
+#[tokio::test]
+async fn revoke_idempotent_on_already_revoked() {
+    let fix = build().await;
+    let uri = "https://example.com/v1/t";
+    register_type(&fix, uri).await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/endorsements")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({ "subjectDid": SUBJECT_DID, "type": uri, "claim": { "x": 1 } }).to_string(),
+        ))
+        .unwrap();
+    let (_, v) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
+    let id = v["id"].as_str().unwrap().to_string();
+
+    for _ in 0..2 {
+        let req = Request::builder()
+            .method("DELETE")
+            .uri(format!("/v1/credentials/endorsements/{id}"))
+            .header("authorization", format!("Bearer {}", fix.admin_token))
+            .header("trust-task", SHOW_TASK)
+            .body(Body::empty())
+            .unwrap();
+        let resp = fix.router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}
+
+#[tokio::test]
+async fn revoke_non_admin_non_issuer_forbidden() {
+    let fix = build().await;
+    let uri = "https://example.com/v1/t";
+    register_type(&fix, uri).await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/endorsements")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({ "subjectDid": SUBJECT_DID, "type": uri, "claim": { "x": 1 } }).to_string(),
+        ))
+        .unwrap();
+    let (_, v) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
+    let id = v["id"].as_str().unwrap().to_string();
+
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/credentials/endorsements/{id}"))
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", SHOW_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -75,6 +75,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -118,6 +120,8 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -106,6 +106,8 @@ async fn build_fixture() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -147,6 +149,8 @@ async fn build_fixture() -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -90,6 +90,8 @@ async fn build_fixture() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -203,6 +205,8 @@ async fn build_fixture() -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer,

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -78,6 +78,8 @@ async fn build_fixture() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -163,6 +165,8 @@ async fn build_fixture() -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -47,6 +47,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -79,6 +81,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/personhood.rs
+++ b/vtc-service/tests/personhood.rs
@@ -96,6 +96,8 @@ async fn build_fixture() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -285,6 +287,8 @@ async fn build_fixture() -> Fixture {
         sync_cursor_ks,
         relationships_ks,
         relationships_by_did_ks,
+        endorsement_types_ks,
+        endorsements_ks,
         registry_client: None,
         registry_health: RegistryHealth::new(),
         audit_ks: audit_ks.clone(),

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -105,6 +105,8 @@ async fn build_fixture() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -183,6 +185,8 @@ async fn build_fixture() -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -69,6 +69,8 @@ async fn build() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -106,6 +108,8 @@ async fn build() -> Fixture {
         sync_cursor_ks,
         relationships_ks,
         relationships_by_did_ks,
+        endorsement_types_ks,
+        endorsements_ks,
         registry_client: None,
         registry_health: RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -97,6 +97,8 @@ async fn build_fixture() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -210,6 +212,8 @@ async fn build_fixture() -> Fixture {
         sync_cursor_ks,
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: RegistryHealth::new(),
         audit_ks: audit_ks.clone(),

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -80,6 +80,8 @@ async fn build_fixture() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -189,6 +191,8 @@ async fn build_fixture() -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -84,6 +84,8 @@ async fn build_fixture() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -183,6 +185,8 @@ async fn build_fixture() -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         audit_ks,

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -82,6 +82,8 @@ async fn build_fixture() -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -194,6 +196,8 @@ async fn build_fixture() -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         audit_ks,

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -245,6 +245,8 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
@@ -272,6 +274,8 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
         sync_cursor_ks: sync_cursor_ks.clone(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         credential_signer: None,

--- a/vtc-service/tests/status_lists.rs
+++ b/vtc-service/tests/status_lists.rs
@@ -72,6 +72,8 @@ async fn build_fixture(with_signer: bool) -> Fixture {
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
     let install_store = InstallTokenStore::new(install_ks.clone());
@@ -120,6 +122,8 @@ async fn build_fixture(with_signer: bool) -> Fixture {
         sync_cursor_ks,
         relationships_ks,
         relationships_by_did_ks,
+        endorsement_types_ks,
+        endorsements_ks,
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
         audit_ks,


### PR DESCRIPTION
## Summary

Phase 4 PR-4 / 5. **Custom endorsement gate met.** Heaviest PR of Phase 4 per the planning slice — bundles M4.7 (endorsements keyspace + builder) and M4.8 (type registry + endorsement CRUD) per D4 review.

### Two new modules

- **`vtc_service::endorsements`** — `endorsements:` keyspace + `Endorsement` model + storage helpers. Critical surface: `count_live_by_type` powers the type-registry's "refuse delete if in use" check.
- **`vtc_service::endorsement_types`** — operator-uploaded type registry. URIs percent-encoded into fjall keys (colons/slashes don't collide). `RESERVED_TYPE_URIS` list ships with `"CommunityRole"` pre-reserved.

### Seven new routes

| Endpoint | Auth | Outcome |
|----------|------|---------|
| `POST /v1/endorsement-types` | Admin | Register; 409 on reserved/duplicate |
| `GET /v1/endorsement-types` | Admin | Paginated list |
| `DELETE /v1/endorsement-types/{uri}` | Admin | Refuses with 409 while live endorsements exist |
| `POST /v1/credentials/endorsements` | Admin OR Issuer (VTC-ACL check) | Issue VEC + allocate status slot + audit |
| `GET /v1/credentials/endorsements` | Admin OR Issuer | Paginated list |
| `GET /v1/credentials/endorsements/{id}` | Admin OR Issuer | Show |
| `DELETE /v1/credentials/endorsements/{id}` | Admin OR Issuer | Flip status bit + idempotent + paired audit |

### Key design notes

- **D4 review bundle**: type registry + endorsement CRUD ship as one PR. ~900 LoC in route handlers + ~600 LoC in storage modules.
- **D8 review confirmed**: custom endorsements share the existing `Revocation` status list — no upstream `affinidi-status-list` PR needed.
- **Auth model**: JWT role degrades non-Admin VTC roles to `Reader`, so the issuance + revoke handlers read the VTC ACL row directly to distinguish `Issuer` from `Member`. Admins always pass; everyone else fails.
- **Revoke audit pairs**: `CustomEndorsementRevoked` (semantic) + `StatusListFlipped` (bit-flip accounting) for uniform downstream observability.
- **Issue audit pairs**: `CustomEndorsementIssued` + `VecIssued` for uniform credential-issuance accounting.
- **7 Trust Tasks** ship; per-method-selector workarounds documented (same pattern as members/personhood and members/{did}).
- **22 test fixtures** bulk-patched with the two new AppState keyspace fields.

## Test plan

- [x] 13 endorsement integration tests pass (registry CRUD + endorsement CRUD + audit verification)
- [x] 15 storage/builder unit tests pass (endorsements ×6, endorsement_types ×5, custom_endorsement ×4)
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` green (319 vtc-service lib + every integration suite + 191 vti-common + 347 vta-sdk + 99 vta-service + e2e)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] DCO sign-off

After merge: **PR-5 (M4.9-M4.12)** — Phase 4 closeout (audit snapshot pass, Trust Task index sweep, plan + spec amendments, workspace gate). Phase 4 closes.

Refs: #46 vtc-mvp Phase 4 plan §M4.7 + §M4.8 (D4 review bundle)