### PR TITLE
feat(vtc): ceremony registry on the daemon + defaults/refer/raw-facts follow-ups

### DIFF
--- a/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
+++ b/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
@@ -1,24 +1,32 @@
-// Ceremony manifest — the thin registry.
+// Ceremony manifest — the registry, now daemon-served.
 //
-// A ceremony is one instance of the decision pipeline (TRIGGER → GATHER
-// → VERIFY → FACTS → EVALUATE(<purpose>.rego) → VERDICT → EFFECTS). The
-// pipeline is generic; what differs per ceremony is *declarative*: its
-// metadata (purpose, package, nature), the simulator form fields, and
-// how those fields assemble into a verified-Facts document.
+// The daemon owns which ceremonies exist and how their decision
+// surface is shaped (`GET /v1/ceremonies`). Each manifest carries the
+// metadata, the simulator's input `fields` (a declarative UI schema),
+// and a `factsTemplate` — a JSON skeleton of the verified-Facts `input`
+// document with directives this module materializes from the field
+// values. The Ceremonies surface renders entirely from this; adding a
+// ceremony over an existing effect is a manifest entry on the daemon,
+// not frontend code.
 //
-// This module is that declaration. The Ceremonies surface renders every
-// ceremony from it — no per-ceremony components — so adding a ceremony
-// over an existing effect is a manifest entry, not new UI code.
-//
-// Deliberately thin: `buildFacts` stays a hand-written function per
-// ceremony (the one piece that isn't yet pure data). A later step can
-// derive it from a facts-schema served by the daemon. The *effects* a
-// ceremony triggers remain reviewed Rust — this registry only describes
-// the decision surface, never mutates state.
+// Template directives (resolved client-side, since the dry-run builds
+// the facts and POSTs them to /policies/{id}/test):
+//   "$now"            → current ISO timestamp
+//   "$field:<key>"    → the field value ("" / undefined ⇒ key omitted)
+//   {"$if": <key>, "then": …, "else": …} → branch on the field's truthiness
 
-export type CeremonyKey = "directory" | "join" | "leave" | "role-change";
+import { getJson } from "@/lib/api";
+
 export type Nature = "read-only" | "constructive" | "destructive" | "mutating";
 export type Wired = "live" | "legacy" | "unwired";
+
+/** Declarative `showWhen`: render the field only when `field`'s value
+ * equals `eq`, or its truthiness matches `truthy`. */
+export interface ShowWhenSpec {
+  field: string;
+  eq?: unknown;
+  truthy?: boolean;
+}
 
 /** A single simulator input. `select` shows a dropdown; `toggle` a switch. */
 export interface FieldDef {
@@ -26,29 +34,23 @@ export interface FieldDef {
   label: string;
   hint?: string;
   type: "select" | "toggle";
-  /** Options for a `select` field. */
   options?: { value: string; label: string }[];
   default: string | boolean;
-  /** Render this field only when the predicate holds (e.g. dependent fields). */
-  showWhen?: (v: FieldValues) => boolean;
+  showWhen?: ShowWhenSpec;
 }
 
 export type FieldValues = Record<string, string | boolean>;
 
 export interface CeremonyManifest {
-  key: CeremonyKey;
-  label: string;
-  nature: Nature;
-  /** API policy purpose key, or null when the ceremony has no policy. */
-  purpose: string | null;
-  /** Rego package whose `decision` rule the host evaluates. */
+  purpose: string;
   pkg: string;
+  nature: Nature;
+  label: string;
   wired: Wired;
   blurb: string;
-  /** Declarative simulator form. */
   fields: FieldDef[];
-  /** Assemble the verified-Facts document the policy decides over. */
-  buildFacts: (v: FieldValues) => Record<string, unknown>;
+  /** JSON skeleton of the verified-Facts `input`, with directives. */
+  factsTemplate: unknown;
 }
 
 export const natureColor: Record<Nature, string> = {
@@ -58,212 +60,73 @@ export const natureColor: Record<Nature, string> = {
   mutating: "var(--vd-refer)",
 };
 
+const TRUST_TASK_CEREMONIES =
+  "https://trusttasks.org/openvtc/vtc/ceremonies/list/1.0";
+
+export async function fetchCeremonies(): Promise<CeremonyManifest[]> {
+  return getJson<CeremonyManifest[]>("/v1/ceremonies", {
+    trustTask: TRUST_TASK_CEREMONIES,
+  });
+}
+
 /** The default value map for a ceremony's simulator form. */
 export function defaultValues(m: CeremonyManifest): FieldValues {
   return Object.fromEntries(m.fields.map((f) => [f.key, f.default]));
 }
 
-// Shared scaffolding every ceremony's Facts doc carries.
-function baseContext() {
-  return {
-    community_did: "did:webvh:demo.example",
-    channel: "rest",
-    member_count: 42,
-  };
+/** Evaluate a field's `showWhen` predicate against the current values. */
+export function evalShowWhen(
+  spec: ShowWhenSpec | undefined,
+  values: FieldValues,
+): boolean {
+  if (!spec) return true;
+  const v = values[spec.field];
+  if (spec.eq !== undefined) return v === spec.eq;
+  if (spec.truthy !== undefined) return Boolean(v) === spec.truthy;
+  return true;
 }
-function memberRow(role: string) {
-  return { role, status: "active", joined_at: "2026-01-02T00:00:00Z" };
-}
-const ROLE_OPTIONS = [
-  { value: "member", label: "member" },
-  { value: "moderator", label: "moderator" },
-  { value: "admin", label: "admin" },
-];
 
-export const CEREMONIES: CeremonyManifest[] = [
-  {
-    key: "directory",
-    label: "Directory",
-    nature: "read-only",
-    purpose: "directory",
-    pkg: "vtc.directory",
-    wired: "live",
-    blurb:
-      "A member views another member's record. Read-only — the verdict's allow carries a field projection, capped by the PII boundary.",
-    fields: [
-      {
-        key: "viewerRole",
-        label: "Viewer's community role",
-        hint: "actor.role — admin sees the fuller record",
-        type: "select",
-        options: [
-          { value: "admin", label: "admin" },
-          { value: "member", label: "member" },
-          { value: "", label: "none (authenticated)" },
-        ],
-        default: "member",
-      },
-      {
-        key: "subjectIsMember",
-        label: "Subject is a member",
-        hint: "state.subject_member present",
-        type: "toggle",
-        default: true,
-      },
-      {
-        key: "subjectRole",
-        label: "Subject's role",
-        hint: "state.subject_member.role",
-        type: "select",
-        options: ROLE_OPTIONS,
-        default: "member",
-        showWhen: (v) => v.subjectIsMember === true,
-      },
-    ],
-    buildFacts: (v) => ({
-      purpose: "directory",
-      now: new Date().toISOString(),
-      actor: {
-        did: "did:key:zViewer",
-        role: (v.viewerRole as string) || undefined,
-        authenticated: true,
-      },
-      subject: { did: "did:key:zTarget" },
-      context: baseContext(),
-      evidence: {
-        request: { fields_requested: ["did", "role", "joined_at", "status"] },
-      },
-      state: {
-        subject_member: v.subjectIsMember
-          ? memberRow(v.subjectRole as string)
-          : null,
-      },
-    }),
-  },
-  {
-    key: "join",
-    label: "Join",
-    nature: "constructive",
-    purpose: "join",
-    pkg: "vtc.join",
-    wired: "live",
-    blurb:
-      "A DID joins the community. A trusted presented credential auto-admits (allow → issue the membership credential); everything else is referred to the moderator queue for review.",
-    fields: [
-      {
-        key: "joinTrusted",
-        label: "Presented credential is trusted",
-        hint: "evidence.presentation.credentials[].issuer_trusted",
-        type: "toggle",
-        default: false,
-      },
-    ],
-    buildFacts: (v) => ({
-      purpose: "join",
-      now: new Date().toISOString(),
-      actor: { did: "did:key:zApplicant", authenticated: true },
-      subject: { did: "did:key:zApplicant" },
-      context: baseContext(),
-      evidence: {
-        presentation: {
-          verified: true,
-          holder: "did:key:zApplicant",
-          credentials: [
-            {
-              type: "WitnessCredential",
-              issuer: "did:webvh:notary.example",
-              issuer_trusted: v.joinTrusted === true,
-              status: "valid",
-              claims: {},
-            },
-          ],
-        },
-      },
-      state: { subject_member: null },
-    }),
-  },
-  {
-    key: "leave",
-    label: "Leave",
-    nature: "destructive",
-    purpose: "removal",
-    pkg: "vtc.removal",
-    wired: "live",
-    blurb:
-      "A member departs or is removed. Self-leave is unconditional; an admin may remove a non-admin. The no-last-admin invariant + revocation are host-enforced in the effect.",
-    fields: [
-      {
-        key: "selfLeave",
-        label: "Self-leave",
-        hint: "actor.did == subject.did — always allowed",
-        type: "toggle",
-        default: false,
-      },
-      {
-        key: "subjectRole",
-        label: "Subject's role",
-        hint: "an admin may remove a non-admin only",
-        type: "select",
-        options: ROLE_OPTIONS,
-        default: "member",
-        showWhen: (v) => v.selfLeave !== true,
-      },
-    ],
-    buildFacts: (v) => {
-      const actorDid = "did:key:zActor";
-      const subjectDid = v.selfLeave ? actorDid : "did:key:zTarget";
-      return {
-        purpose: "leave",
-        now: new Date().toISOString(),
-        actor: { did: actorDid, role: "admin", authenticated: true },
-        subject: { did: subjectDid },
-        context: baseContext(),
-        evidence: { request: { disposition: "tombstone" } },
-        state: { subject_member: memberRow(v.subjectRole as string) },
-      };
-    },
-  },
-  {
-    key: "role-change",
-    label: "Role change",
-    nature: "mutating",
-    purpose: "roleChange",
-    pkg: "vtc.role_change",
-    wired: "live",
-    blurb:
-      "A member's role changes in place (the DID + VMC are unchanged; the role VEC is re-minted). The one ceremony whose allow may grant admin — gated by a verified step-up; demotions are guarded by no-last-admin.",
-    fields: [
-      {
-        key: "targetRole",
-        label: "Target role",
-        hint: "evidence.request.target_role",
-        type: "select",
-        options: [
-          { value: "member", label: "member" },
-          { value: "moderator", label: "moderator" },
-          { value: "admin", label: "admin (promotion)" },
-        ],
-        default: "moderator",
-      },
-      {
-        key: "stepUp",
-        label: "Step-up verified",
-        hint: "admin needs step-up — else the verdict refers",
-        type: "toggle",
-        default: false,
-        showWhen: (v) => v.targetRole === "admin",
-      },
-    ],
-    buildFacts: (v) => ({
-      purpose: "role-change",
-      now: new Date().toISOString(),
-      actor: { did: "did:key:zAdmin", role: "admin", authenticated: true },
-      subject: { did: "did:key:zTarget" },
-      context: baseContext(),
-      evidence: {
-        request: { target_role: v.targetRole as string, step_up: v.stepUp === true },
-      },
-      state: { subject_member: memberRow("member") },
-    }),
-  },
-];
+// A key dropped from its parent object (an unset optional field).
+const OMIT = Symbol("omit");
+
+function materialize(node: unknown, values: FieldValues, now: string): unknown {
+  if (typeof node === "string") {
+    if (node === "$now") return now;
+    if (node.startsWith("$field:")) {
+      const v = values[node.slice("$field:".length)];
+      return v === undefined || v === "" ? OMIT : v;
+    }
+    return node;
+  }
+  if (Array.isArray(node)) {
+    return node
+      .map((n) => materialize(n, values, now))
+      .filter((x) => x !== OMIT);
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    if ("$if" in obj) {
+      const cond = Boolean(values[obj.$if as string]);
+      return materialize(cond ? obj.then : obj.else, values, now);
+    }
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(obj)) {
+      const r = materialize(val, values, now);
+      if (r !== OMIT) out[k] = r;
+    }
+    return out;
+  }
+  return node;
+}
+
+/** Build the verified-Facts document for a dry-run from a manifest's
+ * facts template + the operator's field values. */
+export function materializeFacts(
+  template: unknown,
+  values: FieldValues,
+): Record<string, unknown> {
+  return materialize(template, values, new Date().toISOString()) as Record<
+    string,
+    unknown
+  >;
+}

--- a/vtc-service/admin-ui/src/lib/rule-ir.ts
+++ b/vtc-service/admin-ui/src/lib/rule-ir.ts
@@ -83,6 +83,8 @@ const HELPERS: Record<string, string> = {
     'cred_held(t) if {\n\tsome c in input.evidence.presentation.credentials\n\tc.type == t\n\tc.status == "valid"\n}',
   cred_trusted:
     'cred_trusted(t) if {\n\tsome c in input.evidence.presentation.credentials\n\tc.type == t\n\tc.issuer_trusted\n\tc.status == "valid"\n}',
+  cred_any_trusted:
+    'cred_any_trusted if {\n\tsome c in input.evidence.presentation.credentials\n\tc.issuer_trusted\n\tc.status == "valid"\n}',
   has_valid_invitation:
     "has_valid_invitation if {\n\tinput.evidence.invitation.verified\n\tnot input.evidence.invitation.consumed\n}",
   agreed:
@@ -123,6 +125,16 @@ const JOIN: ConditionDef[] = [
       f.evidence?.invitation?.consumed !== true,
   },
   {
+    id: "holds_any_trusted",
+    label: "holds any trusted credential",
+    expr: () => "cred_any_trusted",
+    helper: "cred_any_trusted",
+    test: (f) =>
+      creds(f).some(
+        (c) => c.issuer_trusted === true && c.status === "valid",
+      ),
+  },
+  {
     id: "holds_trusted",
     label: "holds a trusted credential",
     arg: { label: "credential type", placeholder: "WitnessCredential" },
@@ -153,6 +165,12 @@ const JOIN: ConditionDef[] = [
 ];
 
 const LEAVE: ConditionDef[] = [
+  {
+    id: "subject_not_admin",
+    label: "subject is not an admin",
+    expr: () => 'input.state.subject_member.role != "admin"',
+    test: (f) => f.state?.subject_member?.role !== "admin",
+  },
   {
     id: "disposition_requested",
     label: "a disposition was requested",
@@ -387,6 +405,7 @@ export function effectToEnglish(effect: Effect): string {
   const w = effect.with ?? {};
   switch (effect.effect) {
     case "allow":
+      if (w.role === "$target") return "admit — set the requested role";
       if (typeof w.role === "string") return `admit — set role to ${w.role}`;
       if (typeof w.disposition === "string")
         return `allow — remove (${w.disposition})`;

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -15,8 +15,9 @@
 
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
 
-import { postJson } from "@/lib/api";
+import { getJson, postJson } from "@/lib/api";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { formatIso } from "@/lib/format";
 import {
@@ -51,6 +52,27 @@ import {
 } from "@/lib/ceremony-manifest";
 
 const TRUST_TASK_TEST = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
+const TRUST_TASK_JOIN_REQUESTS =
+  "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0";
+
+// Queues a refer verdict can route to that map to an actionable admin
+// surface. The moderator queue is the join-requests inbox.
+const QUEUE_LINKS: Record<string, { label: string; to: string }> = {
+  moderator: { label: "Join requests", to: "/join-requests" },
+};
+
+interface JoinRequestsPage {
+  items: unknown[];
+  total_estimate?: number;
+}
+
+async function fetchPendingCount(): Promise<number> {
+  const page = await getJson<JoinRequestsPage>(
+    "/v1/join-requests?status=pending&limit=50",
+    { trustTask: TRUST_TASK_JOIN_REQUESTS },
+  );
+  return page.total_estimate ?? page.items.length;
+}
 
 type Effect = "allow" | "deny" | "refer" | "request_more";
 
@@ -242,6 +264,10 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
   const [satisfied, setSatisfied] = useState<string[]>([]);
   // The facts that produced the current verdict — fed to the trace.
   const [lastFacts, setLastFacts] = useState<ExplainFacts | null>(null);
+  // Advanced: edit the verified-Facts JSON directly, overriding the
+  // field-driven template (for facts the declared toggles don't cover).
+  const [rawMode, setRawMode] = useState(false);
+  const [rawText, setRawText] = useState("");
 
   const policyQuery = useQuery({
     queryKey: ["active-policy", ceremony.purpose],
@@ -257,7 +283,11 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
     setAuthoring(false);
     setSatisfied([]);
     setLastFacts(null);
+    setRawMode(false);
   }, [ceremony]);
+
+  const seedRaw = () =>
+    JSON.stringify(materializeFacts(ceremony.factsTemplate, form), null, 2);
 
   // The active policy's IR, when it was authored visually — enables the
   // local decision trace.
@@ -280,9 +310,26 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
   async function run() {
     const policy = policyQuery.data;
     if (!policy) return;
+
+    // Build the facts up front so a raw-JSON parse error fails fast,
+    // before the animation starts.
+    let facts: Record<string, unknown>;
+    if (rawMode) {
+      try {
+        facts = JSON.parse(rawText) as Record<string, unknown>;
+      } catch {
+        setError("Raw facts are not valid JSON.");
+        return;
+      }
+    } else {
+      facts = materializeFacts(ceremony.factsTemplate, form);
+    }
+    for (const need of satisfied) facts = satisfyNeed(facts, need);
+
     setRunning(true);
     setVerdict(null);
     setError(null);
+    setLastFacts(facts as ExplainFacts);
 
     // Animate the token across the stages while the request is in flight.
     for (let i = 0; i < STAGES.length; i++) {
@@ -290,9 +337,6 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
     }
 
     try {
-      let facts = materializeFacts(ceremony.factsTemplate, form);
-      for (const need of satisfied) facts = satisfyNeed(facts, need);
-      setLastFacts(facts as ExplainFacts);
       const resp = await postJson<TestResponse>(
         `/v1/policies/${policy.id}/test`,
         { query: `data.${ceremony.pkg}.decision`, input: facts },
@@ -393,11 +437,32 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
             </p>
           ) : (
             <>
-              <SimFields
-                fields={ceremony.fields}
-                values={form}
-                onChange={onFieldsChange}
-              />
+              {rawMode ? (
+                <RawFactsEditor
+                  value={rawText}
+                  onChange={setRawText}
+                  onReset={() => setRawText(seedRaw())}
+                  onUseFields={() => setRawMode(false)}
+                />
+              ) : (
+                <>
+                  <SimFields
+                    fields={ceremony.fields}
+                    values={form}
+                    onChange={onFieldsChange}
+                  />
+                  <button
+                    type="button"
+                    className="cer-raw-toggle"
+                    onClick={() => {
+                      setRawText(seedRaw());
+                      setRawMode(true);
+                    }}
+                  >
+                    Advanced: edit raw facts ▸
+                  </button>
+                </>
+              )}
 
               <button
                 className="cer-run"
@@ -438,6 +503,10 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
                       running={running}
                     />
                   )}
+                  {verdict.effect === "refer" &&
+                    typeof verdict.with?.queue === "string" && (
+                      <ReferQueue queue={verdict.with.queue as string} />
+                    )}
                   {activeIR && lastFacts && (
                     <DecisionTrace
                       ir={activeIR}
@@ -943,6 +1012,32 @@ function SimFields({
   );
 }
 
+// A refer verdict routes to a queue. When that queue maps to an admin
+// surface (the moderator queue → the join-requests inbox), link to it
+// and show how many items are waiting — closing the loop from "this
+// would be referred" to "go act on it".
+function ReferQueue({ queue }: { queue: string }) {
+  const link = QUEUE_LINKS[queue];
+  const pending = useQuery({
+    queryKey: ["pending-count", queue],
+    queryFn: fetchPendingCount,
+    enabled: !!link,
+  });
+  return (
+    <div className="cer-refer">
+      <span className="cer-refer-q">
+        → routes to the <b>{queue}</b> queue
+      </span>
+      {link && (
+        <Link to={link.to} className="cer-refer-link">
+          {link.label}
+          {pending.data !== undefined ? ` · ${pending.data} pending` : ""} ▸
+        </Link>
+      )}
+    </div>
+  );
+}
+
 // The request_more negotiation, in miniature: the verdict listed what
 // it needs; the operator satisfies the ones the simulator understands
 // and re-runs, modelling the applicant supplying the evidence.
@@ -1047,6 +1142,57 @@ function DecisionTrace({
           have been hand-edited away from its visual form.
         </p>
       )}
+    </div>
+  );
+}
+
+// Advanced simulator input: the verified-Facts JSON, edited directly.
+// Overrides the field-driven template, for evidence the declared
+// toggles don't model (extra credentials, custom claims, edge shapes).
+function RawFactsEditor({
+  value,
+  onChange,
+  onReset,
+  onUseFields,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onReset: () => void;
+  onUseFields: () => void;
+}) {
+  let invalid = false;
+  try {
+    JSON.parse(value);
+  } catch {
+    invalid = true;
+  }
+  return (
+    <div className="cer-raw">
+      <p className="cer-sub" style={{ fontSize: "var(--text-xs)" }}>
+        This JSON is sent to the policy verbatim — the field toggles are
+        ignored. Seeded from the current fields.
+      </p>
+      <textarea
+        className="cer-rego-input"
+        rows={14}
+        spellCheck={false}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-invalid={invalid}
+      />
+      {invalid && (
+        <p className="cer-sub" style={{ color: "var(--vd-deny)" }}>
+          Not valid JSON.
+        </p>
+      )}
+      <div className="rule-actions">
+        <button type="button" className="rule-cancel" onClick={onReset}>
+          Reset to fields
+        </button>
+        <button type="button" className="rule-cancel" onClick={onUseFields}>
+          Use fields ▸
+        </button>
+      </div>
     </div>
   );
 }

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -40,12 +40,13 @@ import {
 } from "@/lib/rule-ir";
 import { EnglishView, RuleEditor } from "@/plugins/RuleEditor";
 import {
-  type CeremonyKey,
   type CeremonyManifest,
   type FieldDef,
   type FieldValues,
-  CEREMONIES,
   defaultValues,
+  evalShowWhen,
+  fetchCeremonies,
+  materializeFacts,
   natureColor,
 } from "@/lib/ceremony-manifest";
 
@@ -155,8 +156,17 @@ function satisfyNeed(facts: Facts, need: string): Facts {
 // ---------------------------------------------------------------------------
 
 export function Ceremonies() {
-  const [active, setActive] = useState<CeremonyKey | "other">("directory");
-  const ceremony = CEREMONIES.find((c) => c.key === active);
+  // The daemon is the source of truth for the ceremony registry.
+  const query = useQuery({ queryKey: ["ceremonies"], queryFn: fetchCeremonies });
+  const ceremonies = query.data ?? [];
+  const [active, setActive] = useState<string>("");
+
+  // Default to the first ceremony once the registry loads.
+  useEffect(() => {
+    if (!active && ceremonies[0]) setActive(ceremonies[0].purpose);
+  }, [ceremonies, active]);
+
+  const ceremony = ceremonies.find((c) => c.purpose === active) ?? null;
 
   return (
     <div style={{ maxWidth: 1180 }}>
@@ -171,14 +181,21 @@ export function Ceremonies() {
         live verdict the daemon would reach.
       </p>
 
+      {query.isLoading && <p className="cer-sub">Loading the registry…</p>}
+      {query.error && (
+        <p className="cer-sub" style={{ color: "var(--vd-deny)" }}>
+          {(query.error as Error).message}
+        </p>
+      )}
+
       <div className="cer-tabs" role="tablist">
-        {CEREMONIES.map((c) => (
+        {ceremonies.map((c) => (
           <button
-            key={c.key}
+            key={c.purpose}
             role="tab"
-            aria-selected={c.key === active}
-            className={`cer-tab${c.key === active ? " on" : ""}`}
-            onClick={() => setActive(c.key)}
+            aria-selected={c.purpose === active}
+            className={`cer-tab${c.purpose === active ? " on" : ""}`}
+            onClick={() => setActive(c.purpose)}
           >
             <span
               className="nature"
@@ -205,7 +222,11 @@ export function Ceremonies() {
         </button>
       </div>
 
-      {ceremony ? <CeremonyPanel ceremony={ceremony} /> : <OtherPolicies />}
+      {active === "other" ? (
+        <OtherPolicies />
+      ) : ceremony ? (
+        <CeremonyPanel key={ceremony.purpose} ceremony={ceremony} />
+      ) : null}
     </div>
   );
 }
@@ -225,7 +246,6 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
   const policyQuery = useQuery({
     queryKey: ["active-policy", ceremony.purpose],
     queryFn: () => fetchActivePolicy(ceremony.purpose as Purpose),
-    enabled: ceremony.purpose !== null,
   });
 
   // Reset the form + verdict whenever the ceremony changes.
@@ -270,7 +290,7 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
     }
 
     try {
-      let facts = ceremony.buildFacts(form);
+      let facts = materializeFacts(ceremony.factsTemplate, form);
       for (const need of satisfied) facts = satisfyNeed(facts, need);
       setLastFacts(facts as ExplainFacts);
       const resp = await postJson<TestResponse>(
@@ -308,7 +328,7 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
 
       <div className="cer-meta-row">
         <span className="cer-chip">
-          purpose <b>{ceremony.purpose ?? "—"}</b>
+          purpose <b>{ceremony.purpose}</b>
         </span>
         <span className="cer-chip">
           package <b>{ceremony.pkg}</b>
@@ -436,15 +456,11 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
           <div className="cer-panel-title">
             Decision policy <span className="ln" />
           </div>
-          {ceremony.purpose === null ? (
-            <p className="cer-sub">No policy purpose for this ceremony yet.</p>
-          ) : (
-            <PolicyManager
-              key={ceremony.purpose}
-              purpose={ceremony.purpose as Purpose}
-              onEditingChange={setAuthoring}
-            />
-          )}
+          <PolicyManager
+            key={ceremony.purpose}
+            purpose={ceremony.purpose as Purpose}
+            onEditingChange={setAuthoring}
+          />
         </div>
       </div>
     </>
@@ -892,7 +908,7 @@ function SimFields({
   return (
     <>
       {fields
-        .filter((f) => !f.showWhen || f.showWhen(values))
+        .filter((f) => evalShowWhen(f.showWhen, values))
         .map((f) => (
           <div className="cer-field" key={f.key}>
             <label>

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -1910,6 +1910,60 @@ dd .copy-icon-btn {
   animation: cer-pop 0.35s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+/* raw-facts editor (advanced simulator input) */
+.cer-raw {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.cer-raw-toggle {
+  margin-top: var(--space-2);
+  align-self: flex-start;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-faint);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+}
+.cer-raw-toggle:hover {
+  color: var(--text);
+}
+
+/* refer → queue link */
+.cer-refer {
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--vd-refer) 40%, var(--border));
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+.cer-refer-q {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+.cer-refer-q b {
+  color: var(--vd-refer);
+}
+.cer-refer-link {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--brand);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--brand) 40%, var(--border));
+  border-radius: var(--radius-md);
+}
+.cer-refer-link:hover {
+  background: var(--brand-tint);
+  text-decoration: none;
+}
+
 /* request_more negotiation loop */
 .cer-needs {
   margin-top: var(--space-3);

--- a/vtc-service/policies/default/directory.rego
+++ b/vtc-service/policies/default/directory.rego
@@ -19,6 +19,12 @@ package vtc.directory
 
 import rego.v1
 
+# This default is the visual form of the policy below — the admin-UI
+# reads the header to render it in plain English, show a decision
+# trace, and open it in the route-card editor. Keep it in step with the
+# body if you hand-edit the Rego.
+# @vtc-rule-ir: eyJwdXJwb3NlIjoiZGlyZWN0b3J5Iiwicm91dGVzIjpbeyJuYW1lIjoiQWRtaW4gdmlld2VyIiwid2hlbiI6eyJhbGwiOlsidmlld2VyX2lzX2FkbWluIl19LCJ0aGVuIjp7ImVmZmVjdCI6ImFsbG93Iiwid2l0aCI6eyJmaWVsZHMiOlsiZGlkIiwicm9sZSIsImpvaW5lZF9hdCIsInN0YXR1cyJdfX19LHsibmFtZSI6IkF1dGhlbnRpY2F0ZWQgbWVtYmVyIiwid2hlbiI6eyJhbGwiOlsidmlld2VyX2lzX21lbWJlciJdfSwidGhlbiI6eyJlZmZlY3QiOiJhbGxvdyIsIndpdGgiOnsiZmllbGRzIjpbImRpZCIsInJvbGUiXX19fSx7Im5hbWUiOiJOb3QgYSBtZW1iZXIiLCJ3aGVuIjp7ImFsbCI6WyJhbHdheXMiXX0sInRoZW4iOnsiZWZmZWN0IjoiZGVueSIsIndpdGgiOnsiY29kZSI6Im5vdC1hLW1lbWJlciJ9fX1dfQ==
+
 # structural totality — a non-member sees nothing
 default decision := {"effect": "deny", "with": {"code": "not-a-member"}}
 

--- a/vtc-service/policies/default/join.rego
+++ b/vtc-service/policies/default/join.rego
@@ -23,6 +23,12 @@ package vtc.join
 
 import rego.v1
 
+# This default is the visual form of the policy below — the admin-UI
+# reads the header to render it in plain English, show a decision
+# trace, and open it in the route-card editor. Keep it in step with the
+# body if you hand-edit the Rego.
+# @vtc-rule-ir: eyJwdXJwb3NlIjoiam9pbiIsInJvdXRlcyI6W3sibmFtZSI6IlRydXN0ZWQgY3JlZGVudGlhbCIsIndoZW4iOnsiYWxsIjpbImhvbGRzX2FueV90cnVzdGVkIl19LCJ0aGVuIjp7ImVmZmVjdCI6ImFsbG93Iiwid2l0aCI6eyJyb2xlIjoibWVtYmVyIn19fSx7Im5hbWUiOiJNb2RlcmF0b3IgcmV2aWV3Iiwid2hlbiI6eyJhbGwiOlsiYWx3YXlzIl19LCJ0aGVuIjp7ImVmZmVjdCI6InJlZmVyIiwid2l0aCI6eyJxdWV1ZSI6Im1vZGVyYXRvciJ9fX1dfQ==
+
 # structural totality — unmatched submissions go to moderator review
 default decision := {"effect": "refer", "with": {"queue": "moderator"}}
 

--- a/vtc-service/policies/default/removal.rego
+++ b/vtc-service/policies/default/removal.rego
@@ -26,6 +26,12 @@ package vtc.removal
 
 import rego.v1
 
+# This default is the visual form of the policy below — the admin-UI
+# reads the header to render it in plain English, show a decision
+# trace, and open it in the route-card editor. Keep it in step with the
+# body if you hand-edit the Rego.
+# @vtc-rule-ir: eyJwdXJwb3NlIjoicmVtb3ZhbCIsInJvdXRlcyI6W3sibmFtZSI6IlNlbGYtbGVhdmUiLCJ3aGVuIjp7ImFsbCI6WyJhY3Rvcl9pc19zZWxmIl19LCJ0aGVuIjp7ImVmZmVjdCI6ImFsbG93Iiwid2l0aCI6eyJkaXNwb3NpdGlvbiI6InRvbWJzdG9uZSJ9fX0seyJuYW1lIjoiQWRtaW4gcmVtb3ZlcyBub24tYWRtaW4iLCJ3aGVuIjp7ImFsbCI6WyJzdWJqZWN0X25vdF9hZG1pbiJdfSwidGhlbiI6eyJlZmZlY3QiOiJhbGxvdyIsIndpdGgiOnsiZGlzcG9zaXRpb24iOiJ0b21ic3RvbmUifX19LHsibmFtZSI6IlJlZnVzZWQiLCJ3aGVuIjp7ImFsbCI6WyJhbHdheXMiXX0sInRoZW4iOnsiZWZmZWN0IjoiZGVueSIsIndpdGgiOnsiY29kZSI6InJlbW92YWwtZGVuaWVkIn19fV19
+
 # structural totality — unmatched removals are refused
 default decision := {"effect": "deny", "with": {"code": "removal-denied"}}
 

--- a/vtc-service/policies/default/role_change.rego
+++ b/vtc-service/policies/default/role_change.rego
@@ -21,6 +21,12 @@ package vtc.role_change
 
 import rego.v1
 
+# This default is the visual form of the policy below — the admin-UI
+# reads the header to render it in plain English, show a decision
+# trace, and open it in the route-card editor. Keep it in step with the
+# body if you hand-edit the Rego.
+# @vtc-rule-ir: eyJwdXJwb3NlIjoicm9sZUNoYW5nZSIsInJvdXRlcyI6W3sibmFtZSI6IlN0YW5kYXJkIHJvbGUiLCJ3aGVuIjp7ImFsbCI6WyJ0YXJnZXRfcm9sZV9zdGFuZGFyZCJdfSwidGhlbiI6eyJlZmZlY3QiOiJhbGxvdyIsIndpdGgiOnsicm9sZSI6IiR0YXJnZXQifX19LHsibmFtZSI6IkFkbWluIHdpdGggc3RlcC11cCIsIndoZW4iOnsiYWxsIjpbInByb21vdGVzX3RvX2FkbWluIiwic3RlcF91cF9kb25lIl19LCJ0aGVuIjp7ImVmZmVjdCI6ImFsbG93Iiwid2l0aCI6eyJyb2xlIjoiYWRtaW4ifX19LHsibmFtZSI6IkFkbWluIG5lZWRzIHN0ZXAtdXAiLCJ3aGVuIjp7ImFsbCI6WyJwcm9tb3Rlc190b19hZG1pbiJdfSwidGhlbiI6eyJlZmZlY3QiOiJyZWZlciIsIndpdGgiOnsicXVldWUiOiJzdGVwLXVwIn19fSx7Im5hbWUiOiJSZWZ1c2VkIiwid2hlbiI6eyJhbGwiOlsiYWx3YXlzIl19LCJ0aGVuIjp7ImVmZmVjdCI6ImRlbnkiLCJ3aXRoIjp7ImNvZGUiOiJuby1tYXRjaGluZy1yb3V0ZSJ9fX1dfQ==
+
 # structural totality — unmatched role changes are refused
 default decision := {"effect": "deny", "with": {"code": "no-matching-route"}}
 

--- a/vtc-service/src/routes/ceremonies.rs
+++ b/vtc-service/src/routes/ceremonies.rs
@@ -1,0 +1,348 @@
+//! `GET /v1/ceremonies` — the ceremony registry.
+//!
+//! The daemon is the source of truth for *which* ceremonies exist and
+//! how their decision surface is shaped. Each manifest carries the
+//! ceremony's metadata (purpose, package, nature, copy), the
+//! simulator's input **fields** (a declarative UI schema), and a
+//! **facts template** — a JSON skeleton of the verified-Facts `input`
+//! document with `$field:<key>` / `$now` / `$if` directives the
+//! admin-UI materializes from the field values.
+//!
+//! This is what makes a ceremony *over an existing effect* data, not
+//! code: adding one is a manifest entry here, and the admin-UI renders
+//! its whole flow + simulator from this endpoint — no per-ceremony
+//! frontend. The effect a ceremony triggers (admit / depart / remint /
+//! project) stays reviewed Rust; this registry only describes the
+//! decision surface.
+
+use axum::Json;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+
+use crate::auth::AuthClaims;
+
+#[derive(Serialize)]
+pub struct FieldOption {
+    pub value: &'static str,
+    pub label: &'static str,
+}
+
+/// A `showWhen` predicate, declarative so it crosses the wire: render
+/// the field only when `field`'s value equals `eq` (or its truthiness
+/// matches `truthy`).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShowWhen {
+    pub field: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eq: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truthy: Option<bool>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldDef {
+    pub key: &'static str,
+    pub label: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<&'static str>,
+    #[serde(rename = "type")]
+    pub field_type: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<FieldOption>>,
+    pub default: JsonValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_when: Option<ShowWhen>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CeremonyManifest {
+    pub purpose: &'static str,
+    pub pkg: &'static str,
+    pub nature: &'static str,
+    pub label: &'static str,
+    pub wired: &'static str,
+    pub blurb: &'static str,
+    pub fields: Vec<FieldDef>,
+    /// JSON skeleton of the verified-Facts `input`, with `$field:<key>`
+    /// / `$now` / `$if` directives the admin-UI materializes.
+    pub facts_template: JsonValue,
+}
+
+fn role_options() -> Vec<FieldOption> {
+    vec![
+        FieldOption {
+            value: "member",
+            label: "member",
+        },
+        FieldOption {
+            value: "moderator",
+            label: "moderator",
+        },
+        FieldOption {
+            value: "admin",
+            label: "admin",
+        },
+    ]
+}
+
+fn base_context() -> JsonValue {
+    json!({
+        "community_did": "did:webvh:demo.example",
+        "channel": "rest",
+        "member_count": 42,
+    })
+}
+
+fn manifests() -> Vec<CeremonyManifest> {
+    vec![
+        CeremonyManifest {
+            purpose: "directory",
+            pkg: "vtc.directory",
+            nature: "read-only",
+            label: "Directory",
+            wired: "live",
+            blurb: "A member views another member's record. Read-only — the verdict's allow carries a field projection, capped by the PII boundary.",
+            fields: vec![
+                FieldDef {
+                    key: "viewerRole",
+                    label: "Viewer's community role",
+                    hint: Some("actor.role — admin sees the fuller record"),
+                    field_type: "select",
+                    options: Some(vec![
+                        FieldOption {
+                            value: "admin",
+                            label: "admin",
+                        },
+                        FieldOption {
+                            value: "member",
+                            label: "member",
+                        },
+                        FieldOption {
+                            value: "",
+                            label: "none (authenticated)",
+                        },
+                    ]),
+                    default: json!("member"),
+                    show_when: None,
+                },
+                FieldDef {
+                    key: "subjectIsMember",
+                    label: "Subject is a member",
+                    hint: Some("state.subject_member present"),
+                    field_type: "toggle",
+                    options: None,
+                    default: json!(true),
+                    show_when: None,
+                },
+                FieldDef {
+                    key: "subjectRole",
+                    label: "Subject's role",
+                    hint: Some("state.subject_member.role"),
+                    field_type: "select",
+                    options: Some(role_options()),
+                    default: json!("member"),
+                    show_when: Some(ShowWhen {
+                        field: "subjectIsMember",
+                        eq: None,
+                        truthy: Some(true),
+                    }),
+                },
+            ],
+            facts_template: json!({
+                "purpose": "directory",
+                "now": "$now",
+                "actor": { "did": "did:key:zViewer", "role": "$field:viewerRole", "authenticated": true },
+                "subject": { "did": "did:key:zTarget" },
+                "context": base_context(),
+                "evidence": { "request": { "fields_requested": ["did", "role", "joined_at", "status"] } },
+                "state": {
+                    "subject_member": {
+                        "$if": "subjectIsMember",
+                        "then": { "role": "$field:subjectRole", "status": "active", "joined_at": "2026-01-02T00:00:00Z" },
+                        "else": null
+                    }
+                }
+            }),
+        },
+        CeremonyManifest {
+            purpose: "join",
+            pkg: "vtc.join",
+            nature: "constructive",
+            label: "Join",
+            wired: "live",
+            blurb: "A DID joins the community. A trusted presented credential auto-admits (allow → issue the membership credential); everything else is referred to the moderator queue for review.",
+            fields: vec![FieldDef {
+                key: "joinTrusted",
+                label: "Presented credential is trusted",
+                hint: Some("evidence.presentation.credentials[].issuer_trusted"),
+                field_type: "toggle",
+                options: None,
+                default: json!(false),
+                show_when: None,
+            }],
+            facts_template: json!({
+                "purpose": "join",
+                "now": "$now",
+                "actor": { "did": "did:key:zApplicant", "authenticated": true },
+                "subject": { "did": "did:key:zApplicant" },
+                "context": base_context(),
+                "evidence": {
+                    "presentation": {
+                        "verified": true,
+                        "holder": "did:key:zApplicant",
+                        "credentials": [{
+                            "type": "WitnessCredential",
+                            "issuer": "did:webvh:notary.example",
+                            "issuer_trusted": "$field:joinTrusted",
+                            "status": "valid",
+                            "claims": {}
+                        }]
+                    }
+                },
+                "state": { "subject_member": null }
+            }),
+        },
+        CeremonyManifest {
+            purpose: "removal",
+            pkg: "vtc.removal",
+            nature: "destructive",
+            label: "Leave",
+            wired: "live",
+            blurb: "A member departs or is removed. Self-leave is unconditional; an admin may remove a non-admin. The no-last-admin invariant + revocation are host-enforced in the effect.",
+            fields: vec![
+                FieldDef {
+                    key: "selfLeave",
+                    label: "Self-leave",
+                    hint: Some("actor.did == subject.did — always allowed"),
+                    field_type: "toggle",
+                    options: None,
+                    default: json!(false),
+                    show_when: None,
+                },
+                FieldDef {
+                    key: "subjectRole",
+                    label: "Subject's role",
+                    hint: Some("an admin may remove a non-admin only"),
+                    field_type: "select",
+                    options: Some(role_options()),
+                    default: json!("member"),
+                    show_when: Some(ShowWhen {
+                        field: "selfLeave",
+                        eq: None,
+                        truthy: Some(false),
+                    }),
+                },
+            ],
+            facts_template: json!({
+                "purpose": "leave",
+                "now": "$now",
+                "actor": { "did": "did:key:zActor", "role": "admin", "authenticated": true },
+                "subject": { "did": { "$if": "selfLeave", "then": "did:key:zActor", "else": "did:key:zTarget" } },
+                "context": base_context(),
+                "evidence": { "request": { "disposition": "tombstone" } },
+                "state": { "subject_member": { "role": "$field:subjectRole", "status": "active", "joined_at": "2026-01-02T00:00:00Z" } }
+            }),
+        },
+        CeremonyManifest {
+            purpose: "roleChange",
+            pkg: "vtc.role_change",
+            nature: "mutating",
+            label: "Role change",
+            wired: "live",
+            blurb: "A member's role changes in place (the DID + VMC are unchanged; the role VEC is re-minted). The one ceremony whose allow may grant admin — gated by a verified step-up; demotions are guarded by no-last-admin.",
+            fields: vec![
+                FieldDef {
+                    key: "targetRole",
+                    label: "Target role",
+                    hint: Some("evidence.request.target_role"),
+                    field_type: "select",
+                    options: Some(vec![
+                        FieldOption {
+                            value: "member",
+                            label: "member",
+                        },
+                        FieldOption {
+                            value: "moderator",
+                            label: "moderator",
+                        },
+                        FieldOption {
+                            value: "admin",
+                            label: "admin (promotion)",
+                        },
+                    ]),
+                    default: json!("moderator"),
+                    show_when: None,
+                },
+                FieldDef {
+                    key: "stepUp",
+                    label: "Step-up verified",
+                    hint: Some("admin needs step-up — else the verdict refers"),
+                    field_type: "toggle",
+                    options: None,
+                    default: json!(false),
+                    show_when: Some(ShowWhen {
+                        field: "targetRole",
+                        eq: Some(json!("admin")),
+                        truthy: None,
+                    }),
+                },
+            ],
+            facts_template: json!({
+                "purpose": "role-change",
+                "now": "$now",
+                "actor": { "did": "did:key:zAdmin", "role": "admin", "authenticated": true },
+                "subject": { "did": "did:key:zTarget" },
+                "context": base_context(),
+                "evidence": { "request": { "target_role": "$field:targetRole", "step_up": "$field:stepUp" } },
+                "state": { "subject_member": { "role": "member", "status": "active", "joined_at": "2026-01-02T00:00:00Z" } }
+            }),
+        },
+    ]
+}
+
+/// `GET /v1/ceremonies` — list the ceremony manifests. Authenticated
+/// (any session); the payload is admin-UI metadata, not secret, but
+/// the surface lives behind the same gate as the rest of the API.
+pub async fn list(_claims: AuthClaims) -> Json<Vec<CeremonyManifest>> {
+    Json(manifests())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn four_ceremonies_with_stable_purposes() {
+        let m = manifests();
+        let purposes: Vec<_> = m.iter().map(|c| c.purpose).collect();
+        assert_eq!(purposes, vec!["directory", "join", "removal", "roleChange"]);
+    }
+
+    #[test]
+    fn every_field_default_is_present_and_typed() {
+        for c in manifests() {
+            for f in &c.fields {
+                assert!(!f.default.is_null(), "{}::{} default", c.purpose, f.key);
+                if f.field_type == "select" {
+                    assert!(
+                        f.options.is_some(),
+                        "{}::{} needs options",
+                        c.purpose,
+                        f.key
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn facts_template_carries_the_purpose() {
+        for c in manifests() {
+            let p = c.facts_template.get("purpose").and_then(|v| v.as_str());
+            assert!(p.is_some(), "{} facts_template purpose", c.purpose);
+        }
+    }
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -4,6 +4,7 @@ mod admin;
 mod admin_ui;
 mod audit;
 mod auth;
+mod ceremonies;
 mod community;
 mod config;
 pub(crate) mod did_log;
@@ -216,6 +217,8 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
     let members_show = TrustTask::new("https://trusttasks.org/openvtc/vtc/members/show/1.0")
         .expect("static Trust-Task URL");
     let directory_query = TrustTask::new("https://trusttasks.org/openvtc/vtc/directory/query/1.0")
+        .expect("static Trust-Task URL");
+    let ceremonies_list = TrustTask::new("https://trusttasks.org/openvtc/vtc/ceremonies/list/1.0")
         .expect("static Trust-Task URL");
     // `members_update` (`members/update/1.0`) shares the
     // `members/{did}` mount with `show` for now — TrustTaskRouter
@@ -506,6 +509,9 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
         // Directory ceremony (read-only field projection via the
         // ceremony decision pipeline).
         .route_with_task("/directory/{did}", get(directory::query), directory_query)
+        // Ceremony registry — the admin-UI renders its flow + simulator
+        // from these manifests (purpose / fields / facts template).
+        .route_with_task("/ceremonies", get(ceremonies::list), ceremonies_list)
         // Members (Phase 1 M1.4–M1.6).
         .route_with_task("/members", get(members::read::list_members), members_list)
         // `/v1/members/me` for self-remove (M1.11.1). Must be


### PR DESCRIPTION
## What

The four remaining ceremony-UX ideas, in one PR (three commits). They round out the surface: the registry moves to the daemon, the shipped defaults become legible/editable, refer verdicts become actionable, and the simulator gets an escape hatch.

## The four

**#2 — Default policies are now visually-authored** (`320c4fc`)
The four ceremony default `.rego` files carry the `# @vtc-rule-ir:` header, so plain-English, the decision trace, and the route-card editor work on a **fresh install** — not only after an operator re-authors. Added two vocabulary conditions the defaults needed (`holds_any_trusted`, `subject_not_admin`). The embedded IR compiles to Rego semantically identical to each curated body (round-trip + compile verified); the header is a comment, bodies untouched.

**#3 — Daemon-served ceremony registry + schema-driven simulator** (`754c32b`)
`GET /v1/ceremonies` returns a manifest per ceremony — metadata, the simulator's input **fields** (declarative UI schema), and a **facts template** (`$now` / `$field:<key>` / `$if` directives). The admin-UI renders its whole flow + simulator from it; no hardcoded `CEREMONIES`. `materializeFacts` interprets the template client-side and reproduces the previous `buildFacts` output exactly. **Adding a ceremony over an existing effect is now a manifest entry on the daemon, not frontend code** — the effect itself stays reviewed Rust.

**#1 — refer → moderator queue link** (`b99d803`)
A refer verdict names the queue it routes to; when that maps to an admin surface (moderator → the join-requests inbox) it links there with the **live pending count** — one click from "would be referred" to the work queue. Driven by the verdict's `with.queue`.

**#4 — Raw-facts simulator override** (`b99d803`)
An "edit raw facts" mode swaps the field form for the verified-Facts JSON (seeded from the fields, parse-checked, sent verbatim) — for evidence the declared toggles don't model.

## Verification

- Rust: full `vtc-service` test suite green (incl. 54 policy + 16 directory/join integration tests proving the headered defaults compile via regorus with unchanged decisions, + 3 new manifest tests); `cargo clippy --all-targets` clean; `cargo fmt`.
- Frontend: `npm run build` (tsc + vite) clean.
- Pure functions checked standalone (vite-node): the four embedded IRs round-trip + compile faithfully; `materializeFacts` matches the old `buildFacts` byte-for-byte (role omitted when empty, conditional subject/member, self-leave aliasing).
- Screenshot-verified via a mocked-daemon harness: tabs + schema forms render from the served registry; the refer→queue link shows the live count; the raw-facts editor seeds + overrides. Harness removed before commit.
