### PR TITLE
feat(vta): set delegated step-up approver at grant time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Set a delegated step-up approver at grant time
+
+The ACL create/grant body gains an optional `step_up_approver` — the VID a
+delegated AAL2 step-up's approve-request is addressed to (the holder's
+mobile/browser approver). It's stored on the entry and read by the step-up
+gate's delegated mode. Makes delegated step-up operable end-to-end:
+previously the gate could route to an approver but there was no way to set
+one outside tests.
+
+- `vta-sdk` `CreateAclBody` + `CreateAclResultBody` gain
+  `step_up_approver: Option<String>` (additive, `serde(default)`); the REST
+  `POST /acl` request + the `vta/acl/create/1.0` trust task accept it and
+  the result reflects it. `vta-sdk` 0.9.2 → 0.9.3.
+- Still pending: setting/clearing the approver on an *existing* entry
+  (`acl/update`) and the wire `auth/step-up/policy/0.1` handler for remote
+  policy management.
+
 ### Key rotation goes through `acl/swap-key`
 
 The SDK's first-auth key rotation (`session::rotate_key`, REST path) now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.2",
+ "vta-sdk 0.9.3",
 ]
 
 [[package]]
@@ -2968,7 +2968,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.2",
+ "vta-sdk 0.9.3",
 ]
 
 [[package]]
@@ -6269,7 +6269,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.2",
+ "vta-sdk 0.9.3",
 ]
 
 [[package]]
@@ -9470,7 +9470,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.2",
+ "vta-sdk 0.9.3",
  "x25519-dalek",
 ]
 
@@ -9539,7 +9539,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9655,7 +9655,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.2",
+ "vta-sdk 0.9.3",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9731,7 +9731,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.2",
+ "vta-sdk 0.9.3",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9774,7 +9774,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.2",
+ "vta-sdk 0.9.3",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9801,7 +9801,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.2",
+ "vta-sdk 0.9.3",
  "vta-service",
  "vti-common",
 ]

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -11,6 +11,12 @@ pub struct CreateAclBody {
     /// Unix-epoch seconds at which the entry auto-expires. `None` = permanent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
+    /// VID authorized to ratify a delegated AAL2 step-up for this subject —
+    /// the `recipient` an `auth/step-up/approve-request/0.1` is addressed to
+    /// (the holder's mobile/browser approver). Stored on the ACL entry as
+    /// `step_up_approver`. `None` = no delegated approver configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_up_approver: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -24,4 +30,8 @@ pub struct CreateAclResultBody {
     /// Unix-epoch seconds at which the entry auto-expires, if set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
+    /// The delegated step-up approver the maintainer now holds for this
+    /// subject, if any (echoes the stored `step_up_approver`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_up_approver: Option<String>,
 }

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -540,6 +540,7 @@ pub async fn handle_create_acl(
             body.label,
             body.allowed_contexts,
             body.expires_at,
+            body.step_up_approver,
             "didcomm",
         )
         .await

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -78,6 +78,7 @@ fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
         created_at: e.created_at,
         created_by: e.created_by.clone(),
         expires_at: e.expires_at,
+        step_up_approver: e.step_up_approver.clone(),
     }
 }
 
@@ -92,6 +93,7 @@ pub async fn create_acl(
     label: Option<String>,
     allowed_contexts: Vec<String>,
     expires_at: Option<u64>,
+    step_up_approver: Option<String>,
     channel: &str,
 ) -> Result<CreateAclResultBody, AppError> {
     auth.require_manage()?;
@@ -108,7 +110,8 @@ pub async fn create_acl(
     let entry = AclEntry::new(did, role, auth.did.clone())
         .with_label(label)
         .with_contexts(allowed_contexts)
-        .with_expires_at(expires_at);
+        .with_expires_at(expires_at)
+        .with_step_up_approver(step_up_approver);
 
     store_acl_entry(acl_ks, &entry).await?;
 
@@ -665,6 +668,7 @@ mod tests {
             None,
             vec!["ctx-typo".into()],
             None,
+            None,
             "test",
         )
         .await
@@ -696,6 +700,7 @@ mod tests {
             Role::Admin,
             None,
             vec!["ctx-real".into()],
+            None,
             None,
             "test",
         )

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -588,6 +588,7 @@ pub async fn provision_integration(
         request.label().map(str::to_string),
         vec![context.clone()],
         None,
+        None,
         "provision-integration",
     )
     .await
@@ -855,6 +856,7 @@ async fn provision_admin_rotation(
         Role::Admin,
         request.label().map(str::to_string),
         vec![context.to_string()],
+        None,
         None,
         "provision-integration",
     )

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -41,6 +41,10 @@ pub struct CreateAclRequest {
     /// `null` for a permanent entry.
     #[serde(default)]
     pub expires_at: Option<u64>,
+    /// VID authorized to ratify a delegated AAL2 step-up for this subject
+    /// (the approve-request `recipient`). Omit for no delegated approver.
+    #[serde(default)]
+    pub step_up_approver: Option<String>,
 }
 
 /// POST /acl — create a new ACL entry for a DID. Auth: Admin or Initiator.
@@ -63,6 +67,7 @@ pub async fn create_acl(
         req.label,
         req.allowed_contexts,
         req.expires_at,
+        req.step_up_approver,
         "rest",
     )
     .await?;

--- a/vta-service/src/routes/trust_tasks/acl.rs
+++ b/vta-service/src/routes/trust_tasks/acl.rs
@@ -99,6 +99,7 @@ pub(super) async fn handle_create(
         req.label,
         req.allowed_contexts,
         req.expires_at,
+        req.step_up_approver,
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -593,6 +593,33 @@ async fn swap_key_gated_without_carve_out() {
 }
 
 #[tokio::test]
+async fn acl_grant_persists_step_up_approver() {
+    let (app, ctx) = TestApp::new().await;
+    // Step-up ships disabled, so an AAL1 admin can grant without a gate.
+    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/acl",
+            &token,
+            json!({
+                "did": "did:key:z6MkGrantee",
+                "role": "application",
+                "allowed_contexts": ["ctx1"],
+                "step_up_approver": "did:key:z6MkApprover"
+            }),
+        ))
+        .await;
+
+    assert!(status.is_success(), "grant should succeed: {status} {body}");
+    // The configured approver round-trips through the create result.
+    assert_eq!(
+        body["step_up_approver"], "did:key:z6MkApprover",
+        "grant must persist + reflect the step-up approver: {body}"
+    );
+}
+
+#[tokio::test]
 async fn delegated_step_up_routes_to_configured_approver() {
     use vti_common::acl::{AclEntry, Role, store_acl_entry};
     use vti_common::auth::step_up::{StepUpFloor, StepUpMode};


### PR DESCRIPTION
## Summary

Makes delegated step-up (#196) **operable end-to-end**. Until now the gate could *route* an approve-request to an approver, but nothing could *set* one outside tests. This threads `step_up_approver` through the grant path.

- **`vta-sdk`** `CreateAclBody` + `CreateAclResultBody` gain `step_up_approver: Option<String>` (additive, `serde(default)`).
- **`operations::acl::create_acl`** takes it and stores it on the entry via `AclEntry::with_step_up_approver`; the result reflects it.
- Threaded through every grant surface: REST `POST /acl` (`CreateAclRequest`), the `vta/acl/create/1.0` trust task, and the DIDComm create handler. Provision-integration grants pass `None`.
- **`vta-sdk` 0.9.2 → 0.9.3** (additive) + CHANGELOG.

## Test
`acl_grant_persists_step_up_approver` — granting with `step_up_approver` succeeds and the create result reflects it. Combined with #196's `delegated_step_up_routes_to_configured_approver` (which proves the gate *reads* it), delegated step-up is now settable → routable end-to-end.

## CI
`cargo fmt --check` ✅ · `cargo clippy -p vta-sdk -p vta-service --all-targets` ✅ · `api_integration` (107) ✅.

## Remaining for the policy epic (#50)
- Setting/clearing the approver on an **existing** entry (`acl/update` / `acl/change-role` gaining the field) — useful to add an approver to an already-granted admin without re-granting.
- The wire **`auth/step-up/policy/0.1`** handler for **remote** policy management (the local CLI #197 already covers offline management).

Both are small "completeness" follow-ups; the core feature (set approver → gate routes to it → approver ratifies) is operable after this.