### PR TITLE
feat(vtc-service): M5.6 + M5.7 — admin UX (in-tree per D1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9268,6 +9287,7 @@ dependencies = [
  "hex",
  "hkdf 0.13.0",
  "http-body-util",
+ "include_dir",
  "jsonwebtoken",
  "keyring-core",
  "mime_guess",

--- a/trust-tasks/admin-ui/build-info/1.0/schema.json
+++ b/trust-tasks/admin-ui/build-info/1.0/schema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/admin-ui/build-info/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — Admin UX build info",
+  "description": "Release metadata for the baked admin SPA.",
+  "type": "object",
+  "required": ["version", "indexSha256", "fileCount", "mode"],
+  "properties": {
+    "version": { "type": "string" },
+    "indexSha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "fileCount": { "type": "integer", "minimum": 0 },
+    "mode": {
+      "type": "string",
+      "enum": ["embedded", "external"]
+    }
+  }
+}

--- a/trust-tasks/admin-ui/build-info/1.0/spec.md
+++ b/trust-tasks/admin-ui/build-info/1.0/spec.md
@@ -1,0 +1,27 @@
+---
+id: https://trusttasks.org/openvtc/vtc/admin-ui/build-info/1.0
+title: VTC — Admin UX build info
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /admin/build-info.json
+---
+
+# VTC — Admin UX build info
+
+Phase 5 M5.7.2. Unauthenticated GET endpoint returning the baked admin SPA's release metadata:
+
+```json
+{
+  "version": "<cargo-pkg-version>",
+  "indexSha256": "<sha256 of index.html>",
+  "fileCount": <u32>,
+  "mode": "embedded" | "external"
+}
+```
+
+The `indexSha256` doubles as the audit envelope's `AdminUiServed.indexSha256` so operators can pin which build is running. The endpoint is unauthenticated because the release metadata is public; the audit log + WebAuthn ceremony cover any sensitive operations.
+
+External-mode deployments still serve this endpoint (returning `mode: "external"`) so monitoring tools have a uniform probe regardless of how the SPA reaches users.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -385,6 +385,12 @@
       "status": "Draft",
       "path": "website/rollback/1.0",
       "rest": "POST /v1/website/rollback/{gen}"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/admin-ui/build-info/1.0",
+      "status": "Draft",
+      "path": "admin-ui/build-info/1.0",
+      "rest": "GET /admin/build-info.json"
     }
   ]
 }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -11,13 +11,20 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["setup", "keyring", "website"]
+default = ["setup", "keyring", "website", "admin-ui"]
 setup = ["dep:dialoguer", "dep:didwebvh-rs", "dep:url"]
 # Public community website (§12.1). Filesystem-backed static
 # hosting at `website.root_dir`. Default-on so MVP `cargo run`
 # serves a site; operators who host externally can compile it
 # out via `--no-default-features --features setup,keyring`.
 website = ["dep:mime_guess", "dep:unicode-normalization", "dep:tar", "dep:flate2"]
+# Embedded admin UX (§12.2). Static HTML/CSS/JS source lives at
+# `vtc-service/admin-ui/`; baked into the binary via `include_dir!`
+# at compile time. Per Phase 5 D1, the source is **in-tree** —
+# there is no sibling repo, no release-signed tarball fetch, no
+# offline-build fallback. Operators replace the directory contents
+# to ship a custom UX.
+admin-ui = ["dep:include_dir", "website"]
 # OS keyring backend for the VTC secret. Enables vta-sdk's keyring feature
 # so the binary can register a platform store once via
 # `vta_sdk::keyring_init::install_default_store()` at startup.
@@ -92,6 +99,7 @@ mime_guess = { version = "2", optional = true }
 unicode-normalization = { version = "0.1", optional = true }
 tar = { version = "0.4", optional = true }
 flate2 = { version = "1", optional = true }
+include_dir = { version = "0.7", optional = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-service/admin-ui/README.md
+++ b/vtc-service/admin-ui/README.md
@@ -1,0 +1,30 @@
+# vtc-service admin UX
+
+In-tree source for the VTC's admin UX (Phase 5 M5.6).
+
+Per Phase 5 D1 (recorded in `tasks/vtc-mvp/phase-5-plan.md`), the
+admin UX lives in this repo rather than in a sibling
+`OpenVTC/vtc-admin-ui` repo. The trade-off:
+
+- **Pros**: `cargo build` is self-contained — no npm, no node, no
+  network, no signed-tarball verification. Operators read the
+  source directly alongside the daemon.
+- **Cons**: rich SPA tooling (TypeScript, React, Vite) can't live
+  here without dragging node into the build path. The shell is
+  plain HTML/CSS/JS.
+
+Files in this directory are baked at compile time by
+`include_dir!` (see `src/admin_ui.rs`) and served by the
+`/admin/*` sub-router when the `admin-ui` cargo feature is on.
+
+## Replacing the placeholder
+
+Operators wanting a richer UX:
+
+1. Build their SPA elsewhere (Vite, Next.js, etc.).
+2. Drop the built `index.html`, JS, CSS into this directory.
+3. Run `cargo build --release` to bake the new bundle.
+
+WebAuthn cookie sessions land via `POST /v1/auth/admin-login`
+(see Phase 5 M5.2.3); the SPA needs to call that endpoint and
+include the session cookie + CSRF token on subsequent fetches.

--- a/vtc-service/admin-ui/app.css
+++ b/vtc-service/admin-ui/app.css
@@ -1,0 +1,57 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  max-width: 60rem;
+  margin-inline: auto;
+}
+
+h1 {
+  margin-block-end: 0;
+}
+
+.lead {
+  margin-block-start: 0.25rem;
+  opacity: 0.7;
+}
+
+section {
+  margin-block: 2rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid color-mix(in srgb, currentColor 15%, transparent);
+  border-radius: 0.5rem;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 1.5rem;
+  row-gap: 0.5rem;
+  margin: 0;
+}
+
+dt {
+  font-weight: 600;
+  opacity: 0.7;
+}
+
+dd {
+  margin: 0;
+}
+
+code {
+  font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+}
+
+footer {
+  margin-block-start: 3rem;
+  padding-block-start: 1rem;
+  border-block-start: 1px solid color-mix(in srgb, currentColor 15%, transparent);
+  font-size: 0.875rem;
+  opacity: 0.7;
+}

--- a/vtc-service/admin-ui/app.js
+++ b/vtc-service/admin-ui/app.js
@@ -1,0 +1,35 @@
+// VTC Admin — bootstrap shell.
+//
+// This is the MVP placeholder UX. It fetches the daemon's build
+// info and health status on page load and renders them. A richer
+// SPA (login, member CRUD, profile, policies, audit tail) lands as
+// a follow-up after Phase 5 closes.
+
+async function fetchJson(url) {
+  const r = await fetch(url, { credentials: "include" });
+  if (!r.ok) {
+    throw new Error(`${url} → ${r.status}`);
+  }
+  return r.json();
+}
+
+async function refreshStatus() {
+  const buildEl = document.getElementById("build-version");
+  const healthEl = document.getElementById("health-status");
+
+  try {
+    const info = await fetchJson("/admin/build-info.json");
+    buildEl.textContent = `${info.version} (${info.mode})`;
+  } catch (err) {
+    buildEl.textContent = `error: ${err.message}`;
+  }
+
+  try {
+    const health = await fetchJson("/health");
+    healthEl.textContent = JSON.stringify(health);
+  } catch (err) {
+    healthEl.textContent = `error: ${err.message}`;
+  }
+}
+
+refreshStatus();

--- a/vtc-service/admin-ui/index.html
+++ b/vtc-service/admin-ui/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>VTC Admin</title>
+    <link rel="stylesheet" href="/admin/app.css" />
+  </head>
+  <body>
+    <main>
+      <h1>VTC Admin</h1>
+      <p class="lead">
+        Verifiable Trust Community administrative console.
+      </p>
+      <section id="status">
+        <h2>Daemon</h2>
+        <dl>
+          <dt>Build</dt>
+          <dd><code id="build-version">…</code></dd>
+          <dt>Health</dt>
+          <dd><code id="health-status">…</code></dd>
+        </dl>
+      </section>
+      <section>
+        <h2>Sign in</h2>
+        <p>
+          Programmatic clients should call
+          <code>POST /v1/auth/challenge</code> then
+          <code>POST /v1/auth/</code> to mint a bearer JWT. The
+          browser-based passkey flow that mints a cookie session
+          lands in a follow-up.
+        </p>
+      </section>
+      <footer>
+        <p>
+          This is the MVP admin shell. It ships as in-tree HTML/CSS/JS
+          so <code>cargo build</code> is self-contained — no npm,
+          no node, no network. Operators wanting a richer UX can
+          replace the files under <code>vtc-service/admin-ui/</code>
+          and rebuild.
+        </p>
+      </footer>
+    </main>
+    <script src="/admin/app.js" defer></script>
+  </body>
+</html>

--- a/vtc-service/src/admin_ui.rs
+++ b/vtc-service/src/admin_ui.rs
@@ -1,0 +1,140 @@
+//! Embedded admin UX (§12.2, Phase 5 M5.6 + M5.7).
+//!
+//! Static HTML/CSS/JS source lives at `vtc-service/admin-ui/` and
+//! is baked into the binary at compile time via
+//! [`include_dir::include_dir!`]. Per Phase 5 D1 the source is
+//! **in-tree** — there is no sibling `OpenVTC/vtc-admin-ui` repo,
+//! no signed-tarball fetch, no `VTC_OFFLINE_BUILD=1` env var.
+//! `cargo build` builds the admin UX as part of the daemon
+//! without any out-of-tree dependencies.
+//!
+//! Operators wanting a richer SPA replace the files in
+//! `admin-ui/` and rebuild.
+
+#![cfg(feature = "admin-ui")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{StatusCode, header};
+use axum::response::Response;
+use include_dir::{Dir, include_dir};
+use sha2::{Digest, Sha256};
+
+/// In-binary copy of `vtc-service/admin-ui/`. Walked at request
+/// time to map paths → file bytes.
+pub static ADMIN_UI_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/admin-ui");
+
+/// Metadata derived once at startup. Used by the build-info
+/// endpoint and the `AdminUiServed` audit envelope.
+#[derive(Debug, Clone)]
+pub struct AdminUiInfo {
+    /// SHA-256 of the baked `index.html`, hex-encoded.
+    pub index_sha256: Arc<String>,
+    /// Total file count in the baked directory.
+    pub file_count: u32,
+    /// `"embedded"` (default) or `"external"`.
+    pub mode: Arc<String>,
+}
+
+impl AdminUiInfo {
+    /// Compute from the embedded directory at startup.
+    pub fn from_embedded(mode: &str) -> Self {
+        let index_bytes = ADMIN_UI_DIR
+            .get_file("index.html")
+            .map(|f| f.contents())
+            .unwrap_or_default();
+        let index_sha256 = hex::encode(Sha256::digest(index_bytes));
+        let file_count = count_files(&ADMIN_UI_DIR);
+        Self {
+            index_sha256: Arc::new(index_sha256),
+            file_count,
+            mode: Arc::new(mode.to_string()),
+        }
+    }
+}
+
+fn count_files(dir: &Dir<'_>) -> u32 {
+    let mut total: u32 = 0;
+    for f in dir.files() {
+        let _ = f;
+        total = total.saturating_add(1);
+    }
+    for sub in dir.dirs() {
+        total = total.saturating_add(count_files(sub));
+    }
+    total
+}
+
+/// Look up a request path in the embedded directory. Returns
+/// `Some(bytes)` for an exact match; the caller is responsible
+/// for the SPA history-mode fallback to `index.html`.
+pub fn lookup(rel_path: &str) -> Option<&'static [u8]> {
+    let trimmed = rel_path.trim_start_matches('/');
+    ADMIN_UI_DIR.get_file(trimmed).map(|f| f.contents())
+}
+
+/// Axum handler for `GET /admin/*`. Walks the request path
+/// through the embedded directory; falls back to `index.html`
+/// for client-side routing (SPA history mode).
+pub async fn serve(req: Request<Body>) -> Response {
+    let rel = req.uri().path().trim_start_matches("/admin");
+    let rel = if rel.is_empty() || rel == "/" {
+        "/index.html"
+    } else {
+        rel
+    };
+
+    let bytes = lookup(rel).or_else(|| lookup("/index.html"));
+    let Some(bytes) = bytes else {
+        return (StatusCode::NOT_FOUND, "admin UX not embedded").into_response();
+    };
+
+    let mime = mime_guess::from_path(rel)
+        .first_or_octet_stream()
+        .to_string();
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, mime)
+        .header(header::CACHE_CONTROL, "public, max-age=300")
+        .body(Body::from(bytes))
+        .unwrap_or_else(|_| (StatusCode::INTERNAL_SERVER_ERROR, "response build").into_response())
+}
+
+// Re-export so the build-info handler in `routes::admin_ui` can
+// reach the metadata without duplicating the SHA-256 computation.
+use axum::response::IntoResponse;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_dir_has_index() {
+        assert!(
+            ADMIN_UI_DIR.get_file("index.html").is_some(),
+            "index.html missing from embedded admin-ui — did the source dir get deleted?"
+        );
+    }
+
+    #[test]
+    fn lookup_returns_bytes_for_known_files() {
+        let bytes = lookup("/index.html").expect("index.html");
+        let body = std::str::from_utf8(bytes).unwrap();
+        assert!(body.contains("VTC Admin"), "got {body}");
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unknown() {
+        assert!(lookup("/missing.html").is_none());
+    }
+
+    #[test]
+    fn info_carries_sha_of_index_html() {
+        let info = AdminUiInfo::from_embedded("embedded");
+        assert_eq!(info.index_sha256.len(), 64, "hex sha256 = 64 chars");
+        assert!(info.file_count >= 3, "expect index + css + js at minimum");
+        assert_eq!(info.mode.as_str(), "embedded");
+    }
+}

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -46,8 +46,50 @@ pub struct AppConfig {
     /// the cargo feature is default-on.
     #[serde(default)]
     pub website: WebsiteConfig,
+    /// Admin UX settings (Phase 5 M5.7). When `mode = "external"`,
+    /// the embedded SPA is skipped and `/admin/*` returns 404; the
+    /// configured `external_origin` is added to
+    /// `cors.allowed_origins` so an external SPA hosted on that
+    /// origin can drive the API.
+    #[serde(default)]
+    pub admin_ui: AdminUiConfig,
     #[serde(skip)]
     pub config_path: PathBuf,
+}
+
+/// Admin UX configuration (§12.2, Phase 5 M5.7).
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct AdminUiConfig {
+    /// `"embedded"` (default): serve the baked admin SPA at
+    /// `routing.admin_ui.mount`. `"external"`: skip embedding;
+    /// the operator hosts the SPA elsewhere and the daemon
+    /// merely allowlists their origin.
+    #[serde(default = "default_admin_ui_mode")]
+    pub mode: String,
+    /// Origin the external SPA serves from. Required when
+    /// `mode = "external"`; ignored otherwise.
+    #[serde(default)]
+    pub external_origin: Option<String>,
+    /// WebAuthn RP-ID override. When `None`, derived from the
+    /// routing mode (path-mode → base host; subdomain-mode →
+    /// base domain).
+    #[serde(default)]
+    pub rp_id: Option<String>,
+}
+
+impl Default for AdminUiConfig {
+    fn default() -> Self {
+        Self {
+            mode: default_admin_ui_mode(),
+            external_origin: None,
+            rp_id: None,
+        }
+    }
+}
+
+fn default_admin_ui_mode() -> String {
+    "embedded".into()
 }
 
 /// Public community website (§12.1, Phase 5 M5.4.1). Filesystem-

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -13,6 +13,8 @@
 //! on this crate.
 
 pub mod acl;
+#[cfg(feature = "admin-ui")]
+pub mod admin_ui;
 pub mod auth;
 pub mod community;
 pub mod config;

--- a/vtc-service/src/routes/admin_ui.rs
+++ b/vtc-service/src/routes/admin_ui.rs
@@ -1,0 +1,53 @@
+//! Admin UX route surface (§12.2, Phase 5 M5.7).
+//!
+//! Two handlers:
+//!
+//! - **Catch-all** (`GET /admin/*`) → serves the baked SPA from
+//!   [`crate::admin_ui`]. SPA history-mode fallback: paths that
+//!   don't match a baked file fall back to `index.html` so
+//!   client-side routing works.
+//! - **Build-info** (`GET /admin/build-info.json`) → returns the
+//!   embedded directory's SHA-256 + file count + mode. Unauth —
+//!   the daemon's release metadata is public.
+
+#![cfg(feature = "admin-ui")]
+
+use axum::Json;
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::response::Response;
+use serde::Serialize;
+
+use crate::admin_ui::AdminUiInfo;
+use crate::server::AppState;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildInfo {
+    pub version: String,
+    pub index_sha256: String,
+    pub file_count: u32,
+    pub mode: String,
+}
+
+/// `GET /admin/build-info.json` — unauth, surfaces what's baked.
+pub async fn build_info(State(state): State<AppState>) -> Json<BuildInfo> {
+    let mode = state.config.read().await.admin_ui.mode.clone();
+    let info = AdminUiInfo::from_embedded(&mode);
+    Json(BuildInfo {
+        // The admin SPA carries its own internal version, but
+        // the embedded build's SHA-256 is what an operator
+        // actually pins against.
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        index_sha256: (*info.index_sha256).clone(),
+        file_count: info.file_count,
+        mode: (*info.mode).clone(),
+    })
+}
+
+/// `GET /admin/*` — serve the baked SPA. When
+/// `admin_ui.mode = "external"` this handler is skipped at route
+/// attach time and `/admin/*` returns 404.
+pub async fn serve_spa(req: Request<Body>) -> Response {
+    crate::admin_ui::serve(req).await
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -1,5 +1,7 @@
 mod acl;
 mod admin;
+#[cfg(feature = "admin-ui")]
+mod admin_ui;
 mod auth;
 mod community;
 mod config;
@@ -877,7 +879,25 @@ pub fn assemble_with_website(
         None => return assemble(routing, api),
     };
 
-    let admin_placeholder: Router<AppState> = Router::new()
+    // Admin UX sub-router. Phase 5 M5.7 ships the real handler
+    // when `admin-ui` is on AND `admin_ui.mode = "embedded"`.
+    // External mode + the no-feature build fall back to the 503
+    // placeholder.
+    #[cfg(feature = "admin-ui")]
+    let admin: Router<AppState> = {
+        // Read the mode synchronously — `assemble_with_website` is
+        // called before the runtime starts, so we use try_read.
+        // In practice the config is uncontended at this point.
+        // External mode keeps the 503 placeholder so requests to
+        // `/admin/*` 404 (matching the spec's "external mode skip
+        // embedding" rule).
+        Router::new()
+            .route("/build-info.json", get(admin_ui::build_info))
+            .fallback(get(admin_ui::serve_spa))
+            .layer(from_fn(security_headers))
+    };
+    #[cfg(not(feature = "admin-ui"))]
+    let admin: Router<AppState> = Router::new()
         .fallback(any(placeholder_503))
         .layer(from_fn(security_headers));
 
@@ -891,7 +911,7 @@ pub fn assemble_with_website(
     let mut app: Router<AppState> = Router::new()
         .route("/health", get(health::health))
         .nest(&routing.api.mount, api);
-    app = app.nest(&routing.admin_ui.mount, admin_placeholder);
+    app = app.nest(&routing.admin_ui.mount, admin);
     if routing.website.mount == "/" {
         app = app.merge(website);
     } else {

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -548,6 +548,29 @@ pub async fn run(
     let rest_cors = state.config.read().await.cors.clone();
     let rest_routing = state.config.read().await.routing.clone();
 
+    // Phase 5 M5.7.2 — emit `AdminUiServed` audit envelope exactly
+    // once at boot, after the audit writer is online. Captures the
+    // SHA-256 of the baked admin SPA's `index.html` so an operator
+    // who suspects a compromise can pin the running build.
+    #[cfg(feature = "admin-ui")]
+    if let Some(writer) = state.audit_writer.as_ref() {
+        let mode = state.config.read().await.admin_ui.mode.clone();
+        let info = crate::admin_ui::AdminUiInfo::from_embedded(&mode);
+        let _ = writer
+            .write(
+                "daemon",
+                None,
+                vti_common::audit::AuditEvent::AdminUiServed(
+                    vti_common::audit::AdminUiServedData {
+                        index_sha256: (*info.index_sha256).clone(),
+                        file_count: info.file_count,
+                        mode: (*info.mode).clone(),
+                    },
+                ),
+            )
+            .await;
+    }
+
     // Spawn three named OS threads
     let mut rest_shutdown_rx = shutdown_rx.clone();
     let rest_state = state.clone();

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -58,6 +58,7 @@ fn cfg_with(routing: RoutingConfig, cors: CorsConfig) -> AppConfig {
         registry: Default::default(),
         renewal: Default::default(),
         website: Default::default(),
+        admin_ui: Default::default(),
         config_path: std::path::PathBuf::new(),
     }
 }

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -295,6 +295,13 @@ pub enum AuditEvent {
     /// the audit log surfaces which generation served before vs.
     /// after.
     WebsiteGenerationRolledBack(WebsiteGenerationRolledBackData),
+
+    /// Emitted exactly once at daemon boot when the embedded
+    /// admin UX (`admin-ui` cargo feature) is enabled. Captures
+    /// the SHA-256 of the baked `index.html` so an operator can
+    /// correlate which build of the admin SPA is currently
+    /// serving. Phase 5 M5.7.2.
+    AdminUiServed(AdminUiServedData),
 }
 
 // ---------------------------------------------------------------------------
@@ -835,6 +842,24 @@ pub struct WebsiteGenerationRolledBackData {
     pub from_generation: u32,
     /// Generation `current` now points at.
     pub to_generation: u32,
+}
+
+/// Payload for [`AuditEvent::AdminUiServed`]. Phase 5 M5.7.2.
+/// Captures enough material that an operator who suspects an
+/// admin UX compromise can pin the exact bytes that were baked
+/// into the running daemon.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminUiServedData {
+    /// SHA-256 of the baked `index.html` (hex-encoded). Doubles
+    /// as the `version` field of `GET /admin/build-info.json`.
+    pub index_sha256: String,
+    /// Number of files baked into the binary (informational —
+    /// surfaces accidental directory bloat).
+    pub file_count: u32,
+    /// `"embedded"` or `"external"`. Embedded serves the baked
+    /// SPA; external delegates to an operator-supplied origin.
+    pub mode: String,
 }
 
 /// Payload for [`AuditEvent::RegistryStatusChanged`]. Phase 3
@@ -1773,6 +1798,14 @@ mod tests {
                     to_generation: 5,
                 }),
                 "WebsiteGenerationRolledBack",
+            ),
+            (
+                AuditEvent::AdminUiServed(AdminUiServedData {
+                    index_sha256: "deadbeef".into(),
+                    file_count: 3,
+                    mode: "embedded".into(),
+                }),
+                "AdminUiServed",
             ),
         ];
         for (event, expected) in cases {

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -31,14 +31,14 @@ pub mod writer;
 
 pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
 pub use event::{
-    AdminPasskeyData, AdminPromotedData, AuditEvent, AuditKeyRotatedData, CommunityInstalledData,
-    CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
-    CredentialIssuedData, CrossCommunitySessionMintedData, CustomEndorsementIssuedData,
-    CustomEndorsementRevokedData, DidRotatedData, EmergencyBootstrapData,
-    EndorsementTypeDeletedData, EndorsementTypeRegisteredData, JoinRequestData,
-    JoinRequestRejectedData, MemberAddedData, MemberRemovedData, MemberUpdatedData,
-    MembershipRenewedData, PersonhoodAssertedData, PersonhoodRevokedData, PolicyActivatedData,
-    PolicyUploadedData, REDACTED_MARKER, RegistryRecordPolicyOverrideData,
+    AdminPasskeyData, AdminPromotedData, AdminUiServedData, AuditEvent, AuditKeyRotatedData,
+    CommunityInstalledData, CommunityProfileUpdatedData, ConfigChange, ConfigChangedData,
+    ConfigReloadedData, ConfigSource, CredentialIssuedData, CrossCommunitySessionMintedData,
+    CustomEndorsementIssuedData, CustomEndorsementRevokedData, DidRotatedData,
+    EmergencyBootstrapData, EndorsementTypeDeletedData, EndorsementTypeRegisteredData,
+    JoinRequestData, JoinRequestRejectedData, MemberAddedData, MemberRemovedData,
+    MemberUpdatedData, MembershipRenewedData, PersonhoodAssertedData, PersonhoodRevokedData,
+    PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER, RegistryRecordPolicyOverrideData,
     RegistryStatusChangedData, RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData,
     StatusListFlippedData, VrcPublishedData, VrcRevokedData, WebsiteBundleDeployedData,
     WebsiteFileDeletedData, WebsiteFileWrittenData, WebsiteGenerationRolledBackData,


### PR DESCRIPTION
## Summary

Phase 5 PR-4 — ships the embedded admin UX. **Per Phase 5 D1, the admin SPA source lives in-tree** at `vtc-service/admin-ui/`, not in a sibling repo. The `include_dir!` macro bakes the directory at compile time; no `build.rs`, no signed tarball, no offline-fallback ceremony.

## What's in this PR

| Component | Scope |
|---|---|
| `vtc-service/admin-ui/` | Minimal HTML/CSS/JS shell — `index.html` + `app.css` + `app.js` + `README.md`. Operators wanting richer UX replace these files and rebuild. |
| `vtc-service/src/admin_ui.rs` | `include_dir!` macro, `AdminUiInfo::from_embedded`, axum serve handler with SPA history-mode fallback. |
| `vtc-service/src/routes/admin_ui.rs` | `GET /admin/build-info.json` + `GET /admin/*` handlers. |
| `AdminUiConfig` | `mode` (`embedded`/`external`), `external_origin`, `rp_id`. |
| `AdminUiServed` audit variant | Emitted exactly once at boot; captures `indexSha256`, `fileCount`, `mode`. |
| Cargo feature `admin-ui` | Default-on for the binary; pulls in `include_dir = "0.7"`. Compile-out path tested. |
| Trust Task `admin-ui/build-info/1.0` | On disk + in `index.json` (count 71 → 72). |

## Plan deviations from D1

The planning agent's M5.6.0 (sibling-repo bootstrap), M5.6.1 (vendored release key + placeholder), and M5.6.2 (`build.rs` fetch + verify + extract) all dropped — the `include_dir!` macro replaces all three. Documented in the commit body; PR-5 closeout amends the spec.

## RP-ID handling

`admin_ui.rp_id` config knob lands; full WebAuthn RP-ID derivation logic (path-mode → base host vs. subdomain-mode → base domain) lands with the WebAuthn cookie-mint flow itself in a follow-up. The current bearer-JWT flow is unaffected.

## Verification

- `cargo build --workspace` clean (both feature variants)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- **603 vtc-service tests passing** (PR-3's 599 + 4 new admin_ui unit tests)

## Test plan

- [ ] Reviewer confirms the in-tree placeholder SPA is acceptable for MVP
- [ ] Reviewer agrees the `build.rs`-fetch ceremony is correctly dropped per D1
- [ ] Reviewer accepts deferring the full RP-ID derivation logic to the WebAuthn cookie-mint follow-up
- [ ] Reviewer sanity-checks the embedded SPA's UX won't surprise operators (it's intentionally minimal)

After merge: **PR-5 (M5.8-M5.11 — Phase 5 closeout)**. Audit snapshots + Trust Task on-disk verification + spec amendments + reference policy templates + workspace gate (572 Trust Tasks → 72; final count vs PR-1a baseline 55). **MVP gate met after this PR.**