### PR TITLE
feat(vta): resolve step-up floors per operation-class

### DIFF
--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -9,7 +9,9 @@ use crate::acl::Role;
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::error::AppError;
 use crate::operations;
-use crate::routes::trust_tasks::RequireStepUp;
+use crate::routes::trust_tasks::{
+    AclChangeRoleOp, AclGrantOp, AclRevokeOp, AclSwapKeyOp, RequireStepUp,
+};
 use crate::server::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -47,7 +49,7 @@ pub async fn create_acl(
     // Role first, step-up second: a caller lacking the role gets a permission
     // error; an authorized AAL1 caller gets the step-up `403`. ACL mutations
     // require AAL2 (operator policy).
-    _step_up: RequireStepUp,
+    _step_up: RequireStepUp<AclGrantOp>,
     State(state): State<AppState>,
     Json(req): Json<CreateAclRequest>,
 ) -> Result<(StatusCode, Json<CreateAclResultBody>), AppError> {
@@ -89,7 +91,7 @@ pub struct UpdateAclRequest {
 /// extractor fails earlier with a clearer error).
 pub async fn update_acl(
     auth: AdminAuth,
-    _step_up: RequireStepUp,
+    _step_up: RequireStepUp<AclChangeRoleOp>,
     State(state): State<AppState>,
     Path(did): Path<String>,
     Json(req): Json<UpdateAclRequest>,
@@ -114,7 +116,7 @@ pub async fn update_acl(
 /// DELETE /acl/{did} — remove an ACL entry. Auth: Admin or Initiator.
 pub async fn delete_acl(
     auth: ManageAuth,
-    _step_up: RequireStepUp,
+    _step_up: RequireStepUp<AclRevokeOp>,
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<StatusCode, AppError> {
@@ -164,7 +166,7 @@ pub enum SwapAclRequest {
 /// `acl/swap-key/0.1` body during the deprecation window.
 pub async fn swap_acl(
     auth: AuthClaims,
-    _step_up: RequireStepUp,
+    _step_up: RequireStepUp<AclSwapKeyOp>,
     State(state): State<AppState>,
     Json(req): Json<SwapAclRequest>,
 ) -> Result<Json<CreateAclResultBody>, AppError> {

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -11,7 +11,7 @@ use vta_sdk::protocols::context_management::{
 use crate::auth::{AdminAuth, AuthClaims, SuperAdminAuth};
 use crate::error::AppError;
 use crate::operations;
-use crate::routes::trust_tasks::RequireStepUp;
+use crate::routes::trust_tasks::{ContextDeleteOp, RequireStepUp};
 use crate::server::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -136,8 +136,9 @@ pub async fn preview_delete_context_handler(
 /// DELETE /contexts/{id} — delete a context and its associated resources. Auth: Super Admin only.
 pub async fn delete_context_handler(
     auth: SuperAdminAuth,
-    // Deleting a context requires a stepped-up (AAL2) session (operator policy).
-    _step_up: RequireStepUp,
+    // Deleting a context requires a stepped-up (AAL2) session when the
+    // `context/delete` policy floor demands it.
+    _step_up: RequireStepUp<ContextDeleteOp>,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Query(query): Query<DeleteContextQuery>,

--- a/vta-service/src/routes/trust_tasks/acl.rs
+++ b/vta-service/src/routes/trust_tasks/acl.rs
@@ -68,8 +68,10 @@ pub(super) async fn handle_create(
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
     }
-    // ACL mutations require a stepped-up (AAL2) session (operator policy).
-    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+    // ACL grant is gated per the `acl/grant` step-up floor (operator policy).
+    if let Some(resp) =
+        super::step_up::require_step_up(state, auth, super::step_up::op::ACL_GRANT, &doc).await
+    {
         return resp;
     }
     let req: CreateAclBody = match parse_payload(&doc) {
@@ -135,8 +137,11 @@ pub(super) async fn handle_update(
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
-    // ACL mutations require a stepped-up (AAL2) session (operator policy).
-    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+    // ACL change-role is gated per the `acl/change-role` step-up floor.
+    if let Some(resp) =
+        super::step_up::require_step_up(state, auth, super::step_up::op::ACL_CHANGE_ROLE, &doc)
+            .await
+    {
         return resp;
     }
     let req: UpdateAclBody = match parse_payload(&doc) {
@@ -186,8 +191,10 @@ pub(super) async fn handle_delete(
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
     }
-    // ACL mutations require a stepped-up (AAL2) session (operator policy).
-    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+    // ACL revoke is gated per the `acl/revoke` step-up floor (operator policy).
+    if let Some(resp) =
+        super::step_up::require_step_up(state, auth, super::step_up::op::ACL_REVOKE, &doc).await
+    {
         return resp;
     }
     let req: DeleteAclBody = match parse_payload(&doc) {

--- a/vta-service/src/routes/trust_tasks/contexts.rs
+++ b/vta-service/src/routes/trust_tasks/contexts.rs
@@ -200,8 +200,10 @@ pub(super) async fn handle_delete(
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }
-    // Deleting a context requires a stepped-up (AAL2) session (operator policy).
-    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+    // Deleting a context is gated per the `context/delete` step-up floor.
+    if let Some(resp) =
+        super::step_up::require_step_up(state, auth, super::step_up::op::CONTEXT_DELETE, &doc).await
+    {
         return resp;
     }
     let req: DeleteContextBody = match parse_payload(&doc) {

--- a/vta-service/src/routes/trust_tasks/keys.rs
+++ b/vta-service/src/routes/trust_tasks/keys.rs
@@ -156,8 +156,10 @@ pub(super) async fn handle_revoke(
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
-    // Revoking (deleting) a key requires a stepped-up (AAL2) session (operator policy).
-    if let Some(resp) = super::step_up::require_step_up(state, auth, &doc).await {
+    // Revoking (deleting) a key is gated per the `key/revoke` step-up floor.
+    if let Some(resp) =
+        super::step_up::require_step_up(state, auth, super::step_up::op::KEY_REVOKE, &doc).await
+    {
         return resp;
     }
     let req: RevokeKeyBody = match parse_payload(&doc) {

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -60,7 +60,9 @@ mod passkey_vms;
 mod provision_integration;
 mod seeds;
 mod step_up;
-pub(crate) use step_up::RequireStepUp;
+pub(crate) use step_up::{
+    AclChangeRoleOp, AclGrantOp, AclRevokeOp, AclSwapKeyOp, ContextDeleteOp, RequireStepUp,
+};
 mod vault;
 #[cfg(feature = "webvh")]
 mod webvh;

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -492,6 +492,7 @@ pub(crate) async fn issue_step_up_challenge(
 pub(super) async fn require_step_up(
     state: &AppState,
     auth: &AuthClaims,
+    op_class: &str,
     doc: &TrustTask<Value>,
 ) -> Option<Response> {
     if auth.acr == STEP_UP_TARGET_ACR {
@@ -499,12 +500,10 @@ pub(super) async fn require_step_up(
     }
     let (vta_did, gated) = {
         let cfg = state.config.read().await;
-        // Step-up policy gate. Slice 1 resolves against the `*` catch-all
-        // floor only (no per-op-class threading yet); a disabled policy
-        // yields `None` → not gated → the operation proceeds at AAL1. This
-        // is what makes the shipping default (step-up off) admit every
-        // operation, including the first-auth key rotation.
-        let gated = cfg.auth.step_up.floor_for("*").requires_aal2();
+        // Resolve the step-up floor for this operation-class (most specific
+        // floor, else the `*` catch-all, else none). A disabled policy
+        // yields `None` → not gated → the operation proceeds at AAL1.
+        let gated = cfg.auth.step_up.floor_for(op_class).requires_aal2();
         (cfg.vta_did.clone().unwrap_or_default(), gated)
     };
     if !gated {
@@ -533,19 +532,54 @@ pub(super) async fn require_step_up(
     Some(reject_with(doc, reject))
 }
 
-/// Request extractor enforcing a **stepped-up (AAL2)** session.
+/// Stable operation-class identifiers used to resolve step-up floors.
+/// These are the gated VTA operations; they mirror the canonical
+/// `acl/*` / `context/*` / `key/*` slugs the `auth/step-up/policy/0.1`
+/// spec uses for its `Floor.operation`.
+pub mod op {
+    pub const ACL_GRANT: &str = "acl/grant";
+    pub const ACL_CHANGE_ROLE: &str = "acl/change-role";
+    pub const ACL_REVOKE: &str = "acl/revoke";
+    pub const ACL_SWAP_KEY: &str = "acl/swap-key";
+    pub const CONTEXT_DELETE: &str = "context/delete";
+    pub const KEY_REVOKE: &str = "key/revoke";
+}
+
+/// Compile-time operation-class marker for the [`RequireStepUp`] extractor.
+/// Each gated REST route names its op-class via a zero-sized type so the
+/// extractor can resolve the matching policy floor without reading the body.
+pub trait StepUpOp {
+    const OP_CLASS: &'static str;
+}
+
+macro_rules! step_up_op {
+    ($name:ident, $class:expr) => {
+        pub struct $name;
+        impl StepUpOp for $name {
+            const OP_CLASS: &'static str = $class;
+        }
+    };
+}
+
+step_up_op!(AclGrantOp, op::ACL_GRANT);
+step_up_op!(AclChangeRoleOp, op::ACL_CHANGE_ROLE);
+step_up_op!(AclRevokeOp, op::ACL_REVOKE);
+step_up_op!(AclSwapKeyOp, op::ACL_SWAP_KEY);
+step_up_op!(ContextDeleteOp, op::CONTEXT_DELETE);
+
+/// Request extractor enforcing a **stepped-up (AAL2)** session for a
+/// specific operation-class `O`.
 ///
 /// A zero-sized marker: it gates, it does not carry claims. Pair it with the
 /// handler's role extractor (`AdminAuth`, `ManageAuth`, …), which yields the
-/// claims — `RequireStepUp` only asserts the session reached AAL2. On an AAL1
-/// session it mints a pending step-up and rejects with the
-/// `403`-carrying-approve-request ([`issue_step_up_challenge`]), so a caller
-/// hitting a step-up-gated endpoint is handed everything needed to elevate.
-/// Applied to the AAL2-gated REST routes (ACL mutations, context delete); the
+/// claims — `RequireStepUp` only asserts the session reached AAL2 *when the
+/// policy floor for `O::OP_CLASS` requires it*. On a gated AAL1 session it
+/// mints a pending step-up and rejects with the `403`-carrying-approve-request
+/// ([`issue_step_up_challenge`]). Applied to the AAL2-gated REST routes; the
 /// trust-task equivalents use [`require_step_up`].
-pub struct RequireStepUp;
+pub struct RequireStepUp<O: StepUpOp>(std::marker::PhantomData<O>);
 
-impl FromRequestParts<AppState> for RequireStepUp {
+impl<O: StepUpOp> FromRequestParts<AppState> for RequireStepUp<O> {
     type Rejection = Response;
 
     async fn from_request_parts(parts: &mut Parts, state: &AppState) -> Result<Self, Response> {
@@ -553,18 +587,17 @@ impl FromRequestParts<AppState> for RequireStepUp {
             .await
             .map_err(IntoResponse::into_response)?;
         if claims.acr == "aal2" {
-            return Ok(RequireStepUp);
+            return Ok(RequireStepUp(std::marker::PhantomData));
         }
         let (vta_did, gated) = {
             let cfg = state.config.read().await;
-            // Step-up policy gate (see `require_step_up`): slice 1 resolves
-            // against the `*` catch-all floor; a disabled policy is not
-            // gated and the request proceeds at AAL1.
-            let gated = cfg.auth.step_up.floor_for("*").requires_aal2();
+            // Resolve the floor for this route's operation-class. A disabled
+            // policy (or no matching floor) is not gated → proceed at AAL1.
+            let gated = cfg.auth.step_up.floor_for(O::OP_CLASS).requires_aal2();
             (cfg.vta_did.clone().unwrap_or_default(), gated)
         };
         if !gated {
-            return Ok(RequireStepUp);
+            return Ok(RequireStepUp(std::marker::PhantomData));
         }
         Err(issue_step_up_challenge(
             &state.sessions_ks,

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -75,14 +75,22 @@ impl TestContext {
     /// floor. The config Arc is shared with the live router, so this takes
     /// effect for subsequent requests.
     async fn enable_step_up_all(&self) {
-        use vti_common::auth::step_up::{StepUpFloor, StepUpMode, StepUpPolicy};
+        use vti_common::auth::step_up::{StepUpFloor, StepUpMode};
+        self.set_step_up_floors(vec![StepUpFloor {
+            operation: "*".into(),
+            mode: StepUpMode::SelfApprove,
+            allow_aal1_if_non_escalating: false,
+        }])
+        .await;
+    }
+
+    /// Enable the step-up policy with an explicit set of floors. The config
+    /// Arc is shared with the live router, so this takes effect immediately.
+    async fn set_step_up_floors(&self, floors: Vec<vti_common::auth::step_up::StepUpFloor>) {
+        use vti_common::auth::step_up::StepUpPolicy;
         self.inner.config.write().await.auth.step_up = StepUpPolicy {
             enabled: true,
-            floors: vec![StepUpFloor {
-                operation: "*".into(),
-                mode: StepUpMode::SelfApprove,
-                allow_aal1_if_non_escalating: false,
-            }],
+            floors,
         };
     }
 }
@@ -501,6 +509,40 @@ async fn acl_mutation_requires_step_up() {
             .as_str()
             .is_some_and(|c| c.len() >= 16),
         "approve-request must carry a ≥16-char challenge"
+    );
+}
+
+#[tokio::test]
+async fn step_up_floor_is_per_operation_class() {
+    use vti_common::auth::step_up::{StepUpFloor, StepUpMode};
+    let (app, ctx) = TestApp::new().await;
+    // Gate ONLY `context/delete` — no floor for `acl/grant`, no `*` catch-all.
+    ctx.set_step_up_floors(vec![StepUpFloor {
+        operation: "context/delete".into(),
+        mode: StepUpMode::SelfApprove,
+        allow_aal1_if_non_escalating: false,
+    }])
+    .await;
+    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/acl",
+            &token,
+            json!({
+                "did": "did:key:z6MkUngated",
+                "role": "application",
+                "label": "ungated app",
+                "allowed_contexts": ["ctx1"]
+            }),
+        ))
+        .await;
+
+    // The `acl/grant` route must NOT be step-up-gated by a context/delete-only
+    // policy — op-class resolution is specific, not all-or-nothing.
+    assert_ne!(
+        body["error"], "step_up_required",
+        "acl/grant gated by a context/delete-only floor: {status} {body}"
     );
 }
 


### PR DESCRIPTION
## Summary

Slice 2 of the configurable step-up policy (follows #191). Slice 1 resolved every gate against the `*` catch-all floor; this threads the **operation-class** through both gate surfaces so per-op floors apply — an operator can now say `acl/grant = delegated` while leaving `acl/swap-key` ungated, etc.

- **`step_up.rs`**: stable op-class ids (`acl/grant`, `acl/change-role`, `acl/revoke`, `acl/swap-key`, `context/delete`, `key/revoke`) matching the spec's `Floor.operation`. `require_step_up` now takes an `op_class` and resolves `floor_for(op_class)`. The REST `RequireStepUp` extractor is generic over a compile-time `StepUpOp` marker, so each route declares its op-class in the type (`RequireStepUp<AclGrantOp>`, …) — no body read needed.
- **Wired every gated site** to its op-class: REST acl create/update/delete/swap + context delete; trust-task acl create/update/delete, context delete, key revoke.

## Test
`step_up_floor_is_per_operation_class` — a `context/delete`-only floor does **not** gate an `acl/grant`, proving resolution is specific rather than all-or-nothing. Existing gate tests (which use the `*` floor) are unchanged.

## Behaviour
Unchanged for a disabled policy (AAL1 everywhere) and for a `*`-only floor. This is purely additive precision over slice 1.

## Follow-ups (separate PRs)
- Server-verified non-escalation carve-out (`allowAal1IfNonEscalating`) — needs the request body, so it lands in the handlers, not the extractor.
- Delegated-mode approver routing to `AclEntry.stepUp.approver` (converges with #49).
- SDK `rotate_key` → `acl/swap-key`.
- `vta step-up policy {show,set,disable}` CLI + wire `auth/step-up/policy/0.1` management.

## CI
- `cargo fmt --check` ✅
- `cargo clippy -p vta-service --all-targets` ✅ (no warnings)
- tests ✅ — `api_integration` (102, incl. the new per-op-class test) + `step_up_approve_response`