### PR TITLE
feat(vta): step-up policy config + ship-default-disabled gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8997,9 +8997,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ae2eb8b8056bc4639cb0b91dd70b1ac21655455cbc4f5961c9985f8ead2325"
+checksum = "ea8d06258ead96a073a54979db44c7adc2e8e92fc561bb75dbd9656326900e60"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -497,13 +497,19 @@ pub(super) async fn require_step_up(
     if auth.acr == STEP_UP_TARGET_ACR {
         return None;
     }
-    let vta_did = state
-        .config
-        .read()
-        .await
-        .vta_did
-        .clone()
-        .unwrap_or_default();
+    let (vta_did, gated) = {
+        let cfg = state.config.read().await;
+        // Step-up policy gate. Slice 1 resolves against the `*` catch-all
+        // floor only (no per-op-class threading yet); a disabled policy
+        // yields `None` → not gated → the operation proceeds at AAL1. This
+        // is what makes the shipping default (step-up off) admit every
+        // operation, including the first-auth key rotation.
+        let gated = cfg.auth.step_up.floor_for("*").requires_aal2();
+        (cfg.vta_did.clone().unwrap_or_default(), gated)
+    };
+    if !gated {
+        return None;
+    }
     let reject = match mint_pending_step_up(
         &state.sessions_ks,
         &vta_did,
@@ -549,13 +555,17 @@ impl FromRequestParts<AppState> for RequireStepUp {
         if claims.acr == "aal2" {
             return Ok(RequireStepUp);
         }
-        let vta_did = state
-            .config
-            .read()
-            .await
-            .vta_did
-            .clone()
-            .unwrap_or_default();
+        let (vta_did, gated) = {
+            let cfg = state.config.read().await;
+            // Step-up policy gate (see `require_step_up`): slice 1 resolves
+            // against the `*` catch-all floor; a disabled policy is not
+            // gated and the request proceeds at AAL1.
+            let gated = cfg.auth.step_up.floor_for("*").requires_aal2();
+            (cfg.vta_did.clone().unwrap_or_default(), gated)
+        };
+        if !gated {
+            return Ok(RequireStepUp);
+        }
         Err(issue_step_up_challenge(
             &state.sessions_ks,
             &vta_did,

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -68,6 +68,23 @@ impl TestContext {
     fn acl_ks(&self) -> &KeyspaceHandle {
         &self.inner.acl_ks
     }
+
+    /// Turn on the AAL2 step-up policy for every operation. The shipping
+    /// default is disabled (AAL1 everywhere); tests that assert the gate
+    /// fires opt in here, mirroring an operator enabling step-up with a `*`
+    /// floor. The config Arc is shared with the live router, so this takes
+    /// effect for subsequent requests.
+    async fn enable_step_up_all(&self) {
+        use vti_common::auth::step_up::{StepUpFloor, StepUpMode, StepUpPolicy};
+        self.inner.config.write().await.auth.step_up = StepUpPolicy {
+            enabled: true,
+            floors: vec![StepUpFloor {
+                operation: "*".into(),
+                mode: StepUpMode::SelfApprove,
+                allow_aal1_if_non_escalating: false,
+            }],
+        };
+    }
 }
 
 impl TestContext {
@@ -450,6 +467,8 @@ async fn acl_create_and_list() {
 #[tokio::test]
 async fn acl_mutation_requires_step_up() {
     let (app, ctx) = TestApp::new().await;
+    // Opt into step-up enforcement (shipping default is disabled).
+    ctx.enable_step_up_all().await;
     // A normal (AAL1) admin session: correct role, but not stepped up.
     let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
 

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -166,6 +166,20 @@ async fn did_signed_approve_response_elevates_session_to_aal2() {
 async fn trust_task_acl_mutation_requires_step_up() {
     let (router, ctx) = build_test_app().await;
 
+    // Opt into step-up enforcement (shipping default is disabled): a `*`
+    // floor at AAL2 so the AAL1 trust-task mutation below is gated.
+    {
+        use vti_common::auth::step_up::{StepUpFloor, StepUpMode, StepUpPolicy};
+        ctx.config.write().await.auth.step_up = StepUpPolicy {
+            enabled: true,
+            floors: vec![StepUpFloor {
+                operation: "*".into(),
+                mode: StepUpMode::SelfApprove,
+                allow_aal1_if_non_escalating: false,
+            }],
+        };
+    }
+
     let did = "did:key:z6MkAal1Admin".to_string();
     let session_id = "sess-stepup-tt-1".to_string();
 

--- a/vti-common/src/auth/step_up.rs
+++ b/vti-common/src/auth/step_up.rs
@@ -41,6 +41,113 @@ pub struct PendingStepUp {
     pub expires_at: u64,
 }
 
+/// Step-up enforcement mode for an operation-class — the assurance the
+/// relying party requires before the operation runs. Mirrors the
+/// `auth/step-up/policy/0.1` `FloorMode`. Strictness (least → most):
+/// `None` < `SelfApprove` < `DelegatedAny` < `Delegated`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum StepUpMode {
+    /// AAL1 permitted — no step-up required.
+    #[default]
+    None,
+    /// The caller elevates its own session (AAL2 via its own authenticator).
+    #[serde(rename = "self")]
+    SelfApprove,
+    /// A specific approver (the caller's `AclEntry.stepUp.approver`) must
+    /// ratify the elevation.
+    Delegated,
+    /// Any VID meeting the maintainer's approver criterion may ratify.
+    DelegatedAny,
+}
+
+impl StepUpMode {
+    /// Strictness rank for floor/override composition (higher = stricter).
+    fn rank(self) -> u8 {
+        match self {
+            StepUpMode::None => 0,
+            StepUpMode::SelfApprove => 1,
+            StepUpMode::DelegatedAny => 2,
+            StepUpMode::Delegated => 3,
+        }
+    }
+
+    /// Whether this mode demands AAL2 (anything stricter than `None`).
+    pub fn requires_aal2(self) -> bool {
+        self != StepUpMode::None
+    }
+
+    /// The stricter of two modes — used to compose a system floor with a
+    /// per-entry override (additive-only: an override may raise, never lower).
+    pub fn strictest(self, other: StepUpMode) -> StepUpMode {
+        if other.rank() > self.rank() {
+            other
+        } else {
+            self
+        }
+    }
+}
+
+/// A per-operation-class step-up floor. Mirrors `auth/step-up/policy/0.1`
+/// `Floor`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StepUpFloor {
+    /// Operation-class this floor governs: a stable op-class id (e.g.
+    /// `acl/grant`, `acl/swap-key`, `context/delete`, `key/revoke`,
+    /// `vault/release`) or `*` for the catch-all default.
+    pub operation: String,
+    /// Minimum mode required to perform the operation.
+    pub mode: StepUpMode,
+    /// Admit a non-escalating self-service request at AAL1 even when `mode`
+    /// requires AAL2 — the rotation/enrolment carve-out. Default `false`
+    /// (fail-closed for escalating operations).
+    #[serde(default)]
+    pub allow_aal1_if_non_escalating: bool,
+}
+
+/// The relying party's system-wide step-up policy.
+///
+/// **Ships disabled.** A freshly-provisioned VTA has no registered approver
+/// and could not otherwise be administered (it could not even register the
+/// first approver), so until an operator turns it on every operation proceeds
+/// at AAL1. Mirrors the `auth/step-up/policy/0.1` payload; the VTA serializes
+/// it under `[auth.step_up]` in its config.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct StepUpPolicy {
+    /// Master switch. `false` (the default) ⇒ step-up is NOT enforced
+    /// anywhere; every operation proceeds at AAL1 regardless of `floors`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Per-operation-class floors. Empty ⇒ nothing is gated even when
+    /// `enabled`.
+    #[serde(default)]
+    pub floors: Vec<StepUpFloor>,
+}
+
+impl StepUpPolicy {
+    /// Resolve the system-floor mode for an operation-class: the most
+    /// specific matching floor, else the `*` catch-all, else `None`. Always
+    /// `None` when the policy is disabled.
+    pub fn floor_for(&self, operation: &str) -> StepUpMode {
+        self.floor_record(operation)
+            .map(|f| f.mode)
+            .unwrap_or(StepUpMode::None)
+    }
+
+    /// The matching floor record (exact match preferred over the `*`
+    /// catch-all), or `None` when disabled or unmatched. Carries the
+    /// `allow_aal1_if_non_escalating` flag for the carve-out.
+    pub fn floor_record(&self, operation: &str) -> Option<&StepUpFloor> {
+        if !self.enabled {
+            return None;
+        }
+        self.floors
+            .iter()
+            .find(|f| f.operation == operation)
+            .or_else(|| self.floors.iter().find(|f| f.operation == "*"))
+    }
+}
+
 fn step_up_key(challenge: &str) -> String {
     format!("stepup:{challenge}")
 }
@@ -220,5 +327,94 @@ mod tests {
         );
         assert_eq!(p.expires_at, p.created_at + 300);
         assert_eq!(p.target_acr, "aal2");
+    }
+
+    fn floor(op: &str, mode: StepUpMode) -> StepUpFloor {
+        StepUpFloor {
+            operation: op.to_string(),
+            mode,
+            allow_aal1_if_non_escalating: false,
+        }
+    }
+
+    #[test]
+    fn default_policy_is_disabled_and_never_gates() {
+        let p = StepUpPolicy::default();
+        assert!(!p.enabled);
+        // Disabled ⇒ every operation resolves to None regardless of floors.
+        assert_eq!(p.floor_for("acl/grant"), StepUpMode::None);
+        assert_eq!(p.floor_for("*"), StepUpMode::None);
+        assert!(!p.floor_for("anything").requires_aal2());
+    }
+
+    #[test]
+    fn disabled_policy_ignores_configured_floors() {
+        let p = StepUpPolicy {
+            enabled: false,
+            floors: vec![floor("*", StepUpMode::Delegated)],
+        };
+        assert_eq!(p.floor_for("acl/grant"), StepUpMode::None);
+        assert!(p.floor_record("acl/grant").is_none());
+    }
+
+    #[test]
+    fn enabled_resolves_exact_then_catch_all() {
+        let p = StepUpPolicy {
+            enabled: true,
+            floors: vec![
+                floor("*", StepUpMode::SelfApprove),
+                floor("acl/grant", StepUpMode::Delegated),
+            ],
+        };
+        // Exact match wins over `*`.
+        assert_eq!(p.floor_for("acl/grant"), StepUpMode::Delegated);
+        // Unlisted op falls back to the catch-all.
+        assert_eq!(p.floor_for("context/delete"), StepUpMode::SelfApprove);
+    }
+
+    #[test]
+    fn enabled_without_catch_all_is_none_for_unlisted() {
+        let p = StepUpPolicy {
+            enabled: true,
+            floors: vec![floor("acl/grant", StepUpMode::Delegated)],
+        };
+        assert_eq!(p.floor_for("acl/swap-key"), StepUpMode::None);
+        assert_eq!(p.floor_for("acl/grant"), StepUpMode::Delegated);
+    }
+
+    #[test]
+    fn mode_strictness_is_additive() {
+        // Override may raise, never lower (strictest wins).
+        assert_eq!(
+            StepUpMode::SelfApprove.strictest(StepUpMode::Delegated),
+            StepUpMode::Delegated
+        );
+        assert_eq!(
+            StepUpMode::Delegated.strictest(StepUpMode::SelfApprove),
+            StepUpMode::Delegated
+        );
+        assert_eq!(
+            StepUpMode::None.strictest(StepUpMode::SelfApprove),
+            StepUpMode::SelfApprove
+        );
+        assert!(!StepUpMode::None.requires_aal2());
+        assert!(StepUpMode::SelfApprove.requires_aal2());
+        assert!(StepUpMode::DelegatedAny.requires_aal2());
+    }
+
+    #[test]
+    fn mode_serde_uses_spec_wire_tokens() {
+        assert_eq!(
+            serde_json::to_string(&StepUpMode::SelfApprove).unwrap(),
+            "\"self\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StepUpMode::DelegatedAny).unwrap(),
+            "\"delegated-any\""
+        );
+        assert_eq!(
+            serde_json::from_str::<StepUpMode>("\"none\"").unwrap(),
+            StepUpMode::None
+        );
     }
 }

--- a/vti-common/src/config.rs
+++ b/vti-common/src/config.rs
@@ -37,6 +37,11 @@ pub struct AuthConfig {
     pub session_cleanup_interval: u64,
     /// Base64url-no-pad encoded 32-byte Ed25519 private key for JWT signing.
     pub jwt_signing_key: Option<String>,
+    /// AAL2 step-up policy. Defaults to disabled (AAL1 everywhere) — a fresh
+    /// VTA has no approver registered, so step-up is opt-in once one exists.
+    /// See `auth/step-up/policy/0.1`.
+    #[serde(default)]
+    pub step_up: crate::auth::step_up::StepUpPolicy,
 }
 
 // Manual Debug so a `tracing::debug!(?config, ...)`, panic-with-debug,
@@ -56,6 +61,7 @@ impl std::fmt::Debug for AuthConfig {
                 "jwt_signing_key",
                 &self.jwt_signing_key.as_ref().map(|_| "<redacted>"),
             )
+            .field("step_up", &self.step_up)
             .finish()
     }
 }
@@ -177,6 +183,7 @@ impl Default for AuthConfig {
             challenge_ttl: default_challenge_ttl(),
             session_cleanup_interval: default_session_cleanup_interval(),
             jwt_signing_key: None,
+            step_up: crate::auth::step_up::StepUpPolicy::default(),
         }
     }
 }
@@ -206,6 +213,7 @@ mod tests {
             challenge_ttl: 300,
             session_cleanup_interval: 600,
             jwt_signing_key: Some("SUPER_SECRET_KEY_MATERIAL_MUST_NOT_LEAK".into()),
+            step_up: Default::default(),
         };
         let dbg = format!("{cfg:?}");
         assert!(
@@ -275,6 +283,7 @@ mod tests {
             challenge_ttl: 300,
             session_cleanup_interval: 600,
             jwt_signing_key: Some("key-material".into()),
+            step_up: Default::default(),
         };
         let json = serde_json::to_string(&cfg).expect("serialize");
         assert!(


### PR DESCRIPTION
## Summary

First slice of the configurable AAL2 **step-up policy** (DTGWG spec [PR #67](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/67), `trust-tasks-rs 0.1.5`). It replaces the hardcoded `RequireStepUp` gate (#180) with a policy the VTA consults — and **fixes the `pnm health` 403**: with step-up shipping **disabled**, the first-auth key rotation's ACL write is no longer gated.

### `vti-common`
- `StepUpMode` / `StepUpFloor` / `StepUpPolicy` in `auth::step_up`:
  - floor resolution (most-specific op-class, else `*` catch-all, else `none`),
  - additive-only `strictest` composition (a per-entry override may raise, never lower),
  - wire tokens matching the spec (`none` / `self` / `delegated` / `delegated-any`).
- Added to `AuthConfig` as `[auth.step_up]`, **serde-default = disabled**.

### `vta-service`
- Both gate surfaces — the REST `RequireStepUp` extractor and the trust-task `require_step_up` — now consult the policy. A **disabled** policy (the shipping default) is not gated, so every operation proceeds at AAL1 until an operator turns step-up on. This is the *"default = AAL1 everywhere until a step-up client is configured"* posture we agreed: a fresh VTA has no approver and couldn't otherwise be administered.
- This slice resolves against the `*` catch-all floor (per-op-class threading is a follow-up).

### Tests
Policy-resolution unit tests (disabled-never-gates, exact-then-catch-all, additive strictness, serde tokens). The two integration tests that assert the gate fires now opt into the policy via `enable_step_up_all`, mirroring an operator enabling step-up.

## Follow-ups (separate PRs, per branch-after-merge)
- Per-op-class op-class threading into the gate.
- The server-verified non-escalation carve-out (`allowAal1IfNonEscalating`).
- Delegated-mode approver routing to `AclEntry.stepUp.approver` (converges with the iOS/browser approver, #49).
- `vta step-up policy {show,set,disable}` CLI (break-glass) + wire `auth/step-up/policy/0.1` management.
- Migrate the SDK `rotate_key` from `POST /acl` create+delete → `POST /acl/swap` (`acl/swap-key`).

## CI
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets` ✅ (no warnings)
- `cargo deny check` ✅ advisories/bans/licenses/sources ok
- tests ✅ — `vti-common` (incl. new policy tests), `vta-service` (incl. the two step-up gate integration tests)