### PR TITLE
docs(vtc): ceremony decision pipeline design bundle

### DIFF
--- a/docs/05-design-notes/examples/README.md
+++ b/docs/05-design-notes/examples/README.md
@@ -1,0 +1,69 @@
+# Ceremony policy examples
+
+Concrete, illustrative companions to [`../vtc-ceremony-catalog.md`](../vtc-ceremony-catalog.md). Each ceremony
+has its **Rule IR** (`*.ir.json`) and the **compiled Rego** (`*.rego`) that the
+[`../vtc-ceremony-rule-ir.md`](../vtc-ceremony-rule-ir.md) compiler emits from it. The Rego reads a `VerifiedFacts`
+`input` ([pipeline §3](../vtc-ceremony-pipeline.md)) and returns a `decision` verdict ([pipeline §4](../vtc-ceremony-pipeline.md)).
+
+> These are **design illustrations**, not shipped policy. They use `import future.keywords` for broad
+> `regorus`/`opa` compatibility. The no-last-admin guard (leave) and privilege ceiling (join) are **host-enforced**
+> around the policy, not in Rego.
+
+## Files
+
+| Ceremony | IR | Rego | Shows |
+|---|---|---|---|
+| Join | `join.ir.json` | `join.rego` | all four verdicts incl. `request_more` |
+| Leave | `leave.ir.json` | `leave.rego` | `actor ≠ subject`, `allow.with.disposition`, `refer` for admin-removes-admin |
+| Role-change | `role-change.ir.json` | `role-change.rego` | in-place mutation; `allow` **may** grant `admin` (the sanctioned path, gated by step-up); `refer` = escalation |
+| Directory | `directory.ir.json` | `directory.rego` | synchronous read; `allow.with.fields` is a **projection**, not a boolean |
+
+IR convention: a `then.with.disposition` of `"$request"` means "the disposition the actor requested, else
+`PolicyDefault`" — the compiler emits the `disposition` helper for it (see `leave.rego`).
+
+## Run them
+
+```sh
+# OPA
+opa eval -d join.rego        -i facts.join.json        'data.vtc.join.decision'
+opa eval -d leave.rego       -i facts.leave.json       'data.vtc.leave.decision'
+opa eval -d role-change.rego -i facts.role-change.json 'data.vtc.role_change.decision'
+opa eval -d directory.rego   -i facts.directory.json   'data.vtc.directory.decision'
+```
+
+(`regorus eval` works equivalently against the same files.)
+
+## Test vectors (sample `input` → expected verdict)
+
+**Join** — `facts.join.json`: a trusted `WitnessCredential`, no code-of-conduct agreement yet.
+First-match falls past *Verified human* (agreement missing) to *Almost there*:
+```json
+{ "effect": "request_more", "with": { "needs": ["agreed:code-of-conduct"], "presentation_definition": { "id": "vtc-join-coc" } } }
+```
+Add `"agreements": {"code-of-conduct": true}` under `evidence.request` and re-run → *Verified human* matches:
+```json
+{ "effect": "allow", "with": { "role": "member", "obligations": ["reciprocate_vmc"] } }
+```
+
+**Leave** — `facts.leave.json`: an admin removing a non-admin member. Falls to *Admin removes member*:
+```json
+{ "effect": "allow", "with": { "disposition": "Tombstone" } }
+```
+(If `state.subject_member.role` were `"admin"`, *Admin removes admin* matches → `refer` to `second-admin`. If the
+removal would empty the admin set, the **host** refuses before effects regardless of this verdict.)
+
+**Role-change** — `facts.role-change.json`: an admin requesting to promote a moderator to `admin`, **without**
+step-up. *Standard* doesn't match (target is admin), *Promote-verified* needs `step_up`, so it falls to
+*Promote (needs step-up)*:
+```json
+{ "effect": "refer", "with": { "queue": "step-up" } }
+```
+(Set `"step_up": true` → *Promote-verified* matches → `allow` with `role: admin`. A standard target like
+`"moderator"` matches *Standard role change* → `allow` with `role: <target>`. Note role-change legitimately
+grants `admin` here — that's its job; the privilege ceiling only constrains *join*.)
+
+**Directory** — `facts.directory.json`: an authenticated member viewing another member. Falls to *Member viewer*:
+```json
+{ "effect": "allow", "with": { "fields": ["did", "role"] } }
+```
+(An admin viewer matches *Admin viewer* → the full field set. A non-member hits the structural default → `deny`.)

--- a/docs/05-design-notes/examples/directory.ir.json
+++ b/docs/05-design-notes/examples/directory.ir.json
@@ -1,0 +1,15 @@
+{
+  "purpose": "directory",
+  "routes": [
+    {
+      "name": "Admin viewer",
+      "when": { "all": ["viewer_is_admin"] },
+      "then": { "effect": "allow", "with": { "fields": ["did", "role", "joined_at", "status", "extensions"] } }
+    },
+    {
+      "name": "Member viewer",
+      "when": { "all": ["viewer_is_member"] },
+      "then": { "effect": "allow", "with": { "fields": ["did", "role"] } }
+    }
+  ]
+}

--- a/docs/05-design-notes/examples/directory.rego
+++ b/docs/05-design-notes/examples/directory.rego
@@ -1,0 +1,20 @@
+package vtc.directory
+
+import future.keywords.if
+
+# Compiled from directory.ir.json by the VTC Rule IR compiler (illustrative).
+# A SYNCHRONOUS read ceremony: `allow` carries a FIELD PROJECTION, not a boolean.
+# No thread, no state write — the host returns exactly `with.fields` of the subject.
+
+# structural totality — a non-member sees nothing
+default decision := {"effect": "deny", "with": {"code": "not-a-member"}}
+
+# P1 Admin viewer — full record
+decision := {"effect": "allow", "with": {"fields": ["did", "role", "joined_at", "status", "extensions"]}} if {
+	input.actor.role == "admin"
+}
+
+# P2 Member viewer — minimal projection
+else := {"effect": "allow", "with": {"fields": ["did", "role"]}} if {
+	input.actor.authenticated == true
+}

--- a/docs/05-design-notes/examples/facts.directory.json
+++ b/docs/05-design-notes/examples/facts.directory.json
@@ -1,0 +1,9 @@
+{
+  "purpose": "directory",
+  "now": "2026-05-30T12:00:00Z",
+  "actor": { "did": "did:key:z6MkViewer", "role": "member", "authenticated": true },
+  "subject": { "did": "did:key:z6MkTarget" },
+  "context": { "community_did": "did:webvh:acme.example", "channel": "rest", "member_count": 1421 },
+  "evidence": { "request": { "fields_requested": ["did", "role", "joined_at"] } },
+  "state": { "subject_member": { "role": "member", "status": "active", "joined_at": "2026-03-03T00:00:00Z" } }
+}

--- a/docs/05-design-notes/examples/facts.join.json
+++ b/docs/05-design-notes/examples/facts.join.json
@@ -1,0 +1,19 @@
+{
+  "purpose": "join",
+  "now": "2026-05-30T12:00:00Z",
+  "actor": { "did": "did:key:z6MkHuman", "authenticated": true },
+  "subject": { "did": "did:key:z6MkHuman" },
+  "context": { "community_did": "did:webvh:acme.example", "channel": "rest", "member_count": 1421 },
+  "evidence": {
+    "invitation": null,
+    "presentation": {
+      "verified": true,
+      "holder": "did:key:z6MkHuman",
+      "credentials": [
+        { "type": "WitnessCredential", "issuer": "did:webvh:notary.example", "issuer_trusted": true, "status": "valid", "claims": { "kind": "proximity" } }
+      ]
+    },
+    "request": { "agreements": {} }
+  },
+  "state": { "subject_member": null }
+}

--- a/docs/05-design-notes/examples/facts.leave.json
+++ b/docs/05-design-notes/examples/facts.leave.json
@@ -1,0 +1,9 @@
+{
+  "purpose": "leave",
+  "now": "2026-05-30T12:00:00Z",
+  "actor": { "did": "did:key:z6MkAdmin", "role": "admin", "authenticated": true },
+  "subject": { "did": "did:key:z6MkLeaver" },
+  "context": { "community_did": "did:webvh:acme.example", "channel": "rest", "member_count": 1421 },
+  "evidence": { "request": { "reason": "code-of-conduct-violation" } },
+  "state": { "subject_member": { "role": "member", "status": "active", "joined_at": "2026-01-02T00:00:00Z" } }
+}

--- a/docs/05-design-notes/examples/facts.role-change.json
+++ b/docs/05-design-notes/examples/facts.role-change.json
@@ -1,0 +1,9 @@
+{
+  "purpose": "role-change",
+  "now": "2026-05-30T12:00:00Z",
+  "actor": { "did": "did:key:z6MkAdmin", "role": "admin", "authenticated": true },
+  "subject": { "did": "did:key:z6MkTarget" },
+  "context": { "community_did": "did:webvh:acme.example", "channel": "rest", "member_count": 1421 },
+  "evidence": { "request": { "target_role": "admin", "step_up": false } },
+  "state": { "subject_member": { "role": "moderator", "status": "active", "joined_at": "2026-02-02T00:00:00Z" } }
+}

--- a/docs/05-design-notes/examples/join.ir.json
+++ b/docs/05-design-notes/examples/join.ir.json
@@ -1,0 +1,26 @@
+{
+  "purpose": "join",
+  "routes": [
+    {
+      "name": "Invitation",
+      "listed": false,
+      "when": { "all": ["has_valid_invitation"] },
+      "then": { "effect": "allow", "with": { "role": "member", "obligations": ["reciprocate_vmc"] } }
+    },
+    {
+      "name": "Verified human",
+      "when": { "all": [ { "holds_trusted": "WitnessCredential" }, { "agreed": "code-of-conduct" } ] },
+      "then": { "effect": "allow", "with": { "role": "member", "obligations": ["reciprocate_vmc"] } }
+    },
+    {
+      "name": "Almost there",
+      "when": { "all": [ { "holds_trusted": "WitnessCredential" } ] },
+      "then": { "effect": "request_more", "with": { "needs": ["agreed:code-of-conduct"] } }
+    },
+    {
+      "name": "Open review",
+      "when": { "all": ["always"] },
+      "then": { "effect": "refer", "with": { "queue": "moderator" } }
+    }
+  ]
+}

--- a/docs/05-design-notes/examples/join.rego
+++ b/docs/05-design-notes/examples/join.rego
@@ -1,0 +1,61 @@
+package vtc.join
+
+import future.keywords.if
+import future.keywords.in
+
+# Compiled from join.ir.json by the VTC Rule IR compiler (illustrative).
+# Crypto (signatures, holder-binding, revocation, issuer-trust) is resolved by the
+# host BEFORE evaluation; this policy reasons only over verified facts in `input`.
+# The privilege ceiling (no admin via join) is host-enforced, not encoded here.
+
+# structural totality — compiler-appended, operator cannot remove
+default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}
+
+# P1 Invitation (unlisted)
+decision := {"effect": "allow", "with": {"role": "member", "obligations": ["reciprocate_vmc"]}} if {
+	has_valid_invitation
+}
+
+# P2 Verified human
+else := {"effect": "allow", "with": {"role": "member", "obligations": ["reciprocate_vmc"]}} if {
+	cred_trusted("WitnessCredential")
+	agreed("code-of-conduct")
+}
+
+# P3 Almost there
+else := {"effect": "request_more", "with": {"needs": ["agreed:code-of-conduct"], "presentation_definition": {"id": "vtc-join-coc"}}} if {
+	cred_trusted("WitnessCredential")
+}
+
+# P4 Open review (catch-all)
+else := {"effect": "refer", "with": {"queue": "moderator"}} if {
+	true
+}
+
+# ---- helpers ----
+cred_held(t) if {
+	some c in input.evidence.presentation.credentials
+	c.type == t
+	c.status == "valid"
+}
+
+cred_trusted(t) if {
+	some c in input.evidence.presentation.credentials
+	c.type == t
+	c.issuer_trusted
+	c.status == "valid"
+}
+
+endorsement_count := count([c |
+	some c in input.evidence.presentation.credentials
+	c.type == "EndorsementCredential"
+])
+
+has_valid_invitation if {
+	input.evidence.invitation.verified
+	not input.evidence.invitation.consumed
+}
+
+agreed(tag) if {
+	input.evidence.request.agreements[tag] == true
+}

--- a/docs/05-design-notes/examples/leave.ir.json
+++ b/docs/05-design-notes/examples/leave.ir.json
@@ -1,0 +1,20 @@
+{
+  "purpose": "leave",
+  "routes": [
+    {
+      "name": "Self-exit",
+      "when": { "all": ["actor_is_self"] },
+      "then": { "effect": "allow", "with": { "disposition": "$request" } }
+    },
+    {
+      "name": "Admin removes admin",
+      "when": { "all": ["actor_is_admin", "subject_is_admin"] },
+      "then": { "effect": "refer", "with": { "queue": "second-admin" } }
+    },
+    {
+      "name": "Admin removes member",
+      "when": { "all": ["actor_is_admin"] },
+      "then": { "effect": "allow", "with": { "disposition": "Tombstone" } }
+    }
+  ]
+}

--- a/docs/05-design-notes/examples/leave.rego
+++ b/docs/05-design-notes/examples/leave.rego
@@ -1,0 +1,32 @@
+package vtc.leave
+
+import future.keywords.if
+
+# Compiled from leave.ir.json by the VTC Rule IR compiler (illustrative).
+# IMPORTANT: the no-last-admin invariant is enforced by the HOST around this policy
+# (vtc-mvp.md §10.2), NOT in Rego — a policy edit can never disable it.
+
+# structural totality — compiler-appended
+default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}
+
+# P1 Self-exit — member leaves voluntarily, choosing a disposition
+decision := {"effect": "allow", "with": {"disposition": disposition}} if {
+	input.actor.did == input.subject.did
+}
+
+# P2 Admin removing another admin → needs a second admin
+else := {"effect": "refer", "with": {"queue": "second-admin"}} if {
+	input.actor.role == "admin"
+	input.state.subject_member.role == "admin"
+}
+
+# P3 Admin removing a non-admin member
+else := {"effect": "allow", "with": {"disposition": "Tombstone"}} if {
+	input.actor.role == "admin"
+}
+
+# ---- helpers ----
+# "$request" in the IR → the disposition the actor asked for, else PolicyDefault
+disposition := input.evidence.request.disposition if {
+	input.evidence.request.disposition
+} else := "PolicyDefault"

--- a/docs/05-design-notes/examples/role-change.ir.json
+++ b/docs/05-design-notes/examples/role-change.ir.json
@@ -1,0 +1,20 @@
+{
+  "purpose": "role-change",
+  "routes": [
+    {
+      "name": "Standard role change",
+      "when": { "all": ["target_role_standard"] },
+      "then": { "effect": "allow", "with": { "role": "$target" } }
+    },
+    {
+      "name": "Promote to admin (verified)",
+      "when": { "all": ["promotes_to_admin", "step_up_done"] },
+      "then": { "effect": "allow", "with": { "role": "admin" } }
+    },
+    {
+      "name": "Promote to admin (needs step-up)",
+      "when": { "all": ["promotes_to_admin"] },
+      "then": { "effect": "refer", "with": { "queue": "step-up" } }
+    }
+  ]
+}

--- a/docs/05-design-notes/examples/role-change.rego
+++ b/docs/05-design-notes/examples/role-change.rego
@@ -1,0 +1,31 @@
+package vtc.role_change
+
+import future.keywords.if
+
+# Compiled from role-change.ir.json by the VTC Rule IR compiler (illustrative).
+# Unlike join, role-change MAY grant "admin" — it is the sanctioned promotion
+# path, gated by step-up (and optionally M-of-N). The no-last-admin guard on
+# demotion is HOST-enforced around this policy, never in Rego.
+
+# structural totality — compiler-appended
+default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}
+
+# P1 Standard role change (member / moderator / custom)
+decision := {"effect": "allow", "with": {"role": target_role}} if {
+	input.evidence.request.target_role != "admin"
+}
+
+# P2 Promote to admin — step-up verified
+else := {"effect": "allow", "with": {"role": "admin"}} if {
+	input.evidence.request.target_role == "admin"
+	input.evidence.request.step_up == true
+}
+
+# P3 Promote to admin — needs step-up
+else := {"effect": "refer", "with": {"queue": "step-up"}} if {
+	input.evidence.request.target_role == "admin"
+}
+
+# ---- helpers ----
+# "$target" in the IR → the requested target_role
+target_role := input.evidence.request.target_role

--- a/docs/05-design-notes/vtc-ceremonies-exec-summary.md
+++ b/docs/05-design-notes/vtc-ceremonies-exec-summary.md
@@ -1,0 +1,90 @@
+# VTC Community Ceremonies — Executive Summary
+
+> **Start here.** Fronts a five-document design bundle (+ runnable examples and an interactive guide). Read in
+> the order in §5.
+
+**Status:** Design proposal for review · **Scope:** target architecture (greenfield), with an honest build-vs-reuse map
+
+---
+
+## 1. The question
+
+A community has many **governed state transitions** — joining, leaving, role changes, directory lookups,
+personhood assertions, relationship publishing. Each must be **configurable, policy-driven, auditable, and
+followable by software unattended**. How do we build them without a bespoke subsystem per ceremony?
+
+## 2. The core idea
+
+**One decision pipeline; every ceremony is an instance of it.**
+
+```
+TRIGGER → GATHER → VERIFY (host) → FACTS → EVALUATE (<purpose>.rego) → VERDICT → EFFECTS (<purpose>)
+```
+
+The expensive parts — verification, the four-valued verdict, versioning/rollback, governance, the visual
+policy compiler — are built **once** and inherited by every ceremony. Adding a new ceremony is a policy module
++ an evidence slot + an effect handler, not a new subsystem.
+
+## 3. Proven by a catalog, not asserted
+
+Four maximally-different ceremonies run through the *same* pipeline:
+
+| Ceremony | `actor`=`subject`? | Effects | Invariant | Threaded? |
+|---|---|---|---|---|
+| **Join** | yes | issue (constructive) | privilege ceiling | yes |
+| **Leave** | no | revoke (destructive) | no-last-admin | optional |
+| **Role-change** | no | re-issue (mutating) | ceiling + step-up | optional |
+| **Directory** | no | return a filter (read-only) | PII boundary | **no (sync)** |
+
+Join and Leave invert each other (constructive/self vs destructive/other); Directory is the stress test — a
+synchronous read returning a *projection*, proving threads and effects are optional, purpose-specific stages.
+
+## 4. The design in seven decisions
+
+1. **One pipeline, parameterized by purpose** — not nine bespoke flows.
+2. **Crypto only in Verify** — policy reasons over a `Verified*` view; skipping verification doesn't compile.
+3. **Four-valued verdict** — `allow / deny / refer / request_more` (the last enables negotiation + async review).
+4. **Structured Facts** — policy sees verified, typed credentials; no lossy `vp_claims` projection.
+5. **Dual artifact** — one policy compiles to Rego (enforce) + a DIF Presentation Definition (so clients
+   self-assemble evidence) + plain English.
+6. **Visual Rule IR → compiler** — operators don't write raw Rego; the compiler also checks invariants.
+7. **Append-only signed policy log** with **fail-forward rollback** and **optional M-of-N governance** — per
+   purpose, one mechanism.
+
+## 5. Suggested reading order
+
+| # | Document | What it gives you |
+|---|---|---|
+| 1 | **(this page)** | the frame |
+| 2 | [`vtc-ceremony-pipeline.md`](./vtc-ceremony-pipeline.md) | the architecture — pipeline, Facts, Verdict, invariants, versioning, **build-vs-reuse (§10)**, staged plan |
+| 3 | [`vtc-ceremony-catalog.md`](./vtc-ceremony-catalog.md) | the proof — join / leave / role-change / directory as instances, with worked examples |
+| 4 | [`vtc-ceremony-rule-ir.md`](./vtc-ceremony-rule-ir.md) | the authoring vocabulary — Rule IR grammar + compile-to-Rego mapping (the canonical source the examples & guide derive from) |
+| 5 | [`vtc-ceremony-protocol.md`](./vtc-ceremony-protocol.md) | the generalized `{family}/*` Trust Task wire protocol |
+| ▸ | [`examples/`](./examples/) | runnable IR + `.rego` + sample facts for join / leave / role-change / directory |
+| ▶ | [`vtc-ceremony-visual-guide.html`](./vtc-ceremony-visual-guide.html) | **interactive** — switch between join / leave / role-change / directory: edit routes, simulate, version & roll back, read the live-compiled Rego/PD |
+
+*Read 2 for the whole picture; 3 proves it generalizes; 4 is the canonical vocabulary; 5 is the wire detail;
+open the guide alongside 2 and the examples alongside 4.*
+
+## 6. Greenfield, but not rewrite-everything
+
+The `vtc-mvp.md` §3 cornerstones are **kept**: embedded `regorus`, VTA-mints/VTC-caches keys, VC-as-projection,
+status-list privacy, audit, the `Verified*` typestate, Trust Task discipline. The rework is concentrated in the
+ceremony/policy *modelling*: one pipeline (vs nine flows), structured Facts (vs `vp_claims`), a verdict object
+(vs boolean), a signed policy log (vs pointer+archive), default-deny (vs accept-any), the IR compiler (vs
+raw-Rego upload), and ceremony threads (vs a flat status enum). Full map in pipeline §10.
+
+## 7. What reviewers should decide
+
+(Full list in pipeline §12.) The genuine forks: **default posture** (deny vs the MVP's accept-any),
+**`acl`/`members` keyspace split** (keep vs unify), **invitation delegation** (community-only vs `can_invite`),
+**governance quorum** (single-admin vs opt-in M-of-N), **credential type strings** (settle the `Verifiable…`
+prefix now).
+
+## 8. Status & caveats
+
+- **Design, not implementation** — nothing here is compiled or tested.
+- Code-grounded claims (engine, key model, keyspaces, defaults) were **verified against the tree**; this doc
+  proposes replacing several of those — see the build-vs-reuse map, which is explicit about what changes.
+- Presentation Definition examples are **illustrative**, not schema-validated. New Trust Task families
+  (`departures`, `role-changes`, `directory`, and join's `manifest`/`present`/`status`/`accept`) are **proposed**.

--- a/docs/05-design-notes/vtc-ceremony-catalog.md
+++ b/docs/05-design-notes/vtc-ceremony-catalog.md
@@ -1,0 +1,177 @@
+# VTC Ceremony Catalog — Instances of the Pipeline
+
+**Status:** Design proposal (for review) · **Parent:** [`vtc-ceremony-pipeline.md`](./vtc-ceremony-pipeline.md)
+**Purpose:** Prove the one pipeline generalizes by running four maximally-different ceremonies through it, then
+map the remaining purposes. If the abstraction only ever served *join*, it would be over-engineering. These four
+exercise it along every axis that matters.
+
+> **Notation.** Bare `§N` references are to [`vtc-ceremony-pipeline.md`](./vtc-ceremony-pipeline.md). MVP
+> references are written `vtc-mvp.md §N`.
+
+---
+
+## 1. The validation matrix
+
+The four ceremonies are chosen to differ on *every* axis — if one pipeline handles all four, it handles the rest.
+
+| Ceremony | Trigger / `actor` | `actor` = `subject`? | Evidence | Effects | Hard invariant | Threaded? | Direction |
+|---|---|---|---|---|---|---|---|
+| **Join** | applicant (unauth) | **yes** | VP (invitation? / credentials?) | issue VMC + VEC, write ACL+Member | privilege ceiling | yes | constructive |
+| **Leave** | member (self) **or** admin | **no** (admin case) | disposition choice / removal reason | revoke VMC, apply disposition, registry departure | no-last-admin | optional | **destructive** |
+| **Role-change** | admin | **no** | target + desired role (+ step-up) | re-issue VEC, update ACL role | privilege ceiling + step-up | optional | **mutating** |
+| **Directory** | any member (a query) | **no** | the query (fields requested) | return a **field projection** (no write) | PII boundary | **no** (sync) | **read-only** |
+
+Join is constructive/self/threaded; Leave inverts it (destructive/other/one-shot); Role-change is in-place
+mutation with an escalation guard; Directory is a stateless read that returns a *filter*, not a boolean. All four
+are the **same** `verify → facts → evaluate → verdict → effects` pipeline with different plug-ins.
+
+---
+
+## 2. Join (onboarding)
+
+The canonical evidence-bearing ceremony. Full treatment because it exercises all four verdicts.
+
+- **Trigger:** applicant, unauthenticated, rate-limited. `actor` = `subject` = the applicant.
+- **Evidence:** a VP — optionally an `InvitationCredential` (VIC) and/or other credentials.
+- **Routes (policy):** first-match over `evidence`. e.g. `has_valid_invitation → allow(role from invitation)`;
+  `cred_trusted("WitnessCredential") AND agreed("code-of-conduct") → allow(member)`;
+  `cred_trusted("WitnessCredential") → request_more(code-of-conduct)`; else `refer(moderator)`.
+- **Verdict realization:** `allow` ⇒ admit; `request_more` ⇒ return a PD; `refer` ⇒ moderator queue;
+  `deny` ⇒ reject.
+- **Effects (allow):** allocate status-list index → mint VMC + role VEC → write ACL + Member → sealed-transfer →
+  audit. Obligation `reciprocate_vmc` (the member counter-signs → bidirectional DTG edge).
+- **Invariant:** privilege ceiling — join never grants `admin`.
+
+**Worked example (request_more → allow), facts round 1:**
+
+```jsonc
+{ "purpose":"join", "now":"…",
+  "actor":   { "did":"did:key:z6MkHuman", "authenticated":true },
+  "subject": { "did":"did:key:z6MkHuman" },
+  "context": { "community_did":"did:webvh:acme.example", "channel":"rest", "member_count":1421 },
+  "evidence":{ "invitation":null,
+    "presentation":{ "verified":true, "holder":"did:key:z6MkHuman",
+      "credentials":[ { "type":"WitnessCredential", "issuer":"did:webvh:notary.example",
+                        "issuer_trusted":true, "status":"valid", "claims":{"kind":"proximity"} } ] } },
+  "state":   { "subject_member":null } }
+```
+
+Witness present, agreement absent → first-match yields `{"effect":"request_more","with":{"needs":["agreed:code-of-conduct"],
+"presentation_definition":{…}}}`. Round 2 (same thread) carries the agreement → `{"effect":"allow","with":{"role":"member",
+"obligations":["reciprocate_vmc"]}}`.
+
+---
+
+## 3. Leave / Exit (offboarding) — *the inverse of join*
+
+The second ceremony, chosen to invert join. Maps to MVP `removal` (`vtc-mvp.md` §10.2).
+
+- **Trigger:** the **member** (voluntary self-exit) **or** an **admin** (involuntary removal). So `actor` may be
+  the subject or a third party — the pipeline carries both in `actor`/`subject`.
+- **Evidence:**
+  - self → a `request: { disposition: Purge | Tombstone | Historical | PolicyDefault }` (`vtc-mvp.md` §10.2).
+  - admin → a `request: { reason }` + the target as `subject`.
+- **Routes (policy `leave.rego`):** e.g. `actor_is_self → allow(disposition from request | policy default)`;
+  `actor_is_admin AND not subject_is_admin → allow(disposition default)`;
+  `actor_is_admin AND subject_is_admin → refer(second-admin)`; else `deny`.
+- **Verdict realization:** `allow.with.disposition` carries the departure disposition (the policy *decides* it,
+  generalizing join's `role`). `refer` ⇒ a second admin must co-sign. `request_more` ⇒ e.g. require a
+  documented-reason credential. `deny` ⇒ refuse (policy protects certain roles).
+- **Effects (allow):** revoke VMC (flip status-list bit, immediate) → delete/anonymize the Member record per
+  disposition → enqueue registry departure → audit `MemberRemoved`. **Destructive — issues nothing.**
+- **Invariant:** **no-last-admin** — host refuses any leave/removal that would zero the admin set
+  (`vtc-mvp.md` §10.2), regardless of policy.
+
+**What this proves:** `actor ≠ subject`, destructive effects, a *different* hard invariant, and that the
+`allow` payload is purpose-shaped (`disposition`, not `role`) — all on the same pipeline, with the same verify
+stage and the same four verdicts.
+
+**Worked example (admin removing a member):**
+
+```jsonc
+{ "purpose":"leave", "now":"…",
+  "actor":   { "did":"did:key:z6MkAdmin", "role":"admin", "authenticated":true },
+  "subject": { "did":"did:key:z6MkLeaver" },
+  "context": { "community_did":"did:webvh:acme.example", "channel":"rest", "member_count":1421 },
+  "evidence":{ "request":{ "reason":"code-of-conduct-violation" } },
+  "state":   { "subject_member":{ "role":"member", "status":"active", "joined_at":"…" } } }
+```
+
+`actor_is_admin AND not subject_is_admin` → `{"effect":"allow","with":{"disposition":"Tombstone"}}`. Host runs
+the destructive effects; the no-last-admin guard is moot here (subject isn't an admin) but would have refused
+had `subject.role == "admin"` and the set would empty.
+
+---
+
+## 4. Role-change / promotion — *in-place mutation + escalation*
+
+- **Trigger:** admin. `actor ≠ subject`.
+- **Evidence:** `request: { target_role }`; for promotion-to-admin, a fresh **step-up** user-verification.
+- **Routes (`role-change.rego`):** `target_role in {member,moderator,custom:*} → allow(target_role)`;
+  `target_role == "admin" → refer(step-up)` *(or quorum)*; demotion guarded by no-last-admin.
+- **Verdict realization:** `allow.with.role` ⇒ re-issue the role VEC + update the ACL role (mutation, not
+  issuance-from-scratch). `refer` ⇒ the step-up / M-of-N path.
+- **Effects (allow):** re-issue role VEC → update ACL role → audit `RoleChanged`. No new membership.
+- **Invariants:** privilege ceiling (policy can't grant admin directly) **and** step-up reauth for admin
+  promotion (`vtc-mvp.md` §9.7, §10.4) **and** no-last-admin on demotion.
+
+**What this proves:** the pipeline handles *mutation of an existing member*, and that `refer` cleanly models an
+**escalation** (step-up / quorum), not just human moderation. Two invariants stack on one ceremony.
+
+---
+
+## 5. Directory access — *read-time, synchronous, returns a filter (the stress test)*
+
+Deliberately included because it's the ceremony most likely to break a naïve "verdict + effects + thread" model.
+
+- **Trigger:** any member issues a query. `actor` = viewer, `subject` = the member being looked up.
+- **Evidence:** `request: { fields_requested }`.
+- **Routes (`directory.rego`):** `allow(fields: <subset visible to actor.role>)` — the policy returns a **field
+  projection**, not a yes/no. e.g. members see `{did, role}`; admins see more.
+- **Verdict realization:** `allow.with.fields` is the *permitted projection*. `deny` ⇒ empty result.
+  `refer`/`request_more` are unused.
+- **Effects (allow):** **return the projection in the same response — no state write, no thread.**
+- **Invariant:** PII boundary (`vtc-mvp.md` §8.1) — fields outside the projection never leave.
+
+**What this proves — the important one:** the pipeline **degrades to a stateless, synchronous read filter**.
+There is no thread, no issuance, no mutation; `allow` carries a *projection* rather than an obligation. If one
+abstraction spans a multi-day onboarding negotiation (join) *and* a sub-millisecond field filter (directory)
+without special-casing, the pipeline is the right shape — and threads/effects are correctly modelled as
+*optional, purpose-specific* rather than mandatory.
+
+---
+
+## 6. The remaining purposes map cleanly
+
+The other `vtc-mvp.md` §7.1 purposes are further instances — listed to show coverage, not specified here:
+
+| Purpose | `actor` / `subject` | Evidence | `allow` effect | Notes |
+|---|---|---|---|---|
+| **Personhood** | member self | VP w/ `WitnessCredential` | set `personhood` flag, re-mint VMC | minimal-allow default (`vtc-mvp.md` §6.4) |
+| **Relationship** (VRC) | member → other member | self-issued VRC | store edge if both are members | `vtc-mvp.md` §12.3 |
+| **Renewal** | member self | none | re-mint VMC + VEC | today unconditional; pipeline lets it be policy-gated |
+| **Registry / departure** | system | the departing member | choose disposition + publish | runs inside Leave's effects |
+| **Cross-community recognition** | foreign issuer | foreign VEC | honor external role | federation; TRQP-resolved |
+| **Directory** | member viewer | query | field projection | §5 |
+
+Every one is `verify → facts → evaluate → verdict → effects` with a different policy module, evidence slot, and
+effect handler. None needs a bespoke flow.
+
+---
+
+## 7. Why this matters for the build
+
+Because the catalog is *instances*, the expensive machinery is built once and inherited:
+
+- one **verify** stage (all ceremonies),
+- one **Verdict** type + **request_more/refer** machinery (all),
+- one **versioning / rollback / governance** mechanism (all purposes),
+- one **IR + compiler** (per-purpose vocabulary, shared codegen),
+- one **Trust Task protocol** shape (see [`vtc-ceremony-protocol.md`](./vtc-ceremony-protocol.md)).
+
+Adding the *sixth* ceremony is writing a policy module, an evidence slot, an effect handler, and a vocabulary —
+not a new subsystem.
+
+Runnable policies for all four ceremonies above — the Rule IR, the compiled `.rego`, and sample `input` facts
+with expected verdicts — are in [`examples/`](./examples/) (`join`, `leave`, `role-change`, `directory`). The
+authoring vocabulary and compile mapping are in [`vtc-ceremony-rule-ir.md`](./vtc-ceremony-rule-ir.md).

--- a/docs/05-design-notes/vtc-ceremony-pipeline.md
+++ b/docs/05-design-notes/vtc-ceremony-pipeline.md
@@ -1,0 +1,297 @@
+# VTC Ceremony Decision Pipeline — Architecture (greenfield)
+
+**Status:** Design proposal (for review) · **Audience:** VTC planners / architects
+**Position:** Target architecture. Treats community state transitions as a clean-slate design and maps, in §10,
+which existing `vtc-service` code is **reused** vs **rebuilt**. Where it cites the MVP it is for grounding, not
+as a constraint — this is the shape we'd build if starting fresh.
+
+**Companions:** [`vtc-ceremony-catalog.md`](./vtc-ceremony-catalog.md) (the ceremonies that validate this
+pipeline — join, leave, role-change, directory), [`vtc-ceremony-rule-ir.md`](./vtc-ceremony-rule-ir.md) (the
+authoring vocabulary + compiler) with runnable [`examples/`](./examples/),
+[`vtc-ceremony-protocol.md`](./vtc-ceremony-protocol.md) (the Trust Task wire protocol), and
+[`vtc-ceremony-visual-guide.html`](./vtc-ceremony-visual-guide.html) (interactive — switch between join / leave /
+directory). Start at [`vtc-ceremonies-exec-summary.md`](./vtc-ceremonies-exec-summary.md).
+
+> **Notation.** Bare `§N` references are to *this* document. References to the MVP spec are written
+> `vtc-mvp.md §N`.
+
+---
+
+## 1. The thesis
+
+Don't build a join ceremony. **Build one decision pipeline and make every community ceremony an instance of
+it.** A community has many governed state transitions — joining, leaving, role changes, directory queries,
+personhood assertions, relationship publishing. They look different, but they have the *identical* shape:
+
+> *something triggers a transition → evidence is gathered → the host verifies it → policy decides over verified
+> facts → effects are applied.*
+
+The MVP already hints at this: `vtc-mvp.md` §7 lists **nine policy purposes**, each with its own `input`
+contract, and §10 shows join / removal / personhood all doing verify → policy → effect — but each wired
+bespoke. The greenfield move is to **factor that into one pipeline**, parameterized by *purpose*. Everything
+expensive to build once — verification, the verdict model, versioning, rollback, governance, the visual
+authoring compiler — is then built **once** and inherited by every ceremony.
+
+The catalog ([`vtc-ceremony-catalog.md`](./vtc-ceremony-catalog.md)) proves it by running four maximally
+different ceremonies through this single pipeline.
+
+---
+
+## 2. The pipeline
+
+```
+            ┌─────────────────────────── one pipeline, parameterized by `purpose` ──────────────────────────┐
+ TRIGGER ─▶ GATHER ─▶ VERIFY (host) ─▶ FACTS ─▶ EVALUATE (<purpose>.rego) ─▶ VERDICT ─▶ EFFECTS (<purpose>) ─▶ done
+ actor/      evidence   crypto, binding,  typed,    policy over verified       allow|deny|   purpose-specific
+ subject                status, trust     verified  facts only                 refer|        handler keyed by
+                                          facts                                 request_more  the verdict
+                            │                                                        │
+                            └── identity/authenticity failure → abort (never reach policy)
+                                                                                     └── request_more / refer → THREAD continues
+```
+
+| Stage | Generic responsibility | Purpose-specific part |
+|---|---|---|
+| **Trigger** | identifies `actor` (authenticated initiator) and `subject` (who the transition is about; may differ) | who is allowed to trigger |
+| **Gather** | collect evidence (client-side / local) | what evidence the ceremony needs |
+| **Verify** | crypto, holder-binding, freshness, revocation status, issuer-trust (TRQP) → `VerifiedFacts` | which evidence kinds apply |
+| **Facts** | the typed, purpose-agnostic policy input (§3) | the `evidence`/`state` slots populated |
+| **Evaluate** | run `<purpose>.rego` over facts; never touches crypto | the policy module |
+| **Verdict** | one of four effects + a `with` payload (§4) | how each effect is realized |
+| **Effects** | apply the decision; emit audit | the effect handler (issue / revoke / mutate / project) |
+| **Thread** | optional: persists for async (`refer`) or multi-round (`request_more`) ceremonies | whether the ceremony is threaded |
+
+**Two invariants make this safe and generic:** (1) crypto lives entirely in *Verify*, so policy reasons only
+over a `Verified*` view (typestate discipline — a call site that skips verification doesn't compile); (2)
+*Effects* are the only stage that mutates state, driven solely by the verdict.
+
+---
+
+## 3. The Facts contract (purpose-agnostic policy input)
+
+One input shape for every ceremony. No lossy projections — policy sees structured, pre-verified facts.
+
+```jsonc
+input = {
+  "purpose":  "join" | "leave" | "role-change" | "directory" | "personhood" | "relationship" | …,
+  "now":      "2026-05-30T12:00:00Z",
+
+  "actor":    { "did", "role", "authenticated": true },   // who initiated; role from ACL if a member
+  "subject":  { "did" },                                   // who the transition is about (may == actor.did)
+
+  "context":  { "community_did", "channel", "member_count" },
+
+  // What the actor presented. Ceremonies populate the slots they use; the rest are absent.
+  "evidence": {
+    "invitation":   null | { "verified", "issuer", "issuer_role", "scopes", "consumed" },
+    "presentation": null | { "verified", "holder",
+                             "credentials": [ { "type", "issuer", "issuer_trusted", "status", "claims", "valid_until" } ] },
+    "request":      null | { /* ceremony params: disposition | target_role | fields_requested | … */ }
+  },
+
+  // Current authoritative state relevant to the decision (read from the ACL/Member keyspaces).
+  "state":    { "subject_member": null | { "role", "status", "joined_at", "personhood" } }
+}
+```
+
+The compiler emits helper rules over this (`cred_trusted(t)`, `has_valid_invitation`, `actor_is_admin`,
+`subject_is_self`, …) so authors never hand-write traversals. Per-purpose worked instances live in the catalog.
+
+---
+
+## 4. The Verdict (four-valued, generic)
+
+`<purpose>.rego` returns one `decision` object, discriminated by `effect`:
+
+```jsonc
+{ "effect": "allow" | "deny" | "refer" | "request_more",
+  "with": {
+    // allow        → ceremony payload: { role } | { disposition } | { fields } | { obligations }
+    // deny         → { code, reason }
+    // refer        → { queue, reason }                       // needs a human / quorum
+    // request_more → { needs, presentation_definition }      // needs more evidence (threaded continuation)
+  } }
+```
+
+The four effects generalize cleanly:
+
+| Effect | Meaning (any ceremony) | Join realizes as | Leave realizes as |
+|---|---|---|---|
+| `allow` | the transition proceeds | admit + issue VMC | execute departure + disposition |
+| `deny` | refused | reject request | refuse removal |
+| `refer` | needs a human / quorum | moderator queue | second-admin / appeal |
+| `request_more` | needs more evidence | return a Presentation Definition | require a reason credential |
+
+`allow` is the only effect with a purpose-specific *payload* (`with`). `deny` / `refer` / `request_more` are
+identical across ceremonies. This is why one pipeline suffices.
+
+---
+
+## 5. Effects & host-enforced invariants
+
+**Effects** are a per-purpose handler keyed by the verdict — the only stage that writes state. Examples:
+join-`allow` issues + writes ACL; leave-`allow` revokes + applies disposition; role-`allow` re-issues a VEC +
+updates ACL; directory-`allow` returns a field projection (no write).
+
+**Invariants** are hard guards the host enforces *around* the policy — a policy can never override them. They
+are per-purpose:
+
+| Invariant | Applies to | Rule |
+|---|---|---|
+| **Structural totality** | all | the compiler appends `default decision := {"effect":"deny", …}` — every evaluation yields a decision |
+| **Privilege ceiling** | join, role-change | policy may grant `member/moderator/custom`, never `admin`; admin promotion is a separate step-up path |
+| **No-last-admin** | leave, role-change | the transition is refused if it would leave the community with zero admins |
+| **Step-up reauth** | role-change (to admin), high-risk | a fresh WebAuthn user-verification ceremony is required before effects run |
+| **PII boundary** | directory, registry | only whitelisted fields cross a trust boundary |
+
+Invariants are checked by the host before/after evaluation, not encoded in Rego — so an operator's policy edit
+can never disable them.
+
+---
+
+## 6. Threads — async and multi-round are opt-in
+
+Not every ceremony is a conversation. A **thread** (a correlated, persisted exchange) exists only when the
+ceremony can go async (`refer`) or multi-round (`request_more`):
+
+- **Threaded** — join (request_more negotiation, async moderator review), leave-with-appeal, role-change with
+  step-up or quorum.
+- **One-shot synchronous** — directory access: the actor queries, the policy decides, the host returns a
+  filtered projection in the same response. No thread, no persistence.
+
+The pipeline treats "threaded" as a property of the *purpose*, not a mandatory stage. This is the abstraction's
+key flex — it degrades gracefully from a multi-day onboarding negotiation to a sub-millisecond read filter
+without special-casing.
+
+---
+
+## 7. Authoring — visual Rule IR → compiler (per purpose)
+
+Operators do **not** write raw Rego (a footgun, and a security surface). For every purpose, the visual builder
+edits a constrained **Rule IR** (a JSON AST over a fixed vocabulary of conditions and effects). A deterministic
+compiler emits, per policy:
+
+1. the **Rego** module (enforcement),
+2. a **DIF Presentation Definition** (so software clients self-assemble the evidence — for evidence-bearing
+   ceremonies),
+3. a **plain-English** rendering (admin review + public manifest), and
+4. **static invariant checks** ("every path terminates", "no `allow{role:admin}`", purpose-specific rules).
+
+Raw Rego is an expert-only, validated escape hatch — not the front door. A **policy simulator** dry-runs sample
+facts against a *draft* before activation. The condition/effect vocabulary is per purpose (join speaks
+credentials + invitations; leave speaks disposition + tenure; directory speaks viewer-role + fields) but the
+*compiler and IR machinery are shared*.
+
+Full grammar, the per-purpose condition/effect vocabulary, and the deterministic compile-to-Rego mapping live in
+[`vtc-ceremony-rule-ir.md`](./vtc-ceremony-rule-ir.md); runnable compiled policies (IR + `.rego` + sample facts)
+for join / leave / directory are in [`examples/`](./examples/).
+
+---
+
+## 8. Versioning, rollback, governance (shared across purposes)
+
+Per-purpose, but one mechanism:
+
+- **Append-only, hash-chained, DID-signed policy log** (one per purpose) — the governance record. The active
+  policy is the log head; prior versions are navigable, not just "archived".
+- **Fail-forward rollback** — rolling back to v3 *appends* a new v6 carrying v3's content (`parent: v5,
+  kind: rollback`); the chain never rewinds. (Same discipline as WebVH `did.jsonl` and runtime-service-management
+  rollback.)
+- **Semantic diffs** — because the Rule IR is structured JSON, diffs are "route X added / priority raised", not
+  Rego text diffs.
+- **Optional M-of-N governance** — `propose → approve (DID-signed proofs accumulate into a proof set) →
+  activate at quorum`. The proposal thread *is* the governance record. Per-community, per-purpose opt-in.
+
+Because this is purpose-generic, every ceremony gets versioning, rollback, and governance for free.
+
+---
+
+## 9. Safety rails
+
+- Crypto only in *Verify*; policy sees booleans/facts, never signatures.
+- Invariants (§5) host-enforced, not policy-encoded.
+- Default posture is **deny** (see §10 — a clean-slate change from the MVP's accept-any), with an install-time
+  forced choice of posture per purpose.
+- Atomic activation (CAS on the per-purpose log head); rollback re-validates the old IR compiles under the
+  current vocabulary; both are signed + audited.
+- Unauthenticated triggers (e.g. join over DIDComm) are rate-limited *before* evaluation.
+
+---
+
+## 10. Relationship to current code — build vs reuse (honest)
+
+Greenfield does **not** mean rewrite-everything. The `vtc-mvp.md` §3 cornerstones are good; the rework is
+concentrated in the ceremony/policy *modelling*.
+
+**Reuse as-is:**
+
+| Keep | Why |
+|---|---|
+| `regorus` embedded engine (`vtc-mvp.md` §3-D) | single artifact, low latency — right call |
+| VTA mints keys / VTC caches + signs locally (§3-A) | clean custody boundary |
+| **VC-as-projection; VTC never reads its own VCs for authz** (§3-B) | excellent, rare clarity — keep loudly |
+| DTG-catalog-only credentials (§3-C), status-list privacy design, HMAC-actor audit envelope | sound |
+| The `Verified*` typestate (`vtc-mvp.md` §10.1) | generalize from `VerifiedJoinRequest` → `VerifiedFacts` |
+| Trust Task wire discipline (§3-L), JWT audience isolation, install/passkey flows | keep |
+
+**Rebuild (cheap now, painful later):**
+
+| Replace | With |
+|---|---|
+| 9 bespoke per-purpose flows | **one pipeline** parameterized by purpose (this doc) |
+| `vp_claims` lossy projection (`vtc-mvp.md` §7.3) | **structured `evidence.presentation.credentials[]`** (§3); drop `vp_claims` |
+| boolean allow/deny (§10.1) | **four-valued Verdict object** (§4) |
+| active-pointer + archived priors (§5.4/§7.2) | **append-only signed policy log + fail-forward rollback** (§8) |
+| `policies.open` accept-any default (§7.1) | **default-deny + install-time posture choice** (§9) |
+| raw-Rego upload as primary door | **Rule IR + compiler primary**; raw Rego expert-only (§7) |
+| flat `JoinStatus` enum | **ceremony thread / state machine** for async purposes (§6) |
+| `VerifiableMembershipCredential` vs DTG `MembershipCredential` naming drift | **align type strings to DTG exactly** — settle while cheap |
+
+**Reconsider (lower confidence):** the `acl:<did>` / `members:<did>` split may be premature optimization at
+community scale — consider unifying with an in-memory auth index. The Trust Task router should be method-aware
+and expose `/capabilities` for discovery.
+
+---
+
+## 11. Staged plan
+
+| Stage | Deliverable | Depends on |
+|---|---|---|
+| **A · Pipeline core** | `VerifiedFacts` contract (§3), four-valued Verdict (§4), the verify→evaluate→effects spine parameterized by purpose, host-enforced invariants (§5). | — |
+| **B · Two ceremonies** | **Join** and **Leave** as the first two instances (catalog) — proves actor≠subject + constructive vs destructive on one pipeline. | A |
+| **C · request_more + discovery** | the `request_more` verdict + Presentation Definition generation + the ceremony manifest. | A |
+| **D · Rule IR + compiler** | the IR, the shared compiler (Rego + PD + English + invariant checks), the simulator. | A |
+| **E · Versioning / rollback / governance** | per-purpose append-only signed log, fail-forward rollback, M-of-N. | D |
+| **F · Protocol breadth** | role-change + directory instances; the generalized `<ceremony>/*` Trust Task families. | A, B |
+
+**Critical path:** A is the spine; B proves it; C/D/E/F broaden. Build the pipeline before the second ceremony,
+not after the fifth.
+
+---
+
+## 12. Open decisions
+
+| # | Decision | Recommendation |
+|---|---|---|
+| 1 | Default posture per purpose | **Deny**, with a forced install-time choice (change from MVP accept-any) |
+| 2 | First-match vs scored route resolution | Ordered first-match (deterministic, legible) |
+| 3 | Membership topology — star (paired VMCs) vs proof-set circles | Start star; leave circles open |
+| 4 | Invitation delegation — community-only vs members with `can_invite` | Allow, with depth/scope bounds |
+| 5 | Governance quorum — single-admin vs opt-in M-of-N | Per-community, per-purpose opt-in |
+| 6 | `acl`/`members` keyspace split — keep vs unify | Revisit; likely unify at community scale |
+| 7 | Credential `type` strings — `Verifiable…` prefix vs bare DTG names | Settle now to avoid a translation layer |
+
+---
+
+## References
+
+- [`vtc-ceremony-catalog.md`](./vtc-ceremony-catalog.md) · [`vtc-ceremony-rule-ir.md`](./vtc-ceremony-rule-ir.md)
+  · [`examples/`](./examples/) · [`vtc-ceremony-protocol.md`](./vtc-ceremony-protocol.md)
+  · [`vtc-ceremonies-exec-summary.md`](./vtc-ceremonies-exec-summary.md) ·
+  [`vtc-ceremony-visual-guide.html`](./vtc-ceremony-visual-guide.html)
+- MVP grounding: [`vtc-mvp.md`](./vtc-mvp.md) · Rollback pattern:
+  [`runtime-service-management.md`](./runtime-service-management.md)
+- DTG credentials: <https://github.com/OpenVTC/dtg-credentials> · DIF Presentation Exchange:
+  <https://identity.foundation/presentation-exchange/> · ToIP TRQP:
+  <https://github.com/trustoverip/tswg-trust-registry-protocol> · Rego:
+  <https://www.openpolicyagent.org/docs/policy-language>

--- a/docs/05-design-notes/vtc-ceremony-protocol.md
+++ b/docs/05-design-notes/vtc-ceremony-protocol.md
@@ -1,0 +1,158 @@
+# VTC Ceremony Trust Task Protocol — Generalized
+
+**Status:** Design proposal (for review) · **Parent:** [`vtc-ceremony-pipeline.md`](./vtc-ceremony-pipeline.md)
+**Depends on:** the Verdict (§4) and Facts (§3) of the pipeline doc, and the instances in
+[`vtc-ceremony-catalog.md`](./vtc-ceremony-catalog.md).
+**Purpose:** one wire pattern for *all* ceremonies. The choreography is the same; only the family name and the
+effect payload differ.
+
+> **Notation.** Bare `§N` references are to [`vtc-ceremony-pipeline.md`](./vtc-ceremony-pipeline.md). MVP
+> references are written `vtc-mvp.md §N`.
+
+---
+
+## 1. Conventions (inherited from `vtc-mvp.md` §9.4)
+
+- **URL form:** `https://trusttasks.org/openvtc/vtc/{family}/{verb}/{major}.{minor}` — `org = openvtc`,
+  `domain = vtc`. One **family per ceremony** (`join-requests`, `departures`, `role-changes`, `directory`).
+- **REST binding:** every request carries a `Trust-Task` header, exact-matched at attach time (mismatch → 415,
+  missing → 400).
+- **DIDComm binding:** the message `type` **is** the Trust Task URL.
+- **Per-task artefacts:** `trust-tasks/{family}/{verb}/{maj}.{min}/{spec.md,schema.json}` + an `index.json`
+  entry. Lifecycle Draft → Reviewing → Published → Deprecated; these ship at **Draft**.
+- **Rate limit (`vtc-mvp.md` §9.6):** unauthenticated triggers use a per-sender-DID leaky bucket *before*
+  evaluation.
+
+---
+
+## 2. The generic verb set
+
+Every ceremony family draws from the **same** small verb set — most ceremonies use a subset.
+
+| Verb | Kind | Used by | Meaning |
+|---|---|---|---|
+| `manifest` | read | evidence-bearing ceremonies | discover requirements: the Presentation Definition + human summary |
+| `request` | request→**verdict** | all | open the ceremony; carries the actor's evidence; returns the Verdict |
+| `present` | request→**verdict** | threaded ceremonies | continuation after `request_more`, same thread |
+| `status` | read | threaded ceremonies | poll a thread in `Pending`/`Deferred` |
+| `resolve` | request | ceremonies with `refer` | a human/quorum decision that advances a referred thread |
+| `accept` | request | ceremonies with a reciprocal step | counter-sign (e.g. the join VMC → bidirectional edge) |
+
+A **synchronous** ceremony (directory) uses only `request` and gets its result inline — no `present`/`status`.
+A **threaded** ceremony (join) uses `manifest` + `request` + `present` + `status` + `accept`.
+
+`Gather`, `Verify`, and `Evaluate` are **not** tasks — Gather is local; Verify + Evaluate run server-side inside
+the `request`/`present` handler (§2 pipeline boundary).
+
+---
+
+## 3. The Verdict response (shared by `request` and `present`, every family)
+
+One response shape across all ceremonies — the Verdict (§4) plus thread metadata:
+
+```jsonc
+{
+  "thread_id":  "urn:uuid:…",        // present for threaded ceremonies; absent for synchronous ones
+  "request_id": "…",
+  "verdict": {
+    "effect": "allow" | "deny" | "refer" | "request_more",
+    "with": {
+      // allow        → ceremony payload (role | disposition | fields | obligations) + host-added bundle_ref where issuance occurs
+      // deny         → code, reason
+      // refer        → queue, reason
+      // request_more → needs, presentation_definition
+    }
+  }
+}
+```
+
+`bundle_ref` (a sealed-transfer pointer) is **added by the host** on issuing ceremonies — it is not emitted by
+the policy. Framework errors (malformed/expired/rate-limited/verification failure) use the `trust-task-error`
+type (`vtc-mvp.md` §9.4 — exact URI TBD), **not** a `deny` verdict: `deny` means the policy refused; an error
+means the request never reached the policy.
+
+---
+
+## 4. Per-ceremony families
+
+| Family | Verbs | Trigger auth | Synchronous? |
+|---|---|---|---|
+| `join-requests/*` | `manifest`, `request` *(= the MVP `submit`)*, `present`, `status`, `accept` | inner VP (holder) + optional outer relayer | no (threaded) |
+| `departures/*` | `request`, `status`, `resolve` | member session (self) **or** admin (involuntary) | usually one-shot |
+| `role-changes/*` | `request`, `resolve` *(step-up / quorum)* | admin session + step-up | one-shot or short thread |
+| `directory/*` | `query` *(a `request` alias)* | member session | **yes** (inline) |
+
+> The existing `join-requests/submit/1.0` is this pattern's `request` verb for the join family; keep the URI,
+> read it as `request`. New families follow the identical shape.
+
+---
+
+## 5. Threading, async, relayer ≠ holder
+
+- **Thread** (`thread_id`) exists only for threaded ceremonies (§6 pipeline). `request` mints it; `present` /
+  `status` / `resolve` / `accept` carry it. A thread is in one state (`Pending`/`Deferred`/terminal); terminal
+  states reject further verbs with the error type. Bind `present` to `thread_id` **+** holder DID (anti-hijack).
+- **Async** — `refer` parks the thread `Deferred`; `resolve` (or the existing admin REST surface) advances it.
+  When the actor is DIDComm-reachable the host may **push** the follow-up; `status` poll is the universal
+  fallback.
+- **Relayer ≠ holder** (onion auth, reused from provision-integration): the **outer** envelope (REST bearer /
+  DIDComm authcrypt) authenticates the *relayer* who carries the request; the **inner** VP authenticates the
+  *holder*. Issued bundles are sealed to the holder — the relayer can't read them and can't forge the VP, so no
+  privilege escalation. Enables air-gapped onboarding.
+
+---
+
+## 6. Sequence sketches
+
+**Join — threaded, request_more then allow:**
+
+```
+Applicant ─join-requests/manifest (read)─▶ VTC ─▶ {PD}
+Applicant ─join-requests/request {VP}────▶ VTC : verify → evaluate → request_more
+Applicant ◀──── {verdict: request_more, presentation_definition} ────
+Applicant ─join-requests/present {VP+more, thread}─▶ VTC : evaluate → allow
+Applicant ◀──── {verdict: allow, bundle_ref} ──── ; then join-requests/accept (reciprocal VMC)
+```
+
+**Leave — one-shot, admin removal:**
+
+```
+Admin ─departures/request {subject, reason}─▶ VTC : verify(actor=admin) → evaluate → allow{disposition}
+Admin ◀──── {verdict: allow, disposition: "Tombstone"} ────   # host revokes VMC, applies disposition, audits
+```
+
+**Directory — synchronous, no thread:**
+
+```
+Member ─directory/query {target, fields}─▶ VTC : verify → evaluate → allow{fields}
+Member ◀──── {verdict: allow, fields: {did, role}} ────       # filtered projection, inline, no persistence
+```
+
+---
+
+## 7. Deliverables (Draft)
+
+New `trust-tasks/` entries, following the `vtc-mvp.md` §9.4 `spec.md` + `schema.json` + `index.json` convention,
+shipped **with** the code that implements each verb:
+
+```
+join-requests/{manifest,present,status,accept}/1.0/   # request = existing submit, extend schema with the Verdict union
+departures/{request,status,resolve}/1.0/
+role-changes/{request,resolve}/1.0/
+directory/query/1.0/
+```
+
+A shared `schema.json` fragment defines the Verdict union once and is referenced by every `request`/`present`
+response — one source of truth for the wire shape across all ceremonies.
+
+---
+
+## 8. Open items
+
+- **`manifest` / `.well-known` alias** for generic-wallet discovery without knowing the task surface — worth it?
+- **`resolve` vs the existing REST admin surface** (`POST /v1/join-requests/{id}/{approve,reject}`,
+  `vtc-mvp.md` §9.5) — `resolve` is the generalized form; keep both or migrate?
+- **Synchronous-ceremony envelopes** — do `directory/query` results need the full Trust Task envelope, or a
+  lighter read path? (Leaning: same envelope, exempt from threading fields.)
+- **Per-family rate-limit tuning** — join (unauth) needs the tightest bucket; member-triggered ceremonies inherit
+  session auth.

--- a/docs/05-design-notes/vtc-ceremony-rule-ir.md
+++ b/docs/05-design-notes/vtc-ceremony-rule-ir.md
@@ -1,0 +1,204 @@
+# VTC Ceremony Rule IR & Compiler
+
+**Status:** Design proposal (for review) · **Parent:** [`vtc-ceremony-pipeline.md`](./vtc-ceremony-pipeline.md)
+**Purpose:** The canonical vocabulary. Operators author a constrained **Rule IR** (a JSON AST); a deterministic
+compiler emits Rego + a Presentation Definition + English + invariant checks. This document is the **single
+source of truth** that the example policies ([`examples/`](./examples/)) and the interactive guide
+([`vtc-ceremony-visual-guide.html`](./vtc-ceremony-visual-guide.html)) both derive from — keep them in sync with
+this file.
+
+> **Notation.** Bare `§N` references are to [`vtc-ceremony-pipeline.md`](./vtc-ceremony-pipeline.md). MVP
+> references are written `vtc-mvp.md §N`.
+
+---
+
+## 1. The IR document
+
+A policy is an **ordered list of routes** (first-match) for one purpose. The IR — not the Rego — is the
+versioned source of truth (§8 of the pipeline doc), so diffs are semantic.
+
+```jsonc
+{
+  "purpose": "join",                 // matches a PolicyPurpose
+  "routes": [
+    { "name": "Invitation",
+      "listed": false,               // appears in the public manifest? (omit ⇒ true)
+      "when": { "all": [ "has_valid_invitation" ] },
+      "then": { "effect": "allow", "with": { "role": "member" } } },
+    { "name": "Open review",
+      "when": { "all": [ "always" ] },
+      "then": { "effect": "refer", "with": { "queue": "moderator" } } }
+  ]
+  // the compiler ALWAYS appends a structural default: deny / no-matching-route
+}
+```
+
+**Condition grammar** (`when`):
+
+```
+cond     := leaf | { "all": [cond, …] } | { "any": [cond, …] } | { "not": cond }
+leaf     := "<id>"                       // no-arg condition, e.g. "has_valid_invitation"
+          | { "<id>": <arg> }            // arg'd condition, e.g. { "holds_trusted": "WitnessCredential" }
+```
+
+`all` = AND, `any` = OR, `not` = negation. Leaves come from the vocabulary in §2.
+
+---
+
+## 2. Condition vocabulary
+
+Conditions are **questions over already-verified Facts** (§3 of the pipeline doc). They never touch crypto — the
+host resolved that in *Verify*. Each row gives the IR leaf, its argument, and the Rego it compiles to.
+
+### 2.1 Shared (any purpose)
+
+| IR leaf | Arg | Compiles to (Rego over `input`) |
+|---|---|---|
+| `always` | — | `true` |
+| `actor_is_admin` | — | `input.actor.role == "admin"` |
+| `actor_is_self` | — | `input.actor.did == input.subject.did` |
+| `subject_is_admin` | — | `input.state.subject_member.role == "admin"` |
+| `member_count_lt` | int | `input.context.member_count < <n>` |
+
+### 2.2 Join (evidence: invitation + presentation + agreements)
+
+| IR leaf | Arg | Compiles to |
+|---|---|---|
+| `has_valid_invitation` | — | `has_valid_invitation` *(helper)* |
+| `holds` | type str | `cred_held("<type>")` *(helper)* |
+| `holds_trusted` | type str | `cred_trusted("<type>")` *(helper)* |
+| `endorsements_gte` | int | `endorsement_count >= <n>` |
+| `agreed` | tag str | `agreed("<tag>")` *(helper)* |
+
+### 2.3 Leave (evidence: request{disposition?, reason?})
+
+| IR leaf | Arg | Compiles to |
+|---|---|---|
+| `actor_is_self` | — | *(shared)* |
+| `actor_is_admin` | — | *(shared)* |
+| `subject_is_admin` | — | *(shared)* |
+| `disposition_requested` | — | `input.evidence.request.disposition` |
+
+### 2.4 Directory (evidence: request{fields_requested})
+
+| IR leaf | Arg | Compiles to |
+|---|---|---|
+| `viewer_is_admin` | — | `input.actor.role == "admin"` |
+| `viewer_is_member` | — | `input.actor.authenticated == true` |
+
+### 2.5 Role-change (evidence: request{target_role, step_up})
+
+| IR leaf | Arg | Compiles to |
+|---|---|---|
+| `target_role_standard` | — | `input.evidence.request.target_role != "admin"` |
+| `promotes_to_admin` | — | `input.evidence.request.target_role == "admin"` |
+| `step_up_done` | — | `input.evidence.request.step_up == true` |
+
+`allow.with.role` of `"$target"` → the requested `target_role` (compiler emits the `target_role` helper).
+**Unlike join, role-change MAY grant `admin`** — it is the sanctioned promotion path, gated by `step_up_done`
+(or M-of-N). No-last-admin on demotion stays host-enforced.
+
+Adding a purpose = adding a vocabulary block here + an effect handler (§5 of the pipeline doc). The compiler and
+combinator logic are unchanged.
+
+---
+
+## 3. Effect vocabulary (`then`)
+
+Four effects (§4 of the pipeline doc). Only `allow` carries a purpose-specific `with` payload.
+
+| `effect` | `with` payload | Compiles to |
+|---|---|---|
+| `allow` | `{ role }` \| `{ disposition }` \| `{ fields }` (+ `obligations`) | `{"effect":"allow","with":{…}}` |
+| `deny` | `{ code, reason }` | `{"effect":"deny","with":{…}}` |
+| `refer` | `{ queue, reason }` | `{"effect":"refer","with":{…}}` |
+| `request_more` | `{ needs, presentation_definition }` | `{"effect":"request_more","with":{…}}` (PD from §5) |
+
+---
+
+## 4. Compile → Rego
+
+Ordered first-match compiles to a single `decision` rule with an **`else` chain** (native Rego first-match),
+backed by the structural-default deny. Helper rules are appended once.
+
+```rego
+package vtc.<purpose>
+import future.keywords.if
+import future.keywords.in
+
+# structural totality (compiler-appended; operator cannot remove)
+default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}
+
+# routes in priority order → else chain
+decision := <then₁> if { <when₁> }
+else := <then₂> if { <when₂> }
+else := <thenₙ> if { <whenₙ> }
+
+# helpers (emitted as used)
+cred_held(t) if { some c in input.evidence.presentation.credentials; c.type == t; c.status == "valid" }
+cred_trusted(t) if { some c in input.evidence.presentation.credentials; c.type == t; c.issuer_trusted; c.status == "valid" }
+endorsement_count := count([c | some c in input.evidence.presentation.credentials; c.type == "EndorsementCredential"])
+has_valid_invitation if { input.evidence.invitation.verified; not input.evidence.invitation.consumed }
+agreed(tag) if { input.evidence.request.agreements[tag] == true }
+```
+
+**Mapping rules**
+- A route's `when` combinator → Rego conjunction (`all` → newline-separated expressions; `any` → a helper rule
+  with multiple bodies; `not` → `not <expr>`).
+- A route's `then` → the literal decision object.
+- Routes emit in array order; the `else` chain makes the **first** matching route win.
+- The appended `default decision` guarantees totality (§9 rail). It is unreachable whenever the last route is a
+  catch-all (`when: ["always"]`) — which is the recommended final route — but always present as a backstop.
+
+**Static invariant checks** (run at compile, fail the build):
+- no `allow.with.role == "admin"` (privilege ceiling);
+- every `when` leaf is in the purpose's vocabulary (no free Rego);
+- a catch-all or default guarantees totality (always true by construction);
+- purpose-specific checks (e.g. leave: no route may bypass the host's no-last-admin guard — enforced outside
+  Rego, but the compiler warns if a route's effect assumes it).
+
+---
+
+## 5. Compile → Presentation Definition
+
+For evidence-bearing purposes (join), the compiler unions the credential/invitation conditions of the **listed**
+routes into a DIF Presentation Definition, one `submission_requirement` group per listed route (alternatives):
+
+- `holds` / `holds_trusted` → an `input_descriptor` constraining `$.type`.
+- `agreed` → an `input_descriptor` constraining `$.agreements.<tag>` to `true`.
+- `has_valid_invitation` on an **unlisted** route → omitted (the invitation is the private signal).
+
+Synchronous, non-evidence purposes (directory) produce no PD.
+
+---
+
+## 6. Compile → English
+
+One line per route, in priority order, e.g.:
+
+```
+To join Acme, the first matching route applies:
+  P1 Invitation (unlisted): hold a valid invitation → admitted as member
+  P2 Verified human: a trusted WitnessCredential AND agree to the code of conduct → admitted as member
+  P3 Almost there: a trusted WitnessCredential → asked for the code-of-conduct agreement
+  P4 Open review: anyone else → sent to moderator review
+  ∎ default: → denied
+```
+
+---
+
+## 7. Worked: the Join policy
+
+The IR, the compiled Rego, and a sample-facts test vector are in [`examples/`](./examples/):
+`join.ir.json` → `join.rego`, plus `leave.ir.json`/`leave.rego` and `directory.ir.json`/`directory.rego`. Each
+`.rego` is exactly what this compiler emits from its `.ir.json`. See [`examples/README.md`](./examples/README.md)
+for sample `input` documents and expected verdicts, and how to run them with `regorus`/`opa`.
+
+---
+
+## 8. Adding a new ceremony
+
+1. Add an evidence slot to Facts (§3 of the pipeline doc) if needed.
+2. Add a vocabulary block here (§2) + the effect's `with` payload (§3).
+3. Add an effect handler (the only purpose-specific code; §5 of the pipeline doc).
+4. The IR editor, compiler, PD/English generators, versioning, and Trust Task protocol are inherited unchanged.

--- a/docs/05-design-notes/vtc-ceremony-visual-guide.html
+++ b/docs/05-design-notes/vtc-ceremony-visual-guide.html
@@ -1,0 +1,1112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VTC Ceremony Pipeline · Visual Guide</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400&family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap" rel="stylesheet" />
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<style>
+  :root{
+    --bg:#090c12; --bg-2:#0c1018; --panel:#10141d; --panel-2:#141a24;
+    --line:rgba(150,170,200,.12); --line-2:rgba(150,170,200,.22);
+    --ink:#e7ecf4; --muted:#8a94a8; --faint:#5b6577;
+    --brand:#2dd4bf;            /* structural / teal */
+    --admit:#34d399; --deny:#fb7185; --refer:#fbbf24; --more:#a78bfa;
+    --shadow:0 24px 60px -24px rgba(0,0,0,.7);
+    --r:14px;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{
+    background:
+      radial-gradient(1200px 620px at 78% -8%, rgba(45,212,191,.10), transparent 60%),
+      radial-gradient(900px 500px at 6% 4%, rgba(167,139,250,.08), transparent 55%),
+      var(--bg);
+    color:var(--ink);
+    font-family:'IBM Plex Sans',system-ui,sans-serif;
+    font-weight:400; line-height:1.5;
+    -webkit-font-smoothing:antialiased;
+    min-height:100vh;
+    padding:0 0 80px;
+  }
+  body::before{ /* engineering grid */
+    content:""; position:fixed; inset:0; z-index:0; pointer-events:none;
+    background-image:
+      linear-gradient(var(--line) 1px,transparent 1px),
+      linear-gradient(90deg,var(--line) 1px,transparent 1px);
+    background-size:46px 46px; mask:radial-gradient(120% 90% at 50% 0%, #000 35%, transparent 88%);
+    opacity:.5;
+  }
+  .wrap{position:relative; z-index:1; max-width:1240px; margin:0 auto; padding:0 26px}
+  .mono{font-family:'IBM Plex Mono',monospace}
+
+  /* ---- header ---- */
+  header{padding:46px 0 26px; border-bottom:1px solid var(--line); margin-bottom:30px}
+  .kicker{font-family:'IBM Plex Mono',monospace; font-size:11.5px; letter-spacing:.32em;
+    text-transform:uppercase; color:var(--brand); display:flex; gap:12px; align-items:center}
+  .kicker::before{content:""; width:26px; height:1px; background:var(--brand); display:inline-block}
+  h1{font-family:'Fraunces',serif; font-weight:500; font-size:clamp(34px,5vw,58px);
+    line-height:1.02; margin:16px 0 10px; letter-spacing:-.01em}
+  h1 em{font-style:italic; color:var(--brand)}
+  .sub{color:var(--muted); max-width:62ch; font-size:15.5px}
+  .cer-tabs{display:flex; gap:8px; margin-top:20px}
+  .cer-tab{font-family:'IBM Plex Mono'; font-size:12px; letter-spacing:.04em; padding:8px 15px; border-radius:9px;
+    border:1px solid var(--line-2); color:var(--muted); cursor:pointer; transition:.15s}
+  .cer-tab:hover{color:var(--ink)}
+  .cer-tab.on{border-color:var(--brand); color:var(--brand); background:rgba(45,212,191,.08)}
+  .cer-tab small{color:var(--faint); margin-left:7px}
+  .meta-row{display:flex; gap:10px; flex-wrap:wrap; margin-top:16px; align-items:center}
+  .chip{font-family:'IBM Plex Mono',monospace; font-size:11.5px; padding:6px 11px; border-radius:999px;
+    border:1px solid var(--line-2); color:var(--muted); background:rgba(255,255,255,.015)}
+  .chip b{color:var(--ink); font-weight:500}
+  .chip.active-v{border-color:rgba(45,212,191,.5); color:var(--brand)}
+
+  /* ---- section scaffold ---- */
+  section{margin:42px 0}
+  .sec-head{display:flex; align-items:baseline; gap:14px; margin-bottom:18px}
+  .sec-num{font-family:'IBM Plex Mono',monospace; font-size:12px; color:var(--faint)}
+  h2{font-family:'Fraunces',serif; font-weight:500; font-size:24px; margin:0; letter-spacing:-.01em}
+  .sec-note{color:var(--muted); font-size:13.5px; margin-left:auto; max-width:46ch; text-align:right}
+
+  .panel{background:linear-gradient(180deg,var(--panel),var(--bg-2)); border:1px solid var(--line);
+    border-radius:var(--r); box-shadow:var(--shadow)}
+
+  /* ---- flow diagram ---- */
+  .flow-card{padding:10px 8px 4px}
+  #flow{width:100%; height:auto; display:block}
+  .node-box{fill:var(--panel-2); stroke:var(--line-2); stroke-width:1; rx:11; transition:.25s}
+  .node-box.hot{stroke:var(--brand); fill:#16202a}
+  .node-t{fill:var(--ink); font-family:'IBM Plex Sans'; font-size:14px; font-weight:500}
+  .node-s{fill:var(--faint); font-family:'IBM Plex Mono'; font-size:9.5px; letter-spacing:.04em}
+  .node-i{fill:var(--faint); font-family:'IBM Plex Mono'; font-size:10px}
+  .edge{stroke:var(--line-2); stroke-width:1.6; fill:none; marker-end:url(#arrow)}
+  .edge.loop{stroke:var(--more); stroke-dasharray:5 5; opacity:0; marker-end:url(#arrow-more)}
+  .edge.loop.show{opacity:.9}
+  .loop-label{fill:var(--more); font-family:'IBM Plex Mono'; font-size:10px; opacity:0}
+  .loop-label.show{opacity:1}
+  #token{fill:var(--brand); filter:drop-shadow(0 0 7px rgba(45,212,191,.9))}
+  .outcomes{display:flex; gap:10px; flex-wrap:wrap; padding:6px 14px 16px}
+  .oc{flex:1 1 0; min-width:150px; border:1px solid var(--line); border-radius:11px; padding:11px 13px;
+    background:rgba(255,255,255,.012); opacity:.42; transition:.3s}
+  .oc .och{font-family:'IBM Plex Mono'; font-size:11px; letter-spacing:.12em; text-transform:uppercase; display:flex; gap:8px; align-items:center}
+  .oc .ocd{font-size:12px; color:var(--muted); margin-top:5px}
+  .oc .dot{width:9px; height:9px; border-radius:50%; display:inline-block}
+  .oc.allow .dot{background:var(--admit)} .oc.refer .dot{background:var(--refer)}
+  .oc.deny .dot{background:var(--deny)} .oc.more .dot{background:var(--more)}
+  .oc.lit{opacity:1; transform:translateY(-2px)}
+  .oc.allow.lit{border-color:var(--admit); box-shadow:0 0 0 1px var(--admit),0 10px 30px -12px var(--admit)}
+  .oc.refer.lit{border-color:var(--refer); box-shadow:0 0 0 1px var(--refer),0 10px 30px -12px var(--refer)}
+  .oc.deny.lit{border-color:var(--deny); box-shadow:0 0 0 1px var(--deny),0 10px 30px -12px var(--deny)}
+  .oc.more.lit{border-color:var(--more); box-shadow:0 0 0 1px var(--more),0 10px 30px -12px var(--more)}
+
+  /* ---- workspace grid ---- */
+  .work{display:grid; grid-template-columns:1.32fr 1fr; gap:22px}
+  @media(max-width:980px){.work{grid-template-columns:1fr}}
+  .pad{padding:18px}
+  .panel-title{font-family:'IBM Plex Mono'; font-size:11px; letter-spacing:.18em; text-transform:uppercase;
+    color:var(--faint); display:flex; align-items:center; gap:10px; margin-bottom:14px}
+  .panel-title .ln{flex:1; height:1px; background:var(--line)}
+
+  /* ---- route cards ---- */
+  .route{border:1px solid var(--line); border-radius:12px; background:var(--panel-2); margin-bottom:12px;
+    transition:.2s; position:relative; overflow:hidden}
+  .route::before{content:""; position:absolute; left:0; top:0; bottom:0; width:3px; background:var(--line-2)}
+  .route.eff-allow::before{background:var(--admit)} .route.eff-refer::before{background:var(--refer)}
+  .route.eff-deny::before{background:var(--deny)} .route.eff-request_more::before{background:var(--more)}
+  .route.fired{border-color:var(--brand); box-shadow:0 0 0 1px rgba(45,212,191,.35)}
+  .route.skipped{opacity:.5}
+  .rt-head{display:flex; align-items:center; gap:10px; padding:11px 12px 9px}
+  .pri{font-family:'IBM Plex Mono'; font-size:11px; color:var(--faint); width:22px; height:22px;
+    border:1px solid var(--line-2); border-radius:6px; display:grid; place-items:center; flex:none}
+  .rt-name{font-weight:500; font-size:14.5px; background:transparent; border:none; color:var(--ink);
+    font-family:'IBM Plex Sans'; width:auto; min-width:90px}
+  .rt-name:focus{outline:none; border-bottom:1px solid var(--brand)}
+  .vis{font-family:'IBM Plex Mono'; font-size:9.5px; letter-spacing:.1em; text-transform:uppercase;
+    padding:2px 7px; border-radius:5px; border:1px solid var(--line-2); color:var(--faint); cursor:pointer}
+  .vis.unlisted{color:var(--more); border-color:rgba(167,139,250,.4)}
+  .rt-tools{margin-left:auto; display:flex; gap:4px}
+  .ib{background:transparent; border:1px solid var(--line); color:var(--muted); width:24px; height:24px;
+    border-radius:6px; cursor:pointer; font-family:'IBM Plex Mono'; font-size:13px; display:grid; place-items:center; transition:.15s}
+  .ib:hover{border-color:var(--brand); color:var(--brand)}
+  .ib:disabled{opacity:.3; cursor:not-allowed}
+  .drag-handle{cursor:grab; color:var(--faint); font-size:14px; user-select:none; padding:0 3px 0 1px; line-height:1}
+  .drag-handle:active{cursor:grabbing}
+  .route.dragging{opacity:.35}
+  .route.drag-over{box-shadow:inset 0 3px 0 -1px var(--brand)}
+  .flow-legend{display:flex; gap:18px; flex-wrap:wrap; padding:13px 16px 0; font-family:'IBM Plex Mono'; font-size:11px; color:var(--muted)}
+  .flow-legend span{display:flex; gap:7px; align-items:center}
+  .flow-ns{padding:5px 16px 0; font-family:'IBM Plex Mono'; font-size:10px; color:var(--faint)}
+  .kd{width:8px; height:8px; border-radius:50%; display:inline-block}
+  .kd.wire{background:var(--brand)} .kd.local{background:var(--faint)} .kd.internal{background:var(--more)}
+  .kind-dot.wire{fill:var(--brand)} .kind-dot.local{fill:var(--faint)} .kind-dot.internal{fill:var(--more)}
+  .rt-body{padding:0 12px 12px; display:flex; flex-direction:column; gap:9px}
+  .when-row{display:flex; gap:7px; flex-wrap:wrap; align-items:center}
+  .comb{font-family:'IBM Plex Mono'; font-size:10px; letter-spacing:.1em; color:var(--brand);
+    border:1px solid rgba(45,212,191,.35); border-radius:5px; padding:3px 7px; cursor:pointer; user-select:none}
+  .cond{font-family:'IBM Plex Mono'; font-size:11px; padding:4px 8px; border-radius:6px;
+    border:1px solid var(--line-2); background:rgba(255,255,255,.02); color:var(--ink); display:inline-flex; gap:6px; align-items:center}
+  .cond.met{border-color:rgba(52,211,153,.5); color:var(--admit)}
+  .cond.unmet{border-color:rgba(251,113,133,.4); color:var(--deny)}
+  .cond .x{cursor:pointer; opacity:.5; font-weight:600} .cond .x:hover{opacity:1}
+  .add-cond, .then-sel{font-family:'IBM Plex Mono'; font-size:11px; background:var(--bg-2);
+    border:1px dashed var(--line-2); color:var(--muted); border-radius:6px; padding:4px 8px; cursor:pointer}
+  .then-row{display:flex; gap:8px; align-items:center; font-size:12.5px; color:var(--muted); padding-top:2px; flex-wrap:wrap}
+  .arrow-then{font-family:'IBM Plex Mono'; color:var(--faint)}
+  select,input.txt{background:var(--bg-2); border:1px solid var(--line-2); color:var(--ink);
+    font-family:'IBM Plex Mono'; font-size:11.5px; border-radius:6px; padding:4px 7px}
+  .add-route{width:100%; padding:11px; border:1px dashed var(--line-2); background:transparent;
+    color:var(--muted); border-radius:11px; cursor:pointer; font-family:'IBM Plex Mono'; font-size:12px; transition:.15s}
+  .add-route:hover{border-color:var(--brand); color:var(--brand)}
+  .default-route{border-style:dashed; opacity:.8}
+  .default-route .rt-head{padding-bottom:11px}
+
+  /* ---- simulator ---- */
+  .presets{display:flex; flex-wrap:wrap; gap:6px; margin-bottom:16px}
+  .preset{font-family:'IBM Plex Mono'; font-size:11px; padding:6px 10px; border-radius:8px;
+    border:1px solid var(--line-2); background:rgba(255,255,255,.015); color:var(--muted); cursor:pointer; transition:.15s}
+  .preset:hover{border-color:var(--brand); color:var(--ink)}
+  .wallet{display:flex; flex-direction:column; gap:2px; margin-bottom:16px}
+  .ev{display:flex; align-items:center; gap:11px; padding:9px 4px; border-bottom:1px solid var(--line)}
+  .ev:last-child{border-bottom:none}
+  .ev-label{font-size:13px}
+  .ev-label small{display:block; color:var(--faint); font-family:'IBM Plex Mono'; font-size:10px; margin-top:1px}
+  .ev .ctrl{margin-left:auto}
+  .tog{width:42px; height:23px; border-radius:999px; background:var(--bg-2); border:1px solid var(--line-2);
+    position:relative; cursor:pointer; transition:.2s}
+  .tog::after{content:""; position:absolute; top:2px; left:2px; width:17px; height:17px; border-radius:50%;
+    background:var(--faint); transition:.2s}
+  .tog.on{background:rgba(45,212,191,.22); border-color:var(--brand)}
+  .tog.on::after{left:21px; background:var(--brand)}
+  .tog.dim{opacity:.4; pointer-events:none}
+  .stepper{display:flex; align-items:center; gap:9px; font-family:'IBM Plex Mono'; font-size:13px}
+  .stepper button{width:24px; height:24px; border-radius:6px; border:1px solid var(--line-2);
+    background:var(--bg-2); color:var(--ink); cursor:pointer}
+  .run{width:100%; margin-top:6px; padding:13px; border-radius:11px; border:1px solid var(--brand);
+    background:linear-gradient(180deg,rgba(45,212,191,.16),rgba(45,212,191,.05)); color:var(--brand);
+    font-family:'IBM Plex Mono'; font-size:13px; letter-spacing:.06em; cursor:pointer; transition:.15s}
+  .run:hover{background:rgba(45,212,191,.24)}
+  .verdict{margin-top:16px; border-radius:12px; border:1px solid var(--line); padding:16px; display:none; background:var(--bg-2)}
+  .verdict.show{display:block; animation:pop .35s ease}
+  @keyframes pop{from{opacity:0; transform:translateY(6px)}to{opacity:1; transform:none}}
+  .v-top{display:flex; align-items:center; gap:10px}
+  .v-badge{font-family:'IBM Plex Mono'; font-size:12px; letter-spacing:.1em; text-transform:uppercase;
+    padding:5px 11px; border-radius:7px; font-weight:600}
+  .v-badge.allow{background:rgba(52,211,153,.16); color:var(--admit)}
+  .v-badge.refer{background:rgba(251,191,36,.16); color:var(--refer)}
+  .v-badge.deny{background:rgba(251,113,133,.16); color:var(--deny)}
+  .v-badge.request_more{background:rgba(167,139,250,.16); color:var(--more)}
+  .v-route{font-family:'IBM Plex Mono'; font-size:11px; color:var(--muted)}
+  .v-expl{margin-top:11px; font-size:13.5px; color:var(--ink)}
+  .v-missing{margin-top:12px; display:flex; gap:8px; flex-wrap:wrap; align-items:center}
+  .satisfy{font-family:'IBM Plex Mono'; font-size:11px; padding:5px 9px; border-radius:7px; cursor:pointer;
+    border:1px solid var(--more); color:var(--more); background:rgba(167,139,250,.08)}
+  .satisfy:hover{background:rgba(167,139,250,.2)}
+
+  /* ---- version history ---- */
+  .draft-banner{display:none; align-items:center; gap:12px; padding:11px 15px; border-radius:11px;
+    border:1px solid rgba(251,191,36,.4); background:rgba(251,191,36,.07); color:var(--refer);
+    font-size:13px; margin-bottom:16px; font-family:'IBM Plex Mono'}
+  .draft-banner.show{display:flex}
+  .draft-banner .sp{flex:1}
+  .db-btn{font-family:'IBM Plex Mono'; font-size:11.5px; padding:6px 11px; border-radius:7px; cursor:pointer; border:1px solid transparent}
+  .db-btn.go{border-color:var(--admit); color:var(--admit); background:rgba(52,211,153,.1)}
+  .db-btn.discard{border-color:var(--line-2); color:var(--muted)}
+  .timeline{position:relative; padding-left:26px}
+  .timeline::before{content:""; position:absolute; left:8px; top:6px; bottom:6px; width:1px; background:var(--line-2)}
+  .ver{position:relative; margin-bottom:14px; padding:13px 15px; border:1px solid var(--line); border-radius:11px; background:var(--panel-2)}
+  .ver::before{content:""; position:absolute; left:-22px; top:18px; width:11px; height:11px; border-radius:50%;
+    background:var(--bg); border:2px solid var(--faint)}
+  .ver.active::before{background:var(--brand); border-color:var(--brand); box-shadow:0 0 0 4px rgba(45,212,191,.2)}
+  .ver.rollback::before{border-color:var(--more)}
+  .ver-top{display:flex; align-items:center; gap:10px; flex-wrap:wrap}
+  .ver-v{font-family:'Fraunces'; font-size:18px; font-weight:600}
+  .ver-tag{font-family:'IBM Plex Mono'; font-size:9.5px; letter-spacing:.1em; text-transform:uppercase;
+    padding:2px 7px; border-radius:5px; border:1px solid var(--line-2); color:var(--faint)}
+  .ver-tag.active{color:var(--brand); border-color:var(--brand)}
+  .ver-tag.rollback{color:var(--more); border-color:rgba(167,139,250,.4)}
+  .ver-hash{font-family:'IBM Plex Mono'; font-size:11px; color:var(--faint); margin-left:auto}
+  .ver-note{font-size:13.5px; margin-top:7px}
+  .ver-meta{font-family:'IBM Plex Mono'; font-size:10.5px; color:var(--faint); margin-top:6px; display:flex; gap:14px; flex-wrap:wrap}
+  .ver-acts{display:flex; gap:7px; margin-top:11px}
+  .ver-btn{font-family:'IBM Plex Mono'; font-size:11px; padding:5px 11px; border-radius:7px; cursor:pointer;
+    border:1px solid var(--line-2); background:transparent; color:var(--muted); transition:.15s}
+  .ver-btn:hover{border-color:var(--brand); color:var(--brand)}
+  .ver-btn.rb:hover{border-color:var(--more); color:var(--more)}
+
+  /* diff */
+  .diff{margin-top:8px; border-top:1px dashed var(--line); padding-top:10px; display:none; flex-direction:column; gap:3px}
+  .diff.show{display:flex}
+  .dl{font-family:'IBM Plex Mono'; font-size:11.5px; padding:2px 8px; border-radius:5px}
+  .dl.add{color:var(--admit); background:rgba(52,211,153,.07)}
+  .dl.rem{color:var(--deny); background:rgba(251,113,133,.07)}
+  .dl.mov{color:var(--refer); background:rgba(251,191,36,.06)}
+  .dl.same{color:var(--faint)}
+
+  /* ---- compiled output ---- */
+  details.compiled{border:1px solid var(--line); border-radius:var(--r); background:var(--panel); overflow:hidden}
+  details.compiled summary{cursor:pointer; padding:16px 18px; font-family:'IBM Plex Mono'; font-size:12px;
+    letter-spacing:.12em; text-transform:uppercase; color:var(--muted); list-style:none; display:flex; align-items:center; gap:10px}
+  details.compiled summary::-webkit-details-marker{display:none}
+  details.compiled summary::before{content:"▸"; color:var(--brand); transition:.2s}
+  details.compiled[open] summary::before{transform:rotate(90deg)}
+  .tabs{display:flex; gap:6px; padding:0 18px 14px}
+  .tab{font-family:'IBM Plex Mono'; font-size:11.5px; padding:6px 13px; border-radius:8px; cursor:pointer;
+    border:1px solid var(--line); color:var(--muted); background:transparent}
+  .tab.on{border-color:var(--brand); color:var(--brand); background:rgba(45,212,191,.08)}
+  pre{margin:0; padding:18px 20px; background:var(--bg-2); border-top:1px solid var(--line); overflow:auto;
+    font-family:'IBM Plex Mono'; font-size:12px; line-height:1.65; color:#c9d3e2}
+  pre .k{color:var(--more)} pre .s{color:var(--admit)} pre .c{color:var(--faint); font-style:italic} pre .n{color:var(--refer)}
+
+  footer{margin-top:54px; padding-top:24px; border-top:1px solid var(--line); color:var(--faint);
+    font-size:12.5px; font-family:'IBM Plex Mono'}
+  footer a{color:var(--brand); text-decoration:none}
+  .legend{display:flex; gap:18px; flex-wrap:wrap; margin-top:16px; font-family:'IBM Plex Mono'; font-size:11.5px; color:var(--muted)}
+  .legend span{display:flex; gap:7px; align-items:center}
+  .legend i{width:10px; height:10px; border-radius:3px; display:inline-block}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header>
+    <div class="kicker">Ceremony Decision Pipeline · interactive</div>
+    <h1>One pipeline, <em>every ceremony</em>.</h1>
+    <p class="sub">Every community ceremony is an instance of one decision pipeline. Pick a ceremony, edit its
+      routes, drop a sample scenario into the simulator, watch which route fires, then version the policy and roll
+      it back — fail-forward. The vocabulary matches <b>vtc-ceremony-rule-ir.md</b> and <b>examples/</b>.</p>
+    <div class="cer-tabs" id="cerTabs">
+      <span class="cer-tab on" data-c="join">Join<small>onboard</small></span>
+      <span class="cer-tab" data-c="leave">Leave<small>offboard</small></span>
+      <span class="cer-tab" data-c="role-change">Role-change<small>mutate</small></span>
+      <span class="cer-tab" data-c="directory">Directory<small>read</small></span>
+    </div>
+    <div class="meta-row">
+      <span class="chip">ceremony <b id="cerChip">join</b></span>
+      <span class="chip">community <b>did:webvh:acme.example</b></span>
+      <span class="chip active-v" id="activeChip">active <b>v1</b></span>
+      <span class="chip">engine <b>regorus · Rego</b></span>
+    </div>
+    <div class="legend">
+      <span><i style="background:var(--admit)"></i> <span id="legAllow">allow (here: admit)</span></span>
+      <span><i style="background:var(--refer)"></i> refer · human / quorum</span>
+      <span><i style="background:var(--more)"></i> request_more · negotiation</span>
+      <span><i style="background:var(--deny)"></i> deny</span>
+    </div>
+  </header>
+
+  <!-- 1 · CEREMONY FLOW -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">01</span><h2>The pipeline</h2>
+      <span class="sec-note">Crypto is verified host-side in <em>Pre-verify</em>; <em>Evaluate</em> runs the policy over verified facts. Same stages for every ceremony — only Effects differ.</span>
+    </div>
+    <div class="panel flow-card">
+      <div class="flow-legend">
+        <span><i class="kd wire"></i> wire · Trust Task</span>
+        <span><i class="kd local"></i> local · client</span>
+        <span><i class="kd internal"></i> server-internal</span>
+      </div>
+      <div class="flow-ns" id="flowNs"></div>
+      <svg id="flow" viewBox="0 -20 1120 280" preserveAspectRatio="xMidYMid meet"></svg>
+      <div class="outcomes" id="outcomes"></div>
+    </div>
+  </section>
+
+  <!-- 2 · ROUTES + SIMULATOR -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">02</span><h2>Routes &amp; simulator</h2>
+      <span class="sec-note">A “path” is a prioritized rule branch. The actor presents what they have; the policy matches the first eligible route, top-down.</span>
+    </div>
+    <div class="work">
+      <div class="panel pad">
+        <div class="panel-title"><span id="routesTitle">Join policy · routes</span> <span class="ln"></span> <span class="mono" style="font-size:11px;color:var(--faint)">first-match ↓</span></div>
+        <div id="routes"></div>
+        <button class="add-route" id="addRoute">+ add route</button>
+      </div>
+
+      <div class="panel pad">
+        <div class="panel-title"><span id="simTitle">Simulator · applicant wallet</span> <span class="ln"></span></div>
+        <div class="presets" id="presets"></div>
+        <div class="wallet" id="wallet"></div>
+        <button class="run" id="run">▶ run ceremony</button>
+        <div class="verdict" id="verdict"></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 3 · VERSIONS -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">03</span><h2>Version history &amp; rollback</h2>
+      <span class="sec-note">Per-ceremony, append-only, hash-chained — like WebVH. Rollback fails forward: it appends a new version, it never rewinds.</span>
+    </div>
+    <div class="panel pad">
+      <div class="draft-banner" id="draftBanner">
+        <span>▲ Draft has unsaved changes vs active <b id="dbActive">v1</b></span>
+        <span class="sp"></span>
+        <button class="db-btn go" id="activateBtn">activate as new version</button>
+        <button class="db-btn discard" id="discardBtn">discard</button>
+      </div>
+      <div class="timeline" id="timeline"></div>
+    </div>
+  </section>
+
+  <!-- 4 · COMPILED -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">04</span><h2>Compiled artifacts</h2>
+      <span class="sec-note">The Rule IR compiles to Rego (enforce) + a Presentation Definition (evidence-bearing ceremonies) + a human summary.</span>
+    </div>
+    <details class="compiled" open>
+      <summary>generated from the current routes — regenerates on every edit</summary>
+      <div class="tabs" id="tabs">
+        <span class="tab on" data-t="rego" id="regoTab">join.rego</span>
+        <span class="tab" data-t="pd">presentation_definition.json</span>
+        <span class="tab" data-t="en">human summary</span>
+      </div>
+      <pre id="compiledOut"></pre>
+    </details>
+  </section>
+
+  <footer>
+    Design aid for <b>vtc-service</b> · the ceremony decision pipeline (see
+    <span class="mono">vtc-ceremony-pipeline.md</span>, <span class="mono">vtc-ceremony-catalog.md</span>,
+    <span class="mono">vtc-ceremony-rule-ir.md</span>). Not wired to the running service — it models the intended
+    shape. Verdict colours are the generic <span class="mono">allow / refer / request_more / deny</span>;
+    each ceremony realizes <span class="mono">allow</span> differently (join → admit, leave → execute departure,
+    directory → return a field projection). Concepts:
+    <a href="https://identity.foundation/presentation-exchange/">DIF Presentation Exchange</a> ·
+    DTG credentials · <a href="https://www.openpolicyagent.org/docs/policy-language">Rego</a>.
+  </footer>
+</div>
+
+<script>
+/* ============================================================= UTIL */
+const clone = o => JSON.parse(JSON.stringify(o));
+function shortHash(obj){
+  const s=JSON.stringify(obj); let h=0x811c9dc5;
+  for(let i=0;i<s.length;i++){ h^=s.charCodeAt(i); h=Math.imul(h,0x01000193); }
+  return (h>>>0).toString(16).padStart(8,'0');
+}
+function esc(s){ return s.replace(/&/g,'&amp;').replace(/</g,'&lt;'); }
+
+/* ============================================================= CEREMONY CONFIGS */
+const CEREMONIES = {
+  join: {
+    label:'Join', simLabel:'applicant wallet', pkg:'vtc.join', family:'join-requests',
+    allowLabel:'admit', flowEffects:'issue + accept', genPD:true, allowObligation:'reciprocate_vmc',
+    manifestNs:'tasks under https://trusttasks.org/openvtc/vtc/join-requests/  ·  “…/” = that prefix',
+    v1note:'Initial join policy — invitation, verified-human, almost-there, open review',
+    allowPayload:{key:'role', kind:'text', def:'member'},
+    effects:['allow','request_more','refer','deny'],
+    conds:{
+      has_valid_invitation:{label:'Valid invitation (VIC)', short:'has_valid_invitation', rego:'has_valid_invitation', cred:null},
+      witness:{label:'Trusted WitnessCredential',           short:'holds_trusted("WitnessCredential")', rego:'cred_trusted("WitnessCredential")', cred:'WitnessCredential'},
+      coc:{label:'Agrees to code of conduct',               short:'agreed("code-of-conduct")', rego:'agreed("code-of-conduct")', cred:null},
+      endorse2:{label:'≥2 member endorsements',             short:'endorsement_count >= 2', rego:'endorsement_count >= 2', cred:'EndorsementCredential'},
+      always:{label:'Any applicant',                        short:'true', rego:'true', cred:null},
+    },
+    outcomes:{
+      allow:'issue VMC + role VEC · reciprocal edge · write ACL',
+      refer:'queue for a moderator — human-in-the-loop review',
+      request_more:'return a Presentation Definition for what’s missing',
+      deny:'no matching route — structural default-deny',
+    },
+    helpers:[
+      'cred_trusted(t) <span class="k">if</span> { <span class="k">some</span> c <span class="k">in</span> input.evidence.presentation.credentials; c.type == t; c.issuer_trusted; c.status == <span class="s">"valid"</span> }',
+      'has_valid_invitation <span class="k">if</span> { input.evidence.invitation.verified; <span class="k">not</span> input.evidence.invitation.consumed }',
+      'endorsement_count := <span class="n">count</span>([c | <span class="k">some</span> c <span class="k">in</span> input.evidence.presentation.credentials; c.type == <span class="s">"EndorsementCredential"</span>])',
+      'agreed(tag) <span class="k">if</span> { input.evidence.request.agreements[tag] == <span class="k">true</span> }',
+    ],
+    usesIn:true,
+    scenario:{
+      init:()=>({inv:false, witnessPresent:false, witnessTrusted:true, coc:false, endorsements:0}),
+      fields:[
+        {id:'inv',            label:'Valid invitation (VIC)', sub:'DTG InvitationCredential, issuer authorized', type:'tog'},
+        {id:'witnessPresent', label:'WitnessCredential',      sub:'holds a WitnessCredential',                   type:'tog'},
+        {id:'witnessTrusted', label:'…issuer recognized',     sub:'resolved via trust registry (TRQP)',          type:'tog', dimWhen:'witnessPresent'},
+        {id:'coc',            label:'Agrees to code of conduct', sub:'evidence.request.agreements["code-of-conduct"]', type:'tog'},
+        {id:'endorsements',   label:'Member endorsements',    sub:'EndorsementCredentials from members',          type:'step'},
+      ],
+      presets:[
+        {n:'Unknown DID',     w:{inv:false,witnessPresent:false,witnessTrusted:true,coc:false,endorsements:0}},
+        {n:'Invited (VIC)',   w:{inv:true, witnessPresent:false,witnessTrusted:true,coc:false,endorsements:0}},
+        {n:'Verified human',  w:{inv:false,witnessPresent:true, witnessTrusted:true,coc:true, endorsements:0}},
+        {n:'Almost (no CoC)', w:{inv:false,witnessPresent:true, witnessTrusted:true,coc:false,endorsements:0}},
+        {n:'Untrusted issuer',w:{inv:false,witnessPresent:true, witnessTrusted:false,coc:true,endorsements:0}},
+      ],
+      test:(id,sc)=>{ switch(id){
+        case 'has_valid_invitation': return !!sc.inv;
+        case 'witness':  return sc.witnessPresent && sc.witnessTrusted;
+        case 'coc':      return !!sc.coc;
+        case 'endorse2': return (sc.endorsements||0) >= 2;
+        case 'always':   return true;
+        default:         return false; } },
+      satisfy:(need,sc)=>{ if(need==='coc') sc.coc=true; else if(need==='witness'){ sc.witnessPresent=true; sc.witnessTrusted=true; } else if(need==='endorse2') sc.endorsements=2; },
+    },
+    defaultRoutes:()=>[
+      {name:'Invitation',   comb:'all', conds:['has_valid_invitation'], effect:{type:'allow', role:'member'},        listed:false},
+      {name:'Verified human',comb:'all', conds:['witness','coc'],       effect:{type:'allow', role:'member'},        listed:true},
+      {name:'Almost there', comb:'all', conds:['witness'],              effect:{type:'request_more', needs:['coc']}, listed:true},
+      {name:'Open review',  comb:'all', conds:['always'],               effect:{type:'refer', queue:'moderator'},    listed:true},
+    ],
+  },
+
+  leave: {
+    label:'Leave', simLabel:'departure scenario', pkg:'vtc.leave', family:'departures',
+    allowLabel:'execute departure', flowEffects:'revoke + disposition', genPD:false,
+    manifestNs:'tasks under https://trusttasks.org/openvtc/vtc/departures/  ·  actor ≠ subject · destructive',
+    v1note:'Initial leave policy — self-exit, admin-removes-admin → second-admin, admin-removes-member',
+    allowPayload:{key:'disposition', kind:'select', opts:['Tombstone','Purge','Historical','$request'], def:'Tombstone'},
+    effects:['allow','refer','request_more','deny'],
+    conds:{
+      actor_is_self:{label:'Actor is the member (self-exit)', short:'actor_is_self', rego:'input.actor.did == input.subject.did', cred:null},
+      actor_is_admin:{label:'Actor is an admin',             short:'actor_is_admin', rego:'input.actor.role == <span class="s">"admin"</span>', cred:null},
+      subject_is_admin:{label:'Subject is an admin',         short:'subject_is_admin', rego:'input.state.subject_member.role == <span class="s">"admin"</span>', cred:null},
+      disposition_requested:{label:'A disposition was requested', short:'disposition_requested', rego:'input.evidence.request.disposition', cred:null},
+      always:{label:'Anyone',                                short:'true', rego:'true', cred:null},
+    },
+    outcomes:{
+      allow:'revoke VMC (flip status bit) · apply disposition · registry departure',
+      refer:'a second admin must co-sign the removal',
+      request_more:'require a documented-reason credential first',
+      deny:'policy refuses — no matching route',
+    },
+    helpers:[
+      '<span class="c"># "$request" → the disposition the actor asked for, else PolicyDefault</span>',
+      'disposition := input.evidence.request.disposition <span class="k">if</span> { input.evidence.request.disposition } <span class="k">else</span> := <span class="s">"PolicyDefault"</span>',
+      '<span class="c"># NOTE: no-last-admin is enforced by the HOST around this policy, never in Rego.</span>',
+    ],
+    usesIn:false,
+    scenario:{
+      init:()=>({actor:'admin', subjectRole:'member', disposition:'(none)'}),
+      fields:[
+        {id:'actor',       label:'Actor (who triggers)',   sub:'self-exit vs admin removal',     type:'select', opts:['self','admin']},
+        {id:'subjectRole', label:'Subject’s current role', sub:'state.subject_member.role',       type:'select', opts:['member','admin']},
+        {id:'disposition', label:'Requested disposition',  sub:'self-exit may choose one',        type:'select', opts:['(none)','Tombstone','Purge','Historical']},
+      ],
+      presets:[
+        {n:'Self-exit',       w:{actor:'self',  subjectRole:'member', disposition:'Tombstone'}},
+        {n:'Admin → member',  w:{actor:'admin', subjectRole:'member', disposition:'(none)'}},
+        {n:'Admin → admin',   w:{actor:'admin', subjectRole:'admin',  disposition:'(none)'}},
+      ],
+      test:(id,sc)=>{ switch(id){
+        case 'actor_is_self':    return sc.actor==='self';
+        case 'actor_is_admin':   return sc.actor==='admin';
+        case 'subject_is_admin': return sc.subjectRole==='admin';
+        case 'disposition_requested': return sc.disposition!=='(none)';
+        case 'always':           return true;
+        default:                 return false; } },
+      satisfy:null,
+    },
+    defaultRoutes:()=>[
+      {name:'Self-exit',          comb:'all', conds:['actor_is_self'],                  effect:{type:'allow', disposition:'$request'}, listed:false},
+      {name:'Admin removes admin',comb:'all', conds:['actor_is_admin','subject_is_admin'], effect:{type:'refer', queue:'second-admin'}, listed:false},
+      {name:'Admin removes member',comb:'all',conds:['actor_is_admin'],                 effect:{type:'allow', disposition:'Tombstone'}, listed:false},
+    ],
+  },
+
+  directory: {
+    label:'Directory', simLabel:'viewer', pkg:'vtc.directory', family:'directory',
+    allowLabel:'return fields', flowEffects:'return projection', genPD:false,
+    manifestNs:'tasks under https://trusttasks.org/openvtc/vtc/directory/  ·  synchronous · no thread',
+    v1note:'Initial directory policy — admin sees full record, member sees did + role',
+    allowPayload:{key:'fields', kind:'text', def:'did, role'},
+    effects:['allow','deny'],
+    conds:{
+      viewer_is_admin:{label:'Viewer is an admin', short:'viewer_is_admin', rego:'input.actor.role == <span class="s">"admin"</span>', cred:null},
+      viewer_is_member:{label:'Viewer is a member', short:'viewer_is_member', rego:'input.actor.authenticated == <span class="k">true</span>', cred:null},
+      always:{label:'Anyone', short:'true', rego:'true', cred:null},
+    },
+    outcomes:{
+      allow:'return exactly the permitted field projection — inline, no write',
+      refer:'(unused for directory)',
+      request_more:'(unused for directory)',
+      deny:'non-member → empty result',
+    },
+    helpers:[],
+    usesIn:false,
+    scenario:{
+      init:()=>({viewer:'member'}),
+      fields:[
+        {id:'viewer', label:'Viewer', sub:'who is asking the directory', type:'select', opts:['admin','member','non-member']},
+      ],
+      presets:[
+        {n:'Admin viewer',  w:{viewer:'admin'}},
+        {n:'Member viewer', w:{viewer:'member'}},
+        {n:'Non-member',    w:{viewer:'non-member'}},
+      ],
+      test:(id,sc)=>{ switch(id){
+        case 'viewer_is_admin':  return sc.viewer==='admin';
+        case 'viewer_is_member': return sc.viewer!=='non-member';
+        case 'always':           return true;
+        default:                 return false; } },
+      satisfy:null,
+    },
+    defaultRoutes:()=>[
+      {name:'Admin viewer', comb:'all', conds:['viewer_is_admin'],  effect:{type:'allow', fields:'did, role, joined_at, status, extensions'}, listed:false},
+      {name:'Member viewer',comb:'all', conds:['viewer_is_member'], effect:{type:'allow', fields:'did, role'},                                listed:false},
+    ],
+  },
+
+  'role-change': {
+    label:'Role-change', simLabel:'role-change scenario', pkg:'vtc.role_change', regoFile:'role-change.rego', family:'role-changes',
+    allowLabel:'re-issue role', flowEffects:'re-issue VEC', genPD:false,
+    manifestNs:'tasks under https://trusttasks.org/openvtc/vtc/role-changes/  ·  actor ≠ subject · escalation',
+    v1note:'Initial role-change policy — standard roles direct, admin promotion via step-up',
+    allowPayload:{key:'role', kind:'select', opts:['$target','member','moderator','admin'], def:'$target'},
+    effects:['allow','refer','request_more','deny'],
+    conds:{
+      target_role_standard:{label:'Target role is standard (not admin)', short:'target_role_standard', rego:'input.evidence.request.target_role != <span class="s">"admin"</span>', cred:null},
+      promotes_to_admin:{label:'Target role is admin',                    short:'promotes_to_admin',    rego:'input.evidence.request.target_role == <span class="s">"admin"</span>', cred:null},
+      step_up_done:{label:'Step-up reauth completed',                     short:'step_up_done',         rego:'input.evidence.request.step_up == <span class="k">true</span>', cred:null},
+      always:{label:'Anyone',                                            short:'true',                 rego:'true', cred:null},
+    },
+    outcomes:{
+      allow:'re-issue the role VEC · update the ACL role',
+      refer:'step-up reauth (or M-of-N) required before admin promotion',
+      request_more:'require additional evidence before the change',
+      deny:'policy refuses — no matching route',
+    },
+    helpers:[
+      '<span class="c"># "$target" → the requested target_role</span>',
+      'target_role := input.evidence.request.target_role',
+      '<span class="c"># admin promotion is allowed HERE (gated by step_up) — unlike join.</span>',
+      '<span class="c"># no-last-admin on demotion is HOST-enforced, never in Rego.</span>',
+    ],
+    usesIn:false,
+    scenario:{
+      init:()=>({targetRole:'moderator', stepUp:false}),
+      fields:[
+        {id:'targetRole', label:'Target role',               sub:'evidence.request.target_role',      type:'select', opts:['member','moderator','admin']},
+        {id:'stepUp',     label:'Step-up reauth completed',  sub:'fresh WebAuthn user-verification',  type:'tog'},
+      ],
+      presets:[
+        {n:'Promote to moderator',          w:{targetRole:'moderator', stepUp:false}},
+        {n:'Promote to admin (no step-up)', w:{targetRole:'admin',     stepUp:false}},
+        {n:'Promote to admin (verified)',   w:{targetRole:'admin',     stepUp:true}},
+      ],
+      test:(id,sc)=>{ switch(id){
+        case 'target_role_standard': return sc.targetRole!=='admin';
+        case 'promotes_to_admin':    return sc.targetRole==='admin';
+        case 'step_up_done':         return sc.stepUp===true;
+        case 'always':               return true;
+        default:                     return false; } },
+      satisfy:null,
+    },
+    defaultRoutes:()=>[
+      {name:'Standard role change',            comb:'all', conds:['target_role_standard'],           effect:{type:'allow', role:'$target'}, listed:false},
+      {name:'Promote to admin (verified)',     comb:'all', conds:['promotes_to_admin','step_up_done'], effect:{type:'allow', role:'admin'},   listed:false},
+      {name:'Promote to admin (needs step-up)',comb:'all', conds:['promotes_to_admin'],              effect:{type:'refer', queue:'step-up'}, listed:false},
+    ],
+  },
+};
+
+/* ============================================================= STATE */
+let cur = 'join';
+const RT = {};
+const C = () => CEREMONIES[cur];
+const S = () => RT[cur];
+
+function initAll(){
+  Object.keys(CEREMONIES).forEach(id=>{
+    const cf=CEREMONIES[id];
+    const routes=cf.defaultRoutes();
+    RT[id]={ routes, scenario:cf.scenario.init(), versions:[{
+      v:1, kind:'create', note:cf.v1note, author:'did:key:z6Mk…Adm1n', ts:'2026-05-20 09:14Z',
+      parent:null, snapshot:clone(routes), hash:shortHash(routes)
+    }], activeV:1, lastResult:null, dragIndex:null };
+  });
+}
+
+/* ============================================================= EVAL */
+function condMet(id, sc){ return C().scenario.test(id, sc); }
+function routeMatches(r, sc){
+  const xs=r.conds.map(c=>condMet(c,sc));
+  return r.comb==='any' ? xs.some(Boolean) : xs.every(Boolean);
+}
+function evaluate(sc){
+  const routes=S().routes;
+  for(let i=0;i<routes.length;i++) if(routeMatches(routes[i],sc)) return {idx:i, route:routes[i], effect:routes[i].effect.type};
+  return {idx:-1, route:null, effect:'deny'};
+}
+function newEffect(type){
+  if(type==='allow'){ const p=C().allowPayload, o={type:'allow'}; o[p.key]=p.def; return o; }
+  if(type==='refer') return {type:'refer', queue:'moderator'};
+  if(type==='request_more') return {type:'request_more', needs:[]};
+  return {type:'deny', reason:'policy'};
+}
+
+/* ============================================================= FLOW DIAGRAM (D3) */
+const STAGES = [
+  {id:'discover',t:'Discover',  s:'…/manifest',      kind:'wire'},
+  {id:'gather',  t:'Gather',    s:'evidence',        kind:'local'},
+  {id:'submit',  t:'Submit',    s:'…/request',       kind:'wire'},
+  {id:'verify',  t:'Pre-verify',s:'host · crypto',   kind:'internal'},
+  {id:'evaluate',t:'Evaluate',  s:'policy · Rego',   kind:'internal'},
+  {id:'verdict', t:'Verdict',   s:'request#response',kind:'wire'},
+  {id:'effects', t:'Effects',   s:'issue + accept',  kind:'wire'},
+];
+const NW=128, NH=54, NY=70;
+const X = i => 36 + i*(1120-72-NW)/(STAGES.length-1) + NW/2;
+
+const svg = d3.select('#flow');
+const defs = svg.append('defs');
+[['arrow','var(--line-2)'],['arrow-more','var(--more)']].forEach(([id,col])=>{
+  defs.append('marker').attr('id',id).attr('viewBox','0 0 10 10').attr('refX',9).attr('refY',5)
+    .attr('markerWidth',7).attr('markerHeight',7).attr('orient','auto-start-reverse')
+    .append('path').attr('d','M0,0 L10,5 L0,10 Z').attr('fill',col);
+});
+const gEdge = svg.append('g');
+for(let i=0;i<STAGES.length-1;i++){
+  gEdge.append('path').attr('class','edge')
+    .attr('d',`M${X(i)+NW/2},${NY+NH/2} L${X(i+1)-NW/2-3},${NY+NH/2}`);
+}
+const lx0=X(5), lx1=X(1);
+svg.append('path').attr('class','edge loop').attr('id','loopEdge')
+  .attr('d',`M${lx0},${NY} C ${lx0},${-2} ${lx1},${-2} ${lx1},${NY-2}`);
+svg.append('text').attr('class','loop-label').attr('id','loopLabel')
+  .attr('x',(lx0+lx1)/2).attr('y',6).attr('text-anchor','middle').text('…/present ↺');
+const gNode = svg.selectAll('.node').data(STAGES).join('g').attr('class','node').attr('id',d=>'n-'+d.id);
+gNode.append('rect').attr('class','node-box').attr('width',NW).attr('height',NH)
+  .attr('x',(d,i)=>X(i)-NW/2).attr('y',NY).attr('rx',11);
+gNode.append('text').attr('class','node-i').attr('x',(d,i)=>X(i)-NW/2+11).attr('y',NY+18).text((d,i)=>String(i+1).padStart(2,'0'));
+gNode.append('text').attr('class','node-t').attr('x',(d,i)=>X(i)).attr('y',NY+26).attr('text-anchor','middle').text(d=>d.t);
+gNode.append('text').attr('class','node-s').attr('id',d=>'ns-'+d.id).attr('x',(d,i)=>X(i)).attr('y',NY+42).attr('text-anchor','middle').text(d=>d.s);
+gNode.append('circle').attr('class',d=>'kind-dot '+d.kind).attr('r',3.2)
+  .attr('cx',(d,i)=>X(i)+NW/2-10).attr('cy',NY+10);
+const token = svg.append('circle').attr('id','token').attr('r',6).attr('cx',X(0)).attr('cy',NY+NH/2).attr('opacity',0);
+
+const OUTCOME_DEFS = [
+  {k:'allow', cls:'allow', h:'allow'},
+  {k:'refer', cls:'refer', h:'refer'},
+  {k:'request_more', cls:'more', h:'request_more'},
+  {k:'deny',  cls:'deny',  h:'deny'},
+];
+function renderOutcomes(){
+  d3.select('#outcomes').selectAll('.oc').data(OUTCOME_DEFS, d=>d.k).join('div')
+    .attr('class',d=>`oc ${d.cls}`).attr('id',d=>'oc-'+d.k)
+    .html(d=>`<div class="och"><span class="dot"></span>${d.h}</div><div class="ocd">${C().outcomes[d.k]}</div>`);
+}
+
+function animateToken(fromX,toX,dur){
+  return new Promise(res=>{
+    token.attr('opacity',1); const t0=performance.now();
+    function step(now){ const p=Math.min(1,(now-t0)/dur), e=p<.5?2*p*p:1-Math.pow(-2*p+2,2)/2;
+      token.attr('cx',fromX+(toX-fromX)*e); if(p<1) requestAnimationFrame(step); else res(); }
+    requestAnimationFrame(step);
+  });
+}
+function animateArc(dur){
+  const path=document.getElementById('loopEdge'), L=path.getTotalLength();
+  d3.select('#loopEdge').classed('show',true); d3.select('#loopLabel').classed('show',true);
+  return new Promise(res=>{ const t0=performance.now();
+    function step(now){ const p=Math.min(1,(now-t0)/dur), pt=path.getPointAtLength(L*p);
+      token.attr('cx',pt.x).attr('cy',pt.y); if(p<1) requestAnimationFrame(step); else { token.attr('cy',NY+NH/2); res(); } }
+    requestAnimationFrame(step);
+  });
+}
+function resetFlow(){
+  svg.selectAll('.node-box').classed('hot',false);
+  d3.selectAll('.oc').classed('lit',false);
+  d3.select('#loopEdge').classed('show',false); d3.select('#loopLabel').classed('show',false);
+  token.attr('opacity',0).attr('cx',X(0)).attr('cy',NY+NH/2);
+}
+async function runFlow(result){
+  resetFlow();
+  for(let i=0;i<=5;i++){
+    svg.select('#n-'+STAGES[i].id).select('.node-box').classed('hot',true);
+    await animateToken(i===0?X(0):X(i-1), X(i), i===0?260:300);
+  }
+  d3.select('#oc-'+result.effect).classed('lit',true);
+  if(result.effect==='allow'){
+    await animateToken(X(5),X(6),320);
+    svg.select('#n-effects').select('.node-box').classed('hot',true);
+  } else if(result.effect==='request_more'){
+    await new Promise(r=>setTimeout(r,250));
+    await animateArc(900);
+    svg.select('#n-gather').select('.node-box').classed('hot',true);
+  }
+  token.transition().duration(400).attr('opacity',0);
+}
+
+/* ============================================================= ROUTES UI */
+const routesEl = d3.select('#routes');
+function renderRoutes(){
+  const routes=S().routes, lastResult=S().lastResult, conds=C().conds;
+  const data=routes.map((r,i)=>({r,i}));
+  const sel=routesEl.selectAll('.route:not(.default-route)').data(data,(d,i)=>i);
+  sel.exit().remove();
+  const enter=sel.enter().append('div').attr('class','route');
+  enter.append('div').attr('class','rt-head');
+  enter.append('div').attr('class','rt-body');
+  const all=enter.merge(sel);
+
+  all.attr('class',d=>{
+    let c='route eff-'+d.r.effect.type;
+    if(lastResult){ if(lastResult.idx===d.i) c+=' fired'; else if(lastResult.idx<0 || d.i<lastResult.idx) c+=' skipped'; }
+    return c;
+  });
+
+  all.on('dragover',function(e){ e.preventDefault(); e.dataTransfer.dropEffect='move'; d3.select(this).classed('drag-over',true); })
+    .on('dragleave',function(){ d3.select(this).classed('drag-over',false); })
+    .on('drop',function(e,d){ e.preventDefault(); d3.select(this).classed('drag-over',false); reorder(S().dragIndex,d.i); });
+
+  all.select('.rt-head').html('').each(function(d){
+    const head=d3.select(this);
+    head.append('span').attr('class','drag-handle').attr('draggable',true).attr('title','drag to reorder').text('⠿')
+      .on('dragstart',function(e){ S().dragIndex=d.i; e.dataTransfer.effectAllowed='move';
+        e.dataTransfer.setData('text/plain',String(d.i)); this.closest('.route').classList.add('dragging'); })
+      .on('dragend',function(){ S().dragIndex=null; d3.selectAll('.route').classed('dragging',false).classed('drag-over',false); });
+    head.append('div').attr('class','pri').text('P'+(d.i+1));
+    head.append('input').attr('class','rt-name').attr('value',d.r.name).on('change',function(){ d.r.name=this.value; onEdit(); });
+    head.append('span').attr('class','vis'+(d.r.listed?'':' unlisted')).text(d.r.listed?'public':'unlisted')
+      .attr('title','toggle manifest visibility').on('click',()=>{ d.r.listed=!d.r.listed; onEdit(); });
+    const tools=head.append('div').attr('class','rt-tools');
+    tools.append('button').attr('class','ib').attr('title','move up').property('disabled',d.i===0).text('↑').on('click',()=>move(d.i,-1));
+    tools.append('button').attr('class','ib').attr('title','move down').property('disabled',d.i===routes.length-1).text('↓').on('click',()=>move(d.i,1));
+    tools.append('button').attr('class','ib').attr('title','delete route').text('✕').on('click',()=>{ S().routes.splice(d.i,1); onEdit(); });
+  });
+
+  all.select('.rt-body').html('').each(function(d){
+    const body=d3.select(this);
+    const wr=body.append('div').attr('class','when-row');
+    if(d.r.conds.length>1){
+      wr.append('span').attr('class','comb').text(d.r.comb.toUpperCase())
+        .on('click',()=>{ d.r.comb=d.r.comb==='all'?'any':'all'; onEdit(); });
+    }
+    d.r.conds.forEach((cid,ci)=>{
+      const met=S().lastResult ? condMet(cid,S().scenario) : null;
+      const chip=wr.append('span').attr('class','cond'+(met===true?' met':met===false?' unmet':''));
+      chip.append('span').text(conds[cid]?conds[cid].short:cid);
+      chip.append('span').attr('class','x').text('×').on('click',()=>{ d.r.conds.splice(ci,1); onEdit(); });
+    });
+    const addSel=wr.append('select').attr('class','add-cond');
+    addSel.append('option').attr('value','').text('+ when');
+    Object.keys(conds).filter(k=>!d.r.conds.includes(k)).forEach(k=>addSel.append('option').attr('value',k).text(conds[k].label));
+    addSel.on('change',function(){ if(this.value){ d.r.conds.push(this.value); onEdit(); } });
+
+    const tr=body.append('div').attr('class','then-row');
+    tr.append('span').attr('class','arrow-then').text('then →');
+    const eSel=tr.append('select');
+    C().effects.forEach(e=>eSel.append('option').attr('value',e).attr('selected',e===d.r.effect.type?true:null).text(e));
+    eSel.on('change',function(){ d.r.effect=newEffect(this.value); onEdit(); });
+
+    const eff=d.r.effect;
+    if(eff.type==='allow'){
+      const p=C().allowPayload;
+      tr.append('span').text(p.key);
+      if(p.kind==='select'){
+        const s=tr.append('select').on('change',function(){ eff[p.key]=this.value; updateCompiled(); });
+        p.opts.forEach(o=>s.append('option').attr('value',o).attr('selected',(eff[p.key]||p.def)===o?true:null).text(o));
+      } else {
+        tr.append('input').attr('class','txt').style('width','120px').attr('value',eff[p.key]||p.def)
+          .on('change',function(){ eff[p.key]=this.value; updateCompiled(); });
+      }
+    } else if(eff.type==='refer'){
+      tr.append('span').text('to queue');
+      tr.append('input').attr('class','txt').style('width','110px').attr('value',eff.queue||'moderator').on('change',function(){ eff.queue=this.value; updateCompiled(); });
+    } else if(eff.type==='request_more'){
+      tr.append('span').text('needs');
+      (eff.needs||[]).forEach(n=>tr.append('span').attr('class','cond').style('color','var(--more)').text(conds[n]?conds[n].short:n));
+    } else if(eff.type==='deny'){
+      tr.append('span').text('reason');
+      tr.append('input').attr('class','txt').style('width','130px').attr('value',eff.reason||'policy').on('change',function(){ eff.reason=this.value; updateCompiled(); });
+    }
+  });
+
+  routesEl.selectAll('.default-route').remove();
+  routesEl.append('div').attr('class','route default-route eff-deny')
+    .html(`<div class="rt-head"><div class="pri">∎</div>
+      <span class="rt-name" style="color:var(--faint)">default</span>
+      <span class="vis" style="color:var(--faint)">structural</span></div>
+      <div class="rt-body"><div class="then-row"><span class="arrow-then">then →</span>
+      <span class="cond unmet">deny · no-matching-route</span>
+      <span style="color:var(--faint);font-size:11px">compiler-appended · cannot be removed</span></div></div>`);
+}
+function move(i,dir){
+  const routes=S().routes, j=i+dir; if(j<0||j>=routes.length) return;
+  [routes[i],routes[j]]=[routes[j],routes[i]]; onEdit();
+}
+function reorder(from,to){
+  if(from==null || from===to || to==null) return;
+  const routes=S().routes, item=routes.splice(from,1)[0];
+  routes.splice(to,0,item); S().lastResult=null; onEdit();
+}
+
+/* ============================================================= SIMULATOR UI */
+function renderPresets(){
+  d3.select('#presets').selectAll('.preset').data(C().scenario.presets, d=>d.n).join('div').attr('class','preset')
+    .text(d=>d.n).on('click',d=>{ S().scenario=clone(d.w); renderScenario(); });
+}
+function renderScenario(){
+  const sc=S().scenario, defs=C().scenario.fields;
+  const sel=d3.select('#wallet').selectAll('.ev').data(defs,d=>d.id);
+  sel.exit().remove();
+  const enter=sel.enter().append('div').attr('class','ev');
+  enter.append('div').attr('class','ev-label'); enter.append('div').attr('class','ctrl');
+  const all=enter.merge(sel);
+  all.select('.ev-label').html(d=>`${d.label}<small>${d.sub}</small>`);
+  all.select('.ctrl').html('').each(function(d){
+    const c=d3.select(this);
+    if(d.type==='tog'){
+      const dim=d.dimWhen && !sc[d.dimWhen];
+      c.append('div').attr('class','tog'+(sc[d.id]?' on':'')+(dim?' dim':'')).on('click',()=>{ sc[d.id]=!sc[d.id]; renderScenario(); });
+    } else if(d.type==='step'){
+      const st=c.append('div').attr('class','stepper');
+      st.append('button').text('−').on('click',()=>{ sc[d.id]=Math.max(0,(sc[d.id]||0)-1); renderScenario(); });
+      st.append('span').text(sc[d.id]||0);
+      st.append('button').text('+').on('click',()=>{ sc[d.id]=Math.min(5,(sc[d.id]||0)+1); renderScenario(); });
+    } else if(d.type==='select'){
+      const s=c.append('select').on('change',function(){ sc[d.id]=this.value; renderScenario(); });
+      d.opts.forEach(o=>s.append('option').attr('value',o).attr('selected',sc[d.id]===o?true:null).text(o));
+    }
+  });
+}
+
+async function run(){
+  const res=evaluate(S().scenario);
+  S().lastResult=res;
+  renderRoutes();
+  await runFlow(res);
+  showVerdict(res);
+}
+function showVerdict(res){
+  const v=d3.select('#verdict').attr('class','verdict show');
+  const eff=res.effect, rname=res.route?res.route.name:'—', pri=res.idx<0?'default':'P'+(res.idx+1);
+  let expl='', extra='';
+  if(eff==='allow'){
+    const e=res.route.effect, p=C().allowPayload, sc=S().scenario; let val=e[p.key]||p.def;
+    if(val==='$target') val=sc.targetRole;
+    else if(val==='$request') val=(sc.disposition && sc.disposition!=='(none)')?sc.disposition:'PolicyDefault';
+    expl=`<b>allow</b> — ${C().allowLabel}. Verdict carries <b>${p.key}: ${val}</b>. ${C().outcomes.allow}.`;
+  } else if(eff==='refer'){
+    expl=`<b>refer</b> → <b>${res.route.effect.queue||'moderator'}</b>. ${C().outcomes.refer}.`;
+  } else if(eff==='request_more'){
+    const needs=(res.route.effect.needs||[]).filter(n=>!condMet(n,S().scenario));
+    expl=`<b>request_more</b> on the <b>${rname}</b> route. ${C().outcomes.request_more}, then loops back to Gather.`;
+    if(C().scenario.satisfy && needs.length){
+      extra=`<div class="v-missing"><span style="color:var(--faint);font-family:'IBM Plex Mono';font-size:11px">still need:</span>`+
+        needs.map(n=>`<button class="satisfy" data-need="${n}">+ ${C().conds[n]?C().conds[n].short:n}</button>`).join('')+`</div>`;
+    }
+  } else {
+    expl=`<b>deny</b> — ${C().outcomes.deny}. The compiler guarantees the policy always reaches a decision.`;
+  }
+  v.html(`<div class="v-top"><span class="v-badge ${eff}">${eff}</span><span class="v-route">matched ${pri} · ${rname}</span></div><div class="v-expl">${expl}</div>${extra}`);
+  v.selectAll('.satisfy').on('click',function(){ C().scenario.satisfy(this.getAttribute('data-need'), S().scenario); renderScenario(); run(); });
+}
+
+/* ============================================================= VERSIONS */
+function isDraftDirty(){
+  const active=S().versions.find(x=>x.v===S().activeV);
+  return active ? shortHash(S().routes)!==active.hash : true;
+}
+function renderVersions(){
+  d3.select('#activeChip').html(`active <b>v${S().activeV}</b>`);
+  d3.select('#dbActive').text('v'+S().activeV);
+  d3.select('#draftBanner').classed('show', isDraftDirty());
+
+  const list=[...S().versions].sort((a,b)=>b.v-a.v);
+  const sel=d3.select('#timeline').selectAll('.ver').data(list,d=>d.v);
+  sel.exit().remove();
+  const enter=sel.enter().append('div');
+  enter.merge(sel).attr('class',d=>'ver'+(d.v===S().activeV?' active':'')+(d.kind==='rollback'?' rollback':''))
+    .html(d=>{
+      const tags=[];
+      if(d.v===S().activeV) tags.push('<span class="ver-tag active">active</span>');
+      if(d.kind==='rollback') tags.push('<span class="ver-tag rollback">rollback → v'+d.rollbackOf+'</span>');
+      if(d.kind==='create') tags.push('<span class="ver-tag">genesis</span>');
+      return `<div class="ver-top"><span class="ver-v">v${d.v}</span>${tags.join('')}
+          <span class="ver-hash">sha256:${d.hash}</span></div>
+        <div class="ver-note">${d.note}</div>
+        <div class="ver-meta"><span>✎ ${d.author}</span><span>◷ ${d.ts}</span>
+          ${d.parent?'<span>← parent v'+d.parent+'</span>':''}</div>
+        <div class="ver-acts">
+          ${d.v!==S().activeV?`<button class="ver-btn rb" data-rb="${d.v}">⟲ roll back to v${d.v}</button>`:''}
+          <button class="ver-btn" data-diff="${d.v}">⇄ diff vs active</button>
+          <button class="ver-btn" data-load="${d.v}">view routes</button>
+        </div>
+        <div class="diff" id="diff-${d.v}"></div>`;
+    });
+  d3.select('#timeline').selectAll('[data-rb]').on('click',function(){ rollback(+this.getAttribute('data-rb')); });
+  d3.select('#timeline').selectAll('[data-load]').on('click',function(){ loadVersion(+this.getAttribute('data-load')); });
+  d3.select('#timeline').selectAll('[data-diff]').on('click',function(){ toggleDiff(+this.getAttribute('data-diff')); });
+}
+function activateDraft(){
+  const r=S(), v=r.versions.length+1;
+  r.versions.push({ v, kind:'edit', note:prompt('Change note for v'+v+':','Edited '+cur+' routes')||'(no note)',
+    author:'did:key:z6Mk…Adm1n', ts:nowStamp(), parent:r.activeV, snapshot:clone(r.routes), hash:shortHash(r.routes) });
+  r.activeV=v; renderAll();
+}
+function rollback(target){
+  const r=S(), src=r.versions.find(x=>x.v===target), v=r.versions.length+1;
+  r.versions.push({ v, kind:'rollback', rollbackOf:target, note:`Roll back to v${target} — “${src.note}”`,
+    author:'did:key:z6Mk…Adm1n', ts:nowStamp(), parent:r.activeV, snapshot:clone(src.snapshot), hash:src.hash });
+  r.activeV=v; r.routes=clone(src.snapshot); r.lastResult=null; renderAll();
+}
+function loadVersion(target){
+  const r=S(), src=r.versions.find(x=>x.v===target);
+  r.routes=clone(src.snapshot); r.lastResult=null; renderAll();
+}
+function discardDraft(){
+  const r=S(), active=r.versions.find(x=>x.v===r.activeV);
+  r.routes=clone(active.snapshot); r.lastResult=null; renderAll();
+}
+function toggleDiff(v){
+  const el=d3.select('#diff-'+v), open=el.classed('show');
+  d3.selectAll('.diff').classed('show',false).html('');
+  if(open) return;
+  const from=S().versions.find(x=>x.v===v).snapshot, to=S().routes;
+  el.classed('show',true);
+  el.selectAll('.dl').data(semanticDiff(from,to)).join('div').attr('class',d=>'dl '+d.k).text(d=>d.t);
+}
+function semanticDiff(from,to){
+  const out=[], conds=C().conds, fn=from.map(r=>r.name), tn=to.map(r=>r.name);
+  fn.forEach(n=>{ if(!tn.includes(n)) out.push({k:'rem',t:`− route “${n}” removed`}); });
+  tn.forEach((n,ti)=>{
+    if(!fn.includes(n)){ out.push({k:'add',t:`+ route “${n}” added at P${ti+1}`}); return; }
+    const fi=fn.indexOf(n);
+    if(fi!==ti) out.push({k:'mov',t:`⇅ “${n}” priority P${fi+1} → P${ti+1}`});
+    const fr=from[fi], tr=to[ti];
+    if(fr.conds.join('+')!==tr.conds.join('+'))
+      out.push({k:'mov',t:`  ~ “${n}” when: [${fr.conds.map(c=>conds[c]?conds[c].short:c).join(', ')}] → [${tr.conds.map(c=>conds[c]?conds[c].short:c).join(', ')}]`});
+    if(fr.effect.type!==tr.effect.type) out.push({k:'mov',t:`  ~ “${n}” effect: ${fr.effect.type} → ${tr.effect.type}`});
+  });
+  if(!out.length) out.push({k:'same',t:'= identical — no changes vs this version'});
+  return out;
+}
+let tick=0; function nowStamp(){ tick++; return `2026-05-30 ${(10+tick).toString().padStart(2,'0')}:0${tick%6}Z`; }
+
+/* ============================================================= COMPILED OUTPUT */
+let activeTab='rego';
+d3.select('#tabs').selectAll('.tab').on('click',function(){
+  d3.selectAll('.tab').classed('on',false); d3.select(this).classed('on',true);
+  activeTab=this.getAttribute('data-t'); updateCompiled();
+});
+function regoVal(eff){
+  if(eff.type==='allow'){
+    const k=C().allowPayload.key; let payload;
+    if(k==='role'){
+      const rv=eff.role||'member';
+      const roleEx = rv==='$target' ? `<span class="s">"role"</span>: target_role` : `<span class="s">"role"</span>: <span class="s">"${rv}"</span>`;
+      payload = roleEx + (C().allowObligation ? `, <span class="s">"obligations"</span>: [<span class="s">"${C().allowObligation}"</span>]` : '');
+    }
+    else if(k==='disposition') payload=(eff.disposition||'')==='$request'
+      ? `<span class="s">"disposition"</span>: disposition`
+      : `<span class="s">"disposition"</span>: <span class="s">"${eff.disposition||'Tombstone'}"</span>`;
+    else { const arr=(eff.fields||'').split(',').map(s=>s.trim()).filter(Boolean).map(f=>`<span class="s">"${f}"</span>`).join(', ');
+      payload=`<span class="s">"fields"</span>: [${arr}]`; }
+    return `{<span class="s">"effect"</span>: <span class="s">"allow"</span>, <span class="s">"with"</span>: {${payload}}}`;
+  }
+  if(eff.type==='refer') return `{<span class="s">"effect"</span>: <span class="s">"refer"</span>, <span class="s">"with"</span>: {<span class="s">"queue"</span>: <span class="s">"${eff.queue||'moderator'}"</span>}}`;
+  if(eff.type==='request_more') return `{<span class="s">"effect"</span>: <span class="s">"request_more"</span>, <span class="s">"with"</span>: {<span class="s">"needs"</span>: [${(eff.needs||[]).map(n=>'<span class="s">"'+n+'"</span>').join(', ')}]}}`;
+  return `{<span class="s">"effect"</span>: <span class="s">"deny"</span>, <span class="s">"with"</span>: {<span class="s">"reason"</span>: <span class="s">"${eff.reason||'policy'}"</span>}}`;
+}
+function condLines(r){
+  const conds=C().conds;
+  if(r.conds.length===0) return ['  <span class="c"># (no conditions)</span>'];
+  if(r.comb==='any' && r.conds.length>1) return ['  '+r.conds.map(c=>conds[c].rego).join('  <span class="c"># or</span>  ')];
+  return r.conds.map(c=>'  '+conds[c].rego);
+}
+function genRego(){
+  const cf=C(), L=[];
+  L.push('<span class="c"># Compiled from the visual routes — illustrative (see vtc-ceremony-rule-ir.md).</span>');
+  L.push('<span class="c"># Crypto resolved by the host BEFORE eval; policy reads only verified facts in `input`.</span>');
+  L.push('');
+  L.push(`<span class="k">package</span> ${cf.pkg}`);
+  L.push('');
+  L.push('<span class="k">import</span> future.keywords.if');
+  if(cf.usesIn) L.push('<span class="k">import</span> future.keywords.in');
+  L.push('');
+  L.push('<span class="k">default</span> decision := {<span class="s">"effect"</span>: <span class="s">"deny"</span>, <span class="s">"with"</span>: {<span class="s">"code"</span>: <span class="s">"no-matching-route"</span>}}');
+  L.push('');
+  S().routes.forEach((r,i)=>{
+    L.push(`<span class="c"># P${i+1} · ${r.name}${r.listed?'':'  (unlisted)'}</span>`);
+    const head = i===0 ? `decision := ${regoVal(r.effect)} <span class="k">if</span> {`
+                       : `<span class="k">else</span> := ${regoVal(r.effect)} <span class="k">if</span> {`;
+    L.push(head);
+    condLines(r).forEach(l=>L.push(l));
+    L.push('}');
+  });
+  if(cf.helpers.length){ L.push(''); L.push('<span class="c"># ---- helpers (over already-verified facts) ----</span>'); cf.helpers.forEach(h=>L.push(h)); }
+  return L.join('\n');
+}
+function genPD(){
+  if(!C().genPD){
+    return '<span class="c">// '+C().label+' presents no credentials — no Presentation Definition.</span>\n'
+         + '<span class="c">// (PDs are generated only for evidence-bearing ceremonies, e.g. Join.)</span>';
+  }
+  const conds=C().conds, groups=S().routes.filter(r=>r.listed), descriptors=[];
+  groups.forEach((r,gi)=>r.conds.forEach(c=>{
+    if(conds[c] && conds[c].cred) descriptors.push({
+      id:`${r.name.toLowerCase().replace(/\s+/g,'-')}-${c}`, group:[`g${gi}`],
+      name:`${r.name}: ${conds[c].label}`,
+      constraints:{fields:[{path:['$.type'],filter:{contains:{const:conds[c].cred}}}]}
+    });
+  }));
+  const obj={ id:'vtc-'+cur, name:'Acme community '+cur+' requirements',
+    submission_requirements:groups.map((r,gi)=>({name:r.name, rule:'pick', count:1, from:`g${gi}`})),
+    input_descriptors:descriptors };
+  let s=esc(JSON.stringify(obj,null,2)).replace(/"([^"]+)":/g,'<span class="k">"$1"</span>:').replace(/: "([^"]*)"/g,': <span class="s">"$1"</span>');
+  return '<span class="c">// Unlisted routes (e.g. VIC) are excluded — the invite is the private signal.</span>\n'+s;
+}
+function genEnglish(){
+  const conds=C().conds, L=['<span class="c"># Human summary — published in the ceremony manifest.</span>',''];
+  L.push(`For <b>${C().label}</b> at Acme, the first matching route applies:`); L.push('');
+  S().routes.forEach((r,i)=>{
+    const when=r.conds.length? r.conds.map(c=>conds[c]?conds[c].label:c).join(r.comb==='any'?'  OR  ':'  AND  ') : 'always';
+    const e=r.effect; let then;
+    if(e.type==='allow'){ const p=C().allowPayload; const pv=e[p.key]||p.def; const disp=pv==='$target'?'requested role':pv==='$request'?'requested or PolicyDefault':pv; then=`→ <b>allow</b> (${C().allowLabel}; ${p.key}: ${disp})`; }
+    else if(e.type==='refer') then=`→ <b>refer</b> to ${e.queue||'moderator'}`;
+    else if(e.type==='request_more') then=`→ <b>request_more</b> (${(e.needs||[]).join(', ')})`;
+    else then=`→ <b>deny</b>`;
+    L.push(`  <span class="n">P${i+1}</span> <b>${r.name}</b>${r.listed?'':' <span class="c">(unlisted)</span>'}: ${when}  ${then}`);
+  });
+  L.push('  <span class="n">∎</span> <b>default</b>: anything else → denied.');
+  return L.join('\n');
+}
+function updateCompiled(){
+  const out=d3.select('#compiledOut');
+  if(activeTab==='rego') out.html(genRego());
+  else if(activeTab==='pd') out.html(genPD());
+  else out.html(genEnglish());
+}
+
+/* ============================================================= CHROME / SWITCH */
+function updateChrome(){
+  d3.select('#cerChip').text(cur);
+  d3.select('#legAllow').text(`allow (here: ${C().allowLabel})`);
+  d3.select('#routesTitle').text(`${C().label} policy · routes`);
+  d3.select('#simTitle').text(`Simulator · ${C().simLabel}`);
+  d3.select('#flowNs').text(C().manifestNs);
+  d3.select('#regoTab').text(C().regoFile || C().pkg.split('.')[1]+'.rego');
+  svg.select('#ns-effects').text(C().flowEffects);
+  d3.select('#cerTabs').selectAll('.cer-tab').classed('on',function(){ return this.getAttribute('data-c')===cur; });
+  renderOutcomes();
+  d3.select('#verdict').attr('class','verdict');   // hide stale verdict
+}
+function switchCeremony(id){
+  if(id===cur) return;
+  cur=id; resetFlow(); updateChrome(); renderAll();
+}
+
+/* ============================================================= WIRING */
+function onEdit(){ S().lastResult=null; renderRoutes(); renderVersions(); updateCompiled(); }
+function renderAll(){ renderPresets(); renderRoutes(); renderScenario(); renderVersions(); updateCompiled(); }
+
+d3.select('#cerTabs').selectAll('.cer-tab').on('click',function(){ switchCeremony(this.getAttribute('data-c')); });
+d3.select('#addRoute').on('click',()=>{ S().routes.push({name:'New route', comb:'all', conds:['always'], effect:newEffect(C().effects.includes('refer')?'refer':C().effects[0]), listed:true}); onEdit(); });
+d3.select('#run').on('click',run);
+d3.select('#activateBtn').on('click',activateDraft);
+d3.select('#discardBtn').on('click',discardDraft);
+
+initAll();
+updateChrome();
+renderAll();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

A **design-only** bundle (no code wired to `vtc-service`) proposing that community state transitions —
**ceremonies** — be modeled as instances of **one decision pipeline**, rather than a bespoke flow per ceremony.

This is positioned as **post-MVP / vNext**: it builds on the Phase-2 substrate and includes an explicit
**build-vs-reuse** map (`vtc-ceremony-pipeline.md` §10) — the `vtc-mvp.md` §3 cornerstones (embedded `regorus`,
VTA-mints/VTC-caches keys, VC-as-projection, status-list privacy, audit, the `Verified*` typestate, Trust Task
discipline) are kept; the rework is concentrated in the ceremony/policy *modelling*.

## The idea

```
TRIGGER -> GATHER -> VERIFY (host) -> FACTS -> EVALUATE (<purpose>.rego) -> VERDICT -> EFFECTS (<purpose>)
```

- Crypto lives entirely in **Verify**; the policy reasons over a `Verified*` view (skipping verification doesn't compile).
- **Four-valued verdict**: `allow / deny / refer / request_more`. Only `allow` carries a purpose-specific payload.
- Threads + effects are **optional, purpose-specific** stages.

## Validated by a catalog, not asserted

Four maximally-different ceremonies run through the *same* pipeline:

| Ceremony | actor=subject? | effects | invariant | threaded? |
|---|---|---|---|---|
| **Join** | yes | issue (constructive) | privilege ceiling | yes |
| **Leave** | no | revoke (destructive) | no-last-admin | optional |
| **Role-change** | no | re-issue (mutating) | ceiling + step-up | optional |
| **Directory** | no | return a field *projection* (read-only) | PII boundary | **no (sync)** |

## Files (suggested reading order)

1. `vtc-ceremonies-exec-summary.md` — start here
2. `vtc-ceremony-pipeline.md` — architecture, build-vs-reuse (§10), staged plan, open decisions
3. `vtc-ceremony-catalog.md` — the four instances + worked examples + remaining-purposes map
4. `vtc-ceremony-rule-ir.md` — the authoring vocabulary (Rule IR grammar + compile-to-Rego mapping)
5. `vtc-ceremony-protocol.md` — generalized `{family}/*` Trust Task wire protocol
6. `examples/` — runnable IR + `.rego` + sample facts for join / leave / role-change / directory (`opa`/`regorus`)
7. `vtc-ceremony-visual-guide.html` — interactive D3 guide; switch ceremonies, edit routes, simulate, version + fail-forward rollback, read live-compiled artifacts

## Open decisions for review

(Full list in `vtc-ceremony-pipeline.md` §12.) The genuine forks: **default posture** (deny vs the MVP's
accept-any), **`acl`/`members` keyspace split** (keep vs unify), **invitation delegation** (community-only vs
`can_invite`), **governance quorum** (single-admin vs opt-in M-of-N), and the **credential `type` string**
convention (`Verifiable…` prefix vs bare DTG names).

## Notes for reviewers

- **Design documents, not implementation** — nothing here is compiled or tested in `vtc-service`.
- Code-grounded claims (engine, key model, keyspaces, defaults) were verified against the current tree; this
  bundle *proposes replacing* several of those — see the build-vs-reuse map.
- The interactive HTML guide is a self-contained D3 page (CDN deps); it has not been browser-smoke-tested in CI.
- Presentation Definition examples are illustrative, not schema-validated; new Trust Task families
  (`departures`, `role-changes`, `directory`, join's `manifest`/`present`/`status`/`accept`) are **proposed**.
