### PR TITLE
feat(vta): refresh via auth/refresh/0.1 Trust Task over REST

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,8 @@ new flow, update both this section and the relevant `docs/*.md`.
 ### DIDComm challenge-response auth
 - **What**: Session initiation for any authenticated call.
 - **Endpoints**: `POST /auth/challenge` → challenge + session_id;
-  `POST /auth/` → JWT access token (15m) + refresh token (24h).
+  `POST /auth/` → JWT access token (15m) + refresh token (24h);
+  `POST /auth/refresh` → rotated access + refresh tokens.
 - **Wire** (`POST /auth/` content-negotiates on the body shape; all paths
   converge on `vti_common::auth::handlers::handle_authenticate`):
   - **DI-signed Trust Task (canonical REST)** — a plain JSON
@@ -288,6 +289,12 @@ new flow, update both this section and the relevant `docs/*.md`.
     the session at `/auth/challenge`; the DI path passes `created_time: None`
     (no-op freshness check), the DIDComm path enforces a 60s window on the
     envelope's `created_time`.
+  - **`POST /auth/refresh` content-negotiates the same way**: a plain
+    `auth/refresh/0.1` Trust Task (canonical REST) **or** a DIDComm envelope.
+    Refresh carries *no proof* — the opaque refresh token in the payload is the
+    bearer credential (OAuth2 §10.4 rotation), so the Trust Task path passes
+    `signer_did: None`. Together with the authenticate path above, the mobile
+    engine runs its whole login→refresh loop over plain REST, no mediator.
 - **Claims**: `{ aud, sub, session_id, role, contexts, exp }`. Audience
   separates VTA from VTC — cross-audience tokens are rejected.
 - **Code**: `vta-service/src/routes/auth.rs`, `vti-common/src/auth/`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63cac399b6d7547a9af38375e596dc6df60d206d02eec037e69f30600a37dac6"
+checksum = "bda6f871ba314dc0955490c1e85317609217846c5ddace9dda0ab2f6704d5dbe"
 dependencies = [
  "affinidi-encoding",
  "base58",
@@ -122,14 +122,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-authentication"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e65b65ec17cacb1cc292671a96caa0492a62377f0f9f8c1ebd2458c5a039e49"
+checksum = "f9ebfbaca40c3c02c6f75cbafcef50957049818eb6d6c5ed05a5a3e649769503"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.14.0",
  "affinidi-secrets-resolver",
  "base64 0.22.1",
  "chrono",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-common"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a10e1890c284e5d918492f55d58ed2fa442071ff88cfe52f2395e7ee3eb9b01"
+checksum = "9fe027b966094b1a10afedc57c3eb947f1ce9aa9e46eaed439afae873676d325"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-web"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60190b239183934f3c14e21d966d10ee3c83297077bc24fbe55e8af15896317e"
+checksum = "f6eb7955717be071a68847e752805d2c363bc03af6ee944fdf894f51f5e10154"
 dependencies = [
  "affinidi-did-common",
  "percent-encoding",
@@ -234,14 +234,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-meeting-place"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af99d980dc43f21a99c7672f9a4d35b8ad0c8ee9603ef48e5e146b0e900712d"
+checksum = "38c268d1292de575de95238238790f7815e3379c3fd04e3f56918b563bf4e001"
 dependencies = [
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.14.0",
  "affinidi-tdk-common",
  "base64 0.22.1",
  "chrono",
@@ -279,13 +279,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "affinidi-messaging-didcomm-service"
-version = "0.3.1"
+name = "affinidi-messaging-didcomm"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036decd259540cf6495c074f2432cf4e295ff30e190b28653dffd79ad1103007"
+checksum = "08f942b5c39668555d7dbb27a03842e96cb2f116791010f493d25f0d17ed2625"
 dependencies = [
- "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk 0.18.3",
+ "aes 0.8.4",
+ "base64ct",
+ "cbc 0.1.2",
+ "ed25519-dalek",
+ "hmac 0.12.1",
+ "k256",
+ "p256",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror 2.0.18",
+ "url",
+ "uuid",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "affinidi-messaging-didcomm-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd3dd78a0535983774c8f3f4fdbd2aaa09f5ce1b109870aa017d5675874c6d1d"
+dependencies = [
+ "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
  "async-trait",
@@ -303,16 +328,16 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.15.5"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89aecc77a0fa030ab8a92d9c5f4725f0cca171059b8c9d81bd1d388bb5b6dcd"
+checksum = "f831560ac5106539a583d7f1bb9b33badbb942896b4140aad46694c184f7ea3a"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.14.0",
  "affinidi-messaging-mediator-common",
- "affinidi-messaging-sdk 0.18.3",
+ "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "ahash 0.8.12",
  "async-convert",
@@ -398,42 +423,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.17.0"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad8146b7f587d1ad1be5a01fed4c4cac19f014ed881d1b3c592b487462b071d"
+checksum = "1e2f281adc328e53a31585945179cf62c0e7ea24c96dcae505acd1d8946b47d2"
 dependencies = [
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-encoding",
- "affinidi-messaging-didcomm",
- "affinidi-secrets-resolver",
- "affinidi-tdk-common",
- "ahash 0.8.12",
- "base64 0.22.1",
- "futures-util",
- "regex",
- "rustls 0.23.40",
- "rustls-pemfile 2.2.0",
- "serde",
- "serde_json",
- "sha256",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "affinidi-messaging-sdk"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffea0bd76545452d691b9b923b9caed7bb924bd3120bde0613db47b8feaed2f1"
-dependencies = [
- "affinidi-did-authentication",
- "affinidi-did-common",
- "affinidi-encoding",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.14.0",
  "affinidi-messaging-mediator-common",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
@@ -462,7 +459,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-mediator",
  "affinidi-messaging-mediator-common",
- "affinidi-messaging-sdk 0.18.3",
+ "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "async-trait",
@@ -493,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933214490477763c4c7eb01ec7438d58887b2994bbb8f5d4699b4c7a5acce52a"
+checksum = "e5f5b82eb03c6356e54c041739aaad4bd1a8c25cf19e9b0e9690a32014c3e956"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -518,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-status-list"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7519418d6004ad52e67a7b23fb6171bd91b5bcd9ccc26e44fefcc8ba1452fcd"
+checksum = "59a4be4e13f529c146c9c1e45cb78b17a77bb41605998cd9c42509b99fa4b422"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -533,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e81cd0d2e2de8abfff4b90690fb7a389adfd2bbec388f6ee936541965fe5b87"
+checksum = "ca8bce3db70173a18eebb28ffc22522256dd5dac49ff1ec587f9f50e63aae966"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -543,8 +540,8 @@ dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-meeting-place",
- "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk 0.17.0",
+ "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
  "clap",
@@ -558,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a70cf88c7fc0c7dc4fa085ea89efaefd647887b37cff2581c04e120ac3af970"
+checksum = "325cf3d04813a5ae8ce92bf4363a4e4da561ce71dd1aca06638ebe9ec0830a52"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",
@@ -6953,9 +6950,9 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.10.5"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
 dependencies = [
  "hashbrown 0.16.1",
  "memchr",
@@ -9022,9 +9019,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3e51c2b623b09bf61abc0a680ea69576ca346f21be8a566a1997437e597d05"
+checksum = "84ae2eb8b8056bc4639cb0b91dd70b1ac21655455cbc4f5961c9985f8ead2325"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9520,7 +9517,7 @@ version = "0.1.0"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.14.0",
  "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
@@ -9540,7 +9537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcfddb2f41f35ad49650e63848aa32ddaecb7f24b4e2337561d7a586e2fd7faf"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.13.3",
  "affinidi-tdk",
  "base64 0.22.1",
  "chrono",
@@ -9567,7 +9564,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.14.0",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "affinidi-vc",
@@ -9613,7 +9610,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.14.0",
  "affinidi-messaging-didcomm-service",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
@@ -9696,7 +9693,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.14.0",
  "affinidi-messaging-didcomm-service",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
@@ -9807,8 +9804,8 @@ name = "vti-e2e-tests"
 version = "0.6.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk 0.18.3",
+ "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",
  "affinidi-tdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -133,7 +133,7 @@ dependencies = [
  "affinidi-secrets-resolver",
  "base64 0.22.1",
  "chrono",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -213,7 +213,7 @@ checksum = "f6eb7955717be071a68847e752805d2c363bc03af6ee944fdf894f51f5e10154"
 dependencies = [
  "affinidi-did-common",
  "percent-encoding",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
@@ -245,7 +245,7 @@ dependencies = [
  "affinidi-tdk-common",
  "base64 0.22.1",
  "chrono",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -352,7 +352,7 @@ dependencies = [
  "futures-util",
  "governor",
  "hostname",
- "http 1.4.0",
+ "http 1.4.1",
  "humantime",
  "itertools",
  "jsonwebtoken",
@@ -362,7 +362,7 @@ dependencies = [
  "rand 0.10.1",
  "redis",
  "regex",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "ring",
  "rustls 0.23.40",
  "semver",
@@ -405,7 +405,7 @@ dependencies = [
  "num-format",
  "rand 0.10.1",
  "regex",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "semver",
  "serde",
  "serde_json",
@@ -570,7 +570,7 @@ dependencies = [
  "dbus-secret-service-keyring-store",
  "keyring-core",
  "moka",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rustls 0.23.40",
  "rustls-pemfile 2.2.0",
  "rustls-platform-verifier 0.7.0",
@@ -983,7 +983,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "sha1",
  "time",
  "tokio",
@@ -1057,7 +1057,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.107.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff0bb3e6249447a5ecfeec4616de4f04498a4337302b6ffe221b4a8745905c4"
+checksum = "3c07c0605c62c02a7ca33ee4f9db8ec0d9085e38bf74b1f02d7e357646e3b63f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1084,16 +1084,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.105.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4e56ac810211dc33810c7aa3612eda29a8b1e8c7e2db6e960c8657e3d95e42"
+checksum = "8b6fa2aa029a7298bc3d863c253fe6745dac677620f20c337b6ca7cc208f7201"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1108,16 +1108,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.99.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
+checksum = "bee2719d4a5e5e147bb9e9b77490df6ece750df1094968aa857b09b618a1881a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1132,17 +1132,18 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.101.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
+checksum = "b30d254992d56ef19f430396e5765b11e0f5bd21a7a557cb12fca1c8c18b9636"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -1156,16 +1157,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.104.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
+checksum = "59f4f8065fe615dbed9096458ba98dda6d641553ffd5aedd27e37e65211aca9f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1181,7 +1182,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
@@ -1201,7 +1202,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "percent-encoding",
  "sha2 0.11.0",
  "time",
@@ -1231,7 +1232,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -1252,10 +1253,10 @@ dependencies = [
  "h2 0.3.27",
  "h2 0.4.14",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -1316,7 +1317,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1337,7 +1338,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1363,7 +1364,7 @@ checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -1377,7 +1378,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1427,10 +1428,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1460,7 +1461,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -1483,7 +1484,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "headers",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -1503,9 +1504,9 @@ dependencies = [
  "bytes",
  "either",
  "fs-err 3.3.0",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.23.40",
@@ -1726,9 +1727,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "hex-conservative",
 ]
@@ -1993,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2197,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
@@ -2256,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -2701,7 +2702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3008,7 +3009,7 @@ dependencies = [
  "chrono",
  "getrandom 0.4.2",
  "percent-encoding",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
@@ -3076,9 +3077,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3800,9 +3801,9 @@ dependencies = [
  "google-cloud-gax",
  "hex",
  "hmac 0.13.0",
- "http 1.4.0",
+ "http 1.4.1",
  "jsonwebtoken",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rustc_version",
  "rustls 0.23.40",
  "rustls-pki-types",
@@ -3826,7 +3827,7 @@ dependencies = [
  "futures",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project",
  "rand 0.10.1",
  "serde",
@@ -3846,16 +3847,16 @@ dependencies = [
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-rpc",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "lazy_static",
  "opentelemetry",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "percent-encoding",
  "pin-project",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rustc_version",
  "serde",
  "serde_json",
@@ -4026,7 +4027,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4116,7 +4117,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.0",
+ "http 1.4.1",
  "httpdate",
  "mime",
  "sha1",
@@ -4128,7 +4129,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -4251,9 +4252,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -4277,7 +4278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -4288,7 +4289,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -4346,16 +4347,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -4387,8 +4388,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.40",
  "rustls-native-certs",
@@ -4403,7 +4404,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4433,14 +4434,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5228,9 +5229,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -5327,9 +5328,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loom"
@@ -5434,9 +5435,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmem"
@@ -5472,7 +5473,7 @@ dependencies = [
  "base64 0.22.1",
  "evmap",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "indexmap 2.14.0",
@@ -5543,9 +5544,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -6282,7 +6283,7 @@ dependencies = [
  "hex",
  "multibase",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -6500,7 +6501,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6538,7 +6539,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6793,9 +6794,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d32a1ac9123f0d84fda64bfc02a271d9868483162dd2d9099b5c362ece064c"
+checksum = "a12e6b5f4d8ef33944e833e2b1859ad478deab6e431d7337b30ee2efe21f7543"
 dependencies = [
  "ahash 0.8.12",
  "arc-swap",
@@ -6815,7 +6816,7 @@ dependencies = [
  "rustls-native-certs",
  "ryu",
  "sha1_smol",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
@@ -7006,9 +7007,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7016,10 +7017,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
@@ -7116,8 +7117,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "http 1.4.0",
- "reqwest 0.13.3",
+ "http 1.4.1",
+ "reqwest 0.13.4",
  "rustify_derive",
  "serde",
  "serde_json",
@@ -7746,9 +7747,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -7905,9 +7906,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -8591,7 +8592,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -8748,10 +8749,10 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -8780,16 +8781,16 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -8850,7 +8851,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -8884,7 +8885,7 @@ dependencies = [
  "axum",
  "forwarded-header-value",
  "governor",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project",
  "thiserror 2.0.18",
  "tonic 0.14.6",
@@ -8990,7 +8991,7 @@ dependencies = [
  "axum",
  "chrono",
  "jsonwebtoken",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -9046,7 +9047,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -9064,9 +9065,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typespec"
@@ -9095,7 +9096,7 @@ dependencies = [
  "futures",
  "pin-project",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "time",
@@ -9391,9 +9392,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -9433,8 +9434,8 @@ checksum = "30ffcc0e81025065dda612ec1e26a3d81bb16ef3062354873d17a35965d68522"
 dependencies = [
  "async-trait",
  "derive_builder",
- "http 1.4.0",
- "reqwest 0.13.3",
+ "http 1.4.1",
+ "reqwest 0.13.4",
  "rustify",
  "rustify_derive",
  "serde",
@@ -9486,7 +9487,7 @@ dependencies = [
  "multibase",
  "rand 0.10.1",
  "ratatui",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -9546,7 +9547,7 @@ dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
  "multibase",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -9583,7 +9584,7 @@ dependencies = [
  "keyring-core",
  "multibase",
  "nitro_attest",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -9605,7 +9606,7 @@ dependencies = [
 name = "vta-service"
 version = "0.7.0"
 dependencies = [
- "aes 0.9.0",
+ "aes 0.9.1",
  "aes-gcm",
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9652,7 +9653,7 @@ dependencies = [
  "multibase",
  "p256",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -9732,7 +9733,7 @@ dependencies = [
  "multibase",
  "rand 0.10.1",
  "regorus",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -9812,7 +9813,7 @@ dependencies = [
  "chrono",
  "ed25519-dalek",
  "multibase",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -10633,9 +10634,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "once_cell",
@@ -10860,18 +10861,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -32,7 +32,7 @@ affinidi-tdk = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 affinidi-messaging-sdk = "0.18"
-affinidi-messaging-didcomm = "0.13"
+affinidi-messaging-didcomm = "0.14"
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }
 tempfile = "3"

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -47,7 +47,7 @@ tokio = { workspace = true }
 # networked methods (did:web / did:webvh) need network-mode config — later.
 affinidi-did-resolver-cache-sdk = { workspace = true }
 # DIDComm v2 authcrypt/anoncrypt pack + unpack. Pinned to vta-sdk's version.
-affinidi-messaging-didcomm = "0.13"
+affinidi-messaging-didcomm = "0.14"
 
 # ── Deferred wiring (kept out of slice 1 on purpose) ────────────────────────
 # The FFI build + bindgen pipeline is proven first with a minimal surface.

--- a/vta-mobile-core/src/didcomm.rs
+++ b/vta-mobile-core/src/didcomm.rs
@@ -154,6 +154,14 @@ impl DidcommSession {
                 signer_kid,
             } => (message, true, signer_kid),
             UnpackResult::Plaintext(message) => (message, false, None),
+            // `UnpackResult` is `#[non_exhaustive]` as of didcomm 0.14; reject
+            // any variant this engine version doesn't recognise rather than
+            // guess its authentication semantics.
+            _ => {
+                return Err(FfiError::InvalidInput {
+                    reason: "unsupported DIDComm unpack result variant".to_string(),
+                });
+            }
         };
 
         Ok(UnpackedMessage {

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -127,7 +127,7 @@ sha2 = { workspace = true, optional = true }
 # Used by `client` (didcomm_light::pack_anoncrypt) to produce JWEs the
 # workspace's pinned DIDComm decrypt path will accept (ECDH-ES+A256KW +
 # A256CBC-HS512). Same pinned version as `vta-service`.
-affinidi-messaging-didcomm = { version = "0.13", optional = true }
+affinidi-messaging-didcomm = { version = "0.14", optional = true }
 # Used by `client` (didcomm_light::resolve_vta_keyagreement) to resolve
 # `did:webvh:` VTAs without pulling in the heavyweight TDK runtime. Same
 # workspace-pinned version as `vta-service`.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -101,7 +101,7 @@ affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }
 hkdf = { workspace = true }
 affinidi-tdk = { workspace = true }
-affinidi-messaging-didcomm = "0.13"
+affinidi-messaging-didcomm = "0.14"
 affinidi-messaging-didcomm-service = { workspace = true }
 async-trait = "0.1"
 affinidi-tdk-common = "0.6"

--- a/vta-service/src/routes/auth.rs
+++ b/vta-service/src/routes/auth.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use trust_tasks_rs::specs::auth::authenticate::v0_1 as authenticate;
+use trust_tasks_rs::specs::auth::refresh::v0_1 as refresh;
 use uuid::Uuid;
 
 use vta_sdk::protocols::auth::{
@@ -273,6 +274,16 @@ pub async fn refresh(
     State(state): State<AppState>,
     body: String,
 ) -> Result<Json<AuthenticateResponse>, AppError> {
+    // Canonical REST path: an `auth/refresh/0.1` Trust Task. Refresh carries no
+    // proof — the opaque refresh token in the payload *is* the credential
+    // (OAuth2 §10.4 semantics), verified server-side by the rotating
+    // reverse-index. Tried first so a VTA with no DIDComm transport configured
+    // can still refresh over plain REST. Falls through to the DIDComm-envelope
+    // path for any body that isn't such a document.
+    if let Some(resp) = try_refresh_trust_task(&state, &body).await? {
+        return Ok(Json(resp));
+    }
+
     let atm = state
         .atm
         .as_ref()
@@ -319,6 +330,51 @@ pub async fn refresh(
         outcome = "success"
     );
     Ok(Json(resp))
+}
+
+/// Try to refresh from an `auth/refresh/0.1` Trust Task document (the canonical
+/// REST transport).
+///
+/// Mirrors [`try_authenticate_trust_task`], but refresh carries **no proof**:
+/// the opaque refresh token in the payload is the bearer credential, verified
+/// by the canonical handler's rotating reverse-index. `signer_did` is therefore
+/// `None` — there's no proven signer to bind, and the handler treats `None` as
+/// "skip the optional signer-DID check" (the token is sufficient).
+///
+/// Returns `Ok(None)` when the body isn't an `auth/refresh/0.1` Trust Task (→
+/// fall through to the DIDComm path); `Err` when it *is* one but is invalid.
+async fn try_refresh_trust_task(
+    state: &AppState,
+    body: &str,
+) -> Result<Option<AuthenticateResponse>, AppError> {
+    let doc: TrustTask<Value> = match serde_json::from_str(body) {
+        Ok(doc) => doc,
+        Err(_) => return Ok(None), // not a Trust Task document → DIDComm path
+    };
+    if doc.type_uri.to_string() != vta_sdk::trust_tasks::TASK_AUTH_REFRESH_0_1 {
+        return Ok(None);
+    }
+
+    let payload: refresh::Payload = serde_json::from_value(doc.payload.clone())
+        .map_err(|e| AppError::Authentication(format!("invalid refresh payload: {e}")))?;
+    let refresh_token = payload.refresh_token.to_string();
+
+    let backend = crate::auth::VtaAuthBackend::from_state(state).await?;
+    let resp = vti_common::auth::handlers::handle_refresh(
+        &backend,
+        vti_common::auth::RefreshInput {
+            refresh_token,
+            signer_did: None,
+        },
+    )
+    .await?;
+    audit!(
+        "auth.refresh",
+        actor = &resp.session.subject,
+        resource = &resp.session.id,
+        outcome = "success"
+    );
+    Ok(Some(resp))
 }
 
 // ---------- POST /auth/credentials ----------

--- a/vta-service/src/webvh_auth.rs
+++ b/vta-service/src/webvh_auth.rs
@@ -202,6 +202,8 @@ mod tests {
             UnpackResult::Signed { message, .. } => message,
             UnpackResult::Plaintext(_) => panic!("expected Signed result, got Plaintext"),
             UnpackResult::Encrypted { .. } => panic!("expected Signed result, got Encrypted"),
+            // `UnpackResult` is `#[non_exhaustive]` as of didcomm 0.14.
+            _ => panic!("expected Signed result, got an unrecognised UnpackResult variant"),
         }
     }
 

--- a/vta-service/tests/refresh_trust_task.rs
+++ b/vta-service/tests/refresh_trust_task.rs
@@ -1,0 +1,151 @@
+//! Integration test for **refresh via an `auth/refresh/0.1` Trust Task over
+//! REST** — the transport-agnostic refresh path that completes the mobile REST
+//! auth loop (login lands in `authenticate_trust_task.rs`).
+//!
+//! Refresh carries **no proof**: the opaque refresh token in the payload is the
+//! bearer credential (OAuth2 §10.4), verified server-side by the rotating
+//! reverse-index. So this exercises route → `TrustTask` parse → canonical
+//! `handle_refresh` → token rotation, with no signing ceremony.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vta_service::test_support::{TestAppContext, build_test_app};
+use vti_common::auth::session::{
+    Session, SessionState, now_epoch, store_refresh_index, store_session,
+};
+
+async fn seed_admin_acl(ctx: &TestAppContext, did: &str) {
+    let entry = vti_common::acl::AclEntry {
+        did: did.into(),
+        role: vti_common::acl::Role::Admin,
+        label: None,
+        allowed_contexts: vec![],
+        created_at: 1,
+        created_by: "test".into(),
+        expires_at: None,
+        kind: Default::default(),
+        capabilities: vec![],
+        device: None,
+        version: 0,
+    };
+    vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
+        .await
+        .expect("seed admin ACL");
+}
+
+/// Seed an authenticated session with a live refresh token + its reverse index.
+async fn seed_authenticated_session(
+    ctx: &TestAppContext,
+    did: &str,
+    refresh_token: &str,
+) -> String {
+    let session_id = format!("sess-{}", uuid::Uuid::new_v4());
+    let session = Session {
+        session_id: session_id.clone(),
+        did: did.to_string(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: Some(refresh_token.to_string()),
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".into()],
+        acr: "aal1".into(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session)
+        .await
+        .expect("store session");
+    store_refresh_index(&ctx.sessions_ks, refresh_token, &session_id)
+        .await
+        .expect("store refresh index");
+    session_id
+}
+
+fn refresh_doc(refresh_token: &str) -> Vec<u8> {
+    json!({
+        "id": "urn:uuid:refresh-itest-1",
+        "type": "https://trusttasks.org/spec/auth/refresh/0.1",
+        "issuer": "did:key:z6MkRefresher",
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": { "refreshToken": refresh_token },
+    })
+    .to_string()
+    .into_bytes()
+}
+
+fn post(uri: &str, body: Vec<u8>) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("x-forwarded-for", "203.0.113.9")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+async fn send(router: &axum::Router, req: Request<Body>) -> (StatusCode, Value) {
+    let resp = router.clone().oneshot(req).await.expect("request");
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({"raw": String::from_utf8_lossy(&bytes).to_string()}));
+    (status, v)
+}
+
+#[tokio::test]
+async fn trust_task_refresh_rotates_tokens() {
+    let (router, ctx) = build_test_app().await;
+    let did = "did:key:z6MkRefresher";
+    let old_token = "refresh-tok-itest-aaaa";
+    seed_admin_acl(&ctx, did).await;
+    seed_authenticated_session(&ctx, did, old_token).await;
+
+    let (status, body) = send(&router, post("/auth/refresh", refresh_doc(old_token))).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "Trust Task refresh must succeed: {body}"
+    );
+    assert_eq!(body["session"]["subject"], did, "{body}");
+    assert!(
+        body["tokens"]["accessToken"]
+            .as_str()
+            .is_some_and(|t| !t.is_empty()),
+        "a fresh access token is issued: {body}"
+    );
+    // RFC 6749 §10.4 rotation: a new refresh token, different from the old one.
+    let new_token = body["tokens"]["refreshToken"]
+        .as_str()
+        .expect("rotated refresh token");
+    assert_ne!(new_token, old_token, "refresh token must rotate: {body}");
+
+    // The presented token works exactly once — a replay is rejected.
+    let (replay_status, _) = send(&router, post("/auth/refresh", refresh_doc(old_token))).await;
+    assert_eq!(
+        replay_status,
+        StatusCode::UNAUTHORIZED,
+        "a consumed refresh token must not refresh again"
+    );
+}
+
+#[tokio::test]
+async fn trust_task_refresh_rejects_unknown_token() {
+    let (router, _ctx) = build_test_app().await;
+    let (status, _) = send(
+        &router,
+        post("/auth/refresh", refresh_doc("refresh-tok-never-issued")),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "an unknown refresh token must be rejected"
+    );
+}

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -103,7 +103,7 @@ subtle = { workspace = true }
 # message handler in `messaging.rs` (M1.8.2). The service crate
 # accepts `Message` / `UnpackMetadata` by value but doesn't
 # re-export them.
-affinidi-messaging-didcomm = "0.13"
+affinidi-messaging-didcomm = "0.14"
 tokio-util = { workspace = true, features = ["rt"] }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 base64 = { workspace = true }


### PR DESCRIPTION
## Transport-agnostic refresh — completes the mobile REST auth loop

`/auth/refresh` had the **same DIDComm-packing gap** that #181 just fixed for `/auth/`. So #181 let a mobile client *log in* over plain REST, but its session would die at the 15-minute access-token expiry with **no REST renewal path** — the loop was half-built. This closes it.

`POST /auth/refresh` now content-negotiates on the body shape; both transports converge on the canonical `handle_refresh`:

| Body | Path |
|---|---|
| `auth/refresh/0.1` Trust Task | **new — canonical REST** (tried first; a REST-only VTA with no `atm` can refresh) |
| DIDComm packed envelope | unchanged |

### Key difference from #181: no proof
Refresh carries **no Data-Integrity proof** — there's no DI verification here. The opaque refresh token in the payload **is** the bearer credential (RFC 6749 §10.4 rotation), verified server-side by the rotating reverse-index. So `signer_did: None` (the canonical handler skips the optional signer-DID bind when absent — the token is sufficient). This is exactly what **`vta-mobile-core::build_refresh` (#166, `IS_PROOF_REQUIRED == false`)** already produces.

Detection is the same robust shape check as #181 (a DIDComm JWE/JWS isn't a `TrustTask`, so it falls through; an invalid refresh document surfaces the real error).

### Tests (no signing ceremony)
- `trust_task_refresh_rotates_tokens` — seed authenticated session + refresh index → POST → `200` + fresh access token + **rotated** refresh token; replay of the consumed token → `401`.
- `trust_task_refresh_rejects_unknown_token` → `401`.

Full `vta-service` suite (690 tests, incl. `auth_flow` confirming the DIDComm fall-through) + `clippy -D warnings` + `cargo deny`: green. CLAUDE.md auth-flow updated.

### Scope
Additive — does **not** touch the legacy `atm/1.0/authenticate/refresh` alias (separate deprecation slice).

---
**Mobile REST auth loop now complete:** `/auth/challenge` → authenticate (#181) → **refresh (this PR)**. Remaining epic items: `whoami` + `sessions/list` REST handlers, then deprecate the `atm/1.0` aliases.

---

## Also in this PR: affinidi + trust-tasks dependency bump

Brings the workspace onto the latest affinidi stack + `trust-tasks-rs 0.1.4`. Because the affinidi crates are co-released and the entire latest line moved to **`affinidi-messaging-didcomm 0.14`** (breaking `Message`/`MessageHandler` API), this also **migrates our DIDComm integration 0.13 → 0.14**.

- **Family bump** (targeted `--precise`, so the lockfile diff is affinidi/trust-tasks only — no incidental hyper/aws/uuid churn): tdk 0.7.2, tdk-common 0.6.2, crypto 0.1.7, status-list 0.1.2, secrets-resolver 0.5.6, did-common 0.3.4, did-authentication 0.3.4, did-web 0.1.1, meeting-place 0.4.1, messaging-sdk 0.18.4, messaging-didcomm-service 0.3.2, messaging-mediator 0.15.7, messaging-didcomm 0.14, trust-tasks-rs 0.1.4 (+ `regress` 0.11, its transitive).
- **Manifest pins** bumped to didcomm `0.14` in the 5 crates that depend on it directly (vta-sdk, vta-service, vtc-service, vta-mobile-core, tests/e2e).
- **Code migration:** the only source-breaking change in 0.14 is `UnpackResult` becoming `#[non_exhaustive]` — wildcard arms added at the two match sites (`webvh_auth.rs` test helper; `vta-mobile-core/didcomm.rs` engine unpack, which now rejects an unrecognised variant rather than guess its auth semantics). `Message`/`MessageHandler` were source-compatible once versions were coherent.
- didcomm `0.13.3` remains only for the `messaging-mediator → published vta-sdk 0.7.0` chain (didcomm-test harness) — outside our control, isolated from our crates.

Verified: `cargo check --workspace --all-targets`, full workspace test suite (excl. e2e), `clippy -D warnings`, `cargo deny` — all green.

### Update: full dependency refresh

Follow-up commit runs a full `cargo update` so the **entire lockfile** is on the latest semver-compatible versions (not just affinidi/trust-tasks). Lockfile-only — no manifest pins changed; all within existing `major.minor` ranges except `shlex` (build-time arg splitter) crossing 1 → 2 with no API impact on our use. ~25 transitive crates (hyper 1.10.1, reqwest 0.13.4, aws-sdk-* patches, uuid 1.23.2, http 1.4.1, zerocopy 0.8.50, …). Full workspace suite + clippy + cargo deny: green.