### PR TITLE
feat(vta-mobile-core): DIDComm session — authcrypt pack/unpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9520,6 +9520,7 @@ version = "0.1.0"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
  "base64 0.22.1",
  "chrono",
  "ed25519-dalek",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -43,6 +43,8 @@ tokio = { workspace = true }
 # DID resolution. Default config is local (did:key / did:peer resolve offline);
 # networked methods (did:web / did:webvh) need network-mode config — later.
 affinidi-did-resolver-cache-sdk = { workspace = true }
+# DIDComm v2 authcrypt/anoncrypt pack + unpack. Pinned to vta-sdk's version.
+affinidi-messaging-didcomm = "0.13"
 
 # ── Deferred wiring (kept out of slice 1 on purpose) ────────────────────────
 # The FFI build + bindgen pipeline is proven first with a minimal surface.

--- a/vta-mobile-core/src/didcomm.rs
+++ b/vta-mobile-core/src/didcomm.rs
@@ -1,11 +1,276 @@
-//! DIDComm pack / unpack — wraps the `affinidi-tdk` DIDComm stack.
+//! DIDComm pack / unpack — wraps `affinidi-messaging-didcomm`.
 //!
-//! **Slice 3.**
+//! **Slice 3b.** A stateful [`DidcommSession`] bound to one holder identity:
+//! `unpack` (decrypt/verify inbound) and `pack_authcrypt` (sender-authenticated
+//! encrypt outbound). The native layer owns the mediator WebSocket and hands
+//! raw envelope bytes here.
 //!
-//! Planned surface (pure functions; the transport is native):
-//! - `unpack(jwe_bytes, recipient_key_handle) -> PlaintextMessage`
-//! - `pack_authcrypt(message, sender_handle, recipient_did) -> JweBytes`
-//! - `wrap_forward(jwe, mediator_did) -> JweBytes`
+//! ## Custody (Tier-2, interim)
 //!
-//! The native layer owns the WebSocket to the mediator and hands raw envelope
-//! bytes here for decryption / encryption.
+//! Per the Mobile Key-Custody Profile, DIDComm needs the holder's **X25519**
+//! key for ECDH, which mobile secure hardware cannot hold. So the holder key is
+//! **software-held**: native loads it from the keystore (biometric-gated) and
+//! passes it at session construction; it lives in app memory while the session
+//! is open. When the P-256/Tier-1 enabler lands, the key material moves behind
+//! an enclave key-agreement callback **without changing this FFI surface**.
+
+use std::sync::{Arc, Mutex};
+
+use affinidi_messaging_didcomm::DIDCommAgent;
+use affinidi_messaging_didcomm::Message;
+use affinidi_messaging_didcomm::crypto::key_agreement::{
+    Curve, PrivateKeyAgreement, PublicKeyAgreement,
+};
+use affinidi_messaging_didcomm::identity::{PrivateIdentity, ResolvedIdentity};
+use affinidi_messaging_didcomm::message::unpack::UnpackResult;
+
+use crate::error::FfiError;
+
+/// Holder key material for a DIDComm session. **Tier-2 (software-held)** — see
+/// the module docs. Native loads these from the keystore and SHOULD zeroize
+/// them on session end.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct HolderKeys {
+    /// The holder DID (used as the authcrypt sender).
+    pub did: String,
+    /// keyAgreement verification-method id (DID URL fragment).
+    pub key_agreement_kid: String,
+    /// X25519 key-agreement private key (32 bytes).
+    pub key_agreement_private_x25519: Vec<u8>,
+    /// signing verification-method id.
+    pub signing_kid: String,
+    /// Ed25519 signing private key (32 bytes).
+    pub signing_private_ed25519: Vec<u8>,
+}
+
+/// A resolved peer's public key-agreement key — e.g. from [`crate::resolver`].
+/// Needed to authcrypt *to* the peer and to verify the peer's authcrypt.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct Peer {
+    pub did: String,
+    pub key_agreement_kid: String,
+    /// X25519 key-agreement public key (32 bytes).
+    pub key_agreement_public_x25519: Vec<u8>,
+}
+
+/// The outcome of unpacking an inbound DIDComm message.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct UnpackedMessage {
+    /// The plaintext DIDComm message as JSON (`type`/`body`/`from`/`to`/`id`/…).
+    pub message_json: String,
+    /// `true` when the message was authcrypt'd (sender-authenticated) or signed.
+    /// `false` for anoncrypt and unauthenticated plaintext — do not trust
+    /// `from` in that case.
+    pub sender_authenticated: bool,
+    /// The authenticated sender key id, when present.
+    pub sender_kid: Option<String>,
+}
+
+/// A DIDComm session bound to one holder identity. Holds the library agent
+/// (the holder identity + resolved peers). Thread-safe via an internal lock.
+#[derive(uniffi::Object)]
+pub struct DidcommSession {
+    agent: Mutex<DIDCommAgent>,
+    holder_did: String,
+}
+
+#[uniffi::export]
+impl DidcommSession {
+    /// Open a session for the holder, building its [`PrivateIdentity`] from the
+    /// supplied (Tier-2, software-held) key material.
+    #[uniffi::constructor]
+    pub fn new(holder: HolderKeys) -> Result<Arc<Self>, FfiError> {
+        let key_agreement_private = PrivateKeyAgreement::from_raw_bytes(
+            Curve::X25519,
+            &holder.key_agreement_private_x25519,
+        )
+        .map_err(|e| FfiError::InvalidInput {
+            reason: format!("holder keyAgreement key: {e}"),
+        })?;
+        let signing_private = to_array_32(&holder.signing_private_ed25519, "holder signing key")?;
+
+        let identity = PrivateIdentity {
+            did: holder.did.clone(),
+            key_agreement_kid: holder.key_agreement_kid,
+            key_agreement_private,
+            signing_kid: Some(holder.signing_kid),
+            signing_private: Some(signing_private),
+        };
+        let mut agent = DIDCommAgent::new();
+        agent.add_identity(identity);
+        Ok(Arc::new(Self {
+            agent: Mutex::new(agent),
+            holder_did: holder.did,
+        }))
+    }
+
+    /// Add a resolved peer (its key-agreement public key) so the session can
+    /// authcrypt to it and verify its authcrypt.
+    pub fn add_peer(&self, peer: Peer) -> Result<(), FfiError> {
+        let key_agreement_public = PublicKeyAgreement::X25519(to_array_32(
+            &peer.key_agreement_public_x25519,
+            "peer keyAgreement key",
+        )?);
+        let resolved = ResolvedIdentity {
+            did: peer.did,
+            key_agreement_kid: peer.key_agreement_kid,
+            key_agreement_public,
+            signing_kid: None,
+            verifying_key: None,
+        };
+        self.agent
+            .lock()
+            .expect("didcomm session lock")
+            .add_peer(resolved);
+        Ok(())
+    }
+
+    /// Decrypt/verify an inbound DIDComm message (authcrypt / anoncrypt / signed
+    /// / plaintext). For authcrypt verification, pass the expected `sender_did`
+    /// (which must have been added via [`add_peer`](Self::add_peer)).
+    pub fn unpack(
+        &self,
+        packed: String,
+        sender_did: Option<String>,
+    ) -> Result<UnpackedMessage, FfiError> {
+        let result = self
+            .agent
+            .lock()
+            .expect("didcomm session lock")
+            .unpack(&packed, sender_did.as_deref())
+            .map_err(|e| FfiError::InvalidInput {
+                reason: format!("unpack failed: {e}"),
+            })?;
+
+        let (message, sender_authenticated, sender_kid) = match result {
+            UnpackResult::Encrypted {
+                message,
+                authenticated,
+                sender_kid,
+                ..
+            } => (message, authenticated, sender_kid),
+            UnpackResult::Signed {
+                message,
+                signer_kid,
+            } => (message, true, signer_kid),
+            UnpackResult::Plaintext(message) => (message, false, None),
+        };
+
+        Ok(UnpackedMessage {
+            message_json: serde_json::to_string(&message).map_err(|e| FfiError::InvalidInput {
+                reason: format!("serialize message: {e}"),
+            })?,
+            sender_authenticated,
+            sender_kid,
+        })
+    }
+
+    /// Authcrypt (sender-authenticated, encrypted) a plaintext DIDComm message
+    /// JSON to `recipient_did` — which MUST have been added via
+    /// [`add_peer`](Self::add_peer). Returns the JWE the native layer sends
+    /// (typically wrapped in a `routing/2.0/forward` to the mediator).
+    pub fn pack_authcrypt(
+        &self,
+        message_json: String,
+        recipient_did: String,
+    ) -> Result<String, FfiError> {
+        let msg: Message = serde_json::from_str(&message_json).map_err(|e| FfiError::Decode {
+            reason: format!("not a valid DIDComm message: {e}"),
+        })?;
+        self.agent
+            .lock()
+            .expect("didcomm session lock")
+            .pack_authcrypt(&msg, &self.holder_did, &recipient_did)
+            .map_err(|e| FfiError::InvalidInput {
+                reason: format!("authcrypt failed: {e}"),
+            })
+    }
+}
+
+fn to_array_32(bytes: &[u8], what: &str) -> Result<[u8; 32], FfiError> {
+    bytes.try_into().map_err(|_| FfiError::InvalidInput {
+        reason: format!("{what} must be 32 bytes, got {}", bytes.len()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Derive the X25519 public key for a raw private scalar via the library
+    // (no extra dependency).
+    fn x25519_public(private_32: &[u8]) -> Vec<u8> {
+        let sk = PrivateKeyAgreement::from_raw_bytes(Curve::X25519, private_32).unwrap();
+        match sk.public_key() {
+            PublicKeyAgreement::X25519(p) => p.to_vec(),
+            _ => unreachable!("constructed as X25519"),
+        }
+    }
+
+    fn holder(did: &str, ka_priv: [u8; 32], sign_priv: [u8; 32]) -> HolderKeys {
+        HolderKeys {
+            did: did.to_string(),
+            key_agreement_kid: format!("{did}#key-agreement"),
+            key_agreement_private_x25519: ka_priv.to_vec(),
+            signing_kid: format!("{did}#signing"),
+            signing_private_ed25519: sign_priv.to_vec(),
+        }
+    }
+
+    fn peer(did: &str, ka_priv: [u8; 32]) -> Peer {
+        Peer {
+            did: did.to_string(),
+            key_agreement_kid: format!("{did}#key-agreement"),
+            key_agreement_public_x25519: x25519_public(&ka_priv),
+        }
+    }
+
+    #[test]
+    fn authcrypt_round_trip_between_two_sessions() {
+        let alice_ka = [1u8; 32];
+        let alice_sign = [2u8; 32];
+        let bob_ka = [3u8; 32];
+        let bob_sign = [4u8; 32];
+        let alice_did = "did:example:alice";
+        let bob_did = "did:example:bob";
+
+        let alice = DidcommSession::new(holder(alice_did, alice_ka, alice_sign)).unwrap();
+        alice.add_peer(peer(bob_did, bob_ka)).unwrap();
+        let bob = DidcommSession::new(holder(bob_did, bob_ka, bob_sign)).unwrap();
+        bob.add_peer(peer(alice_did, alice_ka)).unwrap();
+
+        let msg = serde_json::json!({
+            "id": "m-1",
+            "type": "https://didcomm.org/basicmessage/2.0/message",
+            "from": alice_did,
+            "to": [bob_did],
+            "body": { "content": "hello bob" }
+        })
+        .to_string();
+
+        let jwe = alice.pack_authcrypt(msg, bob_did.to_string()).unwrap();
+        // It's an encrypted envelope, not plaintext.
+        assert!(jwe.contains("ciphertext"));
+
+        let unpacked = bob.unpack(jwe, Some(alice_did.to_string())).unwrap();
+        assert!(
+            unpacked.sender_authenticated,
+            "authcrypt is sender-authenticated"
+        );
+        let m: serde_json::Value = serde_json::from_str(&unpacked.message_json).unwrap();
+        assert_eq!(m["body"]["content"], "hello bob");
+        assert_eq!(m["from"], alice_did);
+    }
+
+    #[test]
+    fn rejects_bad_holder_key_length() {
+        let mut h = holder("did:example:x", [1u8; 32], [2u8; 32]);
+        h.key_agreement_private_x25519 = vec![0u8; 16]; // wrong length
+        // (DidcommSession isn't Debug — it holds key material — so match instead
+        // of unwrap_err.)
+        assert!(matches!(
+            DidcommSession::new(h),
+            Err(FfiError::InvalidInput { .. })
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

`DidcommSession` — a UniFFI object over `affinidi-messaging-didcomm` that gives the agent end-to-end DIDComm message handling: decrypt inbound step-up requests and encrypt responses. With the step-up builders (#158/#159) and the resolver (#160), the engine can now run the full cross-device flow over DIDComm.

## What's here (`didcomm.rs`)

- `DidcommSession::new(holder)` — opens a session bound to one holder identity.
- `add_peer(peer)` — registers a resolved peer's keyAgreement pubkey (e.g. from `resolve_did`).
- `unpack(packed, sender_did)` — decrypt/verify inbound (authcrypt / anoncrypt / signed / plaintext). Returns `sender_authenticated` so callers don't trust `from` on anoncrypt/plaintext.
- `pack_authcrypt(message_json, recipient_did)` — sender-authenticated encrypt; returns the JWE (native wraps it in `routing/2.0/forward` to the mediator).

## Custody — Tier-2 (interim), per the Mobile Key-Custody Profile

DIDComm needs the holder's **X25519** key for ECDH, which mobile secure hardware can't hold — so the key is **software-held**: native loads it from the keystore (biometric-gated) and passes it at construction; the session holds it while open. **The FFI surface is unchanged when the P-256/Tier-1 enclave key-agreement callback lands** — only where the key comes from changes. `DidcommSession` deliberately does not derive `Debug` (it holds key material).

## Verification (full local CI, isolated worktree)

- `cargo test -p vta-mobile-core` → **17 passed**, including a real **authcrypt round-trip** between two sessions (pack at Alice → unpack at Bob, sender-authenticated, body intact) + a bad-key-length rejection ✓
- `cargo clippy --all-targets -- -D warnings` clean ✓
- `cargo deny check` exit 0 ✓
- Bindings generate: Kotlin `class DidcommSession` (Disposable/AutoCloseable) with `addPeer`/`packAuthcrypt`/`unpack` ✓

Adds `affinidi-messaging-didcomm 0.13` (matches vta-sdk).

## Next

- `pack_anoncrypt` + `routing/2.0/forward` wrapper (mediator delivery) — small follow-up on the same session.
- Slice 3c — `vta-sdk` session (VTA auth/JWT).
- The P-256/Tier-1 enclave key-agreement callback (per the profile) — moves this from Tier-2 to hardware custody without changing the surface.
