### PR TITLE
feat(device): device/heartbeat handler (Phase 2/C2)

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -892,6 +892,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
     // Device slice
     TASK_DEVICE_REGISTER_0_1,
+    TASK_DEVICE_HEARTBEAT_0_1,
     // ACL slice
     TASK_ACL_LIST_1_0,
     TASK_ACL_CREATE_1_0,

--- a/vta-service/src/operations/device.rs
+++ b/vta-service/src/operations/device.rs
@@ -91,6 +91,50 @@ pub async fn register_device(
     Ok(json!({ "binding": to_wire_binding(&entry) }))
 }
 
+/// Device heartbeat: refresh the binding's `lastSeenAt` (and `platform` if the
+/// device reports a change), and return the maintainer's server time + any
+/// queued operations. The caller MUST be a registered device (else
+/// `not_registered`).
+///
+/// Does **not** bump the ACL entry `version` — a heartbeat is a metadata
+/// refresh, not a policy change, so it must not collide with concurrent admin
+/// edits guarded by `If-Match`. High-volume, so it is not individually audited
+/// (the spec permits sampling).
+///
+/// `queuedOperations` is empty until `device/wipe` lands (C3); `syncHint` is
+/// `up-to-date` until vault/sync is wired (the `vaultSeq` hint is accepted but
+/// not yet acted on).
+pub async fn heartbeat_device(
+    acl_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    platform: Option<String>,
+) -> Result<Value, AppError> {
+    let did = auth.did.clone();
+    let mut entry = get_acl_entry(acl_ks, &did).await?.ok_or_else(|| {
+        AppError::NotFound(format!(
+            "device/heartbeat:not_registered — no DeviceBinding for {did}"
+        ))
+    })?;
+    let binding = entry.device.as_mut().ok_or_else(|| {
+        AppError::NotFound(format!(
+            "device/heartbeat:not_registered — no DeviceBinding for {did}"
+        ))
+    })?;
+
+    let now = chrono::Utc::now().to_rfc3339();
+    binding.last_seen_at = Some(now.clone());
+    if platform.is_some() {
+        binding.platform = platform;
+    }
+    store_acl_entry(acl_ks, &entry).await?;
+
+    Ok(json!({
+        "serverTime": now,
+        "queuedOperations": [],
+        "syncHint": "up-to-date",
+    }))
+}
+
 /// Assemble the wire `DeviceBinding` (device/_shared schema) from an ACL entry
 /// that carries a [`DeviceBinding`]. Reused by `device/list`.
 ///
@@ -357,5 +401,62 @@ mod tests {
         .await
         .expect_err("re-registration must conflict");
         assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn heartbeat_refreshes_last_seen_and_platform() {
+        let (acl_ks, audit_ks, _dir) = fresh().await;
+        let did = "did:key:zDevice";
+        store_acl_entry(
+            &acl_ks,
+            &AclEntry::new(did, Role::Application, "did:key:zSetup"),
+        )
+        .await
+        .unwrap();
+        register_device(
+            &acl_ks,
+            &audit_ks,
+            &device_auth(did),
+            mobile_kind(),
+            "Phone".into(),
+            Some("iOS 19.0".into()),
+            Some("did:key:zHpke".into()),
+            "test",
+        )
+        .await
+        .unwrap();
+
+        let body = heartbeat_device(&acl_ks, &device_auth(did), Some("iOS 19.1".into()))
+            .await
+            .expect("heartbeat on a registered device succeeds");
+        assert_eq!(body["syncHint"], "up-to-date");
+        assert!(body["queuedOperations"].as_array().unwrap().is_empty());
+        assert!(body["serverTime"].is_string());
+
+        // Platform update + lastSeenAt are persisted; version is NOT bumped.
+        let entry = get_acl_entry(&acl_ks, did).await.unwrap().unwrap();
+        let b = entry.device.unwrap();
+        assert_eq!(b.platform.as_deref(), Some("iOS 19.1"));
+        assert!(b.last_seen_at.is_some());
+        assert_eq!(
+            entry.version, 1,
+            "heartbeat must not bump the entry version"
+        );
+    }
+
+    #[tokio::test]
+    async fn heartbeat_rejects_unregistered_device() {
+        let (acl_ks, _audit_ks, _dir) = fresh().await;
+        // ACL entry exists but no DeviceBinding attached.
+        store_acl_entry(
+            &acl_ks,
+            &AclEntry::new("did:key:zBare", Role::Application, "did:key:zSetup"),
+        )
+        .await
+        .unwrap();
+        let err = heartbeat_device(&acl_ks, &device_auth("did:key:zBare"), None)
+            .await
+            .expect_err("heartbeat without a binding must be refused");
+        assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
     }
 }

--- a/vta-service/src/routes/trust_tasks/device.rs
+++ b/vta-service/src/routes/trust_tasks/device.rs
@@ -9,6 +9,7 @@
 use axum::response::Response;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
+use trust_tasks_rs::specs::device::heartbeat::v0_1 as heartbeat_spec;
 use trust_tasks_rs::specs::device::register::v0_1 as register_spec;
 
 use crate::auth::AuthClaims;
@@ -19,7 +20,10 @@ use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, s
 
 /// URIs handled by this slice. Aggregated by the dispatcher's parity harness.
 #[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
-pub(super) const DISPATCHED_URIS: &[&str] = &[vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_1];
+pub(super) const DISPATCHED_URIS: &[&str] = &[
+    vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_1,
+    vta_sdk::trust_tasks::TASK_DEVICE_HEARTBEAT_0_1,
+];
 
 /// `device/register/0.1` — the caller claims its DeviceBinding. The DID must
 /// already be in the ACL; re-registration is refused.
@@ -51,6 +55,23 @@ pub(super) async fn handle_register(
     )
     .await
     {
+        Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+/// `device/heartbeat/0.1` — periodic check-in; refreshes `lastSeenAt` (and
+/// `platform` if changed) and returns server time + queued operations.
+pub(super) async fn handle_heartbeat(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    let payload: heartbeat_spec::Payload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    match operations::device::heartbeat_device(&state.acl_ks, auth, payload.platform).await {
         Ok(body) => success_response(&doc, body),
         Err(e) => app_error_to_reject(&doc, e),
     }

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -342,6 +342,9 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_1 => {
             device::handle_register(state, auth, doc).await
         }
+        vta_sdk::trust_tasks::TASK_DEVICE_HEARTBEAT_0_1 => {
+            device::handle_heartbeat(state, auth, doc).await
+        }
         // ─── Contexts slice ──────────────────────────────────────────
         vta_sdk::trust_tasks::TASK_CONTEXTS_LIST_1_0 => {
             contexts::handle_list(state, auth, doc).await


### PR DESCRIPTION
Periodic device check-in — completes the C2 pair (register + heartbeat). Builds on #212.

## Changes
- **`operations/device.rs` — `heartbeat_device`**: requires a registered device (else `not_registered`); refreshes `lastSeenAt` and `platform` (if the device reports a change). Deliberately **does not bump the ACL entry `version`** — a heartbeat is a metadata refresh, not a policy change, so it must not collide with `If-Match`-guarded admin edits. Not individually audited (high-volume; the spec permits sampling).
- `queuedOperations` is empty until `device/wipe` lands (C3); `syncHint` is `up-to-date` until vault/sync is wired (the `vaultSeq` hint is accepted but not yet acted on).
- Dispatch: `handle_heartbeat` + `DISPATCHED_URIS` + `dispatch_typed` arm on `TASK_DEVICE_HEARTBEAT_0_1`; `vta-sdk` `ALL_URIS` += heartbeat.

## Verification
- New tests: heartbeat refreshes `lastSeenAt`/`platform` **without** bumping `version`; `not_registered` for a bare ACL entry (entry exists, no binding).
- 7 device tests + dispatcher parity harness green; `clippy`/`fmt`/`cargo deny` clean.

## Next
C3 — `device/list` (reuses `to_wire_binding` from #212) + `disable` + `wipe`. Then C4 — `device/set-wake` (populates `DeviceBinding.wake`, provisions the gateway). Then Phase 3 — the VTA-trigger in `maybe_push_step_up`.