### PR TITLE
ci(vta-mobile-core): gate the mobile cross-compile + UniFFI bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,3 +208,41 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - run: cargo check -p vta-enclave --no-default-features --features rest,didcomm,vsock-store
+
+  mobile:
+    # Cross-compile vta-mobile-core for the iOS + Android targets the app repos
+    # consume, and regenerate the UniFFI bindings. The host check/test/clippy
+    # jobs only build for the runner's own architecture; without this job a
+    # dependency or deployment-target regression that breaks the phone build
+    # (e.g. the aws-lc-sys `___chkstk_darwin` iOS link failure this job's
+    # deployment-target pin guards against) — or an FFI type that no longer
+    # generates bindings — would land green. macOS runner because iOS needs
+    # Xcode; the macOS image also ships the Android NDK.
+    name: Mobile build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-mobile-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-mobile-
+            ${{ runner.os }}-cargo-
+
+      - name: Cross-compile (iOS + Android) and generate bindings
+        run: |
+          export ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-$ANDROID_NDK_LATEST_HOME}"
+          ./vta-mobile-core/scripts/build-mobile.sh all

--- a/vta-mobile-core/scripts/build-mobile.sh
+++ b/vta-mobile-core/scripts/build-mobile.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Cross-compile vta-mobile-core for the mobile targets and generate the
+# Kotlin/Swift bindings. This is the buildability gate: it proves the engine
+# links into the artifacts the app repos consume (Android .so via the NDK, iOS
+# static/dylib for the xcframework) and that the UniFFI surface still generates.
+# It does NOT package or publish the AAR / xcframework — that is a later slice.
+#
+# Run locally:
+#   vta-mobile-core/scripts/build-mobile.sh            # all platforms
+#   vta-mobile-core/scripts/build-mobile.sh ios        # iOS + bindgen only (no NDK needed)
+#   vta-mobile-core/scripts/build-mobile.sh android    # Android only (needs the NDK)
+#
+# Requirements:
+#   - iOS    : a macOS host with Xcode CLT; rust targets below.
+#   - Android: cargo-ndk + an Android NDK (ANDROID_NDK_HOME / ANDROID_NDK_ROOT /
+#              ANDROID_NDK_LATEST_HOME); rust targets below.
+#
+# ── Deployment / API floor (load-bearing — do not lower without re-checking the
+#    link) ─────────────────────────────────────────────────────────────────────
+# IPHONEOS_DEPLOYMENT_TARGET is pinned to 16.0 on purpose. The dependency tree
+# pulls aws-lc-sys (transitively, via the resolver/DIDComm rustls stack), whose
+# assembly references `___chkstk_darwin`. Rust's default iOS deployment target
+# (10.0) predates that runtime symbol, so the device link fails with
+# "Undefined symbols for architecture arm64: ___chkstk_darwin". 16.0 resolves it
+# and is a sane modern floor for the passkey/AAL2 APIs the agent needs. If you
+# must lower it, re-run `… ios` and confirm the link before merging.
+set -euo pipefail
+
+PLATFORMS="${1:-all}"
+PROFILE="${PROFILE:-debug}"
+IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-16.0}"
+ANDROID_API="${ANDROID_API:-24}"
+export IPHONEOS_DEPLOYMENT_TARGET
+
+# Resolve to the workspace root regardless of where the script is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$WORKSPACE_ROOT"
+
+CARGO_PROFILE_FLAG=""
+PROFILE_DIR="debug"
+if [ "$PROFILE" = "release" ]; then
+  CARGO_PROFILE_FLAG="--release"
+  PROFILE_DIR="release"
+fi
+
+IOS_TARGETS=(aarch64-apple-ios aarch64-apple-ios-sim)
+# cargo-ndk ABI names (it maps these to the android triples + NDK toolchain).
+ANDROID_ABIS=(arm64-v8a armeabi-v7a x86_64)
+
+build_ios() {
+  echo "── iOS (deployment target $IPHONEOS_DEPLOYMENT_TARGET, $PROFILE) ──"
+  for target in "${IOS_TARGETS[@]}"; do
+    echo "  • $target"
+    cargo build -p vta-mobile-core --lib --target "$target" $CARGO_PROFILE_FLAG
+  done
+}
+
+build_android() {
+  echo "── Android (min API $ANDROID_API, $PROFILE) ──"
+  if ! command -v cargo-ndk >/dev/null 2>&1; then
+    echo "  cargo-ndk not found. Install with: cargo install cargo-ndk --locked" >&2
+    exit 1
+  fi
+  local ndk_args=()
+  for abi in "${ANDROID_ABIS[@]}"; do ndk_args+=(-t "$abi"); done
+  cargo ndk "${ndk_args[@]}" -p "$ANDROID_API" -o "target/mobile/jniLibs" \
+    build -p vta-mobile-core --lib $CARGO_PROFILE_FLAG
+}
+
+# Generate the foreign-language bindings from the host build and assert the
+# expected entry-point files exist — this is what catches an FFI surface that
+# no longer generates (e.g. an unsupported type slipped into an exported fn).
+check_bindings() {
+  echo "── UniFFI bindings (kotlin + swift) ──"
+  cargo build -p vta-mobile-core --lib $CARGO_PROFILE_FLAG
+  local lib=""
+  for cand in "target/$PROFILE_DIR/libvta_mobile_core.dylib" \
+              "target/$PROFILE_DIR/libvta_mobile_core.so"; do
+    if [ -f "$cand" ]; then lib="$cand"; break; fi
+  done
+  if [ -z "$lib" ]; then
+    echo "  could not find the built libvta_mobile_core dynamic library" >&2
+    exit 1
+  fi
+  local out="target/bindings"
+  rm -rf "$out"
+  for lang in kotlin swift; do
+    cargo run -p vta-mobile-core --bin uniffi-bindgen -- \
+      generate --library "$lib" --language "$lang" --out-dir "$out/$lang"
+  done
+  # Kotlin lands under org/openvtc/vta/mobilecore/, Swift as VtaMobileCore.swift
+  # (see uniffi.toml). Assert each language produced output.
+  test -n "$(find "$out/kotlin" -name '*.kt' -print -quit)" \
+    || { echo "  no Kotlin bindings generated" >&2; exit 1; }
+  test -n "$(find "$out/swift" -name '*.swift' -print -quit)" \
+    || { echo "  no Swift bindings generated" >&2; exit 1; }
+  echo "  bindings generated under $out/{kotlin,swift}"
+}
+
+case "$PLATFORMS" in
+  ios)     build_ios; check_bindings ;;
+  android) build_android; check_bindings ;;
+  all)     build_ios; build_android; check_bindings ;;
+  *) echo "usage: $0 [ios|android|all]" >&2; exit 2 ;;
+esac
+
+echo "mobile build gate: OK"

--- a/vta-mobile-core/scripts/build-mobile.sh
+++ b/vta-mobile-core/scripts/build-mobile.sh
@@ -65,7 +65,10 @@ build_android() {
   fi
   local ndk_args=()
   for abi in "${ANDROID_ABIS[@]}"; do ndk_args+=(-t "$abi"); done
-  cargo ndk "${ndk_args[@]}" -p "$ANDROID_API" -o "target/mobile/jniLibs" \
+  # NOTE: `--platform` (the API level), spelled in full on purpose. cargo-ndk's
+  # short `-p` was dropped in v4; `-p 24` is forwarded to cargo as `--package 24`
+  # and panics with "unknown package: 24".
+  cargo ndk "${ndk_args[@]}" --platform "$ANDROID_API" -o "target/mobile/jniLibs" \
     build -p vta-mobile-core --lib $CARGO_PROFILE_FLAG
 }
 


### PR DESCRIPTION
## Slice — mobile build + CI gate

Reviewing the engine, I found the auth lifecycle complete (challenge → authenticate → refresh → whoami → revoke) but one thing unverified: **the crate had never been compiled for a phone**, and CI didn't gate it. I probed it — and it **did not build for iOS**:

```
Undefined symbols for architecture arm64: "___chkstk_darwin",
  referenced from ... in libaws_lc_sys ... bcm.o
```

**Root cause:** the dep tree pulls `aws-lc-sys` (transitively, via the resolver/DIDComm rustls stack); its assembly references `___chkstk_darwin`, a runtime symbol absent at Rust's default iOS deployment target (**10.0**). Pinning `IPHONEOS_DEPLOYMENT_TARGET=16.0` resolves the link — the full iOS device + simulator build then succeeds. (I first hypothesised the dependency itself couldn't cross-compile and tried feature-trimming the resolver; building it disproved that — it's purely the deployment target. The trim was reverted.)

### What this adds

- **`vta-mobile-core/scripts/build-mobile.sh`** — cross-compiles:
  - **iOS**: `aarch64-apple-ios` (device) + `aarch64-apple-ios-sim`, deployment target **16.0**
  - **Android**: `arm64-v8a` / `armeabi-v7a` / `x86_64` via `cargo-ndk`, min API **24**
  
  …then generates the **Kotlin + Swift** bindings and asserts each produced output. Runnable locally: `build-mobile.sh ios | android | all`. The deployment-target rationale lives in the script header.
- **A `mobile` CI job** (macOS runner — iOS needs Xcode; the image also ships the Android NDK) that runs the script on every PR. A dependency/deployment-target regression that breaks the phone build, or an FFI type that no longer generates bindings, can no longer land green.

### Scope

No artifact packaging/publishing yet (the AAR/xcframework + registry is a later slice). This is the **buildability + bindings gate** that slice — and the app repos — depend on.

### Verification

- **iOS + bindgen leg verified locally**: `build-mobile.sh ios` → `mobile build gate: OK`; `libvta_mobile_core.{a,dylib}` produced for `aarch64-apple-ios`; Kotlin (`org/openvtc/vta/mobilecore/vta_mobile_core.kt`) + Swift (`VtaMobileCore.swift` + header + modulemap) generated.
- **Android leg** runs first in CI (no NDK on the dev host); it follows `cargo-ndk`'s standard usage.
- CI YAML validated; script passes `bash -n`.

> Decisions baked in (adjustable): iOS min **16.0**, Android min API **24**.
