### PR TITLE
fix(vtc): correct admin-UI auth Trust-Task URLs to match the routes

### DIFF
--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -187,8 +187,8 @@ export interface WhoamiResponse {
   allowedContexts: string[];
 }
 
-const WHOAMI_TASK = "https://trusttasks.org/openvtc/vtc/auth/whoami/1.0";
-const SIGN_OUT_TASK = "https://trusttasks.org/openvtc/vtc/auth/sign-out/1.0";
+const WHOAMI_TASK = "https://trusttasks.org/spec/auth/whoami/0.1";
+const SIGN_OUT_TASK = "https://trusttasks.org/spec/auth/revoke-session/0.1";
 
 /** Fetch the caller's session identity. Throws on 401/403. */
 export const fetchWhoami = (): Promise<WhoamiResponse> =>

--- a/vtc-service/admin-ui/src/pages/Login.tsx
+++ b/vtc-service/admin-ui/src/pages/Login.tsx
@@ -30,9 +30,9 @@ import {
 } from "@/lib/wallet";
 
 const TRUST_TASK_START =
-  "https://trusttasks.org/openvtc/vtc/auth/passkey-login/start/1.0";
+  "https://trusttasks.org/spec/auth/passkey/login/start/0.1";
 const TRUST_TASK_FINISH =
-  "https://trusttasks.org/openvtc/vtc/auth/passkey-login/finish/1.0";
+  "https://trusttasks.org/spec/auth/passkey/login/finish/0.1";
 const TRUST_TASK_ADMIN_SESSION =
   "https://trusttasks.org/openvtc/vtc/auth/admin-session/1.0";
 

--- a/vtc-service/admin-ui/src/plugins/sessions.tsx
+++ b/vtc-service/admin-ui/src/plugins/sessions.tsx
@@ -24,9 +24,9 @@ type SortKey = "did" | "state" | "createdAt" | "refreshExpiresAt";
 type SortDir = "asc" | "desc";
 
 const TRUST_TASK_MANAGE =
-  "https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0";
+  "https://trusttasks.org/spec/auth/sessions/list/0.1";
 const TRUST_TASK_REVOKE =
-  "https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/revoke/1.0";
+  "https://trusttasks.org/spec/auth/revoke-session/0.1";
 
 type SessionState = "Pending" | "Authenticated" | "Revoked";
 


### PR DESCRIPTION
## Problem (found during live VTC testing)

Passkey login returned **`TrustTaskMismatch` (415)**. The auth routes were consolidated to canonical `spec/auth/*` Trust-Task URLs, but the admin UI still sent the old `openvtc/vtc/auth/*` scheme. The daemon's exact-match Trust-Task gate rejected every auth request. Pre-existing drift (not introduced by the wallet-login work), surfaced now during end-to-end testing.

It also would have broken the new VTA-wallet login: after the bearer→cookie bridge, the SPA re-probes `whoami` to flip to the authenticated view — and `whoami`'s task was mismatched too.

## Fix

Reconcile the admin-UI Trust-Task constants with the route definitions:

| | admin-UI sent | now |
|---|---|---|
| passkey login start | `openvtc/vtc/auth/passkey-login/start/1.0` | `spec/auth/passkey/login/start/0.1` |
| passkey login finish | `openvtc/vtc/auth/passkey-login/finish/1.0` | `spec/auth/passkey/login/finish/0.1` |
| whoami | `openvtc/vtc/auth/whoami/1.0` | `spec/auth/whoami/0.1` |
| sign-out | `openvtc/vtc/auth/sign-out/1.0` | `spec/auth/revoke-session/0.1` |
| sessions list | `openvtc/vtc/auth/legacy/sessions/manage/1.0` | `spec/auth/sessions/list/0.1` |
| session revoke | `openvtc/vtc/auth/legacy/sessions/revoke/1.0` | `spec/auth/revoke-session/0.1` |

`admin-session` (wallet bridge) and the install / members / acl / policies / passkeys-management tasks already matched the routes — verified.

tsc + Vite build clean. **Requires rebuilding the daemon** (the admin UI is baked into the binary via `include_dir!`).