### PR TITLE
feat(provision-integration): context inference per canonical spec

### DIFF
--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -428,7 +428,11 @@ pub async fn run_provision_integration(
     let resp = client
         .provision_integration(ProvisionIntegrationRequest {
             request: vp,
-            context: target_context.clone(),
+            // `--context` is required on the pnm-cli surface today, so
+            // we always pass a concrete value. The wire field is
+            // `Option<String>` per the canonical spec; future flag
+            // changes can pass `None` to opt into VTA-side inference.
+            context: Some(target_context.clone()),
             assertion: Some(assertion_mode),
             vc_validity_seconds,
             create_context,

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -40,6 +40,13 @@ pub mod problem_report_codes {
     /// "Token may be expired" — which is misleading when the real
     /// problem is a privilege-laundering rejection or an ACL miss.
     pub const FORBIDDEN: &str = "e.p.msg.forbidden";
+    /// Per the canonical `provision/integration/0.1` spec: emitted
+    /// when the caller omits `payload.context` AND the maintainer
+    /// cannot infer a unique target context from the relayer's grant
+    /// or its own contexts state. The problem-report body's `args`
+    /// carries `candidates: Vec<String>` so the relayer can surface
+    /// the list to the operator and retry with an explicit choice.
+    pub const PROVISION_CONTEXT_REQUIRED: &str = "provision/integration:context_required";
 }
 
 /// Extract code and comment from a problem-report message body.

--- a/vta-sdk/src/provision_client/runner_didcomm.rs
+++ b/vta-sdk/src/provision_client/runner_didcomm.rs
@@ -56,7 +56,8 @@ pub async fn provision_via_didcomm(
     let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
 
     let response =
-        provision_integration_didcomm(&session, vp, ask.context.clone(), None, None, false).await?;
+        provision_integration_didcomm(&session, vp, Some(ask.context.clone()), None, None, false)
+            .await?;
 
     response_to_result(&seed, nonce, response)
 }
@@ -352,7 +353,8 @@ pub async fn provision_admin_rotation_via_didcomm(
     let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
 
     let response =
-        provision_integration_didcomm(&session, vp, ask.context.clone(), None, None, false).await?;
+        provision_integration_didcomm(&session, vp, Some(ask.context.clone()), None, None, false)
+            .await?;
 
     crate::provision_client::result::admin_rotation_response_to_reply(&seed, nonce, response)
 }

--- a/vta-sdk/src/provision_client/runner_rest.rs
+++ b/vta-sdk/src/provision_client/runner_rest.rs
@@ -185,7 +185,7 @@ pub(crate) async fn run_rest_attempt_full_setup(
 
     let req = ProvisionIntegrationRequest {
         request: vp,
-        context: ask.context.clone(),
+        context: Some(ask.context.clone()),
         assertion: None,
         vc_validity_seconds: None,
         create_context: false,
@@ -330,7 +330,7 @@ pub(crate) async fn run_rest_attempt_admin_rotated(
 
     let req = ProvisionIntegrationRequest {
         request: vp,
-        context: ask.context.clone(),
+        context: Some(ask.context.clone()),
         assertion: None,
         vc_validity_seconds: None,
         create_context: false,

--- a/vta-sdk/src/provision_integration/didcomm.rs
+++ b/vta-sdk/src/provision_integration/didcomm.rs
@@ -61,10 +61,18 @@ const DEFAULT_TIMEOUT_SECS: u64 = 60;
 /// target context isn't yet registered — same semantics as the REST
 /// path. Default is `false` (caller must have created the context
 /// out-of-band).
+///
+/// `context` is `Option<String>`. Pass `Some(name)` for the
+/// integration-class pattern (caller knows which bucket to provision
+/// into); pass `None` to let the VTA infer per the canonical Trust
+/// Task spec's three rules — typical for wallet-class callers that
+/// don't track the maintainer's context layout. See
+/// [`crate::provision_integration::http::ProvisionIntegrationRequest::context`]
+/// for the full inference rules + error semantics.
 pub async fn provision_integration_didcomm(
     session: &DIDCommSession,
     request: BootstrapRequest,
-    context: String,
+    context: Option<String>,
     assertion: Option<AssertionMode>,
     vc_validity_seconds: Option<i64>,
     create_context: bool,

--- a/vta-sdk/src/provision_integration/http.rs
+++ b/vta-sdk/src/provision_integration/http.rs
@@ -19,7 +19,25 @@ pub struct ProvisionIntegrationRequest {
     /// server verifies on intake.
     pub request: BootstrapRequest,
     /// VTA context to provision into.
-    pub context: String,
+    ///
+    /// **Optional** per the canonical Trust Task spec
+    /// (`https://trusttasks.org/spec/provision/integration/0.1`). When
+    /// absent, the maintainer infers the target context using these
+    /// rules in order:
+    ///
+    /// 1. If the relayer's ACL grant scopes to exactly one context →
+    ///    use that context.
+    /// 2. If the relayer is a super-admin (Admin role with empty
+    ///    `allowed_contexts`) AND the maintainer has exactly one
+    ///    context registered → use it.
+    /// 3. Otherwise the maintainer refuses with
+    ///    `provision/integration:context_required` and `details.
+    ///    candidates: Vec<String>` listing the plausible contexts.
+    ///
+    /// Wallet-class consumers SHOULD omit; integration-class consumers
+    /// SHOULD send explicitly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
     /// Optional — default `did-signed`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assertion: Option<AssertionMode>,

--- a/vta-sdk/tests/provision_client_e2e.rs
+++ b/vta-sdk/tests/provision_client_e2e.rs
@@ -520,7 +520,7 @@ async fn admin_rotated_via_rest_round_trip() {
 
     let req = ProvisionIntegrationRequest {
         request: signed,
-        context: "ctx-1".into(),
+        context: Some("ctx-1".into()),
         assertion: None,
         vc_validity_seconds: None,
         create_context: false,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1432,6 +1432,36 @@ pub async fn handle_provision_integration(
     let vc_validity = body.vc_validity_seconds.map(chrono::Duration::seconds);
 
     let deps = operations::provision_integration::ProvisionIntegrationDeps::from(state.as_ref());
+
+    // Resolve the target context. When the caller sent one, use it
+    // verbatim (integration-class consumer pattern). When omitted, run
+    // the spec's three inference rules — single-context grant, super-
+    // admin + single-context maintainer, else AmbiguousContext.
+    let context = match body.context {
+        Some(c) => c,
+        None => match app_try!(
+            operations::provision_integration::infer_target_context(&auth, &deps.contexts_ks).await
+        ) {
+            Ok(ctx) => ctx,
+            Err(operations::provision_integration::AmbiguousContext {
+                candidates,
+                message,
+            }) => {
+                // Emit the canonical Trust Task error code so clients
+                // can surface candidates structurally. `args` carries
+                // the list in arrival order (sorted by the helper).
+                let report = ProblemReport {
+                    code: vta_sdk::protocols::problem_report_codes::PROVISION_CONTEXT_REQUIRED
+                        .to_string(),
+                    comment: message,
+                    args: candidates,
+                    escalate_to: None,
+                };
+                return Ok(Some(DIDCommResponse::problem_report(report)));
+            }
+        },
+    };
+
     // `--create-context` from the wire body. Same semantics as the
     // REST handler — super-admin gate enforced inside
     // `operations::contexts::create_context`. Idempotent.
@@ -1439,7 +1469,7 @@ pub async fn handle_provision_integration(
         operations::provision_integration::ensure_target_context_or_create(
             &deps.contexts_ks,
             &auth,
-            &body.context,
+            &context,
             body.create_context,
         )
         .await
@@ -1450,7 +1480,7 @@ pub async fn handle_provision_integration(
             &auth,
             operations::provision_integration::ProvisionIntegrationParams {
                 request: verified,
-                context: body.context,
+                context,
                 assertion_mode,
                 vc_validity,
             },

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -49,7 +49,7 @@ mod templates;
 mod vta_keys;
 mod webvh;
 
-pub use preconditions::ensure_target_context_or_create;
+pub use preconditions::{AmbiguousContext, ensure_target_context_or_create, infer_target_context};
 
 use std::collections::BTreeMap;
 use std::sync::Arc;

--- a/vta-service/src/operations/provision_integration/preconditions.rs
+++ b/vta-service/src/operations/provision_integration/preconditions.rs
@@ -14,6 +14,108 @@ use vta_sdk::provision_integration::{BootstrapAsk, DidTemplateRef, VerifiedBoots
 
 use super::ProvisionIntegrationDeps;
 
+/// Returned when [`infer_target_context`] cannot pick a single target
+/// context — caller has admin in multiple contexts, or is a super-admin
+/// against a multi-context maintainer. Carries the plausible candidates
+/// so the transport layer can surface them to the relayer and let them
+/// retry with an explicit choice.
+///
+/// The caller renders this differently per transport: the DIDComm
+/// handler emits a `provision/integration:context_required` problem
+/// report with `args = candidates`; the REST handler returns a 400
+/// with the message and candidates inlined.
+#[derive(Debug)]
+pub struct AmbiguousContext {
+    pub candidates: Vec<String>,
+    pub message: String,
+}
+
+/// Infer the target context the maintainer should provision into when
+/// the caller omits `payload.context`. Implements the three rules
+/// pinned in
+/// `dtgwg-trust-tasks-tf/specs/provision/integration/0.1/spec.md`
+/// §"Context inference":
+///
+/// 1. **Single-context grant.** If the relayer's ACL entry scopes to
+///    exactly one context, use that context.
+/// 2. **Single-context maintainer.** If the relayer is a super-admin
+///    AND the maintainer has exactly one context registered, use it.
+/// 3. **Ambiguous.** Anything else returns
+///    [`Err(AmbiguousContext)`] so the caller can surface candidates
+///    + retry with an explicit value.
+///
+/// `Result<Result<…>, …>` is intentional: the outer `Result` is the
+/// usual `AppError` plumbing (store-level failures); the inner Result
+/// distinguishes "inferred ok" from "ambiguous, here are the candidates"
+/// without conflating the two with store errors.
+pub async fn infer_target_context(
+    auth: &AuthClaims,
+    contexts_ks: &KeyspaceHandle,
+) -> Result<Result<String, AmbiguousContext>, AppError> {
+    // Rule 1: single-context grant — operator already named the bucket
+    // on the wire when they granted the ephemeral. Respect it.
+    if let Some(ctx) = auth.default_context() {
+        return Ok(Ok(ctx.to_string()));
+    }
+
+    // Rule 2: super-admin + single-context maintainer. Covers the
+    // typical wallet onboarding case where the operator ran
+    // `pnm acl create --did <eph> --role admin` (no `--contexts`)
+    // against a single-context VTA.
+    if auth.is_super_admin() {
+        let contexts = crate::contexts::list_contexts(contexts_ks).await?;
+        let mut ids: Vec<String> = contexts.iter().map(|c| c.id.clone()).collect();
+        ids.sort();
+        match ids.len() {
+            0 => {
+                // No contexts at all — distinct from "ambiguous". The
+                // operator needs to create a context first; surface as
+                // NotFound with a remediation hint matching the rest of
+                // provision-integration's error vocabulary.
+                return Err(AppError::NotFound(
+                    "no contexts registered on this VTA — create one with \
+                     'vta contexts create --id <name>' (offline) or \
+                     'pnm contexts create' (online), then retry"
+                        .into(),
+                ));
+            }
+            1 => return Ok(Ok(ids.into_iter().next().expect("len == 1"))),
+            n => {
+                return Ok(Err(AmbiguousContext {
+                    candidates: ids,
+                    message: format!(
+                        "super-admin grant against {n} contexts — \
+                         specify which to provision into via payload.context"
+                    ),
+                }));
+            }
+        }
+    }
+
+    // Rule 3a: multi-context relayer (not super-admin) — caller has
+    // admin in N > 1 contexts but didn't say which. Return the list.
+    if auth.allowed_contexts.len() > 1 {
+        let mut ids = auth.allowed_contexts.clone();
+        ids.sort();
+        return Ok(Err(AmbiguousContext {
+            message: format!(
+                "caller holds admin in {} contexts — specify which to provision into via payload.context",
+                ids.len()
+            ),
+            candidates: ids,
+        }));
+    }
+
+    // Defensive fallthrough: caller is not super-admin (would have
+    // matched above), has 0 or 1 allowed_contexts but default_context
+    // returned None (so it's 0). A non-super-admin with zero context
+    // grants shouldn't reach the inference step — `require_admin`
+    // would have rejected. But surface clearly if it does.
+    Err(AppError::Forbidden(
+        "caller has admin role but no context grants — refusing to infer".into(),
+    ))
+}
+
 /// Ensure the target `context` exists, optionally creating it
 /// inline when `create_context` is set. Centralised here so REST,
 /// DIDComm, and the offline CLI all enforce the same semantics:
@@ -185,5 +287,134 @@ pub(super) fn extract_admin_template(ask: &BootstrapAsk) -> Option<DidTemplateRe
     match ask {
         BootstrapAsk::TemplateBootstrap(ask) => ask.admin_template.clone(),
         BootstrapAsk::AdminRotation(ask) => Some(ask.admin_template.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::Role;
+    use crate::store::Store;
+    use vti_common::config::StoreConfig;
+
+    async fn fresh_contexts_ks() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store.keyspace("contexts").expect("open contexts ks");
+        (dir, store, ks)
+    }
+
+    fn auth(role: Role, allowed_contexts: Vec<&str>) -> AuthClaims {
+        AuthClaims {
+            did: "did:key:zTestCaller".into(),
+            role,
+            allowed_contexts: allowed_contexts.iter().map(|s| (*s).to_string()).collect(),
+            session_id: "test-session".into(),
+            // Synthesized auth claim, not from a JWT — mirrors the
+            // shape used by `AuthClaims::synthesize` for DIDComm-only
+            // callers in the codebase.
+            access_expires_at: 0,
+            amr: vec!["synth".into()],
+            acr: String::new(),
+        }
+    }
+
+    async fn seed_context(ks: &KeyspaceHandle, id: &str) {
+        crate::contexts::create_context(ks, id, id)
+            .await
+            .expect("seed context");
+    }
+
+    /// Rule 1: single allowed context → returns it. The relayer's grant
+    /// already named the bucket; inference respects it without
+    /// consulting the contexts keyspace.
+    #[tokio::test]
+    async fn infer_returns_single_allowed_context() {
+        let (_dir, _store, ks) = fresh_contexts_ks().await;
+        // Seed multiple contexts to confirm the inference doesn't reach
+        // for rule 2's fallback when rule 1 already resolves.
+        seed_context(&ks, "ctx_a").await;
+        seed_context(&ks, "ctx_b").await;
+
+        let a = auth(Role::Admin, vec!["ctx_b"]);
+        let result = infer_target_context(&a, &ks).await.expect("ok");
+        assert_eq!(result.expect("not ambiguous"), "ctx_b");
+    }
+
+    /// Rule 2: super-admin grant + maintainer has exactly one context →
+    /// use it. This is the typical wallet onboarding case where the
+    /// operator ran `pnm acl create --did <eph> --role admin` (no
+    /// `--contexts` flag = super-admin scoping).
+    #[tokio::test]
+    async fn infer_super_admin_with_single_context() {
+        let (_dir, _store, ks) = fresh_contexts_ks().await;
+        seed_context(&ks, "only").await;
+
+        let a = auth(Role::Admin, vec![]); // empty → super-admin
+        assert!(a.is_super_admin());
+
+        let result = infer_target_context(&a, &ks).await.expect("ok");
+        assert_eq!(result.expect("not ambiguous"), "only");
+    }
+
+    /// Rule 3a: super-admin + multiple contexts → ambiguous; carry the
+    /// candidates so the caller can surface them and retry.
+    #[tokio::test]
+    async fn infer_super_admin_with_multiple_contexts_is_ambiguous() {
+        let (_dir, _store, ks) = fresh_contexts_ks().await;
+        seed_context(&ks, "ctx_a").await;
+        seed_context(&ks, "ctx_b").await;
+        seed_context(&ks, "ctx_c").await;
+
+        let a = auth(Role::Admin, vec![]);
+
+        let result = infer_target_context(&a, &ks).await.expect("ok");
+        let ambiguous = result.expect_err("must be ambiguous with 3 contexts");
+        assert_eq!(
+            ambiguous.candidates,
+            vec![
+                "ctx_a".to_string(),
+                "ctx_b".to_string(),
+                "ctx_c".to_string()
+            ]
+        );
+        assert!(ambiguous.message.contains("3 contexts"));
+    }
+
+    /// Rule 3b: multi-context grant (non-super-admin) → ambiguous,
+    /// candidates come from the relayer's own `allowed_contexts`.
+    #[tokio::test]
+    async fn infer_multi_context_grant_is_ambiguous() {
+        let (_dir, _store, ks) = fresh_contexts_ks().await;
+
+        let a = auth(Role::Admin, vec!["ctx_x", "ctx_y"]);
+
+        let result = infer_target_context(&a, &ks).await.expect("ok");
+        let ambiguous = result.expect_err("two contexts → ambiguous");
+        assert_eq!(
+            ambiguous.candidates,
+            vec!["ctx_x".to_string(), "ctx_y".to_string()]
+        );
+    }
+
+    /// Super-admin against an empty maintainer → NotFound, not
+    /// AmbiguousContext. The remediation is "create a context first"
+    /// rather than "pick from the list" (the list is empty).
+    #[tokio::test]
+    async fn infer_super_admin_with_no_contexts_returns_not_found() {
+        let (_dir, _store, ks) = fresh_contexts_ks().await;
+
+        let a = auth(Role::Admin, vec![]);
+
+        let err = infer_target_context(&a, &ks)
+            .await
+            .expect_err("must NotFound");
+        assert!(
+            matches!(err, AppError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
     }
 }

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -531,9 +531,13 @@ mod provision {
         /// The integration's VP-framed bootstrap request (signed by its
         /// ephemeral `client_did`).
         pub request: BootstrapRequest,
-        /// VTA context to provision into. See library-fn docs for
-        /// context-hint reconciliation rules.
-        pub context: String,
+        /// VTA context to provision into. **Optional** per the canonical
+        /// Trust Task spec; omit to let the VTA infer from the caller's
+        /// ACL grant or its own contexts state. See
+        /// `vta_sdk::provision_integration::http::ProvisionIntegrationRequest`
+        /// for the full inference rules + error semantics when ambiguous.
+        #[serde(default)]
+        pub context: Option<String>,
         /// Optional — default `DidSigned`. Rejected unless the assertion
         /// mode is one the server is happy to sign (pinned-only is
         /// accepted on the HTTP surface because dev/test HTTP use is
@@ -628,6 +632,37 @@ mod provision {
         let vc_validity = req.vc_validity_seconds.map(chrono::Duration::seconds);
 
         let deps = crate::operations::provision_integration::ProvisionIntegrationDeps::from(&state);
+
+        // Resolve the target context. When the caller sent one, use it
+        // verbatim; otherwise run the spec's inference rules. On
+        // ambiguity we collapse into Validation here — REST clients
+        // (pnm-cli, scripts) get the message + candidates inline. The
+        // DIDComm path emits the canonical
+        // `provision/integration:context_required` code so structured
+        // clients can branch on it; REST's typed-error vocabulary
+        // wasn't designed for arbitrary new codes, so we stay with the
+        // existing 400 shape.
+        let context = match req.context {
+            Some(c) => c,
+            None => match crate::operations::provision_integration::infer_target_context(
+                &auth.0,
+                &deps.contexts_ks,
+            )
+            .await?
+            {
+                Ok(ctx) => ctx,
+                Err(crate::operations::provision_integration::AmbiguousContext {
+                    candidates,
+                    message,
+                }) => {
+                    return Err(AppError::Validation(format!(
+                        "{message} (candidates: {})",
+                        candidates.join(", "),
+                    )));
+                }
+            },
+        };
+
         // `--create-context`: create the target context inline if
         // it doesn't exist. Hits the super-admin gate inside
         // `operations::contexts::create_context` — context-admin
@@ -637,7 +672,7 @@ mod provision {
             crate::operations::provision_integration::ensure_target_context_or_create(
                 &deps.contexts_ks,
                 &auth.0,
-                &req.context,
+                &context,
                 req.create_context,
             )
             .await?;
@@ -646,7 +681,7 @@ mod provision {
             &auth.0,
             ProvisionIntegrationParams {
                 request: verified,
-                context: req.context,
+                context,
                 assertion_mode,
                 vc_validity,
             },

--- a/vta-service/src/routes/trust_tasks/provision_integration.rs
+++ b/vta-service/src/routes/trust_tasks/provision_integration.rs
@@ -28,7 +28,8 @@ use vta_sdk::provision_integration::http::{
 use crate::auth::AuthClaims;
 use crate::error::AppError;
 use crate::operations::provision_integration::{
-    ProvisionIntegrationDeps, ProvisionIntegrationParams, ensure_target_context_or_create,
+    AmbiguousContext, ProvisionIntegrationDeps, ProvisionIntegrationParams,
+    ensure_target_context_or_create, infer_target_context,
     provision_integration as provision_integration_op,
 };
 use crate::server::AppState;
@@ -73,6 +74,30 @@ pub(super) async fn handle_request(
     let vc_validity = req.vc_validity_seconds.map(chrono::Duration::seconds);
     let deps = ProvisionIntegrationDeps::from(state);
 
+    // Resolve the target context. When the caller sent one, use it
+    // verbatim; otherwise run the spec's inference rules. Ambiguous
+    // → MalformedRequest with the candidates inline (trust-task
+    // envelopes don't carry the canonical `provision/integration:
+    // context_required` code yet — REST surfaces what we have here).
+    let context = match req.context {
+        Some(c) => c,
+        None => match infer_target_context(auth, &deps.contexts_ks).await {
+            Ok(Ok(c)) => c,
+            Ok(Err(AmbiguousContext {
+                candidates,
+                message,
+            })) => {
+                return reject_with(
+                    &doc,
+                    trust_tasks_rs::RejectReason::MalformedRequest {
+                        reason: format!("{message} (candidates: {})", candidates.join(", ")),
+                    },
+                );
+            }
+            Err(e) => return app_error_to_reject(&doc, e),
+        },
+    };
+
     // `create_context: true` — create the target context inline if it
     // doesn't exist. Hits the super-admin gate inside
     // operations::contexts::create_context; context-admin callers
@@ -80,7 +105,7 @@ pub(super) async fn handle_request(
     let context_created = match ensure_target_context_or_create(
         &deps.contexts_ks,
         auth,
-        &req.context,
+        &context,
         req.create_context,
     )
     .await
@@ -94,7 +119,7 @@ pub(super) async fn handle_request(
         auth,
         ProvisionIntegrationParams {
             request: verified,
-            context: req.context,
+            context,
             assertion_mode: AssertionModeOpAdapter(assertion_mode).into(),
             vc_validity,
         },


### PR DESCRIPTION
## Summary

Implements the inference rules pinned in `dtgwg-trust-tasks-tf/specs/provision/integration/0.1/spec.md` §"Context inference" (the spec relaxation that landed in trust-tasks #52).

When the caller omits `payload.context`, the VTA picks the target context using three rules in order:

1. **Single-context grant.** Relayer's ACL row scopes to exactly one context → use it.
2. **Single-context maintainer.** Relayer is a super-admin AND the maintainer has exactly one context registered → use it.
3. **Ambiguous → refuse** with the candidates listed.

Subtype: super-admin against zero registered contexts surfaces as `NotFound` (remediation: "create a context first") rather than ambiguous.

## Wire shape

`ProvisionIntegrationRequest.context` becomes `Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]`. The SDK's `provision_integration_didcomm()` helper takes `Option<String>` too. Internal call sites (pnm-cli, provision_client runners, e2e tests) wrap their existing `String` values with `Some(...)`, so behaviour is unchanged for any client that was sending `context`.

## Transport-specific error rendering

When inference is ambiguous, each transport renders differently:

- **DIDComm**: problem-report with the canonical Trust Task code `provision/integration:context_required` (new constant `vta_sdk::protocols::problem_report_codes::PROVISION_CONTEXT_REQUIRED`) and `args = candidates` so structured clients can branch on it.
- **REST**: collapses into `AppError::Validation` (400) with the message + candidates inlined. REST's typed-error vocabulary wasn't designed for arbitrary new codes, and the only REST client (pnm-cli) reads the body anyway.
- **Trust-task envelope** (`spec/vta/provision-integration/request/1.0`): `MalformedRequest` with the message + candidates inlined.

## Inference helper

Lives in `vta-service/src/operations/provision_integration/preconditions.rs`:

```rust
pub async fn infer_target_context(
    auth: &AuthClaims,
    contexts_ks: &KeyspaceHandle,
) -> Result<Result<String, AmbiguousContext>, AppError>
```

The double Result splits "store-level failure" from "ambiguous, here are the candidates" so the transport layer can render each appropriately.

## Test plan

- [x] `cargo check -p vta-sdk -p vta-service -p pnm-cli` — clean
- [x] `cargo fmt` — clean
- [x] 5 new unit tests in `preconditions.rs::tests`:
  - `infer_returns_single_allowed_context` — Rule 1
  - `infer_super_admin_with_single_context` — Rule 2
  - `infer_super_admin_with_multiple_contexts_is_ambiguous` — Rule 3a
  - `infer_multi_context_grant_is_ambiguous` — Rule 3b
  - `infer_super_admin_with_no_contexts_returns_not_found` — empty-store edge case
- [x] `cargo test --lib -p vta-sdk -p vta-service` — 230/231 lib tests pass; the single failure is `trust_tasks::tests::every_uri_in_canonical_namespace` complaining about `vault/list/0.1` — **pre-existing on main**, confirmed via `git stash` test.

## Pre-existing breakage (orthogonal to this PR)

- `vta-service/tests/auth_flow.rs` + `api_integration.rs` fail to compile due to `AclEntry` shape drift (missing `capabilities`, `device`, `kind` fields).
- `trust_tasks::tests::every_uri_in_canonical_namespace` complains about `vault/list/0.1` URI shape.

Both reproduce on `main` before my changes. Separate cleanup PR.

## Out of scope

Wallet (M2C-D) — popup picker UX revert + omit `context` from the wire body. Sits on top of this PR landing + deploying. Will be a small follow-up in `pnm-browser-plugin`.