### PR TITLE
feat(vta-mobile-core): scaffold UniFFI engine crate for the mobile agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tower 0.5.3",
  "tower-http",
  "tracing",
@@ -768,6 +768,47 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -1451,7 +1492,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "either",
- "fs-err",
+ "fs-err 3.3.0",
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.9.0",
@@ -1609,10 +1650,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bech32"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bip39"
@@ -1864,6 +1923,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,7 +2202,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
@@ -3450,6 +3541,15 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "fs-err"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
@@ -3648,6 +3748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3657,6 +3763,17 @@ dependencies = [
  "bstr",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -5921,6 +6038,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6068,7 +6191,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -6077,7 +6200,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -6129,6 +6252,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "pnm-cli"
 version = "0.7.0"
 dependencies = [
@@ -6148,7 +6277,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
@@ -7238,6 +7367,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7296,6 +7445,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -7676,6 +7829,12 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
@@ -7717,6 +7876,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
@@ -8263,7 +8428,7 @@ dependencies = [
  "phf 0.11.3",
  "sha2 0.10.9",
  "signal-hook",
- "siphasher",
+ "siphasher 1.0.3",
  "terminfo",
  "termios",
  "thiserror 1.0.69",
@@ -8276,6 +8441,15 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
 ]
 
 [[package]]
@@ -8505,6 +8679,15 @@ dependencies = [
  "libc",
  "tokio",
  "vsock",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -9001,6 +9184,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "uniffi"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err 2.11.0",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "serde",
+ "textwrap",
+ "toml 0.5.11",
+ "uniffi_meta",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_checksum_derive"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "log",
+ "once_cell",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+dependencies = [
+ "bincode",
+ "camino",
+ "fs-err 2.11.0",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "toml 0.5.11",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "siphasher 0.3.11",
+ "uniffi_checksum_derive",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err 2.11.0",
+ "once_cell",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "uniffi_testing",
+ "weedle2",
+]
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9200,6 +9501,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vta-mobile-core"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "thiserror 2.0.18",
+ "uniffi",
+]
+
+[[package]]
 name = "vta-sdk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9330,7 +9640,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tower 0.5.3",
  "tower-http",
  "tower_governor",
@@ -9411,7 +9721,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tower 0.5.3",
  "tower-http",
  "tower_governor",
@@ -9789,6 +10099,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,24 @@ members = [
   "pnm-cli",
   "tests/e2e",
   "vta-cli-common",
+  "vta-mobile-core",
+  "vta-sdk",
+  "vta-service",
+  "vta-enclave",
+  "vtc-service",
+  "vti-common",
+  "vti-webauthn",
+]
+# `vta-mobile-core` is a UniFFI client crate that cross-compiles to Android/iOS.
+# Keep it out of `default-members` so a bare `cargo build`/`test` for the server
+# does not pull `uniffi` (or the mobile crate) into the build graph. CI that runs
+# `--workspace` still builds and lints it; the mobile-artifacts job cross-compiles it.
+default-members = [
+  "cnm-cli",
+  "didcomm-test",
+  "pnm-cli",
+  "tests/e2e",
+  "vta-cli-common",
   "vta-sdk",
   "vta-service",
   "vta-enclave",
@@ -27,6 +45,9 @@ license = "Apache-2.0"
 repository = "https://github.com/OpenVTC/verifiable-trust-infrastructure"
 
 [workspace.dependencies]
+
+# Foreign-language bindings for the mobile engine crate (`vta-mobile-core`).
+uniffi = "0.28"
 
 # Affinidi Trust Development Kit
 affinidi-tdk = "0.7"

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "vta-mobile-core"
+version = "0.1.0"
+description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
+edition.workspace = true
+# Not a crates.io library — the published artifacts are the Android AAR
+# (org.openvtc.vta:mobile-core-android) and the VtaMobileCore.xcframework,
+# produced by the dedicated mobile-artifacts CI job, not `cargo publish`.
+publish = false
+authors.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+# Underscore form is the FFI library name (libvta_mobile_core.{so,dylib,a}).
+name = "vta_mobile_core"
+# cdylib → Android .so + the library uniffi-bindgen introspects;
+# staticlib → iOS xcframework; lib → in-crate tests and host builds.
+crate-type = ["cdylib", "staticlib", "lib"]
+
+[dependencies]
+# `cli` feature provides `uniffi::uniffi_bindgen_main` for the bindgen binary.
+uniffi = { workspace = true, features = ["cli"] }
+thiserror = { workspace = true }
+base64 = { workspace = true }
+
+# ── Deferred wiring (kept out of slice 1 on purpose) ────────────────────────
+# The FFI build + bindgen pipeline is proven first with a minimal surface.
+#   slice 2 — Trust Tasks (pure, sync). Needs a republished trust-tasks-rs:
+#             crates.io 0.1.2 predates the `evidence` / `acceptableEvidence`
+#             fields merged to dtgwg-trust-tasks-tf (PRs #61/#62).
+#     trust-tasks-rs    = { workspace = true }
+#     trust-tasks-proof = { workspace = true }
+#   slice 3 — VTA session/auth (async over the FFI boundary, tokio runtime):
+#     vta-sdk      = { workspace = true, features = ["session"] }
+#     vti-webauthn = { path = "../vti-webauthn" }   # shared WebAuthn types
+
+[[bin]]
+# `cargo run -p vta-mobile-core --bin uniffi-bindgen -- generate ...`
+name = "uniffi-bindgen"
+path = "src/bin/uniffi-bindgen.rs"
+
+[lints]
+workspace = true

--- a/vta-mobile-core/src/api.rs
+++ b/vta-mobile-core/src/api.rs
@@ -1,0 +1,58 @@
+//! The pure-function FFI façade.
+//!
+//! Everything callable from Kotlin/Swift is `#[uniffi::export]`ed here (or
+//! re-exported from a sibling module). Slice 1 keeps the surface minimal and
+//! synchronous to prove the build + bindgen pipeline end to end.
+
+use base64::Engine as _;
+
+use crate::error::FfiError;
+
+/// Engine build/version metadata. A trivial record so the host app can confirm
+/// the FFI bridge is live and log which engine build it loaded.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct EngineInfo {
+    /// The `vta-mobile-core` crate version.
+    pub version: String,
+    /// The UniFFI namespace (matches the generated Kotlin/Swift module).
+    pub namespace: String,
+}
+
+/// Returns the engine version string. The simplest possible FFI round-trip —
+/// the host app's first call to confirm linkage.
+#[uniffi::export]
+pub fn library_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Returns engine metadata as a structured record (exercises UniFFI record
+/// codegen across the boundary).
+#[uniffi::export]
+pub fn engine_info() -> EngineInfo {
+    EngineInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        namespace: "vta_mobile_core".to_string(),
+    }
+}
+
+/// Decodes a base64url step-up challenge and returns its length in bytes,
+/// enforcing the ≥128-bit (16-byte) minimum the `auth/step-up/approve-request`
+/// spec requires. A first *real*, pure, synchronous check that exercises the
+/// `Result`/[`FfiError`] surface across the FFI boundary.
+#[uniffi::export]
+pub fn challenge_len_bytes(challenge_b64url: String) -> Result<u32, FfiError> {
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(challenge_b64url.as_bytes())
+        .map_err(|e| FfiError::Decode {
+            reason: format!("challenge is not valid base64url: {e}"),
+        })?;
+    if bytes.len() < 16 {
+        return Err(FfiError::InvalidInput {
+            reason: format!(
+                "challenge is {} bytes; the step-up spec requires ≥16 (128 bits)",
+                bytes.len()
+            ),
+        });
+    }
+    Ok(bytes.len() as u32)
+}

--- a/vta-mobile-core/src/bin/uniffi-bindgen.rs
+++ b/vta-mobile-core/src/bin/uniffi-bindgen.rs
@@ -1,0 +1,14 @@
+//! Binding generator entry point.
+//!
+//! Generates the foreign-language bindings from the built library in
+//! "library mode", e.g.:
+//!
+//! ```sh
+//! cargo build -p vta-mobile-core            # produces target/debug/libvta_mobile_core.{dylib,so}
+//! cargo run  -p vta-mobile-core --bin uniffi-bindgen -- \
+//!     generate --library target/debug/libvta_mobile_core.dylib \
+//!     --language kotlin --out-dir target/bindings/kotlin
+//! ```
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/vta-mobile-core/src/didcomm.rs
+++ b/vta-mobile-core/src/didcomm.rs
@@ -1,0 +1,11 @@
+//! DIDComm pack / unpack — wraps the `affinidi-tdk` DIDComm stack.
+//!
+//! **Slice 3.**
+//!
+//! Planned surface (pure functions; the transport is native):
+//! - `unpack(jwe_bytes, recipient_key_handle) -> PlaintextMessage`
+//! - `pack_authcrypt(message, sender_handle, recipient_did) -> JweBytes`
+//! - `wrap_forward(jwe, mediator_did) -> JweBytes`
+//!
+//! The native layer owns the WebSocket to the mediator and hands raw envelope
+//! bytes here for decryption / encryption.

--- a/vta-mobile-core/src/error.rs
+++ b/vta-mobile-core/src/error.rs
@@ -1,0 +1,23 @@
+//! The error type that crosses the FFI boundary.
+//!
+//! Kept coarse and stable: the host app switches on the *variant* for control
+//! flow; the `reason`/detail strings are for logs and diagnostics, not for
+//! parsing. New variants are additive — never reshape an existing one, or you
+//! break every generated binding.
+
+/// Errors returned across the UniFFI boundary to Kotlin / Swift.
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum FfiError {
+    /// Caller supplied a value that failed a precondition (shape, range, …).
+    #[error("invalid input: {reason}")]
+    InvalidInput { reason: String },
+
+    /// A value that should have been a recognised encoding (base64url, JSON, …)
+    /// could not be decoded.
+    #[error("decode error: {reason}")]
+    Decode { reason: String },
+
+    /// The requested operation is part of a not-yet-wired build-out slice.
+    #[error("not yet implemented: {what}")]
+    Unimplemented { what: String },
+}

--- a/vta-mobile-core/src/keys.rs
+++ b/vta-mobile-core/src/keys.rs
@@ -1,0 +1,12 @@
+//! Key-handle abstraction — the seam between this engine and *native* custody.
+//!
+//! **Slice 3.** Private key material never crosses the FFI boundary and is
+//! never held in Rust. Instead the native app implements a signing callback
+//! backed by the Secure Enclave / StrongBox (biometric-gated), and passes a
+//! handle in; this engine calls back out to sign.
+//!
+//! Planned surface (UniFFI callback interface / trait):
+//! - `trait Signer { fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>, FfiError>; fn did(&self) -> String; }`
+//!
+//! So `stepup`/`session` request signatures over bytes they construct, and the
+//! biometric prompt + enclave operation happen entirely on the native side.

--- a/vta-mobile-core/src/lib.rs
+++ b/vta-mobile-core/src/lib.rs
@@ -1,0 +1,46 @@
+//! `vta-mobile-core` — the shared engine behind the VTA mobile agent
+//! (`vta-mobile-agent-android` / `vta-mobile-agent-ios`), exposed to both
+//! platforms through a single UniFFI surface.
+//!
+//! ## Design
+//!
+//! The FFI surface is deliberately a set of **pure functions over bytes**.
+//! Everything stateful or platform-bound stays *native* and is handed to this
+//! crate as inputs:
+//!
+//! - key custody (Secure Enclave / StrongBox) and biometric gating,
+//! - the mediator WebSocket transport and APNs/FCM push wake-up,
+//! - the platform WebAuthn / passkey APIs,
+//! - all UI.
+//!
+//! This crate wraps the existing Rust building blocks — `vta-sdk` (VTA auth /
+//! session), `trust-tasks-rs` + `trust-tasks-proof` (Trust Task build/verify),
+//! and the `affinidi-tdk` DIDComm/resolver/crypto stack — so the wire crypto
+//! is written once and shared, never reimplemented per platform.
+//!
+//! ## Build-out slices
+//!
+//! 1. **this slice** — skeleton + minimal sync surface; prove the crate builds
+//!    and Kotlin/Swift bindings generate.
+//! 2. Trust Task build/verify (pure, sync) — see [`task`], [`stepup`].
+//! 3. VTA session/auth (async) — see [`session`]; DIDComm pack/unpack —
+//!    see [`didcomm`]; push registration — see [`push`].
+
+uniffi::setup_scaffolding!();
+
+pub mod api;
+mod error;
+
+// Planned module surface. These are stubs in slice 1; each file documents the
+// FFI it will expose and which slice wires it. They are kept as real modules
+// so the crate layout matches the mapped design from day one.
+pub mod didcomm;
+pub mod keys;
+pub mod push;
+pub mod resolver;
+pub mod session;
+pub mod stepup;
+pub mod task;
+
+pub use api::*;
+pub use error::FfiError;

--- a/vta-mobile-core/src/push.rs
+++ b/vta-mobile-core/src/push.rs
@@ -1,0 +1,11 @@
+//! Push registration — build the DIDComm `set-device-info` message.
+//!
+//! **Slice 3.** Implements the device side of the push wake-up binding
+//! (`https://trusttasks.org/binding/push/0.1`): the engine assembles the
+//! `set-device-info` body from a [`PushRegistration`]-shaped input; the native
+//! layer obtains the APNs/FCM token and sends the packed message to the
+//! mediator over the live DIDComm channel.
+//!
+//! Planned surface:
+//! - `build_set_device_info(platform, token, topic) -> MessageJson`
+//! - `build_delete_device_info() -> MessageJson`

--- a/vta-mobile-core/src/resolver.rs
+++ b/vta-mobile-core/src/resolver.rs
@@ -1,0 +1,10 @@
+//! DID resolution — wraps `affinidi-did-resolver-cache-sdk`.
+//!
+//! **Slice 3.**
+//!
+//! Planned surface:
+//! - `resolve_did(did) -> DidDocumentJson`
+//! - `key_agreement_key(did) -> Multikey`   (for authcrypt to the VTA)
+//!
+//! Backed by the caching resolver so repeated lookups (every inbound message)
+//! stay cheap; the native layer may seed an offline cache for known DIDs.

--- a/vta-mobile-core/src/session.rs
+++ b/vta-mobile-core/src/session.rs
@@ -1,0 +1,13 @@
+//! VTA session / authentication — wraps `vta-sdk`.
+//!
+//! **Slice 3** (async over the FFI boundary; needs `vta-sdk` `session` feature
+//! and a UniFFI `async_runtime = "tokio"` export).
+//!
+//! Planned surface:
+//! - `start_auth(vta_did) -> AuthChallenge`
+//! - `complete_auth(challenge, signed) -> TokenBundle`
+//! - `refresh(refresh_token) -> TokenBundle`
+//!
+//! Key material never crosses the boundary: signing is performed natively via
+//! a [`crate::keys`] handle; this module orchestrates the challenge/response
+//! and JWT lifecycle using `vta-sdk`'s client.

--- a/vta-mobile-core/src/stepup.rs
+++ b/vta-mobile-core/src/stepup.rs
@@ -1,0 +1,16 @@
+//! AAL step-up — build the `auth/step-up/approve-response` document.
+//!
+//! **Slice 2** (build) + **slice 3** (signing handle). Blocked on the same
+//! `trust-tasks-rs` republish as [`crate::task`].
+//!
+//! Planned surface (supports BOTH gates from the merged spec):
+//! - `build_approve_response_did_signed(req, decision, key_handle) -> TaskJson`
+//!     — gate = framework Data Integrity proof (subject DID signature).
+//! - `build_approve_response_webauthn(req, assertion) -> TaskJson`
+//!     — gate = WebAuthn `AuthenticatorAssertionResponse` over the challenge;
+//!       the assertion is produced natively (ASAuthorization / Credential
+//!       Manager) and passed in.
+//!
+//! The native layer decides which gate to use based on the request's
+//! `acceptableEvidence`; this module assembles and (for did-signed) signs via
+//! a [`crate::keys`] handle.

--- a/vta-mobile-core/src/task.rs
+++ b/vta-mobile-core/src/task.rs
@@ -1,0 +1,10 @@
+//! Trust Task build / verify — wraps `trust-tasks-rs` + `trust-tasks-proof`.
+//!
+//! **Slice 2** (pure, synchronous). Blocked on republishing `trust-tasks-rs`:
+//! crates.io 0.1.2 predates the `evidence` / `acceptableEvidence` fields
+//! merged to `dtgwg-trust-tasks-tf` (PRs #61/#62).
+//!
+//! Planned surface:
+//! - `parse_step_up_request(json) -> StepUpRequest`   (subject, reason, challenge, acceptable_evidence)
+//! - `verify_task_proof(json) -> VerifiedTask`         (Data Integrity proof check)
+//! - `build_error(thread_id, code) -> TaskJson`

--- a/vta-mobile-core/uniffi.toml
+++ b/vta-mobile-core/uniffi.toml
@@ -1,0 +1,8 @@
+# Foreign-binding configuration for vta-mobile-core.
+# Names match the mobile topology decided for this engine.
+
+[bindings.kotlin]
+package_name = "org.openvtc.vta.mobilecore"
+
+[bindings.swift]
+module_name = "VtaMobileCore"


### PR DESCRIPTION
## Summary

First slice of the **VTA mobile agent**'s shared engine. `vta-mobile-core` is a new workspace member that compiles to a **UniFFI** library; the Android AAR (`org.openvtc.vta:mobile-core-android`) and the `VtaMobileCore.xcframework` built from it are what the two app repos (`vta-mobile-agent-android` / `vta-mobile-agent-ios`) will consume. The engine is hosted here (rather than in a standalone repo or `affinidi-tdk-rs`) because it links **`vta-sdk`** directly for VTA auth/session reuse.

This slice is intentionally a **skeleton + minimal synchronous surface** — the goal is to prove the crate builds and that Kotlin/Swift bindings generate, before wiring the real engine.

## What's here

- **Crate** `vta-mobile-core` (`crate-type = cdylib + staticlib + lib`), UniFFI namespace `vta_mobile_core`, package/module names set in `uniffi.toml` (`org.openvtc.vta.mobilecore` / `VtaMobileCore`).
- **FFI façade** (`api.rs`): `library_version()`, `engine_info()`, `challenge_len_bytes()` (enforces the ≥128-bit step-up challenge minimum) + a stable `FfiError`.
- **Stub modules** documenting the planned surface and which slice wires each: `session` (vta-sdk auth, async), `didcomm` (pack/unpack), `resolver`, `task` + `stepup` (Trust Task build/verify — both the did-signed and WebAuthn step-up gates), `push` (`set-device-info`), `keys` (native custody callback — private keys never cross the FFI boundary).
- **`uniffi-bindgen`** binary for library-mode generation.

## Guardrails for hosting client code in the seed-holding workspace

- Excluded from **`default-members`** so a bare `cargo build`/`test` for the server doesn't pull `uniffi` or this crate into the build graph. CI `--workspace` still builds and lints it; a dedicated mobile-artifacts job will cross-compile it.
- Depends only on **client** crates — never `vta-service`/`vta-enclave` — so the master-seed boundary is untouched.

## Verification

- `cargo check -p vta-mobile-core` ✓ (uniffi 0.28.3)
- Kotlin + Swift bindings generate via `uniffi-bindgen` library mode ✓
- `cargo check -p vti-common` ✓ — no regression from the lockfile change (the `Cargo.lock` diff is the uniffi tool tree only; no existing crate version moved)

## Deferred (next slices)

- **Slice 2** — wire `task.rs`/`stepup.rs` against `trust-tasks-rs`. Blocked on a republish: crates.io `trust-tasks-rs 0.1.2` predates the `evidence`/`acceptableEvidence` fields merged to `dtgwg-trust-tasks-tf`.
- **Slice 3** — `vta-sdk` session (async over FFI), DIDComm pack/unpack, push `set-device-info`, and the native key-handle callback interface.
