### PR TITLE
feat(device): device/register handler + dispatch wiring (Phase 2/C2)

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -890,6 +890,8 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_PASSKEY_LOGIN_START_0_1,
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
+    // Device slice
+    TASK_DEVICE_REGISTER_0_1,
     // ACL slice
     TASK_ACL_LIST_1_0,
     TASK_ACL_CREATE_1_0,
@@ -1028,6 +1030,7 @@ mod tests {
         const ALLOWED_PREFIXES: &[&str] = &[
             "https://trusttasks.org/spec/vta/",
             "https://trusttasks.org/spec/auth/",
+            "https://trusttasks.org/spec/device/",
             "https://trusttasks.org/spec/did-management/",
             "https://trusttasks.org/spec/vault/",
             "https://trusttasks.org/spec/webvh/",

--- a/vta-service/src/operations/device.rs
+++ b/vta-service/src/operations/device.rs
@@ -1,0 +1,361 @@
+//! `device/*` family operations — Companion/Service lifecycle.
+//!
+//! A [`DeviceBinding`] is the device-facing half of an [`AclEntry`], co-stored
+//! under the `acl` keyspace. `device/register/0.1` attaches the binding to the
+//! caller's existing ACL entry (placed there by provision-integration +
+//! acl/swap-key). See dtgwg `device/*`.
+
+use serde_json::{Value, json};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::acl::{
+    AclEntry, Capability, CompanionFormFactor, ConsumerKind, DeviceBinding, ServiceKind,
+    derived_capabilities_for_role, get_acl_entry, store_acl_entry,
+};
+use crate::audit;
+use crate::auth::AuthClaims;
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+use trust_tasks_rs::specs::device::register::v0_1 as register_spec;
+
+/// Register the caller's device: attach a [`DeviceBinding`] to its existing ACL
+/// entry. The caller (`auth.did`) MUST already be in the ACL (its long-term key,
+/// swapped in at enrolment). Re-registration is refused — the device rotates
+/// keys and retries — per the spec. Returns the `{ binding }` response payload.
+///
+/// `attestation` is **accepted but not yet verified** (the spec treats it as a
+/// policy input, not a gate; platform-attestation verification — Apple App
+/// Attest / Play Integrity — is a follow-up). A stricter deployment will gate
+/// on it later.
+#[allow(clippy::too_many_arguments)]
+pub async fn register_device(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    consumer_kind: ConsumerKind,
+    display_name: String,
+    platform: Option<String>,
+    hpke_public_key: Option<String>,
+    channel: &str,
+) -> Result<Value, AppError> {
+    let did = auth.did.clone();
+
+    // The device must already hold an ACL entry (its long-term key, swapped in
+    // at enrolment). No entry → no pending enrolment.
+    let mut entry = get_acl_entry(acl_ks, &did).await?.ok_or_else(|| {
+        AppError::NotFound(format!(
+            "device/register:no_pending_enrolment — DID {did} is not in the ACL; \
+             complete provision-integration + acl/swap-key first"
+        ))
+    })?;
+
+    // Re-registration is intentionally not idempotent (spec): rotate keys + retry.
+    if entry.device.is_some() {
+        return Err(AppError::Conflict(format!(
+            "device/register:already_registered — a DeviceBinding already exists for {did}"
+        )));
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let binding = DeviceBinding {
+        device_id: format!("dev-{}", Uuid::new_v4()),
+        display_name,
+        platform,
+        registered_at: now.clone(),
+        last_seen_at: Some(now),
+        disabled_at: None,
+        wiped_at: None,
+        hpke_public_key,
+        wake: None,
+    };
+
+    entry.kind = consumer_kind;
+    entry.device = Some(binding);
+    entry.version = entry.version.saturating_add(1);
+    store_acl_entry(acl_ks, &entry).await?;
+
+    info!(channel, did = %did, "device registered");
+    let _ = audit::record(
+        audit_ks,
+        "device.register",
+        &did,
+        Some(&did),
+        "success",
+        Some(channel),
+        None,
+    )
+    .await;
+
+    Ok(json!({ "binding": to_wire_binding(&entry) }))
+}
+
+/// Assemble the wire `DeviceBinding` (device/_shared schema) from an ACL entry
+/// that carries a [`DeviceBinding`]. Reused by `device/list`.
+///
+/// Built as JSON directly: the internal [`ConsumerKind`] serialises its
+/// Companion `formFactor` field as kebab-case (`form-factor`), which does not
+/// match the wire schema's camelCase `formFactor`, so the discriminator is
+/// mapped explicitly here ([`kind_to_wire`]) rather than via serde.
+///
+/// # Panics
+/// If `entry.device` is `None` — callers must check first.
+pub fn to_wire_binding(entry: &AclEntry) -> Value {
+    let b = entry
+        .device
+        .as_ref()
+        .expect("to_wire_binding requires entry.device to be Some");
+
+    let mut out = json!({
+        "deviceId": b.device_id,
+        "consumerDid": entry.did,
+        "consumerKind": kind_to_wire(&entry.kind),
+        "displayName": b.display_name,
+        "registeredAt": b.registered_at,
+        "pushCapable": b.push_capable(),
+        "capabilities": wire_capabilities(entry),
+    });
+    let map = out.as_object_mut().expect("json object");
+    if let Some(p) = &b.platform {
+        map.insert("platform".into(), json!(p));
+    }
+    if let Some(t) = &b.last_seen_at {
+        map.insert("lastSeenAt".into(), json!(t));
+    }
+    if let Some(t) = &b.disabled_at {
+        map.insert("disabledAt".into(), json!(t));
+    }
+    if let Some(t) = &b.wiped_at {
+        map.insert("wipedAt".into(), json!(t));
+    }
+    out
+}
+
+/// Wire `ConsumerKind` (register payload) → internal [`ConsumerKind`].
+/// Explicit because the two types' serde forms differ (see [`to_wire_binding`]).
+pub fn wire_kind_to_internal(w: &register_spec::ConsumerKind) -> ConsumerKind {
+    use register_spec::{ConsumerKindFormFactor as Wff, ConsumerKindServiceKind as Wsk};
+    match w {
+        register_spec::ConsumerKind::Companion { form_factor } => ConsumerKind::Companion {
+            form_factor: match form_factor {
+                Wff::Browser => CompanionFormFactor::Browser,
+                Wff::Mobile => CompanionFormFactor::Mobile,
+                Wff::Desktop => CompanionFormFactor::Desktop,
+            },
+        },
+        register_spec::ConsumerKind::Service { service_kind } => ConsumerKind::Service {
+            service_kind: match service_kind {
+                Wsk::Mediator => ServiceKind::Mediator,
+                Wsk::AiAgent => ServiceKind::AiAgent,
+                Wsk::Daemon => ServiceKind::Daemon,
+            },
+        },
+    }
+}
+
+/// Internal [`ConsumerKind`] → wire JSON (camelCase `formFactor`/`serviceKind`).
+fn kind_to_wire(kind: &ConsumerKind) -> Value {
+    match kind {
+        ConsumerKind::Companion { form_factor } => json!({
+            "kind": "companion",
+            "formFactor": match form_factor {
+                CompanionFormFactor::Browser => "browser",
+                CompanionFormFactor::Mobile => "mobile",
+                CompanionFormFactor::Desktop => "desktop",
+            },
+        }),
+        ConsumerKind::Service { service_kind } => json!({
+            "kind": "service",
+            "serviceKind": match service_kind {
+                ServiceKind::Mediator => "mediator",
+                ServiceKind::AiAgent => "ai-agent",
+                ServiceKind::Daemon => "daemon",
+            },
+        }),
+    }
+}
+
+/// Wire capability list (kebab-case), mirrored from the ACL entry — derived from
+/// the role for legacy entries with no explicit set. Drops the VTA-internal
+/// `sign-trust-task` capability, which is absent from the wire schema's closed
+/// `Capability` enum.
+fn wire_capabilities(entry: &AclEntry) -> Vec<Value> {
+    let caps = if entry.capabilities.is_empty() {
+        derived_capabilities_for_role(&entry.role)
+    } else {
+        entry.capabilities.clone()
+    };
+    caps.iter()
+        .filter(|c| !matches!(c, Capability::SignTrustTask))
+        .map(|c| serde_json::to_value(c).expect("Capability serialises"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::Role;
+
+    fn entry_with_binding() -> AclEntry {
+        let mut e = AclEntry::new("did:key:zDevice", Role::Application, "did:key:zSetup");
+        e.kind = ConsumerKind::Companion {
+            form_factor: CompanionFormFactor::Mobile,
+        };
+        e.device = Some(DeviceBinding {
+            device_id: "dev-abc".into(),
+            display_name: "Glenn's iPhone".into(),
+            platform: Some("iOS 19".into()),
+            registered_at: "2026-06-02T00:00:00+00:00".into(),
+            last_seen_at: Some("2026-06-02T00:00:00+00:00".into()),
+            disabled_at: None,
+            wiped_at: None,
+            hpke_public_key: Some("did:key:zHpke".into()),
+            wake: None,
+        });
+        e
+    }
+
+    #[test]
+    fn wire_binding_uses_camel_case_consumer_kind() {
+        let v = to_wire_binding(&entry_with_binding());
+        // Companion formFactor must be camelCase to match the wire schema.
+        assert_eq!(v["consumerKind"]["kind"], "companion");
+        assert_eq!(v["consumerKind"]["formFactor"], "mobile");
+        assert_eq!(v["consumerDid"], "did:key:zDevice");
+        assert_eq!(v["deviceId"], "dev-abc");
+        assert_eq!(v["pushCapable"], false); // no wake channel yet
+        // hpkePublicKey is a register-payload field, not part of the binding.
+        assert!(v.get("hpkePublicKey").is_none());
+    }
+
+    #[test]
+    fn wire_capabilities_drops_internal_sign_trust_task() {
+        let mut e = entry_with_binding();
+        e.capabilities = vec![
+            Capability::VaultRead,
+            Capability::SignTrustTask,
+            Capability::Sign,
+        ];
+        let caps = wire_capabilities(&e);
+        let strs: Vec<&str> = caps.iter().map(|c| c.as_str().unwrap()).collect();
+        assert!(strs.contains(&"vault-read"));
+        assert!(strs.contains(&"sign"));
+        assert!(
+            !strs.contains(&"sign-trust-task"),
+            "internal-only capability must not leak to the wire: {strs:?}"
+        );
+    }
+
+    #[test]
+    fn consumer_kind_round_trips_through_explicit_maps() {
+        // service / ai-agent survives wire→internal→wire.
+        let internal = ConsumerKind::Service {
+            service_kind: ServiceKind::AiAgent,
+        };
+        let wire = kind_to_wire(&internal);
+        assert_eq!(wire["serviceKind"], "ai-agent");
+    }
+
+    // ── register_device (enrolment) ─────────────────────────────────
+
+    use crate::auth::AuthClaims;
+    use crate::store::{KeyspaceHandle, Store};
+    use vti_common::config::StoreConfig;
+
+    async fn fresh() -> (KeyspaceHandle, KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        let acl_ks = store.keyspace("acl").unwrap();
+        let audit_ks = store.keyspace("audit").unwrap();
+        (acl_ks, audit_ks, dir)
+    }
+
+    fn device_auth(did: &str) -> AuthClaims {
+        AuthClaims {
+            did: did.into(),
+            role: Role::Application,
+            allowed_contexts: vec![],
+            session_id: "s".into(),
+            access_expires_at: 0,
+            amr: Vec::new(),
+            acr: String::new(),
+        }
+    }
+
+    fn mobile_kind() -> ConsumerKind {
+        ConsumerKind::Companion {
+            form_factor: CompanionFormFactor::Mobile,
+        }
+    }
+
+    #[tokio::test]
+    async fn register_rejects_did_not_in_acl() {
+        let (acl_ks, audit_ks, _dir) = fresh().await;
+        let err = register_device(
+            &acl_ks,
+            &audit_ks,
+            &device_auth("did:key:zUnknown"),
+            mobile_kind(),
+            "Phone".into(),
+            None,
+            Some("did:key:zHpke".into()),
+            "test",
+        )
+        .await
+        .expect_err("a DID with no ACL entry must be refused");
+        assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn register_attaches_binding_then_refuses_reregistration() {
+        let (acl_ks, audit_ks, _dir) = fresh().await;
+        let did = "did:key:zDevice";
+        // Seed the device's ACL entry (as provision-integration + swap-key would).
+        store_acl_entry(
+            &acl_ks,
+            &AclEntry::new(did, Role::Application, "did:key:zSetup"),
+        )
+        .await
+        .unwrap();
+
+        let body = register_device(
+            &acl_ks,
+            &audit_ks,
+            &device_auth(did),
+            mobile_kind(),
+            "Glenn's iPhone".into(),
+            Some("iOS 19".into()),
+            Some("did:key:zHpke".into()),
+            "test",
+        )
+        .await
+        .expect("first registration succeeds");
+        assert_eq!(body["binding"]["consumerKind"]["formFactor"], "mobile");
+        assert_eq!(body["binding"]["consumerDid"], did);
+
+        // The binding is now attached to the ACL entry…
+        let entry = get_acl_entry(&acl_ks, did).await.unwrap().unwrap();
+        let bound = entry.device.expect("binding attached");
+        assert_eq!(bound.hpke_public_key.as_deref(), Some("did:key:zHpke"));
+        assert!(bound.device_id.starts_with("dev-"));
+
+        // …and a second registration is refused (rotate keys + retry).
+        let err = register_device(
+            &acl_ks,
+            &audit_ks,
+            &device_auth(did),
+            mobile_kind(),
+            "Glenn's iPhone".into(),
+            None,
+            Some("did:key:zHpke".into()),
+            "test",
+        )
+        .await
+        .expect_err("re-registration must conflict");
+        assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+    }
+}

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -6,6 +6,7 @@ pub mod backup;
 pub mod cache;
 pub mod config;
 pub mod contexts;
+pub mod device;
 pub mod did_templates;
 #[cfg(feature = "webvh")]
 pub mod did_webvh;

--- a/vta-service/src/routes/trust_tasks/device.rs
+++ b/vta-service/src/routes/trust_tasks/device.rs
@@ -1,0 +1,57 @@
+//! `device/*` slice trust-task handlers.
+//!
+//! A `DeviceBinding` is the device-facing half of an `AclEntry`; these handlers
+//! attach/refresh it on the caller's existing ACL entry. Auth: the caller
+//! (`auth.did`, JWT-authenticated) acts on its **own** binding — registration
+//! requires the DID to already be in the ACL (provision-integration +
+//! acl/swap-key). See dtgwg `device/*`.
+
+use axum::response::Response;
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+use trust_tasks_rs::specs::device::register::v0_1 as register_spec;
+
+use crate::auth::AuthClaims;
+use crate::operations;
+use crate::server::AppState;
+
+use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
+
+/// URIs handled by this slice. Aggregated by the dispatcher's parity harness.
+#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
+pub(super) const DISPATCHED_URIS: &[&str] = &[vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_1];
+
+/// `device/register/0.1` — the caller claims its DeviceBinding. The DID must
+/// already be in the ACL; re-registration is refused.
+pub(super) async fn handle_register(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    let payload: register_spec::Payload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+
+    let consumer_kind = operations::device::wire_kind_to_internal(&payload.consumer_kind);
+    let display_name = payload.display_name.to_string();
+    let hpke_public_key = payload.hpke_public_key.as_ref().map(|k| k.to_string());
+    // `attestation` and `keyCustody` are accepted but not yet acted on (spec:
+    // policy input, not gate; verification is a follow-up).
+
+    match operations::device::register_device(
+        &state.acl_ks,
+        &state.audit_ks,
+        auth,
+        consumer_kind,
+        display_name,
+        payload.platform,
+        hpke_public_key,
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -49,6 +49,7 @@ mod auth;
 mod backup;
 mod config;
 mod contexts;
+mod device;
 mod did_templates;
 mod discovery;
 mod helpers;
@@ -187,6 +188,7 @@ fn aggregate_dispatched_uris() -> Vec<&'static str> {
     v.extend(backup::DISPATCHED_URIS);
     v.extend(config::DISPATCHED_URIS);
     v.extend(contexts::DISPATCHED_URIS);
+    v.extend(device::DISPATCHED_URIS);
     v.extend(did_templates::DISPATCHED_URIS);
     v.extend(discovery::DISPATCHED_URIS);
     v.extend(keys::DISPATCHED_URIS);
@@ -336,6 +338,10 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         vta_sdk::trust_tasks::TASK_ACL_GET_1_0 => acl::handle_get(state, auth, doc).await,
         vta_sdk::trust_tasks::TASK_ACL_UPDATE_1_0 => acl::handle_update(state, auth, doc).await,
         vta_sdk::trust_tasks::TASK_ACL_DELETE_1_0 => acl::handle_delete(state, auth, doc).await,
+        // ─── Device slice ─────────────────────────────────────────────
+        vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_1 => {
+            device::handle_register(state, auth, doc).await
+        }
         // ─── Contexts slice ──────────────────────────────────────────
         vta_sdk::trust_tasks::TASK_CONTEXTS_LIST_1_0 => {
             contexts::handle_list(state, auth, doc).await

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -227,6 +227,11 @@ pub struct DeviceBinding {
     pub disabled_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wiped_at: Option<String>,
+    /// X25519 public key (`did:key` form) the maintainer HPKE-seals payloads to
+    /// (sealed secrets, session blobs, sync events). Supplied by the device at
+    /// `device/register/0.1`. `None` on legacy rows and pure ACL entries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hpke_public_key: Option<String>,
     /// Push wake channel (opaque gateway handle + VTA-owned trigger allowlist).
     /// `None` until the device conveys a handle via `device/set-wake/0.1`;
     /// absent on legacy rows. The push token is never stored here.
@@ -652,6 +657,7 @@ mod tests {
             last_seen_at: None,
             disabled_at: None,
             wiped_at: None,
+            hpke_public_key: None,
             wake: None,
         }
     }


### PR DESCRIPTION
First `device/*` handler on the VTA — the prerequisite for `device/set-wake` (the push-wake path, dtgwg #68). Builds on C1 (#210).

## Approach
A `DeviceBinding` is the device-facing half of an `AclEntry`, so `register` attaches the binding to the **caller's existing ACL entry** (placed there by provision-integration + acl/swap-key) — no separate store.

## Changes
- **`operations/device.rs` — `register_device`**: caller (`auth.did`) must already be in the ACL → else `no_pending_enrolment` (NotFound); re-registration refused → `already_registered` (Conflict); mints `device_id`, attaches the `DeviceBinding`, bumps the entry version. **`attestation`/`keyCustody` accepted but not yet verified** — the spec treats attestation as policy-input-not-gate; platform-attestation verification (Apple App Attest / Play Integrity) is a follow-up.
- **`to_wire_binding` + explicit `ConsumerKind`/`Capability` maps**: the internal `vti-common` `ConsumerKind` serialises Companion's field as kebab `form-factor`, which does **not** match the wire schema's camelCase `formFactor` — so the discriminator is mapped explicitly rather than via a serde round-trip. Also drops the VTA-internal `sign-trust-task` capability (absent from the wire schema's closed `Capability` enum). *(This is the known internal/wire reconciliation gap; the broader fix — realigning the shared type's serde — needs a data migration and stays separate.)*
- **`vti-common`**: `DeviceBinding` gains `hpke_public_key` (the spec-required device recipient key supplied at register).
- **dispatch**: new `routes/trust_tasks/device.rs` slice + `DISPATCHED_URIS` + `dispatch_typed` arm on `TASK_DEVICE_REGISTER_0_1`.
- **`vta-sdk`**: `TASK_DEVICE_REGISTER_0_1` → `ALL_URIS`; added `spec/device/` to the canonical-namespace test (the prefix allowlist only had `vta/ auth/ did-management/ vault/ webvh/`, so this is required for the URI test to pass).

## Verification
- New tests: register happy-path (binding attached, camelCase `consumerKind`), `no_pending_enrolment`, `already_registered`, wire-binding mapping, capability filtering. Dispatcher parity harness green (register dispatched).
- `vta-service` builds; `clippy`/`fmt --check`/`cargo deny` clean.

## Scope
Register only (the set-wake prerequisite). **`device/heartbeat`** is the immediate follow-up; `list`/`disable`/`wipe` are C3; `set-wake` + gateway provisioning is C4.