### PR TITLE
fix(vtc): install link auto-bootstraps the first admin (creates the ACL entry)

### DIFF
--- a/vtc-service/admin-ui/src/pages/Install.tsx
+++ b/vtc-service/admin-ui/src/pages/Install.tsx
@@ -24,6 +24,8 @@ const TRUST_TASK_START =
   "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0";
 const TRUST_TASK_FINISH =
   "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0";
+const TRUST_TASK_BOOTSTRAP =
+  "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0";
 
 type Phase =
   | { kind: "awaiting-code" }
@@ -201,6 +203,33 @@ export function Install() {
       adminDid: string;
       setupSessionToken: string;
     };
+
+    // ── admin/bootstrap ──
+    // This is the ONLY place the first admin's ACL entry (VtcAclEntry) is
+    // written, so without it passkey login fails with "DID not in ACL".
+    // Drive it here so the install link fully sets up the admin in one go.
+    // 409 = an admin already exists — i.e. this is an *invited* admin whose
+    // ACL was already granted by `vtc admin invite`, or a re-claim — which
+    // is fine: the passkey is registered and the DID is already authorised.
+    const bootstrap = await postJson(
+      "/v1/admin/bootstrap",
+      TRUST_TASK_BOOTSTRAP,
+      { setup_session_token: finishBody.setupSessionToken },
+    );
+    if (bootstrap.status !== 200 && bootstrap.status !== 409) {
+      const b = bootstrap.body as { error?: string; message?: string } | null;
+      setPhase({
+        kind: "error",
+        title: `Admin bootstrap failed (${bootstrap.status})`,
+        message:
+          b?.error ??
+          b?.message ??
+          "Your passkey registered, but finalising admin access failed.",
+        hint: "Check the daemon logs, then re-open the install URL to retry.",
+      });
+      return;
+    }
+
     setPhase({
       kind: "success",
       adminDid: finishBody.adminDid,
@@ -269,7 +298,7 @@ export function Install() {
 
       {phase.kind === "success" && (
         <section className="card">
-          <h3>Passkey registered ✅</h3>
+          <h3>Admin set up ✅</h3>
           <dl>
             <dt>Admin DID</dt>
             <dd>
@@ -277,10 +306,13 @@ export function Install() {
             </dd>
           </dl>
           <p>
-            Save the setup-session token below — your CNM CLI uses it
-            to complete the bootstrap handshake.
+            Your passkey is registered and this DID is now an admin. Open the
+            VTC admin UI and sign in with your passkey.
           </p>
-          <pre>{phase.setupSessionToken}</pre>
+          <details>
+            <summary>Setup-session token (advanced / CNM CLI)</summary>
+            <pre>{phase.setupSessionToken}</pre>
+          </details>
         </section>
       )}
 

--- a/vtc-service/src/routing/csrf.rs
+++ b/vtc-service/src/routing/csrf.rs
@@ -58,6 +58,9 @@ const CSRF_EXEMPT_PATHS: &[&str] = &[
     "/v1/auth/admin-login",
     "/v1/install/claim/start",
     "/v1/install/claim/finish",
+    // First-admin finalisation — unauthenticated (the setup-session JWT in
+    // the body is the credential), driven by the install page + CNM CLI.
+    "/v1/admin/bootstrap",
 ];
 
 /// Tower middleware function. Wire via


### PR DESCRIPTION
## Problem (live testing)

Setting up a VTC and using the printed install link to register the first admin's passkey left login failing with **"DID not in ACL"** — the "unknown DID" symptom.

## Root cause

The admin SPA's `Install.tsx` runs the passkey ceremony, then only **displays** the setup-session token and tells you "your CNM CLI uses it to complete the bootstrap." It **never calls `POST /v1/admin/bootstrap`** — which is the *only* place the first admin's `VtcAclEntry` is written. With no ACL entry, passkey login's `check_acl_full` returns `Forbidden("DID not in ACL: <did>")`.

The DID itself is correct all the way through (`provision.admin_did()` → install token → `PasskeyUser.did` → setup-session `sub` → bootstrap ACL → login `check_acl`). **There is no DID mismatch** — the bug is purely the missing bootstrap call. (Invited admins via `vtc admin invite` already work, because the invite command writes their ACL entry directly.)

## Fix (browser auto-bootstrap)

- `Install.tsx` now calls `/v1/admin/bootstrap` with the setup-session token right after `claim/finish`, so the install link fully provisions the first admin in one step. `409 Conflict` (an admin already exists — an *invited* admin, or a re-claim) is treated as success.
- Success copy updated to **"Admin set up ✅ — sign in with your passkey"**; the setup-session token is tucked behind an advanced/CNM `<details>` disclosure.
- Added `/v1/admin/bootstrap` to the **CSRF exempt** list — it's unauthenticated (the setup-session JWT in the body is the credential), same category as `/v1/install/claim/*`, so both the browser install page and the CNM CLI reach it without a session cookie.

## Verification

`tsc` + Vite build clean; `vtc-service` compiles. The bootstrap endpoint itself is already covered by `admin_bootstrap.rs` tests; this change is the SPA *calling* it, so the end-to-end browser flow (setup → install link → passkey → login) should be re-tested in person after a daemon rebuild (admin UI is baked via `include_dir!`).