### PR TITLE
feat(vault): M2B.2a scaffolding — proxy-login URI + SessionBlob + stub

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -269,6 +269,14 @@ pub const TASK_VAULT_DELETE_0_1: &str = "https://trusttasks.org/spec/vault/delet
 /// consumer. Auth: FillRelease.
 pub const TASK_VAULT_RELEASE_0_1: &str = "https://trusttasks.org/spec/vault/release/0.1";
 
+/// `spec/vault/proxy-login/0.1` — the VTA performs an authentication at
+/// the third-party site on the holder's behalf using the entry's secret
+/// material and returns a SessionBlob (cookies + headers + optional
+/// localStorage) wrapped in a pluggable cipher envelope sealed to the
+/// requesting consumer. The long-term credential never leaves the VTA.
+/// Auth: ProxyLogin.
+pub const TASK_VAULT_PROXY_LOGIN_0_1: &str = "https://trusttasks.org/spec/vault/proxy-login/0.1";
+
 // ─── Config slice (spec/vta/config/*) ────────────────────────────────────
 
 /// `spec/vta/config/get/1.0` — read the current VTA configuration
@@ -700,6 +708,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_VAULT_UPSERT_0_1,
     TASK_VAULT_DELETE_0_1,
     TASK_VAULT_RELEASE_0_1,
+    TASK_VAULT_PROXY_LOGIN_0_1,
     // Config slice
     TASK_CONFIG_GET_1_0,
     TASK_CONFIG_UPDATE_1_0,

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -342,6 +342,9 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         vta_sdk::trust_tasks::TASK_VAULT_RELEASE_0_1 => {
             vault::handle_release(state, auth, doc).await
         }
+        vta_sdk::trust_tasks::TASK_VAULT_PROXY_LOGIN_0_1 => {
+            vault::handle_proxy_login(state, auth, doc).await
+        }
         // ─── Config slice ────────────────────────────────────────────
         vta_sdk::trust_tasks::TASK_CONFIG_GET_1_0 => config::handle_get(state, auth, doc).await,
         vta_sdk::trust_tasks::TASK_CONFIG_UPDATE_1_0 => {

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -40,6 +40,7 @@ pub(super) const DISPATCHED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_VAULT_UPSERT_0_1,
     vta_sdk::trust_tasks::TASK_VAULT_DELETE_0_1,
     vta_sdk::trust_tasks::TASK_VAULT_RELEASE_0_1,
+    vta_sdk::trust_tasks::TASK_VAULT_PROXY_LOGIN_0_1,
 ];
 
 /// Request body for `vault/list/0.1`. Mirrors the canonical
@@ -1031,6 +1032,25 @@ pub(super) async fn handle_release(
             sealed_secret: SealedEnvelopeWire::DidcommAuthcrypt { jwe },
             secret_kind,
             ttl_seconds,
+        },
+    )
+}
+
+/// M2B.2a stub for `spec/vault/proxy-login/0.1`. URI is wired into the
+/// dispatcher so clients posting proxy-login get a clear maintainer-
+/// defined reject rather than `unsupported_type`. The real driver bodies
+/// (DID-self-issued in M2B.2b, Password POST in M2B.5) land as follow-up
+/// PRs against this scaffolding.
+pub(super) async fn handle_proxy_login(
+    _state: &AppState,
+    _auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    reject_with(
+        &doc,
+        RejectReason::TaskFailed {
+            reason: "vault/proxy-login/0.1: handler not yet implemented — M2B.2b lands the DID-self-issued (SIOP) driver, M2B.5 adds Password POST".into(),
+            details: None,
         },
     )
 }

--- a/vti-common/src/vault/mod.rs
+++ b/vti-common/src/vault/mod.rs
@@ -388,6 +388,104 @@ pub async fn delete_vault_entry(vault: &KeyspaceHandle, id: &str) -> Result<(), 
     vault.remove(vault_key(id)).await
 }
 
+// ───────────────────────────────────────────────────────────────────────
+// SessionBlob — the cleartext payload of vault/proxy-login/0.1's sealed
+// response (M2B). Mirrors `vault/_shared/0.1/session-blob` schema field
+// for field. Wallet consumers receive this inside a SealedEnvelope and
+// inject the contents into their browser session for the bound origin.
+//
+// Sensitive fields here are server-managed (the VTA issues the session
+// bytes), so unlike VaultSecret these aren't user-typed — but the
+// `headers[].value` and `cookies[].value` carry bearer tokens / session
+// IDs and MUST be zeroised at TTL by the consumer just like VaultSecret.
+// ───────────────────────────────────────────────────────────────────────
+
+/// Cleartext session material returned by vault/proxy-login/0.1 — the
+/// VTA performs the login at the third party, captures the resulting
+/// session credentials, and ships them in this shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionBlob {
+    /// Maintainer-assigned opaque id for this session — used by future
+    /// `vault/session/{revoke, refresh}/0.1` tasks (post-M2B) to act on
+    /// the session without re-identifying it by content.
+    pub session_id: String,
+    /// RFC 3339. The consumer MUST discard the blob (cookies + headers)
+    /// at this time even if the user hasn't finished interacting.
+    pub expires_at: String,
+    /// Cookies the consumer injects into the bound origin's cookie jar.
+    /// Order is significant for sites that set multiple cookies with the
+    /// same name on different paths.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cookies: Vec<CookieJarEntry>,
+    /// HTTP request headers the consumer attaches to outbound requests
+    /// for the bound origin. Typically `Authorization: Bearer …` for
+    /// the SIOP / OAuth paths.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub headers: Vec<RequestHeader>,
+    /// Optional localStorage entries to set on the origin (SPAs that
+    /// store session material there rather than in cookies).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub local_storage: Vec<StorageEntry>,
+    /// Optional sessionStorage entries to set on the origin.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub session_storage: Vec<StorageEntry>,
+    /// The web origin this session is for. Consumers MUST refuse to
+    /// inject the session into any other origin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bind_origin: Option<String>,
+    /// Refresh policy hint for the consumer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_hint: Option<RefreshHint>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RefreshHint {
+    /// Don't refresh on your own; the maintainer drives renewal.
+    MaintainerOnly,
+    /// Call back to vault/proxy-login when the third party returns 401.
+    On401,
+    /// Pre-emptively refresh shortly before `expiresAt`.
+    BeforeExpiry,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CookieJarEntry {
+    pub name: String,
+    pub value: String,
+    pub domain: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secure: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_only: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub same_site: Option<SameSite>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SameSite {
+    Strict,
+    Lax,
+    None,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestHeader {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageEntry {
+    pub key: String,
+    pub value: String,
+}
+
 /// List vault entries matching `filter`, ordered by `last_used_at`
 /// descending (entries without `last_used_at` sort last). Returns the
 /// metadata projection only — secrets stay in the keyspace.


### PR DESCRIPTION
## Summary

M2B kickoff. Same pattern that worked for M2A.4 (#122): lay down the type + URI surface so the driver bodies land cleanly in focused follow-ups.

### \`vti-common::vault\`

- **\`SessionBlob\`** struct matching the canonical \`vault/_shared/0.1/session-blob\` schema field-for-field — \`sessionId\`, \`expiresAt\`, \`cookies[]\`, \`headers[]\`, \`localStorage[]\`, \`sessionStorage[]\`, \`bindOrigin?\`, \`refreshHint?\`.
- Sub-types: \`CookieJarEntry\` (full Set-Cookie shape with sameSite enum), \`RequestHeader\`, \`StorageEntry\`, \`RefreshHint\` enum (\`maintainer-only\` / \`on-401\` / \`before-expiry\`), \`SameSite\` enum.

### \`vta-sdk::trust_tasks\`

- \`TASK_VAULT_PROXY_LOGIN_0_1\` constant; wired into \`ALL_URIS\`.

### \`vta-service::routes::trust_tasks::vault\`

- Stub \`handle_proxy_login\` → \`task_failed: not yet implemented — M2B.2b lands DID-self-issued (SIOP), M2B.5 adds Password POST\`.
- \`DISPATCHED_URIS\` extended; dispatcher arm wired.

## Why scaffolding-first

M2B is the most complex single milestone in the vault track — site drivers, sealing the SessionBlob via the existing authcrypt machinery, optional cookie injection on the wallet side. Landing the wire surface first means M2B.2b reviewers focus on the SIOP id_token issuance path in isolation, and the wallet-side work (M2B.3) can start in parallel against a known-good URI.

## Test plan

- [x] \`cargo check\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] \`cargo test -p vti-common --lib vault\` — 3/3 (no new tests; existing pass).
- [x] \`cargo test -p vta-service --lib\` — **463/463**, dispatcher parity included.
- [ ] Manual: POST a proxy-login envelope to a deployed VTA, confirm \`task_failed\` with the M2B.2b/M2B.5 message (validates the URI is reachable + the dispatcher routes it).

## What's next

- **M2B.2b** — DID-self-issued (SIOP) driver body.
- **M2B.3** — wallet client + popup "Use" button.
- **M2B.4** — affinidi-webvh-service demo extension.
- **M2B.5** — Password POST driver + cookie injection (after SIOP proven).

## Version bumps

None — at the +1 cap.