### PR TITLE
feat(vta): server-side AAL step-up (approve-response, both gates) — step-up 2/3

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -90,6 +90,13 @@ pub const TASK_AUTH_PASSKEY_LOGIN_START_0_1: &str =
 pub const TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1: &str =
     "https://trusttasks.org/spec/auth/passkey/login/finish/0.1";
 
+/// `spec/auth/step-up/approve-response/0.1` — an approver's signed
+/// ratification of a pending AAL step-up. The relying party verifies the
+/// carried gate (did-signed Data Integrity proof, or a WebAuthn assertion)
+/// and elevates the session's `amr`/`acr`.
+pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1: &str =
+    "https://trusttasks.org/spec/auth/step-up/approve-response/0.1";
+
 // ─── ACL slice (spec/vta/acl/*) ──────────────────────────────────────────
 
 /// `spec/vta/acl/list/1.0` — list ACL entries, optionally filtered by
@@ -844,6 +851,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_REVOKE_SESSION_0_1,
     TASK_AUTH_PASSKEY_LOGIN_START_0_1,
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
+    TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
     // ACL slice
     TASK_ACL_LIST_1_0,
     TASK_ACL_CREATE_1_0,

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -59,6 +59,7 @@ mod passkey_vms;
 #[cfg(feature = "webvh")]
 mod provision_integration;
 mod seeds;
+mod step_up;
 mod vault;
 #[cfg(feature = "webvh")]
 mod webvh;

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -189,6 +189,7 @@ fn aggregate_dispatched_uris() -> Vec<&'static str> {
     v.extend(keys::DISPATCHED_URIS);
     v.extend(management::DISPATCHED_URIS);
     v.extend(seeds::DISPATCHED_URIS);
+    v.extend(step_up::DISPATCHED_URIS);
     v.extend(vault::DISPATCHED_URIS);
     // Feature-gated slices add their `v.extend(slice::DISPATCHED_URIS)`
     // here under `#[cfg(feature = "...")]`. The corresponding URIs
@@ -318,6 +319,9 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         // ─── Auth slice (authenticated operations) ───────────────────
         vta_sdk::trust_tasks::TASK_AUTH_REVOKE_SESSION_0_1 => {
             auth::handle_revoke_session(state, auth, doc).await
+        }
+        vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1 => {
+            step_up::handle_approve_response(state, auth, doc).await
         }
         // ─── ACL slice ────────────────────────────────────────────────
         vta_sdk::trust_tasks::TASK_ACL_LIST_1_0 => acl::handle_list(state, auth, doc).await,

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -16,8 +16,28 @@
 //! lands alongside it.
 
 use affinidi_data_integrity::{DataIntegrityProof, DidKeyResolver, VerifyOptions};
-use serde_json::Value;
-use trust_tasks_rs::TrustTask;
+use axum::response::Response;
+use base64::Engine as _;
+use base64::engine::general_purpose;
+use serde_json::{Value, json};
+use trust_tasks_rs::specs::auth::step_up::approve_response::v0_1 as approve_response;
+use trust_tasks_rs::{RejectReason, TrustTask};
+
+use crate::audit::audit;
+use crate::auth::AuthClaims;
+use crate::auth::session::{get_session, now_epoch, update_session};
+use crate::operations::passkey_login::{
+    VtaVmResolver, enumerate_passkey_vms, verify_passkey_login,
+};
+use crate::server::AppState;
+use vti_common::auth::step_up::{ConsumeOutcome, consume_pending_step_up};
+
+use super::helpers::{parse_payload, reject_with, success_response};
+
+/// URIs dispatched by this slice (aggregated by the dispatcher's parity harness).
+#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
+pub(super) const DISPATCHED_URIS: &[&str] =
+    &[vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1];
 
 /// Why a step-up gate failed to verify. Maps to the spec's approve-response
 /// error codes in the handler.
@@ -41,7 +61,6 @@ pub(super) enum GateError {
 ///
 /// `did:key` resolution is local (no I/O); the mobile holder key is always a
 /// `did:key`, matching the engine's signing side.
-#[allow(dead_code)] // wired by the approve-response handler (next in this slice)
 pub(super) async fn verify_did_signed_gate(
     doc: &TrustTask<Value>,
     expected_subject: &str,
@@ -70,6 +89,287 @@ pub(super) async fn verify_did_signed_gate(
     di.verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
         .await
         .map_err(|e| GateError::ProofInvalid(e.to_string()))
+}
+
+/// A `task_failed` reject carrying a spec error code (e.g.
+/// `auth/step-up/approve-response:challenge_unknown`) as the reason.
+fn step_up_failure(code: &str) -> RejectReason {
+    RejectReason::TaskFailed {
+        reason: code.to_string(),
+        details: None,
+    }
+}
+
+/// AAL ordinal for the `aal1 < aal2 < aal3` ceiling/floor comparison.
+fn acr_rank(acr: &str) -> u8 {
+    match acr {
+        "aal3" => 3,
+        "aal2" => 2,
+        "aal1" => 1,
+        _ => 0,
+    }
+}
+
+fn gate_err_to_reject(e: GateError) -> RejectReason {
+    match e {
+        GateError::NoGate => step_up_failure("auth/step-up/approve-response:no_gate"),
+        GateError::SubjectMismatch => {
+            step_up_failure("auth/step-up/approve-response:subject_mismatch")
+        }
+        GateError::ProofInvalid(_) => {
+            step_up_failure("auth/step-up/approve-response:proof_invalid")
+        }
+    }
+}
+
+/// Verify the **webauthn** gate: map the carried assertion to
+/// [`vti_webauthn::AssertionPayload`], resolve `credential.id` to one of the
+/// subject's passkey verification methods, and verify per WebAuthn L2 §7.2
+/// against the bound challenge (reusing [`verify_passkey_login`], exactly as
+/// `auth/passkey/login/finish` does). Returns the `assertion_invalid` reject on
+/// any verification failure.
+async fn verify_webauthn_gate(
+    state: &AppState,
+    subject: &str,
+    challenge: &str,
+    assertion: &approve_response::AssertionResponse,
+) -> Result<(), RejectReason> {
+    let did_resolver = state
+        .did_resolver
+        .clone()
+        .ok_or_else(|| RejectReason::InternalError {
+            reason: "DID resolver not configured".to_string(),
+        })?;
+    let public_url = state
+        .config
+        .read()
+        .await
+        .public_url
+        .clone()
+        .ok_or_else(|| RejectReason::InternalError {
+            reason: "public_url not configured".to_string(),
+        })?;
+    let config = vti_webauthn::VerifierConfig::from_public_url(&public_url, true).map_err(|e| {
+        RejectReason::InternalError {
+            reason: format!("verifier config: {e}"),
+        }
+    })?;
+    let resolver = VtaVmResolver::new(did_resolver);
+
+    let invalid = || step_up_failure("auth/step-up/approve-response:assertion_invalid");
+    let dec = |s: &str| {
+        general_purpose::URL_SAFE_NO_PAD
+            .decode(s.as_bytes())
+            .or_else(|_| general_purpose::URL_SAFE.decode(s.as_bytes()))
+    };
+
+    let credential_id = dec(&assertion.id).map_err(|_| invalid())?;
+
+    // Resolve credential.id → the subject's passkey VM (spec: resolve the
+    // credential to a subject and verify it equals the session's subject).
+    let vms = enumerate_passkey_vms(&resolver, subject)
+        .await
+        .map_err(|e| RejectReason::InternalError {
+            reason: format!("passkey VM enumeration: {e}"),
+        })?;
+    let vm = vms
+        .into_iter()
+        .find(|v| v.credential_id == credential_id)
+        .ok_or_else(invalid)?;
+
+    let payload = vti_webauthn::AssertionPayload {
+        credential_id,
+        authenticator_data: dec(&assertion.response.authenticator_data).map_err(|_| invalid())?,
+        client_data_json: dec(&assertion.response.client_data_json).map_err(|_| invalid())?,
+        signature: dec(&assertion.response.signature).map_err(|_| invalid())?,
+        verification_method: vm.vm_url,
+    };
+
+    verify_passkey_login(&payload, challenge.as_bytes(), &resolver, &config)
+        .await
+        .map(|_| ())
+        .map_err(|_| invalid())
+}
+
+/// Handler for `auth/step-up/approve-response/0.1`.
+///
+/// Consumes the approver's ratification of a pending step-up and, on a verified
+/// gate, elevates the (caller's own) session's `amr`/`acr`. Follows the spec's
+/// relying-party conformance rules; the bearer JWT (`auth`) identifies the
+/// caller, and the approve-response's gate (did-signed proof or webauthn
+/// assertion) is the second factor.
+pub(super) async fn handle_approve_response(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    // 1. Parse the typed payload.
+    let payload: approve_response::Payload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+    let subject = payload.subject.to_string();
+    let session_id = payload.session_id.to_string();
+    let challenge = payload.challenge.to_string();
+
+    // 2. Subject binding: the document issuer AND the bearer caller must be the
+    //    subject (same-session step-up — the caller elevates their own session).
+    if doc.issuer.as_deref() != Some(subject.as_str()) {
+        return reject_with(
+            &doc,
+            step_up_failure("auth/step-up/approve-response:subject_mismatch"),
+        );
+    }
+    if auth.did != subject {
+        return reject_with(
+            &doc,
+            RejectReason::PermissionDenied {
+                reason: "caller is not the subject of this step-up".to_string(),
+            },
+        );
+    }
+
+    // 3. Locate + consume the pending step-up by echoed challenge (single use).
+    let pending = match consume_pending_step_up(&state.sessions_ks, &challenge, now_epoch()).await {
+        Ok(ConsumeOutcome::Found(p)) => *p,
+        Ok(ConsumeOutcome::NotFound) => {
+            return reject_with(
+                &doc,
+                step_up_failure("auth/step-up/approve-response:challenge_unknown"),
+            );
+        }
+        Ok(ConsumeOutcome::Expired) => {
+            return reject_with(
+                &doc,
+                step_up_failure("auth/step-up/approve-response:challenge_expired"),
+            );
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "step-up consume failed");
+            return reject_with(
+                &doc,
+                RejectReason::InternalError {
+                    reason: format!("step-up lookup: {e}"),
+                },
+            );
+        }
+    };
+    if pending.subject != subject || pending.session_id != session_id {
+        return reject_with(
+            &doc,
+            step_up_failure("auth/step-up/approve-response:subject_mismatch"),
+        );
+    }
+
+    // 4. A `denied` decision is a signed refusal — verify the did-signed gate,
+    //    audit, and elevate nothing.
+    if payload.decision == approve_response::PayloadDecision::Denied {
+        if let Err(e) = verify_did_signed_gate(&doc, &subject).await {
+            return reject_with(&doc, gate_err_to_reject(e));
+        }
+        audit!(
+            "auth.step_up_denied",
+            actor = &subject,
+            resource = &session_id,
+            outcome = "declined"
+        );
+        return success_response(
+            &doc,
+            json!({
+                "status": "rejected",
+                "reason": payload.denied_reason.unwrap_or_else(|| "user declined".to_string()),
+            }),
+        );
+    }
+
+    // 5. Approved — verify exactly one cryptographic gate.
+    let factor: &str = match payload.evidence.as_ref() {
+        None | Some(approve_response::Evidence::DidSigned) => {
+            if let Err(e) = verify_did_signed_gate(&doc, &subject).await {
+                return reject_with(&doc, gate_err_to_reject(e));
+            }
+            "did"
+        }
+        Some(approve_response::Evidence::Webauthn(assertion)) => {
+            match verify_webauthn_gate(state, &subject, &challenge, assertion).await {
+                Ok(()) => "passkey",
+                Err(reason) => return reject_with(&doc, reason),
+            }
+        }
+    };
+
+    // 6. AAL ceiling/floor: elevate to the requested targetAcr, which MUST be
+    //    ≤ the approver's grantedAcr (default aal2). Otherwise `acr_unsatisfied`.
+    let granted = payload.granted_acr.as_deref().unwrap_or("aal2");
+    let target = pending.target_acr.as_str();
+    if acr_rank(target) > acr_rank(granted) {
+        return reject_with(
+            &doc,
+            step_up_failure("auth/step-up/approve-response:acr_unsatisfied"),
+        );
+    }
+
+    // 7. Load + elevate the session.
+    let mut session = match get_session(&state.sessions_ks, &session_id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            return reject_with(
+                &doc,
+                step_up_failure("auth/step-up/approve-response:challenge_unknown"),
+            );
+        }
+        Err(e) => {
+            return reject_with(
+                &doc,
+                RejectReason::InternalError {
+                    reason: format!("session lookup: {e}"),
+                },
+            );
+        }
+    };
+    if !session.amr.iter().any(|m| m == factor) {
+        session.amr.push(factor.to_string());
+    }
+    session.acr = target.to_string(); // ≤ granted, enforced above
+    if let Err(e) = update_session(&state.sessions_ks, &session).await {
+        return reject_with(
+            &doc,
+            RejectReason::InternalError {
+                reason: format!("session update: {e}"),
+            },
+        );
+    }
+    audit!(
+        "auth.step_up",
+        actor = &subject,
+        resource = &session_id,
+        outcome = "success"
+    );
+
+    // 8. Elevated ack with the updated session snapshot. The client refreshes
+    //    to mint a new access token at the elevated acr (refresh preserves it).
+    let issued_at = chrono::DateTime::from_timestamp(session.created_at as i64, 0)
+        .map(|d| d.to_rfc3339())
+        .unwrap_or_default();
+    let expires_at = session
+        .refresh_expires_at
+        .and_then(|e| chrono::DateTime::from_timestamp(e as i64, 0))
+        .map(|d| d.to_rfc3339())
+        .unwrap_or_default();
+    success_response(
+        &doc,
+        json!({
+            "status": "elevated",
+            "session": {
+                "id": session.session_id,
+                "subject": session.did,
+                "issuedAt": issued_at,
+                "expiresAt": expires_at,
+                "amr": session.amr,
+                "acr": session.acr,
+            },
+        }),
+    )
 }
 
 #[cfg(test)]

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -1,0 +1,179 @@
+//! AAL step-up gate verification (`auth/step-up/approve-response/0.1`).
+//!
+//! The relying party (this VTA) elevates a session only when the approve-
+//! response carries exactly one verifiable cryptographic gate, per the spec's
+//! consumer conformance rules:
+//!
+//! - **did-signed** — the document's Data Integrity proof (`eddsa-jcs-2022`)
+//!   verifies under a key the subject controls, and the proof's
+//!   `verificationMethod` DID equals the subject. [`verify_did_signed_gate`].
+//! - **webauthn** — the carried assertion verifies per WebAuthn L2 §7.2 against
+//!   the bound challenge (handled by the approve-response handler reusing
+//!   `verify_passkey_login`).
+//!
+//! This module is the did-signed verifier; the handler that consumes the
+//! pending step-up, dispatches on `evidence.kind`, and elevates the session
+//! lands alongside it.
+
+use affinidi_data_integrity::{DataIntegrityProof, DidKeyResolver, VerifyOptions};
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+
+/// Why a step-up gate failed to verify. Maps to the spec's approve-response
+/// error codes in the handler.
+#[derive(Debug, PartialEq)]
+pub(super) enum GateError {
+    /// No verifiable gate present (`no_gate`).
+    NoGate,
+    /// The proof's verificationMethod DID is not the session subject
+    /// (`subject_mismatch`).
+    SubjectMismatch,
+    /// The framework proof is present but failed verification (`proof_invalid`).
+    ProofInvalid(String),
+}
+
+/// Verify the **did-signed** gate on an approve-response document.
+///
+/// `expected_subject` is the session's subject (the handler has already checked
+/// it equals the payload `subject` and the document `issuer`). Here we bind the
+/// *cryptographic* identity: the proof's `verificationMethod` DID MUST equal it,
+/// and the `eddsa-jcs-2022` signature MUST verify under that `did:key`.
+///
+/// `did:key` resolution is local (no I/O); the mobile holder key is always a
+/// `did:key`, matching the engine's signing side.
+#[allow(dead_code)] // wired by the approve-response handler (next in this slice)
+pub(super) async fn verify_did_signed_gate(
+    doc: &TrustTask<Value>,
+    expected_subject: &str,
+) -> Result<(), GateError> {
+    let proof = doc.proof.as_ref().ok_or(GateError::NoGate)?;
+
+    // The framework `Proof` round-trips into a `DataIntegrityProof` (same shape;
+    // the mobile engine builds it the same way).
+    let di: DataIntegrityProof = serde_json::to_value(proof)
+        .ok()
+        .and_then(|v| serde_json::from_value(v).ok())
+        .ok_or_else(|| GateError::ProofInvalid("not a Data Integrity proof".to_string()))?;
+
+    // Bind identity: the signing key's DID must be the subject. The resolver
+    // confirms the signature is by this verificationMethod; this check ties
+    // that VM to the subject so a valid proof by a *different* DID can't elevate.
+    let vm_did = di.verification_method.split('#').next().unwrap_or_default();
+    if vm_did != expected_subject {
+        return Err(GateError::SubjectMismatch);
+    }
+
+    // Verify over the document with the proof removed (eddsa-jcs-2022
+    // canonicalizes the proofless document; the signature lives on `di`).
+    let mut unsigned = doc.clone();
+    unsigned.proof = None;
+    di.verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+        .await
+        .map_err(|e| GateError::ProofInvalid(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_data_integrity::crypto_suites::CryptoSuite;
+    use affinidi_data_integrity::prepare_sign_input;
+    use ed25519_dalek::{Signer, SigningKey};
+    use multibase::Base;
+    use serde_json::json;
+    use trust_tasks_rs::Proof;
+
+    /// did:key for an Ed25519 verifying key (multicodec 0xed01 + key, base58btc).
+    fn did_key(sk: &SigningKey) -> (String, String) {
+        let pk = sk.verifying_key();
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(pk.as_bytes());
+        let mb = multibase::encode(Base::Base58Btc, mc);
+        (format!("did:key:{mb}"), mb)
+    }
+
+    /// Build an approve-response-shaped TrustTask and attach a did-signed
+    /// eddsa-jcs-2022 proof from `sk` (mirrors the engine's signing side).
+    fn signed_doc(sk: &SigningKey, subject: &str, vm: &str) -> TrustTask<Value> {
+        // Build a TrustTask<Value> by deserialization (for_payload needs
+        // P: Payload, which Value isn't) — proofless, ready to sign.
+        let doc_json = json!({
+            "id": "approve-resp-1",
+            "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
+            "issuer": subject,
+            "recipient": "did:web:vta.example",
+            "payload": {
+                "subject": subject,
+                "sessionId": "sess-1",
+                "challenge": "VHJhbnNmZXJDb25maXJtTm9uY2VYWQ",
+                "decision": "approved",
+                "grantedAcr": "aal2",
+            },
+        });
+        let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
+
+        let mut di = DataIntegrityProof {
+            type_: "DataIntegrityProof".to_string(),
+            cryptosuite: CryptoSuite::EddsaJcs2022,
+            created: Some("2026-05-31T00:00:00Z".to_string()),
+            verification_method: vm.to_string(),
+            proof_purpose: "assertionMethod".to_string(),
+            proof_value: None,
+            context: None,
+        };
+        let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
+        let sig = sk.sign(&input);
+        di.proof_value = Some(multibase::encode(Base::Base58Btc, sig.to_bytes()));
+        let proof_json = serde_json::to_value(&di).unwrap();
+        doc.proof = Some(serde_json::from_value::<Proof>(proof_json).unwrap());
+        doc
+    }
+
+    #[tokio::test]
+    async fn verifies_a_did_signed_approve_response() {
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let (did, mb) = did_key(&sk);
+        let vm = format!("{did}#{mb}");
+        let doc = signed_doc(&sk, &did, &vm);
+        assert_eq!(verify_did_signed_gate(&doc, &did).await, Ok(()));
+    }
+
+    #[tokio::test]
+    async fn rejects_when_proof_absent() {
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let (did, mb) = did_key(&sk);
+        let vm = format!("{did}#{mb}");
+        let mut doc = signed_doc(&sk, &did, &vm);
+        doc.proof = None;
+        assert_eq!(
+            verify_did_signed_gate(&doc, &did).await,
+            Err(GateError::NoGate)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_when_vm_did_is_not_the_subject() {
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let (did, mb) = did_key(&sk);
+        let vm = format!("{did}#{mb}");
+        let doc = signed_doc(&sk, &did, &vm);
+        // Same valid proof, but a different expected subject.
+        assert_eq!(
+            verify_did_signed_gate(&doc, "did:key:zSomeoneElse").await,
+            Err(GateError::SubjectMismatch)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_a_tampered_document() {
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let (did, mb) = did_key(&sk);
+        let vm = format!("{did}#{mb}");
+        let mut doc = signed_doc(&sk, &did, &vm);
+        // Tamper the payload after signing → signature no longer verifies.
+        doc.payload = json!({ "subject": did, "decision": "approved", "tampered": true });
+        assert!(matches!(
+            verify_did_signed_gate(&doc, &did).await,
+            Err(GateError::ProofInvalid(_))
+        ));
+    }
+}


### PR DESCRIPTION
## Server-side AAL step-up — slice 2 of 3

Completes the relying-party half of `auth/step-up/*` (the mobile engine already ships the approver half, #158/#159). An AAL1 session is elevated to AAL2 by a verified `approve-response`. Builds on the pending-store (#176).

**Key finding (corrected from earlier):** the VTA already depends on `trust-tasks-rs 0.1.3`, whose `specs` are *not* feature-gated — so `specs::auth::step_up::approve_response::v0_1` types are available server-side with **no new publish and no dependency change**. The handler deserializes straight into the generated `Payload`, symmetric with the engine.

### What it does — `handle_approve_response` (trust-task dispatcher)
- binds `subject == document issuer == bearer caller` (same-session step-up);
- consumes the pending step-up (#176) by echoed `challenge` → `challenge_unknown`/`challenge_expired` (single-use);
- verifies **exactly one gate** by `evidence.kind`:
  - **did-signed** — `DataIntegrityProof::verify` + `DidKeyResolver` over the proofless document; proof VM DID must equal the subject (`amr += did`). *This is net-new server-side DI-proof verification — the capability the dispatcher had explicitly deferred.*
  - **webauthn** — map `AssertionResponse` → `vti_webauthn::AssertionPayload`, resolve `credential.id` → the subject's passkey VM, reuse `verify_passkey_login` (`amr += passkey`);
- enforces the AAL ceiling/floor (`target ≤ granted`, else `acr_unsatisfied`);
- elevates the session (`amr`/`acr`) and returns the elevated `#response` snapshot;
- `denied` decisions verify the did-signed gate, audit, and elevate nothing.

Spec error codes (`no_gate` / `subject_mismatch` / `proof_invalid` / `assertion_invalid` / `acr_unsatisfied` / `challenge_*`) surface as `task_failed` reasons. New `TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1` URI + `ALL_URIS` in `vta-sdk`; dispatcher match arm + parity-harness `DISPATCHED_URIS`.

### Tests
- **did-signed verifier** — 4 unit tests (valid proof verifies; no-gate; wrong-subject; tampered) signing with a throwaway Ed25519 key, mirroring the engine's proven pattern.
- **dispatcher parity harness** green (confirms the new URI is wired + in `ALL_URIS`).
- `vta-sdk` (104) + `trust_tasks` (15) suites pass; `clippy -D warnings` clean.

### Follow-up
A handler **HTTP round-trip integration test** (bearer JWT → POST approve-response → assert session elevated) — needs the `AppState`/bearer fixture; immediate fast-follow. Then slice 3: the `403`-carries-approve-request extractor wiring.

> Same-device/same-session step-up. Cross-device (approver ≠ session holder) and the `did-signed`-over-DIDComm redundancy are later refinements.
