### PR TITLE
feat(vtc-admin): collapsible desktop nav rail

### DIFF
--- a/vtc-service/admin-ui/src/App.tsx
+++ b/vtc-service/admin-ui/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { NavLink, Route, Routes, useLocation } from "react-router-dom";
-import { Menu, RefreshCw, X } from "lucide-react";
+import { ChevronsLeft, ChevronsRight, Menu, RefreshCw, X } from "lucide-react";
 
 import { getPlugins, subscribePlugins, type PluginManifest } from "@/plugin-api";
 import { PluginHost } from "@/components/PluginHost";
@@ -28,6 +28,22 @@ export default function App() {
   const allPlugins = usePlugins();
   const { pathname } = useLocation();
   const [navOpen, setNavOpen] = useState(false);
+  // Desktop nav collapse — an icons-only rail to reclaim horizontal
+  // space. Persisted so the operator's choice survives reloads.
+  const [navCollapsed, setNavCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem("vtc-admin-nav-collapsed") === "1";
+    } catch {
+      return false;
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem("vtc-admin-nav-collapsed", navCollapsed ? "1" : "0");
+    } catch {
+      // Private-mode / blocked storage: collapse just won't persist.
+    }
+  }, [navCollapsed]);
   const qc = useQueryClient();
   const toast = useToast();
   // De-dupe back-to-back expiry events: one expired session can fire
@@ -147,7 +163,11 @@ export default function App() {
   });
 
   return (
-    <div className={`layout${navOpen ? " nav-open" : ""}`}>
+    <div
+      className={`layout${navOpen ? " nav-open" : ""}${
+        navCollapsed ? " nav-collapsed" : ""
+      }`}
+    >
       <button
         type="button"
         className="nav-toggle"
@@ -161,16 +181,35 @@ export default function App() {
         </span>
         Menu
       </button>
-      <aside className="nav" id="admin-nav">
+      <aside
+        className={`nav${navCollapsed ? " collapsed" : ""}`}
+        id="admin-nav"
+      >
         <header>
-          <h1>VTC Admin</h1>
+          <div className="nav-brand">
+            <h1>VTC Admin</h1>
+            <button
+              type="button"
+              className="nav-collapse-btn"
+              aria-label={
+                navCollapsed ? "Expand navigation" : "Collapse navigation"
+              }
+              aria-expanded={!navCollapsed}
+              title={navCollapsed ? "Expand" : "Collapse"}
+              onClick={() => setNavCollapsed((v) => !v)}
+            >
+              <span className="button-icon" aria-hidden="true">
+                {navCollapsed ? <ChevronsRight /> : <ChevronsLeft />}
+              </span>
+            </button>
+          </div>
           <SessionBadge whoami={probe.data} />
           <ThemeSwitcher />
         </header>
         <ul>
           {plugins.map((p) => (
             <li key={p.id}>
-              <NavLink to={p.path}>
+              <NavLink to={p.path} title={p.label}>
                 <span className="nav-icon" aria-hidden="true">
                   <PluginIcon plugin={p} />
                 </span>
@@ -291,7 +330,9 @@ function ReloadPluginsButton() {
         <span className="button-icon" aria-hidden="true">
           <RefreshCw />
         </span>
-        {pending ? "Reloading plugins…" : "Reload plugins"}
+        <span className="nav-footer-label">
+          {pending ? "Reloading plugins…" : "Reload plugins"}
+        </span>
       </button>
     </div>
   );

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -336,6 +336,10 @@ button.primary:focus-visible {
     display: inline-flex;
   }
 
+  .nav-collapse-btn {
+    display: none;
+  }
+
   .nav {
     position: fixed;
     top: 0;
@@ -525,6 +529,70 @@ button.primary:focus-visible {
   margin: 0;
   font-size: var(--text-sm);
   text-align: left;
+}
+
+/* ── Nav: desktop collapse (icons-only rail) ─────────────────── */
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.nav-collapse-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    color var(--motion-fast),
+    border-color var(--motion-fast);
+}
+.nav-collapse-btn:hover {
+  color: var(--text);
+  border-color: var(--text-faint);
+}
+.nav-collapse-btn .button-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* The collapsed rail is a desktop affordance only — the mobile nav is a
+   full-label slide-over, so scope every collapsed rule to ≥721px and
+   hide the toggle below it. */
+@media (min-width: 721px) {
+  .layout.nav-collapsed {
+    grid-template-columns: 64px 1fr;
+  }
+  .nav.collapsed .nav-brand {
+    justify-content: center;
+  }
+  .nav.collapsed h1,
+  .nav.collapsed .session-badge,
+  .nav.collapsed .theme-switcher,
+  .nav.collapsed .nav-label,
+  .nav.collapsed .nav-footer-label {
+    display: none;
+  }
+  .nav.collapsed a {
+    justify-content: center;
+    gap: 0;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .nav.collapsed .nav-footer {
+    align-items: center;
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 /* ── Theme switcher (segmented) ──────────────────────────────── */


### PR DESCRIPTION
## What

The left nav can now **collapse to an icons-only rail** on desktop, reclaiming horizontal width for wide working surfaces (e.g. the visual policy editor). Follow-up to #222, where the author-mode editor surfaced how much horizontal room these surfaces want.

## How

- A chevron toggle in the nav header — `«` collapse / `»` expand. State persists in `localStorage` (`vtc-admin-nav-collapsed`), so the choice survives reloads.
- **Collapsed:** a 64px rail showing plugin icons only. Brand, session badge, theme switcher, item labels, and the footer label hide; icons centre; the active item keeps its highlight + left border. Each nav link carries a `title` tooltip so the icons stay identifiable.
- **Desktop-only:** every collapsed rule is scoped to `@media (min-width: 721px)` and the toggle is hidden below it — the mobile slide-over nav (already full-label) is untouched.

## Verification

- `npm run build` clean (tsc + vite).
- Screenshot-verified via a harness reproducing the real shell markup + classes, in both states:
  - Expanded (220px): header + `«` toggle, session badge, full icon+label items, "Reload plugins" label.
  - Collapsed (64px): icons-only rail, `»` toggle, active item highlighted, content reflowed left, no overflow.
  - Harness removed before commit.

Scoped change: only `App.tsx` (markup + persisted toggle state) and `styles.css` (the rail rules).
