### PR TITLE
feat(vtc): ceremony effect executor (Admit) + route approve through it

### DIFF
--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -1,0 +1,225 @@
+//! The Effects executor — apply an [`EffectPlan`] against `AppState`
+//! (ceremony-pipeline design §5, the "apply" half of the effect
+//! stage).
+//!
+//! [`super::effects::plan`] produced a typed *intent*; this is where
+//! that intent becomes state. It is the **only** stage that mutates
+//! community state, and it is driven solely by the verdict-derived
+//! plan. The pure decision spine (verify → evaluate → invariant →
+//! decide → plan) is all testable without I/O; this module is the
+//! single I/O seam.
+//!
+//! ## Single entry point, shared by the bespoke flow
+//!
+//! [`apply`] is the one executor. The MVP's manual join-approve route
+//! ([`crate::routes::join_requests::decide::approve`]) is refactored
+//! to go through it too — it builds an [`EffectPlan::Admit`] and calls
+//! [`apply`], so the pipeline genuinely supersedes the bespoke write
+//! path rather than duplicating it. The approve route's integration
+//! tests therefore exercise the [`EffectPlan::Admit`] arm end-to-end.
+//!
+//! ## What's wired
+//!
+//! - **Admit** (join) — write the ACL row + Member record, issue the
+//!   VMC + role VEC, flip the status-list slot. Fully wired.
+//! - **NoStateChange** (deny / refer / request_more) — no-op.
+//! - **Project** (directory) — not handled here: the directory route
+//!   serializes the projection into its HTTP response inline, so a
+//!   `Project` plan reaching the executor is a caller bug.
+//! - **Depart** (leave) / **Remint** (role-change) — not yet wired:
+//!   their ceremonies (routes + facts assembly + the no-last-admin
+//!   invariant) don't exist yet, so wiring their executors now would
+//!   be untested speculation. They return a clear error until then.
+
+use affinidi_status_list::StatusPurpose;
+use affinidi_vc::VerifiableCredential;
+use uuid::Uuid;
+use vti_common::error::AppError;
+
+use super::effects::EffectPlan;
+use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use crate::auth::session::now_epoch;
+use crate::credentials::{
+    CredentialStatusRef, RoleVecParams, VmcParams, build_role_vec, build_vmc,
+};
+use crate::members::{Member, store_member};
+use crate::server::AppState;
+use crate::status_list;
+
+/// What the executor did. Carries back whatever the caller needs to
+/// audit + respond — currently the credentials minted on admit.
+#[derive(Debug)]
+pub enum EffectOutcome {
+    /// A member was admitted; carries the issued credentials so the
+    /// caller can audit them and hand them to the applicant. Boxed —
+    /// the two VCs make this variant far larger than the others.
+    Admitted(Box<AdmitOutcome>),
+    /// No state was changed (the verdict was deny / refer /
+    /// request_more).
+    None,
+}
+
+/// The credentials minted when a member is admitted.
+#[derive(Debug)]
+pub struct AdmitOutcome {
+    pub vmc: VerifiableCredential,
+    pub role_vec: VerifiableCredential,
+    pub status_list_index: u32,
+}
+
+/// Apply an effect plan.
+///
+/// `actor_did` is the authenticated initiator (the admin on the manual
+/// approve path, the relayer/holder on a ceremony path) — recorded as
+/// the ACL row's `created_by`. The caller owns audit + the HTTP
+/// response; this function owns the writes.
+pub async fn apply(
+    state: &AppState,
+    plan: EffectPlan,
+    actor_did: &str,
+) -> Result<EffectOutcome, AppError> {
+    match plan {
+        EffectPlan::Admit {
+            subject,
+            role,
+            // Obligations (e.g. `reciprocate_vmc` to form the
+            // bidirectional membership edge) are not yet discharged —
+            // the reciprocal-VMC handshake lands with the join
+            // ceremony route.
+            obligations: _,
+        } => {
+            let role = parse_role(&role)?;
+            let outcome = admit(state, &subject, role, actor_did).await?;
+            Ok(EffectOutcome::Admitted(Box::new(outcome)))
+        }
+        EffectPlan::NoStateChange => Ok(EffectOutcome::None),
+        EffectPlan::Project { .. } => Err(AppError::Internal(
+            "directory projection is applied by the route, not the effect executor".into(),
+        )),
+        EffectPlan::Depart { .. } | EffectPlan::Remint { .. } => Err(AppError::Internal(
+            "leave / role-change effect executor is not yet wired".into(),
+        )),
+    }
+}
+
+/// Parse the policy-granted role string into a [`VtcRole`]. The
+/// privilege ceiling already rejected an `admin` grant on join before
+/// the plan was built, so this is the final wire-form parse.
+fn parse_role(role: &str) -> Result<VtcRole, AppError> {
+    role.parse::<VtcRole>()
+        .map_err(|_| AppError::Validation(format!("effect plan carries an unknown role: {role}")))
+}
+
+/// Admit a DID as a member: write the ACL row + Member record, issue
+/// the VMC + role VEC, flip the status-list slot.
+///
+/// Writes the ACL first (the auth-gating truth), then the Member row,
+/// then issues credentials and stamps their ids back onto the member.
+/// A failure partway leaves the safer state (auth path works; metadata
+/// reconcilable by the next admin action).
+async fn admit(
+    state: &AppState,
+    subject_did: &str,
+    role: VtcRole,
+    actor_did: &str,
+) -> Result<AdmitOutcome, AppError> {
+    if get_acl_entry(&state.acl_ks, subject_did).await?.is_some() {
+        return Err(AppError::Conflict(format!(
+            "{subject_did} already has an ACL row; refusing to admit a duplicate membership"
+        )));
+    }
+
+    let acl = VtcAclEntry {
+        did: subject_did.to_string(),
+        role: role.clone(),
+        label: None,
+        allowed_contexts: vec![],
+        created_at: now_epoch(),
+        created_by: actor_did.to_string(),
+        expires_at: None,
+    };
+    store_acl_entry(&state.acl_ks, &acl).await?;
+
+    let mut member = Member::fresh(subject_did);
+    store_member(&state.members_ks, &member).await?;
+
+    let (vmc, role_vec, status_list_index) =
+        issue_member_credentials(state, subject_did, role).await?;
+    member.status_list_index = Some(status_list_index);
+    member.current_vmc_id = top_level_id(&vmc);
+    member.current_role_vec_id = top_level_id(&role_vec);
+    store_member(&state.members_ks, &member).await?;
+
+    Ok(AdmitOutcome {
+        vmc,
+        role_vec,
+        status_list_index,
+    })
+}
+
+/// Allocate a revocation-list slot, mint the VMC + role VEC at `role`,
+/// persist the updated status-list state. Returns the signed VCs + the
+/// allocated index.
+///
+/// The status-list state is stored only *after* both VCs build
+/// successfully, so a build failure doesn't permanently burn a slot.
+async fn issue_member_credentials(
+    state: &AppState,
+    subject_did: &str,
+    role: VtcRole,
+) -> Result<(VerifiableCredential, VerifiableCredential, u32), AppError> {
+    let signer = state.credential_signer.as_ref().ok_or_else(|| {
+        AppError::Internal(
+            "credential signer not initialised — cannot mint VMC (run setup first)".into(),
+        )
+    })?;
+
+    let mut row = status_list::get_state(&state.status_lists_ks, StatusPurpose::Revocation)
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal(
+                "revocation status list not provisioned — set `public_url` + restart".into(),
+            )
+        })?;
+
+    let slot = status_list::allocate(&mut row).ok_or_else(|| {
+        AppError::Internal(format!(
+            "revocation status list exhausted (capacity = {})",
+            row.capacity
+        ))
+    })?;
+
+    let status_ref = CredentialStatusRef::revocation(row.list_credential_id.clone(), slot);
+
+    let vmc_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let vmc = build_vmc(
+        signer,
+        VmcParams::new(subject_did)
+            .with_id(vmc_id)
+            .with_status_ref(status_ref)
+            .with_personhood(false),
+    )
+    .await?;
+
+    let vec_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let role_vec = build_role_vec(
+        signer,
+        RoleVecParams::new(subject_did, role).with_id(vec_id),
+    )
+    .await?;
+
+    status_list::store_state(&state.status_lists_ks, &row).await?;
+    status_list::maybe_emit_occupancy_warning(&row);
+
+    Ok((vmc, role_vec, slot))
+}
+
+/// Pull the top-level `id` field off a signed VC. The upstream
+/// `VerifiableCredential` type doesn't expose it directly — issuance
+/// splices it onto the wire form via JSON, so reading it back requires
+/// a JSON round-trip. Shared with the approve route's audit helper.
+pub(crate) fn top_level_id(vc: &VerifiableCredential) -> Option<String> {
+    serde_json::to_value(vc)
+        .ok()
+        .and_then(|v| v.get("id").and_then(|i| i.as_str().map(str::to_string)))
+}

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -34,12 +34,15 @@
 //! - [`effects`] — plans the per-purpose state change a verdict
 //!   authorizes ([`effects::EffectPlan`]). The directory projection
 //!   (read-only) is fully realized; the write plans (admit / depart /
-//!   re-mint) await their async executor.
+//!   re-mint) are typed intents the executor applies.
+//! - [`execute`] — the async effect executor ([`execute::apply`]):
+//!   applies a plan against `AppState`. The **Admit** (join) write
+//!   path is wired and is the op the manual approve route now goes
+//!   through; **Depart** / **Remint** await their ceremonies.
 //!
-//! Still to land on top of this spine (pipeline §11): the async
-//! **effect executor** that applies the write plans against
-//! `AppState` (reusing the issue-VMC / write-ACL helpers), and the
-//! remaining state-dependent invariant — no-last-admin (see
+//! Still to land on top of this spine (pipeline §11): the Depart /
+//! Remint executor arms (with their leave / role-change ceremonies)
+//! and the remaining state-dependent invariant — no-last-admin (see
 //! [`invariant`]).
 //!
 //! ## Relationship to the existing `policy` + `join` modules
@@ -55,6 +58,7 @@
 
 pub mod effects;
 pub mod evaluate;
+pub mod execute;
 pub mod facts;
 pub mod invariant;
 pub mod verdict;
@@ -62,6 +66,7 @@ pub mod verify;
 
 pub use effects::{EffectPlan, plan};
 pub use evaluate::evaluate;
+pub use execute::{AdmitOutcome, EffectOutcome, apply};
 pub use facts::{
     Actor, Context, Credential, CredentialStatus, Evidence, Facts, Invitation, MemberState,
     Presentation, Purpose, State, Subject,

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -7,7 +7,6 @@
 //! already validated at submit time so the only failure modes
 //! here are auth + duplicate-membership.
 
-use affinidi_status_list::StatusPurpose;
 use affinidi_vc::VerifiableCredential;
 use axum::Json;
 use axum::extract::{Path, State};
@@ -22,18 +21,14 @@ use vti_common::audit::{
 };
 use vti_common::error::AppError;
 
-use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use crate::acl::VtcRole;
 use crate::auth::AdminAuth;
-use crate::auth::session::now_epoch;
+use crate::ceremony::execute::{self, top_level_id};
+use crate::ceremony::{EffectOutcome, EffectPlan};
 use crate::credentials::vec::VEC_TYPE;
 use crate::credentials::vmc::VMC_TYPE;
-use crate::credentials::{
-    CredentialStatusRef, RoleVecParams, VmcParams, build_role_vec, build_vmc,
-};
 use crate::join::{JoinStatus, get_join_request, store_join_request};
-use crate::members::{Member, store_member};
 use crate::server::AppState;
-use crate::status_list;
 
 const REJECT_REASON_MAX: usize = 1024;
 
@@ -76,48 +71,23 @@ pub async fn approve(
             req.status
         )));
     }
-    if get_acl_entry(&state.acl_ks, &req.applicant_did)
-        .await?
-        .is_some()
-    {
-        return Err(AppError::Conflict(format!(
-            "{} already has an ACL row; refusing to approve a duplicate membership",
-            req.applicant_did
-        )));
-    }
-
-    // Write ACL first (auth-gating truth), then Member, then flip
-    // the JoinRequest status. A crash between ACL + Member would
-    // leave the auth path working but the metadata missing — the
-    // safer direction (Phase 2 reconcile / next admin action can
-    // patch the gap).
-    let now = now_epoch();
-    let acl = VtcAclEntry {
-        did: req.applicant_did.clone(),
-        role: VtcRole::Member,
-        label: None,
-        allowed_contexts: vec![],
-        created_at: now,
-        created_by: admin.0.did.clone(),
-        expires_at: None,
+    // Effects: admit the applicant as a member. The ceremony effect
+    // executor owns the duplicate-ACL guard, the ACL + Member writes,
+    // and credential issuance (it is the single state-mutating seam —
+    // see `ceremony::execute`). Approve wraps it with the join-request
+    // status flip + audit. A duplicate ACL surfaces as the executor's
+    // `Conflict` → 409, same as before.
+    let plan = EffectPlan::Admit {
+        subject: req.applicant_did.clone(),
+        role: VtcRole::Member.to_string(),
+        obligations: vec![],
     };
-    store_acl_entry(&state.acl_ks, &acl).await?;
-
-    let mut member = Member::fresh(&req.applicant_did);
-    store_member(&state.members_ks, &member).await?;
-
-    // M2.12: issue VMC + role VEC + flip status-list slot. Done
-    // after the ACL + Member rows are persisted so the credential
-    // pointers reference a row that exists. A failure here
-    // surfaces as 500 — the ACL + Member rows remain, so the
-    // operator can retry via the M2.13 renewal endpoint once the
-    // underlying issue is fixed.
-    let (vmc, role_vec, status_list_index) =
-        issue_join_credentials(&state, &req.applicant_did).await?;
-    member.status_list_index = Some(status_list_index);
-    member.current_vmc_id = top_level_id(&vmc);
-    member.current_role_vec_id = top_level_id(&role_vec);
-    store_member(&state.members_ks, &member).await?;
+    let EffectOutcome::Admitted(creds) = execute::apply(&state, plan, &admin.0.did).await? else {
+        return Err(AppError::Internal(
+            "admit effect did not produce credentials".into(),
+        ));
+    };
+    let (vmc, role_vec, status_list_index) = (creds.vmc, creds.role_vec, creds.status_list_index);
 
     req.status = JoinStatus::Approved;
     store_join_request(&state.join_requests_ks, &req).await?;
@@ -180,77 +150,6 @@ pub async fn approve(
             ),
         }),
     ))
-}
-
-/// Allocate a revocation-list slot, mint the VMC + role VEC,
-/// persist the updated status-list state. Returns the signed
-/// VCs + the allocated index for the audit trail.
-///
-/// Sealed-transfer to the applicant's DID is deferred — for
-/// M2.12 the credentials are returned inline in the approve
-/// response and the admin caller hands them off out-of-band.
-async fn issue_join_credentials(
-    state: &AppState,
-    applicant_did: &str,
-) -> Result<(VerifiableCredential, VerifiableCredential, u32), AppError> {
-    let signer = state.credential_signer.as_ref().ok_or_else(|| {
-        AppError::Internal(
-            "credential signer not initialised — cannot mint VMC (run setup first)".into(),
-        )
-    })?;
-
-    let mut row = status_list::get_state(&state.status_lists_ks, StatusPurpose::Revocation)
-        .await?
-        .ok_or_else(|| {
-            AppError::Internal(
-                "revocation status list not provisioned — set `public_url` + restart".into(),
-            )
-        })?;
-
-    let slot = status_list::allocate(&mut row).ok_or_else(|| {
-        AppError::Internal(format!(
-            "revocation status list exhausted (capacity = {})",
-            row.capacity
-        ))
-    })?;
-
-    let status_ref = CredentialStatusRef::revocation(row.list_credential_id.clone(), slot);
-
-    let vmc_id = format!("urn:uuid:{}", Uuid::new_v4());
-    let vmc = build_vmc(
-        signer,
-        VmcParams::new(applicant_did)
-            .with_id(vmc_id)
-            .with_status_ref(status_ref)
-            .with_personhood(false),
-    )
-    .await?;
-
-    let vec_id = format!("urn:uuid:{}", Uuid::new_v4());
-    let role_vec = build_role_vec(
-        signer,
-        RoleVecParams::new(applicant_did, VtcRole::Member).with_id(vec_id),
-    )
-    .await?;
-
-    // Persist the status-list state *after* both VCs build
-    // successfully — if either build fails we don't permanently
-    // burn a slot. (The state lives only in this function's
-    // local copy until the store_state call.)
-    status_list::store_state(&state.status_lists_ks, &row).await?;
-    status_list::maybe_emit_occupancy_warning(&row);
-
-    Ok((vmc, role_vec, slot))
-}
-
-/// Pull the top-level `id` field off a signed VC. The
-/// upstream `VerifiableCredential` type doesn't expose it
-/// directly — we splice it onto the wire form via JSON, so
-/// reading it back requires a JSON round-trip.
-fn top_level_id(vc: &VerifiableCredential) -> Option<String> {
-    serde_json::to_value(vc)
-        .ok()
-        .and_then(|v| v.get("id").and_then(|i| i.as_str().map(str::to_string)))
 }
 
 /// Build a [`CredentialIssuedData`] payload from a signed VC.

--- a/vtc-service/tests/ceremony_execute.rs
+++ b/vtc-service/tests/ceremony_execute.rs
@@ -1,0 +1,245 @@
+//! Integration coverage for the ceremony effect executor
+//! (`vtc_service::ceremony::execute::apply`).
+//!
+//! The manual join-approve route already exercises the `Admit` arm via
+//! `tests/join_requests.rs` (approve now goes through the executor).
+//! This file covers what approve can't:
+//! - admit at a **non-`member` role** (approve hardcodes `member`),
+//!   proving the plan's role is honoured;
+//! - the duplicate-ACL guard living in the executor;
+//! - the trivial dispatch arms (`NoStateChange` no-op, `Depart` not
+//!   yet wired).
+//!
+//! It calls `apply` directly against a built `AppState` rather than
+//! over HTTP — the executor is below the route layer.
+
+use std::sync::Arc;
+
+use affinidi_status_list::StatusPurpose;
+use tokio::sync::RwLock;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use vtc_service::ceremony::EffectPlan;
+use vtc_service::ceremony::execute::{self, EffectOutcome};
+use vtc_service::config::AppConfig;
+use vtc_service::install::InstallTokenStore;
+use vtc_service::members::get_member;
+use vtc_service::server::AppState;
+
+const RP_ORIGIN: &str = "https://vtc.example.com";
+const ACTOR_DID: &str = "did:key:zActor";
+
+/// Build an `AppState` with a credential signer + provisioned status
+/// lists — the minimum the `Admit` arm needs. JWT / webauthn / audit
+/// are left `None`; the executor doesn't touch them.
+async fn build_state() -> (AppState, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    let sessions_ks = store.keyspace("sessions").unwrap();
+    let acl_ks = store.keyspace("acl").unwrap();
+    let community_ks = store.keyspace("community").unwrap();
+    let config_ks = store.keyspace("config").unwrap();
+    let passkey_ks = store.keyspace("passkey").unwrap();
+    let install_ks = store.keyspace("install").unwrap();
+    let members_ks = store.keyspace("members").unwrap();
+    let join_requests_ks = store.keyspace("join_requests").unwrap();
+    let policies_ks = store.keyspace("policies").unwrap();
+    let active_policies_ks = store.keyspace("active_policies").unwrap();
+    let status_lists_ks = store.keyspace("status_lists").unwrap();
+    let registry_records_ks = store.keyspace("registry_records").unwrap();
+    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
+    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let relationships_ks = store.keyspace("relationships").unwrap();
+    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
+    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
+    let endorsements_ks = store.keyspace("endorsements").unwrap();
+    let audit_ks = store.keyspace("audit").unwrap();
+    let audit_key_ks = store.keyspace("audit_key").unwrap();
+
+    // The admit path allocates a revocation slot when issuing the VMC.
+    for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+        let url = format!("{RP_ORIGIN}/v1/status-lists/{purpose}");
+        vtc_service::status_list::ensure_initial(&status_lists_ks, purpose, url)
+            .await
+            .expect("ensure_initial status list");
+    }
+
+    let credential_signer = Some(Arc::new(
+        vtc_service::credentials::LocalSigner::from_ed25519_seed(
+            "did:webvh:vtc.example.com:abc".into(),
+            &[0xCC; 32],
+        ),
+    ));
+
+    let install_store = InstallTokenStore::new(install_ks.clone());
+
+    let config: AppConfig = toml::from_str(&format!(
+        r#"
+        vtc_did = "did:webvh:vtc.example.com:abc"
+        public_url = "{RP_ORIGIN}"
+        [store]
+        data_dir = "{}"
+        "#,
+        dir.path().display(),
+    ))
+    .expect("parse config");
+
+    let state = AppState {
+        sessions_ks,
+        acl_ks,
+        community_ks,
+        config_ks,
+        passkey_ks,
+        install_ks,
+        members_ks,
+        join_requests_ks,
+        policies_ks,
+        active_policies_ks,
+        status_lists_ks,
+        registry_records_ks,
+        sync_queue_ks,
+        sync_cursor_ks,
+        relationships_ks,
+        relationships_by_did_ks,
+        endorsement_types_ks,
+        endorsements_ks,
+        registry_client: None,
+        registry_health: vtc_service::registry::RegistryHealth::new(),
+        credential_signer,
+        audit_ks,
+        audit_key_ks,
+        config: Arc::new(RwLock::new(config)),
+        did_resolver: None,
+        secrets_resolver: None,
+        jwt_keys: None,
+        atm: None,
+        webauthn: None,
+        public_url: Some(RP_ORIGIN.to_string()),
+        install_signer: None,
+        install_store,
+        audit_writer: None,
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        supervisor: None,
+    };
+
+    (state, dir)
+}
+
+/// `Admit` at a non-`member` role writes the ACL row at that role,
+/// writes the Member record, and issues the credentials — proving the
+/// plan's role is honoured (approve only ever admits `member`).
+#[tokio::test]
+async fn admit_honours_the_plan_role() {
+    let (state, _dir) = build_state().await;
+    let subject = "did:key:zModerator";
+
+    let plan = EffectPlan::Admit {
+        subject: subject.into(),
+        role: "moderator".into(),
+        obligations: vec![],
+    };
+    let outcome = execute::apply(&state, plan, ACTOR_DID)
+        .await
+        .expect("apply");
+
+    let EffectOutcome::Admitted(creds) = outcome else {
+        panic!("expected Admitted, got {outcome:?}");
+    };
+
+    // ACL row written at the granted role, created_by the actor.
+    let acl = get_acl_entry(&state.acl_ks, subject)
+        .await
+        .unwrap()
+        .expect("acl row");
+    assert_eq!(acl.role, VtcRole::Moderator);
+    assert_eq!(acl.created_by, ACTOR_DID);
+
+    // Member row written with the credential pointers stamped.
+    let member = get_member(&state.members_ks, subject)
+        .await
+        .unwrap()
+        .expect("member row");
+    assert_eq!(member.status_list_index, Some(creds.status_list_index));
+    assert!(member.current_vmc_id.is_some(), "VMC id stamped");
+    assert!(member.current_role_vec_id.is_some(), "role VEC id stamped");
+}
+
+/// Admitting a DID that already holds an ACL row is a conflict — the
+/// executor refuses a duplicate membership.
+#[tokio::test]
+async fn admit_duplicate_acl_is_conflict() {
+    let (state, _dir) = build_state().await;
+    let subject = "did:key:zExisting";
+
+    store_acl_entry(
+        &state.acl_ks,
+        &VtcAclEntry {
+            did: subject.into(),
+            role: VtcRole::Member,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: vtc_service::auth::session::now_epoch(),
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let plan = EffectPlan::Admit {
+        subject: subject.into(),
+        role: "member".into(),
+        obligations: vec![],
+    };
+    let err = execute::apply(&state, plan, ACTOR_DID)
+        .await
+        .expect_err("duplicate admit must conflict");
+    assert!(
+        matches!(err, vti_common::error::AppError::Conflict(_)),
+        "got {err:?}"
+    );
+}
+
+/// A `NoStateChange` plan (deny / refer / request_more) writes nothing.
+#[tokio::test]
+async fn no_state_change_is_a_noop() {
+    let (state, _dir) = build_state().await;
+
+    let outcome = execute::apply(&state, EffectPlan::NoStateChange, ACTOR_DID)
+        .await
+        .expect("apply");
+    assert!(matches!(outcome, EffectOutcome::None), "got {outcome:?}");
+
+    // Nothing was admitted.
+    assert!(
+        get_acl_entry(&state.acl_ks, "did:key:zAnyone")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+/// The leave (`Depart`) executor arm is not yet wired and errors
+/// rather than silently no-op'ing.
+#[tokio::test]
+async fn depart_is_not_yet_wired() {
+    let (state, _dir) = build_state().await;
+
+    let plan = EffectPlan::Depart {
+        subject: "did:key:zLeaver".into(),
+        disposition: Some("revoke-vmc".into()),
+    };
+    let err = execute::apply(&state, plan, ACTOR_DID)
+        .await
+        .expect_err("depart is not wired yet");
+    assert!(
+        matches!(err, vti_common::error::AppError::Internal(_)),
+        "got {err:?}"
+    );
+}


### PR DESCRIPTION
## What

Adds the **async effect executor** — the "apply" half of the ceremony pipeline's effect stage (design §5) — and refactors the manual join-approve route to go *through* it. Builds on #204 (the pure decision spine).

The decision spine (verify → evaluate → invariant → decide → plan) is all pure and testable. This PR adds the single I/O seam that turns a typed `EffectPlan` into actual state.

## Commit

- **`ceremony/execute.rs`** — `apply(state, plan, actor_did) -> EffectOutcome`. The **Admit** (join) arm writes the ACL row + Member record, issues the VMC + role VEC, and flips the status-list slot — moved verbatim out of `approve`'s `issue_join_credentials` and made **role-parameterized** (no longer hardcodes `member`). `NoStateChange` is a no-op; `Project` errors (the directory route applies its projection inline); `Depart`/`Remint` return a clear "not yet wired" until their ceremonies land. `EffectOutcome::Admitted` is boxed (two VCs make it the large variant).
- **`routes/join_requests/decide.rs`** — `approve` now builds an `EffectPlan::Admit` and calls `execute::apply` instead of duplicating the write path. The pipeline genuinely supersedes the bespoke flow. Approve keeps its join-request status flip + audit; the duplicate-ACL guard moved into the executor (still surfaces as 409). Net **−125 lines** of duplication.
- **`tests/ceremony_execute.rs`** — 4 tests for what approve can't cover: admit at a non-`member` role (moderator), the duplicate-ACL conflict, the `NoStateChange` no-op, and the not-yet-wired `Depart`.

## Why approve goes through the executor

The build-vs-reuse map (pipeline §10) says the pipeline should *replace* the nine bespoke per-purpose flows, not run alongside them. Routing approve through `apply` is that replacement for join's write path — and it means approve's 15 existing integration tests now exercise the `Admit` arm end-to-end, so the executor is covered by both the new direct tests and the existing route tests.

## Testing

- Full `vtc-service` suite green (32 binaries), including all 15 `join_requests` tests unchanged — the refactor is behavior-preserving.
- 4 new executor tests green.
- `cargo fmt` + `clippy` (`-D warnings` safe). Rebased on current `main`.

## Not in this PR (follow-ups)

- **Depart** (leave) / **Remint** (role-change) executor arms — they land with their ceremonies (routes + facts-assembly + the **no-last-admin** invariant).
- Stage B: a real join *ceremony* route (VP submit → assemble join Facts → `decide(join.rego)` → `execute::apply(Admit)`), vs today's manual admin approve.