### PR TITLE
fix(vta-mobile-core): don't double-prefix the xcframework zip path (release fix)

### DIFF
--- a/vta-mobile-core/scripts/package-ios.sh
+++ b/vta-mobile-core/scripts/package-ios.sh
@@ -111,7 +111,11 @@ cat > "$CK_DIR/Package.swift" <<'SWIFT'
 import PackageDescription
 let package = Package(name: "checksum")
 SWIFT
-CHECKSUM="$(cd "$CK_DIR" && swift package compute-checksum "$WORKSPACE_ROOT/$ZIP")"
+# `$ZIP` is absolute (it's under `$TARGET_DIR`), so pass it as-is. Re-prefixing
+# `$WORKSPACE_ROOT` double-prefixed the path and broke the release once #175
+# made `TARGET_DIR` absolute (v0.1.0 predated that, so it passed; v0.2.0 was the
+# first release after #175 and failed at this step).
+CHECKSUM="$(cd "$CK_DIR" && swift package compute-checksum "$ZIP")"
 echo "$CHECKSUM" > "$ZIP.sha256"
 
 rm -rf "$STAGE"


### PR DESCRIPTION
## The v0.2.0 release failed at "Zipping + checksum"

The xcframework built fine and the Swift bindings generated, but the release errored:

```
error: file not found at path:
  …/verifiable-trust-infrastructure/Users/runner/work/…/target/mobile/ios/VtaMobileCore.xcframework.zip
```

A **doubled path** — `$GITHUB_WORKSPACE` + an already-absolute path. Cause, in `package-ios.sh`:

```sh
CHECKSUM="$(cd "$CK_DIR" && swift package compute-checksum "$WORKSPACE_ROOT/$ZIP")"
```

`$ZIP` = `$OUT/…zip` = `$TARGET_DIR/mobile/ios/…zip`, and **#175 made `TARGET_DIR` absolute** (`CARGO_TARGET_DIR` or `$WORKSPACE_ROOT/target`). So `$ZIP` is already absolute, and re-prefixing `$WORKSPACE_ROOT` double-prefixes it.

**Why it only just broke:** v0.1.0 was released *before* #175 (when `$ZIP` was relative, so the prefix was correct). v0.2.0 is the **first release after #175**, so it hit the bug. The fix: pass `$ZIP` as-is (absolute → resolves correctly from the throwaway checksum package dir).

One-line change; the other path uses (`$OUT`, `$ZIP`, etc.) were already absolute and fine (verified no other `$WORKSPACE_ROOT/$abs` prefixing). `bash -n` clean. The packaging only runs on the macOS release runner, so the real validation is **re-cutting `vta-mobile-core-v0.2.0`** after this merges (I'll delete + re-push the tag — the v0.2.0 release never published, so there's no artifact to clobber).
