### PR TITLE
VTA handler: vault/sign-trust-task/0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9277,6 +9277,7 @@ dependencies = [
  "aes 0.9.0",
  "aes-gcm",
  "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -277,6 +277,17 @@ pub const TASK_VAULT_RELEASE_0_1: &str = "https://trusttasks.org/spec/vault/rele
 /// Auth: ProxyLogin.
 pub const TASK_VAULT_PROXY_LOGIN_0_1: &str = "https://trusttasks.org/spec/vault/proxy-login/0.1";
 
+/// `spec/vault/sign-trust-task/0.1` — the VTA attaches an eddsa-jcs-2022
+/// Data Integrity proof to a Trust Task envelope, signing as the
+/// principal DID of a `did-self-issued` or `didcomm-peer` vault entry.
+/// The long-term signing key never leaves the VTA. Per-envelope signing
+/// complement to proxy-login's session-credential minting — used when a
+/// consumer needs to issue follow-up tasks during a proxy-login'd
+/// session and the RP expects them signed by the session DID.
+/// Auth: SignTrustTask capability.
+pub const TASK_VAULT_SIGN_TRUST_TASK_0_1: &str =
+    "https://trusttasks.org/spec/vault/sign-trust-task/0.1";
+
 // ─── Config slice (spec/vta/config/*) ────────────────────────────────────
 
 /// `spec/vta/config/get/1.0` — read the current VTA configuration
@@ -709,6 +720,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_VAULT_DELETE_0_1,
     TASK_VAULT_RELEASE_0_1,
     TASK_VAULT_PROXY_LOGIN_0_1,
+    TASK_VAULT_SIGN_TRUST_TASK_0_1,
     // Config slice
     TASK_CONFIG_GET_1_0,
     TASK_CONFIG_UPDATE_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -96,6 +96,9 @@ affinidi-crypto = { workspace = true }
 # direct so `vta-service::operations::provision_integration` can name
 # the type.
 affinidi-secrets-resolver = { workspace = true }
+# Data Integrity (eddsa-jcs-2022) — used by the vault/sign-trust-task
+# handler to attach proofs to envelopes on behalf of the holder.
+affinidi-data-integrity = { workspace = true }
 hkdf = { workspace = true }
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.13"

--- a/vta-service/src/operations/vault/mod.rs
+++ b/vta-service/src/operations/vault/mod.rs
@@ -11,6 +11,7 @@
 //! land in M2B.5 — they'll grow this module rather than the handler's
 //! file so the auth-elevated paths stay scoped here.
 
+use affinidi_secrets_resolver::secrets::Secret;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ed25519_dalek::{Signer, SigningKey};
@@ -34,6 +35,10 @@ pub mod password_post;
 /// Audit channel tag for the internal authority used by
 /// proxy-login key resolution.
 const PROXY_LOGIN_CHANNEL: &str = "vault-proxy-login-internal";
+
+/// Audit channel tag for the internal authority used by
+/// sign-trust-task key resolution.
+const SIGN_TRUST_TASK_CHANNEL: &str = "vault-sign-trust-task-internal";
 
 /// Default SIOP id_token lifetime (seconds). The vault/proxy-login spec
 /// recommends a short window; 300 s matches the step-up token's TTL and
@@ -71,6 +76,39 @@ pub async fn load_signing_key_by_id(
     let seed: [u8; 32] = decode_private_key_multibase(&resp.private_key_multibase)
         .map_err(|e| AppError::Internal(format!("decode signing-key seed for {key_id}: {e}")))?;
     Ok(SigningKey::from_bytes(&seed))
+}
+
+/// Load an Ed25519 signing key by id as an affinidi
+/// [`Secret`](affinidi_secrets_resolver::secrets::Secret) — the form
+/// `affinidi_data_integrity::DataIntegrityProof::sign` consumes.
+/// Companion to [`load_signing_key_by_id`] which returns the raw
+/// `ed25519_dalek::SigningKey` used by the SIOP id_token JWS path.
+///
+/// Auth: gated by `InternalAuthority`. The caller (sign-trust-task
+/// handler) has already validated the `SignTrustTask` capability and
+/// the entry's context scope.
+pub async fn load_signing_secret_by_id(
+    keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    audit_ks: &KeyspaceHandle,
+    key_id: &str,
+) -> Result<Secret, AppError> {
+    let authority = InternalAuthority::new("vault-sign-trust-task");
+    let resp = crate::operations::keys::get_key_secret_internal(
+        keys_ks,
+        imported_ks,
+        seed_store,
+        audit_ks,
+        authority,
+        key_id,
+        SIGN_TRUST_TASK_CHANNEL,
+    )
+    .await?;
+    let mut secret = Secret::from_multibase(&resp.private_key_multibase, None)
+        .map_err(|e| AppError::Internal(format!("construct Secret for {key_id}: {e}")))?;
+    secret.id = key_id.to_string();
+    Ok(secret)
 }
 
 /// Build a SIOPv2 id_token (compact Ed25519 JWS) on behalf of a

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -345,6 +345,9 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         vta_sdk::trust_tasks::TASK_VAULT_PROXY_LOGIN_0_1 => {
             vault::handle_proxy_login(state, auth, doc).await
         }
+        vta_sdk::trust_tasks::TASK_VAULT_SIGN_TRUST_TASK_0_1 => {
+            vault::handle_sign_trust_task(state, auth, doc).await
+        }
         // ─── Config slice ────────────────────────────────────────────
         vta_sdk::trust_tasks::TASK_CONFIG_GET_1_0 => config::handle_get(state, auth, doc).await,
         vta_sdk::trust_tasks::TASK_CONFIG_UPDATE_1_0 => {

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -432,6 +432,28 @@ fn require_proxy_login(auth: &AuthClaims, doc: &TrustTask<Value>) -> Result<(), 
     }
 }
 
+/// Used by vault/sign-trust-task. Per-envelope signing on the entry's
+/// principal DID — strictly more privileged than `Sign` (which is the
+/// generic signing oracle), distinct from `ProxyLogin` (which mints a
+/// session credential, not an arbitrary envelope). Splitting them lets
+/// operators grant proxy-login without sign-trust-task to limit blast
+/// radius on Service consumers.
+fn require_sign_trust_task(auth: &AuthClaims, doc: &TrustTask<Value>) -> Result<(), Response> {
+    if role_has_capability(&auth.role, Capability::SignTrustTask) {
+        Ok(())
+    } else {
+        Err(reject_with(
+            doc,
+            RejectReason::PermissionDenied {
+                reason: format!(
+                    "vault sign-trust-task denied: role {} does not carry SignTrustTask capability",
+                    auth.role
+                ),
+            },
+        ))
+    }
+}
+
 /// Unseal a `SealedEnvelope` into the cleartext [`VaultSecret`].
 ///
 /// M2A supports the `didcomm-authcrypt` variant only. The JWE is unpacked
@@ -1462,6 +1484,298 @@ pub(super) async fn handle_proxy_login(
             sealed_session_blob: SealedEnvelopeWire::DidcommAuthcrypt { jwe },
             session_id,
             expires_at,
+        },
+    )
+}
+
+// ─── vault/sign-trust-task/0.1 ─────────────────────────────────────
+
+/// Request body for `vault/sign-trust-task/0.1`. Mirrors the canonical
+/// schema. `consumerContext` / `stepUpProof` are accepted but not yet
+/// consumed (M3 policy engine will read consumerContext; step-up gating
+/// across sign-trust-task lands as a follow-up to the proxy-login wiring).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultSignTrustTaskBody {
+    entry_id: String,
+    unsigned_envelope: Value,
+    #[serde(default)]
+    #[allow(dead_code)]
+    consumer_context: Option<Value>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    step_up_proof: Option<Value>,
+}
+
+/// Response body for `vault/sign-trust-task/0.1`. Same `unsigned_envelope`
+/// the consumer submitted with a `proof` field attached.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultSignTrustTaskResponseBody {
+    signed_envelope: Value,
+}
+
+/// Handler for `spec/vault/sign-trust-task/0.1`. Attaches an
+/// `eddsa-jcs-2022` Data Integrity proof to a Trust Task envelope,
+/// signing as the principal DID of a `did-self-issued` or
+/// `didcomm-peer` vault entry.
+///
+/// The long-term signing key never leaves the maintainer. This is the
+/// per-envelope-signing complement to `vault/proxy-login/0.1`: proxy-
+/// login mints a session credential at session-start; sign-trust-task
+/// signs individual follow-up tasks during that session so the proof
+/// VM matches the authenticated session DID at the relying party.
+///
+/// Conformance check order matches the spec's error precedence:
+/// `not_found` → `permission_denied` (cap) → context scope →
+/// `not_signable` (entry kind) → `envelope_invalid` (structure) →
+/// `envelope_already_proofed` → `envelope_issuer_mismatch` →
+/// `envelope_expired` → sign.
+pub(super) async fn handle_sign_trust_task(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    if let Err(r) = require_sign_trust_task(auth, &doc) {
+        return r;
+    }
+    let req: VaultSignTrustTaskBody = match parse_payload(&doc) {
+        Ok(v) => v,
+        Err(r) => return r,
+    };
+
+    // Load entry — conflate not-found with permission-denied to deny
+    // enumeration (matches handle_release / handle_proxy_login).
+    let stored = match get_stored_vault_entry(&state.vault_ks, &req.entry_id).await {
+        Ok(Some(e)) => e,
+        Ok(None) => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: format!(
+                        "vault/sign-trust-task:not_found — no entry at id {}",
+                        req.entry_id
+                    ),
+                    details: None,
+                },
+            );
+        }
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    if let Err(r) = enforce_context_scope(auth, Some(&stored.entry.context_id), &doc) {
+        return r;
+    }
+
+    // Only signable kinds (DID-anchored secrets) carry a principal
+    // identity the maintainer can sign as. Password / OAuth / passkey
+    // / bearer / ssh / custom kinds have no DID — reject loudly so the
+    // consumer can fall back to a different flow (proxy-login for
+    // session creds, release for browser autofill).
+    let (principal_did, signing_key_id) = match &stored.secret {
+        VaultSecret::DidSelfIssued {
+            did,
+            signing_key_id,
+            ..
+        }
+        | VaultSecret::DidcommPeer {
+            peer_did: did,
+            signing_key_id,
+            ..
+        } => (did.clone(), signing_key_id.clone()),
+        other => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: format!(
+                        "vault/sign-trust-task:not_signable — entry kind '{}' has no DID-based signing identity",
+                        secret_kind_label(other.kind()),
+                    ),
+                    details: Some(serde_json::json!({
+                        "secretKind": secret_kind_label(other.kind()),
+                    })),
+                },
+            );
+        }
+    };
+
+    // Structural validation of the supplied envelope. Per spec: id,
+    // type, issuer, recipient, issuedAt, payload all required; proof
+    // must be absent.
+    let envelope_obj = match req.unsigned_envelope.as_object() {
+        Some(o) => o,
+        None => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: "vault/sign-trust-task:envelope_invalid — unsignedEnvelope must be a JSON object".into(),
+                    details: None,
+                },
+            );
+        }
+    };
+    for field in ["id", "type", "issuer", "recipient", "issuedAt", "payload"] {
+        if !envelope_obj.contains_key(field) {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: format!(
+                        "vault/sign-trust-task:envelope_invalid — missing required field '{field}'"
+                    ),
+                    details: Some(serde_json::json!({ "missing": field })),
+                },
+            );
+        }
+    }
+    if envelope_obj.contains_key("proof") {
+        return reject_with(
+            &doc,
+            RejectReason::TaskFailed {
+                reason: "vault/sign-trust-task:envelope_already_proofed — strip the existing proof and resubmit".into(),
+                details: None,
+            },
+        );
+    }
+
+    // Strict issuer match: the maintainer refuses to silently rewrite
+    // the consumer's issuer. Mismatch is loud so consumer bugs surface
+    // explicitly rather than as cryptic verification failures at the
+    // recipient.
+    let envelope_issuer = match envelope_obj.get("issuer").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: "vault/sign-trust-task:envelope_invalid — issuer must be a string"
+                        .into(),
+                    details: None,
+                },
+            );
+        }
+    };
+    if envelope_issuer != principal_did {
+        return reject_with(
+            &doc,
+            RejectReason::TaskFailed {
+                reason: "vault/sign-trust-task:envelope_issuer_mismatch — envelope.issuer must equal the entry's principalDid".into(),
+                details: Some(serde_json::json!({
+                    "envelopeIssuer": envelope_issuer,
+                    "expectedIssuer": principal_did,
+                })),
+            },
+        );
+    }
+
+    // expiresAt (if present) must not be in the past.
+    if let Some(exp_v) = envelope_obj.get("expiresAt") {
+        let exp_str = exp_v.as_str().unwrap_or_default();
+        match chrono::DateTime::parse_from_rfc3339(exp_str) {
+            Ok(exp) if exp < chrono::Utc::now() => {
+                return reject_with(
+                    &doc,
+                    RejectReason::TaskFailed {
+                        reason: "vault/sign-trust-task:envelope_expired — envelope.expiresAt is in the past".into(),
+                        details: Some(serde_json::json!({ "expiresAt": exp_str })),
+                    },
+                );
+            }
+            Ok(_) => {} // future-dated, fine
+            Err(_) => {
+                return reject_with(
+                    &doc,
+                    RejectReason::TaskFailed {
+                        reason: "vault/sign-trust-task:envelope_invalid — expiresAt must be an RFC 3339 timestamp".into(),
+                        details: Some(serde_json::json!({ "expiresAt": exp_str })),
+                    },
+                );
+            }
+        }
+    }
+
+    // Load the signing key as an affinidi Secret (the shape
+    // DataIntegrityProof::sign consumes). The kid the proof's
+    // verificationMethod field carries IS the entry's signing_key_id —
+    // the maintainer trusts the stored entry's reference because the
+    // upsert path validated it at the time the entry was written.
+    let secret = match crate::operations::vault::load_signing_secret_by_id(
+        &state.keys_ks,
+        &state.imported_ks,
+        &*state.seed_store,
+        &state.audit_ks,
+        &signing_key_id,
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // Sign. `DataIntegrityProof::sign` takes the document WITHOUT a
+    // `proof` field — we already validated none is present. The
+    // resulting `proof` object carries cryptosuite, verificationMethod
+    // (`<principalDid>#<signingKeyId>`), proofPurpose=assertionMethod,
+    // created, and proofValue.
+    let proof = match affinidi_data_integrity::DataIntegrityProof::sign(
+        &req.unsigned_envelope,
+        &secret,
+        affinidi_data_integrity::SignOptions::new(),
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Internal(format!("DataIntegrityProof sign failed: {e}")),
+            );
+        }
+    };
+    let proof_value = match serde_json::to_value(&proof) {
+        Ok(v) => v,
+        Err(e) => {
+            return app_error_to_reject(&doc, AppError::Internal(format!("serialize proof: {e}")));
+        }
+    };
+
+    // Attach proof to the envelope. Mutate the parsed JSON in place so
+    // every other field — including any consumer-supplied `ext` — is
+    // preserved byte-for-byte.
+    let mut signed = req.unsigned_envelope.clone();
+    signed
+        .as_object_mut()
+        .expect("envelope is an object — checked above")
+        .insert("proof".to_string(), proof_value);
+
+    // Audit log — `{who, when, entryId, envelope: {id, type, recipient}, outcome}`.
+    // Per the spec, payload is OMITTED (it may carry sensitive RP-side
+    // task content).
+    let envelope_id = envelope_obj
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let envelope_type = envelope_obj
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let envelope_recipient = envelope_obj
+        .get("recipient")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    tracing::info!(
+        actor = %auth.did,
+        entry_id = %req.entry_id,
+        envelope_id,
+        envelope_type,
+        envelope_recipient,
+        principal_did = %principal_did,
+        "vault/sign-trust-task: signed"
+    );
+
+    success_response(
+        &doc,
+        VaultSignTrustTaskResponseBody {
+            signed_envelope: signed,
         },
     )
 }

--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -241,6 +241,9 @@ fn as_vti_acl_entry(e: &VtcAclEntry) -> vti_common::acl::AclEntry {
         created_at: e.created_at,
         created_by: e.created_by.clone(),
         expires_at: e.expires_at,
+        kind: Default::default(),
+        capabilities: vec![],
+        device: None,
         version: 0,
     }
 }

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -161,6 +161,9 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         created_at: now_epoch(),
         created_by: "did:key:vtc-install".into(),
         expires_at: None,
+        kind: Default::default(),
+        capabilities: vec![],
+        device: None,
         version: 0,
     };
     store_acl_entry(&acl_ks, &acl_entry).await.unwrap();

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -272,6 +272,9 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
             created_at: 0,
             created_by: "did:key:vtc-install".into(),
             expires_at: None,
+            kind: Default::default(),
+            capabilities: vec![],
+            device: None,
             version: 0,
         },
     )

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -126,6 +126,12 @@ pub enum Capability {
     DeviceAdmin,
     Sign,
     KeyMint,
+    /// Per-envelope Trust Task signing via `vault/sign-trust-task/0.1` —
+    /// distinct from `ProxyLogin` (which mints a session credential) and
+    /// from `Sign` (the generic signing oracle). Keeping it separate lets
+    /// operators grant proxy-login without sign-trust-task to limit
+    /// blast radius on Service consumers (AI agents, etc.).
+    SignTrustTask,
 }
 
 /// Returns true if `role` is granted `cap` by the default capability
@@ -150,6 +156,7 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::PolicyAdmin,
             Capability::DeviceAdmin,
             Capability::Sign,
+            Capability::SignTrustTask,
             Capability::KeyMint,
         ],
         Role::Initiator => vec![
@@ -159,6 +166,7 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::FillRelease,
             Capability::DeviceAdmin,
             Capability::Sign,
+            Capability::SignTrustTask,
             Capability::KeyMint,
         ],
         Role::Application => vec![
@@ -166,6 +174,7 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::Sign,
+            Capability::SignTrustTask,
         ],
         Role::Reader => vec![Capability::VaultRead],
         Role::Monitor => vec![],


### PR DESCRIPTION
Server-side handler for the new \`vault/sign-trust-task/0.1\` Trust Task that just merged at https://trusttasks.org/spec/vault/sign-trust-task/0.1.

## What it solves

RP pages doing a follow-up Trust Task (\`acl/grant/0.1\`, \`vault/upsert\`, etc.) after a successful \`vault/proxy-login/0.1\` session hit:

> \`proof verification failed: proof verificationMethod DID does not match the authenticated caller\`

— because the wallet was signing tasks with its **holder did:key** while the session was authenticated as the entry's **principalDid**. This handler lets the wallet ask the VTA to sign with the principal's key, so the proof VM matches the session DID at the RP.

## Pieces

- **\`vti-common\`**: new \`Capability::SignTrustTask\`, distinct from \`ProxyLogin\` (session-minting) and \`Sign\` (generic oracle). Admin / Initiator / Application carry it by default. Splitting keeps operators able to grant proxy-login without sign-trust-task to limit blast radius on Service consumers.
- **\`vta-sdk\`**: \`TASK_VAULT_SIGN_TRUST_TASK_0_1\` URI constant + registry entry.
- **\`vta-service::operations::vault::load_signing_secret_by_id\`**: companion to the existing \`load_signing_key_by_id\` but returns an affinidi \`Secret\` (the shape \`DataIntegrityProof::sign\` consumes). Separate audit channel tag (\`vault-sign-trust-task-internal\`) so signing operations are distinguishable from proxy-login in the audit log.
- **\`vta-service::routes::trust_tasks::vault::handle_sign_trust_task\`**: full conformance per the spec — cap gate → entry lookup → context scope → secretKind (must be \`DidSelfIssued\` or \`DidcommPeer\`; everything else returns \`not_signable\`) → envelope structural validation → strict \`envelope.issuer == principalDid\` (refuses to silently rewrite — \`envelope_issuer_mismatch\` on mismatch) → \`envelope_already_proofed\` (refuses re-signing) → \`envelope_expired\` → DataIntegrityProof::sign → attach proof → audit log (without inner payload, per spec) → respond.
- **\`affinidi-data-integrity\`** added to vta-service's deps (was already a workspace dep used by vta-sdk and vtc-service).

## Conformance checklist

- [x] Cap gate (SignTrustTask)
- [x] Entry lookup + context scope (deny enumeration via not_found / permission_denied conflation)
- [x] not_signable for non-DID kinds
- [x] envelope_invalid (missing required fields / non-object)
- [x] envelope_already_proofed
- [x] envelope_issuer_mismatch — strict, no silent rewrite
- [x] envelope_expired
- [x] Audit log omits envelope.payload (carries sensitive RP-side data)
- [x] Proof shape: eddsa-jcs-2022, verificationMethod = \`<principalDid>#<signingKeyId>\`, proofPurpose = assertionMethod (all from \`DataIntegrityProof::sign\`'s defaults + Secret.id)
- [ ] Policy-engine gate (M3 policy hookup — separate task; the handler already passes consumer_context through if future code wants it)
- [ ] Step-up enforcement — accepted but not consumed (matches proxy-login's current stance)

## What's NOT in this PR

- Integration tests covering the request → signed-envelope round-trip. Needs an AppState fixture + populated vault entry — same scaffolding the existing proxy-login tests use. Adding this is a follow-up.
- Plugin-side wiring. PR 3 of the original 3-PR plan: \`window.vtaWallet.signTrustTask(envelope, { asDid })\` extension, offscreen looks up the vault entry by principalDid and routes to this new task. Tracked separately.

## Test plan

- [x] \`cargo build --package vta-service\` clean.
- [x] \`cargo test --lib --package vta-service vault::\` — all 28 existing vault tests pass.
- [ ] Manual: end-to-end smoke once the plugin-side wiring lands.