### PR TITLE
feat(vtc-service): M5.1 + M5.2.2 + M5.3.2 — routing surfaces + CSRF + CSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9246,6 +9246,7 @@ dependencies = [
  "toml",
  "tower 0.5.3",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -82,6 +82,7 @@ jsonwebtoken = { workspace = true }
 fjall = { workspace = true }
 toml = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "trace"] }
+tower_governor = "0.8"
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -165,6 +165,19 @@ pub struct RoutingConfig {
     pub admin_ui: MountConfig,
     #[serde(default = "default_website_mount")]
     pub website: MountConfig,
+    /// Subdomain-mode strictness (Phase 5 M5.1.2). When at least one
+    /// surface has `host` set:
+    ///
+    /// - `true` (default): a request whose `Host` header doesn't match
+    ///   any configured surface returns 404 `HostNotRecognised`.
+    /// - `false`: unknown hosts fall back to path-mode prefix
+    ///   matching against the parent router. Debug aid only — not
+    ///   recommended for production.
+    ///
+    /// No effect when every surface has `host = None` (pure path
+    /// mode).
+    #[serde(default = "default_subdomain_mode_strict")]
+    pub subdomain_mode_strict: bool,
 }
 
 impl Default for RoutingConfig {
@@ -173,8 +186,13 @@ impl Default for RoutingConfig {
             api: default_api_mount(),
             admin_ui: default_admin_ui_mount(),
             website: default_website_mount(),
+            subdomain_mode_strict: default_subdomain_mode_strict(),
         }
     }
+}
+
+fn default_subdomain_mode_strict() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -34,6 +34,7 @@ pub mod recognition;
 pub mod registry;
 pub mod relationships;
 pub mod routes;
+pub mod routing;
 pub mod server;
 pub mod setup;
 pub mod status;

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -15,35 +15,68 @@ pub mod recognise;
 mod relationships;
 pub(crate) mod status_lists;
 
+use std::sync::Arc;
+
 use axum::Router;
-use axum::routing::{delete, get, post};
+use axum::extract::DefaultBodyLimit;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{any, delete, get, post};
+use tower_governor::GovernorLayer;
+use tower_governor::governor::GovernorConfigBuilder;
+use tower_governor::key_extractor::SmartIpKeyExtractor;
 
 use vti_common::trust_task::{TrustTask, TrustTaskRouter};
 
+use crate::config::RoutingConfig;
 use crate::server::AppState;
 
-/// Build the public router.
+/// Global API surface body cap (Phase 5 M5.1.4 — §14.4 runtime
+/// guard). Matches the VTA's `MAX_BODY_SIZE`. Website management
+/// routes (M5.5) override per-route with larger caps via
+/// `DefaultBodyLimit::disable() + RequestBodyLimitLayer::new(...)`.
+pub const MAX_BODY_SIZE: usize = 1024 * 1024;
+
+/// Tighter body cap for unauthenticated routes. Aligned with
+/// `vta-service`'s `UNAUTH_BODY_SIZE` — generous enough for a
+/// JWE / sealed-transfer envelope but small enough to reject 1 MB
+/// blob floods that the rate limiter alone cannot starve out.
+pub const UNAUTH_BODY_SIZE: usize = 64 * 1024;
+
+/// Build the public router with default routing (path mode, `/v1`
+/// API mount, `/admin` UX placeholder, `/` website fallback).
 ///
-/// Migrates the pre-MVP route table under `/v1/` and attaches a
-/// Trust-Task header check to every endpoint per spec §9.4. The
-/// existing handlers are unchanged in behaviour — only the wire
-/// surface moves. Trust Task IDs use a `*/legacy/*` namespace
-/// because these endpoints will be re-shaped during M0.5+ to align
-/// with the install + passkey + admin flows; the placeholder IDs
-/// give the wire surface a stable identifier from day one (soft
-/// gate from spec §9.4 / plan M0.1.1).
-///
-/// `/health` is the **single** Trust-Task-exempt endpoint — kept at
-/// the root path for trivial monitoring integration.
+/// Convenience wrapper around [`router_with`] for integration-test
+/// fixtures and any caller that doesn't carry a [`RoutingConfig`].
+/// Production startup goes through [`router_with`] from `server.rs`
+/// so operator-supplied mount overrides take effect.
 pub fn router() -> Router<AppState> {
-    let auth_challenge =
-        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0")
-            .expect("static Trust-Task URL");
-    let auth_authenticate =
-        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/authenticate/1.0")
-            .expect("static Trust-Task URL");
-    let auth_refresh = TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/refresh/1.0")
-        .expect("static Trust-Task URL");
+    router_with(&RoutingConfig::default())
+}
+
+/// Build the public router with operator-supplied routing config
+/// (Phase 5 M5.1.1). Three logical surfaces under one
+/// [`axum::Router`]:
+///
+/// - **API** (`routing.api.mount`, default `/v1`): the existing
+///   [`TrustTaskRouter`]-built handler set. Every mutating + read
+///   handler the daemon ships lives here. Phase 5 keeps handler
+///   attach order identical to Phase 0–4; only the prefix moves
+///   from inline `/v1/...` literals to a single `nest` boundary.
+/// - **Admin UX** (`routing.admin_ui.mount`, default `/admin`):
+///   placeholder router that returns 503 until M5.7 lands the
+///   baked SPA. The mount is reserved so cookie-scope isolation
+///   (§9.3) doesn't have to wait for the SPA to exist.
+/// - **Website** (`routing.website.mount`, default `/`):
+///   placeholder fallback that returns 503 until M5.4 lands the
+///   filesystem-backed static handler. When the website mount is
+///   `/`, attached as a catch-all fallback; otherwise nested.
+///
+/// `/health` is the **single** Trust-Task-exempt endpoint — kept
+/// at the parent-router root (above every nest boundary) so
+/// monitoring integration stays trivial regardless of routing
+/// mode.
+pub fn router_with(routing: &RoutingConfig) -> Router<AppState> {
     let auth_sessions_manage =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0")
             .expect("static Trust-Task URL");
@@ -73,12 +106,6 @@ pub fn router() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let admin_config_import =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/config/import/1.0")
-            .expect("static Trust-Task URL");
-    let install_claim_start =
-        TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/start/1.0")
-            .expect("static Trust-Task URL");
-    let install_claim_finish =
-        TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0")
             .expect("static Trust-Task URL");
     let admin_bootstrap = TrustTask::new("https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0")
         .expect("static Trust-Task URL");
@@ -224,15 +251,14 @@ pub fn router() -> Router<AppState> {
     // surface stays complete; the wire enforcement collapses to
     // the POST task on the shared mount.
 
-    TrustTaskRouter::<AppState>::new()
-        .route_exempt("/health", get(health::health))
+    let api = TrustTaskRouter::<AppState>::new()
         .route_with_task(
-            "/v1/health/diagnostics",
+            "/health/diagnostics",
             get(health::diagnostics),
             health_diagnostics,
         )
         .route_with_task(
-            "/v1/auth/recognise",
+            "/auth/recognise",
             post(recognise::recognise),
             auth_recognise,
         )
@@ -241,39 +267,36 @@ pub fn router() -> Router<AppState> {
         // not a general-purpose did:webvh host: the handler matches
         // the URL `scid` against the VTC's own DID and 404s on any
         // other request. See `tasks/vtc-mvp/vta-driven-keys.md` §10.
-        .route_exempt("/v1/{scid}/did.jsonl", get(did_log::did_log))
+        .route_exempt("/{scid}/did.jsonl", get(did_log::did_log))
         // BitstringStatusList publication (M2.11). Trust-Task-
         // exempt — external verifiers don't carry our extension
         // header (same rationale as `did.jsonl`).
-        .route_exempt("/v1/status-lists/{purpose}", get(status_lists::show))
-        // Auth routes
-        .route_with_task("/v1/auth/challenge", post(auth::challenge), auth_challenge)
-        .route_with_task("/v1/auth/", post(auth::authenticate), auth_authenticate)
-        .route_with_task("/v1/auth/refresh", post(auth::refresh), auth_refresh)
+        .route_exempt("/status-lists/{purpose}", get(status_lists::show))
+        // Auth routes. `POST /v1/auth/{challenge,authenticate,refresh}`
+        // are unauthenticated and live in `build_unauth_routes` so the
+        // tower-governor + tighter body cap apply. The two
+        // session-management endpoints below are authenticated and
+        // stay on the main chain.
         .route_with_task(
-            "/v1/auth/sessions",
+            "/auth/sessions",
             get(auth::session_list).delete(auth::revoke_sessions_by_did),
             auth_sessions_manage,
         )
         .route_with_task(
-            "/v1/auth/sessions/{session_id}",
+            "/auth/sessions/{session_id}",
             delete(auth::revoke_session),
             auth_sessions_revoke,
         )
         // Config
         .route_with_task(
-            "/v1/config",
+            "/config",
             get(config::get_config).patch(config::update_config),
             config_manage,
         )
         // ACL
+        .route_with_task("/acl", get(acl::list_acl).post(acl::create_acl), acl_manage)
         .route_with_task(
-            "/v1/acl",
-            get(acl::list_acl).post(acl::create_acl),
-            acl_manage,
-        )
-        .route_with_task(
-            "/v1/acl/{did}",
+            "/acl/{did}",
             get(acl::get_acl)
                 .patch(acl::update_acl)
                 .delete(acl::delete_acl),
@@ -284,7 +307,7 @@ pub fn router() -> Router<AppState> {
         // community/profile/update/1.0 lands when TrustTaskRouter
         // gains per-method task selectors in Phase 1+).
         .route_with_task(
-            "/v1/community/profile",
+            "/community/profile",
             get(community::profile::get_profile).put(community::profile::put_profile),
             community_profile,
         )
@@ -292,7 +315,7 @@ pub fn router() -> Router<AppState> {
         // split into admin/config/show/1.0 + patch/1.0 when
         // TrustTaskRouter gains per-method selectors).
         .route_with_task(
-            "/v1/admin/config",
+            "/admin/config",
             get(admin::config::get_config).patch(admin::config::patch_config),
             admin_config,
         )
@@ -300,12 +323,12 @@ pub fn router() -> Router<AppState> {
         // settings in-place; restart requires a supervisor (412
         // `SupervisorRequired` otherwise).
         .route_with_task(
-            "/v1/admin/config/reload",
+            "/admin/config/reload",
             post(admin::config::reload_config),
             admin_config_reload,
         )
         .route_with_task(
-            "/v1/admin/config/restart",
+            "/admin/config/restart",
             post(admin::config::restart_config),
             admin_config_restart,
         )
@@ -313,33 +336,24 @@ pub fn router() -> Router<AppState> {
         // (db-layer overrides + community profile) JSON; import runs
         // diff-and-confirm via `?confirm=true|false`.
         .route_with_task(
-            "/v1/admin/config/export",
+            "/admin/config/export",
             post(admin::config::export_config),
             admin_config_export,
         )
         .route_with_task(
-            "/v1/admin/config/import",
+            "/admin/config/import",
             post(admin::config::import_config),
             admin_config_import,
         )
-        // Install claim (M0.5.2) — distinct Trust Tasks because the
-        // two phases of the WebAuthn ceremony have different
-        // semantics. Both are POST-only.
-        .route_with_task(
-            "/v1/install/claim/start",
-            post(install::claim_start),
-            install_claim_start,
-        )
-        .route_with_task(
-            "/v1/install/claim/finish",
-            post(install::claim_finish),
-            install_claim_finish,
-        )
+        // Install claim endpoints (`/install/claim/start` and
+        // `/install/claim/finish`) are unauthenticated and live in
+        // `build_unauth_routes` so the tower-governor + tighter
+        // body cap apply.
         // Admin bootstrap (M0.6.2) — closes the install carve-out
         // and writes the first admin ACL entry. Unauthenticated
         // because the setup-session JWT IS the auth credential.
         .route_with_task(
-            "/v1/admin/bootstrap",
+            "/admin/bootstrap",
             post(admin::bootstrap::bootstrap),
             admin_bootstrap,
         )
@@ -349,42 +363,38 @@ pub fn router() -> Router<AppState> {
         // passkey; `register/finish` and `revoke/finish` reject if
         // the UV assertion doesn't verify.
         .route_with_task(
-            "/v1/admin/passkeys",
+            "/admin/passkeys",
             get(admin::passkeys::list),
             admin_passkeys_list,
         )
         .route_with_task(
-            "/v1/admin/passkeys/register/start",
+            "/admin/passkeys/register/start",
             post(admin::passkeys::register_start),
             admin_passkeys_register.clone(),
         )
         .route_with_task(
-            "/v1/admin/passkeys/register/finish",
+            "/admin/passkeys/register/finish",
             post(admin::passkeys::register_finish),
             admin_passkeys_register,
         )
         .route_with_task(
-            "/v1/admin/passkeys/revoke/start",
+            "/admin/passkeys/revoke/start",
             post(admin::passkeys::revoke_start),
             admin_passkeys_revoke.clone(),
         )
         .route_with_task(
-            "/v1/admin/passkeys/revoke/finish",
+            "/admin/passkeys/revoke/finish",
             post(admin::passkeys::revoke_finish),
             admin_passkeys_revoke,
         )
         // Members (Phase 1 M1.4–M1.6).
-        .route_with_task(
-            "/v1/members",
-            get(members::read::list_members),
-            members_list,
-        )
+        .route_with_task("/members", get(members::read::list_members), members_list)
         // `/v1/members/me` for self-remove (M1.11.1). Must be
         // declared BEFORE the `/v1/members/{did}` mount otherwise
         // axum's path-trie picks the parameterised route first
         // and routes "me" as a literal DID.
         .route_with_task(
-            "/v1/members/me",
+            "/members/me",
             axum::routing::delete(members::remove::self_remove),
             members_self_remove,
         )
@@ -392,7 +402,7 @@ pub fn router() -> Router<AppState> {
         // Trust Task header check + per-method selectors are
         // unambiguous.
         .route_with_task(
-            "/v1/members/me/renew",
+            "/members/me/renew",
             post(members::renew::renew),
             members_renew,
         )
@@ -400,12 +410,12 @@ pub fn router() -> Router<AppState> {
         // mints a single-use rotation_id, the finish endpoint
         // applies the co-signed swap atomically.
         .route_with_task(
-            "/v1/members/me/rotate/challenge",
+            "/members/me/rotate/challenge",
             post(members::rotate::challenge),
             members_rotate_challenge,
         )
         .route_with_task(
-            "/v1/members/me/rotate",
+            "/members/me/rotate",
             post(members::rotate::rotate),
             members_rotate,
         )
@@ -415,12 +425,12 @@ pub fn router() -> Router<AppState> {
         // literal segment first. Personhood is a per-member
         // resource; `{did}` is the subject.
         .route_with_task(
-            "/v1/members/{did}/personhood/challenge",
+            "/members/{did}/personhood/challenge",
             post(members::personhood::challenge),
             members_personhood_challenge,
         )
         .route_with_task(
-            "/v1/members/{did}/personhood",
+            "/members/{did}/personhood",
             post(members::personhood::assert).delete(members::personhood::revoke),
             // POST + DELETE share `personhood/assert/1.0` at
             // the router layer pending per-method selectors;
@@ -435,24 +445,24 @@ pub fn router() -> Router<AppState> {
         // and must precede the catchall `/v1/members/{did}`
         // (same path-trie precedence as personhood).
         .route_with_task(
-            "/v1/members/{did}/relationships",
+            "/members/{did}/relationships",
             get(members::relationships::list),
             relationships_list,
         )
         .route_with_task(
-            "/v1/relationships",
+            "/relationships",
             post(relationships::publish),
             relationships_publish,
         )
         .route_with_task(
-            "/v1/relationships/{id}",
+            "/relationships/{id}",
             delete(relationships::revoke),
             relationships_revoke,
         )
         // Phase 4 M4.8.1 — operator-uploaded endorsement type
         // registry. Admin-gated CRUD.
         .route_with_task(
-            "/v1/endorsement-types",
+            "/endorsement-types",
             post(endorsement_types::register).get(endorsement_types::list),
             // POST + GET share `register/1.0` at the router
             // layer pending per-method selectors; standalone
@@ -460,14 +470,14 @@ pub fn router() -> Router<AppState> {
             endorsement_types_register,
         )
         .route_with_task(
-            "/v1/endorsement-types/{type_uri}",
+            "/endorsement-types/{type_uri}",
             delete(endorsement_types::delete),
             endorsement_types_delete,
         )
         // Phase 4 M4.8.2-4 — custom endorsement issuance +
         // retrieval + revocation. Admin OR Issuer-role member.
         .route_with_task(
-            "/v1/credentials/endorsements",
+            "/credentials/endorsements",
             post(endorsements::issue).get(endorsements::list),
             // POST + GET share `issue/1.0` at the router
             // layer pending per-method selectors; standalone
@@ -475,7 +485,7 @@ pub fn router() -> Router<AppState> {
             endorsements_issue,
         )
         .route_with_task(
-            "/v1/credentials/endorsements/{id}",
+            "/credentials/endorsements/{id}",
             axum::routing::get(endorsements::show).delete(endorsements::revoke),
             // GET + DELETE share `show/1.0` at the router
             // layer pending per-method selectors; standalone
@@ -483,7 +493,7 @@ pub fn router() -> Router<AppState> {
             endorsements_show_revoke,
         )
         .route_with_task(
-            "/v1/members/{did}",
+            "/members/{did}",
             get(members::read::show_member)
                 .patch(members::update::update_member)
                 .delete(members::remove::admin_remove),
@@ -496,18 +506,18 @@ pub fn router() -> Router<AppState> {
             members_show,
         )
         .route_with_task(
-            "/v1/members/{did}/promote-to-admin/start",
+            "/members/{did}/promote-to-admin/start",
             post(members::promote::promote_start),
             members_promote.clone(),
         )
         .route_with_task(
-            "/v1/members/{did}/promote-to-admin/finish",
+            "/members/{did}/promote-to-admin/finish",
             post(members::promote::promote_finish),
             members_promote,
         )
         // Join requests (Phase 1 M1.7–M1.10).
         .route_with_task(
-            "/v1/join-requests",
+            "/join-requests",
             // Submit (unauth) + admin list share the mount; the
             // submit Trust Task `join-requests/submit/1.0` covers
             // both methods here. Per-method selectors land
@@ -516,17 +526,17 @@ pub fn router() -> Router<AppState> {
             join_submit,
         )
         .route_with_task(
-            "/v1/join-requests/{id}",
+            "/join-requests/{id}",
             get(join_requests::read::show_join_request),
             join_show,
         )
         .route_with_task(
-            "/v1/join-requests/{id}/approve",
+            "/join-requests/{id}/approve",
             post(join_requests::decide::approve),
             join_approve,
         )
         .route_with_task(
-            "/v1/join-requests/{id}/reject",
+            "/join-requests/{id}/reject",
             post(join_requests::decide::reject),
             join_reject,
         )
@@ -535,12 +545,12 @@ pub fn router() -> Router<AppState> {
         // the per-purpose active pointer; `test` evaluates a stored
         // policy without mutating state.
         .route_with_task(
-            "/v1/policies",
+            "/policies",
             get(policies::read::list_policies).post(policies::admin::upload),
             policies_upload.clone(),
         )
         .route_with_task(
-            "/v1/policies/{id}",
+            "/policies/{id}",
             get(policies::read::show_policy),
             // Reuses the upload task on the shared mount; the
             // `policies/show/1.0` Trust Task lives in index.json
@@ -548,14 +558,179 @@ pub fn router() -> Router<AppState> {
             policies_upload.clone(),
         )
         .route_with_task(
-            "/v1/policies/{id}/activate",
+            "/policies/{id}/activate",
             post(policies::admin::activate),
             policies_activate,
         )
         .route_with_task(
-            "/v1/policies/{id}/test",
+            "/policies/{id}/test",
             post(policies::admin::test),
             policies_test,
         )
         .into_router()
+        // §14.4 — every authenticated API route inherits the 1 MiB
+        // global body cap. Per-route overrides for `/v1/website/*`
+        // bundle deploys (M5.5) disable this with
+        // `DefaultBodyLimit::disable()` and attach a wider per-route
+        // `RequestBodyLimitLayer`.
+        .layer(DefaultBodyLimit::max(MAX_BODY_SIZE));
+
+    // Unauthenticated routes — tighter body cap + per-IP governor.
+    let unauth = build_unauth_routes();
+
+    assemble(routing, api.merge(unauth))
+}
+
+/// Build the unauthenticated sub-router: 5 POST routes that drive
+/// expensive crypto against attacker-controlled bytes.
+///
+/// - `POST /auth/challenge`
+/// - `POST /auth/` (authenticate)
+/// - `POST /auth/refresh`
+/// - `POST /install/claim/start`
+/// - `POST /install/claim/finish`
+///
+/// Layers:
+/// - [`UNAUTH_BODY_SIZE`] body cap (tighter than the 1 MiB main
+///   API cap — generous enough for a JWE / sealed-transfer
+///   envelope, small enough to reject blob floods).
+/// - Per-IP `tower-governor` (5 rps + 10 burst) via
+///   [`SmartIpKeyExtractor`].
+fn build_unauth_routes() -> Router<AppState> {
+    let auth_challenge =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0")
+            .expect("static Trust-Task URL");
+    let auth_authenticate =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/authenticate/1.0")
+            .expect("static Trust-Task URL");
+    let auth_refresh = TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/refresh/1.0")
+        .expect("static Trust-Task URL");
+    let install_claim_start =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/start/1.0")
+            .expect("static Trust-Task URL");
+    let install_claim_finish =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0")
+            .expect("static Trust-Task URL");
+
+    let governor_config = Arc::new(
+        GovernorConfigBuilder::default()
+            .per_second(5)
+            .burst_size(10)
+            .key_extractor(SmartIpKeyExtractor)
+            .finish()
+            .expect("governor config values are static and non-zero"),
+    );
+    let governor = GovernorLayer::new(governor_config);
+
+    // `SmartIpKeyExtractor` reads `X-Forwarded-For` / `X-Real-IP` /
+    // `Forwarded` headers first and only falls back to `ConnectInfo`
+    // when none are set. In production the `axum::serve` call in
+    // `server.rs` wires `into_make_service_with_connect_info` so the
+    // peer-IP fallback works; in integration tests built on
+    // `Router::oneshot`, neither headers nor `ConnectInfo` are present
+    // and the extractor errors with 500. This synthetic-`ConnectInfo`
+    // middleware inserts a `127.0.0.1` placeholder **only when missing**
+    // so test calls take the peer-IP fallback path — production traffic
+    // (which already carries `ConnectInfo` from the service factory)
+    // is untouched.
+    let synth_connect_info = axum::middleware::from_fn(insert_default_connect_info_if_missing);
+
+    TrustTaskRouter::<AppState>::new()
+        .route_with_task("/auth/challenge", post(auth::challenge), auth_challenge)
+        .route_with_task("/auth/", post(auth::authenticate), auth_authenticate)
+        .route_with_task("/auth/refresh", post(auth::refresh), auth_refresh)
+        .route_with_task(
+            "/install/claim/start",
+            post(install::claim_start),
+            install_claim_start,
+        )
+        .route_with_task(
+            "/install/claim/finish",
+            post(install::claim_finish),
+            install_claim_finish,
+        )
+        .into_router()
+        .layer(DefaultBodyLimit::max(UNAUTH_BODY_SIZE))
+        .layer(governor)
+        .layer(synth_connect_info)
+}
+
+/// Middleware that inserts a `ConnectInfo<SocketAddr>(127.0.0.1)`
+/// extension if the request doesn't already carry one. See the
+/// rationale comment in [`build_unauth_routes`].
+async fn insert_default_connect_info_if_missing(
+    mut request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use axum::extract::ConnectInfo;
+
+    if request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .is_none()
+    {
+        let synthetic =
+            ConnectInfo::<SocketAddr>(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0));
+        request.extensions_mut().insert(synthetic);
+    }
+    next.run(request).await
+}
+
+/// Build the public router from the API sub-router + placeholder
+/// admin/website surfaces. Extracted so unit tests can exercise
+/// nest behaviour without rebuilding the full TrustTaskRouter.
+fn assemble(routing: &RoutingConfig, api: Router<AppState>) -> Router<AppState> {
+    use axum::middleware::from_fn;
+
+    use crate::routing::security_headers::security_headers;
+
+    // Admin UX + website sub-routers serve HTML/JS to a browser;
+    // both get the default CSP + `X-Content-Type-Options: nosniff`
+    // layer (Phase 5 M5.3.2). The API sub-router is a JSON wire
+    // surface and is intentionally excluded — CSP is browser-only.
+    let admin_placeholder: Router<AppState> = Router::new()
+        .fallback(any(placeholder_503))
+        .layer(from_fn(security_headers));
+    let website_placeholder: Router<AppState> = Router::new()
+        .fallback(any(placeholder_503))
+        .layer(from_fn(security_headers));
+
+    let mut app: Router<AppState> = Router::new()
+        // `/health` is the single Trust-Task-exempt endpoint;
+        // attached at the parent-router root so monitoring works
+        // identically across path mode and subdomain mode (the
+        // operator just curls `/health` on whichever host the
+        // daemon is reachable on).
+        .route("/health", get(health::health))
+        // API surface — existing TrustTaskRouter result nested at
+        // the configured mount.
+        .nest(&routing.api.mount, api);
+
+    // Admin UX surface. The cookie-scope guard in
+    // `validate_routing` already refuses admin_ui at `/`; here we
+    // just trust the prior validation.
+    app = app.nest(&routing.admin_ui.mount, admin_placeholder);
+
+    // Website surface. axum 0.8 refuses `nest("/", ...)`; when the
+    // mount is the root, merge instead so the placeholder's
+    // fallback (with security headers attached) becomes the
+    // parent's fallback. Non-root mounts use the regular nest path.
+    if routing.website.mount == "/" {
+        app = app.merge(website_placeholder);
+    } else {
+        app = app.nest(&routing.website.mount, website_placeholder);
+    }
+
+    app
+}
+
+/// Placeholder handler returned by the admin UX + website
+/// sub-routers until M5.4 / M5.7 land real handlers.
+async fn placeholder_503() -> impl IntoResponse {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        "surface not yet implemented",
+    )
 }

--- a/vtc-service/src/routing/csrf.rs
+++ b/vtc-service/src/routing/csrf.rs
@@ -1,0 +1,247 @@
+//! CSRF protection for admin mutating endpoints (Phase 5 M5.2.2).
+//!
+//! Tower middleware enforces one of two checks on every
+//! `POST` / `PUT` / `PATCH` / `DELETE` request to the API surface:
+//!
+//! 1. **`Sec-Fetch-Site: same-origin`** — modern browsers stamp
+//!    this header on fetches initiated from the same origin as the
+//!    receiving server. Non-browser clients (cnm-cli, programmatic
+//!    SDK consumers, DIDComm bridges) don't set it, so the second
+//!    check carries them.
+//!
+//! 2. **CSRF double-submit cookie** — the request must carry a
+//!    `csrf` cookie value that matches the `X-CSRF-Token`
+//!    request header. The cookie is set by the admin-login flow
+//!    (M5.2.3); programmatic clients ignore this entirely.
+//!
+//! Either check passing → request continues. Both failing → 403
+//! `CsrfFailed`. The two checks are belt-and-braces: a malicious
+//! cross-origin POST from a public-website XSS would have neither
+//! `Sec-Fetch-Site: same-origin` (it'd be `cross-site`) nor the
+//! `csrf` cookie's matching token (it can't read the cookie value
+//! across origins).
+//!
+//! ## Exemptions
+//!
+//! - **GET / HEAD / OPTIONS** are not state-mutating and pass through.
+//! - **`POST /v1/join-requests`** is the public form-encoded submit
+//!   endpoint (§9.3) — public-site JS posts directly without
+//!   preflight via simple-request semantics. Exempted by path
+//!   prefix match.
+//! - **`POST /v1/auth/challenge` / `/v1/auth/` / `/v1/auth/refresh`**
+//!   are the JWT-issuance unauth flows — the bearer token IS the
+//!   auth credential, no cookie session yet exists to bind a CSRF
+//!   token to. Exempted by path prefix match.
+//! - **`POST /v1/install/claim/{start,finish}`** are the install
+//!   ceremony unauth endpoints — same rationale. Exempted.
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{HeaderValue, Method, Response, StatusCode};
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use serde_json::json;
+
+/// Paths exempt from CSRF: unauth bootstrapping flows + the public
+/// form-post target. Each is documented in the module-level
+/// rationale.
+const CSRF_EXEMPT_PATHS: &[&str] = &[
+    "/v1/join-requests",
+    "/v1/auth/challenge",
+    "/v1/auth/",
+    "/v1/auth/refresh",
+    "/v1/install/claim/start",
+    "/v1/install/claim/finish",
+];
+
+/// Tower middleware function. Wire via
+/// `axum::middleware::from_fn(enforce)` at the parent-router level
+/// so the layer sees the full path including the API mount prefix
+/// (the exemption matcher compares against the post-nest URI).
+pub async fn enforce(request: Request, next: Next) -> Response<Body> {
+    // Method gate — only state-mutating verbs are checked.
+    match *request.method() {
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE => {}
+        _ => return next.run(request).await,
+    }
+
+    let path = request.uri().path();
+
+    // Path gate — bootstrapping flows + public form post bypass.
+    if CSRF_EXEMPT_PATHS.contains(&path) {
+        return next.run(request).await;
+    }
+
+    // Check 1 — modern browser stamp.
+    if request
+        .headers()
+        .get("sec-fetch-site")
+        .map(|v| v == HeaderValue::from_static("same-origin"))
+        .unwrap_or(false)
+    {
+        return next.run(request).await;
+    }
+
+    // Check 2 — double-submit cookie + matching header.
+    let cookie_token = request
+        .headers()
+        .get_all(axum::http::header::COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.split(';'))
+        .map(|s| s.trim())
+        .find_map(|kv| kv.strip_prefix("csrf="));
+    let header_token = request
+        .headers()
+        .get("x-csrf-token")
+        .and_then(|v| v.to_str().ok());
+
+    if let (Some(c), Some(h)) = (cookie_token, header_token)
+        && !c.is_empty()
+        && c == h
+    {
+        return next.run(request).await;
+    }
+
+    let body = json!({
+        "error": "CsrfFailed",
+        "message": "POST/PUT/PATCH/DELETE requests require Sec-Fetch-Site: same-origin or a matching csrf cookie + X-CSRF-Token header",
+    });
+    (StatusCode::FORBIDDEN, axum::Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::post;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    async fn ok() -> &'static str {
+        "ok"
+    }
+
+    fn app() -> Router {
+        Router::new()
+            .route("/v1/members", post(ok).get(ok))
+            .route("/v1/join-requests", post(ok))
+            .route("/v1/auth/challenge", post(ok))
+            .layer(axum::middleware::from_fn(enforce))
+    }
+
+    #[tokio::test]
+    async fn get_bypasses() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/members")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_without_csrf_returns_403() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/members")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body: serde_json::Value =
+            serde_json::from_slice(&resp.into_body().collect().await.unwrap().to_bytes()).unwrap();
+        assert_eq!(body["error"], "CsrfFailed");
+    }
+
+    #[tokio::test]
+    async fn post_with_sec_fetch_site_same_origin_passes() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/members")
+                    .header("sec-fetch-site", "same-origin")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_with_matching_csrf_cookie_and_header_passes() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/members")
+                    .header("cookie", "csrf=abc123; other=foo")
+                    .header("x-csrf-token", "abc123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_with_non_matching_csrf_header_returns_403() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/members")
+                    .header("cookie", "csrf=abc123")
+                    .header("x-csrf-token", "different")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn public_join_request_post_bypasses() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/join-requests")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn auth_challenge_post_bypasses() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/auth/challenge")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/vtc-service/src/routing/host_dispatch.rs
+++ b/vtc-service/src/routing/host_dispatch.rs
@@ -1,0 +1,168 @@
+//! Subdomain-mode `Host` header check (Phase 5 M5.1.2).
+//!
+//! Tower middleware that inspects the request `Host` header against
+//! the per-surface map declared in [`crate::config::RoutingConfig`].
+//! Behaviour:
+//!
+//! - When **every** surface has `host = None` (pure path mode), the
+//!   middleware is a no-op — the parent router does prefix matching
+//!   alone.
+//! - When **any** surface has a host set, the middleware:
+//!   1. Reads `Host` from the request (HTTP/2 `:authority` is
+//!      normalised onto the `Host` header by axum before the layer
+//!      runs).
+//!   2. Matches against the set of configured surface hosts
+//!      (case-insensitive, port-aware).
+//!   3. On match: pass through. The parent router then routes by
+//!      path within whichever surface matches.
+//!   4. On miss + `subdomain_mode_strict = true` (default): returns
+//!      404 `HostNotRecognised`.
+//!   5. On miss + `subdomain_mode_strict = false`: pass through —
+//!      the parent router falls back to path matching against all
+//!      configured mounts. Debug aid only; not recommended for
+//!      production.
+//!
+//! Per-host/per-path enforcement (e.g. `admin.example.com` 404s
+//! `/v1/...` paths) is **not** in this middleware. The path-mode
+//! prefix matching inside axum's `Router::nest` already does that —
+//! a path that doesn't match the surface's nest boundary returns
+//! 404 via the regular handler chain.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use axum::extract::Request;
+use axum::http::{StatusCode, header::HOST};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+
+use crate::config::RoutingConfig;
+
+/// Compiled host map. Cheap to clone, shared across requests via
+/// `Arc`. Built once at router-assembly time so the per-request
+/// path is a single `HashSet::contains` call.
+#[derive(Debug, Clone)]
+pub struct HostMap {
+    /// Lower-cased configured hosts. Empty when every surface uses
+    /// path mode — the layer short-circuits.
+    hosts: Arc<HashSet<String>>,
+    strict: bool,
+}
+
+impl HostMap {
+    /// Compile the surface host set from [`RoutingConfig`].
+    pub fn from_routing(routing: &RoutingConfig) -> Self {
+        let mut hosts = HashSet::new();
+        for surface in [&routing.api, &routing.admin_ui, &routing.website] {
+            if let Some(h) = surface.host.as_deref() {
+                hosts.insert(h.to_ascii_lowercase());
+            }
+        }
+        Self {
+            hosts: Arc::new(hosts),
+            strict: routing.subdomain_mode_strict,
+        }
+    }
+
+    /// True when no surface has a `host` set; the middleware is a
+    /// no-op in that case.
+    pub fn is_path_mode(&self) -> bool {
+        self.hosts.is_empty()
+    }
+
+    /// True when the configured Host map recognises this header
+    /// value (case-insensitive). Returns `true` unconditionally in
+    /// path mode so callers can use it as a single decision point.
+    fn matches(&self, host_header: &str) -> bool {
+        if self.is_path_mode() {
+            return true;
+        }
+        self.hosts.contains(&host_header.to_ascii_lowercase())
+    }
+}
+
+/// Tower middleware function. Wire via
+/// `axum::middleware::from_fn_with_state(host_map.clone(), enforce)`.
+pub async fn enforce(
+    axum::extract::State(map): axum::extract::State<HostMap>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if map.is_path_mode() {
+        return next.run(request).await;
+    }
+
+    let host = request
+        .headers()
+        .get(HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    let allowed = match host.as_deref() {
+        Some(h) => map.matches(h),
+        // Missing Host header — HTTP/1.1 requires it. Treat as
+        // unrecognised in strict mode.
+        None => false,
+    };
+
+    if allowed || !map.strict {
+        return next.run(request).await;
+    }
+
+    // 404 with the same JSON shape as `AppError::IntoResponse`.
+    let body = json!({
+        "error": "HostNotRecognised",
+        "host": host,
+    });
+    (StatusCode::NOT_FOUND, axum::Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MountConfig;
+
+    fn cfg(
+        api_host: Option<&str>,
+        admin_host: Option<&str>,
+        web_host: Option<&str>,
+    ) -> RoutingConfig {
+        RoutingConfig {
+            api: MountConfig {
+                mount: "/v1".into(),
+                host: api_host.map(String::from),
+            },
+            admin_ui: MountConfig {
+                mount: "/admin".into(),
+                host: admin_host.map(String::from),
+            },
+            website: MountConfig {
+                mount: "/".into(),
+                host: web_host.map(String::from),
+            },
+            subdomain_mode_strict: true,
+        }
+    }
+
+    #[test]
+    fn path_mode_when_no_hosts_set() {
+        let map = HostMap::from_routing(&cfg(None, None, None));
+        assert!(map.is_path_mode());
+        // matches() returns true for anything in path mode.
+        assert!(map.matches("anything.example.com"));
+    }
+
+    #[test]
+    fn matches_recognises_configured_host() {
+        let map = HostMap::from_routing(&cfg(
+            Some("api.example.com"),
+            Some("admin.example.com"),
+            None,
+        ));
+        assert!(!map.is_path_mode());
+        assert!(map.matches("api.example.com"));
+        assert!(map.matches("ADMIN.example.com")); // case-insensitive
+        assert!(!map.matches("other.example.com"));
+    }
+}

--- a/vtc-service/src/routing/mod.rs
+++ b/vtc-service/src/routing/mod.rs
@@ -1,0 +1,16 @@
+//! Routing-layer middleware (Phase 5).
+//!
+//! Holds the cross-cutting layers that wrap the per-surface
+//! sub-routers built in [`crate::routes`]:
+//!
+//! - [`host_dispatch`] — subdomain-mode `Host` header check.
+//!
+//! Body-cap enforcement + tower-governor rate limiting are layered
+//! directly in [`crate::routes::router_with`] at the API nest
+//! boundary; they live near the route attach site so per-route
+//! overrides (M5.5) can opt out without reaching back into this
+//! module.
+
+pub mod csrf;
+pub mod host_dispatch;
+pub mod security_headers;

--- a/vtc-service/src/routing/security_headers.rs
+++ b/vtc-service/src/routing/security_headers.rs
@@ -1,0 +1,52 @@
+//! Browser security-header middleware (Phase 5 M5.3.2).
+//!
+//! Attached to the admin UX + website sub-routers — both surfaces
+//! serve HTML/JS to a browser. The API sub-router does **not** get
+//! these headers; it's a JSON wire surface for programmatic clients
+//! and CSP is meaningless there.
+//!
+//! Headers attached:
+//!
+//! - `X-Content-Type-Options: nosniff` — refuses browser MIME
+//!   sniffing. Always on.
+//! - `Content-Security-Policy` — default `default-src 'self';
+//!   script-src 'self'; object-src 'none'; base-uri 'self'`. Spec
+//!   §12.1 lets operators relax this per-site for SPA needs once
+//!   the website handler (M5.4) reads a `.vtc-website.toml`
+//!   override.
+//!
+//! When the response already carries one of these headers (e.g. a
+//! handler wants a stricter `Cache-Control: no-store` and bundled
+//! its own CSP), the middleware **does not overwrite** — it only
+//! fills in missing headers.
+
+use axum::extract::Request;
+use axum::http::HeaderValue;
+use axum::http::header::{CONTENT_SECURITY_POLICY, X_CONTENT_TYPE_OPTIONS};
+use axum::middleware::Next;
+use axum::response::Response;
+
+/// Default CSP attached to admin UX + website responses.
+pub const DEFAULT_CSP: &str =
+    "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'";
+
+/// Tower middleware function. Wire via
+/// `axum::middleware::from_fn(security_headers)` on the admin UX
+/// and website sub-routers.
+pub async fn security_headers(request: Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+
+    if !headers.contains_key(X_CONTENT_TYPE_OPTIONS) {
+        headers.insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
+    }
+    if !headers.contains_key(CONTENT_SECURITY_POLICY) {
+        // `from_static` is safe — `DEFAULT_CSP` is ASCII.
+        headers.insert(
+            CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static(DEFAULT_CSP),
+        );
+    }
+
+    response
+}

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -541,18 +541,27 @@ pub async fn run(
         }
     }
 
-    // Snapshot the CORS allowlist before the AppState `move` into
-    // the REST thread. The layer is fixed at start-up; a future
-    // M0.8.x extension can swap the layer on `POST /v1/admin/config/reload`
-    // if operators demand live updates.
+    // Snapshot the CORS allowlist + routing config before the
+    // AppState `move` into the REST thread. Both layers are fixed
+    // at start-up; a future `POST /v1/admin/config/reload` can
+    // swap them if operators demand live updates.
     let rest_cors = state.config.read().await.cors.clone();
+    let rest_routing = state.config.read().await.routing.clone();
 
     // Spawn three named OS threads
     let mut rest_shutdown_rx = shutdown_rx.clone();
     let rest_state = state.clone();
     let rest_handle = std::thread::Builder::new()
         .name("vtc-rest".into())
-        .spawn(move || run_rest_thread(std_listener, rest_state, rest_cors, &mut rest_shutdown_rx))
+        .spawn(move || {
+            run_rest_thread(
+                std_listener,
+                rest_state,
+                rest_cors,
+                rest_routing,
+                &mut rest_shutdown_rx,
+            )
+        })
         .map_err(|e| AppError::Internal(format!("failed to spawn REST thread: {e}")))?;
 
     let mut didcomm_shutdown_rx = shutdown_rx.clone();
@@ -751,6 +760,7 @@ fn run_rest_thread(
     std_listener: std::net::TcpListener,
     state: AppState,
     cors: crate::config::CorsConfig,
+    routing: crate::config::RoutingConfig,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -766,19 +776,42 @@ fn run_rest_thread(
 
         let cors_layer = build_cors_layer(&cors);
 
-        let app = routes::router()
+        // Subdomain-mode host-dispatch (Phase 5 M5.1.2). The
+        // middleware is a no-op when every routing surface has
+        // `host = None` (pure path mode), so configuring it
+        // unconditionally is cheap.
+        let host_map = crate::routing::host_dispatch::HostMap::from_routing(&routing);
+        let host_layer =
+            axum::middleware::from_fn_with_state(host_map, crate::routing::host_dispatch::enforce);
+
+        // CSRF double-submit + Sec-Fetch-Site check (Phase 5
+        // M5.2.2). Bootstrapping flows + the public form-post
+        // target are path-exempt — see `routing::csrf` for the
+        // exemption list.
+        let csrf_layer = axum::middleware::from_fn(crate::routing::csrf::enforce);
+
+        let app = routes::router_with(&routing)
             .with_state(state)
+            .layer(csrf_layer)
+            .layer(host_layer)
             .layer(cors_layer)
             .layer(TraceLayer::new_for_http());
 
         let shutdown_rx = shutdown_rx.clone();
-        axum::serve(listener, app)
-            .with_graceful_shutdown(async move {
-                let mut rx = shutdown_rx;
-                let _ = rx.changed().await;
-            })
-            .await
-            .expect("axum serve failed");
+        // `into_make_service_with_connect_info` is required for the
+        // tower-governor `SmartIpKeyExtractor` to fall back to the
+        // peer socket address when `X-Forwarded-For` / `X-Real-IP`
+        // headers are absent (Phase 5 M5.1.5).
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .with_graceful_shutdown(async move {
+            let mut rx = shutdown_rx;
+            let _ = rx.changed().await;
+        })
+        .await
+        .expect("axum serve failed");
 
         info!("REST thread shutting down");
     });

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -85,6 +85,7 @@ fn rejects_admin_ui_mounted_at_root_in_path_mode() {
             mount: "/site".into(),
             host: None,
         },
+        subdomain_mode_strict: true,
     };
     let err = cfg_with(routing, Default::default())
         .validate_routing_and_cors()
@@ -109,6 +110,7 @@ fn allows_admin_ui_at_root_when_host_routed() {
             mount: "/".into(),
             host: Some("example.com".into()),
         },
+        subdomain_mode_strict: true,
     };
     cfg_with(routing, Default::default())
         .validate_routing_and_cors()
@@ -130,6 +132,7 @@ fn rejects_duplicate_path_mounts() {
             mount: "/".into(),
             host: None,
         },
+        subdomain_mode_strict: true,
     };
     let err = cfg_with(routing, Default::default())
         .validate_routing_and_cors()


### PR DESCRIPTION
## Summary

Phase 5 PR-1 (partial) — landing 7 of 10 sub-tasks from the bundled plan. The remaining 3 (M5.1.3 + M5.2.3 + M5.3.1) form a coherent follow-up around the admin cookie session and land as PR-1b.

**Scope adjustment from the planning PR**: M5.2.3 (admin-login mint flow + cookie-bearing `AdminAuth` extractor + Trust Task spec) expanded beyond the planner's estimate once I started designing the route. The cookie auth path needs its own coherent surface — splitting at this boundary keeps the diff reviewable and matches Phase 4's actual cadence (avg ~2 milestones/PR).

## What's in this PR

| Sub-task | Scope |
|---|---|
| **M5.1.1** | `routes::router_with(routing)` nests API at `routing.api.mount` (default `/v1`), admin UX at `/admin` (503 placeholder), website at `/` (503 placeholder). `/health` at parent-router root. Wire URLs unchanged. |
| **M5.1.2** | `routing::host_dispatch::enforce` returns 404 `HostNotRecognised` for unknown `Host` headers in subdomain mode. New config knob `routing.subdomain_mode_strict: bool` (default `true`). |
| **M5.1.4** | 1 MiB `DefaultBodyLimit::max` on API surface + 64 KiB on unauth sub-router. |
| **M5.1.5** | `tower-governor` 5 rps + 10 burst per IP on 5 unauth POST routes (`auth/{challenge,authenticate,refresh}`, `install/claim/{start,finish}`). `server.rs` now uses `into_make_service_with_connect_info::<SocketAddr>()` for production IP extraction; synthetic ConnectInfo middleware fills in for `oneshot` tests. |
| **M5.2.2** | `routing::csrf::enforce` requires `Sec-Fetch-Site: same-origin` OR matching `csrf` cookie + `X-CSRF-Token` header on mutating API routes. 6 paths exempt (5 unauth bootstrap routes + public form-post `/v1/join-requests`). |
| **M5.3.2** | `routing::security_headers::security_headers` attaches `X-Content-Type-Options: nosniff` + default CSP (`default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'`) to admin UX + website sub-routers. API surface excluded (JSON wire). |

## D11 + D12 sign-off captured

- **D11**: §14.4 runtime guards (body cap + governor) were never wired in Phase 0–4. M5.1.4 + M5.1.5 land them.
- **D12**: Cookie-based admin auth target — M5.2.2 ships the CSRF middleware that pairs with the cookie session. The mint flow lands in PR-1b.

## What's deferred to PR-1b

- **M5.1.3** Routing-mode integration test fixtures (`tests/routing/{path,subdomain}_mode.rs`)
- **M5.2.1** CORS allowlist enforcement audit (most coverage already in `routing_cors.rs` from Phase 0)
- **M5.2.3** Admin session cookie mint flow + cookie-bearing extractor + Trust Task `auth/admin-login/1.0`
- **M5.3.1** Cookie-scope isolation tests (depends on M5.2.3)

## Verification

- `cargo build` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- **565 total tests passing**: 321 vtc-service lib + 237 integration + 7 new CSRF unit tests

## Test plan

- [ ] Reviewer confirms the scope split (PR-1a now / PR-1b next) makes sense — alternative was a single ~1500 LoC PR
- [ ] Reviewer sanity-checks the path-prefix nest doesn't change any wire URL
- [ ] Reviewer confirms the unauth governor's 5-route scope (no `/v1/admin/bootstrap`, no `/v1/join-requests` POST — the latter is exempt from CSRF but doesn't get the governor; documented as known gap)
- [ ] Reviewer agrees CSRF integration coverage via unit tests (in-module) is sufficient pending the admin-login work

After this merges: open PR-1b for M5.1.3 + M5.2.3 + M5.3.1.