### PR TITLE
feat(vtc-admin): thin ceremony registry + author-mode layout fix

### DIFF
--- a/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
+++ b/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
@@ -1,0 +1,269 @@
+// Ceremony manifest — the thin registry.
+//
+// A ceremony is one instance of the decision pipeline (TRIGGER → GATHER
+// → VERIFY → FACTS → EVALUATE(<purpose>.rego) → VERDICT → EFFECTS). The
+// pipeline is generic; what differs per ceremony is *declarative*: its
+// metadata (purpose, package, nature), the simulator form fields, and
+// how those fields assemble into a verified-Facts document.
+//
+// This module is that declaration. The Ceremonies surface renders every
+// ceremony from it — no per-ceremony components — so adding a ceremony
+// over an existing effect is a manifest entry, not new UI code.
+//
+// Deliberately thin: `buildFacts` stays a hand-written function per
+// ceremony (the one piece that isn't yet pure data). A later step can
+// derive it from a facts-schema served by the daemon. The *effects* a
+// ceremony triggers remain reviewed Rust — this registry only describes
+// the decision surface, never mutates state.
+
+export type CeremonyKey = "directory" | "join" | "leave" | "role-change";
+export type Nature = "read-only" | "constructive" | "destructive" | "mutating";
+export type Wired = "live" | "legacy" | "unwired";
+
+/** A single simulator input. `select` shows a dropdown; `toggle` a switch. */
+export interface FieldDef {
+  key: string;
+  label: string;
+  hint?: string;
+  type: "select" | "toggle";
+  /** Options for a `select` field. */
+  options?: { value: string; label: string }[];
+  default: string | boolean;
+  /** Render this field only when the predicate holds (e.g. dependent fields). */
+  showWhen?: (v: FieldValues) => boolean;
+}
+
+export type FieldValues = Record<string, string | boolean>;
+
+export interface CeremonyManifest {
+  key: CeremonyKey;
+  label: string;
+  nature: Nature;
+  /** API policy purpose key, or null when the ceremony has no policy. */
+  purpose: string | null;
+  /** Rego package whose `decision` rule the host evaluates. */
+  pkg: string;
+  wired: Wired;
+  blurb: string;
+  /** Declarative simulator form. */
+  fields: FieldDef[];
+  /** Assemble the verified-Facts document the policy decides over. */
+  buildFacts: (v: FieldValues) => Record<string, unknown>;
+}
+
+export const natureColor: Record<Nature, string> = {
+  "read-only": "var(--brand)",
+  constructive: "var(--vd-allow)",
+  destructive: "var(--vd-deny)",
+  mutating: "var(--vd-refer)",
+};
+
+/** The default value map for a ceremony's simulator form. */
+export function defaultValues(m: CeremonyManifest): FieldValues {
+  return Object.fromEntries(m.fields.map((f) => [f.key, f.default]));
+}
+
+// Shared scaffolding every ceremony's Facts doc carries.
+function baseContext() {
+  return {
+    community_did: "did:webvh:demo.example",
+    channel: "rest",
+    member_count: 42,
+  };
+}
+function memberRow(role: string) {
+  return { role, status: "active", joined_at: "2026-01-02T00:00:00Z" };
+}
+const ROLE_OPTIONS = [
+  { value: "member", label: "member" },
+  { value: "moderator", label: "moderator" },
+  { value: "admin", label: "admin" },
+];
+
+export const CEREMONIES: CeremonyManifest[] = [
+  {
+    key: "directory",
+    label: "Directory",
+    nature: "read-only",
+    purpose: "directory",
+    pkg: "vtc.directory",
+    wired: "live",
+    blurb:
+      "A member views another member's record. Read-only — the verdict's allow carries a field projection, capped by the PII boundary.",
+    fields: [
+      {
+        key: "viewerRole",
+        label: "Viewer's community role",
+        hint: "actor.role — admin sees the fuller record",
+        type: "select",
+        options: [
+          { value: "admin", label: "admin" },
+          { value: "member", label: "member" },
+          { value: "", label: "none (authenticated)" },
+        ],
+        default: "member",
+      },
+      {
+        key: "subjectIsMember",
+        label: "Subject is a member",
+        hint: "state.subject_member present",
+        type: "toggle",
+        default: true,
+      },
+      {
+        key: "subjectRole",
+        label: "Subject's role",
+        hint: "state.subject_member.role",
+        type: "select",
+        options: ROLE_OPTIONS,
+        default: "member",
+        showWhen: (v) => v.subjectIsMember === true,
+      },
+    ],
+    buildFacts: (v) => ({
+      purpose: "directory",
+      now: new Date().toISOString(),
+      actor: {
+        did: "did:key:zViewer",
+        role: (v.viewerRole as string) || undefined,
+        authenticated: true,
+      },
+      subject: { did: "did:key:zTarget" },
+      context: baseContext(),
+      evidence: {
+        request: { fields_requested: ["did", "role", "joined_at", "status"] },
+      },
+      state: {
+        subject_member: v.subjectIsMember
+          ? memberRow(v.subjectRole as string)
+          : null,
+      },
+    }),
+  },
+  {
+    key: "join",
+    label: "Join",
+    nature: "constructive",
+    purpose: "join",
+    pkg: "vtc.join",
+    wired: "live",
+    blurb:
+      "A DID joins the community. A trusted presented credential auto-admits (allow → issue the membership credential); everything else is referred to the moderator queue for review.",
+    fields: [
+      {
+        key: "joinTrusted",
+        label: "Presented credential is trusted",
+        hint: "evidence.presentation.credentials[].issuer_trusted",
+        type: "toggle",
+        default: false,
+      },
+    ],
+    buildFacts: (v) => ({
+      purpose: "join",
+      now: new Date().toISOString(),
+      actor: { did: "did:key:zApplicant", authenticated: true },
+      subject: { did: "did:key:zApplicant" },
+      context: baseContext(),
+      evidence: {
+        presentation: {
+          verified: true,
+          holder: "did:key:zApplicant",
+          credentials: [
+            {
+              type: "WitnessCredential",
+              issuer: "did:webvh:notary.example",
+              issuer_trusted: v.joinTrusted === true,
+              status: "valid",
+              claims: {},
+            },
+          ],
+        },
+      },
+      state: { subject_member: null },
+    }),
+  },
+  {
+    key: "leave",
+    label: "Leave",
+    nature: "destructive",
+    purpose: "removal",
+    pkg: "vtc.removal",
+    wired: "live",
+    blurb:
+      "A member departs or is removed. Self-leave is unconditional; an admin may remove a non-admin. The no-last-admin invariant + revocation are host-enforced in the effect.",
+    fields: [
+      {
+        key: "selfLeave",
+        label: "Self-leave",
+        hint: "actor.did == subject.did — always allowed",
+        type: "toggle",
+        default: false,
+      },
+      {
+        key: "subjectRole",
+        label: "Subject's role",
+        hint: "an admin may remove a non-admin only",
+        type: "select",
+        options: ROLE_OPTIONS,
+        default: "member",
+        showWhen: (v) => v.selfLeave !== true,
+      },
+    ],
+    buildFacts: (v) => {
+      const actorDid = "did:key:zActor";
+      const subjectDid = v.selfLeave ? actorDid : "did:key:zTarget";
+      return {
+        purpose: "leave",
+        now: new Date().toISOString(),
+        actor: { did: actorDid, role: "admin", authenticated: true },
+        subject: { did: subjectDid },
+        context: baseContext(),
+        evidence: { request: { disposition: "tombstone" } },
+        state: { subject_member: memberRow(v.subjectRole as string) },
+      };
+    },
+  },
+  {
+    key: "role-change",
+    label: "Role change",
+    nature: "mutating",
+    purpose: "roleChange",
+    pkg: "vtc.role_change",
+    wired: "live",
+    blurb:
+      "A member's role changes in place (the DID + VMC are unchanged; the role VEC is re-minted). The one ceremony whose allow may grant admin — gated by a verified step-up; demotions are guarded by no-last-admin.",
+    fields: [
+      {
+        key: "targetRole",
+        label: "Target role",
+        hint: "evidence.request.target_role",
+        type: "select",
+        options: [
+          { value: "member", label: "member" },
+          { value: "moderator", label: "moderator" },
+          { value: "admin", label: "admin (promotion)" },
+        ],
+        default: "moderator",
+      },
+      {
+        key: "stepUp",
+        label: "Step-up verified",
+        hint: "admin needs step-up — else the verdict refers",
+        type: "toggle",
+        default: false,
+        showWhen: (v) => v.targetRole === "admin",
+      },
+    ],
+    buildFacts: (v) => ({
+      purpose: "role-change",
+      now: new Date().toISOString(),
+      actor: { did: "did:key:zAdmin", role: "admin", authenticated: true },
+      subject: { did: "did:key:zTarget" },
+      context: baseContext(),
+      evidence: {
+        request: { target_role: v.targetRole as string, step_up: v.stepUp === true },
+      },
+      state: { subject_member: memberRow("member") },
+    }),
+  },
+];

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -30,6 +30,15 @@ import {
 } from "@/lib/policies-api";
 import { blankIR, parseRego } from "@/lib/rule-ir";
 import { RuleEditor } from "@/plugins/RuleEditor";
+import {
+  type CeremonyKey,
+  type CeremonyManifest,
+  type FieldDef,
+  type FieldValues,
+  CEREMONIES,
+  defaultValues,
+  natureColor,
+} from "@/lib/ceremony-manifest";
 
 const TRUST_TASK_TEST = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
 
@@ -57,71 +66,6 @@ const EFFECTS: { key: Effect; label: string; blurb: string }[] = [
   },
 ];
 
-type CeremonyKey = "directory" | "join" | "leave" | "role-change";
-type Wired = "live" | "legacy" | "unwired";
-
-interface Ceremony {
-  key: CeremonyKey;
-  label: string;
-  nature: string;
-  /** API policy purpose key, or null when the ceremony has no policy. */
-  purpose: string | null;
-  /** Rego package whose `decision` rule the host evaluates. */
-  pkg: string;
-  wired: Wired;
-  blurb: string;
-}
-
-const CEREMONIES: Ceremony[] = [
-  {
-    key: "directory",
-    label: "Directory",
-    nature: "read-only",
-    purpose: "directory",
-    pkg: "vtc.directory",
-    wired: "live",
-    blurb:
-      "A member views another member's record. Read-only — the verdict's allow carries a field projection, capped by the PII boundary.",
-  },
-  {
-    key: "join",
-    label: "Join",
-    nature: "constructive",
-    purpose: "join",
-    pkg: "vtc.join",
-    wired: "live",
-    blurb:
-      "A DID joins the community. A trusted presented credential auto-admits (allow → issue the membership credential); everything else is referred to the moderator queue for review.",
-  },
-  {
-    key: "leave",
-    label: "Leave",
-    nature: "destructive",
-    purpose: "removal",
-    pkg: "vtc.removal",
-    wired: "live",
-    blurb:
-      "A member departs or is removed. Self-leave is unconditional; an admin may remove a non-admin. The no-last-admin invariant + revocation are host-enforced in the effect.",
-  },
-  {
-    key: "role-change",
-    label: "Role change",
-    nature: "mutating",
-    purpose: "roleChange",
-    pkg: "vtc.role_change",
-    wired: "live",
-    blurb:
-      "A member's role changes in place (the DID + VMC are unchanged; the role VEC is re-minted). The one ceremony whose allow may grant admin — gated by a verified step-up; demotions are guarded by no-last-admin.",
-  },
-];
-
-const natureColor: Record<string, string> = {
-  "read-only": "var(--brand)",
-  constructive: "var(--vd-allow)",
-  destructive: "var(--vd-deny)",
-  mutating: "var(--vd-refer)",
-};
-
 interface TestResponse {
   id: string;
   result: {
@@ -140,135 +84,6 @@ function pluckDecision(resp: TestResponse): Verdict | null {
   const v = value as Record<string, unknown>;
   if (typeof v.effect !== "string") return null;
   return { effect: v.effect as Effect, with: v.with as Record<string, unknown> };
-}
-
-// ---------------------------------------------------------------------------
-// Facts assembly — a compact, ceremony-specific editor produces the
-// verified-Facts document the policy decides over.
-// ---------------------------------------------------------------------------
-
-interface FormState {
-  // directory
-  viewerRole: string;
-  subjectIsMember: boolean;
-  subjectRole: string;
-  // leave
-  selfLeave: boolean;
-  // role-change
-  targetRole: string;
-  stepUp: boolean;
-  // join
-  joinTrusted: boolean;
-}
-
-const DEFAULT_FORM: FormState = {
-  viewerRole: "member",
-  subjectIsMember: true,
-  subjectRole: "member",
-  selfLeave: false,
-  targetRole: "moderator",
-  stepUp: false,
-  joinTrusted: false,
-};
-
-function buildFacts(c: Ceremony, f: FormState): Record<string, unknown> {
-  const now = new Date().toISOString();
-  const context = {
-    community_did: "did:webvh:demo.example",
-    channel: "rest",
-    member_count: 42,
-  };
-
-  if (c.key === "directory") {
-    return {
-      purpose: "directory",
-      now,
-      actor: {
-        did: "did:key:zViewer",
-        role: f.viewerRole || undefined,
-        authenticated: true,
-      },
-      subject: { did: "did:key:zTarget" },
-      context,
-      evidence: {
-        request: { fields_requested: ["did", "role", "joined_at", "status"] },
-      },
-      state: {
-        subject_member: f.subjectIsMember
-          ? {
-              role: f.subjectRole,
-              status: "active",
-              joined_at: "2026-01-02T00:00:00Z",
-            }
-          : null,
-      },
-    };
-  }
-
-  if (c.key === "join") {
-    return {
-      purpose: "join",
-      now,
-      actor: { did: "did:key:zApplicant", authenticated: true },
-      subject: { did: "did:key:zApplicant" },
-      context,
-      evidence: {
-        presentation: {
-          verified: true,
-          holder: "did:key:zApplicant",
-          credentials: [
-            {
-              type: "WitnessCredential",
-              issuer: "did:webvh:notary.example",
-              issuer_trusted: f.joinTrusted,
-              status: "valid",
-              claims: {},
-            },
-          ],
-        },
-      },
-      state: { subject_member: null },
-    };
-  }
-
-  if (c.key === "role-change") {
-    return {
-      purpose: "role-change",
-      now,
-      actor: { did: "did:key:zAdmin", role: "admin", authenticated: true },
-      subject: { did: "did:key:zTarget" },
-      context,
-      evidence: {
-        request: { target_role: f.targetRole, step_up: f.stepUp },
-      },
-      state: {
-        subject_member: {
-          role: "member",
-          status: "active",
-          joined_at: "2026-01-02T00:00:00Z",
-        },
-      },
-    };
-  }
-
-  // leave
-  const actorDid = "did:key:zActor";
-  const subjectDid = f.selfLeave ? actorDid : "did:key:zTarget";
-  return {
-    purpose: "leave",
-    now,
-    actor: { did: actorDid, role: "admin", authenticated: true },
-    subject: { did: subjectDid },
-    context,
-    evidence: { request: { disposition: "tombstone" } },
-    state: {
-      subject_member: {
-        role: f.subjectRole,
-        status: "active",
-        joined_at: "2026-01-02T00:00:00Z",
-      },
-    },
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -331,12 +146,13 @@ export function Ceremonies() {
   );
 }
 
-function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
-  const [form, setForm] = useState<FormState>(DEFAULT_FORM);
+function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
+  const [form, setForm] = useState<FieldValues>(() => defaultValues(ceremony));
   const [verdict, setVerdict] = useState<Verdict | null>(null);
   const [phase, setPhase] = useState(-1);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [authoring, setAuthoring] = useState(false);
 
   const policyQuery = useQuery({
     queryKey: ["active-policy", ceremony.purpose],
@@ -344,12 +160,14 @@ function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
     enabled: ceremony.purpose !== null,
   });
 
-  // Reset the verdict whenever the ceremony changes.
+  // Reset the form + verdict whenever the ceremony changes.
   useEffect(() => {
+    setForm(defaultValues(ceremony));
     setVerdict(null);
     setError(null);
     setPhase(-1);
-  }, [ceremony.key]);
+    setAuthoring(false);
+  }, [ceremony]);
 
   const canSimulate = ceremony.wired === "live";
 
@@ -366,7 +184,7 @@ function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
     }
 
     try {
-      const facts = buildFacts(ceremony, form);
+      const facts = ceremony.buildFacts(form);
       const resp = await postJson<TestResponse>(
         `/v1/policies/${policy.id}/test`,
         { query: `data.${ceremony.pkg}.decision`, input: facts },
@@ -452,7 +270,7 @@ function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
         </div>
       </div>
 
-      <div className="cer-work">
+      <div className={`cer-work${authoring ? " authoring" : ""}`}>
         {/* Simulator */}
         <div className="card">
           <div className="cer-panel-title">
@@ -467,18 +285,11 @@ function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
             </p>
           ) : (
             <>
-              {ceremony.key === "join" && (
-                <JoinForm form={form} setForm={setForm} />
-              )}
-              {ceremony.key === "directory" && (
-                <DirectoryForm form={form} setForm={setForm} />
-              )}
-              {ceremony.key === "leave" && (
-                <LeaveForm form={form} setForm={setForm} />
-              )}
-              {ceremony.key === "role-change" && (
-                <RoleChangeForm form={form} setForm={setForm} />
-              )}
+              <SimFields
+                fields={ceremony.fields}
+                values={form}
+                onChange={setForm}
+              />
 
               <button
                 className="cer-run"
@@ -515,14 +326,18 @@ function CeremonyPanel({ ceremony }: { ceremony: Ceremony }) {
         </div>
 
         {/* Decision policy — source + versions + activate + upload */}
-        <div className="card">
+        <div className="card cer-policy-panel">
           <div className="cer-panel-title">
             Decision policy <span className="ln" />
           </div>
           {ceremony.purpose === null ? (
             <p className="cer-sub">No policy purpose for this ceremony yet.</p>
           ) : (
-            <PolicyManager purpose={ceremony.purpose as Purpose} />
+            <PolicyManager
+              key={ceremony.purpose}
+              purpose={ceremony.purpose as Purpose}
+              onEditingChange={setAuthoring}
+            />
           )}
         </div>
       </div>
@@ -540,11 +355,22 @@ function pkgFor(purpose: Purpose): string {
   return `vtc.${purpose === "roleChange" ? "role_change" : purpose}`;
 }
 
-function PolicyManager({ purpose }: { purpose: Purpose }) {
+function PolicyManager({
+  purpose,
+  onEditingChange,
+}: {
+  purpose: Purpose;
+  /** Notifies the parent so it can widen the layout for the editor. */
+  onEditingChange?: (editing: boolean) => void;
+}) {
   const qc = useQueryClient();
   const confirm = useConfirm();
   const [showUpload, setShowUpload] = useState(false);
-  const [editing, setEditing] = useState(false);
+  const [editing, setEditingState] = useState(false);
+  const setEditing = (v: boolean) => {
+    setEditingState(v);
+    onEditingChange?.(v);
+  };
 
   const query = useQuery({
     queryKey: ["policies", purpose],
@@ -777,160 +603,52 @@ function OtherPolicies() {
   );
 }
 
-function DirectoryForm({
-  form,
-  setForm,
+// Generic simulator form — renders a ceremony's declared fields. A
+// `select` becomes a dropdown, a `toggle` a switch; a field with a
+// `showWhen` predicate only renders when it holds (dependent fields).
+function SimFields({
+  fields,
+  values,
+  onChange,
 }: {
-  form: FormState;
-  setForm: (f: FormState) => void;
+  fields: FieldDef[];
+  values: FieldValues;
+  onChange: (v: FieldValues) => void;
 }) {
   return (
     <>
-      <div className="cer-field">
-        <label>
-          Viewer's community role
-          <small>actor.role — admin sees the fuller record</small>
-        </label>
-        <select
-          className="input"
-          value={form.viewerRole}
-          onChange={(e) => setForm({ ...form, viewerRole: e.target.value })}
-        >
-          <option value="admin">admin</option>
-          <option value="member">member</option>
-          <option value="">none (authenticated)</option>
-        </select>
-      </div>
-      <div className="cer-field">
-        <label>
-          Subject is a member
-          <small>state.subject_member present</small>
-        </label>
-        <Toggle
-          on={form.subjectIsMember}
-          onClick={() =>
-            setForm({ ...form, subjectIsMember: !form.subjectIsMember })
-          }
-        />
-      </div>
-      {form.subjectIsMember && (
-        <div className="cer-field">
-          <label>
-            Subject's role
-            <small>state.subject_member.role</small>
-          </label>
-          <select
-            className="input"
-            value={form.subjectRole}
-            onChange={(e) => setForm({ ...form, subjectRole: e.target.value })}
-          >
-            <option value="member">member</option>
-            <option value="moderator">moderator</option>
-            <option value="admin">admin</option>
-          </select>
-        </div>
-      )}
-    </>
-  );
-}
-
-function LeaveForm({
-  form,
-  setForm,
-}: {
-  form: FormState;
-  setForm: (f: FormState) => void;
-}) {
-  return (
-    <>
-      <div className="cer-field">
-        <label>
-          Self-leave
-          <small>actor.did == subject.did — always allowed</small>
-        </label>
-        <Toggle
-          on={form.selfLeave}
-          onClick={() => setForm({ ...form, selfLeave: !form.selfLeave })}
-        />
-      </div>
-      {!form.selfLeave && (
-        <div className="cer-field">
-          <label>
-            Subject's role
-            <small>an admin may remove a non-admin only</small>
-          </label>
-          <select
-            className="input"
-            value={form.subjectRole}
-            onChange={(e) => setForm({ ...form, subjectRole: e.target.value })}
-          >
-            <option value="member">member</option>
-            <option value="moderator">moderator</option>
-            <option value="admin">admin</option>
-          </select>
-        </div>
-      )}
-    </>
-  );
-}
-
-function JoinForm({
-  form,
-  setForm,
-}: {
-  form: FormState;
-  setForm: (f: FormState) => void;
-}) {
-  return (
-    <div className="cer-field">
-      <label>
-        Presented credential is trusted
-        <small>evidence.presentation.credentials[].issuer_trusted</small>
-      </label>
-      <Toggle
-        on={form.joinTrusted}
-        onClick={() => setForm({ ...form, joinTrusted: !form.joinTrusted })}
-      />
-    </div>
-  );
-}
-
-function RoleChangeForm({
-  form,
-  setForm,
-}: {
-  form: FormState;
-  setForm: (f: FormState) => void;
-}) {
-  return (
-    <>
-      <div className="cer-field">
-        <label>
-          Target role
-          <small>evidence.request.target_role</small>
-        </label>
-        <select
-          className="input"
-          value={form.targetRole}
-          onChange={(e) => setForm({ ...form, targetRole: e.target.value })}
-        >
-          <option value="member">member</option>
-          <option value="moderator">moderator</option>
-          <option value="admin">admin (promotion)</option>
-        </select>
-      </div>
-      {form.targetRole === "admin" && (
-        <div className="cer-field">
-          <label>
-            Step-up verified
-            <small>admin needs step-up — else the verdict refers</small>
-          </label>
-          <Toggle
-            on={form.stepUp}
-            onClick={() => setForm({ ...form, stepUp: !form.stepUp })}
-          />
-        </div>
-      )}
+      {fields
+        .filter((f) => !f.showWhen || f.showWhen(values))
+        .map((f) => (
+          <div className="cer-field" key={f.key}>
+            <label>
+              {f.label}
+              {f.hint && <small>{f.hint}</small>}
+            </label>
+            {f.type === "toggle" ? (
+              <Toggle
+                on={values[f.key] === true}
+                onClick={() =>
+                  onChange({ ...values, [f.key]: values[f.key] !== true })
+                }
+              />
+            ) : (
+              <select
+                className="input"
+                value={String(values[f.key] ?? "")}
+                onChange={(e) =>
+                  onChange({ ...values, [f.key]: e.target.value })
+                }
+              >
+                {f.options?.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        ))}
     </>
   );
 }

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -379,6 +379,10 @@ button.primary:focus-visible {
 .content {
   padding: var(--space-8) var(--space-10);
   max-width: 80rem;
+  /* The 1fr grid track is minmax(auto,1fr) by default; auto lets inner
+     content (long code lines) expand it and scroll the page. Pin the
+     floor to 0 so overflow stays inside the scrollable panels. */
+  min-width: 0;
 }
 
 /* ── Nav ─────────────────────────────────────────────────────── */
@@ -1741,6 +1745,20 @@ dd .copy-icon-btn {
   gap: var(--space-5);
   margin-top: var(--space-5);
 }
+/* Grid items default to min-width:auto, so an unbreakable line (e.g. the
+   compiled-Rego @vtc-rule-ir header) would expand the track and scroll
+   the whole page. Let the panels shrink so inner overflow:auto wins. */
+.cer-work > * {
+  min-width: 0;
+}
+/* Author mode: the visual editor needs full width, so stack the work
+   area with the decision policy on top and the simulator below it. */
+.cer-work.authoring {
+  grid-template-columns: 1fr;
+}
+.cer-work.authoring .cer-policy-panel {
+  order: -1;
+}
 @media (max-width: 940px) {
   .cer-work {
     grid-template-columns: 1fr;
@@ -1962,6 +1980,10 @@ dd .copy-icon-btn {
   display: grid;
   grid-template-columns: 1.25fr 1fr;
   gap: var(--space-4);
+  min-width: 0;
+}
+.rule-editor > * {
+  min-width: 0;
 }
 @media (max-width: 1100px) {
   .rule-editor {


### PR DESCRIPTION
## What

Step 3 of the ceremony/policy convergence — **kept thin first**. A single manifest now describes each ceremony, and the Ceremonies surface renders entirely from it. Adding a ceremony **over an existing effect** becomes a manifest entry rather than new UI code.

Plus a layout fix surfaced in review: opening the visual editor scrolled the page off to the right.

## The registry (`lib/ceremony-manifest.ts`)

Each `CeremonyManifest` entry declares, declaratively:
- **metadata** — `purpose`, `pkg`, `nature`, `label`, `blurb`, `wired`
- **`fields`** — the simulator inputs (`select`/`toggle`, with optional `showWhen` for dependent fields)
- **`buildFacts(values)`** — assembles the verified-Facts document the policy decides over

`plugins/ceremonies.tsx` drops the hardcoded `CEREMONIES` array, the `FormState` union, the `buildFacts` switch, and the four bespoke `*Form` components — replaced by the manifest + one generic `<SimFields>` renderer. **Behaviour-identical**: same flow diagram, same simulator, same policy panel.

> Deliberately thin: `buildFacts` stays a hand-written function per ceremony (the one piece not yet pure data — a later step can derive it from a daemon-served facts-schema). The registry only describes the *decision* surface; the **effects** a ceremony triggers (admit/depart/remint/project) remain reviewed Rust. **Decisions are data, effects are code.**

## Layout fix

- **Root cause:** nested CSS-grid items default to `min-width: auto`, so the unbreakable compiled-Rego `@vtc-rule-ir` header line expanded every track (`.content` `1fr` → `.cer-work` → `.card` → `.rule-editor` → `.rule-preview`) instead of letting the `<pre>`'s `overflow-x:auto` scroll internally. Fixed by pinning `min-width: 0` down that chain.
- In **author mode** the work area now **stacks** — Decision policy on top, Simulate below — so the visual editor gets full width (the cards | compiled-Rego split no longer fights for half a column).

## Verification

- `npm run build` clean (tsc + vite).
- Screenshot-verified via a mocked-daemon harness reproducing the real `.layout`/`.content` shell: (1) the manifest-driven simulator renders all field types incl. dependent `showWhen` fields (role-change → step-up appears only for admin target); (2) author mode is stacked and the long Rego line no longer overflows the page. Harness removed before commit.

Net `+375 / −366` — the registry roughly pays for itself in deleted per-ceremony code.
