### PR TITLE
feat(vtc): ceremony effect executor Depart arm + route removal through it

### DIFF
--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -21,30 +21,46 @@
 //! ## What's wired
 //!
 //! - **Admit** (join) — write the ACL row + Member record, issue the
-//!   VMC + role VEC, flip the status-list slot. Fully wired.
+//!   VMC + role VEC, flip the status-list slot. Fully wired; the
+//!   manual approve route goes through it.
+//! - **Depart** (leave) — enforce the no-last-admin invariant, delete
+//!   the ACL row, apply the disposition to the Member row, and revoke
+//!   the credential (flip the revocation bit). Fully wired; the
+//!   `DELETE /v1/members/{me,did}` removal routes go through it.
 //! - **NoStateChange** (deny / refer / request_more) — no-op.
 //! - **Project** (directory) — not handled here: the directory route
 //!   serializes the projection into its HTTP response inline, so a
 //!   `Project` plan reaching the executor is a caller bug.
-//! - **Depart** (leave) / **Remint** (role-change) — not yet wired:
-//!   their ceremonies (routes + facts assembly + the no-last-admin
-//!   invariant) don't exist yet, so wiring their executors now would
-//!   be untested speculation. They return a clear error until then.
+//! - **Remint** (role-change) — not yet wired (its ceremony doesn't
+//!   exist yet); returns a clear error until then.
+
+use std::sync::LazyLock;
 
 use affinidi_status_list::StatusPurpose;
 use affinidi_vc::VerifiableCredential;
+use tokio::sync::Mutex;
+use tracing::warn;
 use uuid::Uuid;
 use vti_common::error::AppError;
 
 use super::effects::EffectPlan;
-use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use crate::acl::{
+    VtcAclEntry, VtcRole, delete_acl_entry, get_acl_entry, list_acl_entries, store_acl_entry,
+};
 use crate::auth::session::now_epoch;
 use crate::credentials::{
     CredentialStatusRef, RoleVecParams, VmcParams, build_role_vec, build_vmc,
 };
-use crate::members::{Member, store_member};
+use crate::members::{Disposition, Member, delete_member, get_member, store_member};
 use crate::server::AppState;
 use crate::status_list;
+
+/// Process-wide mutex serialising every member departure so the
+/// "would this leave zero admins?" check + ACL delete is one atomic
+/// critical section — concurrent removals can't both pass the check
+/// and both delete. (fjall isn't multi-process safe regardless, so a
+/// process-wide lock is the right grain.)
+static LAST_ADMIN_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 /// What the executor did. Carries back whatever the caller needs to
 /// audit + respond — currently the credentials minted on admit.
@@ -54,6 +70,9 @@ pub enum EffectOutcome {
     /// caller can audit them and hand them to the applicant. Boxed —
     /// the two VCs make this variant far larger than the others.
     Admitted(Box<AdmitOutcome>),
+    /// A member departed; carries the applied disposition + the
+    /// revocation slot that was flipped (for the caller's audit).
+    Departed(DepartOutcome),
     /// No state was changed (the verdict was deny / refer /
     /// request_more).
     None,
@@ -65,6 +84,19 @@ pub struct AdmitOutcome {
     pub vmc: VerifiableCredential,
     pub role_vec: VerifiableCredential,
     pub status_list_index: u32,
+}
+
+/// The result of a member departure.
+#[derive(Debug)]
+pub struct DepartOutcome {
+    /// The disposition that was applied to the Member row (resolved to
+    /// a concrete value — never `PolicyDefault`).
+    pub disposition: Disposition,
+    /// The revocation status-list slot that was flipped, if the member
+    /// held one and the flip succeeded. `None` if there was no slot or
+    /// the best-effort flip failed (the ACL/Member removal still
+    /// committed — a failed flip is logged, not unwound).
+    pub revoked_slot: Option<u32>,
 }
 
 /// Apply an effect plan.
@@ -92,12 +124,20 @@ pub async fn apply(
             let outcome = admit(state, &subject, role, actor_did).await?;
             Ok(EffectOutcome::Admitted(Box::new(outcome)))
         }
+        EffectPlan::Depart {
+            subject,
+            disposition,
+        } => {
+            let disposition = parse_disposition(disposition.as_deref());
+            let outcome = depart(state, &subject, disposition, actor_did).await?;
+            Ok(EffectOutcome::Departed(outcome))
+        }
         EffectPlan::NoStateChange => Ok(EffectOutcome::None),
         EffectPlan::Project { .. } => Err(AppError::Internal(
             "directory projection is applied by the route, not the effect executor".into(),
         )),
-        EffectPlan::Depart { .. } | EffectPlan::Remint { .. } => Err(AppError::Internal(
-            "leave / role-change effect executor is not yet wired".into(),
+        EffectPlan::Remint { .. } => Err(AppError::Internal(
+            "role-change effect executor is not yet wired".into(),
         )),
     }
 }
@@ -212,6 +252,129 @@ async fn issue_member_credentials(
     status_list::maybe_emit_occupancy_warning(&row);
 
     Ok((vmc, role_vec, slot))
+}
+
+/// Parse the plan's disposition string into a concrete
+/// [`Disposition`]. An absent or unrecognized disposition (and
+/// `policydefault`) falls back to [`Disposition::Tombstone`] — the
+/// safe middle ground. The caller's decide stage is expected to have
+/// already resolved `PolicyDefault` against the policy; this is the
+/// final, never-`PolicyDefault` value the effect applies.
+fn parse_disposition(disposition: Option<&str>) -> Disposition {
+    match disposition {
+        Some("purge") => Disposition::Purge,
+        Some("historical") => Disposition::Historical,
+        // tombstone / policydefault / unknown / absent → tombstone.
+        _ => Disposition::Tombstone,
+    }
+}
+
+/// Remove a member: enforce the no-last-admin invariant, delete the
+/// ACL row, apply the disposition to the Member row, and best-effort
+/// flip the revocation bit.
+///
+/// The whole no-last-admin check + ACL delete runs under
+/// [`LAST_ADMIN_LOCK`] so concurrent departures can't both pass the
+/// "still has an admin" check and both delete. The invariant is
+/// host-enforced here (pipeline §5: a policy can never authorize
+/// leaving zero admins) — on violation nothing is written and a
+/// [`AppError::Conflict`] surfaces (→ 409).
+async fn depart(
+    state: &AppState,
+    subject_did: &str,
+    disposition: Disposition,
+    _actor_did: &str,
+) -> Result<DepartOutcome, AppError> {
+    let _guard = LAST_ADMIN_LOCK.lock().await;
+
+    // No-last-admin invariant — checked before any write so a refusal
+    // leaves the community untouched.
+    if let Some(acl) = get_acl_entry(&state.acl_ks, subject_did).await?
+        && matches!(acl.role, VtcRole::Admin)
+    {
+        let other_admins = list_acl_entries(&state.acl_ks)
+            .await?
+            .iter()
+            .filter(|e| e.did != subject_did && matches!(e.role, VtcRole::Admin))
+            .count();
+        if other_admins == 0 {
+            return Err(AppError::Conflict(format!(
+                "refusing to remove the last admin ({subject_did}) — promote another \
+                 member to admin first"
+            )));
+        }
+    }
+
+    let member = get_member(&state.members_ks, subject_did).await?;
+    // Capture the revocation slot before the disposition path mutates
+    // (purge deletes the row) or clears it.
+    let slot = member.as_ref().and_then(|m| m.status_list_index);
+
+    delete_acl_entry(&state.acl_ks, subject_did).await?;
+
+    match (disposition, member) {
+        (Disposition::Purge, _) => {
+            delete_member(&state.members_ks, subject_did).await?;
+        }
+        (Disposition::Tombstone, Some(mut m)) => {
+            m.tombstone();
+            store_member(&state.members_ks, &m).await?;
+        }
+        (Disposition::Historical, Some(mut m)) => {
+            m.mark_historical();
+            store_member(&state.members_ks, &m).await?;
+        }
+        // No Member row — Tombstone/Historical are trivially satisfied.
+        (Disposition::Tombstone | Disposition::Historical, None) => {}
+        (Disposition::PolicyDefault, _) => {
+            // parse_disposition never yields PolicyDefault; this arm
+            // exists only to keep the match total.
+            unreachable!("disposition must be concrete before depart");
+        }
+    }
+
+    // Revoke the member's credentials by flipping the revocation bit.
+    // Best-effort: the ACL + Member rows are already gone, so a flip
+    // failure is logged, not unwound — the caller can re-flip.
+    let revoked_slot = match slot {
+        Some(slot) => match flip_revocation(state, slot).await {
+            Ok(()) => Some(slot),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    slot,
+                    target = subject_did,
+                    "failed to flip revocation bit on departure — ACL/Member already \
+                     removed; operator must reflip manually"
+                );
+                None
+            }
+        },
+        None => None,
+    };
+
+    Ok(DepartOutcome {
+        disposition,
+        revoked_slot,
+    })
+}
+
+/// Flip the revocation bit at `slot` to `revoked`. Raw write, no
+/// audit — the caller emits the `StatusListFlipped` event from the
+/// returned [`DepartOutcome`].
+async fn flip_revocation(state: &AppState, slot: u32) -> Result<(), AppError> {
+    let mut row = status_list::get_state(&state.status_lists_ks, StatusPurpose::Revocation)
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal(
+                "revocation status list not provisioned — set `public_url` + restart".into(),
+            )
+        })?;
+    status_list::flip(&mut row, slot, true)
+        .map_err(|e| AppError::Internal(format!("flip revocation slot {slot}: {e}")))?;
+    status_list::store_state(&state.status_lists_ks, &row).await?;
+    status_list::maybe_emit_occupancy_warning(&row);
+    Ok(())
 }
 
 /// Pull the top-level `id` field off a signed VC. The upstream

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -66,7 +66,7 @@ pub mod verify;
 
 pub use effects::{EffectPlan, plan};
 pub use evaluate::evaluate;
-pub use execute::{AdmitOutcome, EffectOutcome, apply};
+pub use execute::{AdmitOutcome, DepartOutcome, EffectOutcome, apply};
 pub use facts::{
     Actor, Context, Credential, CredentialStatus, Evidence, Facts, Invitation, MemberState,
     Presentation, Purpose, State, Subject,

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -19,34 +19,28 @@
 //! Phase-1 communities are small; Phase 2+ can swap in an
 //! admin-count index.
 
-use std::sync::LazyLock;
-
+use affinidi_status_list::StatusPurpose;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
-use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use vti_common::audit::{AuditEvent, MemberRemovedData, StatusListFlippedData};
 use vti_common::error::AppError;
 
-use crate::acl::{VtcRole, delete_acl_entry, get_acl_entry, list_acl_entries};
+use crate::acl::get_acl_entry;
 use crate::auth::{AdminAuth, AuthClaims};
-use crate::members::{Disposition, delete_member, get_member, store_member};
+use crate::ceremony::execute;
+use crate::ceremony::{EffectOutcome, EffectPlan};
+use crate::members::{Disposition, get_member};
 use crate::policy::{
     PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy, get_active_policy_id,
     get_policy,
 };
 use crate::server::AppState;
-
-/// Process-wide mutex that serialises every removal, self- and
-/// admin- alike, so the "would this leave zero admins?" check is
-/// not racy. Cannot defend against multi-process — fjall isn't
-/// multi-process safe to begin with (project memory).
-static LAST_ADMIN_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -161,24 +155,17 @@ pub async fn remove_inner(
         .as_ref()
         .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
 
-    let _guard = LAST_ADMIN_LOCK.lock().await;
-
     let target_acl = get_acl_entry(&state.acl_ks, target_did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
 
     let target_member = get_member(&state.members_ks, target_did).await?;
-    // Capture the status-list slot **before** the disposition
-    // path mutates the Member row (purge deletes it; tombstone
-    // clears extensions but leaves status_list_index intact —
-    // we still want to read it from the pre-mutation snapshot).
-    let status_list_index = target_member.as_ref().and_then(|m| m.status_list_index);
 
-    // Phase 2 policy step (M2.7). Admin-remove evaluates the
-    // active `removal.rego` against the canonical input from
-    // spec §7.3. Self-remove bypasses (spec §10.2 makes it
-    // unconditional). The no-last-admin invariant + the route-
-    // layer AdminAuth gate run in addition to the policy check.
+    // Decide. Admin-remove evaluates the active `removal.rego` `allow`
+    // rule against the canonical input (spec §7.3); self-remove is
+    // unconditional (spec §10.2). The no-last-admin invariant + the
+    // credential revocation are the *effect*, enforced by the executor
+    // below — not here.
     if is_admin_remove {
         let input = json!({
             "actor_did": actor_did,
@@ -195,12 +182,11 @@ pub async fn remove_inner(
         }
     }
 
-    // Resolve disposition. Caller's request wins; member's
-    // departure_preference is the fallback; `PolicyDefault`
-    // consults the active `removal.rego`'s `min_disposition`
-    // output (Phase 1 plan §D6 placeholder). A non-decodable
-    // policy output falls back to `Tombstone` — the boring
-    // middle ground Phase 1 already used.
+    // Resolve disposition. Caller's request wins; the member's
+    // departure_preference is the fallback; `PolicyDefault` consults
+    // the active `removal.rego`'s `min_disposition` (a non-decodable
+    // output falls back to `Tombstone`). The resolved value is a
+    // concrete disposition handed to the effect executor.
     let initial = disposition
         .or_else(|| target_member.as_ref().map(|m| m.departure_preference))
         .unwrap_or(Disposition::PolicyDefault);
@@ -211,52 +197,20 @@ pub async fn remove_inner(
         other => other,
     };
 
-    // No-last-admin invariant.
-    if matches!(target_acl.role, VtcRole::Admin) {
-        let acl_rows = list_acl_entries(&state.acl_ks).await?;
-        let other_admins = acl_rows
-            .iter()
-            .filter(|e| e.did != target_did && matches!(e.role, VtcRole::Admin))
-            .count();
-        if other_admins == 0 {
-            return Err(AppError::Conflict(format!(
-                "refusing to remove the last admin ({target_did}) — promote another \
-                 member to admin first"
-            )));
-        }
-    }
-
-    // Apply the disposition.
-    delete_acl_entry(&state.acl_ks, target_did).await?;
-    match (resolved, target_member) {
-        (Disposition::Purge, _) => {
-            delete_member(&state.members_ks, target_did).await?;
-        }
-        (Disposition::Tombstone, Some(mut m)) => {
-            m.tombstone();
-            store_member(&state.members_ks, &m).await?;
-        }
-        (Disposition::Historical, Some(mut m)) => {
-            m.mark_historical();
-            store_member(&state.members_ks, &m).await?;
-        }
-        // No Member row to operate on — Tombstone/Historical
-        // semantics are trivially satisfied (nothing to keep).
-        (Disposition::Tombstone | Disposition::Historical, None) => {}
-        (Disposition::PolicyDefault, _) => {
-            // resolve() collapsed this to Tombstone above; this
-            // arm is unreachable but stays here so the match
-            // remains total.
-            unreachable!("PolicyDefault must resolve before dispatch");
-        }
-    }
-
-    let disposition_str = match resolved {
-        Disposition::Purge => "purge",
-        Disposition::Tombstone => "tombstone",
-        Disposition::Historical => "historical",
-        Disposition::PolicyDefault => "policydefault",
+    // Effect: the no-last-admin invariant + ACL/Member removal +
+    // credential revocation, via the ceremony effect executor (the
+    // single state-mutating seam). A last-admin removal surfaces as the
+    // executor's `Conflict` → 409, untouched state.
+    let plan = EffectPlan::Depart {
+        subject: target_did.to_string(),
+        disposition: Some(disposition_wire(resolved).to_string()),
     };
+    let EffectOutcome::Departed(outcome) = execute::apply(state, plan, actor_did).await? else {
+        return Err(AppError::Internal(
+            "depart effect did not produce a departure outcome".into(),
+        ));
+    };
+    let disposition_str = disposition_wire(outcome.disposition);
 
     audit_writer
         .write(
@@ -269,22 +223,20 @@ pub async fn remove_inner(
         )
         .await?;
 
-    // M2.14: flip the revocation bit + emit StatusListFlipped.
-    // Best-effort — a failure here doesn't unwind the ACL +
-    // Member removal (those are already persisted), but it
-    // surfaces in audit + logs so an operator can re-flip
-    // manually if needed.
-    if let Some(slot) = status_list_index
-        && let Err(e) =
-            flip_revocation_for_member(state, slot, audit_writer, actor_did, target_did).await
-    {
-        warn!(
-            error = %e,
-            slot,
-            target = target_did,
-            "failed to flip revocation status-list bit on removal — \
-             ACL/Member already removed; operator must reflip manually"
-        );
+    // M2.14: the executor flipped the revocation bit (best-effort).
+    // Emit the audit event for the slot it reported.
+    if let Some(slot) = outcome.revoked_slot {
+        audit_writer
+            .write(
+                actor_did,
+                Some(target_did),
+                AuditEvent::StatusListFlipped(StatusListFlippedData {
+                    purpose: StatusPurpose::Revocation.to_string(),
+                    index: slot,
+                    revoked: true,
+                }),
+            )
+            .await?;
     }
 
     info!(
@@ -302,54 +254,16 @@ pub async fn remove_inner(
     })
 }
 
-// ---------------------------------------------------------------------------
-// Status-list helpers (M2.14)
-// ---------------------------------------------------------------------------
-
-/// Flip the revocation bit at `slot` + emit `StatusListFlipped`.
-/// Used by [`remove_inner`] after the ACL + Member rows have
-/// already been mutated.
-async fn flip_revocation_for_member(
-    state: &AppState,
-    slot: u32,
-    audit_writer: &vti_common::audit::AuditWriter,
-    actor_did: &str,
-    target_did: &str,
-) -> Result<(), AppError> {
-    let mut row = crate::status_list::get_state(
-        &state.status_lists_ks,
-        affinidi_status_list::StatusPurpose::Revocation,
-    )
-    .await?
-    .ok_or_else(|| {
-        AppError::Internal(
-            "revocation status list not provisioned — set `public_url` + restart".into(),
-        )
-    })?;
-    crate::status_list::flip(&mut row, slot, true)
-        .map_err(|e| AppError::Internal(format!("flip revocation slot {slot}: {e}")))?;
-    crate::status_list::store_state(&state.status_lists_ks, &row).await?;
-    crate::status_list::maybe_emit_occupancy_warning(&row);
-
-    audit_writer
-        .write(
-            actor_did,
-            Some(target_did),
-            AuditEvent::StatusListFlipped(StatusListFlippedData {
-                purpose: affinidi_status_list::StatusPurpose::Revocation.to_string(),
-                index: slot,
-                revoked: true,
-            }),
-        )
-        .await?;
-
-    info!(
-        actor = actor_did,
-        target = target_did,
-        slot,
-        "revocation bit flipped"
-    );
-    Ok(())
+/// Wire string for a resolved (concrete) disposition. Mirrors the
+/// `Disposition` serde representation; used for the response +
+/// audit + the `EffectPlan::Depart` payload.
+fn disposition_wire(d: Disposition) -> &'static str {
+    match d {
+        Disposition::Purge => "purge",
+        Disposition::Tombstone => "tombstone",
+        Disposition::Historical => "historical",
+        Disposition::PolicyDefault => "policydefault",
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/tests/ceremony_execute.rs
+++ b/vtc-service/tests/ceremony_execute.rs
@@ -1,14 +1,15 @@
 //! Integration coverage for the ceremony effect executor
 //! (`vtc_service::ceremony::execute::apply`).
 //!
-//! The manual join-approve route already exercises the `Admit` arm via
-//! `tests/join_requests.rs` (approve now goes through the executor).
-//! This file covers what approve can't:
-//! - admit at a **non-`member` role** (approve hardcodes `member`),
-//!   proving the plan's role is honoured;
-//! - the duplicate-ACL guard living in the executor;
-//! - the trivial dispatch arms (`NoStateChange` no-op, `Depart` not
-//!   yet wired).
+//! The manual approve + removal routes already exercise the `Admit`
+//! and `Depart` arms over HTTP (`tests/join_requests.rs`,
+//! `tests/removal.rs` — both now go through the executor). This file
+//! covers the arms directly, including cases the routes don't:
+//! - admit at a **non-`member` role** (approve hardcodes `member`);
+//! - the duplicate-ACL guard on admit;
+//! - depart removing + revoking a member, and the no-last-admin
+//!   invariant living in the executor;
+//! - the `NoStateChange` no-op.
 //!
 //! It calls `apply` directly against a built `AppState` rather than
 //! over HTTP — the executor is below the route layer.
@@ -25,7 +26,7 @@ use vtc_service::ceremony::EffectPlan;
 use vtc_service::ceremony::execute::{self, EffectOutcome};
 use vtc_service::config::AppConfig;
 use vtc_service::install::InstallTokenStore;
-use vtc_service::members::get_member;
+use vtc_service::members::{Disposition, get_member};
 use vtc_service::server::AppState;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
@@ -225,21 +226,97 @@ async fn no_state_change_is_a_noop() {
     );
 }
 
-/// The leave (`Depart`) executor arm is not yet wired and errors
-/// rather than silently no-op'ing.
+/// Depart removes a member: deletes the ACL row, applies the
+/// disposition (tombstone keeps the row but clears credentials), and
+/// revokes by flipping the member's revocation slot.
 #[tokio::test]
-async fn depart_is_not_yet_wired() {
+async fn depart_removes_member_and_revokes() {
     let (state, _dir) = build_state().await;
+    let subject = "did:key:zLeaver";
+
+    // Admit first so there's an ACL + Member + revocation slot to remove.
+    let admit = EffectPlan::Admit {
+        subject: subject.into(),
+        role: "member".into(),
+        obligations: vec![],
+    };
+    let EffectOutcome::Admitted(creds) = execute::apply(&state, admit, ACTOR_DID)
+        .await
+        .expect("admit")
+    else {
+        panic!("expected Admitted");
+    };
+    let slot = creds.status_list_index;
+
+    // Depart with tombstone.
+    let plan = EffectPlan::Depart {
+        subject: subject.into(),
+        disposition: Some("tombstone".into()),
+    };
+    let EffectOutcome::Departed(outcome) = execute::apply(&state, plan, ACTOR_DID)
+        .await
+        .expect("depart")
+    else {
+        panic!("expected Departed");
+    };
+    assert_eq!(outcome.disposition, Disposition::Tombstone);
+    assert_eq!(
+        outcome.revoked_slot,
+        Some(slot),
+        "the member's slot was flipped"
+    );
+
+    // ACL gone; Member row tombstoned (kept, removed_at set, VMC cleared).
+    assert!(
+        get_acl_entry(&state.acl_ks, subject)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let m = get_member(&state.members_ks, subject)
+        .await
+        .unwrap()
+        .expect("tombstoned member row is kept");
+    assert!(m.removed_at.is_some());
+    assert!(
+        m.current_vmc_id.is_none(),
+        "tombstone clears the VMC pointer"
+    );
+}
+
+/// Depart enforces the no-last-admin invariant: removing the sole
+/// admin is a conflict and leaves the ACL untouched.
+#[tokio::test]
+async fn depart_refuses_the_last_admin() {
+    let (state, _dir) = build_state().await;
+    let admin = "did:key:zSoleAdmin";
+
+    store_acl_entry(
+        &state.acl_ks,
+        &VtcAclEntry {
+            did: admin.into(),
+            role: VtcRole::Admin,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: vtc_service::auth::session::now_epoch(),
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
 
     let plan = EffectPlan::Depart {
-        subject: "did:key:zLeaver".into(),
-        disposition: Some("revoke-vmc".into()),
+        subject: admin.into(),
+        disposition: Some("tombstone".into()),
     };
     let err = execute::apply(&state, plan, ACTOR_DID)
         .await
-        .expect_err("depart is not wired yet");
+        .expect_err("last admin must be protected");
     assert!(
-        matches!(err, vti_common::error::AppError::Internal(_)),
+        matches!(err, vti_common::error::AppError::Conflict(_)),
         "got {err:?}"
     );
+    // The refusal left the ACL row in place.
+    assert!(get_acl_entry(&state.acl_ks, admin).await.unwrap().is_some());
 }


### PR DESCRIPTION
## What

Wires the **leave/removal effect** (pipeline §5 `Depart`) into the ceremony executor and routes the existing removal flow through it — the destructive counterpart to the `Admit` work in #206. Builds on #206.

## Commit

- **`ceremony/execute.rs`** — `apply`'s `Depart` arm enforces the **no-last-admin invariant** (under a process-wide lock moved here from `remove.rs`), deletes the ACL row, applies the disposition to the Member row (`purge`/`tombstone`/`historical`), and best-effort flips the revocation bit. Returns `EffectOutcome::Departed(DepartOutcome { disposition, revoked_slot })`. The no-last-admin check runs **before any write**, so a refusal (`Conflict` → 409) leaves the community untouched.
- **`routes/members/remove.rs`** — `remove_inner` now does only the **decide** work (`removal.rego` `allow` eval + disposition resolution) and routes the write block through `execute::apply(EffectPlan::Depart)` — the single state-mutating seam. It keeps its audit (`MemberRemoved` + `StatusListFlipped`, emitted from the returned slot). The `LAST_ADMIN_LOCK` + the flip helper moved into the executor.
- **`tests/ceremony_execute.rs`** — replaced the stale "depart not wired" test with `depart_removes_member_and_revokes` (admit → depart → ACL gone, member tombstoned, slot flipped) and `depart_refuses_the_last_admin`.

## Why route removal through the executor

Same rationale as #206 (Admit/approve): the pipeline should *replace* the bespoke per-purpose write paths, not run alongside them. Routing `remove_inner` through `Depart` means there's one removal-write implementation, and the **8 existing removal integration tests are unchanged and still green** — the refactor is behaviour-preserving, and those tests now exercise the `Depart` arm end-to-end.

## Scope note — no decision-shaped `leave.rego` yet

`remove_inner` still reads the **boolean** `removal.rego` (`allow` + `min_disposition`) — its "decide" stage is unchanged. The full leave **ceremony** (assemble leave `Facts` with `actor ≠ subject` → `decide(leave.rego)` → `execute::apply(Depart)`, the parallel to a Stage-B join route) is a follow-up. This PR is the executor + write-path unification only, matching the shape of #206.

## Testing

- Full `vtc-service` suite green (33 binaries), including all 8 `removal` tests unchanged.
- New executor `Depart` tests green.
- `cargo fmt` + `clippy` (`-D warnings` safe).

## Follow-ups

- The leave *ceremony* route + a decision-shaped `leave`/`removal` policy (this is where the leave/removal naming drift finally gets settled).
- **Remint** (role-change) executor arm + its ceremony.
- UI: none of the ceremony pipeline (directory, leave) has an admin-UI surface yet.