### PR TITLE
feat(vta-mobile-core): VTA authentication as auth/* Trust Tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9525,6 +9525,7 @@ dependencies = [
  "chrono",
  "ed25519-dalek",
  "multibase",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -25,6 +25,9 @@ crate-type = ["cdylib", "staticlib", "lib"]
 uniffi = { workspace = true, features = ["cli", "tokio"] }
 thiserror = { workspace = true }
 base64 = { workspace = true }
+# `Serialize` bound for the generic proof/serialize helpers; payload types come
+# from trust-tasks-rs (which derives serde) — we only need the trait in scope.
+serde = { workspace = true }
 serde_json = { workspace = true }
 # Generated Trust Task payload types (incl. the step-up `Evidence` union and
 # `acceptableEvidence`, available from 0.1.3).

--- a/vta-mobile-core/src/lib.rs
+++ b/vta-mobile-core/src/lib.rs
@@ -22,12 +22,15 @@
 //!
 //! 1. **this slice** — skeleton + minimal sync surface; prove the crate builds and Kotlin/Swift bindings generate.
 //! 2. Trust Task build/verify (pure, sync) — see [`task`], [`stepup`].
-//! 3. VTA session/auth (async) — see [`session`]; DIDComm pack/unpack — see [`didcomm`]; push registration — see [`push`].
+//! 3. VTA auth — `auth/*` Trust Task build/parse (pure, sync) — see [`session`];
+//!    DIDComm pack/unpack — see [`didcomm`]; async DID resolution — see
+//!    [`resolver`]; push registration — see [`push`].
 
 uniffi::setup_scaffolding!();
 
 pub mod api;
 mod error;
+mod proof;
 
 // Planned module surface. These are stubs in slice 1; each file documents the
 // FFI it will expose and which slice wires it. They are kept as real modules

--- a/vta-mobile-core/src/proof.rs
+++ b/vta-mobile-core/src/proof.rs
@@ -1,0 +1,65 @@
+//! Shared Data Integrity proof construction for DID-signed Trust Tasks.
+//!
+//! The holder key never enters Rust: `affinidi-data-integrity`'s
+//! `prepare_sign_input` does the `eddsa-jcs-2022` canonicalization, the native
+//! [`Signer`] signs the result, and we assemble the proof. Used by the step-up
+//! DID-signed gate ([`crate::stepup`]) and VTA `authenticate` ([`crate::session`]).
+
+use affinidi_data_integrity::crypto_suites::CryptoSuite;
+use affinidi_data_integrity::{DataIntegrityProof, prepare_sign_input};
+use multibase::Base;
+use serde::Serialize;
+use trust_tasks_rs::{Proof, TrustTask};
+
+use crate::error::FfiError;
+use crate::keys::Signer;
+
+/// Build an `eddsa-jcs-2022` Data Integrity proof over `doc` (which MUST NOT yet
+/// carry a proof), signed via the native `signer`, and attach it. `created` is
+/// an RFC 3339 timestamp.
+pub(crate) fn attach_did_signed_proof<P: Serialize>(
+    doc: &mut TrustTask<P>,
+    signer: &dyn Signer,
+    created: &str,
+) -> Result<(), FfiError> {
+    let mut proof_config = DataIntegrityProof {
+        type_: "DataIntegrityProof".to_string(),
+        cryptosuite: CryptoSuite::EddsaJcs2022,
+        created: Some(created.to_string()),
+        verification_method: did_key_vm(&signer.did())?,
+        proof_purpose: "assertionMethod".to_string(),
+        proof_value: None,
+        context: None,
+    };
+
+    // Library does eddsa-jcs-2022 canonicalization + hashing of (document, proof
+    // config); the native enclave signs the result.
+    let signing_input = prepare_sign_input(&*doc, &proof_config, CryptoSuite::EddsaJcs2022)
+        .map_err(|e| FfiError::InvalidInput {
+            reason: format!("failed to canonicalize for signing: {e}"),
+        })?;
+    let signature = signer.sign(signing_input)?;
+    proof_config.proof_value = Some(multibase::encode(Base::Base58Btc, signature));
+
+    let proof_json = serde_json::to_value(&proof_config).map_err(|e| FfiError::InvalidInput {
+        reason: format!("proof serialize: {e}"),
+    })?;
+    doc.proof =
+        Some(
+            serde_json::from_value::<Proof>(proof_json).map_err(|e| FfiError::InvalidInput {
+                reason: format!("proof shape: {e}"),
+            })?,
+        );
+    Ok(())
+}
+
+/// Derive the verification-method URI for a `did:key` holder. The mobile holder
+/// key is a `did:key`, whose verification method is `<did>#<method-specific-id>`.
+pub(crate) fn did_key_vm(did: &str) -> Result<String, FfiError> {
+    let suffix = did
+        .strip_prefix("did:key:")
+        .ok_or_else(|| FfiError::InvalidInput {
+            reason: format!("the DID-signed gate requires a did:key holder; got {did}"),
+        })?;
+    Ok(format!("{did}#{suffix}"))
+}

--- a/vta-mobile-core/src/session.rs
+++ b/vta-mobile-core/src/session.rs
@@ -1,13 +1,290 @@
-//! VTA session / authentication — wraps `vta-sdk`.
+//! VTA authentication, expressed as `auth/*` Trust Tasks.
 //!
-//! **Slice 3** (async over the FFI boundary; needs `vta-sdk` `session` feature
-//! and a UniFFI `async_runtime = "tokio"` export).
+//! The agent authenticates to its VTA the custody-correct way — composing the
+//! engine's own primitives rather than reusing `vta-sdk`'s session (which holds
+//! the raw private key + is REST/keyring-backed, incompatible with the
+//! `Signer`-callback / enclave custody model). The flow:
 //!
-//! Planned surface:
-//! - `start_auth(vta_did) -> AuthChallenge`
-//! - `complete_auth(challenge, signed) -> TokenBundle`
-//! - `refresh(refresh_token) -> TokenBundle`
+//! 1. `build_auth_challenge` → request a nonce (`auth/challenge`, no proof).
+//! 2. `parse_auth_challenge_response` → read the challenge + session id.
+//! 3. `build_authenticate` → present the challenge; the framework **proof**,
+//!    signed by the holder via the native [`Signer`] (reusing the DID-signed
+//!    proof machinery in [`crate::proof`]), IS the authentication.
+//! 4. `parse_authenticate_response` → the issued access/refresh tokens.
 //!
-//! Key material never crosses the boundary: signing is performed natively via
-//! a [`crate::keys`] handle; this module orchestrates the challenge/response
-//! and JWT lifecycle using `vta-sdk`'s client.
+//! Transport is the [`crate::didcomm::DidcommSession`]; these functions only
+//! build/parse the JSON.
+
+use chrono::DateTime;
+use trust_tasks_rs::specs::auth::{
+    authenticate::v0_1 as authenticate, challenge::v0_1 as challenge,
+};
+use trust_tasks_rs::{Payload, TrustTask};
+
+use crate::error::FfiError;
+use crate::keys::Signer;
+use crate::proof::attach_did_signed_proof;
+
+/// Envelope fields shared by the auth request documents. `id` / `issued_at` are
+/// supplied by the native layer (it owns identifiers and the clock).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct AuthEnvelope {
+    /// Document id (e.g. a fresh UUID).
+    pub id: String,
+    /// The holder DID — the subject authenticating (document `issuer`).
+    pub holder_did: String,
+    /// The VTA / auth-service DID (document `recipient`).
+    pub vta_did: String,
+    /// RFC 3339 timestamp for `issuedAt` (and the authenticate proof's `created`).
+    pub issued_at: String,
+}
+
+/// Parsed `auth/challenge` response.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct AuthChallenge {
+    pub challenge: String,
+    pub session_id: String,
+    pub expires_at: String,
+}
+
+/// Parsed token bundle (+ session summary) from an `authenticate` response.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct AuthTokens {
+    pub access_token: String,
+    /// Token presentation scheme — almost always `"Bearer"`. The native layer
+    /// uses it as the `Authorization` header scheme.
+    pub token_type: String,
+    pub expires_in: u64,
+    pub refresh_token: Option<String>,
+    pub refresh_expires_in: Option<u64>,
+    /// Authentication context class of the issued session (e.g. `"aal2"`).
+    pub acr: Option<String>,
+    /// Authentication methods references (e.g. `["did"]`).
+    pub amr: Vec<String>,
+}
+
+/// Build an `auth/challenge/0.1` request to start VTA authentication. No proof —
+/// the response carries the nonce the holder will sign in `authenticate`.
+#[uniffi::export]
+pub fn build_auth_challenge(
+    env: AuthEnvelope,
+    subject: Option<String>,
+    purpose: Option<String>,
+) -> Result<String, FfiError> {
+    let payload = challenge::Payload {
+        subject: subject
+            .map(challenge::PayloadSubject::try_from)
+            .transpose()
+            .map_err(conv)?,
+        purpose: purpose
+            .map(challenge::PayloadPurpose::try_from)
+            .transpose()
+            .map_err(conv)?,
+        ext: None,
+    };
+    serialize(&envelope_doc(&env, payload)?)
+}
+
+/// Parse an `auth/challenge/0.1#response`.
+#[uniffi::export]
+pub fn parse_auth_challenge_response(json: String) -> Result<AuthChallenge, FfiError> {
+    let doc: TrustTask<challenge::Response> = serde_json::from_str(&json).map_err(decode)?;
+    Ok(AuthChallenge {
+        challenge: doc.payload.challenge.to_string(),
+        session_id: doc.payload.session_id.to_string(),
+        expires_at: doc.payload.expires_at.to_rfc3339(),
+    })
+}
+
+/// Build a signed `auth/authenticate/0.1`. The framework Data Integrity proof —
+/// signed by the holder via `signer` — IS the authentication; `challenge` and
+/// `session_id` are echoed from the challenge response.
+#[uniffi::export]
+pub fn build_authenticate(
+    env: AuthEnvelope,
+    challenge: String,
+    session_id: String,
+    scope: Vec<String>,
+    signer: Box<dyn Signer>,
+) -> Result<String, FfiError> {
+    let payload = authenticate::Payload {
+        challenge: authenticate::PayloadChallenge::try_from(challenge).map_err(conv)?,
+        session_id: authenticate::PayloadSessionId::try_from(session_id).map_err(conv)?,
+        scope: scope
+            .into_iter()
+            .map(authenticate::PayloadScopeItem::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(conv)?,
+        ext: None,
+    };
+    let mut doc = envelope_doc(&env, payload)?;
+    attach_did_signed_proof(&mut doc, &*signer, &env.issued_at)?;
+    serialize(&doc)
+}
+
+/// Parse an `auth/authenticate/0.1#response` — the issued tokens + session.
+#[uniffi::export]
+pub fn parse_authenticate_response(json: String) -> Result<AuthTokens, FfiError> {
+    let doc: TrustTask<authenticate::Response> = serde_json::from_str(&json).map_err(decode)?;
+    let tokens = doc.payload.tokens;
+    let session = doc.payload.session;
+    Ok(AuthTokens {
+        access_token: tokens.access_token.to_string(),
+        token_type: tokens.token_type.to_string(),
+        expires_in: tokens.expires_in.get(),
+        refresh_token: tokens.refresh_token.map(|t| t.to_string()),
+        refresh_expires_in: tokens.refresh_expires_in.map(|n| n.get()),
+        acr: session.acr,
+        amr: session.amr.iter().map(|a| a.to_string()).collect(),
+    })
+}
+
+/// Build the request envelope (issuer/recipient/issuedAt) for an auth payload.
+fn envelope_doc<P: Payload>(env: &AuthEnvelope, payload: P) -> Result<TrustTask<P>, FfiError> {
+    let issued_at = DateTime::parse_from_rfc3339(&env.issued_at)
+        .map_err(|e| FfiError::InvalidInput {
+            reason: format!("issued_at is not an RFC 3339 timestamp: {e}"),
+        })?
+        .with_timezone(&chrono::Utc);
+    let mut doc = TrustTask::for_payload(env.id.clone(), payload);
+    doc.issuer = Some(env.holder_did.clone());
+    doc.recipient = Some(env.vta_did.clone());
+    doc.issued_at = Some(issued_at);
+    Ok(doc)
+}
+
+fn serialize<P: serde::Serialize>(doc: &TrustTask<P>) -> Result<String, FfiError> {
+    serde_json::to_string(doc).map_err(|e| FfiError::InvalidInput {
+        reason: format!("failed to serialize auth document: {e}"),
+    })
+}
+
+fn conv<E: ::std::fmt::Display>(e: E) -> FfiError {
+    FfiError::InvalidInput {
+        reason: e.to_string(),
+    }
+}
+
+fn decode<E: ::std::fmt::Display>(e: E) -> FfiError {
+    FfiError::Decode {
+        reason: format!("not a valid auth document: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env() -> AuthEnvelope {
+        AuthEnvelope {
+            id: "auth-1".to_string(),
+            holder_did: "did:key:zHolder".to_string(),
+            vta_did: "did:web:vta.example".to_string(),
+            issued_at: "2026-05-30T10:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn challenge_request_has_no_proof_and_right_type() {
+        let json = build_auth_challenge(env(), Some("did:key:zHolder".into()), None).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "https://trusttasks.org/spec/auth/challenge/0.1");
+        assert_eq!(v["issuer"], "did:key:zHolder");
+        assert_eq!(v["recipient"], "did:web:vta.example");
+        assert!(v.get("proof").is_none());
+    }
+
+    #[test]
+    fn authenticate_is_signed_and_verifies_against_the_holder_key() {
+        use ed25519_dalek::{Signer as _, SigningKey};
+        use multibase::Base;
+
+        let sk = SigningKey::from_bytes(&[42u8; 32]);
+        let pk = sk.verifying_key();
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(pk.as_bytes());
+        let mb = multibase::encode(Base::Base58Btc, mc);
+        let did = format!("did:key:{mb}");
+
+        struct EnclaveStub {
+            sk: SigningKey,
+            did: String,
+        }
+        impl Signer for EnclaveStub {
+            fn did(&self) -> String {
+                self.did.clone()
+            }
+            fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>, FfiError> {
+                Ok(self.sk.sign(&payload).to_bytes().to_vec())
+            }
+        }
+
+        let e = AuthEnvelope {
+            id: "auth-2".to_string(),
+            holder_did: did.clone(),
+            vta_did: "did:web:vta.example".to_string(),
+            issued_at: "2026-05-30T10:00:00Z".to_string(),
+        };
+        let json = build_authenticate(
+            e,
+            "VHJhbnNmZXJDb25maXJtTm9uY2VYWQ".to_string(),
+            "sess-1".to_string(),
+            vec!["vault-read".to_string()],
+            Box::new(EnclaveStub {
+                sk,
+                did: did.clone(),
+            }),
+        )
+        .unwrap();
+
+        let doc: TrustTask<authenticate::Payload> = serde_json::from_str(&json).unwrap();
+        let proof = doc.proof.clone().expect("authenticate must be signed");
+        let di: affinidi_data_integrity::DataIntegrityProof =
+            serde_json::from_value(serde_json::to_value(&proof).unwrap()).unwrap();
+        assert_eq!(di.verification_method, format!("{did}#{mb}"));
+
+        let mut unsigned = doc;
+        unsigned.proof = None;
+        di.verify_with_public_key(
+            &unsigned,
+            pk.as_bytes(),
+            affinidi_data_integrity::VerifyOptions::default(),
+        )
+        .expect("the authenticate proof must verify against the holder key");
+    }
+
+    #[test]
+    fn parses_authenticate_response_tokens() {
+        let json = r#"{
+          "id": "r-1",
+          "type": "https://trusttasks.org/spec/auth/authenticate/0.1#response",
+          "issuer": "did:web:vta.example",
+          "recipient": "did:key:zHolder",
+          "payload": {
+            "session": {
+              "id": "sess-1",
+              "subject": "did:key:zHolder",
+              "issuedAt": "2026-05-30T10:00:01Z",
+              "expiresAt": "2026-05-30T10:30:01Z",
+              "amr": ["did"],
+              "acr": "aal1"
+            },
+            "tokens": {
+              "accessToken": "eyJhbGciOi.access",
+              "tokenType": "Bearer",
+              "expiresIn": 900,
+              "refreshToken": "rt_abc",
+              "refreshExpiresIn": 86400
+            }
+          }
+        }"#;
+        let t = parse_authenticate_response(json.to_string()).unwrap();
+        assert_eq!(t.access_token, "eyJhbGciOi.access");
+        assert_eq!(t.token_type, "Bearer");
+        assert_eq!(t.expires_in, 900);
+        assert_eq!(t.refresh_token.as_deref(), Some("rt_abc"));
+        assert_eq!(t.refresh_expires_in, Some(86400));
+        assert_eq!(t.acr.as_deref(), Some("aal1"));
+        assert_eq!(t.amr, vec!["did".to_string()]);
+    }
+}

--- a/vta-mobile-core/src/stepup.rs
+++ b/vta-mobile-core/src/stepup.rs
@@ -9,15 +9,13 @@
 //!   produces the canonical signing input, the native [`crate::keys::Signer`]
 //!   signs it in the enclave, and we assemble the proof from the signature.
 
-use affinidi_data_integrity::crypto_suites::CryptoSuite;
-use affinidi_data_integrity::{DataIntegrityProof, prepare_sign_input};
 use chrono::DateTime;
-use multibase::Base;
 use trust_tasks_rs::TrustTask;
 use trust_tasks_rs::specs::auth::step_up::approve_response::v0_1 as approve_response;
 
 use crate::error::FfiError;
 use crate::keys::Signer;
+use crate::proof::attach_did_signed_proof;
 
 /// A WebAuthn assertion produced natively (`ASAuthorization` / Credential
 /// Manager). Binary fields are base64url-encoded, mirroring
@@ -92,39 +90,7 @@ pub fn build_approve_response_did_signed(
     signer: Box<dyn Signer>,
 ) -> Result<String, FfiError> {
     let mut doc = assemble_doc(&draft, approve_response::Evidence::DidSigned)?;
-
-    // Proof config with everything but the proofValue (the "sign these bytes"
-    // request shape `prepare_sign_input` expects).
-    let mut proof_config = DataIntegrityProof {
-        type_: "DataIntegrityProof".to_string(),
-        cryptosuite: CryptoSuite::EddsaJcs2022,
-        created: Some(draft.issued_at.clone()),
-        verification_method: did_key_vm(&signer.did())?,
-        proof_purpose: "assertionMethod".to_string(),
-        proof_value: None,
-        context: None,
-    };
-
-    // Library does eddsa-jcs-2022 canonicalization + hashing of (document,
-    // proof config); the native enclave signs the result.
-    let signing_input = prepare_sign_input(&doc, &proof_config, CryptoSuite::EddsaJcs2022)
-        .map_err(|e| FfiError::InvalidInput {
-            reason: format!("failed to canonicalize for signing: {e}"),
-        })?;
-    let signature = signer.sign(signing_input)?;
-    proof_config.proof_value = Some(multibase::encode(Base::Base58Btc, signature));
-
-    // Attach as the framework proof (DataIntegrityProof -> trust_tasks_rs::Proof
-    // via their shared JSON shape).
-    let proof_json = serde_json::to_value(&proof_config).map_err(|e| FfiError::InvalidInput {
-        reason: format!("proof serialize: {e}"),
-    })?;
-    doc.proof = Some(
-        serde_json::from_value(proof_json).map_err(|e| FfiError::InvalidInput {
-            reason: format!("proof shape: {e}"),
-        })?,
-    );
-
+    attach_did_signed_proof(&mut doc, &*signer, &draft.issued_at)?;
     serialize(&doc)
 }
 
@@ -163,18 +129,6 @@ fn serialize(doc: &TrustTask<approve_response::Payload>) -> Result<String, FfiEr
     serde_json::to_string(doc).map_err(|e| FfiError::InvalidInput {
         reason: format!("failed to serialize approve-response: {e}"),
     })
-}
-
-/// Derive the verification-method URI for a `did:key` holder. The mobile holder
-/// key is always a `did:key` (per the engine's design), whose verification
-/// method is `<did>#<method-specific-id>`.
-fn did_key_vm(did: &str) -> Result<String, FfiError> {
-    let suffix = did
-        .strip_prefix("did:key:")
-        .ok_or_else(|| FfiError::InvalidInput {
-            reason: format!("the did-signed step-up gate requires a did:key holder; got {did}"),
-        })?;
-    Ok(format!("{did}#{suffix}"))
 }
 
 /// Map a `trust-tasks-rs` newtype `ConversionError` (e.g. challenge below the
@@ -273,7 +227,9 @@ mod tests {
     /// proofValue assembly are correct (a real RP would verify the same way).
     #[test]
     fn did_signed_response_verifies_against_the_holder_key() {
+        use affinidi_data_integrity::DataIntegrityProof;
         use ed25519_dalek::{Signer as _, SigningKey};
+        use multibase::Base;
 
         let sk = SigningKey::from_bytes(&[7u8; 32]);
         let pk = sk.verifying_key();


### PR DESCRIPTION
## Slice 3c — VTA authentication

Adds the VTA authentication flow to the mobile engine, built the **custody-correct** way.

`vta-sdk`'s session holds the raw private key in a keyring and talks REST — incompatible with the engine's `Signer`-callback / enclave-custody model. So instead of wrapping it, authentication is composed from the engine's own primitives as `auth/*` Trust Task documents.

### FFI surface (`session.rs`, pure build/parse)

| Function | Document | Notes |
|---|---|---|
| `build_auth_challenge` | `auth/challenge/0.1` | no proof |
| `parse_auth_challenge_response` | `…#response` | → challenge + sessionId + expiry |
| `build_authenticate` | `auth/authenticate/0.1` | **gated by an `eddsa-jcs-2022` Data Integrity proof** signed by the holder via the native `Signer` — the proof *is* the authentication |
| `parse_authenticate_response` | `…#response` | → access/refresh tokens + session |

The holder key never enters Rust: `prepare_sign_input` does the canonicalization, the native enclave `Signer` signs the result.

`AuthTokens` surfaces `tokenType` (the `Authorization` scheme), `expiresIn`, the optional refresh token + expiry, and the session `acr`/`amr` so the native layer can drive AAL state.

### Shared proof helper

Extracts the DID-signed proof construction into `proof.rs` (`attach_did_signed_proof` + `did_key_vm`) so the step-up DID-signed gate and VTA `authenticate` share one source of truth; `stepup.rs` refactored onto it.

### Verification

- `cargo test -p vta-mobile-core` — 22 passed (incl. authenticate proof verifies against the holder key via an ed25519 stand-in for the enclave; response parses tokens + session)
- `cargo clippy -p vta-mobile-core --all-targets -- -D warnings` — clean
- `cargo deny check` — ok
- Kotlin bindgen — `buildAuthChallenge` / `buildAuthenticate` / `parseAuthChallengeResponse` / `parseAuthenticateResponse` and the `Auth*` records surface with correct signatures (`buildAuthenticate` takes the `Signer` callback)
