### PR TITLE
fix(acl): swap_acl drops ephemeral TTL; sweeper logs + audits removals

### DIFF
--- a/vta-service/src/acl_sweeper.rs
+++ b/vta-service/src/acl_sweeper.rs
@@ -2,8 +2,14 @@
 //!
 //! Called from the storage thread's interval loop. Walks the ACL keyspace
 //! once and deletes any rows whose `expires_at` has passed.
+//!
+//! Every deletion is logged at `info!` AND recorded in the audit log as
+//! an `acl.expire` event so operators can correlate "DID not in ACL"
+//! errors with the deletion that caused them. Without this trail, the
+//! sweeper's removals are invisible — there's nothing for the operator
+//! to grep / SIEM-query when an entry mysteriously stops working.
 
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::acl::{AclEntry, delete_acl_entry};
 use crate::error::AppError;
@@ -16,7 +22,25 @@ fn now_epoch() -> u64 {
         .unwrap_or(0)
 }
 
-pub async fn sweep_expired(acl_ks: &KeyspaceHandle) -> Result<(), AppError> {
+/// Sweep the ACL keyspace and delete any row whose `expires_at` has
+/// passed. Each deletion produces:
+///
+/// - one `info!` line with `did`, `role`, `expired_at`, and a
+///   `reason = "expired"` field so operators can grep
+///   `acl_sweeper` lines and see WHICH DIDs were pruned, not just
+///   the aggregate count;
+/// - one `audit::record(acl.expire, system:sweeper, <did>, ...)`
+///   entry so the removal is queryable from the audit log alongside
+///   `acl.create` / `acl.swap` / `acl.revoke`.
+///
+/// Audit-record failures are warn-logged but don't abort the sweep
+/// — the deletion has already happened; losing the audit row is
+/// strictly worse if it would cause the keyspace to keep an
+/// expired entry around.
+pub async fn sweep_expired(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+) -> Result<(), AppError> {
     let now = now_epoch();
     let mut pruned = 0usize;
 
@@ -34,8 +58,45 @@ pub async fn sweep_expired(acl_ks: &KeyspaceHandle) -> Result<(), AppError> {
             }
         };
         if entry.is_expired(now) {
-            delete_acl_entry(acl_ks, &entry.did).await?;
+            let did = entry.did.clone();
+            let role = entry.role.to_string();
+            let expired_at = entry.expires_at;
+
+            delete_acl_entry(acl_ks, &did).await?;
             pruned += 1;
+
+            info!(
+                did = %did,
+                role = %role,
+                expired_at = ?expired_at,
+                now_epoch = now,
+                reason = "expired",
+                "acl sweeper deleted expired entry"
+            );
+
+            // Audit-log the removal so operators can correlate
+            // "DID not in ACL" errors with the sweeper's prior
+            // deletion. The actor is `system:sweeper` (synthetic,
+            // matches the format `cli:vault-seed` uses elsewhere)
+            // because no human / consumer triggered this — it's a
+            // background timer firing on a previously-set TTL.
+            if let Err(e) = crate::audit::record(
+                audit_ks,
+                "acl.expire",
+                "system:sweeper",
+                Some(&did),
+                "success",
+                None,
+                None,
+            )
+            .await
+            {
+                warn!(
+                    did = %did,
+                    error = %e,
+                    "acl sweeper: deletion succeeded but audit::record failed; audit log will be missing this removal"
+                );
+            }
         }
     }
 
@@ -43,4 +104,106 @@ pub async fn sweep_expired(acl_ks: &KeyspaceHandle) -> Result<(), AppError> {
         info!(acl_pruned = pruned, "acl sweeper pruned expired rows");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::{ConsumerKind, Role, store_acl_entry};
+    use crate::store::Store;
+    use vti_common::config::StoreConfig;
+
+    async fn fresh_store() -> (Store, KeyspaceHandle, KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&config).unwrap();
+        let acl_ks = store.keyspace("acl").unwrap();
+        let audit_ks = store.keyspace("audit").unwrap();
+        (store, acl_ks, audit_ks, dir)
+    }
+
+    fn entry(did: &str, expires_at: Option<u64>) -> AclEntry {
+        AclEntry {
+            did: did.into(),
+            role: Role::Admin,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now_epoch(),
+            created_by: "test".into(),
+            expires_at,
+            kind: ConsumerKind::default(),
+            capabilities: Vec::new(),
+            device: None,
+            version: 0,
+        }
+    }
+
+    /// Expired entries get deleted; permanent (no `expires_at`)
+    /// entries are untouched. This is the core invariant — without
+    /// it, either the wallet's long-term DID would be permanently
+    /// orphaned by stale entries, or every entry would be at risk.
+    #[tokio::test]
+    async fn sweeper_deletes_expired_and_preserves_permanent() {
+        let (_store, acl_ks, audit_ks, _dir) = fresh_store().await;
+
+        let now = now_epoch();
+        let expired = entry("did:key:zExpired", Some(now - 1));
+        let live_ttl = entry("did:key:zLiveTtl", Some(now + 3600));
+        let permanent = entry("did:key:zPermanent", None);
+        store_acl_entry(&acl_ks, &expired).await.unwrap();
+        store_acl_entry(&acl_ks, &live_ttl).await.unwrap();
+        store_acl_entry(&acl_ks, &permanent).await.unwrap();
+
+        sweep_expired(&acl_ks, &audit_ks).await.unwrap();
+
+        // Expired entry: gone.
+        assert!(
+            crate::acl::get_acl_entry(&acl_ks, &expired.did)
+                .await
+                .unwrap()
+                .is_none(),
+            "expired entry must be pruned"
+        );
+        // Live-TTL + permanent: still there.
+        assert!(
+            crate::acl::get_acl_entry(&acl_ks, &live_ttl.did)
+                .await
+                .unwrap()
+                .is_some(),
+            "live-TTL entry must NOT be pruned"
+        );
+        assert!(
+            crate::acl::get_acl_entry(&acl_ks, &permanent.did)
+                .await
+                .unwrap()
+                .is_some(),
+            "permanent entry must NOT be pruned"
+        );
+
+        // Audit-log entry for the deletion exists under
+        // `log:<timestamp>:<uuid>`. Without this, the sweeper's
+        // removals would be invisible to forensic queries.
+        let audit_rows = audit_ks.prefix_iter_raw("log:").await.unwrap();
+        let mut found_expire_row_for_did = false;
+        for (_, value) in audit_rows {
+            let s = String::from_utf8_lossy(&value);
+            if s.contains("acl.expire") && s.contains(&expired.did) {
+                found_expire_row_for_did = true;
+                break;
+            }
+        }
+        assert!(
+            found_expire_row_for_did,
+            "audit log must contain an acl.expire entry for the pruned DID"
+        );
+    }
+
+    /// Sweep over an empty keyspace is a no-op + does not panic.
+    #[tokio::test]
+    async fn sweeper_handles_empty_keyspace() {
+        let (_store, acl_ks, audit_ks, _dir) = fresh_store().await;
+        sweep_expired(&acl_ks, &audit_ks).await.unwrap();
+    }
 }

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -398,6 +398,18 @@ pub async fn swap_acl(
         )));
     }
 
+    // DO NOT inherit `expires_at` from the ephemeral. The swap
+    // expresses the operator's intent to hand off authority to the
+    // long-term DID — preserving the ephemeral's TTL would silently
+    // expire the long-term entry on the same clock (typically 1 h,
+    // since onboarding scripts set --expires 1h on the ephemeral by
+    // design). The acl_sweeper would then physically delete the
+    // long-term entry an hour later, and /auth/challenge would
+    // start returning "DID not in ACL" with no audit-log trace of
+    // the create→swap→sweep chain. Operators who genuinely want a
+    // time-limited long-term entry can `acl change-role --expires
+    // …` afterwards. See PR fixing this and the parallel
+    // acl_sweeper change that audit-logs every deletion.
     let entry = AclEntry {
         did: new_did.clone(),
         role: old.role.clone(),
@@ -405,7 +417,7 @@ pub async fn swap_acl(
         allowed_contexts: old.allowed_contexts.clone(),
         created_at: now,
         created_by: auth.did.clone(),
-        expires_at: old.expires_at,
+        expires_at: None,
         kind: old.kind.clone(),
         capabilities: old.capabilities.clone(),
         device: old.device.clone(),
@@ -417,7 +429,15 @@ pub async fn swap_acl(
     store_acl_entry(acl_ks, &entry).await?;
     delete_acl_entry(acl_ks, &auth.did).await?;
 
-    info!(channel, old = %auth.did, new = %new_did, role = %entry.role, "ACL entry swapped");
+    info!(
+        channel,
+        old = %auth.did,
+        new = %new_did,
+        role = %entry.role,
+        old_expires_at = ?old.expires_at,
+        new_expires_at = ?entry.expires_at,
+        "ACL entry swapped; long-term entry is permanent (ephemeral TTL not inherited)"
+    );
     audit!(
         "acl.swap",
         actor = &auth.did,

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -945,7 +945,14 @@ fn run_storage_thread(
                             warn!("audit cleanup error: {e}");
                         }
                         // Prune expired AclEntry rows and PendingBootstrap rows.
-                        if let Err(e) = crate::acl_sweeper::sweep_expired(&acl_ks).await {
+                        // `audit_ks` threaded in so each deletion produces
+                        // an `acl.expire` audit entry — without it, the
+                        // sweeper's removals leave no trail and operators
+                        // can't distinguish "entry was never created" from
+                        // "entry was created then expired and pruned".
+                        if let Err(e) =
+                            crate::acl_sweeper::sweep_expired(&acl_ks, &audit_ks).await
+                        {
                             warn!("acl sweeper error: {e}");
                         }
                         // Expire & retention-prune in-flight backup


### PR DESCRIPTION
## Summary

Two compounding bugs were silently expiring wallet ACL entries across daemon restarts. The wallet's holder did:peer would mysteriously vanish from the ACL ~1 hour after onboarding — \`/auth/challenge\` would start returning \`forbidden: DID not in ACL\` with **no audit-log trail** for either the cause or the deletion. Took an investigation pass to root-cause.

## The two bugs

### 1. \`swap_acl\` inherited \`expires_at\` from the ephemeral

Onboarding helpers correctly grant the ephemeral did:key with \`--expires 1h\` — appropriate for a single-use key. \`swap_acl\` at \`vta-service/src/operations/acl.rs:408\` then carried that \`expires_at\` verbatim onto the long-term holder did:peer entry. The long-term entry expired 1 h after the swap.

\`\`\`rust
// before
expires_at: old.expires_at,   // inherits the ephemeral's TTL

// after
expires_at: None,             // swap is an authority handoff, not a TTL inheritance
\`\`\`

The swap expresses operator intent to hand off authority to the long-term DID. Carrying a TTL silently undermines that. Operators who genuinely want a time-limited long-term entry can \`acl change-role --expires …\` afterwards.

### 2. \`acl_sweeper\` deleted expired rows silently

\`acl_sweeper::sweep_expired\` walks the keyspace on a timer and calls \`delete_acl_entry\` for expired rows. Pre-fix:

- Logged only \`info!(acl_pruned = N, ...)\` — count only, no DID-level detail.
- Did NOT call \`audit::record\`. The audit log had \`acl.create\` rows but no removal record.

So the wallet's "DID not in ACL" error and the sweep that caused it were impossible to correlate from logs OR the audit-log API.

## Fix

- \`swap_acl\` now sets \`expires_at: None\` on the long-term entry. Info-log includes both \`old_expires_at\` and \`new_expires_at\` so the TTL drop is visible.
- \`acl_sweeper::sweep_expired\` now takes \`audit_ks\` and writes one \`audit::record("acl.expire", "system:sweeper", <did>, ...)\` per deletion.
- Per-deletion \`info!\` line includes \`did\`, \`role\`, \`expired_at\`, \`now_epoch\`, \`reason = "expired"\`. Aggregate count log preserved.
- Audit-record failures are warn-logged but don't abort the sweep — the deletion has already happened, suppressing it because audit failed would be strictly worse.
- Storage-thread call site at \`server.rs:948\` threads \`audit_ks\` in.

## Tests

Two new unit tests in \`acl_sweeper::tests\`:

- \`sweeper_deletes_expired_and_preserves_permanent\` — three entries (expired, live-TTL, permanent); after sweep, expired is gone, others remain; asserts the audit log contains a matching \`acl.expire\` row for the pruned DID.
- \`sweeper_handles_empty_keyspace\` — no-op + no panic.

\`swap_acl\` regression test sketched but dropped: the function takes a signed VP + DID resolver that's heavy to mock at the unit-test layer. The one-line \`expires_at: None\` change is straightforward and the load-bearing invariant is documented in the inline comment.

## Test plan

- [x] \`cargo test -p vta-service --lib\` — 493 lib tests pass (491 + 2 new).
- [x] \`cargo fmt --check\` clean.
- [ ] **Operator validation**: after merge + deploy + reload extension, re-onboard the wallet; confirm \`pnm acl list\` shows the wallet's did:peer entry with \`expires_at: null\`; restart the daemon; entry is still there; auth-challenge succeeds.

## Why this surfaced now

The bug pre-dated this PR (the inheritance was load-bearing in \`swap_acl\` since it was written, and the sweeper has always been silent). It bit operators during M2B.4 SIOP demo testing because that's the first time someone restarted the daemon while expecting persistent wallet auth. Worth a follow-up:

- An offline \`vta audit list [--action acl.expire]\` CLI so operators can query the audit log without writing a custom fjall reader.
- Default \`pnm bootstrap\` script's \`--expires\` on the ephemeral could go down to e.g. 5 minutes — long enough for any human-paced swap, short enough to fail loudly if something's wrong.