### PR TITLE
chore: gitignore .claude/ agent scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ Thumbs.db
 *.swp
 *.swo
 *~
+
+# Claude Code agent scratch: screenshots from chrome-devtools MCP,
+# scheduled-task lockfile, settings.local.json, ephemeral worktree
+# dirs. All operator-local, never checked in.
+.claude/


### PR DESCRIPTION
## Summary

`.claude/` collects Claude Code agent state — scheduled-task lock,
screenshots from chrome-devtools MCP, `settings.local.json`, and
ephemeral worktree dirs. All operator-local; never meant to be
checked in. Was surfacing in every `git status` as untracked.

One-line addition under the existing OS-artifacts block in
`.gitignore`.

## Test plan

- [x] `git status` no longer reports `.claude/` as untracked.