### PR TITLE
feat(vta): set step-up approver on existing entries (acl/update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,25 @@
 
 ## Unreleased
 
-### Set a delegated step-up approver at grant time
+### Set a delegated step-up approver at grant *and update* time
 
-The ACL create/grant body gains an optional `step_up_approver` — the VID a
-delegated AAL2 step-up's approve-request is addressed to (the holder's
-mobile/browser approver). It's stored on the entry and read by the step-up
-gate's delegated mode. Makes delegated step-up operable end-to-end:
+The ACL create/grant and update bodies gain an optional `step_up_approver`
+— the VID a delegated AAL2 step-up's approve-request is addressed to (the
+holder's mobile/browser approver). It's stored on the entry and read by the
+step-up gate's delegated mode. Makes delegated step-up operable end-to-end:
 previously the gate could route to an approver but there was no way to set
-one outside tests.
+one outside tests. `update` follows the existing set-if-`Some`/leave-if-
+`None` semantics (clearing isn't expressible, matching `label`).
 
 - `vta-sdk` `CreateAclBody` + `CreateAclResultBody` gain
   `step_up_approver: Option<String>` (additive, `serde(default)`); the REST
   `POST /acl` request + the `vta/acl/create/1.0` trust task accept it and
-  the result reflects it. `vta-sdk` 0.9.2 → 0.9.3.
-- Still pending: setting/clearing the approver on an *existing* entry
-  (`acl/update`) and the wire `auth/step-up/policy/0.1` handler for remote
-  policy management.
+  the result reflects it. `UpdateAclBody` + the REST `PATCH /acl/{did}` +
+  the `vta/acl/update/1.0` trust task likewise accept it. `vta-sdk`
+  0.9.2 → 0.9.4.
+- Still pending (optional): the wire `auth/step-up/policy/0.1` handler for
+  *remote* policy management — the `vta step-up` CLI already covers local
+  management.
 
 ### Key rotation goes through `acl/swap-key`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.3",
+ "vta-sdk 0.9.4",
 ]
 
 [[package]]
@@ -2968,7 +2968,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.3",
+ "vta-sdk 0.9.4",
 ]
 
 [[package]]
@@ -6269,7 +6269,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.3",
+ "vta-sdk 0.9.4",
 ]
 
 [[package]]
@@ -9470,7 +9470,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.3",
+ "vta-sdk 0.9.4",
  "x25519-dalek",
 ]
 
@@ -9539,7 +9539,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9655,7 +9655,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.3",
+ "vta-sdk 0.9.4",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9731,7 +9731,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.3",
+ "vta-sdk 0.9.4",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9774,7 +9774,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.3",
+ "vta-sdk 0.9.4",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9801,7 +9801,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.3",
+ "vta-sdk 0.9.4",
  "vta-service",
  "vti-common",
 ]

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/acl_management/update.rs
+++ b/vta-sdk/src/protocols/acl_management/update.rs
@@ -11,6 +11,11 @@ pub struct UpdateAclBody {
     pub label: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_contexts: Option<Vec<String>>,
+    /// Set the delegated step-up approver VID. `Some` sets it; `None` leaves
+    /// it unchanged (matching the other fields — clearing an existing
+    /// approver isn't expressible here, consistent with `label`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_up_approver: Option<String>,
 }
 
 pub type UpdateAclResultBody = CreateAclResultBody;

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -680,6 +680,7 @@ pub async fn handle_update_acl(
                 role,
                 label: body.label,
                 allowed_contexts: body.allowed_contexts,
+                step_up_approver: body.step_up_approver,
             },
             "didcomm",
         )

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -21,6 +21,8 @@ pub struct UpdateAclParams {
     pub role: Option<Role>,
     pub label: Option<String>,
     pub allowed_contexts: Option<Vec<String>>,
+    /// `Some` sets the delegated step-up approver; `None` leaves it unchanged.
+    pub step_up_approver: Option<String>,
 }
 
 /// Compute the symmetric difference of two context lists — every
@@ -208,6 +210,9 @@ pub async fn update_acl(
     }
     if let Some(label) = params.label {
         entry.label = Some(label);
+    }
+    if let Some(approver) = params.step_up_approver {
+        entry.step_up_approver = Some(approver);
     }
     if let Some(allowed_contexts) = params.allowed_contexts {
         // Validate the *symmetric difference* of (old, new), not just
@@ -565,6 +570,7 @@ mod tests {
             UpdateAclParams {
                 role: None,
                 label: None,
+                step_up_approver: None,
                 allowed_contexts: Some(vec!["ctx-a".into()]),
             },
             "test",
@@ -598,6 +604,7 @@ mod tests {
             UpdateAclParams {
                 role: None,
                 label: None,
+                step_up_approver: None,
                 allowed_contexts: Some(vec!["ctx-a".into()]),
             },
             "test",
@@ -628,6 +635,7 @@ mod tests {
             UpdateAclParams {
                 role: None,
                 label: None,
+                step_up_approver: None,
                 allowed_contexts: Some(vec!["ctx-a".into(), "ctx-b".into()]),
             },
             "test",
@@ -790,6 +798,7 @@ mod tests {
             UpdateAclParams {
                 role: None,
                 label: None,
+                step_up_approver: None,
                 allowed_contexts: Some(vec!["ctx-a".into(), "ctx-ghost".into()]),
             },
             "test",

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -89,6 +89,9 @@ pub struct UpdateAclRequest {
     pub role: Option<Role>,
     pub label: Option<String>,
     pub allowed_contexts: Option<Vec<String>>,
+    /// Set the delegated step-up approver VID (`Some` sets; `None` leaves).
+    #[serde(default)]
+    pub step_up_approver: Option<String>,
 }
 
 /// PATCH /acl/{did} — update role, label, or allowed contexts for an ACL entry.
@@ -111,6 +114,7 @@ pub async fn update_acl(
             role: req.role,
             label: req.label,
             allowed_contexts: req.allowed_contexts,
+            step_up_approver: req.step_up_approver,
         },
         "rest",
     )

--- a/vta-service/src/routes/trust_tasks/acl.rs
+++ b/vta-service/src/routes/trust_tasks/acl.rs
@@ -173,6 +173,7 @@ pub(super) async fn handle_update(
             role,
             label: req.label,
             allowed_contexts: req.allowed_contexts,
+            step_up_approver: req.step_up_approver,
         },
         TRANSPORT_TRUST_TASK,
     )

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -593,6 +593,38 @@ async fn swap_key_gated_without_carve_out() {
 }
 
 #[tokio::test]
+async fn acl_update_sets_step_up_approver() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+    // Grant with no approver…
+    let (status, _) = app
+        .request(post_auth(
+            "/acl",
+            &token,
+            json!({ "did": "did:key:z6MkGrantee2", "role": "application", "allowed_contexts": ["ctx1"] }),
+        ))
+        .await;
+    assert!(status.is_success());
+
+    // …then add one via PATCH.
+    let (status, body) = app
+        .request(patch_auth(
+            "/acl/did:key:z6MkGrantee2",
+            &token,
+            json!({ "step_up_approver": "did:key:z6MkApprover" }),
+        ))
+        .await;
+    assert!(
+        status.is_success(),
+        "update should succeed: {status} {body}"
+    );
+    assert_eq!(
+        body["step_up_approver"], "did:key:z6MkApprover",
+        "update must set + reflect the step-up approver: {body}"
+    );
+}
+
+#[tokio::test]
 async fn acl_grant_persists_step_up_approver() {
     let (app, ctx) = TestApp::new().await;
     // Step-up ships disabled, so an AAL1 admin can grant without a gate.


### PR DESCRIPTION
## Summary

Completeness follow-up to #198. The delegated step-up approver can now be set on an **existing** entry via `acl/update`, so an operator can add an approver to an already-granted admin without re-granting.

- **`vta-sdk`** `UpdateAclBody` gains `step_up_approver: Option<String>` (additive, `serde(default)`). `vta-sdk` 0.9.3 → 0.9.4.
- `UpdateAclParams` + `operations::acl::update_acl` apply it with the existing **set-if-`Some`/leave-if-`None`** semantics (clearing isn't expressible — consistent with `label`).
- Threaded through REST `PATCH /acl/{did}` (`UpdateAclRequest`), the `vta/acl/update/1.0` trust task, and the DIDComm update handler.

## Test
`acl_update_sets_step_up_approver` — grant without an approver, then PATCH one in; the result reflects it. (With #198's grant test + #196's routing test, the full set/route/fail-closed loop is covered.)

## CI
`cargo fmt --check` ✅ · `cargo clippy -p vta-sdk -p vta-service --all-targets` ✅ · `api_integration` (108) ✅.

## This closes the operable gap on delegated step-up
An approver can be set at grant (#198) **or after the fact** (this PR); the gate routes the approve-request to it (#196); a missing one fail-closes (#196). Combined with the policy CLI (#197), the rotation fix (#194), the carve-out (#193), per-op floors (#192), and the disabled-default config (#191) — the step-up policy epic (#50) is functionally complete.

## One optional item remains
The wire **`auth/step-up/policy/0.1`** handler for **remote** policy management. The `vta step-up` CLI (#197) already covers local/offline management, so this is a convenience rather than a gap — deferred unless you want remote/programmatic policy administration.