### PR TITLE
chore(vta-mobile-core): bump to 0.2.1 for the didcomm 0.15 re-cut

### DIFF
--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.2.0"
+version = "0.2.1"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR


### PR DESCRIPTION
## Summary

Bumps `vta-mobile-core` 0.2.0 → 0.2.1 so we can cut a **`vta-mobile-core-v0.2.1`** release on the unified **didcomm 0.15** stack.

The last engine release (`v0.2.0`) was built on `affinidi-messaging-didcomm 0.14`; the workspace moved to **0.15** in #189 (the `crypto`-module migration in `vta-mobile-core/src/didcomm.rs` landed there). Re-cutting on 0.15:
- matches the VTA (now on didcomm 0.15), and
- lets the iOS app consume a 0.15 engine **and** `didcomm_holder_keys` (added in v0.2.0) for the DIDComm receive path — the iOS `Package.swift` currently pins the stale `v0.1.0`.

No source change beyond the version; the 0.15 migration already merged. After this merges I'll push the `vta-mobile-core-v0.2.1` tag, which triggers `release-mobile-ios.yml` to build + publish the xcframework + checksum.

## Next (separate)
- Push the `v0.2.1` tag → release.
- Bump iOS `Package.swift` `engineTag` v0.1.0 → v0.2.1 + re-vendor `VtaMobileCore.swift`.
- iOS DIDComm receive path (Stage 1b) → mediator pickup (Stage 2).