### PR TITLE
fix(vta-service): L5 — enforce recipient + expiry in trust-task dispatcher

### DIFF
--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -205,7 +205,30 @@ pub(crate) async fn dispatch_trust_task_core(
         Err(e) => return body_parse_error_response(&e.to_string()),
     };
 
-    // 2. Session-pubkey binding pre-check.
+    // 2. Framework §7.2 items 4 + 5 — expiry + recipient
+    //    enforcement. Closes L5 from the May 2026 security
+    //    review: the hand-rolled dispatcher previously skipped
+    //    these, so a Trust-Task envelope addressed at a
+    //    different recipient would be silently accepted and an
+    //    expired envelope would be honoured.
+    //
+    //    Audience binding (proof + recipient required for non-
+    //    bearer specs, framework §7.2 item 8) is typed —
+    //    `enforce_audience_binding` needs `P: Payload`, so each
+    //    slice's typed handler runs it after `parse_payload`.
+    {
+        let vta_did = state.config.read().await.vta_did.clone();
+        if let Some(my_vid) = vta_did.as_deref() {
+            if let Err(reason) = doc.validate_basic(chrono::Utc::now(), my_vid) {
+                return reject_with(&doc, reason);
+            }
+        }
+        // No vta_did configured → service is in setup; skip
+        // the recipient check (no identity to bind against).
+        // Production VTAs always have vta_did set by `vta setup`.
+    }
+
+    // 3. Session-pubkey binding pre-check.
     //
     // Once `AuthClaims` carries `session_pubkey_b58btc` (Phase 3 work,
     // mirrors `webvh-service`'s pattern) the dispatcher will enforce
@@ -214,7 +237,7 @@ pub(crate) async fn dispatch_trust_task_core(
     // no passkey-bound sessions exist yet on the VTA side.
     let _ = auth;
 
-    // 3. Dispatch by type URI.
+    // 4. Dispatch by type URI.
     dispatch_typed(state, auth, doc).await
 }
 


### PR DESCRIPTION
## Summary

Closes **L5** from the May 2026 cross-system auth security review: VTA's hand-rolled `dispatch_trust_task_core` was skipping the framework's §7.2 items 4 + 5 (recipient + expiry checks). A Trust-Task envelope addressed to a *different* VTA's DID was being silently accepted as long as the local `AuthClaims` permitted the operation; an expired envelope was being honoured without complaint.

## Fix

Pre-dispatch step in `dispatch_trust_task_core`:

```rust
if let Some(my_vid) = vta_did.as_deref() {
    if let Err(reason) = doc.validate_basic(chrono::Utc::now(), my_vid) {
        return reject_with(&doc, reason);
    }
}
```

`validate_basic` rejects:
- `recipient != my_vid` → `RejectReason::WrongRecipient` → 401
- `now >= expires_at` → `RejectReason::Expired` → 401

Both render through the existing `reject_with` helper as the framework's `trust-task-error/0.1` document shape.

## What's intentionally NOT in this PR

- **Audience binding** (framework §7.2 item 8 — proof + non-bearer spec ⇒ recipient required) is typed. `enforce_audience_binding` requires `P: Payload`, so it can't run on the untyped `TrustTask<Value>` at the dispatcher layer. Each slice's typed handler is the right place to add it after `parse_payload`; that's a follow-up audit per handler. Noted in the code comment.
- **VTC changes.** VTC handlers receive bare typed payloads (`Json<ChallengeRequest>` etc.), not full envelopes — there's no recipient field on the wire to enforce at this layer. The Trust-Task framework header validation lives in the `TrustTaskRouter` middleware. Spec-conformance separately, but not L5.
- **did-hosting changes.** did-hosting already calls `consume_inbound` via `run_pipeline` → the framework's `validate_basic` was already being enforced.

## Edge case: no `vta_did` configured

A freshly-installed VTA binary that hasn't been through `vta setup` has no DID to bind against. The pre-check skips when `vta_did` is `None`, so the dispatcher still works in that setup window. Production VTAs always have `vta_did` set; documented inline.

## Test plan

- [x] `cargo check -p vta-service` clean.
- [x] `cargo test --workspace` passes.
- [ ] Manual smoke: POST a Trust-Task envelope with `recipient: "did:webvh:some-other-vta"` to the dispatcher; confirm 401 + `WrongRecipient` reject. POST an envelope with `expires_at` in the past; confirm 401 + `Expired` reject.

## After this merges

That closes the May 2026 cross-system auth security review's full punch list. H/M/L items all addressed:

- H1: enabled in `OpenVTC/vta-browser-plugin#3` (companion PR — settings toggle + auto-migrate + lock UX).
- H2, H3, H4, H5: closed in #113 + `rp-sdk-js@0.1.0`.
- M1, M2, M3, M4, M5, M6: closed in #113 + plugin #2.
- L1, L2, L3, L4: closed in #113.
- **L5: this PR.**