### PR TITLE
feat(vta-mobile-core): package the iOS xcframework + SwiftPM checksum

### DIFF
--- a/vta-mobile-core/scripts/package-ios.sh
+++ b/vta-mobile-core/scripts/package-ios.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Assemble the iOS distribution artifacts for vta-mobile-core:
+#
+#   target/mobile/ios/VtaMobileCore.xcframework       — device + simulator static libs
+#   target/mobile/ios/VtaMobileCore.xcframework.zip   — the binaryTarget payload
+#   target/mobile/ios/VtaMobileCore.xcframework.zip.sha256  — SwiftPM checksum
+#   target/mobile/ios/Sources/VtaMobileCore.swift     — the Swift API wrapper (compiled by the consumer)
+#
+# Distribution (decided): the .zip is uploaded to a GitHub Release and consumed
+# from the vta-mobile-agent-ios SwiftPM package via
+#   .binaryTarget(url: "…/VtaMobileCore.xcframework.zip", checksum: "<sha256>")
+# alongside the VtaMobileCore.swift source. This script only *produces* the
+# artifacts + checksum; the tag-triggered release workflow publishes them.
+#
+# macOS + Xcode only. Run: vta-mobile-core/scripts/package-ios.sh
+#
+# IPHONEOS_DEPLOYMENT_TARGET is pinned to 16.0 for the same reason as
+# build-mobile.sh: aws-lc-sys's assembly references `___chkstk_darwin`, absent
+# at Rust's default iOS target (10.0), so the device link fails below 16.0.
+set -euo pipefail
+
+PROFILE="${PROFILE:-release}"
+IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-16.0}"
+export IPHONEOS_DEPLOYMENT_TARGET
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$WORKSPACE_ROOT"
+
+CARGO_PROFILE_FLAG=""
+PROFILE_DIR="debug"
+if [ "$PROFILE" = "release" ]; then
+  CARGO_PROFILE_FLAG="--release"
+  PROFILE_DIR="release"
+fi
+
+DEVICE_TARGET="aarch64-apple-ios"
+SIM_TARGETS=(aarch64-apple-ios-sim x86_64-apple-ios)
+LIB="libvta_mobile_core.a"
+OUT="target/mobile/ios"
+STAGE="$OUT/staging"
+
+rm -rf "$OUT"
+mkdir -p "$STAGE/headers" "$OUT/Sources"
+
+echo "── Building static libs (deployment target $IPHONEOS_DEPLOYMENT_TARGET, $PROFILE) ──"
+for target in "$DEVICE_TARGET" "${SIM_TARGETS[@]}"; do
+  echo "  • $target"
+  cargo build -p vta-mobile-core --lib --target "$target" $CARGO_PROFILE_FLAG
+done
+
+# A static-library xcframework needs one slice per platform. The device slice
+# is a single arch; the simulator slice fuses the arm64 + x86_64 sim libs with
+# lipo (one xcframework slice cannot list two libraries for the same platform).
+echo "── Fusing simulator slice (arm64 + x86_64) ──"
+SIM_FAT="$STAGE/sim/$LIB"
+mkdir -p "$STAGE/sim"
+lipo -create \
+  "target/aarch64-apple-ios-sim/$PROFILE_DIR/$LIB" \
+  "target/x86_64-apple-ios/$PROFILE_DIR/$LIB" \
+  -output "$SIM_FAT"
+
+# Generate the Swift bindings from a host build (the generated source + C header
+# + modulemap are target-independent). The .swift is the consumer-compiled API;
+# the header + modulemap travel *inside* the xcframework so the static lib's
+# C symbols are importable.
+echo "── Generating Swift bindings ──"
+cargo build -p vta-mobile-core --lib $CARGO_PROFILE_FLAG
+HOST_LIB=""
+for cand in "target/$PROFILE_DIR/libvta_mobile_core.dylib" \
+            "target/$PROFILE_DIR/libvta_mobile_core.so"; do
+  [ -f "$cand" ] && HOST_LIB="$cand" && break
+done
+[ -n "$HOST_LIB" ] || { echo "  host library not found for bindgen" >&2; exit 1; }
+BIND="$STAGE/bindings"
+cargo run -p vta-mobile-core --bin uniffi-bindgen -- \
+  generate --library "$HOST_LIB" --language swift --out-dir "$BIND"
+
+cp "$BIND/VtaMobileCore.swift" "$OUT/Sources/VtaMobileCore.swift"
+# xcframework -headers wants the C header plus a `module.modulemap` (exact name).
+cp "$BIND/VtaMobileCoreFFI.h" "$STAGE/headers/"
+cp "$BIND/VtaMobileCoreFFI.modulemap" "$STAGE/headers/module.modulemap"
+
+echo "── Assembling VtaMobileCore.xcframework ──"
+xcodebuild -create-xcframework \
+  -library "target/$DEVICE_TARGET/$PROFILE_DIR/$LIB" -headers "$STAGE/headers" \
+  -library "$SIM_FAT" -headers "$STAGE/headers" \
+  -output "$OUT/VtaMobileCore.xcframework" >/dev/null
+
+echo "── Zipping + checksum ──"
+ZIP="$OUT/VtaMobileCore.xcframework.zip"
+# `ditto --keepParent` preserves the .xcframework dir at the zip root, as
+# SwiftPM's binaryTarget unpacking expects.
+ditto -c -k --keepParent "$OUT/VtaMobileCore.xcframework" "$ZIP"
+
+# SwiftPM's own checksum (sha256 of the zip) — the value a binaryTarget pins.
+# `swift package compute-checksum` must run inside a package, so use a throwaway.
+CK_DIR="$STAGE/checksum-pkg"
+mkdir -p "$CK_DIR"
+cat > "$CK_DIR/Package.swift" <<'SWIFT'
+// swift-tools-version:5.9
+import PackageDescription
+let package = Package(name: "checksum")
+SWIFT
+CHECKSUM="$(cd "$CK_DIR" && swift package compute-checksum "$WORKSPACE_ROOT/$ZIP")"
+echo "$CHECKSUM" > "$ZIP.sha256"
+
+rm -rf "$STAGE"
+
+echo ""
+echo "iOS artifacts ready under $OUT/:"
+echo "  VtaMobileCore.xcframework(.zip)"
+echo "  Sources/VtaMobileCore.swift"
+echo "  checksum (sha256): $CHECKSUM"


### PR DESCRIPTION
## Mobile artifacts — slice 1 of 3: iOS xcframework

First slice of the artifacts pipeline (distribution decided: **GitHub Releases + SwiftPM `binaryTarget`** for iOS, GitHub Packages for the Android AAR). Builds on the mobile build gate (#169).

Adds `vta-mobile-core/scripts/package-ios.sh`, which produces the iOS distribution artifacts:

| Output (`target/mobile/ios/`) | Purpose |
|---|---|
| `VtaMobileCore.xcframework(.zip)` | the `binaryTarget` payload |
| `VtaMobileCore.xcframework.zip.sha256` | the SwiftPM checksum to pin |
| `Sources/VtaMobileCore.swift` | the Swift API wrapper the consumer compiles |

How it works:
- builds the **release** static libs for device (`aarch64-apple-ios`) + both simulator arches (`aarch64-apple-ios-sim`, `x86_64-apple-ios`) at deployment target **16.0**;
- **lipo**-fuses the simulator arches (one xcframework slice can't list two libraries for the same platform);
- generates the target-independent Swift bindings — header + modulemap go *inside* the framework, `VtaMobileCore.swift` is emitted for the consumer;
- assembles the xcframework, zips with `ditto --keepParent`, and computes the SwiftPM `compute-checksum` value.

The consumer side (a `.binaryTarget(url:checksum:)` in `vta-mobile-agent-ios`) is intentionally **not** in this repo — this repo only *produces* the artifacts.

### Verification (local, Xcode 26.2)

```
AvailableLibraries: ios-arm64, ios-arm64_x86_64-simulator
ios-arm64 lib:                arm64 (non-fat)
ios-arm64_x86_64-simulator:   x86_64 arm64 (fat)
+ VtaMobileCore.xcframework.zip, .sha256, Sources/VtaMobileCore.swift
```

### Scope

Packaging runs at **release time** (the tag-triggered publish workflow — slice 3), not on every PR; the existing `mobile` CI job already gates per-PR buildability, so this avoids doubling iOS build time on every PR. Follow-ups: **Android AAR module** (slice 2), then the **publish workflow** (slice 3).
