### PR TITLE
chore(release): bump publishable crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,7 +2204,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2217,7 +2217,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.8.0",
+ "vta-sdk 0.9.0",
 ]
 
 [[package]]
@@ -2991,7 +2991,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.8.0",
+ "vta-sdk 0.9.0",
 ]
 
 [[package]]
@@ -6270,7 +6270,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6292,7 +6292,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.8.0",
+ "vta-sdk 0.9.0",
 ]
 
 [[package]]
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9493,7 +9493,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.8.0",
+ "vta-sdk 0.9.0",
  "x25519-dalek",
 ]
 
@@ -9560,7 +9560,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9604,7 +9604,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -9676,7 +9676,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.8.0",
+ "vta-sdk 0.9.0",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9689,7 +9689,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9752,7 +9752,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.8.0",
+ "vta-sdk 0.9.0",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9762,7 +9762,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -9795,7 +9795,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.8.0",
+ "vta-sdk 0.9.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9822,7 +9822,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.8.0",
+ "vta-sdk 0.9.0",
  "vta-service",
  "vti-common",
 ]

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.8", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.7" }
+vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.8" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.8", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,12 +21,12 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.8", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
-vta-cli-common = { path = "../vta-cli-common", version = "0.7" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.8" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.8", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.9", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -27,8 +27,8 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.7", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.8", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.8", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.9", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -68,8 +68,8 @@ path = "src/main.rs"
 required-features = ["cli-synthesis"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.8", features = ["encryption", "passkey"] }
-vta-sdk = { path = "../vta-sdk", version = "0.8", features = ["didcomm", "sealed-transfer", "provision-integration"] }
+vti-common = { path = "../vti-common", version = "0.9", features = ["encryption", "passkey"] }
+vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["didcomm", "sealed-transfer", "provision-integration"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -89,7 +89,7 @@ trust-tasks-proof = { workspace = true }
 # generation, bundle opening). Used by `vta bootstrap request` /
 # `vta bootstrap open` so cold-start clients can run the offline flow
 # without depending on `pnm`.
-vta-cli-common = { path = "../vta-cli-common", version = "0.7" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.8" }
 affinidi-crypto = { workspace = true }
 # Low-level `Secret` type for loading the VTA's signing key at
 # provision time. Already transitively present via affinidi-tdk; made

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -58,13 +58,13 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.8", features = [
+vti-common = { path = "../vti-common", version = "0.9", features = [
   "passkey",
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.
   "setup",
 ] }
-vta-sdk = { path = "../vta-sdk", version = "0.8", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.9", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -43,7 +43,7 @@ setup = ["dep:dialoguer"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.8", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.9", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }


### PR DESCRIPTION
## Release version bumps

Prepares a crates.io release of the auth-convergence + dependency work (#176–#182). The in-repo versions were **identical to what's already published**, so the new code can't go out without a bump (crates.io versions are immutable). Bumps are **+1 minor above published**, with `major.minor` internal pins updated to match (workspace convention).

| Crate | was (published) | now |
|---|---|---|
| `vti-common` | 0.8.0 | **0.9.0** |
| `vta-sdk` | 0.8.0 | **0.9.0** |
| `vta-cli-common` | 0.7.0 | **0.8.0** |
| `vta-service` | 0.7.0 | **0.8.0** |
| `vtc-service` | 0.7.0 | **0.8.0** |
| `pnm-cli` | 0.7.0 | **0.8.0** |
| `cnm-cli` | 0.7.0 | **0.8.0** |

**Internal pin cascade** (kept at `major.minor`): `vti-common 0.8→0.9`, `vta-sdk 0.8→0.9`, `vta-cli-common 0.7→0.8`, `vta-service 0.7→0.8` updated at every dependent (incl. `vta-enclave`).

**Unchanged:** `vti-webauthn` (0.1.0 — no changes, stays pinned `0.1`). `publish = false` members (`vta-enclave`, `vta-mobile-core`, `didcomm-test`, `vti-e2e-tests`) keep their own versions; only their pins to the bumped crates were updated so the workspace builds. *(Note: `vta-enclave` — the TEE VTA binary — stays at 0.7.0; bump it separately if you track the deployed VTA version off it.)*

Metadata-only (no source changes). `cargo check --workspace --all-targets` green.

### Publish order (after merge — leaves first)
`vti-common` → `vta-sdk` → `vta-cli-common` → (`vta-service`, `vtc-service`) → (`pnm-cli`, `cnm-cli`).
(`vti-webauthn 0.1.0` is already on crates.io, so the `vta-service` dep resolves.)
