### PR TITLE
feat(vault): proxy-login — thread caller nonce into SIOP id_token

### DIFF
--- a/vta-service/src/operations/vault.rs
+++ b/vta-service/src/operations/vault.rs
@@ -68,7 +68,8 @@ pub async fn load_signing_key_by_id(
 /// `did-self-issued` vault entry. Header carries the entry's
 /// `signing_key_id` as `kid`; payload follows SIOP shape with
 /// `iss == sub` (the self-issued DID), `aud` (the relying-party DID or
-/// origin), random `nonce`, server-issued `iat`/`exp`.
+/// origin), `nonce` (caller-supplied verbatim if `Some`, else a fresh
+/// UUIDv4), server-issued `iat`/`exp`.
 ///
 /// Unlike `step_up_approval::build_vta_approval_token` which has
 /// `iss = vta_did, sub = holder_did` (VTA vouches for someone), SIOP
@@ -77,14 +78,20 @@ pub async fn load_signing_key_by_id(
 /// presents the DID as both issuer and subject because the relying
 /// party only knows the DID, not who custodies its keys.
 ///
-/// `nonce` is generated server-side (UUIDv4) — the spec accepts a
-/// client `nonce` claim in `ttlSecondsHint` siblings but for M2B.2b
-/// the wallet doesn't supply one and the maintainer is the authority
-/// on nonce freshness anyway.
+/// **Nonce handling.** Per `vault/proxy-login/0.1` conformance bullet
+/// #5, when the consumer supplies `nonce` the maintainer MUST embed
+/// it verbatim. The canonical use is SIOPv2: the RP's authorization-
+/// request `nonce` MUST appear as the `nonce` claim in the id_token
+/// or the RP's exact-match check fails. We treat the supplied nonce
+/// as opaque — no trimming, canonicalisation, or re-encoding. When
+/// `None`, the maintainer generates a fresh UUIDv4; that path is
+/// appropriate for push-mode flows where the consumer doesn't
+/// pre-fetch a challenge.
 pub fn build_siop_id_token(
     siop_did: &str,
     signing_key_id: &str,
     audience: &str,
+    nonce: Option<&str>,
     iat: u64,
     ttl_secs: u64,
     signing_key: &SigningKey,
@@ -94,11 +101,15 @@ pub fn build_siop_id_token(
         "typ": "JWT",
         "kid": signing_key_id,
     });
+    let nonce_claim = match nonce {
+        Some(n) => n.to_string(),
+        None => uuid::Uuid::new_v4().to_string(),
+    };
     let payload = json!({
         "iss": siop_did,
         "sub": siop_did,
         "aud": audience,
-        "nonce": uuid::Uuid::new_v4().to_string(),
+        "nonce": nonce_claim,
         "iat": iat,
         "exp": iat.saturating_add(ttl_secs),
     });
@@ -134,7 +145,7 @@ mod tests {
         let iat = 1_700_000_000u64;
         let ttl = 300;
 
-        let jws = build_siop_id_token(siop_did, &kid, audience, iat, ttl, &signing_key)
+        let jws = build_siop_id_token(siop_did, &kid, audience, None, iat, ttl, &signing_key)
             .expect("build SIOP id_token");
 
         let parts: Vec<&str> = jws.split('.').collect();
@@ -183,6 +194,7 @@ mod tests {
             "did:webvh:foo",
             "did:webvh:foo#key-0",
             "did:web:rp.example",
+            None,
             1_700_000_000,
             300,
             &signing_key,
@@ -194,6 +206,57 @@ mod tests {
         assert!(
             wrong_key.verify(signing_input.as_bytes(), &sig).is_err(),
             "verification must fail against an unrelated public key"
+        );
+    }
+
+    #[test]
+    fn siop_id_token_embeds_caller_nonce_verbatim() {
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        // Pick a nonce that's NOT a UUID and contains characters the
+        // server might be tempted to canonicalise — verifies we treat
+        // it as opaque per the spec.
+        let nonce = "rp-challenge_5e3f-AB cd~!@#$%^&*()";
+        let jws = build_siop_id_token(
+            "did:webvh:foo",
+            "did:webvh:foo#key-0",
+            "did:web:rp.example",
+            Some(nonce),
+            1_700_000_000,
+            300,
+            &signing_key,
+        )
+        .expect("build SIOP id_token with caller nonce");
+        let parts: Vec<&str> = jws.split('.').collect();
+        let payload_json: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+        assert_eq!(
+            payload_json["nonce"], nonce,
+            "caller-supplied nonce must appear verbatim in the id_token's nonce claim"
+        );
+    }
+
+    #[test]
+    fn siop_id_token_generates_uuid_nonce_when_none_supplied() {
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        let jws = build_siop_id_token(
+            "did:webvh:foo",
+            "did:webvh:foo#key-0",
+            "did:web:rp.example",
+            None,
+            1_700_000_000,
+            300,
+            &signing_key,
+        )
+        .unwrap();
+        let parts: Vec<&str> = jws.split('.').collect();
+        let payload_json: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+        let n = payload_json["nonce"].as_str().expect("nonce is a string");
+        // UUIDv4: 8-4-4-4-12 hex with dashes = 36 chars total.
+        assert_eq!(n.len(), 36, "fallback nonce is a UUIDv4 (36 chars)");
+        assert!(
+            uuid::Uuid::parse_str(n).is_ok(),
+            "fallback nonce parses as a UUID"
         );
     }
 }

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -283,7 +283,10 @@ const PROXY_LOGIN_INNER_MSG_TYPE: &str =
 /// (M3 policy engine will read consumerContext; step-up gating across
 /// the proxy-login flow lands as a follow-up to step-up's release-flow
 /// integration). `ttlSecondsHint` is accepted but capped by the
-/// maintainer.
+/// maintainer. `nonce` (M2B.4) is embedded verbatim in the SIOP
+/// id_token's `nonce` claim — the canonical use is the wallet
+/// threading the RP's `/auth/challenge` value through so the resulting
+/// id_token passes the RP's nonce check.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct VaultProxyLoginBody {
@@ -308,9 +311,24 @@ struct VaultProxyLoginBody {
     #[serde(default)]
     #[allow(dead_code)]
     step_up_proof: Option<Value>,
+    /// Caller-supplied nonce — embedded verbatim as the SIOP id_token's
+    /// `nonce` claim for the `did-self-issued` driver. Drivers without
+    /// a nonce concept (Password POST, OAuth refresh — M2B.5+) ignore.
+    /// Capped to the canonical schema's 512-char ceiling at the parse
+    /// boundary; a longer string would fail JSON-Schema validation
+    /// upstream but we double-check below to keep the SIOP token shape
+    /// sane.
+    #[serde(default)]
+    nonce: Option<String>,
     #[serde(default)]
     ttl_seconds_hint: Option<u32>,
 }
+
+/// Schema-level ceiling for `nonce` per `vault/proxy-login/0.1`. The
+/// canonical payload schema enforces this; we re-check here so a
+/// malformed-but-parseable request still gets a clean reject rather
+/// than a multi-KB JWT.
+const NONCE_MAX_LEN: usize = 512;
 
 /// Response body for `vault/proxy-login/0.1`. The `sealedSessionBlob`
 /// is the same pluggable cipher envelope shape used by `vault/release` —
@@ -1146,6 +1164,24 @@ pub(super) async fn handle_proxy_login(
         Err(resp) => return resp,
     };
 
+    // Defense-in-depth nonce bounds check. The canonical schema
+    // enforces `minLength: 1, maxLength: 512`; this guard handles
+    // requests that bypassed schema validation (e.g. dispatcher
+    // changes that disable schema-first parsing).
+    if let Some(n) = req.nonce.as_deref()
+        && (n.is_empty() || n.len() > NONCE_MAX_LEN)
+    {
+        return reject_with(
+            &doc,
+            RejectReason::MalformedRequest {
+                reason: format!(
+                    "vault/proxy-login: nonce length {} outside [1, {NONCE_MAX_LEN}]",
+                    n.len()
+                ),
+            },
+        );
+    }
+
     // Load entry — conflate not-found with permission-denied to deny
     // enumeration (matches handle_release).
     let mut stored = match get_stored_vault_entry(&state.vault_ks, &req.entry_id).await {
@@ -1282,6 +1318,7 @@ pub(super) async fn handle_proxy_login(
         &siop_did,
         &signing_key_id,
         &audience,
+        req.nonce.as_deref(),
         iat,
         ttl_secs,
         &signing_key,


### PR DESCRIPTION
## Summary

Pick up the optional \`nonce\` field added to \`vault/proxy-login/0.1\` in [trust-tasks-tf #46](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/46). When the consumer supplies it, the SIOP driver embeds the value verbatim as the id_token's \`nonce\` claim — opaque, no canonicalisation. When absent, the maintainer still generates a fresh UUIDv4 (push-mode flows where the consumer doesn't pre-fetch a challenge).

Closes the round-trip gap that blocked the M2B.4 demo: the RP issues a challenge, the wallet threads it through proxy-login, the VTA mints an id_token with that nonce, the RP's exact-match check succeeds.

## Changes

- \`operations::vault::build_siop_id_token\` gains a \`nonce: Option<&str>\` parameter.
- \`routes::trust_tasks::vault::VaultProxyLoginBody\` deserializes \`nonce: Option<String>\`. The handler bounds-checks \`[1, 512]\` chars (defense in depth against schema bypass) and passes it through.

## Test plan

- [x] \`cargo test -p vta-service --lib\` — 473/473 green.
- [x] New tests:
  - \`siop_id_token_embeds_caller_nonce_verbatim\` — uses a non-UUID with shell-escape characters to verify we don't sanitise it.
  - \`siop_id_token_generates_uuid_nonce_when_none_supplied\` — fallback path.
- [x] \`cargo fmt --check\` clean.