### PR TITLE
feat(did-templates): push-gateway built-in template

### DIFF
--- a/docs/02-vta/did-templates.md
+++ b/docs/02-vta/did-templates.md
@@ -13,8 +13,9 @@ consumer gets the new shape on the next create. No redeploy.
 ## Why templates
 
 - **Data, not code.** An operator can ship a new agent kind by dropping a JSON
-  file, no recompile. The built-ins (`didcomm-mediator`, `vta-admin`,
-  `vtc-host`, `did-host-http-didcomm`, `did-host-http`, `did-host-didcomm`)
+  file, no recompile. The built-ins (`didcomm-mediator`, `push-gateway`,
+  `vta-admin`, `vtc-host`, `did-host-http-didcomm`, `did-host-http`,
+  `did-host-didcomm`)
   are baseline shapes, not the only shapes.
 - **Method-agnostic.** Same format works for `did:webvh`, `did:web`, or
   `did:key` — the loader only knows about `{TOKEN}` placeholders. Method-
@@ -139,6 +140,11 @@ template without explicit scope is **context → global → builtin**:
   with `pnm did-templates init <kind>`. Current built-ins:
   - `didcomm-mediator` — DIDComm v2 routing mediator with a URL-based service
     endpoint.
+  - `push-gateway` — push wake-up gateway identity: signing + key-agreement
+    methods and a `DIDCommMessaging` service so devices, VTAs, and mediators
+    can authcrypt `push/*` Trust Tasks (register / provision / wake) to it.
+    Requires `URL` (the gateway's DIDComm endpoint). Provisioned like the
+    mediator; implements the push wake-up binding.
   - `vta-admin` — did:key admin DID for provision-integration admin rollover.
   - `vtc-host` — Verifiable Trust Community (VTC) service identity. Mints
     the did:webvh under which a `vtc-service` binary operates and advertises

--- a/vta-sdk/src/did_templates/builtin.rs
+++ b/vta-sdk/src/did_templates/builtin.rs
@@ -13,6 +13,7 @@ pub const BUILTIN_NAMES: &[&str] = &[
     "did-host-http",
     "did-host-http-didcomm",
     "didcomm-mediator",
+    "push-gateway",
     "vta-admin",
     "vtc-host",
 ];
@@ -34,6 +35,7 @@ const LEGACY_ALIASES: &[(&str, &str)] = &[
 ];
 
 const DIDCOMM_MEDIATOR: &str = include_str!("../../templates/didcomm-mediator.json");
+const PUSH_GATEWAY: &str = include_str!("../../templates/push-gateway.json");
 const VTA_ADMIN: &str = include_str!("../../templates/vta-admin.json");
 const VTC_HOST: &str = include_str!("../../templates/vtc-host.json");
 const DID_HOST_HTTP_DIDCOMM: &str = include_str!("../../templates/did-host-http-didcomm.json");
@@ -61,6 +63,7 @@ pub fn load_embedded(name: &str) -> Result<DidTemplate, TemplateError> {
     let canonical = resolve_alias(name);
     let raw = match canonical {
         "didcomm-mediator" => DIDCOMM_MEDIATOR,
+        "push-gateway" => PUSH_GATEWAY,
         "vta-admin" => VTA_ADMIN,
         "vtc-host" => VTC_HOST,
         "did-host-http-didcomm" => DID_HOST_HTTP_DIDCOMM,

--- a/vta-sdk/templates/push-gateway.json
+++ b/vta-sdk/templates/push-gateway.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "name": "push-gateway",
+  "kind": "push-gateway",
+  "description": "Push wake-up gateway: signing + key-agreement methods and a DIDCommMessaging service so devices, VTAs, and mediators can authcrypt push/* Trust Tasks (register/provision/wake) to it. Implements https://trusttasks.org/binding/push/0.1.",
+  "methods": ["webvh", "web"],
+  "requiredVars": ["URL"],
+  "optionalVars": {
+    "ACCEPT": ["didcomm/v2"],
+    "ROUTING_KEYS": [],
+    "WEBVH_SERVER": null
+  },
+  "defaults": {
+    "preRotationCount": 2,
+    "portable": true
+  },
+  "document": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/multikey/v1",
+      "https://didcomm.org/messaging/v2"
+    ],
+    "id": "{DID}",
+    "verificationMethod": [
+      {
+        "id": "{DID}#key-0",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{SIGNING_KEY_MB}"
+      },
+      {
+        "id": "{DID}#key-1",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{KA_KEY_MB}"
+      }
+    ],
+    "authentication": ["{DID}#key-0"],
+    "assertionMethod": ["{DID}#key-0"],
+    "keyAgreement": ["{DID}#key-1"],
+    "service": [
+      {
+        "id": "{DID}#service",
+        "type": ["DIDCommMessaging"],
+        "serviceEndpoint": [
+          {
+            "accept": "{ACCEPT}",
+            "routingKeys": "{ROUTING_KEYS}",
+            "uri": "{URL}"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The push wake-up gateway is a **provisioned VTA integration with a `did:webvh` identity** — minted via a DID template through provision-integration, exactly like `didcomm-mediator` and the `did-host-*` nodes (not a self-generated `did:key`). This adds the template that enables that.

## `push-gateway`
Mints signing (Ed25519) + key-agreement (X25519) methods and a `DIDCommMessaging` service at `{URL}`, so devices, VTAs, and mediators can **authcrypt `push/*` Trust Tasks** (register / provision / wake) to the gateway's DID — the DIDComm (preferred) transport of the push wake-up binding.

Shape mirrors `didcomm-mediator`, minus:
- the WebSocket transport (the gateway is DIDComm-over-HTTP), and
- the mediator's challenge-auth (`#auth`) service — the gateway authenticates senders via authcrypt **unpack**, not a challenge ceremony.

`requiredVars: [URL]`; `methods: [webvh, web]`.

## Changes
- `vta-sdk/templates/push-gateway.json` + `builtin.rs` registration (`BUILTIN_NAMES` + `include_str!` + match).
- `docs/02-vta/did-templates.md` built-in list.

## Verification
`every_builtin_parses_and_validates` covers the new template; `clippy`/`fmt` clean.

## Next
The gateway's first-boot provision-integration consumer flow (obtain its `did:webvh` + keys via this template, publish the log so it resolves), then the gateway's DIDComm unpack surface (G2b) feeding the G2a dispatch core.