### PR TITLE
fix(vtc): active-policy lookup ignored purpose filter under limit=1 (simulator greyed out)

### DIFF
--- a/vtc-service/src/routes/policies/read.rs
+++ b/vtc-service/src/routes/policies/read.rs
@@ -93,6 +93,34 @@ pub async fn list_policies(
     State(state): State<AppState>,
     Query(query): Query<ListPoliciesQuery>,
 ) -> Result<Json<Paginated<PolicyResponse>>, AppError> {
+    // `status=active` is resolved directly from the per-purpose active
+    // pointers, not the paginated keyspace scan. The purpose/status
+    // filters below run *after* pagination, so a small `limit` (the
+    // simulator's active-policy lookup sends `limit=1`) would drop the
+    // active row for every purpose whose row isn't in the first page —
+    // surfacing the active policy for one arbitrary purpose only. The
+    // active set is at most one row per `PolicyPurpose`, so resolve it
+    // deterministically and ignore limit/cursor.
+    if matches!(query.status, Some(PolicyStatusFilter::Active)) {
+        let mut items = Vec::new();
+        for purpose in PolicyPurpose::ALL {
+            if query.purpose.is_some_and(|f| f != purpose) {
+                continue;
+            }
+            if let Some(id) = get_active_policy_id(&state.active_policies_ks, purpose).await?
+                && let Some(p) = get_policy(&state.policies_ks, id).await?
+            {
+                items.push(PolicyResponse::from_policy(p, true));
+            }
+        }
+        let total = items.len() as u64;
+        return Ok(Json(Paginated {
+            items,
+            next_cursor: None,
+            total_estimate: Some(total),
+        }));
+    }
+
     let limit = query.limit.unwrap_or(50).clamp(1, MAX_LIMIT);
 
     let audit_writer = state

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -663,6 +663,54 @@ async fn list_filters_by_status() {
     assert_eq!(items[0]["isActive"], false);
 }
 
+/// Regression: the simulator's active-policy lookup
+/// (`?purpose=X&status=active&limit=1`) must return X's active row even
+/// when several purposes have active policies. The purpose/status
+/// filters run *after* pagination, so `limit=1` used to fetch one
+/// arbitrary keyspace row and filter it — surfacing the active policy
+/// for a single purpose only (whichever sorted first). status=active is
+/// now resolved from the per-purpose active pointers directly.
+#[tokio::test]
+async fn list_active_by_purpose_is_exact_under_limit_one() {
+    let fix = build_fixture().await;
+    let join = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
+    let removal = upload_policy(&fix, "removal", ALT_POLICY).await;
+    let join_id = join["id"].as_str().unwrap();
+    let removal_id = removal["id"].as_str().unwrap();
+
+    // Activate a policy for both purposes.
+    for id in [join_id, removal_id] {
+        let req = auth_request(
+            "POST",
+            &format!("/v1/policies/{id}/activate"),
+            ACTIVATE_TASK,
+            &fix.admin_token,
+            json!({}),
+        );
+        fix.router.clone().oneshot(req).await.unwrap();
+    }
+
+    // Each purpose's active lookup returns ITS row, despite limit=1.
+    for (purpose, id) in [("join", join_id), ("removal", removal_id)] {
+        let resp = fix
+            .router
+            .clone()
+            .oneshot(auth_get(
+                &format!("/v1/policies?purpose={purpose}&status=active&limit=1"),
+                LIST_TASK,
+                &fix.admin_token,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp.into_body()).await;
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 1, "{purpose}: active lookup returns one row");
+        assert_eq!(items[0]["id"], id, "{purpose}: active id");
+        assert_eq!(items[0]["isActive"], true);
+    }
+}
+
 /// `GET /v1/policies/{id}` returns the full row + isActive flag.
 #[tokio::test]
 async fn show_returns_full_row() {


### PR DESCRIPTION
## Symptom

Logged in as a VTC admin, the Ceremonies "Run decision" simulator works for **one ceremony only** (e.g. Leave) — the other three are greyed out.

## Root cause

`GET /v1/policies` applies its `purpose` / `status` filters **after** pagination (a deliberate page-size-invariant tradeoff, documented in `read.rs`). The admin-UI's active-policy lookup sends:

```
GET /v1/policies?purpose=<X>&status=active&limit=1
```

With `limit=1`, the handler fetches **one arbitrary row** from the whole `policies:*` keyspace, then filters it by purpose + active. So it returns the active policy for whichever purpose sorts first, and an empty list for every other purpose → the panel's `policyQuery.data` is undefined → the button stays `disabled`. Exactly one ceremony (the first-sorting one) is simulatable.

This never surfaced earlier because the simulator was only ever verified against a mocked policies endpoint that always returned an active row.

## Fix

Resolve `status=active` straight from the per-purpose `active_policies:<purpose>` pointers (≤ one row per `PolicyPurpose`), honouring an optional `purpose` filter, instead of through the lossy paginated scan. `limit`/`cursor` don't apply to the active set and are ignored. `status=archived` and the unfiltered list are untouched. Backend-only — the existing frontend call now works.

## Verification

- New regression test `list_active_by_purpose_is_exact_under_limit_one`: activates policies for two purposes, asserts each `?purpose=X&status=active&limit=1` returns X's row. **Fails on main** (0 rows for the non-first purpose), passes with the fix.
- `cargo test -p vtc-service --test policies` green (15); `cargo clippy --all-targets` clean; `cargo fmt`.
