### PR TITLE
feat(vault): Password POST driver for vault/proxy-login

### DIFF
--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -115,6 +115,9 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+# Used by the password-POST proxy-login driver to form-encode credentials
+# (operations::vault::password_post). Previously dev-only.
+urlencoding = "2"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 bip39 = "2"
@@ -190,7 +193,6 @@ aws-lc-rs = { version = "1", optional = true }
 [dev-dependencies]
 tempfile = "3"
 http-body-util = "0.1"
-urlencoding = "2"
 # Self-dep with `test-support` enabled so integration tests under
 # `tests/` get the shared `test_support::build_test_app` HTTP scaffolding
 # without each having to copy ~140 LoC of AppState-wiring boilerplate.

--- a/vta-service/src/operations/vault/mod.rs
+++ b/vta-service/src/operations/vault/mod.rs
@@ -22,6 +22,15 @@ use crate::operations::internal_authority::InternalAuthority;
 use crate::store::KeyspaceHandle;
 use vta_sdk::did_key::decode_private_key_multibase;
 
+/// HTTP-POST driver for vault/proxy-login/0.1 against
+/// `VaultSecret::Password` entries with a populated `loginConfig`.
+/// Pulls in `reqwest` + `url`, so it's gated behind `webvh` — every
+/// real consumer of vta-service (local binary + enclave) enables that
+/// feature already, but the gating keeps `cargo check
+/// --no-default-features` honest.
+#[cfg(feature = "webvh")]
+pub mod password_post;
+
 /// Audit channel tag for the internal authority used by
 /// proxy-login key resolution.
 const PROXY_LOGIN_CHANNEL: &str = "vault-proxy-login-internal";

--- a/vta-service/src/operations/vault/password_post.rs
+++ b/vta-service/src/operations/vault/password_post.rs
@@ -1,0 +1,741 @@
+//! Password POST driver for `vault/proxy-login/0.1`.
+//!
+//! When the vault entry's `VaultSecret::Password` carries a
+//! `loginConfig`, the maintainer performs an HTTP POST against
+//! `loginConfig.login_url` with the entry's credentials, captures the
+//! resulting `Set-Cookie` headers, and returns them in the SessionBlob
+//! that the consumer authcrypt-unseals. The long-term password leaves
+//! the VTA only as the body of one outbound HTTPS request — it never
+//! travels back to the consumer.
+//!
+//! Scope (per `vault/_shared/0.1/vault-secret#/$defs/PasswordLoginConfig`):
+//!
+//! - JSON or `application/x-www-form-urlencoded` request body.
+//! - Optional caller-configurable field names (`username`, `password`,
+//!   `totp`); defaults match the most common consumer APIs.
+//! - Optional constant extra fields the site expects.
+//! - Caller-configurable HTTP success status (default `[200, 204]`);
+//!   anything outside the success set maps to `credential_rejected`
+//!   (4xx) or `target_unreachable` (5xx).
+//! - Captured cookies are filtered to the loginUrl's host (defense
+//!   against malicious sites setting cookies for unrelated origins).
+//!
+//! Out of scope for M2B.5 — these need a richer driver (future spec):
+//!
+//! - CSRF tokens fetched in a separate round-trip before the POST.
+//! - Multi-step MFA / 2FA prompts beyond a single TOTP field.
+//! - Anti-bot challenges (Cloudflare, reCAPTCHA, hCaptcha).
+//! - Cookies the maintainer's HTTP client receives during pre-fetch
+//!   (the driver issues exactly one POST and reads `Set-Cookie` from
+//!   that response).
+
+use std::collections::BTreeMap;
+
+use reqwest::header::{CONTENT_TYPE, COOKIE, SET_COOKIE};
+
+use vti_common::vault::{
+    CookieJarEntry, PasswordLoginConfig, PasswordLoginFormat, SameSite, TotpSeed,
+};
+
+use crate::error::AppError;
+
+/// Per-request timeout. Consumer-site login APIs typically respond in
+/// well under a second; 15 s gives us margin for slow links without
+/// letting a misbehaving target hold a worker indefinitely.
+const POST_TIMEOUT_SECS: u64 = 15;
+
+/// Outcome categories for the Password POST driver. Map onto the
+/// canonical `vault/proxy-login/0.1` error codes at the handler
+/// boundary.
+#[derive(Debug, thiserror::Error)]
+pub enum PasswordPostError {
+    /// `loginConfig.login_url` is malformed or unsupported (e.g.
+    /// `http://` against a non-loopback host).
+    #[error("login_url invalid: {0}")]
+    InvalidLoginUrl(String),
+    /// TOTP code was required by config but couldn't be generated
+    /// (e.g. no `TotpSeed` populated, or the algorithm isn't
+    /// implemented yet — TOTP generation lands in a follow-up).
+    #[error("totp generation not supported in this maintainer build: {0}")]
+    TotpNotImplemented(String),
+    /// HTTP-level failure before the response — DNS, connection
+    /// refused, TLS handshake, etc. Maps to `target_unreachable`.
+    #[error("HTTP request to {url} failed: {source}")]
+    Transport {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    /// Server returned a status the loginConfig declared as failure.
+    /// 4xx maps to `credential_rejected`, 5xx maps to
+    /// `target_unreachable`. Body excerpt is captured for diagnostics
+    /// but NEVER logged unredacted (it could echo back parts of the
+    /// credential — sites do varying things on auth failure).
+    #[error("login rejected with HTTP {status}")]
+    NonSuccessStatus { status: u16 },
+    /// Response was 2xx-ish but the body / headers can't be parsed
+    /// (e.g. malformed Set-Cookie). Maps to `target_unreachable` —
+    /// the consumer SHOULD retry; if it keeps failing, the entry's
+    /// loginConfig is probably mis-shaped for this site and the user
+    /// needs to update it.
+    #[error("response parse failure: {0}")]
+    ResponseParse(String),
+}
+
+/// Map a [`PasswordPostError`] to the right `AppError` shape so the
+/// trust-task handler emits the canonical proxy-login error code.
+/// `Transport` and 5xx `NonSuccessStatus` both become
+/// `target_unreachable` (retryable); 4xx becomes `credential_rejected`
+/// (not retryable); everything else is `Internal`.
+impl From<PasswordPostError> for AppError {
+    fn from(value: PasswordPostError) -> Self {
+        match value {
+            PasswordPostError::NonSuccessStatus { status } if (400..500).contains(&status) => {
+                AppError::Validation(format!("vault/proxy-login: credential_rejected ({status})"))
+            }
+            PasswordPostError::NonSuccessStatus { status } => {
+                AppError::Internal(format!("vault/proxy-login: target_unreachable ({status})"))
+            }
+            PasswordPostError::Transport { url, source } => AppError::Internal(format!(
+                "vault/proxy-login: target_unreachable {url}: {source}"
+            )),
+            PasswordPostError::InvalidLoginUrl(msg) => {
+                AppError::Validation(format!("vault/proxy-login: invalid login_url — {msg}"))
+            }
+            PasswordPostError::TotpNotImplemented(msg) => {
+                AppError::Internal(format!("vault/proxy-login: {msg}"))
+            }
+            PasswordPostError::ResponseParse(msg) => {
+                AppError::Internal(format!("vault/proxy-login: response parse — {msg}"))
+            }
+        }
+    }
+}
+
+/// Validate the loginConfig's URL is one we're willing to POST to.
+/// Per the canonical spec, `http://` is permitted only for the
+/// localhost loopback — anywhere else, the credentials would leak in
+/// transit. The check accepts `127.0.0.0/8`, `::1`, and the literal
+/// hostname `localhost`.
+pub fn validate_login_url(login_url: &str) -> Result<url::Url, PasswordPostError> {
+    let url = url::Url::parse(login_url)
+        .map_err(|e| PasswordPostError::InvalidLoginUrl(format!("not a URL: {e}")))?;
+    match url.scheme() {
+        "https" => Ok(url),
+        "http" => {
+            // `url::Url::host_str` strips the IPv6 brackets, but
+            // host_str() returns the inner address — e.g. "::1" for
+            // `http://[::1]:8080/`. Defense in depth: handle both
+            // bracketed and bare in case future url-crate behaviour
+            // changes.
+            let host = url
+                .host_str()
+                .unwrap_or("")
+                .trim_start_matches('[')
+                .trim_end_matches(']');
+            let is_loopback = host == "localhost"
+                || host == "::1"
+                || host.starts_with("127.")
+                || host == "0.0.0.0";
+            if is_loopback {
+                Ok(url)
+            } else {
+                Err(PasswordPostError::InvalidLoginUrl(format!(
+                    "http:// is permitted only for loopback hosts; got {host}"
+                )))
+            }
+        }
+        other => Err(PasswordPostError::InvalidLoginUrl(format!(
+            "unsupported scheme {other}"
+        ))),
+    }
+}
+
+/// Build the request body the driver POSTs to the login URL. Returns
+/// the (Content-Type, serialised body) tuple. JSON uses serde_json's
+/// canonical encoding; form-urlencoded uses `application/x-www-form-
+/// urlencoded` with stable key ordering (BTreeMap iteration).
+pub fn build_request_body(
+    config: &PasswordLoginConfig,
+    username: Option<&str>,
+    password: &str,
+    totp_code: Option<&str>,
+) -> Result<(&'static str, String), PasswordPostError> {
+    // Build the field map in a stable order — sorted by key — so the
+    // wire shape is deterministic. Some sites do simple integrity
+    // checks on body shape; deterministic ordering avoids silent
+    // breakage from BTreeMap-vs-HashMap iteration differences.
+    let mut fields: BTreeMap<String, String> = BTreeMap::new();
+    if let Some(u) = username {
+        fields.insert(config.effective_username_field().to_string(), u.to_string());
+    }
+    fields.insert(
+        config.effective_password_field().to_string(),
+        password.to_string(),
+    );
+    if let Some(field) = config.totp_field.as_deref() {
+        match totp_code {
+            Some(code) => {
+                fields.insert(field.to_string(), code.to_string());
+            }
+            None => {
+                return Err(PasswordPostError::TotpNotImplemented(
+                    "loginConfig.totpField is set but no TOTP seed is available or TOTP \
+                     generation is not yet implemented in this maintainer build"
+                        .into(),
+                ));
+            }
+        }
+    }
+    if let Some(extra) = config.extra_fields.as_ref() {
+        for (k, v) in extra {
+            fields.insert(k.clone(), v.clone());
+        }
+    }
+
+    match config.format {
+        PasswordLoginFormat::Json => {
+            let body = serde_json::to_string(&fields).map_err(|e| {
+                PasswordPostError::ResponseParse(format!("serialise JSON body: {e}"))
+            })?;
+            Ok(("application/json", body))
+        }
+        PasswordLoginFormat::FormUrlencoded => {
+            // Hand-encode rather than pulling in form_urlencoded just
+            // for this — keys + values are utf-8 already.
+            let mut buf = String::new();
+            for (k, v) in &fields {
+                if !buf.is_empty() {
+                    buf.push('&');
+                }
+                buf.push_str(&urlencoding::encode(k));
+                buf.push('=');
+                buf.push_str(&urlencoding::encode(v));
+            }
+            Ok(("application/x-www-form-urlencoded", buf))
+        }
+    }
+}
+
+/// Parse a `Set-Cookie` response-header value into a `CookieJarEntry`.
+/// Spec'd permissively per RFC 6265 §5.2 — unknown attributes are
+/// ignored; missing attributes get the canonical defaults
+/// (`path: "/"`, no `domain` → host-only, no `expires` → session
+/// cookie). Returns `None` if the header doesn't carry a valid
+/// name=value pair.
+///
+/// Domain filtering: when the response's Set-Cookie carries a `Domain`
+/// attribute, the maintainer SHOULD only accept it if the domain is
+/// equal to or a parent of the login URL's host. We enforce this at
+/// the caller (in `run_password_post`), not here — this parser is
+/// shape-only.
+pub fn parse_set_cookie(header: &str) -> Option<CookieJarEntry> {
+    let mut parts = header.split(';').map(str::trim);
+    let nv = parts.next()?;
+    let (name, value) = nv.split_once('=')?;
+    let name = name.trim().to_string();
+    let value = value.trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+
+    let mut domain: Option<String> = None;
+    let mut path: Option<String> = None;
+    let mut expires: Option<String> = None;
+    let mut secure = false;
+    let mut http_only = false;
+    let mut same_site: Option<SameSite> = None;
+
+    for attr in parts {
+        if attr.is_empty() {
+            continue;
+        }
+        let (k, v) = match attr.split_once('=') {
+            Some((k, v)) => (k.trim(), Some(v.trim())),
+            None => (attr.trim(), None),
+        };
+        let kl = k.to_ascii_lowercase();
+        match (kl.as_str(), v) {
+            ("domain", Some(v)) => domain = Some(v.trim_start_matches('.').to_string()),
+            ("path", Some(v)) => path = Some(v.to_string()),
+            ("expires", Some(v)) => expires = Some(v.to_string()),
+            ("max-age", Some(_)) => {} // RFC 6265 Max-Age supersedes Expires but we
+            // forward the cookie unconditionally — the browser
+            // re-derives expiry from whichever attribute is present
+            ("secure", _) => secure = true,
+            ("httponly", _) => http_only = true,
+            ("samesite", Some(v)) => {
+                same_site = match v.to_ascii_lowercase().as_str() {
+                    "strict" => Some(SameSite::Strict),
+                    "lax" => Some(SameSite::Lax),
+                    "none" => Some(SameSite::None),
+                    _ => None,
+                };
+            }
+            _ => {}
+        }
+    }
+
+    Some(CookieJarEntry {
+        name,
+        value,
+        domain: domain.unwrap_or_default(),
+        path: path.unwrap_or_else(|| "/".to_string()),
+        expires,
+        secure: if secure { Some(true) } else { None },
+        http_only: if http_only { Some(true) } else { None },
+        same_site,
+    })
+}
+
+/// True iff `cookie_domain` is the same as or a child of `host`.
+/// RFC 6265 §5.1.3 — a cookie with `Domain=example.com` is sent for
+/// `*.example.com` AND `example.com`. We accept the cookie iff the
+/// cookie's declared domain doesn't *extend* the trust to an
+/// unrelated host. When the cookie has no Domain attribute, it's
+/// host-only — we set `domain = host` for the consumer.
+pub fn cookie_domain_matches(host: &str, cookie_domain: &str) -> bool {
+    if cookie_domain.is_empty() {
+        return true; // host-only — caller fills in `host`
+    }
+    let h = host.trim_start_matches('.').to_ascii_lowercase();
+    let cd = cookie_domain.trim_start_matches('.').to_ascii_lowercase();
+    h == cd || h.ends_with(&format!(".{cd}"))
+}
+
+/// Perform the proxy login. Returns the cookie list the maintainer
+/// should put into the SessionBlob, or a [`PasswordPostError`] that
+/// the caller maps to a canonical Trust Task error code.
+///
+/// TOTP: this driver does NOT yet generate TOTP codes from a
+/// `TotpSeed`. A future patch wires in `totp-lite` (or equivalent)
+/// behind a feature flag. For now, presence of `totpField` in the
+/// config when no TOTP code can be supplied is an error so the user
+/// sees a clear `not_implemented` message rather than a silent
+/// auth-without-TOTP failure at the third party.
+pub async fn run_password_post(
+    config: &PasswordLoginConfig,
+    username: Option<&str>,
+    password: &str,
+    totp: Option<&TotpSeed>,
+) -> Result<Vec<CookieJarEntry>, PasswordPostError> {
+    // 1. Validate URL.
+    let url = validate_login_url(&config.login_url)?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| PasswordPostError::InvalidLoginUrl("URL has no host".into()))?
+        .to_string();
+
+    // 2. TOTP generation — punt unless we explicitly support it.
+    let totp_code: Option<&str> = match (config.totp_field.as_deref(), totp) {
+        (None, _) => None,
+        (Some(_), None) => {
+            return Err(PasswordPostError::TotpNotImplemented(
+                "config.totpField set but entry has no totp seed".into(),
+            ));
+        }
+        (Some(_), Some(_seed)) => {
+            return Err(PasswordPostError::TotpNotImplemented(
+                "TOTP code generation lands in a follow-up patch — use entries without \
+                 loginConfig.totpField for M2B.5"
+                    .into(),
+            ));
+        }
+    };
+
+    // 3. Build body.
+    let (content_type, body) = build_request_body(config, username, password, totp_code)?;
+
+    // 4. POST.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(POST_TIMEOUT_SECS))
+        // No cookie store — we capture cookies from the immediate
+        // response. The maintainer issues exactly one POST; persistent
+        // cookies don't apply to this driver.
+        //
+        // No redirect following — when the loginConfig declares 3xx
+        // statuses (e.g. 302) as success, we want to surface that
+        // response with its Set-Cookie headers, not chase the
+        // Location URL into a logged-in dashboard the maintainer
+        // shouldn't actually fetch (and which would echo bytes back
+        // to the operator). Sites that legitimately need redirect-
+        // following on the login response are an edge case worth a
+        // future driver flag.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| PasswordPostError::Transport {
+            url: url.to_string(),
+            source: e,
+        })?;
+    let resp = client
+        .post(url.clone())
+        .header(CONTENT_TYPE, content_type)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| PasswordPostError::Transport {
+            url: url.to_string(),
+            source: e,
+        })?;
+
+    let status = resp.status().as_u16();
+    let success = config.effective_success_status();
+    if !success.contains(&status) {
+        return Err(PasswordPostError::NonSuccessStatus { status });
+    }
+
+    // 5. Parse Set-Cookie headers. reqwest exposes them via the multi-
+    // valued header iterator — there can be many on one response.
+    let mut cookies = Vec::new();
+    for header_value in resp.headers().get_all(SET_COOKIE).iter() {
+        let raw = header_value
+            .to_str()
+            .map_err(|e| PasswordPostError::ResponseParse(format!("Set-Cookie not utf-8: {e}")))?;
+        let Some(mut cookie) = parse_set_cookie(raw) else {
+            continue;
+        };
+        // Domain filter. If the cookie declared a Domain attribute
+        // that doesn't match the login URL's host, discard it —
+        // defense against a malicious target setting cookies for
+        // unrelated origins.
+        if !cookie.domain.is_empty() && !cookie_domain_matches(&host, &cookie.domain) {
+            tracing::warn!(
+                login_host = %host,
+                cookie_domain = %cookie.domain,
+                cookie_name = %cookie.name,
+                "discarding Set-Cookie whose Domain doesn't match login URL host"
+            );
+            continue;
+        }
+        if cookie.domain.is_empty() {
+            cookie.domain = host.clone();
+        }
+        cookies.push(cookie);
+    }
+
+    // No cookies on a 2xx is suspicious but not fatal — some sites
+    // return 200 with a body-carried token instead. Future drivers
+    // for those cases can extract the token by JSON path; this M2B.5
+    // driver just returns an empty cookie list and the caller decides.
+    Ok(cookies)
+}
+
+// `COOKIE` is imported above for symmetry with `SET_COOKIE`; not used
+// at the moment but lets a follow-up that pre-fetches a CSRF token
+// (and threads it into the POST) compile without re-importing.
+const _: Option<&reqwest::header::HeaderName> = Some(&COOKIE);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_min(url: &str) -> PasswordLoginConfig {
+        PasswordLoginConfig {
+            login_url: url.to_string(),
+            format: PasswordLoginFormat::Json,
+            username_field: None,
+            password_field: None,
+            totp_field: None,
+            extra_fields: None,
+            success_status: None,
+        }
+    }
+
+    #[test]
+    fn validate_login_url_accepts_https() {
+        assert!(validate_login_url("https://example.com/login").is_ok());
+    }
+
+    #[test]
+    fn validate_login_url_accepts_http_to_loopback() {
+        for url in [
+            "http://localhost:3000/login",
+            "http://127.0.0.1/api/login",
+            "http://[::1]:8080/login",
+        ] {
+            assert!(
+                validate_login_url(url).is_ok(),
+                "loopback http should be accepted: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_login_url_rejects_http_to_non_loopback() {
+        let err = validate_login_url("http://example.com/login").unwrap_err();
+        assert!(
+            matches!(err, PasswordPostError::InvalidLoginUrl(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_login_url_rejects_unsupported_scheme() {
+        assert!(matches!(
+            validate_login_url("ftp://example.com/login"),
+            Err(PasswordPostError::InvalidLoginUrl(_))
+        ));
+    }
+
+    #[test]
+    fn build_request_body_json_default_fields() {
+        let (ct, body) = build_request_body(
+            &cfg_min("https://example.com/login"),
+            Some("alice"),
+            "hunter2",
+            None,
+        )
+        .unwrap();
+        assert_eq!(ct, "application/json");
+        // BTreeMap iteration is alphabetical, so the JSON has
+        // deterministic key order: password, username.
+        assert_eq!(body, r#"{"password":"hunter2","username":"alice"}"#);
+    }
+
+    #[test]
+    fn build_request_body_form_urlencoded_with_extras() {
+        let mut config = cfg_min("https://example.com/login");
+        config.format = PasswordLoginFormat::FormUrlencoded;
+        config.username_field = Some("email".into());
+        let mut extras = BTreeMap::new();
+        extras.insert("grantType".to_string(), "password".to_string());
+        config.extra_fields = Some(extras);
+
+        let (ct, body) = build_request_body(&config, Some("a@b.com"), "p ass!", None).unwrap();
+        assert_eq!(ct, "application/x-www-form-urlencoded");
+        // url-encoded — '@' → %40, ' ' → %20 (urlencoding crate), '!' → %21
+        // Alphabetical ordering by key: email, grantType, password.
+        assert_eq!(
+            body,
+            "email=a%40b.com&grantType=password&password=p%20ass%21"
+        );
+    }
+
+    #[test]
+    fn build_request_body_omits_username_when_none() {
+        let (_ct, body) =
+            build_request_body(&cfg_min("https://example.com/login"), None, "secret", None)
+                .unwrap();
+        assert_eq!(body, r#"{"password":"secret"}"#);
+    }
+
+    #[test]
+    fn build_request_body_errors_when_totp_field_set_but_no_code() {
+        let mut config = cfg_min("https://example.com/login");
+        config.totp_field = Some("otp".into());
+        let err = build_request_body(&config, Some("a"), "p", None).unwrap_err();
+        assert!(matches!(err, PasswordPostError::TotpNotImplemented(_)));
+    }
+
+    #[test]
+    fn parse_set_cookie_minimal() {
+        let c = parse_set_cookie("session=abc123").unwrap();
+        assert_eq!(c.name, "session");
+        assert_eq!(c.value, "abc123");
+        assert_eq!(c.path, "/"); // default
+        assert!(c.domain.is_empty()); // caller fills host
+        assert_eq!(c.secure, None);
+        assert_eq!(c.http_only, None);
+    }
+
+    #[test]
+    fn parse_set_cookie_full() {
+        let c = parse_set_cookie(
+            "session=xyz; Domain=.example.com; Path=/api; Secure; HttpOnly; SameSite=Lax; Expires=Wed, 09 Jun 2027 10:18:14 GMT",
+        )
+        .unwrap();
+        assert_eq!(c.name, "session");
+        assert_eq!(c.value, "xyz");
+        assert_eq!(c.domain, "example.com"); // leading dot stripped
+        assert_eq!(c.path, "/api");
+        assert_eq!(c.secure, Some(true));
+        assert_eq!(c.http_only, Some(true));
+        assert_eq!(c.same_site, Some(SameSite::Lax));
+        assert_eq!(c.expires.as_deref(), Some("Wed, 09 Jun 2027 10:18:14 GMT"));
+    }
+
+    #[test]
+    fn parse_set_cookie_rejects_empty_name() {
+        assert!(parse_set_cookie("=abc; Path=/").is_none());
+    }
+
+    #[test]
+    fn cookie_domain_matches_canonical_cases() {
+        // Exact match.
+        assert!(cookie_domain_matches("api.example.com", "api.example.com"));
+        // Parent-domain Set-Cookie applies to subdomain.
+        assert!(cookie_domain_matches("api.example.com", "example.com"));
+        // Unrelated domain.
+        assert!(!cookie_domain_matches("api.example.com", "evil.com"));
+        // Sibling domain (Domain=example.org should NOT match
+        // example.com's subdomain).
+        assert!(!cookie_domain_matches("api.example.com", "example.org"));
+        // Leading dot on the cookie's Domain attribute is permitted.
+        assert!(cookie_domain_matches("api.example.com", ".example.com"));
+        // Case-insensitive.
+        assert!(cookie_domain_matches("API.example.COM", "example.com"));
+        // Empty cookie_domain treated as host-only — match anything;
+        // caller fills the host afterwards.
+        assert!(cookie_domain_matches("anything.example", ""));
+    }
+
+    // ─── HTTP integration tests via wiremock ──────────────────────
+    // Drive the full POST round-trip against a real local server so
+    // the request shape (content-type, body), success-status logic,
+    // and Set-Cookie capture are all exercised together.
+    mod http {
+        use super::*;
+        use wiremock::matchers::{body_string_contains, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn make_cfg(login_url: String) -> PasswordLoginConfig {
+            PasswordLoginConfig {
+                login_url,
+                format: PasswordLoginFormat::Json,
+                username_field: None,
+                password_field: None,
+                totp_field: None,
+                extra_fields: None,
+                success_status: None,
+            }
+        }
+
+        #[tokio::test]
+        async fn success_2xx_captures_cookies_and_fills_host_only_domain() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/api/login"))
+                .and(header("content-type", "application/json"))
+                .and(body_string_contains("\"username\":\"alice\""))
+                .and(body_string_contains("\"password\":\"hunter2\""))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        // Two cookies: one host-only (no Domain), one with a
+                        // matching Domain attribute. Both should be captured.
+                        .append_header("set-cookie", "session=abc; Path=/; HttpOnly")
+                        .append_header("set-cookie", "csrf=xyz; Path=/; Secure"),
+                )
+                .mount(&server)
+                .await;
+
+            let cfg = make_cfg(format!("{}/api/login", server.uri()));
+            let cookies = run_password_post(&cfg, Some("alice"), "hunter2", None)
+                .await
+                .expect("password POST should succeed");
+            assert_eq!(cookies.len(), 2);
+            // Host-only cookies get the loginUrl's host filled in.
+            let host = url::Url::parse(&cfg.login_url)
+                .unwrap()
+                .host_str()
+                .unwrap()
+                .to_string();
+            for c in &cookies {
+                assert_eq!(c.domain, host, "host-only cookie's domain should be filled");
+            }
+            assert!(cookies.iter().any(|c| c.name == "session"));
+            assert!(cookies.iter().any(|c| c.name == "csrf"));
+        }
+
+        #[tokio::test]
+        async fn http_4xx_maps_to_credential_rejected() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/login"))
+                .respond_with(ResponseTemplate::new(401))
+                .mount(&server)
+                .await;
+            let cfg = make_cfg(format!("{}/login", server.uri()));
+            let err = run_password_post(&cfg, Some("a"), "b", None)
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, PasswordPostError::NonSuccessStatus { status: 401 }),
+                "got {err:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn http_5xx_maps_to_target_unreachable() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/login"))
+                .respond_with(ResponseTemplate::new(503))
+                .mount(&server)
+                .await;
+            let cfg = make_cfg(format!("{}/login", server.uri()));
+            let err = run_password_post(&cfg, Some("a"), "b", None)
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err,
+                PasswordPostError::NonSuccessStatus { status: 503 }
+            ));
+        }
+
+        #[tokio::test]
+        async fn form_urlencoded_body_shape() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/api/login"))
+                .and(header("content-type", "application/x-www-form-urlencoded"))
+                .and(body_string_contains("username=alice"))
+                .and(body_string_contains("password=hunter2"))
+                .respond_with(ResponseTemplate::new(200))
+                .mount(&server)
+                .await;
+            let mut cfg = make_cfg(format!("{}/api/login", server.uri()));
+            cfg.format = PasswordLoginFormat::FormUrlencoded;
+            let cookies = run_password_post(&cfg, Some("alice"), "hunter2", None)
+                .await
+                .expect("form-urlencoded POST should succeed");
+            assert_eq!(cookies.len(), 0, "no Set-Cookie on this response");
+        }
+
+        #[tokio::test]
+        async fn custom_success_status_treats_302_as_success() {
+            // Some sites respond with 302 + Set-Cookie on successful
+            // login (legacy form-post pattern). The maintainer
+            // declares 302 in success_status so the driver accepts
+            // it without following the redirect.
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/login"))
+                .respond_with(
+                    ResponseTemplate::new(302)
+                        .append_header("set-cookie", "session=ok; Path=/")
+                        .append_header("location", "/dashboard"),
+                )
+                .mount(&server)
+                .await;
+            let mut cfg = make_cfg(format!("{}/login", server.uri()));
+            cfg.success_status = Some(vec![302]);
+            let cookies = run_password_post(&cfg, Some("a"), "b", None)
+                .await
+                .expect("302 should be treated as success per config");
+            assert_eq!(cookies.len(), 1);
+            assert_eq!(cookies[0].name, "session");
+        }
+
+        #[tokio::test]
+        async fn cookie_with_unrelated_domain_is_discarded() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/login"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        // Two cookies: one host-matched (kept), one with
+                        // Domain=evil.com (discarded — defense against a
+                        // malicious target setting cookies for unrelated
+                        // origins).
+                        .append_header("set-cookie", "kept=a; Path=/")
+                        .append_header("set-cookie", "evil=b; Domain=evil.com; Path=/"),
+                )
+                .mount(&server)
+                .await;
+            let cfg = make_cfg(format!("{}/login", server.uri()));
+            let cookies = run_password_post(&cfg, Some("a"), "b", None).await.unwrap();
+            assert_eq!(cookies.len(), 1, "evil-domain cookie must be discarded");
+            assert_eq!(cookies[0].name, "kept");
+        }
+    }
+}

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -1146,16 +1146,32 @@ pub(super) async fn handle_release(
     )
 }
 
-/// Handler for `spec/vault/proxy-login/0.1` — M2B.2b ships the
-/// DID-self-issued (SIOP) driver. The VTA mints a SIOPv2 id_token on
-/// the entry's behalf, wraps it in a [`SessionBlob`] with a single
-/// `Authorization: Bearer …` header, authcrypts the blob to the
-/// calling wallet, and returns it. The long-term signing key (and the
-/// entry's DID) never leaves the VTA.
+/// Per-driver TTL ceilings. SIOP is capped by the underlying id_token's
+/// `exp` (300 s, the canonical M2B.2b limit). Password POST is capped
+/// by the maintainer's policy; we keep it short by default so a
+/// compromised wallet can't replay the session indefinitely. The
+/// caller's `ttlSecondsHint` is honoured up to the ceiling and
+/// silently truncated above it.
+const PASSWORD_POST_TTL_CEILING_SECS: u64 = 900;
+
+/// Handler for `spec/vault/proxy-login/0.1`. Two drivers wired today:
 ///
-/// Other `secretKind`s reject with `task_failed: not_implemented` —
-/// Password POST + cookie injection lands in M2B.5; OAuth refresh +
-/// DIDComm-peer drivers follow that.
+/// - **`did-self-issued`** (M2B.2b): VTA mints a SIOPv2 id_token on
+///   the entry's behalf, wraps it in a [`SessionBlob`] with a single
+///   `Authorization: Bearer …` header. Long-term signing key never
+///   leaves the VTA.
+/// - **`password`** with a `loginConfig` (M2B.5): VTA performs an
+///   HTTP POST against the configured login URL with the entry's
+///   credentials, captures the resulting Set-Cookie headers, and
+///   returns them in a [`SessionBlob`] for the consumer to inject
+///   into its browser. Long-term password leaves the VTA only as
+///   the body of one outbound HTTPS request.
+///
+/// `password` without a `loginConfig` rejects with `not_proxyable`
+/// (consumer falls back to `vault/release` for browser-fill). Other
+/// secret kinds (`passkey`, `oauth-tokens`, `didcomm-peer`,
+/// `bearer-token`, `ssh-key`, `custom`) reject with
+/// `not_implemented` — future drivers will light them up.
 pub(super) async fn handle_proxy_login(
     state: &AppState,
     auth: &AuthClaims,
@@ -1211,64 +1227,9 @@ pub(super) async fn handle_proxy_login(
         return r;
     }
 
-    // M2B.2b only implements the DID-self-issued driver. Reject other
-    // secret kinds with `not_implemented` so wallets can fall back to
-    // vault/release (the existing browser-fill path) for those.
-    let (siop_did, signing_key_id) = match &stored.secret {
-        VaultSecret::DidSelfIssued {
-            did,
-            signing_key_id,
-            ..
-        } => (did.clone(), signing_key_id.clone()),
-        other => {
-            return reject_with(
-                &doc,
-                RejectReason::TaskFailed {
-                    reason: format!(
-                        "vault/proxy-login:not_implemented — entry secretKind {kind} has no proxy-login driver yet (M2B.2b ships did-self-issued; M2B.5 adds password)",
-                        kind = match other.kind() {
-                            SecretKind::Password => "password",
-                            SecretKind::Passkey => "passkey",
-                            SecretKind::OauthTokens => "oauth-tokens",
-                            SecretKind::DidSelfIssued => "did-self-issued",
-                            SecretKind::DidcommPeer => "didcomm-peer",
-                            SecretKind::BearerToken => "bearer-token",
-                            SecretKind::SshKey => "ssh-key",
-                            SecretKind::Custom => "custom",
-                        }
-                    ),
-                    details: Some(serde_json::json!({
-                        "secretKind": other.kind(),
-                        "supportedKinds": ["did-self-issued"],
-                    })),
-                },
-            );
-        }
-    };
-
-    // Derive the SIOP audience. The wallet may pin a target on the
-    // request; otherwise the maintainer picks the entry's first
-    // DID-shaped target, falling back to the first web-origin. App
-    // targets (iOS/Android) don't define a SIOP audience and would
-    // need a separate flow.
-    let (audience, bind_origin) = match resolve_siop_audience(&req.target, &stored.entry.targets) {
-        Some(pair) => pair,
-        None => {
-            return reject_with(
-                &doc,
-                RejectReason::TaskFailed {
-                    reason:
-                        "vault/proxy-login:no_audience — entry has no DID or web-origin target to use as SIOP audience"
-                            .into(),
-                    details: Some(serde_json::json!({
-                        "entryTargets": &stored.entry.targets,
-                    })),
-                },
-            );
-        }
-    };
-
-    // ATM is required for outbound authcrypt of the SessionBlob.
+    // ATM + vta_did are needed for the shared authcrypt tail
+    // regardless of driver — hoist them above the dispatch so both
+    // arms see the same readiness checks.
     let atm = match state.atm.as_ref() {
         Some(atm) => atm,
         None => {
@@ -1297,64 +1258,154 @@ pub(super) async fn handle_proxy_login(
         }
     };
 
-    // Cap TTL at the SIOP id_token TTL — the SessionBlob can't outlive
-    // the bearer token inside it. Client hint is honoured up to that
-    // ceiling.
-    let ttl_secs = req
-        .ttl_seconds_hint
-        .map(|t| (t as u64).min(crate::operations::vault::PROXY_LOGIN_ID_TOKEN_TTL_SECS))
-        .unwrap_or(crate::operations::vault::PROXY_LOGIN_ID_TOKEN_TTL_SECS);
-
-    // Load the entry's signing key and mint the SIOP id_token.
-    let signing_key = match crate::operations::vault::load_signing_key_by_id(
-        &state.keys_ks,
-        &state.imported_ks,
-        &*state.seed_store,
-        &state.audit_ks,
-        &signing_key_id,
-    )
-    .await
-    {
-        Ok(k) => k,
-        Err(e) => return app_error_to_reject(&doc, e),
-    };
-
-    let iat = chrono::Utc::now().timestamp().max(0) as u64;
-    let id_token = match crate::operations::vault::build_siop_id_token(
-        &siop_did,
-        &signing_key_id,
-        &audience,
-        req.nonce.as_deref(),
-        iat,
-        ttl_secs,
-        &signing_key,
-    ) {
-        Ok(t) => t,
-        Err(e) => return app_error_to_reject(&doc, e),
-    };
-
-    // Assemble the SessionBlob. SIOP path is cookie-free: the wallet
-    // attaches the id_token as `Authorization: Bearer …` to the bound
-    // origin's outbound requests, and the RP swaps it for its own
-    // session cookie. No localStorage / sessionStorage entries needed.
-    let session_id = Uuid::new_v4().to_string();
-    let expires_at_dt = chrono::Utc::now() + chrono::Duration::seconds(ttl_secs as i64);
-    let expires_at = expires_at_dt.to_rfc3339();
-    let session_blob = SessionBlob {
-        session_id: session_id.clone(),
-        expires_at: expires_at.clone(),
-        cookies: Vec::new(),
-        headers: vec![RequestHeader {
-            name: "Authorization".to_string(),
-            value: format!("Bearer {id_token}"),
-        }],
-        local_storage: Vec::new(),
-        session_storage: Vec::new(),
-        bind_origin,
-        // SIOP id_tokens are one-shot — the wallet calls vault/proxy-login
-        // again when the token expires. M3 may upgrade to BeforeExpiry once
-        // the wallet has a background-refresh loop.
-        refresh_hint: None,
+    // Driver dispatch. Each arm constructs a `SessionBlob` (plus its
+    // own session_id + expires_at) and the shared tail authcrypts +
+    // persists + responds. Adding a new driver (e.g. OAuth refresh)
+    // means one more arm here — the wrapper code stays put.
+    let (session_blob, session_id, expires_at) = match &stored.secret {
+        // ─── M2B.2b: did-self-issued (SIOP id_token) ───
+        VaultSecret::DidSelfIssued {
+            did: siop_did,
+            signing_key_id,
+            ..
+        } => {
+            let (audience, bind_origin) = match resolve_siop_audience(
+                &req.target,
+                &stored.entry.targets,
+            ) {
+                Some(pair) => pair,
+                None => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::TaskFailed {
+                            reason:
+                                "vault/proxy-login:no_audience — entry has no DID or web-origin target to use as SIOP audience"
+                                    .into(),
+                            details: Some(serde_json::json!({
+                                "entryTargets": &stored.entry.targets,
+                            })),
+                        },
+                    );
+                }
+            };
+            let ttl_secs = req
+                .ttl_seconds_hint
+                .map(|t| (t as u64).min(crate::operations::vault::PROXY_LOGIN_ID_TOKEN_TTL_SECS))
+                .unwrap_or(crate::operations::vault::PROXY_LOGIN_ID_TOKEN_TTL_SECS);
+            let signing_key = match crate::operations::vault::load_signing_key_by_id(
+                &state.keys_ks,
+                &state.imported_ks,
+                &*state.seed_store,
+                &state.audit_ks,
+                signing_key_id,
+            )
+            .await
+            {
+                Ok(k) => k,
+                Err(e) => return app_error_to_reject(&doc, e),
+            };
+            let iat = chrono::Utc::now().timestamp().max(0) as u64;
+            let id_token = match crate::operations::vault::build_siop_id_token(
+                siop_did,
+                signing_key_id,
+                &audience,
+                req.nonce.as_deref(),
+                iat,
+                ttl_secs,
+                &signing_key,
+            ) {
+                Ok(t) => t,
+                Err(e) => return app_error_to_reject(&doc, e),
+            };
+            build_session_blob_with_bearer(id_token, bind_origin, ttl_secs)
+        }
+        // ─── M2B.5: password (HTTP-POST driver) ───
+        VaultSecret::Password {
+            username,
+            password,
+            totp,
+            login_config: Some(login_config),
+            ..
+        } => {
+            #[cfg(feature = "webvh")]
+            {
+                let cookies = match crate::operations::vault::password_post::run_password_post(
+                    login_config,
+                    username.as_deref(),
+                    password,
+                    totp.as_ref(),
+                )
+                .await
+                {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return reject_with(
+                            &doc,
+                            password_post_error_to_reject(&e, &stored.entry.id),
+                        );
+                    }
+                };
+                let ttl_secs = req
+                    .ttl_seconds_hint
+                    .map(|t| (t as u64).min(PASSWORD_POST_TTL_CEILING_SECS))
+                    .unwrap_or(PASSWORD_POST_TTL_CEILING_SECS);
+                // bind_origin: prefer the entry's first WebOrigin (where the
+                // user actually browses); falls back to the loginUrl's
+                // origin when the entry only carries DID / app targets
+                // (atypical but possible — e.g. an API-first site with a
+                // DID-bound target).
+                let bind_origin = first_web_origin(&stored.entry.targets).or_else(|| {
+                    url::Url::parse(&login_config.login_url)
+                        .ok()
+                        .and_then(|u| u.origin().ascii_serialization().into())
+                });
+                build_session_blob_with_cookies(cookies, bind_origin, ttl_secs)
+            }
+            #[cfg(not(feature = "webvh"))]
+            {
+                let _ = (username, password, totp, login_config);
+                return reject_with(
+                    &doc,
+                    RejectReason::TaskFailed {
+                        reason:
+                            "vault/proxy-login:not_implemented — password driver requires the `webvh` feature"
+                                .into(),
+                        details: None,
+                    },
+                );
+            }
+        }
+        VaultSecret::Password {
+            login_config: None, ..
+        } => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason:
+                        "vault/proxy-login:not_proxyable — password entry has no loginConfig; use vault/release for browser-fill"
+                            .into(),
+                    details: Some(serde_json::json!({
+                        "secretKind": "password",
+                        "remediation": "fall back to vault/release/0.1",
+                    })),
+                },
+            );
+        }
+        other => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: format!(
+                        "vault/proxy-login:not_implemented — entry secretKind {kind} has no proxy-login driver yet",
+                        kind = secret_kind_label(other.kind())
+                    ),
+                    details: Some(serde_json::json!({
+                        "secretKind": other.kind(),
+                        "supportedKinds": ["did-self-issued", "password"],
+                    })),
+                },
+            );
+        }
     };
 
     let session_body = match serde_json::to_value(&session_blob) {
@@ -1432,6 +1483,135 @@ pub(super) async fn handle_proxy_login(
 /// uses the DID for the SIOP exchange but the page lives at the origin).
 /// Returns `None` from `bind_origin` when no web origin is in play (e.g.
 /// pure-DIDComm RP — no browser origin to bind to).
+/// Construct a SessionBlob carrying a bearer-token Authorization
+/// header — the SIOP driver's output shape. Cookie-free. Returns
+/// `(blob, session_id, expires_at_rfc3339)`.
+fn build_session_blob_with_bearer(
+    bearer: String,
+    bind_origin: Option<String>,
+    ttl_secs: u64,
+) -> (SessionBlob, String, String) {
+    let session_id = Uuid::new_v4().to_string();
+    let expires_at = (chrono::Utc::now() + chrono::Duration::seconds(ttl_secs as i64)).to_rfc3339();
+    let blob = SessionBlob {
+        session_id: session_id.clone(),
+        expires_at: expires_at.clone(),
+        cookies: Vec::new(),
+        headers: vec![RequestHeader {
+            name: "Authorization".to_string(),
+            value: format!("Bearer {bearer}"),
+        }],
+        local_storage: Vec::new(),
+        session_storage: Vec::new(),
+        bind_origin,
+        // SIOP id_tokens are one-shot — the wallet calls vault/proxy-login
+        // again when the token expires. M3 may upgrade to BeforeExpiry once
+        // the wallet has a background-refresh loop.
+        refresh_hint: None,
+    };
+    (blob, session_id, expires_at)
+}
+
+/// Construct a SessionBlob carrying cookies — the Password POST
+/// driver's output shape. No bearer header (the cookies ARE the
+/// session). Returns `(blob, session_id, expires_at_rfc3339)`.
+fn build_session_blob_with_cookies(
+    cookies: Vec<vti_common::vault::CookieJarEntry>,
+    bind_origin: Option<String>,
+    ttl_secs: u64,
+) -> (SessionBlob, String, String) {
+    let session_id = Uuid::new_v4().to_string();
+    let expires_at = (chrono::Utc::now() + chrono::Duration::seconds(ttl_secs as i64)).to_rfc3339();
+    let blob = SessionBlob {
+        session_id: session_id.clone(),
+        expires_at: expires_at.clone(),
+        cookies,
+        headers: Vec::new(),
+        local_storage: Vec::new(),
+        session_storage: Vec::new(),
+        bind_origin,
+        // Password POST sessions can hint the wallet to refresh on 401
+        // (the third party's cookie expired); the maintainer would then
+        // re-run vault/proxy-login. M3 wires this hint into a real
+        // wallet-side refresh loop.
+        refresh_hint: Some(vti_common::vault::RefreshHint::On401),
+    };
+    (blob, session_id, expires_at)
+}
+
+/// Pick the first `web-origin` target on the entry. Used by the
+/// password driver to derive the SessionBlob's `bind_origin` — the
+/// scheme + host + port the wallet will inject cookies into. Returns
+/// `None` if the entry has no web-origin target.
+fn first_web_origin(targets: &[SiteTarget]) -> Option<String> {
+    targets.iter().find_map(|t| match t {
+        SiteTarget::WebOrigin { origin } => Some(origin.clone()),
+        _ => None,
+    })
+}
+
+/// Human-readable label for a [`SecretKind`] — used in error messages
+/// so the consumer sees `secretKind password` instead of
+/// `secretKind 0`.
+fn secret_kind_label(kind: SecretKind) -> &'static str {
+    match kind {
+        SecretKind::Password => "password",
+        SecretKind::Passkey => "passkey",
+        SecretKind::OauthTokens => "oauth-tokens",
+        SecretKind::DidSelfIssued => "did-self-issued",
+        SecretKind::DidcommPeer => "didcomm-peer",
+        SecretKind::BearerToken => "bearer-token",
+        SecretKind::SshKey => "ssh-key",
+        SecretKind::Custom => "custom",
+    }
+}
+
+/// Translate a [`crate::operations::vault::password_post::PasswordPostError`]
+/// into the canonical `vault/proxy-login/0.1` reject reason. Per the
+/// spec: 4xx HTTP → `credential_rejected` (not retryable); 5xx HTTP +
+/// transport failures → `target_unreachable` (retryable); bad config
+/// → `malformed_request`; TOTP-not-supported → `not_implemented`.
+#[cfg(feature = "webvh")]
+fn password_post_error_to_reject(
+    err: &crate::operations::vault::password_post::PasswordPostError,
+    entry_id: &str,
+) -> RejectReason {
+    use crate::operations::vault::password_post::PasswordPostError;
+    match err {
+        PasswordPostError::NonSuccessStatus { status } if (400..500).contains(status) => {
+            RejectReason::TaskFailed {
+                reason: format!(
+                    "vault/proxy-login:credential_rejected — third party returned HTTP {status} for entry {entry_id}"
+                ),
+                details: Some(serde_json::json!({
+                    "status": status,
+                    "remediation": "rotate the entry's password via vault/upsert/0.1",
+                })),
+            }
+        }
+        PasswordPostError::NonSuccessStatus { status } => RejectReason::TaskFailed {
+            reason: format!(
+                "vault/proxy-login:target_unreachable — third party returned HTTP {status}"
+            ),
+            details: Some(serde_json::json!({ "status": status, "retryable": true })),
+        },
+        PasswordPostError::Transport { url, source } => RejectReason::TaskFailed {
+            reason: format!("vault/proxy-login:target_unreachable — {source} ({url})"),
+            details: Some(serde_json::json!({ "url": url, "retryable": true })),
+        },
+        PasswordPostError::InvalidLoginUrl(msg) => RejectReason::MalformedRequest {
+            reason: format!("vault/proxy-login:invalid_login_url — {msg}"),
+        },
+        PasswordPostError::TotpNotImplemented(msg) => RejectReason::TaskFailed {
+            reason: format!("vault/proxy-login:not_implemented — {msg}"),
+            details: None,
+        },
+        PasswordPostError::ResponseParse(msg) => RejectReason::InternalError {
+            reason: format!("vault/proxy-login: response parse failure — {msg}"),
+        },
+    }
+}
+
 fn resolve_siop_audience(
     explicit: &Option<SiteTarget>,
     entry_targets: &[SiteTarget],

--- a/vta-service/src/vault_cli.rs
+++ b/vta-service/src/vault_cli.rs
@@ -140,6 +140,7 @@ fn demo_records(context_id: &str) -> Vec<StoredVaultEntry> {
         username: Some("demo".into()),
         password: "PLACEHOLDER-replace-via-vault/upsert/0.1".into(),
         totp: None,
+        login_config: None,
         secure_notes: None,
         custom_fields: Vec::new(),
     };

--- a/vti-common/src/vault/mod.rs
+++ b/vti-common/src/vault/mod.rs
@@ -226,6 +226,14 @@ pub enum VaultSecret {
         password: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         totp: Option<TotpSeed>,
+        /// Optional driver config for `vault/proxy-login/0.1` against
+        /// this entry. When present, the maintainer performs an HTTP
+        /// POST against `loginConfig.loginUrl` with the entry's
+        /// credentials. When absent, proxy-login returns
+        /// `not_proxyable` and the consumer falls back to vault/release
+        /// for browser-fill. See `vault/_shared/0.1/vault-secret#/$defs/PasswordLoginConfig`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        login_config: Option<PasswordLoginConfig>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -342,6 +350,77 @@ pub enum TotpAlgorithm {
     Sha256,
     #[serde(rename = "SHA512")]
     Sha512,
+}
+
+/// Driver config for HTTP-POST proxy-login against a Password-kind
+/// entry. Mirrors `vault/_shared/0.1/vault-secret#/$defs/PasswordLoginConfig`.
+///
+/// When this struct is present on a Password secret, the maintainer
+/// performs an HTTP POST against `login_url` carrying the entry's
+/// credentials and captures the resulting Set-Cookie headers into the
+/// SessionBlob. When absent, vault/proxy-login returns `not_proxyable`
+/// and the consumer falls back to vault/release for a browser-fill
+/// flow.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasswordLoginConfig {
+    /// Absolute URL the maintainer POSTs credentials to. MUST be
+    /// `https://` for any non-loopback host — see the canonical spec
+    /// for the loopback carve-out.
+    pub login_url: String,
+    /// Request-body encoding. `Json` → `application/json`,
+    /// `FormUrlEncoded` → `application/x-www-form-urlencoded`.
+    #[serde(default)]
+    pub format: PasswordLoginFormat,
+    /// Field name carrying the username. Default `"username"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username_field: Option<String>,
+    /// Field name carrying the password. Default `"password"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password_field: Option<String>,
+    /// Optional field name carrying the TOTP code. When set AND the
+    /// entry's `totp` is populated, the maintainer computes the
+    /// current code and includes it in the request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub totp_field: Option<String>,
+    /// Constant field/value pairs the maintainer MUST include
+    /// alongside the credentials. Useful for fixed selectors the site
+    /// expects (e.g. `grantType: password`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_fields: Option<std::collections::BTreeMap<String, String>>,
+    /// HTTP status codes the maintainer treats as login success.
+    /// Default `[200, 204]` (set via accessor when None — keeps the
+    /// wire shape clean).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub success_status: Option<Vec<u16>>,
+}
+
+impl PasswordLoginConfig {
+    /// The set of HTTP statuses the maintainer treats as success,
+    /// falling back to the canonical default `[200, 204]` when the
+    /// caller didn't override.
+    pub fn effective_success_status(&self) -> Vec<u16> {
+        self.success_status
+            .clone()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| vec![200, 204])
+    }
+
+    pub fn effective_username_field(&self) -> &str {
+        self.username_field.as_deref().unwrap_or("username")
+    }
+
+    pub fn effective_password_field(&self) -> &str {
+        self.password_field.as_deref().unwrap_or("password")
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum PasswordLoginFormat {
+    #[default]
+    Json,
+    FormUrlencoded,
 }
 
 /// Free-form user-defined field on Password / Custom variants.
@@ -810,6 +889,7 @@ mod tests {
                 username: Some("u".into()),
                 password: "p".into(),
                 totp: None,
+                login_config: None,
                 secure_notes: None,
                 custom_fields: vec![],
             },


### PR DESCRIPTION
## Summary

Implements the M2B.5 Password POST driver per the canonical \`PasswordLoginConfig\` added in [trust-tasks-tf #49](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/49). When a Password vault entry carries \`loginConfig\`, \`vault/proxy-login/0.1\` now:

1. POSTs the entry's \`username\` + \`password\` (+ optional TOTP field; TOTP code generation is a follow-up) to the configured \`loginUrl\`, either as JSON or form-urlencoded.
2. Validates response status against \`loginConfig.successStatus\` (default \`[200, 204]\`); 4xx → \`credential_rejected\`, 5xx → \`target_unreachable\`.
3. Captures Set-Cookie headers; cookies whose \`Domain\` doesn't match the loginUrl's host are discarded.
4. Returns the cookies inside a SessionBlob — same envelope shape M2B.2b uses for SIOP, just cookies instead of an Authorization header.

\`Password\` without \`loginConfig\` → \`not_proxyable\` (consumer falls back to vault/release). Other secret kinds still reject with \`not_implemented\`.

## Security / scope guards

- \`loginUrl\` MUST be \`https://\` for any non-loopback host. \`http://\` to \`localhost\`/\`127.0.0.0/8\`/\`::1\` is permitted (dev/demo only).
- reqwest client configured \`redirect = none\` — when \`successStatus\` declares 3xx, we surface the response with its Set-Cookie headers instead of chasing the Location URL into a logged-in dashboard.
- Cookie domain filter — Set-Cookie with unrelated Domain attribute dropped with warn log.
- TTL ceiling 900 s for Password (vs 300 s for SIOP); caller hint capped.

## Layers touched

- \`vti-common\`: \`VaultSecret::Password\` gains optional \`login_config\`; new \`PasswordLoginConfig\` + \`PasswordLoginFormat\` types.
- \`vta-service\`: \`operations/vault\` converted to a directory module so \`password_post.rs\` sits alongside the SIOP helpers.
- \`handle_proxy_login\` refactored to dispatch on secret variant. Each arm returns \`(SessionBlob, session_id, expires_at)\`; the shared authcrypt + persist + respond tail is unchanged. Helper extractors split out: \`build_session_blob_with_bearer\` (SIOP), \`build_session_blob_with_cookies\` (Password), \`first_web_origin\`, \`secret_kind_label\`, \`password_post_error_to_reject\`. Ready for future drivers to slot in as match arms.

## Test plan

- [x] 491/491 \`vta-service\` lib tests pass.
- [x] 18 new tests in \`operations::vault::password_post\` — 12 pure-fn (URL validation, body shaping, Set-Cookie parsing, domain matching) + 6 wiremock-backed HTTP round-trips (2xx + cookies, 4xx → credential_rejected, 5xx → target_unreachable, form-urlencoded shape, custom success status incl. 302, unrelated-domain cookies discarded).
- [x] \`cargo clippy\` clean.
- [ ] Pre-existing integration-test breakage in \`tests/{auth_flow,api_integration}.rs\` (AclEntry field cascade from M1) is unrelated and out of scope.

## Up next in the M2B.5 chain

- \`pnm-browser-plugin\`: new \`packages/demo-rp\` — minimal Node.js HTTP service with login form + protected page so the end-to-end cookie-injection flow has a target.
- \`pnm-browser-plugin\`: \`chrome.cookies.set\` wiring on the wallet side so the captured cookies inject into the bound origin's cookie jar after a successful proxy-login.