### PR TITLE
feat(vta-mobile-core): async resolve_did over FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compat"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ba85bc55464dcbf728b56d97e119d673f4cf9062be330a9a26f3acf504a590"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9238,6 +9251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
 dependencies = [
  "anyhow",
+ "async-compat",
  "bytes",
  "log",
  "once_cell",
@@ -9505,12 +9519,14 @@ name = "vta-mobile-core"
 version = "0.1.0"
 dependencies = [
  "affinidi-data-integrity",
+ "affinidi-did-resolver-cache-sdk",
  "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
  "multibase",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "trust-tasks-rs",
  "uniffi",
 ]

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -20,8 +20,9 @@ name = "vta_mobile_core"
 crate-type = ["cdylib", "staticlib", "lib"]
 
 [dependencies]
-# `cli` feature provides `uniffi::uniffi_bindgen_main` for the bindgen binary.
-uniffi = { workspace = true, features = ["cli"] }
+# `cli` provides `uniffi::uniffi_bindgen_main`; `tokio` lets us export async
+# functions (`#[uniffi::export(async_runtime = "tokio")]`).
+uniffi = { workspace = true, features = ["cli", "tokio"] }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 serde_json = { workspace = true }
@@ -37,6 +38,11 @@ chrono = { workspace = true }
 affinidi-data-integrity = { workspace = true }
 # Multibase (base58btc) encoding of the signature into `proofValue`.
 multibase = { workspace = true }
+# Async runtime for the FFI async exports + a process-wide resolver cell.
+tokio = { workspace = true }
+# DID resolution. Default config is local (did:key / did:peer resolve offline);
+# networked methods (did:web / did:webvh) need network-mode config — later.
+affinidi-did-resolver-cache-sdk = { workspace = true }
 
 # ── Deferred wiring (kept out of slice 1 on purpose) ────────────────────────
 # The FFI build + bindgen pipeline is proven first with a minimal surface.

--- a/vta-mobile-core/src/resolver.rs
+++ b/vta-mobile-core/src/resolver.rs
@@ -1,10 +1,77 @@
 //! DID resolution — wraps `affinidi-did-resolver-cache-sdk`.
 //!
-//! **Slice 3.**
-//!
-//! Planned surface:
-//! - `resolve_did(did) -> DidDocumentJson`
-//! - `key_agreement_key(did) -> Multikey`   (for authcrypt to the VTA)
-//!
-//! Backed by the caching resolver so repeated lookups (every inbound message)
-//! stay cheap; the native layer may seed an offline cache for known DIDs.
+//! **Slice 3a.** The engine's first *async* export, proving the async-over-FFI
+//! path (`#[uniffi::export(async_runtime = "tokio")]`). Default config is
+//! **local**: `did:key` / `did:peer` resolve offline — which already covers the
+//! holder/relying-party key lookups needed to verify step-up proofs. Networked
+//! methods (`did:web` / `did:webvh`) need a network-mode config and are a
+//! follow-up.
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
+use tokio::sync::OnceCell;
+
+use crate::error::FfiError;
+
+/// One process-wide caching resolver, lazily initialised on first use. The
+/// resolver caches immutable methods (key/peer) indefinitely, so repeated
+/// lookups stay cheap.
+static CLIENT: OnceCell<DIDCacheClient> = OnceCell::const_new();
+
+async fn client() -> Result<&'static DIDCacheClient, FfiError> {
+    CLIENT
+        .get_or_try_init(|| async {
+            DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+                .await
+                .map_err(|e| FfiError::InvalidInput {
+                    reason: format!("DID resolver init failed: {e}"),
+                })
+        })
+        .await
+}
+
+/// Resolve a DID to its DID Document, returned as JSON.
+///
+/// Used to find a peer's verification keys (to verify a relying party's step-up
+/// proof) and key-agreement key (for DIDComm). `did:key` / `did:peer` resolve
+/// locally; other methods will require a network-mode resolver config
+/// (follow-up). The first async function exported across the FFI boundary.
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn resolve_did(did: String) -> Result<String, FfiError> {
+    let response = client()
+        .await?
+        .resolve(&did)
+        .await
+        .map_err(|e| FfiError::InvalidInput {
+            reason: format!("could not resolve {did}: {e}"),
+        })?;
+    serde_json::to_string(&response.doc).map_err(|e| FfiError::InvalidInput {
+        reason: format!("could not serialize DID document: {e}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // One test (one runtime) — the process-wide resolver is initialised and
+    // used within the same runtime, avoiding cross-runtime handle issues.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resolves_did_key_locally_and_rejects_garbage() {
+        let did = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
+        let json = resolve_did(did.to_string())
+            .await
+            .expect("did:key resolves locally");
+        let doc: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(doc["id"], did);
+        assert!(
+            doc.get("verificationMethod").is_some(),
+            "did:key document exposes a verificationMethod"
+        );
+
+        let err = resolve_did("not-a-did".to_string())
+            .await
+            .expect_err("a non-DID must fail");
+        assert!(matches!(err, FfiError::InvalidInput { .. }));
+    }
+}


### PR DESCRIPTION
## Summary

First **async** export from the mobile engine, de-risking the async-over-FFI path before the heavier Slice 3 work. `resolve_did` wraps `affinidi-did-resolver-cache-sdk` behind a process-wide cached client and is exported with `#[uniffi::export(async_runtime = "tokio")]` — so it generates a Kotlin **`suspend fun`** / Swift **`async`** function.

## Why this first

`vta-sdk` session auth and DIDComm pack/unpack are all async. This slice proves the UniFFI `tokio` runtime path works end to end with a single, self-contained function before that bigger surface depends on it.

## What's here (`resolver.rs`)

- `resolve_did(did) -> DID Document JSON`, async. Backed by a lazily-initialised process-wide `DIDCacheClient` (immutable methods cached indefinitely, so repeat lookups are cheap).
- Default config is **local**: `did:key` / `did:peer` resolve offline — which already covers the holder/relying-party key lookups needed to verify step-up proofs. Networked methods (`did:web` / `did:webvh`) need network-mode config — a documented follow-up.
- Enables uniffi's `tokio` feature; adds `tokio` + `affinidi-did-resolver-cache-sdk` deps.

## Verification (full local CI, isolated worktree)

- `cargo test -p vta-mobile-core` → 15 passed (async test resolves a known `did:key` locally + rejects a non-DID) ✓
- `cargo clippy --all-targets -- -D warnings` clean ✓
- `cargo deny check` exit 0, no errors ✓
- Bindings confirm the async surface: Kotlin `suspend fun resolveDid(...)` ✓

## Next

- **Slice 3b** — DIDComm pack/unpack (async) over `affinidi-tdk`.
- **Slice 3c** — `vta-sdk` session: VTA challenge/authenticate + JWT refresh (async).
