### PR TITLE
chore: bump vta-sdk 0.6 → 0.7 for pre-publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.6.0",
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.6.0",
+ "vta-sdk 0.7.0",
 ]
 
 [[package]]
@@ -2889,7 +2889,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.6.0",
+ "vta-sdk 0.7.0",
 ]
 
 [[package]]
@@ -6152,7 +6152,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.6.0",
+ "vta-sdk 0.7.0",
 ]
 
 [[package]]
@@ -9180,7 +9180,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.6.0",
+ "vta-sdk 0.7.0",
  "x25519-dalek",
 ]
 
@@ -9202,6 +9202,34 @@ dependencies = [
 [[package]]
 name = "vta-sdk"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bff1e0c2c00bc1ccdc85d380f8f3a63b1f1a420ea9e8bda3da871aa5cb108e9"
+dependencies = [
+ "aes 0.9.0",
+ "aes-gcm",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "multibase",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.7.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9241,34 +9269,6 @@ dependencies = [
  "wiremock",
  "x25519-dalek",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bff1e0c2c00bc1ccdc85d380f8f3a63b1f1a420ea9e8bda3da871aa5cb108e9"
-dependencies = [
- "aes 0.9.0",
- "aes-gcm",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "ed25519-dalek",
- "getrandom 0.4.2",
- "multibase",
- "reqwest 0.13.3",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "x25519-dalek",
 ]
 
 [[package]]
@@ -9344,7 +9344,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.6.0",
+ "vta-sdk 0.7.0",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9420,7 +9420,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.6.0",
+ "vta-sdk 0.7.0",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9461,7 +9461,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.6.0",
+ "vta-sdk 0.7.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9488,7 +9488,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.6.0",
+ "vta-sdk 0.7.0",
  "vta-service",
  "vti-common",
 ]

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.6", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.7", features = ["session"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.6" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.6", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.7", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.6", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.7", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.6", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.7", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -69,7 +69,7 @@ required-features = ["cli-synthesis"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.7", features = ["encryption", "passkey"] }
-vta-sdk = { path = "../vta-sdk", version = "0.6", features = ["didcomm", "sealed-transfer", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.7", features = ["didcomm", "sealed-transfer", "provision-integration"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -64,7 +64,7 @@ vti-common = { path = "../vti-common", version = "0.7", features = [
   # the wizard calls into.
   "setup",
 ] }
-vta-sdk = { path = "../vta-sdk", version = "0.6", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.7", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -43,7 +43,7 @@ setup = ["dep:dialoguer"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.6", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.7", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }


### PR DESCRIPTION
## Summary

vti-common 0.7 can't be published because its `vta-sdk = "0.6"` dep resolves to the crates.io 0.6.0 release during the publish verify step — and 0.6.0 predates the canonical wire types that the auth-architecture work introduced. Publishing fails with:

```
error[E0432]: unresolved imports `vta_sdk::protocols::auth::Session`,
  `vta_sdk::protocols::auth::TokenBundle`,
  `vta_sdk::protocols::auth::epoch_to_rfc3339`
```

This PR bumps vta-sdk to 0.7.0 so it can be published alongside vti-common 0.7. After this merges:

```
cargo publish -p vta-sdk     # publishes 0.7.0
cargo publish -p vti-common  # now resolves vta-sdk = "0.7" cleanly
```

## What's in 0.7 (vs published 0.6.0)

The substantive changes already landed on the auth-architecture branch (merged in #113):

- New `protocols::auth::{Session, TokenBundle, AuthenticateResponse, ChallengeResponse, epoch_to_rfc3339, ChallengeRequest, RevokeSessionRequest, RevokeSessionResponse}` — canonical SIOPv2 + RFC 6749 wire types.
- `auth/*` URI constants renamed `_1_0 → _0_1` for trust-tasks canonical alignment + repointed at `trusttasks.org/spec/auth/*/0.1`.
- `did` → `subject` field rename on `ChallengeRequest` (with serde alias for one upgrade cycle).
- Structural restructuring: `AuthenticateResponse` now `{ session, tokens }` instead of the legacy `{ sessionId, data: { accessToken, accessExpiresAt } }`.

## Changes in this PR

- `vta-sdk/Cargo.toml`: `version = "0.6.0"` → `"0.7.0"`.
- All internal path-pins flipped from `version = "0.6"` to `"0.7"` (workspace.dependencies-style consumers): vti-common, vta-service, vtc-service, vta-cli-common, pnm-cli, cnm-cli, didcomm-test.
- `Cargo.lock` regenerated.

## Test plan

- [x] `cargo check --workspace` clean.
- [x] `cargo publish --dry-run -p vta-sdk --allow-dirty` packages 0.7.0 without errors.
- [ ] After merge, real publish in order: `cargo publish -p vta-sdk` → wait ~30s for index → `cargo publish -p vti-common`.