### PR TITLE
feat(device): DeviceBinding wake channel + device task URIs (Phase 2/C1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,7 +2679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8997,9 +8997,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8d06258ead96a073a54979db44c7adc2e8e92fc561bb75dbd9656326900e60"
+checksum = "e7e7dbafd9c86e62361207636907e71ffc74ffb2585ffec958ce8d95933de7a1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -107,6 +107,32 @@ pub const TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1: &str =
 pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1: &str =
     "https://trusttasks.org/spec/auth/step-up/approve-response/0.1";
 
+// ─── Device slice (spec/device/*) ────────────────────────────────────────
+// Canonical Trust Task registry shapes (dtgwg `device/*`). Companion/Service
+// lifecycle on the VTA: register a device, heartbeat, list, disable, wipe, and
+// set the push wake channel (the opaque gateway handle conveyed by the device).
+
+/// `device/register/0.1` — a Companion/Service claims its DeviceBinding after
+/// the provision-integration + acl/swap-key bootstrap.
+pub const TASK_DEVICE_REGISTER_0_1: &str = "https://trusttasks.org/spec/device/register/0.1";
+
+/// `device/heartbeat/0.1` — periodic check-in; refreshes `lastSeenAt` and
+/// delivers queued operations.
+pub const TASK_DEVICE_HEARTBEAT_0_1: &str = "https://trusttasks.org/spec/device/heartbeat/0.1";
+
+/// `device/list/0.1` — list the maintainer's registered devices.
+pub const TASK_DEVICE_LIST_0_1: &str = "https://trusttasks.org/spec/device/list/0.1";
+
+/// `device/disable/0.1` — disable a device (cannot authenticate; record kept).
+pub const TASK_DEVICE_DISABLE_0_1: &str = "https://trusttasks.org/spec/device/disable/0.1";
+
+/// `device/wipe/0.1` — issue a wipe instruction for a device.
+pub const TASK_DEVICE_WIPE_0_1: &str = "https://trusttasks.org/spec/device/wipe/0.1";
+
+/// `device/set-wake/0.1` — the device conveys its opaque push `WakeHandle` to
+/// the VTA, which owns the trigger allowlist and provisions the push gateway.
+pub const TASK_DEVICE_SET_WAKE_0_1: &str = "https://trusttasks.org/spec/device/set-wake/0.1";
+
 // ─── ACL slice (spec/vta/acl/*) ──────────────────────────────────────────
 
 /// `spec/vta/acl/list/1.0` — list ACL entries, optionally filtered by

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -181,6 +181,30 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
     }
 }
 
+/// A device's push **wake channel** — the opaque gateway handle plus the
+/// VTA-owned trigger allowlist. Set via `device/set-wake/0.1`. Mirrors the push
+/// wake-up binding (<https://trusttasks.org/binding/push/0.1>) `WakeHandle` +
+/// `WakeTriggerPolicy`.
+///
+/// The raw platform push token is **never** stored here — it lives at the push
+/// gateway alone, behind the opaque `handle`. The VTA holds only the handle and
+/// the allowlist it provisions to the gateway.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WakeChannel {
+    /// The push gateway that issued the handle (a DID or an https URL) — where
+    /// the VTA and other triggers send a contentless wake.
+    pub gateway: String,
+    /// Opaque gateway-issued handle for this device's push channel. Reveals no
+    /// platform token; rotates when the device re-registers with the gateway.
+    pub handle: String,
+    /// DIDs the VTA has authorized to trigger a wake for this handle (the
+    /// allowlist it provisions to the gateway). Typically the device's mediator
+    /// and/or the VTA's own DID. Empty means no party may wake the device.
+    #[serde(default)]
+    pub allowed_triggers: Vec<String>,
+}
+
 /// Metadata for a registered Companion/Service device. M1 stores the field
 /// shape so the ACL row can carry it forward; the registration flow that
 /// populates it lands in M4 (`device/register/0.1`).
@@ -203,6 +227,20 @@ pub struct DeviceBinding {
     pub disabled_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wiped_at: Option<String>,
+    /// Push wake channel (opaque gateway handle + VTA-owned trigger allowlist).
+    /// `None` until the device conveys a handle via `device/set-wake/0.1`;
+    /// absent on legacy rows. The push token is never stored here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wake: Option<WakeChannel>,
+}
+
+impl DeviceBinding {
+    /// The non-secret `pushCapable` visibility flag (push binding §2): the
+    /// device has a usable wake channel — a handle is set and the device is
+    /// neither disabled nor wiped.
+    pub fn push_capable(&self) -> bool {
+        self.wake.is_some() && self.disabled_at.is_none() && self.wiped_at.is_none()
+    }
 }
 
 /// An entry in the Access Control List.
@@ -601,6 +639,67 @@ mod tests {
     fn role_parse_rejects_unknown() {
         let err = Role::parse("godmode").expect_err("unknown role must error");
         assert!(format!("{err:?}").contains("godmode"), "got {err:?}");
+    }
+
+    // ── DeviceBinding wake channel (push wake-up binding) ───────────────
+
+    fn sample_binding() -> DeviceBinding {
+        DeviceBinding {
+            device_id: "dev-1".into(),
+            display_name: "Glenn's iPhone".into(),
+            platform: Some("iOS 19".into()),
+            registered_at: "2026-06-02T00:00:00Z".into(),
+            last_seen_at: None,
+            disabled_at: None,
+            wiped_at: None,
+            wake: None,
+        }
+    }
+
+    #[test]
+    fn wake_channel_round_trips_camel_case() {
+        let mut b = sample_binding();
+        b.wake = Some(WakeChannel {
+            gateway: "https://gw.example".into(),
+            handle: "z6MkOpaque".into(),
+            allowed_triggers: vec!["did:web:mediator".into(), "did:web:vta".into()],
+        });
+        let json = serde_json::to_string(&b).unwrap();
+        // Wire is camelCase, mirroring the spec shapes.
+        assert!(json.contains("\"wake\""), "{json}");
+        assert!(json.contains("\"allowedTriggers\""), "{json}");
+        let back: DeviceBinding = serde_json::from_str(&json).unwrap();
+        assert_eq!(b, back);
+    }
+
+    #[test]
+    fn legacy_row_without_wake_deserialises_to_none() {
+        // A binding serialised before the wake field existed.
+        let legacy =
+            r#"{"deviceId":"dev-1","displayName":"old","registeredAt":"2026-01-01T00:00:00Z"}"#;
+        let b: DeviceBinding = serde_json::from_str(legacy).unwrap();
+        assert!(b.wake.is_none());
+        assert!(!b.push_capable());
+    }
+
+    #[test]
+    fn push_capable_requires_wake_and_active_device() {
+        let mut b = sample_binding();
+        assert!(!b.push_capable(), "no wake channel → not push-capable");
+
+        b.wake = Some(WakeChannel {
+            gateway: "did:web:gw".into(),
+            handle: "h".into(),
+            allowed_triggers: vec!["did:web:vta".into()],
+        });
+        assert!(b.push_capable(), "wake set + active → push-capable");
+
+        b.disabled_at = Some("2026-06-02T01:00:00Z".into());
+        assert!(!b.push_capable(), "disabled device is not push-capable");
+
+        b.disabled_at = None;
+        b.wiped_at = Some("2026-06-02T02:00:00Z".into());
+        assert!(!b.push_capable(), "wiped device is not push-capable");
     }
 
     #[test]


### PR DESCRIPTION
First slice of the VTA `device/*` family, and the storage foundation for the push wake-up path (dtgwg #68 → push gateway + VTA-owned trigger allowlist).

## Discovery that shaped this
`AclEntry` already carries `device: Option<DeviceBinding>` — a DeviceBinding is the device-facing half of an AclEntry, co-stored under the existing `acl` keyspace. So C1 is **not** a new keyspace; it extends the existing embedding. (There are still no device handlers/operations/dispatch — those are greenfield, in C2–C4.)

## Changes
- **vti-common** — add `WakeChannel { gateway, handle, allowedTriggers }` and `DeviceBinding.wake: Option<WakeChannel>` (`serde(default)` ⇒ legacy rows deserialise as `None`). The **raw push token is never stored** — only the opaque gateway handle and the VTA-owned trigger allowlist (mirrors the binding's `WakeHandle` + `WakeTriggerPolicy`). Add `DeviceBinding::push_capable()` — the non-secret visibility flag (wake set, device neither disabled nor wiped).
- **vta-sdk** — add the `device/*` task type-URI constants (`register`, `heartbeat`, `list`, `disable`, `wipe`, `set-wake`): the dispatch foundation C2+ hangs match arms off.
- **Cargo.lock** — bump `trust-tasks-rs` 0.1.5 → **0.1.6** (just published) for the `device/set-wake` + `WakeHandle`/`WakeTriggerPolicy` types the family consumes.

## Verification
- New tests: `WakeChannel` camelCase round-trip, legacy-row → `None`, `push_capable` state logic.
- **Whole workspace builds on 0.1.6** (the bump is additive across consumers); `clippy` clean; `fmt --check` clean; `vta-sdk` (104+10) + `vti-common` acl (29) tests pass; `cargo deny` ok (no new deps).

## Notes
- No version bumps on `vti-common`/`vta-sdk` here — additive API, bumped at release time (as `trust-tasks-rs` was via its own `chore(release)`).
- Next: **C2** wires the dispatch arms + `device/register` + `device/heartbeat` handlers/operations; **C4** populates `wake` via `device/set-wake` and provisions the gateway.