### PR TITLE
refactor(acl): add AclEntry builder; convert all construction sites

### DIFF
--- a/vta-service/src/acl_sweeper.rs
+++ b/vta-service/src/acl_sweeper.rs
@@ -109,7 +109,7 @@ pub async fn sweep_expired(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::acl::{ConsumerKind, Role, store_acl_entry};
+    use crate::acl::{Role, store_acl_entry};
     use crate::store::Store;
     use vti_common::config::StoreConfig;
 
@@ -125,19 +125,7 @@ mod tests {
     }
 
     fn entry(did: &str, expires_at: Option<u64>) -> AclEntry {
-        AclEntry {
-            did: did.into(),
-            role: Role::Admin,
-            label: None,
-            allowed_contexts: vec![],
-            created_at: now_epoch(),
-            created_by: "test".into(),
-            expires_at,
-            kind: ConsumerKind::default(),
-            capabilities: Vec::new(),
-            device: None,
-            version: 0,
-        }
+        AclEntry::new(did, Role::Admin, "test").with_expires_at(expires_at)
     }
 
     /// Expired entries get deleted; permanent (no `expires_at`)

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -809,19 +809,14 @@ pub async fn run_context_create(
             Some(raw) => Some(vta_cli_common::duration::duration_to_expires_at(raw)?),
             None => None,
         };
-        let entry = crate::acl::AclEntry {
-            did: did.clone(),
-            role: crate::acl::Role::Admin,
-            label: admin_label,
-            allowed_contexts: vec![id.clone()],
-            created_at: vti_common::auth::session::now_epoch(),
-            created_by: format!("vta-context-create:{}", auth.did),
-            expires_at,
-            kind: Default::default(),
-            capabilities: Vec::new(),
-            device: None,
-            version: 0,
-        };
+        let entry = crate::acl::AclEntry::new(
+            did.clone(),
+            crate::acl::Role::Admin,
+            format!("vta-context-create:{}", auth.did),
+        )
+        .with_label(admin_label)
+        .with_contexts(vec![id.clone()])
+        .with_expires_at(expires_at);
         crate::acl::store_acl_entry(&acl_ks, &entry).await?;
         eprintln!("Admin ACL entry created for {did} (context: {id}).");
     }
@@ -1103,19 +1098,9 @@ pub async fn run_context_reprovision(
     if existing.is_none() {
         use crate::acl::AclEntry;
         use chrono::Utc;
-        let entry = AclEntry {
-            did: admin_did.clone(),
-            role: Role::Admin,
-            label: None,
-            allowed_contexts: vec![id.clone()],
-            created_at: Utc::now().timestamp() as u64,
-            created_by: auth.did.clone(),
-            expires_at: None,
-            kind: Default::default(),
-            capabilities: Vec::new(),
-            device: None,
-            version: 0,
-        };
+        let entry = AclEntry::new(admin_did.clone(), Role::Admin, auth.did.clone())
+            .with_contexts(vec![id.clone()])
+            .with_created_at(Utc::now().timestamp() as u64);
         crate::acl::store_acl_entry(&state.acl_ks, &entry).await?;
         store.persist().await?;
         eprintln!("Created ACL entry for {admin_did} in context '{id}'");

--- a/vta-service/src/did_key.rs
+++ b/vta-service/src/did_key.rs
@@ -61,22 +61,9 @@ pub async fn run_create_did_key(args: CreateDidKeyArgs) -> Result<(), Box<dyn st
     // Optionally create ACL entry
     if args.admin {
         let acl_ks = store.keyspace("acl")?;
-        let entry = AclEntry {
-            did: did.clone(),
-            role: Role::Admin,
-            label: args.label.clone(),
-            allowed_contexts: vec![args.context.clone()],
-            created_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-            created_by: "cli:create-did-key".into(),
-            expires_at: None,
-            kind: Default::default(),
-            capabilities: Vec::new(),
-            device: None,
-            version: 0,
-        };
+        let entry = AclEntry::new(did.clone(), Role::Admin, "cli:create-did-key")
+            .with_label(args.label.clone())
+            .with_contexts(vec![args.context.clone()]);
         store_acl_entry(&acl_ks, &entry).await?;
         eprintln!(
             "ACL entry created: {} (admin, context: {})",

--- a/vta-service/src/import_did.rs
+++ b/vta-service/src/import_did.rs
@@ -54,22 +54,9 @@ pub async fn run_import_did(args: ImportDidArgs) -> Result<(), Box<dyn std::erro
         }
     }
 
-    let entry = AclEntry {
-        did: args.did.clone(),
-        role: role.clone(),
-        label: args.label.clone(),
-        allowed_contexts: args.context.clone(),
-        created_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-        created_by: "cli:import-did".into(),
-        expires_at: None,
-        kind: Default::default(),
-        capabilities: Vec::new(),
-        device: None,
-        version: 0,
-    };
+    let entry = AclEntry::new(args.did.clone(), role.clone(), "cli:import-did")
+        .with_label(args.label.clone())
+        .with_contexts(args.context.clone());
 
     store_acl_entry(&acl_ks, &entry).await?;
     store.persist().await?;

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1960,22 +1960,9 @@ async fn run_bootstrap_admin(
     }
 
     // Create the super admin ACL entry
-    let entry = acl::AclEntry {
-        did: did.clone(),
-        role: acl::Role::Admin,
-        label,
-        allowed_contexts: vec![], // Empty = super admin
-        created_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-        created_by: "cli:bootstrap-admin".into(),
-        expires_at: None,
-        kind: Default::default(),
-        capabilities: Vec::new(),
-        device: None,
-        version: 0,
-    };
+    // Empty contexts = super admin
+    let entry =
+        acl::AclEntry::new(did.clone(), acl::Role::Admin, "cli:bootstrap-admin").with_label(label);
     acl::store_acl_entry(&acl_ks, &entry).await?;
 
     // Seal the VTA

--- a/vta-service/src/messaging/auth.rs
+++ b/vta-service/src/messaging/auth.rs
@@ -87,19 +87,10 @@ mod tests {
         let did = "did:key:zExpired";
         store_acl_entry(
             &acl_ks,
-            &AclEntry {
-                did: did.into(),
-                role: Role::Admin,
-                label: None,
-                allowed_contexts: vec!["ctx-a".into()],
-                created_at: now_epoch().saturating_sub(7200),
-                created_by: "test".into(),
-                expires_at: Some(now_epoch().saturating_sub(60)), // expired one minute ago
-                kind: Default::default(),
-                capabilities: Vec::new(),
-                device: None,
-                version: 0,
-            },
+            &AclEntry::new(did, Role::Admin, "test")
+                .with_contexts(vec!["ctx-a".into()])
+                .with_created_at(now_epoch().saturating_sub(7200))
+                .with_expires_at(Some(now_epoch().saturating_sub(60))), // expired one minute ago
         )
         .await
         .unwrap();
@@ -120,19 +111,9 @@ mod tests {
         let did = "did:key:zLive";
         store_acl_entry(
             &acl_ks,
-            &AclEntry {
-                did: did.into(),
-                role: Role::Admin,
-                label: None,
-                allowed_contexts: vec!["ctx-a".into(), "ctx-b".into()],
-                created_at: now_epoch(),
-                created_by: "test".into(),
-                expires_at: Some(now_epoch() + 3600),
-                kind: Default::default(),
-                capabilities: Vec::new(),
-                device: None,
-                version: 0,
-            },
+            &AclEntry::new(did, Role::Admin, "test")
+                .with_contexts(vec!["ctx-a".into(), "ctx-b".into()])
+                .with_expires_at(Some(now_epoch() + 3600)),
         )
         .await
         .unwrap();
@@ -150,24 +131,9 @@ mod tests {
     async fn fragment_in_sender_collapses_to_base_did() {
         let (_store, acl_ks, _dir) = fresh_acl_ks().await;
         let base = "did:key:zBase";
-        store_acl_entry(
-            &acl_ks,
-            &AclEntry {
-                did: base.into(),
-                role: Role::Reader,
-                label: None,
-                allowed_contexts: vec![],
-                created_at: now_epoch(),
-                created_by: "test".into(),
-                expires_at: None,
-                kind: Default::default(),
-                capabilities: Vec::new(),
-                device: None,
-                version: 0,
-            },
-        )
-        .await
-        .unwrap();
+        store_acl_entry(&acl_ks, &AclEntry::new(base, Role::Reader, "test"))
+            .await
+            .unwrap();
 
         let msg = message_from(&format!("{base}#zBase"));
         let claims = auth_from_message(&msg, &acl_ks).await.unwrap();

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -105,19 +105,10 @@ pub async fn create_acl(
         )));
     }
 
-    let entry = AclEntry {
-        did: did.to_string(),
-        role,
-        label,
-        allowed_contexts,
-        created_at: now_epoch(),
-        created_by: auth.did.clone(),
-        expires_at,
-        kind: Default::default(),
-        capabilities: Vec::new(),
-        device: None,
-        version: 0,
-    };
+    let entry = AclEntry::new(did, role, auth.did.clone())
+        .with_label(label)
+        .with_contexts(allowed_contexts)
+        .with_expires_at(expires_at);
 
     store_acl_entry(acl_ks, &entry).await?;
 
@@ -410,19 +401,13 @@ pub async fn swap_acl(
     // time-limited long-term entry can `acl change-role --expires
     // …` afterwards. See PR fixing this and the parallel
     // acl_sweeper change that audit-logs every deletion.
-    let entry = AclEntry {
-        did: new_did.clone(),
-        role: old.role.clone(),
-        label: old.label.clone(),
-        allowed_contexts: old.allowed_contexts.clone(),
-        created_at: now,
-        created_by: auth.did.clone(),
-        expires_at: None,
-        kind: old.kind.clone(),
-        capabilities: old.capabilities.clone(),
-        device: old.device.clone(),
-        version: 0,
-    };
+    let entry = AclEntry::new(new_did.clone(), old.role.clone(), auth.did.clone())
+        .with_label(old.label.clone())
+        .with_contexts(old.allowed_contexts.clone())
+        .with_created_at(now)
+        .with_kind(old.kind.clone())
+        .with_capabilities(old.capabilities.clone())
+        .with_device(old.device.clone());
 
     // Create new before deleting old: a crash between the two leaves the old
     // DID authoritative (stale, not locked out).
@@ -461,7 +446,6 @@ pub async fn swap_acl(
 mod tests {
     use super::*;
     use crate::acl::{AclEntry, store_acl_entry};
-    use crate::auth::session::now_epoch;
     use crate::store::Store;
     use vti_common::config::StoreConfig;
 
@@ -524,19 +508,8 @@ mod tests {
     async fn seed_target(acl_ks: &KeyspaceHandle, did: &str, contexts: &[&str]) {
         store_acl_entry(
             acl_ks,
-            &AclEntry {
-                did: did.into(),
-                role: Role::Admin,
-                label: None,
-                allowed_contexts: contexts.iter().map(|s| s.to_string()).collect(),
-                created_at: now_epoch(),
-                created_by: "seed".into(),
-                expires_at: None,
-                kind: Default::default(),
-                capabilities: Vec::new(),
-                device: None,
-                version: 0,
-            },
+            &AclEntry::new(did, Role::Admin, "seed")
+                .with_contexts(contexts.iter().map(|s| s.to_string()).collect()),
         )
         .await
         .unwrap();

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -1860,19 +1860,10 @@ mod tests {
         // (and doesn't need a separate auth ceremony for the grant).
         let request = signed_admin_rotation_request("vta-admin", "ctx-swap").await;
         let client_did = request.holder().to_string();
-        let ephemeral_row = AclEntry {
-            did: client_did.clone(),
-            role: Role::Admin,
-            label: Some("ephemeral".into()),
-            allowed_contexts: vec!["ctx-swap".into()],
-            created_at: 0,
-            created_by: "test".into(),
-            expires_at: None,
-            kind: Default::default(),
-            capabilities: vec![],
-            device: None,
-            version: 0,
-        };
+        let ephemeral_row = AclEntry::new(client_did.clone(), Role::Admin, "test")
+            .with_label(Some("ephemeral".into()))
+            .with_contexts(vec!["ctx-swap".into()])
+            .with_created_at(0);
         store_acl_entry(&deps.acl_ks, &ephemeral_row)
             .await
             .expect("seed ephemeral ACL row");

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -265,19 +265,9 @@ async fn mint_mode_b(
         .insert_raw(BOOTSTRAP_CARVEOUT_CLOSED_KEY, did.as_bytes().to_vec())
         .await?;
 
-    let entry = AclEntry {
-        did: did.clone(),
-        role: Role::Admin,
-        label: Some("TEE first-boot admin".to_string()),
-        allowed_contexts: vec![],
-        created_at: now,
-        created_by: "tee:mode-b".to_string(),
-        expires_at: None,
-        kind: Default::default(),
-        capabilities: vec![],
-        device: None,
-        version: 0,
-    };
+    let entry = AclEntry::new(did.clone(), Role::Admin, "tee:mode-b")
+        .with_label(Some("TEE first-boot admin".to_string()))
+        .with_created_at(now);
     store_acl_entry(&state.acl_ks, &entry).await?;
 
     let credential = CredentialBundle {

--- a/vta-service/src/seal.rs
+++ b/vta-service/src/seal.rs
@@ -340,7 +340,6 @@ fn verify_challenge_signature(
 mod tests {
     use super::*;
     use crate::acl::AclEntry;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     /// Seal a fresh store under `data_dir` with a single super-admin
     /// ACL entry. The store is opened, populated, and dropped — the
@@ -352,22 +351,8 @@ mod tests {
         let store = Store::open(&config).expect("open store");
         let acl_ks = store.keyspace("acl").expect("acl keyspace");
 
-        let entry = AclEntry {
-            did: admin_did.to_string(),
-            role: Role::Admin,
-            label: Some("test-super-admin".into()),
-            allowed_contexts: vec![],
-            created_at: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-            created_by: "test".into(),
-            expires_at: None,
-            kind: Default::default(),
-            capabilities: Vec::new(),
-            device: None,
-            version: 0,
-        };
+        let entry = AclEntry::new(admin_did, Role::Admin, "test")
+            .with_label(Some("test-super-admin".into()));
         acl::store_acl_entry(&acl_ks, &entry).await.expect("acl");
         seal(&acl_ks, admin_did).await.expect("seal");
         store.persist().await.expect("persist");

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1183,22 +1183,7 @@ async fn seed_initial_admin(
         .into());
     }
 
-    let entry = acl::AclEntry {
-        did: did.to_string(),
-        role: acl::Role::Admin,
-        label,
-        allowed_contexts: vec![],
-        created_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-        created_by: "cli:setup-from-file".into(),
-        expires_at: None,
-        kind: Default::default(),
-        capabilities: Vec::new(),
-        device: None,
-        version: 0,
-    };
+    let entry = acl::AclEntry::new(did, acl::Role::Admin, "cli:setup-from-file").with_label(label);
     acl::store_acl_entry(&acl_ks, &entry).await?;
     let _seal_record = seal::seal(&acl_ks, did).await?;
     store.persist().await?;

--- a/vta-service/src/tee/admin_bootstrap.rs
+++ b/vta-service/src/tee/admin_bootstrap.rs
@@ -114,19 +114,8 @@ pub async fn maybe_bootstrap_admin(
         // closed immediately because the admin identity is already known.
         info!(did = %admin_did, context_id, "bootstrapping super-admin from config admin_did");
 
-        let entry = AclEntry {
-            did: admin_did.clone(),
-            role: Role::Admin,
-            label: Some("TEE bootstrap admin".to_string()),
-            allowed_contexts: vec![],
-            created_at: now_epoch(),
-            created_by: "tee:bootstrap".to_string(),
-            expires_at: None,
-            kind: Default::default(),
-            capabilities: vec![],
-            device: None,
-            version: 0,
-        };
+        let entry = AclEntry::new(admin_did.clone(), Role::Admin, "tee:bootstrap")
+            .with_label(Some("TEE bootstrap admin".to_string()));
         store_acl_entry(&acl_ks, &entry).await?;
 
         keys_ks

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -250,6 +250,79 @@ pub struct AclEntry {
 }
 
 impl AclEntry {
+    /// Create an entry with the required identity fields. Optional metadata
+    /// takes sensible defaults: no `label`, no `allowed_contexts`, never
+    /// expires, default [`ConsumerKind`], no `capabilities`, no `device`
+    /// binding, `version = 0`, and `created_at = now`. Layer non-defaults on
+    /// with the `with_*` builder methods.
+    ///
+    /// This is the single construction entry point — adding a new optional
+    /// field here defaults it everywhere, so callers don't churn.
+    pub fn new(did: impl Into<String>, role: Role, created_by: impl Into<String>) -> Self {
+        Self {
+            did: did.into(),
+            role,
+            label: None,
+            allowed_contexts: Vec::new(),
+            created_at: crate::auth::session::now_epoch(),
+            created_by: created_by.into(),
+            expires_at: None,
+            kind: ConsumerKind::default(),
+            capabilities: Vec::new(),
+            device: None,
+            version: 0,
+        }
+    }
+
+    /// Override `created_at` (defaults to now). Use when replaying a known
+    /// timestamp — bootstrap import, tests, migration.
+    pub fn with_created_at(mut self, created_at: u64) -> Self {
+        self.created_at = created_at;
+        self
+    }
+
+    /// Set the optional human-readable label.
+    pub fn with_label(mut self, label: Option<String>) -> Self {
+        self.label = label;
+        self
+    }
+
+    /// Set the allowed-contexts (scope) list.
+    pub fn with_contexts(mut self, allowed_contexts: Vec<String>) -> Self {
+        self.allowed_contexts = allowed_contexts;
+        self
+    }
+
+    /// Set the optional expiry (unix seconds). `None` is permanent.
+    pub fn with_expires_at(mut self, expires_at: Option<u64>) -> Self {
+        self.expires_at = expires_at;
+        self
+    }
+
+    /// Set the consumer kind (Companion vs Service).
+    pub fn with_kind(mut self, kind: ConsumerKind) -> Self {
+        self.kind = kind;
+        self
+    }
+
+    /// Set the fine-grained capability set.
+    pub fn with_capabilities(mut self, capabilities: Vec<Capability>) -> Self {
+        self.capabilities = capabilities;
+        self
+    }
+
+    /// Attach optional Companion/Service device-binding metadata.
+    pub fn with_device(mut self, device: Option<DeviceBinding>) -> Self {
+        self.device = device;
+        self
+    }
+
+    /// Set the optimistic-concurrency version (defaults to 0).
+    pub fn with_version(mut self, version: u32) -> Self {
+        self.version = version;
+        self
+    }
+
     /// Returns true if this entry has passed its configured `expires_at`.
     /// Permanent entries (no `expires_at`) never expire.
     pub fn is_expired(&self, now_unix: u64) -> bool {
@@ -463,35 +536,12 @@ mod tests {
     }
 
     fn sample_entry(did: &str, role: Role) -> AclEntry {
-        AclEntry {
-            did: did.to_string(),
-            role,
-            label: Some(format!("test-{did}")),
-            allowed_contexts: vec![],
-            created_at: now_epoch(),
-            created_by: "did:key:zSetup".into(),
-            expires_at: None,
-            kind: Default::default(),
-            capabilities: Vec::new(),
-            device: None,
-            version: 0,
-        }
+        AclEntry::new(did, role, "did:key:zSetup").with_label(Some(format!("test-{did}")))
     }
 
     fn scoped_entry(did: &str, role: Role, contexts: &[&str]) -> AclEntry {
-        AclEntry {
-            did: did.to_string(),
-            role,
-            label: None,
-            allowed_contexts: contexts.iter().map(|s| s.to_string()).collect(),
-            created_at: now_epoch(),
-            created_by: "did:key:zSetup".into(),
-            expires_at: None,
-            kind: Default::default(),
-            capabilities: Vec::new(),
-            device: None,
-            version: 0,
-        }
+        AclEntry::new(did, role, "did:key:zSetup")
+            .with_contexts(contexts.iter().map(|s| s.to_string()).collect())
     }
 
     fn super_admin_claims() -> AuthClaims {


### PR DESCRIPTION
## Summary

Prep refactor before adding the step-up approver to `AclEntry`. `AclEntry` had **no constructor** — every one of ~21 construction sites hand-wrote the full struct literal, repeating the `kind / capabilities / device / version` default tail. Each accreted field (M1 `kind`, capabilities, M4 `device`, M6 `version`) churned every site; the next field (`step_up_approver`) would too.

Adds `AclEntry::new(did, role, created_by)` (metadata defaults; `created_at = now`) plus `with_*` builder methods, and converts every literal in `vti-common` + `vta-service` to it.

```rust
AclEntry::new(did, role, &auth.did)
    .with_label(label)
    .with_contexts(allowed_contexts)
    .with_expires_at(expires_at)
```

## Why now
We've been accreting `AclEntry` fields slice-by-slice without stopping to tidy the construction story. The 24-site churn was the blocker that pushed me toward a separate `step_up_approvers` keyspace for the approver. With a builder, **a new optional field is zero-churn** — one struct field + one `with_*` + the constructor default. So the approver can live **directly on `AclEntry`** (matching the spec's `stepUp.approver` wire shape) in the follow-up, no keyspace workaround.

## Safety
- **Serialized shape unchanged** — fields stay flat with `#[serde(default)]`; stored rows are byte-identical. Pure construction-ergonomics refactor.
- Behavior-preserving: `vti-common` (228) and `vta-service` (518 lib + 104 api_integration + the rest) suites pass **unchanged**; `clippy` + `fmt` clean. Removed three imports the conversions made unused.

## Follow-up
Next PR adds `step_up_approver: Option<String>` to `AclEntry` via the builder + the gate's delegated-mode routing (addresses the approve-request to the approver; fail-closed when absent) — the bridge to #49.

## Not in scope (flagged for later)
The internal `AclEntry` (`did`/`allowed_contexts`, no `updated_at/by`) has drifted from the wire `AclEntry` in trust-tasks-rs (`subject`/`scopes`, `updatedAt/By`, `ext`). Reconciling those two shapes is a separate, larger question.