### PR TITLE
fix(vtc): serve self-hosted DID at /.well-known/did.jsonl

### DIFF
--- a/docs/03-vtc/getting-started.md
+++ b/docs/03-vtc/getting-started.md
@@ -116,22 +116,27 @@ VTC DID should be published**:
   `did.jsonl` at the VTC base URL.
 - **tenant domain** — when the chosen server is multi-tenant, pick
   the domain the DID is allocated under (otherwise the server's
-  default is used).
+  default is used). *(hosted mode only)*
 - **path** — the optional `<path>` label in
-  `did:webvh:<scid>:<host>:<path>`; blank lets the host assign one.
+  `did:webvh:<scid>:<host>:<path>`; blank lets the server assign one.
+  *(hosted mode only)* In **serverless** mode there is no path: the
+  DID is `did:webvh:<scid>:<host>`, which resolves to
+  `https://<host>/.well-known/did.jsonl` — the daemon serves it
+  itself, so the wizard doesn't prompt for a path.
 
 The picker enumerates the catalogue over whichever transport the VTA
 advertises (REST when available, otherwise DIDComm), and provisioning
 then runs over the auto-selected transport (DIDComm-first when both are
 advertised). If the VTA DID can't be resolved or reached, the wizard
-falls back to the VTA's own 0-or-1-server auto-selection and shows only
-the path prompt.
+falls back to the VTA's own 0-or-1-server auto-selection (no path
+prompt — the VTA picks a server or self-hosts).
 
 It then drives the provision-integration round trip against the VTA,
 opens the sealed bundle, and writes:
 
 - `<data_dir>/did/<scid>.jsonl` — the `did:webvh` log entry the
-  daemon serves at `GET /v1/{scid}/did.jsonl`.
+  daemon serves at `GET /.well-known/did.jsonl` (the URL the VTC's
+  own DID resolves to).
 - `config.toml` — the VTC's runtime configuration.
 - The `VtcKeyBundle` to the configured secrets backend.
 

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -108,7 +108,8 @@ Flow:
 5. Write the `did.jsonl` log from
    `TemplateBootstrapPayload.config.outputs` to
    `<store.data_dir>/did/<scid>.jsonl`. The daemon publishes
-   it at `GET /v1/{scid}/did.jsonl` (Trust-Task-exempt).
+   it at `GET /.well-known/did.jsonl` (Trust-Task-exempt) — the
+   URL a serverless `did:webvh:<scid>:<host>` resolves to.
 6. Write `config.toml` (`vtc_did`, `vta_did`, `public_url`,
    `store`, `secrets`, `auth.jwt_signing_key`).
 7. Initialise all fjall keyspaces (§13).

--- a/vtc-service/src/routes/did_log.rs
+++ b/vtc-service/src/routes/did_log.rs
@@ -8,15 +8,27 @@
 //!
 //! ## Wire shape
 //!
-//! `GET /v1/{scid}/did.jsonl` → `200 application/jsonl` with the
+//! `GET /.well-known/did.jsonl` → `200 application/jsonl` with the
 //! log content.
 //!
+//! This path is **not** arbitrary: a serverless VTC's DID is
+//! `did:webvh:<scid>:<host>` (no path component), which by the
+//! did:webvh resolution convention resolves to
+//! `https://<host>/.well-known/did.jsonl`. Serving the log here is
+//! what makes the VTC's own DID resolvable from the VTC itself — no
+//! external hosting required. The route is mounted at the
+//! parent-router root (above the `/v1` API nest) so the URL the DID
+//! resolves to is the URL we serve, regardless of routing mode.
+//!
 //! Trust-Task-**exempt** because DID resolvers won't carry our
-//! private extension header.
+//! private extension header. Because the route lives on the bare
+//! parent router (not the `TrustTaskRouter`), it carries no
+//! Trust-Task gate to exempt in the first place.
 //!
 //! ## Storage
 //!
-//! Reads from `<config.store.data_dir>/did/<scid>.jsonl`. The setup
+//! Reads from `<config.store.data_dir>/did/<scid>.jsonl`, where
+//! `<scid>` is the SCID of the VTC's own `config.vtc_did`. The setup
 //! wizard wrote the file at first-boot when it opened the VTA's
 //! `TemplateBootstrapPayload` — see
 //! `vta_sdk::sealed_transfer::template_bootstrap::TemplateOutput`'s
@@ -24,31 +36,31 @@
 //!
 //! ## Safety
 //!
-//! The `scid` parameter is constrained to a charset that matches
-//! the did:webvh SCID grammar (alphanumeric only). The match
-//! against `config.vtc_did`'s SCID is exact; a mismatch returns
-//! 404 (we don't host arbitrary DIDs).
+//! The VTC hosts exactly one DID — its own. The SCID is taken from
+//! `config.vtc_did` (operator-controlled at setup, not the request)
+//! and is validated against the did:webvh SCID grammar
+//! (alphanumeric, `-`, `_`) before it reaches the filesystem, so a
+//! malformed configured DID can't drive a path-traversal read.
 
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::IntoResponse;
 
 use crate::server::AppState;
 
-/// `GET /v1/{scid}/did.jsonl`
-pub async fn did_log(State(state): State<AppState>, Path(scid): Path<String>) -> impl IntoResponse {
-    if !is_valid_scid(&scid) {
-        return (StatusCode::NOT_FOUND, "did log not found").into_response();
-    }
+/// `GET /.well-known/did.jsonl`
+pub async fn did_log(State(state): State<AppState>) -> impl IntoResponse {
     let config = state.config.read().await;
 
-    // Confirm the requested scid matches the VTC's own DID. The VTC
-    // is not a general-purpose did:webvh host — we host exactly one
-    // DID, our own.
-    match config.vtc_did.as_deref().and_then(extract_scid_from_did) {
-        Some(expected) if expected == scid => {}
-        _ => return (StatusCode::NOT_FOUND, "did log not found").into_response(),
-    }
+    // The VTC is not a general-purpose did:webvh host — it serves
+    // exactly one DID, its own. Resolve the SCID from `config.vtc_did`;
+    // before setup has run (or for a non-webvh DID) there's nothing to
+    // serve. `extract_scid_from_did` also validates the SCID grammar,
+    // so the filename below can't escape the `did/` directory.
+    let scid = match config.vtc_did.as_deref().and_then(extract_scid_from_did) {
+        Some(scid) => scid,
+        None => return (StatusCode::NOT_FOUND, "did log not found").into_response(),
+    };
 
     let path = config
         .store

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -354,12 +354,6 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             get(health::diagnostics),
             health_diagnostics,
         )
-        // `did:webvh` log publication (Trust-Task-exempt — DID
-        // resolvers don't carry our extension header). The VTC is
-        // not a general-purpose did:webvh host: the handler matches
-        // the URL `scid` against the VTC's own DID and 404s on any
-        // other request. See `tasks/vtc-mvp/vta-driven-keys.md` §10.
-        .route_exempt("/{scid}/did.jsonl", get(did_log::did_log))
         // BitstringStatusList publication (M2.11). Trust-Task-
         // exempt — external verifiers don't carry our extension
         // header (same rationale as `did.jsonl`).
@@ -968,6 +962,14 @@ fn assemble(routing: &RoutingConfig, api: Router<AppState>) -> Router<AppState> 
         // operator just curls `/health` on whichever host the
         // daemon is reachable on).
         .route("/health", get(health::health))
+        // `did:webvh` log publication. Mounted at the parent root
+        // (above the `/v1` nest) because a serverless VTC's DID,
+        // `did:webvh:<scid>:<host>`, resolves to
+        // `https://<host>/.well-known/did.jsonl` by the did:webvh
+        // convention — the log has to live at that exact URL for the
+        // VTC's own DID to be resolvable. The VTC hosts exactly one
+        // DID, its own. See `tasks/vtc-mvp/vta-driven-keys.md` §10.
+        .route("/.well-known/did.jsonl", get(did_log::did_log))
         // API surface — existing TrustTaskRouter result nested at
         // the configured mount.
         .nest(&routing.api.mount, api);
@@ -1067,6 +1069,11 @@ pub fn assemble_with_website(
 
     let mut app: Router<AppState> = Router::new()
         .route("/health", get(health::health))
+        // `did:webvh` log publication — see the matching comment in
+        // `assemble`. Parent-root mount so a serverless VTC's
+        // `did:webvh:<scid>:<host>` resolves to
+        // `https://<host>/.well-known/did.jsonl`, the URL we serve.
+        .route("/.well-known/did.jsonl", get(did_log::did_log))
         .nest(&routing.api.mount, api);
     app = app.nest(&routing.admin_ui.mount, admin);
     // axum 0.8's `nest("/admin", inner)` registers `/admin` (bare)

--- a/vtc-service/src/routes/status_lists.rs
+++ b/vtc-service/src/routes/status_lists.rs
@@ -2,7 +2,7 @@
 //! /v1/status-lists/{purpose}` (M2.11).
 //!
 //! Verifier-facing, unauthenticated, Trust-Task-exempt — same
-//! rationale as `/v1/{scid}/did.jsonl`: external verifiers
+//! rationale as `/.well-known/did.jsonl`: external verifiers
 //! resolve credentials through standard W3C verification flows
 //! that don't carry our extension header.
 //!

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -146,7 +146,7 @@ pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), AppErr
     let bundle = VtcKeyBundle::from_did_key_material(integration_did.clone(), integration_key);
 
     // 5. Persist the did.jsonl log so the daemon's `GET
-    //    /v1/{scid}/did.jsonl` route can serve it after restart.
+    //    /.well-known/did.jsonl` route can serve it after restart.
     let did_log = provision.webvh_log().ok_or_else(|| {
         AppError::Internal(
             "vtc-host template did not produce a did.jsonl output — the VTC must be a did:webvh"
@@ -466,6 +466,10 @@ async fn select_webvh_target(
     println!("  This is the DID every member, credential, and trust-registry entry will");
     println!("  reference — choose its host and path deliberately.");
     println!();
+    println!("  Serverless instead drops the <path>: the VTC self-hosts its own");
+    println!("  did.jsonl at <host>/.well-known/did.jsonl, served by this daemon — no");
+    println!("  external did-hosting server required.");
+    println!();
 
     // Connect over whichever transport the VTA advertises so we can offer
     // live server/domain pickers. Any failure here is non-fatal: we fall
@@ -492,21 +496,30 @@ async fn select_webvh_target(
     };
 
     let Some(client) = client else {
-        // No live catalogue — offer just the optional path, matching the
-        // pre-picker behaviour and leaving server selection to the VTA.
-        let path = prompt_webvh_path(None)?;
-        return Ok(WebvhTarget {
-            path,
-            ..WebvhTarget::default()
-        });
+        // No live catalogue — leave server selection to the VTA (it
+        // auto-picks a registered did-hosting server, or self-hosts).
+        // We don't prompt for a path: it's only meaningful once a
+        // hosting server is in play, and a serverless DID ignores it
+        // entirely (it always resolves at `<host>/.well-known/`), so a
+        // prompt here would have unpredictable effect.
+        return Ok(WebvhTarget::default());
     };
 
     let server_id = prompt_webvh_server(&client).await?;
-    let domain = match server_id.as_deref() {
-        Some(sid) => prompt_webvh_domain(&client, sid).await?,
-        None => None,
+    let (domain, path) = match server_id.as_deref() {
+        // A hosting server is selected: the `<path>` is a real label
+        // under that server, so offer it (and the tenant-domain picker).
+        Some(sid) => {
+            let domain = prompt_webvh_domain(&client, sid).await?;
+            let path = prompt_webvh_path(sid)?;
+            (domain, path)
+        }
+        // Serverless: the VTC self-hosts its `did.jsonl`, and the DID
+        // `did:webvh:<scid>:<host>` always resolves at
+        // `<host>/.well-known/did.jsonl`. There's no meaningful path to
+        // pick, so we don't ask.
+        None => (None, None),
     };
-    let path = prompt_webvh_path(server_id.as_deref())?;
 
     Ok(WebvhTarget {
         server_id,
@@ -671,25 +684,18 @@ async fn prompt_webvh_domain(
     }
 }
 
-/// Prompt for the optional `<path>` component of the VTC DID. Blank input
-/// → `None` (the host assigns one). The help text is tailored to whether
-/// a hosting server was selected.
-fn prompt_webvh_path(server_id: Option<&str>) -> Result<Option<String>, AppError> {
+/// Prompt for the optional `<path>` label of the VTC DID under the
+/// selected hosting server. Blank input → `None` (the server assigns
+/// one). Only called in hosted mode: serverless self-hosting always
+/// resolves at `<host>/.well-known/did.jsonl`, so it has no path to pick.
+fn prompt_webvh_path(server_id: &str) -> Result<Option<String>, AppError> {
     println!();
-    match server_id {
-        Some(sid) => {
-            println!("  Optional path label under the hosting server `{sid}`. It becomes the");
-            println!("  trailing `<path>` of the VTC DID — e.g. `acme` yields a DID ending");
-            println!("  `:acme`. Operators with a naming convention (community slug, env)");
-            println!("  can pin it; leave blank to let the server assign one.");
-        }
-        None => {
-            println!("  Optional path label for the VTC DID. It becomes the trailing");
-            println!("  `<path>` component. Leave blank to let the host assign one.");
-        }
-    }
+    println!("  Optional path label under the hosting server `{server_id}`. It becomes the");
+    println!("  trailing `<path>` of the VTC DID — e.g. `acme` yields a DID ending");
+    println!("  `:acme`. Operators with a naming convention (community slug, env)");
+    println!("  can pin it; leave blank to let the server assign one.");
     let raw: String = Input::new()
-        .with_prompt("WebVH path (blank → auto-assigned)")
+        .with_prompt("WebVH path (blank → server-assigned)")
         .default(String::new())
         .allow_empty(true)
         .interact_text()

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -1,12 +1,14 @@
-//! Integration coverage for `GET /v1/{scid}/did.jsonl`.
+//! Integration coverage for `GET /.well-known/did.jsonl`.
 //!
-//! The VTC publishes exactly one did:webvh log — its own. Tests
-//! verify the happy path + the boundary cases the design doc
+//! The VTC publishes exactly one did:webvh log — its own — at the
+//! `.well-known` path its `did:webvh:<scid>:<host>` resolves to.
+//! Tests verify the happy path + the boundary cases the design doc
 //! (`tasks/vtc-mvp/vta-driven-keys.md` §10) calls out:
 //!
 //! - Trust-Task-exempt (no header → 200).
-//! - 404 when the scid in the URL doesn't match config.vtc_did.
-//! - 404 when the file doesn't exist on disk.
+//! - 404 when `config.vtc_did`'s log file is absent on disk.
+//! - 404 when the configured DID's SCID is malformed (no path
+//!   traversal reaches the filesystem).
 
 mod common;
 
@@ -157,36 +159,40 @@ async fn happy_path_returns_log_content_as_jsonl() {
 "#;
     seed_did_log(&fix.data_dir, VTC_SCID, log);
 
-    let (status, body, ct) = get(&fix.router, &format!("/v1/{VTC_SCID}/did.jsonl")).await;
+    let (status, body, ct) = get(&fix.router, "/.well-known/did.jsonl").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, log.as_bytes());
     assert_eq!(ct.as_deref(), Some("application/jsonl"));
 }
 
 #[tokio::test]
-async fn returns_404_when_scid_mismatches_vtc_did() {
+async fn returns_404_when_only_a_foreign_scid_log_exists() {
+    // The VTC serves exactly its own DID's log. A stray log file for
+    // some other SCID on disk must not be served — we read only the
+    // SCID derived from `config.vtc_did`.
     let fix = build_fixture(VTC_DID).await;
     seed_did_log(&fix.data_dir, "different", "{}");
 
-    let (status, _, _) = get(&fix.router, "/v1/different/did.jsonl").await;
+    let (status, _, _) = get(&fix.router, "/.well-known/did.jsonl").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
-async fn returns_404_when_file_missing_even_for_correct_scid() {
+async fn returns_404_when_file_missing() {
     let fix = build_fixture(VTC_DID).await;
     // no seed_did_log — file absent
-    let (status, _, _) = get(&fix.router, &format!("/v1/{VTC_SCID}/did.jsonl")).await;
+    let (status, _, _) = get(&fix.router, "/.well-known/did.jsonl").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
-async fn returns_404_for_path_traversal_attempt_in_scid() {
-    let fix = build_fixture(VTC_DID).await;
-    seed_did_log(&fix.data_dir, VTC_SCID, "{}");
-    // Path traversal characters fail `is_valid_scid` and 404
-    // before any filesystem touch.
-    let (status, _, _) = get(&fix.router, "/v1/..%2f..%2fetc%2fpasswd/did.jsonl").await;
+async fn returns_404_when_configured_scid_is_malformed() {
+    // The SCID is taken from `config.vtc_did`, not the URL. A
+    // configured DID whose trailing component fails the SCID grammar
+    // (here, path-traversal characters) is rejected before any
+    // filesystem read, so it can't escape the `did/` directory.
+    let fix = build_fixture("did:webvh:vtc.example.com:..%2f..%2fetc%2fpasswd").await;
+    let (status, _, _) = get(&fix.router, "/.well-known/did.jsonl").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
@@ -202,7 +208,7 @@ async fn route_is_trust_task_exempt() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/v1/{VTC_SCID}/did.jsonl"))
+                .uri("/.well-known/did.jsonl")
                 .body(Body::empty())
                 .unwrap(),
         )


### PR DESCRIPTION
## Problem

When setting up a VTC **serverless** (no did-hosting server) and leaving the WebVH path blank, the VTC's own `did:webvh` was **unresolvable from the VTC itself**. Two root causes:

1. **Route/DID mismatch.** A serverless VTC mints its identity from the bare base URL. `didwebvh-rs` derives a no-path DID — `did:webvh:<scid>:<host>` — which by the did:webvh convention resolves to `https://<host>/.well-known/did.jsonl`. But the daemon served the log at `GET /v1/{scid}/did.jsonl`, *inside* the `/v1` API nest. The DID's resolution URL and the served URL never matched.

2. **Dead path prompt.** `create_did_webvh`'s serverless branch only reads `params.url` and ignores `params.path`, so the wizard's WebVH-path prompt was silently discarded in serverless mode — it always produced `.well-known`.

A serverless VTC *can and should* self-host its own DID with no external infrastructure; it only failed because of the route-path mismatch.

## Fix

- **Move the `did.jsonl` route to the parent-router root** at `GET /.well-known/did.jsonl` (next to `/health`), out of the `/v1` `TrustTaskRouter` nest. The handler resolves the single SCID from `config.vtc_did` rather than a URL parameter (SCID-grammar validation still guards against path traversal). The URL the DID resolves to is now exactly the URL we serve, in any routing mode.
- **Drop the WebVH path prompt in serverless mode.** It's offered only when a did-hosting server is selected (where it's actually consumed). The wizard now explains that serverless self-hosts at `<host>/.well-known/did.jsonl`.
- Update `did_log` integration + unit tests and the operator/design docs to match.

### Left intentionally unchanged
The `vtc-status-list` service endpoint (`{URL}{STATUS_LIST_PATH}` → `<host>/v1/status-lists`) is self-consistent because the DID document spells the path out explicitly. Only `did.jsonl` resolution relied on the implicit `.well-known` convention.

## Verification
`cargo check`, `clippy`, `fmt` clean. `did_log` integration tests (5) and `routes::did_log` unit tests (5) pass.

## Follow-up (not in this PR)
Hosted-mode path UX could be reworked into an explicit menu (server-default / let-server-assign / specify path).