### PR TITLE
feat(vtc-admin): ceremony simulator legibility + lifecycle UX

### DIFF
--- a/vtc-service/admin-ui/src/lib/rule-ir.ts
+++ b/vtc-service/admin-ui/src/lib/rule-ir.ts
@@ -37,6 +37,32 @@ export interface RuleIR {
 // a named helper rule.
 // ---------------------------------------------------------------------------
 
+/** The verified-Facts shape the local condition evaluator reads — a
+ * permissive view of the daemon's `input` document. */
+export interface ExplainFacts {
+  actor?: { did?: string; role?: string; authenticated?: boolean };
+  subject?: { did?: string };
+  state?: { subject_member?: { role?: string } | null };
+  evidence?: {
+    invitation?: { verified?: boolean; consumed?: boolean };
+    presentation?: {
+      credentials?: Array<{
+        type?: string;
+        issuer_trusted?: boolean;
+        status?: string;
+      }>;
+    };
+    request?: {
+      agreements?: Record<string, boolean>;
+      disposition?: string;
+      target_role?: string;
+      step_up?: boolean;
+    };
+  };
+}
+
+const creds = (f: ExplainFacts) => f.evidence?.presentation?.credentials ?? [];
+
 export interface ConditionDef {
   id: string;
   label: string;
@@ -46,6 +72,10 @@ export interface ConditionDef {
   expr: (arg?: string) => string;
   /** Helper-rule id pulled in when this condition is used. */
   helper?: string;
+  /** Local mirror of `expr` for the decision trace — evaluates the
+   * condition against the facts client-side. Kept in lock-step with
+   * `expr` (both describe the same predicate). */
+  test: (facts: ExplainFacts, arg?: string) => boolean;
 }
 
 const HELPERS: Record<string, string> = {
@@ -61,21 +91,24 @@ const HELPERS: Record<string, string> = {
 };
 
 const SHARED: ConditionDef[] = [
-  { id: "always", label: "always", expr: () => "true" },
+  { id: "always", label: "always", expr: () => "true", test: () => true },
   {
     id: "actor_is_admin",
     label: "actor is admin",
     expr: () => 'input.actor.role == "admin"',
+    test: (f) => f.actor?.role === "admin",
   },
   {
     id: "actor_is_self",
     label: "actor is the subject",
     expr: () => "input.actor.did == input.subject.did",
+    test: (f) => !!f.actor?.did && f.actor.did === f.subject?.did,
   },
   {
     id: "subject_is_admin",
     label: "subject is admin",
     expr: () => 'input.state.subject_member.role == "admin"',
+    test: (f) => f.state?.subject_member?.role === "admin",
   },
 ];
 
@@ -85,6 +118,9 @@ const JOIN: ConditionDef[] = [
     label: "holds a valid invitation",
     expr: () => "has_valid_invitation",
     helper: "has_valid_invitation",
+    test: (f) =>
+      f.evidence?.invitation?.verified === true &&
+      f.evidence?.invitation?.consumed !== true,
   },
   {
     id: "holds_trusted",
@@ -92,6 +128,10 @@ const JOIN: ConditionDef[] = [
     arg: { label: "credential type", placeholder: "WitnessCredential" },
     expr: (a) => `cred_trusted(${JSON.stringify(a ?? "")})`,
     helper: "cred_trusted",
+    test: (f, a) =>
+      creds(f).some(
+        (c) => c.type === a && c.issuer_trusted === true && c.status === "valid",
+      ),
   },
   {
     id: "holds",
@@ -99,6 +139,8 @@ const JOIN: ConditionDef[] = [
     arg: { label: "credential type", placeholder: "EmailCredential" },
     expr: (a) => `cred_held(${JSON.stringify(a ?? "")})`,
     helper: "cred_held",
+    test: (f, a) =>
+      creds(f).some((c) => c.type === a && c.status === "valid"),
   },
   {
     id: "agreed",
@@ -106,6 +148,7 @@ const JOIN: ConditionDef[] = [
     arg: { label: "agreement tag", placeholder: "code-of-conduct" },
     expr: (a) => `agreed(${JSON.stringify(a ?? "")})`,
     helper: "agreed",
+    test: (f, a) => f.evidence?.request?.agreements?.[a ?? ""] === true,
   },
 ];
 
@@ -114,6 +157,7 @@ const LEAVE: ConditionDef[] = [
     id: "disposition_requested",
     label: "a disposition was requested",
     expr: () => "input.evidence.request.disposition",
+    test: (f) => !!f.evidence?.request?.disposition,
   },
 ];
 
@@ -122,11 +166,13 @@ const DIRECTORY: ConditionDef[] = [
     id: "viewer_is_admin",
     label: "viewer is admin",
     expr: () => 'input.actor.role == "admin"',
+    test: (f) => f.actor?.role === "admin",
   },
   {
     id: "viewer_is_member",
     label: "viewer is authenticated",
     expr: () => "input.actor.authenticated == true",
+    test: (f) => f.actor?.authenticated === true,
   },
 ];
 
@@ -135,16 +181,19 @@ const ROLE_CHANGE: ConditionDef[] = [
     id: "target_role_standard",
     label: "target role is not admin",
     expr: () => 'input.evidence.request.target_role != "admin"',
+    test: (f) => f.evidence?.request?.target_role !== "admin",
   },
   {
     id: "promotes_to_admin",
     label: "promotes to admin",
     expr: () => 'input.evidence.request.target_role == "admin"',
+    test: (f) => f.evidence?.request?.target_role === "admin",
   },
   {
     id: "step_up_done",
     label: "step-up verified",
     expr: () => "input.evidence.request.step_up == true",
+    test: (f) => f.evidence?.request?.step_up === true,
   },
 ];
 
@@ -447,4 +496,65 @@ export function irToEnglish(ir: RuleIR): EnglishLine[] {
       isCatchAll: catchAll,
     };
   });
+}
+
+// ---------------------------------------------------------------------------
+// Decision trace — evaluate the routes against a facts document locally
+// (mirroring the compiled Rego) to explain which route fired and why.
+// Only meaningful for IR-authored policies, where the local `test`
+// predicates are the same logic the Rego compiles from.
+// ---------------------------------------------------------------------------
+
+export interface ConditionTrace {
+  label: string;
+  passed: boolean;
+}
+export interface RouteTrace {
+  name: string;
+  effect: Effect["effect"];
+  conditions: ConditionTrace[];
+  /** All conditions held. */
+  matched: boolean;
+  /** The first matching route — the one whose effect the verdict takes. */
+  fired: boolean;
+  /** First-match short-circuits: routes after the fired one aren't run. */
+  reached: boolean;
+  isCatchAll: boolean;
+}
+export interface DecisionTrace {
+  routes: RouteTrace[];
+  fired: RouteTrace | null;
+}
+
+/** Evaluate an IR against a facts document, first-match, and report the
+ * per-route / per-condition outcome. */
+export function explainDecision(
+  ir: RuleIR,
+  facts: ExplainFacts,
+): DecisionTrace {
+  const defs = conditionsFor(ir.purpose);
+  let firedIdx = -1;
+  const routes: RouteTrace[] = ir.routes.map((route, i) => {
+    const conditions = route.when.all.map((c) => {
+      const def = defs.find((x) => x.id === condId(c));
+      const passed = def ? def.test(facts, condArg(c)) : false;
+      return { label: conditionToEnglish(c, ir.purpose), passed };
+    });
+    const matched = conditions.every((c) => c.passed);
+    if (matched && firedIdx === -1) firedIdx = i;
+    return {
+      name: route.name,
+      effect: route.then.effect,
+      conditions,
+      matched,
+      fired: false,
+      reached: true,
+      isCatchAll: isCatchAll(route.when),
+    };
+  });
+  routes.forEach((r, i) => {
+    r.fired = i === firedIdx;
+    r.reached = firedIdx === -1 || i <= firedIdx;
+  });
+  return { routes, fired: firedIdx >= 0 ? (routes[firedIdx] ?? null) : null };
 }

--- a/vtc-service/admin-ui/src/lib/rule-ir.ts
+++ b/vtc-service/admin-ui/src/lib/rule-ir.ts
@@ -365,6 +365,69 @@ export interface EnglishLine {
   isCatchAll: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Semantic diff — compare two IR revisions at the route level, so a
+// version bump reads as "what changed" rather than a Rego text diff.
+// ---------------------------------------------------------------------------
+
+function condKey(c: Condition): string {
+  const a = condArg(c);
+  return a ? `${condId(c)}:${a}` : condId(c);
+}
+
+export interface RouteDiff {
+  name: string;
+  status: "added" | "removed" | "changed" | "unchanged";
+  /** Human change lines, e.g. "when: + agreed to code-of-conduct". */
+  changes: string[];
+}
+
+/** Route-level diff of two IR revisions (prev → next), matched by name. */
+export function diffIR(prev: RuleIR, next: RuleIR): RouteDiff[] {
+  const prevByName = new Map(prev.routes.map((r) => [r.name, r]));
+  const nextByName = new Map(next.routes.map((r) => [r.name, r]));
+  const order: string[] = [];
+  for (const r of next.routes) order.push(r.name);
+  for (const r of prev.routes) if (!nextByName.has(r.name)) order.push(r.name);
+
+  const seen = new Set<string>();
+  const diffs: RouteDiff[] = [];
+  for (const name of order) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const a = prevByName.get(name);
+    const b = nextByName.get(name);
+    if (a && !b) {
+      diffs.push({ name, status: "removed", changes: [] });
+      continue;
+    }
+    if (!a && b) {
+      diffs.push({ name, status: "added", changes: [] });
+      continue;
+    }
+    if (!a || !b) continue;
+    const changes: string[] = [];
+    const ak = new Set(a.when.all.map(condKey));
+    const bk = new Set(b.when.all.map(condKey));
+    for (const c of b.when.all)
+      if (!ak.has(condKey(c)))
+        changes.push(`when: + ${conditionToEnglish(c, next.purpose)}`);
+    for (const c of a.when.all)
+      if (!bk.has(condKey(c)))
+        changes.push(`when: − ${conditionToEnglish(c, prev.purpose)}`);
+    if (JSON.stringify(a.then) !== JSON.stringify(b.then))
+      changes.push(
+        `then: ${effectToEnglish(a.then)} → ${effectToEnglish(b.then)}`,
+      );
+    diffs.push({
+      name,
+      status: changes.length ? "changed" : "unchanged",
+      changes,
+    });
+  }
+  return diffs;
+}
+
 /** Render an IR as ordered plain-English lines (first-match framing). */
 export function irToEnglish(ir: RuleIR): EnglishLine[] {
   return ir.routes.map((route, i) => {

--- a/vtc-service/admin-ui/src/lib/rule-ir.ts
+++ b/vtc-service/admin-ui/src/lib/rule-ir.ts
@@ -303,3 +303,85 @@ export function blankIR(purpose: string): RuleIR {
     routes: [{ name: "Catch-all", when: { all: ["always"] }, then: fallback }],
   };
 }
+
+// ---------------------------------------------------------------------------
+// Plain-English rendering — turn an IR into a readable summary so an
+// operator who doesn't read Rego can confirm what the policy does.
+// ---------------------------------------------------------------------------
+
+export function condId(c: Condition): string {
+  return typeof c === "string" ? c : (Object.keys(c)[0] ?? "");
+}
+export function condArg(c: Condition): string | undefined {
+  return typeof c === "string" ? undefined : Object.values(c)[0];
+}
+function isCatchAll(when: { all: Condition[] }): boolean {
+  return (
+    when.all.length === 0 ||
+    (when.all.length === 1 && condId(when.all[0] as Condition) === "always")
+  );
+}
+
+/** A human phrase for a single condition, e.g. "holds a trusted
+ * credential WitnessCredential". */
+export function conditionToEnglish(cond: Condition, purpose: string): string {
+  const defs = conditionsFor(purpose);
+  const id = condId(cond);
+  const arg = condArg(cond);
+  const label = defs.find((x) => x.id === id)?.label ?? id;
+  return arg ? `${label} ${arg}` : label;
+}
+
+/** A human phrase for an effect, e.g. "admit as member" / "refer to the
+ * moderator queue". */
+export function effectToEnglish(effect: Effect): string {
+  const w = effect.with ?? {};
+  switch (effect.effect) {
+    case "allow":
+      if (typeof w.role === "string") return `admit — set role to ${w.role}`;
+      if (typeof w.disposition === "string")
+        return `allow — remove (${w.disposition})`;
+      if (Array.isArray(w.fields))
+        return `allow — share ${(w.fields as unknown[]).join(", ")}`;
+      return "allow";
+    case "deny":
+      return typeof w.code === "string" ? `deny (${w.code})` : "deny";
+    case "refer":
+      return typeof w.queue === "string"
+        ? `refer to the ${w.queue} queue`
+        : "refer for review";
+    case "request_more":
+      return Array.isArray(w.needs) && (w.needs as unknown[]).length
+        ? `ask for ${(w.needs as unknown[]).join(", ")}`
+        : "ask for more evidence";
+  }
+}
+
+export interface EnglishLine {
+  name: string;
+  effect: Effect["effect"];
+  /** A full sentence describing the route. */
+  text: string;
+  isCatchAll: boolean;
+}
+
+/** Render an IR as ordered plain-English lines (first-match framing). */
+export function irToEnglish(ir: RuleIR): EnglishLine[] {
+  return ir.routes.map((route, i) => {
+    const catchAll = isCatchAll(route.when);
+    const lead = i === 0 ? "If" : "else if";
+    const when = route.when.all
+      .map((c) => conditionToEnglish(c, ir.purpose))
+      .join(" and ");
+    const then = effectToEnglish(route.then);
+    const text = catchAll
+      ? `Otherwise, ${then}.`
+      : `${lead} ${when}, then ${then}.`;
+    return {
+      name: route.name,
+      effect: route.then.effect,
+      text,
+      isCatchAll: catchAll,
+    };
+  });
+}

--- a/vtc-service/admin-ui/src/plugins/RuleEditor.tsx
+++ b/vtc-service/admin-ui/src/plugins/RuleEditor.tsx
@@ -13,6 +13,7 @@ import {
   compileToRego,
   conditionsFor,
   effectsFor,
+  irToEnglish,
 } from "@/lib/rule-ir";
 
 function condId(c: Condition): string {
@@ -38,9 +39,11 @@ export function RuleEditor({
   saving: boolean;
 }) {
   const [ir, setIr] = useState<RuleIR>(initial);
+  const [view, setView] = useState<"english" | "rego">("english");
   const vocab = useMemo(() => conditionsFor(purpose), [purpose]);
   const effects = useMemo(() => effectsFor(purpose), [purpose]);
   const rego = useMemo(() => compileToRego(ir, pkg), [ir, pkg]);
+  const english = useMemo(() => irToEnglish(ir), [ir]);
 
   const setRoutes = (routes: Route[]) => setIr({ ...ir, routes });
   const patchRoute = (i: number, patch: Partial<Route>) =>
@@ -97,12 +100,33 @@ export function RuleEditor({
       </div>
 
       <div className="rule-preview">
-        <div className="cer-panel-title">
-          Compiled Rego <span className="ln" />
+        <div className="rule-view-tabs" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === "english"}
+            className={view === "english" ? "on" : ""}
+            onClick={() => setView("english")}
+          >
+            Plain English
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === "rego"}
+            className={view === "rego" ? "on" : ""}
+            onClick={() => setView("rego")}
+          >
+            Compiled Rego
+          </button>
         </div>
-        <pre className="cer-policy" style={{ maxHeight: 360 }}>
-          {rego}
-        </pre>
+        {view === "english" ? (
+          <EnglishView lines={english} />
+        ) : (
+          <pre className="cer-policy" style={{ maxHeight: 360 }}>
+            {rego}
+          </pre>
+        )}
         <div className="rule-actions">
           <button
             type="button"
@@ -123,6 +147,26 @@ export function RuleEditor({
         </div>
       </div>
     </div>
+  );
+}
+
+// A readable summary of a policy's routes — one line per route, the
+// effect colour-coded, first-match framing. Shared by the editor
+// preview and the read-only active-policy view.
+export function EnglishView({
+  lines,
+}: {
+  lines: ReturnType<typeof irToEnglish>;
+}) {
+  return (
+    <ul className="rule-english">
+      {lines.map((l, i) => (
+        <li key={i} className={`eng-line eff-${l.effect}`}>
+          <span className="eng-name">{l.name}</span>
+          <span className="eng-text">{l.text}</span>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -88,6 +88,61 @@ function pluckDecision(resp: TestResponse): Verdict | null {
 }
 
 // ---------------------------------------------------------------------------
+// request_more loop — a verdict can ask for more evidence (`with.needs`).
+// The simulator models the negotiation: satisfy a need and re-run, the
+// way an applicant would supply it and re-present.
+// ---------------------------------------------------------------------------
+
+/** The `needs` array from a request_more verdict, as strings. */
+function verdictNeeds(verdict: Verdict | null): string[] {
+  const needs = verdict?.with?.needs;
+  return Array.isArray(needs) ? needs.map(String) : [];
+}
+
+/** A need the simulator knows how to satisfy by patching the facts. */
+function isSatisfiable(need: string): boolean {
+  const kind = need.split(":")[0];
+  return ["agreed", "cred", "credential", "trusted"].includes(kind ?? "");
+}
+
+type Facts = Record<string, unknown>;
+
+/** Apply a satisfied need to the facts — e.g. `agreed:code-of-conduct`
+ * sets the agreement flag; `trusted:WitnessCredential` adds a trusted
+ * credential to the presentation. */
+function satisfyNeed(facts: Facts, need: string): Facts {
+  const f = structuredClone(facts) as Facts;
+  const [kind, ...rest] = need.split(":");
+  const arg = rest.join(":");
+  const evidence = (f.evidence ??= {}) as Record<string, unknown>;
+  if (kind === "agreed") {
+    const request = (evidence.request ??= {}) as Record<string, unknown>;
+    request.agreements = {
+      ...((request.agreements as Record<string, unknown>) ?? {}),
+      [arg]: true,
+    };
+  } else if (kind === "cred" || kind === "credential" || kind === "trusted") {
+    const subject = f.subject as { did?: string } | undefined;
+    const presentation = (evidence.presentation ??= {
+      verified: true,
+      holder: subject?.did,
+      credentials: [],
+    }) as Record<string, unknown>;
+    presentation.credentials = [
+      ...((presentation.credentials as unknown[]) ?? []),
+      {
+        type: arg,
+        issuer: "did:example:satisfied",
+        issuer_trusted: true,
+        status: "valid",
+        claims: {},
+      },
+    ];
+  }
+  return f;
+}
+
+// ---------------------------------------------------------------------------
 // Components
 // ---------------------------------------------------------------------------
 
@@ -154,6 +209,8 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [authoring, setAuthoring] = useState(false);
+  // Needs the operator has chosen to satisfy for the request_more loop.
+  const [satisfied, setSatisfied] = useState<string[]>([]);
 
   const policyQuery = useQuery({
     queryKey: ["active-policy", ceremony.purpose],
@@ -168,7 +225,18 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
     setError(null);
     setPhase(-1);
     setAuthoring(false);
+    setSatisfied([]);
   }, [ceremony]);
+
+  // Editing the base evidence invalidates any satisfied needs.
+  const onFieldsChange = (v: FieldValues) => {
+    setForm(v);
+    setSatisfied([]);
+  };
+  const toggleNeed = (need: string) =>
+    setSatisfied((s) =>
+      s.includes(need) ? s.filter((n) => n !== need) : [...s, need],
+    );
 
   const canSimulate = ceremony.wired === "live";
 
@@ -185,7 +253,8 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
     }
 
     try {
-      const facts = ceremony.buildFacts(form);
+      let facts = ceremony.buildFacts(form);
+      for (const need of satisfied) facts = satisfyNeed(facts, need);
       const resp = await postJson<TestResponse>(
         `/v1/policies/${policy.id}/test`,
         { query: `data.${ceremony.pkg}.decision`, input: facts },
@@ -289,7 +358,7 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
               <SimFields
                 fields={ceremony.fields}
                 values={form}
-                onChange={setForm}
+                onChange={onFieldsChange}
               />
 
               <button
@@ -311,16 +380,27 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
               )}
 
               {verdict && !error && (
-                <div className="cer-verdict">
-                  <span className={`cer-vbadge ${verdict.effect}`}>
-                    {verdict.effect}
-                  </span>
-                  <div className="cer-vwith">
-                    {verdict.with
-                      ? JSON.stringify(verdict.with, null, 2)
-                      : "{}"}
+                <>
+                  <div className="cer-verdict">
+                    <span className={`cer-vbadge ${verdict.effect}`}>
+                      {verdict.effect}
+                    </span>
+                    <div className="cer-vwith">
+                      {verdict.with
+                        ? JSON.stringify(verdict.with, null, 2)
+                        : "{}"}
+                    </div>
                   </div>
-                </div>
+                  {verdict.effect === "request_more" && (
+                    <NeedsLoop
+                      needs={verdictNeeds(verdict)}
+                      satisfied={satisfied}
+                      onToggle={toggleNeed}
+                      onRerun={run}
+                      running={running}
+                    />
+                  )}
+                </>
               )}
             </>
           )}
@@ -819,6 +899,60 @@ function SimFields({
           </div>
         ))}
     </>
+  );
+}
+
+// The request_more negotiation, in miniature: the verdict listed what
+// it needs; the operator satisfies the ones the simulator understands
+// and re-runs, modelling the applicant supplying the evidence.
+function NeedsLoop({
+  needs,
+  satisfied,
+  onToggle,
+  onRerun,
+  running,
+}: {
+  needs: string[];
+  satisfied: string[];
+  onToggle: (need: string) => void;
+  onRerun: () => void;
+  running: boolean;
+}) {
+  const anySelected = needs.some(
+    (n) => isSatisfiable(n) && satisfied.includes(n),
+  );
+  return (
+    <div className="cer-needs">
+      <div className="cer-needs-title">Satisfy to continue</div>
+      {needs.map((n) => {
+        const ok = isSatisfiable(n);
+        return (
+          <label
+            key={n}
+            className={`cer-need${ok ? "" : " unsupported"}`}
+            title={ok ? undefined : "The simulator can't auto-satisfy this need"}
+          >
+            <input
+              type="checkbox"
+              disabled={!ok}
+              checked={ok && satisfied.includes(n)}
+              onChange={() => onToggle(n)}
+            />
+            <code>{n}</code>
+            {!ok && <span className="cer-need-note">manual</span>}
+          </label>
+        );
+      })}
+      <button
+        type="button"
+        className="cer-run"
+        style={{ marginTop: "var(--space-2)" }}
+        onClick={onRerun}
+        disabled={running || !anySelected}
+      >
+        {running ? "Evaluating…" : "Re-run with satisfied evidence ▸"}
+      </button>
+    </div>
   );
 }
 

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -29,7 +29,15 @@ import {
   fetchPolicies,
   uploadPolicy,
 } from "@/lib/policies-api";
-import { blankIR, diffIR, irToEnglish, parseRego } from "@/lib/rule-ir";
+import {
+  type ExplainFacts,
+  type RuleIR,
+  blankIR,
+  diffIR,
+  explainDecision,
+  irToEnglish,
+  parseRego,
+} from "@/lib/rule-ir";
 import { EnglishView, RuleEditor } from "@/plugins/RuleEditor";
 import {
   type CeremonyKey,
@@ -211,6 +219,8 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
   const [authoring, setAuthoring] = useState(false);
   // Needs the operator has chosen to satisfy for the request_more loop.
   const [satisfied, setSatisfied] = useState<string[]>([]);
+  // The facts that produced the current verdict — fed to the trace.
+  const [lastFacts, setLastFacts] = useState<ExplainFacts | null>(null);
 
   const policyQuery = useQuery({
     queryKey: ["active-policy", ceremony.purpose],
@@ -226,7 +236,14 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
     setPhase(-1);
     setAuthoring(false);
     setSatisfied([]);
+    setLastFacts(null);
   }, [ceremony]);
+
+  // The active policy's IR, when it was authored visually — enables the
+  // local decision trace.
+  const activeIR = policyQuery.data
+    ? parseRego(policyQuery.data.regoSource)
+    : null;
 
   // Editing the base evidence invalidates any satisfied needs.
   const onFieldsChange = (v: FieldValues) => {
@@ -255,6 +272,7 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
     try {
       let facts = ceremony.buildFacts(form);
       for (const need of satisfied) facts = satisfyNeed(facts, need);
+      setLastFacts(facts as ExplainFacts);
       const resp = await postJson<TestResponse>(
         `/v1/policies/${policy.id}/test`,
         { query: `data.${ceremony.pkg}.decision`, input: facts },
@@ -398,6 +416,13 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
                       onToggle={toggleNeed}
                       onRerun={run}
                       running={running}
+                    />
+                  )}
+                  {activeIR && lastFacts && (
+                    <DecisionTrace
+                      ir={activeIR}
+                      facts={lastFacts}
+                      verdictEffect={verdict.effect}
                     />
                   )}
                 </>
@@ -952,6 +977,60 @@ function NeedsLoop({
       >
         {running ? "Evaluating…" : "Re-run with satisfied evidence ▸"}
       </button>
+    </div>
+  );
+}
+
+// "Why this verdict" — the local first-match trace over the active
+// policy's routes: which conditions held, which route fired. Derived
+// from the IR, so it explains visually-authored policies; a note flags
+// the rare case where the live Rego was hand-edited away from its IR.
+function DecisionTrace({
+  ir,
+  facts,
+  verdictEffect,
+}: {
+  ir: RuleIR;
+  facts: ExplainFacts;
+  verdictEffect: Effect;
+}) {
+  const trace = explainDecision(ir, facts);
+  const drift = trace.fired ? trace.fired.effect !== verdictEffect : true;
+  return (
+    <div className="cer-trace">
+      <div className="cer-trace-title">Why this verdict</div>
+      {trace.routes.map((r, i) => (
+        <div
+          key={i}
+          className={`trace-route eff-${r.effect}${r.fired ? " fired" : ""}${
+            !r.reached ? " skipped" : ""
+          }`}
+        >
+          <div className="trace-head">
+            <span className="trace-mark" aria-hidden>
+              {r.fired ? "▶" : r.reached ? "·" : "⌀"}
+            </span>
+            <span className="trace-name">{r.name}</span>
+            {r.fired && <span className="trace-fired">fired</span>}
+            {!r.reached && <span className="trace-note">not reached</span>}
+          </div>
+          {r.reached && !r.isCatchAll && (
+            <ul className="trace-conds">
+              {r.conditions.map((c, j) => (
+                <li key={j} className={c.passed ? "pass" : "fail"}>
+                  <span aria-hidden>{c.passed ? "✓" : "✗"}</span> {c.label}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+      {drift && (
+        <p className="cer-trace-drift">
+          The live verdict differs from this trace — the active policy may
+          have been hand-edited away from its visual form.
+        </p>
+      )}
     </div>
   );
 }

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -28,8 +28,8 @@ import {
   fetchPolicies,
   uploadPolicy,
 } from "@/lib/policies-api";
-import { blankIR, parseRego } from "@/lib/rule-ir";
-import { RuleEditor } from "@/plugins/RuleEditor";
+import { blankIR, irToEnglish, parseRego } from "@/lib/rule-ir";
+import { EnglishView, RuleEditor } from "@/plugins/RuleEditor";
 import {
   type CeremonyKey,
   type CeremonyManifest,
@@ -355,6 +355,46 @@ function pkgFor(purpose: Purpose): string {
   return `vtc.${purpose === "roleChange" ? "role_change" : purpose}`;
 }
 
+// Active policy source — a plain-English summary when it was authored
+// visually (carries the IR header), with a toggle to the raw Rego. A
+// hand-written policy shows only the Rego.
+function ActivePolicyView({ source }: { source: string }) {
+  const ir = parseRego(source);
+  const [view, setView] = useState<"english" | "rego">(
+    ir ? "english" : "rego",
+  );
+  if (!ir) return <pre className="cer-policy">{source}</pre>;
+  return (
+    <>
+      <div className="rule-view-tabs" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "english"}
+          className={view === "english" ? "on" : ""}
+          onClick={() => setView("english")}
+        >
+          Plain English
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "rego"}
+          className={view === "rego" ? "on" : ""}
+          onClick={() => setView("rego")}
+        >
+          Rego
+        </button>
+      </div>
+      {view === "english" ? (
+        <EnglishView lines={irToEnglish(ir)} />
+      ) : (
+        <pre className="cer-policy">{source}</pre>
+      )}
+    </>
+  );
+}
+
 function PolicyManager({
   purpose,
   onEditingChange,
@@ -434,7 +474,7 @@ function PolicyManager({
               sha <b>{active.sha256.slice(0, 12)}…</b>
             </span>
           </div>
-          <pre className="cer-policy">{active.regoSource}</pre>
+          <ActivePolicyView source={active.regoSource} />
         </>
       )}
       {!query.isLoading && !active && (

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -20,6 +20,7 @@ import { postJson } from "@/lib/api";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { formatIso } from "@/lib/format";
 import {
+  type PolicyRow,
   type Purpose,
   CEREMONY_PURPOSES,
   OTHER_PURPOSES,
@@ -28,7 +29,7 @@ import {
   fetchPolicies,
   uploadPolicy,
 } from "@/lib/policies-api";
-import { blankIR, irToEnglish, parseRego } from "@/lib/rule-ir";
+import { blankIR, diffIR, irToEnglish, parseRego } from "@/lib/rule-ir";
 import { EnglishView, RuleEditor } from "@/plugins/RuleEditor";
 import {
   type CeremonyKey,
@@ -433,6 +434,23 @@ function PolicyManager({
     },
   });
 
+  // Fail-forward rollback: never rewind the chain — copy the chosen
+  // revision's source into a NEW revision and activate that. History
+  // only ever grows; the active pointer always moves forward.
+  const rollback = useMutation({
+    mutationFn: async (row: PolicyRow) => {
+      const created = await uploadPolicy({
+        purpose,
+        regoSource: row.regoSource,
+      });
+      await activatePolicy(created.id);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["policies", purpose] });
+      void qc.invalidateQueries({ queryKey: ["active-policy", purpose] });
+    },
+  });
+
   const items = query.data?.items ?? [];
   const active = items.find((p) => p.isActive) ?? null;
   const canAuthor = CEREMONY_PURPOSES.includes(purpose);
@@ -492,34 +510,29 @@ function PolicyManager({
           </div>
           <div className="cer-versions">
             {items.map((p) => (
-              <div
+              <VersionRow
                 key={p.id}
-                className={`cer-ver${p.isActive ? " active" : ""}`}
-              >
-                <span className="cer-ver-v">v{p.version}</span>
-                <span className="cer-ver-meta">{formatIso(p.createdAt)}</span>
-                {p.isActive ? (
-                  <span className="cer-chip" style={{ color: "var(--vd-allow)" }}>
-                    active
-                  </span>
-                ) : (
-                  <button
-                    type="button"
-                    className="cer-ver-activate"
-                    disabled={activate.isPending}
-                    onClick={async () => {
-                      const ok = await confirm({
-                        title: `Activate ${purpose} v${p.version}?`,
-                        message: `The current active policy for "${purpose}" becomes archived.`,
-                        confirmLabel: "Activate",
-                      });
-                      if (ok) activate.mutate(p.id);
-                    }}
-                  >
-                    Activate
-                  </button>
-                )}
-              </div>
+                row={p}
+                active={active}
+                purpose={purpose}
+                busy={activate.isPending || rollback.isPending}
+                onActivate={async () => {
+                  const ok = await confirm({
+                    title: `Activate ${purpose} v${p.version}?`,
+                    message: `The current active policy for "${purpose}" becomes archived.`,
+                    confirmLabel: "Activate",
+                  });
+                  if (ok) activate.mutate(p.id);
+                }}
+                onRollback={async () => {
+                  const ok = await confirm({
+                    title: `Roll back ${purpose} to v${p.version}?`,
+                    message: `Fail-forward: v${p.version}'s content is copied into a new revision and activated. The chain isn't rewound.`,
+                    confirmLabel: "Roll back",
+                  });
+                  if (ok) rollback.mutate(p);
+                }}
+              />
             ))}
           </div>
         </>
@@ -562,6 +575,122 @@ function PolicyManager({
         />
       )}
     </>
+  );
+}
+
+// One row in the version history. A non-active row can be compared to
+// the live policy (route-level diff) and either activated (a newer
+// draft) or rolled back to (an older revision, fail-forward).
+function VersionRow({
+  row,
+  active,
+  purpose,
+  busy,
+  onActivate,
+  onRollback,
+}: {
+  row: PolicyRow;
+  active: PolicyRow | null;
+  purpose: Purpose;
+  busy: boolean;
+  onActivate: () => void;
+  onRollback: () => void;
+}) {
+  const [comparing, setComparing] = useState(false);
+  const isOlder = active ? row.version < active.version : false;
+
+  return (
+    <div className={`cer-ver${row.isActive ? " active" : ""}`}>
+      <div className="cer-ver-head">
+        <span className="cer-ver-v">v{row.version}</span>
+        <span className="cer-ver-meta">{formatIso(row.createdAt)}</span>
+        {row.isActive ? (
+          <span className="cer-chip" style={{ color: "var(--vd-allow)" }}>
+            active
+          </span>
+        ) : (
+          <>
+            {active && !row.isActive && (
+              <button
+                type="button"
+                className="cer-ver-compare"
+                aria-expanded={comparing}
+                onClick={() => setComparing((v) => !v)}
+              >
+                {comparing ? "Hide diff" : "Compare ▾"}
+              </button>
+            )}
+            <button
+              type="button"
+              className="cer-ver-activate"
+              disabled={busy}
+              onClick={isOlder ? onRollback : onActivate}
+            >
+              {isOlder ? "Roll back" : "Activate"}
+            </button>
+          </>
+        )}
+      </div>
+      {comparing && active && (
+        <VersionDiff purpose={purpose} from={active} to={row} />
+      )}
+    </div>
+  );
+}
+
+// The route-level diff between the live policy and another revision —
+// "what changes if this becomes active". Falls back to a note when
+// either side wasn't authored visually (no IR to compare).
+function VersionDiff({
+  purpose,
+  from,
+  to,
+}: {
+  purpose: Purpose;
+  from: PolicyRow;
+  to: PolicyRow;
+}) {
+  const fromIr = parseRego(from.regoSource);
+  const toIr = parseRego(to.regoSource);
+  if (!fromIr || !toIr) {
+    return (
+      <p className="cer-sub" style={{ fontSize: "var(--text-xs)" }}>
+        A structured diff needs both revisions authored visually — one here
+        is hand-written Rego.
+      </p>
+    );
+  }
+  const diffs = diffIR(fromIr, toIr);
+  const changed = diffs.filter((d) => d.status !== "unchanged");
+  return (
+    <div className="cer-diff">
+      <div className="cer-diff-head">
+        v{from.version} <span aria-hidden>→</span> v{to.version}
+      </div>
+      {changed.length === 0 ? (
+        <p className="cer-sub" style={{ fontSize: "var(--text-xs)" }}>
+          No route-level changes — the decision is identical.
+        </p>
+      ) : (
+        changed.map((d) => (
+          <div key={`${purpose}-${d.name}`} className={`diff-route ${d.status}`}>
+            <span className="diff-mark" aria-hidden>
+              {d.status === "added" ? "+" : d.status === "removed" ? "−" : "~"}
+            </span>
+            <div className="diff-body">
+              <span className="diff-name">{d.name}</span>
+              {d.status === "added" && <em> route added</em>}
+              {d.status === "removed" && <em> route removed</em>}
+              {d.changes.map((c, i) => (
+                <span key={i} className="diff-change">
+                  {c}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
   );
 }
 

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -1909,6 +1909,48 @@ dd .copy-icon-btn {
   background: var(--bg-elev);
   animation: cer-pop 0.35s cubic-bezier(0.16, 1, 0.3, 1);
 }
+
+/* request_more negotiation loop */
+.cer-needs {
+  margin-top: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--vd-more) 40%, var(--border));
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.cer-needs-title {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vd-more);
+}
+.cer-need {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.cer-need input {
+  accent-color: var(--vd-more);
+}
+.cer-need.unsupported {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.cer-need-note {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-faint);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-2);
+}
 @keyframes cer-pop {
   from {
     opacity: 0;

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -1989,12 +1989,17 @@ dd .copy-icon-btn {
 }
 .cer-ver {
   display: flex;
-  align-items: center;
-  gap: var(--space-3);
+  flex-direction: column;
+  gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elev);
+}
+.cer-ver-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
 }
 .cer-ver.active {
   border-color: color-mix(in srgb, var(--vd-allow) 50%, var(--border));
@@ -2028,6 +2033,71 @@ dd .copy-icon-btn {
 .cer-ver-activate:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+.cer-ver-compare {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-2);
+  border: 0;
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+}
+.cer-ver-compare:hover {
+  color: var(--text);
+}
+
+/* Route-level version diff */
+.cer-diff {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+}
+.cer-diff-head {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.diff-route {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-start;
+}
+.diff-mark {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  width: 1ch;
+  flex: none;
+}
+.diff-route.added .diff-mark {
+  color: var(--vd-allow);
+}
+.diff-route.removed .diff-mark {
+  color: var(--vd-deny);
+}
+.diff-route.changed .diff-mark {
+  color: var(--vd-refer);
+}
+.diff-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+.diff-name {
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+.diff-change {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
 }
 .cer-rego-input {
   width: 100%;

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -1951,6 +1951,100 @@ dd .copy-icon-btn {
   border-radius: var(--radius-sm);
   padding: 0 var(--space-2);
 }
+
+/* Decision trace — which route fired and why */
+.cer-trace {
+  margin-top: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.cer-trace-title {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.trace-route {
+  position: relative;
+  padding: var(--space-2) var(--space-2) var(--space-2) var(--space-3);
+  border-left: 2px solid var(--border);
+}
+.trace-route.skipped {
+  opacity: 0.45;
+}
+.trace-route.fired.eff-allow {
+  border-left-color: var(--vd-allow);
+}
+.trace-route.fired.eff-deny {
+  border-left-color: var(--vd-deny);
+}
+.trace-route.fired.eff-refer {
+  border-left-color: var(--vd-refer);
+}
+.trace-route.fired.eff-request_more {
+  border-left-color: var(--vd-more);
+}
+.trace-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.trace-mark {
+  font-family: var(--font-mono);
+  color: var(--text-faint);
+  width: 1ch;
+}
+.trace-route.fired .trace-mark {
+  color: var(--text);
+}
+.trace-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text);
+}
+.trace-fired,
+.trace-note {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+}
+.trace-fired {
+  color: var(--bg);
+  background: var(--brand);
+}
+.trace-note {
+  color: var(--text-faint);
+  border: 1px solid var(--border);
+}
+.trace-conds {
+  list-style: none;
+  margin: var(--space-1) 0 0;
+  padding: 0 0 0 calc(1ch + var(--space-2));
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-size: var(--text-xs);
+}
+.trace-conds .pass {
+  color: var(--vd-allow);
+}
+.trace-conds .fail {
+  color: var(--text-faint);
+}
+.cer-trace-drift {
+  font-size: var(--text-xs);
+  color: var(--vd-refer);
+  margin: 0;
+}
 @keyframes cer-pop {
   from {
     opacity: 0;

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -2223,6 +2223,87 @@ dd .copy-icon-btn {
   display: flex;
   flex-direction: column;
 }
+
+/* English | Rego view toggle (editor preview + active-policy view) */
+.rule-view-tabs {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-3);
+  width: max-content;
+}
+.rule-view-tabs button {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: var(--space-1) var(--space-3);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+}
+.rule-view-tabs button.on {
+  background: var(--brand-tint-strong);
+  color: var(--text);
+}
+
+/* Plain-English route summary */
+.rule-english {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.eng-line {
+  position: relative;
+  padding: var(--space-2) var(--space-3) var(--space-2) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elev);
+  overflow: hidden;
+}
+.eng-line::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+}
+.eng-line.eff-allow::before {
+  background: var(--vd-allow);
+}
+.eng-line.eff-deny::before {
+  background: var(--vd-deny);
+}
+.eng-line.eff-refer::before {
+  background: var(--vd-refer);
+}
+.eng-line.eff-request_more::before {
+  background: var(--vd-more);
+}
+.eng-name {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin-bottom: 2px;
+}
+.eng-text {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
 .rule-actions {
   display: flex;
   gap: var(--space-2);


### PR DESCRIPTION
## What

The four ceremony-UX legibility & lifecycle pieces, in one PR (four reviewable commits). They turn the Ceremonies surface from "author + dry-run" into "author + understand + negotiate + manage".

All frontend-only; no daemon changes. Each builds on the Rule IR, so they apply to visually-authored policies (hand-written Rego degrades gracefully with a note).

## The four

**1. Plain-English policy rendering** (`3556977`)
`irToEnglish(ir)` renders a policy as ordered first-match sentences ("If holds a trusted credential … then admit — set role to member." / "Otherwise, refer to the moderator queue."). The editor preview and the active-policy view both gain a **Plain English | Rego** toggle (English default).

**2. Version diff + fail-forward rollback** (`78f4180`)
`diffIR(prev, next)` produces a route-level diff (added / removed / changed, with readable lines like `when: + step-up verified`, `then: refer → admit`). Each non-active version gets **Compare ▾** (diff vs the live policy) and a purpose-aware action: a newer draft **Activates**; an older revision **Rolls back fail-forward** — its source is copied into a new revision and activated, so the chain only ever grows (matches the runtime-service-management rollback discipline).

**3. `request_more` negotiation loop** (`c3acad4`)
When a dry-run lands on `request_more`, its `with.needs` render as a **"Satisfy to continue"** checklist. Toggling a need the simulator understands (`agreed:<tag>`, `trusted:<type>`) patches the verified-Facts and **Re-run** feeds them back through the same test path — so the loop walks `request_more → allow` without leaving the panel.

**4. Decision explanation — "why this verdict"** (`de8829b`)
Each condition gains a local `test` predicate mirroring its Rego `expr`; `explainDecision(ir, facts)` walks the routes first-match and reports per-condition ✓/✗, the route that **fired**, and which later routes were short-circuited (not reached). Rendered under the verdict, colour-coded by effect. If the live verdict disagrees with the local trace (Rego hand-edited away from its IR), a note flags the drift.

## Verification

- `npm run build` clean (tsc + vite) after every commit.
- Pure functions checked standalone (vite-node): `irToEnglish`, `diffIR` (symmetric add/remove/change), `explainDecision` (first-match short-circuit — a matched-but-not-reached route is correctly marked).
- Screenshot-verified each via a mocked-daemon harness reproducing the real shell: English summary, route-diff, the request_more satisfy-and-rerun loop, and the "why this verdict" trace. Harness removed before each commit.
