### PR TITLE
feat(vtc): `vtc acl {list,add,remove}` CLI for ACL management

### DIFF
--- a/vtc-service/src/acl_cli.rs
+++ b/vtc-service/src/acl_cli.rs
@@ -1,0 +1,141 @@
+//! Offline ACL management for the `vtc` CLI.
+//!
+//! `vtc acl {list,add,remove}` — direct fjall access to the `acl`
+//! keyspace, no running daemon and no auth ceremony (the operator's
+//! filesystem access *is* the authority, same trust model as
+//! `vtc create-did-key --admin` and `vtc admin invite`). Run on a
+//! **stopped** daemon — fjall takes an exclusive lock, so the commands
+//! fail while the server holds the store open. Not for TEE deployments
+//! (the store lives behind the vsock proxy there).
+//!
+//! For online ACL management against a running VTC, use the admin UI
+//! (ACL plugin) or the REST `/v1/acl` surface.
+
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::acl::{
+    VtcAclEntry, VtcRole, delete_acl_entry, get_acl_entry, list_acl_entries, store_acl_entry,
+};
+use crate::config::AppConfig;
+use crate::store::Store;
+
+type CliResult = Result<(), Box<dyn std::error::Error>>;
+
+fn now_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// `vtc acl list` — print every ACL entry.
+pub async fn run_acl_list(config_path: Option<PathBuf>) -> CliResult {
+    let config = AppConfig::load(config_path)?;
+    let store = Store::open(&config.store)?;
+    let acl_ks = store.keyspace("acl")?;
+
+    let mut entries = list_acl_entries(&acl_ks).await?;
+    if entries.is_empty() {
+        println!("No ACL entries.");
+        return Ok(());
+    }
+    entries.sort_by(|a, b| a.did.cmp(&b.did));
+
+    let now = now_epoch();
+    println!(
+        "   {:<48} {:<14} {:<12} LABEL / CONTEXTS",
+        "DID", "ROLE", "EXPIRES"
+    );
+    for e in &entries {
+        let expires = match e.expires_at {
+            None => "never".to_string(),
+            Some(t) if t <= now => "EXPIRED".to_string(),
+            Some(t) => format!("{}s", t - now),
+        };
+        let mut detail = e.label.clone().unwrap_or_default();
+        if !e.allowed_contexts.is_empty() {
+            if !detail.is_empty() {
+                detail.push_str("  ");
+            }
+            detail.push_str(&format!("contexts=[{}]", e.allowed_contexts.join(",")));
+        }
+        println!(
+            "   {:<48} {:<14} {:<12} {}",
+            e.did,
+            e.role.to_string(),
+            expires,
+            detail
+        );
+    }
+    println!(
+        "\n{} entr{}.",
+        entries.len(),
+        if entries.len() == 1 { "y" } else { "ies" }
+    );
+    Ok(())
+}
+
+/// `vtc acl add` — create or overwrite the ACL entry for a DID.
+pub struct AclAddArgs {
+    pub config_path: Option<PathBuf>,
+    pub did: String,
+    pub role: String,
+    pub label: Option<String>,
+    pub contexts: Vec<String>,
+    /// Expiry, in seconds from now. `None` → no expiry.
+    pub expires: Option<u64>,
+}
+
+pub async fn run_acl_add(args: AclAddArgs) -> CliResult {
+    // Parse the role first so a typo fails before we touch the store.
+    let role = VtcRole::from_str(&args.role)?;
+
+    let config = AppConfig::load(args.config_path)?;
+    let store = Store::open(&config.store)?;
+    let acl_ks = store.keyspace("acl")?;
+
+    let now = now_epoch();
+    let existing = get_acl_entry(&acl_ks, &args.did).await?;
+    let entry = VtcAclEntry {
+        did: args.did.clone(),
+        role,
+        label: args.label,
+        allowed_contexts: args.contexts,
+        // Preserve the original creation time on update.
+        created_at: existing.as_ref().map(|e| e.created_at).unwrap_or(now),
+        created_by: "cli:acl-add".into(),
+        expires_at: args.expires.map(|ttl| now.saturating_add(ttl)),
+    };
+    store_acl_entry(&acl_ks, &entry).await?;
+    store.persist().await?;
+
+    println!(
+        "{} ACL entry for {} (role {}).",
+        if existing.is_some() {
+            "Updated"
+        } else {
+            "Added"
+        },
+        args.did,
+        entry.role
+    );
+    Ok(())
+}
+
+/// `vtc acl remove` — delete the ACL entry for a DID.
+pub async fn run_acl_remove(config_path: Option<PathBuf>, did: String) -> CliResult {
+    let config = AppConfig::load(config_path)?;
+    let store = Store::open(&config.store)?;
+    let acl_ks = store.keyspace("acl")?;
+
+    if get_acl_entry(&acl_ks, &did).await?.is_none() {
+        println!("No ACL entry for {did} — nothing to remove.");
+        return Ok(());
+    }
+    delete_acl_entry(&acl_ks, &did).await?;
+    store.persist().await?;
+    println!("Removed ACL entry for {did}.");
+    Ok(())
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -13,6 +13,7 @@
 //! on this crate.
 
 pub mod acl;
+pub mod acl_cli;
 #[cfg(feature = "admin-ui")]
 pub mod admin_ui;
 pub mod auth;

--- a/vtc-service/src/main.rs
+++ b/vtc-service/src/main.rs
@@ -1,7 +1,7 @@
 // Module tree is declared in lib.rs (so integration tests under
 // `tests/` can pull the same modules the binary uses). Re-import the
 // pieces this binary needs at the top level.
-use vtc_service::{config, did_key, keys, server, status, store};
+use vtc_service::{acl_cli, config, did_key, keys, server, status, store};
 #[cfg(feature = "setup")]
 use vtc_service::{emergency, setup};
 
@@ -42,6 +42,41 @@ enum Commands {
     Admin {
         #[command(subcommand)]
         command: AdminCommands,
+    },
+    /// Manage ACL entries (offline — run on a **stopped** daemon)
+    Acl {
+        #[command(subcommand)]
+        command: AclCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum AclCommands {
+    /// List every ACL entry.
+    List,
+    /// Add or update the ACL entry for a DID.
+    Add {
+        /// The subject DID the entry grants a role to.
+        #[arg(long)]
+        did: String,
+        /// Role: admin | moderator | issuer | member | custom:<name>.
+        #[arg(long, default_value = "member")]
+        role: String,
+        /// Human-readable label.
+        #[arg(long)]
+        label: Option<String>,
+        /// Comma-separated context IDs to scope the entry to.
+        #[arg(long, value_delimiter = ',')]
+        contexts: Vec<String>,
+        /// Expiry in seconds from now (omit for no expiry).
+        #[arg(long)]
+        expires: Option<u64>,
+    },
+    /// Remove the ACL entry for a DID.
+    Remove {
+        /// The subject DID whose entry to delete.
+        #[arg(long)]
+        did: String,
     },
 }
 
@@ -159,6 +194,33 @@ async fn main() {
             {
                 let _ = command;
                 eprintln!("admin subcommands are unavailable (compiled without 'setup')");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Acl { command }) => {
+            let result = match command {
+                AclCommands::List => acl_cli::run_acl_list(cli.config).await,
+                AclCommands::Add {
+                    did,
+                    role,
+                    label,
+                    contexts,
+                    expires,
+                } => {
+                    acl_cli::run_acl_add(acl_cli::AclAddArgs {
+                        config_path: cli.config,
+                        did,
+                        role,
+                        label,
+                        contexts,
+                        expires,
+                    })
+                    .await
+                }
+                AclCommands::Remove { did } => acl_cli::run_acl_remove(cli.config, did).await,
+            };
+            if let Err(e) = result {
+                eprintln!("Error: {e}");
                 std::process::exit(1);
             }
         }

--- a/vtc-service/tests/acl_cli.rs
+++ b/vtc-service/tests/acl_cli.rs
@@ -1,0 +1,135 @@
+//! Offline `vtc acl` CLI integration tests.
+//!
+//! Drives the `acl_cli` handlers against a temp store + minimal config
+//! file, exactly as the `vtc acl {list,add,remove}` subcommands do, and
+//! verifies the resulting `acl` keyspace state.
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+use vti_common::config::StoreConfig;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry};
+use vtc_service::acl_cli::{AclAddArgs, run_acl_add, run_acl_list, run_acl_remove};
+use vtc_service::store::Store;
+
+const DID: &str = "did:key:z6MkAclCliTestAdmin";
+
+/// A temp dir + a minimal `config.toml` pointing the store at it.
+/// Returns `(dir, config_path, data_dir)`; keep `dir` alive for the test.
+fn fixture() -> (TempDir, PathBuf, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let data_dir = dir.path().join("data");
+    let cfg_path = dir.path().join("config.toml");
+    std::fs::write(
+        &cfg_path,
+        format!("[store]\ndata_dir = \"{}\"\n", data_dir.display()),
+    )
+    .expect("write config");
+    (dir, cfg_path, data_dir)
+}
+
+/// Re-open the store and read back an entry — the CLI handler drops its
+/// own store (releasing the fjall lock) before this runs.
+async fn read_entry(data_dir: &Path, did: &str) -> Option<VtcAclEntry> {
+    let store = Store::open(&StoreConfig {
+        data_dir: data_dir.to_path_buf(),
+    })
+    .expect("open store");
+    let ks = store.keyspace("acl").expect("acl ks");
+    get_acl_entry(&ks, did).await.expect("get_acl_entry")
+}
+
+#[tokio::test]
+async fn add_list_remove_round_trip() {
+    let (_dir, cfg, data_dir) = fixture();
+
+    run_acl_add(AclAddArgs {
+        config_path: Some(cfg.clone()),
+        did: DID.into(),
+        role: "admin".into(),
+        label: Some("ops".into()),
+        contexts: vec!["ctx-1".into(), "ctx-2".into()],
+        expires: Some(3600),
+    })
+    .await
+    .expect("add");
+
+    let e = read_entry(&data_dir, DID).await.expect("entry stored");
+    assert_eq!(e.role, VtcRole::Admin);
+    assert_eq!(e.label.as_deref(), Some("ops"));
+    assert_eq!(e.allowed_contexts, vec!["ctx-1", "ctx-2"]);
+    assert!(e.expires_at.is_some(), "expiry should be set");
+
+    // `list` runs cleanly against a populated store.
+    run_acl_list(Some(cfg.clone())).await.expect("list");
+
+    run_acl_remove(Some(cfg.clone()), DID.into())
+        .await
+        .expect("remove");
+    assert!(read_entry(&data_dir, DID).await.is_none(), "entry removed");
+}
+
+#[tokio::test]
+async fn add_is_upsert_and_preserves_created_at() {
+    let (_dir, cfg, data_dir) = fixture();
+
+    run_acl_add(AclAddArgs {
+        config_path: Some(cfg.clone()),
+        did: DID.into(),
+        role: "member".into(),
+        label: None,
+        contexts: vec![],
+        expires: None,
+    })
+    .await
+    .expect("add member");
+    let first = read_entry(&data_dir, DID).await.expect("first");
+    assert_eq!(first.role, VtcRole::Member);
+
+    // Re-add the same DID with a new role — upsert, not duplicate.
+    run_acl_add(AclAddArgs {
+        config_path: Some(cfg.clone()),
+        did: DID.into(),
+        role: "moderator".into(),
+        label: Some("mod".into()),
+        contexts: vec![],
+        expires: None,
+    })
+    .await
+    .expect("upsert moderator");
+    let second = read_entry(&data_dir, DID).await.expect("second");
+    assert_eq!(second.role, VtcRole::Moderator);
+    assert_eq!(second.label.as_deref(), Some("mod"));
+    assert_eq!(
+        second.created_at, first.created_at,
+        "created_at preserved across update"
+    );
+}
+
+#[tokio::test]
+async fn add_rejects_unknown_role() {
+    let (_dir, cfg, data_dir) = fixture();
+    let result = run_acl_add(AclAddArgs {
+        config_path: Some(cfg),
+        did: DID.into(),
+        role: "wizard".into(),
+        label: None,
+        contexts: vec![],
+        expires: None,
+    })
+    .await;
+    assert!(result.is_err(), "unknown role must be rejected");
+    // Nothing was written.
+    assert!(read_entry(&data_dir, DID).await.is_none());
+}
+
+#[tokio::test]
+async fn remove_missing_did_is_ok() {
+    let (_dir, cfg, _data_dir) = fixture();
+    // Removing a DID that was never added is a clean no-op (the store is
+    // created on open), not an error.
+    run_acl_remove(Some(cfg), "did:key:zNeverAdded".into())
+        .await
+        .expect("remove missing is ok");
+}


### PR DESCRIPTION
Adds CLI ACL management to the `vtc` binary — list, add, remove ACL entries.

```
vtc acl list
vtc acl add --did <did> --role <admin|moderator|issuer|member|custom:x> [--label <l>] [--contexts a,b] [--expires <secs>]
vtc acl remove --did <did>
```

**Offline** (direct fjall access to the `acl` keyspace, no auth ceremony) — same trust model as the existing `vtc create-did-key --admin` and `vtc admin invite`. Run on a **stopped** daemon (fjall takes an exclusive lock); not for TEE deployments. For online management against a running VTC, the admin-UI ACL plugin + REST `/v1/acl` remain.

- `add` is an upsert and preserves the original `created_at` on update.
- `remove` is a clean no-op when the DID isn't present.
- Reuses the existing `acl` storage API (`list/get/store/delete_acl_entry`) and `VtcRole::from_str`.

**Tests**: 4 integration tests (round-trip add→list→remove, upsert-preserves-created-at, unknown-role rejected, remove-missing-ok). fmt + clippy clean.