### PR TITLE
feat(vtc-admin-ui): cryptographic-blueprint theme + live Ceremonies surface

### DIFF
--- a/vtc-service/admin-ui/package-lock.json
+++ b/vtc-service/admin-ui/package-lock.json
@@ -8,8 +8,9 @@
       "name": "vtc-admin-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@fontsource-variable/inter": "^5.1.0",
-        "@fontsource-variable/jetbrains-mono": "^5.1.0",
+        "@fontsource-variable/fraunces": "^5.2.9",
+        "@fontsource/ibm-plex-mono": "^5.2.7",
+        "@fontsource/ibm-plex-sans": "^5.2.8",
         "@tanstack/react-query": "^5.62.0",
         "lucide-react": "^0.469.0",
         "react": "^19.0.0",
@@ -749,19 +750,28 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fontsource-variable/inter": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
-      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+    "node_modules/@fontsource-variable/fraunces": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/fraunces/-/fraunces-5.2.9.tgz",
+      "integrity": "sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
-    "node_modules/@fontsource-variable/jetbrains-mono": {
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-sans": {
       "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
-      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.2.8.tgz",
+      "integrity": "sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/vtc-service/admin-ui/package.json
+++ b/vtc-service/admin-ui/package.json
@@ -11,8 +11,9 @@
     "lint": "tsc -b --noEmit"
   },
   "dependencies": {
-    "@fontsource-variable/inter": "^5.1.0",
-    "@fontsource-variable/jetbrains-mono": "^5.1.0",
+    "@fontsource-variable/fraunces": "^5.2.9",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/ibm-plex-sans": "^5.2.8",
     "@tanstack/react-query": "^5.62.0",
     "lucide-react": "^0.469.0",
     "react": "^19.0.0",

--- a/vtc-service/admin-ui/src/main.tsx
+++ b/vtc-service/admin-ui/src/main.tsx
@@ -9,8 +9,18 @@ import { loadThirdPartyPlugins } from "@/lib/plugin-loader";
 import { applyStoredTheme } from "@/lib/theme";
 import { ToastProvider } from "@/lib/toast";
 import { registerBuiltinPlugins } from "@/plugins";
-import "@fontsource-variable/inter";
-import "@fontsource-variable/jetbrains-mono";
+// Self-hosted "cryptographic blueprint" type: Fraunces (display,
+// roman + italic), IBM Plex Sans (body), IBM Plex Mono (data/labels).
+// Self-hosted rather than CDN so the admin UI stays offline-capable
+// and leaks no font request to a third party.
+import "@fontsource-variable/fraunces";
+import "@fontsource-variable/fraunces/wght-italic.css";
+import "@fontsource/ibm-plex-sans/400.css";
+import "@fontsource/ibm-plex-sans/500.css";
+import "@fontsource/ibm-plex-sans/600.css";
+import "@fontsource/ibm-plex-mono/400.css";
+import "@fontsource/ibm-plex-mono/500.css";
+import "@fontsource/ibm-plex-mono/600.css";
 import "@/styles.css";
 
 // Apply the persisted theme before first paint so the cascade picks

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -1,0 +1,740 @@
+// Ceremonies — the live decision pipeline.
+//
+// Wires the ceremony visual guide to the running daemon. A community
+// state transition (directory query, join, leave, role change) is one
+// pipeline parameterized by purpose:
+//
+//   TRIGGER → GATHER → VERIFY → FACTS → EVALUATE(<purpose>.rego)
+//           → VERDICT → EFFECTS
+//
+// This surface visualizes that flow and lets an operator *dry-run* a
+// ceremony: it assembles a verified-Facts document and evaluates the
+// active decision policy via `POST /v1/policies/{id}/test` (which
+// never mutates state), then renders the real four-valued verdict —
+// the same `decide()` the routes run, minus the effect.
+
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { getJson, postJson } from "@/lib/api";
+
+const TRUST_TASK_POLICIES =
+  "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
+const TRUST_TASK_TEST = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
+
+type Effect = "allow" | "deny" | "refer" | "request_more";
+
+// The pipeline stages, in order. The token travels along these.
+const STAGES = [
+  "Trigger",
+  "Gather",
+  "Verify",
+  "Facts",
+  "Evaluate",
+  "Verdict",
+  "Effects",
+] as const;
+
+const EFFECTS: { key: Effect; label: string; blurb: string }[] = [
+  { key: "allow", label: "Allow", blurb: "the transition proceeds" },
+  { key: "deny", label: "Deny", blurb: "refused" },
+  { key: "refer", label: "Refer", blurb: "needs a human / quorum" },
+  {
+    key: "request_more",
+    label: "Request more",
+    blurb: "needs more evidence (threaded)",
+  },
+];
+
+type CeremonyKey = "directory" | "join" | "leave" | "role-change";
+type Wired = "live" | "legacy" | "unwired";
+
+interface Ceremony {
+  key: CeremonyKey;
+  label: string;
+  nature: string;
+  /** API policy purpose key, or null when the ceremony has no policy. */
+  purpose: string | null;
+  /** Rego package whose `decision` rule the host evaluates. */
+  pkg: string;
+  wired: Wired;
+  blurb: string;
+}
+
+const CEREMONIES: Ceremony[] = [
+  {
+    key: "directory",
+    label: "Directory",
+    nature: "read-only",
+    purpose: "directory",
+    pkg: "vtc.directory",
+    wired: "live",
+    blurb:
+      "A member views another member's record. Read-only — the verdict's allow carries a field projection, capped by the PII boundary.",
+  },
+  {
+    key: "join",
+    label: "Join",
+    nature: "constructive",
+    purpose: "join",
+    pkg: "vtc.join",
+    wired: "legacy",
+    blurb:
+      "A DID joins the community. The effect admits the member and issues a credential; the join policy is still the legacy boolean shape pending its decision-pipeline migration.",
+  },
+  {
+    key: "leave",
+    label: "Leave",
+    nature: "destructive",
+    purpose: "removal",
+    pkg: "vtc.removal",
+    wired: "live",
+    blurb:
+      "A member departs or is removed. Self-leave is unconditional; an admin may remove a non-admin. The no-last-admin invariant + revocation are host-enforced in the effect.",
+  },
+  {
+    key: "role-change",
+    label: "Role change",
+    nature: "mutating",
+    purpose: null,
+    pkg: "vtc.role_change",
+    wired: "unwired",
+    blurb:
+      "A member's role changes in place — the one ceremony whose allow may grant admin, gated by a step-up. Not yet wired into the executor (Remint).",
+  },
+];
+
+const natureColor: Record<string, string> = {
+  "read-only": "var(--brand)",
+  constructive: "var(--vd-allow)",
+  destructive: "var(--vd-deny)",
+  mutating: "var(--vd-refer)",
+};
+
+interface PolicyRow {
+  id: string;
+  purpose: string;
+  regoSource: string;
+  sha256: string;
+  version: number;
+  isActive: boolean;
+}
+interface PoliciesPage {
+  items: PolicyRow[];
+}
+interface TestResponse {
+  id: string;
+  result: {
+    result?: { expressions?: { value?: unknown }[] }[];
+  };
+}
+
+async function fetchActivePolicy(purpose: string): Promise<PolicyRow | null> {
+  const page = await getJson<PoliciesPage>(
+    `/v1/policies?purpose=${purpose}&status=active&limit=1`,
+    { trustTask: TRUST_TASK_POLICIES },
+  );
+  return page.items.find((p) => p.isActive) ?? page.items[0] ?? null;
+}
+
+interface Verdict {
+  effect: Effect;
+  with?: Record<string, unknown>;
+}
+
+function pluckDecision(resp: TestResponse): Verdict | null {
+  const value = resp.result?.result?.[0]?.expressions?.[0]?.value;
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.effect !== "string") return null;
+  return { effect: v.effect as Effect, with: v.with as Record<string, unknown> };
+}
+
+// ---------------------------------------------------------------------------
+// Facts assembly — a compact, ceremony-specific editor produces the
+// verified-Facts document the policy decides over.
+// ---------------------------------------------------------------------------
+
+interface FormState {
+  // directory
+  viewerRole: string;
+  subjectIsMember: boolean;
+  subjectRole: string;
+  // leave
+  selfLeave: boolean;
+}
+
+const DEFAULT_FORM: FormState = {
+  viewerRole: "member",
+  subjectIsMember: true,
+  subjectRole: "member",
+  selfLeave: false,
+};
+
+function buildFacts(c: Ceremony, f: FormState): Record<string, unknown> {
+  const now = new Date().toISOString();
+  const context = {
+    community_did: "did:webvh:demo.example",
+    channel: "rest",
+    member_count: 42,
+  };
+
+  if (c.key === "directory") {
+    return {
+      purpose: "directory",
+      now,
+      actor: {
+        did: "did:key:zViewer",
+        role: f.viewerRole || undefined,
+        authenticated: true,
+      },
+      subject: { did: "did:key:zTarget" },
+      context,
+      evidence: {
+        request: { fields_requested: ["did", "role", "joined_at", "status"] },
+      },
+      state: {
+        subject_member: f.subjectIsMember
+          ? {
+              role: f.subjectRole,
+              status: "active",
+              joined_at: "2026-01-02T00:00:00Z",
+            }
+          : null,
+      },
+    };
+  }
+
+  // leave
+  const actorDid = "did:key:zActor";
+  const subjectDid = f.selfLeave ? actorDid : "did:key:zTarget";
+  return {
+    purpose: "leave",
+    now,
+    actor: { did: actorDid, role: "admin", authenticated: true },
+    subject: { did: subjectDid },
+    context,
+    evidence: { request: { disposition: "tombstone" } },
+    state: {
+      subject_member: {
+        role: f.subjectRole,
+        status: "active",
+        joined_at: "2026-01-02T00:00:00Z",
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
+
+export function Ceremonies() {
+  const [active, setActive] = useState<CeremonyKey>("directory");
+  const ceremony = CEREMONIES.find((c) => c.key === active)!;
+
+  return (
+    <div style={{ maxWidth: 1180 }}>
+      <div className="cer-kicker">Verifiable Trust Community · Pipeline</div>
+      <h1 className="cer-h1">
+        One pipeline, every <em>ceremony</em>
+      </h1>
+      <p className="cer-sub">
+        Joining, leaving, directory lookups, role changes — each community
+        state transition is an instance of one decision pipeline. Pick a
+        ceremony, shape the facts, and dry-run the live policy to see the
+        verdict the daemon would reach.
+      </p>
+
+      <div className="cer-tabs" role="tablist">
+        {CEREMONIES.map((c) => (
+          <button
+            key={c.key}
+            role="tab"
+            aria-selected={c.key === active}
+            className={`cer-tab${c.key === active ? " on" : ""}`}
+            onClick={() => setActive(c.key)}
+          >
+            <span
+              className="nature"
+              style={{ color: natureColor[c.nature] }}
+              aria-hidden
+            />
+            {c.label}
+            <small>{c.nature}</small>
+          </button>
+        ))}
+      </div>
+
+      <CeremonyPanel ceremony={ceremony} />
+    </div>
+  );
+}
+
+function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
+  const [form, setForm] = useState<FormState>(DEFAULT_FORM);
+  const [verdict, setVerdict] = useState<Verdict | null>(null);
+  const [phase, setPhase] = useState(-1);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const policyQuery = useQuery({
+    queryKey: ["ceremony-policy", ceremony.purpose],
+    queryFn: () => fetchActivePolicy(ceremony.purpose!),
+    enabled: ceremony.purpose !== null,
+  });
+
+  // Reset the verdict whenever the ceremony changes.
+  useEffect(() => {
+    setVerdict(null);
+    setError(null);
+    setPhase(-1);
+  }, [ceremony.key]);
+
+  const canSimulate = ceremony.wired === "live";
+
+  async function run() {
+    const policy = policyQuery.data;
+    if (!policy) return;
+    setRunning(true);
+    setVerdict(null);
+    setError(null);
+
+    // Animate the token across the stages while the request is in flight.
+    for (let i = 0; i < STAGES.length; i++) {
+      setTimeout(() => setPhase(i), i * 110);
+    }
+
+    try {
+      const facts = buildFacts(ceremony, form);
+      const resp = await postJson<TestResponse>(
+        `/v1/policies/${policy.id}/test`,
+        { query: `data.${ceremony.pkg}.decision`, input: facts },
+        { trustTask: TRUST_TASK_TEST },
+      );
+      const v = pluckDecision(resp);
+      // Land the verdict as the token reaches the Verdict stage.
+      window.setTimeout(
+        () => {
+          if (v) setVerdict(v);
+          else
+            setError(
+              "The active policy produced no decision — it may still be the legacy boolean shape rather than a decision spine.",
+            );
+          setPhase(-1);
+          setRunning(false);
+        },
+        STAGES.length * 110 + 120,
+      );
+    } catch (e) {
+      const err = e as { message?: string };
+      setError(err.message ?? "policy test failed");
+      setPhase(-1);
+      setRunning(false);
+    }
+  }
+
+  return (
+    <>
+      <p className="cer-sub" style={{ marginTop: "var(--space-5)" }}>
+        {ceremony.blurb}
+      </p>
+
+      <div className="cer-meta-row">
+        <span className="cer-chip">
+          purpose <b>{ceremony.purpose ?? "—"}</b>
+        </span>
+        <span className="cer-chip">
+          package <b>{ceremony.pkg}</b>
+        </span>
+        <span className="cer-chip">
+          status{" "}
+          <b
+            style={{
+              color:
+                ceremony.wired === "live"
+                  ? "var(--vd-allow)"
+                  : ceremony.wired === "legacy"
+                    ? "var(--vd-refer)"
+                    : "var(--text-faint)",
+            }}
+          >
+            {ceremony.wired === "live"
+              ? "decision pipeline"
+              : ceremony.wired === "legacy"
+                ? "legacy boolean policy"
+                : "not yet wired"}
+          </b>
+        </span>
+      </div>
+
+      <div className="card" style={{ marginTop: "var(--space-5)", padding: 0 }}>
+        <div style={{ padding: "var(--space-4) var(--space-4) 0" }}>
+          <FlowDiagram phase={phase} verdict={verdict} />
+        </div>
+        <div style={{ padding: "0 var(--space-4) var(--space-4)" }}>
+          <div className="cer-outcomes">
+            {EFFECTS.map((e) => (
+              <div
+                key={e.key}
+                className={`cer-oc ${e.key}${
+                  verdict?.effect === e.key ? " lit" : ""
+                }`}
+              >
+                <div className="oc-h">
+                  <span className="dot" />
+                  {e.label}
+                </div>
+                <div className="oc-d">{e.blurb}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="cer-work">
+        {/* Simulator */}
+        <div className="card">
+          <div className="cer-panel-title">
+            Simulate <span className="ln" />
+          </div>
+
+          {!canSimulate ? (
+            <p className="cer-sub">
+              {ceremony.wired === "legacy"
+                ? "This ceremony still runs the legacy boolean policy — dry-run lands with its decision-pipeline migration."
+                : "This ceremony isn't wired into the executor yet, so there's no decision policy to dry-run."}
+            </p>
+          ) : (
+            <>
+              {ceremony.key === "directory" && (
+                <DirectoryForm form={form} setForm={setForm} />
+              )}
+              {ceremony.key === "leave" && (
+                <LeaveForm form={form} setForm={setForm} />
+              )}
+
+              <button
+                className="cer-run"
+                onClick={run}
+                disabled={running || policyQuery.isLoading || !policyQuery.data}
+              >
+                {running ? "Evaluating…" : "Run decision ▸"}
+              </button>
+
+              {error && (
+                <div
+                  className="cer-verdict"
+                  style={{ borderColor: "var(--vd-deny)" }}
+                >
+                  <span className="cer-vbadge deny">error</span>
+                  <div className="cer-vwith">{error}</div>
+                </div>
+              )}
+
+              {verdict && !error && (
+                <div className="cer-verdict">
+                  <span className={`cer-vbadge ${verdict.effect}`}>
+                    {verdict.effect}
+                  </span>
+                  <div className="cer-vwith">
+                    {verdict.with
+                      ? JSON.stringify(verdict.with, null, 2)
+                      : "{}"}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Active policy */}
+        <div className="card">
+          <div className="cer-panel-title">
+            Active decision policy <span className="ln" />
+          </div>
+          {ceremony.purpose === null ? (
+            <p className="cer-sub">No policy purpose for this ceremony yet.</p>
+          ) : policyQuery.isLoading ? (
+            <p className="cer-sub">Loading…</p>
+          ) : policyQuery.data ? (
+            <>
+              <div
+                className="cer-meta-row"
+                style={{ marginTop: 0, marginBottom: "var(--space-3)" }}
+              >
+                <span className="cer-chip">
+                  v<b>{policyQuery.data.version}</b>
+                </span>
+                <span className="cer-chip">
+                  sha <b>{policyQuery.data.sha256.slice(0, 12)}…</b>
+                </span>
+              </div>
+              <pre className="cer-policy">{policyQuery.data.regoSource}</pre>
+            </>
+          ) : (
+            <p className="cer-sub">No active policy found for this purpose.</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function DirectoryForm({
+  form,
+  setForm,
+}: {
+  form: FormState;
+  setForm: (f: FormState) => void;
+}) {
+  return (
+    <>
+      <div className="cer-field">
+        <label>
+          Viewer's community role
+          <small>actor.role — admin sees the fuller record</small>
+        </label>
+        <select
+          className="input"
+          value={form.viewerRole}
+          onChange={(e) => setForm({ ...form, viewerRole: e.target.value })}
+        >
+          <option value="admin">admin</option>
+          <option value="member">member</option>
+          <option value="">none (authenticated)</option>
+        </select>
+      </div>
+      <div className="cer-field">
+        <label>
+          Subject is a member
+          <small>state.subject_member present</small>
+        </label>
+        <Toggle
+          on={form.subjectIsMember}
+          onClick={() =>
+            setForm({ ...form, subjectIsMember: !form.subjectIsMember })
+          }
+        />
+      </div>
+      {form.subjectIsMember && (
+        <div className="cer-field">
+          <label>
+            Subject's role
+            <small>state.subject_member.role</small>
+          </label>
+          <select
+            className="input"
+            value={form.subjectRole}
+            onChange={(e) => setForm({ ...form, subjectRole: e.target.value })}
+          >
+            <option value="member">member</option>
+            <option value="moderator">moderator</option>
+            <option value="admin">admin</option>
+          </select>
+        </div>
+      )}
+    </>
+  );
+}
+
+function LeaveForm({
+  form,
+  setForm,
+}: {
+  form: FormState;
+  setForm: (f: FormState) => void;
+}) {
+  return (
+    <>
+      <div className="cer-field">
+        <label>
+          Self-leave
+          <small>actor.did == subject.did — always allowed</small>
+        </label>
+        <Toggle
+          on={form.selfLeave}
+          onClick={() => setForm({ ...form, selfLeave: !form.selfLeave })}
+        />
+      </div>
+      {!form.selfLeave && (
+        <div className="cer-field">
+          <label>
+            Subject's role
+            <small>an admin may remove a non-admin only</small>
+          </label>
+          <select
+            className="input"
+            value={form.subjectRole}
+            onChange={(e) => setForm({ ...form, subjectRole: e.target.value })}
+          >
+            <option value="member">member</option>
+            <option value="moderator">moderator</option>
+            <option value="admin">admin</option>
+          </select>
+        </div>
+      )}
+    </>
+  );
+}
+
+function Toggle({ on, onClick }: { on: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      onClick={onClick}
+      className="cer-toggle"
+      style={{
+        width: 42,
+        height: 23,
+        borderRadius: 999,
+        border: `1px solid ${on ? "var(--brand)" : "var(--border-strong)"}`,
+        background: on ? "var(--brand-tint-strong)" : "var(--bg-subtle)",
+        position: "relative",
+        cursor: "pointer",
+        transition: "all var(--motion-fast)",
+        flex: "none",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          top: 2,
+          left: on ? 21 : 2,
+          width: 17,
+          height: 17,
+          borderRadius: "50%",
+          background: on ? "var(--brand)" : "var(--text-faint)",
+          transition: "all var(--motion-fast)",
+        }}
+      />
+    </button>
+  );
+}
+
+// Inline SVG pipeline flow. Seven stage nodes, an edge between each,
+// and a token that lights nodes as it travels. The Evaluate node goes
+// hot while the policy runs; the matching outcome lights below.
+function FlowDiagram({
+  phase,
+  verdict,
+}: {
+  phase: number;
+  verdict: Verdict | null;
+}) {
+  const n = STAGES.length;
+  const W = 1080;
+  const H = 120;
+  const padX = 20;
+  const boxW = 124;
+  const boxH = 48;
+  const gap = (W - padX * 2 - boxW * n) / (n - 1);
+  const y = 36;
+
+  const xOf = (i: number) => padX + i * (boxW + gap);
+  const tokenIdx = phase >= 0 ? phase : -1;
+  const effClass = verdict
+    ? `vd-${verdict.effect === "request_more" ? "more" : verdict.effect}`
+    : "";
+
+  return (
+    <svg
+      className="cer-flow"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label="Decision pipeline flow"
+    >
+      <defs>
+        <marker
+          id="cer-arrow"
+          viewBox="0 0 8 8"
+          refX="6"
+          refY="4"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L8,4 L0,8 z" />
+        </marker>
+      </defs>
+      {/* edges */}
+      {STAGES.slice(0, -1).map((_, i) => {
+        const x1 = xOf(i) + boxW;
+        const x2 = xOf(i + 1);
+        return (
+          <line
+            key={`e${i}`}
+            className="edge"
+            x1={x1}
+            y1={y + boxH / 2}
+            x2={x2 - 3}
+            y2={y + boxH / 2}
+            markerEnd="url(#cer-arrow)"
+          />
+        );
+      })}
+      {/* nodes */}
+      {STAGES.map((s, i) => {
+        const x = xOf(i);
+        // During the run the token heats each node; once a verdict
+        // lands, Evaluate stays hot and the Verdict node (and Effects,
+        // for an allow) take the verdict's colour.
+        let cls = "node-box";
+        if (tokenIdx === i) cls += " hot";
+        if (verdict) {
+          if (i === 4) cls += " hot";
+          if (i === 5) cls += ` ${effClass}`;
+          if (i === 6 && verdict.effect === "allow") cls += ` ${effClass}`;
+        }
+        return (
+          <g key={s}>
+            <rect
+              className={cls}
+              x={x}
+              y={y}
+              width={boxW}
+              height={boxH}
+              rx={11}
+            />
+            <text
+              className="node-t"
+              x={x + boxW / 2}
+              y={y + boxH / 2 + 1}
+              textAnchor="middle"
+              dominantBaseline="middle"
+            >
+              {s}
+            </text>
+            <text
+              className="stage-label"
+              x={x + boxW / 2}
+              y={y + boxH + 14}
+              textAnchor="middle"
+            >
+              {i === 0
+                ? "actor"
+                : i === 2
+                  ? "host crypto"
+                  : i === 4
+                    ? `${"<purpose>"}.rego`
+                    : i === 6
+                      ? "issue / revoke"
+                      : ""}
+            </text>
+          </g>
+        );
+      })}
+      {/* token */}
+      {tokenIdx >= 0 && (
+        <circle
+          className="token"
+          r={6}
+          cx={xOf(tokenIdx) + boxW / 2}
+          cy={y + boxH / 2}
+        />
+      )}
+    </svg>
+  );
+}

--- a/vtc-service/admin-ui/src/plugins/index.ts
+++ b/vtc-service/admin-ui/src/plugins/index.ts
@@ -21,11 +21,13 @@ import {
   Smartphone,
   Tag,
   Users,
+  Workflow,
 } from "lucide-react";
 
 import { registerPlugin } from "@/plugin-api";
 import { Acl } from "@/plugins/acl";
 import { Audit } from "@/plugins/audit";
+import { Ceremonies } from "@/plugins/ceremonies";
 import { Dashboard } from "@/plugins/dashboard";
 import { JoinRequests } from "@/plugins/joinRequests";
 import { Members } from "@/plugins/members";
@@ -41,6 +43,14 @@ export function registerBuiltinPlugins(): void {
     path: "/",
     iconComponent: LayoutDashboard,
     reactComponent: Dashboard,
+  });
+
+  registerPlugin({
+    id: "ceremonies",
+    label: "Ceremonies",
+    path: "/ceremonies",
+    iconComponent: Workflow,
+    reactComponent: Ceremonies,
   });
 
   registerPlugin({

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -10,13 +10,16 @@
 :root {
   color-scheme: light dark;
 
-  /* Type — 14px base, Inter Variable + JetBrains Mono self-hosted */
+  /* Type — "cryptographic blueprint": Fraunces display, IBM Plex
+   * Sans body, IBM Plex Mono for data/labels. 14px base. Matches the
+   * ceremony visual guide so the whole UX speaks one language. */
   --font-sans:
-    "Inter Variable", "Inter", ui-sans-serif, system-ui, -apple-system,
-    "Segoe UI", Roboto, sans-serif;
+    "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+    Roboto, sans-serif;
   --font-mono:
-    "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular,
-    "SF Mono", Menlo, Consolas, monospace;
+    "IBM Plex Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    monospace;
+  --font-display: "Fraunces", Georgia, "Times New Roman", serif;
 
   --text-xs: 11px;
   --text-xs-leading: 16px;
@@ -50,15 +53,15 @@
   --gray-900: #18181b;
   --gray-950: #09090b;
 
-  /* Brand — indigo (locked) */
-  --brand-50: #efeffe;
-  --brand-100: #e0e1fd;
-  --brand-200: #c5c5fa;
-  --brand-300: #a0a0f3;
-  --brand-400: #7c7ce8;
-  --brand-500: #5b5bd6;
-  --brand-600: #4a4ac4;
-  --brand-700: #3e3ea1;
+  /* Brand — teal ("structural"), from the ceremony blueprint */
+  --brand-50: #effcf9;
+  --brand-100: #d2f6ef;
+  --brand-200: #a6ece0;
+  --brand-300: #5eead4;
+  --brand-400: #2dd4bf;
+  --brand-500: #14b8a6;
+  --brand-600: #0d9488;
+  --brand-700: #0f766e;
 
   /* Semantic */
   --success-500: #16a34a;
@@ -92,35 +95,47 @@
   --motion-medium: 180ms cubic-bezier(0.16, 1, 0.3, 1);
   --motion-slow: 260ms cubic-bezier(0.16, 1, 0.3, 1);
 
-  /* Semantic surface tokens — auto-follow OS via light-dark() */
-  --bg: light-dark(#ffffff, var(--gray-950));
-  --bg-elev: light-dark(var(--gray-50), var(--gray-900));
-  --bg-subtle: light-dark(var(--gray-100), var(--gray-800));
-  --bg-hover: light-dark(var(--gray-100), color-mix(in srgb, var(--gray-800) 60%, transparent));
-  --border: light-dark(var(--gray-200), var(--gray-800));
-  --border-strong: light-dark(var(--gray-300), var(--gray-700));
-  --text: light-dark(var(--gray-900), var(--gray-50));
-  --text-muted: light-dark(var(--gray-600), var(--gray-400));
-  --text-faint: light-dark(var(--gray-500), var(--gray-500));
-  --brand: light-dark(var(--brand-500), var(--brand-400));
-  --brand-fg: #ffffff;
-  --brand-hover: light-dark(var(--brand-600), var(--brand-300));
+  /* Semantic surface tokens — "cryptographic blueprint".
+   * Dark is the primary identity (deep blue-black ground, bluish
+   * translucent rule lines, teal structural accent); light is a
+   * coherent draughting-paper counterpart. Auto-follows OS via
+   * light-dark(); the manual switcher pins via `color-scheme`. */
+  --bg: light-dark(#f6f8fb, #090c12);
+  --bg-elev: light-dark(#ffffff, #10141d);
+  --bg-subtle: light-dark(#eef2f7, #141a24);
+  --bg-hover: light-dark(#e9eef5, rgba(150, 170, 200, 0.06));
+  --border: light-dark(#e1e7ef, rgba(150, 170, 200, 0.13));
+  --border-strong: light-dark(#cdd5e0, rgba(150, 170, 200, 0.24));
+  --text: light-dark(#0d1320, #e7ecf4);
+  --text-muted: light-dark(#586176, #8a94a8);
+  --text-faint: light-dark(#8b94a4, #5b6577);
+  --brand: light-dark(var(--brand-600), var(--brand-400));
+  --brand-fg: light-dark(#ffffff, #04181a);
+  --brand-hover: light-dark(var(--brand-700), var(--brand-300));
   --brand-tint: light-dark(
-    color-mix(in srgb, var(--brand-500) 8%, transparent),
-    color-mix(in srgb, var(--brand-400) 14%, transparent)
+    color-mix(in srgb, var(--brand-600) 8%, transparent),
+    color-mix(in srgb, var(--brand-400) 12%, transparent)
   );
   --brand-tint-strong: light-dark(
-    color-mix(in srgb, var(--brand-500) 14%, transparent),
-    color-mix(in srgb, var(--brand-400) 22%, transparent)
+    color-mix(in srgb, var(--brand-600) 14%, transparent),
+    color-mix(in srgb, var(--brand-400) 20%, transparent)
   );
-  --focus-ring: light-dark(var(--brand-500), var(--brand-400));
-  --success: light-dark(var(--success-500), var(--success-400));
-  --warning: light-dark(var(--warning-500), var(--warning-400));
-  --danger: light-dark(var(--danger-500), var(--danger-400));
+  --focus-ring: light-dark(var(--brand-600), var(--brand-400));
+  --success: light-dark(var(--success-500), #34d399);
+  --warning: light-dark(var(--warning-500), #fbbf24);
+  --danger: light-dark(var(--danger-500), #fb7185);
   --danger-tint: light-dark(
     color-mix(in srgb, var(--danger-500) 9%, transparent),
-    color-mix(in srgb, var(--danger-400) 16%, transparent)
+    color-mix(in srgb, #fb7185 16%, transparent)
   );
+
+  /* Verdict palette — the four ceremony effects, shared by the
+   * ceremonies plugin and any surface that renders a decision.
+   * allow=emerald, deny=rose, refer=amber, request_more=violet. */
+  --vd-allow: light-dark(#059669, #34d399);
+  --vd-deny: light-dark(#e11d48, #fb7185);
+  --vd-refer: light-dark(#d97706, #fbbf24);
+  --vd-more: light-dark(#7c3aed, #a78bfa);
 
   /* Elevation — 1px border + optional faint shadow */
   --elev-0: none;
@@ -167,7 +182,60 @@ body {
   letter-spacing: var(--tracking-tight);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: "cv11", "ss01";
+  min-height: 100vh;
+}
+
+/* Blueprint ground — a faint engineering grid + two structural
+ * radial washes, masked toward the top. Fixed + non-interactive so it
+ * sits behind the whole shell. The grid lines use the same bluish rule
+ * colour as borders, so light + dark both read as "draughting". */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(var(--border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border) 1px, transparent 1px);
+  background-size: 46px 46px;
+  mask: radial-gradient(125% 90% at 50% 0%, #000 30%, transparent 86%);
+  opacity: 0.55;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(
+      1100px 560px at 82% -10%,
+      color-mix(in srgb, var(--brand) 9%, transparent),
+      transparent 60%
+    ),
+    radial-gradient(
+      820px 460px at 4% 2%,
+      color-mix(in srgb, var(--vd-more) 7%, transparent),
+      transparent 55%
+    );
+}
+
+/* Keep the app above the ground layers. */
+#root {
+  position: relative;
+  z-index: 1;
+}
+
+/* Display type — Fraunces, the blueprint's serif voice, on the big
+ * structural headings. Component-level titles opt in via this. */
+h1,
+.page-title,
+.display {
+  font-family: var(--font-display);
+  font-weight: 500;
+  letter-spacing: var(--tracking-tight);
 }
 
 /* Numeric surfaces — tabular nums so columns align. */
@@ -1445,4 +1513,384 @@ dd .copy-icon-btn {
 
 .toast-dismiss:hover {
   color: var(--text);
+}
+
+/* ── Ceremonies plugin ───────────────────────────────────────────
+ *
+ * The live-pipeline surface: the decision flow diagram, ceremony
+ * selector, decision-policy view, and the verdict simulator. Wires
+ * the ceremony visual guide to the running daemon. Verdict colours
+ * come from the shared --vd-* tokens. */
+
+.cer-kicker {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--brand);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.cer-kicker::before {
+  content: "";
+  width: 26px;
+  height: 1px;
+  background: var(--brand);
+}
+.cer-h1 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: clamp(28px, 4vw, 44px);
+  line-height: 1.04;
+  letter-spacing: var(--tracking-tight);
+  margin: var(--space-3) 0 var(--space-2);
+}
+.cer-h1 em {
+  font-style: italic;
+  color: var(--brand);
+}
+.cer-sub {
+  color: var(--text-muted);
+  max-width: 64ch;
+  font-size: var(--text-md);
+}
+
+/* Ceremony selector tabs */
+.cer-tabs {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin: var(--space-5) 0 var(--space-2);
+}
+.cer-tab {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  letter-spacing: 0.04em;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--motion-fast);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.cer-tab:hover {
+  color: var(--text);
+  border-color: var(--text-faint);
+}
+.cer-tab.on {
+  border-color: var(--brand);
+  color: var(--brand);
+  background: var(--brand-tint);
+}
+.cer-tab small {
+  color: var(--text-faint);
+  font-size: var(--text-xs);
+}
+.cer-tab .nature {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.7;
+}
+
+/* Pipeline flow diagram */
+.cer-flow {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.cer-flow .node-box {
+  fill: var(--bg-subtle);
+  stroke: var(--border-strong);
+  stroke-width: 1;
+  transition: all var(--motion-slow);
+}
+.cer-flow .node-box.hot {
+  stroke: var(--brand);
+  fill: color-mix(in srgb, var(--brand) 12%, var(--bg-subtle));
+}
+.cer-flow .node-t {
+  fill: var(--text);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+}
+.cer-flow .node-s {
+  fill: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+}
+.cer-flow .edge {
+  stroke: var(--border-strong);
+  stroke-width: 1.6;
+  fill: none;
+}
+.cer-flow marker path {
+  fill: var(--border-strong);
+}
+/* Verdict-coloured nodes — the Verdict (and, for an allow, Effects)
+ * node takes the decision's colour once it lands. */
+.cer-flow .node-box.vd-allow {
+  stroke: var(--vd-allow);
+  fill: color-mix(in srgb, var(--vd-allow) 13%, var(--bg-subtle));
+}
+.cer-flow .node-box.vd-deny {
+  stroke: var(--vd-deny);
+  fill: color-mix(in srgb, var(--vd-deny) 13%, var(--bg-subtle));
+}
+.cer-flow .node-box.vd-refer {
+  stroke: var(--vd-refer);
+  fill: color-mix(in srgb, var(--vd-refer) 13%, var(--bg-subtle));
+}
+.cer-flow .node-box.vd-more {
+  stroke: var(--vd-more);
+  fill: color-mix(in srgb, var(--vd-more) 13%, var(--bg-subtle));
+}
+.cer-flow .token {
+  fill: var(--brand);
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--brand) 80%, transparent));
+}
+.cer-flow .stage-label {
+  fill: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* Outcome chips below the flow */
+.cer-outcomes {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-top: var(--space-4);
+}
+.cer-oc {
+  flex: 1 1 0;
+  min-width: 150px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elev);
+  opacity: 0.5;
+  transition: all var(--motion-slow);
+}
+.cer-oc .oc-h {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+.cer-oc .oc-d {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  margin-top: var(--space-1);
+}
+.cer-oc .dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+}
+.cer-oc.allow .dot {
+  background: var(--vd-allow);
+}
+.cer-oc.deny .dot {
+  background: var(--vd-deny);
+}
+.cer-oc.refer .dot {
+  background: var(--vd-refer);
+}
+.cer-oc.request_more .dot {
+  background: var(--vd-more);
+}
+.cer-oc.lit {
+  opacity: 1;
+  transform: translateY(-2px);
+}
+.cer-oc.allow.lit {
+  border-color: var(--vd-allow);
+  box-shadow: 0 0 0 1px var(--vd-allow);
+}
+.cer-oc.deny.lit {
+  border-color: var(--vd-deny);
+  box-shadow: 0 0 0 1px var(--vd-deny);
+}
+.cer-oc.refer.lit {
+  border-color: var(--vd-refer);
+  box-shadow: 0 0 0 1px var(--vd-refer);
+}
+.cer-oc.request_more.lit {
+  border-color: var(--vd-more);
+  box-shadow: 0 0 0 1px var(--vd-more);
+}
+
+/* Workspace: facts/simulator on the left, policy on the right */
+.cer-work {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-5);
+  margin-top: var(--space-5);
+}
+@media (max-width: 940px) {
+  .cer-work {
+    grid-template-columns: 1fr;
+  }
+}
+.cer-panel-title {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+.cer-panel-title .ln {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* Facts form rows */
+.cer-field {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-1);
+  border-bottom: 1px solid var(--border);
+}
+.cer-field:last-of-type {
+  border-bottom: none;
+}
+.cer-field label {
+  font-size: var(--text-base);
+  flex: 1;
+}
+.cer-field label small {
+  display: block;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  margin-top: 1px;
+}
+.cer-field select {
+  width: auto;
+  min-width: 150px;
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+/* Run button + verdict */
+.cer-run {
+  width: 100%;
+  margin-top: var(--space-4);
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--brand);
+  background: var(--brand-tint);
+  color: var(--brand);
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  transition: background var(--motion-fast);
+}
+.cer-run:hover {
+  background: var(--brand-tint-strong);
+}
+.cer-run:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.cer-verdict {
+  margin-top: var(--space-4);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border);
+  padding: var(--space-4);
+  background: var(--bg-elev);
+  animation: cer-pop 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes cer-pop {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+.cer-vbadge {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
+  font-weight: 600;
+}
+.cer-vbadge.allow {
+  background: color-mix(in srgb, var(--vd-allow) 16%, transparent);
+  color: var(--vd-allow);
+}
+.cer-vbadge.deny {
+  background: color-mix(in srgb, var(--vd-deny) 16%, transparent);
+  color: var(--vd-deny);
+}
+.cer-vbadge.refer {
+  background: color-mix(in srgb, var(--vd-refer) 16%, transparent);
+  color: var(--vd-refer);
+}
+.cer-vbadge.request_more {
+  background: color-mix(in srgb, var(--vd-more) 16%, transparent);
+  color: var(--vd-more);
+}
+.cer-vwith {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.cer-policy {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  white-space: pre;
+  overflow-x: auto;
+  color: var(--text-muted);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  max-height: 420px;
+}
+.cer-meta-row {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: var(--space-4);
+}
+.cer-chip {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+}
+.cer-chip b {
+  color: var(--text);
+  font-weight: 500;
 }


### PR DESCRIPTION
## What

Re-themes the whole VTC admin UI to the ceremony visual guide's "cryptographic blueprint" identity, and adds a **Ceremonies** surface that wires that guide's interactive model to the running daemon.

## Design system (the whole UX, via the token layer)

The SPA's components read semantic CSS tokens, so re-theming is a token swap that cascades everywhere:

- **Type** → Fraunces (display), IBM Plex Sans (body), IBM Plex Mono (data/labels), **self-hosted via fontsource** (dropped Inter + JetBrains; no CDN, so the admin UI stays offline-capable and leaks no font request).
- **Palette** → the blueprint's deep blue-black ground, bluish translucent rule lines, teal "structural" brand (was indigo). Dark is the primary identity; light is a coherent draughting-paper counterpart. Added shared verdict tokens (`--vd-allow/deny/refer/more`).
- An engineering-grid + radial-wash ground behind the shell.
- All existing plugins inherit it — no per-plugin restyle.

## Ceremonies plugin (new, `/ceremonies`)

- Visualizes the decision pipeline (TRIGGER→…→EFFECTS) with an animated token, directional flow, and verdict-coloured Verdict/Effects nodes.
- Ceremony selector — directory / join / leave / role-change — each with its nature + decision-pipeline status.
- **Live, non-destructive simulator**: assembles a verified-Facts document and dry-runs the active decision policy via `POST /v1/policies/{id}/test`, rendering the real four-valued verdict — the same `decide()` the routes run, minus the effect. Directory + leave are live; join shows its legacy-boolean status; role-change is flagged unwired.
- Shows the active decision-policy source per ceremony.

## Verification

- `tsc` + `vite build` clean.
- Verified visually via a temporary dev harness (the real `<Ceremonies>` component against a mocked daemon) + headless-Chrome screenshots: the theme in light + dark, and both verdict paths — directory→allow (emerald, Evaluate→Verdict→Effects light) and leave→deny (rose, Verdict node + DENY chip). The harness was removed before commit.
- **Not** live-verified: the re-themed inner plugins (members / policies / acl / audit) — typecheck-clean and inherit the token theme, but only login + ceremonies were screenshotted.

## Follow-ups

- Self-host verification of the re-themed inner plugins.
- Richer simulator facts controls; a human-readable "why" on the verdict.
- Wire join + role-change onto the decision pipeline (then they become live in the simulator too).