### PR TITLE
chore: bump consumer crates 0.6 → 0.7 to align with vta-sdk + vti-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cnm-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6130,7 +6130,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pnm-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9162,7 +9162,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "vta-enclave"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9273,7 +9273,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes 0.9.0",
  "aes-gcm",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -22,7 +22,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
 vta-sdk = { path = "../vta-sdk", version = "0.7", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.6" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.7" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -26,7 +26,7 @@ affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
-vta-cli-common = { path = "../vta-cli-common", version = "0.6" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.7" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 # `vta-enclave` is a Linux-only Nitro Enclave binary (vsock-store depends
 # on `tokio-vsock`). Publishing to crates.io would surface "fails on
@@ -27,7 +27,7 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.6", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.7", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.7", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -89,7 +89,7 @@ trust-tasks-proof = { workspace = true }
 # generation, bundle opening). Used by `vta bootstrap request` /
 # `vta bootstrap open` so cold-start clients can run the offline flow
 # without depending on `pnm`.
-vta-cli-common = { path = "../vta-cli-common", version = "0.6" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.7" }
 affinidi-crypto = { workspace = true }
 # Low-level `Secret` type for loading the VTA's signing key at
 # provision time. Already transitively present via affinidi-tdk; made


### PR DESCRIPTION
## Summary

- Bumps the five consumer crates (`vta-cli-common`, `vta-service`, `vta-enclave`, `pnm-cli`, `cnm-cli`) from `0.6.0` → `0.7.0` to align with `vta-sdk` and `vti-common`, which were bumped to `0.7.0` in #115.
- Updates internal dep pins (`vta-service → vta-cli-common`, `vta-enclave → vta-service`, both CLIs → `vta-cli-common`) to track, using the workspace's `major.minor`-only convention.
- `vtc-service` stays on its independent `0.1.0` cadence.

## Why

The recent `webvh-rest-auth-hardened` release (#113) merged substantial feature work — canonical `AuthBackend` trait, AAL/MFA claims (`amr`/`acr`), runtime services state moved from `config.toml` to fjall, `acl-management/swap-acl` trust-task, DIDComm step-up approval. `vta-sdk` + `vti-common` were bumped pre-publish; the consumer crates were left behind. This commit closes the gap so the workspace is internally consistent and ready for the next round of publishes.

## Test plan
- [x] `cargo check --workspace --all-targets` passes (warnings pre-existing on main, not from this PR)
- [x] `Cargo.lock` diff is just the five version strings (5 insertions / 5 deletions)
- [x] DCO sign-off present on the commit
- [ ] CI green