### PR TITLE
feat(vta-sdk): DIDCommSession::receive_next (unsolicited inbound)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### DIDComm session: receive unsolicited inbound messages
+
+`vta-sdk`'s `DIDCommSession` gains `receive_next(timeout_secs)` — polls the
+mediator's live stream and returns the next **unsolicited** inbound message
+(unpacked, as JSON), not bound to a sent request's thread id. This is the
+foundation for the mobile approver receiving a VTA-pushed
+`auth/step-up/approve-request/0.1` over the mediator (the engine FFI for the
+iOS proxied step-up wraps it). Reuses the proven `message_pickup().live_stream_next`
+path. `vta-sdk` 0.9.4 → 0.9.5 (additive).
+
 ### Set a delegated step-up approver at grant *and update* time
 
 The ACL create/grant and update bodies gain an optional `step_up_approver`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.4",
+ "vta-sdk 0.9.5",
 ]
 
 [[package]]
@@ -2968,7 +2968,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.4",
+ "vta-sdk 0.9.5",
 ]
 
 [[package]]
@@ -6269,7 +6269,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.4",
+ "vta-sdk 0.9.5",
 ]
 
 [[package]]
@@ -9470,7 +9470,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.4",
+ "vta-sdk 0.9.5",
  "x25519-dalek",
 ]
 
@@ -9491,7 +9491,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9539,7 +9539,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9655,7 +9655,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.4",
+ "vta-sdk 0.9.5",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9731,7 +9731,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.4",
+ "vta-sdk 0.9.5",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9774,7 +9774,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.4",
+ "vta-sdk 0.9.5",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9801,7 +9801,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.4",
+ "vta-sdk 0.9.5",
  "vta-service",
  "vti-common",
 ]

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.4"
+version = "0.9.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -292,6 +292,45 @@ impl DIDCommSession {
         }
     }
 
+    /// Receive the next **unsolicited** inbound DIDComm message — e.g. an
+    /// `auth/step-up/approve-request/0.1` the VTA pushed to this holder via the
+    /// mediator. Polls the mediator's live stream for up to `timeout_secs`;
+    /// returns `Ok(None)` if nothing arrived in time.
+    ///
+    /// Unlike [`Self::send_and_wait`], this is not bound to a thread id — it
+    /// surfaces whatever the mediator delivers next. The returned string is the
+    /// **unpacked** DIDComm message as JSON (`{ id, type, body, from, … }`);
+    /// ATM has already decrypted it under the holder key, so the caller works
+    /// with plaintext (the application Trust Task rides in `body`).
+    pub async fn receive_next(&self, timeout_secs: u64) -> Result<Option<String>, VtaError> {
+        let timeout = std::time::Duration::from_secs(timeout_secs);
+        let wait_duration = std::time::Duration::from_secs(5);
+        let deadline = tokio::time::Instant::now() + timeout;
+
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(None);
+            }
+            let wait = wait_duration.min(remaining);
+
+            let next = self
+                .atm
+                .message_pickup()
+                .live_stream_next(&self.profile, Some(wait), true)
+                .await
+                .map_err(|e| VtaError::DidcommTransport(format!("message pickup error: {e}")))?;
+
+            let (msg, _meta) = match next {
+                Some(pair) => pair,
+                None => continue, // nothing yet — keep waiting until the deadline
+            };
+            debug!(msg_type = %msg.typ, "received inbound DIDComm message");
+            let json = serde_json::to_string(&msg).map_err(VtaError::from)?;
+            return Ok(Some(json));
+        }
+    }
+
     /// Gracefully shut down the DIDComm session.
     pub async fn shutdown(&self) {
         self.atm.graceful_shutdown().await;


### PR DESCRIPTION
## Summary

Foundation for **Stage 2** of the iOS proxied step-up (the engine-FFI-via-ATM approach you picked). Adds `DIDCommSession::receive_next(timeout_secs)` to `vta-sdk`:

- Polls the mediator's live stream and returns the next **unsolicited** inbound DIDComm message (unpacked, as JSON `{ id, type, body, … }`), **not** bound to a sent request's thread id.
- Where `send_and_wait` is request-response, this surfaces whatever the mediator delivers — i.e. a VTA-pushed `auth/step-up/approve-request/0.1` (#202) arriving at the holder's device.
- Reuses the proven `atm.message_pickup().live_stream_next` path (same receive loop as `send_and_wait`, minus the thread-id filter). ATM decrypts under the holder key, so the caller gets plaintext (the Trust Task rides in `body`).

`vta-sdk` 0.9.4 → 0.9.5 (additive) + CHANGELOG.

## Why this first
The mobile engine `vta-mobile-core` will expose a mediator-connected *receive* FFI that **wraps this** (rather than reimplementing the affinidi mediator protocol — authenticate + message-pickup 3.0 + WebSocket — in Swift). This is the small, low-risk, reusable foundation; the heavier engine change (adding the `vta-sdk[session]` dep to the mobile engine + an async `MediatorSession` FFI + a `v0.3.0` release) follows as its own PR where the iOS cross-compile gets validated.

## Testing
Can't be unit-tested without a live mediator; it mirrors the already-shipping `send_and_wait` receive path (`live_stream_next`), so the risk is low. End-to-end validation lands with the engine FFI + iOS wiring against the live mediator.

Note: `cargo clippy -p vta-sdk --features session` surfaces 2 **pre-existing** unused-import warnings in `client/bootstrap.rs` (feature-gated, not introduced here) — flagging for a separate cleanup.