### PR TITLE
fix(vta-mobile-core): make mobile scripts honor the cargo target dir

### DIFF
--- a/vta-mobile-core/scripts/build-mobile.sh
+++ b/vta-mobile-core/scripts/build-mobile.sh
@@ -38,6 +38,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$WORKSPACE_ROOT"
 
+# Where cargo writes build output. Honor a caller/CI-provided CARGO_TARGET_DIR;
+# otherwise pin to the workspace ./target. Export it so cargo and this script
+# agree on the location even when a global cargo config sets
+# `build.target-dir` (the env var overrides config) — otherwise cargo writes
+# elsewhere and the bindgen/ndk steps below can't find the libraries.
+TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT/target}"
+export CARGO_TARGET_DIR="$TARGET_DIR"
+
 CARGO_PROFILE_FLAG=""
 PROFILE_DIR="debug"
 if [ "$PROFILE" = "release" ]; then
@@ -68,7 +76,7 @@ build_android() {
   # NOTE: `--platform` (the API level), spelled in full on purpose. cargo-ndk's
   # short `-p` was dropped in v4; `-p 24` is forwarded to cargo as `--package 24`
   # and panics with "unknown package: 24".
-  cargo ndk "${ndk_args[@]}" --platform "$ANDROID_API" -o "target/mobile/jniLibs" \
+  cargo ndk "${ndk_args[@]}" --platform "$ANDROID_API" -o "$TARGET_DIR/mobile/jniLibs" \
     build -p vta-mobile-core --lib $CARGO_PROFILE_FLAG
 }
 
@@ -79,15 +87,15 @@ check_bindings() {
   echo "── UniFFI bindings (kotlin + swift) ──"
   cargo build -p vta-mobile-core --lib $CARGO_PROFILE_FLAG
   local lib=""
-  for cand in "target/$PROFILE_DIR/libvta_mobile_core.dylib" \
-              "target/$PROFILE_DIR/libvta_mobile_core.so"; do
+  for cand in "$TARGET_DIR/$PROFILE_DIR/libvta_mobile_core.dylib" \
+              "$TARGET_DIR/$PROFILE_DIR/libvta_mobile_core.so"; do
     if [ -f "$cand" ]; then lib="$cand"; break; fi
   done
   if [ -z "$lib" ]; then
     echo "  could not find the built libvta_mobile_core dynamic library" >&2
     exit 1
   fi
-  local out="target/bindings"
+  local out="$TARGET_DIR/bindings"
   rm -rf "$out"
   for lang in kotlin swift; do
     cargo run -p vta-mobile-core --bin uniffi-bindgen -- \

--- a/vta-mobile-core/scripts/package-ios.sh
+++ b/vta-mobile-core/scripts/package-ios.sh
@@ -28,6 +28,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$WORKSPACE_ROOT"
 
+# Where cargo writes build output. Honor a caller/CI-provided CARGO_TARGET_DIR;
+# otherwise pin to the workspace ./target. Export it so cargo and this script
+# agree even when a global cargo config sets `build.target-dir` (the env var
+# overrides config) — otherwise cargo writes elsewhere and the lipo / bindgen /
+# xcframework steps below can't find the static libraries.
+TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT/target}"
+export CARGO_TARGET_DIR="$TARGET_DIR"
+
 CARGO_PROFILE_FLAG=""
 PROFILE_DIR="debug"
 if [ "$PROFILE" = "release" ]; then
@@ -38,7 +46,7 @@ fi
 DEVICE_TARGET="aarch64-apple-ios"
 SIM_TARGETS=(aarch64-apple-ios-sim x86_64-apple-ios)
 LIB="libvta_mobile_core.a"
-OUT="target/mobile/ios"
+OUT="$TARGET_DIR/mobile/ios"
 STAGE="$OUT/staging"
 
 rm -rf "$OUT"
@@ -57,8 +65,8 @@ echo "── Fusing simulator slice (arm64 + x86_64) ──"
 SIM_FAT="$STAGE/sim/$LIB"
 mkdir -p "$STAGE/sim"
 lipo -create \
-  "target/aarch64-apple-ios-sim/$PROFILE_DIR/$LIB" \
-  "target/x86_64-apple-ios/$PROFILE_DIR/$LIB" \
+  "$TARGET_DIR/aarch64-apple-ios-sim/$PROFILE_DIR/$LIB" \
+  "$TARGET_DIR/x86_64-apple-ios/$PROFILE_DIR/$LIB" \
   -output "$SIM_FAT"
 
 # Generate the Swift bindings from a host build (the generated source + C header
@@ -68,8 +76,8 @@ lipo -create \
 echo "── Generating Swift bindings ──"
 cargo build -p vta-mobile-core --lib $CARGO_PROFILE_FLAG
 HOST_LIB=""
-for cand in "target/$PROFILE_DIR/libvta_mobile_core.dylib" \
-            "target/$PROFILE_DIR/libvta_mobile_core.so"; do
+for cand in "$TARGET_DIR/$PROFILE_DIR/libvta_mobile_core.dylib" \
+            "$TARGET_DIR/$PROFILE_DIR/libvta_mobile_core.so"; do
   [ -f "$cand" ] && HOST_LIB="$cand" && break
 done
 [ -n "$HOST_LIB" ] || { echo "  host library not found for bindgen" >&2; exit 1; }
@@ -84,7 +92,7 @@ cp "$BIND/VtaMobileCoreFFI.modulemap" "$STAGE/headers/module.modulemap"
 
 echo "── Assembling VtaMobileCore.xcframework ──"
 xcodebuild -create-xcframework \
-  -library "target/$DEVICE_TARGET/$PROFILE_DIR/$LIB" -headers "$STAGE/headers" \
+  -library "$TARGET_DIR/$DEVICE_TARGET/$PROFILE_DIR/$LIB" -headers "$STAGE/headers" \
   -library "$SIM_FAT" -headers "$STAGE/headers" \
   -output "$OUT/VtaMobileCore.xcframework" >/dev/null
 


### PR DESCRIPTION
## Portability fix for the mobile build scripts

`build-mobile.sh` and `package-ios.sh` hardcoded `./target` for the lipo / bindgen / cargo-ndk / xcframework steps. When cargo's target directory is redirected — a global `~/.cargo/config` with `[build] target-dir`, or a `CARGO_TARGET_DIR` pointing elsewhere — cargo writes the build output there while the scripts look in `./target`, so they fail:

```
lipo: can't open input file: target/aarch64-apple-ios-sim/release/libvta_mobile_core.a
```

(Hit while building the v0.1.0 xcframework locally on a machine whose `~/.cargo/config` redirects `target-dir` to `~/.cargo/target`. Invisible in CI, which has no such redirect.)

### Fix

Resolve a single `TARGET_DIR = ${CARGO_TARGET_DIR:-$WORKSPACE_ROOT/target}`, **export** it, and reference it everywhere instead of a literal `./target`. Exporting makes cargo and the scripts agree on one location:
- a caller/CI-provided `CARGO_TARGET_DIR` is honored as-is;
- otherwise it pins to `$WORKSPACE_ROOT/target`, and the export **overrides** any config `build.target-dir` so cargo writes where the scripts look.

### Verification

Re-ran `build-mobile.sh ios` under the breaking condition (`env -u CARGO_TARGET_DIR`, so the config redirect takes over) — it now completes: builds both iOS targets, generates the Kotlin+Swift bindings, artifacts land in the script-controlled target dir (`mobile build gate: OK`). Previously this failed at the lipo step. Both scripts pass `bash -n`; no remaining hardcoded `target/` paths in code (doc comments unchanged).
