### PR TITLE
feat(vta): server step-up — pending store (1/3)

### DIFF
--- a/vti-common/src/auth/mod.rs
+++ b/vti-common/src/auth/mod.rs
@@ -6,6 +6,7 @@ pub mod jwt;
 pub mod passkey;
 pub mod session;
 pub mod siop;
+pub mod step_up;
 
 pub use backend::{
     AttestationOutcome, AuthAuditEvent, AuthBackend, AuthError, AuthenticateInput, ChallengeInput,

--- a/vti-common/src/auth/step_up.rs
+++ b/vti-common/src/auth/step_up.rs
@@ -1,0 +1,224 @@
+//! Pending step-up store.
+//!
+//! When an AAL1 session hits a step-up-gated operation, the relying party
+//! (the VTA) mints a **pending step-up**: a short-lived, single-use record
+//! binding a fresh `challenge` to the `session_id`/`subject` being elevated and
+//! the `targetAcr` requested. It is keyed by the challenge so the matching
+//! `auth/step-up/approve-response/0.1` can be located by its echoed challenge.
+//!
+//! Stored under `stepup:{challenge}` in the sessions keyspace, mirroring the
+//! `nonce:`/`refresh:` index conventions in [`crate::auth::session`]. Records
+//! are consumed exactly once on a successful (or expired) match so an
+//! approve-response cannot be replayed.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+use super::session::now_epoch;
+
+/// A pending AAL step-up awaiting an `approve-response`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PendingStepUp {
+    /// base64url challenge the approver echoes + signs/asserts over. The
+    /// store key is `stepup:{challenge}`.
+    pub challenge: String,
+    /// The session being elevated.
+    pub session_id: String,
+    /// The VID whose session is being elevated; the approve-response's
+    /// `subject` (and proof VM DID / credential subject) MUST equal this.
+    pub subject: String,
+    /// The acr the relying party requested. The elevated session MUST reach
+    /// at least this, else `acr_unsatisfied`.
+    pub target_acr: String,
+    /// Evidence kinds the relying party will accept (`did-signed`,
+    /// `webauthn`). Empty = any supported kind.
+    #[serde(default)]
+    pub acceptable_evidence: Vec<String>,
+    pub created_at: u64,
+    /// Unix seconds after which the step-up is no longer valid.
+    pub expires_at: u64,
+}
+
+fn step_up_key(challenge: &str) -> String {
+    format!("stepup:{challenge}")
+}
+
+/// Outcome of consuming a pending step-up by challenge.
+#[derive(Debug, PartialEq)]
+pub enum ConsumeOutcome {
+    /// No pending step-up matched the challenge (`challenge_unknown`).
+    NotFound,
+    /// A match existed but had expired (`challenge_expired`). The stale
+    /// record is removed as a side effect.
+    Expired,
+    /// A live match; the record was removed (single-use).
+    Found(Box<PendingStepUp>),
+}
+
+/// Store a pending step-up keyed by its challenge.
+pub async fn store_pending_step_up(
+    sessions: &KeyspaceHandle,
+    pending: &PendingStepUp,
+) -> Result<(), AppError> {
+    sessions
+        .insert(step_up_key(&pending.challenge), pending)
+        .await
+}
+
+/// Read a pending step-up by challenge without consuming it. Returns the raw
+/// record (no expiry filtering) — callers that want single-use semantics
+/// should use [`consume_pending_step_up`].
+pub async fn get_pending_step_up(
+    sessions: &KeyspaceHandle,
+    challenge: &str,
+) -> Result<Option<PendingStepUp>, AppError> {
+    sessions.get(step_up_key(challenge)).await
+}
+
+/// Locate and **consume** the pending step-up matching `challenge` (single
+/// use). On a live match the record is removed and returned; on an expired
+/// match the stale record is removed and [`ConsumeOutcome::Expired`] returned;
+/// a miss yields [`ConsumeOutcome::NotFound`].
+///
+/// Typed records are stored encrypted-aware via `insert`, so consumption is a
+/// `get` (which decrypts) + `remove`, matching how the rest of the session
+/// layer handles typed rows. The remove makes the challenge single-use.
+pub async fn consume_pending_step_up(
+    sessions: &KeyspaceHandle,
+    challenge: &str,
+    now: u64,
+) -> Result<ConsumeOutcome, AppError> {
+    let key = step_up_key(challenge);
+    let Some(pending): Option<PendingStepUp> = sessions.get(key.clone()).await? else {
+        return Ok(ConsumeOutcome::NotFound);
+    };
+    // Single-use either way: remove before returning so neither a live nor an
+    // expired challenge can be presented twice.
+    sessions.remove(key).await?;
+    if now >= pending.expires_at {
+        return Ok(ConsumeOutcome::Expired);
+    }
+    Ok(ConsumeOutcome::Found(Box::new(pending)))
+}
+
+/// Convenience: build a pending step-up expiring `ttl_secs` from now.
+pub fn new_pending_step_up(
+    challenge: impl Into<String>,
+    session_id: impl Into<String>,
+    subject: impl Into<String>,
+    target_acr: impl Into<String>,
+    acceptable_evidence: Vec<String>,
+    ttl_secs: u64,
+) -> PendingStepUp {
+    let created_at = now_epoch();
+    PendingStepUp {
+        challenge: challenge.into(),
+        session_id: session_id.into(),
+        subject: subject.into(),
+        target_acr: target_acr.into(),
+        acceptable_evidence,
+        created_at,
+        expires_at: created_at.saturating_add(ttl_secs),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+
+    async fn ks() -> KeyspaceHandle {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Leak the tempdir for the test's lifetime so the fjall files survive.
+        let dir = Box::leak(Box::new(dir));
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        store.keyspace("sessions").expect("keyspace")
+    }
+
+    fn sample(challenge: &str, expires_at: u64) -> PendingStepUp {
+        PendingStepUp {
+            challenge: challenge.to_string(),
+            session_id: "sess-1".to_string(),
+            subject: "did:key:zHolder".to_string(),
+            target_acr: "aal2".to_string(),
+            acceptable_evidence: vec!["did-signed".into(), "webauthn".into()],
+            created_at: 1000,
+            expires_at,
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trips_and_consumes_once() {
+        let ks = ks().await;
+        let p = sample("VHJhbnNmZXJDb25maXJtTm9uY2VYWQ", now_epoch() + 300);
+        store_pending_step_up(&ks, &p).await.unwrap();
+
+        // get does not consume
+        assert_eq!(
+            get_pending_step_up(&ks, &p.challenge).await.unwrap(),
+            Some(p.clone())
+        );
+
+        // first consume returns it
+        match consume_pending_step_up(&ks, &p.challenge, now_epoch())
+            .await
+            .unwrap()
+        {
+            ConsumeOutcome::Found(found) => assert_eq!(*found, p),
+            other => panic!("expected Found, got {other:?}"),
+        }
+        // second consume is a miss (single-use)
+        assert_eq!(
+            consume_pending_step_up(&ks, &p.challenge, now_epoch())
+                .await
+                .unwrap(),
+            ConsumeOutcome::NotFound
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_challenge_is_not_found() {
+        let ks = ks().await;
+        assert_eq!(
+            consume_pending_step_up(&ks, "no-such-challenge", now_epoch())
+                .await
+                .unwrap(),
+            ConsumeOutcome::NotFound
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_challenge_is_consumed_and_reported_expired() {
+        let ks = ks().await;
+        let p = sample("RXhwaXJlZENoYWxsZW5nZVZhbHVlWA", 1000); // expires_at in the past
+        store_pending_step_up(&ks, &p).await.unwrap();
+        assert_eq!(
+            consume_pending_step_up(&ks, &p.challenge, now_epoch())
+                .await
+                .unwrap(),
+            ConsumeOutcome::Expired
+        );
+        // expired record was removed
+        assert_eq!(get_pending_step_up(&ks, &p.challenge).await.unwrap(), None);
+    }
+
+    #[test]
+    fn new_pending_sets_expiry() {
+        let p = new_pending_step_up(
+            "VHJhbnNmZXJDb25maXJtTm9uY2VYWQ",
+            "sess-1",
+            "did:key:zHolder",
+            "aal2",
+            vec!["webauthn".into()],
+            300,
+        );
+        assert_eq!(p.expires_at, p.created_at + 300);
+        assert_eq!(p.target_acr, "aal2");
+    }
+}


### PR DESCRIPTION
## Server-side AAL step-up — slice 1 of 3

First slice of converging the VTA onto the canonical `auth/step-up/*` Trust Tasks (the relying-party half; the mobile engine already ships the approver half). This is the **foundation**: a pending step-up store.

`vti_common::auth::step_up` adds `PendingStepUp` — a short-lived, single-use record keyed by challenge (`stepup:{challenge}` in the sessions keyspace, mirroring the existing `nonce:`/`refresh:` index conventions). When an AAL1 session hits a step-up-gated op, the relying party mints one binding the fresh challenge to `{session_id, subject, target_acr, acceptable_evidence}`; the matching `approve-response` is later located and **consumed** by its echoed challenge. `consume_pending_step_up` removes the record on any match (live or expired) so an approve-response can't be replayed.

Implementation note: typed record stored via `insert` (serde_json + encryption-aware), consumed via `get` + `remove` — not `take_raw`, which returns raw/encrypted bytes and is reserved for the plaintext `insert_raw` indexes.

### Tests
Round-trip + single-use consume; unknown challenge → `NotFound`; expired → consumed + `Expired`; `new_pending_step_up` expiry math. `cargo test -p vti-common auth::step_up` green; clippy `-D warnings` clean.

### Sequence (this workstream)
1. **(this PR)** pending step-up store
2. approve-response dispatcher consumer + gate verification (did-signed DI proof / webauthn assertion → session elevation), per the `approve-response/0.1` conformance rules
3. the `403`-carries-approve-request extractor wiring

Scoped to the store only; no handler/extractor changes here, so nothing is wired into request handling yet.
