### PR TITLE
fix(deps): bump openssl 0.10.79 → 0.10.80 in enclave-proxy (CVE-2026-45784)

### DIFF
--- a/deploy/nitro/enclave-proxy/Cargo.lock
+++ b/deploy/nitro/enclave-proxy/Cargo.lock
@@ -983,7 +983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2895,9 +2895,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -2935,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary

Resolves **Dependabot alert #26** — GHSA-phqj-4mhp-q6mq / CVE-2026-45784 (medium):
potential out-of-bounds write in `CipherCtxRef::cipher_update_inplace` for AES-KW-PAD ciphers, affecting `openssl >= 0.10.50, < 0.10.80`.

Bumps `openssl` **0.10.79 → 0.10.80** (and `openssl-sys` 0.9.115 → 0.9.116) in `deploy/nitro/enclave-proxy/Cargo.lock`. Semver-compatible patch, lockfile-only — no manifest or API change.

## Context / exposure
- `openssl` is a **transitive** dependency, not direct. Chain: `affinidi-did-resolver-cache-sdk` → `reqwest` (default `native-tls` backend) → `native-tls` → `openssl`.
- `deploy/nitro/enclave-proxy` is **excluded from the main cargo workspace** (Linux-only `tokio-vsock`), so this never surfaced in workspace builds and doesn't touch any of the publishable crates.
- The proxy's own TLS uses **rustls/ring**, and the vulnerable **AES-KW-PAD** path isn't exercised by TLS — so practical exposure is low. This is hygiene to clear the alert.

## Verification
- `cargo update -p openssl --precise 0.10.80` (lockfile-only).
- Confirmed `openssl 0.10.80` in the lockfile.
- No build run here (crate is Linux-only); it builds on the EC2 parent instance per the crate's header comment.