### PR TITLE
fix(vtc): never allocate a status-list slot whose bit is already set

### DIFF
--- a/vtc-service/src/status_list/allocator.rs
+++ b/vtc-service/src/status_list/allocator.rs
@@ -33,9 +33,17 @@ use super::storage::StatusListState;
 /// Side-effects: sets `assigned[index] = true`. Does **not**
 /// touch the bitstring — the bit stays `0` (= "valid") until a
 /// subsequent [`flip`] revokes / suspends.
+///
+/// A candidate slot must be **both** unassigned **and** have its
+/// bit currently clear. The second condition matters because
+/// [`add_initial_decoys`] flips bits on *unassigned* slots: without
+/// the `!is_set` filter the allocator could hand a member a decoy
+/// slot whose bit already reads `1`, so the member's credential
+/// would resolve as *revoked from the moment of issuance*. Decoy
+/// slots are therefore skipped and remain permanent noise.
 pub fn allocate(state: &mut StatusListState) -> Option<u32> {
     let available: Vec<usize> = (0..state.capacity)
-        .filter(|&i| !state.assigned[i])
+        .filter(|&i| !state.assigned[i] && !state.is_set(i))
         .collect();
     if available.is_empty() {
         return None;
@@ -211,6 +219,48 @@ mod tests {
             occupancy(&state) >= 0.75,
             "expected occupancy >= 0.75, got {}",
             occupancy(&state)
+        );
+    }
+
+    /// Regression (deterministic): when every unassigned slot
+    /// already carries a bit (all decoys, nothing assigned), the
+    /// allocator must refuse rather than hand one out. The old
+    /// allocator filtered on `assigned` alone and returned a
+    /// decoy slot here — which in production gives a member a
+    /// credential that reads as revoked at issuance.
+    #[test]
+    fn allocate_refuses_when_all_free_slots_are_decoys() {
+        let mut state = fresh_state(Some(8));
+        // Flip a bit on every slot; leave all of them unassigned.
+        for i in 0..8 {
+            flip(&mut state, i as u32, true).unwrap();
+        }
+        assert!(
+            allocate(&mut state).is_none(),
+            "allocate must not return a slot whose bit is already set"
+        );
+    }
+
+    /// Regression: under a realistic decoy load, every slot the
+    /// allocator hands out has a clear bit. Drains the list to be
+    /// sure no decoy slot ever slips through.
+    #[test]
+    fn allocate_never_returns_a_set_slot_under_decoys() {
+        let mut state = fresh_state(Some(256));
+        add_initial_decoys(&mut state, 200);
+        let mut handed_out = 0usize;
+        while let Some(idx) = allocate(&mut state) {
+            assert!(
+                !state.is_set(idx as usize),
+                "allocate returned slot {idx} whose bit was already set (decoy)"
+            );
+            handed_out += 1;
+        }
+        // Only the non-decoy slots are allocatable.
+        assert!(handed_out > 0, "expected some allocatable slots");
+        assert!(
+            handed_out <= 256 - state.count_set(),
+            "allocated more slots than there were clear ones"
         );
     }
 


### PR DESCRIPTION
## Summary

What looked like a parallel-only flaky test (`removal.rs::admin_remove_flips_revocation_bit`) was the visible symptom of a **real production correctness bug** in the status-list slot allocator.

## Root cause

`status_list::allocator::allocate` selected a slot by filtering only on `!assigned[i]`. But `add_initial_decoys` flips bits on **unassigned** slots for herd privacy (`INITIAL_DECOY_FRACTION = 0.05`). So a slot can be `assigned = false` **and** `bit = 1` (a decoy), and `allocate` would happily hand it out.

The result: ~5% of allocations gave a member a slot whose status bit already reads `1`, so the freshly issued credential **resolves as revoked from the moment of issuance**. This affects every issuance path that assigns a slot:

- `routes/members/personhood.rs`
- `routes/join_requests/decide.rs`
- `routes/members/renew.rs`
- `routes/endorsements.rs`

## Why it looked like a flake

`admin_remove_flips_revocation_bit` allocates a slot and asserts `!pre.is_set(slot)` ("bit should start cleared"). ~5% of the time `allocate` returned a decoy slot and the assertion failed. It correlated with `--test-threads` purely by RNG luck across runs, not by any shared state — the fixtures are fully isolated (own tempdir/store/keyspaces).

## Fix

`allocate` now requires a candidate to be **both** unassigned and have a clear bit:

```rust
.filter(|&i| !state.assigned[i] && !state.is_set(i))
```

Decoy slots are skipped and remain permanent noise; allocated slots always start at `0` (valid). **No data migration** — persisted bitstrings are unchanged.

## Tests

- New deterministic regression: all free slots decoyed → `allocate` must refuse.
- New realistic regression: drain under a heavy decoy load → every handed-out slot has a clear bit.
- Existing capacity-drain / never-reallocate tests still pass (they build all-zero states, unaffected).
- `status_list` unit suite: 16/16.
- `removal` binary: **10/10 consecutive parallel runs green** (was intermittently failing before).
- `cargo clippy -p vtc-service`: clean.

Closes the flake noted in PR #148.