### PR TITLE
fix(vtc-service): bump version 0.1.0 → 0.7.0 to rejoin the release train

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9357,7 +9357,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.1.0"
+version = "0.7.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

`vtc-service`'s manifest had regressed to **0.1.0** while crates.io already has it published up to **0.6.0** (`0.2.0 → 0.6.0`, same repo). That blocks any release — you can't cut a version below what's already live.

This bumps `vtc-service` to **0.7.0**, which:
- matches the sibling service/CLI tier (`vta-service`, `vta-cli-common`, `pnm-cli`, `cnm-cli` are all `0.7.0`), and
- is a clean minor over the published `0.6.0`.

## Dependency pins
Unchanged and already correct — `vtc-service` pins `vti-common = "0.8"` and `vta-sdk = "0.8"` (`major.minor`, matching the `0.8.0` leaf crates). No crate depends on `vtc-service`, so nothing downstream is affected. `Cargo.lock` updated to reflect the new version.

## Verification
- `cargo check -p vtc-service` passes.
- `cargo metadata` + `Cargo.lock` show `vtc-service 0.7.0`.

## Note (not in this PR)
Other crates are also ahead of crates.io and pending publish; in particular `vti-webauthn` (0.1.0) is publishable but **never published**, and `vta-service` depends on it — it must be published first. See the publish order below.