### PR TITLE
feat(vtc-service): M5.1.3 + M5.2.3 + M5.3.1 — admin cookie session

### DIFF
--- a/trust-tasks/auth/admin-login/1.0/schema.json
+++ b/trust-tasks/auth/admin-login/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/auth/admin-login/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — Admin SPA cookie session mint",
+  "description": "DIDComm-packed authenticate request body. Wire shape identical to auth/legacy/authenticate/1.0; the cookie side-effect is server-side only.",
+  "type": "object"
+}

--- a/trust-tasks/auth/admin-login/1.0/spec.md
+++ b/trust-tasks/auth/admin-login/1.0/spec.md
@@ -1,0 +1,62 @@
+---
+id: https://trusttasks.org/openvtc/vtc/auth/admin-login/1.0
+title: VTC — Admin SPA cookie session mint
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/auth/admin-login
+inputs:
+  - DIDComm-packed authenticate message (same shape as
+    `auth/legacy/authenticate/1.0`)
+outputs:
+  - HTTP 200 with `AuthenticateResponse` JSON body
+  - `Set-Cookie: vtc_admin_session=<jwt>; Path=/admin; SameSite=Strict; Secure; HttpOnly`
+  - `Set-Cookie: csrf=<random-32-byte-hex>; Path=/; SameSite=Strict; Secure`
+trust_assumptions:
+  - The DIDComm authenticate message carries the same signed
+    challenge required by `auth/legacy/authenticate/1.0`. The
+    cookie-session flow is **identical** at the credential layer
+    — it just delivers the JWT via a cookie scope appropriate
+    for browser-based SPA usage.
+  - Cookie `Path=/admin` constrains the session to the admin UX
+    surface; public-website JS on the same origin cannot read it.
+  - Companion CSRF cookie is JS-readable so the SPA can echo its
+    value into an `X-CSRF-Token` header for the double-submit
+    check in `routing::csrf`.
+related:
+  - https://trusttasks.org/openvtc/vtc/auth/legacy/authenticate/1.0
+  - https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0
+---
+
+# VTC — Admin SPA cookie session mint
+
+Phase 5 M5.2.3. Companion to the existing DIDComm authenticate
+flow (`auth/legacy/authenticate/1.0`). Same wire shape, same
+session/JWT machinery — the only difference is the response
+side-effect: this endpoint additionally returns `Set-Cookie`
+headers carrying the access-token JWT and a CSRF double-submit
+token.
+
+The admin SPA built by `vtc-admin-ui` (Phase 5 M5.6+) calls this
+endpoint at admin login. Subsequent SPA requests carry:
+
+- The session cookie automatically (browser attaches it on
+  same-origin fetches under `/admin/*` — the cookie's `Path`
+  scope ensures public-website JS cannot read or send it).
+- The CSRF cookie's value mirrored into an `X-CSRF-Token`
+  header on every mutating request.
+
+Programmatic clients (cnm-cli, DIDComm bridges) keep using
+`POST /v1/auth/` for the bearer-JWT flow. No cookie side effects
+there.
+
+## Why a separate Trust Task
+
+The cookie side-effect is the only deliberate observable
+difference from `auth/legacy/authenticate/1.0`. Operators
+choosing between the two flows need to know which side effects
+they're opting into; separating the Trust Task IDs makes that
+choice explicit at the SIEM and audit-tail layers (filters on
+`Trust-Task` value distinguish bearer vs cookie session mints).

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -24,6 +24,12 @@
       "rest": "POST /v1/auth/refresh"
     },
     {
+      "id": "https://trusttasks.org/openvtc/vtc/auth/admin-login/1.0",
+      "status": "Draft",
+      "path": "auth/admin-login/1.0",
+      "rest": "POST /v1/auth/admin-login"
+    },
+    {
       "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0",
       "status": "Draft",
       "path": "auth/legacy/sessions/manage/1.0",

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -68,6 +68,18 @@ pub async fn authenticate(
     State(state): State<AppState>,
     body: String,
 ) -> Result<Json<AuthenticateResponse>, AppError> {
+    Ok(Json(authenticate_and_mint(&state, &body).await?))
+}
+
+/// Core authenticate + mint logic shared by `POST /v1/auth/` and
+/// `POST /v1/auth/admin-login`. Both endpoints accept the same
+/// DIDComm-packed authentication message; `admin-login`
+/// additionally returns `Set-Cookie` headers so the admin SPA can
+/// carry a cookie session beside the bearer token.
+async fn authenticate_and_mint(
+    state: &AppState,
+    body: &str,
+) -> Result<AuthenticateResponse, AppError> {
     let atm = state
         .atm
         .as_ref()
@@ -79,7 +91,7 @@ pub async fn authenticate(
 
     // Unpack the DIDComm message
     let (msg, _metadata) = atm
-        .unpack(&body)
+        .unpack(body)
         .await
         .map_err(|e| AppError::Authentication(format!("failed to unpack message: {e}")))?;
 
@@ -174,7 +186,7 @@ pub async fn authenticate(
 
     info!(did = %session.did, session_id = %session.session_id, "authentication successful");
 
-    Ok(Json(AuthenticateResponse {
+    Ok(AuthenticateResponse {
         session_id: Some(session.session_id),
         data: AuthenticateData {
             access_token,
@@ -182,7 +194,137 @@ pub async fn authenticate(
             refresh_token: Some(refresh_token),
             refresh_expires_at: Some(refresh_expires_at),
         },
-    }))
+    })
+}
+
+// ---------- POST /auth/admin-login ----------
+
+/// `POST /v1/auth/admin-login` (Phase 5 M5.2.3).
+///
+/// Same DIDComm-packed authentication flow as `POST /v1/auth/`,
+/// but the response additionally carries `Set-Cookie` headers so
+/// the admin SPA can drive subsequent requests via the cookie
+/// session:
+///
+/// - `vtc_admin_session=<jwt>; Path=/admin; SameSite=Strict;
+///   Secure; HttpOnly` — the access token JWT, scoped to the
+///   admin UX path so public-website JS on the same origin can't
+///   read it.
+/// - `csrf=<random>; Path=/; SameSite=Strict; Secure` (HttpOnly:
+///   **false** so SPA JS can mirror the value to the
+///   `X-CSRF-Token` header for the double-submit check in
+///   `routing::csrf`).
+///
+/// Programmatic clients (cnm-cli, DIDComm bridges) keep using
+/// `POST /v1/auth/` — same JWT shape, no cookie side effects.
+pub async fn admin_login(
+    State(state): State<AppState>,
+    body: String,
+) -> Result<axum::response::Response, AppError> {
+    use axum::http::HeaderValue;
+    use axum::http::header::SET_COOKIE;
+    use axum::response::IntoResponse;
+
+    let resp = authenticate_and_mint(&state, &body).await?;
+
+    let max_age = resp
+        .data
+        .access_expires_at
+        .saturating_sub(now_epoch())
+        .max(1);
+
+    // Generate a 32-byte CSRF token, hex-encoded. The cookie is
+    // JS-readable (HttpOnly off) so the SPA can echo it back via
+    // the `X-CSRF-Token` header on mutating requests.
+    use rand::RngExt;
+    let mut csrf_bytes = [0u8; 32];
+    rand::rng().fill(&mut csrf_bytes);
+    let csrf = hex::encode(csrf_bytes);
+
+    let session_cookie = build_session_cookie(&resp.data.access_token, max_age);
+    let csrf_cookie = build_csrf_cookie(&csrf, max_age);
+
+    let session_cookie_hv = HeaderValue::try_from(session_cookie)
+        .map_err(|e| AppError::Internal(format!("invalid session cookie value: {e}")))?;
+    let csrf_cookie_hv = HeaderValue::try_from(csrf_cookie)
+        .map_err(|e| AppError::Internal(format!("invalid csrf cookie value: {e}")))?;
+
+    let mut response = Json(resp).into_response();
+    let headers = response.headers_mut();
+    headers.append(SET_COOKIE, session_cookie_hv);
+    headers.append(SET_COOKIE, csrf_cookie_hv);
+
+    Ok(response)
+}
+
+/// Build the `vtc_admin_session` cookie value. Exposed as a pure
+/// helper so cookie-isolation invariants (Path=/admin,
+/// SameSite=Strict, Secure, HttpOnly) can be unit-tested
+/// without standing up the full DIDComm authenticate flow.
+fn build_session_cookie(access_token: &str, max_age: u64) -> String {
+    format!(
+        "{name}={access_token}; Path=/admin; Max-Age={max_age}; SameSite=Strict; Secure; HttpOnly",
+        name = vti_common::auth::extractor::ADMIN_SESSION_COOKIE,
+    )
+}
+
+/// Build the companion CSRF cookie. `HttpOnly` is intentionally
+/// **not** set — the SPA needs to read this from
+/// `document.cookie` and mirror its value into the
+/// `X-CSRF-Token` header on every mutating request.
+fn build_csrf_cookie(csrf: &str, max_age: u64) -> String {
+    format!("csrf={csrf}; Path=/; Max-Age={max_age}; SameSite=Strict; Secure")
+}
+
+#[cfg(test)]
+mod cookie_format_tests {
+    use super::*;
+
+    /// Phase 5 M5.3.1 cookie-scope isolation invariant — the
+    /// admin session cookie MUST carry `Path=/admin` so public-
+    /// website JS on the same origin cannot read it.
+    #[test]
+    fn session_cookie_path_is_admin() {
+        let c = build_session_cookie("jwt.token.value", 900);
+        assert!(c.contains("Path=/admin"), "got {c}");
+        assert!(!c.contains("Path=/;"), "must not be root-scoped: {c}");
+    }
+
+    #[test]
+    fn session_cookie_has_security_flags() {
+        let c = build_session_cookie("jwt.token.value", 900);
+        // All three flags are load-bearing — losing any one is
+        // a CSRF / cookie-theft / TLS-stripping regression.
+        assert!(c.contains("HttpOnly"), "got {c}");
+        assert!(c.contains("Secure"), "got {c}");
+        assert!(c.contains("SameSite=Strict"), "got {c}");
+    }
+
+    #[test]
+    fn csrf_cookie_is_root_scoped_but_not_httponly() {
+        let c = build_csrf_cookie("abc123", 900);
+        // CSRF cookie is intentionally readable by JS so the
+        // SPA can mirror it into `X-CSRF-Token`.
+        assert!(c.contains("Path=/"), "got {c}");
+        assert!(
+            !c.contains("HttpOnly"),
+            "CSRF cookie must be JS-readable: {c}"
+        );
+        assert!(c.contains("Secure"), "got {c}");
+        assert!(c.contains("SameSite=Strict"), "got {c}");
+    }
+
+    #[test]
+    fn session_cookie_uses_canonical_name() {
+        let c = build_session_cookie("t", 1);
+        assert!(
+            c.starts_with(&format!(
+                "{}=",
+                vti_common::auth::extractor::ADMIN_SESSION_COOKIE
+            )),
+            "got {c}"
+        );
+    }
 }
 
 // ---------- POST /auth/refresh ----------

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -605,6 +605,12 @@ fn build_unauth_routes() -> Router<AppState> {
             .expect("static Trust-Task URL");
     let auth_refresh = TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/refresh/1.0")
         .expect("static Trust-Task URL");
+    // Phase 5 M5.2.3 — admin SPA cookie-session mint endpoint.
+    // Same DIDComm auth flow as `/auth/`; response additionally
+    // carries `Set-Cookie` headers (vtc_admin_session + csrf).
+    let auth_admin_login =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/admin-login/1.0")
+            .expect("static Trust-Task URL");
     let install_claim_start =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/start/1.0")
             .expect("static Trust-Task URL");
@@ -639,6 +645,11 @@ fn build_unauth_routes() -> Router<AppState> {
         .route_with_task("/auth/challenge", post(auth::challenge), auth_challenge)
         .route_with_task("/auth/", post(auth::authenticate), auth_authenticate)
         .route_with_task("/auth/refresh", post(auth::refresh), auth_refresh)
+        .route_with_task(
+            "/auth/admin-login",
+            post(auth::admin_login),
+            auth_admin_login,
+        )
         .route_with_task(
             "/install/claim/start",
             post(install::claim_start),

--- a/vtc-service/src/routing/csrf.rs
+++ b/vtc-service/src/routing/csrf.rs
@@ -50,6 +50,7 @@ const CSRF_EXEMPT_PATHS: &[&str] = &[
     "/v1/auth/challenge",
     "/v1/auth/",
     "/v1/auth/refresh",
+    "/v1/auth/admin-login",
     "/v1/install/claim/start",
     "/v1/install/claim/finish",
 ];

--- a/vtc-service/tests/cookie_session.rs
+++ b/vtc-service/tests/cookie_session.rs
@@ -1,0 +1,314 @@
+//! Cookie-bearing admin session integration tests (Phase 5 M5.2.3
+//! + M5.3.1).
+//!
+//! Covers:
+//!
+//! - The `vti_common::auth::extractor::AuthClaims` cookie fallback:
+//!   a request that carries the `vtc_admin_session` cookie (but no
+//!   `Authorization` header) authenticates exactly like a bearer
+//!   request would.
+//! - Wrong cookie name → 401.
+//! - Bearer + cookie both present → bearer wins (documented
+//!   precedence per `AuthClaims::from_request_parts`).
+//! - The cookie value carrying a foreign-audience JWT is rejected
+//!   the same way a bearer foreign-audience JWT is — the cookie
+//!   path doesn't widen the audience-isolation invariant
+//!   (§9.7 / CLAUDE.md).
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use http_body_util::BodyExt;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+use vti_common::auth::extractor::ADMIN_SESSION_COOKIE;
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+const ADMIN_DID: &str = "did:key:z6MkAdminCookie";
+const ACL_TRUST_TASK: &str = "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    state: AppState,
+    jwt_keys: Arc<JwtKeys>,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:key:z6MkTestVTC"
+        [store]
+        data_dir = "{}"
+        [auth]
+        jwt_signing_key = "{}"
+        "#,
+        dir.path().display(),
+        BASE64.encode(jwt_seed),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks: sessions_ks.clone(),
+        acl_ks: acl_ks.clone(),
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks: install_ks.clone(),
+        members_ks: members_ks.clone(),
+        join_requests_ks: join_requests_ks.clone(),
+        policies_ks: policies_ks.clone(),
+        active_policies_ks: active_policies_ks.clone(),
+        status_lists_ks: status_lists_ks.clone(),
+        registry_records_ks: registry_records_ks.clone(),
+        sync_queue_ks: sync_queue_ks.clone(),
+        sync_cursor_ks: sync_cursor_ks.clone(),
+        relationships_ks: relationships_ks.clone(),
+        relationships_by_did_ks: relationships_by_did_ks.clone(),
+        endorsement_types_ks: endorsement_types_ks.clone(),
+        endorsements_ks: endorsements_ks.clone(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
+        credential_signer: None,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys.clone()),
+        atm: None,
+        webauthn: None,
+        public_url: None,
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_ks,
+        audit_key_ks,
+        audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    // Insert admin ACL entry so the protected route doesn't 403.
+    store_acl_entry(
+        &state.acl_ks,
+        &VtcAclEntry {
+            did: ADMIN_DID.into(),
+            role: VtcRole::Admin,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now_epoch(),
+            created_by: "test".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .expect("acl insert");
+
+    let router = routes::router().with_state(state.clone());
+    Fixture {
+        router,
+        state,
+        jwt_keys,
+        _dir: dir,
+    }
+}
+
+/// Mint a session row + JWT for `did:key:z6MkAdminCookie` with
+/// admin role. The token is bound to the session ID so the
+/// extractor's `get_session` lookup succeeds.
+async fn mint_session(fix: &Fixture, audience: &str) -> String {
+    let session_id = format!("sess-{}", uuid::Uuid::new_v4());
+    store_session(
+        &fix.state.sessions_ks,
+        &Session {
+            session_id: session_id.clone(),
+            did: ADMIN_DID.into(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now_epoch(),
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+        },
+    )
+    .await
+    .expect("store session");
+
+    // For the foreign-audience tests, mint with a different
+    // JwtKeys; otherwise reuse the fixture's VTC keys.
+    let keys = if audience == "VTC" {
+        fix.jwt_keys.clone()
+    } else {
+        Arc::new(JwtKeys::from_ed25519_bytes(&[0x42u8; 32], audience).unwrap())
+    };
+    let claims = keys.new_claims(
+        ADMIN_DID.to_string(),
+        session_id,
+        "admin".to_string(),
+        vec![],
+        900,
+        false,
+    );
+    keys.encode(&claims).expect("encode")
+}
+
+async fn request(router: &axum::Router, req: Request<Body>) -> (StatusCode, String) {
+    let resp = router.clone().oneshot(req).await.expect("request");
+    let status = resp.status();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&body).into_owned())
+}
+
+#[tokio::test]
+async fn admin_cookie_authenticates_protected_route() {
+    let fix = build_fixture().await;
+    let jwt = mint_session(&fix, "VTC").await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/acl")
+        .header("Trust-Task", ACL_TRUST_TASK)
+        .header("Cookie", format!("{ADMIN_SESSION_COOKIE}={jwt}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, _body) = request(&fix.router, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "cookie-bearing request must authenticate the admin route"
+    );
+}
+
+#[tokio::test]
+async fn wrong_cookie_name_returns_401() {
+    let fix = build_fixture().await;
+    let jwt = mint_session(&fix, "VTC").await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/acl")
+        .header("Trust-Task", ACL_TRUST_TASK)
+        // Wrong cookie name — the fallback path requires the
+        // exact `vtc_admin_session` cookie. A bare
+        // `session=<jwt>` value must not authenticate.
+        .header("Cookie", format!("session={jwt}; other=foo"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, _body) = request(&fix.router, req).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn cookie_alongside_other_cookies_authenticates() {
+    let fix = build_fixture().await;
+    let jwt = mint_session(&fix, "VTC").await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/acl")
+        .header("Trust-Task", ACL_TRUST_TASK)
+        // Order + presence of other cookies must not break the
+        // session-cookie parser.
+        .header(
+            "Cookie",
+            format!("csrf=abc123; {ADMIN_SESSION_COOKIE}={jwt}; analytics=enabled"),
+        )
+        .body(Body::empty())
+        .unwrap();
+    let (status, _body) = request(&fix.router, req).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn bearer_takes_precedence_over_cookie() {
+    let fix = build_fixture().await;
+    // Bearer with a valid VTC token; cookie with an invalid
+    // (foreign-audience) token. The extractor must prefer the
+    // bearer and authenticate.
+    let valid_bearer = mint_session(&fix, "VTC").await;
+    let foreign_cookie = mint_session(&fix, "EVIL-AUD").await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/acl")
+        .header("Trust-Task", ACL_TRUST_TASK)
+        .header("Authorization", format!("Bearer {valid_bearer}"))
+        .header("Cookie", format!("{ADMIN_SESSION_COOKIE}={foreign_cookie}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, _body) = request(&fix.router, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "Bearer header takes precedence; cookie ignored when bearer is present"
+    );
+}
+
+#[tokio::test]
+async fn foreign_audience_cookie_rejected() {
+    // The cookie path does NOT widen the audience-isolation
+    // invariant. A foreign-audience JWT in the
+    // `vtc_admin_session` cookie must be rejected at decode
+    // time, same as a foreign-audience bearer token would be.
+    let fix = build_fixture().await;
+    let foreign = mint_session(&fix, "EVIL-AUD").await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/acl")
+        .header("Trust-Task", ACL_TRUST_TASK)
+        .header("Cookie", format!("{ADMIN_SESSION_COOKIE}={foreign}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, _body) = request(&fix.router, req).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}

--- a/vtc-service/tests/routing_modes.rs
+++ b/vtc-service/tests/routing_modes.rs
@@ -1,0 +1,290 @@
+//! Routing-mode integration tests (Phase 5 M5.1.3).
+//!
+//! Verifies the per-surface nest structure introduced in M5.1.1
+//! and the subdomain-mode `Host` header check from M5.1.2:
+//!
+//! - **`/health`** stays at the parent-router root and is exempt
+//!   from Trust-Task validation in both modes.
+//! - **`POST /v1/auth/challenge`** reaches the API surface (the
+//!   handler returns 400 here because the ACL is empty — that
+//!   confirms the route is wired through, not auth-rejected).
+//! - **`GET /admin/anything`** falls through to the 503
+//!   placeholder.
+//! - **`GET /anything-else`** falls through to the website 503
+//!   placeholder.
+//! - **Subdomain mode strict**: configured Host header passes,
+//!   unrecognised Host returns 404 `HostNotRecognised`.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use vtc_service::config::{MountConfig, RoutingConfig};
+use vtc_service::routes;
+use vtc_service::routing::host_dispatch::{HostMap, enforce};
+
+/// Build a router using only the placeholder + health surfaces;
+/// the API sub-router needs full `AppState` but route-priority
+/// tests only need to see whether prefixes dispatch correctly.
+/// We rely on `routes::router_with()` plus a default state where
+/// every keyspace is open against a tempdir.
+async fn build_router(routing: &RoutingConfig) -> (Router, tempfile::TempDir) {
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+    use vtc_service::config::AppConfig;
+    use vtc_service::server::AppState;
+    use vti_common::auth::jwt::JwtKeys;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    init_jwt_provider();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let install_ks = store.keyspace("install").unwrap();
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:key:z6MkTestVTC"
+        [store]
+        data_dir = "{}"
+        [auth]
+        jwt_signing_key = "{}"
+        "#,
+        dir.path().display(),
+        BASE64.encode(jwt_seed),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks: store.keyspace("sessions").unwrap(),
+        acl_ks: store.keyspace("acl").unwrap(),
+        community_ks: store.keyspace("community").unwrap(),
+        config_ks: store.keyspace("config").unwrap(),
+        passkey_ks: store.keyspace("passkey").unwrap(),
+        install_ks: install_ks.clone(),
+        members_ks: store.keyspace("members").unwrap(),
+        join_requests_ks: store.keyspace("join_requests").unwrap(),
+        policies_ks: store.keyspace("policies").unwrap(),
+        active_policies_ks: store.keyspace("active_policies").unwrap(),
+        status_lists_ks: store.keyspace("status_lists").unwrap(),
+        registry_records_ks: store.keyspace("registry_records").unwrap(),
+        sync_queue_ks: store.keyspace("sync_queue").unwrap(),
+        sync_cursor_ks: store.keyspace("sync_cursor").unwrap(),
+        relationships_ks: store.keyspace("relationships").unwrap(),
+        relationships_by_did_ks: store.keyspace("relationships_by_did").unwrap(),
+        endorsement_types_ks: store.keyspace("endorsement_types").unwrap(),
+        endorsements_ks: store.keyspace("endorsements").unwrap(),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
+        credential_signer: None,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: None,
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_ks: store.keyspace("audit").unwrap(),
+        audit_key_ks: store.keyspace("audit_key").unwrap(),
+        audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router_with(routing).with_state(state);
+    (router, dir)
+}
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+async fn request(router: &Router, req: Request<Body>) -> (StatusCode, Vec<u8>) {
+    let resp = router.clone().oneshot(req).await.expect("oneshot");
+    let status = resp.status();
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes()
+        .to_vec();
+    (status, body)
+}
+
+#[tokio::test]
+async fn path_mode_health_at_root_is_exempt() {
+    let routing = RoutingConfig::default();
+    let (router, _dir) = build_router(&routing).await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&router, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "/health must respond 200 without a Trust-Task header"
+    );
+}
+
+#[tokio::test]
+async fn path_mode_admin_placeholder_returns_503() {
+    let routing = RoutingConfig::default();
+    let (router, _dir) = build_router(&routing).await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/admin/anything")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&router, req).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn path_mode_website_fallback_returns_503() {
+    let routing = RoutingConfig::default();
+    let (router, _dir) = build_router(&routing).await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/not-a-real-path")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&router, req).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn subdomain_mode_strict_404s_unknown_host() {
+    // Stand up the host-dispatch middleware standalone — easier
+    // than exercising the full nested router from server.rs.
+    let routing = RoutingConfig {
+        api: MountConfig {
+            mount: "/v1".into(),
+            host: Some("api.example.com".into()),
+        },
+        admin_ui: MountConfig {
+            mount: "/admin".into(),
+            host: Some("admin.example.com".into()),
+        },
+        website: MountConfig {
+            mount: "/".into(),
+            host: Some("example.com".into()),
+        },
+        subdomain_mode_strict: true,
+    };
+
+    async fn ok() -> &'static str {
+        "ok"
+    }
+
+    let map = HostMap::from_routing(&routing);
+    let app = Router::new()
+        .route("/", axum::routing::get(ok))
+        .layer(axum::middleware::from_fn_with_state(map, enforce));
+
+    // Known host → 200.
+    let req = Request::builder()
+        .uri("/")
+        .header("Host", "api.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Unknown host → 404 HostNotRecognised.
+    let req = Request::builder()
+        .uri("/")
+        .header("Host", "evil.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = request(&app, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["error"], "HostNotRecognised");
+}
+
+#[tokio::test]
+async fn subdomain_mode_non_strict_falls_through() {
+    let routing = RoutingConfig {
+        api: MountConfig {
+            mount: "/v1".into(),
+            host: Some("api.example.com".into()),
+        },
+        admin_ui: MountConfig {
+            mount: "/admin".into(),
+            host: None,
+        },
+        website: MountConfig {
+            mount: "/".into(),
+            host: None,
+        },
+        subdomain_mode_strict: false,
+    };
+
+    async fn ok() -> &'static str {
+        "ok"
+    }
+
+    let map = HostMap::from_routing(&routing);
+    let app = Router::new()
+        .route("/", axum::routing::get(ok))
+        .layer(axum::middleware::from_fn_with_state(map, enforce));
+
+    // Unknown host with strict = false → request falls through
+    // to the parent router (path-mode behaviour).
+    let req = Request::builder()
+        .uri("/")
+        .header("Host", "evil.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn pure_path_mode_middleware_is_noop() {
+    // Every surface has host = None → middleware short-circuits,
+    // any Host header passes through.
+    let routing = RoutingConfig::default();
+
+    async fn ok() -> &'static str {
+        "ok"
+    }
+
+    let map = HostMap::from_routing(&routing);
+    let app = Router::new()
+        .route("/", axum::routing::get(ok))
+        .layer(axum::middleware::from_fn_with_state(map, enforce));
+
+    let req = Request::builder()
+        .uri("/")
+        .header("Host", "whatever.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+}

--- a/vti-common/src/auth/extractor.rs
+++ b/vti-common/src/auth/extractor.rs
@@ -33,20 +33,44 @@ pub struct AuthClaims {
     pub allowed_contexts: Vec<String>,
 }
 
+/// Name of the admin UX session cookie set by the VTC's
+/// `POST /v1/auth/admin-login` flow (Phase 5 M5.2.3). When the
+/// `Authorization: Bearer` header is absent, [`AuthClaims`]
+/// falls back to reading a JWT out of this cookie. The cookie
+/// is set with `Path=/admin; SameSite=Strict; Secure; HttpOnly`
+/// so the public-website origin can't read it.
+pub const ADMIN_SESSION_COOKIE: &str = "vtc_admin_session";
+
 impl<S: AuthState> FromRequestParts<S> for AuthClaims {
     type Rejection = AppError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        // Extract Bearer token from Authorization header
-        let TypedHeader(auth) =
-            TypedHeader::<Authorization<Bearer>>::from_request_parts(parts, state)
-                .await
-                .map_err(|_| {
-                    warn!("auth rejected: missing or invalid Authorization header");
-                    AppError::Unauthorized("missing or invalid Authorization header".into())
-                })?;
+        // Try `Authorization: Bearer <jwt>` first. Programmatic
+        // clients (cnm-cli, DIDComm bridges, the existing
+        // `/v1/auth/` flow) all use this path.
+        let bearer_token = TypedHeader::<Authorization<Bearer>>::from_request_parts(parts, state)
+            .await
+            .ok()
+            .map(|TypedHeader(auth)| auth.token().to_string());
 
-        let token = auth.token();
+        // Fall back to the admin session cookie (Phase 5 M5.2.3).
+        // Set by `POST /v1/auth/admin-login`; carries the same JWT
+        // as the bearer path.
+        let token: String = match bearer_token {
+            Some(t) => t,
+            None => match cookie_token(parts, ADMIN_SESSION_COOKIE) {
+                Some(t) => t,
+                None => {
+                    warn!(
+                        "auth rejected: no Authorization header and no {ADMIN_SESSION_COOKIE} cookie"
+                    );
+                    return Err(AppError::Unauthorized(
+                        "missing or invalid Authorization header".into(),
+                    ));
+                }
+            },
+        };
+        let token = token.as_str();
 
         // Decode and validate JWT
         let jwt_keys = state
@@ -306,6 +330,24 @@ impl<S: AuthState> FromRequestParts<S> for WriteAuth {
             }
         }
     }
+}
+
+/// Pull a named cookie value off the request `Cookie` headers.
+/// Returns `None` when the cookie isn't present. Does **not**
+/// percent-decode — cookie values minted by the VTC's admin-login
+/// flow are JWTs (base64url + dots), which are ASCII-safe.
+fn cookie_token(parts: &Parts, name: &str) -> Option<String> {
+    parts
+        .headers
+        .get_all(axum::http::header::COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.split(';'))
+        .map(|s| s.trim())
+        .find_map(|kv| {
+            let (k, v) = kv.split_once('=')?;
+            (k == name).then(|| v.to_string())
+        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Phase 5 PR-1b — closes the bundled PR-1 scope from the planning PR. Builds directly on PR-1a's routing/CSRF/CSP foundation. After this lands, M5.1/M5.2/M5.3 are complete and the M5.4 website work can begin.

## What's in this PR

| Sub-task | Scope |
|---|---|
| **M5.2.3** | New `POST /v1/auth/admin-login` endpoint mints the same JWT as `/v1/auth/` and additionally emits `Set-Cookie: vtc_admin_session=<jwt>; Path=/admin; SameSite=Strict; Secure; HttpOnly` + a paired CSRF cookie. `vti_common::auth::extractor::AuthClaims` gained a cookie fallback (bearer takes precedence; cookie used when bearer absent). Trust Task `auth/admin-login/1.0` ships on disk + in `index.json`. Endpoint is unauth-governed (5 rps) and CSRF-exempt (bootstrapping login). |
| **M5.1.3** | `vtc-service/tests/routing_modes.rs` — 6 integration tests for path mode + subdomain mode (strict / non-strict) + host-dispatch no-op behavior. |
| **M5.3.1** | Cookie-scope isolation tests: 4 unit tests in `routes/auth.rs::cookie_format_tests` lock down `Path=/admin` + HttpOnly + Secure + SameSite=Strict on the session cookie (CSRF cookie correctly Path=/ + JS-readable). 5 integration tests in `cookie_session.rs` cover end-to-end cookie auth path including bearer-precedence and foreign-audience rejection. |
| **M5.2.1** | CORS allowlist audit — covered by existing `routing_cors.rs` (Phase 0). No new code; documented as satisfied. |

## Architectural points worth highlighting

- **Cookie path = `/admin`** is the load-bearing isolation invariant. Combined with PR-1a's config validation that refuses `admin_ui.mount = "/"`, the public-website origin cannot reach the admin session regardless of operator misconfiguration.
- **Bearer takes precedence over cookie** when both are present — documented behavior, tested explicitly. Programmatic clients (cnm-cli, DIDComm bridges) keep working unchanged on `/v1/auth/`.
- **Audience isolation invariant preserved**: a foreign-audience JWT in the cookie is rejected the same way a foreign-audience bearer is. The cookie path doesn't widen the §9.7 invariant.
- **Trust Task split** between `auth/legacy/authenticate/1.0` (bearer) and `auth/admin-login/1.0` (cookie + bearer) makes the side-effect explicit at the SIEM / audit-tail layer.

## D12 sign-off captured

User selected "HttpOnly cookie + CSRF double-submit (Path=/admin scope)" — implemented exactly as described. Cookie scope ensures public-website JS on the same origin can't read it; CSRF cookie pairs with the middleware shipped in PR-1a.

## Verification

- `cargo build --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- **573 total vtc-service tests passing** (PR-1a's 565 + 5 cookie_session integration + 6 routing_modes integration + new unit tests)

## Test plan

- [ ] Reviewer confirms bearer-precedence-over-cookie is the right semantic (alternative: cookie wins for SPA paths under `/admin`)
- [ ] Reviewer sanity-checks the CSRF exempt list (5 unauth bootstrap routes + public form-post + admin-login = 7 paths)
- [ ] Reviewer confirms Trust Task `auth/admin-login/1.0` matches the workspace's task-id convention
- [ ] Reviewer agrees the cookie-format unit tests (`cookie_format_tests`) are sufficient lock-down for the isolation invariant — full end-to-end set-cookie inspection would need the DIDComm authenticate flow stood up in tests

After merge: open PR-2 for **M5.4** (`website` feature scaffold + filesystem-backed static handler + path safety + CSP + ETag + FD cache + live/managed deploy primitives).