### PR TITLE
feat(vta): auth/whoami/0.1 session introspection over the dispatcher

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -78,6 +78,11 @@ pub const TASK_AUTH_REFRESH_0_1: &str = "https://trusttasks.org/spec/auth/refres
 pub const TASK_AUTH_REVOKE_SESSION_0_1: &str =
     "https://trusttasks.org/spec/auth/revoke-session/0.1";
 
+/// `spec/auth/whoami/0.1` — introspect the caller's current session: the
+/// live `acr`/`amr` (reflecting any step-up since the token was minted) plus
+/// freshly-resolved roles/scopes. Authenticated (bearer JWT); no token re-issue.
+pub const TASK_AUTH_WHOAMI_0_1: &str = "https://trusttasks.org/spec/auth/whoami/0.1";
+
 /// `spec/auth/passkey/login/start/0.1` — begin a WebAuthn assertion
 /// ceremony. Same wire form serves initial login AND AAL step-up via the
 /// payload's `purpose` field.
@@ -849,6 +854,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_AUTHENTICATE_0_1,
     TASK_AUTH_REFRESH_0_1,
     TASK_AUTH_REVOKE_SESSION_0_1,
+    TASK_AUTH_WHOAMI_0_1,
     TASK_AUTH_PASSKEY_LOGIN_START_0_1,
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,

--- a/vta-service/src/routes/trust_tasks/auth.rs
+++ b/vta-service/src/routes/trust_tasks/auth.rs
@@ -7,23 +7,26 @@
 //! harness for the full list.
 
 use axum::response::Response;
-use serde_json::Value;
+use serde_json::{Value, json};
 use trust_tasks_rs::{RejectReason, TrustTask};
-use vta_sdk::protocols::auth::{RevokeSessionRequest, RevokeSessionResponse};
+use vta_sdk::protocols::auth::{RevokeSessionRequest, RevokeSessionResponse, epoch_to_rfc3339};
 
-use crate::acl::Role;
+use crate::acl::{Role, check_acl_full};
 use crate::audit::audit;
 use crate::auth::AuthClaims;
 use crate::auth::session::{delete_session, get_session};
 use crate::server::AppState;
 
-use super::helpers::{reject_with, success_response};
+use super::helpers::{app_error_to_reject, reject_with, success_response};
 
 /// URIs handled by this slice. Aggregated by the dispatcher's parity
 /// harness — see the feature-gating convention in
 /// `docs/05-design-notes/trust-task-feature-gating.md`.
 #[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
-pub(super) const DISPATCHED_URIS: &[&str] = &[vta_sdk::trust_tasks::TASK_AUTH_REVOKE_SESSION_0_1];
+pub(super) const DISPATCHED_URIS: &[&str] = &[
+    vta_sdk::trust_tasks::TASK_AUTH_REVOKE_SESSION_0_1,
+    vta_sdk::trust_tasks::TASK_AUTH_WHOAMI_0_1,
+];
 
 /// Handler for `spec/vta/auth/revoke-session/1.0`.
 ///
@@ -118,4 +121,81 @@ pub(super) async fn handle_revoke_session(
 
     // 6. Build the success response document.
     success_response(&doc, RevokeSessionResponse::default())
+}
+
+/// Handler for `spec/auth/whoami/0.1`.
+///
+/// Introspection for an authenticated caller. The bearer JWT is the auth (like
+/// revoke-session) — the holder's optional DI proof on the document is *not*
+/// required here, since the authenticated transport already established who's
+/// asking. Returns the session's **live** `acr`/`amr`, which reflect any
+/// step-up that happened since the access token was minted (the JWT's own
+/// `acr`/`amr` are stale until the next refresh), plus **freshly-resolved**
+/// roles/scopes from the ACL — so a policy change is visible without re-issuing
+/// tokens. No tokens are minted or rotated.
+pub(super) async fn handle_whoami(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    // Live session state: acr/amr are updated in place by step-up, and
+    // created_at is the session's issue time.
+    let session = match get_session(&state.sessions_ks, &auth.session_id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: format!("session not found: {}", auth.session_id),
+                    details: None,
+                },
+            );
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "session lookup failed in whoami");
+            return reject_with(
+                &doc,
+                RejectReason::InternalError {
+                    reason: format!("session lookup: {e}"),
+                },
+            );
+        }
+    };
+
+    // Re-resolve roles/scopes so a policy/ACL change since the token was minted
+    // is reflected. A caller deauthorised mid-token surfaces here as the ACL
+    // error (their authority really is gone).
+    let (role, contexts) = match check_acl_full(&state.acl_ks, &auth.did).await {
+        Ok(rc) => rc,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    let mut session_info = json!({
+        "id": auth.session_id,
+        "subject": auth.did,
+        "issuedAt": epoch_to_rfc3339(session.created_at),
+        "expiresAt": epoch_to_rfc3339(auth.access_expires_at),
+        "amr": session.amr,
+    });
+    // `acr` is optional in the spec — include it only when the session has one.
+    if !session.acr.is_empty() {
+        session_info["acr"] = Value::String(session.acr.clone());
+    }
+
+    // Mirror the access token's scope representation (`ctx:<id>`), built by the
+    // canonical authenticate handler.
+    let scopes: Vec<String> = contexts.iter().map(|c| format!("ctx:{c}")).collect();
+    let body = json!({
+        "session": session_info,
+        "roles": [role.to_string()],
+        "scopes": scopes,
+    });
+
+    audit!(
+        "auth.whoami",
+        actor = &auth.did,
+        resource = &auth.session_id,
+        outcome = "success"
+    );
+    success_response(&doc, body)
 }

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -321,6 +321,7 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         vta_sdk::trust_tasks::TASK_AUTH_REVOKE_SESSION_0_1 => {
             auth::handle_revoke_session(state, auth, doc).await
         }
+        vta_sdk::trust_tasks::TASK_AUTH_WHOAMI_0_1 => auth::handle_whoami(state, auth, doc).await,
         vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1 => {
             step_up::handle_approve_response(state, auth, doc).await
         }
@@ -606,6 +607,7 @@ mod tests {
         let _ = vta_sdk::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1;
         let _ = vta_sdk::trust_tasks::TASK_AUTH_REFRESH_0_1;
         let _ = vta_sdk::trust_tasks::TASK_AUTH_REVOKE_SESSION_0_1;
+        let _ = vta_sdk::trust_tasks::TASK_AUTH_WHOAMI_0_1;
         let _ = vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_START_0_1;
         let _ = vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1;
     }

--- a/vta-service/tests/whoami_trust_task.rs
+++ b/vta-service/tests/whoami_trust_task.rs
@@ -1,0 +1,150 @@
+//! Integration test for `auth/whoami/0.1` — session introspection over the
+//! trust-task dispatcher (bearer-authed, like revoke-session).
+//!
+//! The point of whoami is to surface the **live** session state: a bearer
+//! token minted at AAL1 keeps saying `acr=aal1` until it's refreshed, but if
+//! the session was stepped up to AAL2 in the meantime, whoami reports the
+//! current `acr` (read from the session, not the stale token) plus
+//! freshly-resolved roles/scopes — without re-issuing any token.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vta_service::test_support::{TestAppContext, build_test_app};
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+
+async fn seed_admin_acl(ctx: &TestAppContext, did: &str, contexts: Vec<String>) {
+    let entry = vti_common::acl::AclEntry {
+        did: did.into(),
+        role: vti_common::acl::Role::Admin,
+        label: None,
+        allowed_contexts: contexts,
+        created_at: 1,
+        created_by: "test".into(),
+        expires_at: None,
+        kind: Default::default(),
+        capabilities: vec![],
+        device: None,
+        version: 0,
+    };
+    vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
+        .await
+        .expect("seed admin ACL");
+}
+
+#[tokio::test]
+async fn whoami_reports_live_session_acr_not_stale_token() {
+    let (router, ctx) = build_test_app().await;
+    let did = "did:key:z6MkWhoamiSubject";
+    let session_id = "sess-whoami-1";
+    seed_admin_acl(&ctx, did, vec!["ctx1".into()]).await;
+
+    // The session has been stepped up to AAL2 (e.g. via approve-response).
+    let session = Session {
+        session_id: session_id.into(),
+        did: did.into(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".into(), "passkey".into()],
+        acr: "aal2".into(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+
+    // The bearer token, however, was minted BEFORE the step-up: no `with_aal`,
+    // so its `acr` is stale (empty / AAL1).
+    let claims = ctx.jwt_keys.new_claims(
+        did.into(),
+        session_id.into(),
+        "admin".into(),
+        vec![],
+        900,
+        false,
+    );
+    let token = ctx.jwt_keys.encode(&claims).unwrap();
+
+    let doc = json!({
+        "id": "urn:uuid:whoami-itest-1",
+        "type": "https://trusttasks.org/spec/auth/whoami/0.1",
+        "issuer": did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {},
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(status, StatusCode::OK, "whoami must succeed: {v}");
+    let s = &v["payload"]["session"];
+    assert_eq!(s["subject"], did, "{v}");
+    assert_eq!(s["id"], session_id, "{v}");
+    // The live session acr (aal2) — NOT the stale token's (aal1/empty).
+    assert_eq!(
+        s["acr"], "aal2",
+        "whoami must report the session's current acr, not the token's: {v}"
+    );
+    assert!(
+        s["amr"].as_array().unwrap().iter().any(|m| m == "passkey"),
+        "live amr should include the step-up factor: {v}"
+    );
+    // Freshly-resolved authority from the ACL.
+    assert!(
+        v["payload"]["roles"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|r| r == "admin"),
+        "{v}"
+    );
+    assert!(
+        v["payload"]["scopes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c == "ctx:ctx1"),
+        "scopes mirror the access-token `ctx:<id>` form: {v}"
+    );
+    // issuedAt / expiresAt are present timestamps.
+    assert!(s["issuedAt"].as_str().is_some(), "{v}");
+    assert!(s["expiresAt"].as_str().is_some(), "{v}");
+}
+
+#[tokio::test]
+async fn whoami_without_bearer_is_unauthorized() {
+    let (router, _ctx) = build_test_app().await;
+    let doc = json!({
+        "id": "urn:uuid:whoami-itest-2",
+        "type": "https://trusttasks.org/spec/auth/whoami/0.1",
+        "issuer": "did:key:z6MkAnon",
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {},
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::OK,
+        "whoami requires a bearer token (the dispatcher is authed)"
+    );
+}


### PR DESCRIPTION
## whoami — session introspection (auth convergence)

Adds the **server side** of `auth/whoami/0.1`. The mobile engine already builds this document (#167); there was no VTA handler for it. Routed through the trust-task dispatcher and **bearer-authed, exactly like `revoke-session`** — the authenticated transport (bearer JWT) is the auth, so the holder's optional DI proof on the document isn't required here.

### Why it's more than echoing the JWT
whoami reports the session's **live** state. A bearer token minted at AAL1 keeps claiming `acr=aal1` until it's refreshed — but if the session was **stepped up to AAL2** in the meantime (via `approve-response`, #177), whoami returns the *current* `acr`/`amr` read from the session record, plus **freshly-resolved** roles/scopes from the ACL. So a client learns it can refresh to a higher-AAL token, or that its authority changed, without re-issuing anything.

### What it does
- **vta-sdk:** `TASK_AUTH_WHOAMI_0_1` const + `ALL_URIS` entry.
- **dispatcher** (`routes/trust_tasks/auth.rs::handle_whoami`): session lookup (live `acr`/`amr`, `issuedAt` = session creation), ACL re-resolve (`roles` + `ctx:<id>` `scopes`, mirroring the access-token scope form), `expiresAt` from the bearer claim. Wired into `dispatch_typed` + `DISPATCHED_URIS`; cross-crate parity harness green.

### Tests
- `whoami_reports_live_session_acr_not_stale_token` — a **stale AAL1 token over an AAL2 session** → whoami returns `aal2` + the `passkey` amr + `admin` role + `ctx:ctx1` scope (proves it reads live session state, not the token).
- `whoami_without_bearer_is_unauthorized`.

Full `vta-service` + `vta-sdk` suites, `clippy -D warnings`, `cargo deny`: green.

---
Auth-convergence epic (task #47): authenticate (#181) · refresh (#182) · **whoami (this PR)**. Remaining: `sessions/list` parity over the dispatcher, then deprecate the legacy `atm/1.0` aliases once clients have migrated.
