### PR TITLE
fix(vta-sdk): provision WEBVH_PATH bridge + move workspace to DIDComm 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,29 +33,66 @@ Derivation is conservative on both sides: bare origins, empty paths and
 letting the server run its own allocation; `…/webvh` → `webvh`,
 `…/dids/daemon` → `dids/daemon`, query/fragment stripped.
 
-### Dependencies: affinidi-messaging crates updated
+### Dependencies: DIDComm 0.15 across the affinidi-messaging stack
 
-Bumped the affinidi-messaging stack to latest where it unifies cleanly:
-mediator/mediator-common/test-mediator, affinidi-crypto (0.1.10),
-affinidi-status-list (0.1.3). This collapses `didcomm` to a single
-`0.14.0` (dropping the duplicate `0.13.3`) and unifies `vta-sdk` to the
-published `0.9.0` so the affinidi mediator consumes it directly. The
-`didcomm-service` / `affinidi-messaging-sdk` jump to `didcomm 0.15` is
-**deferred** — that subset of the affinidi stack is internally split
-across didcomm major versions and pulling it now would re-fork `didcomm`.
+Moved the whole workspace to `affinidi-messaging-didcomm 0.15`, now that
+the affinidi side published the releases that close the previous split:
+
+- `affinidi-tdk` 0.7.2 → **0.7.3** (`didcomm ^0.15`) — the production
+  unblock. tdk re-exports didcomm and our `DIDCommSession` passes
+  `Message` values into its transport, so tdk and our direct didcomm dep
+  must share one version. While tdk capped at `^0.14`, 0.15 was
+  unreachable (two incompatible `Message` types).
+- `affinidi-messaging-mediator` 0.15.11 → **0.15.12** (`^0.15`) +
+  `affinidi-messaging-test-mediator` 0.2.3 → **0.2.4** (the embedded test
+  fixture).
+- `affinidi-messaging-sdk` 0.18.4 → **0.18.6** and
+  `affinidi-messaging-didcomm-service` 0.3.2 → **0.3.3** (both already on
+  `^0.15`, now selected).
+- `affinidi-crypto` 0.1.10, `affinidi-status-list` 0.1.3 (latest).
+
+Code migration for the 0.15 API:
+
+- didcomm 0.15 removed its own `crypto` module; `Curve` /
+  `PrivateKeyAgreement` / `PublicKeyAgreement` now live in
+  `affinidi_crypto::jose::key_agreement`. Updated the imports in
+  `vta-sdk` (`didcomm_light`) and `vta-mobile-core` (`didcomm`), and added
+  `affinidi-crypto` to vta-sdk's `client` feature (it now names that type
+  in its own right). `anoncrypt`'s shape is otherwise unchanged; the
+  `pack_anoncrypt` JWE round-trip test still passes.
+- `affinidi-messaging-sdk` 0.18.5 added
+  `WebSocketResponses::Disconnected`; handled it in `didcomm-test`'s
+  listen loop (logs and stops — the socket is gone).
+
+Resolution note: the dev-only test tree still pulls a second
+`didcomm 0.14.1` transitively through the **published** `vta-sdk 0.9.0`
+that `affinidi-messaging-mediator` depends on. The mediator pins
+`vta-sdk = "^0.9"`, so this self-heals the moment `vta-sdk 0.9.1` (this
+release, on didcomm 0.15) is published — the resolver then selects it for
+the mediator too and the duplicate disappears. `cargo deny` treats the
+transient duplicate as a warning, consistent with the other accepted
+build-graph duplicates.
 
 ### Version bumps
 
-This cycle's bumps for the provision-path fix above (the publish
-boundary already advanced to `vta-sdk` 0.9.0 / `vta-service` 0.8.0 in
-the #183 release bump):
+This cycle's bumps for the provision-path fix + the didcomm 0.15 move
+(the publish boundary already advanced to `vta-sdk` 0.9.0 /
+`vta-service` 0.8.0 in the #183 release bump):
 
-- `vta-sdk` 0.9.0 → 0.9.1 — patch: behavioural bugfix, no public API
-  change (the new helpers are crate-internal). External consumers
-  pinned at `"0.9"` pick the fix up with no pin change.
-- `vta-service` 0.8.0 → 0.8.1 — patch: carries the Option B safety net;
-  bumped so it can be republished. `vta-enclave`'s `"0.8"` pin is
-  unaffected.
+- `vta-sdk` 0.9.0 → 0.9.1 — provision bugfix (crate-internal helpers, no
+  API change) **plus** the `affinidi-messaging-didcomm` 0.14 → 0.15 dep
+  bump. Kept in the `0.9.x` line on purpose: `affinidi-messaging-mediator`
+  0.15.12 pins `vta-sdk = "^0.9"` *and* `didcomm = "^0.15"` at the same
+  time, so the affinidi side explicitly expects a `0.9.x` of vta-sdk that
+  carries didcomm 0.15. A `0.10.0` bump would fall outside their `^0.9`
+  pin and lock them on the old didcomm-0.14 `vta-sdk 0.9.0` — defeating
+  the unification. (Strict semver would call a public-dep major bump
+  breaking; here it's deliberate ecosystem coordination, not an
+  accident.) External consumers pinned at `"0.9"` pick it up with no pin
+  change.
+- `vta-service` 0.8.0 → 0.8.1 — patch: carries the Option B safety net +
+  the didcomm 0.15 pin; bumped so it can be republished. `vta-enclave`'s
+  `"0.8"` pin is unaffected.
 
 Historical (0.7 → 0.8 cycle, retained for context):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,62 @@
 
 ## Unreleased
 
+### Fix: server-managed provisioning drops the DID path (`e.p.did.path-invalid`)
+
+When a consumer (e.g. the did-hosting-daemon) provisions an integration
+against a VTA that has **exactly one** registered webvh server, the SDK
+auto-selects that server and runs the server-managed path. In that mode
+the hosting server reads `WEBVH_PATH` and ignores the path folded into
+the `URL` template var — but `run_provision` passed `webvh_path = None`,
+so `WEBVH_PATH` was never injected and the hosting server received an
+empty path, rejecting with `e.p.did.path-invalid: path must not be
+empty` (HTTP 500 at the gateway).
+
+Fixed at two layers (defense-in-depth):
+
+- **SDK (vta-sdk, the fix):** `run_provision`'s `PreflightDone` handler
+  now derives the path from the ask's `URL` var (via the new
+  `runner::webvh_path_from_url`) when it auto-selects a server, and
+  passes it as `webvh_path` to `run_provision_flight`. The var-injection
+  is factored into `runner_didcomm::inject_webvh_vars` and unit-tested.
+  Serverless mode (no server selected) is unchanged — it reads the path
+  straight from `URL`.
+- **VTA service (vta-service, safety net):** `provision_integration`
+  falls back to the path parsed from the `URL` var
+  (`webvh::webvh_path_from_url_var`) when a `WEBVH_SERVER` is set but no
+  explicit `WEBVH_PATH` was provided. Read-only; never overrides an
+  explicit `WEBVH_PATH`.
+
+Derivation is conservative on both sides: bare origins, empty paths and
+`.well-known` (the webvh log marker, never a DID path) yield no path,
+letting the server run its own allocation; `…/webvh` → `webvh`,
+`…/dids/daemon` → `dids/daemon`, query/fragment stripped.
+
+### Dependencies: affinidi-messaging crates updated
+
+Bumped the affinidi-messaging stack to latest where it unifies cleanly:
+mediator/mediator-common/test-mediator, affinidi-crypto (0.1.10),
+affinidi-status-list (0.1.3). This collapses `didcomm` to a single
+`0.14.0` (dropping the duplicate `0.13.3`) and unifies `vta-sdk` to the
+published `0.9.0` so the affinidi mediator consumes it directly. The
+`didcomm-service` / `affinidi-messaging-sdk` jump to `didcomm 0.15` is
+**deferred** — that subset of the affinidi stack is internally split
+across didcomm major versions and pulling it now would re-fork `didcomm`.
+
 ### Version bumps
+
+This cycle's bumps for the provision-path fix above (the publish
+boundary already advanced to `vta-sdk` 0.9.0 / `vta-service` 0.8.0 in
+the #183 release bump):
+
+- `vta-sdk` 0.9.0 → 0.9.1 — patch: behavioural bugfix, no public API
+  change (the new helpers are crate-internal). External consumers
+  pinned at `"0.9"` pick the fix up with no pin change.
+- `vta-service` 0.8.0 → 0.8.1 — patch: carries the Option B safety net;
+  bumped so it can be republished. `vta-enclave`'s `"0.8"` pin is
+  unaffected.
+
+Historical (0.7 → 0.8 cycle, retained for context):
 
 Only the two crates external repos (did-hosting-common,
 webvh-witness, rp-sdk, …) consume are bumped:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda6f871ba314dc0955490c1e85317609217846c5ddace9dda0ab2f6704d5dbe"
+checksum = "383822b5aa105040ae6debb29d0321cbb5ad8f755d2c050e437c923434aa72c8"
 dependencies = [
  "affinidi-encoding",
  "base58",
@@ -129,7 +129,7 @@ dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-secrets-resolver",
  "base64 0.22.1",
  "chrono",
@@ -241,7 +241,7 @@ dependencies = [
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-tdk-common",
  "base64 0.22.1",
  "chrono",
@@ -251,31 +251,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "affinidi-messaging-didcomm"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30fccad4b186b4224ffd2291d320ec2026f6ccf28d483c125d5bc4f6b35cedd"
-dependencies = [
- "aes 0.8.4",
- "base64ct",
- "cbc 0.1.2",
- "ed25519-dalek",
- "hmac 0.12.1",
- "k256",
- "p256",
- "rand_core 0.6.4",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "subtle",
- "thiserror 2.0.18",
- "url",
- "uuid",
- "x25519-dalek",
- "zeroize",
 ]
 
 [[package]]
@@ -309,7 +284,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd3dd78a0535983774c8f3f4fdbd2aaa09f5ce1b109870aa017d5675874c6d1d"
 dependencies = [
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
@@ -328,14 +303,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.15.7"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f831560ac5106539a583d7f1bb9b33badbb942896b4140aad46694c184f7ea3a"
+checksum = "339f6a1a628bade11221b4c0d595a2dc920c4c5288b3305d957b3b6d754ff2cc"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-messaging-mediator-common",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
@@ -381,14 +356,14 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.7.0",
+ "vta-sdk 0.9.0",
 ]
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bce90b6f71b9509a6d683a1574e65c48bb7d5b00601ecb6836e8bfcdde50a0"
+checksum = "8e937ffebbf13ef9925702cf2235aa100cebfb513ef8cca94c5865a369001a53"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -430,7 +405,7 @@ dependencies = [
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-encoding",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-messaging-mediator-common",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
@@ -515,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-status-list"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a4be4e13f529c146c9c1e45cb78b17a77bb41605998cd9c42509b99fa4b422"
+checksum = "146663e9f7bcab5bf7b3fb1b1f83d2b306183b1e7115dcda0aada32fbea504f3"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -540,7 +515,7 @@ dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-meeting-place",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
@@ -2217,7 +2192,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.0",
+ "vta-sdk 0.9.1",
 ]
 
 [[package]]
@@ -2991,7 +2966,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.0",
+ "vta-sdk 0.9.1",
 ]
 
 [[package]]
@@ -6292,7 +6267,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.0",
+ "vta-sdk 0.9.1",
 ]
 
 [[package]]
@@ -9493,7 +9468,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.0",
+ "vta-sdk 0.9.1",
  "x25519-dalek",
 ]
 
@@ -9519,7 +9494,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
@@ -9534,12 +9509,12 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfddb2f41f35ad49650e63848aa32ddaecb7f24b4e2337561d7a586e2fd7faf"
+checksum = "83528ccb61f586e8a0b0ec395e108b2fcf092a7e7c065de3a85cbb8069c0fd0e"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm 0.13.3",
+ "affinidi-messaging-didcomm",
  "affinidi-tdk",
  "base64 0.22.1",
  "chrono",
@@ -9561,12 +9536,12 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "affinidi-vc",
@@ -9605,14 +9580,14 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
@@ -9677,7 +9652,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.0",
+ "vta-sdk 0.9.1",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9695,7 +9670,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
@@ -9753,7 +9728,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.0",
+ "vta-sdk 0.9.1",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9796,7 +9771,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.0",
+ "vta-sdk 0.9.1",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9806,7 +9781,7 @@ name = "vti-e2e-tests"
 version = "0.6.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm 0.14.0",
+ "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",
@@ -9823,7 +9798,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.0",
+ "vta-sdk 0.9.1",
  "vta-service",
  "vti-common",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,11 +79,14 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383822b5aa105040ae6debb29d0321cbb5ad8f755d2c050e437c923434aa72c8"
 dependencies = [
+ "aes 0.8.4",
  "affinidi-encoding",
  "base58",
  "base64 0.22.1",
+ "cbc 0.1.2",
  "ed25519-dalek",
  "getrandom 0.2.17",
+ "hmac 0.12.1",
  "k256",
  "multibase",
  "p256",
@@ -92,6 +95,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "subtle",
  "thiserror 2.0.18",
  "x25519-dalek",
  "zeroize",
@@ -122,14 +126,15 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-authentication"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ebfbaca40c3c02c6f75cbafcef50957049818eb6d6c5ed05a5a3e649769503"
+checksum = "51f6dddb1c766bd2907802b2d9f6c47b511531664e5715828a667c7cf57cef9d"
 dependencies = [
+ "affinidi-crypto",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-secrets-resolver",
  "base64 0.22.1",
  "chrono",
@@ -234,14 +239,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-meeting-place"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c268d1292de575de95238238790f7815e3379c3fd04e3f56918b563bf4e001"
+checksum = "3e2d17c3c6f7340ef079449a40c840997fe5bcc7b64d35c0b86a028b7236cf74"
 dependencies = [
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-tdk-common",
  "base64 0.22.1",
  "chrono",
@@ -255,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f942b5c39668555d7dbb27a03842e96cb2f116791010f493d25f0d17ed2625"
+checksum = "a764d321eb211a662d84c8b225f8cde09164fa045c680907638b0e5f5cfac4eb"
 dependencies = [
  "aes 0.8.4",
  "base64ct",
@@ -279,12 +284,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "affinidi-messaging-didcomm-service"
-version = "0.3.2"
+name = "affinidi-messaging-didcomm"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3dd78a0535983774c8f3f4fdbd2aaa09f5ce1b109870aa017d5675874c6d1d"
+checksum = "9a20a4728d64691ee53bb7af10721050fea21bee3eba2f48f6c3556ce66617f5"
 dependencies = [
- "affinidi-messaging-didcomm",
+ "affinidi-crypto",
+ "base64ct",
+ "ed25519-dalek",
+ "k256",
+ "p256",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "affinidi-messaging-didcomm-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b4b95a1c5aad5ad17259954ca3bf647ad109cb92ac5b1d6a0dc951434e0a99"
+dependencies = [
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
@@ -303,14 +328,15 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.15.11"
+version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339f6a1a628bade11221b4c0d595a2dc920c4c5288b3305d957b3b6d754ff2cc"
+checksum = "3fd932bb1a30c629bdbed212e0098fb1e014424cd21b53b8e27ee1440031a9a7"
 dependencies = [
+ "affinidi-crypto",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-messaging-mediator-common",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
@@ -398,14 +424,15 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2f281adc328e53a31585945179cf62c0e7ea24c96dcae505acd1d8946b47d2"
+checksum = "536aa87c41fcfb795574e5b6d7275dcfd94599cf20442e62f2acefdcb976bef5"
 dependencies = [
+ "affinidi-crypto",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-encoding",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-messaging-mediator-common",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
@@ -427,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a527868dba7d46940ea26b2daec2a41d97ee6f4e86d818209314f0b0ba7473b7"
+checksum = "0386ac7c4c0b770acd2d1a2b077a3b97cc19dd63d2d803eeabebff7930af07dc"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-mediator",
@@ -505,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8bce3db70173a18eebb28ffc22522256dd5dac49ff1ec587f9f50e63aae966"
+checksum = "9aa8f1cc1d16a7e58b3ecae5d2bc8cd31169923ec531fe0559982e0507619451"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -515,7 +542,7 @@ dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-meeting-place",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
@@ -3646,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -9494,7 +9521,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
@@ -9514,7 +9541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83528ccb61f586e8a0b0ec395e108b2fcf092a7e7c065de3a85cbb8069c0fd0e"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.14.1",
  "affinidi-tdk",
  "base64 0.22.1",
  "chrono",
@@ -9541,7 +9568,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "affinidi-vc",
@@ -9587,7 +9614,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-messaging-didcomm-service",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
@@ -9670,7 +9697,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-messaging-didcomm-service",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
@@ -9781,7 +9808,7 @@ name = "vti-e2e-tests"
 version = "0.6.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
+ "affinidi-messaging-didcomm 0.15.0",
  "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",

--- a/didcomm-test/src/main.rs
+++ b/didcomm-test/src/main.rs
@@ -243,6 +243,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             }
                         }
                     }
+                    Ok(WebSocketResponses::Disconnected) => {
+                        // New in messaging-sdk 0.18.5: the transport signals a
+                        // lost socket instead of silently blocking. Stop
+                        // listening — the connection is gone.
+                        warn!("websocket disconnected");
+                        break;
+                    }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         warn!("channel lagged, missed {n} messages");
                     }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -32,7 +32,7 @@ affinidi-tdk = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 affinidi-messaging-sdk = "0.18"
-affinidi-messaging-didcomm = "0.14"
+affinidi-messaging-didcomm = "0.15"
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }
 tempfile = "3"

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { workspace = true }
 # networked methods (did:web / did:webvh) need network-mode config — later.
 affinidi-did-resolver-cache-sdk = { workspace = true }
 # DIDComm v2 authcrypt/anoncrypt pack + unpack. Pinned to vta-sdk's version.
-affinidi-messaging-didcomm = "0.14"
+affinidi-messaging-didcomm = "0.15"
 
 # ── Deferred wiring (kept out of slice 1 on purpose) ────────────────────────
 # The FFI build + bindgen pipeline is proven first with a minimal surface.

--- a/vta-mobile-core/src/didcomm.rs
+++ b/vta-mobile-core/src/didcomm.rs
@@ -18,9 +18,8 @@ use std::sync::{Arc, Mutex};
 
 use affinidi_messaging_didcomm::DIDCommAgent;
 use affinidi_messaging_didcomm::Message;
-use affinidi_messaging_didcomm::crypto::key_agreement::{
-    Curve, PrivateKeyAgreement, PublicKeyAgreement,
-};
+// didcomm 0.15 moved the key-agreement types into `affinidi-crypto`.
+use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement, PublicKeyAgreement};
 use affinidi_messaging_didcomm::identity::{Mediator, PrivateIdentity, ResolvedIdentity};
 use affinidi_messaging_didcomm::message::unpack::UnpackResult;
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -18,6 +18,11 @@ client = [
   "dep:uuid",
   "dep:affinidi-tdk",
   "dep:affinidi-messaging-didcomm",
+  # didcomm 0.15 moved `PublicKeyAgreement` out of
+  # `affinidi_messaging_didcomm::crypto` into `affinidi_crypto::jose`.
+  # `didcomm_light::pack_anoncrypt` (gated on `client`) names that type,
+  # so `client` must pull `affinidi-crypto` in its own right.
+  "dep:affinidi-crypto",
   "dep:didwebvh-rs",
   "dep:tokio",
   "dep:ed25519-dalek",
@@ -127,7 +132,7 @@ sha2 = { workspace = true, optional = true }
 # Used by `client` (didcomm_light::pack_anoncrypt) to produce JWEs the
 # workspace's pinned DIDComm decrypt path will accept (ECDH-ES+A256KW +
 # A256CBC-HS512). Same pinned version as `vta-service`.
-affinidi-messaging-didcomm = { version = "0.14", optional = true }
+affinidi-messaging-didcomm = { version = "0.15", optional = true }
 # Used by `client` (didcomm_light::resolve_vta_keyagreement) to resolve
 # `did:webvh:` VTAs without pulling in the heavyweight TDK runtime. Same
 # workspace-pinned version as `vta-service`.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/didcomm_light.rs
+++ b/vta-sdk/src/didcomm_light.rs
@@ -10,7 +10,7 @@
 //!
 //! Algorithm: ECDH-ES+A256KW (key agreement) + A256CBC-HS512 (content
 //! encryption) — the algorithm pair the workspace's pinned
-//! `affinidi-messaging-didcomm-0.13` actually decrypts. An earlier
+//! `affinidi-messaging-didcomm-0.15` actually decrypts. An earlier
 //! revision emitted A256GCM instead, which the crate doesn't support;
 //! every call fell through to the slower `session::challenge_response`
 //! tier-3 fallback in `integration::auth::try_rest`. Delegating to the
@@ -50,7 +50,10 @@ pub fn pack_anoncrypt(
     recipient_x25519_pub: &[u8; 32],
     recipient_kid: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    use affinidi_messaging_didcomm::crypto::key_agreement::PublicKeyAgreement;
+    // didcomm 0.15 moved the key-agreement types out of its own
+    // `crypto` module into `affinidi-crypto`; `anoncrypt` now takes the
+    // `affinidi_crypto::jose` shape. Same enum, same X25519 variant.
+    use affinidi_crypto::jose::key_agreement::PublicKeyAgreement;
     use affinidi_messaging_didcomm::jwe::encrypt::anoncrypt;
 
     let recipient_pub = PublicKeyAgreement::X25519(*recipient_x25519_pub);
@@ -399,14 +402,14 @@ mod tests {
 
     #[test]
     fn test_pack_anoncrypt_produces_valid_jwe() {
-        use affinidi_messaging_didcomm::crypto::key_agreement::{Curve, PrivateKeyAgreement};
+        use affinidi_crypto::jose::key_agreement::{Curve, PrivateKeyAgreement};
         use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as B64};
 
         // Generate a recipient X25519 keypair via the same crate the
         // server uses — keeps the test honest about wire compatibility.
         let recipient_private = PrivateKeyAgreement::generate(Curve::X25519);
         let recipient_pub_bytes = match recipient_private.public_key() {
-            affinidi_messaging_didcomm::crypto::key_agreement::PublicKeyAgreement::X25519(b) => b,
+            affinidi_crypto::jose::key_agreement::PublicKeyAgreement::X25519(b) => b,
             _ => unreachable!("we asked for X25519"),
         };
 

--- a/vta-sdk/src/provision_client/runner.rs
+++ b/vta-sdk/src/provision_client/runner.rs
@@ -323,6 +323,30 @@ pub async fn run_connection_test(
 /// catalogue has 0 or 1 entries; bails with `WorkflowFailed` when there
 /// are 2+ (interactive consumers should drive `run_connection_test` +
 /// `run_provision_flight` directly to surface a picker).
+///
+/// The consumer's DID path is conventionally folded into the template `URL`
+/// var (`https://host.example.com/webvh`). In serverless mode the VTA reads
+/// the path straight from `URL`; in server-managed mode it reads `WEBVH_PATH`
+/// and ignores `URL`. So when this auto-selects a server, it must lift the path
+/// out of `URL` into `WEBVH_PATH` — otherwise the path is silently dropped and
+/// the hosting server rejects the empty path
+/// (`e.p.did.path-invalid`). [`webvh_path_from_url`] does that derivation.
+///
+/// Empty path / bare origin / `.well-known` → `None` (no `WEBVH_PATH`, let the
+/// server assign); `/webvh` → `webvh`; `/dids/daemon` → `dids/daemon`.
+pub(crate) fn webvh_path_from_url(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map_or(url, |(_, rest)| rest);
+    let path = after_scheme.split_once('/').map_or("", |(_, p)| p);
+    // Drop any query / fragment, then strip surrounding slashes.
+    let path = path.split(['?', '#']).next().unwrap_or("");
+    let trimmed = path.trim_matches('/');
+    if trimmed.is_empty() || trimmed == ".well-known" {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_provision(
     intent: VtaIntent,
@@ -393,6 +417,18 @@ pub async fn run_provision(
                         return Err(ProvisionError::WorkflowFailed(msg));
                     }
                 };
+                // Server-managed mode ignores `URL` and reads the path from
+                // `WEBVH_PATH`. When we auto-selected a server, lift the path
+                // out of the ask's `URL` var so the consumer's "path folded
+                // into URL" contract still works (else it's silently dropped →
+                // hosting server rejects the empty path). No-op for serverless
+                // (webvh_server_id == None), which uses `URL` directly.
+                let webvh_path = webvh_server_id.as_ref().and_then(|_| {
+                    ask.integration_template_vars
+                        .get("URL")
+                        .and_then(|v| v.as_str())
+                        .and_then(webvh_path_from_url)
+                });
                 let mediator_did_clone = mediator_did.clone();
                 let rest_url_clone = rest_url.clone();
                 let _ = events.send(VtaEvent::PreflightDone {
@@ -416,7 +452,7 @@ pub async fn run_provision(
                         rest_url_clone,
                         flight_ask,
                         webvh_server_id,
-                        None,
+                        webvh_path,
                         flight_messages,
                         flight_tx,
                     )
@@ -522,5 +558,44 @@ mod tests {
     fn select_returns_neither_when_no_transport_advertised() {
         let r = resolved(None, None);
         assert_eq!(select_initial_transport(&r), InitialChoice::Neither);
+    }
+
+    #[test]
+    fn webvh_path_from_url_bare_origin_is_none() {
+        assert_eq!(webvh_path_from_url("https://host.example.com"), None);
+        assert_eq!(webvh_path_from_url("https://host.example.com/"), None);
+    }
+
+    #[test]
+    fn webvh_path_from_url_well_known_is_none() {
+        // `.well-known` is the webvh log marker, not a DID path.
+        assert_eq!(
+            webvh_path_from_url("https://host.example.com/.well-known"),
+            None
+        );
+    }
+
+    #[test]
+    fn webvh_path_from_url_single_segment() {
+        assert_eq!(
+            webvh_path_from_url("https://host.example.com/webvh"),
+            Some("webvh".to_string())
+        );
+    }
+
+    #[test]
+    fn webvh_path_from_url_multi_segment() {
+        assert_eq!(
+            webvh_path_from_url("https://host.example.com/dids/daemon"),
+            Some("dids/daemon".to_string())
+        );
+    }
+
+    #[test]
+    fn webvh_path_from_url_strips_query_and_fragment() {
+        assert_eq!(
+            webvh_path_from_url("https://host.example.com/dids/daemon?ts=1#x"),
+            Some("dids/daemon".to_string())
+        );
     }
 }

--- a/vta-sdk/src/provision_client/runner_didcomm.rs
+++ b/vta-sdk/src/provision_client/runner_didcomm.rs
@@ -382,6 +382,33 @@ pub async fn provision_admin_rotation_via_didcomm(
 /// `integration_template_vars` so the VTA forwards the operator's path
 /// suggestion to the webvh server's `request_uri` call; `None` → server
 /// auto-assigns. Only meaningful when `webvh_server_id` is `Some`.
+/// Inject the webvh transport-metadata vars (`WEBVH_SERVER`,
+/// `WEBVH_PATH`) into an ask's `integration_template_vars`.
+///
+/// `webvh_path` is only meaningful in server-managed mode
+/// (`webvh_server_id` set): the VTA reads `WEBVH_PATH` and ignores the
+/// path folded into `URL`, so the path must travel as its own var or the
+/// hosting server gets an empty path (`e.p.did.path-invalid`). Serverless
+/// mode reads the path straight from `URL`, so callers pass `None` there.
+pub(crate) fn inject_webvh_vars(
+    ask: &mut ProvisionAsk,
+    webvh_server_id: Option<&str>,
+    webvh_path: Option<&str>,
+) {
+    if let Some(id) = webvh_server_id {
+        ask.integration_template_vars.insert(
+            "WEBVH_SERVER".to_string(),
+            serde_json::Value::String(id.to_string()),
+        );
+    }
+    if let Some(p) = webvh_path {
+        ask.integration_template_vars.insert(
+            "WEBVH_PATH".to_string(),
+            serde_json::Value::String(p.to_string()),
+        );
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_provision_flight(
     vta_did: String,
@@ -398,18 +425,7 @@ pub async fn run_provision_flight(
     let _ = tx.send(VtaEvent::CheckStart(DiagCheck::ProvisionIntegration));
 
     let mut ask = ask;
-    if let Some(ref id) = webvh_server_id {
-        ask.integration_template_vars.insert(
-            "WEBVH_SERVER".to_string(),
-            serde_json::Value::String(id.clone()),
-        );
-    }
-    if let Some(ref p) = webvh_path {
-        ask.integration_template_vars.insert(
-            "WEBVH_PATH".to_string(),
-            serde_json::Value::String(p.clone()),
-        );
-    }
+    inject_webvh_vars(&mut ask, webvh_server_id.as_deref(), webvh_path.as_deref());
     if ask.label.is_none() {
         ask.label = Some(format!(
             "{} setup — {}",
@@ -471,5 +487,70 @@ pub async fn run_provision_flight(
             };
             let _ = tx.send(VtaEvent::Failed(hint));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provision_client::runner::webvh_path_from_url;
+    use serde_json::json;
+
+    /// Regression for `e.p.did.path-invalid` (server-managed, single
+    /// auto-selected server): the path folded into `URL` must reach the
+    /// VTA as `WEBVH_PATH`. Mirrors the derive→inject chain that
+    /// `run_provision`'s `PreflightDone` handler runs before the flight.
+    #[test]
+    fn server_managed_url_path_is_injected_as_webvh_path() {
+        let mut ask = ProvisionAsk::for_template(
+            "did-hosting-control",
+            [(
+                "URL".to_string(),
+                json!("https://host.example.com/dids/daemon"),
+            )]
+            .into_iter()
+            .collect(),
+            "ctx",
+        );
+
+        // What the PreflightDone handler does: derive path from URL when a
+        // server was auto-selected, then inject it for the flight.
+        let server_id = Some("srv-1".to_string());
+        let derived = server_id
+            .as_ref()
+            .and_then(|_| ask.integration_template_vars.get("URL"))
+            .and_then(|v| v.as_str())
+            .and_then(webvh_path_from_url);
+        assert_eq!(derived.as_deref(), Some("dids/daemon"));
+
+        inject_webvh_vars(&mut ask, server_id.as_deref(), derived.as_deref());
+
+        assert_eq!(
+            ask.integration_template_vars.get("WEBVH_PATH"),
+            Some(&json!("dids/daemon"))
+        );
+        assert_eq!(
+            ask.integration_template_vars.get("WEBVH_SERVER"),
+            Some(&json!("srv-1"))
+        );
+    }
+
+    /// Serverless mode (no server selected) leaves `WEBVH_PATH` unset — the
+    /// VTA reads the path straight from `URL`.
+    #[test]
+    fn serverless_leaves_webvh_path_unset() {
+        let mut ask = ProvisionAsk::for_template(
+            "did-hosting-control",
+            [(
+                "URL".to_string(),
+                json!("https://host.example.com/dids/daemon"),
+            )]
+            .into_iter()
+            .collect(),
+            "ctx",
+        );
+        inject_webvh_vars(&mut ask, None, None);
+        assert!(!ask.integration_template_vars.contains_key("WEBVH_PATH"));
+        assert!(!ask.integration_template_vars.contains_key("WEBVH_SERVER"));
     }
 }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -101,7 +101,7 @@ affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }
 hkdf = { workspace = true }
 affinidi-tdk = { workspace = true }
-affinidi-messaging-didcomm = "0.14"
+affinidi-messaging-didcomm = "0.15"
 affinidi-messaging-didcomm-service = { workspace = true }
 async-trait = "0.1"
 affinidi-tdk-common = "0.6"

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -300,7 +300,18 @@ pub async fn provision_integration(
     // the operator sets it in `mediator_template_vars`. Removed from the
     // map so the template renderer doesn't also see it — it is transport
     // metadata, not document content.
-    let webvh_path = webvh::take_webvh_path(&mut template_vars)?;
+    let mut webvh_path = webvh::take_webvh_path(&mut template_vars)?;
+
+    // Defense-in-depth: in server-managed mode (`WEBVH_SERVER` set) the
+    // hosting server reads `WEBVH_PATH` and ignores `URL`. A consumer that
+    // folded the DID path into `URL` but didn't set `WEBVH_PATH` would hand
+    // the server an empty path → `e.p.did.path-invalid`. When that happens,
+    // derive the path from the `URL` var so the integration still lands.
+    // Only applies when a server is selected and no explicit path was given;
+    // serverless mode reads the path from `URL` directly and is untouched.
+    if webvh_server_id.is_some() && webvh_path.is_none() {
+        webvh_path = webvh::webvh_path_from_url_var(&template_vars);
+    }
 
     // Optional `WEBVH_DOMAIN` template var: when the webvh hosting server
     // is multi-tenant, this pins which tenant domain the DID is allocated

--- a/vta-service/src/operations/provision_integration/webvh.rs
+++ b/vta-service/src/operations/provision_integration/webvh.rs
@@ -92,6 +92,33 @@ pub(super) fn take_webvh_path(
     Ok(Some(trimmed.to_string()))
 }
 
+/// Defense-in-depth fallback: derive a `WEBVH_PATH` from the `URL`
+/// template var when the operator folded the DID path into the URL but
+/// did not set `WEBVH_PATH` explicitly.
+///
+/// Server-managed mode reads `WEBVH_PATH` and ignores `URL`, so a
+/// consumer that only set `URL` (`https://host.example.com/dids/daemon`)
+/// would otherwise hand the hosting server an empty path and get
+/// `e.p.did.path-invalid`. This reads `URL` (without removing it) and
+/// returns the path component for the caller to use as a fallback.
+///
+/// Read-only and conservative: bare origins, empty paths and
+/// `.well-known` (the webvh log marker, never a DID path) → `None`,
+/// letting the server run its own allocation. Mirrors the SDK-side
+/// `runner::webvh_path_from_url` so both layers agree on the derivation.
+pub(super) fn webvh_path_from_url_var(template_vars: &BTreeMap<String, Value>) -> Option<String> {
+    let url = template_vars.get("URL").and_then(|v| v.as_str())?;
+    let after_scheme = url.split_once("://").map_or(url, |(_, rest)| rest);
+    let path = after_scheme.split_once('/').map_or("", |(_, p)| p);
+    let path = path.split(['?', '#']).next().unwrap_or("");
+    let trimmed = path.trim_matches('/');
+    if trimmed.is_empty() || trimmed == ".well-known" {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 /// Remove and return the optional `WEBVH_DOMAIN` template var.
 ///
 /// `WEBVH_DOMAIN` is transport metadata — it tells the webvh hosting
@@ -186,5 +213,47 @@ mod tests {
             take_webvh_domain(&mut v),
             Err(AppError::Validation(_))
         ));
+    }
+
+    #[test]
+    fn webvh_path_from_url_var_absent_is_none() {
+        let v = vars(&[]);
+        assert_eq!(webvh_path_from_url_var(&v), None);
+    }
+
+    #[test]
+    fn webvh_path_from_url_var_bare_origin_is_none() {
+        let v = vars(&[("URL", json!("https://host.example.com"))]);
+        assert_eq!(webvh_path_from_url_var(&v), None);
+        let v = vars(&[("URL", json!("https://host.example.com/"))]);
+        assert_eq!(webvh_path_from_url_var(&v), None);
+    }
+
+    #[test]
+    fn webvh_path_from_url_var_well_known_is_none() {
+        // `.well-known` is the webvh log marker, never a DID path.
+        let v = vars(&[("URL", json!("https://host.example.com/.well-known"))]);
+        assert_eq!(webvh_path_from_url_var(&v), None);
+    }
+
+    #[test]
+    fn webvh_path_from_url_var_single_segment() {
+        let v = vars(&[("URL", json!("https://host.example.com/webvh"))]);
+        assert_eq!(webvh_path_from_url_var(&v), Some("webvh".to_string()));
+    }
+
+    #[test]
+    fn webvh_path_from_url_var_multi_segment() {
+        let v = vars(&[("URL", json!("https://host.example.com/dids/daemon"))]);
+        assert_eq!(webvh_path_from_url_var(&v), Some("dids/daemon".to_string()));
+    }
+
+    #[test]
+    fn webvh_path_from_url_var_strips_query_and_fragment() {
+        let v = vars(&[(
+            "URL",
+            json!("https://host.example.com/dids/daemon?x=1#frag"),
+        )]);
+        assert_eq!(webvh_path_from_url_var(&v), Some("dids/daemon".to_string()));
     }
 }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -103,7 +103,7 @@ subtle = { workspace = true }
 # message handler in `messaging.rs` (M1.8.2). The service crate
 # accepts `Message` / `UnpackMetadata` by value but doesn't
 # re-export them.
-affinidi-messaging-didcomm = "0.14"
+affinidi-messaging-didcomm = "0.15"
 tokio-util = { workspace = true, features = ["rt"] }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 base64 = { workspace = true }


### PR DESCRIPTION
## Summary

Two bundled changes:

### 1. Fix: server-managed provisioning drops the DID path (`e.p.did.path-invalid`)

Provisioning against a VTA with **exactly one** registered webvh server auto-selects that server and runs the server-managed path, where the hosting server reads `WEBVH_PATH` and **ignores** the path folded into `URL`. `run_provision` passed `webvh_path = None` → empty path → `e.p.did.path-invalid: path must not be empty` (HTTP 500).

Fixed at two layers:
- **vta-sdk:** `PreflightDone` derives the path from the ask's `URL` var (`runner::webvh_path_from_url`) when it auto-selects a server, passes it to `run_provision_flight`; injection factored into `runner_didcomm::inject_webvh_vars`. Serverless path unchanged.
- **vta-service (safety net):** `provision_integration` falls back to the path parsed from `URL` (`webvh::webvh_path_from_url_var`) when `WEBVH_SERVER` is set but no explicit `WEBVH_PATH`. Read-only; never overrides explicit.

Conservative derivation on both sides (`.well-known`/bare origin → none; `/webvh` → `webvh`; `/dids/daemon` → `dids/daemon`; query/fragment stripped), with matching unit tests + the requested regression test on the derive→inject chain.

### 2. DIDComm 0.15 across the affinidi-messaging stack

Now that the affinidi side published the releases closing the 0.14/0.15 split, the **whole workspace moves to `affinidi-messaging-didcomm 0.15`**:

- **`affinidi-tdk` 0.7.2 → 0.7.3** (`didcomm ^0.15`) — the production unblock. tdk re-exports didcomm and `DIDCommSession` passes `Message` into its transport, so tdk + our direct didcomm dep must share one version; while tdk capped at `^0.14`, 0.15 was unreachable (incompatible `Message` types).
- **mediator** 0.15.11 → 0.15.12, **test-mediator** 0.2.3 → 0.2.4, **messaging-sdk** 0.18.4 → 0.18.6, **didcomm-service** 0.3.2 → 0.3.3, plus `affinidi-crypto` 0.1.10 / `affinidi-status-list` 0.1.3 (latest).

**API migration:**
- didcomm 0.15 removed its `crypto` module; `Curve`/`PrivateKeyAgreement`/`PublicKeyAgreement` now live in `affinidi_crypto::jose::key_agreement`. Migrated imports in `vta-sdk` (`didcomm_light`) and `vta-mobile-core` (`didcomm`); added `affinidi-crypto` to vta-sdk's `client` feature. `anoncrypt`'s shape is unchanged — the `pack_anoncrypt` JWE round-trip test still passes.
- messaging-sdk 0.18.5 added `WebSocketResponses::Disconnected`; handled in `didcomm-test`'s listen loop.

## Versioning

- **`vta-sdk` 0.9.0 → 0.9.1** — provision bugfix **+** didcomm 0.14→0.15 dep bump. **Deliberately kept in `0.9.x`:** mediator 0.15.12 pins `vta-sdk = "^0.9"` *and* `didcomm = "^0.15"` at once, so the affinidi side expects a `0.9.x` of vta-sdk carrying didcomm 0.15. A `0.10.0` would fall outside their `^0.9` pin and strand them on the didcomm-0.14 `vta-sdk 0.9.0`. Ecosystem coordination, by design.
- **`vta-service` 0.8.0 → 0.8.1** — Option B safety net + didcomm 0.15 pin.

**Transient duplicate:** the dev-only test tree still pulls a second `didcomm 0.14.1` via the *published* `vta-sdk 0.9.0` that the mediator depends on. The mediator's `^0.9` pin means this **self-heals the moment `vta-sdk 0.9.1` publishes**. `cargo deny` treats it as a warning (consistent with existing accepted dups).

## CI

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets` ✅ no warnings
- `cargo deny check` ✅ advisories/bans/licenses/sources ok
- tests ✅ — vta-sdk, vta-service, vtc-service, vta-mobile-core all green; `pack_anoncrypt` round-trip passes on 0.15