### PR TITLE
feat(vault): M1 foundation — VaultEntry, ACL extensions, vault/list+get handlers

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -238,6 +238,23 @@ pub const TASK_AUDIT_UPDATE_RETENTION_1_0: &str =
 pub const TASK_DISCOVERY_CAPABILITIES_1_0: &str =
     "https://trusttasks.org/spec/vta/discovery/capabilities/1.0";
 
+// ─── Vault slice (spec/vault/*/0.1) ──────────────────────────────────────
+//
+// Canonical public Trust Tasks from the dtgwg-trust-tasks-tf registry.
+// M1 ships the two read-only tasks (list + get); upsert, delete, sync,
+// proxy-login, release, usage land in M2+.
+
+/// `spec/vault/list/0.1` — query the metadata view of stored vault
+/// entries, filtered by context, target, secret-kind, tag, etc. Secret
+/// material is never returned by this task. Auth: any caller with the
+/// derived `VaultRead` capability (i.e. role ∈ {Admin, Initiator,
+/// Application, Reader}).
+pub const TASK_VAULT_LIST_0_1: &str = "https://trusttasks.org/spec/vault/list/0.1";
+
+/// `spec/vault/get/0.1` — fetch the metadata view of a single entry by
+/// id. Same auth as vault/list.
+pub const TASK_VAULT_GET_0_1: &str = "https://trusttasks.org/spec/vault/get/0.1";
+
 // ─── Config slice (spec/vta/config/*) ────────────────────────────────────
 
 /// `spec/vta/config/get/1.0` — read the current VTA configuration
@@ -663,6 +680,9 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUDIT_UPDATE_RETENTION_1_0,
     // Discovery
     TASK_DISCOVERY_CAPABILITIES_1_0,
+    // Vault slice (public 0.1 spec)
+    TASK_VAULT_LIST_0_1,
+    TASK_VAULT_GET_0_1,
     // Config slice
     TASK_CONFIG_GET_1_0,
     TASK_CONFIG_UPDATE_1_0,

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -817,6 +817,9 @@ pub async fn run_context_create(
             created_at: vti_common::auth::session::now_epoch(),
             created_by: format!("vta-context-create:{}", auth.did),
             expires_at,
+            kind: Default::default(),
+            capabilities: Vec::new(),
+            device: None,
             version: 0,
         };
         crate::acl::store_acl_entry(&acl_ks, &entry).await?;
@@ -1108,6 +1111,9 @@ pub async fn run_context_reprovision(
             created_at: Utc::now().timestamp() as u64,
             created_by: auth.did.clone(),
             expires_at: None,
+            kind: Default::default(),
+            capabilities: Vec::new(),
+            device: None,
             version: 0,
         };
         crate::acl::store_acl_entry(&state.acl_ks, &entry).await?;

--- a/vta-service/src/did_key.rs
+++ b/vta-service/src/did_key.rs
@@ -72,6 +72,9 @@ pub async fn run_create_did_key(args: CreateDidKeyArgs) -> Result<(), Box<dyn st
                 .as_secs(),
             created_by: "cli:create-did-key".into(),
             expires_at: None,
+            kind: Default::default(),
+            capabilities: Vec::new(),
+            device: None,
             version: 0,
         };
         store_acl_entry(&acl_ks, &entry).await?;

--- a/vta-service/src/import_did.rs
+++ b/vta-service/src/import_did.rs
@@ -65,6 +65,9 @@ pub async fn run_import_did(args: ImportDidArgs) -> Result<(), Box<dyn std::erro
             .as_secs(),
         created_by: "cli:import-did".into(),
         expires_at: None,
+        kind: Default::default(),
+        capabilities: Vec::new(),
+        device: None,
         version: 0,
     };
 

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1580,6 +1580,9 @@ async fn run_bootstrap_admin(
             .as_secs(),
         created_by: "cli:bootstrap-admin".into(),
         expires_at: None,
+        kind: Default::default(),
+        capabilities: Vec::new(),
+        device: None,
         version: 0,
     };
     acl::store_acl_entry(&acl_ks, &entry).await?;

--- a/vta-service/src/messaging/auth.rs
+++ b/vta-service/src/messaging/auth.rs
@@ -95,6 +95,9 @@ mod tests {
                 created_at: now_epoch().saturating_sub(7200),
                 created_by: "test".into(),
                 expires_at: Some(now_epoch().saturating_sub(60)), // expired one minute ago
+                kind: Default::default(),
+                capabilities: Vec::new(),
+                device: None,
                 version: 0,
             },
         )
@@ -125,6 +128,9 @@ mod tests {
                 created_at: now_epoch(),
                 created_by: "test".into(),
                 expires_at: Some(now_epoch() + 3600),
+                kind: Default::default(),
+                capabilities: Vec::new(),
+                device: None,
                 version: 0,
             },
         )
@@ -154,6 +160,9 @@ mod tests {
                 created_at: now_epoch(),
                 created_by: "test".into(),
                 expires_at: None,
+                kind: Default::default(),
+                capabilities: Vec::new(),
+                device: None,
                 version: 0,
             },
         )

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -113,6 +113,9 @@ pub async fn create_acl(
         created_at: now_epoch(),
         created_by: auth.did.clone(),
         expires_at,
+        kind: Default::default(),
+        capabilities: Vec::new(),
+        device: None,
         version: 0,
     };
 
@@ -393,6 +396,9 @@ pub async fn swap_acl(
         created_at: now,
         created_by: auth.did.clone(),
         expires_at: old.expires_at,
+        kind: old.kind.clone(),
+        capabilities: old.capabilities.clone(),
+        device: old.device.clone(),
         version: 0,
     };
 
@@ -496,6 +502,9 @@ mod tests {
                 created_at: now_epoch(),
                 created_by: "seed".into(),
                 expires_at: None,
+                kind: Default::default(),
+                capabilities: Vec::new(),
+                device: None,
                 version: 0,
             },
         )

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -59,6 +59,7 @@ mod passkey_vms;
 #[cfg(feature = "webvh")]
 mod provision_integration;
 mod seeds;
+mod vault;
 #[cfg(feature = "webvh")]
 mod webvh;
 
@@ -151,6 +152,7 @@ fn aggregate_dispatched_uris() -> Vec<&'static str> {
     v.extend(keys::DISPATCHED_URIS);
     v.extend(management::DISPATCHED_URIS);
     v.extend(seeds::DISPATCHED_URIS);
+    v.extend(vault::DISPATCHED_URIS);
     // Feature-gated slices add their `v.extend(slice::DISPATCHED_URIS)`
     // here under `#[cfg(feature = "...")]`. The corresponding URIs
     // must also appear in `KNOWN_FEATURE_GATED_URIS` so the parity
@@ -332,6 +334,9 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         vta_sdk::trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0 => {
             discovery::handle_capabilities(state, auth, doc).await
         }
+        // ─── Vault slice (public 0.1 spec) ──────────────────────────
+        vta_sdk::trust_tasks::TASK_VAULT_LIST_0_1 => vault::handle_list(state, auth, doc).await,
+        vta_sdk::trust_tasks::TASK_VAULT_GET_0_1 => vault::handle_get(state, auth, doc).await,
         // ─── Config slice ────────────────────────────────────────────
         vta_sdk::trust_tasks::TASK_CONFIG_GET_1_0 => config::handle_get(state, auth, doc).await,
         vta_sdk::trust_tasks::TASK_CONFIG_UPDATE_1_0 => {

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -1,0 +1,265 @@
+//! Vault slice trust-task handlers — M1 read-only surface.
+//!
+//! Handles `spec/vault/list/0.1` and `spec/vault/get/0.1` per the canonical
+//! [trust-tasks-tf](https://github.com/trustoverip/dtgwg-trust-tasks-tf) spec.
+//! Upsert, delete, sync, proxy-login, release, and usage handlers land in
+//! later milestones (M2+).
+//!
+//! Auth: gated on the derived `VaultRead` capability for the caller's role.
+//! Legacy ACL entries (no explicit `capabilities` set) fall back to
+//! [`vti_common::acl::derived_capabilities_for_role`] — Admin, Initiator,
+//! Application, and Reader all carry `VaultRead`. Monitor does not.
+
+use axum::response::Response;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+use vti_common::acl::{Capability, role_has_capability};
+use vti_common::vault::{
+    SecretKind, SiteTarget, VaultEntry, VaultListFilter, get_vault_entry,
+    list_vault_entries as list_entries_store,
+};
+
+use crate::auth::AuthClaims;
+use crate::error::AppError;
+use crate::server::AppState;
+
+use super::helpers::{app_error_to_reject, parse_payload, reject_with, success_response};
+use trust_tasks_rs::RejectReason;
+
+/// URIs handled by this slice. Aggregated by the dispatcher's parity
+/// harness.
+#[allow(dead_code)]
+pub(super) const DISPATCHED_URIS: &[&str] = &[
+    vta_sdk::trust_tasks::TASK_VAULT_LIST_0_1,
+    vta_sdk::trust_tasks::TASK_VAULT_GET_0_1,
+];
+
+/// Request body for `vault/list/0.1`. Mirrors the canonical
+/// `payload.schema.json` of the spec; field names are camelCase to match
+/// the wire form Companions emit from `@openvtc/trust-tasks`.
+///
+/// Pagination is accepted but currently single-page — the maintainer
+/// returns up to `page_size` entries with `truncated: false` and no cursor.
+/// Real cursor-based pagination lands when the vault grows past a few
+/// thousand entries; for M1 with hand-seeded test data it's overkill.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultListBody {
+    context_id: Option<String>,
+    target_origin_prefix: Option<String>,
+    target_did: Option<String>,
+    target_ios_bundle_id: Option<String>,
+    target_android_package: Option<String>,
+    secret_kind: Option<SecretKind>,
+    tag: Option<String>,
+    used_since: Option<String>,
+    never_used: Option<bool>,
+    expires_before: Option<String>,
+    breached: Option<bool>,
+    page_size: Option<u32>,
+    // `cursor` accepted on the wire for forward-compat but ignored in M1.
+    #[serde(default)]
+    #[allow(dead_code)]
+    cursor: Option<String>,
+}
+
+/// Response body for `vault/list/0.1`. Wraps the entries the
+/// canonical schema declares under `$defs.Response`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultListResponseBody {
+    entries: Vec<VaultEntry>,
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    redacted_fields: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultGetBody {
+    id: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultGetResponseBody {
+    entry: VaultEntry,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    redacted_fields: Option<Vec<String>>,
+}
+
+/// Reject the request unless the caller's role implies `VaultRead`. When
+/// AclEntry-level explicit capabilities arrive (M4), this check upgrades
+/// to consult the entry's `capabilities` Vec instead of deriving from role.
+fn require_vault_read(auth: &AuthClaims, doc: &TrustTask<Value>) -> Result<(), Response> {
+    if role_has_capability(&auth.role, Capability::VaultRead) {
+        Ok(())
+    } else {
+        Err(reject_with(
+            doc,
+            RejectReason::PermissionDenied {
+                reason: format!(
+                    "vault read denied: role {} does not carry VaultRead capability",
+                    auth.role
+                ),
+            },
+        ))
+    }
+}
+
+/// Reject if the caller's `allowed_contexts` is non-empty AND `context_id`
+/// (if supplied) is not in the allowed list. Empty allowed_contexts means
+/// super-admin scope.
+fn enforce_context_scope(
+    auth: &AuthClaims,
+    context_id: Option<&str>,
+    doc: &TrustTask<Value>,
+) -> Result<(), Response> {
+    let Some(ctx) = context_id else {
+        return Ok(()); // No context filter — caller's full visibility applies.
+    };
+    if auth.allowed_contexts.is_empty() {
+        return Ok(()); // Super-admin (or unscoped) sees everything.
+    }
+    if auth.allowed_contexts.iter().any(|c| c == ctx) {
+        return Ok(());
+    }
+    Err(reject_with(
+        doc,
+        RejectReason::PermissionDenied {
+            reason: format!("vault scope denied: caller is not authorised for context {ctx}"),
+        },
+    ))
+}
+
+/// Handler for `spec/vault/list/0.1`.
+pub(super) async fn handle_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    if let Err(r) = require_vault_read(auth, &doc) {
+        return r;
+    }
+
+    let req: VaultListBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    // Reject mutually-exclusive filter combinations the spec calls out.
+    if req.used_since.is_some() && req.never_used == Some(true) {
+        return reject_with(
+            &doc,
+            RejectReason::MalformedRequest {
+                reason: "vault/list: usedSince and neverUsed are mutually exclusive".into(),
+            },
+        );
+    }
+
+    if let Err(r) = enforce_context_scope(auth, req.context_id.as_deref(), &doc) {
+        return r;
+    }
+
+    let filter = VaultListFilter {
+        context_id: req.context_id.as_deref(),
+        target_origin_prefix: req.target_origin_prefix.as_deref(),
+        target_did: req.target_did.as_deref(),
+        target_ios_bundle_id: req.target_ios_bundle_id.as_deref(),
+        target_android_package: req.target_android_package.as_deref(),
+        secret_kind: req.secret_kind,
+        tag: req.tag.as_deref(),
+        used_since: req.used_since.as_deref(),
+        never_used: req.never_used,
+        expires_before: req.expires_before.as_deref(),
+        breached: req.breached,
+    };
+
+    let mut entries = match list_entries_store(&state.vault_ks, &filter).await {
+        Ok(v) => v,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // If the caller's role is scoped to a subset of contexts and they
+    // queried without a `contextId` filter, narrow the result set to
+    // visible contexts only. This is defence-in-depth in addition to
+    // `enforce_context_scope` — that path covers the explicit-filter case;
+    // this one covers the implicit-all-contexts case.
+    if !auth.allowed_contexts.is_empty() && req.context_id.is_none() {
+        entries.retain(|e| auth.allowed_contexts.iter().any(|c| c == &e.context_id));
+    }
+
+    // M1 pagination: single page. Apply page_size as a hard truncation.
+    let page_size = req.page_size.unwrap_or(100) as usize;
+    let truncated = entries.len() > page_size;
+    entries.truncate(page_size);
+
+    success_response(
+        &doc,
+        VaultListResponseBody {
+            entries,
+            truncated,
+            cursor: None,
+            redacted_fields: None,
+        },
+    )
+}
+
+/// Handler for `spec/vault/get/0.1`.
+pub(super) async fn handle_get(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    if let Err(r) = require_vault_read(auth, &doc) {
+        return r;
+    }
+    let req: VaultGetBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let entry = match get_vault_entry(&state.vault_ks, &req.id).await {
+        Ok(Some(e)) => e,
+        // Conflate not-found with permission-denied to deny enumeration.
+        Ok(None) => {
+            return app_error_to_reject(
+                &doc,
+                AppError::NotFound(format!("vault entry {} not found", req.id)),
+            );
+        }
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    if let Err(r) = enforce_context_scope(auth, Some(&entry.context_id), &doc) {
+        return r;
+    }
+
+    success_response(
+        &doc,
+        VaultGetResponseBody {
+            entry,
+            redacted_fields: None,
+        },
+    )
+}
+
+// Suppress an unused-import warning on the SiteTarget re-export — kept
+// available for handler call-sites that materialise SiteTarget literals
+// in upcoming milestones.
+#[allow(dead_code)]
+type _SiteTargetReexport = SiteTarget;
+
+// M1 leaves handler-level tests to the integration suite (tests/) and to
+// end-to-end verification via the plugin UI in M1.6. The vti-common
+// `vault` module's tests cover the filter/sort logic in isolation; the
+// dispatcher's parity-harness test asserts these URIs are wired. Real
+// HTTP round-trips against the dispatcher arrive in M2 once vault/upsert
+// is available to seed entries through the same authenticated channel
+// (rather than reaching into the keyspace from a test, which would
+// duplicate the wire-form encoder).
+#[allow(dead_code)]
+const _: &() = &();

--- a/vta-service/src/seal.rs
+++ b/vta-service/src/seal.rs
@@ -363,6 +363,9 @@ mod tests {
                 .as_secs(),
             created_by: "test".into(),
             expires_at: None,
+            kind: Default::default(),
+            capabilities: Vec::new(),
+            device: None,
             version: 0,
         };
         acl::store_acl_entry(&acl_ks, &entry).await.expect("acl");

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -80,6 +80,10 @@ pub struct AppState {
     pub audit_ks: KeyspaceHandle,
     pub imported_ks: KeyspaceHandle,
     pub cache_ks: KeyspaceHandle,
+    /// Vault — third-party credentials the holder has stored on this VTA.
+    /// M1 reads only; upsert/delete/sync/release land in M2+. Encrypted at
+    /// rest like every other secret-bearing keyspace.
+    pub vault_ks: KeyspaceHandle,
     /// Persistent runtime state for service enable/disable
     /// (`operations::protocol::runtime_state`). Replaces the legacy
     /// `[services]` block in `config.toml` as the source of truth for whether
@@ -208,6 +212,7 @@ pub async fn build_app_state(
     let audit_ks = apply_encryption(store.keyspace("audit")?);
     let imported_ks = apply_encryption(store.keyspace("imported_secrets")?);
     let cache_ks = store.keyspace("cache")?;
+    let vault_ks = apply_encryption(store.keyspace("vault")?);
     // Persistent runtime state for service enable/disable. Encrypted because
     // a couple of bool records are cheap and the keyspace may grow.
     let service_state_ks = apply_encryption(store.keyspace("service_state")?);
@@ -267,6 +272,7 @@ pub async fn build_app_state(
         audit_ks,
         imported_ks,
         cache_ks,
+        vault_ks,
         service_state_ks,
         sealed_nonces_ks,
         backup_bundles_ks,
@@ -407,6 +413,7 @@ pub async fn run(
         let audit_ks = apply_encryption(store.keyspace("audit")?);
         let imported_ks = apply_encryption(store.keyspace("imported_secrets")?);
         let cache_ks = store.keyspace("cache")?;
+        let vault_ks = apply_encryption(store.keyspace("vault")?);
         let service_state_ks = apply_encryption(store.keyspace("service_state")?);
         let sealed_nonces_ks = store.keyspace("sealed_nonces")?;
         let backup_bundles_ks = apply_encryption(store.keyspace("backup_bundles")?);
@@ -579,6 +586,7 @@ pub async fn run(
             audit_ks,
             imported_ks,
             cache_ks,
+            vault_ks,
             service_state_ks: service_state_ks.clone(),
             sealed_nonces_ks,
             backup_bundles_ks,

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1193,6 +1193,9 @@ async fn seed_initial_admin(
             .as_secs(),
         created_by: "cli:setup-from-file".into(),
         expires_at: None,
+        kind: Default::default(),
+        capabilities: Vec::new(),
+        device: None,
         version: 0,
     };
     acl::store_acl_entry(&acl_ks, &entry).await?;

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -474,6 +474,7 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
     }
     let audit_ks = store.keyspace("audit").unwrap();
     let cache_ks = store.keyspace("cache").unwrap();
+    let vault_ks = store.keyspace("vault").unwrap();
     let service_state_ks = store.keyspace("service_state").unwrap();
     let imported_ks = store.keyspace("imported_secrets").unwrap();
     let sealed_nonces_ks = store.keyspace("sealed_nonces").unwrap();
@@ -542,6 +543,7 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
         audit_ks,
         imported_ks,
         cache_ks,
+        vault_ks,
         service_state_ks,
         sealed_nonces_ks,
         backup_bundles_ks: backup_bundles_ks.clone(),

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -56,6 +56,146 @@ impl Role {
     }
 }
 
+/// Consumer-kind discriminator distinguishing user-driven Companions
+/// (browser plugin, mobile app, desktop app) from headless Services
+/// (mediator, AI agent, daemon). Companion vs Service drives UX
+/// affordances and default policy posture; the variant payload narrows
+/// the form factor / service role for finer-grained policy hooks.
+///
+/// Wire form (kebab-case discriminator) matches the canonical Trust
+/// Task shared schema `device/_shared/0.1/device-binding#/$defs/ConsumerKind`.
+///
+/// `#[serde(default)]` on the AclEntry field returns `Service { Daemon }`
+/// for legacy rows that pre-date the field — a safe fallback for any
+/// existing operator-deployed mediator or daemon.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum ConsumerKind {
+    #[serde(rename_all = "kebab-case")]
+    Companion { form_factor: CompanionFormFactor },
+    #[serde(rename_all = "camelCase")]
+    Service {
+        #[serde(rename = "serviceKind")]
+        service_kind: ServiceKind,
+    },
+}
+
+impl Default for ConsumerKind {
+    fn default() -> Self {
+        ConsumerKind::Service {
+            service_kind: ServiceKind::Daemon,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CompanionFormFactor {
+    Browser,
+    Mobile,
+    Desktop,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ServiceKind {
+    Mediator,
+    AiAgent,
+    Daemon,
+}
+
+/// Fine-grained capability flags scoped to the ACL entry's allowed
+/// contexts. Used by route handlers to gate access at finer resolution
+/// than the [`Role`] hierarchy — for example, an AI-agent Service might
+/// be granted `VaultRead` against a specific context but never
+/// `VaultWrite` or `Sign`. Wire form (kebab-case) matches the canonical
+/// `Capability` shared schema.
+///
+/// For legacy rows with no capability set, [`derived_capabilities_for_role`]
+/// produces a sensible default from the existing role (Admin gets
+/// everything, Reader gets only `vault-read`, etc.) so existing ACL
+/// behaviour is preserved bit-for-bit.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "kebab-case")]
+pub enum Capability {
+    VaultRead,
+    VaultWrite,
+    ProxyLogin,
+    FillRelease,
+    PolicyAdmin,
+    DeviceAdmin,
+    Sign,
+    KeyMint,
+}
+
+/// Returns true if `role` is granted `cap` by the default capability
+/// mapping. Use for capability checks against legacy ACL entries that have
+/// no explicit `capabilities` set; for entries with explicit capabilities,
+/// check the entry's set directly.
+pub fn role_has_capability(role: &Role, cap: Capability) -> bool {
+    derived_capabilities_for_role(role).contains(&cap)
+}
+
+/// Default capability set inferred from a role for entries that pre-date
+/// the explicit `capabilities` field. Keeps existing behaviour byte-identical
+/// — a pre-Phase-3 Admin still has every capability without any data
+/// migration required.
+pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
+    match role {
+        Role::Admin => vec![
+            Capability::VaultRead,
+            Capability::VaultWrite,
+            Capability::ProxyLogin,
+            Capability::FillRelease,
+            Capability::PolicyAdmin,
+            Capability::DeviceAdmin,
+            Capability::Sign,
+            Capability::KeyMint,
+        ],
+        Role::Initiator => vec![
+            Capability::VaultRead,
+            Capability::VaultWrite,
+            Capability::ProxyLogin,
+            Capability::FillRelease,
+            Capability::DeviceAdmin,
+            Capability::Sign,
+            Capability::KeyMint,
+        ],
+        Role::Application => vec![
+            Capability::VaultRead,
+            Capability::ProxyLogin,
+            Capability::FillRelease,
+            Capability::Sign,
+        ],
+        Role::Reader => vec![Capability::VaultRead],
+        Role::Monitor => vec![],
+    }
+}
+
+/// Metadata for a registered Companion/Service device. M1 stores the field
+/// shape so the ACL row can carry it forward; the registration flow that
+/// populates it lands in M4 (`device/register/0.1`).
+///
+/// Wire form mirrors the canonical Trust Task shared schema
+/// `device/_shared/0.1/device-binding#/$defs/DeviceBinding`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceBinding {
+    pub device_id: String,
+    pub display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    /// RFC 3339 — when the device claimed its binding via `device/register/0.1`.
+    pub registered_at: String,
+    /// RFC 3339 — refreshed on every heartbeat / successful auth.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_seen_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wiped_at: Option<String>,
+}
+
 /// An entry in the Access Control List.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AclEntry {
@@ -72,6 +212,21 @@ pub struct AclEntry {
     /// this default).
     #[serde(default)]
     pub expires_at: Option<u64>,
+    /// Consumer kind: Companion (user-driven) vs Service (headless). New in
+    /// M1 (vault-credential-manager design). `#[serde(default)]` ⇒ pre-M1
+    /// rows deserialise as `Service { Daemon }`.
+    #[serde(default)]
+    pub kind: ConsumerKind,
+    /// Fine-grained capability set. Empty Vec on legacy rows; the auth
+    /// layer falls back to [`derived_capabilities_for_role`] when this
+    /// is empty so existing behaviour stays byte-identical.
+    #[serde(default)]
+    pub capabilities: Vec<Capability>,
+    /// Optional Companion/Service device-binding metadata. Populated by
+    /// the M4 `device/register/0.1` flow; absent on legacy rows and on
+    /// pure ACL entries that don't represent a registered device.
+    #[serde(default)]
+    pub device: Option<DeviceBinding>,
     /// Optimistic-concurrency version. Incremented on every
     /// successful update; the route layer's `If-Match` header
     /// compares against this and returns 409 Conflict on a
@@ -307,6 +462,9 @@ mod tests {
             created_at: now_epoch(),
             created_by: "did:key:zSetup".into(),
             expires_at: None,
+            kind: Default::default(),
+            capabilities: Vec::new(),
+            device: None,
             version: 0,
         }
     }
@@ -320,6 +478,9 @@ mod tests {
             created_at: now_epoch(),
             created_by: "did:key:zSetup".into(),
             expires_at: None,
+            kind: Default::default(),
+            capabilities: Vec::new(),
+            device: None,
             version: 0,
         }
     }

--- a/vti-common/src/lib.rs
+++ b/vti-common/src/lib.rs
@@ -12,3 +12,4 @@ pub mod setup;
 pub mod store;
 pub mod telemetry;
 pub mod trust_task;
+pub mod vault;

--- a/vti-common/src/vault/mod.rs
+++ b/vti-common/src/vault/mod.rs
@@ -1,0 +1,449 @@
+//! Vault entries — third-party credentials the holder has stored on the
+//! VTA, used by Companions and Services to authenticate against external
+//! sites and apps. M1 ships the metadata view + read-only store helpers;
+//! upsert, delete, sync, proxy-login, and release land in later milestones.
+//!
+//! Wire format mirrors the canonical Trust Task spec
+//! `https://trusttasks.org/spec/vault/_shared/0.1/vault-entry` field-for-field
+//! — `#[serde(rename_all = "camelCase")]` lines the JSON up with the
+//! schema's camelCase wire form. Timestamps are RFC 3339 strings rather
+//! than Unix epoch (unlike [`crate::acl::AclEntry`]); this matches the spec
+//! directly and avoids a separate wire/domain conversion. The slight
+//! ergonomic loss versus `u64` is fine for v0.1.
+//!
+//! **No secret material lives in this module.** [`VaultEntry`] is the
+//! metadata projection — the `secret_kind` discriminator is present, but
+//! the bytes only ever transit through HPKE-sealed envelopes carried by
+//! the vault/release/0.1 task (which lands in M2).
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+/// Public metadata view of a single vault entry. Direct wire-form match for
+/// the `VaultEntry` `$def` in the canonical Trust Task shared schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultEntry {
+    /// Opaque maintainer-assigned id (ULID recommended).
+    pub id: String,
+    /// Trust context (persona) this entry belongs to.
+    pub context_id: String,
+    /// Binding targets. A request from any matching target uses this entry.
+    pub targets: Vec<SiteTarget>,
+    /// User-facing display name.
+    pub label: String,
+    /// Discriminator for the kind of secret bytes; never the bytes themselves.
+    pub secret_kind: SecretKind,
+    /// User-defined tags for filtering.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    /// Non-sensitive notes (sensitive notes live inside the secret payload).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    /// Optional icon URI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub favicon: Option<String>,
+    /// Opaque policy-engine selector strings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selectors: Vec<String>,
+    /// Names of custom fields (values live in the secret payload).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_field_names: Vec<String>,
+    /// References to encrypted blobs (recovery codes, key files, etc.).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<AttachmentRef>,
+    /// Expected expiry (e.g. OAuth refresh-token expiry, time-limited tokens).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    /// Set when HIBP (or equivalent) detects this credential in a breach.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub breached_at: Option<String>,
+    /// Last password rotation timestamp (for password-kind entries).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password_changed_at: Option<String>,
+    /// RFC 3339 creation timestamp.
+    pub created_at: String,
+    /// DID of the consumer that created the entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
+    /// RFC 3339 last-modification timestamp.
+    pub updated_at: String,
+    /// DID of the consumer that last modified the entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_by: Option<String>,
+    /// Most recent use (proxy-login or release).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_used_at: Option<String>,
+    /// Monotonic version for optimistic concurrency + sync seq baseline.
+    pub version: u32,
+}
+
+/// Binding target for a vault entry. Tagged union over the discriminator
+/// `kind`. Wire form (kebab-case discriminator) matches the canonical
+/// `SiteTarget` shared schema.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum SiteTarget {
+    WebOrigin {
+        origin: String,
+    },
+    Did {
+        did: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    IosApp {
+        bundle_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        team_id: Option<String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    AndroidApp {
+        package_name: String,
+        sha256_cert_fingerprints: Vec<String>,
+    },
+}
+
+/// Discriminator for the kind of secret stored. Wire values are kebab-case
+/// (`oauth-tokens`, `did-self-issued`, etc.) per the canonical schema.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SecretKind {
+    Password,
+    Passkey,
+    OauthTokens,
+    DidSelfIssued,
+    DidcommPeer,
+    BearerToken,
+    SshKey,
+    Custom,
+}
+
+/// Descriptor for an encrypted blob associated with a vault entry. The blob
+/// itself is fetched via a separate mechanism; this struct carries only the
+/// metadata projection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachmentRef {
+    pub id: String,
+    pub name: String,
+    pub size_bytes: u64,
+    /// Hex-encoded SHA-256 of the encrypted blob bytes.
+    pub sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+}
+
+/// Filter criteria for [`list_vault_entries`]. All populated fields are
+/// AND-combined. Matches the `payload.schema.json` of `vault/list/0.1`
+/// minus pagination (`cursor` / `page_size`), which is applied in the
+/// route layer rather than the store helper.
+#[derive(Debug, Default)]
+pub struct VaultListFilter<'a> {
+    pub context_id: Option<&'a str>,
+    pub target_origin_prefix: Option<&'a str>,
+    pub target_did: Option<&'a str>,
+    pub target_ios_bundle_id: Option<&'a str>,
+    pub target_android_package: Option<&'a str>,
+    pub secret_kind: Option<SecretKind>,
+    pub tag: Option<&'a str>,
+    pub used_since: Option<&'a str>,
+    /// When `Some(true)`, return only entries with no `lastUsedAt`. Mutually
+    /// exclusive with `used_since` at the caller level.
+    pub never_used: Option<bool>,
+    pub expires_before: Option<&'a str>,
+    pub breached: Option<bool>,
+}
+
+/// Storage key for a vault entry — `"vault:<id>"`. Prefix scans on
+/// `"vault:"` enumerate every entry in this VTA's keyspace.
+fn vault_key(id: &str) -> String {
+    format!("vault:{id}")
+}
+
+/// Read a single vault entry by id. Returns `Ok(None)` for absent ids so
+/// callers can map to a not_found / permission_denied response per their
+/// enumeration-resistance policy.
+pub async fn get_vault_entry(
+    vault: &KeyspaceHandle,
+    id: &str,
+) -> Result<Option<VaultEntry>, AppError> {
+    vault.get(vault_key(id)).await
+}
+
+/// Store (create or overwrite) a vault entry. Unconditional write — version
+/// checks are the caller's responsibility (the upsert handler will gain a
+/// `If-Match`-style ETag in M2).
+pub async fn put_vault_entry(vault: &KeyspaceHandle, entry: &VaultEntry) -> Result<(), AppError> {
+    vault.insert(vault_key(&entry.id), entry).await
+}
+
+/// Delete a vault entry by id. Use the upcoming `vault/delete/0.1` handler
+/// (M2) for the tombstone-aware path; this helper exists for tests and
+/// administrative scripts.
+pub async fn delete_vault_entry(vault: &KeyspaceHandle, id: &str) -> Result<(), AppError> {
+    vault.remove(vault_key(id)).await
+}
+
+/// List vault entries matching `filter`, ordered by `last_used_at`
+/// descending (entries without `last_used_at` sort last). Pagination is
+/// caller-applied; this helper returns the full filtered set.
+pub async fn list_vault_entries(
+    vault: &KeyspaceHandle,
+    filter: &VaultListFilter<'_>,
+) -> Result<Vec<VaultEntry>, AppError> {
+    let raw = vault.prefix_iter_raw("vault:").await?;
+    let mut out = Vec::with_capacity(raw.len());
+    for (_, bytes) in raw {
+        let entry: VaultEntry = serde_json::from_slice(&bytes)?;
+        if !matches_filter(&entry, filter) {
+            continue;
+        }
+        out.push(entry);
+    }
+    out.sort_by(|a, b| {
+        // Most-recently-used first; absent last_used_at sorts last.
+        match (b.last_used_at.as_deref(), a.last_used_at.as_deref()) {
+            (Some(x), Some(y)) => x.cmp(y),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        }
+    });
+    Ok(out)
+}
+
+fn matches_filter(entry: &VaultEntry, filter: &VaultListFilter<'_>) -> bool {
+    if let Some(ctx) = filter.context_id {
+        if entry.context_id != ctx {
+            return false;
+        }
+    }
+    if let Some(kind) = filter.secret_kind {
+        if entry.secret_kind != kind {
+            return false;
+        }
+    }
+    if let Some(tag) = filter.tag {
+        if !entry.tags.iter().any(|t| t == tag) {
+            return false;
+        }
+    }
+    if let Some(since) = filter.used_since {
+        match entry.last_used_at.as_deref() {
+            Some(last) if last >= since => {}
+            _ => return false,
+        }
+    }
+    if filter.never_used == Some(true) && entry.last_used_at.is_some() {
+        return false;
+    }
+    if let Some(before) = filter.expires_before {
+        match entry.expires_at.as_deref() {
+            Some(ts) if ts < before => {}
+            _ => return false,
+        }
+    }
+    if let Some(want_breached) = filter.breached {
+        let is_breached = entry.breached_at.is_some();
+        if is_breached != want_breached {
+            return false;
+        }
+    }
+    // Target filters: an entry matches when AT LEAST ONE target satisfies the
+    // criterion. Each target filter is independent — passing multiple narrows
+    // the result to entries that have a target matching every criterion (a
+    // single target need not satisfy all of them).
+    if let Some(prefix) = filter.target_origin_prefix {
+        let ok = entry.targets.iter().any(|t| match t {
+            SiteTarget::WebOrigin { origin } => origin.starts_with(prefix),
+            _ => false,
+        });
+        if !ok {
+            return false;
+        }
+    }
+    if let Some(did) = filter.target_did {
+        let ok = entry.targets.iter().any(|t| match t {
+            SiteTarget::Did { did: d } => d == did,
+            _ => false,
+        });
+        if !ok {
+            return false;
+        }
+    }
+    if let Some(bid) = filter.target_ios_bundle_id {
+        let ok = entry.targets.iter().any(|t| match t {
+            SiteTarget::IosApp { bundle_id, .. } => bundle_id == bid,
+            _ => false,
+        });
+        if !ok {
+            return false;
+        }
+    }
+    if let Some(pkg) = filter.target_android_package {
+        let ok = entry.targets.iter().any(|t| match t {
+            SiteTarget::AndroidApp { package_name, .. } => package_name == pkg,
+            _ => false,
+        });
+        if !ok {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(id: &str, ctx: &str, last_used: Option<&str>) -> VaultEntry {
+        VaultEntry {
+            id: id.to_string(),
+            context_id: ctx.to_string(),
+            targets: vec![SiteTarget::WebOrigin {
+                origin: "https://github.com".to_string(),
+            }],
+            label: format!("entry {id}"),
+            secret_kind: SecretKind::Password,
+            tags: vec!["work".to_string()],
+            notes: None,
+            favicon: None,
+            selectors: vec![],
+            custom_field_names: vec![],
+            attachments: vec![],
+            expires_at: None,
+            breached_at: None,
+            password_changed_at: None,
+            created_at: "2026-05-26T10:00:00Z".to_string(),
+            created_by: None,
+            updated_at: "2026-05-26T10:00:00Z".to_string(),
+            updated_by: None,
+            last_used_at: last_used.map(String::from),
+            version: 1,
+        }
+    }
+
+    #[test]
+    fn site_target_round_trip_matches_canonical_wire_form() {
+        let cases = vec![
+            (
+                SiteTarget::WebOrigin {
+                    origin: "https://github.com".to_string(),
+                },
+                r#"{"kind":"web-origin","origin":"https://github.com"}"#,
+            ),
+            (
+                SiteTarget::Did {
+                    did: "did:web:rp.example".to_string(),
+                },
+                r#"{"kind":"did","did":"did:web:rp.example"}"#,
+            ),
+            (
+                SiteTarget::IosApp {
+                    bundle_id: "com.example.app".to_string(),
+                    team_id: Some("ABCD123456".to_string()),
+                },
+                r#"{"kind":"ios-app","bundleId":"com.example.app","teamId":"ABCD123456"}"#,
+            ),
+            (
+                SiteTarget::AndroidApp {
+                    package_name: "com.example.app".to_string(),
+                    sha256_cert_fingerprints: vec!["AA:BB".to_string()],
+                },
+                r#"{"kind":"android-app","packageName":"com.example.app","sha256CertFingerprints":["AA:BB"]}"#,
+            ),
+        ];
+        for (val, expected) in cases {
+            let json = serde_json::to_string(&val).unwrap();
+            assert_eq!(json, expected, "encode {val:?}");
+            let back: SiteTarget = serde_json::from_str(expected).unwrap();
+            assert_eq!(back, val, "round-trip {expected}");
+        }
+    }
+
+    #[test]
+    fn secret_kind_serialises_to_canonical_kebab_case() {
+        let cases = vec![
+            (SecretKind::Password, "\"password\""),
+            (SecretKind::OauthTokens, "\"oauth-tokens\""),
+            (SecretKind::DidSelfIssued, "\"did-self-issued\""),
+            (SecretKind::DidcommPeer, "\"didcomm-peer\""),
+            (SecretKind::BearerToken, "\"bearer-token\""),
+            (SecretKind::SshKey, "\"ssh-key\""),
+        ];
+        for (val, expected) in cases {
+            assert_eq!(serde_json::to_string(&val).unwrap(), expected);
+            let back: SecretKind = serde_json::from_str(expected).unwrap();
+            assert_eq!(back, val);
+        }
+    }
+
+    #[test]
+    fn filter_matches_intersection_of_criteria() {
+        let entry = sample("v1", "ctx_a", Some("2026-05-20T00:00:00Z"));
+
+        // Match-all empty filter
+        assert!(matches_filter(&entry, &VaultListFilter::default()));
+
+        // Single criterion that matches
+        assert!(matches_filter(
+            &entry,
+            &VaultListFilter {
+                context_id: Some("ctx_a"),
+                ..Default::default()
+            }
+        ));
+
+        // Single criterion that misses
+        assert!(!matches_filter(
+            &entry,
+            &VaultListFilter {
+                context_id: Some("ctx_b"),
+                ..Default::default()
+            }
+        ));
+
+        // never_used excludes used entries
+        assert!(!matches_filter(
+            &entry,
+            &VaultListFilter {
+                never_used: Some(true),
+                ..Default::default()
+            }
+        ));
+
+        // used_since accepts a timestamp at or before last_used_at
+        assert!(matches_filter(
+            &entry,
+            &VaultListFilter {
+                used_since: Some("2026-05-19T00:00:00Z"),
+                ..Default::default()
+            }
+        ));
+        assert!(!matches_filter(
+            &entry,
+            &VaultListFilter {
+                used_since: Some("2026-05-21T00:00:00Z"),
+                ..Default::default()
+            }
+        ));
+
+        // Origin prefix matches any web-origin target
+        assert!(matches_filter(
+            &entry,
+            &VaultListFilter {
+                target_origin_prefix: Some("https://github."),
+                ..Default::default()
+            }
+        ));
+        assert!(!matches_filter(
+            &entry,
+            &VaultListFilter {
+                target_origin_prefix: Some("https://gitlab."),
+                ..Default::default()
+            }
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Establishes the server-side foundation for the **VTA-as-universal-credential-manager** design (per the design plan, M1). Read-only surface only: `vault/list/0.1` and `vault/get/0.1` dispatch into a new `vault:` keyspace. Upsert, delete, sync, proxy-login, release, and usage land in M2+.

### \`vti-common\` changes
- **New \`vault\` module**: \`VaultEntry\` (metadata-only — no secret material), \`SiteTarget\` tagged-union (web-origin / did / ios-app / android-app), \`SecretKind\` enum, \`AttachmentRef\`, \`VaultListFilter\`, plus get/put/delete/list-with-filter store helpers. Wire form matches the canonical Trust Task shared schema at \`vault/_shared/0.1/vault-entry\` (camelCase, RFC 3339).
- **\`AclEntry\` extended** with three additive fields, each \`#[serde(default)]\` so legacy rows deserialise unchanged:
  - \`kind: ConsumerKind\` — \`Companion {form_factor}\` vs \`Service {service_kind}\`; default \`Service { Daemon }\`.
  - \`capabilities: Vec<Capability>\` — fine-grained flags (VaultRead/Write, ProxyLogin, FillRelease, PolicyAdmin, DeviceAdmin, Sign, KeyMint); empty Vec on legacy rows falls back to \`derived_capabilities_for_role\` → existing behaviour byte-identical.
  - \`device: Option<DeviceBinding>\` — populated by the M4 \`device/register/0.1\` flow; None on legacy rows.

### \`vta-sdk\` changes
- \`TASK_VAULT_LIST_0_1\` + \`TASK_VAULT_GET_0_1\` URI constants registered in \`ALL_URIS\`.

### \`vta-service\` changes
- \`AppState\` gains \`vault_ks: KeyspaceHandle\` (encrypted at rest, opened in all three init paths).
- New dispatcher slice \`routes/trust_tasks/vault.rs\` with \`handle_list\` + \`handle_get\`.
  - Auth: derived \`VaultRead\` capability (Admin/Initiator/Application/Reader pass; Monitor denied).
  - Context scoping: explicit \`contextId\` filter rejected if outside caller's \`allowed_contexts\`; implicit-all-contexts queries narrowed to caller's scope.
  - Filters: \`contextId\`, \`targetOriginPrefix\`, \`targetDid\`, \`targetIosBundleId\`, \`targetAndroidPackage\`, \`secretKind\`, \`tag\`, \`usedSince\`, \`neverUsed\` (mutually exclusive with \`usedSince\`), \`expiresBefore\`, \`breached\`.
  - Pagination: single-page in M1 (\`pageSize\` truncation; cursor accepted but ignored).
- All existing \`AclEntry\` literals updated for the three new fields.

## Pairs with

- [trust-tasks-tf #43](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/43) — the canonical schemas this handler implements.
- M1.6 plugin-side vault-list UI in pnm-browser-plugin (separate PR; needs a browser test).

## Test plan

- [x] \`cargo check\` clean (only pre-existing unrelated warnings).
- [x] \`cargo test -p vti-common --lib\` → **176 passed** (3 new vault tests).
- [x] \`cargo test -p vta-service --lib\` → **456 passed** including \`dispatcher_handles_every_vta_sdk_uri\` parity test.
- [ ] End-to-end via the plugin vault-list UI (M1.6, separate PR).
- [ ] Manual REST round-trip with a hand-seeded entry once M1.6 is in place.