### PR TITLE
chore(deny): ignore unmaintained bincode + paste advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -133,6 +133,25 @@ ignore = [
   Drop when aws-nitro-enclaves-nsm-api migrates to ciborium (or
   a maintained CBOR library).
   """ },
+
+  { id = "RUSTSEC-2025-0141", reason = """
+  bincode 1.3.x is unmaintained. Build-time only: pulled solely by
+  uniffi_macros (the proc-macro behind vta-mobile-core's #[uniffi::export]
+  scaffolding) to serialise binding metadata at compile time. No runtime
+  presence in any shipped binary; it never touches attacker-influenced
+  input.
+
+  Drop when uniffi (0.28.x) updates to bincode 2.x or drops it.
+  """ },
+
+  { id = "RUSTSEC-2024-0436", reason = """
+  paste 1.0.x is unmaintained. Build-time only: a proc-macro for token
+  pasting pulled by uniffi_core / uniffi_bindgen (again via
+  vta-mobile-core's UniFFI scaffolding). No runtime code; "unmaintained"
+  is the only flagged risk.
+
+  Drop when uniffi (0.28.x) removes its `paste` dependency.
+  """ },
 ]
 
 # License policy. Allow-list is derived from the actual licenses present


### PR DESCRIPTION
## Fix main's red cargo-deny

`cargo-deny` is failing on `main` with two newly-published **unmaintained** advisories (advisory-DB drift — they fail every branch, including unrelated PRs):

| ID | Crate | Path |
|---|---|---|
| `RUSTSEC-2025-0141` | bincode 1.3.x | `uniffi_macros` (proc-macro) |
| `RUSTSEC-2024-0436` | paste 1.0.x | `uniffi_core` / `uniffi_bindgen` |

Both enter **exclusively through `uniffi` → `vta-mobile-core`**, are **build-time-only proc-macro** deps with no runtime presence, and neither touches attacker-influenced input — "unmaintained" is the only flagged risk (not a vulnerability).

Adds justified `ignore` entries matching the existing `deny.toml` pattern, each with a drop-when-`uniffi`-updates condition.

### Verification

`cargo deny check advisories bans sources licenses` → `advisories ok, bans ok, licenses ok, sources ok` (exit 0). No dependency or lockfile change.
