### PR TITLE
feat(vta): authenticate via DI-signed Trust Task over REST

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,22 @@ new flow, update both this section and the relevant `docs/*.md`.
 - **What**: Session initiation for any authenticated call.
 - **Endpoints**: `POST /auth/challenge` → challenge + session_id;
   `POST /auth/` → JWT access token (15m) + refresh token (24h).
-- **Wire**: DIDComm v2 (via mediator) **or** direct REST with a JWS.
+- **Wire** (`POST /auth/` content-negotiates on the body shape; all paths
+  converge on `vti_common::auth::handlers::handle_authenticate`):
+  - **DI-signed Trust Task (canonical REST)** — a plain JSON
+    `auth/authenticate/0.1` document whose holder `eddsa-jcs-2022`
+    Data-Integrity proof *is* the authentication. No DIDComm packing /
+    mediator needed, so a REST-only VTA (no `atm`) can authenticate. The
+    proof's `verificationMethod` DID is the proven signer; `did:key`
+    resolution is local. This is what `vta-mobile-core::build_authenticate`
+    emits. Verified by `routes/auth.rs::verify_authenticate_proof` (mirrors
+    the `step_up.rs` did-signed gate, PR #177).
+  - **DIDComm v2 envelope** (via mediator) — packed message; ATM unpack
+    verifies the sender (`msg.from` is the proven signer). Still supported.
+  - Freshness/replay is anchored by the single-use, TTL'd challenge bound to
+    the session at `/auth/challenge`; the DI path passes `created_time: None`
+    (no-op freshness check), the DIDComm path enforces a 60s window on the
+    envelope's `created_time`.
 - **Claims**: `{ aud, sub, session_id, role, contexts, exp }`. Audience
   separates VTA from VTC — cross-audience tokens are rejected.
 - **Code**: `vta-service/src/routes/auth.rs`, `vti-common/src/auth/`.

--- a/vta-service/src/routes/auth.rs
+++ b/vta-service/src/routes/auth.rs
@@ -1,8 +1,12 @@
+use affinidi_data_integrity::{DataIntegrityProof, DidKeyResolver, VerifyOptions};
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+use trust_tasks_rs::specs::auth::authenticate::v0_1 as authenticate;
 use uuid::Uuid;
 
 use vta_sdk::protocols::auth::{
@@ -69,6 +73,16 @@ pub async fn authenticate(
     State(state): State<AppState>,
     body: String,
 ) -> Result<Json<AuthenticateResponse>, AppError> {
+    // Canonical REST path: a DI-signed `auth/authenticate/0.1` Trust Task
+    // document, where the holder's Data-Integrity proof *is* the
+    // authentication (no DIDComm packing / mediator required). Tried first so
+    // a VTA with no DIDComm transport configured can still authenticate over
+    // plain REST. Falls through to the DIDComm envelope path for any body that
+    // isn't such a document.
+    if let Some(resp) = try_authenticate_trust_task(&state, &body).await? {
+        return Ok(Json(resp));
+    }
+
     let atm = state
         .atm
         .as_ref()
@@ -139,6 +153,106 @@ pub async fn authenticate(
         outcome = "success"
     );
     Ok(Json(resp))
+}
+
+/// Try to authenticate from a DI-signed `auth/authenticate/0.1` Trust Task
+/// document (the canonical REST transport).
+///
+/// Returns:
+/// - `Ok(Some(resp))` — the body was such a document, its proof verified, and
+///   the canonical authenticate handler issued tokens.
+/// - `Ok(None)` — the body is *not* an `auth/authenticate/0.1` Trust Task, so
+///   the caller should fall through to the DIDComm-envelope path.
+/// - `Err(_)` — the body *was* an authenticate document but is invalid (bad
+///   proof, malformed payload, challenge mismatch, …). We don't fall through:
+///   the caller's intent was unambiguous, so surface the real failure.
+///
+/// A DIDComm packed envelope is a JWE/JWS with none of a Trust Task's
+/// `id`/`type`/`payload` fields, so it fails the `TrustTask` parse and yields
+/// `None` — the two transports are unambiguous on the wire.
+async fn try_authenticate_trust_task(
+    state: &AppState,
+    body: &str,
+) -> Result<Option<AuthenticateResponse>, AppError> {
+    let doc: TrustTask<Value> = match serde_json::from_str(body) {
+        Ok(doc) => doc,
+        Err(_) => return Ok(None), // not a Trust Task document → DIDComm path
+    };
+    if doc.type_uri.to_string() != vta_sdk::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1 {
+        return Ok(None);
+    }
+
+    // From here the caller's intent is unambiguous; failures are real.
+    let signer_did = verify_authenticate_proof(&doc).await?;
+    let payload: authenticate::Payload = serde_json::from_value(doc.payload.clone())
+        .map_err(|e| AppError::Authentication(format!("invalid authenticate payload: {e}")))?;
+    let session_id = payload.session_id.to_string();
+    let challenge = payload.challenge.to_string();
+
+    let backend = crate::auth::VtaAuthBackend::from_state(state).await?;
+    let resp = vti_common::auth::handlers::handle_authenticate(
+        &backend,
+        vti_common::auth::AuthenticateInput {
+            session_id: session_id.clone(),
+            challenge,
+            signer_did: signer_did.clone(),
+            // No DIDComm `created_time`; the single-use, TTL'd challenge bound to
+            // the session is the freshness/replay anchor (the canonical handler
+            // treats `None` as a no-op freshness check, same as REST SIOPv2).
+            created_time: None,
+            session_pubkey_b58btc: None,
+        },
+    )
+    .await?;
+    audit!(
+        "auth.authenticate",
+        actor = &signer_did,
+        resource = &session_id,
+        outcome = "success"
+    );
+    Ok(Some(resp))
+}
+
+/// Verify the holder's `eddsa-jcs-2022` Data-Integrity proof on an
+/// `auth/authenticate/0.1` document and return the cryptographically-proven
+/// signer DID (the base DID of the proof's `verificationMethod`).
+///
+/// Mirrors the server-side did-signed gate verification in
+/// `routes/trust_tasks/step_up.rs::verify_did_signed_gate` (PR #177), but here
+/// the subject is *unknown a priori* — it's derived from the proof rather than
+/// checked against an expected value. The signer↔session binding is enforced
+/// downstream by the canonical handler (`signer_did == session.did`).
+/// `did:key` resolution is local (no I/O), matching the mobile holder key.
+async fn verify_authenticate_proof(doc: &TrustTask<Value>) -> Result<String, AppError> {
+    let proof = doc
+        .proof
+        .as_ref()
+        .ok_or_else(|| AppError::Authentication("authenticate document has no proof".into()))?;
+
+    let di: DataIntegrityProof = serde_json::to_value(proof)
+        .ok()
+        .and_then(|v| serde_json::from_value(v).ok())
+        .ok_or_else(|| AppError::Authentication("proof is not a Data Integrity proof".into()))?;
+
+    let signer_did = di
+        .verification_method
+        .split('#')
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    if signer_did.is_empty() {
+        return Err(AppError::Authentication(
+            "proof verificationMethod carries no DID".into(),
+        ));
+    }
+
+    let mut unsigned = doc.clone();
+    unsigned.proof = None;
+    di.verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+        .await
+        .map_err(|e| AppError::Authentication(format!("proof verification failed: {e}")))?;
+
+    Ok(signer_did)
 }
 
 // ---------- POST /auth/refresh ----------

--- a/vta-service/tests/authenticate_trust_task.rs
+++ b/vta-service/tests/authenticate_trust_task.rs
@@ -1,0 +1,219 @@
+//! Integration test for **authenticate via a DI-signed Trust Task over REST** —
+//! the transport-agnostic `auth/authenticate/0.1` path.
+//!
+//! The holder posts a plain JSON `auth/authenticate/0.1` Trust Task whose
+//! `eddsa-jcs-2022` Data-Integrity proof *is* the authentication — no DIDComm
+//! packing / mediator required. Exercises the real route → DI-proof verify
+//! (local `did:key` resolution) → canonical `handle_authenticate` →
+//! session-state transition → token mint, end to end.
+//!
+//! Unlike the DIDComm `POST /auth/` round-trip (which needs a network DID
+//! resolver and lives in the e2e suite), this path resolves `did:key` locally,
+//! so the full sign-then-verify runs in-process here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use affinidi_data_integrity::crypto_suites::CryptoSuite;
+use affinidi_data_integrity::{DataIntegrityProof, prepare_sign_input};
+use ed25519_dalek::{Signer, SigningKey};
+use multibase::Base;
+use trust_tasks_rs::{Proof, TrustTask};
+
+use vta_service::test_support::{TestAppContext, build_test_app};
+
+/// did:key + method-specific-id for an Ed25519 key (multicodec 0xed01).
+fn did_key(sk: &SigningKey) -> (String, String) {
+    let pk = sk.verifying_key();
+    let mut mc = vec![0xed, 0x01];
+    mc.extend_from_slice(pk.as_bytes());
+    let mb = multibase::encode(Base::Base58Btc, mc);
+    (format!("did:key:{mb}"), mb)
+}
+
+/// Grant `did` admin access so it clears the `/auth/challenge` ACL gate and the
+/// authenticate role re-lookup.
+async fn seed_admin_acl(ctx: &TestAppContext, did: &str) {
+    let entry = vti_common::acl::AclEntry {
+        did: did.into(),
+        role: vti_common::acl::Role::Admin,
+        label: None,
+        allowed_contexts: vec![],
+        created_at: 1,
+        created_by: "test".into(),
+        expires_at: None,
+        kind: Default::default(),
+        capabilities: vec![],
+        device: None,
+        version: 0,
+    };
+    vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
+        .await
+        .expect("seed admin ACL");
+}
+
+fn post(uri: &str, body: Vec<u8>) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        // Stable client IP so the per-IP rate limiter doesn't throttle a
+        // parallel `cargo test` run interleaving with the rate-limit test.
+        .header("x-forwarded-for", "203.0.113.7")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+async fn send(router: &axum::Router, req: Request<Body>) -> (StatusCode, Value) {
+    let resp = router.clone().oneshot(req).await.expect("request");
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({"raw": String::from_utf8_lossy(&bytes).to_string()}));
+    (status, v)
+}
+
+/// Build a holder-signed `auth/authenticate/0.1` Trust Task document for the
+/// given challenge + session, signed with `sk` (eddsa-jcs-2022).
+fn signed_authenticate_doc(
+    sk: &SigningKey,
+    did: &str,
+    vm: &str,
+    challenge: &str,
+    session_id: &str,
+) -> TrustTask<Value> {
+    let doc_json = json!({
+        "id": "urn:uuid:authn-itest-1",
+        "type": "https://trusttasks.org/spec/auth/authenticate/0.1",
+        "issuer": did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": { "challenge": challenge, "sessionId": session_id },
+    });
+    let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
+    let mut di = DataIntegrityProof {
+        type_: "DataIntegrityProof".to_string(),
+        cryptosuite: CryptoSuite::EddsaJcs2022,
+        // Safely in the past — DI verify rejects future-dated proofs, and the
+        // wall clock sits right on the 2026-06-01 boundary.
+        created: Some("2026-05-31T12:00:00Z".to_string()),
+        verification_method: vm.to_string(),
+        proof_purpose: "authentication".to_string(),
+        proof_value: None,
+        context: None,
+    };
+    let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
+    di.proof_value = Some(multibase::encode(
+        Base::Base58Btc,
+        sk.sign(&input).to_bytes(),
+    ));
+    doc.proof = Some(serde_json::from_value::<Proof>(serde_json::to_value(&di).unwrap()).unwrap());
+    doc
+}
+
+/// Run a real `/auth/challenge` for `did` and return `(session_id, challenge)`.
+async fn obtain_challenge(router: &axum::Router, did: &str) -> (String, String) {
+    let (status, body) = send(
+        router,
+        post(
+            "/auth/challenge",
+            json!({ "did": did }).to_string().into_bytes(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "challenge must issue: {body}");
+    (
+        body["sessionId"].as_str().unwrap().to_string(),
+        body["challenge"].as_str().unwrap().to_string(),
+    )
+}
+
+#[tokio::test]
+async fn di_signed_authenticate_issues_tokens() {
+    let (router, ctx) = build_test_app().await;
+    let sk = SigningKey::from_bytes(&[7u8; 32]);
+    let (did, mb) = did_key(&sk);
+    let vm = format!("{did}#{mb}");
+    seed_admin_acl(&ctx, &did).await;
+
+    let (session_id, challenge) = obtain_challenge(&router, &did).await;
+    let doc = signed_authenticate_doc(&sk, &did, &vm, &challenge, &session_id);
+
+    let (status, body) = send(&router, post("/auth/", serde_json::to_vec(&doc).unwrap())).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "DI-signed authenticate must succeed: {body}"
+    );
+    assert_eq!(body["session"]["subject"], did, "{body}");
+    assert_eq!(
+        body["session"]["acr"], "aal1",
+        "first factor is AAL1: {body}"
+    );
+    assert!(
+        body["tokens"]["accessToken"]
+            .as_str()
+            .is_some_and(|t| !t.is_empty()),
+        "an access token is issued: {body}"
+    );
+
+    // The session transitioned to Authenticated (so a replay can't re-auth).
+    let stored = vti_common::auth::session::get_session(&ctx.sessions_ks, &session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        stored.state,
+        vti_common::auth::session::SessionState::Authenticated
+    );
+
+    // Replay the exact same document: the session is no longer ChallengeSent.
+    let (replay_status, _) = send(&router, post("/auth/", serde_json::to_vec(&doc).unwrap())).await;
+    assert_ne!(
+        replay_status,
+        StatusCode::OK,
+        "replaying the authenticate document must not re-authenticate"
+    );
+}
+
+#[tokio::test]
+async fn di_signed_authenticate_rejects_tampered_proof() {
+    let (router, ctx) = build_test_app().await;
+    let sk = SigningKey::from_bytes(&[8u8; 32]);
+    let (did, mb) = did_key(&sk);
+    let vm = format!("{did}#{mb}");
+    seed_admin_acl(&ctx, &did).await;
+
+    let (session_id, challenge) = obtain_challenge(&router, &did).await;
+    let mut doc = signed_authenticate_doc(&sk, &did, &vm, &challenge, &session_id);
+
+    // Corrupt the signature: flip a char near the START of the proofValue
+    // (full 6 significant bits) so the tamper is never a no-op.
+    let mut proof = serde_json::to_value(doc.proof.take().unwrap()).unwrap();
+    let pv = proof["proofValue"].as_str().unwrap();
+    let mut chars: Vec<char> = pv.chars().collect();
+    // index 1 is the first base58 char after the multibase prefix 'z'.
+    chars[1] = if chars[1] == 'A' { 'B' } else { 'A' };
+    proof["proofValue"] = Value::String(chars.into_iter().collect());
+    doc.proof = Some(serde_json::from_value(proof).unwrap());
+
+    let (status, body) = send(&router, post("/auth/", serde_json::to_vec(&doc).unwrap())).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "a tampered proof must be rejected: {body}"
+    );
+
+    // The session stays in ChallengeSent — no tokens were issued.
+    let stored = vti_common::auth::session::get_session(&ctx.sessions_ks, &session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        stored.state,
+        vti_common::auth::session::SessionState::ChallengeSent
+    );
+}


### PR DESCRIPTION
## Transport-agnostic authenticate — DI proof over REST

Closes the authentication transport-convergence gap (epic: VTA auth → Trust Task model). The VTA can now accept a plain-JSON `auth/authenticate/0.1` Trust Task whose holder **`eddsa-jcs-2022` Data-Integrity proof *is* the credential** — no DIDComm packing or mediator required.

This is exactly the document **`vta-mobile-core::build_authenticate` (#165)** already produces, so the mobile engine can now log in to a VTA over plain REST.

### How
`POST /auth/` content-negotiates on the body shape; both transports converge on the same canonical `handle_authenticate`:

| Body | Path | Signer derived from |
|---|---|---|
| `auth/authenticate/0.1` Trust Task w/ DI proof | **new — canonical REST** | proof `verificationMethod` (local `did:key` verify) |
| DIDComm packed envelope | unchanged | ATM unpack (`msg.from`) |

- The DI path is **tried first**, so a REST-only VTA (no `atm`/DIDComm configured) can authenticate.
- A DIDComm envelope is a JWE/JWS with none of a Trust Task's `id`/`type`/`payload` fields → the `TrustTask` parse cleanly distinguishes the two. A non-matching body falls through to DIDComm; an *invalid* authenticate document surfaces the real error (no silent fall-through).
- `verify_authenticate_proof` mirrors `step_up.rs`'s #177 did-signed gate, but derives the subject from the proof rather than checking it — the **signer↔session binding** (`signer_did == session.did`) + challenge match are enforced downstream by the canonical handler.
- Freshness/replay is anchored by the single-use, TTL'd challenge, so the DI path passes `created_time: None` (no-op freshness — same as the existing REST SIOPv2 path).

### Tests
The DI path resolves `did:key` locally, so the full sign-then-verify runs **in-process** (unlike the DIDComm round-trip, which needs a network resolver and lives in e2e):
- `di_signed_authenticate_issues_tokens` — `/auth/challenge` → sign → `200` + tokens + session `Authenticated`; **replay rejected**.
- `di_signed_authenticate_rejects_tampered_proof` — `401`, session stays `ChallengeSent`.

Full `vta-service` suite (688 tests) + `clippy -D warnings` + `cargo deny`: green. Workspace CLAUDE.md auth-flow section updated.

### Scope
Additive — does **not** touch the legacy `affinidi.com/atm/1.0/*` alias (that's the separate deprecation slice in the epic).
