### PR TITLE
docs: fix Mermaid render + trust-task YAML frontmatter parse errors

### DIFF
--- a/docs/03-vtc/architecture.md
+++ b/docs/03-vtc/architecture.md
@@ -177,8 +177,8 @@ graph TB
     end
 
     subgraph VTC["VTC (independent process)"]
-        VTC_BUNDLE[VtcKeyBundle<br/>(cached at setup)]
-        VTC_SIGNER[LocalSigner<br/>(in-memory)]
+        VTC_BUNDLE["VtcKeyBundle<br/>(cached at setup)"]
+        VTC_SIGNER["LocalSigner<br/>(in-memory)"]
         VTC_CREDS[VMC / VEC / VRC issuance]
         VTC_BUNDLE --> VTC_SIGNER
         VTC_SIGNER --> VTC_CREDS

--- a/docs/03-vtc/community-lifecycle.md
+++ b/docs/03-vtc/community-lifecycle.md
@@ -83,7 +83,7 @@ trust-registry record so peer communities see the same intent:
 ```mermaid
 flowchart LR
     leave([Member departure])
-    purge[Purge<br/>(RTBF)]
+    purge["Purge<br/>(RTBF)"]
     tomb[Tombstone]
     hist[Historical]
 

--- a/docs/03-vtc/credentials.md
+++ b/docs/03-vtc/credentials.md
@@ -18,7 +18,7 @@ backed by a Bitstring Status List slot for revocation. All use the
 graph TB
     issue[Issue credential]
     slot[Allocate status-list slot<br/>via slot allocator]
-    sign[Sign with LocalSigner<br/>(cached VTA key)]
+    sign["Sign with LocalSigner<br/>(cached VTA key)"]
     persist[Persist credential row]
     audit_i[Audit: VmcIssued / VecIssued / ...]
     return[Return signed VC<br/>+ status-list reference]
@@ -92,8 +92,8 @@ graph LR
 
     subgraph Revocation
         rev[Admin revokes / member self-removes]
-        rev --> bit[storage.flip(slot=42, value=1)]
-        bit --> list[BitstringStatusList credential<br/>(bit 42 now 1)]
+        rev --> bit["storage.flip(slot=42, value=1)"]
+        bit --> list["BitstringStatusList credential<br/>(bit 42 now 1)"]
         list -->|GET /v1/status-lists/revocation| verifier[External verifier]
     end
 ```

--- a/docs/03-vtc/website-and-admin.md
+++ b/docs/03-vtc/website-and-admin.md
@@ -70,7 +70,7 @@ graph TB
         gen1[gen-1/]
         gen2[gen-2/]
         gen3[gen-3/]
-        current[current → gen-3<br/>(symlink)]
+        current["current → gen-3<br/>(symlink)"]
         root2 --> gen1
         root2 --> gen2
         root2 --> gen3

--- a/trust-tasks/audit/list/1.0/spec.md
+++ b/trust-tasks/audit/list/1.0/spec.md
@@ -12,7 +12,8 @@ inputs:
     (Admin role with empty `allowed_contexts`). Pagination via
     `?cursor=<opaque>&limit=<1..=200>` query parameters.
 outputs:
-  - HTTP 200 with a `Paginated<AuditEnvelope>` body: `items`,
+  - >-
+    HTTP 200 with a `Paginated<AuditEnvelope>` body: `items`,
     `next_cursor`, and an optional `total_estimate` (currently
     always omitted).
 trust_assumptions:

--- a/trust-tasks/auth/admin-login/1.0/spec.md
+++ b/trust-tasks/auth/admin-login/1.0/spec.md
@@ -12,8 +12,8 @@ inputs:
     `auth/legacy/authenticate/1.0`)
 outputs:
   - HTTP 200 with `AuthenticateResponse` JSON body
-  - `Set-Cookie: vtc_admin_session=<jwt>; Path=/admin; SameSite=Strict; Secure; HttpOnly`
-  - `Set-Cookie: csrf=<random-32-byte-hex>; Path=/; SameSite=Strict; Secure`
+  - "`Set-Cookie: vtc_admin_session=<jwt>; Path=/admin; SameSite=Strict; Secure; HttpOnly`"
+  - "`Set-Cookie: csrf=<random-32-byte-hex>; Path=/; SameSite=Strict; Secure`"
 trust_assumptions:
   - The DIDComm authenticate message carries the same signed
     challenge required by `auth/legacy/authenticate/1.0`. The

--- a/trust-tasks/auth/sign-out/1.0/spec.md
+++ b/trust-tasks/auth/sign-out/1.0/spec.md
@@ -11,15 +11,17 @@ inputs:
   - Authenticated request (bearer JWT or `vtc_admin_session` cookie)
 outputs:
   - HTTP 204 (No Content)
-  - `Set-Cookie: vtc_admin_session=; Path=/; Max-Age=0; SameSite=Strict; Secure; HttpOnly`
-  - `Set-Cookie: csrf=; Path=/; Max-Age=0; SameSite=Strict; Secure`
+  - "`Set-Cookie: vtc_admin_session=; Path=/; Max-Age=0; SameSite=Strict; Secure; HttpOnly`"
+  - "`Set-Cookie: csrf=; Path=/; Max-Age=0; SameSite=Strict; Secure`"
 trust_assumptions:
-  - Sign-out is **best effort** server-side: the session row may
+  - >-
+    Sign-out is **best effort** server-side: the session row may
     already have been deleted from another tab or expired, and
     that's fine. The cookie expiry header is the user-visible
     side effect — once the browser drops it, the SPA can no
     longer authenticate with this server.
-  - JavaScript on the SPA can't clear the HttpOnly session
+  - >-
+    JavaScript on the SPA can't clear the HttpOnly session
     cookie itself; only the server's `Set-Cookie: Max-Age=0`
     response can. This endpoint exists for exactly that reason.
   - Idempotent — repeated POSTs against an already-revoked


### PR DESCRIPTION
## Summary

Two reported GitHub-render failures, plus their root-cause siblings:

- **Mermaid** (`docs/03-vtc/architecture.md` "Relationship to the VTA"): unquoted `(...)` inside a `[label]` node opens a different Mermaid shape and breaks the parser. Quoted the affected node labels in 4 files / 6 nodes.
- **YAML frontmatter** (`trust-tasks/auth/sign-out/1.0/spec.md`): list items starting with a backtick are illegal YAML plain scalars (`` ` `` is a reserved indicator). Quoted backtick-prefixed scalars; converted multi-line items containing `: ` into folded scalars (`>-`) so YAML's mapping detector doesn't misfire. 3 spec files fixed.

## Files changed

**Mermaid** (label-quoting):
- `docs/03-vtc/architecture.md`
- `docs/03-vtc/community-lifecycle.md`
- `docs/03-vtc/credentials.md`
- `docs/03-vtc/website-and-admin.md`

**YAML frontmatter**:
- `trust-tasks/auth/sign-out/1.0/spec.md` (reported)
- `trust-tasks/auth/admin-login/1.0/spec.md`
- `trust-tasks/audit/list/1.0/spec.md`

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` over all 67 trust-task spec frontmatter blocks → clean
- [x] Scanner for unquoted-paren Mermaid node labels across `docs/**/*.md` → zero hits
- [ ] Reviewer confirms the two reported pages now render in GitHub's preview:
  - https://github.com/OpenVTC/verifiable-trust-infrastructure/blob/fix/doc-render-errors/docs/03-vtc/architecture.md#relationship-to-the-vta
  - https://github.com/OpenVTC/verifiable-trust-infrastructure/blob/fix/doc-render-errors/trust-tasks/auth/sign-out/1.0/spec.md

No code changes — docs and YAML frontmatter only.