### PR TITLE
feat(vta-mobile-core): didcomm_holder_keys FFI (DIDComm transport, stage 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9514,8 +9514,9 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm 0.14.0",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.1.0"
+version = "0.2.0"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -41,6 +41,11 @@ chrono = { workspace = true }
 affinidi-data-integrity = { workspace = true }
 # Multibase (base58btc) encoding of the signature into `proofValue`.
 multibase = { workspace = true }
+# ed25519→x25519 key-agreement derivation + did:key encoding for the DIDComm
+# holder identity (the X25519 key matches the holder did:key's keyAgreement, so
+# a sender resolving the did:key can authcrypt to it). Tested TDK conversions —
+# we compose, never hand-roll. See workspace CLAUDE.md "Default to DIDs".
+affinidi-crypto = { workspace = true }
 # Async runtime for the FFI async exports + a process-wide resolver cell.
 tokio = { workspace = true }
 # DID resolution. Default config is local (did:key / did:peer resolve offline);

--- a/vta-mobile-core/src/didcomm.rs
+++ b/vta-mobile-core/src/didcomm.rs
@@ -245,6 +245,51 @@ fn to_array_32(bytes: &[u8], what: &str) -> Result<[u8; 32], FfiError> {
     })
 }
 
+/// Derive the DIDComm [`HolderKeys`] for an Ed25519 `did:key` holder from its
+/// signing seed, so the native layer can open a [`DidcommSession`] without
+/// re-implementing key derivation.
+///
+/// The key-agreement (X25519) key is the **standard ed25519→x25519 conversion**
+/// of the holder signing key, so its public half equals the `keyAgreement` a
+/// resolver derives from the `did:key`. That means anyone resolving the holder
+/// did:key (e.g. a VTA wanting to send an approve-request) can authcrypt to it,
+/// and this session — holding the matching private — can unpack it.
+///
+/// No new cryptography here: this composes the tested TDK conversions
+/// (`affinidi_crypto::ed25519::{ed25519_private_to_x25519, ed25519_public_to_x25519}`),
+/// per the workspace "Default to DIDs" guidance. `signing_private_ed25519` is
+/// the 32-byte Ed25519 seed; it never leaves the device beyond this struct.
+#[uniffi::export]
+pub fn didcomm_holder_keys(
+    did: String,
+    signing_private_ed25519: Vec<u8>,
+) -> Result<HolderKeys, FfiError> {
+    let ed_multikey = did
+        .strip_prefix("did:key:")
+        .ok_or_else(|| FfiError::InvalidInput {
+            reason: format!("expected a did:key, got {did}"),
+        })?;
+    let signing = to_array_32(&signing_private_ed25519, "holder signing key")?;
+
+    // ed25519 secret → x25519 secret (key agreement private half).
+    let key_agreement_private = affinidi_crypto::ed25519::ed25519_private_to_x25519(&signing);
+    // ed25519 did:key multikey → x25519 multikey (the keyAgreement vm fragment).
+    let (x25519_multikey, _x25519_public) =
+        affinidi_crypto::ed25519::ed25519_public_to_x25519(ed_multikey).map_err(|e| {
+            FfiError::InvalidInput {
+                reason: format!("derive x25519 key agreement from did:key: {e}"),
+            }
+        })?;
+
+    Ok(HolderKeys {
+        did: did.clone(),
+        key_agreement_kid: format!("{did}#{x25519_multikey}"),
+        key_agreement_private_x25519: key_agreement_private.to_vec(),
+        signing_kid: format!("{did}#{ed_multikey}"),
+        signing_private_ed25519,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -373,5 +418,71 @@ mod tests {
         let at_mediator = mediator.unpack(outer, None).unwrap();
         let fwd: serde_json::Value = serde_json::from_str(&at_mediator.message_json).unwrap();
         assert_eq!(fwd["type"], "https://didcomm.org/routing/2.0/forward");
+    }
+
+    /// did:key from a fixed Ed25519 seed.
+    fn did_key_from_seed(seed: &[u8; 32]) -> String {
+        let pk = ed25519_dalek::SigningKey::from_bytes(seed)
+            .verifying_key()
+            .to_bytes();
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&pk)
+    }
+
+    #[test]
+    fn didcomm_holder_keys_match_the_did_key_key_agreement() {
+        let seed = [7u8; 32];
+        let did = did_key_from_seed(&seed);
+        let keys = didcomm_holder_keys(did.clone(), seed.to_vec()).unwrap();
+
+        // The crucial invariant: the public half of the derived X25519 private
+        // equals the keyAgreement a resolver derives from the did:key — so a
+        // sender resolving the did:key authcrypts to a key THIS session can open.
+        let ed_multikey = did.strip_prefix("did:key:").unwrap();
+        let (x25519_multikey, ka_public_from_did) =
+            affinidi_crypto::ed25519::ed25519_public_to_x25519(ed_multikey).unwrap();
+        assert_eq!(
+            x25519_public(&keys.key_agreement_private_x25519),
+            ka_public_from_did,
+            "derived agreement key must be reachable at the holder did:key",
+        );
+        // Kid shapes: `<did>#<x25519-multikey>` and `<did>#<ed25519-multikey>`.
+        assert_eq!(keys.key_agreement_kid, format!("{did}#{x25519_multikey}"));
+        assert_eq!(keys.signing_kid, format!("{did}#{ed_multikey}"));
+        assert_eq!(keys.signing_private_ed25519, seed.to_vec());
+    }
+
+    #[test]
+    fn derived_holders_authcrypt_round_trip() {
+        let alice_did = did_key_from_seed(&[7u8; 32]);
+        let bob_did = did_key_from_seed(&[9u8; 32]);
+        let alice_keys = didcomm_holder_keys(alice_did.clone(), [7u8; 32].to_vec()).unwrap();
+        let bob_keys = didcomm_holder_keys(bob_did.clone(), [9u8; 32].to_vec()).unwrap();
+
+        let peer_of = |k: &HolderKeys| Peer {
+            did: k.did.clone(),
+            key_agreement_kid: k.key_agreement_kid.clone(),
+            key_agreement_public_x25519: x25519_public(&k.key_agreement_private_x25519),
+        };
+
+        let alice = DidcommSession::new(alice_keys.clone()).unwrap();
+        alice.add_peer(peer_of(&bob_keys)).unwrap();
+        let bob = DidcommSession::new(bob_keys.clone()).unwrap();
+        bob.add_peer(peer_of(&alice_keys)).unwrap();
+
+        let msg = serde_json::json!({
+            "id": "m-stepup",
+            "type": "https://trusttasks.org/spec/auth/step-up/approve-request/0.1",
+            "from": alice_did,
+            "to": [bob_did],
+            "body": { "challenge": "abc" }
+        })
+        .to_string();
+
+        let jwe = alice.pack_authcrypt(msg, bob_did.clone()).unwrap();
+        let unpacked = bob.unpack(jwe, Some(alice_did.clone())).unwrap();
+        assert!(unpacked.sender_authenticated);
+        let m: serde_json::Value = serde_json::from_str(&unpacked.message_json).unwrap();
+        assert_eq!(m["from"], alice_did);
+        assert_eq!(m["body"]["challenge"], "abc");
     }
 }


### PR DESCRIPTION
## Engine helper: derive DIDComm `HolderKeys` from the holder did:key

**Stage 1** of the spec-faithful DIDComm transport for the proxied AAL2 step-up approver (so an approve-request can reach the phone via mediator instead of paste/QR). The native layer needs DIDComm `HolderKeys` (an **X25519** key-agreement key) to open a `DidcommSession`, but hand-deriving `ed25519→x25519` + the did:key keyAgreement fragment in Swift/Kotlin is delicate and unverifiable. So this does it **in the engine**, composing the **tested TDK conversions** — no new crypto:

```
didcomm_holder_keys(did, signing_private_ed25519) -> HolderKeys
```

The X25519 agreement key is the standard `ed25519→x25519` conversion of the holder's signing key (`affinidi_crypto::ed25519::ed25519_private_to_x25519`), and the keyAgreement kid is the X25519 multikey (`ed25519_public_to_x25519`). **The crucial property:** the derived agreement *public* equals the keyAgreement a resolver derives from the holder did:key — so a sender resolving the did:key (a VTA sending an approve-request) authcrypts to a key **this** session can open. (Per the workspace "Default to DIDs" guidance, which names these exact helpers.)

### Tests
- `didcomm_holder_keys_match_the_did_key_key_agreement` — the invariant above: derived agreement public **==** `ed25519_public_to_x25519(did:key)`, plus the `<did>#<x25519-multikey>` / `<did>#<ed25519-multikey>` kid shapes.
- `derived_holders_authcrypt_round_trip` — two real did:key holders pack/unpack an authcrypt message end-to-end.

`clippy -D warnings` + `cargo deny` clean; the new fn generates cleanly in the Swift bindings (`didcommHolderKeys`). Added `affinidi-crypto` (workspace) as a dep.

### Release
Engine **0.1.0 → 0.2.0** (additive FFI). After merge, cut the `vta-mobile-core-v0.2.0` release (the existing tag-triggered xcframework workflow) so the iOS app can consume it.

### Next stages (DIDComm transport, infra-iterate)
1b. iOS app: open a `DidcommSession` from these keys + unpack-and-recognize an approve-request (round-trip unit test) — buildable next.
2. Native messagepickup pull from a mediator + `set-device-info` register.
3. VTA outbound send of the approve-request via DIDComm to the holder (net-new; resolve the did:key reachability/routing).
4. APNs doorbell.

Tracked in task #49. Stages 2–4 need a running mediator / Apple push (CI/infra-iterate, not locally testable).
