### PR TITLE
feat(acl): add canonical acl/swap-key/0.1 alongside legacy swap-acl

### DIFF
--- a/vta-sdk/src/protocols/acl_management/mod.rs
+++ b/vta-sdk/src/protocols/acl_management/mod.rs
@@ -30,3 +30,11 @@ pub const DELETE_ACL_RESULT: &str =
 pub const SWAP_ACL: &str = "https://firstperson.network/protocols/acl-management/1.0/swap-acl";
 pub const SWAP_ACL_RESULT: &str =
     "https://firstperson.network/protocols/acl-management/1.0/swap-acl-result";
+
+/// Canonical Trust Task URI for ACL swap-key. The FPN-private `SWAP_ACL`
+/// constant is retained for backwards compatibility during the deprecation
+/// window; new producers SHOULD emit `ACL_SWAP_KEY` and new verifiers
+/// MUST accept both. The canonical task's payload shape is described in
+/// `vta_sdk::protocols::acl_management::swap::SwapKeyBody`.
+pub const ACL_SWAP_KEY: &str = "https://trusttasks.org/spec/acl/swap-key/0.1";
+pub const ACL_SWAP_KEY_RESPONSE: &str = "https://trusttasks.org/spec/acl/swap-key/0.1#response";

--- a/vta-sdk/src/protocols/acl_management/swap.rs
+++ b/vta-sdk/src/protocols/acl_management/swap.rs
@@ -21,17 +21,41 @@ use serde::{Deserialize, Serialize};
 
 pub use super::create::CreateAclResultBody;
 
-/// Request body for `swap-acl` (REST `POST /acl/swap` + DIDComm). The new DID
-/// is read from the *verified* presentation, not the body, so it can't be
-/// spoofed independently of the proof.
+/// Request body for the legacy `swap-acl` DIDComm message type (FPN-private,
+/// retained for the deprecation window). The new DID is read from the
+/// *verified* presentation, not the body, so it can't be spoofed
+/// independently of the proof.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SwapAclBody {
     /// Compact Ed25519 JWS (VP-JWT) proving control of the new DID.
     pub presentation: String,
 }
 
+/// Request body for the canonical `acl/swap-key/0.1` Trust Task. The
+/// `link_proof` field is the VP-JWT that previously rode in `SwapAclBody.presentation`;
+/// `current_subject` and `new_subject` are the explicit subjects the
+/// Trust Task spec requires. The verifier cross-checks `new_subject` against
+/// the holder DID extracted from `link_proof` and rejects on mismatch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapKeyBody {
+    /// The VID being swapped out — MUST equal the DIDComm sender / REST caller.
+    pub current_subject: String,
+    /// The VID being swapped in — MUST equal the `iss` of `link_proof`.
+    pub new_subject: String,
+    /// Compact Ed25519 JWS (VP-JWT) signed by `new_subject` proving consent
+    /// to take over `current_subject`'s ACL entry. The spec marks this
+    /// optional at the framework level, but the FPN deployment policy requires it.
+    pub link_proof: String,
+    /// Optional human-readable rationale recorded in the audit log.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
 /// The swap returns the newly-created ACL entry.
 pub type SwapAclResultBody = CreateAclResultBody;
+/// Alias for the canonical Trust Task response — same shape as the legacy result.
+pub type SwapKeyResponseBody = CreateAclResultBody;
 
 #[cfg(feature = "provision-integration")]
 pub use verify_impl::{AclSwapError, AclSwapPresentation, VerifiedAclSwap};

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -552,10 +552,35 @@ pub async fn handle_swap_acl(
     message: Message,
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
+    // Routed for both the legacy FPN-private `swap-acl` type URI and the
+    // canonical Trust Task `acl/swap-key/0.1` URI. Dispatch on the incoming
+    // type so we accept either wire shape during the deprecation window.
+    // The actual verification is identical: the VP-JWT proves new-subject
+    // control regardless of which envelope carried it.
+    let is_canonical = message.typ == acl_management::ACL_SWAP_KEY;
+
     // No require_manage(): self-service rotation of the caller's own entry.
     let auth = app_try!(auth_from_message(&message, &state.acl_ks).await);
-    let body: vta_sdk::protocols::acl_management::swap::SwapAclBody =
-        serde_json::from_value(message.body).map_err(handler_err)?;
+
+    let (presentation, claimed_new_subject) = if is_canonical {
+        let body: vta_sdk::protocols::acl_management::swap::SwapKeyBody =
+            serde_json::from_value(message.body).map_err(handler_err)?;
+        // Cross-check: the DIDComm sender (authenticated) must equal the
+        // declared currentSubject. Stops a sender from claiming to rotate
+        // someone else's entry by lying in the body.
+        if body.current_subject != auth.did {
+            return Err(handler_err(format!(
+                "acl/swap-key: currentSubject {} does not equal authenticated sender {}",
+                body.current_subject, auth.did
+            )));
+        }
+        (body.link_proof, Some(body.new_subject))
+    } else {
+        let body: vta_sdk::protocols::acl_management::swap::SwapAclBody =
+            serde_json::from_value(message.body).map_err(handler_err)?;
+        (body.presentation, None)
+    };
+
     let did_resolver = state
         .did_resolver
         .as_ref()
@@ -567,19 +592,38 @@ pub async fn handle_swap_acl(
             .clone()
             .ok_or_else(|| handler_err("VTA DID not configured"))?
     };
+
     let result = app_try!(
         operations::acl::swap_acl(
             &state.acl_ks,
             &state.audit_ks,
             &auth,
-            &body.presentation,
+            &presentation,
             did_resolver,
             &vta_did,
             "didcomm",
         )
         .await
     );
-    response(acl_management::SWAP_ACL_RESULT, &result)
+
+    // For canonical Trust Task callers, additionally enforce that the body's
+    // claimed newSubject equals the holder the VP-JWT actually proved. The
+    // operation already verified the VP — `result.did` is the verified holder.
+    if let Some(claimed) = claimed_new_subject {
+        if claimed != result.did {
+            return Err(handler_err(format!(
+                "acl/swap-key: newSubject {} does not match verified VP holder {}",
+                claimed, result.did
+            )));
+        }
+    }
+
+    let response_type = if is_canonical {
+        acl_management::ACL_SWAP_KEY_RESPONSE
+    } else {
+        acl_management::SWAP_ACL_RESULT
+    };
+    response(response_type, &result)
 }
 
 pub async fn handle_get_acl(

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -294,6 +294,12 @@ pub fn build_handler(
             acl_management::SWAP_ACL,
             handler_fn(handlers::handle_swap_acl),
         )?
+        // Canonical Trust Task URI for the same operation — dual-registered
+        // during the deprecation window. Handler dispatches on incoming type.
+        .route(
+            acl_management::ACL_SWAP_KEY,
+            handler_fn(handlers::handle_swap_acl),
+        )?
         // Audit management
         .route(
             audit_management::LIST_LOGS,

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -115,20 +115,69 @@ pub async fn delete_acl(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Request body for `POST /acl/swap`. Accepts both the legacy `{ presentation }`
+/// shape (FPN-private) and the canonical Trust Task `acl/swap-key/0.1` shape
+/// `{ currentSubject, newSubject, linkProof, reason? }`. Distinguished by serde
+/// `untagged` — the canonical variant has the discriminating `linkProof` field.
+/// Field-name aliases let the canonical variant accept both `link_proof`
+/// (snake_case from a Rust producer) and `linkProof` (camelCase from a TS
+/// producer); the spec is camelCase.
 #[derive(Debug, Deserialize)]
-pub struct SwapAclRequest {
-    /// Compact Ed25519 JWS (VP-JWT) proving control of the new DID.
-    pub presentation: String,
+#[serde(untagged)]
+pub enum SwapAclRequest {
+    /// Canonical Trust Task `acl/swap-key/0.1` body. Discriminated by the
+    /// presence of `linkProof` (camelCase per spec, with snake_case alias).
+    Canonical {
+        #[serde(alias = "current_subject")]
+        current_subject: String,
+        #[serde(alias = "new_subject")]
+        new_subject: String,
+        #[serde(alias = "link_proof")]
+        link_proof: String,
+        /// Accepted per the spec but not currently surfaced to the audit
+        /// log — will be wired through when the swap_acl operation signature
+        /// grows a reason parameter. Tolerating the field now means existing
+        /// clients can populate it without breaking on a subsequent migration.
+        #[serde(default)]
+        #[allow(dead_code)]
+        reason: Option<String>,
+    },
+    /// Legacy FPN-private body.
+    Legacy {
+        /// Compact Ed25519 JWS (VP-JWT) proving control of the new DID.
+        presentation: String,
+    },
 }
 
 /// POST /acl/swap — atomically rotate the caller's own ACL entry onto a new
 /// DID proven by the presentation. Auth: any authenticated caller (the swap is
 /// self-service — it only moves the caller's own grant, copying role+contexts).
+///
+/// Accepts both the legacy `{ presentation }` body and the canonical Trust Task
+/// `acl/swap-key/0.1` body during the deprecation window.
 pub async fn swap_acl(
     auth: AuthClaims,
     State(state): State<AppState>,
     Json(req): Json<SwapAclRequest>,
 ) -> Result<Json<CreateAclResultBody>, AppError> {
+    let (presentation, claimed_new_subject) = match req {
+        SwapAclRequest::Canonical {
+            current_subject,
+            new_subject,
+            link_proof,
+            reason: _,
+        } => {
+            if current_subject != auth.did {
+                return Err(AppError::Validation(format!(
+                    "acl/swap-key: currentSubject {} does not equal authenticated caller {}",
+                    current_subject, auth.did
+                )));
+            }
+            (link_proof, Some(new_subject))
+        }
+        SwapAclRequest::Legacy { presentation } => (presentation, None),
+    };
+
     let did_resolver = state
         .did_resolver
         .as_ref()
@@ -144,11 +193,21 @@ pub async fn swap_acl(
         &state.acl_ks,
         &state.audit_ks,
         &auth,
-        &req.presentation,
+        &presentation,
         did_resolver,
         &vta_did,
         "rest",
     )
     .await?;
+
+    if let Some(claimed) = claimed_new_subject {
+        if claimed != result.did {
+            return Err(AppError::Validation(format!(
+                "acl/swap-key: newSubject {} does not match verified VP holder {}",
+                claimed, result.did
+            )));
+        }
+    }
+
     Ok(Json(result))
 }


### PR DESCRIPTION
## Summary

Migrates the wallet's onboarding key-rotation from the FPN-private `https://firstperson.network/protocols/acl-management/1.0/swap-acl` DIDComm type to the canonical Trust Task `https://trusttasks.org/spec/acl/swap-key/0.1` from the [trust-tasks-tf registry](https://github.com/trustoverip/dtgwg-trust-tasks-tf).

**Dual-acceptance during the deprecation window:** the server accepts BOTH wire forms so existing PNM wallets keep working unchanged.

- `vta-sdk`: adds `ACL_SWAP_KEY` + `ACL_SWAP_KEY_RESPONSE` constants and a new `SwapKeyBody { current_subject, new_subject, link_proof, reason? }` struct alongside the existing `SwapAclBody`.
- `vta-service/messaging`: `handle_swap_acl` dispatches on incoming message type. Canonical messages additionally cross-check `currentSubject` against the authenticated DIDComm sender and `newSubject` against the verified VP holder. Router registers both URIs to the same handler.
- `vta-service/routes/acl`: `SwapAclRequest` becomes an untagged enum accepting either `{ presentation }` or `{ currentSubject, newSubject, linkProof, reason? }`.

The VP-JWT verification path is unchanged — it just rides in a different field (`linkProof` vs `presentation`) inside a different envelope.

## Paired with

[OpenVTC/vta-browser-plugin#TBD](https://github.com/OpenVTC/vta-browser-plugin) — the plugin emits the canonical URI.

## Test plan

- [x] `cargo check --package vta-sdk --package vta-service` — clean (only pre-existing unrelated warnings).
- [x] `cargo test --package vta-sdk --features provision-integration` — 190+10 SDK tests pass, including the existing acl_swap VP-verify suite.
- [ ] Manual end-to-end: existing PNM wallet (legacy URI) onboards against this server.
- [ ] Manual end-to-end: new PNM wallet (canonical URI) onboards against this server.