### PR TITLE
feat(vtc): wire role-change ceremony — completes the catalog

### DIFF
--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -96,11 +96,11 @@ const CEREMONIES: Ceremony[] = [
     key: "role-change",
     label: "Role change",
     nature: "mutating",
-    purpose: null,
+    purpose: "roleChange",
     pkg: "vtc.role_change",
-    wired: "unwired",
+    wired: "live",
     blurb:
-      "A member's role changes in place — the one ceremony whose allow may grant admin, gated by a step-up. Not yet wired into the executor (Remint).",
+      "A member's role changes in place (the DID + VMC are unchanged; the role VEC is re-minted). The one ceremony whose allow may grant admin — gated by a verified step-up; demotions are guarded by no-last-admin.",
   },
 ];
 
@@ -162,6 +162,9 @@ interface FormState {
   subjectRole: string;
   // leave
   selfLeave: boolean;
+  // role-change
+  targetRole: string;
+  stepUp: boolean;
 }
 
 const DEFAULT_FORM: FormState = {
@@ -169,6 +172,8 @@ const DEFAULT_FORM: FormState = {
   subjectIsMember: true,
   subjectRole: "member",
   selfLeave: false,
+  targetRole: "moderator",
+  stepUp: false,
 };
 
 function buildFacts(c: Ceremony, f: FormState): Record<string, unknown> {
@@ -201,6 +206,26 @@ function buildFacts(c: Ceremony, f: FormState): Record<string, unknown> {
               joined_at: "2026-01-02T00:00:00Z",
             }
           : null,
+      },
+    };
+  }
+
+  if (c.key === "role-change") {
+    return {
+      purpose: "role-change",
+      now,
+      actor: { did: "did:key:zAdmin", role: "admin", authenticated: true },
+      subject: { did: "did:key:zTarget" },
+      context,
+      evidence: {
+        request: { target_role: f.targetRole, step_up: f.stepUp },
+      },
+      state: {
+        subject_member: {
+          role: "member",
+          status: "active",
+          joined_at: "2026-01-02T00:00:00Z",
+        },
       },
     };
   }
@@ -413,6 +438,9 @@ function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
               {ceremony.key === "leave" && (
                 <LeaveForm form={form} setForm={setForm} />
               )}
+              {ceremony.key === "role-change" && (
+                <RoleChangeForm form={form} setForm={setForm} />
+              )}
 
               <button
                 className="cer-run"
@@ -572,6 +600,46 @@ function LeaveForm({
             <option value="moderator">moderator</option>
             <option value="admin">admin</option>
           </select>
+        </div>
+      )}
+    </>
+  );
+}
+
+function RoleChangeForm({
+  form,
+  setForm,
+}: {
+  form: FormState;
+  setForm: (f: FormState) => void;
+}) {
+  return (
+    <>
+      <div className="cer-field">
+        <label>
+          Target role
+          <small>evidence.request.target_role</small>
+        </label>
+        <select
+          className="input"
+          value={form.targetRole}
+          onChange={(e) => setForm({ ...form, targetRole: e.target.value })}
+        >
+          <option value="member">member</option>
+          <option value="moderator">moderator</option>
+          <option value="admin">admin (promotion)</option>
+        </select>
+      </div>
+      {form.targetRole === "admin" && (
+        <div className="cer-field">
+          <label>
+            Step-up verified
+            <small>admin needs step-up — else the verdict refers</small>
+          </label>
+          <Toggle
+            on={form.stepUp}
+            onClick={() => setForm({ ...form, stepUp: !form.stepUp })}
+          />
         </div>
       )}
     </>

--- a/vtc-service/policies/default/role_change.rego
+++ b/vtc-service/policies/default/role_change.rego
@@ -1,0 +1,44 @@
+# Default `role-change` policy — the role-change ceremony decision
+# spine (ceremony-pipeline design §4).
+#
+# Role-change is the mutating ceremony: a member's role changes in
+# place (the DID + VMC are unchanged; the role VEC is re-minted). It
+# is the one ceremony whose `allow` may grant `admin` — but only with
+# a verified step-up. The host enforces the rest around this policy:
+# the step-up-for-admin invariant (an admin grant without
+# `evidence.request.step_up` is vetoed) and no-last-admin (a demotion
+# that would drop the community to zero admins is refused, 409).
+#
+# Decision logic:
+# - a **standard** change (target is member / moderator / custom) is
+#   allowed, granting the requested role;
+# - **promotion to admin with a verified step-up** is allowed;
+# - **promotion to admin without step-up** is referred to the step-up
+#   queue (the operator must complete the reauth ceremony);
+# - everything else denies.
+
+package vtc.role_change
+
+import rego.v1
+
+# structural totality — unmatched role changes are refused
+default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}
+
+# Standard role change — member / moderator / custom.
+decision := {"effect": "allow", "with": {"role": target_role}} if {
+	target_role != "admin"
+}
+
+# Promotion to admin with a verified step-up.
+else := {"effect": "allow", "with": {"role": "admin"}} if {
+	target_role == "admin"
+	input.evidence.request.step_up == true
+}
+
+# Promotion to admin without step-up — needs the reauth ceremony.
+else := {"effect": "refer", "with": {"queue": "step-up"}} if {
+	target_role == "admin"
+}
+
+# ---- helpers ----
+target_role := input.evidence.request.target_role

--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -27,12 +27,13 @@
 //!   the ACL row, apply the disposition to the Member row, and revoke
 //!   the credential (flip the revocation bit). Fully wired; the
 //!   `DELETE /v1/members/{me,did}` removal routes go through it.
+//! - **Remint** (role-change) — change the ACL role in place + re-mint
+//!   the role VEC, enforcing no-last-admin on demotion. Fully wired;
+//!   the `PATCH /v1/members/{did}` role change goes through it.
 //! - **NoStateChange** (deny / refer / request_more) — no-op.
 //! - **Project** (directory) — not handled here: the directory route
 //!   serializes the projection into its HTTP response inline, so a
 //!   `Project` plan reaching the executor is a caller bug.
-//! - **Remint** (role-change) — not yet wired (its ceremony doesn't
-//!   exist yet); returns a clear error until then.
 
 use std::sync::LazyLock;
 
@@ -73,6 +74,9 @@ pub enum EffectOutcome {
     /// A member departed; carries the applied disposition + the
     /// revocation slot that was flipped (for the caller's audit).
     Departed(DepartOutcome),
+    /// A member's role was changed in place; carries the previous role
+    /// + the re-minted role VEC. Boxed — the VC makes it large.
+    Reminted(Box<RemintOutcome>),
     /// No state was changed (the verdict was deny / refer /
     /// request_more).
     None,
@@ -84,6 +88,17 @@ pub struct AdmitOutcome {
     pub vmc: VerifiableCredential,
     pub role_vec: VerifiableCredential,
     pub status_list_index: u32,
+}
+
+/// The result of an in-place role change.
+#[derive(Debug)]
+pub struct RemintOutcome {
+    /// The role the subject held before the change (for the caller's
+    /// `RoleChanged` audit).
+    pub previous_role: VtcRole,
+    /// The role VEC re-minted at the new role. The DID + VMC are
+    /// unchanged; only the role assertion is re-issued.
+    pub role_vec: VerifiableCredential,
 }
 
 /// The result of a member departure.
@@ -132,12 +147,14 @@ pub async fn apply(
             let outcome = depart(state, &subject, disposition, actor_did).await?;
             Ok(EffectOutcome::Departed(outcome))
         }
+        EffectPlan::Remint { subject, role } => {
+            let role = parse_role(&role)?;
+            let outcome = remint(state, &subject, role).await?;
+            Ok(EffectOutcome::Reminted(Box::new(outcome)))
+        }
         EffectPlan::NoStateChange => Ok(EffectOutcome::None),
         EffectPlan::Project { .. } => Err(AppError::Internal(
             "directory projection is applied by the route, not the effect executor".into(),
-        )),
-        EffectPlan::Remint { .. } => Err(AppError::Internal(
-            "role-change effect executor is not yet wired".into(),
         )),
     }
 }
@@ -252,6 +269,79 @@ async fn issue_member_credentials(
     status_list::maybe_emit_occupancy_warning(&row);
 
     Ok((vmc, role_vec, slot))
+}
+
+/// Change a member's role in place: update the ACL row and re-mint the
+/// role VEC at the new role. The DID + VMC are unchanged.
+///
+/// Enforces the no-last-admin invariant on **demotion** (an admin
+/// being changed to a non-admin role) — host-enforced under
+/// [`LAST_ADMIN_LOCK`], so a demotion that would leave zero admins is
+/// refused (`Conflict` → 409) before any write. The privilege ceiling
+/// / step-up-for-admin invariant is enforced earlier, in
+/// [`super::invariant::enforce`], before the plan is built.
+async fn remint(
+    state: &AppState,
+    subject_did: &str,
+    new_role: VtcRole,
+) -> Result<RemintOutcome, AppError> {
+    let _guard = LAST_ADMIN_LOCK.lock().await;
+
+    let mut acl = get_acl_entry(&state.acl_ks, subject_did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {subject_did}")))?;
+    let previous_role = acl.role.clone();
+
+    // No-last-admin on demotion: refuse to demote the community's only
+    // admin (the inverse of the leave guard).
+    if matches!(previous_role, VtcRole::Admin) && !matches!(new_role, VtcRole::Admin) {
+        let other_admins = list_acl_entries(&state.acl_ks)
+            .await?
+            .iter()
+            .filter(|e| e.did != subject_did && matches!(e.role, VtcRole::Admin))
+            .count();
+        if other_admins == 0 {
+            return Err(AppError::Conflict(format!(
+                "refusing to demote the last admin ({subject_did}) — promote another \
+                 member to admin first"
+            )));
+        }
+    }
+
+    acl.role = new_role.clone();
+    store_acl_entry(&state.acl_ks, &acl).await?;
+
+    // Re-mint the role VEC at the new role + repoint the member.
+    let role_vec = issue_role_vec(state, subject_did, new_role).await?;
+    if let Some(mut member) = get_member(&state.members_ks, subject_did).await? {
+        member.current_role_vec_id = top_level_id(&role_vec);
+        store_member(&state.members_ks, &member).await?;
+    }
+
+    Ok(RemintOutcome {
+        previous_role,
+        role_vec,
+    })
+}
+
+/// Mint a role VEC at `role` for `subject_did`. Used by role-change to
+/// re-issue the role assertion; the VMC + status list are untouched.
+async fn issue_role_vec(
+    state: &AppState,
+    subject_did: &str,
+    role: VtcRole,
+) -> Result<VerifiableCredential, AppError> {
+    let signer = state.credential_signer.as_ref().ok_or_else(|| {
+        AppError::Internal(
+            "credential signer not initialised — cannot re-mint role VEC (run setup first)".into(),
+        )
+    })?;
+    let vec_id = format!("urn:uuid:{}", Uuid::new_v4());
+    build_role_vec(
+        signer,
+        RoleVecParams::new(subject_did, role).with_id(vec_id),
+    )
+    .await
 }
 
 /// Parse the plan's disposition string into a concrete

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -66,7 +66,7 @@ pub mod verify;
 
 pub use effects::{EffectPlan, plan};
 pub use evaluate::evaluate;
-pub use execute::{AdmitOutcome, DepartOutcome, EffectOutcome, apply};
+pub use execute::{AdmitOutcome, DepartOutcome, EffectOutcome, RemintOutcome, apply};
 pub use facts::{
     Actor, Context, Credential, CredentialStatus, Evidence, Facts, Invitation, MemberState,
     Presentation, Purpose, State, Subject,

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -85,13 +85,17 @@ const DEFAULT_SOURCES: &[(PolicyPurpose, &str)] = &[
         PolicyPurpose::Relationships,
         include_str!("../../policies/default/relationships.rego"),
     ),
+    (
+        PolicyPurpose::RoleChange,
+        include_str!("../../policies/default/role_change.rego"),
+    ),
 ];
 
 /// Number of purposes the workspace ships defaults for. Asserted
 /// against [`PolicyPurpose::ALL`] at test time so a missed entry in
 /// `DEFAULT_SOURCES` surfaces as a build-time-ish failure rather
 /// than a silent runtime gap.
-pub const DEFAULT_COUNT: usize = 9;
+pub const DEFAULT_COUNT: usize = 10;
 
 /// Return the embedded default source for `purpose`. Useful to the
 /// admin UX layer that wants to show "reset to default" diffs
@@ -422,6 +426,47 @@ mod tests {
         assert_eq!(
             r.pointer("/result/0/expressions/0/value"),
             Some(&json!({ "effect": "deny", "with": { "code": "removal-denied" } })),
+        );
+    }
+
+    #[test]
+    fn role_change_default_decides_by_target_and_step_up() {
+        let c = compile_default(PolicyPurpose::RoleChange);
+
+        // Standard change to a non-admin role → allow that role.
+        let std = evaluate(
+            &c,
+            "data.vtc.role_change.decision",
+            json!({ "evidence": { "request": { "target_role": "moderator" } } }),
+        )
+        .unwrap();
+        assert_eq!(
+            std.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "allow", "with": { "role": "moderator" } })),
+        );
+
+        // Promotion to admin WITH step-up → allow admin.
+        let promo = evaluate(
+            &c,
+            "data.vtc.role_change.decision",
+            json!({ "evidence": { "request": { "target_role": "admin", "step_up": true } } }),
+        )
+        .unwrap();
+        assert_eq!(
+            promo.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "allow", "with": { "role": "admin" } })),
+        );
+
+        // Promotion to admin WITHOUT step-up → refer to step-up.
+        let refer = evaluate(
+            &c,
+            "data.vtc.role_change.decision",
+            json!({ "evidence": { "request": { "target_role": "admin" } } }),
+        )
+        .unwrap();
+        assert_eq!(
+            refer.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "refer", "with": { "queue": "step-up" } })),
         );
     }
 

--- a/vtc-service/src/policy/model.rs
+++ b/vtc-service/src/policy/model.rs
@@ -114,6 +114,11 @@ pub enum PolicyPurpose {
     CrossCommunityRoles,
     CrossCommunityRelationships,
     Relationships,
+    /// In-place change of a member's role — the role-change ceremony
+    /// (pipeline `vtc.role_change`). The one ceremony whose `allow`
+    /// may grant `admin`, gated by a verified step-up. Distinct from
+    /// [`Self::RoleDefinitions`] (the role→permission matrix).
+    RoleChange,
 }
 
 impl PolicyPurpose {
@@ -121,7 +126,7 @@ impl PolicyPurpose {
     /// boot-time default-policy loader (M2.5) so missing rows can
     /// be filled from the bundled defaults without listing each
     /// purpose explicitly at the call site.
-    pub const ALL: [PolicyPurpose; 9] = [
+    pub const ALL: [PolicyPurpose; 10] = [
         PolicyPurpose::Join,
         PolicyPurpose::Removal,
         PolicyPurpose::Personhood,
@@ -131,6 +136,7 @@ impl PolicyPurpose {
         PolicyPurpose::CrossCommunityRoles,
         PolicyPurpose::CrossCommunityRelationships,
         PolicyPurpose::Relationships,
+        PolicyPurpose::RoleChange,
     ];
 
     /// Lowercase camelCase wire form of this purpose. Stable wire
@@ -147,6 +153,7 @@ impl PolicyPurpose {
             PolicyPurpose::CrossCommunityRoles => "crossCommunityRoles",
             PolicyPurpose::CrossCommunityRelationships => "crossCommunityRelationships",
             PolicyPurpose::Relationships => "relationships",
+            PolicyPurpose::RoleChange => "roleChange",
         }
     }
 }
@@ -204,6 +211,7 @@ mod tests {
                 json!("crossCommunityRelationships"),
             ),
             (PolicyPurpose::Relationships, json!("relationships")),
+            (PolicyPurpose::RoleChange, json!("roleChange")),
         ];
         for (purpose, wire) in cases {
             assert_eq!(serde_json::to_value(purpose).unwrap(), wire);
@@ -242,7 +250,7 @@ mod tests {
         // the bundled default would silently never load. Drive the
         // count + exhaustiveness assertion off the same constant
         // so a missed entry surfaces at test time.
-        assert_eq!(PolicyPurpose::ALL.len(), 9);
+        assert_eq!(PolicyPurpose::ALL.len(), 10);
         for purpose in PolicyPurpose::ALL {
             // Compiles iff the match is total — `as_str` exhaustively
             // matches every variant; this exists so the assertion

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -1,16 +1,36 @@
 //! `PATCH /v1/members/{did}` — M1.5.1.
+//!
+//! Non-role fields (publish consent, departure preference, extensions)
+//! are written directly. A **role change** is the role-change ceremony:
+//! it runs through the decision pipeline ([`crate::ceremony`]) —
+//! assemble Facts → decide the active `roleChange` policy → apply via
+//! the `Remint` executor arm (which updates the ACL role in place,
+//! re-mints the role VEC, and enforces no-last-admin on demotion).
+//!
+//! `role=admin` is still refused on this surface: admin promotion fires
+//! the step-up UV ceremony on its own endpoint
+//! (`POST /v1/members/{did}/promote-to-admin`, spec §10.4), so the
+//! policy's admin branch is reached there, not here.
 
 use axum::Json;
 use axum::extract::{Path, State};
+use chrono::Utc;
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
+use serde_json::{Value as JsonValue, json};
 
 use vti_common::audit::{AuditEvent, MemberUpdatedData, RoleChangedData};
 
-use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry};
 use crate::auth::AdminAuth;
+use crate::ceremony::execute;
+use crate::ceremony::{
+    Actor, Context, EffectOutcome, EffectPlan, Evidence, Facts, MemberState, Purpose,
+    State as FactsState, Subject, Verdict, VerifiedFacts,
+};
+use crate::community::load_profile;
 use crate::error::AppError;
-use crate::members::{Disposition, get_member, store_member};
+use crate::members::{Disposition, Member, get_member, list_members, store_member};
+use crate::policy::{PolicyPurpose, load_active_compiled};
 use crate::routes::members::read::MemberResponse;
 use crate::server::AppState;
 
@@ -32,8 +52,9 @@ pub async fn update_member(
     Json(req): Json<UpdateMemberRequest>,
 ) -> Result<Json<MemberResponse>, AppError> {
     // Role=Admin is forbidden on this surface — it routes to the
-    // separate promote-to-admin endpoint (spec §10.4). Catch it
-    // early so the response carries an operator-friendly hint.
+    // separate promote-to-admin endpoint (spec §10.4), where the
+    // role-change policy's step-up branch is reached. Catch it early so
+    // the response carries an operator-friendly hint.
     if matches!(req.role, Some(VtcRole::Admin)) {
         return Err(AppError::Validation(format!(
             "role=admin is not assignable via PATCH /v1/members/{{did}}; \
@@ -47,24 +68,17 @@ pub async fn update_member(
         .as_ref()
         .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
 
-    let mut acl = get_acl_entry(&state.acl_ks, &did)
+    let acl = get_acl_entry(&state.acl_ks, &did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;
     let mut member = get_member(&state.members_ks, &did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;
 
-    let previous_role = acl.role.clone();
+    // Non-role field updates — written directly (not a ceremony).
+    // Persisted *before* any role change so the Remint executor (which
+    // re-reads the member to repoint its role VEC) sees them.
     let mut fields_changed: Vec<String> = Vec::new();
-    let mut role_changed = false;
-
-    if let Some(new_role) = req.role.clone()
-        && new_role != acl.role
-    {
-        acl.role = new_role;
-        role_changed = true;
-    }
-
     if let Some(consent) = req.publish_consent
         && consent != member.publish_consent
     {
@@ -83,33 +97,36 @@ pub async fn update_member(
         member.extensions = extensions;
         fields_changed.push("extensions".into());
     }
-
-    // Persist in canonical order: ACL row first (auth-gating
-    // truth), then Member row. A crash between the two leaves the
-    // ACL slightly ahead of the metadata, which is the safer
-    // direction (the auth path keeps working).
-    if role_changed {
-        store_acl_entry(&state.acl_ks, &acl).await?;
-    }
     if !fields_changed.is_empty() {
         store_member(&state.members_ks, &member).await?;
     }
 
-    // Audit. Role changes are a separate variant from
-    // non-role updates (spec §10.4 keeps the SIEM filter
-    // simple).
-    if role_changed {
+    // Role change → the role-change ceremony.
+    let role_change = match req.role {
+        Some(new_role) if new_role != acl.role => Some(new_role),
+        _ => None,
+    };
+    if let Some(new_role) = role_change {
+        let granted = role_change_via_pipeline(
+            &state,
+            &auth.0.did,
+            &did,
+            &acl.role.to_string(),
+            &new_role.to_string(),
+        )
+        .await?;
         audit_writer
             .write(
                 &auth.0.did,
                 Some(&did),
                 AuditEvent::RoleChanged(RoleChangedData {
-                    previous_role: previous_role.to_string(),
-                    new_role: acl.role.to_string(),
+                    previous_role: granted.previous_role,
+                    new_role: granted.new_role,
                 }),
             )
             .await?;
     }
+
     if !fields_changed.is_empty() {
         audit_writer
             .write(
@@ -122,13 +139,157 @@ pub async fn update_member(
             .await?;
     }
 
+    // Re-read the authoritative state for the response — the Remint
+    // executor may have changed the ACL role + the member's role-VEC
+    // pointer.
+    let acl = get_acl_entry(&state.acl_ks, &did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;
+    let member = get_member(&state.members_ks, &did)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;
+
     Ok(Json(MemberResponse::from_pair_for_route(acl, member)))
+}
+
+struct RoleChangeResult {
+    previous_role: String,
+    new_role: String,
+}
+
+/// Run a (non-admin) role change through the decision pipeline:
+/// assemble Facts → decide the active `roleChange` policy → apply via
+/// the Remint executor. A policy `deny` → 403; a `refer` (admin
+/// promotion needing step-up — not reachable here since admin is
+/// refused upstream, but an operator policy could still refer) →
+/// `StepUpRequired`.
+async fn role_change_via_pipeline(
+    state: &AppState,
+    actor_did: &str,
+    subject_did: &str,
+    current_role: &str,
+    target_role: &str,
+) -> Result<RoleChangeResult, AppError> {
+    let facts =
+        assemble_role_change_facts(state, actor_did, subject_did, current_role, target_role)
+            .await?;
+    let verified = VerifiedFacts::assemble(facts)?;
+    let policy = load_active_compiled(
+        &state.active_policies_ks,
+        &state.policies_ks,
+        PolicyPurpose::RoleChange,
+    )
+    .await?;
+
+    let allow = match crate::ceremony::decide(&verified, &policy)? {
+        Verdict::Allow(a) => a,
+        Verdict::Refer(r) => {
+            return Err(AppError::StepUpRequired(format!(
+                "role change deferred to the {} queue — complete the step-up ceremony",
+                r.queue
+            )));
+        }
+        Verdict::Deny(d) => {
+            return Err(AppError::Forbidden(format!(
+                "role change denied by policy ({})",
+                d.code
+            )));
+        }
+        Verdict::RequestMore(_) => {
+            return Err(AppError::Internal(
+                "role-change policy returned request_more; role change is synchronous".into(),
+            ));
+        }
+    };
+
+    let granted = allow
+        .role
+        .ok_or_else(|| AppError::Internal("role-change allow carried no role".into()))?;
+
+    let plan = EffectPlan::Remint {
+        subject: subject_did.to_string(),
+        role: granted.clone(),
+    };
+    let EffectOutcome::Reminted(outcome) = execute::apply(state, plan, actor_did).await? else {
+        return Err(AppError::Internal(
+            "remint effect did not produce an outcome".into(),
+        ));
+    };
+
+    Ok(RoleChangeResult {
+        previous_role: outcome.previous_role.to_string(),
+        new_role: granted,
+    })
+}
+
+/// Assemble purpose-`role-change` [`Facts`]: the actor's role, the
+/// subject's current member facts, and the requested `target_role`
+/// (with `step_up: false` — PATCH carries no reauth; the step-up path
+/// is the promote-to-admin endpoint).
+async fn assemble_role_change_facts(
+    state: &AppState,
+    actor_did: &str,
+    subject_did: &str,
+    current_role: &str,
+    target_role: &str,
+) -> Result<Facts, AppError> {
+    let actor_role = get_acl_entry(&state.acl_ks, actor_did)
+        .await?
+        .map(|e| e.role.to_string());
+    let subject_member = get_member(&state.members_ks, subject_did).await?;
+
+    let community_did = load_profile(&state.community_ks)
+        .await?
+        .map(|p| p.community_did)
+        .unwrap_or_default();
+    let member_count = list_members(&state.members_ks).await?.len() as u64;
+
+    Ok(Facts {
+        purpose: Purpose::RoleChange,
+        now: Utc::now(),
+        actor: Actor {
+            did: actor_did.to_string(),
+            role: actor_role,
+            authenticated: true,
+        },
+        subject: Subject {
+            did: subject_did.to_string(),
+        },
+        context: Context {
+            community_did,
+            channel: "rest".to_string(),
+            member_count,
+        },
+        evidence: Evidence {
+            invitation: None,
+            presentation: None,
+            request: Some(json!({ "target_role": target_role, "step_up": false })),
+        },
+        state: FactsState {
+            subject_member: Some(MemberState {
+                role: current_role.to_string(),
+                status: subject_member
+                    .as_ref()
+                    .map(|m| {
+                        if m.removed_at.is_some() {
+                            "removed"
+                        } else {
+                            "active"
+                        }
+                    })
+                    .unwrap_or("active")
+                    .to_string(),
+                joined_at: subject_member.map(|m| m.joined_at).unwrap_or_else(Utc::now),
+                personhood: None,
+            }),
+        },
+    })
 }
 
 // Re-export `from_pair` under a route-only alias so this module
 // doesn't have to make the constructor public on `MemberResponse`.
 impl MemberResponse {
-    pub(crate) fn from_pair_for_route(acl: VtcAclEntry, member: crate::members::Member) -> Self {
+    pub(crate) fn from_pair_for_route(acl: VtcAclEntry, member: Member) -> Self {
         // Inline the same join the read endpoints do — duplicating
         // the body (~10 lines) is cheaper than exposing a public
         // constructor that's only used by route handlers.

--- a/vtc-service/tests/ceremony_execute.rs
+++ b/vtc-service/tests/ceremony_execute.rs
@@ -320,3 +320,101 @@ async fn depart_refuses_the_last_admin() {
     // The refusal left the ACL row in place.
     assert!(get_acl_entry(&state.acl_ks, admin).await.unwrap().is_some());
 }
+
+/// Remint changes a member's role in place and re-mints the role VEC —
+/// the ACL role updates and the member's role-VEC pointer moves.
+#[tokio::test]
+async fn remint_changes_role_and_reissues_vec() {
+    let (state, _dir) = build_state().await;
+    let subject = "did:key:zPromote";
+
+    // Admit as a member first.
+    let admit = EffectPlan::Admit {
+        subject: subject.into(),
+        role: "member".into(),
+        obligations: vec![],
+    };
+    execute::apply(&state, admit, ACTOR_DID)
+        .await
+        .expect("admit");
+    // The role-VEC pointer stamped at admit time.
+    let original_vec_id = get_member(&state.members_ks, subject)
+        .await
+        .unwrap()
+        .expect("member")
+        .current_role_vec_id;
+    assert!(original_vec_id.is_some(), "admit stamped a role VEC");
+
+    // Re-mint at moderator.
+    let plan = EffectPlan::Remint {
+        subject: subject.into(),
+        role: "moderator".into(),
+    };
+    let EffectOutcome::Reminted(outcome) = execute::apply(&state, plan, ACTOR_DID)
+        .await
+        .expect("remint")
+    else {
+        panic!("expected Reminted");
+    };
+    assert_eq!(outcome.previous_role, VtcRole::Member);
+
+    // ACL role updated; the member's role-VEC pointer moved to the new VEC.
+    let acl = get_acl_entry(&state.acl_ks, subject)
+        .await
+        .unwrap()
+        .expect("acl");
+    assert_eq!(acl.role, VtcRole::Moderator);
+    let m = get_member(&state.members_ks, subject)
+        .await
+        .unwrap()
+        .expect("member");
+    assert!(m.current_role_vec_id.is_some());
+    assert_ne!(
+        m.current_role_vec_id, original_vec_id,
+        "the role VEC was re-minted"
+    );
+}
+
+/// Remint enforces no-last-admin on demotion: changing the sole admin
+/// to a non-admin role is a conflict, leaving the ACL untouched.
+#[tokio::test]
+async fn remint_refuses_demoting_the_last_admin() {
+    let (state, _dir) = build_state().await;
+    let admin = "did:key:zSoleAdmin2";
+
+    store_acl_entry(
+        &state.acl_ks,
+        &VtcAclEntry {
+            did: admin.into(),
+            role: VtcRole::Admin,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: vtc_service::auth::session::now_epoch(),
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let plan = EffectPlan::Remint {
+        subject: admin.into(),
+        role: "member".into(),
+    };
+    let err = execute::apply(&state, plan, ACTOR_DID)
+        .await
+        .expect_err("demoting the last admin must conflict");
+    assert!(
+        matches!(err, vti_common::error::AppError::Conflict(_)),
+        "got {err:?}"
+    );
+    // Still admin.
+    assert_eq!(
+        get_acl_entry(&state.acl_ks, admin)
+            .await
+            .unwrap()
+            .unwrap()
+            .role,
+        VtcRole::Admin
+    );
+}

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -83,6 +83,19 @@ async fn build_fixture() -> Fixture {
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
 
+    // Role changes (PATCH /v1/members/{did}) run through the
+    // role-change ceremony, which needs the active decision policy + a
+    // credential signer to re-mint the role VEC.
+    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
+        .await
+        .expect("install default policies");
+    let credential_signer = Some(Arc::new(
+        vtc_service::credentials::LocalSigner::from_ed25519_seed(
+            "did:webvh:vtc.example.com:abc".into(),
+            &[0xCC; 32],
+        ),
+    ));
+
     let install_store = InstallTokenStore::new(install_ks.clone());
     let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
 
@@ -173,7 +186,7 @@ async fn build_fixture() -> Fixture {
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
+        credential_signer,
         audit_ks,
         audit_key_ks,
         config: Arc::new(RwLock::new(config)),


### PR DESCRIPTION
## What

Wires **role-change**, the fourth and final catalog ceremony, end-to-end through the decision pipeline — and makes it live in the admin-UI simulator. With this, all four catalog ceremonies (directory / join / leave / role-change) run on one pipeline.

## Backend

- **`PolicyPurpose::RoleChange`** (10th purpose) + a decision-shaped default **`role_change.rego`** (`data.vtc.role_change.decision`): standard change → `allow{role}`; admin + step-up → `allow{admin}`; admin without step-up → `refer{step-up}`; else deny. (`ALL` / `DEFAULT_COUNT` / wire-shape tests bumped.)
- **`ceremony::execute` `Remint` arm**: updates the ACL role in place, **re-mints the role VEC** at the new role, and enforces **no-last-admin on demotion** (host-guarded under `LAST_ADMIN_LOCK`). New `EffectOutcome::Reminted`.
- **`routes/members/update.rs`**: `PATCH /v1/members/{did}` role changes now go through the pipeline (assemble Facts → `decide(roleChange)` → `Remint`). `deny` → 403, `refer` → `StepUpRequired`. `role=admin` still routes to promote-to-admin (the step-up endpoint). This also fixes a latent gap — the old PATCH updated the ACL role but **never re-issued the role VEC**, leaving it stale.

## Frontend

- `ceremonies.tsx`: role-change is now **live** with a target-role + step-up form, so the simulator dry-runs all three branches (standard allow / admin+step-up allow / admin refer).

## Tests

- New `role_change` default-policy test (all three branches).
- New executor tests: `remint_changes_role_and_reissues_vec` + `remint_refuses_demoting_the_last_admin`.
- `members_crud` fixture gains `install_defaults` + a credential signer (PATCH role-change now needs the active policy + a signer); its role-change test is unchanged and still green.

Full `vtc-service` suite + 7 executor tests green; `fmt` + `clippy` clean; admin-ui `tsc` + build clean. Verified the role-change simulator (allow + refer) via the dev harness.

## Follow-up

**Join** remains on its legacy boolean policy (no simulator) — its decision-pipeline migration (the join *submit* flow → decision shape) is the remaining piece to make the whole catalog uniformly live.