### PR TITLE
feat(vtc): ceremony decision pipeline — spine + directory ceremony

### DIFF
--- a/vtc-service/policies/default/directory.rego
+++ b/vtc-service/policies/default/directory.rego
@@ -1,28 +1,33 @@
-# Default `directory` policy — members see DID + role only
-# (spec §7.1 + §12.3).
+# Default `directory` policy — the ceremony decision spine
+# (ceremony-pipeline design §4; supersedes the Phase-5 boolean
+# placeholder).
 #
-# The directory endpoint lands in Phase 5 (community-facing
-# member directory). The default-deny envelope here describes
-# the privacy floor: any field beyond `did` + `role` is denied
-# unless the operator uploads a wider-scope policy. Audit + the
-# admin-facing `GET /v1/members` already bypass this — it's the
-# *member-to-member* visibility surface this policy gates.
+# The directory ceremony is the read-only instance of the decision
+# pipeline: `allow` carries a FIELD PROJECTION (`with.fields`), not a
+# boolean. The host runs `data.vtc.directory.decision` over the
+# verified Facts (`input.actor` / `input.subject` / `input.state`),
+# realizes the verdict by returning exactly `with.fields` of the
+# subject, and intersects those fields with the community PII-boundary
+# whitelist before they cross the wire.
 #
-# Input shape (spec §7.3):
-#   { viewer_did, viewer_role, target_member, fields_requested,
-#     action }
+# Privacy floor: a non-member viewer sees nothing; an authenticated
+# member sees `did` + `role`; an admin sees the fuller record. An
+# operator can upload a wider- or narrower-scope policy; the PII
+# boundary still caps what any policy can project.
 
 package vtc.directory
 
 import rego.v1
 
-default allow := false
+# structural totality — a non-member sees nothing
+default decision := {"effect": "deny", "with": {"code": "not-a-member"}}
 
-allowed_fields := {"did", "role"}
+# Admin viewer — fuller record
+decision := {"effect": "allow", "with": {"fields": ["did", "role", "joined_at", "status"]}} if {
+	input.actor.role == "admin"
+}
 
-allow if {
-	input.action == "show"
-	every f in input.fields_requested {
-		allowed_fields[f]
-	}
+# Authenticated member viewer — minimal projection
+else := {"effect": "allow", "with": {"fields": ["did", "role"]}} if {
+	input.actor.authenticated == true
 }

--- a/vtc-service/src/ceremony/effects.rs
+++ b/vtc-service/src/ceremony/effects.rs
@@ -1,0 +1,337 @@
+//! The Effects stage — turn a final [`Verdict`] into the concrete,
+//! per-purpose state change it authorizes (ceremony-pipeline design
+//! §5).
+//!
+//! Effects are "the only stage that mutates state, driven solely by
+//! the verdict." This module splits that into two halves so the
+//! decision logic stays pure and testable:
+//!
+//! 1. **Plan** (this module, now) — [`plan`] maps a `(VerifiedFacts,
+//!    Verdict)` pair to a typed [`EffectPlan`]: the *intent* (admit
+//!    this DID as `member`, project these fields, …). Pure, no I/O.
+//! 2. **Apply** (next slice) — an async executor consumes the
+//!    [`EffectPlan`] against `AppState`, reusing the existing
+//!    issue-VMC / write-ACL / write-Member helpers (today's bespoke
+//!    `routes::join_requests::decide::approve` becomes one such
+//!    executor). Deliberately not wired here: it means refactoring a
+//!    tested write path, which belongs in its own change.
+//!
+//! Splitting plan from apply mirrors the pipeline's discipline —
+//! "decide what to do" (pure, the verdict + this plan) is separated
+//! from "do it" (the single state-mutating stage).
+//!
+//! ## The directory effect is fully realized here
+//!
+//! Directory is the read-only ceremony: its `allow` carries a *field
+//! projection*, not a write. The whole effect is computable from the
+//! verified facts — so [`plan`] returns a finished
+//! [`EffectPlan::Project`] with the actual field/value map, and this
+//! is also where the **PII-boundary invariant** (pipeline §5) lands:
+//! the projected fields are `allow.with.fields` ∩ the community's
+//! whitelist, so a policy can never project a field outside the
+//! boundary even if it names one.
+
+use serde_json::{Map, Value as JsonValue};
+use vti_common::error::AppError;
+
+use super::facts::Purpose;
+use super::verdict::Verdict;
+use super::verify::VerifiedFacts;
+
+/// The concrete, per-purpose intent a [`Verdict`] authorizes. The
+/// async executor (next slice) turns the write variants into ACL /
+/// Member / credential mutations; [`Self::Project`] is already
+/// complete (directory is read-only).
+#[derive(Debug, Clone, PartialEq)]
+pub enum EffectPlan {
+    /// Directory `allow` — return exactly these subject fields. The
+    /// map is already filtered through the PII boundary; the executor
+    /// just serializes it to the response.
+    Project { fields: Map<String, JsonValue> },
+    /// Join `allow` — admit `subject` with `role`, then discharge
+    /// `obligations` (e.g. `reciprocate_vmc`). The executor writes
+    /// the ACL + Member rows and issues the VMC + role VEC.
+    Admit {
+        subject: String,
+        role: String,
+        obligations: Vec<String>,
+    },
+    /// Leave `allow` — remove `subject` and wind down their
+    /// credentials per `disposition`. The executor revokes the VMC +
+    /// removes the ACL / Member rows.
+    Depart {
+        subject: String,
+        disposition: Option<String>,
+    },
+    /// Role-change `allow` — re-mint `subject`'s role VEC at `role`
+    /// and update the ACL row in place. The DID + VMC are unchanged.
+    Remint { subject: String, role: String },
+    /// No state change — the verdict was `deny` / `refer` /
+    /// `request_more`. The outcome lives in the [`Verdict`] itself
+    /// (refusal, queue, or Presentation Definition); the effect stage
+    /// writes nothing.
+    NoStateChange,
+}
+
+/// Plan the effect a verdict authorizes.
+///
+/// `pii_whitelist` is the community's directory field whitelist; it
+/// is consulted only for the directory projection (ignored for other
+/// purposes). The host supplies it from community config.
+///
+/// Returns [`AppError::Internal`] if an `allow` is missing a field
+/// its purpose requires (e.g. a join `allow` with no `role`) — a
+/// well-formed, invariant-checked verdict always carries what its
+/// purpose needs, so a gap here is a policy/compiler bug, not caller
+/// input.
+pub fn plan(
+    verified: &VerifiedFacts,
+    verdict: &Verdict,
+    pii_whitelist: &[String],
+) -> Result<EffectPlan, AppError> {
+    let Verdict::Allow(allow) = verdict else {
+        return Ok(EffectPlan::NoStateChange);
+    };
+
+    let facts = verified.facts();
+    let subject = facts.subject.did.clone();
+
+    match facts.purpose {
+        Purpose::Directory => Ok(EffectPlan::Project {
+            fields: project_fields(
+                verified,
+                allow.fields.as_deref().unwrap_or(&[]),
+                pii_whitelist,
+            ),
+        }),
+        Purpose::Join => Ok(EffectPlan::Admit {
+            subject,
+            role: required_role(allow.role.as_deref(), "join")?,
+            obligations: allow.obligations.clone(),
+        }),
+        Purpose::Leave => Ok(EffectPlan::Depart {
+            subject,
+            disposition: allow.disposition.clone(),
+        }),
+        Purpose::RoleChange => Ok(EffectPlan::Remint {
+            subject,
+            role: required_role(allow.role.as_deref(), "role-change")?,
+        }),
+    }
+}
+
+/// A grant whose purpose requires a role must carry one.
+fn required_role(role: Option<&str>, purpose: &str) -> Result<String, AppError> {
+    role.map(str::to_string).ok_or_else(|| {
+        AppError::Internal(format!("{purpose} allow is missing the required `role`"))
+    })
+}
+
+/// Build the directory projection: the subject's facts, restricted to
+/// `allow.with.fields` ∩ `whitelist`.
+///
+/// The projection source is the **verified facts** the policy decided
+/// over (`subject.did` + `state.subject_member`), not a fresh read —
+/// the directory returns exactly the slice of what the policy saw
+/// that it authorized. A requested field absent from the facts (e.g.
+/// `extensions`, which the Phase-1 `MemberState` doesn't carry) is
+/// simply omitted rather than invented.
+fn project_fields(
+    verified: &VerifiedFacts,
+    requested: &[String],
+    whitelist: &[String],
+) -> Map<String, JsonValue> {
+    let facts = verified.facts();
+
+    // Source object: the subject member's fields plus the DID.
+    let mut source = facts
+        .state
+        .subject_member
+        .as_ref()
+        .and_then(|m| serde_json::to_value(m).ok())
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+    source.insert("did".into(), JsonValue::String(facts.subject.did.clone()));
+
+    // PII boundary: a field is projected only if the policy asked for
+    // it AND the community whitelist permits it AND the facts carry
+    // it. The whitelist is the hard guard — intersecting here means a
+    // policy can't widen the projection past the boundary.
+    requested
+        .iter()
+        .filter(|f| whitelist.iter().any(|w| w == *f))
+        .filter_map(|f| source.get(f).map(|v| (f.clone(), v.clone())))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ceremony::facts::{Actor, Context, Evidence, Facts, MemberState, State, Subject};
+    use crate::ceremony::verdict::Allow;
+    use serde_json::json;
+
+    fn facts(purpose: Purpose, member: Option<MemberState>) -> Facts {
+        Facts {
+            purpose,
+            now: "2026-05-30T12:00:00Z".parse().unwrap(),
+            actor: Actor {
+                did: "did:key:zViewer".into(),
+                role: Some("member".into()),
+                authenticated: true,
+            },
+            subject: Subject {
+                did: "did:key:zTarget".into(),
+            },
+            context: Context {
+                community_did: "did:webvh:acme.example".into(),
+                channel: "rest".into(),
+                member_count: 10,
+            },
+            evidence: Evidence::default(),
+            state: State {
+                subject_member: member,
+            },
+        }
+    }
+
+    fn member() -> MemberState {
+        MemberState {
+            role: "member".into(),
+            status: "active".into(),
+            joined_at: "2026-03-03T00:00:00Z".parse().unwrap(),
+            personhood: None,
+        }
+    }
+
+    fn verified(facts: Facts) -> VerifiedFacts {
+        VerifiedFacts::assemble(facts).expect("verified")
+    }
+
+    fn allow(a: Allow) -> Verdict {
+        Verdict::Allow(a)
+    }
+
+    /// A non-allow verdict plans no state change.
+    #[test]
+    fn deny_plans_no_state_change() {
+        let v = verified(facts(Purpose::Join, None));
+        let verdict = Verdict::default_deny();
+        assert_eq!(plan(&v, &verdict, &[]).unwrap(), EffectPlan::NoStateChange);
+    }
+
+    /// A join allow plans an admit with the granted role + obligations.
+    #[test]
+    fn join_allow_plans_admit() {
+        let v = verified(facts(Purpose::Join, None));
+        let verdict = allow(Allow {
+            role: Some("member".into()),
+            obligations: vec!["reciprocate_vmc".into()],
+            ..Default::default()
+        });
+        assert_eq!(
+            plan(&v, &verdict, &[]).unwrap(),
+            EffectPlan::Admit {
+                subject: "did:key:zTarget".into(),
+                role: "member".into(),
+                obligations: vec!["reciprocate_vmc".into()],
+            }
+        );
+    }
+
+    /// A join allow without a role is a policy bug — Internal error.
+    #[test]
+    fn join_allow_without_role_errors() {
+        let v = verified(facts(Purpose::Join, None));
+        let verdict = allow(Allow::default());
+        let err = plan(&v, &verdict, &[]).expect_err("join needs a role");
+        assert!(matches!(err, AppError::Internal(_)), "got {err:?}");
+    }
+
+    /// A leave allow plans a departure carrying the disposition.
+    #[test]
+    fn leave_allow_plans_depart() {
+        let v = verified(facts(Purpose::Leave, Some(member())));
+        let verdict = allow(Allow {
+            disposition: Some("revoke-vmc".into()),
+            ..Default::default()
+        });
+        assert_eq!(
+            plan(&v, &verdict, &[]).unwrap(),
+            EffectPlan::Depart {
+                subject: "did:key:zTarget".into(),
+                disposition: Some("revoke-vmc".into()),
+            }
+        );
+    }
+
+    /// The directory projection returns exactly `with.fields` ∩
+    /// whitelist, pulling values from the verified facts.
+    #[test]
+    fn directory_projection_intersects_fields_with_whitelist() {
+        let v = verified(facts(Purpose::Directory, Some(member())));
+        let verdict = allow(Allow {
+            // Policy asks for did, role, joined_at, status.
+            fields: Some(vec![
+                "did".into(),
+                "role".into(),
+                "joined_at".into(),
+                "status".into(),
+            ]),
+            ..Default::default()
+        });
+        // But the community whitelist only permits did + role.
+        let whitelist = vec!["did".to_string(), "role".to_string()];
+
+        match plan(&v, &verdict, &whitelist).unwrap() {
+            EffectPlan::Project { fields } => {
+                let got = JsonValue::Object(fields);
+                assert_eq!(
+                    got,
+                    json!({ "did": "did:key:zTarget", "role": "member" }),
+                    "status + joined_at must be dropped by the PII boundary",
+                );
+            }
+            other => panic!("expected Project, got {other:?}"),
+        }
+    }
+
+    /// A whitelisted-and-requested field that the facts don't carry
+    /// (e.g. `extensions`) is omitted, not invented.
+    #[test]
+    fn directory_projection_omits_absent_facts() {
+        let v = verified(facts(Purpose::Directory, Some(member())));
+        let verdict = allow(Allow {
+            fields: Some(vec!["did".into(), "extensions".into()]),
+            ..Default::default()
+        });
+        let whitelist = vec!["did".to_string(), "extensions".to_string()];
+
+        match plan(&v, &verdict, &whitelist).unwrap() {
+            EffectPlan::Project { fields } => {
+                assert_eq!(
+                    JsonValue::Object(fields),
+                    json!({ "did": "did:key:zTarget" })
+                );
+            }
+            other => panic!("expected Project, got {other:?}"),
+        }
+    }
+
+    /// A role-change allow plans a re-mint at the target role.
+    #[test]
+    fn role_change_allow_plans_remint() {
+        let v = verified(facts(Purpose::RoleChange, Some(member())));
+        let verdict = allow(Allow {
+            role: Some("moderator".into()),
+            ..Default::default()
+        });
+        assert_eq!(
+            plan(&v, &verdict, &[]).unwrap(),
+            EffectPlan::Remint {
+                subject: "did:key:zTarget".into(),
+                role: "moderator".into(),
+            }
+        );
+    }
+}

--- a/vtc-service/src/ceremony/evaluate.rs
+++ b/vtc-service/src/ceremony/evaluate.rs
@@ -1,0 +1,208 @@
+//! The Evaluate stage — run a purpose's policy over verified facts
+//! and parse the decision (ceremony-pipeline design §2 "Evaluate").
+//!
+//! This is the seam between the generic pipeline and the **reused**
+//! MVP policy engine ([`crate::policy::engine`]): it takes a
+//! [`VerifiedFacts`] (the only thing the pipeline lets reach a
+//! policy), serializes it to the `input` document, runs the purpose's
+//! `decision` query through `regorus`, and parses the result into a
+//! [`Verdict`]. Crypto is already behind us (the [`VerifiedFacts`]
+//! typestate guarantees it), so this stage never touches a signature.
+//!
+//! ## Structural totality is enforced twice
+//!
+//! The Rule-IR compiler appends `default decision := {deny}` to every
+//! policy, so a well-formed module always yields a decision. This
+//! stage adds a **host-side** backstop: if a policy somehow evaluates
+//! to `undefined` (e.g. a hand-written escape-hatch module that
+//! forgot the default), the host synthesizes
+//! [`Verdict::default_deny`] rather than erroring or — far worse —
+//! treating "no decision" as permission. Totality is a safety
+//! property; we don't trust a single enforcement point for it.
+
+use serde_json::Value as JsonValue;
+use vti_common::error::AppError;
+
+use super::verdict::Verdict;
+use super::verify::VerifiedFacts;
+use crate::policy::engine::{self, CompiledPolicy};
+
+/// Evaluate a purpose's compiled policy over verified facts.
+///
+/// The `policy` must be the compiled module for `verified.purpose()`
+/// — the query is derived from the purpose
+/// ([`super::facts::Purpose::decision_query`]), so handing this the
+/// wrong purpose's policy yields `undefined` → a host default-deny
+/// rather than a wrong allow.
+///
+/// Returns the policy's [`Verdict`] (pre-invariant — the host
+/// invariants are applied separately by
+/// [`super::invariant::enforce`]). A malformed decision object is an
+/// [`AppError::Internal`] (a policy/compiler bug, not caller input);
+/// an `undefined` decision degrades to [`Verdict::default_deny`].
+pub fn evaluate(verified: &VerifiedFacts, policy: &CompiledPolicy) -> Result<Verdict, AppError> {
+    let input = verified.to_input()?;
+    let query = verified.purpose().decision_query();
+    let results = engine::evaluate(policy, &query, input)?;
+
+    match decision_value(&results) {
+        Some(decision) => Verdict::from_decision(decision),
+        // Policy evaluated to `undefined` — structural-totality
+        // backstop. A policy that yields no decision denies.
+        None => Ok(Verdict::default_deny()),
+    }
+}
+
+/// Pluck the decision object out of regorus's `QueryResults` shape
+/// (`{ "result": [{ "expressions": [{ "value": V }] }] }`). Returns
+/// `None` when the query was `undefined` — either no `result` rows,
+/// or an empty-object `value` (regorus renders an undefined rule
+/// reference as `{}`, per [`crate::policy::engine`]'s documented
+/// behaviour).
+fn decision_value(results: &JsonValue) -> Option<JsonValue> {
+    let value = results.pointer("/result/0/expressions/0/value")?;
+    if matches!(value, JsonValue::Object(o) if o.is_empty()) {
+        return None;
+    }
+    Some(value.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ceremony::facts::{
+        Actor, Context, Credential, CredentialStatus, Evidence, Facts, Presentation, Purpose,
+        State, Subject,
+    };
+    use crate::policy::engine::compile;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    /// The example `join.rego` decision spine, trimmed to the two
+    /// branches the tests exercise. Package `vtc.join` so
+    /// `Purpose::Join.decision_query()` finds it.
+    const JOIN_REGO: &str = r#"
+package vtc.join
+
+import future.keywords.if
+import future.keywords.in
+
+default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}
+
+decision := {"effect": "allow", "with": {"role": "member", "obligations": ["reciprocate_vmc"]}} if {
+    cred_trusted("WitnessCredential")
+}
+
+cred_trusted(t) if {
+    some c in input.evidence.presentation.credentials
+    c.type == t
+    c.issuer_trusted
+    c.status == "valid"
+}
+"#;
+
+    fn join_facts(issuer_trusted: bool) -> VerifiedFacts {
+        let facts = Facts {
+            purpose: Purpose::Join,
+            now: "2026-05-30T12:00:00Z".parse().unwrap(),
+            actor: Actor {
+                did: "did:key:zHuman".into(),
+                role: None,
+                authenticated: true,
+            },
+            subject: Subject {
+                did: "did:key:zHuman".into(),
+            },
+            context: Context {
+                community_did: "did:webvh:acme.example".into(),
+                channel: "rest".into(),
+                member_count: 10,
+            },
+            evidence: Evidence {
+                invitation: None,
+                presentation: Some(Presentation {
+                    verified: true,
+                    holder: "did:key:zHuman".into(),
+                    credentials: vec![Credential {
+                        credential_type: "WitnessCredential".into(),
+                        issuer: "did:webvh:notary.example".into(),
+                        issuer_trusted,
+                        status: CredentialStatus::Valid,
+                        claims: json!({}),
+                        valid_until: None,
+                    }],
+                }),
+                request: Some(json!({ "agreements": {} })),
+            },
+            state: State {
+                subject_member: None,
+            },
+        };
+        VerifiedFacts::assemble(facts).expect("verified")
+    }
+
+    /// A trusted witness credential matches the allow branch — the
+    /// host parses it into a structured `Verdict::Allow`.
+    #[test]
+    fn allow_branch_parses_into_verdict() {
+        let policy = compile(JOIN_REGO, Uuid::new_v4()).expect("join.rego compiles");
+        let verdict = evaluate(&join_facts(true), &policy).expect("evaluate");
+        assert_eq!(verdict.effect(), "allow");
+        match verdict {
+            Verdict::Allow(a) => {
+                assert_eq!(a.role.as_deref(), Some("member"));
+                assert_eq!(a.obligations, vec!["reciprocate_vmc".to_string()]);
+            }
+            other => panic!("expected allow, got {other:?}"),
+        }
+    }
+
+    /// An untrusted issuer falls through to the compiler-appended
+    /// default — the host sees the explicit deny.
+    #[test]
+    fn unmatched_falls_through_to_policy_default_deny() {
+        let policy = compile(JOIN_REGO, Uuid::new_v4()).unwrap();
+        let verdict = evaluate(&join_facts(false), &policy).expect("evaluate");
+        assert_eq!(verdict, Verdict::default_deny());
+    }
+
+    /// A policy with no `default decision` that doesn't match yields
+    /// `undefined` — the host's structural-totality backstop turns
+    /// that into a deny, never a missing/permissive decision.
+    #[test]
+    fn undefined_decision_degrades_to_host_default_deny() {
+        // No `default decision` line, and the rule body never fires
+        // for our facts (requires an admin actor).
+        const NO_DEFAULT: &str = r#"
+package vtc.join
+
+import future.keywords.if
+
+decision := {"effect": "allow", "with": {"role": "admin"}} if {
+    input.actor.role == "admin"
+}
+"#;
+        let policy = compile(NO_DEFAULT, Uuid::new_v4()).unwrap();
+        let verdict = evaluate(&join_facts(true), &policy).expect("evaluate");
+        assert_eq!(verdict, Verdict::default_deny());
+    }
+
+    /// The query is derived from the facts' purpose; evaluating facts
+    /// against a policy whose package doesn't match the purpose yields
+    /// `undefined` → deny, not a cross-purpose allow.
+    #[test]
+    fn purpose_mismatched_policy_denies() {
+        // A directory policy that would allow, but the facts are a
+        // join — `data.vtc.join.decision` is undefined in this module.
+        const DIRECTORY: &str = r#"
+package vtc.directory
+
+import future.keywords.if
+
+default decision := {"effect": "allow", "with": {"fields": ["did"]}}
+"#;
+        let policy = compile(DIRECTORY, Uuid::new_v4()).unwrap();
+        let verdict = evaluate(&join_facts(true), &policy).expect("evaluate");
+        assert_eq!(verdict, Verdict::default_deny());
+    }
+}

--- a/vtc-service/src/ceremony/facts.rs
+++ b/vtc-service/src/ceremony/facts.rs
@@ -84,6 +84,27 @@ impl Purpose {
             Purpose::Directory => "directory",
         }
     }
+
+    /// The Rego package the Rule-IR compiler emits for this purpose.
+    /// Identifiers can't carry hyphens, so `role-change` →
+    /// `vtc.role_change`. Matches the package declarations in
+    /// `docs/05-design-notes/examples/*.rego`.
+    pub fn rego_package(self) -> &'static str {
+        match self {
+            Purpose::Join => "vtc.join",
+            Purpose::Leave => "vtc.leave",
+            Purpose::RoleChange => "vtc.role_change",
+            Purpose::Directory => "vtc.directory",
+        }
+    }
+
+    /// The full query the evaluate stage runs against a compiled
+    /// policy for this purpose — the `decision` rule in the purpose's
+    /// package. Every ceremony policy exposes a single `decision`
+    /// object (pipeline §4), so this is the one query the host needs.
+    pub fn decision_query(self) -> String {
+        format!("data.{}.decision", self.rego_package())
+    }
 }
 
 /// The purpose-agnostic policy input. Assembled by the host after

--- a/vtc-service/src/ceremony/facts.rs
+++ b/vtc-service/src/ceremony/facts.rs
@@ -1,0 +1,432 @@
+//! The Facts contract — the purpose-agnostic policy `input` every
+//! ceremony shares (ceremony-pipeline design §3).
+//!
+//! One typed shape feeds every `<purpose>.rego` module. It is the
+//! greenfield replacement for the MVP's lossy
+//! [`crate::policy::extract::extract_vp_claims`] projection: instead
+//! of handing the policy a flattened `vp_claims` blob, the host hands
+//! it **structured, pre-verified facts** — `actor` / `subject` /
+//! `context` / `evidence` / `state`. Crypto (signatures,
+//! holder-binding, revocation, issuer-trust) is resolved by the host
+//! *before* a [`Facts`] is ever assembled (see
+//! [`crate::ceremony::verify`]); the policy therefore reasons only
+//! over booleans + claims, never over a signature.
+//!
+//! ## Wire shape is load-bearing
+//!
+//! These structs serialize to the exact JSON the Rule-IR-compiled
+//! Rego reads — `snake_case` keys, `evidence.presentation.
+//! credentials[].issuer_trusted`, `state.subject_member`, and so on.
+//! The runnable policies under
+//! `docs/05-design-notes/examples/*.rego` are the ground truth for
+//! field names; the round-trip tests at the bottom of this module
+//! lock the serialized shape against those examples. Renaming a field
+//! here silently breaks every compiled policy that reads it, so the
+//! `#[serde(rename = …)]` / `rename_all` attributes are part of the
+//! contract, not cosmetic.
+//!
+//! ## Optionality convention
+//!
+//! - Evidence slots a ceremony doesn't use are **absent**
+//!   (`skip_serializing_if`), not `null` — `directory` facts carry
+//!   only `evidence.request`. Rego treats absent + `null` identically
+//!   (both `undefined`), so the compiled helpers (`cred_trusted`,
+//!   `has_valid_invitation`, …) defend against both.
+//! - `state.subject_member` is the one slot serialized as explicit
+//!   `null` when empty (an unknown DID joining has no member row) —
+//!   the design example shows it present-but-null, and policies read
+//!   `input.state.subject_member` directly.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+/// Which ceremony this evaluation is deciding.
+///
+/// This is the **pipeline** vocabulary (`docs/05-design-notes/
+/// vtc-ceremony-catalog.md`), deliberately distinct from the MVP's
+/// nine-variant [`crate::policy::model::PolicyPurpose`]: the
+/// greenfield pipeline replaces "nine bespoke per-purpose flows" with
+/// one pipeline parameterized by this enum (pipeline §10). The
+/// variants here are the four ceremonies that have worked examples +
+/// compiled policies under `docs/05-design-notes/examples/`; more
+/// land as ceremonies are ported onto the pipeline.
+///
+/// Naming reconciliation with `PolicyPurpose` is an open migration
+/// item (pipeline §12, decisions 7): the MVP calls the destructive
+/// ceremony `removal`; the pipeline calls it `leave`. The wire
+/// strings here follow the catalog (`kebab-case`: `role-change`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Purpose {
+    /// A DID joining the community (constructive; actor usually ==
+    /// subject; threaded — supports `request_more` / `refer`).
+    Join,
+    /// A member departing or being removed (destructive; actor may
+    /// differ from subject; no-last-admin invariant applies).
+    Leave,
+    /// A member's role being changed in place (mutating; the one
+    /// ceremony whose `allow` may grant `admin`, gated by step-up).
+    RoleChange,
+    /// A read-only directory query (synchronous, unthreaded; `allow`
+    /// returns a field projection rather than a state mutation).
+    Directory,
+}
+
+impl Purpose {
+    /// Stable wire string (matches the serde representation and the
+    /// `purpose` field of the example facts files).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Purpose::Join => "join",
+            Purpose::Leave => "leave",
+            Purpose::RoleChange => "role-change",
+            Purpose::Directory => "directory",
+        }
+    }
+}
+
+/// The purpose-agnostic policy input. Assembled by the host after
+/// verification; consumed by `<purpose>.rego`.
+///
+/// Construct a [`Facts`] directly only at the host boundary that has
+/// just finished verifying evidence — downstream code should take a
+/// [`crate::ceremony::verify::VerifiedFacts`], which can only be
+/// produced by running [`Facts`] through the verification gate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Facts {
+    /// Which ceremony is being decided. Selects the policy module
+    /// and the effect handler.
+    pub purpose: Purpose,
+    /// Evaluation timestamp. Policies compare credential
+    /// `valid_until` / member `joined_at` against this rather than
+    /// reading a wall-clock, so a simulation can pin "now".
+    pub now: DateTime<Utc>,
+    /// Who initiated the transition.
+    pub actor: Actor,
+    /// Who the transition is *about*. May equal [`Actor::did`]
+    /// (self-join, self-leave) or differ (admin removing a member).
+    pub subject: Subject,
+    /// Ambient community facts the policy may branch on.
+    pub context: Context,
+    /// What the actor presented. Ceremonies populate only the slots
+    /// they use.
+    pub evidence: Evidence,
+    /// Authoritative current state relevant to the decision, read
+    /// from the ACL / member keyspaces.
+    pub state: State,
+}
+
+/// The authenticated initiator of the ceremony.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Actor {
+    /// The actor's DID (the proven signer at the route layer).
+    pub did: String,
+    /// The actor's community role from the ACL, when they are a
+    /// member. Absent for an unknown DID (e.g. an applicant joining).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Whether the route layer authenticated this actor. The host
+    /// rejects truly anonymous triggers before assembling facts; the
+    /// flag is surfaced so policies can branch (e.g. an open-join
+    /// route that tolerates an unauthenticated applicant).
+    pub authenticated: bool,
+}
+
+/// The DID the transition concerns.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Subject {
+    pub did: String,
+}
+
+/// Ambient community context.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Context {
+    /// The community this ceremony runs against.
+    pub community_did: String,
+    /// Transport the trigger arrived over (`"rest"` / `"didcomm"`).
+    pub channel: String,
+    /// Current member count — feeds size-sensitive policy (e.g. a
+    /// quorum threshold or a first-member bootstrap branch).
+    pub member_count: u64,
+}
+
+/// Everything the actor presented, grouped by kind. Each slot is
+/// independently optional; a ceremony populates the slots it needs.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Evidence {
+    /// A community invitation credential (VIC), when the actor
+    /// presented one. Absent for open-join / directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invitation: Option<Invitation>,
+    /// A verifiable presentation's verified projection, when the
+    /// actor presented credentials.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub presentation: Option<Presentation>,
+    /// Ceremony-specific request parameters (e.g. `agreements` for
+    /// join, `disposition` / `reason` for leave, `fields_requested`
+    /// for directory, `target_role` for role-change). Free-form in
+    /// Phase 1; tightened to per-purpose typed requests later.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request: Option<JsonValue>,
+}
+
+/// A verified invitation credential (VIC). All fields are
+/// post-verification facts — `verified` is the host's verdict on the
+/// invitation's signature + binding, not a self-asserted flag.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Invitation {
+    /// Host verdict: did the invitation's signature + binding check
+    /// out. Policy reads this; it never sees the signature.
+    pub verified: bool,
+    /// DID that issued the invitation (community DID or a delegating
+    /// member).
+    pub issuer: String,
+    /// The issuer's community role at issue time, when known —
+    /// distinguishes a community-issued invite from a member
+    /// delegation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issuer_role: Option<String>,
+    /// Scopes the invitation authorizes (e.g. role bounds,
+    /// single-context).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+    /// Whether this single-use invitation has already been consumed —
+    /// the host tracks consumption like the bootstrap carve-out, and
+    /// the compiled `has_valid_invitation` helper rejects a consumed
+    /// invite.
+    pub consumed: bool,
+}
+
+/// The verified projection of a presented VP.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Presentation {
+    /// Host verdict: did the VP proof + holder-binding check out.
+    pub verified: bool,
+    /// The proven holder DID.
+    pub holder: String,
+    /// The credentials inside the VP, each already verified.
+    #[serde(default)]
+    pub credentials: Vec<Credential>,
+}
+
+/// One verified credential from a presentation. Crypto is already
+/// resolved — `issuer_trusted` is the host's TRQP/governance verdict
+/// and `status` is the resolved status-list state, both computed
+/// before the policy runs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Credential {
+    /// The credential `type` (e.g. `WitnessCredential`). Serialized
+    /// as `type` to match the compiled helpers (`cred_trusted(t)`
+    /// matches on `c.type`).
+    #[serde(rename = "type")]
+    pub credential_type: String,
+    /// Issuer DID.
+    pub issuer: String,
+    /// Host verdict: is the issuer trusted for this credential type
+    /// under the community's governance (resolved via TRQP, not
+    /// hardcoded).
+    pub issuer_trusted: bool,
+    /// Resolved revocation/suspension state from the status list.
+    pub status: CredentialStatus,
+    /// The credential's subject claims, verbatim. Free-form; policies
+    /// read specific claim paths.
+    #[serde(default)]
+    pub claims: JsonValue,
+    /// Expiry, when the credential carries one. Policies compare
+    /// against [`Facts::now`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<DateTime<Utc>>,
+}
+
+/// Resolved credential status. The host computes this from the
+/// status-list lookup before evaluation, so the policy branches on a
+/// settled state rather than performing a revocation check itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CredentialStatus {
+    /// Active and not revoked or suspended.
+    Valid,
+    /// Permanently revoked.
+    Revoked,
+    /// Temporarily suspended.
+    Suspended,
+    /// Status could not be resolved (e.g. status list unreachable).
+    /// Surfaced rather than guessed so a policy can choose to refuse.
+    Unknown,
+}
+
+/// Authoritative current state relevant to the decision.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct State {
+    /// The subject's current member row, or `null` if the subject is
+    /// not (yet) a member. Serialized as explicit `null` when empty
+    /// so policies can read `input.state.subject_member` directly.
+    pub subject_member: Option<MemberState>,
+}
+
+/// The subject's current membership, when they are a member.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemberState {
+    /// Current community role.
+    pub role: String,
+    /// Membership status (e.g. `"active"`).
+    pub status: String,
+    /// When the subject joined — feeds tenure-sensitive policy.
+    pub joined_at: DateTime<Utc>,
+    /// Personhood assertion state, when established. Free-form in
+    /// Phase 1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub personhood: Option<JsonValue>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A join applicant with a trusted witness credential — mirrors
+    /// `docs/05-design-notes/examples/facts.join.json` exactly. This
+    /// is the contract test: if the serialized shape drifts from the
+    /// example the compiled `join.rego` reads, this fails.
+    #[test]
+    fn join_facts_match_design_example() {
+        let facts = Facts {
+            purpose: Purpose::Join,
+            now: "2026-05-30T12:00:00Z".parse().unwrap(),
+            actor: Actor {
+                did: "did:key:z6MkHuman".into(),
+                role: None,
+                authenticated: true,
+            },
+            subject: Subject {
+                did: "did:key:z6MkHuman".into(),
+            },
+            context: Context {
+                community_did: "did:webvh:acme.example".into(),
+                channel: "rest".into(),
+                member_count: 1421,
+            },
+            evidence: Evidence {
+                invitation: None,
+                presentation: Some(Presentation {
+                    verified: true,
+                    holder: "did:key:z6MkHuman".into(),
+                    credentials: vec![Credential {
+                        credential_type: "WitnessCredential".into(),
+                        issuer: "did:webvh:notary.example".into(),
+                        issuer_trusted: true,
+                        status: CredentialStatus::Valid,
+                        claims: json!({ "kind": "proximity" }),
+                        valid_until: None,
+                    }],
+                }),
+                request: Some(json!({ "agreements": {} })),
+            },
+            state: State {
+                subject_member: None,
+            },
+        };
+
+        let expected = json!({
+            "purpose": "join",
+            "now": "2026-05-30T12:00:00Z",
+            "actor": { "did": "did:key:z6MkHuman", "authenticated": true },
+            "subject": { "did": "did:key:z6MkHuman" },
+            "context": { "community_did": "did:webvh:acme.example", "channel": "rest", "member_count": 1421 },
+            "evidence": {
+                "presentation": {
+                    "verified": true,
+                    "holder": "did:key:z6MkHuman",
+                    "credentials": [
+                        { "type": "WitnessCredential", "issuer": "did:webvh:notary.example", "issuer_trusted": true, "status": "valid", "claims": { "kind": "proximity" } }
+                    ]
+                },
+                "request": { "agreements": {} }
+            },
+            "state": { "subject_member": null }
+        });
+
+        assert_eq!(serde_json::to_value(&facts).unwrap(), expected);
+        // And it round-trips back from the wire shape.
+        let parsed: Facts = serde_json::from_value(expected).unwrap();
+        assert_eq!(parsed, facts);
+    }
+
+    /// Directory facts carry `actor.role` + a populated
+    /// `subject_member` and omit the unused evidence slots — mirrors
+    /// `facts.directory.json`.
+    #[test]
+    fn directory_facts_omit_unused_evidence_slots() {
+        let facts = Facts {
+            purpose: Purpose::Directory,
+            now: "2026-05-30T12:00:00Z".parse().unwrap(),
+            actor: Actor {
+                did: "did:key:z6MkViewer".into(),
+                role: Some("member".into()),
+                authenticated: true,
+            },
+            subject: Subject {
+                did: "did:key:z6MkTarget".into(),
+            },
+            context: Context {
+                community_did: "did:webvh:acme.example".into(),
+                channel: "rest".into(),
+                member_count: 1421,
+            },
+            evidence: Evidence {
+                invitation: None,
+                presentation: None,
+                request: Some(json!({ "fields_requested": ["did", "role", "joined_at"] })),
+            },
+            state: State {
+                subject_member: Some(MemberState {
+                    role: "member".into(),
+                    status: "active".into(),
+                    joined_at: "2026-03-03T00:00:00Z".parse().unwrap(),
+                    personhood: None,
+                }),
+            },
+        };
+
+        let wire = serde_json::to_value(&facts).unwrap();
+        // Unused evidence slots are absent, not null.
+        assert!(wire["evidence"].get("invitation").is_none());
+        assert!(wire["evidence"].get("presentation").is_none());
+        assert_eq!(wire["actor"]["role"], "member");
+        assert_eq!(wire["state"]["subject_member"]["role"], "member");
+        assert_eq!(
+            wire["evidence"]["request"]["fields_requested"],
+            json!(["did", "role", "joined_at"])
+        );
+    }
+
+    #[test]
+    fn purpose_wire_strings_match_catalog() {
+        for (purpose, wire) in [
+            (Purpose::Join, "join"),
+            (Purpose::Leave, "leave"),
+            (Purpose::RoleChange, "role-change"),
+            (Purpose::Directory, "directory"),
+        ] {
+            assert_eq!(serde_json::to_value(purpose).unwrap(), json!(wire));
+            assert_eq!(purpose.as_str(), wire);
+            let parsed: Purpose = serde_json::from_value(json!(wire)).unwrap();
+            assert_eq!(parsed, purpose);
+        }
+    }
+
+    #[test]
+    fn credential_status_is_lowercase() {
+        assert_eq!(
+            serde_json::to_value(CredentialStatus::Valid).unwrap(),
+            json!("valid")
+        );
+        assert_eq!(
+            serde_json::to_value(CredentialStatus::Revoked).unwrap(),
+            json!("revoked")
+        );
+        let parsed: CredentialStatus = serde_json::from_value(json!("unknown")).unwrap();
+        assert_eq!(parsed, CredentialStatus::Unknown);
+    }
+}

--- a/vtc-service/src/ceremony/invariant.rs
+++ b/vtc-service/src/ceremony/invariant.rs
@@ -22,22 +22,24 @@
 //!   `evidence.request.step_up == true`, so a policy edit can't grant
 //!   admin without the reauth ceremony.
 //!
-//! ## What's deferred (state-dependent invariants)
+//! ## Where the other §5 invariants live
 //!
-//! [`enforce`] is intentionally pure over `(Facts, Verdict)`. Two
-//! design §5 invariants need state this signature doesn't yet carry,
-//! and land with the effect stage that reads it:
+//! [`enforce`] is intentionally pure over `(Facts, Verdict)` — it is
+//! the *pre-effect* veto. Two design §5 invariants are naturally
+//! enforced elsewhere because they need more than the verdict:
 //!
-//! - **No-last-admin (leave, role-change)** — needs the community's
-//!   current admin count from the ACL keyspace; refuses a transition
-//!   that would drop it to zero.
-//! - **PII boundary (directory, registry)** — needs the community's
-//!   field whitelist; intersects it with `allow.with.fields` so a
-//!   policy can't project a field outside the boundary.
-//!
-//! They are listed here, not silently absent, so the gap is explicit:
-//! the host does **not** yet guarantee them, and the effect stage must
-//! before it ships leave / directory writes.
+//! - **PII boundary (directory, registry)** — enforced in the
+//!   **effect/projection** stage ([`super::effects::plan`]), not here:
+//!   the projection intersects `allow.with.fields` with the
+//!   community whitelist as it builds the field map, so a policy can't
+//!   project a field outside the boundary. It belongs with the
+//!   projection because that's the stage that handles the fields.
+//! - **No-last-admin (leave, role-change)** — still deferred. Needs
+//!   the community's current admin count from the ACL keyspace to
+//!   refuse a transition that would drop it to zero. Lands with the
+//!   async effect executor that reads that state. Listed here, not
+//!   silently absent: the host does **not** yet guarantee it, and the
+//!   leave / role-change executor must before it ships.
 
 use super::facts::{Facts, Purpose};
 use super::verdict::Verdict;

--- a/vtc-service/src/ceremony/invariant.rs
+++ b/vtc-service/src/ceremony/invariant.rs
@@ -1,0 +1,249 @@
+//! Host-enforced invariants — hard guards a policy can never override
+//! (ceremony-pipeline design §5).
+//!
+//! Invariants are checked by the **host**, around the policy, not
+//! encoded in Rego — so an operator's policy edit can never disable
+//! them. The policy proposes a [`Verdict`]; [`enforce`] is the host's
+//! veto. A violated invariant refuses the transition regardless of
+//! what the policy said.
+//!
+//! ## What's enforced here (state-free invariants)
+//!
+//! These two are decidable from [`Facts`] + the policy's [`Verdict`]
+//! alone, so they live here now:
+//!
+//! - **Privilege ceiling (join)** — a `join` policy may grant
+//!   `member` / `moderator` / custom roles, **never `admin`**. Admin
+//!   is reachable only through the role-change step-up path. A
+//!   `join` policy that returns `allow{role:admin}` is vetoed.
+//! - **Step-up for admin (role-change)** — role-change *is* the
+//!   sanctioned admin-promotion path, but only with a verified
+//!   step-up. The host re-checks that any `allow{role:admin}` carries
+//!   `evidence.request.step_up == true`, so a policy edit can't grant
+//!   admin without the reauth ceremony.
+//!
+//! ## What's deferred (state-dependent invariants)
+//!
+//! [`enforce`] is intentionally pure over `(Facts, Verdict)`. Two
+//! design §5 invariants need state this signature doesn't yet carry,
+//! and land with the effect stage that reads it:
+//!
+//! - **No-last-admin (leave, role-change)** — needs the community's
+//!   current admin count from the ACL keyspace; refuses a transition
+//!   that would drop it to zero.
+//! - **PII boundary (directory, registry)** — needs the community's
+//!   field whitelist; intersects it with `allow.with.fields` so a
+//!   policy can't project a field outside the boundary.
+//!
+//! They are listed here, not silently absent, so the gap is explicit:
+//! the host does **not** yet guarantee them, and the effect stage must
+//! before it ships leave / directory writes.
+
+use super::facts::{Facts, Purpose};
+use super::verdict::Verdict;
+
+/// The community role that ceremonies may never self-grant through
+/// the join path, and may grant through role-change only behind
+/// step-up. Matches the literal the example policies branch on
+/// (`input.evidence.request.target_role == "admin"`).
+pub const ADMIN_ROLE: &str = "admin";
+
+/// Which host invariant a [`Verdict`] tripped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Invariant {
+    /// Join tried to grant `admin`.
+    PrivilegeCeiling,
+    /// Role-change tried to grant `admin` without a verified step-up.
+    StepUpForAdmin,
+}
+
+impl Invariant {
+    /// Stable code for audit + the synthesized deny.
+    pub fn code(self) -> &'static str {
+        match self {
+            Invariant::PrivilegeCeiling => "privilege-ceiling",
+            Invariant::StepUpForAdmin => "step-up-required",
+        }
+    }
+}
+
+/// A policy decision the host vetoed. Carries which invariant fired
+/// and a human-readable detail for the audit line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvariantViolation {
+    pub invariant: Invariant,
+    pub detail: String,
+}
+
+impl InvariantViolation {
+    /// The denying [`Verdict`] the host substitutes for the vetoed
+    /// decision — the transition is refused, tagged with the
+    /// invariant code so the operator can see *why* their policy's
+    /// allow didn't stick.
+    pub fn into_deny(self) -> Verdict {
+        Verdict::Deny(super::verdict::Deny {
+            code: self.invariant.code().into(),
+            reason: Some(self.detail),
+        })
+    }
+}
+
+/// Apply the host invariants to a policy's [`Verdict`].
+///
+/// Only an `allow` can violate an invariant — `deny` / `refer` /
+/// `request_more` grant nothing, so they pass through untouched. On
+/// veto, returns the [`InvariantViolation`]; the caller
+/// ([`super::decide`]) converts it to a denying verdict and logs it.
+pub fn enforce(facts: &Facts, verdict: Verdict) -> Result<Verdict, InvariantViolation> {
+    let Verdict::Allow(allow) = &verdict else {
+        return Ok(verdict);
+    };
+
+    let grants_admin = allow.role.as_deref() == Some(ADMIN_ROLE);
+
+    match facts.purpose {
+        // Join may never grant admin, full stop.
+        Purpose::Join if grants_admin => Err(InvariantViolation {
+            invariant: Invariant::PrivilegeCeiling,
+            detail: "join policy may not grant the admin role".into(),
+        }),
+        // Role-change may grant admin only behind a verified step-up.
+        Purpose::RoleChange if grants_admin && !step_up_verified(facts) => {
+            Err(InvariantViolation {
+                invariant: Invariant::StepUpForAdmin,
+                detail: "admin promotion requires a verified step-up".into(),
+            })
+        }
+        _ => Ok(verdict),
+    }
+}
+
+/// Whether the facts carry a verified step-up signal
+/// (`evidence.request.step_up == true`). Absent / non-`true` reads as
+/// "not stepped up" — the host defaults to refusing admin promotion.
+fn step_up_verified(facts: &Facts) -> bool {
+    facts
+        .evidence
+        .request
+        .as_ref()
+        .and_then(|r| r.get("step_up"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ceremony::facts::{Actor, Context, Evidence, State, Subject};
+    use crate::ceremony::verdict::Allow;
+    use serde_json::json;
+
+    fn facts(purpose: Purpose, request: serde_json::Value) -> Facts {
+        Facts {
+            purpose,
+            now: "2026-05-30T12:00:00Z".parse().unwrap(),
+            actor: Actor {
+                did: "did:key:zActor".into(),
+                role: Some("admin".into()),
+                authenticated: true,
+            },
+            subject: Subject {
+                did: "did:key:zTarget".into(),
+            },
+            context: Context {
+                community_did: "did:webvh:acme.example".into(),
+                channel: "rest".into(),
+                member_count: 10,
+            },
+            evidence: Evidence {
+                invitation: None,
+                presentation: None,
+                request: Some(request),
+            },
+            state: State {
+                subject_member: None,
+            },
+        }
+    }
+
+    fn allow_role(role: &str) -> Verdict {
+        Verdict::Allow(Allow {
+            role: Some(role.into()),
+            ..Default::default()
+        })
+    }
+
+    /// A join policy granting a non-admin role passes.
+    #[test]
+    fn join_member_grant_passes() {
+        let f = facts(Purpose::Join, json!({}));
+        assert_eq!(
+            enforce(&f, allow_role("member")).unwrap(),
+            allow_role("member")
+        );
+    }
+
+    /// A join policy granting admin is vetoed by the privilege
+    /// ceiling — converted to a deny tagged `privilege-ceiling`.
+    #[test]
+    fn join_admin_grant_is_vetoed() {
+        let f = facts(Purpose::Join, json!({}));
+        let violation = enforce(&f, allow_role("admin")).expect_err("join admin must be vetoed");
+        assert_eq!(violation.invariant, Invariant::PrivilegeCeiling);
+        match violation.into_deny() {
+            Verdict::Deny(d) => assert_eq!(d.code, "privilege-ceiling"),
+            other => panic!("expected deny, got {other:?}"),
+        }
+    }
+
+    /// Role-change to admin *with* step-up is allowed through.
+    #[test]
+    fn role_change_admin_with_step_up_passes() {
+        let f = facts(
+            Purpose::RoleChange,
+            json!({ "target_role": "admin", "step_up": true }),
+        );
+        assert_eq!(
+            enforce(&f, allow_role("admin")).unwrap(),
+            allow_role("admin")
+        );
+    }
+
+    /// Role-change to admin *without* step-up is vetoed even though a
+    /// policy returned allow — the host guards it regardless.
+    #[test]
+    fn role_change_admin_without_step_up_is_vetoed() {
+        let f = facts(
+            Purpose::RoleChange,
+            json!({ "target_role": "admin", "step_up": false }),
+        );
+        let violation = enforce(&f, allow_role("admin")).expect_err("admin needs step-up");
+        assert_eq!(violation.invariant, Invariant::StepUpForAdmin);
+
+        // Absent step_up reads the same as false.
+        let f2 = facts(Purpose::RoleChange, json!({ "target_role": "admin" }));
+        assert!(enforce(&f2, allow_role("admin")).is_err());
+    }
+
+    /// Role-change to a non-admin role doesn't engage the step-up
+    /// guard.
+    #[test]
+    fn role_change_non_admin_passes_without_step_up() {
+        let f = facts(Purpose::RoleChange, json!({ "target_role": "moderator" }));
+        assert_eq!(
+            enforce(&f, allow_role("moderator")).unwrap(),
+            allow_role("moderator")
+        );
+    }
+
+    /// Non-allow verdicts are never touched by the invariant pass.
+    #[test]
+    fn non_allow_verdicts_pass_through() {
+        let f = facts(Purpose::Join, json!({}));
+        let refer = Verdict::Refer(super::super::verdict::Refer {
+            queue: "moderator".into(),
+            reason: None,
+        });
+        assert_eq!(enforce(&f, refer.clone()).unwrap(), refer);
+    }
+}

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -1,0 +1,53 @@
+//! The ceremony decision pipeline — one pipeline, every community
+//! state transition an instance of it.
+//!
+//! Design: `docs/05-design-notes/vtc-ceremony-pipeline.md` (with the
+//! catalog, Rule-IR, and protocol companions). The thesis: a
+//! community has many governed transitions — joining, leaving, role
+//! changes, directory queries — that share one shape:
+//!
+//! ```text
+//! TRIGGER → GATHER → VERIFY (host) → FACTS → EVALUATE (<purpose>.rego)
+//!         → VERDICT → EFFECTS (<purpose>)
+//! ```
+//!
+//! Everything expensive to build — verification, the verdict model,
+//! versioning, governance, the visual authoring compiler — is built
+//! once here and inherited by every ceremony, rather than wired
+//! bespoke per purpose as in the MVP.
+//!
+//! ## What this module contains (pipeline stage A — the spine)
+//!
+//! - [`facts`] — the purpose-agnostic [`Facts`] contract (the typed
+//!   policy `input`), replacing the MVP's lossy `vp_claims`.
+//! - [`verdict`] — the four-valued [`Verdict`] (`allow` / `deny` /
+//!   `refer` / `request_more`), replacing the MVP's boolean.
+//! - [`verify`] — the [`VerifiedFacts`] typestate: the gate that
+//!   guarantees the policy only ever sees verified facts.
+//!
+//! Still to land on top of this spine (pipeline §11): the
+//! `verify → evaluate → effects` driver parameterized by purpose,
+//! the host-enforced invariants (privilege ceiling, no-last-admin,
+//! step-up, PII boundary), and the per-purpose effect handlers.
+//!
+//! ## Relationship to the existing `policy` + `join` modules
+//!
+//! This is the greenfield pipeline; [`crate::policy`] (the regorus
+//! engine plus persistence) is **reused** underneath it — `Verdict`
+//! parses the decision object [`crate::policy::engine::evaluate`]
+//! returns.
+//! The MVP's bespoke [`crate::join`] flow and its `vp_claims`
+//! projection are what this pipeline supersedes; they remain in place
+//! until ceremonies are ported over (build-vs-reuse map, pipeline
+//! §10).
+
+pub mod facts;
+pub mod verdict;
+pub mod verify;
+
+pub use facts::{
+    Actor, Context, Credential, CredentialStatus, Evidence, Facts, Invitation, MemberState,
+    Presentation, Purpose, State, Subject,
+};
+pub use verdict::{Allow, Deny, Refer, RequestMore, Verdict};
+pub use verify::{VerifiedFacts, VerifyError};

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -31,11 +31,16 @@
 //! - [`decide`] — the `evaluate → invariant` driver that turns a
 //!   [`VerifiedFacts`] + the purpose's policy into a final
 //!   [`Verdict`].
+//! - [`effects`] — plans the per-purpose state change a verdict
+//!   authorizes ([`effects::EffectPlan`]). The directory projection
+//!   (read-only) is fully realized; the write plans (admit / depart /
+//!   re-mint) await their async executor.
 //!
-//! Still to land on top of this spine (pipeline §11): the
-//! state-dependent invariants (no-last-admin, PII boundary — see
-//! [`invariant`]) and the per-purpose **effect** handlers that
-//! actually mutate state (issue VMC, revoke, project fields).
+//! Still to land on top of this spine (pipeline §11): the async
+//! **effect executor** that applies the write plans against
+//! `AppState` (reusing the issue-VMC / write-ACL helpers), and the
+//! remaining state-dependent invariant — no-last-admin (see
+//! [`invariant`]).
 //!
 //! ## Relationship to the existing `policy` + `join` modules
 //!
@@ -48,12 +53,14 @@
 //! until ceremonies are ported over (build-vs-reuse map, pipeline
 //! §10).
 
+pub mod effects;
 pub mod evaluate;
 pub mod facts;
 pub mod invariant;
 pub mod verdict;
 pub mod verify;
 
+pub use effects::{EffectPlan, plan};
 pub use evaluate::evaluate;
 pub use facts::{
     Actor, Context, Credential, CredentialStatus, Evidence, Facts, Invitation, MemberState,

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -24,11 +24,18 @@
 //!   `refer` / `request_more`), replacing the MVP's boolean.
 //! - [`verify`] — the [`VerifiedFacts`] typestate: the gate that
 //!   guarantees the policy only ever sees verified facts.
+//! - [`evaluate`] — runs a purpose's policy over verified facts and
+//!   parses the decision, with a host structural-totality backstop.
+//! - [`invariant`] — the host-enforced hard guards a policy can't
+//!   override (privilege ceiling, step-up); applied after evaluate.
+//! - [`decide`] — the `evaluate → invariant` driver that turns a
+//!   [`VerifiedFacts`] + the purpose's policy into a final
+//!   [`Verdict`].
 //!
 //! Still to land on top of this spine (pipeline §11): the
-//! `verify → evaluate → effects` driver parameterized by purpose,
-//! the host-enforced invariants (privilege ceiling, no-last-admin,
-//! step-up, PII boundary), and the per-purpose effect handlers.
+//! state-dependent invariants (no-last-admin, PII boundary — see
+//! [`invariant`]) and the per-purpose **effect** handlers that
+//! actually mutate state (issue VMC, revoke, project fields).
 //!
 //! ## Relationship to the existing `policy` + `join` modules
 //!
@@ -41,13 +48,153 @@
 //! until ceremonies are ported over (build-vs-reuse map, pipeline
 //! §10).
 
+pub mod evaluate;
 pub mod facts;
+pub mod invariant;
 pub mod verdict;
 pub mod verify;
 
+pub use evaluate::evaluate;
 pub use facts::{
     Actor, Context, Credential, CredentialStatus, Evidence, Facts, Invitation, MemberState,
     Presentation, Purpose, State, Subject,
 };
+pub use invariant::{Invariant, InvariantViolation};
 pub use verdict::{Allow, Deny, Refer, RequestMore, Verdict};
 pub use verify::{VerifiedFacts, VerifyError};
+
+use crate::policy::engine::CompiledPolicy;
+use vti_common::error::AppError;
+
+/// The Evaluate → Invariant driver: turn verified facts + the
+/// purpose's compiled policy into a final [`Verdict`].
+///
+/// This is the host's decision spine (pipeline §2). It runs the
+/// policy ([`evaluate`]) and then applies the host-enforced
+/// invariants ([`invariant::enforce`]) the policy can't override. A
+/// vetoed decision is converted to a denying verdict — tagged with
+/// the invariant code — and logged: the policy *proposed* an allow
+/// the host refused, which is an operator-visible misconfiguration,
+/// not a caller error.
+///
+/// What this does **not** do is apply effects. The returned verdict
+/// is the authoritative decision; the per-purpose effect handler
+/// (issue / revoke / project) consumes it next — still to land
+/// (pipeline §11).
+pub fn decide(verified: &VerifiedFacts, policy: &CompiledPolicy) -> Result<Verdict, AppError> {
+    let proposed = evaluate(verified, policy)?;
+    match invariant::enforce(verified.facts(), proposed) {
+        Ok(verdict) => Ok(verdict),
+        Err(violation) => {
+            tracing::warn!(
+                purpose = verified.purpose().as_str(),
+                invariant = violation.invariant.code(),
+                detail = %violation.detail,
+                "ceremony policy decision vetoed by host invariant",
+            );
+            Ok(violation.into_deny())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::engine::compile;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    fn join_facts() -> VerifiedFacts {
+        let facts = Facts {
+            purpose: Purpose::Join,
+            now: "2026-05-30T12:00:00Z".parse().unwrap(),
+            actor: Actor {
+                did: "did:key:zHuman".into(),
+                role: None,
+                authenticated: true,
+            },
+            subject: Subject {
+                did: "did:key:zHuman".into(),
+            },
+            context: Context {
+                community_did: "did:webvh:acme.example".into(),
+                channel: "rest".into(),
+                member_count: 10,
+            },
+            evidence: Evidence::default(),
+            state: State::default(),
+        };
+        VerifiedFacts::assemble(facts).expect("verified")
+    }
+
+    /// End-to-end driver: a (misconfigured) join policy that grants
+    /// admin is run, the host invariant vetoes it, and `decide`
+    /// returns a deny tagged `privilege-ceiling` — the policy's allow
+    /// never takes effect.
+    #[test]
+    fn decide_vetoes_a_join_policy_that_grants_admin() {
+        const ROGUE_JOIN: &str = r#"
+package vtc.join
+
+import future.keywords.if
+
+default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}
+
+# A misconfigured policy that tries to hand out admin on join.
+decision := {"effect": "allow", "with": {"role": "admin"}} if {
+    true
+}
+"#;
+        let policy = compile(ROGUE_JOIN, Uuid::new_v4()).unwrap();
+        let verdict = decide(&join_facts(), &policy).expect("decide");
+        match verdict {
+            Verdict::Deny(d) => assert_eq!(d.code, "privilege-ceiling"),
+            other => panic!("expected host-vetoed deny, got {other:?}"),
+        }
+    }
+
+    /// End-to-end happy path: a well-formed join policy granting
+    /// `member` passes the invariants and `decide` returns the allow
+    /// verbatim.
+    #[test]
+    fn decide_passes_a_well_formed_member_grant() {
+        const GOOD_JOIN: &str = r#"
+package vtc.join
+
+import future.keywords.if
+
+default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}
+
+decision := {"effect": "allow", "with": {"role": "member"}} if {
+    input.actor.authenticated == true
+}
+"#;
+        let policy = compile(GOOD_JOIN, Uuid::new_v4()).unwrap();
+        let verdict = decide(&join_facts(), &policy).expect("decide");
+        assert_eq!(
+            verdict,
+            Verdict::Allow(Allow {
+                role: Some("member".into()),
+                ..Default::default()
+            })
+        );
+    }
+
+    /// A policy returning `deny` is returned untouched — `decide`
+    /// doesn't second-guess a refusal.
+    #[test]
+    fn decide_returns_policy_deny_untouched() {
+        const DENY_JOIN: &str = r#"
+package vtc.join
+
+default decision := {"effect": "deny", "with": {"code": "closed"}}
+"#;
+        let policy = compile(DENY_JOIN, Uuid::new_v4()).unwrap();
+        let verdict = decide(&join_facts(), &policy).expect("decide");
+        assert_eq!(
+            verdict,
+            Verdict::from_decision(json!({ "effect": "deny", "with": { "code": "closed" } }))
+                .unwrap()
+        );
+    }
+}

--- a/vtc-service/src/ceremony/verdict.rs
+++ b/vtc-service/src/ceremony/verdict.rs
@@ -1,0 +1,253 @@
+//! The four-valued Verdict — the single `decision` object every
+//! `<purpose>.rego` returns (ceremony-pipeline design §4).
+//!
+//! Replaces the MVP's boolean `allow`/`deny` (`vtc-mvp.md` §10.1)
+//! with one discriminated object that generalizes across every
+//! ceremony:
+//!
+//! | Effect         | Meaning (any ceremony)        | Join         | Leave              |
+//! |----------------|-------------------------------|--------------|--------------------|
+//! | `allow`        | the transition proceeds       | admit + VMC  | execute departure  |
+//! | `deny`         | refused                       | reject       | refuse removal     |
+//! | `refer`        | needs a human / quorum        | moderator    | second-admin       |
+//! | `request_more` | needs more evidence (threaded)| return a PD  | require a reason   |
+//!
+//! `allow` is the only effect that carries a purpose-specific payload
+//! ([`Allow`]); `deny` / `refer` / `request_more` are identical
+//! across ceremonies, which is what lets one pipeline serve them all.
+//!
+//! ## Wire shape
+//!
+//! The compiled Rego emits `{"effect": "...", "with": {...}}` (see
+//! the examples under `docs/05-design-notes/examples/*.rego`). The
+//! adjacent `#[serde(tag = "effect", content = "with")]` tagging
+//! mirrors that exactly. The host evaluates the policy, plucks the
+//! decision object out of regorus's `QueryResults`
+//! (`result[0].expressions[0].value`), and parses it here via
+//! [`Verdict::from_decision`].
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use vti_common::error::AppError;
+
+/// One policy decision. Discriminated by `effect`; the `with` payload
+/// shape depends on the effect.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "effect", content = "with", rename_all = "snake_case")]
+pub enum Verdict {
+    /// The transition proceeds. Carries a purpose-specific payload —
+    /// the role to grant (join / role-change), the disposition to
+    /// apply (leave), or the fields to project (directory).
+    Allow(Allow),
+    /// The transition is refused outright.
+    Deny(Deny),
+    /// The decision is deferred to a human or a quorum — the ceremony
+    /// thread stays open and resolves asynchronously.
+    Refer(Refer),
+    /// The actor must present more evidence — the ceremony thread
+    /// continues with a returned Presentation Definition the client
+    /// satisfies and re-submits.
+    RequestMore(RequestMore),
+}
+
+/// `allow` payload. Every field is optional so the one struct serves
+/// every ceremony: join populates `role` (+ `obligations`),
+/// role-change populates `role`, leave populates `disposition`,
+/// directory populates `fields`. The host's effect handler reads only
+/// the fields its purpose defines.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Allow {
+    /// Role to grant / set (join, role-change). Subject to the
+    /// host-enforced privilege ceiling — a `join` policy naming
+    /// `admin` here is rejected by the invariant check, not honoured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Departure disposition (leave) — e.g. how the member's
+    /// credentials are wound down.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition: Option<String>,
+    /// Fields to project (directory) — the whitelist the PII-boundary
+    /// invariant intersects with what the policy allowed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<String>>,
+    /// Obligations the host must discharge as part of the effect
+    /// (e.g. `reciprocate_vmc` to form the bidirectional membership
+    /// edge).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub obligations: Vec<String>,
+}
+
+/// `deny` payload — a machine-readable refusal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Deny {
+    /// Stable refusal code (e.g. `no-matching-route`,
+    /// `credential-revoked`). Operator-facing surfaces map this to a
+    /// message + a suggested fix.
+    pub code: String,
+    /// Optional human-readable elaboration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `refer` payload — route the open thread to a human/quorum queue.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Refer {
+    /// The queue the decision is referred to (e.g. `moderator`,
+    /// `second-admin`).
+    pub queue: String,
+    /// Optional context for the reviewer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `request_more` payload — ask the actor for additional evidence and
+/// keep the thread open.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RequestMore {
+    /// What's missing, in the IR's `condition:value` shorthand (e.g.
+    /// `agreed:code-of-conduct`). Legible to both humans and clients.
+    #[serde(default)]
+    pub needs: Vec<String>,
+    /// A DIF Presentation Definition the client satisfies and
+    /// re-presents. Free-form JSON in Phase 1 (the PD generator lands
+    /// with the Rule-IR compiler).
+    #[serde(default)]
+    pub presentation_definition: JsonValue,
+}
+
+impl Verdict {
+    /// Parse a verdict from the decision object a policy returned.
+    ///
+    /// `decision` is the value plucked out of regorus's
+    /// `QueryResults` shape (`result[0].expressions[0].value`) — see
+    /// [`crate::policy::engine::evaluate`]. A policy that returns a
+    /// malformed decision (wrong `effect`, missing required `with`
+    /// field) surfaces as [`AppError::Internal`]: the structural
+    /// totality the compiler guarantees means a well-formed policy
+    /// always yields a parseable decision, so a parse failure is a
+    /// host/policy bug, not caller input.
+    pub fn from_decision(decision: JsonValue) -> Result<Self, AppError> {
+        serde_json::from_value(decision).map_err(|e| {
+            AppError::Internal(format!("policy returned a malformed decision object: {e}"))
+        })
+    }
+
+    /// The bare effect discriminant, for audit lines + metrics that
+    /// don't care about the payload.
+    pub fn effect(&self) -> &'static str {
+        match self {
+            Verdict::Allow(_) => "allow",
+            Verdict::Deny(_) => "deny",
+            Verdict::Refer(_) => "refer",
+            Verdict::RequestMore(_) => "request_more",
+        }
+    }
+
+    /// The structural-totality default the compiler appends to every
+    /// policy: an unmatched evaluation denies. Constructed here so the
+    /// host has a canonical fallback if it ever needs to synthesize
+    /// one (e.g. a policy that evaluates to `undefined`).
+    pub fn default_deny() -> Self {
+        Verdict::Deny(Deny {
+            code: "no-matching-route".into(),
+            reason: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The join `allow` decision the example `join.rego` emits —
+    /// `{"effect":"allow","with":{"role":"member","obligations":["reciprocate_vmc"]}}`.
+    #[test]
+    fn join_allow_round_trips_against_example_rego() {
+        let decision = json!({
+            "effect": "allow",
+            "with": { "role": "member", "obligations": ["reciprocate_vmc"] }
+        });
+        let verdict = Verdict::from_decision(decision.clone()).unwrap();
+        assert_eq!(
+            verdict,
+            Verdict::Allow(Allow {
+                role: Some("member".into()),
+                obligations: vec!["reciprocate_vmc".into()],
+                ..Default::default()
+            })
+        );
+        assert_eq!(verdict.effect(), "allow");
+        assert_eq!(serde_json::to_value(&verdict).unwrap(), decision);
+    }
+
+    /// The `request_more` decision carries needs + a PD.
+    #[test]
+    fn request_more_carries_needs_and_pd() {
+        let decision = json!({
+            "effect": "request_more",
+            "with": {
+                "needs": ["agreed:code-of-conduct"],
+                "presentation_definition": { "id": "vtc-join-coc" }
+            }
+        });
+        let verdict = Verdict::from_decision(decision.clone()).unwrap();
+        match &verdict {
+            Verdict::RequestMore(rm) => {
+                assert_eq!(rm.needs, vec!["agreed:code-of-conduct".to_string()]);
+                assert_eq!(rm.presentation_definition, json!({ "id": "vtc-join-coc" }));
+            }
+            other => panic!("expected request_more, got {other:?}"),
+        }
+        assert_eq!(serde_json::to_value(&verdict).unwrap(), decision);
+    }
+
+    /// The compiler-appended structural-totality default.
+    #[test]
+    fn default_deny_decision_shape() {
+        let decision = json!({ "effect": "deny", "with": { "code": "no-matching-route" } });
+        let verdict = Verdict::from_decision(decision.clone()).unwrap();
+        assert_eq!(verdict, Verdict::default_deny());
+        assert_eq!(serde_json::to_value(&verdict).unwrap(), decision);
+    }
+
+    /// `refer` to the moderator queue (example `join.rego` P4).
+    #[test]
+    fn refer_to_queue() {
+        let decision = json!({ "effect": "refer", "with": { "queue": "moderator" } });
+        let verdict = Verdict::from_decision(decision.clone()).unwrap();
+        assert_eq!(
+            verdict,
+            Verdict::Refer(Refer {
+                queue: "moderator".into(),
+                reason: None,
+            })
+        );
+        assert_eq!(serde_json::to_value(&verdict).unwrap(), decision);
+    }
+
+    /// A malformed decision (unknown effect) is a host/policy bug, not
+    /// caller input — it surfaces as `Internal`, not `Validation`.
+    #[test]
+    fn malformed_decision_is_internal_error() {
+        let err = Verdict::from_decision(json!({ "effect": "explode", "with": {} }))
+            .expect_err("unknown effect must fail");
+        assert!(matches!(err, AppError::Internal(_)), "got {err:?}");
+    }
+
+    /// A leave `allow` populates `disposition`, not `role`.
+    #[test]
+    fn leave_allow_uses_disposition() {
+        let decision = json!({ "effect": "allow", "with": { "disposition": "revoke-vmc" } });
+        let verdict = Verdict::from_decision(decision.clone()).unwrap();
+        assert_eq!(
+            verdict,
+            Verdict::Allow(Allow {
+                disposition: Some("revoke-vmc".into()),
+                ..Default::default()
+            })
+        );
+        // role / fields / obligations are omitted from the wire form.
+        assert_eq!(serde_json::to_value(&verdict).unwrap(), decision);
+    }
+}

--- a/vtc-service/src/ceremony/verify.rs
+++ b/vtc-service/src/ceremony/verify.rs
@@ -1,0 +1,262 @@
+//! The pre-verification typestate — [`VerifiedFacts`]
+//! (ceremony-pipeline design §2 "Verify", §9).
+//!
+//! The pipeline's load-bearing invariant: **crypto lives entirely in
+//! the Verify stage, so the policy reasons only over a verified
+//! view.** This module is where that becomes a *type*, not a
+//! convention. The evaluate stage takes a [`VerifiedFacts`], which can
+//! only be produced by running raw [`Facts`] through
+//! [`VerifiedFacts::assemble`]. A call site that tries to evaluate
+//! un-verified facts doesn't compile — it has a [`Facts`], not a
+//! [`VerifiedFacts`].
+//!
+//! This generalizes the MVP's `VerifiedJoinRequest` (`vtc-mvp.md`
+//! §10.1) from one ceremony to all of them, per the build-vs-reuse
+//! map (pipeline §10: "generalize `VerifiedJoinRequest` →
+//! `VerifiedFacts`").
+//!
+//! ## What "verified" means here
+//!
+//! The per-evidence cryptography — VP proof checking, holder-binding,
+//! invitation-signature verification, status-list resolution,
+//! issuer-trust via TRQP — is performed by the host *upstream* and
+//! recorded into the `verified` / `issuer_trusted` / `status` fields
+//! of [`Facts`]. [`VerifiedFacts::assemble`] is the **gate** that
+//! refuses to let facts reach the policy unless every evidence slot
+//! the actor presented actually carries a passing `verified` verdict.
+//! An authenticity failure aborts here and never reaches policy — the
+//! design's "identity/authenticity failure → abort (never reach
+//! policy)" edge.
+//!
+//! What this gate deliberately does **not** do: re-run the crypto
+//! (that's the host's job, upstream), or judge a credential's
+//! `status` / `issuer_trusted` (those are *facts the policy decides
+//! on*, not authenticity preconditions — a revoked-but-genuinely-
+//! verified credential is a valid fact for a policy to reject).
+
+use serde_json::Value as JsonValue;
+use vti_common::error::AppError;
+
+use super::facts::{Facts, Purpose};
+
+/// Facts that have passed the verification gate. Only constructable
+/// via [`Self::assemble`]; the evaluate stage takes this, never a bare
+/// [`Facts`].
+///
+/// The inner [`Facts`] is private so the only way to obtain a
+/// `VerifiedFacts` is to go through the gate — there is no
+/// `VerifiedFacts { .. }` literal and no `From<Facts>`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VerifiedFacts(Facts);
+
+/// Why a set of facts failed the verification gate. Each variant maps
+/// to an authenticity failure that must abort before policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifyError {
+    /// A presentation was presented but its host verdict is
+    /// `verified: false` — its proof or holder-binding did not check
+    /// out.
+    PresentationNotVerified,
+    /// An invitation was presented but its host verdict is
+    /// `verified: false` — its signature did not check out.
+    InvitationNotVerified,
+}
+
+impl VerifyError {
+    /// Stable code for audit + operator-facing surfaces.
+    pub fn code(&self) -> &'static str {
+        match self {
+            VerifyError::PresentationNotVerified => "presentation-not-verified",
+            VerifyError::InvitationNotVerified => "invitation-not-verified",
+        }
+    }
+}
+
+impl std::fmt::Display for VerifyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VerifyError::PresentationNotVerified => f.write_str("presented VP failed verification"),
+            VerifyError::InvitationNotVerified => {
+                f.write_str("presented invitation failed verification")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VerifyError {}
+
+impl From<VerifyError> for AppError {
+    /// An authenticity failure is a `Forbidden` — the caller's
+    /// evidence didn't check out, so the transition is refused before
+    /// any policy runs. (Not `Validation`: the request was
+    /// well-formed; its cryptographic claims were false.)
+    fn from(e: VerifyError) -> Self {
+        AppError::Forbidden(format!("{} ({})", e, e.code()))
+    }
+}
+
+impl VerifiedFacts {
+    /// Run [`Facts`] through the verification gate.
+    ///
+    /// Refuses any facts whose presented evidence carries a failing
+    /// host verdict: a present-but-unverified presentation or
+    /// invitation aborts the ceremony here. Evidence slots the actor
+    /// didn't present are absent and impose no obligation — a
+    /// directory query with no presentation passes the gate trivially.
+    ///
+    /// On success the facts are sealed into a `VerifiedFacts` that the
+    /// evaluate stage will accept.
+    pub fn assemble(facts: Facts) -> Result<Self, VerifyError> {
+        if let Some(presentation) = &facts.evidence.presentation
+            && !presentation.verified
+        {
+            return Err(VerifyError::PresentationNotVerified);
+        }
+        if let Some(invitation) = &facts.evidence.invitation
+            && !invitation.verified
+        {
+            return Err(VerifyError::InvitationNotVerified);
+        }
+        Ok(VerifiedFacts(facts))
+    }
+
+    /// The verified facts, for read-only inspection (audit, effect
+    /// handlers that need the subject DID, etc.).
+    pub fn facts(&self) -> &Facts {
+        &self.0
+    }
+
+    /// The ceremony these facts decide — selects the policy module and
+    /// effect handler without unwrapping the whole struct.
+    pub fn purpose(&self) -> Purpose {
+        self.0.purpose
+    }
+
+    /// Serialize to the JSON `input` document the policy evaluates
+    /// over. This is the only sanctioned way to feed facts to
+    /// [`crate::policy::engine::evaluate`] — the engine's `input` is
+    /// always the output of a verification gate.
+    pub fn to_input(&self) -> Result<JsonValue, AppError> {
+        serde_json::to_value(&self.0).map_err(AppError::from)
+    }
+
+    /// Consume the wrapper and return the inner facts. For the effect
+    /// stage, which has already evaluated the policy and is applying
+    /// the decision.
+    pub fn into_inner(self) -> Facts {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ceremony::facts::{
+        Actor, Context, Credential, CredentialStatus, Evidence, Invitation, Presentation, State,
+        Subject,
+    };
+    use serde_json::json;
+
+    fn base_facts(purpose: Purpose) -> Facts {
+        Facts {
+            purpose,
+            now: "2026-05-30T12:00:00Z".parse().unwrap(),
+            actor: Actor {
+                did: "did:key:zActor".into(),
+                role: None,
+                authenticated: true,
+            },
+            subject: Subject {
+                did: "did:key:zActor".into(),
+            },
+            context: Context {
+                community_did: "did:webvh:acme.example".into(),
+                channel: "rest".into(),
+                member_count: 10,
+            },
+            evidence: Evidence::default(),
+            state: State::default(),
+        }
+    }
+
+    fn verified_presentation() -> Presentation {
+        Presentation {
+            verified: true,
+            holder: "did:key:zActor".into(),
+            credentials: vec![Credential {
+                credential_type: "WitnessCredential".into(),
+                issuer: "did:webvh:notary.example".into(),
+                issuer_trusted: true,
+                status: CredentialStatus::Valid,
+                claims: json!({}),
+                valid_until: None,
+            }],
+        }
+    }
+
+    /// A directory query with no presented evidence passes the gate —
+    /// absent slots impose no obligation.
+    #[test]
+    fn empty_evidence_passes_the_gate() {
+        let facts = base_facts(Purpose::Directory);
+        let verified = VerifiedFacts::assemble(facts.clone()).expect("empty evidence is fine");
+        assert_eq!(verified.facts(), &facts);
+        assert_eq!(verified.purpose(), Purpose::Directory);
+    }
+
+    /// A verified presentation passes and is sealed in.
+    #[test]
+    fn verified_presentation_passes() {
+        let mut facts = base_facts(Purpose::Join);
+        facts.evidence.presentation = Some(verified_presentation());
+        let verified = VerifiedFacts::assemble(facts).expect("verified presentation passes");
+        // `to_input` reproduces the policy `input` document.
+        let input = verified.to_input().unwrap();
+        assert_eq!(input["evidence"]["presentation"]["verified"], true);
+    }
+
+    /// A presentation whose host verdict is `verified: false` aborts
+    /// here — it never reaches policy.
+    #[test]
+    fn unverified_presentation_is_rejected() {
+        let mut facts = base_facts(Purpose::Join);
+        let mut pres = verified_presentation();
+        pres.verified = false;
+        facts.evidence.presentation = Some(pres);
+        let err = VerifiedFacts::assemble(facts).expect_err("unverified presentation must abort");
+        assert_eq!(err, VerifyError::PresentationNotVerified);
+
+        // And it maps to a Forbidden, not a Validation.
+        let app: AppError = err.into();
+        assert!(matches!(app, AppError::Forbidden(_)), "got {app:?}");
+    }
+
+    /// An invitation whose host verdict is `verified: false` aborts.
+    #[test]
+    fn unverified_invitation_is_rejected() {
+        let mut facts = base_facts(Purpose::Join);
+        facts.evidence.invitation = Some(Invitation {
+            verified: false,
+            issuer: "did:webvh:acme.example".into(),
+            issuer_role: Some("admin".into()),
+            scopes: vec![],
+            consumed: false,
+        });
+        let err = VerifiedFacts::assemble(facts).expect_err("unverified invitation must abort");
+        assert_eq!(err, VerifyError::InvitationNotVerified);
+    }
+
+    /// A genuinely-verified-but-revoked credential is a *valid fact*
+    /// for the policy to reject — the gate does not judge `status`, so
+    /// these facts pass through to be decided by policy.
+    #[test]
+    fn revoked_but_verified_credential_passes_the_gate() {
+        let mut facts = base_facts(Purpose::Join);
+        let mut pres = verified_presentation();
+        pres.credentials[0].status = CredentialStatus::Revoked;
+        facts.evidence.presentation = Some(pres);
+        // verified: true holds — the credential's authenticity is not
+        // in question, only its status, which is the policy's call.
+        VerifiedFacts::assemble(facts).expect("revoked-but-verified is a fact, not an abort");
+    }
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -17,6 +17,7 @@ pub mod acl_cli;
 #[cfg(feature = "admin-ui")]
 pub mod admin_ui;
 pub mod auth;
+pub mod ceremony;
 pub mod community;
 pub mod config;
 pub mod config_store;

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -548,37 +548,49 @@ mod tests {
     }
 
     #[test]
-    fn directory_default_allows_did_and_role_only() {
+    fn directory_default_projects_fields_by_viewer_role() {
+        // The directory default is now the ceremony decision spine: it
+        // returns a {effect, with} object whose `with.fields` is the
+        // projection, branching on the verified-facts `input.actor`.
         let c = compile_default(PolicyPurpose::Directory);
-        let ok = evaluate(
+
+        // Admin viewer → fuller record.
+        let admin = evaluate(
             &c,
-            "data.vtc.directory.allow",
-            json!({
-                "viewer_did": "did:key:zViewer",
-                "viewer_role": "member",
-                "target_member": { "did": "did:key:zTarget" },
-                "fields_requested": ["did", "role"],
-                "action": "show"
-            }),
+            "data.vtc.directory.decision",
+            json!({ "actor": { "role": "admin", "authenticated": true } }),
         )
         .unwrap();
-        assert!(pluck_bool(&ok));
+        assert_eq!(
+            admin.pointer("/result/0/expressions/0/value"),
+            Some(&json!({
+                "effect": "allow",
+                "with": { "fields": ["did", "role", "joined_at", "status"] }
+            })),
+        );
 
+        // Authenticated non-admin member → did + role only.
+        let member = evaluate(
+            &c,
+            "data.vtc.directory.decision",
+            json!({ "actor": { "role": "member", "authenticated": true } }),
+        )
+        .unwrap();
+        assert_eq!(
+            member.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "allow", "with": { "fields": ["did", "role"] } })),
+        );
+
+        // Unauthenticated / non-member → structural-totality deny.
         let denied = evaluate(
             &c,
-            "data.vtc.directory.allow",
-            json!({
-                "viewer_did": "did:key:zViewer",
-                "viewer_role": "member",
-                "target_member": { "did": "did:key:zTarget" },
-                "fields_requested": ["did", "role", "email"],
-                "action": "show"
-            }),
+            "data.vtc.directory.decision",
+            json!({ "actor": { "authenticated": false } }),
         )
         .unwrap();
-        assert!(
-            !pluck_bool(&denied),
-            "directory default must deny when extra fields are requested"
+        assert_eq!(
+            denied.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "deny", "with": { "code": "not-a-member" } })),
         );
     }
 

--- a/vtc-service/src/routes/directory.rs
+++ b/vtc-service/src/routes/directory.rs
@@ -1,0 +1,224 @@
+//! `GET /v1/directory/{did}` — the directory ceremony.
+//!
+//! The first community ceremony wired end-to-end through the decision
+//! pipeline ([`crate::ceremony`]). Directory is the read-only
+//! instance: an authenticated viewer asks to see a subject's member
+//! record, and the active `directory` policy decides which fields the
+//! viewer may see. There is no thread and no state mutation — the
+//! whole ceremony is a single synchronous request → projection.
+//!
+//! Flow (pipeline §2, realized here):
+//! 1. **Trigger / Gather** — the route: an authenticated viewer
+//!    ([`AuthClaims`]) names a `subject` DID.
+//! 2. **Verify / Facts** — [`assemble_directory_facts`] reads the
+//!    viewer's community role and the subject's member row from
+//!    storage into a [`Facts`]. The viewer is already authenticated
+//!    (the extractor verified the JWT + session), so the facts gate
+//!    ([`VerifiedFacts::assemble`]) passes trivially — directory
+//!    carries no presented evidence to verify.
+//! 3. **Evaluate / Verdict** — [`crate::ceremony::decide`] runs the
+//!    active `directory` policy and applies the host invariants.
+//! 4. **Effect** — [`crate::ceremony::plan`] turns an `allow` into a
+//!    field projection, intersected with the PII-boundary whitelist
+//!    ([`DIRECTORY_FIELD_WHITELIST`]).
+//!
+//! ## Role source
+//!
+//! `actor.role` in the facts is the viewer's **community** role
+//! (`VtcRole`, read from the ACL keyspace), not the JWT/VTA `Role` the
+//! [`AuthClaims`] extractor carries — the directory policy branches on
+//! community standing (`admin` vs `member`), which lives in the ACL.
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value as JsonValue, json};
+
+use vti_common::error::AppError;
+
+use crate::acl::get_acl_entry;
+use crate::auth::AuthClaims;
+use crate::ceremony::{
+    self, Actor, Context, Evidence, Facts, MemberState, Purpose, State as FactsState, Subject,
+    Verdict, VerifiedFacts, effects::EffectPlan,
+};
+use crate::community::load_profile;
+use crate::members::{get_member, list_members};
+use crate::policy::engine::{CompiledPolicy, compile};
+use crate::policy::model::PolicyPurpose;
+use crate::policy::storage::{get_active_policy_id, get_policy};
+use crate::server::AppState;
+
+/// The PII boundary for the directory ceremony: the maximum set of
+/// member fields any directory policy may ever project, member-to-
+/// member. A policy can narrow this (the default shows `did` + `role`
+/// to members), but cannot widen past it — [`crate::ceremony::plan`]
+/// intersects the policy's chosen fields with this list. Per-community
+/// configuration of the whitelist is a follow-up; this constant is the
+/// safe default ceiling.
+pub const DIRECTORY_FIELD_WHITELIST: [&str; 4] = ["did", "role", "joined_at", "status"];
+
+/// Optional `?fields=a,b,c` hint — the fields the caller is interested
+/// in. Advisory: the policy decides what it returns, and the PII
+/// boundary caps it. Recorded into the facts so a policy *may* honour
+/// it, but the default directory policy projects by viewer role.
+#[derive(Debug, Default, Deserialize)]
+pub struct DirectoryQuery {
+    #[serde(default)]
+    pub fields: Option<String>,
+}
+
+/// The projected subject record.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DirectoryResponse {
+    pub subject: String,
+    pub fields: Map<String, JsonValue>,
+}
+
+/// `GET /v1/directory/{did}`.
+pub async fn query(
+    viewer: AuthClaims,
+    State(state): State<AppState>,
+    Path(subject_did): Path<String>,
+    Query(q): Query<DirectoryQuery>,
+) -> Result<Json<DirectoryResponse>, AppError> {
+    let facts = assemble_directory_facts(&state, &viewer, &subject_did, q.fields).await?;
+    let verified = VerifiedFacts::assemble(facts)?;
+
+    let policy = load_active_policy(&state, PolicyPurpose::Directory).await?;
+    let verdict = ceremony::decide(&verified, &policy)?;
+
+    match &verdict {
+        Verdict::Allow(_) => {
+            let whitelist: Vec<String> = DIRECTORY_FIELD_WHITELIST
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+            match ceremony::plan(&verified, &verdict, &whitelist)? {
+                EffectPlan::Project { fields } => Ok(Json(DirectoryResponse {
+                    subject: subject_did,
+                    fields,
+                })),
+                // Allow on a directory must plan a projection; any other
+                // plan means the active policy isn't a directory policy.
+                other => Err(AppError::Internal(format!(
+                    "directory allow produced a non-projection effect: {other:?}"
+                ))),
+            }
+        }
+        Verdict::Deny(d) => Err(AppError::Forbidden(format!(
+            "directory access denied ({}){}",
+            d.code,
+            d.reason
+                .as_deref()
+                .map(|r| format!(": {r}"))
+                .unwrap_or_default(),
+        ))),
+        // Directory is synchronous and unthreaded — a policy that
+        // refers or requests-more is misconfigured for this purpose.
+        Verdict::Refer(_) | Verdict::RequestMore(_) => Err(AppError::Internal(
+            "directory policy returned a non-terminal verdict; directory is synchronous".into(),
+        )),
+    }
+}
+
+/// Read the viewer's community role + the subject's member row from
+/// storage into the purpose-agnostic [`Facts`] the policy evaluates
+/// over.
+async fn assemble_directory_facts(
+    state: &AppState,
+    viewer: &AuthClaims,
+    subject_did: &str,
+    fields_hint: Option<String>,
+) -> Result<Facts, AppError> {
+    // Actor's community role comes from the ACL, not the JWT.
+    let actor_role = get_acl_entry(&state.acl_ks, &viewer.did)
+        .await?
+        .map(|e| e.role.to_string());
+
+    // Subject's member facts: role from the ACL, status from the
+    // member row's tombstone, joined_at from the member row.
+    let subject_member = match get_member(&state.members_ks, subject_did).await? {
+        Some(m) => {
+            let role = get_acl_entry(&state.acl_ks, subject_did)
+                .await?
+                .map(|e| e.role.to_string())
+                .unwrap_or_else(|| "member".to_string());
+            let status = if m.removed_at.is_some() {
+                "removed"
+            } else {
+                "active"
+            };
+            Some(MemberState {
+                role,
+                status: status.to_string(),
+                joined_at: m.joined_at,
+                personhood: None,
+            })
+        }
+        None => None,
+    };
+
+    // community_did is informational for directory (the policy doesn't
+    // branch on it); empty when no profile is set yet.
+    let community_did = load_profile(&state.community_ks)
+        .await?
+        .map(|p| p.community_did)
+        .unwrap_or_default();
+
+    let member_count = list_members(&state.members_ks).await?.len() as u64;
+
+    let request = fields_hint.map(|raw| {
+        let fields: Vec<String> = raw
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        json!({ "fields_requested": fields })
+    });
+
+    Ok(Facts {
+        purpose: Purpose::Directory,
+        now: Utc::now(),
+        actor: Actor {
+            did: viewer.did.clone(),
+            role: actor_role,
+            authenticated: true,
+        },
+        subject: Subject {
+            did: subject_did.to_string(),
+        },
+        context: Context {
+            community_did,
+            channel: "rest".to_string(),
+            member_count,
+        },
+        evidence: Evidence {
+            invitation: None,
+            presentation: None,
+            request,
+        },
+        state: FactsState { subject_member },
+    })
+}
+
+/// Fetch the active policy for a purpose and compile it. Generic over
+/// purpose so future ceremony routes reuse it; lives here until a
+/// second consumer pulls it up into the ceremony module.
+async fn load_active_policy(
+    state: &AppState,
+    purpose: PolicyPurpose,
+) -> Result<CompiledPolicy, AppError> {
+    let id = get_active_policy_id(&state.active_policies_ks, purpose)
+        .await?
+        .ok_or_else(|| AppError::Internal(format!("no active {} policy", purpose.as_str())))?;
+    let policy = get_policy(&state.policies_ks, id).await?.ok_or_else(|| {
+        AppError::Internal(format!(
+            "active {} policy {id} points at a missing row",
+            purpose.as_str()
+        ))
+    })?;
+    compile(&policy.rego_source, policy.id)
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -7,6 +7,7 @@ mod auth;
 mod community;
 mod config;
 pub(crate) mod did_log;
+mod directory;
 mod endorsement_types;
 mod endorsements;
 mod health;
@@ -213,6 +214,8 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
     let members_list = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/list/1.0")
         .expect("static Trust-Task URL");
     let members_show = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/show/1.0")
+        .expect("static Trust-Task URL");
+    let directory_query = TrustTask::new("https://trusttasks.org/openvtc/vtc/directory/query/1.0")
         .expect("static Trust-Task URL");
     // `members_update` (`members/update/1.0`) shares the
     // `members/{did}` mount with `show` for now — TrustTaskRouter
@@ -500,6 +503,9 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             axum::routing::delete(admin::invites::revoke_invite),
             admin_invites_revoke,
         )
+        // Directory ceremony (read-only field projection via the
+        // ceremony decision pipeline).
+        .route_with_task("/directory/{did}", get(directory::query), directory_query)
         // Members (Phase 1 M1.4–M1.6).
         .route_with_task("/members", get(members::read::list_members), members_list)
         // `/v1/members/me` for self-remove (M1.11.1). Must be

--- a/vtc-service/tests/directory.rs
+++ b/vtc-service/tests/directory.rs
@@ -1,0 +1,334 @@
+//! Integration coverage for the directory ceremony
+//! (`GET /v1/directory/{did}`).
+//!
+//! Exercises the full decision pipeline through a real HTTP request:
+//! auth → facts-assembly (ACL + member reads) → evaluate (active
+//! `directory.rego`) → invariant → decide → PII-bounded projection.
+//!
+//! The viewers below carry a JWT `role` of `admin` regardless of their
+//! community standing — the directory route reads the *community* role
+//! from the ACL keyspace, not the JWT. The member viewer getting a
+//! member-level projection despite an `admin` JWT role is the assertion
+//! that proves that separation.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+use vti_common::audit::{AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::passkey::build_webauthn;
+use vti_common::auth::session::{Session, SessionState, store_session};
+use vti_common::config::StoreConfig;
+use vti_common::store::{KeyspaceHandle, Store};
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::config::AppConfig;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::{Member, store_member};
+use vtc_service::policy::default::install_defaults;
+use vtc_service::routes;
+use vtc_service::server::AppState;
+
+const RP_ORIGIN: &str = "https://vtc.example.com";
+const DIRECTORY_TASK: &str = "https://trusttasks.org/openvtc/vtc/directory/query/1.0";
+const ADMIN_DID: &str = "did:key:zAdmin1";
+
+fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+struct Fixture {
+    router: axum::Router,
+    jwt_keys: Arc<JwtKeys>,
+    sessions_ks: KeyspaceHandle,
+    acl_ks: KeyspaceHandle,
+    members_ks: KeyspaceHandle,
+    admin_token: String,
+    _dir: tempfile::TempDir,
+}
+
+async fn build_fixture() -> Fixture {
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    // The directory route reads the active `directory` policy, so the
+    // bundled defaults must be installed (server boot does this).
+    install_defaults(&policies_ks, &active_policies_ks)
+        .await
+        .expect("install default policies");
+
+    let install_store = InstallTokenStore::new(install_ks.clone());
+    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
+
+    let key_store = AuditKeyStore::new(audit_key_ks.clone());
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
+
+    let jwt_seed = [0x42u8; 32];
+    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+
+    // Admin viewer: community-admin ACL row + an authenticated session.
+    store_acl_entry(
+        &acl_ks,
+        &VtcAclEntry {
+            did: ADMIN_DID.into(),
+            role: VtcRole::Admin,
+            label: Some("test admin".into()),
+            allowed_contexts: vec![],
+            created_at: vtc_service::auth::session::now_epoch(),
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        public_url = "{RP_ORIGIN}"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks: sessions_ks.clone(),
+        acl_ks: acl_ks.clone(),
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks: members_ks.clone(),
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks,
+        registry_records_ks,
+        sync_queue_ks,
+        sync_cursor_ks,
+        relationships_ks,
+        relationships_by_did_ks,
+        endorsement_types_ks,
+        endorsements_ks,
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
+        credential_signer: None,
+        audit_ks,
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: Some(jwt_keys.clone()),
+        atm: None,
+        webauthn,
+        public_url: Some(RP_ORIGIN.to_string()),
+        install_signer: None,
+        install_store,
+        audit_writer,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    let router = routes::router().with_state(state);
+    let admin_token = mint_token(&jwt_keys, &sessions_ks, ADMIN_DID).await;
+
+    Fixture {
+        router,
+        jwt_keys,
+        sessions_ks,
+        acl_ks,
+        members_ks,
+        admin_token,
+        _dir: dir,
+    }
+}
+
+/// Mint an authenticated session + matching JWT for `did`. The JWT
+/// `role` is always `admin`; the directory route ignores it and reads
+/// the community role from the ACL.
+async fn mint_token(jwt_keys: &Arc<JwtKeys>, sessions_ks: &KeyspaceHandle, did: &str) -> String {
+    let now = vtc_service::auth::session::now_epoch();
+    let session_id = format!("session-{did}");
+    let session = Session {
+        session_id: session_id.clone(),
+        did: did.into(),
+        challenge: "test".into(),
+        state: SessionState::Authenticated,
+        created_at: now,
+        refresh_token: None,
+        refresh_expires_at: None,
+        tee_attested: false,
+        amr: Vec::new(),
+        acr: String::new(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(sessions_ks, &session).await.unwrap();
+    let claims = jwt_keys.new_claims(did.into(), session_id, "admin".into(), vec![], 3600, true);
+    jwt_keys.encode(&claims).unwrap()
+}
+
+/// Seed a member: an ACL row (community role) + a Member record.
+async fn seed_member(fix: &Fixture, did: &str, role: VtcRole) {
+    store_acl_entry(
+        &fix.acl_ks,
+        &VtcAclEntry {
+            did: did.into(),
+            role,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: vtc_service::auth::session::now_epoch(),
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    store_member(&fix.members_ks, &Member::fresh(did))
+        .await
+        .unwrap();
+}
+
+async fn get_directory(
+    router: &axum::Router,
+    subject: &str,
+    token: Option<&str>,
+) -> (StatusCode, Value) {
+    let mut req = Request::builder()
+        .method("GET")
+        .uri(format!("/v1/directory/{subject}"))
+        .header("Trust-Task", DIRECTORY_TASK);
+    if let Some(t) = token {
+        req = req.header("Authorization", format!("Bearer {t}"));
+    }
+    let res = router
+        .clone()
+        .oneshot(req.body(Body::empty()).unwrap())
+        .await
+        .expect("oneshot");
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+/// An admin viewer sees the fuller projection (did, role, joined_at,
+/// status) of a member subject.
+#[tokio::test]
+async fn admin_viewer_sees_full_record() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zSubject", VtcRole::Member).await;
+
+    let (status, body) =
+        get_directory(&fix.router, "did:key:zSubject", Some(&fix.admin_token)).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["subject"], "did:key:zSubject");
+    let fields = &body["fields"];
+    assert_eq!(fields["did"], "did:key:zSubject");
+    assert_eq!(fields["role"], "member");
+    assert_eq!(fields["status"], "active");
+    assert!(
+        fields["joined_at"].is_string(),
+        "joined_at present for admin: {body}"
+    );
+}
+
+/// A community-member viewer sees only `did` + `role` — the PII
+/// boundary + the member branch of the policy drop the rest. The
+/// viewer's JWT role is `admin`; getting a member-level projection
+/// proves the route reads the community role from the ACL, not the JWT.
+#[tokio::test]
+async fn member_viewer_sees_did_and_role_only() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zViewer", VtcRole::Member).await;
+    seed_member(&fix, "did:key:zSubject", VtcRole::Member).await;
+    let viewer_token = mint_token(&fix.jwt_keys, &fix.sessions_ks, "did:key:zViewer").await;
+
+    let (status, body) = get_directory(&fix.router, "did:key:zSubject", Some(&viewer_token)).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    let fields = &body["fields"];
+    assert_eq!(fields["did"], "did:key:zSubject");
+    assert_eq!(fields["role"], "member");
+    // PII boundary: a member viewer never sees status / joined_at.
+    assert!(
+        fields.get("status").is_none(),
+        "status must be hidden from member viewer: {body}"
+    );
+    assert!(
+        fields.get("joined_at").is_none(),
+        "joined_at must be hidden from member viewer: {body}"
+    );
+}
+
+/// An unauthenticated request is rejected by the auth extractor before
+/// the ceremony runs.
+#[tokio::test]
+async fn unauthenticated_is_rejected() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zSubject", VtcRole::Member).await;
+
+    let (status, _) = get_directory(&fix.router, "did:key:zSubject", None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+/// An admin viewer querying a non-member subject gets only the echoed
+/// `did` — there is no member row to project the other fields from, so
+/// the projection drops them rather than inventing them.
+#[tokio::test]
+async fn non_member_subject_projects_did_only() {
+    let fix = build_fixture().await;
+
+    let (status, body) = get_directory(&fix.router, "did:key:zGhost", Some(&fix.admin_token)).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    let fields = &body["fields"];
+    assert_eq!(fields["did"], "did:key:zGhost");
+    assert!(
+        fields.get("role").is_none(),
+        "no role for a non-member: {body}"
+    );
+    assert!(fields.get("status").is_none());
+    assert!(fields.get("joined_at").is_none());
+}


### PR DESCRIPTION
## What

Implements **Stage A** of the VTC ceremony decision pipeline (design merged in #174) and lands the first ceremony — **directory** — end-to-end through it.

The thesis (from `docs/05-design-notes/vtc-ceremony-pipeline.md`): don't build a join ceremony, build **one decision pipeline** parameterized by purpose, and make every community state transition an instance of it:

```
TRIGGER → GATHER → VERIFY (host) → FACTS → EVALUATE (<purpose>.rego) → VERDICT → EFFECTS
```

This PR builds that spine and proves it on the read-only directory ceremony. It does **not** touch the existing MVP join-approve write path — the heavier async effect executor (join/leave writes) is deliberately a follow-up.

## Commits (each self-contained, DCO-signed)

1. **Stage-A types** — purpose-agnostic `Facts` contract (§3), four-valued `Verdict` (§4, `allow`/`deny`/`refer`/`request_more`), and the `VerifiedFacts` typestate (generalizes the MVP's `VerifiedJoinRequest`). New `vtc-service/src/ceremony/` module.
2. **Decision driver** — `evaluate` (runs `<purpose>.rego`, host structural-totality backstop) → `invariant::enforce` (host vetoes a policy can't override: privilege-ceiling, step-up-for-admin) → `decide()`.
3. **Effects planning** — `plan()` maps a verdict to typed per-purpose intent. The **directory** effect is fully realized (field projection); the **PII-boundary invariant** is enforced here (projected fields ∩ community whitelist).
4. **Directory route** — `GET /v1/directory/{did}`: assembles `Facts` from storage (community role from ACL, not JWT), decides, projects. Replaces the Phase-5 placeholder `directory.rego` default with the decision-shaped policy.
5. **Integration test** — 4 cases against a live `AppState`: admin viewer → full record, member viewer → did+role only (proves ACL-vs-JWT role separation), unauthenticated → 401, non-member subject → did only.

## Design decisions worth a reviewer's eye

- **`Purpose` is a new enum**, distinct from the MVP's `PolicyPurpose` (the pipeline's `leave` vs MVP's `removal` naming drift is left as a documented open migration item).
- The **verify gate checks only evidence `verified` flags**, not `status`/`issuer_trusted` — those are facts for the policy to decide on, not authenticity preconditions.
- **No-last-admin invariant is deferred** (needs ACL admin-count state that arrives with the write executor) — documented in `invariant.rs`, not silently absent.
- With the default directory policy, the **policy-deny→403 branch isn't reachable** (P2 admits any authenticated viewer); it's correct for operator policies that gate on community standing.

## Testing

- 35 ceremony unit tests + the updated `directory` default-policy test, all green.
- 4 HTTP integration tests (`tests/directory.rs`), green.
- `cargo fmt` + `clippy` clean. Rebased onto current `main`.

## Not in this PR (follow-ups)

- Async effect executor for join/leave/role-change writes (refactors the tested approve flow into a shared op).
- No-last-admin invariant.
- Stage B: real `join.rego` wiring; `request_more`/`refer` ceremony threads.