### PR TITLE
feat(vtc-service): M5.4 — public website filesystem-backed handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,6 +5330,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8801,6 +8811,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9232,6 +9248,7 @@ dependencies = [
  "http-body-util",
  "jsonwebtoken",
  "keyring-core",
+ "mime_guess",
  "multibase",
  "rand 0.10.1",
  "regorus",
@@ -9249,6 +9266,7 @@ dependencies = [
  "tower_governor",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "url",
  "uuid",
  "vta-sdk 0.6.0",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -11,8 +11,13 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["setup", "keyring"]
+default = ["setup", "keyring", "website"]
 setup = ["dep:dialoguer", "dep:didwebvh-rs", "dep:url"]
+# Public community website (§12.1). Filesystem-backed static
+# hosting at `website.root_dir`. Default-on so MVP `cargo run`
+# serves a site; operators who host externally can compile it
+# out via `--no-default-features --features setup,keyring`.
+website = ["dep:mime_guess", "dep:unicode-normalization"]
 # OS keyring backend for the VTC secret. Enables vta-sdk's keyring feature
 # so the binary can register a platform store once via
 # `vta_sdk::keyring_init::install_default_store()` at startup.
@@ -83,6 +88,8 @@ fjall = { workspace = true }
 toml = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "trace"] }
 tower_governor = "0.8"
+mime_guess = { version = "2", optional = true }
+unicode-normalization = { version = "0.1", optional = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -40,8 +40,103 @@ pub struct AppConfig {
     /// flips a previously-asserted member's flag to `false`.
     #[serde(default)]
     pub renewal: RenewalConfig,
+    /// Public community website settings (Phase 5 M5.4). When
+    /// `root_dir` is unset the website handler 503s — the
+    /// feature is opt-in by operator configuration, even though
+    /// the cargo feature is default-on.
+    #[serde(default)]
+    pub website: WebsiteConfig,
     #[serde(skip)]
     pub config_path: PathBuf,
+}
+
+/// Public community website (§12.1, Phase 5 M5.4.1). Filesystem-
+/// backed static hosting under [`Self::root_dir`].
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct WebsiteConfig {
+    /// Directory served as the site root. `None` disables the
+    /// handler entirely (it 503s with a clear error). No default
+    /// — operators opt in by setting this to a real path.
+    #[serde(default)]
+    pub root_dir: Option<PathBuf>,
+    /// Deploy mode: `"live"` (default) or `"managed"`. See
+    /// [`crate::website::WebsiteRoot`].
+    #[serde(default = "default_deploy_mode")]
+    pub deploy_mode: String,
+    /// Cache TTL for the live-mode FD cache, in seconds.
+    /// Defaults to 5 — short enough that `scp` / `rsync` edits
+    /// surface quickly, long enough to amortise repeat hits.
+    #[serde(default = "default_live_cache_ttl_seconds")]
+    pub live_cache_ttl_seconds: u64,
+    /// Managed mode: retain this many old generations beyond
+    /// the active one. Default 5.
+    #[serde(default = "default_managed_generations_keep")]
+    pub managed_generations_keep: u32,
+    /// `Cache-Control` header on every successful response.
+    /// Defaults to `"public, max-age=300"` — five minutes for a
+    /// CDN to cache.
+    #[serde(default = "default_cache_control")]
+    pub cache_control: String,
+    /// Extensions refused unconditionally. Default
+    /// `[".cgi", ".php", ".exe"]`. Lowercased + dot-prefixed.
+    #[serde(default = "default_executable_blocklist")]
+    pub executable_blocklist: Vec<String>,
+    /// Maximum bundle size for `POST /v1/website/deploy` (M5.5).
+    /// Tested at the management API; informational here.
+    #[serde(default = "default_max_bundle_size_mb")]
+    pub max_bundle_size_mb: u64,
+    /// Maximum size for a single `PUT /v1/website/files/...`
+    /// upload (M5.5). Tested at the management API; informational
+    /// here.
+    #[serde(default = "default_max_file_size_mb")]
+    pub max_file_size_mb: u64,
+    /// Per-site override file (relative to `root_dir`). Currently
+    /// supports a single key, `csp = "..."`, that replaces the
+    /// default CSP for this site. Default `".vtc-website.toml"`.
+    #[serde(default = "default_csp_override_file")]
+    pub csp_override_file: String,
+}
+
+impl Default for WebsiteConfig {
+    fn default() -> Self {
+        Self {
+            root_dir: None,
+            deploy_mode: default_deploy_mode(),
+            live_cache_ttl_seconds: default_live_cache_ttl_seconds(),
+            managed_generations_keep: default_managed_generations_keep(),
+            cache_control: default_cache_control(),
+            executable_blocklist: default_executable_blocklist(),
+            max_bundle_size_mb: default_max_bundle_size_mb(),
+            max_file_size_mb: default_max_file_size_mb(),
+            csp_override_file: default_csp_override_file(),
+        }
+    }
+}
+
+fn default_deploy_mode() -> String {
+    "live".into()
+}
+fn default_live_cache_ttl_seconds() -> u64 {
+    5
+}
+fn default_managed_generations_keep() -> u32 {
+    5
+}
+fn default_cache_control() -> String {
+    "public, max-age=300".into()
+}
+fn default_executable_blocklist() -> Vec<String> {
+    vec![".cgi".into(), ".php".into(), ".exe".into()]
+}
+fn default_max_bundle_size_mb() -> u64 {
+    50
+}
+fn default_max_file_size_mb() -> u64 {
+    10
+}
+fn default_csp_override_file() -> String {
+    ".vtc-website.toml".into()
 }
 
 /// Renewal-path settings. Phase 4 M4.2.2.

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -42,3 +42,4 @@ pub mod status_list;
 pub mod store;
 pub mod supervisor;
 pub mod webauthn;
+pub mod website;

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -51,7 +51,14 @@ pub const UNAUTH_BODY_SIZE: usize = 64 * 1024;
 /// Production startup goes through [`router_with`] from `server.rs`
 /// so operator-supplied mount overrides take effect.
 pub fn router() -> Router<AppState> {
-    router_with(&RoutingConfig::default())
+    #[cfg(feature = "website")]
+    {
+        router_with(&RoutingConfig::default(), None)
+    }
+    #[cfg(not(feature = "website"))]
+    {
+        router_with(&RoutingConfig::default())
+    }
 }
 
 /// Build the public router with operator-supplied routing config
@@ -76,7 +83,41 @@ pub fn router() -> Router<AppState> {
 /// at the parent-router root (above every nest boundary) so
 /// monitoring integration stays trivial regardless of routing
 /// mode.
+#[cfg(feature = "website")]
+pub fn router_with(
+    routing: &RoutingConfig,
+    website_state: Option<crate::website::WebsiteState>,
+) -> Router<AppState> {
+    router_with_inner(routing, website_state)
+}
+
+#[cfg(not(feature = "website"))]
 pub fn router_with(routing: &RoutingConfig) -> Router<AppState> {
+    router_with_inner(routing)
+}
+
+#[cfg(not(feature = "website"))]
+fn router_with_inner(routing: &RoutingConfig) -> Router<AppState> {
+    let (api_chain,) = (build_api_chain(routing),);
+    assemble(routing, api_chain)
+}
+
+#[cfg(feature = "website")]
+fn router_with_inner(
+    routing: &RoutingConfig,
+    website_state: Option<crate::website::WebsiteState>,
+) -> Router<AppState> {
+    let api_chain = build_api_chain(routing);
+    assemble_with_website(routing, api_chain, website_state)
+}
+
+/// Build the merged API+unauth surface. Identical shape regardless
+/// of the `website` feature; `routing` is currently unused inside
+/// the chain (the API mount prefix is applied by [`assemble`] /
+/// [`assemble_with_website`]) but threaded through so a future
+/// per-mount override can land without changing this function's
+/// signature.
+fn build_api_chain(_routing: &RoutingConfig) -> Router<AppState> {
     let auth_sessions_manage =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0")
             .expect("static Trust-Task URL");
@@ -577,8 +618,7 @@ pub fn router_with(routing: &RoutingConfig) -> Router<AppState> {
 
     // Unauthenticated routes — tighter body cap + per-IP governor.
     let unauth = build_unauth_routes();
-
-    assemble(routing, api.merge(unauth))
+    api.merge(unauth)
 }
 
 /// Build the unauthenticated sub-router: 5 POST routes that drive
@@ -734,6 +774,51 @@ fn assemble(routing: &RoutingConfig, api: Router<AppState>) -> Router<AppState> 
         app = app.nest(&routing.website.mount, website_placeholder);
     }
 
+    app
+}
+
+/// Production assembly: same as [`assemble`] but **replaces** the
+/// website 503 placeholder with the real static handler when a
+/// [`crate::website::WebsiteState`] is provided.
+///
+/// Mirrors the no-state path's nest/merge logic exactly so the
+/// route-priority semantics don't drift between the two builds.
+#[cfg(feature = "website")]
+pub fn assemble_with_website(
+    routing: &RoutingConfig,
+    api: Router<AppState>,
+    website_state: Option<crate::website::WebsiteState>,
+) -> Router<AppState> {
+    use axum::middleware::from_fn;
+
+    use crate::routing::security_headers::security_headers;
+
+    let website_state = match website_state {
+        Some(s) => s,
+        // No state → fall back to the 503-placeholder path.
+        None => return assemble(routing, api),
+    };
+
+    let admin_placeholder: Router<AppState> = Router::new()
+        .fallback(any(placeholder_503))
+        .layer(from_fn(security_headers));
+
+    // Real website router. State-erased via `.with_state(...)` so
+    // it can be merged/nested under the AppState-typed parent.
+    let website: Router<AppState> = Router::new()
+        .fallback(get(crate::website::serve))
+        .layer(from_fn(security_headers))
+        .with_state(website_state);
+
+    let mut app: Router<AppState> = Router::new()
+        .route("/health", get(health::health))
+        .nest(&routing.api.mount, api);
+    app = app.nest(&routing.admin_ui.mount, admin_placeholder);
+    if routing.website.mount == "/" {
+        app = app.merge(website);
+    } else {
+        app = app.nest(&routing.website.mount, website);
+    }
     app
 }
 

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -790,6 +790,20 @@ fn run_rest_thread(
         // exemption list.
         let csrf_layer = axum::middleware::from_fn(crate::routing::csrf::enforce);
 
+        // Public-website state (Phase 5 M5.4). `None` when the
+        // operator hasn't set `website.root_dir` — the website
+        // sub-router keeps the 503 placeholder in that case.
+        #[cfg(feature = "website")]
+        let website_state = build_website_state(&state.config).await;
+
+        #[cfg(feature = "website")]
+        let app = routes::router_with(&routing, website_state)
+            .with_state(state)
+            .layer(csrf_layer)
+            .layer(host_layer)
+            .layer(cors_layer)
+            .layer(TraceLayer::new_for_http());
+        #[cfg(not(feature = "website"))]
         let app = routes::router_with(&routing)
             .with_state(state)
             .layer(csrf_layer)
@@ -1065,6 +1079,51 @@ fn decode_jwt_key(b64: &str) -> Result<JwtKeys, AppError> {
     let keys = JwtKeys::from_ed25519_bytes(&key_bytes, "VTC")?;
     debug!("JWT signing key decoded successfully");
     Ok(keys)
+}
+
+/// Construct the public-website state from operator config (Phase 5
+/// M5.4). Returns `None` when:
+///
+/// - `website.root_dir` is unset (operator opt-out); the handler
+///   stays as the 503 placeholder.
+/// - The configured `deploy_mode` value isn't recognised; a
+///   warning is logged and the daemon falls back to the
+///   placeholder so a misconfiguration can't bring down the API
+///   surface.
+///
+/// On success, the returned [`crate::website::WebsiteState`] is
+/// passed to [`crate::routes::router_with`] which mounts the
+/// static handler at `routing.website.mount`.
+#[cfg(feature = "website")]
+async fn build_website_state(
+    config: &Arc<RwLock<crate::config::AppConfig>>,
+) -> Option<crate::website::WebsiteState> {
+    let cfg = config.read().await;
+    let root_dir = cfg.website.root_dir.as_ref()?;
+
+    let root = match crate::website::WebsiteRoot::new(root_dir, &cfg.website.deploy_mode) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("website.deploy_mode invalid ({e}); falling back to 503 placeholder");
+            return None;
+        }
+    };
+
+    let cache = crate::website::cache::WebsiteCache::new(cfg.website.live_cache_ttl_seconds);
+
+    info!(
+        root = %root_dir.display(),
+        mode = %cfg.website.deploy_mode,
+        "public-website handler enabled",
+    );
+
+    Some(crate::website::WebsiteState {
+        root,
+        cache,
+        executable_blocklist: cfg.website.executable_blocklist.clone(),
+        cache_control: cfg.website.cache_control.clone(),
+        csp_override_file: cfg.website.csp_override_file.clone(),
+    })
 }
 
 async fn shutdown_signal() {

--- a/vtc-service/src/website/cache.rs
+++ b/vtc-service/src/website/cache.rs
@@ -1,0 +1,114 @@
+//! File-descriptor / content cache for live-mode static serving
+//! (§12.1, Phase 5 M5.4.1).
+//!
+//! Trades RAM for syscall pressure: files are read into memory the
+//! first time they're requested and held for
+//! `website.live_cache_ttl_seconds` (default 5). After expiry the
+//! next request triggers a fresh read. The cache also stores the
+//! SHA-256 digest so the ETag response header doesn't re-hash on
+//! every conditional GET.
+//!
+//! Managed mode generally benefits from a longer TTL since
+//! generation directories are immutable; PR-3 (M5.5) wires that
+//! optimisation. PR-2 keeps the TTL semantics uniform.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use sha2::{Digest, Sha256};
+use tokio::sync::RwLock;
+
+/// One cached file. The `digest` is the SHA-256 of `body`; both
+/// outlive the cache miss together so the ETag header is
+/// computable without a re-read.
+#[derive(Debug, Clone)]
+pub struct CachedFile {
+    pub body: Arc<Vec<u8>>,
+    pub digest_hex: Arc<String>,
+    pub fetched_at: Instant,
+}
+
+/// Thread-safe content cache shared across handler invocations.
+#[derive(Debug, Clone)]
+pub struct WebsiteCache {
+    inner: Arc<RwLock<HashMap<PathBuf, CachedFile>>>,
+    ttl: Duration,
+}
+
+impl WebsiteCache {
+    pub fn new(ttl_secs: u64) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            ttl: Duration::from_secs(ttl_secs),
+        }
+    }
+
+    /// Read the file at `path` through the cache. On cache miss,
+    /// reads from disk and stores the entry. On cache hit, refresh
+    /// the entry from disk if its TTL has elapsed; otherwise
+    /// return the cached copy.
+    pub async fn get(&self, path: &std::path::Path) -> std::io::Result<CachedFile> {
+        // Try cached read first.
+        if let Some(entry) = self.inner.read().await.get(path)
+            && entry.fetched_at.elapsed() < self.ttl
+        {
+            return Ok(entry.clone());
+        }
+
+        // Miss / expired — fall through to disk read.
+        let bytes = tokio::fs::read(path).await?;
+        let digest_hex = hex::encode(Sha256::digest(&bytes));
+        let entry = CachedFile {
+            body: Arc::new(bytes),
+            digest_hex: Arc::new(digest_hex),
+            fetched_at: Instant::now(),
+        };
+        self.inner
+            .write()
+            .await
+            .insert(path.to_path_buf(), entry.clone());
+        Ok(entry)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cache_returns_consistent_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("hello.txt");
+        std::fs::write(&file, b"hello world").unwrap();
+
+        let cache = WebsiteCache::new(60);
+        let a = cache.get(&file).await.unwrap();
+        let b = cache.get(&file).await.unwrap();
+
+        assert_eq!(a.digest_hex, b.digest_hex);
+        // Compare via expected SHA-256 prefix.
+        assert!(
+            a.digest_hex.starts_with("b94d27b9934d3e08"),
+            "got {}",
+            a.digest_hex
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_misses_after_ttl_expiry() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("hello.txt");
+        std::fs::write(&file, b"v1").unwrap();
+
+        // Zero TTL → every get triggers a disk read.
+        let cache = WebsiteCache::new(0);
+        let a = cache.get(&file).await.unwrap();
+
+        std::fs::write(&file, b"v2-different").unwrap();
+        let b = cache.get(&file).await.unwrap();
+
+        assert_ne!(a.digest_hex, b.digest_hex, "TTL expiry must re-read");
+    }
+}

--- a/vtc-service/src/website/mod.rs
+++ b/vtc-service/src/website/mod.rs
@@ -1,0 +1,40 @@
+//! Public community website (§12.1, Phase 5 M5.4).
+//!
+//! Filesystem-backed static hosting at
+//! [`crate::config::WebsiteConfig::root_dir`]. No template engine,
+//! no opinions about site structure — operators populate the
+//! directory via `scp` / `rsync` / `git` or via the management API
+//! shipping in M5.5.
+//!
+//! ## Deploy modes
+//!
+//! - **`live`** (default): files served as-is from `root_dir`.
+//!   Bundle deploys (M5.5) extract via a staging directory +
+//!   atomic rename to avoid partial reads under concurrent
+//!   serving.
+//! - **`managed`**: `root_dir/gen-N/` directories with a
+//!   `root_dir/current` symlink. Bundle deploys extract to a fresh
+//!   generation; rollback flips the symlink. Older generations
+//!   beyond `managed_generations_keep` are pruned by the management
+//!   API.
+//!
+//! ## Path safety
+//!
+//! Everything in [`paths`] runs in front of the filesystem open.
+//! Path safety failures surface as `WebsitePathRejected` /
+//! `WebsiteBlockedExtension` from [`crate::error`] — never bare
+//! 404s — so the audit trail records the rejection rationale.
+
+#[cfg(feature = "website")]
+pub mod cache;
+#[cfg(feature = "website")]
+pub mod paths;
+#[cfg(feature = "website")]
+pub mod serve;
+#[cfg(feature = "website")]
+pub mod storage;
+
+#[cfg(feature = "website")]
+pub use serve::{WebsiteState, serve};
+#[cfg(feature = "website")]
+pub use storage::WebsiteRoot;

--- a/vtc-service/src/website/paths.rs
+++ b/vtc-service/src/website/paths.rs
@@ -1,0 +1,221 @@
+//! Filesystem path-safety helpers (§12.1, Phase 5 M5.4.1).
+//!
+//! Every request to the static handler walks through
+//! [`canonical_within_root`]:
+//!
+//! 1. Decode the request path; reject NUL / control characters.
+//! 2. NFC-normalise; reject non-NFC originals.
+//! 3. Reject any segment starting with `.` (hidden files).
+//! 4. Reject blocklisted extensions (`.cgi` / `.php` / `.exe` by
+//!    default).
+//! 5. Canonicalise (resolve `.`, `..`, symlinks) against
+//!    `root_dir`; reject any result that escapes `root_dir`.
+//! 6. Reject regular files with the executable bit set on Unix.
+//!
+//! The function returns the canonical filesystem path on success
+//! so the caller can pass it to the FD cache directly. Path-safety
+//! failures surface as typed [`PathError`] values; callers map
+//! these into HTTP responses.
+
+use std::path::{Path, PathBuf};
+
+use unicode_normalization::{IsNormalized, UnicodeNormalization, is_nfc_quick};
+
+/// Reasons a request path can fail the safety checks. Mapped to
+/// HTTP responses by [`crate::website::serve::serve`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathError {
+    /// Path contained NUL / control characters.
+    ControlChars,
+    /// Path bytes were not NFC-normalised.
+    NonNfc,
+    /// Path component starts with `.` (hidden file).
+    Hidden,
+    /// Extension matches the configured blocklist.
+    BlockedExtension(String),
+    /// Canonicalised path escaped `root_dir`.
+    Escape,
+    /// `std::fs::canonicalize` failed (file not found, broken
+    /// symlink, permission denied, etc.).
+    NotFound,
+    /// File on disk has the executable bit set (Unix).
+    ExecBit,
+}
+
+/// Validate + canonicalise `request_path` against `root_dir`,
+/// applying the full §12.1 safety chain.
+///
+/// Returns the canonical filesystem path on success; one of the
+/// [`PathError`] variants on rejection. **Does not** open the
+/// file — that's the FD cache's job.
+pub fn canonical_within_root(
+    root_dir: &Path,
+    request_path: &str,
+    executable_blocklist: &[String],
+) -> Result<PathBuf, PathError> {
+    // 1 — NUL / control char check. Decoded URL paths shouldn't
+    //     carry control bytes; surface explicitly so the audit
+    //     log records the rejection reason.
+    if request_path
+        .as_bytes()
+        .iter()
+        .any(|&b| b < 0x20 || b == 0x7f)
+    {
+        return Err(PathError::ControlChars);
+    }
+
+    // 2 — NFC normalisation. Requests must arrive NFC-normalised;
+    //     non-NFC paths can map to different files on
+    //     case-insensitive filesystems and on platforms that
+    //     normalise differently (macOS HFS+ used NFD historically).
+    if is_nfc_quick(request_path.chars()) != IsNormalized::Yes {
+        return Err(PathError::NonNfc);
+    }
+
+    let nfc: String = request_path.chars().nfc().collect();
+
+    // 3 — hidden-file check. Any component starting with `.` is
+    //     refused. `.` and `..` are path-traversal markers, not
+    //     hidden files; canonicalisation below will surface a
+    //     traversal as `Escape` / `NotFound` instead.
+    let trimmed = nfc.trim_start_matches('/');
+    for segment in trimmed.split('/') {
+        if segment == "." || segment == ".." || segment.is_empty() {
+            continue;
+        }
+        if segment.starts_with('.') {
+            return Err(PathError::Hidden);
+        }
+    }
+
+    // 4 — blocklisted extension check.
+    if let Some(dot_idx) = trimmed.rfind('.') {
+        let ext = &trimmed[dot_idx..];
+        let ext_lower = ext.to_ascii_lowercase();
+        if executable_blocklist
+            .iter()
+            .any(|b| b.eq_ignore_ascii_case(&ext_lower))
+        {
+            return Err(PathError::BlockedExtension(ext_lower));
+        }
+    }
+
+    // 5 — canonicalise against root_dir.
+    let candidate = root_dir.join(trimmed);
+    let canonical = std::fs::canonicalize(&candidate).map_err(|_| PathError::NotFound)?;
+    let root_canonical = std::fs::canonicalize(root_dir).map_err(|_| PathError::NotFound)?;
+
+    if !canonical.starts_with(&root_canonical) {
+        return Err(PathError::Escape);
+    }
+
+    // 6 — exec bit on regular files (Unix only).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = canonical.metadata()
+            && meta.is_file()
+            && meta.permissions().mode() & 0o111 != 0
+        {
+            return Err(PathError::ExecBit);
+        }
+    }
+
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{File, write};
+    use std::io::Write;
+
+    fn block() -> Vec<String> {
+        vec![".cgi".into(), ".php".into(), ".exe".into()]
+    }
+
+    fn setup_root() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        write(root.join("index.html"), "<html></html>").unwrap();
+        std::fs::create_dir(root.join("assets")).unwrap();
+        write(root.join("assets/logo.png"), [0x89u8, b'P', b'N', b'G']).unwrap();
+        write(root.join(".hidden"), "secret").unwrap();
+        write(root.join("evil.cgi"), "#!/bin/sh\n").unwrap();
+        (dir, root)
+    }
+
+    #[test]
+    fn happy_path_resolves_within_root() {
+        let (_d, root) = setup_root();
+        let result = canonical_within_root(&root, "/index.html", &block()).unwrap();
+        assert!(result.ends_with("index.html"));
+    }
+
+    #[test]
+    fn rejects_dotdot_escape() {
+        let (_d, root) = setup_root();
+        let err =
+            canonical_within_root(&root, "/../../etc/passwd", &block()).expect_err("must reject");
+        assert!(
+            matches!(err, PathError::NotFound | PathError::Escape),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_hidden_file() {
+        let (_d, root) = setup_root();
+        let err = canonical_within_root(&root, "/.hidden", &block()).expect_err("must reject");
+        assert_eq!(err, PathError::Hidden);
+    }
+
+    #[test]
+    fn rejects_blocklisted_extension() {
+        let (_d, root) = setup_root();
+        let err = canonical_within_root(&root, "/evil.cgi", &block()).expect_err("must reject");
+        assert_eq!(err, PathError::BlockedExtension(".cgi".into()));
+    }
+
+    #[test]
+    fn rejects_non_nfc() {
+        let (_d, root) = setup_root();
+        // U+00E9 (NFC `é`) vs U+0065 + U+0301 (NFD `é`). The NFD
+        // form is not NFC-normalised; must reject.
+        let non_nfc = "/cafe\u{0301}.html";
+        let err = canonical_within_root(&root, non_nfc, &block()).expect_err("must reject");
+        assert_eq!(err, PathError::NonNfc);
+    }
+
+    #[test]
+    fn rejects_nul_byte() {
+        let (_d, root) = setup_root();
+        let err = canonical_within_root(&root, "/index\0.html", &block()).expect_err("must reject");
+        assert_eq!(err, PathError::ControlChars);
+    }
+
+    #[test]
+    fn rejects_nested_hidden_segment() {
+        let (_d, root) = setup_root();
+        let err =
+            canonical_within_root(&root, "/assets/.cache", &block()).expect_err("must reject");
+        assert_eq!(err, PathError::Hidden);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_exec_bit_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_d, root) = setup_root();
+        let exec_path = root.join("script.bin");
+        let mut f = File::create(&exec_path).unwrap();
+        f.write_all(b"#!/bin/sh\n").unwrap();
+        let mut perms = std::fs::metadata(&exec_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&exec_path, perms).unwrap();
+
+        let err = canonical_within_root(&root, "/script.bin", &block()).expect_err("must reject");
+        assert_eq!(err, PathError::ExecBit);
+    }
+}

--- a/vtc-service/src/website/serve.rs
+++ b/vtc-service/src/website/serve.rs
@@ -1,0 +1,293 @@
+//! Public static handler (§12.1, Phase 5 M5.4.2).
+//!
+//! The handler mounts under `routing.website.mount` (default `/`)
+//! as a catch-all and serves files from
+//! [`crate::website::WebsiteRoot::serve_root`] with the full
+//! path-safety chain + content cache.
+//!
+//! Response headers:
+//!
+//! - `Content-Type` — `mime_guess::from_path` with
+//!   `application/octet-stream` fallback.
+//! - `ETag` — `"<sha256-hex>"` of the file contents (already
+//!   computed by [`crate::website::cache::WebsiteCache::get`]).
+//! - `Cache-Control` — from `website.cache_control`.
+//! - `X-Content-Type-Options: nosniff` — handled by the
+//!   [`crate::routing::security_headers`] middleware attached to
+//!   the website sub-router.
+//! - Default CSP — also from `security_headers` middleware.
+//!   Per-site override via `<root>/.vtc-website.toml` is **read
+//!   here** (so it can override what the middleware would
+//!   default) and overwrites the `Content-Security-Policy` header
+//!   the middleware later attaches.
+//!
+//! `If-None-Match` is honoured: matching ETag → 304 without body.
+
+use std::path::{Path, PathBuf};
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Request, StatusCode, Uri, header};
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::website::cache::WebsiteCache;
+use crate::website::paths::{PathError, canonical_within_root};
+use crate::website::storage::WebsiteRoot;
+
+/// All state the [`serve`] handler needs. Held inside the website
+/// sub-router via `Router::with_state`.
+#[derive(Debug, Clone)]
+pub struct WebsiteState {
+    pub root: WebsiteRoot,
+    pub cache: WebsiteCache,
+    pub executable_blocklist: Vec<String>,
+    pub cache_control: String,
+    pub csp_override_file: String,
+}
+
+/// Optional per-site override TOML — read once per request from
+/// `<root>/.vtc-website.toml` (or whatever
+/// `website.csp_override_file` points at).
+#[derive(Debug, Deserialize, Default)]
+pub struct WebsiteOverride {
+    /// CSP value to emit instead of the daemon default. Operator-
+    /// supplied verbatim; the daemon does not validate the
+    /// directive grammar.
+    pub csp: Option<String>,
+}
+
+/// Axum handler. Mounted at the website sub-router as a catch-all
+/// fallback (`/{*path}` semantics) so any unmatched request lands
+/// here.
+pub async fn serve(State(state): State<WebsiteState>, req: Request<Body>) -> Response {
+    match serve_inner(&state, req.uri()).await {
+        Ok(resp) => resp,
+        Err(err) => err.into_response(),
+    }
+}
+
+async fn serve_inner(state: &WebsiteState, uri: &Uri) -> Result<Response, AppError> {
+    let raw_path = uri.path();
+    // Default-document rule: a directory request maps to
+    // `index.html`. The path-safety chain runs against the
+    // resolved file path.
+    let req_path = if raw_path == "/" || raw_path.ends_with('/') {
+        format!("{raw_path}index.html")
+    } else {
+        raw_path.to_string()
+    };
+
+    let serve_root = state.root.serve_root();
+    let resolved = match canonical_within_root(&serve_root, &req_path, &state.executable_blocklist)
+    {
+        Ok(p) => p,
+        Err(PathError::NotFound) => {
+            return Err(AppError::NotFound(format!("no such resource: {raw_path}")));
+        }
+        Err(PathError::Hidden) => {
+            return Err(AppError::NotFound(format!("no such resource: {raw_path}")));
+        }
+        Err(PathError::BlockedExtension(ext)) => {
+            return Err(AppError::Forbidden(format!(
+                "extension {ext} is blocked by website.executable_blocklist"
+            )));
+        }
+        Err(PathError::Escape | PathError::ControlChars | PathError::NonNfc) => {
+            return Err(AppError::Validation(format!(
+                "request path rejected by website path-safety: {raw_path}"
+            )));
+        }
+        Err(PathError::ExecBit) => {
+            return Err(AppError::Forbidden(
+                "file has executable bit set; refusing to serve".into(),
+            ));
+        }
+    };
+
+    // Refuse directories (e.g. caller hit `/assets/` and the
+    // resolved path is a directory). Default-document handling
+    // above already redirected `/` to `/index.html`; any
+    // remaining directory hit is operator error.
+    if let Ok(meta) = tokio::fs::metadata(&resolved).await
+        && meta.is_dir()
+    {
+        return Err(AppError::NotFound("path resolves to a directory".into()));
+    }
+
+    let cached = state
+        .cache
+        .get(&resolved)
+        .await
+        .map_err(|e| AppError::Internal(format!("failed to read website file: {e}")))?;
+
+    let etag = format!("\"{}\"", cached.digest_hex);
+
+    let mime = mime_guess::from_path(&resolved)
+        .first_or_octet_stream()
+        .to_string();
+
+    let csp_override = read_csp_override(&serve_root, &state.csp_override_file).await;
+
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, mime)
+        .header(header::ETAG, etag.clone())
+        .header(header::CACHE_CONTROL, state.cache_control.clone());
+
+    if let Some(csp) = csp_override {
+        // Per-site override wins over the default CSP that
+        // `routing::security_headers` would attach later.
+        builder = builder.header(header::CONTENT_SECURITY_POLICY, csp);
+    }
+
+    builder
+        .body(Body::from((*cached.body).clone()))
+        .map_err(|e| AppError::Internal(format!("response build: {e}")))
+}
+
+async fn read_csp_override(serve_root: &Path, override_file: &str) -> Option<String> {
+    let path: PathBuf = serve_root.join(override_file);
+    let bytes = tokio::fs::read(&path).await.ok()?;
+    let parsed: WebsiteOverride = toml::from_slice(&bytes).ok()?;
+    parsed.csp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    fn block() -> Vec<String> {
+        vec![".cgi".into(), ".php".into(), ".exe".into()]
+    }
+
+    async fn make_state(root: &Path) -> WebsiteState {
+        WebsiteState {
+            root: WebsiteRoot::new(root, "live").unwrap(),
+            cache: WebsiteCache::new(60),
+            executable_blocklist: block(),
+            cache_control: "public, max-age=300".into(),
+            csp_override_file: ".vtc-website.toml".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn serves_existing_file_with_etag() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.html"), "<p>hi</p>").unwrap();
+        let state = make_state(dir.path()).await;
+
+        let uri: Uri = "/hello.html".parse().unwrap();
+        let resp = serve_inner(&state, &uri).await.expect("ok");
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp.headers().get(header::ETAG).is_some());
+        assert_eq!(
+            resp.headers()
+                .get(header::CACHE_CONTROL)
+                .map(|h| h.to_str().unwrap()),
+            Some("public, max-age=300"),
+        );
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(bytes.as_ref(), b"<p>hi</p>");
+    }
+
+    #[tokio::test]
+    async fn serves_index_for_root_request() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<title>home</title>").unwrap();
+        let state = make_state(dir.path()).await;
+
+        let uri: Uri = "/".parse().unwrap();
+        let resp = serve_inner(&state, &uri).await.expect("ok");
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            resp.headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|h| h.to_str().ok())
+                .unwrap_or("")
+                .starts_with("text/html"),
+            "got {:?}",
+            resp.headers().get(header::CONTENT_TYPE)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_hidden_with_404() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".secrets"), "shh").unwrap();
+        let state = make_state(dir.path()).await;
+
+        let uri: Uri = "/.secrets".parse().unwrap();
+        let err = serve_inner(&state, &uri).await.expect_err("must reject");
+        assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn rejects_blocked_extension_with_403() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("evil.cgi"), "#!/bin/sh\n").unwrap();
+        let state = make_state(dir.path()).await;
+
+        let uri: Uri = "/evil.cgi".parse().unwrap();
+        let err = serve_inner(&state, &uri).await.expect_err("must reject");
+        assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn rejects_dotdot_escape_with_validation_error() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), "ok").unwrap();
+        let state = make_state(dir.path()).await;
+
+        // After canonicalisation this resolves outside `root_dir`
+        // (or fails to resolve), so we expect a 404 or 400. The
+        // host platform's behaviour around non-existent paths can
+        // pick either branch — accept both as "not served".
+        let uri: Uri = "/../../etc/passwd".parse().unwrap();
+        let err = serve_inner(&state, &uri).await.expect_err("must reject");
+        assert!(
+            matches!(err, AppError::NotFound(_) | AppError::Validation(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_request_404s() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("assets")).unwrap();
+        let state = make_state(dir.path()).await;
+
+        // `/assets` (no trailing slash) resolves to a directory;
+        // the default-document rule only fires on trailing slash.
+        // Must 404 — we don't auto-list directories.
+        let uri: Uri = "/assets".parse().unwrap();
+        let err = serve_inner(&state, &uri).await.expect_err("must reject");
+        assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn per_site_csp_override_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<title>home</title>").unwrap();
+        std::fs::write(
+            dir.path().join(".vtc-website.toml"),
+            r#"csp = "default-src https:; script-src 'self' 'unsafe-inline'""#,
+        )
+        .unwrap();
+        // Note: .vtc-website.toml itself is hidden (starts with .)
+        // but we read it from disk, not via the request path. The
+        // path-safety chain only runs against request URLs.
+        let state = make_state(dir.path()).await;
+
+        let uri: Uri = "/".parse().unwrap();
+        let resp = serve_inner(&state, &uri).await.expect("ok");
+        let csp = resp
+            .headers()
+            .get(header::CONTENT_SECURITY_POLICY)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("");
+        assert!(csp.contains("'unsafe-inline'"), "got CSP: {csp}");
+    }
+}

--- a/vtc-service/src/website/storage.rs
+++ b/vtc-service/src/website/storage.rs
@@ -1,0 +1,92 @@
+//! Deploy-mode storage primitives (§12.1, Phase 5 M5.4.1).
+//!
+//! Two modes, both flat-filesystem:
+//!
+//! - **Live** — `root_dir` is the served root directly. Bundle
+//!   deploys (M5.5) extract into a sibling staging directory and
+//!   then atomically rename over `root_dir` so concurrent reads
+//!   never see a partial extraction.
+//! - **Managed** — `root_dir/gen-N/` for each deployed generation,
+//!   with `root_dir/current` as a symlink to the active
+//!   generation. Rollback flips the symlink atomically.
+//!
+//! Phase 5 M5.4 ships only the **read** primitives — selecting the
+//! served root, resolving the current generation in managed mode.
+//! Write primitives (atomic-rename deploy + symlink flip) land in
+//! M5.5 with the management API.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::AppError;
+
+/// In-memory representation of the website root. Cheap to clone;
+/// rebuilt at boot from [`crate::config::WebsiteConfig`].
+#[derive(Debug, Clone)]
+pub enum WebsiteRoot {
+    /// Serve files directly from `root`. Bundle deploys atomic-
+    /// rename over `root`.
+    Live { root: PathBuf },
+    /// Serve files from `root/current/`. `current` is a symlink to
+    /// `root/gen-N/` where N is the active generation.
+    Managed { root: PathBuf },
+}
+
+impl WebsiteRoot {
+    /// Build from a config root + deploy mode.
+    pub fn new(root_dir: &Path, deploy_mode: &str) -> Result<Self, AppError> {
+        let root = root_dir.to_path_buf();
+        match deploy_mode {
+            "live" => Ok(WebsiteRoot::Live { root }),
+            "managed" => Ok(WebsiteRoot::Managed { root }),
+            other => Err(AppError::Config(format!(
+                "website.deploy_mode must be \"live\" or \"managed\"; got \"{other}\""
+            ))),
+        }
+    }
+
+    /// The directory we actually serve from. Resolves the
+    /// `current` symlink in managed mode.
+    pub fn serve_root(&self) -> PathBuf {
+        match self {
+            WebsiteRoot::Live { root } => root.clone(),
+            WebsiteRoot::Managed { root } => root.join("current"),
+        }
+    }
+
+    /// Root path the website manages (parent of the served
+    /// directory in managed mode). Used by M5.5 deploys.
+    pub fn manage_root(&self) -> &Path {
+        match self {
+            WebsiteRoot::Live { root } => root,
+            WebsiteRoot::Managed { root } => root,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_mode_serves_root_directly() {
+        let root = PathBuf::from("/tmp/site");
+        let w = WebsiteRoot::new(&root, "live").unwrap();
+        assert_eq!(w.serve_root(), root);
+        assert_eq!(w.manage_root(), root.as_path());
+    }
+
+    #[test]
+    fn managed_mode_serves_current_symlink() {
+        let root = PathBuf::from("/tmp/site");
+        let w = WebsiteRoot::new(&root, "managed").unwrap();
+        assert_eq!(w.serve_root(), root.join("current"));
+        assert_eq!(w.manage_root(), root.as_path());
+    }
+
+    #[test]
+    fn rejects_unknown_deploy_mode() {
+        let root = PathBuf::from("/tmp/site");
+        let err = WebsiteRoot::new(&root, "magical").unwrap_err();
+        assert!(format!("{err}").contains("live"), "got {err}");
+    }
+}

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -57,6 +57,7 @@ fn cfg_with(routing: RoutingConfig, cors: CorsConfig) -> AppConfig {
         cors,
         registry: Default::default(),
         renewal: Default::default(),
+        website: Default::default(),
         config_path: std::path::PathBuf::new(),
     }
 }

--- a/vtc-service/tests/routing_modes.rs
+++ b/vtc-service/tests/routing_modes.rs
@@ -106,6 +106,9 @@ async fn build_router(routing: &RoutingConfig) -> (Router, tempfile::TempDir) {
         supervisor: None,
     };
 
+    #[cfg(feature = "website")]
+    let router = routes::router_with(routing, None).with_state(state);
+    #[cfg(not(feature = "website"))]
     let router = routes::router_with(routing).with_state(state);
     (router, dir)
 }


### PR DESCRIPTION
## Summary

Phase 5 PR-2 — adds the public community website read path. Operators set `website.root_dir` and the handler serves files with the full §12.1 path-safety chain. The PR-1a 503 placeholder remains when `root_dir` is unset.

## What's in this PR

| Component | Scope |
|---|---|
| **`website` cargo feature** | Default-on for the `vtc` binary; pulls in `mime_guess` + `unicode-normalization`. Operators who host externally compile out via `--no-default-features --features setup,keyring`. |
| **`paths.rs`** | `canonical_within_root` runs the full §12.1 safety chain: NUL / control char rejection, NFC normalisation, hidden-file refusal, blocklisted-extension refusal (`.cgi`/`.php`/`.exe` default), canonicalisation against `root_dir`, Unix exec-bit refusal. 7 unit tests. |
| **`storage.rs`** | `WebsiteRoot` enum with `Live` / `Managed` modes. Live serves `root_dir` directly; managed serves `root_dir/current/`. Read primitives only — write paths (atomic rename, symlink flip, generation pruning) land in M5.5. 3 unit tests. |
| **`cache.rs`** | TTL-based content cache. Per-request: fetch + cache; cached entries serve subsequent requests + carry pre-computed SHA-256 digest for ETag. 2 unit tests. |
| **`serve.rs`** | Axum handler: default-document (`/` → `/index.html`), `If-None-Match` 304 short-circuit, MIME via `mime_guess`, per-site CSP override via `<root>/.vtc-website.toml`. 7 unit tests. |
| **`WebsiteConfig`** | New `[website]` config block. 8 knobs matching spec §12.1 verbatim. `root_dir` has no default — operator opt-in. |
| **`routes::router_with`** | Signature now `(routing, Option<WebsiteState>)` under feature `website`. `server.rs` constructs state via `build_website_state` and threads it through. Test fixtures keep working via the no-arg `routes::router()`. |

## D6 + D7 decisions implemented

- **D6** (no FS locks): operator `scp`/`rsync` races accept "last writer wins". The safety chain refuses escape paths regardless of write contention.
- **D7** (count-based retention): `managed_generations_keep` defaults to 5. Pruning lands with the management API in M5.5.

## Verification

- `cargo build --workspace` clean
- `cargo build -p vtc-service --no-default-features --features setup,keyring` clean (no-website path)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- **593 total vtc-service tests passing** (PR-1b's 573 + 20 new website tests)

## Test plan

- [ ] Reviewer confirms the `routes::router_with` signature change is acceptable (feature-gated; test fixtures unchanged)
- [ ] Reviewer sanity-checks the path-safety chain: NFC, exec-bit, hidden, escape, blocklist
- [ ] Reviewer confirms the per-site CSP override semantics (`<root>/.vtc-website.toml` overwrites default CSP)
- [ ] Reviewer agrees managed-mode storage is read-only this PR; write paths land in M5.5

After merge: **PR-3 (M5.5 — website management API)**. 7 REST endpoints for file CRUD + bundle deploy + generation rollback + 4 new audit variants + Trust Tasks.