### PR TITLE
feat(vta-mobile-core): build DIDComm set-device-info / delete-device-info (push registration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9505,6 +9505,7 @@ name = "vta-mobile-core"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "serde_json",
  "thiserror 2.0.18",
  "uniffi",
 ]

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -24,6 +24,7 @@ crate-type = ["cdylib", "staticlib", "lib"]
 uniffi = { workspace = true, features = ["cli"] }
 thiserror = { workspace = true }
 base64 = { workspace = true }
+serde_json = { workspace = true }
 
 # ── Deferred wiring (kept out of slice 1 on purpose) ────────────────────────
 # The FFI build + bindgen pipeline is proven first with a minimal surface.

--- a/vta-mobile-core/src/lib.rs
+++ b/vta-mobile-core/src/lib.rs
@@ -20,11 +20,9 @@
 //!
 //! ## Build-out slices
 //!
-//! 1. **this slice** — skeleton + minimal sync surface; prove the crate builds
-//!    and Kotlin/Swift bindings generate.
+//! 1. **this slice** — skeleton + minimal sync surface; prove the crate builds and Kotlin/Swift bindings generate.
 //! 2. Trust Task build/verify (pure, sync) — see [`task`], [`stepup`].
-//! 3. VTA session/auth (async) — see [`session`]; DIDComm pack/unpack —
-//!    see [`didcomm`]; push registration — see [`push`].
+//! 3. VTA session/auth (async) — see [`session`]; DIDComm pack/unpack — see [`didcomm`]; push registration — see [`push`].
 
 uniffi::setup_scaffolding!();
 

--- a/vta-mobile-core/src/push.rs
+++ b/vta-mobile-core/src/push.rs
@@ -1,11 +1,193 @@
-//! Push registration — build the DIDComm `set-device-info` message.
+//! Push registration — builds the DIDComm `set-device-info` / `delete-device-info`
+//! messages a backgrounded mobile agent sends to its **mediator** to register or
+//! clear its push channel (push wake-up binding,
+//! `https://trusttasks.org/binding/push/0.1`; adopts Aries RFC 0699 APNs /
+//! 0734 FCM as DIDComm v2 messages).
 //!
-//! **Slice 3.** Implements the device side of the push wake-up binding
-//! (`https://trusttasks.org/binding/push/0.1`): the engine assembles the
-//! `set-device-info` body from a [`PushRegistration`]-shaped input; the native
-//! layer obtains the APNs/FCM token and sends the packed message to the
-//! mediator over the live DIDComm channel.
-//!
-//! Planned surface:
-//! - `build_set_device_info(platform, token, topic) -> MessageJson`
-//! - `build_delete_device_info() -> MessageJson`
+//! The engine builds the message core (`{type, body}`); the native layer adds
+//! envelope headers (`id`/`from`/`to`) and authcrypt-packs it onto the live
+//! DIDComm channel. These messages only tell the mediator *where* to push — the
+//! wake-up push itself is contentless and never carries Trust Task content.
+
+use crate::error::FfiError;
+
+const APNS_PROTOCOL: &str = "https://didcomm.org/push-notifications-apns/1.0";
+const FCM_PROTOCOL: &str = "https://didcomm.org/push-notifications-fcm/1.0";
+
+/// Which APNs environment issued the token — the mediator routes to the matching
+/// Apple endpoint.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum ApnsEnvironment {
+    Sandbox,
+    Production,
+}
+
+/// A device's platform push channel — the body of a `set-device-info` message.
+/// Mirrors the `PushRegistration` shape in the device-binding shared schema.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum PushRegistration {
+    /// Apple Push Notification service.
+    Apns {
+        token: String,
+        topic: String,
+        environment: ApnsEnvironment,
+    },
+    /// Firebase Cloud Messaging.
+    Fcm { token: String },
+    /// Web Push (RFC 8030). Carried out-of-band, not via a DIDComm
+    /// `set-device-info` — the Aries push-notification protocols cover APNs/FCM
+    /// only. Present here so the type mirrors the schema; building a message for
+    /// it returns [`FfiError::Unimplemented`].
+    WebPush {
+        endpoint: String,
+        p256dh: String,
+        auth: String,
+    },
+}
+
+/// The platform discriminator, for messages whose body carries no token
+/// (e.g. `delete-device-info`).
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum PushPlatform {
+    Apns,
+    Fcm,
+    WebPush,
+}
+
+/// Builds the DIDComm `set-device-info` message (`{type, body}` JSON) the agent
+/// sends to its mediator to register or refresh its push channel. The native
+/// layer adds envelope headers and authcrypt-packs it before sending.
+#[uniffi::export]
+pub fn build_set_device_info(registration: PushRegistration) -> Result<String, FfiError> {
+    let (protocol, body) = match registration {
+        PushRegistration::Apns {
+            token,
+            topic,
+            environment,
+        } => {
+            let service = match environment {
+                ApnsEnvironment::Sandbox => "apns_sandbox",
+                ApnsEnvironment::Production => "apns",
+            };
+            (
+                APNS_PROTOCOL,
+                serde_json::json!({
+                    "device_token": token,
+                    "service": service,
+                    "topic": topic,
+                }),
+            )
+        }
+        PushRegistration::Fcm { token } => (
+            FCM_PROTOCOL,
+            serde_json::json!({ "device_token": token, "service": "fcm" }),
+        ),
+        PushRegistration::WebPush { .. } => {
+            return Err(FfiError::Unimplemented {
+                what: "web push registration uses RFC 8030 directly, not a DIDComm \
+                       set-device-info message; APNs/FCM only"
+                    .to_string(),
+            });
+        }
+    };
+    message(protocol, "set-device-info", body)
+}
+
+/// Builds the DIDComm `delete-device-info` message to unregister this device's
+/// push channel (e.g. on logout).
+#[uniffi::export]
+pub fn build_delete_device_info(platform: PushPlatform) -> Result<String, FfiError> {
+    let protocol = match platform {
+        PushPlatform::Apns => APNS_PROTOCOL,
+        PushPlatform::Fcm => FCM_PROTOCOL,
+        PushPlatform::WebPush => {
+            return Err(FfiError::Unimplemented {
+                what: "web push is not registered via DIDComm set-device-info".to_string(),
+            });
+        }
+    };
+    message(protocol, "delete-device-info", serde_json::json!({}))
+}
+
+/// Assemble the `{type, body}` DIDComm message core and serialize it.
+fn message(protocol: &str, verb: &str, body: serde_json::Value) -> Result<String, FfiError> {
+    let msg = serde_json::json!({
+        "type": format!("{protocol}/{verb}"),
+        "body": body,
+    });
+    serde_json::to_string(&msg).map_err(|e| FfiError::InvalidInput {
+        reason: format!("failed to serialize push message: {e}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apns_set_device_info_shape() {
+        let json = build_set_device_info(PushRegistration::Apns {
+            token: "abc123".to_string(),
+            topic: "org.openvtc.vta.agent".to_string(),
+            environment: ApnsEnvironment::Production,
+        })
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            v["type"],
+            "https://didcomm.org/push-notifications-apns/1.0/set-device-info"
+        );
+        assert_eq!(v["body"]["device_token"], "abc123");
+        assert_eq!(v["body"]["service"], "apns");
+        assert_eq!(v["body"]["topic"], "org.openvtc.vta.agent");
+    }
+
+    #[test]
+    fn apns_sandbox_maps_to_service() {
+        let json = build_set_device_info(PushRegistration::Apns {
+            token: "t".to_string(),
+            topic: "x".to_string(),
+            environment: ApnsEnvironment::Sandbox,
+        })
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["body"]["service"], "apns_sandbox");
+    }
+
+    #[test]
+    fn fcm_set_device_info_shape() {
+        let json = build_set_device_info(PushRegistration::Fcm {
+            token: "fcm-tok".to_string(),
+        })
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            v["type"],
+            "https://didcomm.org/push-notifications-fcm/1.0/set-device-info"
+        );
+        assert_eq!(v["body"]["service"], "fcm");
+        assert_eq!(v["body"]["device_token"], "fcm-tok");
+    }
+
+    #[test]
+    fn delete_device_info_shape() {
+        let json = build_delete_device_info(PushPlatform::Fcm).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            v["type"],
+            "https://didcomm.org/push-notifications-fcm/1.0/delete-device-info"
+        );
+        assert!(v["body"].as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn webpush_set_device_info_is_unimplemented() {
+        let err = build_set_device_info(PushRegistration::WebPush {
+            endpoint: "https://push.example/x".to_string(),
+            p256dh: "k".to_string(),
+            auth: "a".to_string(),
+        })
+        .unwrap_err();
+        assert!(matches!(err, FfiError::Unimplemented { .. }));
+    }
+}

--- a/vta-mobile-core/src/stepup.rs
+++ b/vta-mobile-core/src/stepup.rs
@@ -4,12 +4,8 @@
 //! `trust-tasks-rs` republish as [`crate::task`].
 //!
 //! Planned surface (supports BOTH gates from the merged spec):
-//! - `build_approve_response_did_signed(req, decision, key_handle) -> TaskJson`
-//!     — gate = framework Data Integrity proof (subject DID signature).
-//! - `build_approve_response_webauthn(req, assertion) -> TaskJson`
-//!     — gate = WebAuthn `AuthenticatorAssertionResponse` over the challenge;
-//!       the assertion is produced natively (ASAuthorization / Credential
-//!       Manager) and passed in.
+//! - `build_approve_response_did_signed(req, decision, key_handle)` — gate is the framework Data Integrity proof (subject DID signature).
+//! - `build_approve_response_webauthn(req, assertion)` — gate is the WebAuthn `AuthenticatorAssertionResponse` over the challenge, produced natively (ASAuthorization / Credential Manager) and passed in.
 //!
 //! The native layer decides which gate to use based on the request's
 //! `acceptableEvidence`; this module assembles and (for did-signed) signs via


### PR DESCRIPTION
## Summary

Adds the device side of the push wake-up binding (`https://trusttasks.org/binding/push/0.1`) to `vta-mobile-core`: the engine builds the DIDComm `set-device-info` / `delete-device-info` message core (`{type, body}`) that a **backgrounded** mobile agent sends to its **mediator** to register/clear its push channel. Adopts Aries RFC 0699 (APNs) / 0734 (FCM) as DIDComm v2 messages. The native layer adds envelope headers and authcrypt-packs it; the wake-up push itself stays contentless.

## What's here (`push.rs`)

- `PushRegistration` tagged union (`Apns { token, topic, environment }` / `Fcm { token }` / `WebPush { … }`) + `ApnsEnvironment` — generates as a Kotlin **sealed class** / Swift **enum** with associated data.
- `build_set_device_info(registration)` and `build_delete_device_info(platform)`.
- `WebPush` returns `FfiError::Unimplemented` (RFC 8030 is out-of-band, not a DIDComm message); present so the type mirrors the device-binding schema.
- 5 unit tests covering the apns / fcm / sandbox / delete / webpush shapes.

Also: a small `fix` commit collapsing over-indented list continuations in the slice-1 **stub** doc comments (`stepup.rs`, `lib.rs`) — rust 1.96 clippy's `doc_overindented_list_items` (denied by the `-D warnings` gate) flagged them. Doc-only.

## Verification (full local CI, before opening this PR)

- `cargo test -p vta-mobile-core` → 5 passed ✓
- `cargo clippy -p vta-mobile-core --all-targets -- -D warnings` → clean ✓
- `cargo deny check` → exit 0, no errors (only pre-existing duplicate-crate warnings; this change adds no new duplicate) ✓
- Kotlin + Swift bindings generate ✓ (sealed class / enum + the two functions)

Done in an **isolated git worktree** with its own `CARGO_TARGET_DIR` — the shared checkout (other agent active) was never touched.

## Next

- **Slice 2** — `task.rs`/`stepup.rs` against `trust-tasks-rs` (blocked on republishing it past 0.1.2).
- **Slice 3b** — `vta-sdk` session + DIDComm pack/unpack (async over FFI — de-risks the tokio-runtime path).
