### PR TITLE
feat(messaging): wire DIDComm handler for list-webvh-server-domains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8790,9 +8790,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b7851ccd9f033b964ba5533726f489cc8fe1df818b2a5e45f4a75a1c5923ce"
+checksum = "ab965205a434071ff814f009d0e1f9421abd81d022fb1cd1bd0f389f9970413f"
 dependencies = [
  "axum",
  "chrono",
@@ -8809,9 +8809,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac9113d98fb7689d7788d236c90f3238c523686b3f400e90fcf21df5a548faa"
+checksum = "30796be1898deae785ac1f29861fa4b902f407968ec2f4703232e0d8bec11a0c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8826,9 +8826,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dceed5dfb6cb55fc74f1fd1044bb16de14c45cf01ece7903655b73f6a28f620"
+checksum = "b3830755272ec1c7a8910e967ce29f9859477422fb7ca3033b3ae1574916cef7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -982,6 +982,54 @@ pub async fn handle_list_webvh_servers(
     )
 }
 
+/// `list-webvh-server-domains` — relay the registered hosting
+/// server's `/api/me/domains` view through the VTA. Used by `pnm
+/// did-mgmt list-domains` and the interactive `--domain` prompt in
+/// `create-did` / `register-did`. The handler authenticates to the
+/// server with the VTA's own credentials and returns the
+/// caller-scoped subset of hosting domains plus the system default.
+///
+/// Without this arm in the router, pnm-cli's DIDComm transport
+/// returns `unsupported message type:
+/// firstperson.network/protocols/did-management/1.0/list-webvh-server-domains`
+/// and the CLI falls back to the server's resolution chain with a
+/// warning — the symptom that motivated this addition.
+#[cfg(feature = "webvh")]
+pub async fn handle_list_webvh_server_domains(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<Arc<VtaState>>,
+) -> HandlerResult {
+    let auth = app_try!(auth_from_message(&message, &state.acl_ks).await);
+    let body: vta_sdk::protocols::did_management::servers::ListWebvhServerDomainsBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| handler_err("DID resolver not available"))?;
+    let vta_did = state.config.read().await.vta_did.clone();
+    let result = app_try!(
+        operations::did_webvh::list_webvh_server_domains(
+            &state.keys_ks,
+            &state.imported_ks,
+            &state.audit_ks,
+            &state.webvh_ks,
+            &*state.seed_store,
+            &auth,
+            did_resolver,
+            &state.didcomm_bridge,
+            &state.webvh_auth_locks,
+            vta_did.as_deref(),
+            &body.server_id,
+        )
+        .await
+    );
+    response(
+        vta_sdk::protocols::did_management::LIST_WEBVH_SERVER_DOMAINS_RESULT,
+        &result,
+    )
+}
+
 #[cfg(feature = "webvh")]
 pub async fn handle_update_webvh_server(
     _ctx: HandlerContext,

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -375,6 +375,10 @@ pub fn build_handler(
                 handler_fn(handlers::handle_list_webvh_servers),
             )?
             .route(
+                did_management::LIST_WEBVH_SERVER_DOMAINS,
+                handler_fn(handlers::handle_list_webvh_server_domains),
+            )?
+            .route(
                 did_management::UPDATE_WEBVH_SERVER,
                 handler_fn(handlers::handle_update_webvh_server),
             )?


### PR DESCRIPTION
## Summary

Fixes the `unsupported message type: …list-webvh-server-domains` warning that pnm-cli surfaces when calling `pnm did-mgmt list-domains` (and the interactive `--domain` prompt in `create-did` / `register-did`) over the DIDComm transport.

## Root cause

The vta-sdk client has had `list_webvh_server_domains` since v0.6, sending a DIDComm message with type `firstperson.network/protocols/did-management/1.0/list-webvh-server-domains` — but **the VTA's DIDComm router never had a corresponding arm**. Result on any DIDComm-transport CLI:

```
warning: could not list hosting domains on `webvh-prod`
(validation error: unsupported message type:
https://firstperson.network/protocols/did-management/1.0/list-webvh-server-domains);
falling back to the server's default domain.
```

The URI in that error is what the **VTA** rejected, not what did-hosting saw — so this is fixed entirely VTA-side. did-hosting needs no changes for this symptom.

## What this PR does

- **`vta-service/src/messaging/handlers.rs`** — new `handle_list_webvh_server_domains` handler. Authenticates the caller, parses the existing `ListWebvhServerDomainsBody { server_id }` shape, delegates to the already-wired `operations::did_webvh::list_webvh_server_domains` operation. Response goes back under the matching `LIST_WEBVH_SERVER_DOMAINS_RESULT` URI so the SDK client deserialises cleanly. Mirrors the shape of `handle_register_did_with_server`.
- **`vta-service/src/messaging/router.rs`** — register the route arm next to `LIST_WEBVH_SERVERS`.

No vta-sdk changes — the URIs, body types, and result types all already existed in `vta_sdk::protocols::did_management::*`. This PR just wires the consumer.

## Cargo.lock

Bumps `trust-tasks-rs`, `trust-tasks-https`, `trust-tasks-didcomm` from 0.1.1 → 0.1.2 (the spec-published release that includes the new `did-management/me/domains/0.1` and related types from `dtgwg-trust-tasks-tf`). Not strictly required for this handler — it still uses the FPN-namespace DIDComm protocol — but lines up with the merged spec release and avoids a separate no-op bump.

## Test plan

- [x] `cargo build -p vta-service` clean.
- [x] `cargo test -p vta-service --lib` — **499 passing**, same as `main`. The 1 pre-existing failure (`dispatcher_handles_every_vta_sdk_uri` complaining about `vault/sign-trust-task/0.1`) is unrelated carry-over from PR #138; this PR adds no new untracked URIs.
- [x] `cargo fmt --all` clean.
- [ ] Manual: from a pnm-cli using DIDComm transport, `pnm did-mgmt dids create --context openvtc-glenn --server webvh-prod` no longer prints the `unsupported message type` warning and shows the interactive domain picker populated.

## Not in scope

- Migrating this op to a canonical spec URI (`spec/did-management/me/domains/0.1`). The pnm-cli ↔ VTA protocol is VTA-private and isn't directly governed by `dtgwg-trust-tasks-tf` — the spec URI is for VTA ↔ did-hosting (REST today, follows in a separate did-hosting PR).
- did-hosting DIDComm handler for `me/domains/0.1`. Additive; needed only when a hosting server runs DIDComm-only without REST. The current `list_webvh_server_domains` operation already returns empty for DIDComm-only servers and falls back to the server's resolution chain.