### PR TITLE
feat: VTA outbound webvh auth on canonical spec URIs

### DIFF
--- a/vta-service/src/webvh_auth.rs
+++ b/vta-service/src/webvh_auth.rs
@@ -14,7 +14,7 @@
 //!    32-byte random `challenge` to `session_id` server-side with
 //!    a TTL (default 5 min).
 //! 2. Client signs a DIDComm `Message` of `type:
-//!    https://affinidi.com/webvh/1.0/authenticate` with body
+//!    https://trusttasks.org/spec/auth/authenticate/0.1` with body
 //!    `{ session_id, challenge }`, packs it as JWS (EdDSA, Ed25519),
 //!    and POSTs the JWS string to `/api/auth/`.
 //! 3. Daemon `unpack_signed` verifies the JWS, asserts `from` matches
@@ -22,7 +22,7 @@
 //!    its stored session, and returns access + refresh tokens.
 //!
 //! Refresh follows the same shape with `type:
-//! https://affinidi.com/webvh/1.0/authenticate/refresh` and
+//! https://trusttasks.org/spec/auth/refresh/0.1` and
 //! `body: { refresh_token }`.
 //!
 //! ## Audience binding
@@ -54,11 +54,15 @@ use zeroize::Zeroizing;
 
 use crate::error::AppError;
 
-/// DIDComm `type` URI for the initial authenticate request.
-pub const AUTHENTICATE_TYPE: &str = "https://affinidi.com/webvh/1.0/authenticate";
+/// DIDComm `type` URI for the initial authenticate request — the
+/// canonical `spec/auth/authenticate/0.1` per dtgwg-trust-tasks-tf.
+/// did-hosting accepts this natively (and recognises the historical
+/// `affinidi.com/webvh/1.0/authenticate` form during the alias-table
+/// migration window).
+pub const AUTHENTICATE_TYPE: &str = "https://trusttasks.org/spec/auth/authenticate/0.1";
 
-/// DIDComm `type` URI for the refresh request.
-pub const REFRESH_TYPE: &str = "https://affinidi.com/webvh/1.0/authenticate/refresh";
+/// DIDComm `type` URI for the refresh request — `spec/auth/refresh/0.1`.
+pub const REFRESH_TYPE: &str = "https://trusttasks.org/spec/auth/refresh/0.1";
 
 /// Identifies who's signing the request. All fields are borrowed;
 /// the caller owns the lifetime — important because `private_key`
@@ -258,14 +262,23 @@ mod tests {
     }
 
     #[test]
-    fn authenticate_message_type_is_webvh_specific() {
-        // Distinguishing the protocol from generic auth flows means
-        // an attacker who steals a generic-auth JWS can't replay it
-        // as a webvh auth (and vice versa). Pin the constant.
+    fn authenticate_message_type_is_canonical_spec_uri() {
+        // The VTA's outbound authenticate to did-hosting carries the
+        // canonical Trust-Task spec URI per dtgwg-trust-tasks-tf.
+        // did-hosting accepts both this and the historical
+        // `affinidi.com/webvh/1.0/authenticate` form via its alias
+        // table during the migration window; once that alias is
+        // dropped (Phase 3 cleanup on did-hosting) this is the only
+        // form on the wire.
         assert_eq!(
             AUTHENTICATE_TYPE,
-            "https://affinidi.com/webvh/1.0/authenticate",
+            "https://trusttasks.org/spec/auth/authenticate/0.1",
         );
+    }
+
+    #[test]
+    fn refresh_message_type_is_canonical_spec_uri() {
+        assert_eq!(REFRESH_TYPE, "https://trusttasks.org/spec/auth/refresh/0.1",);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 3.1 of the cross-repo did-management migration. The last remaining legacy URI on VTA's outbound to did-hosting (`affinidi.com/webvh/1.0/authenticate*` carried in the signed DIDComm body of `POST /api/auth/` and `/api/auth/refresh`) flips to the canonical `spec/auth/authenticate/0.1` and `spec/auth/refresh/0.1` forms.

did-hosting already accepts both forms via its alias table — this PR puts VTA's outbound on the canonical so the alias entries can be retired in the upcoming Phase 3.2 cleanup on did-hosting.

## Change

- **`AUTHENTICATE_TYPE`**: `affinidi.com/webvh/1.0/authenticate` → `https://trusttasks.org/spec/auth/authenticate/0.1`.
- **`REFRESH_TYPE`**: `affinidi.com/webvh/1.0/authenticate/refresh` → `https://trusttasks.org/spec/auth/refresh/0.1`.
- Module-level docs updated to reference the new URIs.
- Body-pinning unit test (`authenticate_message_type_*`) updated to the new value; new `refresh_message_type_is_canonical_spec_uri` test mirrors it so a future drift on either constant is caught.

## Why now

This is the last remaining VTA → did-hosting legacy URI. With this in, the upcoming `did-hosting` Phase 3.2 PR can drop the entire `v1_aliases.rs` legacy bridge — no MSG_*, no `did-hosting/did/*/1.0`, no `affinidi.com/webvh/1.0/*`. The user controls deployment sync (early release), so we can merge this, deploy to VTA, then land the did-hosting end-state cleanup.

## Test plan

- [x] `cargo test -p vta-service --lib webvh_auth` — 9 passing (+1 new `refresh_message_type_is_canonical_spec_uri`).
- [x] `cargo test -p vta-service --lib` — 500 passing (vs 499 on main). Pre-existing `dispatcher_handles_every_vta_sdk_uri` failure for `vault/sign-trust-task/0.1` is unrelated carry-over from #138.
- [x] `cargo build` clean.
- [x] `cargo fmt --all` clean.