### PR TITLE
feat(vtc): leave ceremony — removal routes through the decision pipeline

### DIFF
--- a/vtc-service/policies/default/removal.rego
+++ b/vtc-service/policies/default/removal.rego
@@ -1,35 +1,40 @@
-# Default `removal` policy — admin may remove any non-admin
-# (spec §7.1 + §10.2). The route layer enforces:
+# Default `removal` policy — the leave/removal ceremony decision spine
+# (ceremony-pipeline design §4; supersedes the boolean Phase-2 shape).
 #
-# 1. `AdminAuth` on the admin-remove endpoint — so the caller is
-#    already known to be an admin when this policy runs.
-# 2. The no-last-admin invariant — the route refuses to leave
-#    zero admins regardless of policy output.
-# 3. Self-remove is its own unconditional endpoint
-#    (`DELETE /v1/members/me`) and bypasses this policy entirely.
+# The leave ceremony is the destructive instance of the decision
+# pipeline: the host assembles verified Facts, runs
+# `data.vtc.removal.decision`, and realizes the verdict via the
+# effect executor (delete ACL + apply disposition + revoke). The
+# package stays `vtc.removal` (PolicyPurpose::Removal); the pipeline
+# calls the ceremony "leave".
 #
-# This policy therefore only gates the "may this admin remove
-# this target" question. Default: allow unless the target is
-# also an admin (admins can only be removed by promotion + the
-# step-up UV path, never via a casual admin-remove).
+# What the host enforces around this policy (never in Rego):
+# - the no-last-admin invariant (refuses to leave zero admins, 409),
+# - the AdminAuth gate on the admin-remove endpoint,
+# - the final disposition (caller request > member preference > the
+#   `with.disposition` below > tombstone).
 #
-# Input shape (spec §7.3):
-#   { actor_did, target_did, target_role, reason, action, now }
+# Decision logic:
+# - **self-leave** (`actor.did == subject.did`) is unconditional — a
+#   member may always leave.
+# - an **admin removing another member** is allowed unless the subject
+#   is themselves an admin (admins leave only via the promotion +
+#   step-up path, never a casual admin-remove).
+# - everything else denies.
 
 package vtc.removal
 
 import rego.v1
 
-default allow := false
+# structural totality — unmatched removals are refused
+default decision := {"effect": "deny", "with": {"code": "removal-denied"}}
 
-allow if {
-	input.action == "remove"
-	input.target_role != "admin"
+# Self-leave — a member may always remove themselves.
+decision := {"effect": "allow", "with": {"disposition": "tombstone"}} if {
+	input.actor.did == input.subject.did
 }
 
-# Phase 1 plan §D6: `Disposition::PolicyDefault` resolves to
-# whatever this policy emits. The default mirrors Phase 1's
-# hardcoded `Tombstone` so existing operator state survives the
-# Phase 1 → Phase 2 transition unchanged.
-default min_disposition := "tombstone"
-
+# Admin removing another member — allowed unless the subject is an admin.
+else := {"effect": "allow", "with": {"disposition": "tombstone"}} if {
+	input.state.subject_member.role != "admin"
+}

--- a/vtc-service/src/ceremony/facts.rs
+++ b/vtc-service/src/ceremony/facts.rs
@@ -85,14 +85,22 @@ impl Purpose {
         }
     }
 
-    /// The Rego package the Rule-IR compiler emits for this purpose.
+    /// The Rego package whose `decision` rule decides this ceremony.
     /// Identifiers can't carry hyphens, so `role-change` →
-    /// `vtc.role_change`. Matches the package declarations in
-    /// `docs/05-design-notes/examples/*.rego`.
+    /// `vtc.role_change`.
+    ///
+    /// Note the [`Purpose::Leave`] → `vtc.removal` mapping: the
+    /// pipeline's friendly name for the destructive ceremony is
+    /// "leave", but it reuses the MVP's `removal` policy purpose
+    /// ([`crate::policy::model::PolicyPurpose::Removal`]) and package
+    /// rather than introducing a parallel `leave` purpose — settling
+    /// the leave/removal naming drift (pipeline §12) in favour of the
+    /// established runtime name. Facts still serialize `purpose:
+    /// "leave"`; only the policy package is `vtc.removal`.
     pub fn rego_package(self) -> &'static str {
         match self {
             Purpose::Join => "vtc.join",
-            Purpose::Leave => "vtc.leave",
+            Purpose::Leave => "vtc.removal",
             Purpose::RoleChange => "vtc.role_change",
             Purpose::Directory => "vtc.directory",
         }

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -239,20 +239,12 @@ async fn member_self_remove_handler(
         .transpose()
         .map_err(DIDCommServiceError::Internal)?;
 
-    // DIDComm self-remove — same bypass as the REST self-remove
-    // path: unconditional (spec §10.2), `removal.rego` is not
-    // consulted. Disposition still routes through the policy
-    // when the member prefers `PolicyDefault`.
-    let outcome = remove_inner(
-        &state,
-        &caller_did,
-        &caller_did,
-        disposition,
-        String::new(),
-        false,
-    )
-    .await
-    .map_err(|e| DIDCommServiceError::Internal(format!("self-remove: {e}")))?;
+    // DIDComm self-leave — actor == subject. The leave decision policy
+    // allows self-leave unconditionally (spec §10.2); the no-last-admin
+    // invariant still applies in the effect stage.
+    let outcome = remove_inner(&state, &caller_did, &caller_did, disposition, String::new())
+        .await
+        .map_err(|e| DIDCommServiceError::Internal(format!("self-remove: {e}")))?;
 
     let receipt = SelfRemoveReceiptBody {
         did: outcome.did,

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -367,27 +367,42 @@ mod tests {
 
     #[test]
     fn removal_default_allows_admin_removing_member() {
+        // The removal default is now the leave-ceremony decision spine:
+        // it returns a {effect, with} object over the verified Facts.
         let c = compile_default(PolicyPurpose::Removal);
-        let input = json!({
-            "actor_did": "did:key:zAdmin",
-            "target_did": "did:key:zMember",
-            "target_role": "member",
-            "reason": "",
-            "action": "remove",
-            "now": "2026-05-12T00:00:00Z"
-        });
-        let r = evaluate(&c, "data.vtc.removal.allow", input).unwrap();
-        assert!(pluck_bool(&r));
+        let r = evaluate(
+            &c,
+            "data.vtc.removal.decision",
+            json!({
+                "actor": { "did": "did:key:zAdmin" },
+                "subject": { "did": "did:key:zMember" },
+                "state": { "subject_member": { "role": "member" } }
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "allow", "with": { "disposition": "tombstone" } })),
+        );
     }
 
     #[test]
-    fn removal_default_min_disposition_is_tombstone() {
+    fn removal_default_allows_self_leave() {
+        // Self-leave (actor == subject) is unconditional.
         let c = compile_default(PolicyPurpose::Removal);
-        let r = evaluate(&c, "data.vtc.removal.min_disposition", json!({})).unwrap();
+        let r = evaluate(
+            &c,
+            "data.vtc.removal.decision",
+            json!({
+                "actor": { "did": "did:key:zSelf" },
+                "subject": { "did": "did:key:zSelf" },
+                "state": { "subject_member": { "role": "member" } }
+            }),
+        )
+        .unwrap();
         assert_eq!(
             r.pointer("/result/0/expressions/0/value"),
-            Some(&json!("tombstone")),
-            "removal default min_disposition mirrors Phase 1's hardcoded Tombstone"
+            Some(&json!({ "effect": "allow", "with": { "disposition": "tombstone" } })),
         );
     }
 
@@ -396,11 +411,18 @@ mod tests {
         let c = compile_default(PolicyPurpose::Removal);
         let r = evaluate(
             &c,
-            "data.vtc.removal.allow",
-            json!({ "action": "remove", "target_role": "admin" }),
+            "data.vtc.removal.decision",
+            json!({
+                "actor": { "did": "did:key:zAdmin" },
+                "subject": { "did": "did:key:zOtherAdmin" },
+                "state": { "subject_member": { "role": "admin" } }
+            }),
         )
         .unwrap();
-        assert!(!pluck_bool(&r));
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "deny", "with": { "code": "removal-denied" } })),
+        );
     }
 
     #[test]

--- a/vtc-service/src/policy/mod.rs
+++ b/vtc-service/src/policy/mod.rs
@@ -50,3 +50,30 @@ pub use storage::{
     clear_active_policy_id, delete_policy, get_active_policy_id, get_policy, list_policies,
     list_policies_paginated, max_version_for, new_policy, set_active_policy_id, store_policy,
 };
+
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// Fetch the active policy for `purpose` and compile it.
+///
+/// Resolves the per-purpose active pointer → the stored `Policy` row →
+/// a [`CompiledPolicy`]. The shared loader every ceremony route uses to
+/// get the policy `decide()` evaluates. Fails closed: a missing active
+/// pointer or row is an [`AppError::Internal`] (the boot-time default
+/// loader guarantees one per purpose), not a silent allow.
+pub async fn load_active_compiled(
+    active_policies_ks: &KeyspaceHandle,
+    policies_ks: &KeyspaceHandle,
+    purpose: PolicyPurpose,
+) -> Result<CompiledPolicy, AppError> {
+    let id = get_active_policy_id(active_policies_ks, purpose)
+        .await?
+        .ok_or_else(|| AppError::Internal(format!("no active {} policy", purpose.as_str())))?;
+    let policy = get_policy(policies_ks, id).await?.ok_or_else(|| {
+        AppError::Internal(format!(
+            "active {} policy {id} points at a missing row",
+            purpose.as_str()
+        ))
+    })?;
+    compile(&policy.rego_source, policy.id)
+}

--- a/vtc-service/src/routes/directory.rs
+++ b/vtc-service/src/routes/directory.rs
@@ -45,9 +45,8 @@ use crate::ceremony::{
 };
 use crate::community::load_profile;
 use crate::members::{get_member, list_members};
-use crate::policy::engine::{CompiledPolicy, compile};
+use crate::policy::load_active_compiled;
 use crate::policy::model::PolicyPurpose;
-use crate::policy::storage::{get_active_policy_id, get_policy};
 use crate::server::AppState;
 
 /// The PII boundary for the directory ceremony: the maximum set of
@@ -87,7 +86,12 @@ pub async fn query(
     let facts = assemble_directory_facts(&state, &viewer, &subject_did, q.fields).await?;
     let verified = VerifiedFacts::assemble(facts)?;
 
-    let policy = load_active_policy(&state, PolicyPurpose::Directory).await?;
+    let policy = load_active_compiled(
+        &state.active_policies_ks,
+        &state.policies_ks,
+        PolicyPurpose::Directory,
+    )
+    .await?;
     let verdict = ceremony::decide(&verified, &policy)?;
 
     match &verdict {
@@ -202,23 +206,4 @@ async fn assemble_directory_facts(
         },
         state: FactsState { subject_member },
     })
-}
-
-/// Fetch the active policy for a purpose and compile it. Generic over
-/// purpose so future ceremony routes reuse it; lives here until a
-/// second consumer pulls it up into the ceremony module.
-async fn load_active_policy(
-    state: &AppState,
-    purpose: PolicyPurpose,
-) -> Result<CompiledPolicy, AppError> {
-    let id = get_active_policy_id(&state.active_policies_ks, purpose)
-        .await?
-        .ok_or_else(|| AppError::Internal(format!("no active {} policy", purpose.as_str())))?;
-    let policy = get_policy(&state.policies_ks, id).await?.ok_or_else(|| {
-        AppError::Internal(format!(
-            "active {} policy {id} points at a missing row",
-            purpose.as_str()
-        ))
-    })?;
-    compile(&policy.rego_source, policy.id)
 }

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -1,23 +1,26 @@
 //! `DELETE /v1/members/me` (M1.11.1) + `DELETE /v1/members/{did}`
-//! (M1.12.1).
+//! (M1.12.1) — the **leave ceremony**.
 //!
-//! Both paths converge on `remove_inner` so the no-last-admin
-//! invariant + disposition resolution + audit emission live in
-//! exactly one place.
+//! Both paths converge on `remove_inner`, which is the leave instance
+//! of the ceremony decision pipeline ([`crate::ceremony`]):
 //!
-//! ## No-last-admin invariant
+//! 1. **Facts** — `assemble_leave_facts` reads the actor's + subject's
+//!    community roles into a purpose-`leave` [`Facts`] (`actor` may
+//!    differ from `subject`: an admin removing a member, or a member
+//!    removing themselves).
+//! 2. **Decide** — the active `removal`-purpose decision policy
+//!    (`data.vtc.removal.decision`) returns allow/deny. The default
+//!    policy allows self-leave unconditionally and an admin removing a
+//!    non-admin; it denies removing an admin.
+//! 3. **Effect** — the verdict is applied by the effect executor
+//!    ([`execute::apply`] with [`EffectPlan::Depart`]), which owns the
+//!    no-last-admin invariant (→ 409, host-enforced), the ACL/Member
+//!    deletion + disposition, and the credential revocation.
 //!
-//! Spec §10.2: a removal that would leave the community with
-//! zero admins is refused with 409 `LastAdminProtected`. The
-//! check + ACL delete run inside the same critical section
-//! guarded by [`LAST_ADMIN_LOCK`] so concurrent removals can't
-//! race past each other.
-//!
-//! Phase 1 implementation: snapshot every ACL row inside the
-//! lock, count Admin rows after removing the target, refuse if
-//! the count would hit zero. Fjall walks are O(n) but
-//! Phase-1 communities are small; Phase 2+ can swap in an
-//! admin-count index.
+//! Disposition precedence (resolved here, around the decision): the
+//! caller's explicit request wins, then the member's
+//! `departure_preference`, then the policy's chosen disposition, then
+//! `tombstone`.
 
 use affinidi_status_list::StatusPurpose;
 use axum::Json;
@@ -25,8 +28,8 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value as JsonValue, json};
-use tracing::{info, warn};
+use serde_json::json;
+use tracing::info;
 
 use vti_common::audit::{AuditEvent, MemberRemovedData, StatusListFlippedData};
 use vti_common::error::AppError;
@@ -34,12 +37,13 @@ use vti_common::error::AppError;
 use crate::acl::get_acl_entry;
 use crate::auth::{AdminAuth, AuthClaims};
 use crate::ceremony::execute;
-use crate::ceremony::{EffectOutcome, EffectPlan};
-use crate::members::{Disposition, get_member};
-use crate::policy::{
-    PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy, get_active_policy_id,
-    get_policy,
+use crate::ceremony::{
+    Actor, Context, EffectOutcome, EffectPlan, Evidence, Facts, MemberState, Purpose,
+    State as FactsState, Subject, Verdict, VerifiedFacts,
 };
+use crate::community::load_profile;
+use crate::members::{Disposition, get_member, list_members};
+use crate::policy::{PolicyPurpose, load_active_compiled};
 use crate::server::AppState;
 
 #[derive(Debug, Deserialize, Default)]
@@ -75,6 +79,9 @@ pub async fn self_remove(
 ) -> Result<(StatusCode, Json<RemoveResponse>), AppError> {
     let body = body.map(|Json(b)| b).unwrap_or_default();
     let target_did = auth.did.clone();
+    // Self-leave: actor == subject. The decision policy allows this
+    // unconditionally (it sees `actor.did == subject.did`); the
+    // no-last-admin invariant still applies in the effect stage.
     let outcome = remove_inner(
         &state,
         &auth.did,
@@ -84,11 +91,6 @@ pub async fn self_remove(
         // departure is the member's own decision and doesn't carry
         // an externally-meaningful justification field.
         String::new(),
-        // Self-remove is unconditional (spec §10.2) — bypasses
-        // the `removal.rego` allow gate. Disposition still
-        // routes through the policy when the member's preference
-        // is `PolicyDefault`.
-        false,
     )
     .await?;
     Ok((StatusCode::OK, Json(outcome)))
@@ -119,15 +121,7 @@ pub async fn admin_remove(
             reason.len(),
         )));
     }
-    let outcome = remove_inner(
-        &state,
-        &admin.0.did,
-        &target_did,
-        body.disposition,
-        reason,
-        true,
-    )
-    .await?;
+    let outcome = remove_inner(&state, &admin.0.did, &target_did, body.disposition, reason).await?;
     Ok((StatusCode::OK, Json(outcome)))
 }
 
@@ -135,20 +129,20 @@ pub async fn admin_remove(
 // Shared inner removal
 // ---------------------------------------------------------------------------
 
-/// Returns `Ok(RemoveResponse)` on success or
-/// `Err(AppError::Conflict)` for the no-last-admin invariant.
+/// The leave ceremony's decide → resolve → effect spine. Returns
+/// `Ok(RemoveResponse)` on departure, `Err(Forbidden)` when the policy
+/// denies, or `Err(Conflict)` for the executor's no-last-admin
+/// invariant.
 ///
-/// `actor_did` is the audit actor (self for self-remove, admin
-/// for admin-remove). `target_did` is the row being removed.
-/// `is_admin_remove` gates the `removal.rego` allow check —
-/// self-remove is unconditional per spec §10.2.
+/// `actor_did` is the initiator (self for self-leave, admin for
+/// admin-remove) — the policy distinguishes the two via `actor.did ==
+/// subject.did`. `target_did` is the subject being removed.
 pub async fn remove_inner(
     state: &AppState,
     actor_did: &str,
     target_did: &str,
     disposition: Option<Disposition>,
     reason: String,
-    is_admin_remove: bool,
 ) -> Result<RemoveResponse, AppError> {
     let audit_writer = state
         .audit_writer
@@ -161,38 +155,55 @@ pub async fn remove_inner(
 
     let target_member = get_member(&state.members_ks, target_did).await?;
 
-    // Decide. Admin-remove evaluates the active `removal.rego` `allow`
-    // rule against the canonical input (spec §7.3); self-remove is
-    // unconditional (spec §10.2). The no-last-admin invariant + the
-    // credential revocation are the *effect*, enforced by the executor
-    // below — not here.
-    if is_admin_remove {
-        let input = json!({
-            "actor_did": actor_did,
-            "target_did": target_did,
-            "target_role": target_acl.role.to_string(),
-            "reason": reason,
-            "action": "remove",
-            "now": Utc::now().to_rfc3339(),
-        });
-        if !evaluate_removal_allow(state, &input).await? {
-            return Err(AppError::Forbidden(
-                "removal denied by policy (removal.rego.allow returned false)".into(),
+    // Decide. Assemble verified leave Facts and run the active
+    // removal-purpose decision policy. The no-last-admin invariant +
+    // the credential revocation are the *effect* (executor below), not
+    // the policy.
+    let facts = assemble_leave_facts(
+        state,
+        actor_did,
+        target_did,
+        &target_acl.role.to_string(),
+        target_member.as_ref(),
+        disposition,
+        &reason,
+    )
+    .await?;
+    let verified = VerifiedFacts::assemble(facts)?;
+    let policy = load_active_compiled(
+        &state.active_policies_ks,
+        &state.policies_ks,
+        PolicyPurpose::Removal,
+    )
+    .await?;
+    let allow = match crate::ceremony::decide(&verified, &policy)? {
+        Verdict::Allow(a) => a,
+        Verdict::Deny(d) => {
+            return Err(AppError::Forbidden(format!(
+                "removal denied by policy ({})",
+                d.code
+            )));
+        }
+        // Leave is synchronous — a refer / request_more verdict is a
+        // misconfigured policy for this purpose.
+        Verdict::Refer(_) | Verdict::RequestMore(_) => {
+            return Err(AppError::Internal(
+                "removal policy returned a non-terminal verdict; leave is synchronous".into(),
             ));
         }
-    }
+    };
 
-    // Resolve disposition. Caller's request wins; the member's
-    // departure_preference is the fallback; `PolicyDefault` consults
-    // the active `removal.rego`'s `min_disposition` (a non-decodable
-    // output falls back to `Tombstone`). The resolved value is a
-    // concrete disposition handed to the effect executor.
+    // Resolve the final disposition: the caller's explicit request
+    // wins; then the member's `departure_preference`; then the policy's
+    // chosen disposition (`with.disposition`); then `Tombstone`.
     let initial = disposition
         .or_else(|| target_member.as_ref().map(|m| m.departure_preference))
         .unwrap_or(Disposition::PolicyDefault);
     let resolved = match initial {
-        Disposition::PolicyDefault => resolve_min_disposition(state)
-            .await
+        Disposition::PolicyDefault => allow
+            .disposition
+            .as_deref()
+            .and_then(parse_disposition_opt)
             .unwrap_or(Disposition::Tombstone),
         other => other,
     };
@@ -267,66 +278,97 @@ fn disposition_wire(d: Disposition) -> &'static str {
 }
 
 // ---------------------------------------------------------------------------
-// Policy helpers (M2.7)
+// Leave-ceremony facts assembly
 // ---------------------------------------------------------------------------
 
-/// Evaluate the active `removal.rego`'s `allow` rule. Fails closed
-/// on every error path — a daemon misconfiguration must not let
-/// removals through that the operator hasn't authored a policy
-/// for.
-async fn evaluate_removal_allow(state: &AppState, input: &JsonValue) -> Result<bool, AppError> {
-    let active_id = get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Removal).await?;
-    let id = match active_id {
-        Some(id) => id,
-        None => {
-            warn!("no active removal policy — refusing admin-remove");
-            return Ok(false);
-        }
-    };
-    let policy = get_policy(&state.policies_ks, id)
+/// Read the actor's community role + the subject's member facts into a
+/// purpose-`leave` [`Facts`] for the decision policy. `subject_role` is
+/// the subject's ACL role (already fetched by the caller for the 404
+/// gate); `subject_member` is their member row, if any.
+async fn assemble_leave_facts(
+    state: &AppState,
+    actor_did: &str,
+    subject_did: &str,
+    subject_role: &str,
+    subject_member: Option<&crate::members::Member>,
+    disposition: Option<Disposition>,
+    reason: &str,
+) -> Result<Facts, AppError> {
+    let actor_role = get_acl_entry(&state.acl_ks, actor_did)
         .await?
-        .ok_or_else(|| AppError::Internal(format!("active removal policy {id} not found")))?;
-    let compiled = compile_policy(&policy.rego_source, policy.id)?;
-    let result = evaluate_policy(&compiled, "data.vtc.removal.allow", input.clone())?;
-    Ok(result
-        .pointer("/result/0/expressions/0/value")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false))
+        .map(|e| e.role.to_string());
+
+    let subject_member_state = Some(MemberState {
+        role: subject_role.to_string(),
+        status: subject_member
+            .map(|m| {
+                if m.removed_at.is_some() {
+                    "removed"
+                } else {
+                    "active"
+                }
+            })
+            .unwrap_or("active")
+            .to_string(),
+        joined_at: subject_member.map(|m| m.joined_at).unwrap_or_else(Utc::now),
+        personhood: None,
+    });
+
+    let community_did = load_profile(&state.community_ks)
+        .await?
+        .map(|p| p.community_did)
+        .unwrap_or_default();
+    let member_count = list_members(&state.members_ks).await?.len() as u64;
+
+    // Ceremony request params: the operator's requested disposition +
+    // the admin-supplied reason. Absent when neither is set.
+    let request = if disposition.is_some() || !reason.is_empty() {
+        let mut m = serde_json::Map::new();
+        if let Some(d) = disposition {
+            m.insert("disposition".into(), json!(disposition_wire(d)));
+        }
+        if !reason.is_empty() {
+            m.insert("reason".into(), json!(reason));
+        }
+        Some(serde_json::Value::Object(m))
+    } else {
+        None
+    };
+
+    Ok(Facts {
+        purpose: Purpose::Leave,
+        now: Utc::now(),
+        actor: Actor {
+            did: actor_did.to_string(),
+            role: actor_role,
+            authenticated: true,
+        },
+        subject: Subject {
+            did: subject_did.to_string(),
+        },
+        context: Context {
+            community_did,
+            channel: "rest".to_string(),
+            member_count,
+        },
+        evidence: Evidence {
+            invitation: None,
+            presentation: None,
+            request,
+        },
+        state: FactsState {
+            subject_member: subject_member_state,
+        },
+    })
 }
 
-/// Read `data.vtc.removal.min_disposition` and convert to a
-/// concrete `Disposition`. Returns `None` when no policy is active
-/// or the policy emits a non-string / unknown value — callers
-/// fall back to `Tombstone`.
-async fn resolve_min_disposition(state: &AppState) -> Option<Disposition> {
-    let active_id = get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Removal)
-        .await
-        .ok()
-        .flatten()?;
-    let policy = get_policy(&state.policies_ks, active_id)
-        .await
-        .ok()
-        .flatten()?;
-    let compiled = compile_policy(&policy.rego_source, policy.id).ok()?;
-    let result = evaluate_policy(
-        &compiled,
-        "data.vtc.removal.min_disposition",
-        JsonValue::Object(Default::default()),
-    )
-    .ok()?;
-    let s = result
-        .pointer("/result/0/expressions/0/value")
-        .and_then(|v| v.as_str())?;
+/// Parse a disposition wire string into a concrete `Disposition`.
+/// Unknown / `policydefault` → `None` (callers fall back to Tombstone).
+fn parse_disposition_opt(s: &str) -> Option<Disposition> {
     match s {
         "purge" => Some(Disposition::Purge),
         "tombstone" => Some(Disposition::Tombstone),
         "historical" => Some(Disposition::Historical),
-        other => {
-            warn!(
-                value = other,
-                "removal.rego min_disposition emitted an unknown disposition — using Tombstone"
-            );
-            None
-        }
+        _ => None,
     }
 }

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -705,18 +705,20 @@ async fn admin_remove_member_blocked_by_deny_all_policy() {
     assert!(get_acl_entry(&fix.acl_ks, target).await.unwrap().is_some());
 }
 
-/// `min_disposition := "purge"` on the active removal.rego
-/// resolves `PolicyDefault` → `Purge`, replacing Phase 1's
-/// hardcoded Tombstone fallback (Phase 1 plan §D6 placeholder).
+/// A leave decision policy whose `allow` carries
+/// `with.disposition: "purge"` resolves `PolicyDefault` → `Purge`,
+/// feeding the policy's chosen disposition into the effect.
 #[tokio::test]
-async fn admin_remove_uses_policy_min_disposition_for_default() {
+async fn admin_remove_uses_policy_disposition_for_default() {
     let fix = build_fixture().await;
     activate_removal_policy(
         &fix,
         "package vtc.removal\nimport rego.v1\n\n\
-         default allow := false\n\
-         allow if {\n  input.action == \"remove\"\n  input.target_role != \"admin\"\n}\n\
-         default min_disposition := \"purge\"\n",
+         default decision := {\"effect\": \"deny\", \"with\": {\"code\": \"removal-denied\"}}\n\
+         decision := {\"effect\": \"allow\", \"with\": {\"disposition\": \"purge\"}} if {\n  \
+           input.actor.did == input.subject.did\n}\n\
+         else := {\"effect\": \"allow\", \"with\": {\"disposition\": \"purge\"}} if {\n  \
+           input.state.subject_member.role != \"admin\"\n}\n",
     )
     .await;
 


### PR DESCRIPTION
## What

Converges the existing `DELETE /v1/members/{me,did}` removal routes onto the ceremony pipeline — **they are now the leave ceremony** (Facts → `decide()` → `Depart`). Settles the leave/removal naming drift: the policy purpose stays `removal`, "leave" is the ceremony's friendly name.

**Stacked on #207** (the `Depart` executor). Base is `feat/vtc-ceremony-leave`; it'll retarget to `main` once #207 merges. No new endpoint — the existing DELETE routes *are* the leave ceremony.

## Commit

- **`ceremony/facts.rs`** — `Purpose::Leave` → `rego_package` `vtc.removal` (reuses the MVP `PolicyPurpose::Removal` slot). Facts still serialize `purpose: "leave"`; only the policy package is `vtc.removal`.
- **`policies/default/removal.rego`** — replaced the boolean `allow` + `min_disposition` with the decision spine (`data.vtc.removal.decision`): self-leave (`actor.did == subject.did`) unconditional; an admin may remove a non-admin; removing an admin denies. `default.rs` tests updated to the decision shape.
- **`routes/members/remove.rs`** — `remove_inner` now assembles leave Facts → `load_active_compiled(Removal)` → `ceremony::decide` → resolve disposition (caller > member preference > policy `with.disposition` > tombstone) → `execute::apply(Depart)`. Dropped the `is_admin_remove` bypass flag (the policy distinguishes self vs admin via `actor == subject`) and the boolean `evaluate_removal_allow` / `resolve_min_disposition` helpers. `self_remove` / `admin_remove` / the DIDComm self-remove caller updated.
- **`policy/mod.rs`** — new shared `load_active_compiled(active_ks, policies_ks, purpose)`; `directory.rs` switched to it (dropped its private copy).

## How it settles self-leave vs admin-remove

The old code special-cased self-remove (unconditional policy bypass). Now the **policy** decides: the default `removal.rego` allows self-leave because `actor.did == subject.did`, and allows admin-remove of a non-admin. The no-last-admin invariant + revocation remain host-enforced in the `Depart` executor — so self-leaving the last admin still 409s, and removing an admin via admin-remove still 403s.

## Testing

- All 15 `removal` integration tests green — one updated from the boolean `min_disposition` shape to the decision `with.disposition` shape; the rest unchanged (behaviour-preserving).
- `directory` tests green (switched to the shared policy loader).
- Full `vtc-service` suite + `clippy -D warnings` clean.

## Follow-ups

- **Remint** (role-change) executor arm + its ceremony.
- **UX**: none of the ceremony pipeline (directory, leave) has an admin-UI surface yet — the next thing to look at.