### PR TITLE
fix(vtc): resolve self-hosted DID at /.well-known/did.jsonl (accept hostname label)

### DIFF
--- a/vta-sdk/src/did_templates/tests.rs
+++ b/vta-sdk/src/did_templates/tests.rs
@@ -32,7 +32,7 @@ fn base_template(extra: Value) -> Value {
 
 fn ambient_vars() -> TemplateVars {
     let mut v = TemplateVars::new();
-    v.insert_string("DID", "did:webvh:example.com:abc");
+    v.insert_string("DID", "did:webvh:abc:example.com");
     v.insert_string("SIGNING_KEY_MB", "z6MkSigning");
     v
 }
@@ -133,7 +133,7 @@ fn renders_embedded_string_placeholder() {
 
     let out = tpl.render(&vars).unwrap();
     assert_eq!(out["uri"], "prefix-https://m.example.com-suffix");
-    assert_eq!(out["id"], "did:webvh:example.com:abc");
+    assert_eq!(out["id"], "did:webvh:abc:example.com");
 }
 
 #[test]
@@ -262,7 +262,7 @@ fn placeholders_in_nested_arrays_and_objects() {
     let mut vars = ambient_vars();
     vars.insert_string("URL", "https://svc.example.com");
     let out = tpl.render(&vars).unwrap();
-    assert_eq!(out["service"][0]["id"], "did:webvh:example.com:abc#svc");
+    assert_eq!(out["service"][0]["id"], "did:webvh:abc:example.com#svc");
     assert_eq!(
         out["service"][0]["serviceEndpoint"]["uri"],
         "https://svc.example.com"
@@ -319,21 +319,21 @@ fn utf8_strings_survive_substitution() {
 fn didcomm_mediator_builtin_renders_end_to_end() {
     let tpl = load_embedded("didcomm-mediator").unwrap();
     let mut vars = TemplateVars::new();
-    vars.insert_string("DID", "did:webvh:example.com:mediator");
+    vars.insert_string("DID", "did:webvh:mediator:example.com");
     vars.insert_string("SIGNING_KEY_MB", "z6MkSign");
     vars.insert_string("KA_KEY_MB", "z6LSKa");
     vars.insert_string("URL", "https://mediator.example.com");
     vars.insert_string("WS_URL", "wss://mediator.example.com/ws");
 
     let doc = tpl.render(&vars).unwrap();
-    assert_eq!(doc["id"], "did:webvh:example.com:mediator");
+    assert_eq!(doc["id"], "did:webvh:mediator:example.com");
     let services = doc["service"].as_array().unwrap();
     assert_eq!(services.len(), 2);
 
     // DIDComm service: id `#service`, type as a single-element array,
     // serviceEndpoint as an array of two endpoint objects (HTTP first,
     // WSS second). Each endpoint carries the same accept/routingKeys.
-    assert_eq!(services[0]["id"], "did:webvh:example.com:mediator#service");
+    assert_eq!(services[0]["id"], "did:webvh:mediator:example.com#service");
     assert_eq!(services[0]["type"], json!(["DIDCommMessaging"]));
     let endpoints = services[0]["serviceEndpoint"].as_array().unwrap();
     assert_eq!(endpoints.len(), 2);
@@ -346,7 +346,7 @@ fn didcomm_mediator_builtin_renders_end_to_end() {
 
     // Authentication service: id `#auth`, type as a single-element array,
     // serviceEndpoint as a plain string at `<URL>/authenticate`.
-    assert_eq!(services[1]["id"], "did:webvh:example.com:mediator#auth");
+    assert_eq!(services[1]["id"], "did:webvh:mediator:example.com#auth");
     assert_eq!(services[1]["type"], json!(["Authentication"]));
     assert_eq!(
         services[1]["serviceEndpoint"],
@@ -363,7 +363,7 @@ fn ws_url_is_derived_from_url_when_omitted() {
     // (`/mediator/v1` over HTTP, `/mediator/v1/ws` over WSS).
     let tpl = load_embedded("didcomm-mediator").unwrap();
     let mut vars = TemplateVars::new();
-    vars.insert_string("DID", "did:webvh:example.com:mediator");
+    vars.insert_string("DID", "did:webvh:mediator:example.com");
     vars.insert_string("SIGNING_KEY_MB", "z6MkSign");
     vars.insert_string("KA_KEY_MB", "z6LSKa");
     vars.insert_string("URL", "https://mediator.example.com/mediator/v1");
@@ -388,7 +388,7 @@ fn ws_url_derivation_handles_plain_http_and_trailing_slash() {
     // `ws://host//ws`.
     let tpl = load_embedded("didcomm-mediator").unwrap();
     let mut vars = TemplateVars::new();
-    vars.insert_string("DID", "did:webvh:example.com:mediator");
+    vars.insert_string("DID", "did:webvh:mediator:example.com");
     vars.insert_string("SIGNING_KEY_MB", "z6MkSign");
     vars.insert_string("KA_KEY_MB", "z6LSKa");
     vars.insert_string("URL", "http://mediator.local/");
@@ -405,7 +405,7 @@ fn explicit_ws_url_overrides_derivation() {
     // an operator who terminates WS at a different host).
     let tpl = load_embedded("didcomm-mediator").unwrap();
     let mut vars = TemplateVars::new();
-    vars.insert_string("DID", "did:webvh:example.com:mediator");
+    vars.insert_string("DID", "did:webvh:mediator:example.com");
     vars.insert_string("SIGNING_KEY_MB", "z6MkSign");
     vars.insert_string("KA_KEY_MB", "z6LSKa");
     vars.insert_string("URL", "https://mediator.example.com");
@@ -426,7 +426,7 @@ fn ws_url_not_derived_for_non_http_scheme() {
     // — surface the missing-var error instead of fabricating something.
     let tpl = load_embedded("didcomm-mediator").unwrap();
     let mut vars = TemplateVars::new();
-    vars.insert_string("DID", "did:webvh:example.com:mediator");
+    vars.insert_string("DID", "did:webvh:mediator:example.com");
     vars.insert_string("SIGNING_KEY_MB", "z6MkSign");
     vars.insert_string("KA_KEY_MB", "z6LSKa");
     vars.insert_string("URL", "didcomm://routed-only");
@@ -473,7 +473,7 @@ fn vta_admin_builtin_renders_end_to_end() {
 fn did_hosting_daemon_builtin_renders_end_to_end() {
     let tpl = load_embedded("did-hosting-daemon").unwrap();
     let mut vars = TemplateVars::new();
-    vars.insert_string("DID", "did:webvh:example.com:host");
+    vars.insert_string("DID", "did:webvh:host:example.com");
     vars.insert_string("SIGNING_KEY_MB", "z6MkSign");
     vars.insert_string("KA_KEY_MB", "z6LSKa");
     vars.insert_string("URL", "https://host.example.com");
@@ -648,10 +648,10 @@ fn vtc_host_renders_with_minimal_vars() {
 
     let out = tpl.render(&vars).unwrap();
 
-    assert_eq!(out["id"], "did:webvh:example.com:abc");
+    assert_eq!(out["id"], "did:webvh:abc:example.com");
     assert_eq!(
         out["verificationMethod"][0]["id"],
-        "did:webvh:example.com:abc#key-0"
+        "did:webvh:abc:example.com#key-0"
     );
     assert_eq!(
         out["verificationMethod"][0]["publicKeyMultibase"],
@@ -659,20 +659,20 @@ fn vtc_host_renders_with_minimal_vars() {
     );
     assert_eq!(
         out["verificationMethod"][1]["id"],
-        "did:webvh:example.com:abc#key-1"
+        "did:webvh:abc:example.com#key-1"
     );
     assert_eq!(
         out["verificationMethod"][1]["publicKeyMultibase"],
         "z6LSKeyAgreement"
     );
-    assert_eq!(out["assertionMethod"][0], "did:webvh:example.com:abc#key-0");
-    assert_eq!(out["authentication"][0], "did:webvh:example.com:abc#key-0");
-    assert_eq!(out["keyAgreement"][0], "did:webvh:example.com:abc#key-1");
+    assert_eq!(out["assertionMethod"][0], "did:webvh:abc:example.com#key-0");
+    assert_eq!(out["authentication"][0], "did:webvh:abc:example.com#key-0");
+    assert_eq!(out["keyAgreement"][0], "did:webvh:abc:example.com#key-1");
 
     // Two services: #vtc-rest at the URL, #vtc-status-list at URL + default path.
     assert_eq!(
         out["service"][0]["id"],
-        "did:webvh:example.com:abc#vtc-rest"
+        "did:webvh:abc:example.com#vtc-rest"
     );
     assert_eq!(out["service"][0]["type"], "VTCRest");
     assert_eq!(
@@ -681,7 +681,7 @@ fn vtc_host_renders_with_minimal_vars() {
     );
     assert_eq!(
         out["service"][1]["id"],
-        "did:webvh:example.com:abc#vtc-status-list"
+        "did:webvh:abc:example.com#vtc-status-list"
     );
     assert_eq!(out["service"][1]["type"], "VTCStatusList");
     assert_eq!(

--- a/vtc-service/src/routes/did_log.rs
+++ b/vtc-service/src/routes/did_log.rs
@@ -34,13 +34,27 @@
 //! `vta_sdk::sealed_transfer::template_bootstrap::TemplateOutput`'s
 //! `did.jsonl` entry.
 //!
+//! ## Filename
+//!
+//! The VTC hosts exactly one DID — its own. The setup wizard wrote
+//! the log to `did/<label>.jsonl`, where `<label>` is the final
+//! colon-separated component of `config.vtc_did`. For a serverless
+//! `did:webvh:<scid>:<host>` that final component is the **host** (the
+//! SCID is the *first* label — see the did:webvh spec and
+//! `vta_sdk::session::url_from_did`, which reads the host as the 2nd
+//! component). This route reads back the same name the wizard wrote,
+//! so the derivation here mirrors the wizard's exactly. The label is
+//! not interpreted as anything — it's only a storage key.
+//!
 //! ## Safety
 //!
-//! The VTC hosts exactly one DID — its own. The SCID is taken from
-//! `config.vtc_did` (operator-controlled at setup, not the request)
-//! and is validated against the did:webvh SCID grammar
-//! (alphanumeric, `-`, `_`) before it reaches the filesystem, so a
-//! malformed configured DID can't drive a path-traversal read.
+//! `config.vtc_did` is operator-controlled at setup, never request-
+//! derived. Before the label reaches the filesystem it's checked for
+//! path-traversal safety (no separators, no `..`), so a malformed
+//! configured DID can't escape the `did/` directory. This is a
+//! *path-safety* check, **not** an SCID-grammar check: a real label is
+//! a hostname and legitimately contains dots — rejecting dots is the
+//! bug that made the VTC's own DID unresolvable.
 
 use axum::extract::State;
 use axum::http::{HeaderValue, StatusCode, header};
@@ -53,12 +67,13 @@ pub async fn did_log(State(state): State<AppState>) -> impl IntoResponse {
     let config = state.config.read().await;
 
     // The VTC is not a general-purpose did:webvh host — it serves
-    // exactly one DID, its own. Resolve the SCID from `config.vtc_did`;
-    // before setup has run (or for a non-webvh DID) there's nothing to
-    // serve. `extract_scid_from_did` also validates the SCID grammar,
-    // so the filename below can't escape the `did/` directory.
-    let scid = match config.vtc_did.as_deref().and_then(extract_scid_from_did) {
-        Some(scid) => scid,
+    // exactly one DID, its own. Derive the on-disk log label from
+    // `config.vtc_did` (the same way the setup wizard did when it wrote
+    // the file); before setup has run (or for a non-webvh DID) there's
+    // nothing to serve. `did_log_label` also rejects path-traversal, so
+    // the filename below can't escape the `did/` directory.
+    let label = match config.vtc_did.as_deref().and_then(did_log_label) {
+        Some(label) => label,
         None => return (StatusCode::NOT_FOUND, "did log not found").into_response(),
     };
 
@@ -66,7 +81,7 @@ pub async fn did_log(State(state): State<AppState>) -> impl IntoResponse {
         .store
         .data_dir
         .join("did")
-        .join(format!("{scid}.jsonl"));
+        .join(format!("{label}.jsonl"));
     drop(config);
 
     let body = match tokio::fs::read(&path).await {
@@ -91,20 +106,31 @@ pub async fn did_log(State(state): State<AppState>) -> impl IntoResponse {
         .into_response()
 }
 
-fn is_valid_scid(s: &str) -> bool {
+/// True if `s` is safe to interpolate into `did/<s>.jsonl` without
+/// escaping the directory. A legitimate label is a hostname or SCID,
+/// so dots are allowed; only path separators, parent-directory refs,
+/// and control characters are rejected.
+fn is_safe_label(s: &str) -> bool {
     !s.is_empty()
-        && s.len() <= 128
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && s.len() <= 253
+        && s != "."
+        && s != ".."
+        && !s.contains("..")
+        && !s.contains('/')
+        && !s.contains('\\')
+        && !s.chars().any(char::is_control)
 }
 
-/// Pull the SCID out of a `did:webvh:<host>:<…path…>:<scid>` —
-/// the SCID is the **last** colon-separated component.
-fn extract_scid_from_did(did: &str) -> Option<String> {
+/// Derive the on-disk log label from the VTC's own `did:webvh`. The
+/// label is the **final** colon-separated component — the same value
+/// the setup wizard used when it wrote `did/<label>.jsonl`. For a
+/// serverless `did:webvh:<scid>:<host>` that's the host. Returns
+/// `None` for a non-webvh DID or a label that isn't filesystem-safe.
+fn did_log_label(did: &str) -> Option<String> {
     let suffix = did.strip_prefix("did:webvh:")?;
-    let last = suffix.split(':').next_back()?;
-    if is_valid_scid(last) {
-        Some(last.to_string())
+    let label = suffix.split(':').next_back()?;
+    if is_safe_label(label) {
+        Some(label.to_string())
     } else {
         None
     }
@@ -119,40 +145,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn valid_scid_accepts_alphanumeric() {
-        assert!(is_valid_scid("abc123"));
-        assert!(is_valid_scid("zQmPLwUBtaqz3a"));
-        assert!(is_valid_scid("foo-bar_baz"));
+    fn safe_label_accepts_hostnames_and_scids() {
+        // A serverless DID's label is the host — dots and all. This is
+        // the case the old SCID-grammar check wrongly rejected.
+        assert!(is_safe_label("vtc.example.com"));
+        assert!(is_safe_label("abc123"));
+        assert!(is_safe_label("zQmPLwUBtaqz3a"));
+        assert!(is_safe_label("foo-bar_baz"));
     }
 
     #[test]
-    fn valid_scid_rejects_separators_and_empty() {
-        assert!(!is_valid_scid(""));
-        assert!(!is_valid_scid("foo/bar"));
-        assert!(!is_valid_scid("foo:bar"));
-        assert!(!is_valid_scid("../etc/passwd"));
+    fn safe_label_rejects_traversal_and_empty() {
+        assert!(!is_safe_label(""));
+        assert!(!is_safe_label("."));
+        assert!(!is_safe_label(".."));
+        assert!(!is_safe_label("foo/bar"));
+        assert!(!is_safe_label("foo\\bar"));
+        assert!(!is_safe_label("../etc/passwd"));
+        assert!(!is_safe_label("a..b"));
     }
 
     #[test]
-    fn extract_scid_from_did_pulls_last_component() {
+    fn did_log_label_takes_the_last_component() {
+        // Real did:webvh — SCID first, host last. The label is the host.
         assert_eq!(
-            extract_scid_from_did("did:webvh:vtc.example.com:abc123").as_deref(),
-            Some("abc123")
+            did_log_label("did:webvh:abc123:vtc.example.com").as_deref(),
+            Some("vtc.example.com")
         );
+        // Hosted DID with a path tail — label is the final component.
         assert_eq!(
-            extract_scid_from_did("did:webvh:vtc.example.com:v1:abc123").as_deref(),
-            Some("abc123")
+            did_log_label("did:webvh:abc123:vtc.example.com:v1").as_deref(),
+            Some("v1")
         );
     }
 
     #[test]
-    fn extract_scid_from_did_returns_none_for_non_webvh() {
-        assert!(extract_scid_from_did("did:key:z6Mk…").is_none());
-        assert!(extract_scid_from_did("not a did").is_none());
+    fn did_log_label_returns_none_for_non_webvh() {
+        assert!(did_log_label("did:key:z6Mk…").is_none());
+        assert!(did_log_label("not a did").is_none());
     }
 
     #[test]
-    fn extract_scid_from_did_returns_none_when_last_component_invalid() {
-        assert!(extract_scid_from_did("did:webvh:vtc.example.com:foo/bar").is_none());
+    fn did_log_label_returns_none_when_last_component_unsafe() {
+        assert!(did_log_label("did:webvh:abc123:../../etc/passwd").is_none());
     }
 }

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -154,8 +154,8 @@ pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), AppErr
         )
     })?;
     let data_dir = default_data_dir_for(&config_path);
-    let scid = extract_scid_or_err(&integration_did)?;
-    write_did_log(&data_dir, &scid, did_log)?;
+    let label = did_log_label_or_err(&integration_did)?;
+    write_did_log(&data_dir, &label, did_log)?;
 
     // 6. Materialise the config. We hold off writing it to disk until
     //    step 7 because the config-secret backend stores the key bundle
@@ -1453,7 +1453,14 @@ fn default_data_dir_for(config_path: &std::path::Path) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("data"))
 }
 
-fn extract_scid_or_err(did: &str) -> Result<String, AppError> {
+/// Derive the on-disk log label for the VTC's own `did:webvh` — the
+/// final colon-separated component (for a serverless
+/// `did:webvh:<scid>:<host>` that's the host). This is purely a
+/// storage-key derivation: the daemon's `GET /.well-known/did.jsonl`
+/// route (`routes::did_log`) reads the log back under the *same*
+/// derivation, so the two must stay in lockstep. Not an SCID — the
+/// SCID is the first label, and nothing here needs it.
+fn did_log_label_or_err(did: &str) -> Result<String, AppError> {
     did.strip_prefix("did:webvh:")
         .and_then(|suffix| suffix.split(':').next_back())
         .map(str::to_string)
@@ -1483,14 +1490,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn extract_scid_from_webvh() {
-        let scid = extract_scid_or_err("did:webvh:vtc.example.com:v1:abc123").unwrap();
-        assert_eq!(scid, "abc123");
+    fn did_log_label_is_the_final_component() {
+        // Real did:webvh is `did:webvh:<scid>:<host>` — the wizard's
+        // log label is the final component, i.e. the host. (The serve
+        // route reads the file back under this same label.)
+        let label = did_log_label_or_err("did:webvh:abc123:vtc.example.com").unwrap();
+        assert_eq!(label, "vtc.example.com");
     }
 
     #[test]
-    fn extract_scid_refuses_non_webvh() {
-        let err = extract_scid_or_err("did:key:z6Mk…").unwrap_err();
+    fn did_log_label_refuses_non_webvh() {
+        let err = did_log_label_or_err("did:key:z6Mk…").unwrap_err();
         assert!(format!("{err}").contains("non-webvh"));
     }
 

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -28,8 +28,18 @@ use vtc_service::install::InstallTokenStore;
 use vtc_service::routes;
 use vtc_service::server::AppState;
 
-const VTC_DID: &str = "did:webvh:vtc.example.com:v1:abc123";
-const VTC_SCID: &str = "abc123";
+// A real `did:webvh` is `did:webvh:<scid>:<host>[:<path>]` — the SCID is
+// the FIRST label after the method, the host second (see the did:webvh
+// spec and `vta-sdk::session::url_from_did`, which reads the host as the
+// 2nd component). This is the serverless shape the VTC mints for itself;
+// it resolves to `https://<host>/.well-known/did.jsonl`. The host carries
+// dots, which is exactly the case that must round-trip.
+const VTC_DID: &str = "did:webvh:abc123:vtc.example.com";
+// The setup wizard writes the log to `did/<label>.jsonl`, where <label>
+// is the *final* colon component of the DID — for this serverless DID
+// that's the host. The serve route reads back the same name, so tests
+// seed the file under this label, not the SCID.
+const VTC_LOG_LABEL: &str = "vtc.example.com";
 
 struct Fixture {
     router: axum::Router,
@@ -152,12 +162,16 @@ async fn get(router: &axum::Router, path: &str) -> (StatusCode, Vec<u8>, Option<
 }
 
 #[tokio::test]
-async fn happy_path_returns_log_content_as_jsonl() {
+async fn serverless_dotted_host_did_resolves_as_jsonl() {
+    // The regression this whole file exists for: a serverless VTC DID
+    // `did:webvh:<scid>:<host>` whose host carries dots must resolve at
+    // `/.well-known/did.jsonl`. The old SCID-grammar gate rejected the
+    // dots and 404'd the VTC's own DID.
     let fix = build_fixture(VTC_DID).await;
     let log = r#"{"versionId":"1-abc","parameters":{}}
 {"versionId":"2-def","parameters":{}}
 "#;
-    seed_did_log(&fix.data_dir, VTC_SCID, log);
+    seed_did_log(&fix.data_dir, VTC_LOG_LABEL, log);
 
     let (status, body, ct) = get(&fix.router, "/.well-known/did.jsonl").await;
     assert_eq!(status, StatusCode::OK);
@@ -166,10 +180,10 @@ async fn happy_path_returns_log_content_as_jsonl() {
 }
 
 #[tokio::test]
-async fn returns_404_when_only_a_foreign_scid_log_exists() {
-    // The VTC serves exactly its own DID's log. A stray log file for
-    // some other SCID on disk must not be served — we read only the
-    // SCID derived from `config.vtc_did`.
+async fn returns_404_when_only_a_foreign_label_log_exists() {
+    // The VTC serves exactly its own DID's log. A stray log file under
+    // some other label on disk must not be served — we read only the
+    // label derived from `config.vtc_did`.
     let fix = build_fixture(VTC_DID).await;
     seed_did_log(&fix.data_dir, "different", "{}");
 
@@ -186,12 +200,12 @@ async fn returns_404_when_file_missing() {
 }
 
 #[tokio::test]
-async fn returns_404_when_configured_scid_is_malformed() {
-    // The SCID is taken from `config.vtc_did`, not the URL. A
-    // configured DID whose trailing component fails the SCID grammar
-    // (here, path-traversal characters) is rejected before any
-    // filesystem read, so it can't escape the `did/` directory.
-    let fix = build_fixture("did:webvh:vtc.example.com:..%2f..%2fetc%2fpasswd").await;
+async fn returns_404_when_configured_label_would_traverse() {
+    // The label is taken from `config.vtc_did`, not the URL. A
+    // configured DID whose final component contains path-traversal
+    // characters is rejected before any filesystem read, so it can't
+    // escape the `did/` directory.
+    let fix = build_fixture("did:webvh:abc123:../../etc/passwd").await;
     let (status, _, _) = get(&fix.router, "/.well-known/did.jsonl").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
@@ -201,7 +215,7 @@ async fn route_is_trust_task_exempt() {
     // No `Trust-Task` header should still serve the response; if
     // the route was Trust-Task-gated this would 400.
     let fix = build_fixture(VTC_DID).await;
-    seed_did_log(&fix.data_dir, VTC_SCID, "{}");
+    seed_did_log(&fix.data_dir, VTC_LOG_LABEL, "{}");
 
     let res = fix
         .router


### PR DESCRIPTION
## Problem

A serverless VTC's own `did:webvh` was unresolvable. #147 correctly moved the log route to `GET /.well-known/did.jsonl`, but the handler still returned **404** for any real deployment.

## Root cause

The handler derives the on-disk log label from `config.vtc_did` as the **final** colon-separated component, then validated it against an **SCID grammar** (alphanumeric only). But a real `did:webvh` is `did:webvh:<scid>:<host>` — SCID **first**, host last — so the final component is the **host**, which legitimately contains dots. `is_valid_scid("vtc.example.com")` returned `false` → `None` → 404, before any file read.

The label is only ever a **storage key** — the setup wizard writes `did/<label>.jsonl` using the *same* final-component derivation. So the correct fix is to validate it for **path-traversal safety** (reject `/`, `\`, `..`, control chars), not SCID grammar. Hostnames pass; traversal doesn't.

**No on-disk filename change → existing installs resolve immediately, no migration.**

## Why it leaked (the important part)

The `tests/did_log.rs` fixtures used a **backwards** DID — `did:webvh:vtc.example.com:v1:abc123` (host first, SCID last). With that shape `next_back()` happened to return the SCID, so the tests passed against broken code. They encoded the same wrong assumption as the bug.

Fixed by rewriting the integration tests to the **real** SCID-first format with a **dotted host** — the exact case that was broken — driven end-to-end through the live route. These tests fail on the pre-fix handler and pass after. Added path-safety unit tests.

## Changes

- `vtc-service/src/routes/did_log.rs` — replace SCID-grammar gate with a path-safety check; rename `extract_scid_from_did`/`is_valid_scid` → `did_log_label`/`is_safe_label` (honest naming).
- `vtc-service/tests/did_log.rs` — real SCID-first + dotted-host fixtures, seed at the actual on-disk label, traversal test.
- `vtc-service/src/setup/wizard.rs` — rename `extract_scid_or_err` → `did_log_label_or_err` (cosmetic; it returns a label, not an SCID).
- `vta-sdk/src/did_templates/tests.rs` — correct backwards `did:webvh:<host>:<scid>` fixtures to SCID-first (test-only, opaque DID var).

## Testing

- `did_log` integration: 5/5 ✅ (fail before fix, pass after)
- `did_log` + `wizard` + `did_templates` unit: all ✅
- `cargo clippy -p vtc-service`: clean

> Note: `vtc-service --test removal::admin_remove_flips_revocation_bit` fails **only under parallel execution** (passes alone and single-threaded). It's a pre-existing test-isolation flake unrelated to this change — flagged for a separate fix.