### PR TITLE
feat(vta): gate ACL changes + context/key deletion behind AAL2 step-up

### DIFF
--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -9,6 +9,7 @@ use crate::acl::Role;
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::error::AppError;
 use crate::operations;
+use crate::routes::trust_tasks::RequireStepUp;
 use crate::server::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -43,6 +44,10 @@ pub struct CreateAclRequest {
 /// POST /acl — create a new ACL entry for a DID. Auth: Admin or Initiator.
 pub async fn create_acl(
     auth: ManageAuth,
+    // Role first, step-up second: a caller lacking the role gets a permission
+    // error; an authorized AAL1 caller gets the step-up `403`. ACL mutations
+    // require AAL2 (operator policy).
+    _step_up: RequireStepUp,
     State(state): State<AppState>,
     Json(req): Json<CreateAclRequest>,
 ) -> Result<(StatusCode, Json<CreateAclResultBody>), AppError> {
@@ -84,6 +89,7 @@ pub struct UpdateAclRequest {
 /// extractor fails earlier with a clearer error).
 pub async fn update_acl(
     auth: AdminAuth,
+    _step_up: RequireStepUp,
     State(state): State<AppState>,
     Path(did): Path<String>,
     Json(req): Json<UpdateAclRequest>,
@@ -108,6 +114,7 @@ pub async fn update_acl(
 /// DELETE /acl/{did} — remove an ACL entry. Auth: Admin or Initiator.
 pub async fn delete_acl(
     auth: ManageAuth,
+    _step_up: RequireStepUp,
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<StatusCode, AppError> {
@@ -157,6 +164,7 @@ pub enum SwapAclRequest {
 /// `acl/swap-key/0.1` body during the deprecation window.
 pub async fn swap_acl(
     auth: AuthClaims,
+    _step_up: RequireStepUp,
     State(state): State<AppState>,
     Json(req): Json<SwapAclRequest>,
 ) -> Result<Json<CreateAclResultBody>, AppError> {

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -11,6 +11,7 @@ use vta_sdk::protocols::context_management::{
 use crate::auth::{AdminAuth, AuthClaims, SuperAdminAuth};
 use crate::error::AppError;
 use crate::operations;
+use crate::routes::trust_tasks::RequireStepUp;
 use crate::server::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -135,6 +136,8 @@ pub async fn preview_delete_context_handler(
 /// DELETE /contexts/{id} — delete a context and its associated resources. Auth: Super Admin only.
 pub async fn delete_context_handler(
     auth: SuperAdminAuth,
+    // Deleting a context requires a stepped-up (AAL2) session (operator policy).
+    _step_up: RequireStepUp,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Query(query): Query<DeleteContextQuery>,

--- a/vta-service/src/routes/trust_tasks/acl.rs
+++ b/vta-service/src/routes/trust_tasks/acl.rs
@@ -68,6 +68,10 @@ pub(super) async fn handle_create(
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
     }
+    // ACL mutations require a stepped-up (AAL2) session (operator policy).
+    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+        return resp;
+    }
     let req: CreateAclBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -131,6 +135,10 @@ pub(super) async fn handle_update(
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
+    // ACL mutations require a stepped-up (AAL2) session (operator policy).
+    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+        return resp;
+    }
     let req: UpdateAclBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -177,6 +185,10 @@ pub(super) async fn handle_delete(
 ) -> Response {
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
+    }
+    // ACL mutations require a stepped-up (AAL2) session (operator policy).
+    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+        return resp;
     }
     let req: DeleteAclBody = match parse_payload(&doc) {
         Ok(r) => r,

--- a/vta-service/src/routes/trust_tasks/contexts.rs
+++ b/vta-service/src/routes/trust_tasks/contexts.rs
@@ -200,6 +200,10 @@ pub(super) async fn handle_delete(
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }
+    // Deleting a context requires a stepped-up (AAL2) session (operator policy).
+    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+        return resp;
+    }
     let req: DeleteContextBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/routes/trust_tasks/keys.rs
+++ b/vta-service/src/routes/trust_tasks/keys.rs
@@ -156,6 +156,10 @@ pub(super) async fn handle_revoke(
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
+    // Revoking (deleting) a key requires a stepped-up (AAL2) session (operator policy).
+    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+        return resp;
+    }
     let req: RevokeKeyBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -60,6 +60,7 @@ mod passkey_vms;
 mod provision_integration;
 mod seeds;
 mod step_up;
+pub(crate) use step_up::RequireStepUp;
 mod vault;
 #[cfg(feature = "webvh")]
 mod webvh;

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -379,27 +379,27 @@ pub(super) async fn handle_approve_response(
     )
 }
 
-/// Mint a pending step-up and build the `403` that *carries the
-/// approve-request* an AAL1 caller must satisfy to elevate.
+/// Target assurance level and lifetime for a minted step-up challenge.
+const STEP_UP_TARGET_ACR: &str = "aal2";
+const STEP_UP_TTL_SECS: u64 = 300;
+
+/// Mint a pending step-up and build the `auth/step-up/approve-request/0.1`
+/// document the AAL1 caller hands to its approver (wallet / VTA).
 ///
-/// This is the relying-party initiation half (the chosen "403 carries the
-/// approve-request" trigger model): a fresh challenge is bound server-side to
-/// the caller's `{session_id, subject, targetAcr=aal2}` via the pending-step-up
-/// store, and the response body carries the `auth/step-up/approve-request/0.1`
-/// document the caller hands to its approver (wallet / VTA). The approver's
-/// `approve-response` is then consumed by [`handle_approve_response`].
-// Applied to step-up-gated endpoints via `RequireStepUp` once policy decides
-// which operations require AAL2; unit-tested in the meantime.
-#[allow(dead_code)]
-pub(crate) async fn issue_step_up_challenge(
+/// A fresh challenge is bound server-side to the caller's
+/// `{session_id, subject, targetAcr=aal2, acceptableEvidence}` via the
+/// pending-step-up store; the approver's `approve-response` is later consumed by
+/// [`handle_approve_response`]. Shared by both gate surfaces — the REST `403`
+/// ([`issue_step_up_challenge`]) and the trust-task reject ([`require_step_up`]).
+/// Returns the approve-request document, or `Err(())` if the pending step-up
+/// could not be persisted (the caller maps that to a 5xx / internal-error reject).
+async fn mint_pending_step_up(
     sessions_ks: &KeyspaceHandle,
     vta_did: &str,
     subject: &str,
     session_id: &str,
     reason: &str,
-) -> Response {
-    const TARGET_ACR: &str = "aal2";
-    const TTL_SECS: u64 = 300;
+) -> Result<Value, ()> {
     let acceptable = vec!["did-signed".to_string(), "webauthn".to_string()];
 
     // 256 bits of challenge entropy (two UUIDv4s) — comfortably over the spec's
@@ -413,21 +413,16 @@ pub(crate) async fn issue_step_up_challenge(
         challenge.clone(),
         session_id,
         subject,
-        TARGET_ACR,
+        STEP_UP_TARGET_ACR,
         acceptable.clone(),
-        TTL_SECS,
+        STEP_UP_TTL_SECS,
     );
     if let Err(e) = store_pending_step_up(sessions_ks, &pending).await {
         tracing::error!(error = %e, "failed to persist pending step-up");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            [(axum::http::header::CONTENT_TYPE, "application/json")],
-            br#"{"error":"internal_error"}"#.to_vec(),
-        )
-            .into_response();
+        return Err(());
     }
 
-    let approve_request = json!({
+    Ok(json!({
         "id": format!("urn:uuid:{}", Uuid::new_v4()),
         "type": "https://trusttasks.org/spec/auth/step-up/approve-request/0.1",
         "issuer": vta_did,
@@ -437,16 +432,43 @@ pub(crate) async fn issue_step_up_challenge(
             "sessionId": session_id,
             "challenge": challenge,
             "reason": reason,
-            "targetAcr": TARGET_ACR,
+            "targetAcr": STEP_UP_TARGET_ACR,
             "acceptableEvidence": acceptable,
-            "ttl": TTL_SECS,
+            "ttl": STEP_UP_TTL_SECS,
         },
-    });
+    }))
+}
+
+/// Mint a pending step-up and return the REST `403` that *carries the
+/// approve-request* an AAL1 caller must satisfy to elevate.
+///
+/// This is the relying-party initiation half (the chosen "403 carries the
+/// approve-request" trigger model) for REST routes; applied via the
+/// [`RequireStepUp`] extractor.
+pub(crate) async fn issue_step_up_challenge(
+    sessions_ks: &KeyspaceHandle,
+    vta_did: &str,
+    subject: &str,
+    session_id: &str,
+    reason: &str,
+) -> Response {
+    let approve_request =
+        match mint_pending_step_up(sessions_ks, vta_did, subject, session_id, reason).await {
+            Ok(ar) => ar,
+            Err(()) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    [(axum::http::header::CONTENT_TYPE, "application/json")],
+                    br#"{"error":"internal_error"}"#.to_vec(),
+                )
+                    .into_response();
+            }
+        };
     // Backward-compatible with the prior 403 shape (`error` + `requiredAcr`),
     // plus the carried approve-request a step-up-aware client acts on.
     let body = json!({
         "error": "step_up_required",
-        "requiredAcr": TARGET_ACR,
+        "requiredAcr": STEP_UP_TARGET_ACR,
         "approveRequest": approve_request,
     });
     (
@@ -457,15 +479,65 @@ pub(crate) async fn issue_step_up_challenge(
         .into_response()
 }
 
+/// Trust-task analogue of [`issue_step_up_challenge`]: enforce a stepped-up
+/// (AAL2) session inside a dispatcher handler.
+///
+/// Returns `None` when the session already satisfies AAL2. Otherwise mints a
+/// pending step-up and returns a routed **reject** whose `details` carry the
+/// `approveRequest`, mirroring the REST `403` so a step-up-aware client acts on
+/// it the same way over either transport.
+///
+/// Call it *after* the handler's role check, so a caller lacking the role still
+/// gets a permission error rather than a step-up prompt.
+pub(super) async fn require_step_up(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: &TrustTask<Value>,
+) -> Option<Response> {
+    if auth.acr == STEP_UP_TARGET_ACR {
+        return None;
+    }
+    let vta_did = state
+        .config
+        .read()
+        .await
+        .vta_did
+        .clone()
+        .unwrap_or_default();
+    let reject = match mint_pending_step_up(
+        &state.sessions_ks,
+        &vta_did,
+        &auth.did,
+        &auth.session_id,
+        "this operation requires a stepped-up (AAL2) session",
+    )
+    .await
+    {
+        Ok(approve_request) => RejectReason::TaskFailed {
+            reason: "auth:step_up_required".to_string(),
+            details: Some(json!({
+                "requiredAcr": STEP_UP_TARGET_ACR,
+                "approveRequest": approve_request,
+            })),
+        },
+        Err(()) => RejectReason::InternalError {
+            reason: "failed to initiate step-up".to_string(),
+        },
+    };
+    Some(reject_with(doc, reject))
+}
+
 /// Request extractor enforcing a **stepped-up (AAL2)** session.
 ///
-/// On an AAL2 session it yields the claims. On an AAL1 session it mints a
-/// pending step-up and rejects with the `403`-carrying-approve-request
-/// ([`issue_step_up_challenge`]) — so a caller hitting a step-up-gated endpoint
-/// is handed everything needed to elevate. Apply to endpoints that require a
-/// second factor (which operations those are is an operator/policy decision).
-#[allow(dead_code)] // applied to step-up-gated endpoints once policy selects them
-pub struct RequireStepUp(pub AuthClaims);
+/// A zero-sized marker: it gates, it does not carry claims. Pair it with the
+/// handler's role extractor (`AdminAuth`, `ManageAuth`, …), which yields the
+/// claims — `RequireStepUp` only asserts the session reached AAL2. On an AAL1
+/// session it mints a pending step-up and rejects with the
+/// `403`-carrying-approve-request ([`issue_step_up_challenge`]), so a caller
+/// hitting a step-up-gated endpoint is handed everything needed to elevate.
+/// Applied to the AAL2-gated REST routes (ACL mutations, context delete); the
+/// trust-task equivalents use [`require_step_up`].
+pub struct RequireStepUp;
 
 impl FromRequestParts<AppState> for RequireStepUp {
     type Rejection = Response;
@@ -475,7 +547,7 @@ impl FromRequestParts<AppState> for RequireStepUp {
             .await
             .map_err(IntoResponse::into_response)?;
         if claims.acr == "aal2" {
-            return Ok(RequireStepUp(claims));
+            return Ok(RequireStepUp);
         }
         let vta_did = state
             .config

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -103,6 +103,44 @@ impl TestContext {
         self.jwt_keys().encode(&claims).expect("encode jwt")
     }
 
+    /// Like [`auth_token`], but the session is **stepped-up (AAL2)** — the JWT
+    /// carries `acr=aal2` and a second factor in `amr`. Required for endpoints
+    /// gated by `RequireStepUp` (ACL mutations, context/key deletion). A plain
+    /// `auth_token` is AAL1, which those endpoints reject with a step-up `403`.
+    async fn auth_token_aal2(&self, did: &str, role: &str, contexts: Vec<String>) -> String {
+        let session_id = format!("sess-{}", uuid::Uuid::new_v4());
+        let session = Session {
+            session_id: session_id.clone(),
+            did: did.to_string(),
+            challenge: String::new(),
+            state: SessionState::Authenticated,
+            created_at: now_epoch(),
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+            amr: vec!["did".into(), "passkey".into()],
+            acr: "aal2".into(),
+            token_id: None,
+            session_pubkey_b58btc: None,
+        };
+        store_session(self.sessions_ks(), &session)
+            .await
+            .expect("store session");
+
+        let claims = self
+            .jwt_keys()
+            .new_claims(
+                did.to_string(),
+                session_id,
+                role.to_string(),
+                contexts,
+                900,
+                false,
+            )
+            .with_aal(vec!["did".into(), "passkey".into()], "aal2");
+        self.jwt_keys().encode(&claims).expect("encode jwt")
+    }
+
     /// Mint a token signed with a different audience. Used to verify
     /// audience-isolation rejection — a VTC-audience token must not
     /// authenticate against a VTA route. CLAUDE.md guards this as a
@@ -375,7 +413,10 @@ async fn scoped_admin_cannot_update_config() {
 #[tokio::test]
 async fn acl_create_and_list() {
     let (app, ctx) = TestApp::new().await;
-    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+    // ACL creation is an AAL2-gated mutation.
+    let token = ctx
+        .auth_token_aal2("did:key:z6MkAdmin", "admin", vec![])
+        .await;
 
     // Create
     let (status, body) = app
@@ -399,6 +440,48 @@ async fn acl_create_and_list() {
     assert!(
         entries.iter().any(|e| e["did"] == "did:key:z6MkNew"),
         "new entry should be in list"
+    );
+}
+
+/// An AAL1 admin hitting an AAL2-gated mutation is rejected with the step-up
+/// `403` that *carries the approve-request* — not a bare 403. The caller has
+/// the right role (so this isn't a permission failure); it just hasn't stepped
+/// up. Mirrors the operator policy: all ACL changes require AAL2.
+#[tokio::test]
+async fn acl_mutation_requires_step_up() {
+    let (app, ctx) = TestApp::new().await;
+    // A normal (AAL1) admin session: correct role, but not stepped up.
+    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/acl",
+            &token,
+            json!({
+                "did": "did:key:z6MkNew",
+                "role": "application",
+                "label": "test app",
+                "allowed_contexts": ["ctx1"]
+            }),
+        ))
+        .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN, "AAL1 must be gated: {body}");
+    assert_eq!(body["error"], "step_up_required");
+    assert_eq!(body["requiredAcr"], "aal2");
+    // The 403 carries the approve-request the caller hands to its approver.
+    let ar = &body["approveRequest"];
+    assert_eq!(
+        ar["type"],
+        "https://trusttasks.org/spec/auth/step-up/approve-request/0.1"
+    );
+    assert_eq!(ar["recipient"], "did:key:z6MkAdmin");
+    assert_eq!(ar["payload"]["targetAcr"], "aal2");
+    assert!(
+        ar["payload"]["challenge"]
+            .as_str()
+            .is_some_and(|c| c.len() >= 16),
+        "approve-request must carry a ≥16-char challenge"
     );
 }
 
@@ -864,7 +947,10 @@ async fn backup_import_wrong_password_returns_auth_error() {
 #[tokio::test]
 async fn acl_get_update_delete_lifecycle() {
     let (app, ctx) = TestApp::new().await;
-    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+    // create/update/delete are AAL2-gated mutations.
+    let token = ctx
+        .auth_token_aal2("did:key:z6MkAdmin", "admin", vec![])
+        .await;
 
     // Create
     app.request(post_auth(
@@ -915,7 +1001,10 @@ async fn acl_get_update_delete_lifecycle() {
 #[tokio::test]
 async fn context_create_get_update_delete() {
     let (app, ctx) = TestApp::new().await;
-    let token = ctx.auth_token("did:key:z6MkSuper", "admin", vec![]).await;
+    // Context deletion (the final step) is AAL2-gated.
+    let token = ctx
+        .auth_token_aal2("did:key:z6MkSuper", "admin", vec![])
+        .await;
 
     // Create
     let (status, _) = app
@@ -2169,7 +2258,11 @@ async fn ctx_did_templates_render_injects_context_vars() {
 #[tokio::test]
 async fn ctx_did_templates_deleted_when_parent_context_deleted() {
     let (app, ctx) = TestApp::new().await;
-    let super_token = ctx.auth_token("did:key:z6MkSuper", "admin", vec![]).await;
+    // This test deletes a context (an AAL2-gated mutation), so it needs a
+    // stepped-up session.
+    let super_token = ctx
+        .auth_token_aal2("did:key:z6MkSuper", "admin", vec![])
+        .await;
     create_test_context(&app, &super_token, "cascade-ctx").await;
 
     // Add a template to the context.

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -156,3 +156,89 @@ async fn did_signed_approve_response_elevates_session_to_aal2() {
     // status (challenge_unknown — the pending step-up is gone).
     assert_ne!(status2, StatusCode::OK, "replay must not elevate again");
 }
+
+/// The trust-task analogue of the REST step-up `403`: an AAL1 caller invoking
+/// an AAL2-gated trust-task operation (here `acl/create`) is rejected with a
+/// reject that *carries the approve-request* in its `details`. The caller has
+/// the required role (admin → `require_manage` passes), so this is the step-up
+/// gate firing — not a permission denial — and it fires before payload parsing.
+#[tokio::test]
+async fn trust_task_acl_mutation_requires_step_up() {
+    let (router, ctx) = build_test_app().await;
+
+    let did = "did:key:z6MkAal1Admin".to_string();
+    let session_id = "sess-stepup-tt-1".to_string();
+
+    // An AAL1 admin session + bearer token: role passes, assurance level does not.
+    let session = Session {
+        session_id: session_id.clone(),
+        did: did.clone(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".to_string()],
+        acr: "aal1".to_string(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+    let claims = ctx.jwt_keys.new_claims(
+        did.clone(),
+        session_id.clone(),
+        "admin".to_string(),
+        vec![],
+        900,
+        false,
+    );
+    let token = ctx.jwt_keys.encode(&claims).unwrap();
+
+    // A well-formed acl/create addressed to the test VTA. The step-up gate fires
+    // before payload parsing, so the body need only route + pass the role check.
+    let doc = json!({
+        "id": "acl-create-itest-1",
+        "type": "https://trusttasks.org/spec/vta/acl/create/1.0",
+        "issuer": did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {
+            "did": "did:key:z6MkSomeNewEntry",
+            "role": "application",
+            "allowed_contexts": ["ctx1"]
+        },
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    // Rejected (not executed), carrying the step-up signal + approve-request.
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "AAL1 must not execute the mutation: {v}"
+    );
+    let details = &v["payload"]["details"];
+    assert_eq!(
+        details["requiredAcr"], "aal2",
+        "step-up reject must carry requiredAcr: {v}"
+    );
+    assert_eq!(
+        details["approveRequest"]["type"],
+        "https://trusttasks.org/spec/auth/step-up/approve-request/0.1",
+        "reject must carry the approve-request: {v}"
+    );
+    assert_eq!(details["approveRequest"]["recipient"], did, "{v}");
+    assert_eq!(
+        details["approveRequest"]["payload"]["targetAcr"], "aal2",
+        "{v}"
+    );
+}


### PR DESCRIPTION
## Apply the step-up gate to the operator policy

Builds on the step-up **trigger** (#179, merged) by applying it to the operations the operator chose: **all ACL changes** and **deleting contexts or keys** — across **both transports**, so an AAL1 caller can't bypass the gate by switching REST ↔ trust-task. This also makes `RequireStepUp` a *live* extractor (drops the temporary `allow(dead_code)`).

### Gated operations

| Operation | REST (`RequireStepUp` extractor) | Trust-task (`require_step_up` guard) |
|---|---|---|
| ACL create | `create_acl` | `acl::handle_create` |
| ACL update | `update_acl` | `acl::handle_update` |
| ACL delete | `delete_acl` | `acl::handle_delete` |
| ACL swap-key | `swap_acl` | — |
| Context delete | `delete_context_handler` | `contexts::handle_delete` |
| Key delete/revoke | *(no REST route)* | `keys::handle_revoke` |

Gate runs **after** the role check on each path, so a caller lacking the role still gets a permission error — not a step-up prompt.

### `step_up.rs` changes
- **`mint_pending_step_up()`** — extracted the challenge-mint + approve-request build, now shared by both surfaces.
- **`require_step_up(state, auth, doc)`** — trust-task analogue of the REST `403`: returns a routed **reject** whose `details` carry the `approveRequest`, mirroring the 403 body so a step-up-aware client acts on it identically over either transport. `None` when already AAL2.
- **`RequireStepUp`** is now a zero-sized marker (it gates; it doesn't carry claims — handlers get those from their role extractor).

### Tests
- `auth_token_aal2` helper (JWT `acr=aal2` + second factor in `amr`).
- 4 existing tests that mutate ACLs / delete a context bumped to AAL2 (a fresh login is AAL1; these ops now require step-up).
- **`acl_mutation_requires_step_up`** — AAL1 admin → `POST /acl` → `403` carrying the approve-request (role ok, just not stepped up).
- **`trust_task_acl_mutation_requires_step_up`** — AAL1 admin → `acl/create` trust-task → reject whose `details` carry the approve-request.

Full `vta-service` suite (686 tests) + `clippy -D warnings` + `cargo deny`: green.

---
Completes the AAL2 step-up workstream end-to-end: #176 pending store · #177 approve-response + both gates · #178 round-trip test · #179 trigger · **this PR: applied to the operator policy**.
