### PR TITLE
feat(vta-mobile-core): MediatorSession FFI — connect + receive over a mediator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9491,7 +9491,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9507,6 +9507,7 @@ dependencies = [
  "tokio",
  "trust-tasks-rs",
  "uniffi",
+ "vta-sdk 0.9.5",
 ]
 
 [[package]]

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.2.1"
+version = "0.3.0"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -53,17 +53,11 @@ tokio = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 # DIDComm v2 authcrypt/anoncrypt pack + unpack. Pinned to vta-sdk's version.
 affinidi-messaging-didcomm = "0.15"
-
-# ── Deferred wiring (kept out of slice 1 on purpose) ────────────────────────
-# The FFI build + bindgen pipeline is proven first with a minimal surface.
-#   slice 2 — Trust Tasks (pure, sync). Needs a republished trust-tasks-rs:
-#             crates.io 0.1.2 predates the `evidence` / `acceptableEvidence`
-#             fields merged to dtgwg-trust-tasks-tf (PRs #61/#62).
-#     trust-tasks-rs    = { workspace = true }
-#     trust-tasks-proof = { workspace = true }
-#   slice 3 — VTA session/auth (async over the FFI boundary, tokio runtime):
-#     vta-sdk      = { workspace = true, features = ["session"] }
-#     vti-webauthn = { path = "../vti-webauthn" }   # shared WebAuthn types
+# Mediator-connected DIDComm session (ATM): the `MediatorSession` FFI wraps
+# `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
+# pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
+# the VTA uses rather than reimplementing the affinidi mediator protocol.
+vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["session"] }
 
 [dev-dependencies]
 # Test-only Ed25519 signing for the did-signed verify round-trip (stands in for

--- a/vta-mobile-core/src/error.rs
+++ b/vta-mobile-core/src/error.rs
@@ -20,4 +20,9 @@ pub enum FfiError {
     /// The requested operation is part of a not-yet-wired build-out slice.
     #[error("not yet implemented: {what}")]
     Unimplemented { what: String },
+
+    /// A DIDComm mediator transport operation failed (connect, authenticate,
+    /// receive). Network/protocol failures from the live mediator surface here.
+    #[error("transport error: {reason}")]
+    Transport { reason: String },
 }

--- a/vta-mobile-core/src/lib.rs
+++ b/vta-mobile-core/src/lib.rs
@@ -37,6 +37,7 @@ mod proof;
 // so the crate layout matches the mapped design from day one.
 pub mod didcomm;
 pub mod keys;
+pub mod mediator;
 pub mod push;
 pub mod resolver;
 pub mod session;

--- a/vta-mobile-core/src/mediator.rs
+++ b/vta-mobile-core/src/mediator.rs
@@ -1,0 +1,71 @@
+//! Mediator-connected DIDComm session for the mobile approver.
+//!
+//! Wraps `vta-sdk`'s [`DIDCommSession`] (the affinidi ATM client) so iOS /
+//! Android can connect to the holder's mediator and pull VTA-pushed messages —
+//! e.g. an `auth/step-up/approve-request/0.1` delivered for the proxied
+//! step-up. The session authenticates to the mediator as the holder and opens
+//! live delivery; [`MediatorSession::receive_next`] yields the next inbound
+//! message already unpacked under the holder key.
+//!
+//! Reusing `vta-sdk`'s session (rather than reimplementing the affinidi
+//! mediator protocol — challenge auth + message-pickup 3.0 + WebSocket — in the
+//! host language) keeps the engine and the VTA on one client.
+
+use std::sync::Arc;
+
+use vta_sdk::didcomm_session::DIDCommSession;
+
+use crate::error::FfiError;
+
+/// A live DIDComm session to a mediator, scoped to one holder identity.
+#[derive(uniffi::Object)]
+pub struct MediatorSession {
+    inner: DIDCommSession,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl MediatorSession {
+    /// Connect to `mediator_did` as the holder and open live delivery.
+    ///
+    /// - `holder_did`: the holder's `did:key`.
+    /// - `holder_signing_private_ed25519`: the holder's 32-byte Ed25519 seed
+    ///   (the key behind its `did:key`). It stays in the engine; only derived
+    ///   DIDComm secrets reach the ATM secrets resolver.
+    /// - `vta_did`: the peer (VTA) this holder converses with.
+    /// - `mediator_did`: the mediator to connect through.
+    #[uniffi::constructor]
+    pub async fn connect(
+        holder_did: String,
+        holder_signing_private_ed25519: Vec<u8>,
+        vta_did: String,
+        mediator_did: String,
+    ) -> Result<Arc<Self>, FfiError> {
+        let private_key_mb =
+            multibase::encode(multibase::Base::Base58Btc, &holder_signing_private_ed25519);
+        let inner = DIDCommSession::connect(&holder_did, &private_key_mb, &vta_did, &mediator_did)
+            .await
+            .map_err(|e| FfiError::Transport {
+                reason: e.to_string(),
+            })?;
+        Ok(Arc::new(Self { inner }))
+    }
+
+    /// Wait up to `timeout_secs` for the next inbound DIDComm message from the
+    /// mediator. Returns the unpacked message as JSON (`{ id, type, body, … }`)
+    /// — the application Trust Task (e.g. the approve-request) rides in `body` —
+    /// or `None` if nothing arrived within the timeout. Call again to keep
+    /// polling.
+    pub async fn receive_next(&self, timeout_secs: u64) -> Result<Option<String>, FfiError> {
+        self.inner
+            .receive_next(timeout_secs)
+            .await
+            .map_err(|e| FfiError::Transport {
+                reason: e.to_string(),
+            })
+    }
+
+    /// Gracefully close the mediator connection (live-delivery WebSocket).
+    pub async fn shutdown(&self) {
+        self.inner.shutdown().await;
+    }
+}


### PR DESCRIPTION
## Summary

**Stage 2** of the iOS proxied step-up — the engine-FFI-via-ATM approach. Adds an async UniFFI `MediatorSession` to `vta-mobile-core` that wraps `vta-sdk::DIDCommSession` (`connect` + the new `receive_next` from #203), so the mobile approver can connect to its mediator and **pull VTA-pushed messages** off it — e.g. the `auth/step-up/approve-request/0.1` the VTA forwards (#202).

- `MediatorSession::connect(holder_did, holder_signing_private_ed25519, vta_did, mediator_did)` — authenticates to the mediator as the holder, opens live delivery. The Ed25519 seed is multibase-encoded in-engine; only derived DIDComm secrets reach the ATM resolver.
- `receive_next(timeout_secs)` — next inbound message as JSON (already unpacked under the holder key; the Trust Task rides in `body`), or `None` on timeout.
- `shutdown()` — closes the live-delivery WebSocket.
- New `FfiError::Transport`.

Reuses the affinidi **ATM** client (via `vta-sdk[session]`) rather than reimplementing the mediator protocol (challenge auth + message-pickup 3.0 + WebSocket) in Swift — engine and VTA stay on one client.

## The risk, validated
This pulls the network stack (reqwest / ATM / tokio / rustls / ring / aws-lc) into the mobile engine. Checked before opening:
- Host build ✅
- **All new deps cross-compile to `aarch64-apple-ios`** ✅
- The iOS **staticlib** (what the xcframework archives) builds clean ✅ (a `cargo build --target` cdylib link error is a deployment-target artifact the staticlib path avoids)

`vta-mobile-core` 0.2.1 → **0.3.0**; also dropped a now-stale "deferred wiring" comment.

## Next
After merge I'll push the **`vta-mobile-core-v0.3.0`** tag (release CI → xcframework + checksum) — I'll run `package-ios.sh` locally first to be doubly sure, then bump the iOS `Package.swift` and wire the receive loop (`MediatorSession.connect` → `receive_next` → `receiveStepUpApproveRequest`).