### PR TITLE
fix(vault): camelCase serde rename on VaultSecret variants to match spec

### DIFF
--- a/vti-common/src/vault/mod.rs
+++ b/vti-common/src/vault/mod.rs
@@ -220,6 +220,17 @@ pub struct StoredVaultEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum VaultSecret {
+    // `rename_all = "camelCase"` on each variant aligns Rust's
+    // default snake_case field names with the canonical wire shape
+    // in `vault/_shared/0.1/vault-secret` (which uses camelCase
+    // throughout: `secureNotes`, `loginConfig`, `signingKeyId`,
+    // `credentialId`, etc.). Without these, every camelCase-emitting
+    // consumer (the browser plugin's `vault/upsert` path is the live
+    // example) silently loses optional fields on deserialize and
+    // emits the wrong shape on serialize. The two new tests in this
+    // file's `mod tests` exercise password + did-self-issued
+    // round-trips and would have caught this earlier.
+    #[serde(rename_all = "camelCase")]
     Password {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         username: Option<String>,
@@ -239,6 +250,7 @@ pub enum VaultSecret {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         custom_fields: Vec<CustomField>,
     },
+    #[serde(rename_all = "camelCase")]
     Passkey {
         credential_id: String,
         private_key: String,
@@ -250,6 +262,7 @@ pub enum VaultSecret {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
+    #[serde(rename_all = "camelCase")]
     OauthTokens {
         provider: String,
         refresh_token: String,
@@ -262,18 +275,21 @@ pub enum VaultSecret {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
+    #[serde(rename_all = "camelCase")]
     DidSelfIssued {
         did: String,
         signing_key_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
+    #[serde(rename_all = "camelCase")]
     DidcommPeer {
         peer_did: String,
         signing_key_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
+    #[serde(rename_all = "camelCase")]
     BearerToken {
         token: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -283,6 +299,7 @@ pub enum VaultSecret {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
+    #[serde(rename_all = "camelCase")]
     SshKey {
         private_key: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -294,6 +311,7 @@ pub enum VaultSecret {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
+    #[serde(rename_all = "camelCase")]
     Custom {
         fields: Vec<CustomField>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -855,6 +873,53 @@ mod tests {
                 ..Default::default()
             }
         ));
+    }
+
+    #[test]
+    fn password_secret_round_trips_camel_case_wire_form() {
+        // The canonical spec (vault/_shared/0.1/vault-secret) uses
+        // camelCase field names (`secureNotes`, `loginConfig`,
+        // `signingKeyId`). Verify the Rust implementation deserializes
+        // the spec-form wire input AND re-emits it in the same shape
+        // — i.e. neither side requires snake_case translation. If
+        // this test fails, every camelCase-emitting consumer (the
+        // browser plugin's vault/upsert path is the live example)
+        // would silently lose optional fields.
+        let camel = r#"{"kind":"password","password":"x","secureNotes":"hi"}"#;
+        let v: VaultSecret = serde_json::from_str(camel).expect("parse camelCase");
+        match &v {
+            VaultSecret::Password { secure_notes, .. } => {
+                assert_eq!(secure_notes.as_deref(), Some("hi"));
+            }
+            _ => panic!("expected Password variant"),
+        }
+        let re = serde_json::to_string(&v).expect("re-emit");
+        assert!(
+            re.contains("\"secureNotes\":\"hi\""),
+            "re-emitted JSON must use camelCase secureNotes; got {re}"
+        );
+    }
+
+    #[test]
+    fn did_self_issued_secret_round_trips_camel_case_wire_form() {
+        let camel = r#"{"kind":"did-self-issued","did":"did:webvh:foo","signingKeyId":"did:webvh:foo#key-0"}"#;
+        let v: VaultSecret = serde_json::from_str(camel).expect("parse camelCase");
+        match &v {
+            VaultSecret::DidSelfIssued {
+                did,
+                signing_key_id,
+                ..
+            } => {
+                assert_eq!(did, "did:webvh:foo");
+                assert_eq!(signing_key_id, "did:webvh:foo#key-0");
+            }
+            _ => panic!("expected DidSelfIssued variant"),
+        }
+        let re = serde_json::to_string(&v).expect("re-emit");
+        assert!(
+            re.contains("\"signingKeyId\":\"did:webvh:foo#key-0\""),
+            "re-emitted JSON must use camelCase signingKeyId; got {re}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The Rust \`VaultSecret\` enum was emitting / accepting field names in default snake_case (\`secure_notes\`, \`signing_key_id\`, \`login_config\`, \`credential_id\`, …) while the canonical wire schema \`vault/_shared/0.1/vault-secret\` uses camelCase (\`secureNotes\`, \`signingKeyId\`, \`loginConfig\`, \`credentialId\`).

Live failure mode: the browser plugin's \`vault/upsert\` path emits camelCase. The VTA's \`serde_json::from_value::<VaultSecret>\` couldn't recognise the camelCase fields, and any optional field silently became \`None\`. M2A passwords happened to work because the only required password-secret field is \`password\` (which is identical in both conventions). M2B.5's \`loginConfig\` and M2B.2b's \`signingKeyId\` are **mandatory** for those drivers — the bug would surface the moment anyone tried the M2B.5 end-to-end demo (which is exactly when I caught it).

## Fix

Add \`#[serde(rename_all = "camelCase")]\` to each \`VaultSecret\` variant. (\`rename_all\` at the enum level is reserved for the \`kind\` tag — kebab-case — so each variant needs its own attribute.)

## Tests

Two new round-trip tests now pin the invariant:

- \`password_secret_round_trips_camel_case_wire_form\` — parses the canonical \`{"kind":"password","password":"x","secureNotes":"hi"}\` form and verifies (a) \`secure_notes\` populated server-side, (b) re-emit produces \`"secureNotes"\` not \`"secure_notes"\`.
- \`did_self_issued_secret_round_trips_camel_case_wire_form\` — same shape for \`signingKeyId\`.

Both would have caught this earlier had they existed. Without them, the next field-naming drift in either direction (Rust side renames, spec changes) will fail loudly.

## Test plan

- [x] \`cargo test -p vti-common --lib\` — 183 pass (was 181; +2 new round-trips).
- [x] \`cargo fmt --check\` clean.

## Out of scope

The vta-service / vti-common pre-existing AclEntry breakage in \`bootstrap.rs\` + \`admin_bootstrap.rs\` (M1 field-additions never propagated to those call sites) is unrelated and untouched.