### PR TITLE
feat(vta): non-escalation carve-out for self-service step-up ops

### DIFF
--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -550,6 +550,14 @@ pub mod op {
 /// extractor can resolve the matching policy floor without reading the body.
 pub trait StepUpOp {
     const OP_CLASS: &'static str;
+    /// `true` when the operation is *structurally* non-escalating: it acts
+    /// only on the caller's own entry and preserves role/scopes (e.g. self
+    /// key-rotation via `acl/swap-key`). Such an op is eligible for a floor's
+    /// `allow_aal1_if_non_escalating` carve-out without inspecting the request
+    /// body — the non-escalation property is guaranteed by the operation
+    /// itself. Escalating ops (grant, change-role, …) leave this `false` and
+    /// fail closed when a method is absent.
+    const IS_NON_ESCALATING: bool = false;
 }
 
 macro_rules! step_up_op {
@@ -559,12 +567,19 @@ macro_rules! step_up_op {
             const OP_CLASS: &'static str = $class;
         }
     };
+    ($name:ident, $class:expr, non_escalating) => {
+        pub struct $name;
+        impl StepUpOp for $name {
+            const OP_CLASS: &'static str = $class;
+            const IS_NON_ESCALATING: bool = true;
+        }
+    };
 }
 
 step_up_op!(AclGrantOp, op::ACL_GRANT);
 step_up_op!(AclChangeRoleOp, op::ACL_CHANGE_ROLE);
 step_up_op!(AclRevokeOp, op::ACL_REVOKE);
-step_up_op!(AclSwapKeyOp, op::ACL_SWAP_KEY);
+step_up_op!(AclSwapKeyOp, op::ACL_SWAP_KEY, non_escalating);
 step_up_op!(ContextDeleteOp, op::CONTEXT_DELETE);
 
 /// Request extractor enforcing a **stepped-up (AAL2)** session for a
@@ -593,7 +608,18 @@ impl<O: StepUpOp> FromRequestParts<AppState> for RequireStepUp<O> {
             let cfg = state.config.read().await;
             // Resolve the floor for this route's operation-class. A disabled
             // policy (or no matching floor) is not gated → proceed at AAL1.
-            let gated = cfg.auth.step_up.floor_for(O::OP_CLASS).requires_aal2();
+            // Non-escalation carve-out: a floor that requires AAL2 still
+            // admits a structurally non-escalating op (e.g. self key-rotation
+            // via `acl/swap-key`) at AAL1 when it sets
+            // `allow_aal1_if_non_escalating` — so a holder with no authenticator
+            // yet can still rotate. Escalating ops never qualify.
+            let gated = match cfg.auth.step_up.floor_record(O::OP_CLASS) {
+                None => false,
+                Some(f) => {
+                    f.mode.requires_aal2()
+                        && !(f.allow_aal1_if_non_escalating && O::IS_NON_ESCALATING)
+                }
+            };
             (cfg.vta_did.clone().unwrap_or_default(), gated)
         };
         if !gated {

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -547,6 +547,64 @@ async fn step_up_floor_is_per_operation_class() {
 }
 
 #[tokio::test]
+async fn swap_key_carve_out_admits_aal1_when_configured() {
+    use vti_common::auth::step_up::{StepUpFloor, StepUpMode};
+    let (app, ctx) = TestApp::new().await;
+    // Gate swap-key at AAL2 but allow the non-escalating self-service carve-out.
+    ctx.set_step_up_floors(vec![StepUpFloor {
+        operation: "acl/swap-key".into(),
+        mode: StepUpMode::SelfApprove,
+        allow_aal1_if_non_escalating: true,
+    }])
+    .await;
+    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    let (_status, body) = app
+        .request(post_auth(
+            "/acl/swap",
+            &token,
+            json!({ "presentation": "not-a-real-vp" }),
+        ))
+        .await;
+
+    // The carve-out admits the swap at AAL1, so it is NOT step-up-gated; it
+    // fails later on the (invalid) presentation rather than on step-up.
+    assert_ne!(
+        body["error"], "step_up_required",
+        "swap-key carve-out should admit AAL1: {body}"
+    );
+}
+
+#[tokio::test]
+async fn swap_key_gated_without_carve_out() {
+    use vti_common::auth::step_up::{StepUpFloor, StepUpMode};
+    let (app, ctx) = TestApp::new().await;
+    // Same AAL2 floor but WITHOUT the carve-out → swap-key is gated.
+    ctx.set_step_up_floors(vec![StepUpFloor {
+        operation: "acl/swap-key".into(),
+        mode: StepUpMode::SelfApprove,
+        allow_aal1_if_non_escalating: false,
+    }])
+    .await;
+    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/acl/swap",
+            &token,
+            json!({ "presentation": "not-a-real-vp" }),
+        ))
+        .await;
+
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "swap-key must be gated: {body}"
+    );
+    assert_eq!(body["error"], "step_up_required");
+}
+
+#[tokio::test]
 async fn acl_application_cannot_manage() {
     let (app, ctx) = TestApp::new().await;
     let token = ctx


### PR DESCRIPTION
## Summary

Slice 3 of the step-up policy (follows #192) — implements the `allow_aal1_if_non_escalating` carve-out from `auth/step-up/policy/0.1`.

The key insight: **`acl/swap-key` (self key-rotation) is *structurally* non-escalating** — it acts only on the caller's own entry and preserves role/scopes — so its eligibility for the carve-out needs **no request-body inspection**. It's modelled as a compile-time `StepUpOp::IS_NON_ESCALATING` marker (`true` for `AclSwapKeyOp`, `false` for the escalating ops), so the carve-out stays in the `RequireStepUp` extractor.

- The extractor admits a gated op at AAL1 when its floor sets `allow_aal1_if_non_escalating` **and** the op is non-escalating. So a holder with no authenticator yet can still rotate even under an *enabled* policy — the bootstrap chicken-and-egg is resolved without weakening escalating ops.
- Escalating ops (`acl/grant`, `acl/change-role`, `acl/revoke`, `context/delete`, `key/revoke`) leave `IS_NON_ESCALATING = false` and continue to **fail closed**.

## Tests
- `swap_key_carve_out_admits_aal1_when_configured` — floor `acl/swap-key {self, allow_aal1_if_non_escalating: true}` → an AAL1 swap is **not** step-up-gated.
- `swap_key_gated_without_carve_out` — same floor without the flag → `403 step_up_required`.

## CI
- `cargo fmt --check` ✅
- `cargo clippy -p vta-service --all-targets` ✅
- `cargo test -p vta-service --test api_integration` ✅ (104, incl. the two carve-out tests)

## Follow-ups
- **SDK `rotate_key` → `acl/swap-key`** — so rotation actually travels this non-escalating path (the other half; pairs with this PR).
- Delegated-mode approver routing to `AclEntry.stepUp.approver` (converges with #49).
- `vta step-up policy {show,set,disable}` CLI + wire `auth/step-up/policy/0.1` management.