### PR TITLE
feat(vault): M2A storage refactor + URI scaffolding for upsert/delete/release

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -255,6 +255,20 @@ pub const TASK_VAULT_LIST_0_1: &str = "https://trusttasks.org/spec/vault/list/0.
 /// id. Same auth as vault/list.
 pub const TASK_VAULT_GET_0_1: &str = "https://trusttasks.org/spec/vault/get/0.1";
 
+/// `spec/vault/upsert/0.1` — create a new vault entry or update an
+/// existing one. Secret material rides inside a pluggable cipher
+/// envelope (see vault/_shared/0.1/sealed-envelope). Auth: VaultWrite.
+pub const TASK_VAULT_UPSERT_0_1: &str = "https://trusttasks.org/spec/vault/upsert/0.1";
+
+/// `spec/vault/delete/0.1` — tombstone an entry with a maintainer-defined
+/// grace window. Auth: VaultWrite.
+pub const TASK_VAULT_DELETE_0_1: &str = "https://trusttasks.org/spec/vault/delete/0.1";
+
+/// `spec/vault/release/0.1` — release the cleartext secret material of an
+/// entry inside a pluggable cipher envelope sealed to the requesting
+/// consumer. Auth: FillRelease.
+pub const TASK_VAULT_RELEASE_0_1: &str = "https://trusttasks.org/spec/vault/release/0.1";
+
 // ─── Config slice (spec/vta/config/*) ────────────────────────────────────
 
 /// `spec/vta/config/get/1.0` — read the current VTA configuration
@@ -683,6 +697,9 @@ pub const ALL_URIS: &[&str] = &[
     // Vault slice (public 0.1 spec)
     TASK_VAULT_LIST_0_1,
     TASK_VAULT_GET_0_1,
+    TASK_VAULT_UPSERT_0_1,
+    TASK_VAULT_DELETE_0_1,
+    TASK_VAULT_RELEASE_0_1,
     // Config slice
     TASK_CONFIG_GET_1_0,
     TASK_CONFIG_UPDATE_1_0,

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -337,6 +337,11 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         // ─── Vault slice (public 0.1 spec) ──────────────────────────
         vta_sdk::trust_tasks::TASK_VAULT_LIST_0_1 => vault::handle_list(state, auth, doc).await,
         vta_sdk::trust_tasks::TASK_VAULT_GET_0_1 => vault::handle_get(state, auth, doc).await,
+        vta_sdk::trust_tasks::TASK_VAULT_UPSERT_0_1 => vault::handle_upsert(state, auth, doc).await,
+        vta_sdk::trust_tasks::TASK_VAULT_DELETE_0_1 => vault::handle_delete(state, auth, doc).await,
+        vta_sdk::trust_tasks::TASK_VAULT_RELEASE_0_1 => {
+            vault::handle_release(state, auth, doc).await
+        }
         // ─── Config slice ────────────────────────────────────────────
         vta_sdk::trust_tasks::TASK_CONFIG_GET_1_0 => config::handle_get(state, auth, doc).await,
         vta_sdk::trust_tasks::TASK_CONFIG_UPDATE_1_0 => {

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -24,7 +24,9 @@ use crate::auth::AuthClaims;
 use crate::error::AppError;
 use crate::server::AppState;
 
-use super::helpers::{app_error_to_reject, parse_payload, reject_with, success_response};
+use super::helpers::{
+    app_error_to_reject, not_implemented_yet, parse_payload, reject_with, success_response,
+};
 use trust_tasks_rs::RejectReason;
 
 /// URIs handled by this slice. Aggregated by the dispatcher's parity
@@ -33,6 +35,9 @@ use trust_tasks_rs::RejectReason;
 pub(super) const DISPATCHED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_VAULT_LIST_0_1,
     vta_sdk::trust_tasks::TASK_VAULT_GET_0_1,
+    vta_sdk::trust_tasks::TASK_VAULT_UPSERT_0_1,
+    vta_sdk::trust_tasks::TASK_VAULT_DELETE_0_1,
+    vta_sdk::trust_tasks::TASK_VAULT_RELEASE_0_1,
 ];
 
 /// Request body for `vault/list/0.1`. Mirrors the canonical
@@ -244,6 +249,46 @@ pub(super) async fn handle_get(
             entry,
             redacted_fields: None,
         },
+    )
+}
+
+/// Handler stub for `spec/vault/upsert/0.1` — wired into the dispatcher
+/// but returns `task_failed: not yet implemented` until M2A.1 lands the
+/// real body. The URI is in the parity harness so a client that POSTs
+/// `vault/upsert/0.1` gets a clear maintainer-defined rejection rather
+/// than `unsupported_type`.
+pub(super) async fn handle_upsert(
+    _state: &AppState,
+    _auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    not_implemented_yet(
+        doc,
+        "vault/upsert/0.1: handler not yet implemented — M2A.1 lands the sealed-envelope unsealing + persist path",
+    )
+}
+
+/// Handler stub for `spec/vault/delete/0.1` — see `handle_upsert`.
+pub(super) async fn handle_delete(
+    _state: &AppState,
+    _auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    not_implemented_yet(
+        doc,
+        "vault/delete/0.1: handler not yet implemented — M2A.2 lands the tombstone path",
+    )
+}
+
+/// Handler stub for `spec/vault/release/0.1` — see `handle_upsert`.
+pub(super) async fn handle_release(
+    _state: &AppState,
+    _auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    not_implemented_yet(
+        doc,
+        "vault/release/0.1: handler not yet implemented — M2A.3 lands the seal-to-consumer path",
     )
 }
 

--- a/vta-service/src/vault_cli.rs
+++ b/vta-service/src/vault_cli.rs
@@ -12,7 +12,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use vti_common::vault::{SecretKind, SiteTarget, VaultEntry, get_vault_entry, put_vault_entry};
+use vti_common::vault::{
+    SecretKind, SiteTarget, StoredVaultEntry, VaultEntry, VaultSecret, get_vault_entry,
+    put_stored_vault_entry,
+};
 
 use crate::config::AppConfig;
 use crate::store::Store;
@@ -41,22 +44,24 @@ pub async fn run_vault_seed(args: VaultSeedArgs) -> Result<(), Box<dyn std::erro
     let store = Store::open(&config.store)?;
     let vault_ks = store.keyspace("vault")?;
 
-    let entries: Vec<VaultEntry> = match (&args.entries_file, &args.context) {
-        (Some(path), _) => load_entries_from_file(path)?,
-        (None, Some(ctx)) => demo_entries(ctx),
+    let records: Vec<StoredVaultEntry> = match (&args.entries_file, &args.context) {
+        (Some(path), _) => load_records_from_file(path)?,
+        (None, Some(ctx)) => demo_records(ctx),
         (None, None) => {
             return Err("either --entries-file <path> or --context <id> is required".into());
         }
     };
 
-    if entries.is_empty() {
+    if records.is_empty() {
         eprintln!("No entries to seed.");
         return Ok(());
     }
 
-    // Validate all entries up front before touching the store — this is the
-    // bulk operation where partial failures would be the most confusing.
-    for (i, e) in entries.iter().enumerate() {
+    // Validate every record up front — bulk operations with partial failure
+    // are confusing. Cheap structural checks + the SecretKind ↔ secret.kind()
+    // invariant (entries-from-JSON could violate this; demo entries can't).
+    for (i, r) in records.iter().enumerate() {
+        let e = &r.entry;
         if e.id.is_empty() {
             return Err(format!("entry {i}: id is empty").into());
         }
@@ -68,6 +73,15 @@ pub async fn run_vault_seed(args: VaultSeedArgs) -> Result<(), Box<dyn std::erro
         }
         if e.label.is_empty() {
             return Err(format!("entry {i} ({}): label is empty", e.id).into());
+        }
+        if !r.secret.matches_kind(e.secret_kind) {
+            return Err(format!(
+                "entry {i} ({}): secretKind {:?} does not match secret variant {:?}",
+                e.id,
+                e.secret_kind,
+                r.secret.kind()
+            )
+            .into());
         }
         if !args.force
             && let Some(existing) = get_vault_entry(&vault_ks, &e.id).await?
@@ -81,121 +95,149 @@ pub async fn run_vault_seed(args: VaultSeedArgs) -> Result<(), Box<dyn std::erro
     }
 
     if args.dry_run {
-        eprintln!("[dry-run] would seed {} entries:", entries.len());
-        for e in &entries {
+        eprintln!("[dry-run] would seed {} entries:", records.len());
+        for r in &records {
             eprintln!(
                 "  {} — {} ({})",
-                e.id,
-                e.label,
-                secret_kind_label(e.secret_kind)
+                r.entry.id,
+                r.entry.label,
+                secret_kind_label(r.entry.secret_kind)
             );
         }
         return Ok(());
     }
 
-    for e in &entries {
-        put_vault_entry(&vault_ks, e).await?;
-        eprintln!("seeded: {} ({})", e.label, e.id);
+    for r in &records {
+        put_stored_vault_entry(&vault_ks, r).await?;
+        eprintln!("seeded: {} ({})", r.entry.label, r.entry.id);
     }
     store.persist().await?;
 
     eprintln!();
-    eprintln!("Seeded {} vault entries.", entries.len());
+    eprintln!("Seeded {} vault entries.", records.len());
     eprintln!("Restart the VTA daemon, then click \"Load entries\" in the wallet popup.");
     Ok(())
 }
 
-fn load_entries_from_file(path: &Path) -> Result<Vec<VaultEntry>, Box<dyn std::error::Error>> {
+fn load_records_from_file(
+    path: &Path,
+) -> Result<Vec<StoredVaultEntry>, Box<dyn std::error::Error>> {
     let bytes = fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
-    let entries: Vec<VaultEntry> = serde_json::from_slice(&bytes)
-        .map_err(|e| format!("parse {} as VaultEntry[]: {e}", path.display()))?;
-    Ok(entries)
+    let records: Vec<StoredVaultEntry> = serde_json::from_slice(&bytes)
+        .map_err(|e| format!("parse {} as StoredVaultEntry[]: {e}", path.display()))?;
+    Ok(records)
 }
 
 /// Built-in demo set — three entries that exercise every visible-in-UI
 /// field of the metadata view (multiple targets including iOS, breach flag,
-/// never-used entry, custom selectors, tags).
-fn demo_entries(context_id: &str) -> Vec<VaultEntry> {
+/// never-used entry, custom selectors, tags). Each carries a placeholder
+/// secret so the StoredVaultEntry shape is well-formed; real credentials
+/// arrive via vault/upsert/0.1 from the wallet.
+fn demo_records(context_id: &str) -> Vec<StoredVaultEntry> {
     let now = chrono::Utc::now().to_rfc3339();
     let stamp = stamp_suffix();
+    let placeholder_password = || VaultSecret::Password {
+        username: Some("demo".into()),
+        password: "PLACEHOLDER-replace-via-vault/upsert/0.1".into(),
+        totp: None,
+        secure_notes: None,
+        custom_fields: Vec::new(),
+    };
+    let placeholder_passkey = || VaultSecret::Passkey {
+        credential_id: "DEMO-credential-id".into(),
+        private_key: "DEMO-private-key".into(),
+        algorithm: Some("EdDSA".into()),
+        rp_id: "github.com".into(),
+        user_handle: Some("DEMO-user-handle".into()),
+        secure_notes: None,
+    };
     vec![
-        VaultEntry {
-            id: format!("vault_demo_github_{stamp}"),
-            context_id: context_id.into(),
-            targets: vec![
-                SiteTarget::WebOrigin {
-                    origin: "https://github.com".into(),
-                },
-                SiteTarget::IosApp {
-                    bundle_id: "com.github.stwalkerster.codehub".into(),
-                    team_id: Some("VEKTX9H2N7".into()),
-                },
-            ],
-            label: "Work GitHub".into(),
-            secret_kind: SecretKind::Passkey,
-            tags: vec!["work".into(), "engineering".into()],
-            notes: None,
-            favicon: None,
-            selectors: vec!["recent_uv_required".into()],
-            custom_field_names: vec![],
-            attachments: vec![],
-            expires_at: None,
-            breached_at: None,
-            password_changed_at: None,
-            created_at: now.clone(),
-            created_by: Some("cli:vault-seed".into()),
-            updated_at: now.clone(),
-            updated_by: None,
-            last_used_at: Some("2026-05-25T22:11:00Z".into()),
-            version: 1,
+        StoredVaultEntry {
+            entry: VaultEntry {
+                id: format!("vault_demo_github_{stamp}"),
+                context_id: context_id.into(),
+                targets: vec![
+                    SiteTarget::WebOrigin {
+                        origin: "https://github.com".into(),
+                    },
+                    SiteTarget::IosApp {
+                        bundle_id: "com.github.stwalkerster.codehub".into(),
+                        team_id: Some("VEKTX9H2N7".into()),
+                    },
+                ],
+                label: "Work GitHub".into(),
+                secret_kind: SecretKind::Passkey,
+                tags: vec!["work".into(), "engineering".into()],
+                notes: None,
+                favicon: None,
+                selectors: vec!["recent_uv_required".into()],
+                custom_field_names: vec![],
+                attachments: vec![],
+                expires_at: None,
+                breached_at: None,
+                password_changed_at: None,
+                created_at: now.clone(),
+                created_by: Some("cli:vault-seed".into()),
+                updated_at: now.clone(),
+                updated_by: None,
+                last_used_at: Some("2026-05-25T22:11:00Z".into()),
+                version: 1,
+            },
+            secret: placeholder_passkey(),
         },
-        VaultEntry {
-            id: format!("vault_demo_aws_{stamp}"),
-            context_id: context_id.into(),
-            targets: vec![SiteTarget::WebOrigin {
-                origin: "https://aws.amazon.com".into(),
-            }],
-            label: "Work AWS — root".into(),
-            secret_kind: SecretKind::Password,
-            tags: vec!["work".into(), "high-value".into()],
-            notes: Some("Recovery email: ops@example.com".into()),
-            favicon: None,
-            selectors: vec!["step_up_push".into()],
-            custom_field_names: vec![],
-            attachments: vec![],
-            expires_at: None,
-            breached_at: Some("2026-04-22T00:00:00Z".into()),
-            password_changed_at: Some("2026-05-01T08:00:00Z".into()),
-            created_at: now.clone(),
-            created_by: Some("cli:vault-seed".into()),
-            updated_at: now.clone(),
-            updated_by: None,
-            last_used_at: Some(now.clone()),
-            version: 1,
+        StoredVaultEntry {
+            entry: VaultEntry {
+                id: format!("vault_demo_aws_{stamp}"),
+                context_id: context_id.into(),
+                targets: vec![SiteTarget::WebOrigin {
+                    origin: "https://aws.amazon.com".into(),
+                }],
+                label: "Work AWS — root".into(),
+                secret_kind: SecretKind::Password,
+                tags: vec!["work".into(), "high-value".into()],
+                notes: Some("Recovery email: ops@example.com".into()),
+                favicon: None,
+                selectors: vec!["step_up_push".into()],
+                custom_field_names: vec![],
+                attachments: vec![],
+                expires_at: None,
+                breached_at: Some("2026-04-22T00:00:00Z".into()),
+                password_changed_at: Some("2026-05-01T08:00:00Z".into()),
+                created_at: now.clone(),
+                created_by: Some("cli:vault-seed".into()),
+                updated_at: now.clone(),
+                updated_by: None,
+                last_used_at: Some(now.clone()),
+                version: 1,
+            },
+            secret: placeholder_password(),
         },
-        VaultEntry {
-            id: format!("vault_demo_hn_{stamp}"),
-            context_id: context_id.into(),
-            targets: vec![SiteTarget::WebOrigin {
-                origin: "https://news.ycombinator.com".into(),
-            }],
-            label: "Hacker News".into(),
-            secret_kind: SecretKind::Password,
-            tags: vec!["personal".into()],
-            notes: None,
-            favicon: None,
-            selectors: vec![],
-            custom_field_names: vec![],
-            attachments: vec![],
-            expires_at: None,
-            breached_at: None,
-            password_changed_at: None,
-            created_at: now.clone(),
-            created_by: Some("cli:vault-seed".into()),
-            updated_at: now,
-            updated_by: None,
-            last_used_at: None,
-            version: 1,
+        StoredVaultEntry {
+            entry: VaultEntry {
+                id: format!("vault_demo_hn_{stamp}"),
+                context_id: context_id.into(),
+                targets: vec![SiteTarget::WebOrigin {
+                    origin: "https://news.ycombinator.com".into(),
+                }],
+                label: "Hacker News".into(),
+                secret_kind: SecretKind::Password,
+                tags: vec!["personal".into()],
+                notes: None,
+                favicon: None,
+                selectors: vec![],
+                custom_field_names: vec![],
+                attachments: vec![],
+                expires_at: None,
+                breached_at: None,
+                password_changed_at: None,
+                created_at: now.clone(),
+                created_by: Some("cli:vault-seed".into()),
+                updated_at: now,
+                updated_by: None,
+                last_used_at: None,
+                version: 1,
+            },
+            secret: placeholder_password(),
         },
     ]
 }

--- a/vti-common/src/vault/mod.rs
+++ b/vti-common/src/vault/mod.rs
@@ -156,39 +156,241 @@ pub struct VaultListFilter<'a> {
     pub breached: Option<bool>,
 }
 
+/// Full record persisted in the `vault:` keyspace. `VaultEntry` is the
+/// metadata projection that ships on the wire via vault/list/0.1 and
+/// vault/get/0.1; the cleartext secret material lives ONLY inside this
+/// stored form and crosses the wire only via vault/release/0.1's pluggable
+/// `sealedSecret` envelope.
+///
+/// Encrypted at rest via the keyspace's transparent AES-256-GCM wrapper
+/// when `storage_encryption_key` is configured (TEE deployments). In
+/// local-dev / non-TEE mode the secret is plaintext on disk — same threat
+/// model as every other secret-bearing keyspace today (the OS account
+/// running the daemon is the security boundary).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredVaultEntry {
+    /// Metadata view — the only half that ships on the wire by default.
+    pub entry: VaultEntry,
+    /// Cleartext secret material. Per the canonical
+    /// `vault/_shared/0.1/vault-secret` shared schema.
+    pub secret: VaultSecret,
+}
+
+/// Cleartext secret material. Field-for-field mirror of
+/// [`vault/_shared/0.1/vault-secret#/$defs/VaultSecret`](https://trusttasks.org/spec/vault/_shared/0.1/vault-secret).
+/// Discriminated by `kind`; wire values are kebab-case per the canonical
+/// schema (`oauth-tokens`, `did-self-issued`, `didcomm-peer`,
+/// `bearer-token`, `ssh-key`).
+///
+/// Sensitive fields (`password`, `private_key`, `refresh_token`,
+/// `secure_notes`, `token`, etc.) MUST be zeroised by handlers as soon as
+/// their use is complete; this enum derives `Debug` for diagnostic
+/// convenience but production logs MUST NOT format `VaultSecret` via
+/// `{:?}` — the strings would leak straight in.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum VaultSecret {
+    Password {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        username: Option<String>,
+        password: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        totp: Option<TotpSeed>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secure_notes: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        custom_fields: Vec<CustomField>,
+    },
+    Passkey {
+        credential_id: String,
+        private_key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        algorithm: Option<String>,
+        rp_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        user_handle: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secure_notes: Option<String>,
+    },
+    OauthTokens {
+        provider: String,
+        refresh_token: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        access_token: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        access_token_expires_at: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        scopes: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secure_notes: Option<String>,
+    },
+    DidSelfIssued {
+        did: String,
+        signing_key_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secure_notes: Option<String>,
+    },
+    DidcommPeer {
+        peer_did: String,
+        signing_key_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secure_notes: Option<String>,
+    },
+    BearerToken {
+        token: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        header_name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        header_prefix: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secure_notes: Option<String>,
+    },
+    SshKey {
+        private_key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        public_key: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        comment: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        passphrase: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secure_notes: Option<String>,
+    },
+    Custom {
+        fields: Vec<CustomField>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secure_notes: Option<String>,
+    },
+}
+
+impl VaultSecret {
+    /// Returns the [`SecretKind`] that matches this variant. The metadata
+    /// view's `secret_kind` field MUST equal this on every persisted
+    /// `StoredVaultEntry`; an inconsistency is a programming error and
+    /// callers can use [`VaultSecret::matches_kind`] to assert at the
+    /// upsert / release boundary.
+    pub fn kind(&self) -> SecretKind {
+        match self {
+            VaultSecret::Password { .. } => SecretKind::Password,
+            VaultSecret::Passkey { .. } => SecretKind::Passkey,
+            VaultSecret::OauthTokens { .. } => SecretKind::OauthTokens,
+            VaultSecret::DidSelfIssued { .. } => SecretKind::DidSelfIssued,
+            VaultSecret::DidcommPeer { .. } => SecretKind::DidcommPeer,
+            VaultSecret::BearerToken { .. } => SecretKind::BearerToken,
+            VaultSecret::SshKey { .. } => SecretKind::SshKey,
+            VaultSecret::Custom { .. } => SecretKind::Custom,
+        }
+    }
+
+    /// Convenience: assert that this secret's variant matches `expected`.
+    /// Used by handler code to fail loudly when the metadata view's
+    /// `secret_kind` disagrees with the unsealed secret's discriminator.
+    pub fn matches_kind(&self, expected: SecretKind) -> bool {
+        self.kind() == expected
+    }
+}
+
+/// RFC 6238 TOTP seed for entries that pair a TOTP with a password.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TotpSeed {
+    /// Base32 (RFC 4648) shared secret.
+    pub secret: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub algorithm: Option<TotpAlgorithm>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digits: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub period: Option<u16>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TotpAlgorithm {
+    #[serde(rename = "SHA1")]
+    Sha1,
+    #[serde(rename = "SHA256")]
+    Sha256,
+    #[serde(rename = "SHA512")]
+    Sha512,
+}
+
+/// Free-form user-defined field on Password / Custom variants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomField {
+    pub name: String,
+    pub value: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hidden: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<CustomFieldKind>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CustomFieldKind {
+    Text,
+    Url,
+    Email,
+    Phone,
+    Number,
+    Date,
+}
+
 /// Storage key for a vault entry — `"vault:<id>"`. Prefix scans on
 /// `"vault:"` enumerate every entry in this VTA's keyspace.
 fn vault_key(id: &str) -> String {
     format!("vault:{id}")
 }
 
-/// Read a single vault entry by id. Returns `Ok(None)` for absent ids so
-/// callers can map to a not_found / permission_denied response per their
-/// enumeration-resistance policy.
+/// Read a single vault entry's metadata view by id. Returns `Ok(None)`
+/// for absent ids so callers can map to a not_found / permission_denied
+/// response per their enumeration-resistance policy. Skips the secret —
+/// use [`get_stored_vault_entry`] when the secret bytes are needed
+/// (vault/release/0.1's handler is the only caller in M2A).
 pub async fn get_vault_entry(
     vault: &KeyspaceHandle,
     id: &str,
 ) -> Result<Option<VaultEntry>, AppError> {
+    Ok(get_stored_vault_entry(vault, id).await?.map(|s| s.entry))
+}
+
+/// Read the full stored record (metadata + secret) by id. Use sparingly —
+/// only the release handler and admin tooling have a legitimate need for
+/// the secret bytes. All other reads go through [`get_vault_entry`].
+pub async fn get_stored_vault_entry(
+    vault: &KeyspaceHandle,
+    id: &str,
+) -> Result<Option<StoredVaultEntry>, AppError> {
     vault.get(vault_key(id)).await
 }
 
-/// Store (create or overwrite) a vault entry. Unconditional write — version
-/// checks are the caller's responsibility (the upsert handler will gain a
-/// `If-Match`-style ETag in M2).
-pub async fn put_vault_entry(vault: &KeyspaceHandle, entry: &VaultEntry) -> Result<(), AppError> {
-    vault.insert(vault_key(&entry.id), entry).await
+/// Store (create or overwrite) a full vault record. Unconditional write —
+/// version + optimistic-concurrency checks are the caller's responsibility
+/// (the upsert handler implements them).
+pub async fn put_stored_vault_entry(
+    vault: &KeyspaceHandle,
+    record: &StoredVaultEntry,
+) -> Result<(), AppError> {
+    debug_assert!(
+        record.secret.matches_kind(record.entry.secret_kind),
+        "StoredVaultEntry mismatch: entry.secret_kind={:?} but secret.kind()={:?}",
+        record.entry.secret_kind,
+        record.secret.kind()
+    );
+    vault.insert(vault_key(&record.entry.id), record).await
 }
 
 /// Delete a vault entry by id. Use the upcoming `vault/delete/0.1` handler
-/// (M2) for the tombstone-aware path; this helper exists for tests and
+/// (M2A) for the tombstone-aware path; this helper exists for tests and
 /// administrative scripts.
 pub async fn delete_vault_entry(vault: &KeyspaceHandle, id: &str) -> Result<(), AppError> {
     vault.remove(vault_key(id)).await
 }
 
 /// List vault entries matching `filter`, ordered by `last_used_at`
-/// descending (entries without `last_used_at` sort last). Pagination is
-/// caller-applied; this helper returns the full filtered set.
+/// descending (entries without `last_used_at` sort last). Returns the
+/// metadata projection only — secrets stay in the keyspace.
 pub async fn list_vault_entries(
     vault: &KeyspaceHandle,
     filter: &VaultListFilter<'_>,
@@ -196,11 +398,11 @@ pub async fn list_vault_entries(
     let raw = vault.prefix_iter_raw("vault:").await?;
     let mut out = Vec::with_capacity(raw.len());
     for (_, bytes) in raw {
-        let entry: VaultEntry = serde_json::from_slice(&bytes)?;
-        if !matches_filter(&entry, filter) {
+        let stored: StoredVaultEntry = serde_json::from_slice(&bytes)?;
+        if !matches_filter(&stored.entry, filter) {
             continue;
         }
-        out.push(entry);
+        out.push(stored.entry);
     }
     out.sort_by(|a, b| {
         // Most-recently-used first; absent last_used_at sorts last.


### PR DESCRIPTION
## Summary

Spec-first prereq for the M2A handler bodies — server-side scaffolding ready to receive the three new vault tasks (\`vault/upsert/0.1\`, \`vault/delete/0.1\`, \`vault/release/0.1\`) per the canonical schemas merged in [trustoverip/dtgwg-trust-tasks-tf#44](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/44).

### \`vti-common::vault\` — new storage shape
- **\`StoredVaultEntry { entry, secret }\`** is what now lives in the \`vault:\` keyspace. \`VaultEntry\` stays as the on-the-wire metadata projection for vault/list + vault/get; the secret only crosses the wire via vault/release/0.1's pluggable cipher envelope.
- **\`VaultSecret\`** tagged-union matching the canonical \`vault/_shared/0.1/vault-secret\` schema field-for-field — \`Password\` / \`Passkey\` / \`OauthTokens\` / \`DidSelfIssued\` / \`DidcommPeer\` / \`BearerToken\` / \`SshKey\` / \`Custom\`. Plus \`TotpSeed\` + \`CustomField\` sub-types.
- Old \`put_vault_entry(VaultEntry)\` replaced by \`put_stored_vault_entry(StoredVaultEntry)\`. New \`get_stored_vault_entry\` returns the full record; \`get_vault_entry\` keeps the metadata-only projection for list/get.
- \`VaultSecret::kind()\` + \`matches_kind()\` invariant — the entry's \`secret_kind\` discriminator must equal the secret variant; debug-asserted at put-time.

### \`vta-sdk::trust_tasks\` — new URI constants
- \`TASK_VAULT_UPSERT_0_1\`, \`TASK_VAULT_DELETE_0_1\`, \`TASK_VAULT_RELEASE_0_1\` added; all three in \`ALL_URIS\`.

### \`vta-service::routes::trust_tasks::vault\` — stub handlers
Stubs return \`task_failed: not yet implemented — M2A.{1,2,3} lands the …\`. The URIs are wired into the dispatcher + the slice's \`DISPATCHED_URIS\` so the parity test passes and clients posting these tasks get a clear maintainer-defined reject rather than the framework's generic \`unsupported_type\`.

### \`vault_cli\` (seed command) — migrated
- Now produces \`StoredVaultEntry\` records (\`put_stored_vault_entry\`). The demo set carries placeholder secrets ("\`PLACEHOLDER-replace-via-vault/upsert/0.1\`") so the storage shape is well-formed.
- \`--entries-file\` parses as \`StoredVaultEntry[]\` (entry + secret).

## Test plan

- [x] \`cargo check -p vti-common -p vta-sdk -p vta-service\` — clean (only pre-existing unrelated warnings).
- [x] \`cargo test -p vti-common --lib\` — 180/180 pass.
- [x] \`cargo test -p vta-service --lib\` — 463/463 pass including the dispatcher parity test that asserts every \`ALL_URIS\` entry has a handler arm.
- [ ] Manual: post a \`vault/upsert/0.1\` envelope to a deployed VTA, confirm it returns the maintainer-defined "not yet implemented" reject (validates that the URI is reachable + the dispatcher routes it).

## What's next

Three small focused PRs to follow, one per handler:
- **M2A.1** — \`handle_upsert\` body: unseal the DIDComm-authcrypt sealedSecret, validate VaultSecret discriminator, persist StoredVaultEntry with optimistic-concurrency.
- **M2A.2** — \`handle_delete\` body: tombstone with grace-window.
- **M2A.3** — \`handle_release\` body: authcrypt the stored secret to the requesting consumer's keyAgreement key.

After that, plugin client + UI as M2A.5/6/7.

## Version bumps

None. \`vta-sdk\` + \`vti-common\` both still at 0.8.0 (published 0.7.0 → at cap).