### PR TITLE
feat(vta): delegated-mode step-up routing to AclEntry.stepUp.approver

### DIFF
--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -34,8 +34,9 @@ use crate::operations::passkey_login::{
     VtaVmResolver, enumerate_passkey_vms, verify_passkey_login,
 };
 use crate::server::AppState;
+use vti_common::acl::get_acl_entry;
 use vti_common::auth::step_up::{
-    ConsumeOutcome, consume_pending_step_up, new_pending_step_up, store_pending_step_up,
+    ConsumeOutcome, StepUpMode, consume_pending_step_up, new_pending_step_up, store_pending_step_up,
 };
 use vti_common::store::KeyspaceHandle;
 
@@ -397,6 +398,7 @@ async fn mint_pending_step_up(
     sessions_ks: &KeyspaceHandle,
     vta_did: &str,
     subject: &str,
+    recipient: &str,
     session_id: &str,
     reason: &str,
 ) -> Result<Value, ()> {
@@ -426,7 +428,9 @@ async fn mint_pending_step_up(
         "id": format!("urn:uuid:{}", Uuid::new_v4()),
         "type": "https://trusttasks.org/spec/auth/step-up/approve-request/0.1",
         "issuer": vta_did,
-        "recipient": subject,
+        // `recipient` is the approver the request is addressed to: the subject
+        // itself for `self` mode, or the configured delegated approver.
+        "recipient": recipient,
         "payload": {
             "subject": subject,
             "sessionId": session_id,
@@ -449,11 +453,14 @@ pub(crate) async fn issue_step_up_challenge(
     sessions_ks: &KeyspaceHandle,
     vta_did: &str,
     subject: &str,
+    recipient: &str,
     session_id: &str,
     reason: &str,
 ) -> Response {
     let approve_request =
-        match mint_pending_step_up(sessions_ks, vta_did, subject, session_id, reason).await {
+        match mint_pending_step_up(sessions_ks, vta_did, subject, recipient, session_id, reason)
+            .await
+        {
             Ok(ar) => ar,
             Err(()) => {
                 return (
@@ -479,6 +486,84 @@ pub(crate) async fn issue_step_up_challenge(
         .into_response()
 }
 
+/// REST `403` for the **fail-closed** case: the operation requires AAL2 but no
+/// step-up method exists for the caller (a `delegated` floor with no
+/// `stepUp.approver` on the caller's ACL entry). Unlike
+/// [`issue_step_up_challenge`], this carries **no** approve-request — there's
+/// nothing the caller can do to elevate until an operator registers an
+/// approver, so we deny rather than hand back a request that can't be satisfied.
+fn step_up_denied_response() -> Response {
+    let body = json!({
+        "error": "step_up_required",
+        "requiredAcr": STEP_UP_TARGET_ACR,
+        "reason": "no step-up approver is configured for this subject; an operator must register one",
+    });
+    (
+        StatusCode::FORBIDDEN,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        serde_json::to_vec(&body).unwrap_or_default(),
+    )
+        .into_response()
+}
+
+/// Step-up enforcement decision resolved from the policy floor for an
+/// operation-class, plus (for `delegated` modes) the caller's configured
+/// approver.
+enum StepUpDecision {
+    /// Not gated — proceed at AAL1 (disabled policy, `none` floor, or the
+    /// non-escalation carve-out applied).
+    Allow,
+    /// Gated — mint an approve-request addressed to `recipient` (the subject
+    /// itself for `self` mode, or the delegated approver).
+    Require { recipient: String },
+    /// Gated, but no usable step-up method exists (a `delegated` floor with no
+    /// approver on the caller's entry) — fail closed.
+    Deny,
+}
+
+/// Resolve the step-up decision for `op_class` requested by `caller_did`.
+///
+/// `is_non_escalating` is the structural carve-out signal (true only for
+/// self-service ops like `acl/swap-key`); it lets a floor with
+/// `allow_aal1_if_non_escalating` admit the op at AAL1.
+async fn resolve_step_up(
+    state: &AppState,
+    op_class: &str,
+    caller_did: &str,
+    is_non_escalating: bool,
+) -> StepUpDecision {
+    let (mode, allow_carveout) = {
+        let cfg = state.config.read().await;
+        match cfg.auth.step_up.floor_record(op_class) {
+            None => return StepUpDecision::Allow,
+            Some(f) => (f.mode, f.allow_aal1_if_non_escalating),
+        }
+    };
+    if !mode.requires_aal2() || (allow_carveout && is_non_escalating) {
+        return StepUpDecision::Allow;
+    }
+    match mode {
+        StepUpMode::None => StepUpDecision::Allow,
+        StepUpMode::SelfApprove => StepUpDecision::Require {
+            recipient: caller_did.to_string(),
+        },
+        // Delegated (and delegated-any, until a broader approver criterion is
+        // defined) route to the caller's configured approver; absent one, fail
+        // closed rather than let the subject self-approve a delegated gate.
+        StepUpMode::Delegated | StepUpMode::DelegatedAny => {
+            match get_acl_entry(&state.acl_ks, caller_did).await {
+                Ok(Some(entry)) => match entry.step_up_approver {
+                    Some(approver) => StepUpDecision::Require {
+                        recipient: approver,
+                    },
+                    None => StepUpDecision::Deny,
+                },
+                _ => StepUpDecision::Deny,
+            }
+        }
+    }
+}
+
 /// Trust-task analogue of [`issue_step_up_challenge`]: enforce a stepped-up
 /// (AAL2) session inside a dispatcher handler.
 ///
@@ -498,21 +583,37 @@ pub(super) async fn require_step_up(
     if auth.acr == STEP_UP_TARGET_ACR {
         return None;
     }
-    let (vta_did, gated) = {
-        let cfg = state.config.read().await;
-        // Resolve the step-up floor for this operation-class (most specific
-        // floor, else the `*` catch-all, else none). A disabled policy
-        // yields `None` → not gated → the operation proceeds at AAL1.
-        let gated = cfg.auth.step_up.floor_for(op_class).requires_aal2();
-        (cfg.vta_did.clone().unwrap_or_default(), gated)
+    // Trust-task gated ops (grant, change-role, revoke, context-delete,
+    // key-revoke) are all escalating — they never qualify for the
+    // non-escalation carve-out.
+    let recipient = match resolve_step_up(state, op_class, &auth.did, false).await {
+        StepUpDecision::Allow => return None,
+        StepUpDecision::Require { recipient } => recipient,
+        StepUpDecision::Deny => {
+            return Some(reject_with(
+                doc,
+                RejectReason::TaskFailed {
+                    reason: "auth:step_up_required".to_string(),
+                    details: Some(json!({
+                        "requiredAcr": STEP_UP_TARGET_ACR,
+                        "reason": "no step-up approver is configured for this subject",
+                    })),
+                },
+            ));
+        }
     };
-    if !gated {
-        return None;
-    }
+    let vta_did = state
+        .config
+        .read()
+        .await
+        .vta_did
+        .clone()
+        .unwrap_or_default();
     let reject = match mint_pending_step_up(
         &state.sessions_ks,
         &vta_did,
         &auth.did,
+        &recipient,
         &auth.session_id,
         "this operation requires a stepped-up (AAL2) session",
     )
@@ -604,31 +705,27 @@ impl<O: StepUpOp> FromRequestParts<AppState> for RequireStepUp<O> {
         if claims.acr == "aal2" {
             return Ok(RequireStepUp(std::marker::PhantomData));
         }
-        let (vta_did, gated) = {
-            let cfg = state.config.read().await;
-            // Resolve the floor for this route's operation-class. A disabled
-            // policy (or no matching floor) is not gated → proceed at AAL1.
-            // Non-escalation carve-out: a floor that requires AAL2 still
-            // admits a structurally non-escalating op (e.g. self key-rotation
-            // via `acl/swap-key`) at AAL1 when it sets
-            // `allow_aal1_if_non_escalating` — so a holder with no authenticator
-            // yet can still rotate. Escalating ops never qualify.
-            let gated = match cfg.auth.step_up.floor_record(O::OP_CLASS) {
-                None => false,
-                Some(f) => {
-                    f.mode.requires_aal2()
-                        && !(f.allow_aal1_if_non_escalating && O::IS_NON_ESCALATING)
-                }
+        // Resolve the floor for this route's operation-class, honoring the
+        // non-escalation carve-out (`O::IS_NON_ESCALATING`) and, for delegated
+        // modes, routing to the caller's configured approver.
+        let recipient =
+            match resolve_step_up(state, O::OP_CLASS, &claims.did, O::IS_NON_ESCALATING).await {
+                StepUpDecision::Allow => return Ok(RequireStepUp(std::marker::PhantomData)),
+                StepUpDecision::Require { recipient } => recipient,
+                StepUpDecision::Deny => return Err(step_up_denied_response()),
             };
-            (cfg.vta_did.clone().unwrap_or_default(), gated)
-        };
-        if !gated {
-            return Ok(RequireStepUp(std::marker::PhantomData));
-        }
+        let vta_did = state
+            .config
+            .read()
+            .await
+            .vta_did
+            .clone()
+            .unwrap_or_default();
         Err(issue_step_up_challenge(
             &state.sessions_ks,
             &vta_did,
             &claims.did,
+            &recipient,
             &claims.session_id,
             "this operation requires a stepped-up (AAL2) session",
         )
@@ -662,6 +759,8 @@ mod tests {
         let resp = issue_step_up_challenge(
             &ks,
             "did:web:vta.example",
+            "did:key:zHolder",
+            // self-approval: recipient == subject
             "did:key:zHolder",
             "sess-9",
             "rotate keys",

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -196,19 +196,7 @@ impl TestContext {
     /// Create an ACL entry for a DID.
     #[allow(dead_code)]
     async fn create_acl(&self, did: &str, role: Role, contexts: Vec<String>) {
-        let entry = vti_common::acl::AclEntry {
-            did: did.to_string(),
-            role,
-            label: None,
-            allowed_contexts: contexts,
-            created_at: now_epoch(),
-            created_by: "test".to_string(),
-            expires_at: None,
-            kind: Default::default(),
-            capabilities: vec![],
-            device: None,
-            version: 0,
-        };
+        let entry = vti_common::acl::AclEntry::new(did, role, "test").with_contexts(contexts);
         self.acl_ks()
             .insert(format!("acl:{did}"), &entry)
             .await
@@ -602,6 +590,83 @@ async fn swap_key_gated_without_carve_out() {
         "swap-key must be gated: {body}"
     );
     assert_eq!(body["error"], "step_up_required");
+}
+
+#[tokio::test]
+async fn delegated_step_up_routes_to_configured_approver() {
+    use vti_common::acl::{AclEntry, Role, store_acl_entry};
+    use vti_common::auth::step_up::{StepUpFloor, StepUpMode};
+    let (app, ctx) = TestApp::new().await;
+    let caller = "did:key:z6MkAdmin";
+    let approver = "did:key:z6MkApprover";
+    // The caller's ACL entry names its delegated approver.
+    store_acl_entry(
+        ctx.acl_ks(),
+        &AclEntry::new(caller, Role::Admin, "test")
+            .with_step_up_approver(Some(approver.to_string())),
+    )
+    .await
+    .unwrap();
+    ctx.set_step_up_floors(vec![StepUpFloor {
+        operation: "acl/grant".into(),
+        mode: StepUpMode::Delegated,
+        allow_aal1_if_non_escalating: false,
+    }])
+    .await;
+    let token = ctx.auth_token(caller, "admin", vec![]).await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/acl",
+            &token,
+            json!({ "did": "did:key:z6MkNew", "role": "application", "allowed_contexts": ["ctx1"] }),
+        ))
+        .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+    assert_eq!(body["error"], "step_up_required");
+    // The approve-request is addressed to the configured approver, not the caller.
+    assert_eq!(
+        body["approveRequest"]["recipient"], approver,
+        "delegated approve-request must be addressed to the configured approver: {body}"
+    );
+}
+
+#[tokio::test]
+async fn delegated_step_up_without_approver_fails_closed() {
+    use vti_common::acl::{AclEntry, Role, store_acl_entry};
+    use vti_common::auth::step_up::{StepUpFloor, StepUpMode};
+    let (app, ctx) = TestApp::new().await;
+    let caller = "did:key:z6MkNoApprover";
+    // ACL entry with NO step-up approver under a delegated floor.
+    store_acl_entry(ctx.acl_ks(), &AclEntry::new(caller, Role::Admin, "test"))
+        .await
+        .unwrap();
+    ctx.set_step_up_floors(vec![StepUpFloor {
+        operation: "acl/grant".into(),
+        mode: StepUpMode::Delegated,
+        allow_aal1_if_non_escalating: false,
+    }])
+    .await;
+    let token = ctx.auth_token(caller, "admin", vec![]).await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/acl",
+            &token,
+            json!({ "did": "did:key:z6MkNew2", "role": "application", "allowed_contexts": ["ctx1"] }),
+        ))
+        .await;
+
+    // Fail-closed: 403 with no approve-request (nothing the caller can do until
+    // an operator registers an approver — the subject can't self-approve a
+    // delegated requirement).
+    assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+    assert_eq!(body["error"], "step_up_required");
+    assert!(
+        body.get("approveRequest").is_none(),
+        "fail-closed must not carry an approve-request: {body}"
+    );
 }
 
 #[tokio::test]

--- a/vta-service/tests/auth_flow.rs
+++ b/vta-service/tests/auth_flow.rs
@@ -62,19 +62,8 @@ async fn challenge_endpoint_issues_session_and_persists_it() {
 
     let did = "did:key:z6MkChallengeTester";
     // Pre-grant the DID admin access so it passes the ACL check.
-    let entry = vti_common::acl::AclEntry {
-        did: did.into(),
-        role: vti_common::acl::Role::Admin,
-        label: None,
-        allowed_contexts: vec![],
-        created_at: 1,
-        created_by: "test".into(),
-        expires_at: None,
-        kind: Default::default(),
-        capabilities: vec![],
-        device: None,
-        version: 0,
-    };
+    let entry = vti_common::acl::AclEntry::new(did, vti_common::acl::Role::Admin, "test")
+        .with_created_at(1);
     vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
         .await
         .expect("seed admin ACL");

--- a/vta-service/tests/authenticate_trust_task.rs
+++ b/vta-service/tests/authenticate_trust_task.rs
@@ -37,19 +37,8 @@ fn did_key(sk: &SigningKey) -> (String, String) {
 /// Grant `did` admin access so it clears the `/auth/challenge` ACL gate and the
 /// authenticate role re-lookup.
 async fn seed_admin_acl(ctx: &TestAppContext, did: &str) {
-    let entry = vti_common::acl::AclEntry {
-        did: did.into(),
-        role: vti_common::acl::Role::Admin,
-        label: None,
-        allowed_contexts: vec![],
-        created_at: 1,
-        created_by: "test".into(),
-        expires_at: None,
-        kind: Default::default(),
-        capabilities: vec![],
-        device: None,
-        version: 0,
-    };
+    let entry = vti_common::acl::AclEntry::new(did, vti_common::acl::Role::Admin, "test")
+        .with_created_at(1);
     vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
         .await
         .expect("seed admin ACL");

--- a/vta-service/tests/refresh_trust_task.rs
+++ b/vta-service/tests/refresh_trust_task.rs
@@ -19,19 +19,8 @@ use vti_common::auth::session::{
 };
 
 async fn seed_admin_acl(ctx: &TestAppContext, did: &str) {
-    let entry = vti_common::acl::AclEntry {
-        did: did.into(),
-        role: vti_common::acl::Role::Admin,
-        label: None,
-        allowed_contexts: vec![],
-        created_at: 1,
-        created_by: "test".into(),
-        expires_at: None,
-        kind: Default::default(),
-        capabilities: vec![],
-        device: None,
-        version: 0,
-    };
+    let entry = vti_common::acl::AclEntry::new(did, vti_common::acl::Role::Admin, "test")
+        .with_created_at(1);
     vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
         .await
         .expect("seed admin ACL");

--- a/vta-service/tests/whoami_trust_task.rs
+++ b/vta-service/tests/whoami_trust_task.rs
@@ -17,19 +17,9 @@ use vta_service::test_support::{TestAppContext, build_test_app};
 use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
 
 async fn seed_admin_acl(ctx: &TestAppContext, did: &str, contexts: Vec<String>) {
-    let entry = vti_common::acl::AclEntry {
-        did: did.into(),
-        role: vti_common::acl::Role::Admin,
-        label: None,
-        allowed_contexts: contexts,
-        created_at: 1,
-        created_by: "test".into(),
-        expires_at: None,
-        kind: Default::default(),
-        capabilities: vec![],
-        device: None,
-        version: 0,
-    };
+    let entry = vti_common::acl::AclEntry::new(did, vti_common::acl::Role::Admin, "test")
+        .with_contexts(contexts)
+        .with_created_at(1);
     vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
         .await
         .expect("seed admin ACL");

--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -230,22 +230,15 @@ pub async fn delete_acl(
 /// match), which is fine because these helpers ignore the role
 /// field entirely.
 fn as_vti_acl_entry(e: &VtcAclEntry) -> vti_common::acl::AclEntry {
-    vti_common::acl::AclEntry {
-        did: e.did.clone(),
-        role: match e.role {
-            VtcRole::Admin => vti_common::acl::Role::Admin,
-            _ => vti_common::acl::Role::Reader,
-        },
-        label: e.label.clone(),
-        allowed_contexts: e.allowed_contexts.clone(),
-        created_at: e.created_at,
-        created_by: e.created_by.clone(),
-        expires_at: e.expires_at,
-        kind: Default::default(),
-        capabilities: vec![],
-        device: None,
-        version: 0,
-    }
+    let role = match e.role {
+        VtcRole::Admin => vti_common::acl::Role::Admin,
+        _ => vti_common::acl::Role::Reader,
+    };
+    vti_common::acl::AclEntry::new(e.did.clone(), role, e.created_by.clone())
+        .with_label(e.label.clone())
+        .with_contexts(e.allowed_contexts.clone())
+        .with_created_at(e.created_at)
+        .with_expires_at(e.expires_at)
 }
 
 #[cfg(test)]

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -153,19 +153,8 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         created_at: Utc::now(),
     };
     store_admin_entry(&passkey_ks, &admin_entry).await.unwrap();
-    let acl_entry = AclEntry {
-        did: admin_did.clone(),
-        role: Role::Admin,
-        label: Some("install bootstrap".into()),
-        allowed_contexts: vec![],
-        created_at: now_epoch(),
-        created_by: "did:key:vtc-install".into(),
-        expires_at: None,
-        kind: Default::default(),
-        capabilities: vec![],
-        device: None,
-        version: 0,
-    };
+    let acl_entry = AclEntry::new(admin_did.clone(), Role::Admin, "did:key:vtc-install")
+        .with_label(Some("install bootstrap".into()));
     store_acl_entry(&acl_ks, &acl_entry).await.unwrap();
 
     let audit_writer = if with_audit {

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -264,19 +264,9 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
 
     store_acl_entry(
         &acl_ks,
-        &AclEntry {
-            did: admin_did.clone(),
-            role: Role::Admin,
-            label: Some("old admin".into()),
-            allowed_contexts: vec![],
-            created_at: 0,
-            created_by: "did:key:vtc-install".into(),
-            expires_at: None,
-            kind: Default::default(),
-            capabilities: vec![],
-            device: None,
-            version: 0,
-        },
+        &AclEntry::new(admin_did.clone(), Role::Admin, "did:key:vtc-install")
+            .with_label(Some("old admin".into()))
+            .with_created_at(0),
     )
     .await
     .unwrap();

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -247,6 +247,17 @@ pub struct AclEntry {
     /// with `version=0`. The first update bumps it to 1.
     #[serde(default)]
     pub version: u32,
+    /// VID authorized to ratify an AAL2 step-up for this subject — the
+    /// `recipient` the VTA addresses an `auth/step-up/approve-request/0.1` to
+    /// when a gated operation resolves to `delegated` mode (the holder's
+    /// mobile authenticator or browser companion). `None` means no delegated
+    /// approver is configured: under a `delegated` floor the operation
+    /// fail-closes (the subject can't self-approve a delegated requirement).
+    /// Mirrors the spec's `AclEntry.stepUp.approver`.
+    ///
+    /// `#[serde(default)]` so pre-existing rows deserialise as `None`.
+    #[serde(default)]
+    pub step_up_approver: Option<String>,
 }
 
 impl AclEntry {
@@ -271,6 +282,7 @@ impl AclEntry {
             capabilities: Vec::new(),
             device: None,
             version: 0,
+            step_up_approver: None,
         }
     }
 
@@ -314,6 +326,12 @@ impl AclEntry {
     /// Attach optional Companion/Service device-binding metadata.
     pub fn with_device(mut self, device: Option<DeviceBinding>) -> Self {
         self.device = device;
+        self
+    }
+
+    /// Set the delegated step-up approver VID (`stepUp.approver`).
+    pub fn with_step_up_approver(mut self, approver: Option<String>) -> Self {
+        self.step_up_approver = approver;
         self
     }
 


### PR DESCRIPTION
## Summary

Completes the step-up policy's **delegated mode** — the VTA-side bridge to the mobile/browser approver (#49). Now possible cleanly thanks to the `AclEntry` builder (#195).

- **`vti-common`**: `AclEntry.step_up_approver: Option<String>` + a `with_step_up_approver` builder method. Zero churn (the builder defaults it; `#[serde(default)]` so existing rows deserialise as `None`). Mirrors the spec's `AclEntry.stepUp.approver`.
- **`vta-service`**: a shared `resolve_step_up` decides per gated request:
  - `self` → approve-request addressed to the subject (today's behaviour),
  - `delegated` / `delegated-any` → addressed to the caller's `step_up_approver`; **fail-closed** (403, *no* approve-request) when none is configured — the subject can't self-approve a delegated gate,
  - disabled-default and the non-escalation carve-out still short-circuit.
  Both gate surfaces (the REST `RequireStepUp` extractor and the trust-task `require_step_up`) route through it; `mint_pending_step_up` / `issue_step_up_challenge` take the resolved `recipient`.
- **Cleanup**: finished #195's builder conversion for the sites it missed (`vta-service/tests` + `vtc-service`'s `vti_common::acl::AclEntry` literals), so the new field stays zero-churn. `VtcAclEntry` (a distinct type) is untouched.

## Tests
- `delegated_step_up_routes_to_configured_approver` — a `delegated` floor routes the approve-request `recipient` to the entry's configured approver.
- `delegated_step_up_without_approver_fails_closed` — a `delegated` floor with no approver → 403 with **no** approve-request.

## CI
- `cargo fmt --check` ✅ · `cargo clippy -p vti-common -p vta-service -p vtc-service --all-targets` ✅
- Tests ✅ — vta-service (518 lib + 106 api_integration + rest), vti-common (228), vtc-service (all).

## Scope note
This is the VTA-side **addressing** of the approve-request. The actual **delivery** to the mobile/browser approver (DIDComm push via mediator / APNs) is #49's transport work.

## Remaining for the policy epic (#50)
Just the **management surface**: `vta step-up policy {show,set,disable}` CLI (break-glass) + how operators set `step_up_approver` on entries (acl/grant wire field + CLI) + the wire `auth/step-up/policy/0.1` handler.