### PR TITLE
feat(vtc-admin): visual Rule-IR authoring for ceremony decisions

### DIFF
--- a/vtc-service/admin-ui/src/lib/rule-ir.ts
+++ b/vtc-service/admin-ui/src/lib/rule-ir.ts
@@ -1,0 +1,305 @@
+// Rule IR + compiler — visual ceremony authoring.
+//
+// A decision policy is authored as a constrained JSON AST (the Rule
+// IR): an ordered list of routes, each `when` (a conjunction of
+// vocabulary conditions) → `then` (a four-valued effect). The compiler
+// emits Rego (the `decision` else-chain + the structural default +
+// the helper rules used). Rego becomes a compiled artifact; operators
+// author the IR. Canonical spec: docs/05-design-notes/
+// vtc-ceremony-rule-ir.md.
+//
+// Round-trip: the compiled Rego carries the IR as a `# @vtc-rule-ir:`
+// comment header (base64 JSON) so a policy authored here can be loaded
+// back into the editor. A policy without that header was hand-written
+// and isn't visually editable.
+
+export type Condition = string | Record<string, string>;
+
+export interface Effect {
+  effect: "allow" | "deny" | "refer" | "request_more";
+  with: Record<string, unknown>;
+}
+
+export interface Route {
+  name: string;
+  when: { all: Condition[] };
+  then: Effect;
+}
+
+export interface RuleIR {
+  purpose: string;
+  routes: Route[];
+}
+
+// ---------------------------------------------------------------------------
+// Condition vocabulary (per the rule-ir spec §2). Each condition
+// compiles to a Rego body expression; helper-backed ones also pull in
+// a named helper rule.
+// ---------------------------------------------------------------------------
+
+export interface ConditionDef {
+  id: string;
+  label: string;
+  /** Argument spec, when the condition is parametrized. */
+  arg?: { label: string; placeholder: string };
+  /** Rego body expression for a (possibly arg'd) use. */
+  expr: (arg?: string) => string;
+  /** Helper-rule id pulled in when this condition is used. */
+  helper?: string;
+}
+
+const HELPERS: Record<string, string> = {
+  cred_held:
+    'cred_held(t) if {\n\tsome c in input.evidence.presentation.credentials\n\tc.type == t\n\tc.status == "valid"\n}',
+  cred_trusted:
+    'cred_trusted(t) if {\n\tsome c in input.evidence.presentation.credentials\n\tc.type == t\n\tc.issuer_trusted\n\tc.status == "valid"\n}',
+  has_valid_invitation:
+    "has_valid_invitation if {\n\tinput.evidence.invitation.verified\n\tnot input.evidence.invitation.consumed\n}",
+  agreed:
+    "agreed(tag) if {\n\tinput.evidence.request.agreements[tag] == true\n}",
+  target_role: "target_role := input.evidence.request.target_role",
+};
+
+const SHARED: ConditionDef[] = [
+  { id: "always", label: "always", expr: () => "true" },
+  {
+    id: "actor_is_admin",
+    label: "actor is admin",
+    expr: () => 'input.actor.role == "admin"',
+  },
+  {
+    id: "actor_is_self",
+    label: "actor is the subject",
+    expr: () => "input.actor.did == input.subject.did",
+  },
+  {
+    id: "subject_is_admin",
+    label: "subject is admin",
+    expr: () => 'input.state.subject_member.role == "admin"',
+  },
+];
+
+const JOIN: ConditionDef[] = [
+  {
+    id: "has_valid_invitation",
+    label: "holds a valid invitation",
+    expr: () => "has_valid_invitation",
+    helper: "has_valid_invitation",
+  },
+  {
+    id: "holds_trusted",
+    label: "holds a trusted credential",
+    arg: { label: "credential type", placeholder: "WitnessCredential" },
+    expr: (a) => `cred_trusted(${JSON.stringify(a ?? "")})`,
+    helper: "cred_trusted",
+  },
+  {
+    id: "holds",
+    label: "holds a credential",
+    arg: { label: "credential type", placeholder: "EmailCredential" },
+    expr: (a) => `cred_held(${JSON.stringify(a ?? "")})`,
+    helper: "cred_held",
+  },
+  {
+    id: "agreed",
+    label: "agreed to",
+    arg: { label: "agreement tag", placeholder: "code-of-conduct" },
+    expr: (a) => `agreed(${JSON.stringify(a ?? "")})`,
+    helper: "agreed",
+  },
+];
+
+const LEAVE: ConditionDef[] = [
+  {
+    id: "disposition_requested",
+    label: "a disposition was requested",
+    expr: () => "input.evidence.request.disposition",
+  },
+];
+
+const DIRECTORY: ConditionDef[] = [
+  {
+    id: "viewer_is_admin",
+    label: "viewer is admin",
+    expr: () => 'input.actor.role == "admin"',
+  },
+  {
+    id: "viewer_is_member",
+    label: "viewer is authenticated",
+    expr: () => "input.actor.authenticated == true",
+  },
+];
+
+const ROLE_CHANGE: ConditionDef[] = [
+  {
+    id: "target_role_standard",
+    label: "target role is not admin",
+    expr: () => 'input.evidence.request.target_role != "admin"',
+  },
+  {
+    id: "promotes_to_admin",
+    label: "promotes to admin",
+    expr: () => 'input.evidence.request.target_role == "admin"',
+  },
+  {
+    id: "step_up_done",
+    label: "step-up verified",
+    expr: () => "input.evidence.request.step_up == true",
+  },
+];
+
+/// Conditions available when authoring a given policy purpose.
+export function conditionsFor(purpose: string): ConditionDef[] {
+  const byPurpose: Record<string, ConditionDef[]> = {
+    join: JOIN,
+    removal: LEAVE,
+    directory: DIRECTORY,
+    roleChange: ROLE_CHANGE,
+  };
+  return [...SHARED, ...(byPurpose[purpose] ?? [])];
+}
+
+/// The effects an operator can choose, and the `with` field each
+/// carries (so the editor shows the right input).
+export interface EffectDef {
+  effect: Effect["effect"];
+  label: string;
+  /** The primary `with` field this effect carries, if any. */
+  field?: { key: string; label: string; placeholder: string };
+}
+
+export function effectsFor(purpose: string): EffectDef[] {
+  const allowField: EffectDef["field"] =
+    purpose === "removal"
+      ? { key: "disposition", label: "disposition", placeholder: "tombstone" }
+      : purpose === "directory"
+        ? { key: "fields", label: "fields (comma-sep)", placeholder: "did,role" }
+        : { key: "role", label: "role", placeholder: "member" };
+  return [
+    { effect: "allow", label: "Allow", field: allowField },
+    {
+      effect: "deny",
+      label: "Deny",
+      field: { key: "code", label: "code", placeholder: "denied" },
+    },
+    {
+      effect: "refer",
+      label: "Refer",
+      field: { key: "queue", label: "queue", placeholder: "moderator" },
+    },
+    {
+      effect: "request_more",
+      label: "Request more",
+      field: { key: "needs", label: "needs (comma-sep)", placeholder: "agreed:code-of-conduct" },
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Compile IR → Rego
+// ---------------------------------------------------------------------------
+
+const IR_HEADER = "# @vtc-rule-ir:";
+
+function regoCondition(cond: Condition, purpose: string): string | null {
+  const defs = conditionsFor(purpose);
+  if (typeof cond === "string") {
+    const d = defs.find((x) => x.id === cond);
+    return d ? d.expr() : null;
+  }
+  const [id, arg] = Object.entries(cond)[0] ?? [];
+  const d = defs.find((x) => x.id === id);
+  return d ? d.expr(arg) : null;
+}
+
+/** The `then` decision object as Rego — `$target` resolves to the
+ * `target_role` helper variable (unquoted). */
+function regoThen(then: Effect): string {
+  const json = JSON.stringify(then);
+  return json.replace(/"\$target"/g, "target_role");
+}
+
+/** Compile a Rule IR to a Rego decision module. `pkg` is the full
+ * package (e.g. `vtc.removal`); the IR is embedded for round-trip. */
+export function compileToRego(ir: RuleIR, pkg: string): string {
+  const usedHelpers = new Set<string>();
+  const defs = conditionsFor(ir.purpose);
+
+  const noteHelper = (cond: Condition) => {
+    const id = typeof cond === "string" ? cond : Object.keys(cond)[0];
+    const d = defs.find((x) => x.id === id);
+    if (d?.helper) usedHelpers.add(d.helper);
+  };
+
+  const lines: string[] = [];
+  lines.push(`package ${pkg}`, "", "import rego.v1", "");
+
+  const irB64 =
+    typeof btoa === "function"
+      ? btoa(unescape(encodeURIComponent(JSON.stringify(ir))))
+      : JSON.stringify(ir);
+  lines.push(`${IR_HEADER} ${irB64}`, "");
+
+  lines.push(
+    "# structural totality — compiler-appended, operator cannot remove",
+    'default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}',
+    "",
+  );
+
+  ir.routes.forEach((route, i) => {
+    const body = route.when.all
+      .map((c) => {
+        noteHelper(c);
+        return `\t${regoCondition(c, ir.purpose) ?? "true"}`;
+      })
+      .join("\n");
+    const head = i === 0 ? "decision :=" : "else :=";
+    if (route.name) lines.push(`# ${route.name}`);
+    lines.push(`${head} ${regoThen(route.then)} if {`, body, "}", "");
+  });
+
+  // `$target` pulls in the target_role helper.
+  if (ir.routes.some((r) => JSON.stringify(r.then).includes("$target"))) {
+    usedHelpers.add("target_role");
+  }
+
+  if (usedHelpers.size > 0) {
+    lines.push("# ---- helpers ----");
+    for (const h of usedHelpers) {
+      if (HELPERS[h]) lines.push(HELPERS[h]!, "");
+    }
+  }
+
+  return lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+}
+
+/** Recover the IR embedded in a compiled policy's `@vtc-rule-ir`
+ * header, or null when the policy wasn't authored visually. */
+export function parseRego(rego: string): RuleIR | null {
+  const line = rego
+    .split("\n")
+    .find((l) => l.startsWith(IR_HEADER));
+  if (!line) return null;
+  const payload = line.slice(IR_HEADER.length).trim();
+  try {
+    const json =
+      typeof atob === "function"
+        ? decodeURIComponent(escape(atob(payload)))
+        : payload;
+    return JSON.parse(json) as RuleIR;
+  } catch {
+    return null;
+  }
+}
+
+/** A fresh single-route IR (catch-all refer/deny) to start authoring. */
+export function blankIR(purpose: string): RuleIR {
+  const fallback: Effect =
+    purpose === "directory"
+      ? { effect: "deny", with: { code: "not-a-member" } }
+      : { effect: "refer", with: { queue: "moderator" } };
+  return {
+    purpose,
+    routes: [{ name: "Catch-all", when: { all: ["always"] }, then: fallback }],
+  };
+}

--- a/vtc-service/admin-ui/src/plugins/RuleEditor.tsx
+++ b/vtc-service/admin-ui/src/plugins/RuleEditor.tsx
@@ -1,0 +1,284 @@
+// Visual rule editor — author a ceremony's decision policy as ordered
+// route cards (when → then), compile to Rego live, and save it as a
+// new policy revision. The deferred "Rule IR" authoring layer, wired
+// to the running daemon.
+
+import { useMemo, useState } from "react";
+
+import {
+  type Condition,
+  type Effect,
+  type RuleIR,
+  type Route,
+  compileToRego,
+  conditionsFor,
+  effectsFor,
+} from "@/lib/rule-ir";
+
+function condId(c: Condition): string {
+  return typeof c === "string" ? c : (Object.keys(c)[0] ?? "");
+}
+function condArg(c: Condition): string | undefined {
+  return typeof c === "string" ? undefined : Object.values(c)[0];
+}
+
+export function RuleEditor({
+  purpose,
+  pkg,
+  initial,
+  onSave,
+  onCancel,
+  saving,
+}: {
+  purpose: string;
+  pkg: string;
+  initial: RuleIR;
+  onSave: (rego: string) => void;
+  onCancel: () => void;
+  saving: boolean;
+}) {
+  const [ir, setIr] = useState<RuleIR>(initial);
+  const vocab = useMemo(() => conditionsFor(purpose), [purpose]);
+  const effects = useMemo(() => effectsFor(purpose), [purpose]);
+  const rego = useMemo(() => compileToRego(ir, pkg), [ir, pkg]);
+
+  const setRoutes = (routes: Route[]) => setIr({ ...ir, routes });
+  const patchRoute = (i: number, patch: Partial<Route>) =>
+    setRoutes(ir.routes.map((r, j) => (j === i ? { ...r, ...patch } : r)));
+
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= ir.routes.length) return;
+    const next = [...ir.routes];
+    const a = next[i]!;
+    next[i] = next[j]!;
+    next[j] = a;
+    setRoutes(next);
+  };
+
+  return (
+    <div className="rule-editor">
+      <div className="rule-cards">
+        {ir.routes.map((route, i) => (
+          <RouteCard
+            key={i}
+            route={route}
+            index={i}
+            count={ir.routes.length}
+            vocab={vocab}
+            effects={effects}
+            onChange={(patch) => patchRoute(i, patch)}
+            onMove={(dir) => move(i, dir)}
+            onRemove={() =>
+              setRoutes(ir.routes.filter((_, j) => j !== i))
+            }
+          />
+        ))}
+        <button
+          type="button"
+          className="rule-add-route"
+          onClick={() =>
+            setRoutes([
+              ...ir.routes,
+              {
+                name: "New route",
+                when: { all: ["always"] },
+                then: { effect: "refer", with: { queue: "moderator" } },
+              },
+            ])
+          }
+        >
+          + Add route
+        </button>
+        <p className="cer-sub" style={{ fontSize: "var(--text-xs)" }}>
+          Routes are first-match, top to bottom. A structural{" "}
+          <code>deny</code> is always appended as the backstop.
+        </p>
+      </div>
+
+      <div className="rule-preview">
+        <div className="cer-panel-title">
+          Compiled Rego <span className="ln" />
+        </div>
+        <pre className="cer-policy" style={{ maxHeight: 360 }}>
+          {rego}
+        </pre>
+        <div className="rule-actions">
+          <button
+            type="button"
+            className="cer-run"
+            disabled={saving}
+            onClick={() => onSave(rego)}
+          >
+            {saving ? "Saving…" : "Save as new revision ▸"}
+          </button>
+          <button
+            type="button"
+            className="rule-cancel"
+            onClick={onCancel}
+            disabled={saving}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RouteCard({
+  route,
+  index,
+  count,
+  vocab,
+  effects,
+  onChange,
+  onMove,
+  onRemove,
+}: {
+  route: Route;
+  index: number;
+  count: number;
+  vocab: ReturnType<typeof conditionsFor>;
+  effects: ReturnType<typeof effectsFor>;
+  onChange: (patch: Partial<Route>) => void;
+  onMove: (dir: -1 | 1) => void;
+  onRemove: () => void;
+}) {
+  const [pendingCond, setPendingCond] = useState(vocab[0]?.id ?? "always");
+  const [pendingArg, setPendingArg] = useState("");
+  const pendingDef = vocab.find((v) => v.id === pendingCond);
+
+  const eff = effects.find((e) => e.effect === route.then.effect) ?? effects[0]!;
+  const effField = eff.field;
+  const effValue = effField
+    ? formatWithValue(route.then.with[effField.key])
+    : "";
+
+  const addCond = () => {
+    if (!pendingDef) return;
+    const cond: Condition = pendingDef.arg
+      ? { [pendingDef.id]: pendingArg }
+      : pendingDef.id;
+    onChange({ when: { all: [...route.when.all, cond] } });
+    setPendingArg("");
+  };
+  const removeCond = (i: number) =>
+    onChange({ when: { all: route.when.all.filter((_, j) => j !== i) } });
+
+  const setEffect = (effect: Effect["effect"]) => {
+    const field = effects.find((e) => e.effect === effect)?.field;
+    onChange({ then: { effect, with: field ? { [field.key]: "" } : {} } });
+  };
+  const setEffValue = (raw: string) => {
+    if (!effField) return;
+    const value =
+      effField.key === "fields" || effField.key === "needs"
+        ? raw.split(",").map((s) => s.trim()).filter(Boolean)
+        : raw;
+    onChange({ then: { effect: route.then.effect, with: { [effField.key]: value } } });
+  };
+
+  return (
+    <div className={`rule-card eff-${route.then.effect}`}>
+      <div className="rule-card-head">
+        <span className="rule-pri">{index + 1}</span>
+        <input
+          className="rule-name"
+          value={route.name}
+          onChange={(e) => onChange({ name: e.target.value })}
+        />
+        <div className="rule-tools">
+          <button
+            type="button"
+            disabled={index === 0}
+            onClick={() => onMove(-1)}
+            title="Move up"
+          >
+            ↑
+          </button>
+          <button
+            type="button"
+            disabled={index === count - 1}
+            onClick={() => onMove(1)}
+            title="Move down"
+          >
+            ↓
+          </button>
+          <button type="button" onClick={onRemove} title="Remove route">
+            ×
+          </button>
+        </div>
+      </div>
+
+      <div className="rule-when">
+        <span className="rule-kw">when all of</span>
+        {route.when.all.map((c, i) => {
+          const def = vocab.find((v) => v.id === condId(c));
+          const arg = condArg(c);
+          return (
+            <span className="rule-cond" key={i}>
+              {def?.label ?? condId(c)}
+              {arg ? <b> {arg}</b> : null}
+              <span className="rule-x" onClick={() => removeCond(i)}>
+                ×
+              </span>
+            </span>
+          );
+        })}
+      </div>
+
+      <div className="rule-add-cond">
+        <select
+          value={pendingCond}
+          onChange={(e) => setPendingCond(e.target.value)}
+        >
+          {vocab.map((v) => (
+            <option key={v.id} value={v.id}>
+              {v.label}
+            </option>
+          ))}
+        </select>
+        {pendingDef?.arg && (
+          <input
+            className="rule-arg"
+            placeholder={pendingDef.arg.placeholder}
+            value={pendingArg}
+            onChange={(e) => setPendingArg(e.target.value)}
+          />
+        )}
+        <button type="button" onClick={addCond}>
+          + condition
+        </button>
+      </div>
+
+      <div className="rule-then">
+        <span className="rule-kw">then</span>
+        <select
+          value={route.then.effect}
+          onChange={(e) => setEffect(e.target.value as Effect["effect"])}
+        >
+          {effects.map((e) => (
+            <option key={e.effect} value={e.effect}>
+              {e.label}
+            </option>
+          ))}
+        </select>
+        {effField && (
+          <input
+            className="rule-arg"
+            placeholder={effField.placeholder}
+            value={effValue}
+            onChange={(e) => setEffValue(e.target.value)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatWithValue(v: unknown): string {
+  if (Array.isArray(v)) return v.join(",");
+  if (typeof v === "string") return v;
+  return "";
+}

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -21,12 +21,15 @@ import { useConfirm } from "@/components/ConfirmDialog";
 import { formatIso } from "@/lib/format";
 import {
   type Purpose,
+  CEREMONY_PURPOSES,
   OTHER_PURPOSES,
   activatePolicy,
   fetchActivePolicy,
   fetchPolicies,
   uploadPolicy,
 } from "@/lib/policies-api";
+import { blankIR, parseRego } from "@/lib/rule-ir";
+import { RuleEditor } from "@/plugins/RuleEditor";
 
 const TRUST_TASK_TEST = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
 
@@ -532,10 +535,16 @@ function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
 // per-ceremony (the right panel) and for the non-ceremony purposes.
 // ---------------------------------------------------------------------------
 
+/** Rego package for a ceremony purpose (role-change → role_change). */
+function pkgFor(purpose: Purpose): string {
+  return `vtc.${purpose === "roleChange" ? "role_change" : purpose}`;
+}
+
 function PolicyManager({ purpose }: { purpose: Purpose }) {
   const qc = useQueryClient();
   const confirm = useConfirm();
   const [showUpload, setShowUpload] = useState(false);
+  const [editing, setEditing] = useState(false);
 
   const query = useQuery({
     queryKey: ["policies", purpose],
@@ -550,8 +559,32 @@ function PolicyManager({ purpose }: { purpose: Purpose }) {
     },
   });
 
+  const saveVisual = useMutation({
+    mutationFn: (rego: string) => uploadPolicy({ purpose, regoSource: rego }),
+    onSuccess: () => {
+      setEditing(false);
+      void qc.invalidateQueries({ queryKey: ["policies", purpose] });
+    },
+  });
+
   const items = query.data?.items ?? [];
   const active = items.find((p) => p.isActive) ?? null;
+  const canAuthor = CEREMONY_PURPOSES.includes(purpose);
+
+  if (editing) {
+    return (
+      <RuleEditor
+        purpose={purpose}
+        pkg={pkgFor(purpose)}
+        initial={
+          (active && parseRego(active.regoSource)) || blankIR(purpose)
+        }
+        saving={saveVisual.isPending}
+        onSave={(rego) => saveVisual.mutate(rego)}
+        onCancel={() => setEditing(false)}
+      />
+    );
+  }
 
   return (
     <>
@@ -626,13 +659,32 @@ function PolicyManager({ purpose }: { purpose: Purpose }) {
         </>
       )}
 
+      {canAuthor && (
+        <>
+          <button
+            type="button"
+            className="cer-run"
+            style={{ marginTop: "var(--space-4)" }}
+            onClick={() => setEditing(true)}
+          >
+            Author visually ▸
+          </button>
+          {active && !parseRego(active.regoSource) && (
+            <p className="cer-sub" style={{ fontSize: "var(--text-xs)" }}>
+              The active policy was hand-written — opening the editor starts
+              from a blank route set.
+            </p>
+          )}
+        </>
+      )}
+
       <button
         type="button"
-        className="cer-run"
-        style={{ marginTop: "var(--space-4)" }}
+        className="rule-cancel"
+        style={{ marginTop: "var(--space-3)" }}
         onClick={() => setShowUpload((v) => !v)}
       >
-        {showUpload ? "Cancel" : "Upload new revision ▸"}
+        {showUpload ? "Cancel" : "Upload raw Rego"}
       </button>
       {showUpload && (
         <UploadPolicyForm

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -1956,3 +1956,199 @@ dd .copy-icon-btn {
   margin-bottom: var(--space-2);
   resize: vertical;
 }
+
+/* ── Visual rule editor ──────────────────────────────────────────── */
+.rule-editor {
+  display: grid;
+  grid-template-columns: 1.25fr 1fr;
+  gap: var(--space-4);
+}
+@media (max-width: 1100px) {
+  .rule-editor {
+    grid-template-columns: 1fr;
+  }
+}
+.rule-cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.rule-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elev);
+  padding: var(--space-3);
+  position: relative;
+  overflow: hidden;
+}
+.rule-card::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--border-strong);
+}
+.rule-card.eff-allow::before {
+  background: var(--vd-allow);
+}
+.rule-card.eff-deny::before {
+  background: var(--vd-deny);
+}
+.rule-card.eff-refer::before {
+  background: var(--vd-refer);
+}
+.rule-card.eff-request_more::before {
+  background: var(--vd-more);
+}
+.rule-card-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+.rule-pri {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-faint);
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  display: grid;
+  place-items: center;
+  flex: none;
+}
+.rule-name {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: var(--text-base);
+  font-weight: 500;
+  padding: 2px 0;
+}
+.rule-name:focus {
+  outline: none;
+  border-bottom-color: var(--brand);
+}
+.rule-tools {
+  display: flex;
+  gap: 2px;
+}
+.rule-tools button {
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+}
+.rule-tools button:hover:not(:disabled) {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+.rule-tools button:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+.rule-when,
+.rule-then,
+.rule-add-cond {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+.rule-kw {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.rule-cond {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-subtle);
+  color: var(--text);
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+.rule-cond b {
+  color: var(--brand);
+  font-weight: 500;
+}
+.rule-x {
+  cursor: pointer;
+  opacity: 0.5;
+  font-weight: 600;
+}
+.rule-x:hover {
+  opacity: 1;
+}
+.rule-add-cond select,
+.rule-then select,
+.rule-arg {
+  height: 30px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  width: auto;
+  min-width: 0;
+}
+.rule-arg {
+  max-width: 160px;
+}
+.rule-add-cond button,
+.rule-add-route {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--border-strong);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.rule-add-cond button:hover,
+.rule-add-route:hover {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+.rule-add-route {
+  width: 100%;
+  padding: var(--space-3);
+}
+.rule-preview {
+  display: flex;
+  flex-direction: column;
+}
+.rule-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+.rule-cancel {
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.rule-cancel:hover {
+  color: var(--text);
+  border-color: var(--text-faint);
+}


### PR DESCRIPTION
## What

Step 2 of the ceremony/policy convergence plan: **visual Rule-IR authoring** so operators build a ceremony's decision logic without writing Rego.

A decision policy is authored as ordered **route cards** (`when` → `then`), first-match top-to-bottom, compiled live to the same decision-shaped Rego the hand-written default policies use.

## How

- **`lib/rule-ir.ts`** — the Rule IR (`{purpose, routes:[{name, when:{all:[Condition]}, then:{effect, with}}]}`), a per-purpose condition + effect vocabulary, and `compileToRego` / `parseRego` / `blankIR`.
  - Compiled output: `package` + `import rego.v1`, a `# @vtc-rule-ir: <base64>` round-trip header, a structural `default decision := {"effect":"deny",…}` backstop, an `else`-chain of named routes, and **only** the helper rules a route references.
  - A policy with no header was hand-written → opens the editor from a blank route set.
- **`plugins/RuleEditor.tsx`** — route-card editor: reorder, add/remove conditions and routes, pick effect + its field, live compiled-Rego preview color-coded by effect (allow/deny/refer/request_more).
- **`plugins/ceremonies.tsx`** — "Author visually ▸" is the primary action for the four ceremony purposes (directory, join, removal, role-change); raw-Rego upload demoted to a secondary control.

## Verification

- `npm run build` clean (tsc + vite).
- Standalone compiler run: emits valid decision-shaped Rego, IR round-trips (`parseRego(compileToRego(ir)) === ir`), unused helpers correctly omitted.
- Screenshot-verified via a mocked-daemon harness: the join policy's embedded IR loads into route cards (color-coded by effect) with a live compiled-Rego pane. Harness removed before commit.

Decisions stay data (Rego), effects stay code — this PR only changes *how operators author the data*.
