### PR TITLE
feat: support REST-only registered servers and isolate daemon auth cache

### DIFF
--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -512,7 +512,7 @@ pub(crate) enum WebvhCommands {
         /// Server identifier
         #[arg(long)]
         id: String,
-        /// Server DID (must resolve to a DID document with a WebVHHostingService endpoint)
+        /// Server DID (must resolve to a DID document with a DIDCommMessaging, WebVHHosting, or WebVHHostingService endpoint)
         #[arg(long)]
         did: String,
         /// Human-readable label

--- a/vta-sdk/src/webvh.rs
+++ b/vta-sdk/src/webvh.rs
@@ -7,12 +7,6 @@ pub struct WebvhServerRecord {
     pub did: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub access_token: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub access_expires_at: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub refresh_token: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -51,6 +45,51 @@ fn default_next_fragment_id() -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn legacy_server_record_ignores_embedded_auth_fields() {
+        let json = r#"{
+            "id": "srv",
+            "did": "did:webvh:Q...:vta.example.com:primary",
+            "label": "edge",
+            "access_token": "leaky-access",
+            "access_expires_at": 42,
+            "refresh_token": "leaky-refresh",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }"#;
+
+        let record: WebvhServerRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(record.id, "srv");
+        assert_eq!(record.did, "did:webvh:Q...:vta.example.com:primary");
+        assert_eq!(record.label.as_deref(), Some("edge"));
+
+        let serialized = serde_json::to_value(&record).unwrap();
+        assert!(serialized.get("access_token").is_none());
+        assert!(serialized.get("access_expires_at").is_none());
+        assert!(serialized.get("refresh_token").is_none());
+    }
+
+    #[test]
+    fn server_record_round_trips_as_metadata_only() {
+        let record = WebvhServerRecord {
+            id: "srv".into(),
+            did: "did:webvh:abc:vta.example.com:primary".into(),
+            label: Some("edge".into()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let json = serde_json::to_value(&record).unwrap();
+        assert!(json.get("access_token").is_none());
+        assert!(json.get("access_expires_at").is_none());
+        assert!(json.get("refresh_token").is_none());
+
+        let restored: WebvhServerRecord = serde_json::from_value(json).unwrap();
+        assert_eq!(restored.id, "srv");
+        assert_eq!(restored.did, "did:webvh:abc:vta.example.com:primary");
+        assert_eq!(restored.label.as_deref(), Some("edge"));
+    }
 
     #[test]
     fn legacy_record_loads_with_default_pre_rotation_and_fragment_id() {

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -571,7 +571,7 @@ enum WebvhCommands {
         /// Server identifier
         #[arg(long)]
         id: String,
-        /// Server DID (must resolve to a DID document with a WebVHHostingService endpoint)
+        /// Server DID (must resolve to a DID document with a DIDCommMessaging, WebVHHosting, or WebVHHostingService endpoint)
         #[arg(long)]
         did: String,
         /// Human-readable label

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -894,10 +894,14 @@ pub async fn handle_register_did_with_server(
         .did_resolver
         .as_ref()
         .ok_or_else(|| handler_err("DID resolver not available"))?;
+    let config = state.config.read().await;
     let result = app_try!(
         operations::did_webvh::register_did_with_server(
             &state.webvh_ks,
+            &state.keys_ks,
             &state.audit_ks,
+            &*state.seed_store,
+            &config,
             &auth,
             did_resolver,
             &state.didcomm_bridge,
@@ -1379,6 +1383,7 @@ pub async fn handle_update_did_webvh(
         expected_version_id: env.body.expected_version_id,
     };
 
+    let config = state.config.read().await;
     let result = app_try!(
         operations::did_webvh::update_did_webvh(
             &state.keys_ks,
@@ -1386,6 +1391,7 @@ pub async fn handle_update_did_webvh(
             &state.webvh_ks,
             &state.audit_ks,
             &*state.seed_store,
+            &config,
             &auth,
             &env.scid,
             opts,
@@ -1431,6 +1437,7 @@ pub async fn handle_rotate_did_webvh_keys(
         label: env.body.label,
     };
 
+    let config = state.config.read().await;
     let result = app_try!(
         operations::did_webvh::rotate_did_webvh_keys(
             &state.keys_ks,
@@ -1438,6 +1445,7 @@ pub async fn handle_rotate_did_webvh_keys(
             &state.webvh_ks,
             &state.audit_ks,
             &*state.seed_store,
+            &config,
             &auth,
             &env.scid,
             opts,

--- a/vta-service/src/operations/backup.rs
+++ b/vta-service/src/operations/backup.rs
@@ -171,7 +171,7 @@ pub async fn export_backup(
             reason: s.reason,
         });
 
-    // 7. Collect WebVH records
+    // 7. Collect WebVH metadata + DID records (auth cache is excluded)
     #[cfg(feature = "webvh")]
     let (webvh_servers, webvh_dids, webvh_logs) = {
         let servers: Vec<vta_sdk::webvh::WebvhServerRecord> = webvh_ks
@@ -377,7 +377,7 @@ pub async fn apply_import(
     clear_keyspace(audit_ks, &["log:"]).await?;
     clear_keyspace(imported_ks, &["secret:"]).await?;
     #[cfg(feature = "webvh")]
-    clear_keyspace(webvh_ks, &["server:", "did:", "log:"]).await?;
+    clear_keyspace(webvh_ks, &["server:", "server-auth:", "did:", "log:"]).await?;
 
     // Also remove counters
     let _ = keys_ks.remove("active_seed_id").await;
@@ -439,7 +439,7 @@ pub async fn apply_import(
         acl_ks.insert("vta:sealed", &record).await?;
     }
 
-    // 9. Write WebVH records
+    // 9. Write WebVH metadata + DID records (auth cache is runtime-only)
     #[cfg(feature = "webvh")]
     {
         for server in &payload.webvh_servers {
@@ -919,6 +919,181 @@ mod tests {
         // Different salts → different ciphertexts
         assert_ne!(env1.kdf.salt, env2.kdf.salt);
         assert_ne!(env1.ciphertext, env2.ciphertext);
+    }
+
+    #[test]
+    fn legacy_backup_payload_with_embedded_webvh_auth_fields_deserializes() {
+        let payload_json = serde_json::json!({
+            "active_seed_hex": hex::encode([42u8; 32]),
+            "active_seed_id": 1,
+            "seed_records": [],
+            "jwt_signing_key": serde_json::Value::Null,
+            "key_records": [],
+            "context_records": [],
+            "context_counter": 0,
+            "acl_entries": [],
+            "seal": serde_json::Value::Null,
+            "webvh_servers": [{
+                "id": "srv",
+                "did": "did:webvh:Q...:vta.example.com:primary",
+                "label": "edge",
+                "access_token": "legacy-access",
+                "access_expires_at": 42,
+                "refresh_token": "legacy-refresh",
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z"
+            }],
+            "webvh_dids": [],
+            "webvh_logs": [],
+            "config": {},
+            "audit_logs": [],
+            "imported_secrets": [],
+            "imported_kek_salt": serde_json::Value::Null
+        });
+
+        let payload: BackupPayload = serde_json::from_value(payload_json).unwrap();
+        assert_eq!(payload.webvh_servers.len(), 1);
+        assert_eq!(payload.webvh_servers[0].id, "srv");
+        assert_eq!(payload.webvh_servers[0].label.as_deref(), Some("edge"));
+
+        let server_json = serde_json::to_value(&payload.webvh_servers[0]).unwrap();
+        assert!(server_json.get("access_token").is_none());
+        assert!(server_json.get("access_expires_at").is_none());
+        assert!(server_json.get("refresh_token").is_none());
+    }
+
+    #[cfg(feature = "webvh")]
+    #[tokio::test]
+    async fn export_backup_excludes_webvh_auth_cache() {
+        use crate::keys::seed_store::{PlaintextSeedStore, SeedStore};
+        use crate::keys::seeds::set_active_seed_id;
+        use crate::operations::Keyspaces;
+        use crate::test_support::{open_test_store, super_admin_claims, test_app_config};
+        use crate::webvh_store::{self, WebvhServerAuthRecord};
+        use vta_sdk::webvh::WebvhServerRecord;
+
+        let ts = open_test_store().await;
+        let seed_store = PlaintextSeedStore::new(&ts.data_dir);
+        seed_store.set(&[7u8; 32]).await.unwrap();
+        set_active_seed_id(&ts.keys_ks, 1).await.unwrap();
+
+        let server = WebvhServerRecord {
+            id: "srv".into(),
+            did: "did:webvh:Q...:vta.example.com:primary".into(),
+            label: Some("edge".into()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        webvh_store::store_server(&ts.webvh_ks, &server)
+            .await
+            .unwrap();
+        webvh_store::store_server_auth(
+            &ts.webvh_ks,
+            &server.id,
+            &WebvhServerAuthRecord {
+                access_token: Some("live-access".into()),
+                access_expires_at: Some(42),
+                refresh_token: Some("live-refresh".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let keyspaces = Keyspaces {
+            keys: &ts.keys_ks,
+            acl: &ts.acl_ks,
+            contexts: &ts.contexts_ks,
+            did_templates: &ts.did_templates_ks,
+            audit: &ts.audit_ks,
+            imported: &ts.imported_ks,
+            webvh: &ts.webvh_ks,
+        };
+        let config = test_app_config(ts.data_dir.clone());
+        let auth = super_admin_claims();
+
+        let envelope = export_backup(
+            &keyspaces,
+            &seed_store,
+            &config,
+            &auth,
+            "test-password-12chars!",
+            false,
+        )
+        .await
+        .unwrap();
+        let payload = decrypt_backup(&envelope, "test-password-12chars!").unwrap();
+
+        assert_eq!(payload.webvh_servers.len(), 1);
+        assert_eq!(payload.webvh_servers[0].id, server.id);
+        let server_json = serde_json::to_value(&payload.webvh_servers[0]).unwrap();
+        assert!(server_json.get("access_token").is_none());
+        assert!(server_json.get("access_expires_at").is_none());
+        assert!(server_json.get("refresh_token").is_none());
+    }
+
+    #[cfg(feature = "webvh")]
+    #[tokio::test]
+    async fn apply_import_clears_webvh_auth_cache() {
+        use std::sync::Arc;
+
+        use crate::keys::seed_store::{PlaintextSeedStore, SeedStore};
+        use crate::operations::Keyspaces;
+        use crate::test_support::{open_test_store, test_app_config};
+        use crate::webvh_store::{self, WebvhServerAuthRecord};
+        use tokio::sync::RwLock;
+        use vta_sdk::webvh::WebvhServerRecord;
+
+        let ts = open_test_store().await;
+        let seed_store: Arc<dyn SeedStore> = Arc::new(PlaintextSeedStore::new(&ts.data_dir));
+
+        webvh_store::store_server_auth(
+            &ts.webvh_ks,
+            "srv",
+            &WebvhServerAuthRecord {
+                access_token: Some("stale-access".into()),
+                access_expires_at: Some(42),
+                refresh_token: Some("stale-refresh".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut payload = test_payload();
+        payload.webvh_servers = vec![WebvhServerRecord {
+            id: "srv".into(),
+            did: "did:webvh:Q...:vta.example.com:primary".into(),
+            label: Some("edge".into()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }];
+
+        let keyspaces = Keyspaces {
+            keys: &ts.keys_ks,
+            acl: &ts.acl_ks,
+            contexts: &ts.contexts_ks,
+            did_templates: &ts.did_templates_ks,
+            audit: &ts.audit_ks,
+            imported: &ts.imported_ks,
+            webvh: &ts.webvh_ks,
+        };
+        let config = RwLock::new(test_app_config(ts.data_dir.clone()));
+
+        apply_import(&payload, &keyspaces, &seed_store, &config, None)
+            .await
+            .unwrap();
+
+        assert!(
+            webvh_store::get_server_auth(&ts.webvh_ks, "srv")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            webvh_store::get_server(&ts.webvh_ks, "srv")
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     // ── vta_did cross-check guard ───────────────────────────────────

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -59,9 +59,9 @@ use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
 use crate::keys::{self, KeyType as SdkKeyType, PreRotationKeyData, encode_private_multibase};
 use crate::store::KeyspaceHandle;
-use crate::webvh_client::{RequestUriResponse, WebvhClient};
+use crate::webvh_client::{RequestUriResponse, WebvhAuthState, WebvhClient};
 use crate::webvh_didcomm::WebvhDIDCommClient;
-use crate::webvh_store;
+use crate::webvh_store::{self, WebvhServerAuthRecord};
 use vta_sdk::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
 use zeroize::Zeroize;
 
@@ -311,6 +311,14 @@ pub async fn create_did_webvh(
     auth.require_admin()?;
     auth.require_context(&params.context_id)?;
 
+    let rest_auth = WebvhRestAuthContext {
+        webvh_ks,
+        keys_ks,
+        seed_store,
+        config,
+        channel,
+    };
+
     // Template is mutually exclusive with raw did_document / did_log — it
     // renders into did_document, so specifying both would ambiguously
     // override.
@@ -384,7 +392,8 @@ pub async fn create_did_webvh(
                     AppError::NotFound(format!("webvh server not found: {server_id}"))
                 })?;
             let transport =
-                WebvhTransport::from_server(&server, did_resolver, didcomm_bridge).await?;
+                WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, &rest_auth)
+                    .await?;
             // Final mode has no mnemonic from a server request — use the SCID as identifier
             transport.publish_did(&scid, did_log).await?;
         }
@@ -599,7 +608,8 @@ pub async fn create_did_webvh(
             .await?
             .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {server_id}")))?;
 
-        let transport = WebvhTransport::from_server(&server, did_resolver, didcomm_bridge).await?;
+        let transport =
+            WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, &rest_auth).await?;
         let uri_response = transport.request_uri(params.path.as_deref()).await?;
 
         // Validate the URL
@@ -952,7 +962,8 @@ pub async fn create_did_webvh(
             .await?
             .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {server_id}")))?;
 
-        let transport = WebvhTransport::from_server(&server, did_resolver, didcomm_bridge).await?;
+        let transport =
+            WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, &rest_auth).await?;
         transport.publish_did(mnemonic, &log_content).await?;
 
         // Store DID record and log
@@ -1001,8 +1012,8 @@ pub async fn create_did_webvh(
 pub async fn delete_did_webvh(
     webvh_ks: &KeyspaceHandle,
     keys_ks: &KeyspaceHandle,
-    _seed_store: &dyn SeedStore,
-    _config: &AppConfig,
+    seed_store: &dyn SeedStore,
+    config: &AppConfig,
     auth: &AuthClaims,
     did: &str,
     did_resolver: &DIDCacheClient,
@@ -1019,7 +1030,14 @@ pub async fn delete_did_webvh(
     let server = webvh_store::get_server(webvh_ks, &record.server_id).await?;
 
     if let Some(server) = server {
-        match WebvhTransport::from_server(&server, did_resolver, didcomm_bridge).await {
+        let rest_auth = WebvhRestAuthContext {
+            webvh_ks,
+            keys_ks,
+            seed_store,
+            config,
+            channel,
+        };
+        match WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, &rest_auth).await {
             Ok(transport) => {
                 if let Err(e) = transport.delete_did(&record.mnemonic).await {
                     tracing::warn!(did = %did, error = %e, "failed to delete DID from webvh-server (continuing local cleanup)");
@@ -1059,6 +1077,231 @@ pub async fn delete_did_webvh(
 // WebVH transport abstraction
 // ---------------------------------------------------------------------------
 
+/// Transport choice inferred from a resolved WebVH server DID document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ResolvedServerTransport {
+    Didcomm,
+    Rest(String),
+}
+
+fn normalize_service_uri(url: String) -> String {
+    url.trim_matches('"').trim_end_matches('/').to_string()
+}
+
+fn resolve_server_transport<T>(
+    services: &[T],
+    service_types: impl Fn(&T) -> &[String],
+    service_uri: impl Fn(&T) -> Option<String>,
+) -> Option<ResolvedServerTransport> {
+    if services
+        .iter()
+        .any(|svc| servers::is_didcomm_service_type(service_types(svc)))
+    {
+        return Some(ResolvedServerTransport::Didcomm);
+    }
+
+    services.iter().find_map(|svc| {
+        if !servers::is_webvh_rest_service_type(service_types(svc)) {
+            return None;
+        }
+        service_uri(svc)
+            .map(normalize_service_uri)
+            .map(ResolvedServerTransport::Rest)
+    })
+}
+
+const WEBVH_REST_TOKEN_REFRESH_SKEW_SECS: u64 = 30;
+
+pub(super) struct WebvhRestAuthContext<'a> {
+    webvh_ks: &'a KeyspaceHandle,
+    keys_ks: &'a KeyspaceHandle,
+    seed_store: &'a dyn SeedStore,
+    config: &'a AppConfig,
+    channel: &'a str,
+}
+
+fn unix_now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn access_token_is_fresh(auth_state: &WebvhServerAuthRecord, now: u64) -> bool {
+    auth_state
+        .access_token
+        .as_ref()
+        .is_some_and(|token| !token.is_empty())
+        && auth_state
+            .access_expires_at
+            .is_some_and(|exp| exp > now.saturating_add(WEBVH_REST_TOKEN_REFRESH_SKEW_SECS))
+}
+
+async fn load_vta_signing_secret(
+    keys_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    config: &AppConfig,
+) -> Result<(String, Secret), AppError> {
+    let vta_did = config
+        .vta_did
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("vta_did is not configured".into()))?
+        .clone();
+    let key_id = format!("{vta_did}#key-0");
+
+    let record: KeyRecord = keys_ks
+        .get(keys::store_key(&key_id))
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("VTA signing key not found: {key_id}")))?;
+
+    if record.key_type != KeyType::Ed25519 {
+        return Err(AppError::Internal(format!(
+            "VTA signing key {key_id} must be Ed25519, found {}",
+            record.key_type
+        )));
+    }
+    if record.status != KeyStatus::Active {
+        return Err(AppError::Internal(format!(
+            "VTA signing key {key_id} is not active"
+        )));
+    }
+    if record.origin != KeyOrigin::Derived {
+        return Err(AppError::Internal(format!(
+            "webvh REST auth currently requires a derived VTA signing key; {key_id} is {:?}",
+            record.origin
+        )));
+    }
+
+    let seed = load_seed_bytes(keys_ks, seed_store, record.seed_id)
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    let bip32 = ExtendedSigningKey::from_seed(&seed)
+        .map_err(|e| AppError::Internal(format!("failed to create BIP-32 root key: {e}")))?;
+    let derivation_path: DerivationPath = record
+        .derivation_path
+        .parse()
+        .map_err(|e| AppError::Internal(format!("invalid derivation path: {e}")))?;
+    let derived_key = bip32
+        .derive(&derivation_path)
+        .map_err(|e| AppError::Internal(format!("key derivation failed: {e}")))?;
+    let private_key_multibase =
+        encode_private_multibase(&KeyType::Ed25519, derived_key.signing_key.as_bytes());
+
+    let signing_secret = if vta_did.starts_with("did:key:") {
+        let seed: [u8; 32] = vta_sdk::did_key::decode_private_key_multibase(&private_key_multibase)
+            .map_err(|e| {
+                AppError::Internal(format!("decode VTA did:key signing seed for {key_id}: {e}"))
+            })?;
+        vta_sdk::did_key::secrets_from_did_key(&vta_did, &seed)
+            .map_err(|e| AppError::Internal(format!("construct did:key secrets: {e}")))?
+            .signing
+    } else {
+        let mut secret = Secret::from_multibase(&private_key_multibase, None).map_err(|e| {
+            AppError::Internal(format!(
+                "construct Secret for VTA signing key {key_id}: {e}"
+            ))
+        })?;
+        secret.id = key_id;
+        secret
+    };
+
+    Ok((vta_did, signing_secret))
+}
+
+fn apply_webvh_auth_state(stored: &mut WebvhServerAuthRecord, auth_state: &WebvhAuthState) {
+    stored.access_token = Some(auth_state.access_token.clone());
+    stored.access_expires_at = Some(auth_state.access_expires_at);
+    if let Some(ref refresh_token) = auth_state.refresh_token {
+        stored.refresh_token = Some(refresh_token.clone());
+    }
+}
+
+async fn build_authenticated_rest_client(
+    server: &WebvhServerRecord,
+    url: &str,
+    auth: &WebvhRestAuthContext<'_>,
+) -> Result<WebvhClient, AppError> {
+    let mut client = WebvhClient::new(url);
+    let now = unix_now_secs();
+    let stored = webvh_store::get_server_auth(auth.webvh_ks, &server.id).await?;
+
+    if let Some(ref auth_state) = stored
+        && access_token_is_fresh(auth_state, now)
+    {
+        if let Some(ref token) = auth_state.access_token {
+            client.set_access_token(token.clone());
+        }
+        return Ok(client);
+    }
+
+    let mut updated = stored.unwrap_or_default();
+
+    if let Some(refresh_token) = updated.refresh_token.clone() {
+        match client.refresh_access_token(&refresh_token).await {
+            Ok(auth_state) => {
+                apply_webvh_auth_state(&mut updated, &auth_state);
+                webvh_store::store_server_auth(auth.webvh_ks, &server.id, &updated).await?;
+                client.set_access_token(auth_state.access_token);
+                info!(
+                    channel = auth.channel,
+                    server_id = %server.id,
+                    server_did = %server.did,
+                    transport = "rest",
+                    "refreshed stored WebVH REST access token"
+                );
+                return Ok(client);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    channel = auth.channel,
+                    server_id = %server.id,
+                    server_did = %server.did,
+                    error = %e,
+                    "failed to refresh WebVH REST access token; falling back to full authentication"
+                );
+            }
+        }
+    }
+
+    if auth.config.vta_did.as_deref().is_none_or(str::is_empty) {
+        info!(
+            channel = auth.channel,
+            server_id = %server.id,
+            server_did = %server.did,
+            transport = "rest",
+            "no configured vta_did yet; using unauthenticated WebVH REST client"
+        );
+        return Ok(client);
+    }
+
+    let (vta_did, signing_secret) =
+        load_vta_signing_secret(auth.keys_ks, auth.seed_store, auth.config).await?;
+    let auth_state = client
+        .authenticate(&vta_did, &signing_secret, &server.did)
+        .await
+        .map_err(|e| {
+            AppError::Internal(format!(
+                "authenticate VTA DID {vta_did} to webvh server {} via REST: {e}",
+                server.did
+            ))
+        })?;
+
+    apply_webvh_auth_state(&mut updated, &auth_state);
+    webvh_store::store_server_auth(auth.webvh_ks, &server.id, &updated).await?;
+    client.set_access_token(auth_state.access_token);
+
+    info!(
+        channel = auth.channel,
+        server_id = %server.id,
+        server_did = %server.did,
+        vta_did = %vta_did,
+        transport = "rest",
+        "authenticated VTA to WebVH REST endpoint"
+    );
+
+    Ok(client)
+}
+
 /// Unified transport for communicating with a WebVH server via REST or DIDComm.
 ///
 /// Owns all necessary state so callers don't need to branch on transport type.
@@ -1073,49 +1316,40 @@ pub(super) enum WebvhTransport<'a> {
 impl<'a> WebvhTransport<'a> {
     /// Resolve the server DID and construct the appropriate transport.
     ///
-    /// Prefers `DIDCommMessaging` and falls back to `WebVHHostingService`.
+    /// Prefers `DIDCommMessaging` and falls back to REST when the DID exposes
+    /// either `WebVHHosting` or `WebVHHostingService`.
     pub(super) async fn from_server(
         server: &WebvhServerRecord,
         did_resolver: &DIDCacheClient,
         didcomm_bridge: &'a Arc<DIDCommBridge>,
+        rest_auth: &WebvhRestAuthContext<'_>,
     ) -> Result<Self, AppError> {
         let resolved = did_resolver.resolve(&server.did).await.map_err(|e| {
             AppError::Internal(format!("failed to resolve server DID {}: {e}", server.did))
         })?;
 
-        // Check for DIDCommMessaging first
-        let has_didcomm = resolved
-            .doc
-            .service
-            .iter()
-            .any(|svc| svc.type_.iter().any(|t| t == "DIDCommMessaging"));
-        if has_didcomm {
-            info!(server_did = %server.did, transport = "didcomm", "resolved webvh server endpoint");
-            return Ok(Self::DIDComm {
-                bridge: didcomm_bridge,
-                server_did: server.did.clone(),
-            });
-        }
-
-        // Fall back to WebVHHostingService
-        for svc in &resolved.doc.service {
-            if svc.type_.iter().any(|t| t == "WebVHHostingService")
-                && let Some(url) = svc.service_endpoint.get_uri()
-            {
-                let url = url.trim_matches('"').trim_end_matches('/').to_string();
-                info!(server_did = %server.did, transport = "rest", %url, "resolved webvh server endpoint");
-                let mut client = WebvhClient::new(&url);
-                if let Some(ref token) = server.access_token {
-                    client.set_access_token(token.clone());
-                }
-                return Ok(Self::Rest(client));
+        match resolve_server_transport(
+            &resolved.doc.service,
+            |svc| &svc.type_,
+            |svc| svc.service_endpoint.get_uri(),
+        ) {
+            Some(ResolvedServerTransport::Didcomm) => {
+                info!(server_did = %server.did, transport = "didcomm", "resolved webvh server endpoint");
+                Ok(Self::DIDComm {
+                    bridge: didcomm_bridge,
+                    server_did: server.did.clone(),
+                })
             }
+            Some(ResolvedServerTransport::Rest(url)) => {
+                info!(server_did = %server.did, transport = "rest", %url, "resolved webvh server endpoint");
+                let client = build_authenticated_rest_client(server, &url, rest_auth).await?;
+                Ok(Self::Rest(client))
+            }
+            None => Err(AppError::Internal(format!(
+                "server DID {} has no DIDCommMessaging, WebVHHosting, or WebVHHostingService endpoint",
+                server.did,
+            ))),
         }
-
-        Err(AppError::Internal(format!(
-            "server DID {} has no DIDCommMessaging or WebVHHostingService endpoint",
-            server.did,
-        )))
     }
 
     async fn request_uri(&self, path: Option<&str>) -> Result<RequestUriResponse, AppError> {
@@ -1226,4 +1460,139 @@ pub(crate) async fn derive_pre_rotation_keys(
     }
 
     Ok((hashes, key_data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ResolvedServerTransport, WEBVH_REST_TOKEN_REFRESH_SKEW_SECS, WebvhAuthState,
+        access_token_is_fresh, apply_webvh_auth_state, resolve_server_transport,
+    };
+    use crate::webvh_store::WebvhServerAuthRecord;
+
+    #[derive(Debug, Clone)]
+    struct TestService {
+        types: Vec<String>,
+        uri: Option<String>,
+    }
+
+    fn service(types: &[&str], uri: Option<&str>) -> TestService {
+        TestService {
+            types: types.iter().map(|t| (*t).to_string()).collect(),
+            uri: uri.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn resolve_server_transport_prefers_didcomm_when_both_didcomm_and_hosting_exist() {
+        let services = [
+            service(&["WebVHHosting"], Some("https://host.example.com/webvh/")),
+            service(&["DIDCommMessaging"], Some("https://mediator.example.com")),
+        ];
+
+        assert_eq!(
+            resolve_server_transport(&services, |svc| &svc.types, |svc| svc.uri.clone()),
+            Some(ResolvedServerTransport::Didcomm)
+        );
+    }
+
+    #[test]
+    fn resolve_server_transport_uses_rest_for_webvh_hosting() {
+        let services = [service(
+            &["WebVHHosting"],
+            Some("\"https://host.example.com/webvh/\""),
+        )];
+
+        assert_eq!(
+            resolve_server_transport(&services, |svc| &svc.types, |svc| svc.uri.clone()),
+            Some(ResolvedServerTransport::Rest(
+                "https://host.example.com/webvh".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn resolve_server_transport_uses_rest_for_webvh_hosting_service() {
+        let services = [service(
+            &["WebVHHostingService"],
+            Some("https://host.example.com/webvh/"),
+        )];
+
+        assert_eq!(
+            resolve_server_transport(&services, |svc| &svc.types, |svc| svc.uri.clone()),
+            Some(ResolvedServerTransport::Rest(
+                "https://host.example.com/webvh".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn resolve_server_transport_returns_none_without_supported_service_types() {
+        let services = [service(&["LinkedDomains"], Some("https://example.com"))];
+
+        assert_eq!(
+            resolve_server_transport(&services, |svc| &svc.types, |svc| svc.uri.clone()),
+            None
+        );
+    }
+
+    #[test]
+    fn access_token_is_fresh_requires_nonempty_token_and_future_expiry() {
+        let now = 1_000u64;
+        let record = WebvhServerAuthRecord {
+            access_token: Some("tok".into()),
+            access_expires_at: Some(now + WEBVH_REST_TOKEN_REFRESH_SKEW_SECS + 1),
+            refresh_token: None,
+        };
+        assert!(access_token_is_fresh(&record, now));
+
+        let mut no_token = record.clone();
+        no_token.access_token = None;
+        assert!(!access_token_is_fresh(&no_token, now));
+
+        let mut empty_token = record.clone();
+        empty_token.access_token = Some(String::new());
+        assert!(!access_token_is_fresh(&empty_token, now));
+
+        let mut missing_expiry = record.clone();
+        missing_expiry.access_expires_at = None;
+        assert!(!access_token_is_fresh(&missing_expiry, now));
+    }
+
+    #[test]
+    fn access_token_is_fresh_respects_refresh_skew_window() {
+        let now = 5_000u64;
+        let record = WebvhServerAuthRecord {
+            access_token: Some("tok".into()),
+            access_expires_at: Some(now + WEBVH_REST_TOKEN_REFRESH_SKEW_SECS),
+            refresh_token: None,
+        };
+
+        assert!(
+            !access_token_is_fresh(&record, now),
+            "expiry at or inside the skew window must trigger refresh/auth"
+        );
+    }
+
+    #[test]
+    fn apply_webvh_auth_state_keeps_existing_refresh_token_when_not_reissued() {
+        let mut record = WebvhServerAuthRecord {
+            access_token: None,
+            access_expires_at: None,
+            refresh_token: Some("existing-refresh".into()),
+        };
+
+        apply_webvh_auth_state(
+            &mut record,
+            &WebvhAuthState {
+                access_token: "new-access".into(),
+                access_expires_at: 42,
+                refresh_token: None,
+            },
+        );
+
+        assert_eq!(record.access_token.as_deref(), Some("new-access"));
+        assert_eq!(record.access_expires_at, Some(42));
+        assert_eq!(record.refresh_token.as_deref(), Some("existing-refresh"));
+    }
 }

--- a/vta-service/src/operations/did_webvh/register_server.rs
+++ b/vta-service/src/operations/did_webvh/register_server.rs
@@ -29,12 +29,14 @@ use tracing::info;
 
 use crate::audit;
 use crate::auth::AuthClaims;
+use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
+use crate::keys::seed_store::SeedStore;
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
-use super::{RaceDetected, RecordSnapshot, WebvhTransport};
+use super::{RaceDetected, RecordSnapshot, WebvhRestAuthContext, WebvhTransport};
 
 /// `server_id` value stored on a DID record that has not yet been
 /// associated with a webvh hosting server. Mirrors the literal used
@@ -116,7 +118,10 @@ impl From<AppError> for RegisterDidWithServerError {
 /// mutations) auto-publish there.
 pub async fn register_did_with_server(
     webvh_ks: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    config: &AppConfig,
     auth: &AuthClaims,
     did_resolver: &DIDCacheClient,
     didcomm_bridge: &Arc<DIDCommBridge>,
@@ -159,7 +164,14 @@ pub async fn register_did_with_server(
 
     // 4. Build the transport for the target server (REST or DIDComm
     //    depending on the server DID's advertised endpoints).
-    let transport = WebvhTransport::from_server(&server, did_resolver, didcomm_bridge)
+    let rest_auth = WebvhRestAuthContext {
+        webvh_ks,
+        keys_ks,
+        seed_store,
+        config,
+        channel,
+    };
+    let transport = WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, &rest_auth)
         .await
         .map_err(|e| RegisterDidWithServerError::Transport(e.to_string()))?;
 
@@ -248,23 +260,34 @@ pub async fn register_did_with_server(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::keys::seed_store::PlaintextSeedStore;
     use crate::store::Store;
     use crate::test_support::test_app_config;
     use vta_sdk::webvh::{WebvhDidRecord, WebvhServerRecord};
     use vti_common::config::StoreConfig as VtiStoreConfig;
 
-    async fn setup() -> (tempfile::TempDir, KeyspaceHandle, KeyspaceHandle) {
+    async fn setup() -> (
+        tempfile::TempDir,
+        KeyspaceHandle,
+        KeyspaceHandle,
+        KeyspaceHandle,
+    ) {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open(&VtiStoreConfig {
             data_dir: dir.path().into(),
         })
         .unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
         let webvh_ks = store.keyspace("webvh").unwrap();
         let audit_ks = store.keyspace("audit").unwrap();
         // Force the test_app_config helper to be exercised so any
         // future field addition surfaces as a test failure.
         let _ = test_app_config(dir.path().into());
-        (dir, webvh_ks, audit_ks)
+        (dir, keys_ks, webvh_ks, audit_ks)
+    }
+
+    fn seed_store(dir: &tempfile::TempDir) -> PlaintextSeedStore {
+        PlaintextSeedStore::new(dir.path())
     }
 
     fn serverless_record(did: &str) -> WebvhDidRecord {
@@ -290,9 +313,6 @@ mod tests {
             id: id.into(),
             did: format!("did:web:{id}.example"),
             label: None,
-            access_token: None,
-            access_expires_at: None,
-            refresh_token: None,
             created_at: now,
             updated_at: now,
         }
@@ -332,12 +352,17 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_non_super_admin() {
-        let (_dir, webvh_ks, audit_ks) = setup().await;
+        let (dir, keys_ks, webvh_ks, audit_ks) = setup().await;
         let resolver = resolver().await;
         let bridge = bridge();
+        let config = test_app_config(dir.path().into());
+        let seed_store = seed_store(&dir);
         let err = register_did_with_server(
             &webvh_ks,
+            &keys_ks,
             &audit_ks,
+            &seed_store,
+            &config,
             &other_user(),
             &resolver,
             &bridge,
@@ -355,12 +380,17 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_when_did_not_found() {
-        let (_dir, webvh_ks, audit_ks) = setup().await;
+        let (dir, keys_ks, webvh_ks, audit_ks) = setup().await;
         let resolver = resolver().await;
         let bridge = bridge();
+        let config = test_app_config(dir.path().into());
+        let seed_store = seed_store(&dir);
         let err = register_did_with_server(
             &webvh_ks,
+            &keys_ks,
             &audit_ks,
+            &seed_store,
+            &config,
             &super_admin(),
             &resolver,
             &bridge,
@@ -378,7 +408,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_when_already_server_managed() {
-        let (_dir, webvh_ks, audit_ks) = setup().await;
+        let (dir, keys_ks, webvh_ks, audit_ks) = setup().await;
         let did = "did:webvh:scid:host:vta";
         let mut rec = serverless_record(did);
         rec.server_id = "existing-host".into();
@@ -386,9 +416,14 @@ mod tests {
 
         let resolver = resolver().await;
         let bridge = bridge();
+        let config = test_app_config(dir.path().into());
+        let seed_store = seed_store(&dir);
         let err = register_did_with_server(
             &webvh_ks,
+            &keys_ks,
             &audit_ks,
+            &seed_store,
+            &config,
             &super_admin(),
             &resolver,
             &bridge,
@@ -409,7 +444,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_when_server_not_registered() {
-        let (_dir, webvh_ks, audit_ks) = setup().await;
+        let (dir, keys_ks, webvh_ks, audit_ks) = setup().await;
         let did = "did:webvh:scid:host:vta";
         webvh_store::store_did(&webvh_ks, &serverless_record(did))
             .await
@@ -420,9 +455,14 @@ mod tests {
 
         let resolver = resolver().await;
         let bridge = bridge();
+        let config = test_app_config(dir.path().into());
+        let seed_store = seed_store(&dir);
         let err = register_did_with_server(
             &webvh_ks,
+            &keys_ks,
             &audit_ks,
+            &seed_store,
+            &config,
             &super_admin(),
             &resolver,
             &bridge,
@@ -440,7 +480,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_when_log_missing() {
-        let (_dir, webvh_ks, audit_ks) = setup().await;
+        let (dir, keys_ks, webvh_ks, audit_ks) = setup().await;
         let did = "did:webvh:scid:host:vta";
         webvh_store::store_did(&webvh_ks, &serverless_record(did))
             .await
@@ -452,9 +492,14 @@ mod tests {
 
         let resolver = resolver().await;
         let bridge = bridge();
+        let config = test_app_config(dir.path().into());
+        let seed_store = seed_store(&dir);
         let err = register_did_with_server(
             &webvh_ks,
+            &keys_ks,
             &audit_ks,
+            &seed_store,
+            &config,
             &super_admin(),
             &resolver,
             &bridge,

--- a/vta-service/src/operations/did_webvh/servers.rs
+++ b/vta-service/src/operations/did_webvh/servers.rs
@@ -21,6 +21,12 @@ use vta_sdk::protocols::did_management::servers::{
 };
 use vta_sdk::webvh::WebvhServerRecord;
 
+const DIDCOMM_MESSAGING_SERVICE_TYPE: &str = "DIDCommMessaging";
+const WEBVH_HOSTING_SERVICE_TYPE: &str = "WebVHHosting";
+const WEBVH_HOSTING_SERVICE_TYPE_LEGACY: &str = "WebVHHostingService";
+const SUPPORTED_SERVER_SERVICE_TYPES_TEXT: &str =
+    "DIDCommMessaging, WebVHHosting, or WebVHHostingService";
+
 pub async fn add_webvh_server(
     webvh_ks: &KeyspaceHandle,
     auth: &AuthClaims,
@@ -46,9 +52,6 @@ pub async fn add_webvh_server(
         id: id.to_string(),
         did: server_did.to_string(),
         label,
-        access_token: None,
-        access_expires_at: None,
-        refresh_token: None,
         created_at: now,
         updated_at: now,
     };
@@ -106,6 +109,7 @@ pub async fn remove_webvh_server(
         .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {id}")))?;
 
     webvh_store::delete_server(webvh_ks, id).await?;
+    webvh_store::delete_server_auth(webvh_ks, id).await?;
 
     info!(channel, id = %id, "webvh server removed");
     Ok(RemoveWebvhServerResultBody {
@@ -114,9 +118,38 @@ pub async fn remove_webvh_server(
     })
 }
 
-/// Validate that a DID resolves and has at least one supported WebVH service.
+/// Returns true when a service type list advertises a DIDComm endpoint.
+pub(super) fn is_didcomm_service_type(service_types: &[String]) -> bool {
+    service_types
+        .iter()
+        .any(|t| t == DIDCOMM_MESSAGING_SERVICE_TYPE)
+}
+
+/// Returns true when a service type list advertises a REST-capable WebVH
+/// hosting endpoint.
+pub(super) fn is_webvh_rest_service_type(service_types: &[String]) -> bool {
+    service_types
+        .iter()
+        .any(|t| t == WEBVH_HOSTING_SERVICE_TYPE || t == WEBVH_HOSTING_SERVICE_TYPE_LEGACY)
+}
+
+/// Returns true when at least one service entry advertises a supported WebVH
+/// server endpoint type.
+pub(super) fn has_supported_server_service<T>(
+    services: &[T],
+    service_types: impl Fn(&T) -> &[String],
+) -> bool {
+    services.iter().any(|svc| {
+        let types = service_types(svc);
+        is_didcomm_service_type(types) || is_webvh_rest_service_type(types)
+    })
+}
+
+/// Validate that a DID resolves and has at least one supported WebVH server
+/// service.
 ///
-/// Checks for either `DIDCommMessaging` or `WebVHHostingService`.
+/// Accepted service types are `DIDCommMessaging`, `WebVHHosting`, and
+/// `WebVHHostingService`.
 pub(super) async fn validate_server_did(
     did_resolver: &DIDCacheClient,
     server_did: &str,
@@ -125,17 +158,141 @@ pub(super) async fn validate_server_did(
         AppError::Validation(format!("failed to resolve server DID {server_did}: {e}"))
     })?;
 
-    let has_supported_service = resolved.doc.service.iter().any(|svc| {
-        svc.type_
-            .iter()
-            .any(|t| t == "WebVHHostingService" || t == "DIDCommMessaging")
-    });
-
-    if !has_supported_service {
+    if !has_supported_server_service(&resolved.doc.service, |svc| &svc.type_) {
         return Err(AppError::Validation(format!(
-            "server DID {server_did} has no WebVHHostingService or DIDCommMessaging service endpoint"
+            "server DID {server_did} has no supported service endpoint (expected {SUPPORTED_SERVER_SERVICE_TYPES_TEXT})"
         )));
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::has_supported_server_service;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+    use crate::test_support::super_admin_claims;
+    use crate::webvh_store::{self, WebvhServerAuthRecord};
+    use vta_sdk::webvh::WebvhServerRecord;
+
+    #[derive(Debug, Clone)]
+    struct TestService {
+        types: Vec<String>,
+    }
+
+    fn service(types: &[&str]) -> TestService {
+        TestService {
+            types: types.iter().map(|t| (*t).to_string()).collect(),
+        }
+    }
+
+    fn sample_server(id: &str) -> WebvhServerRecord {
+        WebvhServerRecord {
+            id: id.into(),
+            did: format!("did:webvh:{id}"),
+            label: Some("edge".into()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    async fn fresh_webvh_keyspace() -> (tempfile::TempDir, Store, crate::store::KeyspaceHandle) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store.keyspace("webvh").expect("open webvh ks");
+        (dir, store, ks)
+    }
+
+    #[test]
+    fn supported_server_service_accepts_didcomm_messaging() {
+        let services = [service(&["DIDCommMessaging"])];
+        assert!(has_supported_server_service(&services, |svc| &svc.types));
+    }
+
+    #[test]
+    fn supported_server_service_accepts_webvh_hosting() {
+        let services = [service(&["WebVHHosting"])];
+        assert!(has_supported_server_service(&services, |svc| &svc.types));
+    }
+
+    #[test]
+    fn supported_server_service_accepts_webvh_hosting_service() {
+        let services = [service(&["WebVHHostingService"])];
+        assert!(has_supported_server_service(&services, |svc| &svc.types));
+    }
+
+    #[test]
+    fn supported_server_service_rejects_unrelated_service_types() {
+        let services = [service(&["LinkedDomains"]), service(&["ExampleService"])];
+        assert!(!has_supported_server_service(&services, |svc| &svc.types));
+    }
+
+    #[tokio::test]
+    async fn list_webvh_servers_serializes_metadata_only_when_auth_cache_exists() {
+        let (_dir, _store, ks) = fresh_webvh_keyspace().await;
+        let auth = super_admin_claims();
+        let server = sample_server("srv");
+        webvh_store::store_server(&ks, &server).await.unwrap();
+        webvh_store::store_server_auth(
+            &ks,
+            &server.id,
+            &WebvhServerAuthRecord {
+                access_token: Some("tok".into()),
+                access_expires_at: Some(42),
+                refresh_token: Some("refresh".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let body = super::list_webvh_servers(&ks, &auth, "test").await.unwrap();
+        let json = serde_json::to_value(&body).unwrap();
+
+        assert_eq!(json["servers"].as_array().unwrap().len(), 1);
+        assert!(json["servers"][0].get("access_token").is_none());
+        assert!(json["servers"][0].get("access_expires_at").is_none());
+        assert!(json["servers"][0].get("refresh_token").is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_webvh_server_deletes_stored_auth_cache() {
+        let (_dir, _store, ks) = fresh_webvh_keyspace().await;
+        let auth = super_admin_claims();
+        let server = sample_server("srv");
+        webvh_store::store_server(&ks, &server).await.unwrap();
+        webvh_store::store_server_auth(
+            &ks,
+            &server.id,
+            &WebvhServerAuthRecord {
+                access_token: Some("tok".into()),
+                access_expires_at: Some(42),
+                refresh_token: Some("refresh".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+        super::remove_webvh_server(&ks, &auth, &server.id, "test")
+            .await
+            .unwrap();
+
+        assert!(
+            webvh_store::get_server(&ks, &server.id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            webvh_store::get_server_auth(&ks, &server.id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
 }

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -739,6 +739,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -791,6 +792,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -845,6 +847,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -865,6 +868,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -913,6 +917,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -933,6 +938,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -982,6 +988,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -1005,6 +1012,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -1051,6 +1059,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             RotateDidWebvhKeysOptions::default(),
@@ -1141,6 +1150,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -1212,6 +1222,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -1233,6 +1244,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -1365,6 +1377,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             RotateDidWebvhKeysOptions {
@@ -1425,6 +1438,7 @@ mod pre_rotation_e2e_tests {
             &ts.webvh_ks,
             &ts.audit_ks,
             &seed_store,
+            &cfg,
             &auth,
             &scid,
             UpdateDidWebvhOptions {

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -24,10 +24,11 @@ use super::state::{find_record_by_scid, state_from_jsonl, state_to_jsonl};
 use super::validate::{validate_document_for_update, validate_watchers, validate_witnesses};
 use crate::audit;
 use crate::auth::AuthClaims;
+use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::keys::seed_store::SeedStore;
-use crate::operations::did_webvh::WebvhTransport;
 use crate::operations::did_webvh::webvh_keys::{self, WebvhKeyHandle, WebvhKeyRole};
+use crate::operations::did_webvh::{WebvhRestAuthContext, WebvhTransport};
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
@@ -39,6 +40,7 @@ pub async fn update_did_webvh(
     webvh_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
+    config: &AppConfig,
     auth: &AuthClaims,
     scid: &str,
     opts: UpdateDidWebvhOptions,
@@ -361,9 +363,17 @@ pub async fn update_did_webvh(
                     record.server_id
                 ))
             })?;
-        let transport = WebvhTransport::from_server(&server, did_resolver, didcomm_bridge)
-            .await
-            .map_err(|e| UpdateDidWebvhError::Publish(format!("transport: {e}")))?;
+        let rest_auth = WebvhRestAuthContext {
+            webvh_ks,
+            keys_ks,
+            seed_store,
+            config,
+            channel,
+        };
+        let transport =
+            WebvhTransport::from_server(&server, did_resolver, didcomm_bridge, &rest_auth)
+                .await
+                .map_err(|e| UpdateDidWebvhError::Publish(format!("transport: {e}")))?;
         transport
             .publish_did(&record.mnemonic, &new_log_jsonl)
             .await

--- a/vta-service/src/operations/did_webvh/update/rotate.rs
+++ b/vta-service/src/operations/did_webvh/update/rotate.rs
@@ -15,6 +15,7 @@ use super::options::{RotateDidWebvhKeysOptions, UpdateDidWebvhOptions, UpdateDid
 use super::orchestrator::update_did_webvh;
 use super::state::{find_record_by_scid, state_from_jsonl};
 use crate::auth::AuthClaims;
+use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::keys::seed_store::SeedStore;
 use crate::store::KeyspaceHandle;
@@ -31,6 +32,7 @@ pub async fn rotate_did_webvh_keys(
     webvh_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
+    config: &AppConfig,
     auth: &AuthClaims,
     scid: &str,
     opts: RotateDidWebvhKeysOptions,
@@ -174,6 +176,7 @@ pub async fn rotate_did_webvh_keys(
         webvh_ks,
         audit_ks,
         seed_store,
+        config,
         auth,
         scid,
         UpdateDidWebvhOptions {

--- a/vta-service/src/operations/protocol/disable_didcomm.rs
+++ b/vta-service/src/operations/protocol/disable_didcomm.rs
@@ -196,12 +196,14 @@ pub async fn disable_didcomm(
     let patched = without_didcomm_service(current_doc);
 
     // Publish via update_did_webvh.
+    let current_config = config.read().await.clone();
     let update_result = update_did_webvh(
         keys_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
         seed_store,
+        &current_config,
         auth,
         &scid,
         UpdateDidWebvhOptions {

--- a/vta-service/src/operations/protocol/disable_rest.rs
+++ b/vta-service/src/operations/protocol/disable_rest.rs
@@ -198,12 +198,14 @@ pub async fn disable_rest(
     let patched = without_rest_service(current_doc);
 
     // 5. Publish via update_did_webvh.
+    let current_config = config.read().await.clone();
     let update_result = update_did_webvh(
         keys_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
         seed_store,
+        &current_config,
         auth,
         &scid,
         UpdateDidWebvhOptions {

--- a/vta-service/src/operations/protocol/enable_didcomm.rs
+++ b/vta-service/src/operations/protocol/enable_didcomm.rs
@@ -186,12 +186,14 @@ pub async fn enable_didcomm(
     // Publish via update_did_webvh — single source of truth for
     // LogEntry append. Rotates control keys; preserves
     // verificationMethod.
+    let current_config = config.read().await.clone();
     let update_result = update_did_webvh(
         keys_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
         seed_store,
+        &current_config,
         auth,
         &scid,
         UpdateDidWebvhOptions {

--- a/vta-service/src/operations/protocol/enable_rest.rs
+++ b/vta-service/src/operations/protocol/enable_rest.rs
@@ -166,12 +166,14 @@ pub async fn enable_rest(
     let patched = with_rest_service(current_doc, &canonical_url)?;
 
     // 5. Publish via update_did_webvh.
+    let current_config = config.read().await.clone();
     let update_result = update_did_webvh(
         keys_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
         seed_store,
+        &current_config,
         auth,
         &scid,
         UpdateDidWebvhOptions {

--- a/vta-service/src/operations/protocol/update_didcomm.rs
+++ b/vta-service/src/operations/protocol/update_didcomm.rs
@@ -248,12 +248,14 @@ pub async fn update_didcomm(
     let patched = with_didcomm_service(current_doc, &resolved.mediator_did)?;
 
     // Publish new LogEntry.
+    let current_config = config.read().await.clone();
     let update_result = update_did_webvh(
         keys_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
         seed_store,
+        &current_config,
         auth,
         &scid,
         UpdateDidWebvhOptions {

--- a/vta-service/src/operations/protocol/update_rest.rs
+++ b/vta-service/src/operations/protocol/update_rest.rs
@@ -167,12 +167,14 @@ pub async fn update_rest(
     let patched = with_rest_service(current_doc, &canonical_url)?;
 
     // 5. Publish via update_did_webvh.
+    let current_config = config.read().await.clone();
     let update_result = update_did_webvh(
         keys_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
         seed_store,
+        &current_config,
         auth,
         &scid,
         UpdateDidWebvhOptions {

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -987,9 +987,6 @@ mod tests {
             id: id.into(),
             did: format!("did:webvh:{id}"),
             label: None,
-            access_token: None,
-            access_expires_at: None,
-            refresh_token: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -233,12 +233,14 @@ pub async fn update_did_handler(
         .did_resolver
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
+    let config = state.config.read().await;
     let result = operations::did_webvh::update_did_webvh(
         &state.keys_ks,
         &state.contexts_ks,
         &state.webvh_ks,
         &state.audit_ks,
         &*state.seed_store,
+        &config,
         &auth.0,
         &scid,
         body,
@@ -263,12 +265,14 @@ pub async fn rotate_did_keys_handler(
         .did_resolver
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
+    let config = state.config.read().await;
     let result = operations::did_webvh::rotate_did_webvh_keys(
         &state.keys_ks,
         &state.contexts_ks,
         &state.webvh_ks,
         &state.audit_ks,
         &*state.seed_store,
+        &config,
         &auth.0,
         &scid,
         body,
@@ -300,9 +304,13 @@ pub async fn register_did_with_server_handler(
         .did_resolver
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
+    let config = state.config.read().await;
     let result = register_did_with_server(
         &state.webvh_ks,
+        &state.keys_ks,
         &state.audit_ks,
+        &*state.seed_store,
+        &config,
         &auth.0,
         did_resolver,
         &state.didcomm_bridge,

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -461,6 +461,7 @@ pub async fn run_edit_did(
         &webvh_ks,
         &audit_ks,
         &*seed_store,
+        &config,
         &auth,
         &scid,
         opts,
@@ -492,15 +493,21 @@ pub async fn run_register_did(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
+    let keys_ks = store.keyspace("keys")?;
     let webvh_ks = store.keyspace("webvh")?;
     let audit_ks = store.keyspace("audit")?;
+    let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
+        Arc::from(create_seed_store(&config)?);
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
 
     let auth = cli_super_admin();
     let result = operations::did_webvh::register_did_with_server(
         &webvh_ks,
+        &keys_ks,
         &audit_ks,
+        &*seed_store,
+        &config,
         &auth,
         &did_resolver,
         &didcomm_bridge,

--- a/vta-service/src/webvh_client.rs
+++ b/vta-service/src/webvh_client.rs
@@ -1,7 +1,15 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use affinidi_tdk::didcomm::Message;
+use affinidi_tdk::didcomm::message::pack;
+use affinidi_tdk::secrets_resolver::secrets::Secret;
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use tracing::{debug, info};
 
 use crate::error::AppError;
+
+const WEBVH_AUTHENTICATE_TYPE: &str = "https://affinidi.com/webvh/1.0/authenticate";
 
 pub struct WebvhClient {
     http: reqwest::Client,
@@ -10,7 +18,9 @@ pub struct WebvhClient {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RequestUriResponse {
+    #[serde(alias = "did_url")]
     pub did_url: String,
     pub mnemonic: String,
 }
@@ -18,6 +28,53 @@ pub struct RequestUriResponse {
 #[derive(Debug, Deserialize)]
 pub struct CheckPathResponse {
     pub available: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebvhAuthState {
+    pub access_token: String,
+    pub access_expires_at: u64,
+    pub refresh_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ChallengeResponse {
+    #[serde(alias = "session_id")]
+    session_id: String,
+    data: ChallengeData,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChallengeData {
+    challenge: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthenticateResponse {
+    data: AuthenticateData,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthenticateData {
+    access_token: String,
+    access_expires_at: u64,
+    refresh_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RefreshResponse {
+    data: RefreshData,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RefreshData {
+    access_token: String,
+    access_expires_at: u64,
 }
 
 impl WebvhClient {
@@ -31,6 +88,103 @@ impl WebvhClient {
 
     pub fn set_access_token(&mut self, token: String) {
         self.access_token = Some(token);
+    }
+
+    /// Authenticate to the WebVH REST API using the VTA's signing DID.
+    ///
+    /// The WebVH control plane expects a DIDComm-signed `authenticate`
+    /// message over HTTP (`POST /api/auth/`) after an unauthenticated
+    /// challenge request (`POST /api/auth/challenge`).
+    pub async fn authenticate(
+        &self,
+        did: &str,
+        secret: &Secret,
+        webvh_did: &str,
+    ) -> Result<WebvhAuthState, AppError> {
+        let private_key_bytes: [u8; 32] = secret
+            .get_private_bytes()
+            .try_into()
+            .map_err(|_| AppError::Internal("webvh auth signing key must be 32 bytes".into()))?;
+
+        let challenge_url = format!("{}/api/auth/challenge", self.server_url);
+        info!(method = "POST", %challenge_url, did = %did, "webvh: requesting rest auth challenge");
+        let challenge_req = self.http.post(&challenge_url).json(&serde_json::json!({
+            "did": did,
+        }));
+        let challenge_resp: ChallengeResponse = self
+            .parse_json(
+                self.send(challenge_req, "POST /api/auth/challenge").await?,
+                "POST /api/auth/challenge",
+            )
+            .await?;
+
+        let created_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let msg = Message::build(
+            uuid::Uuid::new_v4().to_string(),
+            WEBVH_AUTHENTICATE_TYPE.to_string(),
+            serde_json::json!({
+                "challenge": challenge_resp.data.challenge,
+                "session_id": challenge_resp.session_id,
+            }),
+        )
+        .from(did.to_string())
+        .to(webvh_did.to_string())
+        .created_time(created_time)
+        .finalize();
+
+        let packed = pack::pack_signed(&msg, &secret.id, &private_key_bytes)
+            .map_err(|e| AppError::Internal(format!("webvh auth pack_signed failed: {e}")))?;
+
+        let auth_url = format!("{}/api/auth/", self.server_url);
+        info!(method = "POST", %auth_url, did = %did, target = %webvh_did, "webvh: submitting rest auth response");
+        let auth_req = self
+            .http
+            .post(&auth_url)
+            .header("Content-Type", "text/plain")
+            .body(packed);
+        let auth_resp: AuthenticateResponse = self
+            .parse_json(
+                self.send(auth_req, "POST /api/auth/").await?,
+                "POST /api/auth/",
+            )
+            .await?;
+
+        debug!(did = %did, target = %webvh_did, "webvh: rest auth succeeded");
+        Ok(WebvhAuthState {
+            access_token: auth_resp.data.access_token,
+            access_expires_at: auth_resp.data.access_expires_at,
+            refresh_token: Some(auth_resp.data.refresh_token),
+        })
+    }
+
+    /// Refresh the access token for an existing WebVH REST session.
+    pub async fn refresh_access_token(
+        &self,
+        refresh_token: &str,
+    ) -> Result<WebvhAuthState, AppError> {
+        let refresh_url = format!("{}/api/auth/refresh", self.server_url);
+        info!(method = "POST", %refresh_url, "webvh: refreshing rest access token");
+        let refresh_req = self
+            .http
+            .post(&refresh_url)
+            .header("Content-Type", "text/plain")
+            .body(refresh_token.to_string());
+        let refresh_resp: RefreshResponse = self
+            .parse_json(
+                self.send(refresh_req, "POST /api/auth/refresh").await?,
+                "POST /api/auth/refresh",
+            )
+            .await?;
+
+        debug!("webvh: rest token refresh succeeded");
+        Ok(WebvhAuthState {
+            access_token: refresh_resp.data.access_token,
+            access_expires_at: refresh_resp.data.access_expires_at,
+            refresh_token: Some(refresh_token.to_string()),
+        })
     }
 
     /// Apply authorization header (if set) to a request builder.
@@ -61,6 +215,16 @@ impl WebvhClient {
         Ok(resp)
     }
 
+    async fn parse_json<T: DeserializeOwned>(
+        &self,
+        resp: reqwest::Response,
+        context: &str,
+    ) -> Result<T, AppError> {
+        resp.json().await.map_err(|e| {
+            AppError::Internal(format!("webvh-server {context} response parse error: {e}"))
+        })
+    }
+
     /// POST /api/dids — allocate URI (optional path).
     pub async fn request_uri(&self, path: Option<&str>) -> Result<RequestUriResponse, AppError> {
         let url = format!("{}/api/dids", self.server_url);
@@ -72,9 +236,7 @@ impl WebvhClient {
         let req = self.with_auth(self.http.post(&url)).json(&body);
         let resp = self.send(req, "POST /api/dids").await?;
         debug!(method = "POST", status = 200, "webvh: received via rest");
-        resp.json()
-            .await
-            .map_err(|e| AppError::Internal(format!("webvh-server response parse error: {e}")))
+        self.parse_json(resp, "POST /api/dids").await
     }
 
     /// POST /api/dids/register — atomic claim-and-publish.
@@ -106,9 +268,7 @@ impl WebvhClient {
             }));
         let resp = self.send(req, "POST /api/dids/register").await?;
         debug!(method = "POST", status = 200, "webvh: received via rest");
-        resp.json()
-            .await
-            .map_err(|e| AppError::Internal(format!("webvh-server response parse error: {e}")))
+        self.parse_json(resp, "POST /api/dids/register").await
     }
 
     /// PUT /api/dids/{mnemonic} — publish DID log.
@@ -142,8 +302,43 @@ impl WebvhClient {
             .with_auth(self.http.post(&url))
             .json(&serde_json::json!({ "path": path }));
         let resp = self.send(req, "POST /api/dids/check").await?;
-        resp.json()
-            .await
-            .map_err(|e| AppError::Internal(format!("webvh-server response parse error: {e}")))
+        self.parse_json(resp, "POST /api/dids/check").await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn challenge_response_accepts_webvh_daemon_camel_case() {
+        let json = r#"{"sessionId":"sess-123","data":{"challenge":"nonce123"}}"#;
+        let resp: ChallengeResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.session_id, "sess-123");
+        assert_eq!(resp.data.challenge, "nonce123");
+    }
+
+    #[test]
+    fn challenge_response_still_accepts_snake_case() {
+        let json = r#"{"session_id":"sess-123","data":{"challenge":"nonce123"}}"#;
+        let resp: ChallengeResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.session_id, "sess-123");
+        assert_eq!(resp.data.challenge, "nonce123");
+    }
+
+    #[test]
+    fn request_uri_response_accepts_webvh_daemon_camel_case() {
+        let json = r#"{"mnemonic":"services-tgw","didUrl":"http://localhost:8530/services/tgw/did.jsonl"}"#;
+        let resp: RequestUriResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.mnemonic, "services-tgw");
+        assert_eq!(resp.did_url, "http://localhost:8530/services/tgw/did.jsonl");
+    }
+
+    #[test]
+    fn request_uri_response_still_accepts_snake_case() {
+        let json = r#"{"mnemonic":"services-tgw","did_url":"http://localhost:8530/services/tgw/did.jsonl"}"#;
+        let resp: RequestUriResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.mnemonic, "services-tgw");
+        assert_eq!(resp.did_url, "http://localhost:8530/services/tgw/did.jsonl");
     }
 }

--- a/vta-service/src/webvh_store.rs
+++ b/vta-service/src/webvh_store.rs
@@ -1,10 +1,25 @@
+use serde::{Deserialize, Serialize};
 use vta_sdk::webvh::{WebvhDidRecord, WebvhServerRecord};
 
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct WebvhServerAuthRecord {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_expires_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+}
+
 fn server_key(id: &str) -> String {
     format!("server:{id}")
+}
+
+fn server_auth_key(id: &str) -> String {
+    format!("server-auth:{id}")
 }
 
 fn did_key(did: &str) -> String {
@@ -28,6 +43,25 @@ pub async fn store_server(ks: &KeyspaceHandle, record: &WebvhServerRecord) -> Re
 
 pub async fn delete_server(ks: &KeyspaceHandle, id: &str) -> Result<(), AppError> {
     ks.remove(server_key(id)).await
+}
+
+pub(crate) async fn get_server_auth(
+    ks: &KeyspaceHandle,
+    id: &str,
+) -> Result<Option<WebvhServerAuthRecord>, AppError> {
+    ks.get(server_auth_key(id)).await
+}
+
+pub(crate) async fn store_server_auth(
+    ks: &KeyspaceHandle,
+    id: &str,
+    record: &WebvhServerAuthRecord,
+) -> Result<(), AppError> {
+    ks.insert(server_auth_key(id), record).await
+}
+
+pub(crate) async fn delete_server_auth(ks: &KeyspaceHandle, id: &str) -> Result<(), AppError> {
+    ks.remove(server_auth_key(id)).await
 }
 
 pub async fn list_servers(ks: &KeyspaceHandle) -> Result<Vec<WebvhServerRecord>, AppError> {
@@ -74,4 +108,74 @@ pub async fn store_did_log(
 ) -> Result<(), AppError> {
     ks.insert_raw(log_key(did), log_content.as_bytes().to_vec())
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+
+    fn sample_server(id: &str) -> WebvhServerRecord {
+        WebvhServerRecord {
+            id: id.into(),
+            did: format!("did:webvh:{id}"),
+            label: Some("edge".into()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    async fn fresh_webvh_keyspace() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store.keyspace("webvh").expect("open webvh ks");
+        (dir, store, ks)
+    }
+
+    #[tokio::test]
+    async fn server_auth_round_trips_and_deletes() {
+        let (_dir, _store, ks) = fresh_webvh_keyspace().await;
+        let auth = WebvhServerAuthRecord {
+            access_token: Some("tok".into()),
+            access_expires_at: Some(42),
+            refresh_token: Some("refresh".into()),
+        };
+
+        store_server_auth(&ks, "srv", &auth).await.unwrap();
+        assert_eq!(get_server_auth(&ks, "srv").await.unwrap(), Some(auth));
+
+        delete_server_auth(&ks, "srv").await.unwrap();
+        assert!(get_server_auth(&ks, "srv").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_servers_reads_only_metadata_records() {
+        let (_dir, _store, ks) = fresh_webvh_keyspace().await;
+        store_server(&ks, &sample_server("srv")).await.unwrap();
+        store_server_auth(
+            &ks,
+            "srv",
+            &WebvhServerAuthRecord {
+                access_token: Some("tok".into()),
+                access_expires_at: Some(42),
+                refresh_token: Some("refresh".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let servers = list_servers(&ks).await.unwrap();
+        assert_eq!(servers.len(), 1);
+
+        let json = serde_json::to_value(&servers[0]).unwrap();
+        assert!(json.get("access_token").is_none());
+        assert!(json.get("access_expires_at").is_none());
+        assert!(json.get("refresh_token").is_none());
+    }
 }


### PR DESCRIPTION
## Summary

This PR fixes two related issues in the registered WebVH server flow:

1. VTA only recognized `DIDCommMessaging` and the legacy `WebVHHostingService` type, so valid `webvh-daemon` deployments advertising `WebVHHosting` could be rejected or fail REST fallback.
2. Adding daemon REST auth exposed a boundary problem: WebVH auth state was living on `WebvhServerRecord`, which is reused by public API/SDK/backup surfaces.

## Problems identified

### 1. Hosting-type mismatch blocked registered `webvh-daemon` flows

The registered-server flow assumed server DIDs would expose either:

- `DIDCommMessaging`, or
- `WebVHHostingService`

Current daemon deployments can advertise `WebVHHosting` instead. That meant:

- `vta webvh add-server` / `pnm webvh add-server` could reject valid hosting DIDs
- transport resolution could fail for REST-only servers
- registered `webvh-daemon` deployments were not usable unless they also exposed DIDComm or the legacy service type

### 2. VTA did not drive the daemon REST auth flow itself

For REST-backed WebVH publication, the VTA needs to authenticate to the daemon using its configured `vta_did`, then reuse or refresh bearer tokens for subsequent operations. That flow was missing, which blocked publish/update/delete paths against registered REST-only servers.

### 3. WebVH auth cache leaked across public surfaces

`WebvhServerRecord` mixed operator-visible metadata with daemon auth cache (`access_token`, `access_expires_at`, `refresh_token`).

That same type is reused for:

- persisted `server:{id}` records
- REST/DIDComm `list webvh servers` responses
- SDK payloads
- backup export/import

So storing live daemon tokens on that public type would expose bearer state on multiple surfaces.

## Changes made

### Hosting-type alignment and transport resolution

- Accept `DIDCommMessaging`, `WebVHHosting`, and `WebVHHostingService` when validating registered WebVH servers
- Keep `WebVHHostingService` as a compatibility alias
- Update CLI help text and validation messaging to reflect the supported service types
- Centralize transport selection so VTA:
  - prefers DIDComm when available
  - falls back to REST for `WebVHHosting`
  - also falls back to REST for legacy `WebVHHostingService`

### Daemon REST auth support

- Add WebVH REST auth support in `WebvhClient`
- Implement the daemon challenge/response flow:
  - request challenge from `/api/auth/challenge`
  - sign the response as the configured `vta_did`
  - submit the signed message to `/api/auth/`
- Add access-token reuse and refresh handling
- Fall back to full re-authentication when refresh is unavailable or rejected
- Add response parsing compatibility for daemon camelCase fields while keeping existing snake_case compatibility

### Auth-state boundary fix

- Make `WebvhServerRecord` metadata-only
- Move daemon REST auth cache into a service-private record stored separately under `server-auth:{id}`
- Keep server metadata under `server:{id}`
- Remove auth cache when a WebVH server is deleted

This fixes the leak at the type/storage boundary instead of relying on ad hoc response redaction.

### Publish-path integration

Thread the authenticated REST transport through registered-server WebVH operations, including:

- create
- register existing DID with server
- update
- rotate
- delete
- protocol-management paths that publish via `update_did_webvh`

### Backup and compatibility behavior

- Exclude `server-auth:{id}` records from backup export/import
- Clear stale WebVH auth cache on restore
- Preserve read compatibility with legacy records/backups that still contain embedded auth fields by accepting them on deserialize and omitting them on serialize

## Result

This closes the functional blocker for registered REST-only `webvh-daemon` flows and fixes the auth-state leak by separating private daemon token cache from public WebVH server metadata.

## Validation

Added/updated targeted tests covering:

- supported server service types
- DIDComm-vs-REST transport resolution
- access-token freshness and auth-state persistence behavior
- metadata-only `list webvh servers` serialization
- server auth-cache deletion on remove
- backup export/import behavior excluding auth cache
- compatibility with legacy embedded auth fields
- daemon camelCase response parsing

## Notes

For REST-authenticated daemon deployments, the daemon ACL must contain the VTA DID, since the VTA authenticates as its configured `vta_did`.

Current REST auth still assumes the active VTA signing key is seed-derived; imported active VTA identity keys remain a follow-up.