### PR TITLE
feat(vta-mobile-core): native Signer custody callback (keys never cross FFI)

### DIFF
--- a/vta-mobile-core/src/keys.rs
+++ b/vta-mobile-core/src/keys.rs
@@ -1,12 +1,50 @@
 //! Key-handle abstraction — the seam between this engine and *native* custody.
 //!
-//! **Slice 3.** Private key material never crosses the FFI boundary and is
-//! never held in Rust. Instead the native app implements a signing callback
-//! backed by the Secure Enclave / StrongBox (biometric-gated), and passes a
-//! handle in; this engine calls back out to sign.
-//!
-//! Planned surface (UniFFI callback interface / trait):
-//! - `trait Signer { fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>, FfiError>; fn did(&self) -> String; }`
-//!
-//! So `stepup`/`session` request signatures over bytes they construct, and the
-//! biometric prompt + enclave operation happen entirely on the native side.
+//! Private key material **never** crosses the FFI boundary and is never held in
+//! Rust. The native app implements [`Signer`] over a key in the Secure Enclave
+//! (iOS) / StrongBox / Android Keystore, gated behind a biometric prompt, and
+//! passes it in. The engine builds the exact bytes that need signing and calls
+//! back out; the enclave operation and the biometric UI happen entirely
+//! natively. This is the seam every later signing flow ([`crate::stepup`],
+//! [`crate::session`]) is built on.
+
+use crate::error::FfiError;
+
+/// A signing capability backed by a platform-protected private key, implemented
+/// on the **native** (Kotlin/Swift) side. Per the workspace "default to DIDs"
+/// principle, the key is identified by its `did:key`, never a raw pubkey.
+#[uniffi::export(callback_interface)]
+pub trait Signer: Send + Sync {
+    /// The `did:key` (Ed25519) whose key this signer controls. The engine uses
+    /// it as the proof `verificationMethod` on documents it assembles.
+    fn did(&self) -> String;
+
+    /// Sign `payload` with the enclave-held key. The biometric prompt and the
+    /// Secure Enclave / StrongBox operation are performed natively; a user
+    /// cancellation or biometric failure returns [`FfiError`]. The signature is
+    /// raw bytes (EdDSA over `payload`); the engine never sees key material.
+    fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>, FfiError>;
+}
+
+/// Exercises the custody seam end to end: decode a base64url step-up challenge
+/// and have the native [`Signer`] sign those bytes, returning the signature.
+///
+/// This is the round-trip native → engine → native-callback → engine → native
+/// that proves the boundary (and [`FfiError`] propagation *back through* the
+/// callback) works. Later slices replace the raw-challenge input with the
+/// canonicalised signing input of an `auth/step-up/approve-response` document,
+/// but the signing seam — engine builds bytes, native enclave signs them — is
+/// exactly this.
+#[uniffi::export]
+pub fn sign_challenge(
+    signer: Box<dyn Signer>,
+    challenge_b64url: String,
+) -> Result<Vec<u8>, FfiError> {
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(challenge_b64url.as_bytes())
+        .map_err(|e| FfiError::Decode {
+            reason: format!("challenge is not valid base64url: {e}"),
+        })?;
+    signer.sign(bytes)
+}


### PR DESCRIPTION
## Summary

Implements the **key-custody seam** for `vta-mobile-core` — the foundation every later signing flow (step-up approve-response, VTA session auth) builds on.

Private key material **never crosses the FFI boundary** and is never held in Rust. The native app (Kotlin/Swift) implements the `Signer` callback interface over a key in the **Secure Enclave / StrongBox**, gated behind a biometric prompt; the engine builds the exact bytes to sign and calls back out for the signature.

## What's here (`keys.rs`)

- `Signer` (UniFFI `callback_interface`):
  - `did() -> String` — the `did:key` the signer controls (per the workspace "default to DIDs" rule; becomes the proof `verificationMethod`).
  - `sign(payload) -> Result<Vec<u8>, FfiError>` — native enclave op; user-cancel / biometric-fail comes back as `FfiError`.
- `sign_challenge(signer, challenge_b64url)` — exercises the seam end to end (native → engine → native callback → engine → native), including error propagation back through the callback. Later slices swap the raw challenge for the canonical signing input of an `auth/step-up/approve-response`, but the seam is exactly this.

## Verification

Done in an **isolated git worktree** with its own `CARGO_TARGET_DIR` (to avoid disrupting concurrent work in the shared checkout):
- `cargo check -p vta-mobile-core` ✓
- `cargo fmt` ✓
- Kotlin + Swift bindings generate ✓ — confirmed the surface: Kotlin `interface Signer`, Swift `protocol Signer`.

## Next

- **Slice 2** — `task.rs`/`stepup.rs` against `trust-tasks-rs` (blocked on republishing it past 0.1.2).
- **Slice 3b** — `vta-sdk` session (async over FFI), DIDComm pack/unpack, push `set-device-info`.
