### PR TITLE
feat(vta-mobile-core): parse step-up approve-request via trust-tasks-rs 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9009,9 +9009,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3830755272ec1c7a8910e967ce29f9859477422fb7ca3033b3ae1574916cef7"
+checksum = "3f3e51c2b623b09bf61abc0a680ea69576ca346f21be8a566a1997437e597d05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9507,6 +9507,7 @@ dependencies = [
  "base64 0.22.1",
  "serde_json",
  "thiserror 2.0.18",
+ "trust-tasks-rs",
  "uniffi",
 ]
 

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -25,6 +25,9 @@ uniffi = { workspace = true, features = ["cli"] }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 serde_json = { workspace = true }
+# Generated Trust Task payload types (incl. the step-up `Evidence` union and
+# `acceptableEvidence`, available from 0.1.3).
+trust-tasks-rs = { workspace = true }
 
 # ── Deferred wiring (kept out of slice 1 on purpose) ────────────────────────
 # The FFI build + bindgen pipeline is proven first with a minimal surface.

--- a/vta-mobile-core/src/task.rs
+++ b/vta-mobile-core/src/task.rs
@@ -1,10 +1,134 @@
-//! Trust Task build / verify — wraps `trust-tasks-rs` + `trust-tasks-proof`.
+//! Trust Task parsing — wraps `trust-tasks-rs` generated types.
 //!
-//! **Slice 2** (pure, synchronous). Blocked on republishing `trust-tasks-rs`:
-//! crates.io 0.1.2 predates the `evidence` / `acceptableEvidence` fields
-//! merged to `dtgwg-trust-tasks-tf` (PRs #61/#62).
-//!
-//! Planned surface:
-//! - `parse_step_up_request(json) -> StepUpRequest`   (subject, reason, challenge, acceptable_evidence)
-//! - `verify_task_proof(json) -> VerifiedTask`         (Data Integrity proof check)
-//! - `build_error(thread_id, code) -> TaskJson`
+//! **Slice 2.** Parses an inbound `auth/step-up/approve-request` so the native
+//! app can show the user the reason and decide which evidence gate to satisfy.
+//! Building the signed/passkey-backed `approve-response` is the next slice
+//! (needs newtype construction + the WebAuthn assertion record); proof
+//! verification (async, crypto) follows that.
+
+use trust_tasks_rs::TrustTask;
+use trust_tasks_rs::specs::auth::step_up::approve_request::v0_1 as approve_request;
+
+use crate::error::FfiError;
+
+/// The fields of an `auth/step-up/approve-request` the native consent UI needs
+/// to display and to decide how to respond.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct StepUpRequest {
+    /// The relying party that issued the request (document `issuer`), if present.
+    pub relying_party: Option<String>,
+    /// The VID whose session is being elevated.
+    pub subject: String,
+    /// Opaque session id; echoed back verbatim in the response.
+    pub session_id: String,
+    /// base64url challenge the response must bind.
+    pub challenge: String,
+    /// Human-readable reason — MUST be shown to the user verbatim for consent.
+    pub reason: String,
+    /// The acr the relying party wants (e.g. `"aal2"`), if specified.
+    pub target_acr: Option<String>,
+    /// Evidence gates the relying party will accept (`"did-signed"` / `"webauthn"`).
+    /// Empty when the request did not constrain it (any supported kind is allowed).
+    pub acceptable_evidence: Vec<String>,
+    /// Whether the request carried WebAuthn options — i.e. the relying party
+    /// wants a passkey-backed elevation and supplied the ceremony parameters.
+    pub webauthn_requested: bool,
+}
+
+/// Parse an inbound `auth/step-up/approve-request/0.1` Trust Task document.
+///
+/// Deserialises and structurally validates the document via `trust-tasks-rs`
+/// (well-formed envelope + required payload fields + a valid Type URI), then
+/// surfaces the fields the native consent UI needs. Returns [`FfiError::Decode`]
+/// if the input is not a well-formed approve-request.
+#[uniffi::export]
+pub fn parse_step_up_request(json: String) -> Result<StepUpRequest, FfiError> {
+    let doc: TrustTask<approve_request::Payload> =
+        serde_json::from_str(&json).map_err(|e| FfiError::Decode {
+            reason: format!("not a valid auth/step-up/approve-request document: {e}"),
+        })?;
+    let p = doc.payload;
+    Ok(StepUpRequest {
+        relying_party: doc.issuer,
+        subject: p.subject.to_string(),
+        session_id: p.session_id.to_string(),
+        challenge: p.challenge.to_string(),
+        reason: p.reason.to_string(),
+        target_acr: p.target_acr,
+        acceptable_evidence: p
+            .acceptable_evidence
+            .unwrap_or_default()
+            .iter()
+            .map(|e| e.to_string())
+            .collect(),
+        webauthn_requested: p.webauthn.is_some(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The passkey-backed request example from the approve-request spec.
+    const PASSKEY_REQUEST: &str = r#"{
+      "id": "step-up-2345-6789-01bc-def123456789",
+      "type": "https://trusttasks.org/spec/auth/step-up/approve-request/0.1",
+      "issuer": "did:web:bank.example",
+      "recipient": "did:web:alice.example",
+      "issuedAt": "2026-05-23T14:00:00Z",
+      "payload": {
+        "subject": "did:web:alice.example",
+        "sessionId": "ec5d3c89-3f49-49b2-9d7d-2a8c0a8a7b9b",
+        "challenge": "VHJhbnNmZXJDb25maXJtTm9uY2VYWQ",
+        "reason": "Confirm transfer of $1,000 to did:web:bob.example",
+        "targetAcr": "aal2",
+        "acceptableEvidence": ["webauthn"],
+        "webauthn": {
+          "challenge": "VHJhbnNmZXJDb25maXJtTm9uY2VYWQ",
+          "rpId": "bank.example",
+          "userVerification": "required",
+          "allowCredentials": [{ "type": "public-key", "id": "Y3JlZF8xYTJiM2M" }]
+        },
+        "ttl": 120
+      }
+    }"#;
+
+    #[test]
+    fn parses_passkey_backed_request() {
+        let r = parse_step_up_request(PASSKEY_REQUEST.to_string()).unwrap();
+        assert_eq!(r.relying_party.as_deref(), Some("did:web:bank.example"));
+        assert_eq!(r.subject, "did:web:alice.example");
+        assert_eq!(r.session_id, "ec5d3c89-3f49-49b2-9d7d-2a8c0a8a7b9b");
+        assert_eq!(r.challenge, "VHJhbnNmZXJDb25maXJtTm9uY2VYWQ");
+        assert!(r.reason.starts_with("Confirm transfer"));
+        assert_eq!(r.target_acr.as_deref(), Some("aal2"));
+        assert_eq!(r.acceptable_evidence, vec!["webauthn".to_string()]);
+        assert!(r.webauthn_requested);
+    }
+
+    #[test]
+    fn parses_minimal_did_signed_request() {
+        // No acceptableEvidence / webauthn → empty list, not requested.
+        let json = r#"{
+          "id": "x",
+          "type": "https://trusttasks.org/spec/auth/step-up/approve-request/0.1",
+          "issuer": "did:web:bank.example",
+          "payload": {
+            "subject": "did:web:alice.example",
+            "sessionId": "s1",
+            "challenge": "VHJhbnNmZXJDb25maXJtTm9uY2VYWQ",
+            "reason": "Approve sign-in"
+          }
+        }"#;
+        let r = parse_step_up_request(json.to_string()).unwrap();
+        assert!(r.acceptable_evidence.is_empty());
+        assert!(!r.webauthn_requested);
+        assert_eq!(r.target_acr, None);
+    }
+
+    #[test]
+    fn rejects_non_request_json() {
+        let err = parse_step_up_request("{\"not\":\"a request\"}".to_string()).unwrap_err();
+        assert!(matches!(err, FfiError::Decode { .. }));
+    }
+}


### PR DESCRIPTION
## Summary

First slice that consumes the freshly-published **`trust-tasks-rs` 0.1.3** in the mobile engine. Adds `parse_step_up_request` — a typed deserialize of an `auth/step-up/approve-request/0.1` Trust Task — so the native consent UI can show the user the reason and decide which evidence gate to satisfy.

## What's here (`task.rs`)

- Wires `trust-tasks-rs = { workspace = true }` (resolves to 0.1.3) into `vta-mobile-core`.
- `parse_step_up_request(json) -> StepUpRequest` deserialises + structurally validates the document via `trust-tasks-rs` (envelope + required payload fields + valid Type URI), then surfaces: `relying_party`, `subject`, `session_id`, `challenge`, `reason`, `target_acr`, and the **0.1.3 additions** `acceptable_evidence` (gates the RP accepts) and `webauthn_requested`.
- Generates as Kotlin `data class StepUpRequest` / `fun parseStepUpRequest` (Swift equivalents).
- 3 unit tests: passkey-backed request, minimal did-signed request, reject non-request.

## Verification (full local CI, before opening this PR)

- `cargo test -p vta-mobile-core` → 8 passed ✓
- `cargo clippy -p vta-mobile-core --all-targets -- -D warnings` → clean ✓
- `cargo deny check` → exit 0, no errors (trust-tasks-rs was already in the workspace graph; no new duplicates) ✓
- Kotlin + Swift bindings generate ✓

Done in an isolated git worktree with its own `CARGO_TARGET_DIR`; the shared checkout (other agent active) was never touched.

## Next

- **Slice 2b** — `build_approve_response_webauthn` / `_did_signed`: construct + serialise the `approve-response` (newtype construction, the WebAuthn assertion FFI record, `chrono` for `issuedAt`; did-signed gate signs via the `Signer` callback from #151).
