### PR TITLE
feat(vtc): migrate join onto the decision pipeline — catalog fully live

### DIFF
--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -78,9 +78,9 @@ const CEREMONIES: Ceremony[] = [
     nature: "constructive",
     purpose: "join",
     pkg: "vtc.join",
-    wired: "legacy",
+    wired: "live",
     blurb:
-      "A DID joins the community. The effect admits the member and issues a credential; the join policy is still the legacy boolean shape pending its decision-pipeline migration.",
+      "A DID joins the community. A trusted presented credential auto-admits (allow → issue the membership credential); everything else is referred to the moderator queue for review.",
   },
   {
     key: "leave",
@@ -165,6 +165,8 @@ interface FormState {
   // role-change
   targetRole: string;
   stepUp: boolean;
+  // join
+  joinTrusted: boolean;
 }
 
 const DEFAULT_FORM: FormState = {
@@ -174,6 +176,7 @@ const DEFAULT_FORM: FormState = {
   selfLeave: false,
   targetRole: "moderator",
   stepUp: false,
+  joinTrusted: false,
 };
 
 function buildFacts(c: Ceremony, f: FormState): Record<string, unknown> {
@@ -207,6 +210,32 @@ function buildFacts(c: Ceremony, f: FormState): Record<string, unknown> {
             }
           : null,
       },
+    };
+  }
+
+  if (c.key === "join") {
+    return {
+      purpose: "join",
+      now,
+      actor: { did: "did:key:zApplicant", authenticated: true },
+      subject: { did: "did:key:zApplicant" },
+      context,
+      evidence: {
+        presentation: {
+          verified: true,
+          holder: "did:key:zApplicant",
+          credentials: [
+            {
+              type: "WitnessCredential",
+              issuer: "did:webvh:notary.example",
+              issuer_trusted: f.joinTrusted,
+              status: "valid",
+              claims: {},
+            },
+          ],
+        },
+      },
+      state: { subject_member: null },
     };
   }
 
@@ -432,6 +461,9 @@ function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
             </p>
           ) : (
             <>
+              {ceremony.key === "join" && (
+                <JoinForm form={form} setForm={setForm} />
+              )}
               {ceremony.key === "directory" && (
                 <DirectoryForm form={form} setForm={setForm} />
               )}
@@ -603,6 +635,27 @@ function LeaveForm({
         </div>
       )}
     </>
+  );
+}
+
+function JoinForm({
+  form,
+  setForm,
+}: {
+  form: FormState;
+  setForm: (f: FormState) => void;
+}) {
+  return (
+    <div className="cer-field">
+      <label>
+        Presented credential is trusted
+        <small>evidence.presentation.credentials[].issuer_trusted</small>
+      </label>
+      <Toggle
+        on={form.joinTrusted}
+        onClick={() => setForm({ ...form, joinTrusted: !form.joinTrusted })}
+      />
+    </div>
   );
 }
 

--- a/vtc-service/policies/default/join.rego
+++ b/vtc-service/policies/default/join.rego
@@ -1,19 +1,34 @@
-# Default `join` policy — `policies.open` template (spec §7.1).
+# Default `join` policy — the join ceremony decision spine
+# (ceremony-pipeline design §4; supersedes the `policies.open` boolean
+# shape).
 #
-# Accepts every well-formed join request. The submit handler
-# already verifies the holder-binding signature on the VP
-# (Phase 1 M1.8.2); this policy decides whether to surface the
-# request as `Pending` for admin review or reject it outright.
-# Operators replace this with a stricter policy by uploading
-# their own and activating it.
+# Join is the constructive ceremony: a DID asks to join the community.
+# The submit handler verifies the VP holder-binding, assembles verified
+# Facts, runs `data.vtc.join.decision`, and realizes the verdict —
+# `allow` auto-admits (issues the membership credential), `refer` queues
+# the request as Pending for admin review, `deny` rejects it, and
+# `request_more` defers pending more evidence.
 #
-# Input shape (spec §7.3):
-#   { applicant_did, vp_claims, action, now }
+# Default posture: a submission with a **trusted, valid** credential
+# auto-admits; everything else is referred to the moderator queue for
+# human review (the request lands Pending — the same gate the
+# pre-pipeline `policies.open` default produced). Operators replace this
+# with their own decision policy (e.g. admit on a specific credential
+# type, gate on an invitation, require a code-of-conduct agreement).
+#
+# The privilege ceiling is host-enforced around this policy: a `join`
+# verdict may never grant `admin`.
 
 package vtc.join
 
 import rego.v1
 
-default allow := false
+# structural totality — unmatched submissions go to moderator review
+default decision := {"effect": "refer", "with": {"queue": "moderator"}}
 
-allow if input.action == "join"
+# A presented credential from a trusted issuer auto-admits as a member.
+decision := {"effect": "allow", "with": {"role": "member"}} if {
+	some c in input.evidence.presentation.credentials
+	c.issuer_trusted
+	c.status == "valid"
+}

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -191,7 +191,7 @@ async fn join_request_submit_handler(
     let body: JoinRequestSubmitBody = serde_json::from_value(message.body.clone())
         .map_err(|e| DIDCommServiceError::Internal(format!("malformed join-request body: {e}")))?;
 
-    let request = submit_inner(
+    let outcome = submit_inner(
         &state,
         applicant_did,
         body.vp,
@@ -203,9 +203,12 @@ async fn join_request_submit_handler(
     .await
     .map_err(|e| DIDCommServiceError::Internal(format!("submit failed: {e}")))?;
 
+    // The DIDComm receipt carries the request id + status; a sealed
+    // credential bundle for an auto-admitted applicant lands in a
+    // follow-up DIDComm message.
     let receipt = JoinRequestSubmitReceiptBody {
-        request_id: request.id,
-        status: request.status.to_string(),
+        request_id: outcome.request.id,
+        status: outcome.request.status.to_string(),
     };
     let body = serde_json::to_value(&receipt)
         .map_err(|e| DIDCommServiceError::Internal(format!("receipt serialise: {e}")))?;

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -347,26 +347,53 @@ mod tests {
     }
 
     #[test]
-    fn join_default_allows_well_formed_request() {
+    fn join_default_admits_on_trusted_credential() {
+        // The default join policy is now the decision spine: a trusted,
+        // valid presented credential auto-admits as a member.
         let c = compile_default(PolicyPurpose::Join);
-        let input = json!({
-            "applicant_did": "did:key:zApplicant",
-            "vp_claims": {},
-            "action": "join",
-            "now": "2026-05-12T00:00:00Z"
-        });
-        let r = evaluate(&c, "data.vtc.join.allow", input).unwrap();
-        assert!(
-            pluck_bool(&r),
-            "default join policy must allow valid submissions"
+        let r = evaluate(
+            &c,
+            "data.vtc.join.decision",
+            json!({
+                "evidence": {
+                    "presentation": {
+                        "credentials": [
+                            { "type": "WitnessCredential", "issuer_trusted": true, "status": "valid" }
+                        ]
+                    }
+                }
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "allow", "with": { "role": "member" } })),
         );
     }
 
     #[test]
-    fn join_default_denies_wrong_action() {
+    fn join_default_refers_without_trusted_credential() {
+        // No trusted credential → referred to the moderator queue
+        // (the request lands Pending for admin review).
         let c = compile_default(PolicyPurpose::Join);
-        let r = evaluate(&c, "data.vtc.join.allow", json!({ "action": "withdraw" })).unwrap();
-        assert!(!pluck_bool(&r));
+        let r = evaluate(
+            &c,
+            "data.vtc.join.decision",
+            json!({
+                "evidence": {
+                    "presentation": {
+                        "credentials": [
+                            { "type": "EmailCredential", "issuer_trusted": false, "status": "valid" }
+                        ]
+                    }
+                }
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "refer", "with": { "queue": "moderator" } })),
+        );
     }
 
     #[test]

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -41,18 +41,22 @@ use axum::http::StatusCode;
 use chrono::Utc;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value as JsonValue, json};
-use tracing::{info, warn};
+use serde_json::Value as JsonValue;
+use tracing::info;
 use uuid::Uuid;
 
 use vti_common::audit::{AuditEvent, JoinRequestData, JoinRequestRejectedData};
 use vti_common::error::AppError;
 
-use crate::join::{JoinRequest, JoinStatus, JoinTransport, store_join_request};
-use crate::policy::{
-    PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy,
-    extract::extract_vp_claims, get_active_policy_id, get_policy,
+use crate::ceremony::execute::{self, AdmitOutcome};
+use crate::ceremony::{
+    Actor, Context, Credential, CredentialStatus, EffectOutcome, EffectPlan, Evidence, Facts,
+    Presentation, Purpose, State as FactsState, Subject, Verdict, VerifiedFacts,
 };
+use crate::community::load_profile;
+use crate::join::{JoinRequest, JoinStatus, JoinTransport, store_join_request};
+use crate::members::list_members;
+use crate::policy::{PolicyPurpose, extract::extract_vp_claims, load_active_compiled};
 use crate::server::AppState;
 
 pub const JOIN_REQUEST_SUBMIT_DOMAIN_TAG: &[u8] = b"vtc-join-request/v1\0";
@@ -75,13 +79,29 @@ pub struct SubmitRequestBody {
 pub struct SubmitResponse {
     pub request_id: Uuid,
     pub status: String,
+    /// Issued VMC — present only when the join policy **auto-admitted**
+    /// (verdict `allow`). The applicant, who proved holder-binding,
+    /// receives their membership credential inline. `None` when the
+    /// request was queued (`pending`/`deferred`) or rejected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vmc: Option<JsonValue>,
+    /// Issued role VEC — same delivery story as [`Self::vmc`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_vec: Option<JsonValue>,
+}
+
+/// What [`submit_inner`] produced: the persisted request + the
+/// credentials minted if the policy auto-admitted (verdict `allow`).
+pub struct JoinSubmitOutcome {
+    pub request: JoinRequest,
+    pub admit: Option<Box<AdmitOutcome>>,
 }
 
 pub async fn submit(
     State(state): State<AppState>,
     Json(req): Json<SubmitRequestBody>,
 ) -> Result<(StatusCode, Json<SubmitResponse>), AppError> {
-    let request = submit_inner(
+    let outcome = submit_inner(
         &state,
         req.applicant_did,
         req.vp,
@@ -91,22 +111,47 @@ pub async fn submit(
         JoinTransport::Rest,
     )
     .await?;
+
+    let (vmc, role_vec) = match &outcome.admit {
+        Some(a) => (
+            Some(
+                serde_json::to_value(&a.vmc)
+                    .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?,
+            ),
+            Some(
+                serde_json::to_value(&a.role_vec)
+                    .map_err(|e| AppError::Internal(format!("serialise VEC: {e}")))?,
+            ),
+        ),
+        None => (None, None),
+    };
+
     Ok((
         StatusCode::CREATED,
         Json(SubmitResponse {
-            request_id: request.id,
-            status: request.status.to_string(),
+            request_id: outcome.request.id,
+            status: outcome.request.status.to_string(),
+            vmc,
+            role_vec,
         }),
     ))
 }
 
-/// Shared inner implementation called by both REST and the
-/// DIDComm handler. Returns the persisted `JoinRequest`.
+/// Shared inner implementation called by both REST and the DIDComm
+/// handler — the join ceremony's decide → effect spine.
 ///
 /// `signature` is `Some` for REST (where the wire must carry an
-/// explicit holder-binding signature) and `None` for DIDComm
-/// (where the DIDComm envelope's authcrypt sender already
-/// authenticates `applicant_did`).
+/// explicit holder-binding signature) and `None` for DIDComm (where
+/// the DIDComm envelope's authcrypt sender already authenticates
+/// `applicant_did`).
+///
+/// The active `join` decision policy classifies the verified
+/// submission:
+/// - `allow` → **auto-admit** via the [`EffectPlan::Admit`] executor;
+///   the request lands `Approved` and the credentials are returned.
+/// - `refer` → `Pending` (queued for admin review → the approve route).
+/// - `request_more` → `Deferred` (more evidence needed).
+/// - `deny` → `Rejected`, with the verdict stored on `policy_decision`.
 pub async fn submit_inner(
     state: &AppState,
     applicant_did: String,
@@ -115,7 +160,7 @@ pub async fn submit_inner(
     extensions: JsonValue,
     signature_hex: Option<&str>,
     transport: JoinTransport,
-) -> Result<JoinRequest, AppError> {
+) -> Result<JoinSubmitOutcome, AppError> {
     let audit_writer = state
         .audit_writer
         .as_ref()
@@ -126,142 +171,206 @@ pub async fn submit_inner(
         verify_holder_signature(&applicant_did, &vp, registry_consent, &extensions, hex_sig)?;
     }
 
-    // 2. Phase 2 policy step (M2.6). Extract the canonical
-    // `vp_claims` projection per plan §D4 and feed it to the
-    // active `join.rego`. `allow` → row stays Pending; `deny`
-    // → row lands as Rejected with the policy's output stored
-    // on `policy_decision`.
+    // 2. The lossy `vp_claims` projection is still stored on the row
+    // for the admin show + the approve path; the decision pipeline
+    // reads structured Facts instead (assembled below).
     let vp_claims = extract_vp_claims(&vp);
-    let policy_input = json!({
-        "applicant_did": applicant_did,
-        "vp_claims": vp_claims,
-        "action": "join",
-        "now": Utc::now().to_rfc3339(),
-    });
-    let decision = evaluate_join_policy(state, &policy_input).await?;
 
-    // 3. Persist. `vp_claims` is stored alongside the raw `vp`
-    // so the approve path doesn't have to re-extract.
+    // 3. Decide: assemble verified Facts and run the active join policy.
+    let facts = assemble_join_facts(state, &applicant_did, &vp).await?;
+    let verified = VerifiedFacts::assemble(facts)?;
+    let policy = load_active_compiled(
+        &state.active_policies_ks,
+        &state.policies_ks,
+        PolicyPurpose::Join,
+    )
+    .await?;
+    let verdict = crate::ceremony::decide(&verified, &policy)?;
+
+    // 4. Build the request + realize the verdict.
     let mut request = JoinRequest::new(applicant_did.clone(), vp);
     request.vp_claims = vp_claims;
     request.registry_consent = registry_consent;
     request.extensions = extensions;
-    match &decision {
-        JoinPolicyDecision::Allow => {
-            request.status = JoinStatus::Pending;
+
+    let mut admit: Option<Box<AdmitOutcome>> = None;
+    let rejected = matches!(verdict, Verdict::Deny(_));
+    match &verdict {
+        Verdict::Allow(allow) => {
+            // Auto-admit: the join effect (admit + issue VMC) runs now.
+            // A duplicate ACL (re-submit by an existing member) surfaces
+            // as the executor's `Conflict` → 409.
+            let role = allow.role.clone().unwrap_or_else(|| "member".to_string());
+            let plan = EffectPlan::Admit {
+                subject: applicant_did.clone(),
+                role,
+                obligations: allow.obligations.clone(),
+            };
+            if let EffectOutcome::Admitted(creds) =
+                execute::apply(state, plan, &applicant_did).await?
+            {
+                admit = Some(creds);
+            }
+            request.status = JoinStatus::Approved;
         }
-        JoinPolicyDecision::Deny { result } => {
+        Verdict::Refer(_) => request.status = JoinStatus::Pending,
+        Verdict::RequestMore(_) => {
+            request.status = JoinStatus::Deferred;
+            request.policy_decision = Some(serde_json::to_value(&verdict)?);
+        }
+        Verdict::Deny(_) => {
             request.status = JoinStatus::Rejected;
-            request.policy_decision = Some(result.clone());
+            request.policy_decision = Some(serde_json::to_value(&verdict)?);
         }
     }
     store_join_request(&state.join_requests_ks, &request).await?;
 
-    // 4. Audit. Allow → Submitted; deny → Rejected with the
-    // canonical `"policy denied"` reason marker so SIEM can
-    // distinguish admin rejections from policy rejections.
-    match &decision {
-        JoinPolicyDecision::Allow => {
-            audit_writer
-                .write(
-                    &applicant_did,
-                    None,
-                    AuditEvent::JoinRequestSubmitted(JoinRequestData {
-                        request_id: request.id.to_string(),
-                        transport: transport.as_str().to_string(),
-                    }),
-                )
-                .await?;
-        }
-        JoinPolicyDecision::Deny { .. } => {
-            audit_writer
-                .write(
-                    &applicant_did,
-                    None,
-                    AuditEvent::JoinRequestRejected(JoinRequestRejectedData {
-                        request_id: request.id.to_string(),
-                        reason: "policy denied".into(),
-                    }),
-                )
-                .await?;
-        }
+    // 5. Audit — Rejected for a policy deny; Submitted otherwise.
+    if rejected {
+        audit_writer
+            .write(
+                &applicant_did,
+                None,
+                AuditEvent::JoinRequestRejected(JoinRequestRejectedData {
+                    request_id: request.id.to_string(),
+                    reason: "policy denied".into(),
+                }),
+            )
+            .await?;
+    } else {
+        audit_writer
+            .write(
+                &applicant_did,
+                None,
+                AuditEvent::JoinRequestSubmitted(JoinRequestData {
+                    request_id: request.id.to_string(),
+                    transport: transport.as_str().to_string(),
+                }),
+            )
+            .await?;
     }
 
     info!(
         request_id = %request.id,
         applicant = %applicant_did,
         transport = transport.as_str(),
-        decision = decision.kind(),
+        verdict = verdict.effect(),
         "join request submitted"
     );
-    Ok(request)
+    Ok(JoinSubmitOutcome { request, admit })
 }
 
 // ---------------------------------------------------------------------------
-// Policy step (M2.6.1)
+// Join facts assembly (decision-pipeline input)
 // ---------------------------------------------------------------------------
 
-/// Outcome of evaluating the active `join.rego` against the
-/// canonical `input` for a fresh submission. Carries the raw
-/// regorus `QueryResults` JSON so the deny path can persist it on
-/// `JoinRequest.policy_decision` for the audit trail.
-enum JoinPolicyDecision {
-    Allow,
-    Deny { result: JsonValue },
-}
-
-impl JoinPolicyDecision {
-    fn kind(&self) -> &'static str {
-        match self {
-            JoinPolicyDecision::Allow => "allow",
-            JoinPolicyDecision::Deny { .. } => "deny",
-        }
-    }
-}
-
-/// Look up the active `join` policy, compile + evaluate it, and
-/// classify the result as allow / deny. Treats every error path
-/// as deny — a daemon misconfiguration must not silently accept
-/// applicants the operator hasn't authored a policy for.
-async fn evaluate_join_policy(
+/// Assemble purpose-`join` [`Facts`] from a verified submission. The
+/// applicant is the actor + subject (self-join); the VP becomes the
+/// verified presentation the policy decides over.
+async fn assemble_join_facts(
     state: &AppState,
-    input: &JsonValue,
-) -> Result<JoinPolicyDecision, AppError> {
-    let active_id = get_active_policy_id(&state.active_policies_ks, PolicyPurpose::Join).await?;
-    let id = match active_id {
-        Some(id) => id,
-        None => {
-            // M2.5's `install_defaults` should always have run by
-            // the time a request hits this path. Reaching here
-            // means the daemon is missing its default-policy
-            // bootstrap — fail closed.
-            warn!("no active join policy at submit time — refusing submission");
-            return Ok(JoinPolicyDecision::Deny {
-                result: json!({
-                    "error": "no active join policy",
-                }),
-            });
-        }
-    };
-    let policy = get_policy(&state.policies_ks, id)
+    applicant_did: &str,
+    vp: &JsonValue,
+) -> Result<Facts, AppError> {
+    let community_did = load_profile(&state.community_ks)
         .await?
-        .ok_or_else(|| AppError::Internal(format!("active join policy {id} not found")))?;
+        .map(|p| p.community_did)
+        .unwrap_or_default();
+    let member_count = list_members(&state.members_ks).await?.len() as u64;
 
-    // Compile per call. Same trade-off as `POST
-    // /v1/policies/{id}/test` makes (M2.3.1) — regorus's parse is
-    // cheap and per-call compile keeps this path independent of
-    // M2.8's in-memory hot-swap cache, which hasn't landed yet.
-    let compiled = compile_policy(&policy.rego_source, policy.id)?;
-    let result = evaluate_policy(&compiled, "data.vtc.join.allow", input.clone())?;
-    let allow = result
-        .pointer("/result/0/expressions/0/value")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    if allow {
-        Ok(JoinPolicyDecision::Allow)
-    } else {
-        Ok(JoinPolicyDecision::Deny { result })
+    Ok(Facts {
+        purpose: Purpose::Join,
+        now: Utc::now(),
+        // The applicant proved holder-binding at the route layer; they
+        // are not (yet) a member, so they carry no community role.
+        actor: Actor {
+            did: applicant_did.to_string(),
+            role: None,
+            authenticated: true,
+        },
+        subject: Subject {
+            did: applicant_did.to_string(),
+        },
+        context: Context {
+            community_did,
+            channel: "rest".to_string(),
+            member_count,
+        },
+        evidence: Evidence {
+            invitation: None,
+            presentation: Some(presentation_from_vp(applicant_did, vp)),
+            request: None,
+        },
+        state: FactsState {
+            subject_member: None,
+        },
+    })
+}
+
+/// Project the VP into the verified [`Presentation`] the policy reads.
+/// Holder-binding is already checked (`verified: true`). Credentials
+/// surface with `issuer_trusted: false` / `status: valid` — issuer
+/// trust (TRQP) and status-list resolution are follow-ups; the
+/// structured shape is what matters for the decision contract.
+fn presentation_from_vp(applicant_did: &str, vp: &JsonValue) -> Presentation {
+    let holder = vp
+        .get("holder")
+        .and_then(|h| match h {
+            JsonValue::String(s) => Some(s.clone()),
+            JsonValue::Object(o) => o.get("id").and_then(|i| i.as_str()).map(str::to_string),
+            _ => None,
+        })
+        .unwrap_or_else(|| applicant_did.to_string());
+
+    let credentials = vp
+        .get("verifiableCredential")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(credential_from_vc).collect())
+        .unwrap_or_default();
+
+    Presentation {
+        verified: true,
+        holder,
+        credentials,
     }
+}
+
+/// Pull one VC into a [`Credential`]. JWT-encoded VCs (bare strings)
+/// are skipped — full JWT-VP support lands with VP verification.
+fn credential_from_vc(vc: &JsonValue) -> Option<Credential> {
+    let obj = vc.as_object()?;
+    let credential_type = obj
+        .get("type")
+        .and_then(|t| match t {
+            JsonValue::Array(a) => a
+                .iter()
+                .filter_map(|x| x.as_str())
+                .find(|s| *s != "VerifiableCredential")
+                .map(str::to_string),
+            JsonValue::String(s) => Some(s.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| "VerifiableCredential".to_string());
+    let issuer = match obj.get("issuer") {
+        Some(JsonValue::String(s)) => s.clone(),
+        Some(JsonValue::Object(o)) => o
+            .get("id")
+            .and_then(|x| x.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        _ => String::new(),
+    };
+    Some(Credential {
+        credential_type,
+        issuer,
+        issuer_trusted: false,
+        status: CredentialStatus::Valid,
+        claims: obj
+            .get("credentialSubject")
+            .cloned()
+            .unwrap_or(JsonValue::Null),
+        valid_until: None,
+    })
 }
 
 /// Verify the Ed25519 signature over the canonical signing

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -722,11 +722,9 @@ async fn reject_rejects_overlong_reason() {
 // M2.6 — Policy step at submit time
 // ---------------------------------------------------------------------------
 
-/// Upload + activate a join policy that always denies. Returns
-/// nothing — the active pointer is flipped server-side and
-/// subsequent submits see the deny semantics.
-async fn activate_deny_all_join_policy(fix: &Fixture) {
-    let source = "package vtc.join\nimport rego.v1\n\ndefault allow := false\n";
+/// Upload + activate a join policy. The active pointer is flipped
+/// server-side; subsequent submits see the new policy's semantics.
+async fn activate_join_policy(fix: &Fixture, source: &str) {
     let (status, body) = send(
         &fix.router,
         "POST",
@@ -748,6 +746,68 @@ async fn activate_deny_all_join_policy(fix: &Fixture) {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "activate failed: {body}");
+}
+
+async fn activate_deny_all_join_policy(fix: &Fixture) {
+    activate_join_policy(
+        fix,
+        "package vtc.join\nimport rego.v1\n\n\
+         default decision := {\"effect\": \"deny\", \"with\": {\"code\": \"closed\"}}\n",
+    )
+    .await;
+}
+
+/// An `allow` join policy auto-admits: the submit handler runs the
+/// Admit effect, the row lands `approved`, the membership credentials
+/// come back inline, and the applicant is now a member.
+#[tokio::test]
+async fn rest_submit_under_allow_policy_auto_admits() {
+    let fix = build_fixture().await;
+    activate_join_policy(
+        &fix,
+        "package vtc.join\nimport rego.v1\n\n\
+         default decision := {\"effect\": \"allow\", \"with\": {\"role\": \"member\"}}\n",
+    )
+    .await;
+
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
+    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "signature": signature,
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "got {body}");
+    assert_eq!(body["status"], "approved");
+    assert!(body["vmc"]["id"].is_string(), "VMC returned inline: {body}");
+    assert!(
+        body["roleVec"]["id"].is_string(),
+        "role VEC returned: {body}"
+    );
+
+    // The applicant is now a member (ACL + Member rows exist).
+    let acl = vtc_service::acl::get_acl_entry(&fix.acl_ks, &applicant_did)
+        .await
+        .unwrap()
+        .expect("auto-admitted applicant has an ACL row");
+    assert_eq!(acl.role, VtcRole::Member);
+    assert!(
+        vtc_service::members::get_member(&fix.members_ks, &applicant_did)
+            .await
+            .unwrap()
+            .is_some(),
+        "auto-admitted applicant has a Member row"
+    );
 }
 
 /// With the default `policies.open` join policy the submit
@@ -856,13 +916,12 @@ async fn rest_submit_under_deny_all_policy_persists_rejected_with_decision() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(row["status"], "rejected");
-    // `policyDecision` is the regorus QueryResults shape — at
-    // minimum it carries a `result` array with the rule's value.
-    let decision = &row["policyDecision"];
-    let value = decision
-        .pointer("/result/0/expressions/0/value")
-        .expect("policy_decision should carry regorus QueryResults");
-    assert_eq!(value, &json!(false));
+    // `policyDecision` now carries the four-valued verdict the policy
+    // returned — a deny with the policy's code.
+    assert_eq!(
+        row["policyDecision"],
+        json!({ "effect": "deny", "with": { "code": "closed" } }),
+    );
 }
 
 /// Trying to re-approve a policy-rejected row fails the same way


### PR DESCRIPTION
## What

Join was the last ceremony still on its legacy boolean policy. It now runs the decision pipeline end-to-end — so **all four catalog ceremonies (directory / join / leave / role-change) are decision-shaped and live in the admin-UI simulator**.

## Backend

- **`policies/default/join.rego`**: replaced the `policies.open` boolean (`data.vtc.join.allow`) with the decision spine (`data.vtc.join.decision`): a **trusted, valid** presented credential auto-admits as `member`; everything else **refers** to the moderator queue (the request lands `Pending`, preserving today's admin-review gate).
- **`routes/join_requests/submit.rs`**: submit now assembles verified Facts from the VP (`evidence.presentation.credentials`) and runs `ceremony::decide`. The four-valued verdict maps to:
  - `allow` → **auto-admit** via the Admit executor; the row lands `Approved` and the membership credentials (VMC + role VEC) come back **inline** in the submit response.
  - `refer` → `Pending` (queued for admin review → the approve route).
  - `request_more` → `Deferred`.
  - `deny` → `Rejected`.
  `vp_claims` is still extracted + stored on the row for the admin show + the approve path; the pipeline reads structured Facts instead. `submit_inner` now returns `JoinSubmitOutcome { request, admit }`; the DIDComm caller is updated.

## Frontend

- `ceremonies.tsx`: join is now **live** with a "presented credential is trusted" toggle — the simulator dry-runs `allow` (trusted) vs `refer`.

## Tests

- `default.rs` join tests rewritten to the decision shape.
- `join_requests.rs`: deny-all test moved to a decision-deny policy + a verdict-shaped `policy_decision` assertion; new `rest_submit_under_allow_policy_auto_admits` (approved + inline VMC + member created). The default-policy submit tests are **unchanged and still pass** (default refers untrusted submissions → pending).

## Migration note

Operator join policies on the old boolean shape now evaluate to an undefined `decision` → host default-deny (**fail closed**); they must re-author to the decision shape.

Full `vtc-service` suite (incl. 16 join tests) + clippy clean; admin-ui `tsc` + build clean. Verified the join simulator (allow + refer) via the dev harness.

## Catalog status

With this, the ceremony catalog is **complete and uniformly live**: directory (read) · join (constructive) · leave (destructive) · role-change (mutating) — all on one decision pipeline, all simulatable.