### PR TITLE
feat(provision-integration): accept canonical Trust Task URI alongside FPN

### DIFF
--- a/vta-sdk/src/protocols/provision_integration_management.rs
+++ b/vta-sdk/src/protocols/provision_integration_management.rs
@@ -15,16 +15,60 @@
 //! transport-neutral. See
 //! [`crate::provision_integration::http::ProvisionIntegrationRequest`]
 //! and [`crate::provision_integration::http::ProvisionIntegrationResponse`].
+//!
+//! Two URI shapes are accepted on the wire, both routed to the same
+//! handler:
+//!
+//! * The legacy FPN-private URI ([`PROVISION_INTEGRATION`]) — what every
+//!   existing client targets today.
+//! * The canonical Trust Task URI
+//!   ([`CANONICAL_PROVISION_INTEGRATION`]) — landed in
+//!   `dtgwg-trust-tasks-tf` PR #51 as
+//!   `https://trusttasks.org/spec/provision/integration/0.1`. Clients
+//!   migrating to the canonical registry target this URI.
+//!
+//! The handler emits the response under whichever URI the request came
+//! in with — a caller using the canonical URI receives a canonical
+//! response (`#response` fragment), a caller using the FPN URI receives
+//! the legacy `…-result` URI. That keeps both clients working without
+//! either having to know about the other.
 
 pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/provision-integration/1.0";
 
-/// Inbound VP + provisioning options.
+/// Inbound VP + provisioning options. Legacy FPN-private URI.
 pub const PROVISION_INTEGRATION: &str =
     "https://firstperson.network/protocols/provision-integration/1.0/provision-integration";
 
-/// Outbound sealed bundle + summary.
+/// Outbound sealed bundle + summary. Legacy FPN-private URI.
 pub const PROVISION_INTEGRATION_RESULT: &str =
     "https://firstperson.network/protocols/provision-integration/1.0/provision-integration-result";
+
+/// Inbound VP + provisioning options — canonical Trust Task URI. Same
+/// wire body as [`PROVISION_INTEGRATION`]; accepting both is the spec
+/// migration step #51 of `dtgwg-trust-tasks-tf` set up.
+pub const CANONICAL_PROVISION_INTEGRATION: &str =
+    "https://trusttasks.org/spec/provision/integration/0.1";
+
+/// Outbound sealed bundle + summary — canonical Trust Task URI.
+/// Per SPEC.md §4.4.1 of `dtgwg-trust-tasks-tf`, success responses are
+/// emitted under the request URI with a `#response` fragment.
+pub const CANONICAL_PROVISION_INTEGRATION_RESULT: &str =
+    "https://trusttasks.org/spec/provision/integration/0.1#response";
+
+/// Match the result URI to whichever request URI the caller used.
+/// Centralised here so the routing decision lives next to the URI
+/// constants — handlers downstream just call this and don't need to
+/// know which URIs are alias-equivalent.
+pub fn result_uri_for(request_uri: &str) -> &'static str {
+    if request_uri == CANONICAL_PROVISION_INTEGRATION {
+        CANONICAL_PROVISION_INTEGRATION_RESULT
+    } else {
+        // Default to the legacy URI for any URI that's not the canonical
+        // one. Today the only other accepted shape is the FPN-private
+        // URI; future additions widen this match.
+        PROVISION_INTEGRATION_RESULT
+    }
+}
 
 pub mod request {
     //! Body shape for the inbound DIDComm message.
@@ -39,4 +83,53 @@ pub mod result {
     //!
     //! Equivalent to [`crate::provision_integration::http::ProvisionIntegrationResponse`].
     pub use crate::provision_integration::http::{ProvisionIntegrationResponse, ProvisionSummary};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_uri_for_canonical_request_emits_canonical_response() {
+        assert_eq!(
+            result_uri_for(CANONICAL_PROVISION_INTEGRATION),
+            CANONICAL_PROVISION_INTEGRATION_RESULT
+        );
+    }
+
+    #[test]
+    fn result_uri_for_legacy_request_emits_legacy_response() {
+        assert_eq!(
+            result_uri_for(PROVISION_INTEGRATION),
+            PROVISION_INTEGRATION_RESULT
+        );
+    }
+
+    /// Unknown / future URIs default to the legacy result URI.  The router
+    /// only advertises the two URIs we know about, so this branch is
+    /// unreachable in production — but exercising it pins the fallback so
+    /// a future widening doesn't silently change the default response
+    /// shape for an already-deployed client.
+    #[test]
+    fn result_uri_for_unknown_request_defaults_to_legacy() {
+        assert_eq!(
+            result_uri_for("https://example.invalid/something-else"),
+            PROVISION_INTEGRATION_RESULT
+        );
+    }
+
+    /// The canonical Trust Task URI MUST be exactly the value declared in
+    /// `dtgwg-trust-tasks-tf` PR #51's `payload.schema.json` `$id`. Pin
+    /// the string so a refactor here can't drift away from the registry.
+    #[test]
+    fn canonical_uri_matches_registry() {
+        assert_eq!(
+            CANONICAL_PROVISION_INTEGRATION,
+            "https://trusttasks.org/spec/provision/integration/0.1"
+        );
+        assert_eq!(
+            CANONICAL_PROVISION_INTEGRATION_RESULT,
+            "https://trusttasks.org/spec/provision/integration/0.1#response"
+        );
+    }
 }

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1477,18 +1477,26 @@ pub async fn handle_provision_integration(
         },
     };
 
+    // Match the response URI to whichever request URI the caller used.
+    // A client targeting the canonical Trust Task URI
+    // (`https://trusttasks.org/spec/provision/integration/0.1`) receives
+    // the canonical `#response` fragment; the legacy FPN URI gets the
+    // legacy `…-result`. Both share one handler so the routing decision
+    // lives in `result_uri_for` rather than two parallel branches here.
+    let result_uri =
+        vta_sdk::protocols::provision_integration_management::result_uri_for(&message.typ);
+
     info!(
         from = %auth.did,
         admin_did = %result.summary.admin_did,
         admin_rolled_over = result.summary.admin_rolled_over,
         bundle_id = %result.summary.bundle_id_hex,
+        request_uri = %message.typ,
+        result_uri,
         "provision-integration completed via DIDComm"
     );
 
-    response(
-        vta_sdk::protocols::provision_integration_management::PROVISION_INTEGRATION_RESULT,
-        &result,
-    )
+    response(result_uri, &result)
 }
 
 /// Envelope used by the DIDComm update + rotate-keys messages.

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -448,10 +448,22 @@ pub fn build_handler(
 
     // Provision-integration — always available; vta-service depends
     // on vta-sdk with the `provision-integration` feature enabled.
-    router = router.route(
-        provision_integration_management::PROVISION_INTEGRATION,
-        handler_fn(handlers::handle_provision_integration),
-    )?;
+    //
+    // Both the legacy FPN-private URI and the canonical Trust Task URI
+    // route to the same handler; the handler reads the inbound `typ`
+    // and emits the matching response URI (`…-result` for the legacy
+    // shape, `#response` fragment for the canonical shape). Existing
+    // clients on the FPN URI keep working unchanged; new clients can
+    // target the canonical registry without coordinating a URI flip.
+    router = router
+        .route(
+            provision_integration_management::PROVISION_INTEGRATION,
+            handler_fn(handlers::handle_provision_integration),
+        )?
+        .route(
+            provision_integration_management::CANONICAL_PROVISION_INTEGRATION,
+            handler_fn(handlers::handle_provision_integration),
+        )?;
 
     // Step-up approval — the VTA vouches (signs as itself) that a holder
     // may step up their session at a relying party. Always available.


### PR DESCRIPTION
## Summary

Routes the canonical Trust Task URI `https://trusttasks.org/spec/provision/integration/0.1` (landed in `dtgwg-trust-tasks-tf` #51) to the same handler as the legacy FPN-private URI `https://firstperson.network/protocols/provision-integration/1.0/provision-integration`.

The handler now dispatches the response URI based on whichever request URI the caller used:
- canonical request → canonical `#response` fragment
- legacy FPN request → legacy `…-result`

so existing clients on the FPN URI keep working unchanged and new clients targeting the canonical registry get the canonical response URI back. Neither has to know about the other.

Centralised the request → response URI mapping in `result_uri_for` on the SDK so the routing decision lives next to the URI constants rather than spreading across handlers.

## vta-sdk changes

- New `CANONICAL_PROVISION_INTEGRATION` / `CANONICAL_PROVISION_INTEGRATION_RESULT` constants pinned to the exact strings in the canonical spec's `$id`.
- `result_uri_for(request_uri)` helper — unknown URIs default to the legacy response shape so no future router widening can silently change the default for already-deployed clients.
- 4 unit tests: legacy ↔ legacy, canonical ↔ canonical, unknown → legacy fallback, registry-string pin.

## vta-service changes

- `messaging/router.rs` adds a second `.route(...)` for the canonical URI pointing at the same handler.
- `messaging/handlers.rs::handle_provision_integration` reads `message.typ` and emits the matching response URI; logs both `request_uri` + `result_uri` so operators can grep which clients are on the canonical shape.

## Out of scope

- SDK client switchover: `provision_integration_didcomm` keeps emitting the legacy URI. The browser-plugin's M2C-B onboarding client (just landed) targets the legacy URI too — both keep working without change.
- Switching the SDK + the wallet to emit the canonical URI is a follow-up that should land after this is deployed and exercised against real callers (so we have round-trip evidence that the canonical leg works before flipping the defaults).
- Migrating the existing `spec/vta/provision-integration/request/1.0` Trust Task URI in `vta-sdk::trust_tasks` to the canonical `spec/provision/integration/0.1` shape. The two URIs serve different transports (REST trust-task dispatcher vs DIDComm protocol); deciding whether they should converge is a separate spec discussion.

## Test plan

- [x] `cargo check -p vta-sdk -p vta-service` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p vta-sdk --features provision-integration provision_integration_management` — 4/4 new passing
- [x] `cargo test -p vta-service --lib messaging` — 58/58 existing passing
- [x] `cargo clippy -p vta-sdk -p vta-service --features provision-integration` — no new warnings

## Pre-merge note

Pure additive change. No client switchover, no breaking wire-shape changes. The canonical URI becomes accepted; the legacy URI keeps being accepted. Operators see no behavioural change until they choose to migrate a client to the canonical URI.