### PR TITLE
feat(vta): auth/sessions/list/0.1 multi-device session enumeration

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -83,6 +83,11 @@ pub const TASK_AUTH_REVOKE_SESSION_0_1: &str =
 /// freshly-resolved roles/scopes. Authenticated (bearer JWT); no token re-issue.
 pub const TASK_AUTH_WHOAMI_0_1: &str = "https://trusttasks.org/spec/auth/whoami/0.1";
 
+/// `spec/auth/sessions/list/0.1` — enumerate every active session the VTA
+/// holds for the caller's subject (multi-device management). Companion to
+/// whoami (single-session). Authenticated (bearer JWT); read-only.
+pub const TASK_AUTH_SESSIONS_LIST_0_1: &str = "https://trusttasks.org/spec/auth/sessions/list/0.1";
+
 /// `spec/auth/passkey/login/start/0.1` — begin a WebAuthn assertion
 /// ceremony. Same wire form serves initial login AND AAL step-up via the
 /// payload's `purpose` field.
@@ -855,6 +860,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_REFRESH_0_1,
     TASK_AUTH_REVOKE_SESSION_0_1,
     TASK_AUTH_WHOAMI_0_1,
+    TASK_AUTH_SESSIONS_LIST_0_1,
     TASK_AUTH_PASSKEY_LOGIN_START_0_1,
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,

--- a/vta-service/src/routes/trust_tasks/auth.rs
+++ b/vta-service/src/routes/trust_tasks/auth.rs
@@ -14,7 +14,7 @@ use vta_sdk::protocols::auth::{RevokeSessionRequest, RevokeSessionResponse, epoc
 use crate::acl::{Role, check_acl_full};
 use crate::audit::audit;
 use crate::auth::AuthClaims;
-use crate::auth::session::{delete_session, get_session};
+use crate::auth::session::{SessionState, delete_session, get_session, list_sessions, now_epoch};
 use crate::server::AppState;
 
 use super::helpers::{app_error_to_reject, reject_with, success_response};
@@ -26,6 +26,7 @@ use super::helpers::{app_error_to_reject, reject_with, success_response};
 pub(super) const DISPATCHED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_AUTH_REVOKE_SESSION_0_1,
     vta_sdk::trust_tasks::TASK_AUTH_WHOAMI_0_1,
+    vta_sdk::trust_tasks::TASK_AUTH_SESSIONS_LIST_0_1,
 ];
 
 /// Handler for `spec/vta/auth/revoke-session/1.0`.
@@ -198,4 +199,65 @@ pub(super) async fn handle_whoami(
         outcome = "success"
     );
     success_response(&doc, body)
+}
+
+/// Handler for `spec/auth/sessions/list/0.1`.
+///
+/// Enumerates every **active** session the VTA holds for the *caller's own*
+/// subject — the self-service multi-device view, companion to whoami. Scoped to
+/// `auth.did` (a caller only sees their own sessions); this is distinct from
+/// the admin `GET /auth/sessions` REST route, which lists every session.
+/// Bearer-authed like the other dispatcher auth ops; read-only.
+pub(super) async fn handle_sessions_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    let all = match list_sessions(&state.sessions_ks).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(error = %e, "session list failed in sessions/list");
+            return reject_with(
+                &doc,
+                RejectReason::InternalError {
+                    reason: format!("session list: {e}"),
+                },
+            );
+        }
+    };
+
+    let now = now_epoch();
+    let sessions: Vec<Value> = all
+        .into_iter()
+        // The caller's own, authenticated, not-yet-expired sessions.
+        .filter(|s| {
+            s.did == auth.did
+                && s.state == SessionState::Authenticated
+                && s.refresh_expires_at.is_none_or(|exp| exp > now)
+        })
+        .map(|s| {
+            // The session ceases to be valid when its refresh window closes;
+            // fall back to issue time if no refresh token was minted.
+            let expires_at = s.refresh_expires_at.unwrap_or(s.created_at);
+            let mut item = json!({
+                "id": s.session_id,
+                "subject": s.did,
+                "issuedAt": epoch_to_rfc3339(s.created_at),
+                "expiresAt": epoch_to_rfc3339(expires_at),
+                "amr": s.amr,
+            });
+            if !s.acr.is_empty() {
+                item["acr"] = Value::String(s.acr);
+            }
+            item
+        })
+        .collect();
+
+    audit!(
+        "auth.sessions-list",
+        actor = &auth.did,
+        resource = &auth.session_id,
+        outcome = "success"
+    );
+    success_response(&doc, json!({ "sessions": sessions }))
 }

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -322,6 +322,9 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
             auth::handle_revoke_session(state, auth, doc).await
         }
         vta_sdk::trust_tasks::TASK_AUTH_WHOAMI_0_1 => auth::handle_whoami(state, auth, doc).await,
+        vta_sdk::trust_tasks::TASK_AUTH_SESSIONS_LIST_0_1 => {
+            auth::handle_sessions_list(state, auth, doc).await
+        }
         vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1 => {
             step_up::handle_approve_response(state, auth, doc).await
         }
@@ -608,6 +611,7 @@ mod tests {
         let _ = vta_sdk::trust_tasks::TASK_AUTH_REFRESH_0_1;
         let _ = vta_sdk::trust_tasks::TASK_AUTH_REVOKE_SESSION_0_1;
         let _ = vta_sdk::trust_tasks::TASK_AUTH_WHOAMI_0_1;
+        let _ = vta_sdk::trust_tasks::TASK_AUTH_SESSIONS_LIST_0_1;
         let _ = vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_START_0_1;
         let _ = vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1;
     }

--- a/vta-service/tests/sessions_list_trust_task.rs
+++ b/vta-service/tests/sessions_list_trust_task.rs
@@ -1,0 +1,174 @@
+//! Integration test for `auth/sessions/list/0.1` — the multi-device session
+//! enumeration over the trust-task dispatcher (bearer-authed).
+//!
+//! Companion to whoami: lists every **active** session for the **caller's own**
+//! subject. Verifies scoping (a caller never sees another subject's sessions)
+//! and the active filter (expired sessions are omitted).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vta_service::test_support::{TestAppContext, build_test_app};
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+
+#[allow(clippy::too_many_arguments)]
+async fn seed_session(
+    ctx: &TestAppContext,
+    session_id: &str,
+    did: &str,
+    acr: &str,
+    amr: Vec<String>,
+    refresh_expires_at: Option<u64>,
+) {
+    let session = Session {
+        session_id: session_id.into(),
+        did: did.into(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: Some(format!("rt-{session_id}")),
+        refresh_expires_at,
+        tee_attested: false,
+        amr,
+        acr: acr.into(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+}
+
+#[tokio::test]
+async fn sessions_list_returns_only_callers_active_sessions() {
+    let (router, ctx) = build_test_app().await;
+    let did = "did:key:z6MkMultiDevice";
+    let other = "did:key:z6MkSomeoneElse";
+    let now = now_epoch();
+
+    // Two active sessions for the caller (different devices / AALs)…
+    seed_session(
+        &ctx,
+        "sess-a",
+        did,
+        "aal2",
+        vec!["did".into(), "passkey".into()],
+        Some(now + 86_400),
+    )
+    .await;
+    seed_session(
+        &ctx,
+        "sess-b",
+        did,
+        "aal1",
+        vec!["did".into()],
+        Some(now + 3_600),
+    )
+    .await;
+    // …one expired session for the caller (must be filtered out)…
+    seed_session(
+        &ctx,
+        "sess-expired",
+        did,
+        "aal1",
+        vec!["did".into()],
+        Some(now - 10),
+    )
+    .await;
+    // …and one belonging to a different subject (must never leak).
+    seed_session(
+        &ctx,
+        "sess-other",
+        other,
+        "aal2",
+        vec!["did".into()],
+        Some(now + 86_400),
+    )
+    .await;
+
+    // Bearer for the caller (its own session is sess-a).
+    let claims = ctx.jwt_keys.new_claims(
+        did.into(),
+        "sess-a".into(),
+        "admin".into(),
+        vec![],
+        900,
+        false,
+    );
+    let token = ctx.jwt_keys.encode(&claims).unwrap();
+
+    let doc = json!({
+        "id": "urn:uuid:sessions-list-itest-1",
+        "type": "https://trusttasks.org/spec/auth/sessions/list/0.1",
+        "issuer": did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {},
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(status, StatusCode::OK, "sessions/list must succeed: {v}");
+    let sessions = v["payload"]["sessions"].as_array().expect("sessions array");
+
+    // Exactly the caller's two active sessions — not the expired one, not the
+    // other subject's.
+    let ids: Vec<&str> = sessions.iter().filter_map(|s| s["id"].as_str()).collect();
+    assert_eq!(sessions.len(), 2, "only the caller's active sessions: {v}");
+    assert!(ids.contains(&"sess-a") && ids.contains(&"sess-b"), "{v}");
+    assert!(
+        !ids.contains(&"sess-expired"),
+        "expired session must be omitted: {v}"
+    );
+    assert!(
+        !ids.contains(&"sess-other"),
+        "another subject must never leak: {v}"
+    );
+
+    // Each session carries the required fields; sess-a reflects its AAL2 state.
+    for s in sessions {
+        assert_eq!(s["subject"], did, "{v}");
+        assert!(s["issuedAt"].as_str().is_some(), "{v}");
+        assert!(s["expiresAt"].as_str().is_some(), "{v}");
+        assert!(s["amr"].as_array().is_some_and(|a| !a.is_empty()), "{v}");
+    }
+    let sess_a = sessions.iter().find(|s| s["id"] == "sess-a").unwrap();
+    assert_eq!(sess_a["acr"], "aal2", "{v}");
+    assert!(
+        sess_a["amr"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|m| m == "passkey"),
+        "{v}"
+    );
+}
+
+#[tokio::test]
+async fn sessions_list_without_bearer_is_unauthorized() {
+    let (router, _ctx) = build_test_app().await;
+    let doc = json!({
+        "id": "urn:uuid:sessions-list-itest-2",
+        "type": "https://trusttasks.org/spec/auth/sessions/list/0.1",
+        "issuer": "did:key:z6MkAnon",
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {},
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_ne!(resp.status(), StatusCode::OK, "requires a bearer token");
+}


### PR DESCRIPTION
## sessions/list — multi-device session enumeration (auth convergence)

Adds the **server side** of `auth/sessions/list/0.1` (the spec ships in `trust-tasks-rs 0.1.4` — no spec-first work needed). Companion to whoami (#184): whoami introspects the *current* session; sessions/list enumerates **all** of the caller's active sessions for multi-device sign-in management.

Routed through the trust-task dispatcher, **bearer-authed** like whoami / revoke-session, and **scoped to the caller's own subject** (`auth.did`) — a caller only ever sees their own sessions. This is deliberately distinct from the admin `GET /auth/sessions` REST route, which lists *every* session on the VTA.

### What it does
- **vta-sdk:** `TASK_AUTH_SESSIONS_LIST_0_1` const + `ALL_URIS` entry.
- **dispatcher** (`routes/trust_tasks/auth.rs::handle_sessions_list`): `list_sessions` filtered to `{own subject, Authenticated, not-yet-expired}`, each mapped to the spec `Session` shape — `id`/`subject`/`issuedAt`/`expiresAt`/`amr`/`acr` (acr omitted when empty; `expiresAt` = the refresh-window close, i.e. when the session itself dies). Wired into `dispatch_typed` + `DISPATCHED_URIS`; parity harness green.

### Tests
- `sessions_list_returns_only_callers_active_sessions` — two active sessions returned; an **expired** one and **another subject's** both excluded; `sess-a` reflects `aal2` + `passkey`.
- `sessions_list_without_bearer_is_unauthorized`.

Full `vta-service` + `vta-sdk` suites, `clippy -D warnings`, `cargo deny`: green.

---
Auth-convergence epic (task #47): authenticate (#181) · refresh (#182) · whoami (#184) · **sessions/list (this PR)**. The introspection surface is now complete. Remaining: deprecate the legacy `atm/1.0` aliases — but that's gated on clients migrating to the canonical paths we've just shipped, so it's a deliberate later step.
