### PR TITLE
pnm config resolver-url + clearer VTA wizard helper text

### DIFF
--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1154,6 +1154,25 @@ pub(crate) enum ConfigCommands {
         #[arg(long)]
         public_url: Option<String>,
     },
+    /// Manage the remote DID-resolver cache URL stored in
+    /// `~/.config/pnm/config.toml`. When set, PNM dispatches every DID
+    /// resolution to that WebSocket endpoint (typically the same
+    /// `affinidi-did-resolver-cache-server` the local VTA points at)
+    /// instead of resolving in-process.
+    ///
+    /// Examples:
+    ///   pnm config resolver-url                            # show current value
+    ///   pnm config resolver-url ws://127.0.0.1:4445/did/v1/ws
+    ///   pnm config resolver-url --unset                    # clear, resolve locally
+    ResolverUrl {
+        /// WebSocket URL of the resolver-cache server. Omit to print
+        /// the current value.
+        url: Option<String>,
+        /// Clear the configured resolver URL. PNM will resolve DIDs
+        /// in-process again.
+        #[arg(long, conflicts_with = "url")]
+        unset: bool,
+    },
 }
 
 // ── Unified `pnm services …` surface (spec §5.1) ──────────────────
@@ -1767,6 +1786,16 @@ pub(crate) fn requires_auth(cmd: &Commands) -> bool {
     // ProvisionIntegration bridges to the authenticated endpoint.
     if let Commands::Bootstrap { command } = cmd {
         return matches!(command, BootstrapCommands::ProvisionIntegration { .. });
+    }
+    // `pnm config resolver-url …` is purely local — it mutates the
+    // PNM config file at `~/.config/pnm/config.toml` and never talks
+    // to the VTA. Other `pnm config` subcommands hit REST endpoints
+    // and need auth.
+    if let Commands::Config {
+        command: ConfigCommands::ResolverUrl { .. },
+    } = cmd
+    {
+        return false;
     }
     !matches!(
         cmd,

--- a/pnm-cli/src/commands/config.rs
+++ b/pnm-cli/src/commands/config.rs
@@ -4,6 +4,7 @@ use vta_cli_common::commands::config as config_cmd;
 use vta_sdk::client::VtaClient;
 
 use crate::cli::ConfigCommands;
+use crate::config::{PnmConfig, save_config};
 
 pub(crate) async fn run(
     client: &VtaClient,
@@ -25,5 +26,57 @@ pub(crate) async fn run(
             )
             .await
         }
+        ConfigCommands::ResolverUrl { .. } => {
+            // Handled in the pre-auth dispatcher (see `main.rs`) — local
+            // config mutation, no VTA round-trip. Reaching here means
+            // `requires_auth` and the pre-auth match disagreed.
+            unreachable!("`pnm config resolver-url` is handled pre-auth in main.rs");
+        }
     }
+}
+
+/// Local handler for `pnm config resolver-url [url] [--unset]`. Mutates
+/// `~/.config/pnm/config.toml`'s `resolver_url` field. No VTA round-trip.
+///
+/// Argument matrix:
+/// - `(None, false)` — print the current value (or "(unset)" if absent).
+/// - `(Some(url), false)` — set `resolver_url` to `url`.
+/// - `(None, true)` — clear `resolver_url`.
+/// - `(Some(_), true)` — rejected by clap's `conflicts_with`.
+pub(crate) async fn run_resolver_url(
+    config: &mut PnmConfig,
+    url: Option<String>,
+    unset: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if unset {
+        if config.resolver_url.is_some() {
+            config.resolver_url = None;
+            save_config(config)?;
+            eprintln!("Cleared resolver URL. PNM will now resolve DIDs in-process.");
+        } else {
+            eprintln!("No resolver URL was set — nothing to clear.");
+        }
+        return Ok(());
+    }
+
+    if let Some(url) = url {
+        let url = url.trim().to_string();
+        if !(url.starts_with("ws://") || url.starts_with("wss://")) {
+            return Err(
+                format!("resolver URL must start with ws:// or wss:// (got `{url}`)").into(),
+            );
+        }
+        config.resolver_url = Some(url.clone());
+        save_config(config)?;
+        eprintln!("Set resolver URL: {url}");
+        eprintln!("PNM will dispatch DID resolutions to this server on next invocation.");
+        return Ok(());
+    }
+
+    // No url, no --unset: show current value.
+    match &config.resolver_url {
+        Some(u) => println!("{u}"),
+        None => println!("(unset — PNM resolves DIDs in-process)"),
+    }
+    Ok(())
 }

--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -18,12 +18,14 @@ pub(crate) async fn run(
     url_override: Option<&str>,
     keyring_key: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+    use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 
     let session = auth::loaded_session(keyring_key);
 
-    // Single shared DID resolver — cached across all resolutions
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+    // Single shared DID resolver — cached across all resolutions.
+    // Honours PNM_RESOLVER_URL (set from `~/.config/pnm/config.toml`'s
+    // `resolver_url` at startup) for shared-cache deployments.
+    let did_resolver = DIDCacheClient::new(vta_sdk::resolver::build_did_cache_config_from_env())
         .await
         .ok();
 

--- a/pnm-cli/src/config.rs
+++ b/pnm-cli/src/config.rs
@@ -11,6 +11,15 @@ pub struct PnmConfig {
     #[serde(default)]
     pub vtas: BTreeMap<String, VtaConfig>,
 
+    /// WebSocket URL of an external `affinidi-did-resolver-cache-server`
+    /// (e.g. `ws://127.0.0.1:4445/did/v1/ws`). When set, PNM exports it
+    /// as `PNM_RESOLVER_URL` at startup and the SDK dispatches every DID
+    /// resolution to that server instead of resolving in-process. Useful
+    /// when running PNM alongside a VTA pointed at the same server —
+    /// both share the cache.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolver_url: Option<String>,
+
     // Legacy field — migrated to vtas on first load.
     #[serde(default, skip_serializing)]
     url: Option<String>,

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -91,6 +91,28 @@ async fn main() {
         }
     };
 
+    // Propagate the optional remote DID-resolver URL to the SDK as an
+    // env var. `vta_sdk::resolver::build_did_cache_config_from_env`
+    // reads this at every DIDCacheClient construction site, so a single
+    // config setting reaches the three SDK helpers PNM uses
+    // (resolve_vta_endpoint / resolve_vta_url / resolve_mediator_did)
+    // and the local `pnm health` resolver without surface-API churn.
+    //
+    // Respects any value the operator set in their environment — only
+    // sets from config when the env var is absent (or empty).
+    if let Some(url) = pnm_config.resolver_url.as_deref()
+        && !url.is_empty()
+        && std::env::var_os("PNM_RESOLVER_URL")
+            .map(|v| v.is_empty())
+            .unwrap_or(true)
+    {
+        // SAFETY: set on the main thread, before any worker / async
+        // task that reads PNM_RESOLVER_URL has been spawned.
+        unsafe {
+            std::env::set_var("PNM_RESOLVER_URL", url);
+        }
+    }
+
     // Save overrides + move the parsed command into a local so the
     // pre-auth dispatch can consume the inner enums by value (no
     // borrow-vs-move dance against `cli.command`).
@@ -153,6 +175,17 @@ async fn main() {
                 return;
             }
             command = Commands::Vta { command: vta_cmd };
+        }
+        Commands::Config {
+            command: cli::ConfigCommands::ResolverUrl { url, unset },
+        } => {
+            // Purely local — mutates the PNM config file at
+            // `~/.config/pnm/config.toml`. No VTA round-trip.
+            if let Err(e) = commands::config::run_resolver_url(&mut pnm_config, url, unset).await {
+                vta_cli_common::render::print_cli_error(e.as_ref());
+                std::process::exit(1);
+            }
+            return;
         }
         other => {
             command = other;

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -100,6 +100,7 @@ pub mod didcomm_session;
 pub mod keyring_init;
 pub mod keys;
 pub mod prelude;
+pub mod resolver;
 // `protocol` itself is always-on (its `services` submodule holds pure
 // wire types + the shared `validate_service_url` validator that
 // vta-service uses without ever talking to a `VtaClient`). The

--- a/vta-sdk/src/resolver.rs
+++ b/vta-sdk/src/resolver.rs
@@ -1,0 +1,47 @@
+//! DID-cache configuration helper.
+//!
+//! Mirrors the toggle `vta-service` exposes via `config.resolver_url`:
+//! when a WebSocket URL is supplied, the SDK dispatches every DID
+//! resolution to an external `affinidi-did-resolver-cache-server`
+//! (typically running alongside the VTA). When `None`, the SDK
+//! resolves in-process and caches results in memory.
+//!
+//! ## Why the env-var path exists
+//!
+//! `pnm-cli` calls into SDK functions that construct their own
+//! `DIDCacheClient` (`session::resolve_vta_endpoint`,
+//! `session::resolve_vta_url`, `session::resolve_mediator_did`). Those
+//! signatures don't take a config, so threading `PnmConfig.resolver_url`
+//! through every call site would mean breaking the SDK's public API for
+//! every consumer. Instead, PNM exports its setting as
+//! `PNM_RESOLVER_URL` at startup, and the SDK helper picks it up —
+//! a single config setting propagates to every resolver construction
+//! without surface changes.
+//!
+//! `vta-service` / `vtc-service` ignore the env var and build their
+//! resolver explicitly from their own config (`server.rs` calls
+//! `with_network_mode(url)` directly), so PNM's setting does not leak
+//! into long-running daemons that have their own opinion.
+
+use affinidi_did_resolver_cache_sdk::config::{DIDCacheConfig, DIDCacheConfigBuilder};
+
+/// Build a `DIDCacheConfig` honouring an optional remote-resolver URL.
+/// When `url` is `Some`, network-mode is enabled — every resolution is
+/// dispatched to that WebSocket endpoint. When `None`, the SDK resolves
+/// in-process with an in-memory cache.
+pub fn build_did_cache_config(url: Option<&str>) -> DIDCacheConfig {
+    let mut builder = DIDCacheConfigBuilder::default();
+    if let Some(u) = url {
+        builder = builder.with_network_mode(u);
+    }
+    builder.build()
+}
+
+/// Read `PNM_RESOLVER_URL` and build a `DIDCacheConfig` accordingly.
+/// Empty string or unset means local mode.
+pub fn build_did_cache_config_from_env() -> DIDCacheConfig {
+    let url = std::env::var("PNM_RESOLVER_URL")
+        .ok()
+        .filter(|s| !s.is_empty());
+    build_did_cache_config(url.as_deref())
+}

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_tdk::didcomm::Message;
 use affinidi_tdk::secrets_resolver::SecretsResolver;
 use serde::{Deserialize, Serialize};
@@ -1086,7 +1086,7 @@ pub async fn resolve_vta_endpoint(
 ) -> Result<VtaEndpoint, Box<dyn std::error::Error>> {
     debug!(vta_did, "resolving VTA DID for transport selection");
 
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+    let did_resolver = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
         .await
         .map_err(|e| format!("DID resolver init failed: {e}"))?;
 
@@ -1143,7 +1143,7 @@ pub async fn resolve_vta_endpoint(
 pub async fn resolve_vta_url(vta_did: &str) -> Result<String, Box<dyn std::error::Error>> {
     debug!(vta_did, "resolving VTA DID to discover service URL");
 
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+    let did_resolver = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
         .await
         .map_err(|e| format!("DID resolver init failed: {e}"))?;
 
@@ -1244,7 +1244,7 @@ pub async fn send_trust_ping(
 pub async fn resolve_mediator_did(
     vta_did: &str,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+    let did_resolver = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
         .await
         .map_err(|e| format!("DID resolver init failed: {e}"))?;
     resolve_mediator_did_with_resolver(vta_did, &did_resolver).await

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -594,6 +594,23 @@ pub async fn run_setup_wizard(
     // 7b. Optional remote DID resolver — required for TEE network mode
     // (resolver-cache-server sidecar bridged via vsock); useful for
     // any deployment that wants to share a resolver-cache.
+    println!();
+    println!("DID resolution");
+    println!("  The VTA resolves DIDs (did:web, did:webvh, did:key, did:peer) on every");
+    println!("  authcrypt, every proof check, every authenticate. Pick where that work");
+    println!("  happens:");
+    println!();
+    println!("    • Leave EMPTY — resolve in-process with an in-memory cache. Fine for");
+    println!("      single-node deployments. No external dependency.");
+    println!();
+    println!("    • Set a ws:// URL — dispatch every resolution to an external");
+    println!("      `affinidi-did-resolver-cache-server`. That server becomes the shared");
+    println!("      cache across every VTA pointed at it.");
+    println!();
+    println!("  REQUIRED for TEE / Nitro deployments (the enclave cannot fetch did:web");
+    println!("  / did:webvh itself; resolution is bridged to a parent-side cache server");
+    println!("  over vsock). Example: ws://127.0.0.1:4445/did/v1/ws");
+    println!();
     let resolver_url: String = Input::new()
         .with_prompt("Remote DID resolver WebSocket URL (leave empty to resolve locally)")
         .allow_empty(true)


### PR DESCRIPTION
## Summary

- **VTA wizard** — adds a multi-line explanation above the `Remote DID resolver WebSocket URL` prompt covering local vs network mode, the canonical use cases (TEE/Nitro, multi-VTA fleets), and an example URL. Operators were guessing at what the toggle did.
- **PNM CLI** — new opt-in `resolver_url` field on `PnmConfig` plus a `pnm config resolver-url [url] [--unset]` subcommand. When set, exported as `PNM_RESOLVER_URL` so the SDK's three `DIDCacheClient` construction sites (`resolve_vta_endpoint` / `resolve_vta_url` / `resolve_mediator_did`) and `pnm health` all share one external resolver cache — typically the same `affinidi-did-resolver-cache-server` the co-located VTA points at.
- **vta-sdk** — new `vta_sdk::resolver` module with `build_did_cache_config(Option<&str>)` and an env-var convenience. `vta-service` / `vtc-service` / `deploy/nitro` resolver constructions are untouched — they already build from their own explicit `config.resolver_url`, so the env var does not leak into long-running daemons.

## Test plan

- [ ] `cargo check --workspace` clean
- [ ] `cargo fmt --check` clean
- [ ] `cargo test -p pnm-cli -p vta-sdk` green
- [ ] Manually run `vta setup` and confirm the new helper text renders before the prompt
- [ ] `pnm config resolver-url` (no args) prints `(unset — PNM resolves DIDs in-process)` on a fresh config
- [ ] `pnm config resolver-url ws://127.0.0.1:4445/did/v1/ws` persists to `~/.config/pnm/config.toml` and confirms back
- [ ] `pnm config resolver-url http://...` rejects with a clear `must start with ws:// or wss://` error
- [ ] `pnm config resolver-url --unset` clears
- [ ] With `resolver_url` set, run `pnm health` against a VTA pointing at the same resolver-cache-server; verify the resolver hits the cache server (e.g. via its access log) and the latency drops
- [ ] An operator's `PNM_RESOLVER_URL` env var continues to win over the config value