### PR TITLE
feat(vta-sdk): route first-auth key rotation through acl/swap-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Key rotation goes through `acl/swap-key`
+
+The SDK's first-auth key rotation (`session::rotate_key`, REST path) now
+uses the atomic `POST /acl/swap` (`acl/swap-key`) instead of the
+create-then-delete sequence on `POST /acl`. The VTA moves the temp DID's
+ACL entry (same role + contexts) onto the freshly-minted DID and removes
+the temp in one transaction — no transient over-privilege window, and the
+rotation travels the structurally non-escalating swap-key path, so an
+*enabled* step-up policy carrying the rotation carve-out still admits it
+at AAL1.
+
+- `vta-sdk` gains `protocols::acl_management::swap::build_swap_presentation`
+  (client feature) — builds the Ed25519 VP-JWT the swap verifier accepts;
+  round-trip-tested against `AclSwapPresentation::verify`.
+- `vta-sdk` 0.9.1 → 0.9.2 (additive public API). The DIDComm rotation path
+  still uses create-then-delete; migrating it onto swap-key is a follow-up.
+
 ### Fix: server-managed provisioning drops the DID path (`e.p.did.path-invalid`)
 
 When a consumer (e.g. the did-hosting-daemon) provisions an integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.9.1",
 ]
 
 [[package]]
@@ -2194,7 +2194,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.1",
+ "vta-sdk 0.9.2",
 ]
 
 [[package]]
@@ -2968,7 +2968,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.1",
+ "vta-sdk 0.9.2",
 ]
 
 [[package]]
@@ -6269,7 +6269,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.1",
+ "vta-sdk 0.9.2",
 ]
 
 [[package]]
@@ -9470,7 +9470,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.1",
+ "vta-sdk 0.9.2",
  "x25519-dalek",
 ]
 
@@ -9512,6 +9512,34 @@ dependencies = [
 [[package]]
 name = "vta-sdk"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "858ad5093e72c21153d50ec4aa7d361b9b5d356bdb1af2c4016734d0c66ae9b1"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.9.2"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9551,34 +9579,6 @@ dependencies = [
  "wiremock",
  "x25519-dalek",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858ad5093e72c21153d50ec4aa7d361b9b5d356bdb1af2c4016734d0c66ae9b1"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "getrandom 0.4.2",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -9655,7 +9655,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.1",
+ "vta-sdk 0.9.2",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9731,7 +9731,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.1",
+ "vta-sdk 0.9.2",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9774,7 +9774,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.1",
+ "vta-sdk 0.9.2",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9801,7 +9801,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.1",
+ "vta-sdk 0.9.2",
  "vta-service",
  "vti-common",
 ]

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/acl_management/swap.rs
+++ b/vta-sdk/src/protocols/acl_management/swap.rs
@@ -57,6 +57,54 @@ pub type SwapAclResultBody = CreateAclResultBody;
 /// Alias for the canonical Trust Task response — same shape as the legacy result.
 pub type SwapKeyResponseBody = CreateAclResultBody;
 
+/// Build the compact Ed25519 VP-JWT (`presentation` / `link_proof`) that
+/// proves control of `holder_did` for an `acl/swap-key` request.
+///
+/// Signed by `signing_key` (the new DID's Ed25519 key); `aud` is the VTA DID
+/// the request is bound to. The presentation expires `ttl_secs` after `now`
+/// (unix seconds). The shape mirrors exactly what [`AclSwapPresentation::verify`]
+/// accepts: `iss == holder == holder_did`, `vp.type` carrying
+/// `VerifiablePresentation` + `AclSwapRequest`, and a `kid` resolving to the
+/// `did:key` verification method.
+///
+/// `holder_did` MUST be a `did:key` whose multibase suffix is the Ed25519
+/// public key matching `signing_key` (the form [`crate::session`] mints for
+/// rotation).
+#[cfg(feature = "client")]
+pub fn build_swap_presentation(
+    signing_key: &ed25519_dalek::SigningKey,
+    holder_did: &str,
+    aud: &str,
+    now: u64,
+    ttl_secs: u64,
+    nonce: Option<&str>,
+) -> String {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
+    use ed25519_dalek::Signer;
+    use serde_json::json;
+
+    let mb = holder_did.strip_prefix("did:key:").unwrap_or(holder_did);
+    let kid = format!("{holder_did}#{mb}");
+    let header = json!({ "alg": "EdDSA", "typ": "JWT", "kid": kid });
+    let mut payload = json!({
+        "iss": holder_did,
+        "aud": aud,
+        "exp": now + ttl_secs,
+        "vp": { "type": ["VerifiablePresentation", "AclSwapRequest"], "holder": holder_did },
+    });
+    if let Some(n) = nonce {
+        payload["nonce"] = json!(n);
+    }
+    let signing_input = format!(
+        "{}.{}",
+        B64URL.encode(serde_json::to_vec(&header).expect("serialize JWS header")),
+        B64URL.encode(serde_json::to_vec(&payload).expect("serialize JWS payload")),
+    );
+    let sig = signing_key.sign(signing_input.as_bytes());
+    format!("{signing_input}.{}", B64URL.encode(sig.to_bytes()))
+}
+
 #[cfg(feature = "provision-integration")]
 pub use verify_impl::{AclSwapError, AclSwapPresentation, VerifiedAclSwap};
 
@@ -372,6 +420,28 @@ mod verify_impl {
                 "verificationMethod": [{ "id": kid, "publicKeyMultibase": mb }],
             });
             (jws, doc, sk)
+        }
+
+        #[cfg(feature = "client")]
+        #[test]
+        fn builder_round_trips_through_verifier() {
+            // The client-side builder must produce a presentation the
+            // server-side verifier accepts — same key, audience, and shape.
+            let sk = SigningKey::from_bytes(&[9u8; 32]);
+            let mb = crate::did_key::ed25519_multibase_pubkey(&sk.verifying_key().to_bytes());
+            let did = format!("did:key:{mb}");
+            let kid = format!("{did}#{mb}");
+            let jws =
+                super::super::build_swap_presentation(&sk, &did, AUD, 1_000, 300, Some("n-1"));
+            let doc = json!({
+                "id": did,
+                "verificationMethod": [{ "id": kid, "publicKeyMultibase": mb }],
+            });
+            let verified = AclSwapPresentation::new(jws)
+                .verify(&doc, AUD, 1_100)
+                .unwrap();
+            assert_eq!(verified.holder(), did);
+            assert_eq!(verified.nonce(), Some("n-1"));
         }
 
         #[test]

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -693,8 +693,10 @@ async fn rotate_key_didcomm(
     let contexts = acl_entry.allowed_contexts.clone();
     let label = acl_entry.label.clone();
 
-    // 2. Mint a new did:key.
-    let (new_did, new_private_key) = generate_did_key()?;
+    // 2. Mint a new did:key. (The DIDComm rotation path still uses the
+    //    create-then-delete shape; migrating it onto `acl/swap-key` is a
+    //    follow-up — see the REST `rotate_key`.)
+    let (new_did, new_private_key, _new_signing) = generate_did_key()?;
     debug!(%new_did, %role, "minted rotation DID, creating ACL entry over DIDComm");
 
     // 3. Create an ACL entry for the new DID via DIDComm.
@@ -754,12 +756,16 @@ async fn rotate_key_didcomm(
     })
 }
 
-/// Generate a fresh Ed25519 did:key. Returns `(did, private_key_multibase)`.
+/// Generate a fresh Ed25519 did:key. Returns
+/// `(did, private_key_multibase, signing_key)`.
 ///
 /// The seed is sourced from `getrandom` (the OS CSPRNG). `private_key_multibase`
 /// is the raw 32-byte seed base58btc-encoded, matching the format used by the
-/// rest of the workspace (see `decode_private_key_multibase`).
-fn generate_did_key() -> Result<(String, String), Box<dyn std::error::Error>> {
+/// rest of the workspace (see `decode_private_key_multibase`). The
+/// `signing_key` is returned so callers can sign over the new DID (e.g. the
+/// `acl/swap-key` presentation) without re-deriving it from the multibase.
+fn generate_did_key()
+-> Result<(String, String, ed25519_dalek::SigningKey), Box<dyn std::error::Error>> {
     let mut seed = [0u8; 32];
     getrandom::fill(&mut seed)
         .map_err(|e| format!("CSPRNG failed while minting rotated did:key: {e}"))?;
@@ -770,138 +776,81 @@ fn generate_did_key() -> Result<(String, String), Box<dyn std::error::Error>> {
         crate::did_key::ed25519_multibase_pubkey(&pubkey)
     );
     let private_key_multibase = multibase::encode(multibase::Base::Base58Btc, seed);
-    Ok((did, private_key_multibase))
+    Ok((did, private_key_multibase, signing))
 }
 
-/// Swap a `needs_rotation=true` session's temp did:key for a fresh one.
+/// Swap a `needs_rotation=true` session's temp did:key for a fresh one via the
+/// atomic `acl/swap-key` operation.
 ///
 /// Precondition: `temp_token` is a valid bearer token authenticating as
 /// `session.client_did` (the temp DID). Returned `Session` carries the new
-/// did:key and `needs_rotation=false`; caller is responsible for persisting
-/// it alongside the returned `TokenResult` (which is an auth under the new
-/// DID, confirming the ACL swap actually lived).
+/// did:key and `needs_rotation=false`; caller is responsible for persisting it
+/// alongside the returned `TokenResult` (an auth under the new DID, confirming
+/// the swap actually lived).
 ///
 /// Flow:
-/// 1. `GET /acl/{temp_did}` — read role + allowed_contexts the admin granted.
-/// 2. `POST /acl` — create an entry for the new DID with the same scope.
-/// 3. Run challenge-response as the new DID to confirm the new entry is
-///    live. If that fails, we bail *before* deleting the temp — so the
-///    temp still works and the caller can retry.
-/// 4. `DELETE /acl/{temp_did}` — best-effort; warn on failure.
+/// 1. Mint a fresh did:key.
+/// 2. `POST /acl/swap` with a VP-JWT proving control of the new DID. The VTA
+///    atomically moves the temp DID's ACL entry (same role + contexts) onto the
+///    new DID and removes the temp — no create-then-delete over-privilege
+///    window. Because swap-key is structurally non-escalating, an enabled
+///    step-up policy carrying the rotation carve-out still admits it at AAL1.
+/// 3. Run challenge-response as the new DID to obtain a token under it (and
+///    confirm the swap landed).
 async fn rotate_key(
     base_url: &str,
     session: Session,
     temp_token: &str,
 ) -> Result<(Session, TokenResult), Box<dyn std::error::Error>> {
+    use crate::protocols::acl_management::swap::{SwapAclBody, build_swap_presentation};
+
     let http = reqwest::Client::new();
 
-    // 1. Read the ACL entry the admin granted to the temp DID.
-    let acl_url = format!(
-        "{}/acl/{}",
-        base_url.trim_end_matches('/'),
-        &session.client_did
-    );
-    debug!(url = %acl_url, "fetching ACL entry for temp DID");
-    let acl_resp = http
-        .get(&acl_url)
+    // `ensure_authenticated` has already gated `vta_did.is_some()` via
+    // `require_vta_did`; safe to unwrap here.
+    let session_vta_did = session
+        .vta_did
+        .as_deref()
+        .expect("ensure_authenticated gates vta_did.is_some() before calling rotate_key")
+        .to_string();
+
+    // 1. Mint a fresh did:key.
+    let (new_did, new_private_key, new_signing) = generate_did_key()?;
+    debug!(%new_did, "minted rotation DID; swapping via acl/swap-key");
+
+    // 2. Prove control of the new DID and atomically swap the temp entry onto
+    //    it. The VP-JWT is audience-bound to this VTA and short-lived.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let presentation =
+        build_swap_presentation(&new_signing, &new_did, &session_vta_did, now, 300, None);
+    let swap_url = format!("{}/acl/swap", base_url.trim_end_matches('/'));
+    let swap_resp = http
+        .post(&swap_url)
         .bearer_auth(temp_token)
+        .json(&SwapAclBody { presentation })
         .send()
         .await
-        .map_err(|e| format!("GET {acl_url}: {e}"))?;
-    if !acl_resp.status().is_success() {
-        let status = acl_resp.status();
-        let body = acl_resp.text().await.unwrap_or_default();
+        .map_err(|e| format!("POST {swap_url}: {e}"))?;
+    if !swap_resp.status().is_success() {
+        let status = swap_resp.status();
+        let body = swap_resp.text().await.unwrap_or_default();
         return Err(format!(
-            "rotate: cannot read temp DID's ACL entry ({status}): {body} — has your admin run `vta import-did --did {} --role admin` yet?",
+            "rotate: acl/swap-key failed ({status}): {body} — has your admin run \
+             `vta import-did --did {} --role admin` yet?",
             session.client_did
         )
         .into());
     }
-    let acl_entry: crate::client::AclEntryResponse = acl_resp
-        .json()
-        .await
-        .map_err(|e| format!("parse ACL entry: {e}"))?;
-    let role = acl_entry.role.clone();
-    let contexts = acl_entry.allowed_contexts.clone();
-    let label = acl_entry.label.clone();
 
-    // 2. Mint a new did:key and register it.
-    let (new_did, new_private_key) = generate_did_key()?;
-    debug!(%new_did, %role, "minted rotation DID, creating ACL entry");
-    let mut create_req = crate::client::CreateAclRequest::new(&new_did, role).contexts(contexts);
-    if let Some(l) = label {
-        create_req = create_req.label(l);
-    }
-    let acl_post = format!("{}/acl", base_url.trim_end_matches('/'));
-    let create_resp = http
-        .post(&acl_post)
-        .bearer_auth(temp_token)
-        .json(&create_req)
-        .send()
-        .await
-        .map_err(|e| format!("POST {acl_post}: {e}"))?;
-    if !create_resp.status().is_success() {
-        let status = create_resp.status();
-        let body = create_resp.text().await.unwrap_or_default();
-        return Err(
-            format!("rotate: failed to create ACL entry for new DID ({status}): {body}").into(),
-        );
-    }
-
-    // 3. Verify the new DID can actually authenticate. Fail *before* we
-    //    delete the temp — if this errors, the temp still works.
-    //
-    // `ensure_authenticated` has already gated `vta_did.is_some()` via
-    // `require_vta_did`; we're safe to unwrap here.
-    let session_vta_did = session
-        .vta_did
-        .as_deref()
-        .expect("ensure_authenticated gates vta_did.is_some() before calling rotate_key");
-    let new_token_result = challenge_response(
-        base_url,
-        &new_did,
-        &new_private_key,
-        session_vta_did,
-    )
-    .await
-    .map_err(|e| {
-        format!(
-            "rotate: new DID failed challenge-response (ACL entry present but login failed): {e}"
-        )
-    })?;
-
-    // 4. Drop the temp DID from the ACL. Best-effort — if this fails, the
-    //    new DID is already live, so we log and continue rather than leave
-    //    the caller unauthenticated.
-    let del_url = format!(
-        "{}/acl/{}",
-        base_url.trim_end_matches('/'),
-        &session.client_did
-    );
-    match http
-        .delete(&del_url)
-        .bearer_auth(&new_token_result.access_token)
-        .send()
-        .await
-    {
-        Ok(resp) if resp.status().is_success() => {
-            debug!(temp_did = %session.client_did, "temp DID removed from ACL");
-        }
-        Ok(resp) => {
-            tracing::warn!(
-                temp_did = %session.client_did,
-                status = %resp.status(),
-                "could not delete temp DID from ACL after rotation — manual cleanup may be required",
-            );
-        }
-        Err(e) => {
-            tracing::warn!(
-                temp_did = %session.client_did,
-                error = %e,
-                "could not delete temp DID from ACL after rotation — manual cleanup may be required",
-            );
-        }
-    }
+    // 3. Authenticate as the new DID to obtain a token under it (and confirm
+    //    the swap landed). The temp entry is already gone server-side.
+    let new_token_result =
+        challenge_response(base_url, &new_did, &new_private_key, &session_vta_did)
+            .await
+            .map_err(|e| format!("rotate: new DID failed challenge-response after swap: {e}"))?;
 
     let Session { vta_did, .. } = session;
     let rotated = Session {


### PR DESCRIPTION
## Summary

Slice 4 of the step-up work (follows #193) — the SDK half of the original `pnm health` rotation issue.

`session::rotate_key` (REST path) previously rotated via **create-then-delete**: read the temp DID's ACL entry → `POST /acl` (create a new entry) → authenticate → `DELETE /acl/{temp}`. That's the "grant new, revoke old" anti-pattern `acl/swap-key` exists to replace — a transient over-privilege window, and (post-#180) the `POST /acl` create is the call that hit the AAL2 gate.

It now mints the new `did:key` and calls **`POST /acl/swap`** (`acl/swap-key`) with a VP-JWT proving control of the new DID. The VTA atomically moves the temp entry (same role + contexts) onto the new DID and removes the temp in one transaction. Because swap-key is **structurally non-escalating**, an *enabled* step-up policy with the rotation carve-out (#193) still admits it at AAL1 — so rotation works whether step-up is off (default) or on.

## Changes
- **New `protocols::acl_management::swap::build_swap_presentation`** (client feature) — builds the Ed25519 VP-JWT the swap verifier accepts, audience-bound + short-lived. Round-trip-tested against `AclSwapPresentation::verify` (`builder_round_trips_through_verifier`).
- `generate_did_key` also returns the `SigningKey` (so the caller signs the presentation without re-deriving it).
- `rotate_key` rewritten: mint → build presentation → `POST /acl/swap` → challenge-response as the new DID. The GET-entry, create, and delete steps are gone (the swap does all three server-side).
- **`vta-sdk` 0.9.1 → 0.9.2** (additive public API) + CHANGELOG.

## CI
- `cargo fmt --check` ✅
- `cargo clippy -p vta-sdk --features session,provision-client --all-targets` ✅
- `cargo test -p vta-sdk --features session,provision-client,integration` ✅ (incl. the swap builder round-trip)

## Follow-ups
- DIDComm rotation path (`rotate_key_didcomm`) still uses create-then-delete — migrate onto swap-key over DIDComm.
- Delegated-mode approver routing (`AclEntry.stepUp.approver`, ↔ #49) and the `vta step-up policy` CLI + wire `auth/step-up/policy/0.1` management.

## Publish note
`vta-sdk 0.9.2` isn't required on crates.io for this to take effect — `pnm-cli` consumes it via the workspace path, so rebuilding the CLI ships the fix. Publish 0.9.2 when convenient (mediator's `^0.9` pin accepts it).