### PR TITLE
chore(vtc-service): M4.9-M4.12 — Phase 4 closeout

### DIFF
--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -262,11 +262,21 @@ default `"en"`), `created_at`, `extensions` (§3-M).
 
 ```
 did, role, joined_at, status_list_index, publish_consent,
-departure_preference, current_vmc_id, current_role_vec_id, extensions
+departure_preference, current_vmc_id, current_role_vec_id, extensions,
+personhood, personhood_asserted_at
 ```
 
 Admin entries additionally carry `passkeys: Vec<RegisteredPasskey>`
 (§4.3).
+
+**Personhood fields (Phase 4 M4.1 + planning-review D2).** Two
+fields persist: `personhood: bool` (default `false`) and
+`personhood_asserted_at: Option<DateTime<Utc>>` (timestamp of
+the most recent successful assert). The presented VP itself is
+**not** persisted — Phase 4's planning review pinned a
+verify-then-discard model. Operators wanting persistent
+evidence storage layer it via custom rego + the existing
+`extensions` slot.
 
 ### 5.3 `Role`
 
@@ -346,8 +356,25 @@ active_from, active_to, last_synced_at
 | Member ↔ member trust edge | **VRC** | member DID | other member DID | Self-issued, optionally published (§12.3). |
 | Member contact card | **RCard** | member or community | member | jCard value. |
 | Event/proximity witness | **VWC** | external | applicant | Consumed in join VPs; VTC does not issue. |
-| Custom endorsement (badges, attestations) | **VEC** | community (issuer role) | any DID | Community-defined `endorsement` value. The hook for "we don't invent credential types". |
+| Custom endorsement (badges, attestations) | **VEC** | community (issuer role) | any DID | Community-defined `endorsement` value. **Operator-uploaded type registry** (Phase 4 M4.8.1, planning-review D4) — only registered types are issuable. Workspace-reserved `"CommunityRole"` URI refused at registration time. |
 | Persona | VPC | community | member | **v2**. Not in MVP. |
+
+**Custom endorsement type registry (Phase 4 M4.8.1).** Operators
+register endorsement type URIs via
+`POST /v1/endorsement-types` before the issuance path accepts
+them. The issue handler refuses unknown types with `400
+endorsement-type-not-registered`. The delete-type handler
+refuses with `409 endorsement-type-in-use` when any live
+endorsement still references the type.
+
+**Self-issued VRC (Phase 4 M4.6).** Members publish trust edges
+via `POST /v1/relationships`. The caller's session DID must
+equal the VC's `issuer` field — the VTC verifies the
+data-integrity proof against the issuer's resolved `#key-0`
+but never mints VRCs on a member's behalf. Per planning-review
+D7, VRCs carry **no `credentialStatus`** — revocation is row
+deletion in the `relationships:` keyspace via
+`DELETE /v1/relationships/{id}`.
 
 ### 6.2 Status list
 
@@ -366,6 +393,11 @@ active_from, active_to, last_synced_at
   the departed identity. Index space is sized accordingly.
 - Telemetry emits `StatusListOccupancyWarning` at 75% (live +
   reserved). Chaining is v2 (§17).
+- **Custom endorsements share the `Revocation` status list**
+  (Phase 4 M4.8 + planning-review D8). The reserved-slot
+  discipline above applies uniformly across VMC slots +
+  endorsement slots — a revoked endorsement's slot stays
+  permanently reserved.
 
 ### 6.3 Renewal — unconditional on ACL membership
 
@@ -385,19 +417,55 @@ Issuance steps:
    `personhood` flag on the new VMC. If the flag changes from the
    prior VMC, the audit event `MembershipRenewed` records
    `personhood_changed: true`.
+
+   **Renewal-time policy failure is operator-configurable** (Phase
+   4 M4.2.2 + planning-review D5) via
+   `vtc.renewal.on_personhood_fail`:
+   - `downgrade` (default): flag flips to `false`, VMC re-mints
+     with `personhood: false`, paired `PersonhoodRevoked
+     { reason: "renewal-policy" }` audit envelope fires. Preserves
+     §3-B "ACL is authoritative".
+   - `refuse`: returns `422 personhood-renewal-refused`; Member
+     row untouched; no VMC re-mint. The member must re-assert
+     before retrying renewal.
 4. Sealed-transfer to member's DID.
 
 ### 6.4 Personhood
 
-`personhood.rego` ships as a **deny-all stub**. Community admins
-author the actual rule. Personhood is asserted via a dedicated
-`POST /v1/members/{did}/personhood/assert` (re-mints VMC with
-`personhood: true`), and revoked via `DELETE` (re-mints with
-`false`). The policy re-evaluates on every renewal (§6.3 step 3) —
-losing personhood is not gated on operator action.
+`personhood.rego` ships as a **minimal-allow default** (Phase 4
+M4.2.1): allow when the applicant's VP carries at least one
+`WitnessCredential` from a non-empty issuer. Operators upload
+stricter policies when the witness-only baseline isn't enough.
 
-Policy input contract: `data.input = { applicant_did, vp_claims }`.
-Communities extend via `data.*` namespaces they populate themselves.
+**Assert flow (Phase 4 M4.3, planning-review D2 — VP-only body).**
+
+1. Caller mints a single-use nonce via
+   `POST /v1/members/{did}/personhood/challenge` (10-min TTL).
+2. Caller assembles a W3C Verifiable Presentation signed by
+   their `#key-0`, with `proof.challenge` set to the nonce,
+   and submits via `POST /v1/members/{did}/personhood`.
+3. Handler consumes the challenge, verifies the VP proof
+   against the member's resolved `#key-0`, runs
+   `extract_vp_claims`, evaluates `personhood.rego`.
+4. On allow: flag flips, `personhood_asserted_at` stamps now,
+   VMC re-mints with `personhood: true`,
+   `PersonhoodAsserted { vmc_id, asserted_at }` audit emitted.
+5. **The presented VP is then discarded** (planning-review
+   D2). Only the flag + timestamp persist on the `Member` row.
+
+**Revoke flow.** `DELETE /v1/members/{did}/personhood` is
+admin-driven OR self-revoke. Idempotent no-op when already
+`false`. Emits `PersonhoodRevoked { vmc_id, reason: "admin" |
+"self" }`. The renewal-policy downgrade arm (§6.3 step 3) is
+the third trigger, emitting `reason: "renewal-policy"`.
+
+Policy input contract:
+`data.input = { applicant_did, vp_claims }` for the assert
+path; `data.input = { applicant_did, current_personhood,
+asserted_at_seconds_ago, vp_claims }` for the renewal re-eval.
+The empty `vp_claims` on renewal is intentional — operators
+wanting evidence-aware renewal eval upload custom rego that
+consults live inputs (trust-registry queries, etc.).
 
 ## 7. Policy engine
 
@@ -407,7 +475,7 @@ Communities extend via `data.*` namespaces they populate themselves.
 |---|---|---|
 | `join` | Decide join requests | Template `policies.open` (accept any signed VP) |
 | `removal` | Decide admin-initiated removals | Any admin may remove any non-admin |
-| `personhood` | Decide personhood assertion | **Deny-all stub** |
+| `personhood` | Decide personhood assertion | **Minimal-allow on `WitnessCredential` presence** (Phase 4 M4.2.1) |
 | `registry` | Trust-registry publish + departure disposition | Publish on join; default disposition `Tombstone` |
 | `directory` | Member-directory visibility | Members see DID + role only |
 | `role_definitions` | Map roles to permissions (incl. Custom) | The matrix in §5.3 for standard roles only |
@@ -898,6 +966,27 @@ per-key sensitivity: keys flagged `sensitive: true` redact
 `old_value` + `new_value` in the audit record (e.g., TLS paths;
 future webhook URLs with tokens). Complete catalog lives alongside
 the source in `vti-common::audit::events`.
+
+**Phase 4 additions (M4.1.2 + D4 review — eight new variants):**
+- `VrcPublished { vrc_id, subject_did?, edge_type }` — self-issued
+  trust edge stored.
+- `VrcRevoked { vrc_id, revoked_by }` — paired with the
+  `relationships:` row deletion (per D7, no `credentialStatus`
+  bit-flip).
+- `PersonhoodAsserted { vmc_id, asserted_at }` — after a
+  successful `POST .../personhood`. VP is discarded post-eval
+  (D2 review) so no evidence hash appears here.
+- `PersonhoodRevoked { vmc_id?, reason }` — `reason ∈ {
+  "admin", "self", "renewal-policy" }`. `vmc_id` is `None`
+  only on the `refuse`-arm of M4.2.2 (no VMC re-mint).
+- `CustomEndorsementIssued { endorsement_id, endorsement_type,
+  status_list_index }` + paired `VecIssued` for accounting.
+- `CustomEndorsementRevoked { endorsement_id, endorsement_type }`
+  + paired `StatusListFlipped` (same shared-list discipline as
+  VMC revocation).
+- `EndorsementTypeRegistered { type_uri, description? }` /
+  `EndorsementTypeDeleted { type_uri }` — admin-driven registry
+  CRUD (M4.8.1).
 
 ## 12. Optional surfaces
 

--- a/tasks/vtc-mvp/phase-4-plan.md
+++ b/tasks/vtc-mvp/phase-4-plan.md
@@ -699,6 +699,190 @@ pattern).
 ## Phase 4 outcomes
 
 Recorded at M4.11 close-out. Each row links a pre-impl
-decision (D1–D10) or risk (R1–R7) to the as-shipped reality.
+decision (D1–D10) or risk (R1–R6) to the as-shipped reality.
 
-(Filled in at M4.11.)
+### D1 — VRC issuance authority
+
+**As shipped as proposed**: the asserting *member* is the
+issuer. The VTC never mints VRCs; the publish handler
+verifies the caller's session DID equals the VC's `issuer`
+and verifies the data-integrity proof against the issuer's
+resolved `#key-0`. `LocalSigner` is uninvolved.
+
+### D2 — Personhood evidence shape
+
+**As shipped per planning review (VP-only)**: the
+`POST /v1/members/{did}/personhood` body carries a single
+W3C Verifiable Presentation signed by the member's
+`#key-0`. The assert handler verifies the VP proof, runs
+`extract_vp_claims` (Phase 2 M2.6) to produce policy input,
+evaluates `personhood.rego`, then **discards the VP**. Only
+two fields persist on the `Member` row: `personhood: bool`
++ `personhood_asserted_at: Option<DateTime<Utc>>`. Operators
+wanting persistent evidence storage layer it via custom rego
++ extension fields.
+
+### D3 — Personhood revoke trigger
+
+**As shipped as proposed**: three triggers, all wired —
+admin-driven `DELETE`, self-`DELETE`, and renewal-policy
+downgrade (M4.2.2). Each emits `PersonhoodRevoked` with a
+stable `reason` discriminator (`admin` / `self` /
+`renewal-policy`).
+
+### D4 — Custom endorsement type registry
+
+**As shipped per planning review (operator-uploaded
+registry)**: bundled into M4.8 per the planning review.
+- New `endorsement_types:` keyspace with percent-encoded URI
+  keys (handles colons + slashes safely).
+- Three admin-gated CRUD routes under `/v1/endorsement-types`.
+- `RESERVED_TYPE_URIS` ships with `"CommunityRole"`
+  pre-reserved — registrar refuses with `409
+  endorsement-type-reserved`.
+- Issuance path consults `type_exists` and refuses unknown
+  types with `400 endorsement-type-not-registered`.
+- Delete path refuses with `409 endorsement-type-in-use`
+  when `count_live_by_type > 0`.
+
+### D5 — Renewal re-evaluation semantics
+
+**As shipped per planning review (operator-configurable)**:
+config knob `vtc.renewal.on_personhood_fail` with values
+`downgrade` (default) and `refuse`. The renewal hook reads
+`Member.personhood` + `personhood_asserted_at` and feeds
+them to `personhood.rego` as `current_personhood` +
+`asserted_at_seconds_ago`. On downgrade-arm: flag flips +
+VMC re-mints with `personhood: false` + paired
+`PersonhoodRevoked { reason: "renewal-policy" }` audit. On
+refuse-arm: `422 personhood-renewal-refused` + Member row
+untouched. Default config preserves §3-B "ACL is
+authoritative".
+
+### D6 — Audit envelope shape for VRC
+
+**As shipped per planning review (8 variants total, not
+6)**: D6 originally proposed 6 variants; the D4 review's
+type-registry decision added two more
+(`EndorsementTypeRegistered` + `EndorsementTypeDeleted`).
+All 8 variants ship with round-trip + discriminator-table
+coverage in `vti-common/src/audit/event.rs` (M4.1.2).
+
+### D7 — Status-list slot allocation for VRCs
+
+**As shipped as proposed**: VRCs carry **no
+`credentialStatus`**. Revocation is row deletion in the
+`relationships:` keyspace, not a status-list bit flip.
+Verifiers querying the trust-graph see the absence directly;
+external observers relying on a status-list URL get a clean
+404.
+
+### D8 — Custom endorsement revocation
+
+**As shipped per planning review (shared status list)**:
+custom endorsements allocate slots on the same `Revocation`
+BitstringStatusList VMCs use. No upstream
+`affinidi-status-list` PR; no new `StatusPurpose::Endorsement`
+variant. The shared list's reserved-slot discipline (§6.2)
+still applies — revoked slots are never reallocated, even
+across endorsement types.
+
+### D9 — Trust Task IDs
+
+**As shipped as proposed**: 13 new Trust Tasks shipped
+across PR-2/3/4 (challenge + assert + revoke for personhood,
+publish + list + revoke for relationships, register + list +
+delete for endorsement-types, issue + list + show + revoke
+for endorsements). Trust Task index ↔ on-disk count
+verified at M4.10 (55 ↔ 55 ↔ 55).
+
+### D10 — Personhood Rego input shape (default policy)
+
+**As shipped as proposed**: default policy allows on
+`WitnessCredential` presence with a non-empty issuer. The
+renewal-time eval reads `current_personhood` +
+`asserted_at_seconds_ago` (per D2 review's "no evidence
+persistence" — operators get only the flag + age, plus an
+empty `vp_claims` for shape compatibility). Operators
+upload custom rego when they want richer eval.
+
+### R1 — Status-list slot pressure
+
+**Not realised at Phase 4 scale.** Each member can now hold
+a VMC slot **plus** any number of custom endorsement slots.
+For a 100k-member community with average 5 endorsements
+each, that's 600k slots out of the BitstringStatusList's
+131,072-byte minimum capacity (1,048,576 slots). Headroom
+remains; Phase 5+ may add per-purpose dedicated lists if
+endorsement growth outpaces this.
+
+### R2 — Personhood proof TTL
+
+**Not realised yet.** Personhood VPs verify against the
+member's `#key-0` at assert time. The default policy
+doesn't enforce a max age via
+`asserted_at_seconds_ago`; operators uploading time-based
+rego get the input field for free. Phase 5 admin UX can
+surface the staleness when it lands.
+
+### R3 — Custom endorsement claim explosion
+
+**As shipped with the 8 KiB cap.** Each endorsement's
+`claim` body is capped at 8 KiB JSON; the route layer
+validates before any state mutation. Operators wanting
+larger payloads upload via off-chain storage + reference
+URIs in the claim body.
+
+### R4 — VRC graph quadratic growth
+
+**As shipped with secondary index.** The
+`relationships_by_did:` keyspace keeps per-DID list queries
+O(matched-rows) rather than O(full-table). Pagination + the
+§12.3 Purge-strip happen at the route layer; no quadratic
+blowup observed in tests up to 10 edges.
+
+### R5 — Endorsement type registry collisions
+
+**Not realised** thanks to the D4 registry. Operators can't
+pick `"CommunityRole"` (reserved); duplicate registrations
+409. The pre-issue lookup means stale-cache callers get a
+clean 422 rather than minting against a non-existent type.
+
+### R6 — VP-only assert + lost evidence audit trail
+
+**Acknowledged trade-off** from D2 review. The assert audit
+envelope records `vmc_id` + `asserted_at` but not the VP's
+hash — the VP is verify-then-discard. Operators wanting the
+audit trail upload a custom rego + extension fields that
+write claim metadata to `Member.extensions` themselves.
+
+### Spec amendments applied at M4.11
+
+- **§5.2**: `Member` row gains two new fields —
+  `personhood: bool`, `personhood_asserted_at:
+  Option<DateTime<Utc>>`. Evidence is not persisted on the
+  row (planning-review D2).
+- **§5.4**: VRCs carry no `credentialStatus` (D7).
+  Revocation is row deletion via
+  `DELETE /v1/relationships/{id}`.
+- **§6.1**: custom endorsements come with an operator-
+  uploaded type registry (D4 review). Workspace-reserved
+  `"CommunityRole"` URI is refused at registration time.
+- **§6.2**: custom endorsements share the existing
+  `Revocation` status list (D8 review). Reserved-slot
+  discipline applies across both VMC + endorsement slots.
+- **§6.3 step 3**: renewal-time personhood failure is
+  operator-configurable via `vtc.renewal.on_personhood_fail`
+  (`downgrade` | `refuse`, default `downgrade`). The
+  `refuse` flavour returns `422` and skips the VMC re-mint.
+- **§6.4**: personhood assert body is a single Verifiable
+  Presentation (D2 review). Evidence is verified at request
+  time and discarded.
+- **§7.1**: default `personhood.rego` flipped from deny-all
+  to minimal-allow on `WitnessCredential` presence (M4.2.1).
+  Default `relationships.rego` allows when both parties are
+  current community members.
+- **§11.4**: audit catalogue extended with 8 new variants
+  (D6 + D4 review).
+- **§17.1**: reference policy templates documentation
+  deferred to a Phase 5 follow-up.

--- a/tasks/vtc-mvp/phase-4-todo.md
+++ b/tasks/vtc-mvp/phase-4-todo.md
@@ -646,7 +646,7 @@ revocation, status-list backing all live.
 
 ## M4.9 — Audit variants snapshot tests
 
-### `[ ]` M4.9.1 — Round-trip + discriminator coverage
+### `[x]` M4.9.1 — Round-trip + discriminator coverage
 
 - **Acceptance**
   - The **eight** Phase 4 audit variants (D6 + D4 review:
@@ -668,7 +668,7 @@ revocation, status-list backing all live.
 
 ## M4.10 — Trust Task drafts + index
 
-### `[ ]` M4.10.1 — On-disk + index entries
+### `[x]` M4.10.1 — On-disk + index entries
 
 - **Acceptance**
   - **Thirteen** new Trust Task directories per plan §D9 +
@@ -702,7 +702,7 @@ revocation, status-list backing all live.
 
 ## M4.11 — Phase 4 outcomes + spec amendments
 
-### `[ ]` M4.11.1 — Document the as-shipped reality
+### `[x]` M4.11.1 — Document the as-shipped reality
 
 - **Acceptance**
   - `tasks/vtc-mvp/phase-4-plan.md` gains a "Phase 4
@@ -722,7 +722,7 @@ revocation, status-list backing all live.
 
 ## M4.12 — Phase 4 gate
 
-### `[ ]` M4.12.1 — Workspace gate green
+### `[x]` M4.12.1 — Workspace gate green
 
 - **Acceptance** (mirrors M3.14.1)
   - `cargo build --workspace` green.


### PR DESCRIPTION
## Summary

Phase 4 PR-5 / 5 — the closeout. Documents the as-shipped reality and confirms the workspace gate is green. **Phase 4 closes** — VRC graph, personhood assert/revoke, custom endorsement registry + CRUD all live.

- **M4.9** — Audit variant coverage verified. All 8 Phase-4 variants shipped in PR-1 with round-trip + discriminator coverage and have stayed green throughout the phase.
- **M4.10** — Trust Task index ↔ on-disk match verified: **55 ↔ 55 ↔ 55**. 13 new tasks shipped across PR-2/3/4.
- **M4.11** — Phase 4 outcomes recorded:
  - `tasks/vtc-mvp/phase-4-plan.md` gains a "Phase 4 outcomes" section covering D1–D10 + R1–R6 with the as-shipped reality.
  - `docs/05-design-notes/vtc-mvp.md` §§5.2 / 5.4 / 6.1 / 6.2 / 6.3 / 6.4 / 7.1 / 11.4 amended to match what shipped.
  - Memory entry `project_vtc_mvp.md` updated.
- **M4.12** — workspace gate green: `cargo build/clippy/fmt/test --workspace` clean.

### Key Phase 4 outcomes captured

- **D2 (review)** — VP-only assert body; **verify-then-discard** semantics. Only `personhood: bool` + `personhood_asserted_at` persist on the Member row.
- **D4 (review)** — Operator-uploaded type registry bundled into M4.8. Only registered types issuable; `"CommunityRole"` pre-reserved; delete refuses with 409 if any live endorsement still uses the type.
- **D5 (review)** — Operator-configurable renewal failure via `vtc.renewal.on_personhood_fail` (`downgrade` default | `refuse`). Refuse-arm returns 422 without VMC re-mint.
- **D6 + D4 review** — **8 new audit variants** (D6 originally proposed 6; D4's registry decision added 2).
- **D7** — VRCs carry no `credentialStatus`. Revocation = row deletion. Per-DID secondary index keeps list queries O(matched-rows).
- **D8 (confirmed)** — Custom endorsements share the existing Revocation status list. Reserved-slot discipline spans VMC + endorsement slots uniformly.
- **JWT role degrades to Reader for non-Admin VTC roles** — issuance + revoke handlers read the VTC ACL row directly to distinguish `Issuer` from `Member`. Phase 5 may rewrite the auth layer to be VtcRole-aware.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — every test result `ok` across vtc-service (319 lib + every integration suite), vti-common (191), vta-sdk (347), vta-service (99), vti-e2e-tests
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 55 ↔ 55 ↔ 55 Trust Task index ↔ on-disk match
- [x] All Phase 4 todo checkboxes flipped to `[x]`
- [x] DCO sign-off on commit

Phase 4 closes. Phase 5 (public website + admin UX + routing) can proceed — the post-Phase-2 parallel branch lands its final sequential dependency here.