### PR TITLE
chore(deps): sync Cargo.lock for vti-common's SIOP deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9743,6 +9743,7 @@ name = "vti-common"
 version = "0.8.0"
 dependencies = [
  "aes-gcm",
+ "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
  "async-trait",
  "axum",
@@ -9759,6 +9760,7 @@ dependencies = [
  "http-body-util",
  "jsonwebtoken",
  "libc",
+ "multibase",
  "rand 0.10.1",
  "serde",
  "serde_json",


### PR DESCRIPTION
Follow-up to #152. That PR added `affinidi-did-resolver-cache-sdk` + `multibase` to `vti-common`'s `[dependencies]` (for the new `auth::siop` module) but didn't update `Cargo.lock`'s `vti-common` package entry to list them — both crates were already in the lock as packages (used by other crates), so it was easy to miss, but the per-package `dependencies` list still needs them.

Without this, `cargo build --locked` (and any CI that uses it) fails on `main`. Lockfile-only, two added lines, auto-generated by `cargo check`.