### PR TITLE
ci(vta-mobile-core): tag-triggered iOS xcframework release

### DIFF
--- a/.github/workflows/release-mobile-ios.yml
+++ b/.github/workflows/release-mobile-ios.yml
@@ -1,0 +1,77 @@
+name: Release mobile-core iOS xcframework
+
+# Publishes the iOS distribution artifact for vta-mobile-core. The
+# vta-mobile-agent-ios SwiftPM package consumes it as a
+# `.binaryTarget(url:checksum:)` pointing at the GitHub Release asset.
+#
+# Triggers:
+#   - push of a `vta-mobile-core-v*` tag → build AND publish a GitHub Release.
+#     (Namespaced so it does not fire on the workspace-wide `v*` release tags.)
+#   - manual workflow_dispatch → build + validate packaging only, no publish;
+#     a cheap way to smoke-test the xcframework assembly without cutting a tag.
+on:
+  push:
+    tags: ["vta-mobile-core-v*"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # create the Release + upload assets
+
+jobs:
+  ios-xcframework:
+    name: Package + publish iOS xcframework
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-ios-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-ios-
+            ${{ runner.os }}-cargo-
+
+      - name: Assemble VtaMobileCore.xcframework
+        run: ./vta-mobile-core/scripts/package-ios.sh
+
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          DOWNLOAD_BASE: ${{ github.server_url }}/${{ github.repository }}/releases/download
+        run: |
+          set -euo pipefail
+          out="target/mobile/ios"
+          checksum="$(cat "$out/VtaMobileCore.xcframework.zip.sha256")"
+          url="$DOWNLOAD_BASE/$TAG/VtaMobileCore.xcframework.zip"
+          notes="$RUNNER_TEMP/release-notes.md"
+          # Built line-by-line (no heredoc) to stay robust to YAML indentation.
+          {
+            printf '%s\n\n' "\`VtaMobileCore.xcframework\` for $TAG."
+            printf '%s\n\n' "**SwiftPM checksum (sha256):** \`$checksum\`"
+            printf '%s\n\n' "Consume from \`vta-mobile-agent-ios\`'s \`Package.swift\`:"
+            printf '%s\n' '```swift'
+            printf '%s\n' '.binaryTarget('
+            printf '%s\n' '    name: "VtaMobileCoreFFI",'
+            printf '    url: "%s",\n' "$url"
+            printf '    checksum: "%s"\n' "$checksum"
+            printf '%s\n' ')'
+            printf '%s\n\n' '```'
+            printf '%s\n' "\`VtaMobileCore.swift\` (the Swift API wrapper the consumer compiles) is attached as an asset."
+          } > "$notes"
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "vta-mobile-core iOS $TAG" \
+            --notes-file "$notes" \
+            "$out/VtaMobileCore.xcframework.zip" \
+            "$out/VtaMobileCore.xcframework.zip.sha256" \
+            "$out/Sources/VtaMobileCore.swift"


### PR DESCRIPTION
## Mobile artifacts — slice 2: iOS release workflow

Publishes the iOS distribution artifact (assembled by `package-ios.sh`, merged in #172) to a **GitHub Release**, so `vta-mobile-agent-ios` can consume it as a SwiftPM `.binaryTarget(url:checksum:)`.

### Triggers
- **`push` of a `vta-mobile-core-v*` tag** → build **and** publish a Release. Namespaced so it does **not** fire on the workspace-wide `v*` tags (v0.2.0…v0.4.0).
- **`workflow_dispatch`** → build + validate packaging only (the publish step is gated on `refs/tags/`). A cheap way to smoke-test xcframework assembly in CI without cutting a tag.

### What it does
macOS runner → install iOS Rust targets → run `scripts/package-ios.sh` → `gh release create` uploads:
- `VtaMobileCore.xcframework.zip`
- `VtaMobileCore.xcframework.zip.sha256`
- `Sources/VtaMobileCore.swift`

The release notes carry the SwiftPM checksum and a ready-to-paste `.binaryTarget` snippet pointing at the asset URL.

### Verification
- Workflow YAML structure confirmed (triggers, `vta-mobile-core-v*` tag filter, publish step guarded by `startsWith(github.ref, 'refs/tags/')`).
- The publish step's shell + rendered markdown notes were **run locally** with dummy values (`bash -n` clean; notes render correctly with the real URL/checksum).
- Notes are built line-by-line with `printf` (no heredoc) to stay robust to YAML block-scalar indentation.
- xcframework assembly itself verified end-to-end in #172.

> First real publish happens when you push a `vta-mobile-core-v0.1.0` tag (or trigger `workflow_dispatch` to dry-run the build). Next slice: Android AAR + its GitHub Packages publish.
