### PR TITLE
feat(vtc): VTA wallet login for the admin UI (SIOPv2)

### DIFF
--- a/vtc-service/admin-ui/src/lib/wallet.ts
+++ b/vtc-service/admin-ui/src/lib/wallet.ts
@@ -1,0 +1,235 @@
+// VTA browser-extension wallet bridge for the VTC admin UI.
+//
+// On web, the VTA wallet extension injects `window.vtaWallet` into pages it
+// has host-permission for. This module is a thin feature-detect + wrapper
+// that asks the wallet to log into THIS VTC, mirroring did-hosting-ui's
+// `lib/wallet.ts`.
+//
+// Two flows, both ending in a server-issued bearer token that the caller
+// exchanges for the admin cookie session via `/v1/auth/admin-session`:
+//
+//  - `loginWithWallet()` — the holder self-issues a SIOPv2 id_token; the
+//    extension runs the `/auth/challenge` → `/auth/` round-trip internally.
+//  - `loginWithWalletProxy()` — the VTA mints a SIOP id_token on behalf of a
+//    `did-self-issued` vault entry pinned to this VTC; the long-term key
+//    never leaves the VTA.
+//
+// The wallet posts to `${baseUrl}/auth/challenge` and `${baseUrl}/auth/`
+// with no Trust-Task header, so we point `baseUrl` at the VTC's header-exempt
+// `/v1/wallet` surface.
+
+import { fetchHealth } from "@/lib/api";
+
+interface VtaWalletLoginParams {
+  rpDid: string;
+  baseUrl: string;
+}
+
+export interface VtaWalletLoginResult {
+  accessToken: string;
+  refreshToken: string;
+  sessionId: string;
+  holderDid: string;
+}
+
+/** A `did-self-issued` vault entry pinned to this RP, eligible for
+ *  VTA-proxied SIOP login. */
+export interface ProxyVaultEntry {
+  id: string;
+  label: string;
+  contextId: string;
+  secretKind: string;
+  principalDid?: string;
+  targets: Array<{ kind: string; [k: string]: unknown }>;
+  lastUsedAt?: string;
+}
+
+interface VaultListWireResult {
+  entries: ProxyVaultEntry[];
+  truncated: boolean;
+}
+
+interface ProxyLoginWireResult {
+  sessionBlob: {
+    sessionId: string;
+    expiresAt: string;
+    headers?: Array<{ name: string; value: string }>;
+    cookies?: unknown[];
+    bindOrigin?: string;
+  };
+  sessionId: string;
+  expiresAt: string;
+}
+
+interface VtaWalletProvider {
+  login(params: VtaWalletLoginParams): Promise<VtaWalletLoginResult>;
+  vaultList?(params: {
+    targetDid?: string;
+    targetOriginPrefix?: string;
+    secretKind?: string;
+  }): Promise<VaultListWireResult>;
+  proxyLogin?(params: {
+    entryId: string;
+    nonce?: string;
+    target?: { kind: string; [k: string]: unknown };
+    ttlSecondsHint?: number;
+  }): Promise<ProxyLoginWireResult>;
+}
+
+declare global {
+  interface Window {
+    vtaWallet?: VtaWalletProvider;
+  }
+}
+
+/** True iff the wallet extension has injected its provider into the page. */
+export function isWalletAvailable(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.vtaWallet?.login === "function"
+  );
+}
+
+/** True iff the wallet additionally exposes the proxy-login + vault-list
+ *  APIs (newer extension builds). */
+export function isWalletProxyAvailable(): boolean {
+  return (
+    isWalletAvailable() &&
+    typeof window.vtaWallet?.proxyLogin === "function" &&
+    typeof window.vtaWallet?.vaultList === "function"
+  );
+}
+
+/** API base for the wallet's auth round-trip. Points at the VTC's
+ *  header-exempt wallet surface, served same-origin with the admin UI. */
+function walletApiBase(): string {
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  return `${origin}/v1/wallet`;
+}
+
+/** The RP DID the wallet signs the SIOP `id_token` for — this VTC's own
+ *  `did:webvh`, read from `/health`. */
+async function rpDid(): Promise<string> {
+  const health = await fetchHealth();
+  const did = health.vtc_did;
+  if (!did) {
+    throw new Error(
+      "This VTC has no DID configured yet, so wallet login can't be used.",
+    );
+  }
+  return did;
+}
+
+/** Trigger the wallet's SIOPv2 login. Resolves to the server-issued bearer
+ *  token; rejects if the wallet is unavailable, the user denies consent, or
+ *  the server rejects the `id_token`. */
+export async function loginWithWallet(): Promise<VtaWalletLoginResult> {
+  if (!isWalletAvailable()) {
+    throw new Error("VTA wallet extension is not installed.");
+  }
+  return window.vtaWallet!.login({
+    rpDid: await rpDid(),
+    baseUrl: walletApiBase(),
+  });
+}
+
+const AUTH_AUTHENTICATE_TYPE =
+  "https://trusttasks.org/spec/auth/authenticate/0.1";
+
+/** Extract the compact JWS id_token from a SessionBlob's Authorization
+ *  header. */
+function bearerFromBlob(
+  blob: ProxyLoginWireResult["sessionBlob"],
+): string | null {
+  const auth = blob.headers?.find(
+    (h) => h.name.toLowerCase() === "authorization",
+  );
+  if (!auth) return null;
+  const m = /^\s*Bearer\s+(.+)\s*$/i.exec(auth.value);
+  return m && m[1] ? m[1] : null;
+}
+
+/** Enumerate `did-self-issued` vault entries pinned to this VTC. */
+export async function listProxyCandidates(): Promise<ProxyVaultEntry[]> {
+  if (!isWalletProxyAvailable()) {
+    throw new Error("VTA wallet doesn't expose proxy-login APIs.");
+  }
+  const wire = await window.vtaWallet!.vaultList!({
+    targetDid: await rpDid(),
+    secretKind: "did-self-issued",
+  });
+  return wire.entries.filter((e) => Boolean(e.principalDid));
+}
+
+/** Run the full VTA-proxied SIOP login against a chosen entry. The page
+ *  drives the round-trip: fetch a challenge bound to the entry's principal
+ *  DID, ask the VTA to mint an `id_token` with that challenge as nonce, then
+ *  post it to `/auth/`. Resolves to the server-issued bearer. */
+export async function loginWithWalletProxy(
+  entry: ProxyVaultEntry,
+): Promise<VtaWalletLoginResult> {
+  if (!isWalletProxyAvailable()) {
+    throw new Error("VTA wallet doesn't expose proxy-login APIs.");
+  }
+  if (!entry.principalDid) {
+    throw new Error(
+      "Chosen entry has no principal DID — only did-self-issued entries can proxy-login.",
+    );
+  }
+  const rp = await rpDid();
+  const base = walletApiBase().replace(/\/+$/, "");
+
+  // 1. Challenge bound to the entry's principal DID.
+  const chRes = await fetch(`${base}/auth/challenge`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ did: entry.principalDid }),
+  });
+  if (!chRes.ok) {
+    throw new Error(`/auth/challenge failed (${chRes.status})`);
+  }
+  // Challenge response is camelCase; the authenticate payload is snake_case.
+  const ch = (await chRes.json()) as { challenge: string; sessionId: string };
+  if (!ch.sessionId || !ch.challenge) {
+    throw new Error("/auth/challenge: malformed response");
+  }
+
+  // 2. VTA mints the SIOP id_token (long-term key stays in the VTA).
+  const pl = await window.vtaWallet!.proxyLogin!({
+    entryId: entry.id,
+    nonce: ch.challenge,
+    target: { kind: "did", did: rp },
+  });
+  const idToken = bearerFromBlob(pl.sessionBlob);
+  if (!idToken) {
+    throw new Error("vault/proxy-login: SessionBlob carried no id_token.");
+  }
+
+  // 3. Post the id_token; the server verifies + issues a bearer.
+  const authRes = await fetch(`${base}/auth/`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({
+      type: AUTH_AUTHENTICATE_TYPE,
+      payload: { id_token: idToken, session_id: ch.sessionId },
+    }),
+  });
+  if (!authRes.ok) {
+    throw new Error(`/auth/ failed (${authRes.status})`);
+  }
+  const tokenResp = (await authRes.json()) as {
+    session: { id: string };
+    tokens: { accessToken: string; refreshToken?: string };
+  };
+  if (!tokenResp.tokens?.accessToken) {
+    throw new Error("/auth/: missing tokens.accessToken");
+  }
+  return {
+    accessToken: tokenResp.tokens.accessToken,
+    refreshToken: tokenResp.tokens.refreshToken ?? "",
+    sessionId: tokenResp.session.id,
+    holderDid: entry.principalDid,
+  };
+}

--- a/vtc-service/admin-ui/src/pages/Login.tsx
+++ b/vtc-service/admin-ui/src/pages/Login.tsx
@@ -1,14 +1,18 @@
-// Passkey login page.
+// Login page: passkey + VTA-wallet sign-in.
 //
-// Operator clicks "Sign in with passkey" → POST to
-// `/v1/auth/passkey-login/start` → run `navigator.credentials.get`
-// → POST to `/finish` → daemon sets the `vtc_admin_session` cookie
-// (HttpOnly) and the `csrf` cookie (JS-readable). The shell then
-// reloads its sign-in probe and renders the authenticated UI.
+// Passkey: POST `/v1/auth/passkey-login/start` → `navigator.credentials.get`
+// → POST `/finish` → daemon sets the `vtc_admin_session` + `csrf` cookies.
+//
+// VTA wallet (additive — passkey is unchanged): the browser wallet extension
+// runs a SIOPv2 login against the VTC's header-exempt `/v1/wallet` surface
+// and returns a bearer token; we exchange it for the same cookie session via
+// `/v1/auth/admin-session`. A second option proxies the SIOP through the VTA
+// for a `did-self-issued` vault entry. Both end by invalidating the `whoami`
+// probe so the shell re-renders into the authenticated tree.
 
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Fingerprint } from "lucide-react";
+import { Fingerprint, Wallet } from "lucide-react";
 
 import { postJson } from "@/lib/api";
 import {
@@ -16,11 +20,21 @@ import {
   serializeAssertion,
   type JsonPublicKeyOptions,
 } from "@/lib/webauthn";
+import {
+  isWalletAvailable,
+  isWalletProxyAvailable,
+  listProxyCandidates,
+  loginWithWallet,
+  loginWithWalletProxy,
+  type ProxyVaultEntry,
+} from "@/lib/wallet";
 
 const TRUST_TASK_START =
   "https://trusttasks.org/openvtc/vtc/auth/passkey-login/start/1.0";
 const TRUST_TASK_FINISH =
   "https://trusttasks.org/openvtc/vtc/auth/passkey-login/finish/1.0";
+const TRUST_TASK_ADMIN_SESSION =
+  "https://trusttasks.org/openvtc/vtc/auth/admin-session/1.0";
 
 type Phase =
   | { kind: "idle" }
@@ -29,12 +43,28 @@ type Phase =
 
 export function Login() {
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
+  const [walletPhase, setWalletPhase] = useState<Phase>({ kind: "idle" });
+  const [candidates, setCandidates] = useState<ProxyVaultEntry[] | null>(null);
   const queryClient = useQueryClient();
+
+  const walletAvailable = isWalletAvailable();
+  const proxyAvailable = isWalletProxyAvailable();
+  const busy = phase.kind === "running" || walletPhase.kind === "running";
+
+  // Shared success tail: the wallet returned a bearer; mirror it into the
+  // SPA cookie session, then flip the shell to authenticated.
+  const finishWithBearer = async (accessToken: string) => {
+    await postJson<void>(
+      "/v1/auth/admin-session",
+      { accessToken },
+      { trustTask: TRUST_TASK_ADMIN_SESSION },
+    );
+    await queryClient.invalidateQueries({ queryKey: ["whoami"] });
+  };
 
   const signIn = async () => {
     setPhase({ kind: "running" });
     try {
-      // ── /passkey-login/start ──
       const start = await postJson<{
         authId: string;
         options: { publicKey: JsonPublicKeyOptions };
@@ -46,7 +76,6 @@ export function Login() {
         start.options.publicKey,
       ) as PublicKeyCredentialRequestOptions;
 
-      // ── navigator.credentials.get ──
       const credential = (await navigator.credentials.get({
         publicKey,
       })) as PublicKeyCredential | null;
@@ -59,7 +88,6 @@ export function Login() {
         return;
       }
 
-      // ── /passkey-login/finish ──
       await postJson<unknown>(
         "/v1/auth/passkey-login/finish",
         {
@@ -69,11 +97,6 @@ export function Login() {
         { trustTask: TRUST_TASK_FINISH },
       );
 
-      // Success — the daemon set the cookies. Invalidate the
-      // whoami probe (the same key App.tsx uses) so the shell
-      // re-renders into the authenticated tree without a manual
-      // reload. The previous "session-probe" key didn't match any
-      // live query, so the shell stayed stuck on this page.
       await queryClient.invalidateQueries({ queryKey: ["whoami"] });
     } catch (err) {
       const e = err as { status?: number; message?: string };
@@ -90,11 +113,60 @@ export function Login() {
       ) {
         hint = "Passkey prompt cancelled or denied by the browser.";
       }
-      setPhase({
+      setPhase({ kind: "error", message: e.message ?? String(err), hint });
+    }
+  };
+
+  const handleWalletLogin = async () => {
+    setWalletPhase({ kind: "running" });
+    setCandidates(null);
+    try {
+      const result = await loginWithWallet();
+      await finishWithBearer(result.accessToken);
+    } catch (err) {
+      const e = err as { message?: string };
+      setWalletPhase({
         kind: "error",
         message: e.message ?? String(err),
-        hint,
+        hint: "Make sure the VTA wallet extension is unlocked and you approved the request.",
       });
+    }
+  };
+
+  const runProxyLogin = async (entry: ProxyVaultEntry) => {
+    setWalletPhase({ kind: "running" });
+    setCandidates(null);
+    try {
+      const result = await loginWithWalletProxy(entry);
+      await finishWithBearer(result.accessToken);
+    } catch (err) {
+      const e = err as { message?: string };
+      setWalletPhase({ kind: "error", message: e.message ?? String(err) });
+    }
+  };
+
+  const handleProxyStart = async () => {
+    setWalletPhase({ kind: "running" });
+    setCandidates(null);
+    try {
+      const found = await listProxyCandidates();
+      if (found.length === 0) {
+        setWalletPhase({
+          kind: "error",
+          message: "No did-self-issued vault entry is pinned to this VTC.",
+          hint: "Open the wallet, add an entry targeting this VTC's DID, then retry.",
+        });
+        return;
+      }
+      if (found.length === 1) {
+        await runProxyLogin(found[0]!);
+      } else {
+        setWalletPhase({ kind: "idle" });
+        setCandidates(found);
+      }
+    } catch (err) {
+      const e = err as { message?: string };
+      setWalletPhase({ kind: "error", message: e.message ?? String(err) });
     }
   };
 
@@ -103,35 +175,98 @@ export function Login() {
       <div className="login-card">
         <h2>VTC Admin</h2>
         <p className="lead">
-          Sign in with the passkey you registered at install.
+          Sign in with your registered passkey or your VTA wallet.
         </p>
+
         <button
           type="button"
           className="primary"
           onClick={signIn}
-          disabled={phase.kind === "running"}
+          disabled={busy}
         >
           <Fingerprint size={16} aria-hidden="true" />
           {phase.kind === "running"
             ? "Waiting for passkey…"
             : "Sign in with passkey"}
         </button>
-        {phase.kind === "error" && (
-          <section className="card error">
-            <h3>Sign-in failed</h3>
-            <p>{phase.message}</p>
-            {phase.hint && <p className="lead">{phase.hint}</p>}
+
+        {walletAvailable ? (
+          <button
+            type="button"
+            className="secondary"
+            onClick={handleWalletLogin}
+            disabled={busy}
+          >
+            <Wallet size={16} aria-hidden="true" />
+            {walletPhase.kind === "running"
+              ? "Waiting for wallet…"
+              : "Sign in with VTA wallet"}
+          </button>
+        ) : (
+          <p className="lead">
+            Install the VTA wallet browser extension to sign in with your
+            DID — no passkey required.
+          </p>
+        )}
+
+        {proxyAvailable && (
+          <button
+            type="button"
+            className="secondary"
+            onClick={handleProxyStart}
+            disabled={busy}
+          >
+            Sign in via VTA-proxied SIOP
+          </button>
+        )}
+
+        {candidates && (
+          <section className="card">
+            <h3>Pick a proxy identity</h3>
+            <p className="lead">
+              Multiple vault entries are pinned to this VTC. Choose which one
+              to sign in as.
+            </p>
+            {candidates.map((c) => (
+              <button
+                key={c.id}
+                type="button"
+                className="secondary"
+                onClick={() => runProxyLogin(c)}
+                disabled={busy}
+              >
+                {c.label} — <code>{c.principalDid}</code>
+              </button>
+            ))}
           </section>
         )}
+
+        {(phase.kind === "error" || walletPhase.kind === "error") && (
+          <section className="card error">
+            <h3>Sign-in failed</h3>
+            <p>
+              {phase.kind === "error"
+                ? phase.message
+                : walletPhase.kind === "error"
+                  ? walletPhase.message
+                  : null}
+            </p>
+            {phase.kind === "error" && phase.hint && (
+              <p className="lead">{phase.hint}</p>
+            )}
+            {walletPhase.kind === "error" && walletPhase.hint && (
+              <p className="lead">{walletPhase.hint}</p>
+            )}
+          </section>
+        )}
+
         <footer>
           <p>
-            No passkey yet? Open the install URL the daemon operator
-            shared, or ask them to mint a fresh one via{" "}
-            <code>vtc admin invite</code>.
+            No passkey yet? Open the install URL the daemon operator shared, or
+            ask them to mint a fresh one via <code>vtc admin invite</code>.
           </p>
         </footer>
       </div>
     </section>
   );
 }
-

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -49,6 +49,129 @@ pub async fn authenticate(
     Ok(Json(authenticate_and_mint(&state, &body).await?))
 }
 
+/// Clock skew tolerance for SIOP `id_token` freshness checks, matching
+/// did-hosting-control so a wallet token minted against either service
+/// validates identically.
+const SIOP_CLOCK_SKEW_SECS: u64 = 60;
+
+/// The VTA-wallet SIOP login envelope: `{ type, payload }` where the
+/// payload carries a self-issued `id_token`. Field names are snake_case
+/// on the wire (no `rename_all`), matching what the wallet extension and
+/// did-hosting-control's `AuthenticatePayload` use.
+#[derive(Debug, Deserialize)]
+struct SiopAuthEnvelope {
+    #[serde(rename = "type")]
+    typ: String,
+    payload: SiopAuthPayload,
+}
+
+#[derive(Debug, Deserialize)]
+struct SiopAuthPayload {
+    /// Self-issued SIOPv2 id_token (compact EdDSA JWS). Required — its
+    /// presence is what distinguishes this from a DIDComm-packed body.
+    id_token: String,
+    session_id: String,
+    #[serde(default)]
+    session_pubkey_b58btc: Option<String>,
+}
+
+/// Try to authenticate a VTA-wallet SIOP `id_token`.
+///
+/// Returns `Ok(None)` when `body` is not a SIOP envelope (no
+/// `payload.id_token`), so the caller falls through to the DIDComm
+/// path. Returns `Ok(Some(_))` on a successfully verified token, or an
+/// `Err` when the body *is* a SIOP envelope but verification fails.
+///
+/// The wallet does the SIOP round-trip internally: it fetched a
+/// challenge from `/auth/challenge`, the holder self-issued an
+/// `id_token` with `nonce = challenge` and `aud = <this VTC's DID>`,
+/// and posted it here. We verify the signature (via the shared
+/// `vti_common` verifier), bind `aud` to our own DID and check
+/// freshness, then hand the holder DID + nonce to the same canonical
+/// `handle_authenticate` the DIDComm path uses — `nonce` becomes the
+/// `challenge` the session is matched against.
+async fn authenticate_siop(
+    state: &AppState,
+    body: &str,
+) -> Result<Option<AuthenticateResponse>, AppError> {
+    // Not a SIOP envelope → fall through to the DIDComm path.
+    let Ok(env) = serde_json::from_str::<SiopAuthEnvelope>(body) else {
+        return Ok(None);
+    };
+    if !matches!(
+        env.typ.as_str(),
+        "https://affinidi.com/atm/1.0/authenticate"
+            | "https://trusttasks.org/spec/auth/authenticate/0.1"
+    ) || env.payload.id_token.is_empty()
+    {
+        return Ok(None);
+    }
+
+    let resolver = state.did_resolver.as_ref().ok_or_else(|| {
+        AppError::Authentication("DID resolver not configured; cannot verify id_token".into())
+    })?;
+
+    // Cryptographic verification (signature + self-issuance + key
+    // binding). Policy checks (aud, nonce, freshness) are ours below.
+    let verified = vti_common::auth::verify_siop_id_token(&env.payload.id_token, resolver)
+        .await
+        .map_err(|e| AppError::Authentication(format!("id_token verification failed: {e}")))?;
+
+    // Audience binding: the token must be addressed to *this* VTC's DID.
+    let vtc_did = {
+        let cfg = state.config.read().await;
+        cfg.vtc_did.clone()
+    }
+    .ok_or_else(|| AppError::Authentication("VTC DID not configured".into()))?;
+    if verified.audience != vtc_did {
+        return Err(AppError::Authentication(
+            "id_token `aud` does not match this service".into(),
+        ));
+    }
+
+    // Freshness window (mirrors did-hosting-control).
+    let now = now_epoch();
+    if verified.expires_at <= now {
+        return Err(AppError::Authentication("id_token has expired".into()));
+    }
+    if verified.issued_at > now.saturating_add(SIOP_CLOCK_SKEW_SECS) {
+        return Err(AppError::Authentication(
+            "id_token `iat` is in the future".into(),
+        ));
+    }
+    if verified.issued_at > verified.expires_at {
+        return Err(AppError::Authentication(
+            "id_token `iat` is after `exp`".into(),
+        ));
+    }
+
+    // Optional session-bound pubkey must be an Ed25519 multikey.
+    if let Some(pk) = env.payload.session_pubkey_b58btc.as_deref()
+        && !pk.starts_with("z6Mk")
+    {
+        return Err(AppError::Authentication(
+            "session_pubkey_b58btc must be an Ed25519 multikey (z6Mk… prefix)".into(),
+        ));
+    }
+
+    let backend = crate::auth::VtcAuthBackend::from_state(state).await?;
+    let resp = vti_common::auth::handlers::handle_authenticate(
+        &backend,
+        vti_common::auth::AuthenticateInput {
+            session_id: env.payload.session_id,
+            // The SIOP `nonce` is the challenge the session was issued.
+            challenge: verified.nonce,
+            // The holder DID, proven by the verified signature.
+            signer_did: verified.issuer,
+            // REST path — no DIDComm `created_time` to thread.
+            created_time: None,
+            session_pubkey_b58btc: env.payload.session_pubkey_b58btc,
+        },
+    )
+    .await?;
+    Ok(Some(resp))
+}
+
 /// Core authenticate + mint logic shared by `POST /v1/auth/` and
 /// `POST /v1/auth/admin-login`. Both endpoints accept the same
 /// DIDComm-packed authentication message; `admin-login`
@@ -58,6 +181,13 @@ async fn authenticate_and_mint(
     state: &AppState,
     body: &str,
 ) -> Result<AuthenticateResponse, AppError> {
+    // VTA-wallet SIOP login: a `{ type, payload: { id_token, … } }`
+    // envelope. Returns `None` for a DIDComm-packed body, so that path
+    // below is left untouched.
+    if let Some(resp) = authenticate_siop(state, body).await? {
+        return Ok(resp);
+    }
+
     let atm = state
         .atm
         .as_ref()

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -311,6 +311,77 @@ pub async fn admin_login(
     Ok(response)
 }
 
+// ---------- POST /auth/admin-session ----------
+
+/// Request body for [`admin_session`].
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminSessionRequest {
+    /// A valid VTC access token the caller already holds — e.g. from the
+    /// VTA-wallet SIOP login, which returns it in `tokens.accessToken`.
+    pub access_token: String,
+}
+
+/// `POST /v1/auth/admin-session` — exchange a bearer access token for the
+/// admin SPA's cookie session.
+///
+/// The VTA-wallet login path returns a bearer token in the response body
+/// (the wallet extension posts the SIOP `id_token` to `/wallet/auth/` and
+/// reads `tokens.accessToken`), but the admin SPA drives the API with the
+/// `vtc_admin_session` cookie + `csrf` double-submit, not an
+/// `Authorization` header. This endpoint bridges the two: it validates the
+/// presented token (signature + VTC audience + expiry) and, on success,
+/// sets the same `Set-Cookie` pair as [`admin_login`].
+///
+/// No privilege escalation — the caller must already possess a valid VTC
+/// access token, which it could use directly as a bearer; this only mirrors
+/// it into the cookie the browser SPA expects. Browser-only by nature: the
+/// CSRF layer's same-origin check carries the (cookie-less) first call.
+pub async fn admin_session(
+    State(state): State<AppState>,
+    Json(req): Json<AdminSessionRequest>,
+) -> Result<axum::response::Response, AppError> {
+    use axum::http::HeaderValue;
+    use axum::http::header::SET_COOKIE;
+    use axum::response::IntoResponse;
+    use rand::RngExt;
+
+    let jwt_keys = state
+        .jwt_keys
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("JWT keys not configured".into()))?;
+
+    // Validate the token: signature, VTC audience (audience isolation — a
+    // foreign-audience token is rejected here exactly as on every other
+    // surface), and expiry. A bad token never sets a cookie.
+    let claims = jwt_keys
+        .decode(&req.access_token)
+        .map_err(|_| AppError::Authentication("invalid or expired access token".into()))?;
+
+    let max_age = claims.exp.saturating_sub(now_epoch()).max(1);
+
+    let mut csrf_bytes = [0u8; 32];
+    rand::rng().fill(&mut csrf_bytes);
+    let csrf = hex::encode(csrf_bytes);
+
+    let session_cookie = build_session_cookie(&req.access_token, max_age);
+    let csrf_cookie = build_csrf_cookie(&csrf, max_age);
+
+    let mut response = StatusCode::NO_CONTENT.into_response();
+    let headers = response.headers_mut();
+    headers.append(
+        SET_COOKIE,
+        HeaderValue::try_from(session_cookie)
+            .map_err(|e| AppError::Internal(format!("invalid session cookie value: {e}")))?,
+    );
+    headers.append(
+        SET_COOKIE,
+        HeaderValue::try_from(csrf_cookie)
+            .map_err(|e| AppError::Internal(format!("invalid csrf cookie value: {e}")))?,
+    );
+    Ok(response)
+}
+
 // ---------- POST /auth/passkey-login/start ----------
 
 /// `POST /v1/auth/passkey-login/start`.

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -800,6 +800,12 @@ fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
     let auth_admin_login =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/admin-login/1.0")
             .expect("static Trust-Task URL");
+    // Bearer→cookie bridge for the VTA-wallet login: the SPA posts the
+    // wallet-issued access token, the daemon mirrors it into the
+    // `vtc_admin_session` + `csrf` cookies (same shape as admin-login).
+    let auth_admin_session =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/admin-session/1.0")
+            .expect("static Trust-Task URL");
     // Browser-friendly passkey login — same canonical spec serves
     // initial login and AAL step-up via the payload's `purpose` field.
     let auth_passkey_login_start =
@@ -863,6 +869,11 @@ fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
             "/auth/admin-login",
             post(auth::admin_login),
             auth_admin_login,
+        )
+        .route_with_task(
+            "/auth/admin-session",
+            post(auth::admin_session),
+            auth_admin_session,
         )
         .route_with_task(
             "/auth/passkey-login/start",

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -847,6 +847,17 @@ fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
     let unauth_router = TrustTaskRouter::<AppState>::new()
         .route_with_task("/auth/challenge", post(auth::challenge), auth_challenge)
         .route_with_task("/auth/", post(auth::authenticate), auth_authenticate)
+        // VTA-wallet login surface. The browser wallet extension drives
+        // the SIOPv2 round-trip itself and posts to `<base>/auth/challenge`
+        // + `<base>/auth/` with **no** `Trust-Task` header (the op `type`
+        // rides in the body). These header-exempt aliases reuse the same
+        // `challenge` / `authenticate` handlers — the latter's SIOP branch
+        // handles the wallet's `id_token` envelope. The admin-UI points the
+        // wallet at `<origin>/v1/wallet` so it lands here, leaving the
+        // Trust-Task-gated `/auth/*` routes above untouched for DIDComm and
+        // CLI clients. Mirrors did-hosting-control's header-less auth.
+        .route_exempt("/wallet/auth/challenge", post(auth::challenge))
+        .route_exempt("/wallet/auth/", post(auth::authenticate))
         .route_with_task("/auth/refresh", post(auth::refresh), auth_refresh)
         .route_with_task(
             "/auth/admin-login",

--- a/vtc-service/src/routing/csrf.rs
+++ b/vtc-service/src/routing/csrf.rs
@@ -50,6 +50,10 @@ const CSRF_EXEMPT_PATHS: &[&str] = &[
     "/v1/join-requests",
     "/v1/auth/challenge",
     "/v1/auth/",
+    // VTA-wallet header-exempt auth surface (unauthenticated bootstrap,
+    // same rationale as `/v1/auth/*` above — no session cookie yet).
+    "/v1/wallet/auth/challenge",
+    "/v1/wallet/auth/",
     "/v1/auth/refresh",
     "/v1/auth/admin-login",
     "/v1/install/claim/start",

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -336,3 +336,111 @@ async fn wallet_login_rejects_nonce_not_matching_challenge() {
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
+
+// ─── Phase 3: bearer → cookie bridge (`/v1/auth/admin-session`) ───
+
+const ADMIN_SESSION_TASK: &str = "https://trusttasks.org/openvtc/vtc/auth/admin-session/1.0";
+const WHOAMI_TASK: &str = "https://trusttasks.org/spec/auth/whoami/0.1";
+
+/// Run a full wallet login and return the minted bearer access token.
+async fn wallet_login_bearer(fix: &Fixture, sk: &SigningKey, holder: &str, kid: &str) -> String {
+    let (session_id, challenge) = get_challenge(&fix.router, holder).await;
+    let now = now_epoch();
+    let id_token = sign_id_token(sk, kid, holder, holder, VTC_DID, &challenge, now, now + 300);
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/",
+        json!({ "type": AUTH_TYPE, "payload": { "id_token": id_token, "session_id": session_id } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "login failed: {body}");
+    body["tokens"]["accessToken"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn admin_session_bridges_bearer_to_cookie_and_authenticates() {
+    let (sk, holder, kid) = holder_identity(5);
+    let fix = build_fixture(&holder).await;
+    let bearer = wallet_login_bearer(&fix, &sk, &holder, &kid).await;
+
+    // Exchange the bearer for the SPA cookie session. Browser-style:
+    // same-origin stamp carries CSRF, Trust-Task header satisfies the gate.
+    let res = fix
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/admin-session")
+                .header("content-type", "application/json")
+                .header("trust-task", ADMIN_SESSION_TASK)
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({ "accessToken": bearer })).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+
+    // The session cookie must be set; capture it for the follow-up call.
+    let set_cookies: Vec<String> = res
+        .headers()
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(str::to_string))
+        .collect();
+    let session_cookie = set_cookies
+        .iter()
+        .find(|c| c.starts_with("vtc_admin_session="))
+        .expect("vtc_admin_session cookie set");
+    let cookie_pair = session_cookie.split(';').next().unwrap().to_string();
+
+    // The cookie alone (no Authorization header) authenticates `whoami`.
+    let res = fix
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/auth/whoami")
+                .header("trust-task", WHOAMI_TASK)
+                .header("cookie", cookie_pair)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let who: Value =
+        serde_json::from_slice(&res.into_body().collect().await.unwrap().to_bytes()).unwrap();
+    assert_eq!(who["did"].as_str(), Some(holder.as_str()));
+}
+
+#[tokio::test]
+async fn admin_session_rejects_garbage_token() {
+    let (_sk, holder, _kid) = holder_identity(6);
+    let fix = build_fixture(&holder).await;
+
+    let res = fix
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/admin-session")
+                .header("content-type", "application/json")
+                .header("trust-task", ADMIN_SESSION_TASK)
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({ "accessToken": "not.a.jwt" })).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    // No cookie on rejection.
+    assert!(res.headers().get(axum::http::header::SET_COOKIE).is_none());
+}

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -1,0 +1,338 @@
+//! VTA-wallet SIOP login integration tests.
+//!
+//! Drives the header-exempt wallet auth surface end-to-end exactly as
+//! the browser wallet extension does:
+//!
+//! 1. `POST /v1/wallet/auth/challenge { did }` → `{ challenge, sessionId }`.
+//! 2. The holder self-issues a SIOPv2 `id_token` (compact EdDSA JWS,
+//!    `iss == sub == holder`, `aud == this VTC's DID`, `nonce == challenge`).
+//! 3. `POST /v1/wallet/auth/` with `{ type, payload: { id_token, session_id } }`
+//!    → `{ session, tokens }` bearer.
+//!
+//! No `Trust-Task` header is sent on either request — these aliases are
+//! deliberately exempt so the generic wallet extension works unchanged.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use ed25519_dalek::{Signer, SigningKey};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::session::now_epoch;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+/// The RP (this VTC's) DID — only ever string-compared as the id_token
+/// `aud`, so it need not be resolvable.
+const VTC_DID: &str = "did:webvh:scidvtc:vtc.example.com";
+const AUTH_TYPE: &str = "https://trusttasks.org/spec/auth/authenticate/0.1";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture(holder_did: &str) -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    macro_rules! ks {
+        ($n:literal) => {
+            store.keyspace($n).unwrap()
+        };
+    }
+    let install_ks = ks!("install");
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "{VTC_DID}"
+        [store]
+        data_dir = "{}"
+        [auth]
+        jwt_signing_key = "{}"
+        "#,
+        dir.path().display(),
+        B64.encode(jwt_seed),
+    ))
+    .expect("parse config");
+
+    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+        .await
+        .expect("did resolver");
+
+    let state = AppState {
+        sessions_ks: ks!("sessions"),
+        acl_ks: ks!("acl"),
+        community_ks: ks!("community"),
+        config_ks: ks!("config"),
+        passkey_ks: ks!("passkey"),
+        install_ks: install_ks.clone(),
+        members_ks: ks!("members"),
+        join_requests_ks: ks!("join_requests"),
+        policies_ks: ks!("policies"),
+        active_policies_ks: ks!("active_policies"),
+        status_lists_ks: ks!("status_lists"),
+        registry_records_ks: ks!("registry_records"),
+        sync_queue_ks: ks!("sync_queue"),
+        sync_cursor_ks: ks!("sync_cursor"),
+        relationships_ks: ks!("relationships"),
+        relationships_by_did_ks: ks!("relationships_by_did"),
+        endorsement_types_ks: ks!("endorsement_types"),
+        endorsements_ks: ks!("endorsements"),
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
+        credential_signer: None,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: Some(did_resolver),
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys),
+        atm: None,
+        webauthn: None,
+        public_url: None,
+        install_signer: None,
+        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
+        audit_ks: ks!("audit"),
+        audit_key_ks: ks!("audit_key"),
+        audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    // The holder must be an ACL admin: challenge issuance and the
+    // authenticate step both gate on the ACL.
+    store_acl_entry(
+        &state.acl_ks,
+        &VtcAclEntry {
+            did: holder_did.into(),
+            role: VtcRole::Admin,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now_epoch(),
+            created_by: "test".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .expect("acl insert");
+
+    let router = routes::router().with_state(state);
+    Fixture { router, _dir: dir }
+}
+
+/// A fresh Ed25519 holder identity as a `did:key`, plus its
+/// verification-method id (`did:key:z…#z…`).
+fn holder_identity(seed: u8) -> (SigningKey, String, String) {
+    let sk = SigningKey::from_bytes(&[seed; 32]);
+    let mut buf = Vec::with_capacity(34);
+    buf.extend_from_slice(&[0xed, 0x01]);
+    buf.extend_from_slice(&sk.verifying_key().to_bytes());
+    let mb = multibase::encode(multibase::Base::Base58Btc, &buf);
+    let did = format!("did:key:{mb}");
+    let kid = format!("{did}#{mb}");
+    (sk, did, kid)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sign_id_token(
+    sk: &SigningKey,
+    kid: &str,
+    iss: &str,
+    sub: &str,
+    aud: &str,
+    nonce: &str,
+    iat: u64,
+    exp: u64,
+) -> String {
+    let header = json!({ "alg": "EdDSA", "typ": "JWT", "kid": kid });
+    let payload =
+        json!({ "iss": iss, "sub": sub, "aud": aud, "nonce": nonce, "iat": iat, "exp": exp });
+    let h = B64.encode(serde_json::to_vec(&header).unwrap());
+    let p = B64.encode(serde_json::to_vec(&payload).unwrap());
+    let signing_input = format!("{h}.{p}");
+    let sig = sk.sign(signing_input.as_bytes());
+    format!("{signing_input}.{}", B64.encode(sig.to_bytes()))
+}
+
+async fn post_json(router: &axum::Router, path: &str, body: Value) -> (StatusCode, Value) {
+    let res = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, json)
+}
+
+/// Run the challenge → return `(session_id, challenge)`.
+async fn get_challenge(router: &axum::Router, holder: &str) -> (String, String) {
+    let (status, body) = post_json(
+        router,
+        "/v1/wallet/auth/challenge",
+        json!({ "did": holder }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "challenge failed: {body}");
+    let session_id = body["sessionId"].as_str().expect("sessionId").to_string();
+    let challenge = body["challenge"].as_str().expect("challenge").to_string();
+    (session_id, challenge)
+}
+
+#[tokio::test]
+async fn wallet_login_happy_path_mints_bearer() {
+    let (sk, holder, kid) = holder_identity(1);
+    let fix = build_fixture(&holder).await;
+    let (session_id, challenge) = get_challenge(&fix.router, &holder).await;
+
+    let now = now_epoch();
+    let id_token = sign_id_token(
+        &sk,
+        &kid,
+        &holder,
+        &holder,
+        VTC_DID,
+        &challenge,
+        now,
+        now + 300,
+    );
+
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/",
+        json!({ "type": AUTH_TYPE, "payload": { "id_token": id_token, "session_id": session_id } }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "authenticate failed: {body}");
+    assert!(
+        body["tokens"]["accessToken"]
+            .as_str()
+            .is_some_and(|t| !t.is_empty()),
+        "expected a bearer access token, got {body}"
+    );
+    assert_eq!(body["session"]["subject"].as_str(), Some(holder.as_str()));
+}
+
+#[tokio::test]
+async fn wallet_login_rejects_tampered_signature() {
+    let (sk, holder, kid) = holder_identity(2);
+    let fix = build_fixture(&holder).await;
+    let (session_id, challenge) = get_challenge(&fix.router, &holder).await;
+
+    let now = now_epoch();
+    let mut id_token = sign_id_token(
+        &sk,
+        &kid,
+        &holder,
+        &holder,
+        VTC_DID,
+        &challenge,
+        now,
+        now + 300,
+    );
+    // Flip the last signature character.
+    id_token.pop();
+    id_token.push(if id_token.ends_with('A') { 'B' } else { 'A' });
+
+    let (status, _) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/",
+        json!({ "type": AUTH_TYPE, "payload": { "id_token": id_token, "session_id": session_id } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn wallet_login_rejects_wrong_audience() {
+    let (sk, holder, kid) = holder_identity(3);
+    let fix = build_fixture(&holder).await;
+    let (session_id, challenge) = get_challenge(&fix.router, &holder).await;
+
+    let now = now_epoch();
+    // aud is some other RP — must not authenticate against this VTC.
+    let id_token = sign_id_token(
+        &sk,
+        &kid,
+        &holder,
+        &holder,
+        "did:webvh:other:rp.example.com",
+        &challenge,
+        now,
+        now + 300,
+    );
+
+    let (status, _) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/",
+        json!({ "type": AUTH_TYPE, "payload": { "id_token": id_token, "session_id": session_id } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn wallet_login_rejects_nonce_not_matching_challenge() {
+    let (sk, holder, kid) = holder_identity(4);
+    let fix = build_fixture(&holder).await;
+    let (session_id, _challenge) = get_challenge(&fix.router, &holder).await;
+
+    let now = now_epoch();
+    // Wrong nonce — a valid signature over the wrong challenge must
+    // fail the session's challenge-match in handle_authenticate.
+    let id_token = sign_id_token(
+        &sk,
+        &kid,
+        &holder,
+        &holder,
+        VTC_DID,
+        "not-the-challenge",
+        now,
+        now + 300,
+    );
+
+    let (status, _) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/",
+        json!({ "type": AUTH_TYPE, "payload": { "id_token": id_token, "session_id": session_id } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -70,6 +70,11 @@ bytes = "1"
 
 # Secrets resolver (for error type)
 affinidi-tdk = { workspace = true }
+# DID resolution for SIOPv2 id_token verification (auth::siop). The
+# resolver + `DocumentExt` (from affinidi-tdk) turn an `iss` DID into the
+# Ed25519 verifying key. multibase decodes the `did:key` key for pinning.
+affinidi-did-resolver-cache-sdk = { workspace = true }
+multibase = { workspace = true }
 
 # Encryption (feature-gated; `rand` is non-optional and lives in the main
 # dep block since audit_key rotation also needs OS randomness).

--- a/vti-common/src/auth/mod.rs
+++ b/vti-common/src/auth/mod.rs
@@ -5,6 +5,7 @@ pub mod jwt;
 #[cfg(feature = "passkey")]
 pub mod passkey;
 pub mod session;
+pub mod siop;
 
 pub use backend::{
     AttestationOutcome, AuthAuditEvent, AuthBackend, AuthError, AuthenticateInput, ChallengeInput,
@@ -13,3 +14,4 @@ pub use backend::{
 pub use extractor::{
     AdminAuth, AuthClaims, AuthState, ManageAuth, StepUpAuth, SuperAdminAuth, WriteAuth,
 };
+pub use siop::{SiopError, VerifiedSiopIdToken, verify_siop_id_token};

--- a/vti-common/src/auth/siop.rs
+++ b/vti-common/src/auth/siop.rs
@@ -65,8 +65,12 @@ pub enum SiopError {
     NotSelfIssued,
     #[error("id_token header missing `kid`")]
     MissingKid,
+    #[error("id_token header `alg` is `{0}`; only EdDSA is accepted")]
+    UnsupportedAlg(String),
     #[error("id_token header `kid` DID does not match `iss`")]
     KidMismatch,
+    #[error("verification method {0} is not in the DID's `authentication` relationship")]
+    VmNotAuthentication(String),
     #[error("failed to resolve DID {0}")]
     Resolve(String),
     #[error("verification method {0} not found in DID document")]
@@ -187,6 +191,15 @@ async fn resolve_verifying_key(
         .await
         .map_err(|e| SiopError::Resolve(format!("{base_did}: {e}")))?;
 
+    // The key must be published for *authentication* — a SIOP login is an
+    // authentication, so a key the DID controller listed only for
+    // `assertionMethod` / `keyAgreement` / `capabilityInvocation` must not
+    // mint a login token. `did:key` lists its key under every relationship
+    // (incl. authentication), so this doesn't affect the did:key path.
+    if !resolved.doc.contains_authentication(kid) {
+        return Err(SiopError::VmNotAuthentication(kid.to_string()));
+    }
+
     let vm = resolved
         .doc
         .get_verification_method(kid)
@@ -219,6 +232,12 @@ fn extract_signer_kid_compact(header_b64: &str) -> Result<String, SiopError> {
         .map_err(|_| SiopError::Base64("header"))?;
     let header: JwsProtectedHeader =
         serde_json::from_slice(&header_bytes).map_err(|_| SiopError::Json("header"))?;
+    // Verification is hard-wired to Ed25519; reject any other `alg` up
+    // front so a future refactor can't reintroduce alg-confusion, and so
+    // `alg:none` / HS256 tokens fail with a precise error.
+    if !header.alg.eq_ignore_ascii_case("EdDSA") {
+        return Err(SiopError::UnsupportedAlg(header.alg));
+    }
     header.kid.ok_or(SiopError::MissingKid)
 }
 
@@ -348,6 +367,24 @@ mod tests {
         let token = format!("{h}.{p}.AAAA");
         let err = verify_siop_id_token(&token, &resolver).await.unwrap_err();
         assert!(matches!(err, SiopError::MissingClaim("iss")));
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_alg() {
+        let resolver = test_resolver().await;
+        let sk = SigningKey::from_bytes(&[11u8; 32]);
+        let did = did_key_for(&sk);
+        // Valid `iss == sub` so we reach the header check, but `alg` is not
+        // EdDSA — must be rejected before any signature work.
+        let header = serde_json::json!({ "alg": "HS256", "kid": format!("{did}#k") });
+        let payload = serde_json::json!({
+            "iss": did, "sub": did, "aud": "rp", "nonce": "n", "iat": 1, "exp": 2,
+        });
+        let h = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+        let p = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("{h}.{p}.AAAA");
+        let err = verify_siop_id_token(&token, &resolver).await.unwrap_err();
+        assert!(matches!(err, SiopError::UnsupportedAlg(_)));
     }
 
     #[test]

--- a/vti-common/src/auth/siop.rs
+++ b/vti-common/src/auth/siop.rs
@@ -1,0 +1,372 @@
+//! SIOPv2 self-issued `id_token` verification.
+//!
+//! A browser wallet (the VTA wallet extension) self-issues a SIOPv2
+//! `id_token` — a compact EdDSA JWS with claims
+//! `{iss, sub, aud, nonce, iat, exp}` where `iss == sub` (the holder
+//! signs for itself) — and POSTs it to a relying party's `/auth/`
+//! endpoint. This module performs the **cryptographic** verification:
+//! parse the JWS, confirm self-issuance, resolve the issuer DID to its
+//! Ed25519 key, and verify the signature.
+//!
+//! The **policy** checks — `aud` matches this service, `nonce` matches
+//! the issued challenge, and `iat`/`exp` freshness — are deliberately
+//! the caller's job, because they need session and config state this
+//! module doesn't own. [`verify_siop_id_token`] returns the
+//! eagerly-parsed claims so the caller can apply them; the
+//! [`VerifiedSiopIdToken`] type can only be constructed here, so a call
+//! site can't read verified claims without having verified the
+//! signature first.
+//!
+//! Ported from `did-hosting-control`'s SIOP path so the VTA, VTC, and
+//! did-hosting services all verify wallet logins identically.
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_tdk::did_common::DocumentExt;
+use affinidi_tdk::didcomm::jws::envelope::JwsProtectedHeader;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::Deserialize;
+
+/// A SIOPv2 `id_token` whose signature has been verified against the
+/// `iss` DID's resolved Ed25519 key. Constructable only via
+/// [`verify_siop_id_token`]. The caller still must bind `audience` to
+/// this service, `nonce` to the issued challenge, and check the
+/// `issued_at`/`expires_at` freshness window before trusting it.
+#[derive(Debug, Clone)]
+pub struct VerifiedSiopIdToken {
+    /// `iss` (== `sub`) — the holder DID that signed the token.
+    pub issuer: String,
+    /// `aud` — the relying-party DID the token is addressed to.
+    pub audience: String,
+    /// `nonce` — the challenge the relying party issued.
+    pub nonce: String,
+    /// `iat` — issued-at, unix seconds.
+    pub issued_at: u64,
+    /// `exp` — expiry, unix seconds.
+    pub expires_at: u64,
+}
+
+/// Failure modes of [`verify_siop_id_token`]. Every variant maps to a
+/// 401-class authentication failure at the route layer; the messages
+/// are intentionally specific for operator logs but carry no secret
+/// material.
+#[derive(Debug, thiserror::Error)]
+pub enum SiopError {
+    #[error("id_token is not a compact JWS (header.payload.signature)")]
+    MalformedJws,
+    #[error("id_token {0} is not valid base64url")]
+    Base64(&'static str),
+    #[error("id_token {0} is not valid JSON")]
+    Json(&'static str),
+    #[error("id_token missing `{0}`")]
+    MissingClaim(&'static str),
+    #[error("id_token `iss` does not equal `sub`")]
+    NotSelfIssued,
+    #[error("id_token header missing `kid`")]
+    MissingKid,
+    #[error("id_token header `kid` DID does not match `iss`")]
+    KidMismatch,
+    #[error("failed to resolve DID {0}")]
+    Resolve(String),
+    #[error("verification method {0} not found in DID document")]
+    VmNotFound(String),
+    #[error(
+        "verification method {0} is an X25519 key-agreement key; expected an Ed25519 signing key"
+    )]
+    NotSigningKey(String),
+    #[error("id_token `iss` did:key does not match its resolved authentication key")]
+    DidKeyMismatch,
+    #[error("id_token `iss` is not an Ed25519 did:key")]
+    NotEd25519DidKey,
+    #[error("id_token public key is invalid: {0}")]
+    BadPublicKey(String),
+    #[error("id_token signature verification failed")]
+    BadSignature,
+}
+
+/// Claims read out of the JWS payload before verification. All fields
+/// are `Option` so a missing claim becomes a clean error rather than a
+/// deserialization failure.
+#[derive(Deserialize)]
+struct SiopClaims {
+    iss: Option<String>,
+    sub: Option<String>,
+    aud: Option<String>,
+    nonce: Option<String>,
+    iat: Option<u64>,
+    exp: Option<u64>,
+}
+
+/// Verify a SIOPv2 self-issued `id_token` (compact EdDSA JWS).
+///
+/// Steps (cryptographic only — see module docs for what the caller
+/// must still check):
+/// 1. Split the compact JWS into `header.payload.signature`.
+/// 2. Parse the payload and require `iss` present and `iss == sub`.
+/// 3. Resolve the authentication key for `iss`. The header `kid` drives
+///    the verification-method lookup and its base DID must equal `iss`.
+///    For a self-certifying `did:key`, the resolved key is additionally
+///    pinned against the key encoded in the DID string so a `kid`
+///    pointing at a foreign DID's key can't impersonate `iss`. For
+///    document-based methods (`did:webvh`, `did:peer`) the resolved DID
+///    document is the authority.
+/// 4. EdDSA-verify the signature over the ASCII `header.payload`.
+pub async fn verify_siop_id_token(
+    id_token: &str,
+    did_resolver: &DIDCacheClient,
+) -> Result<VerifiedSiopIdToken, SiopError> {
+    // 1. Split the compact JWS. Exactly three dot-separated parts.
+    let mut parts = id_token.split('.');
+    let (header_b64, payload_b64, sig_b64) =
+        match (parts.next(), parts.next(), parts.next(), parts.next()) {
+            (Some(h), Some(p), Some(s), None) => (h, p, s),
+            _ => return Err(SiopError::MalformedJws),
+        };
+
+    // 2. Parse the payload (pre-verify) and enforce self-issuance.
+    let payload_bytes = URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .map_err(|_| SiopError::Base64("payload"))?;
+    let claims: SiopClaims =
+        serde_json::from_slice(&payload_bytes).map_err(|_| SiopError::Json("payload"))?;
+    let iss = claims.iss.ok_or(SiopError::MissingClaim("iss"))?;
+    let sub = claims.sub.ok_or(SiopError::MissingClaim("sub"))?;
+    if iss != sub {
+        return Err(SiopError::NotSelfIssued);
+    }
+
+    // 3. Resolve the Ed25519 key. `kid`'s base DID must equal `iss`;
+    //    `did:key` is additionally pinned to the in-string key.
+    let kid = extract_signer_kid_compact(header_b64)?;
+    let kid_base = kid.split('#').next().unwrap_or(&kid);
+    if kid_base != iss {
+        return Err(SiopError::KidMismatch);
+    }
+    let resolved_key = resolve_verifying_key(did_resolver, &kid).await?;
+    if iss.starts_with("did:key:") {
+        let did_key_pub = ed25519_pubkey_from_did_key(&iss)?;
+        if resolved_key != did_key_pub {
+            return Err(SiopError::DidKeyMismatch);
+        }
+    }
+
+    // 4. EdDSA-verify over the ASCII `header.payload`.
+    let verifying_key = VerifyingKey::from_bytes(&resolved_key)
+        .map_err(|e| SiopError::BadPublicKey(e.to_string()))?;
+    let sig_bytes = URL_SAFE_NO_PAD
+        .decode(sig_b64)
+        .map_err(|_| SiopError::Base64("signature"))?;
+    let signature = Signature::from_slice(&sig_bytes).map_err(|_| SiopError::BadSignature)?;
+    let signing_input = format!("{header_b64}.{payload_b64}");
+    verifying_key
+        .verify(signing_input.as_bytes(), &signature)
+        .map_err(|_| SiopError::BadSignature)?;
+
+    Ok(VerifiedSiopIdToken {
+        issuer: iss,
+        audience: claims.aud.ok_or(SiopError::MissingClaim("aud"))?,
+        nonce: claims.nonce.ok_or(SiopError::MissingClaim("nonce"))?,
+        issued_at: claims.iat.ok_or(SiopError::MissingClaim("iat"))?,
+        expires_at: claims.exp.ok_or(SiopError::MissingClaim("exp"))?,
+    })
+}
+
+/// Resolve `kid`'s base DID and return its Ed25519 public key bytes.
+/// Mirrors the DID-resolve + key-extraction primitive the DIDComm
+/// `unpack_signed` path uses. Rejects obvious X25519 key-agreement
+/// methods; any Ed25519 verification-method type the resolver yields a
+/// 32-byte key for is accepted.
+async fn resolve_verifying_key(
+    did_resolver: &DIDCacheClient,
+    kid: &str,
+) -> Result<[u8; 32], SiopError> {
+    let base_did = kid.split('#').next().unwrap_or(kid);
+    let resolved = did_resolver
+        .resolve(base_did)
+        .await
+        .map_err(|e| SiopError::Resolve(format!("{base_did}: {e}")))?;
+
+    let vm = resolved
+        .doc
+        .get_verification_method(kid)
+        .ok_or_else(|| SiopError::VmNotFound(kid.to_string()))?;
+
+    // X25519 key-agreement keys have narrow, unambiguous type names —
+    // refuse them. We don't whitelist Ed25519 types because the spec
+    // admits several (Ed25519VerificationKey2018/2020, Multikey with a
+    // z6Mk… prefix, JsonWebKey2020 crv:Ed25519).
+    if matches!(
+        vm.type_.as_str(),
+        "X25519KeyAgreementKey2020" | "X25519KeyAgreementKey2019"
+    ) {
+        return Err(SiopError::NotSigningKey(kid.to_string()));
+    }
+
+    let pk_bytes = vm
+        .get_public_key_bytes()
+        .map_err(|e| SiopError::BadPublicKey(e.to_string()))?;
+    pk_bytes
+        .try_into()
+        .map_err(|_| SiopError::BadPublicKey("public key must be 32 bytes".into()))
+}
+
+/// Extract the `kid` from a base64url-encoded compact-JWS protected
+/// header.
+fn extract_signer_kid_compact(header_b64: &str) -> Result<String, SiopError> {
+    let header_bytes = URL_SAFE_NO_PAD
+        .decode(header_b64)
+        .map_err(|_| SiopError::Base64("header"))?;
+    let header: JwsProtectedHeader =
+        serde_json::from_slice(&header_bytes).map_err(|_| SiopError::Json("header"))?;
+    header.kid.ok_or(SiopError::MissingKid)
+}
+
+/// Decode the multibase tail of an Ed25519 `did:key` to its raw 32-byte
+/// public key. Rejects anything that isn't `did:key:z…` with the
+/// multicodec `0xed01` (Ed25519) prefix followed by exactly 32 bytes.
+fn ed25519_pubkey_from_did_key(did: &str) -> Result<[u8; 32], SiopError> {
+    let multibase = did
+        .strip_prefix("did:key:")
+        .ok_or(SiopError::NotEd25519DidKey)?;
+    let (_base, bytes) = multibase::decode(multibase).map_err(|_| SiopError::NotEd25519DidKey)?;
+    let key = bytes
+        .strip_prefix(&[0xed, 0x01])
+        .ok_or(SiopError::NotEd25519DidKey)?;
+    key.try_into().map_err(|_| SiopError::NotEd25519DidKey)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    /// A local (network-free) resolver for the failure-path tests,
+    /// which all short-circuit before any DID resolution happens.
+    async fn test_resolver() -> DIDCacheClient {
+        DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("build DID resolver")
+    }
+
+    /// Build a signed compact-JWS id_token for `did:key` issuers, plus
+    /// helpers to tamper with it. Returns `(id_token, did)`.
+    fn make_did_key_id_token(
+        signing_key: &SigningKey,
+        iss: &str,
+        sub: &str,
+        aud: &str,
+        nonce: &str,
+        iat: u64,
+        exp: u64,
+        kid: &str,
+    ) -> String {
+        let header = serde_json::json!({ "alg": "EdDSA", "typ": "JWT", "kid": kid });
+        let payload = serde_json::json!({
+            "iss": iss, "sub": sub, "aud": aud, "nonce": nonce, "iat": iat, "exp": exp,
+        });
+        let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+        let payload_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let signing_input = format!("{header_b64}.{payload_b64}");
+        let sig = signing_key.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        format!("{signing_input}.{sig_b64}")
+    }
+
+    fn did_key_for(signing_key: &SigningKey) -> String {
+        let pubkey = signing_key.verifying_key().to_bytes();
+        let mut buf = Vec::with_capacity(34);
+        buf.extend_from_slice(&[0xed, 0x01]);
+        buf.extend_from_slice(&pubkey);
+        format!(
+            "did:key:{}",
+            multibase::encode(multibase::Base::Base58Btc, &buf)
+        )
+    }
+
+    // NB: full happy-path verification needs a live DIDCacheClient to
+    // resolve the issuer DID, so the round-trip is exercised in
+    // vtc-service's integration tests (which build a resolver). These
+    // unit tests cover the pure, resolver-independent failure paths
+    // that short-circuit before resolution.
+
+    #[tokio::test]
+    async fn rejects_non_compact_jws() {
+        let resolver = test_resolver().await;
+        let err = verify_siop_id_token("not.a", &resolver).await.unwrap_err();
+        assert!(matches!(err, SiopError::MalformedJws));
+    }
+
+    #[tokio::test]
+    async fn rejects_when_iss_ne_sub() {
+        let resolver = test_resolver().await;
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let did = did_key_for(&sk);
+        let token = make_did_key_id_token(
+            &sk,
+            &did,
+            "did:key:zSomeoneElse",
+            "did:webvh:scid:rp.example",
+            "nonce-1",
+            1000,
+            2000,
+            &format!("{did}#key-0"),
+        );
+        let err = verify_siop_id_token(&token, &resolver).await.unwrap_err();
+        assert!(matches!(err, SiopError::NotSelfIssued));
+    }
+
+    #[tokio::test]
+    async fn rejects_when_kid_base_ne_iss() {
+        let resolver = test_resolver().await;
+        let sk = SigningKey::from_bytes(&[9u8; 32]);
+        let did = did_key_for(&sk);
+        // kid points at a different DID than iss/sub.
+        let token = make_did_key_id_token(
+            &sk,
+            &did,
+            &did,
+            "did:webvh:scid:rp.example",
+            "nonce-1",
+            1000,
+            2000,
+            "did:key:zForeign#key-0",
+        );
+        let err = verify_siop_id_token(&token, &resolver).await.unwrap_err();
+        assert!(matches!(err, SiopError::KidMismatch));
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_iss() {
+        let resolver = test_resolver().await;
+        // Hand-build a token with no `iss`.
+        let header = serde_json::json!({ "alg": "EdDSA", "kid": "did:key:z#k" });
+        let payload = serde_json::json!({ "sub": "did:key:z", "aud": "rp" });
+        let h = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+        let p = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("{h}.{p}.AAAA");
+        let err = verify_siop_id_token(&token, &resolver).await.unwrap_err();
+        assert!(matches!(err, SiopError::MissingClaim("iss")));
+    }
+
+    #[test]
+    fn did_key_decode_round_trips() {
+        let sk = SigningKey::from_bytes(&[3u8; 32]);
+        let did = did_key_for(&sk);
+        let decoded = ed25519_pubkey_from_did_key(&did).unwrap();
+        assert_eq!(decoded, sk.verifying_key().to_bytes());
+    }
+
+    #[test]
+    fn did_key_decode_rejects_non_ed25519() {
+        assert!(matches!(
+            ed25519_pubkey_from_did_key("did:key:zNotMultibaseEd25519!!"),
+            Err(SiopError::NotEd25519DidKey)
+        ));
+        assert!(matches!(
+            ed25519_pubkey_from_did_key("did:web:example.com"),
+            Err(SiopError::NotEd25519DidKey)
+        ));
+    }
+}


### PR DESCRIPTION
Adds **"Sign in with VTA wallet"** (and a VTA-proxied SIOP variant) alongside the existing passkey login on the VTC admin UI, mirroring `affinidi-webvh-service`'s `did-hosting-ui`. The browser wallet extension (`window.vtaWallet`) self-issues a SIOPv2 `id_token` and the VTC verifies it — no extension changes (the extension is generic over `rpDid` + `baseUrl`).

## How it works

1. The wallet extension runs the SIOP round-trip against the VTC's **header-exempt** `/v1/wallet/auth/challenge` + `/v1/wallet/auth/` (it sends no `Trust-Task` header — the Trust-Task-gated `/auth/*` routes are untouched for DIDComm/CLI clients).
2. The holder self-issues a compact-EdDSA-JWS `id_token` (`iss==sub==holder`, `aud==`this VTC's DID, `nonce==`challenge). VTC verifies the signature, binds `aud` to its own DID, checks freshness, and dispatches into the **same canonical `handle_authenticate`** (nonce → challenge) to mint a bearer.
3. The SPA posts that bearer to **`/v1/auth/admin-session`**, which validates it and sets the `vtc_admin_session` + `csrf` cookies the cookie-based admin SPA expects.

## Commits / phases

| Phase | Commit | Summary |
|---|---|---|
| 1 | `5e18243` | `vti-common::auth::siop::verify_siop_id_token` — SIOP verifier ported from did-hosting-common (typestate `VerifiedSiopIdToken`) |
| 2 | `5e18243` | VTC `/auth/` SIOP branch + header-exempt `/v1/wallet/auth/*` routes (CSRF-exempt, rate-limited) |
| 3 | `7ddb400` | `/v1/auth/admin-session` bearer→cookie bridge |
| 4 | `c592ab6` | admin-UI: wallet buttons + `lib/wallet.ts` + proxy picker |
| sec | `49a3378` | security hardening (see below) |

## Security review

An independent review of the auth surface found **0 critical, 0 high, 1 medium, 3 low**. The core design was validated as sound: signature verification is hard-wired to Ed25519 (no `alg`-dispatch, so `alg:none`/HS256 confusion doesn't apply), `iss==sub` enforced, did:key pinning correct, ACL gating airtight at both challenge and authenticate, single-use nonce→challenge→session binding, audience bound server-side, and the admin-session bridge preserves VTC audience isolation and is not login-CSRF-able (not CSRF-exempt; same-origin gated).

**Fixed in `49a3378`:**
- **[MEDIUM]** verifier now requires the `kid` to be in the DID's `authentication` relationship (matters for `did:webvh`/`did:peer` issuers; did:key unaffected).
- **[LOW]** explicit `alg == EdDSA` rejection (defense-in-depth against future refactors).

**Deferred follow-ups (benign/bounded, tracked for a follow-up):**
- [LOW] validate the Multikey codec for document-based issuers (an X25519-typed Multikey is currently caught only by signature failure, not an early type check).
- [LOW] reorder `authenticate_siop` to check session/ACL presence before resolving the attacker-supplied `iss` DID (SSRF amplification; bounded by the per-IP governor, and the DIDComm path already has the same property). Also confirm `DIDCacheClient` egress denies RFC1918/metadata for `did:web*`.

## Testing

- `vti-common` siop: **7/7** unit tests.
- `vtc-service` `wallet_login_siop`: **6/6** integration (happy path + tampered sig + wrong aud + nonce mismatch + full bridge chain login→cookie→`whoami` + garbage-token rejection).
- Regression: `auth_audience` 6/6, `cookie_session` 5/5.
- `cargo fmt --check`, `clippy`, admin-UI `tsc` + Vite build all clean.

## Not yet done (needs a human)

- **Live browser test** with the real `@openvtc/pnm-extension` wallet — the automated tests mint did:key `id_token`s directly; the end-to-end browser handshake against the actual extension hasn't been exercised.