### PR TITLE
fix(vtc): SIOP security follow-ups — Multikey codec check + SSRF gate

### DIFF
--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -107,6 +107,26 @@ async fn authenticate_siop(
         return Ok(None);
     }
 
+    // SSRF hardening: bind the token's (unverified) `iss` to an existing
+    // challenge session *before* resolving it. `verify_siop_id_token`
+    // resolves `iss` — an HTTP fetch for did:web/webvh — so without this an
+    // unauthenticated caller could steer the daemon into resolving an
+    // arbitrary attacker-chosen DID. A session only exists for a DID that
+    // passed the ACL gate at challenge time, so resolution is confined to a
+    // known, authorised DID. These checks are not authoritative (the holder
+    // hasn't proven control of `iss` yet) — `handle_authenticate` below
+    // re-verifies everything; they exist purely to gate the network call.
+    let unverified_iss = vti_common::auth::parse_unverified_iss(&env.payload.id_token)
+        .map_err(|e| AppError::Authentication(format!("id_token: {e}")))?;
+    let session = crate::auth::session::get_session(&state.sessions_ks, &env.payload.session_id)
+        .await?
+        .ok_or_else(|| AppError::Authentication("session not found".into()))?;
+    if unverified_iss != session.did {
+        return Err(AppError::Authentication(
+            "id_token `iss` does not match the challenge session's DID".into(),
+        ));
+    }
+
     let resolver = state.did_resolver.as_ref().ok_or_else(|| {
         AppError::Authentication("DID resolver not configured; cannot verify id_token".into())
     })?;

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -444,3 +444,35 @@ async fn admin_session_rejects_garbage_token() {
     // No cookie on rejection.
     assert!(res.headers().get(axum::http::header::SET_COOKIE).is_none());
 }
+
+#[tokio::test]
+async fn wallet_login_rejects_iss_not_matching_session() {
+    // SSRF gate: a token whose `iss` differs from the DID the challenge
+    // session was issued to is rejected before the verifier resolves `iss`.
+    // `holder` got the challenge (and is ACL'd); `stranger` self-issued the
+    // token. The mismatch must 401.
+    let (_sk_h, holder, _kid_h) = holder_identity(7);
+    let (sk_s, stranger, kid_s) = holder_identity(8);
+    let fix = build_fixture(&holder).await;
+    let (session_id, challenge) = get_challenge(&fix.router, &holder).await;
+
+    let now = now_epoch();
+    let id_token = sign_id_token(
+        &sk_s,
+        &kid_s,
+        &stranger,
+        &stranger,
+        VTC_DID,
+        &challenge,
+        now,
+        now + 300,
+    );
+
+    let (status, _) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/",
+        json!({ "type": AUTH_TYPE, "payload": { "id_token": id_token, "session_id": session_id } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}

--- a/vti-common/src/auth/mod.rs
+++ b/vti-common/src/auth/mod.rs
@@ -14,4 +14,4 @@ pub use backend::{
 pub use extractor::{
     AdminAuth, AuthClaims, AuthState, ManageAuth, StepUpAuth, SuperAdminAuth, WriteAuth,
 };
-pub use siop::{SiopError, VerifiedSiopIdToken, verify_siop_id_token};
+pub use siop::{SiopError, VerifiedSiopIdToken, parse_unverified_iss, verify_siop_id_token};

--- a/vti-common/src/auth/siop.rs
+++ b/vti-common/src/auth/siop.rs
@@ -176,6 +176,33 @@ pub async fn verify_siop_id_token(
     })
 }
 
+/// Parse the `iss` claim from an `id_token` **without** verifying its
+/// signature or resolving any DID. Enforces `iss == sub` (self-issued).
+///
+/// This is a cheap pre-check so a caller can bind the issuer to an existing
+/// session *before* calling [`verify_siop_id_token`] — which performs a
+/// network DID resolution of `iss`. Gating that resolution behind a
+/// session/ACL check stops an unauthenticated caller from steering the
+/// daemon into resolving (HTTP-fetching) an arbitrary attacker-chosen DID.
+///
+/// The returned DID is **not** authenticated — only [`verify_siop_id_token`]
+/// proves the holder controls it. Never trust this value for anything but a
+/// pre-resolution gate.
+pub fn parse_unverified_iss(id_token: &str) -> Result<String, SiopError> {
+    let payload_b64 = id_token.split('.').nth(1).ok_or(SiopError::MalformedJws)?;
+    let payload_bytes = URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .map_err(|_| SiopError::Base64("payload"))?;
+    let claims: SiopClaims =
+        serde_json::from_slice(&payload_bytes).map_err(|_| SiopError::Json("payload"))?;
+    let iss = claims.iss.ok_or(SiopError::MissingClaim("iss"))?;
+    let sub = claims.sub.ok_or(SiopError::MissingClaim("sub"))?;
+    if iss != sub {
+        return Err(SiopError::NotSelfIssued);
+    }
+    Ok(iss)
+}
+
 /// Resolve `kid`'s base DID and return its Ed25519 public key bytes.
 /// Mirrors the DID-resolve + key-extraction primitive the DIDComm
 /// `unpack_signed` path uses. Rejects obvious X25519 key-agreement
@@ -205,10 +232,8 @@ async fn resolve_verifying_key(
         .get_verification_method(kid)
         .ok_or_else(|| SiopError::VmNotFound(kid.to_string()))?;
 
-    // X25519 key-agreement keys have narrow, unambiguous type names —
-    // refuse them. We don't whitelist Ed25519 types because the spec
-    // admits several (Ed25519VerificationKey2018/2020, Multikey with a
-    // z6Mk… prefix, JsonWebKey2020 crv:Ed25519).
+    // X25519 key-agreement keys have narrow, unambiguous *type* names —
+    // refuse them early for a clear error.
     if matches!(
         vm.type_.as_str(),
         "X25519KeyAgreementKey2020" | "X25519KeyAgreementKey2019"
@@ -216,11 +241,28 @@ async fn resolve_verifying_key(
         return Err(SiopError::NotSigningKey(kid.to_string()));
     }
 
-    let pk_bytes = vm
-        .get_public_key_bytes()
-        .map_err(|e| SiopError::BadPublicKey(e.to_string()))?;
-    pk_bytes
-        .try_into()
+    // Extract the key and **validate the multicodec**. The resolver
+    // normalises signing keys to `Multikey` (a `publicKeyMultibase`). Decode
+    // it ourselves and require the Ed25519 multicodec (`0xed01`): an X25519
+    // key published as a `Multikey` (codec `0xec01`, `z6LS…`) would otherwise
+    // decode to 32 bytes and be loaded as an "Ed25519" key, caught only later
+    // at signature verification. Checking the codec here rejects it up front
+    // and refuses any non-Ed25519 curve for the signing key.
+    let multibase = vm
+        .property_set
+        .get("publicKeyMultibase")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            SiopError::BadPublicKey(format!(
+                "verification method {kid} has no publicKeyMultibase"
+            ))
+        })?;
+    let (_base, bytes) = multibase::decode(multibase)
+        .map_err(|e| SiopError::BadPublicKey(format!("publicKeyMultibase: {e}")))?;
+    let key = bytes
+        .strip_prefix(&[0xed, 0x01])
+        .ok_or_else(|| SiopError::NotSigningKey(kid.to_string()))?;
+    key.try_into()
         .map_err(|_| SiopError::BadPublicKey("public key must be 32 bytes".into()))
 }
 
@@ -385,6 +427,35 @@ mod tests {
         let token = format!("{h}.{p}.AAAA");
         let err = verify_siop_id_token(&token, &resolver).await.unwrap_err();
         assert!(matches!(err, SiopError::UnsupportedAlg(_)));
+    }
+
+    #[test]
+    fn parse_unverified_iss_returns_self_issued_did() {
+        let sk = SigningKey::from_bytes(&[15u8; 32]);
+        let did = did_key_for(&sk);
+        let kid = format!("{did}#k");
+        let token = make_did_key_id_token(&sk, &did, &did, "rp", "n", 1, 2, &kid);
+        assert_eq!(parse_unverified_iss(&token).unwrap(), did);
+    }
+
+    #[test]
+    fn parse_unverified_iss_rejects_non_self_issued() {
+        let sk = SigningKey::from_bytes(&[16u8; 32]);
+        let did = did_key_for(&sk);
+        let token = make_did_key_id_token(
+            &sk,
+            &did,
+            "did:key:zOther",
+            "rp",
+            "n",
+            1,
+            2,
+            &format!("{did}#k"),
+        );
+        assert!(matches!(
+            parse_unverified_iss(&token),
+            Err(SiopError::NotSelfIssued)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes the two deferred **LOW** findings from the #152 auth-surface security review. Both are bounded/benign on their own; this is defense-in-depth hardening of the VTA-wallet SIOP login path.

## [LOW] Multikey codec validation
`vti_common::auth::siop::resolve_verifying_key` previously took the resolved verification method's key bytes via `get_public_key_bytes()`, which strips and discards the multicodec prefix. An X25519 key published as a `Multikey` (codec `0xec01`, `z6LS…`) would decode to 32 bytes and be loaded as an "Ed25519" key — caught only later when signature verification failed.

Now it decodes the `publicKeyMultibase` itself and **requires the Ed25519 multicodec (`0xed01`)**, refusing any other curve up front. `did:key` (normalised to `Multikey` with `0xed01`) is unaffected — the integration happy path still passes.

## [LOW] SSRF amplification
`authenticate_siop` (`vtc-service`) called the verifier — which **resolves `iss`** (an HTTP fetch for `did:web`/`did:webvh`) — before any session/ACL gate. An unauthenticated caller could therefore steer the daemon into resolving an arbitrary attacker-chosen DID (bounded by the per-IP governor, blind).

Now it binds the token's **unverified** `iss` to an existing challenge session *before* resolving: a session only exists for a DID that passed the ACL gate at challenge time, so resolution is confined to a known, authorised DID. The authoritative checks (signature, challenge match, signer binding, ACL re-check) remain in `handle_authenticate`. New helper `vti_common::auth::parse_unverified_iss` (enforces `iss==sub`; no resolution, no crypto) — clearly documented as non-authenticating.

## Tests
- `vti-common` siop: **9/9** (+2 `parse_unverified_iss` happy/`iss!=sub`).
- `vtc-service` `wallet_login_siop`: **7/7** (+1 `iss`-not-matching-session → 401; did:key happy path still green, validating the codec change).
- fmt + clippy clean.

## Remaining (ops, out of code scope)
Confirm the production `DIDCacheClient` egress config denies RFC1918 / link-local / cloud-metadata for `did:web*` resolution — the SSRF gate narrows *who* can trigger resolution, but egress hardening is the belt-and-braces network control.