### PR TITLE
fix(vtc-service): de-flake wallet_login_rejects_tampered_signature

### DIFF
--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -267,9 +267,20 @@ async fn wallet_login_rejects_tampered_signature() {
         now,
         now + 300,
     );
-    // Flip the last signature character.
-    id_token.pop();
-    id_token.push(if id_token.ends_with('A') { 'B' } else { 'A' });
+    // Corrupt the signature. Flip a character at the START of the signature
+    // segment, not the trailing char: a 64-byte Ed25519 signature base64url-
+    // encodes to 86 chars whose final char carries only 2 significant bits, so
+    // flipping it (e.g. 'A'->'B') decodes to the same signature bytes under a
+    // lenient decoder and leaves the token validly signed (~25% of runs, since
+    // the per-run challenge randomises the signature). A leading char carries a
+    // full 6 bits, so the flip always changes the signature → reliably invalid.
+    let sig_start = id_token.rfind('.').expect("jws has a signature segment") + 1;
+    let replacement = if id_token.as_bytes()[sig_start] == b'A' {
+        'B'
+    } else {
+        'A'
+    };
+    id_token.replace_range(sig_start..sig_start + 1, &replacement.to_string());
 
     let (status, _) = post_json(
         &fix.router,


### PR DESCRIPTION
## Fix main's flaky Test job

`wallet_login_rejects_tampered_signature` fails ~25% of runs on `main` (it failed on one CI run of an unrelated PR and passed on a near-identical re-run — the tell of a flake). **The server is correct; the test's tamper is flawed.**

### Root cause

The test corrupts the `id_token` by flipping its **last** base64url character between `A`/`B`:

```rust
id_token.pop();
id_token.push(if id_token.ends_with('A') { 'B' } else { 'A' });
```

A 64-byte Ed25519 signature base64url-encodes (`URL_SAFE_NO_PAD`) to 86 chars whose **final char carries only 2 significant bits**. `A`(0) and `B`(1) decode to the same trailing bits under a lenient decoder, so the flip is frequently a **no-op** — the signature stays valid, the server returns 200, and the test (asserting 401) fails. The per-run random challenge re-randomises the signature each run, so the last char is `A` (the no-op case) ~25% of the time.

Reproduced locally: **4/30 failures** before the fix.

### Fix

Flip a character at the **start** of the signature segment. A leading base64url char carries a full 6 significant bits, so the change always alters the decoded signature → the token is reliably invalid.

### Verification

- **30/30 pass** after the fix (was 26/30).
- Full `wallet_login_siop` suite: 7/7 green.
- `cargo fmt` + `cargo clippy -p vtc-service --tests -- -D warnings` clean.

Test-only change; no production code touched.
