### PR TITLE
fix(vtc): self-heal legacy ceremony policies to the decision shape (simulator 'no decision')

### DIFF
--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -34,9 +34,12 @@ use uuid::Uuid;
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
-use super::engine::compile;
-use super::model::PolicyPurpose;
-use super::storage::{get_active_policy_id, new_policy, set_active_policy_id, store_policy};
+use super::engine::{compile, evaluate};
+use super::model::{Policy, PolicyPurpose};
+use super::storage::{
+    get_active_policy_id, get_policy, max_version_for, new_policy, set_active_policy_id,
+    store_policy,
+};
 
 /// Pseudo-DID stamped on every default policy's `author_did`
 /// field. Not a resolvable DID — purely a marker so operators
@@ -191,6 +194,104 @@ pub async fn install_defaults(
     Ok(installed)
 }
 
+/// The ceremony purposes the decision pipeline evaluates as
+/// `data.<pkg>.decision`. An active policy here that doesn't define a
+/// `decision` rule is a pre-migration boolean leftover.
+const CEREMONY_DECISION_PACKAGES: &[(PolicyPurpose, &str)] = &[
+    (PolicyPurpose::Directory, "vtc.directory"),
+    (PolicyPurpose::Join, "vtc.join"),
+    (PolicyPurpose::Removal, "vtc.removal"),
+    (PolicyPurpose::RoleChange, "vtc.role_change"),
+];
+
+/// True when the policy defines a `decision` rule that yields a
+/// four-valued verdict (the decision-pipeline shape). A pre-migration
+/// boolean policy defines `allow`, not `decision`, so this is false.
+fn yields_decision(policy: &Policy, pkg: &str) -> bool {
+    let Ok(compiled) = compile(&policy.rego_source, policy.id) else {
+        return false;
+    };
+    match evaluate(
+        &compiled,
+        &format!("data.{pkg}.decision"),
+        serde_json::json!({}),
+    ) {
+        Ok(results) => results
+            .pointer("/result/0/expressions/0/value")
+            .and_then(|v| v.get("effect"))
+            .and_then(|e| e.as_str())
+            .is_some(),
+        Err(_) => false,
+    }
+}
+
+/// Upgrade any ceremony purpose whose **active** policy predates the
+/// decision-pipeline migration (defines no `decision` rule) to the
+/// shipped decision-shaped default.
+///
+/// A binary upgrade over an existing data store leaves the old boolean
+/// policies active — [`install_defaults`] only fills *missing* pointers,
+/// so it won't touch them — but the routes now evaluate
+/// `data.<pkg>.decision`, which those policies don't define. The route
+/// default-denies and the simulator reports "no decision". This heals
+/// that: a legacy ceremony policy is non-functional, so replacing it
+/// with the shipped default is strictly a repair. Operator-authored
+/// *decision* policies (which define `decision`) are left untouched.
+///
+/// The replacement is appended fail-forward — a new revision at
+/// `max_version + 1`, the active pointer moved to it — never an in-place
+/// rewrite. Returns the number of purposes upgraded.
+pub async fn upgrade_legacy_ceremony_defaults(
+    policies_ks: &KeyspaceHandle,
+    active_policies_ks: &KeyspaceHandle,
+) -> Result<usize, AppError> {
+    let mut upgraded = 0_usize;
+    for &(purpose, pkg) in CEREMONY_DECISION_PACKAGES {
+        let Some(active_id) = get_active_policy_id(active_policies_ks, purpose).await? else {
+            continue; // install_defaults handles the missing case
+        };
+        let Some(active) = get_policy(policies_ks, active_id).await? else {
+            continue;
+        };
+        if yields_decision(&active, pkg) {
+            continue; // already decision-shaped (default or operator's own)
+        }
+
+        let source = default_source(purpose);
+        let id = Uuid::new_v4();
+        let compiled = compile(source, id).map_err(|e| {
+            AppError::Internal(format!(
+                "default policy for {} failed to compile: {e}",
+                purpose.as_str()
+            ))
+        })?;
+        let sha = *compiled.source_sha256();
+        let version = max_version_for(policies_ks, purpose).await? + 1;
+
+        let mut policy = new_policy(
+            purpose,
+            source.to_string(),
+            sha,
+            DEFAULTS_AUTHOR.to_string(),
+            version,
+        );
+        policy.id = id;
+        policy.activated_at = Some(Utc::now());
+
+        store_policy(policies_ks, &policy).await?;
+        set_active_policy_id(active_policies_ks, purpose, id).await?;
+
+        upgraded += 1;
+        warn!(
+            purpose = purpose.as_str(),
+            replaced = %active_id,
+            policy_id = %id,
+            "upgraded a pre-migration ceremony policy to the decision-shaped default"
+        );
+    }
+    Ok(upgraded)
+}
+
 /// Verify every [`PolicyPurpose`] has an active pointer. Called
 /// after [`install_defaults`] succeeds — under normal boot every
 /// purpose should be live. A gap here means a default-install
@@ -289,6 +390,72 @@ mod tests {
         // Re-run is a no-op.
         let again = install_defaults(&policies_ks, &active_ks).await.unwrap();
         assert_eq!(again, 0, "second install must be a no-op");
+    }
+
+    /// A binary-upgrade-over-old-data state: a pre-migration boolean
+    /// ceremony policy (defines `allow`, not `decision`) is replaced by
+    /// the decision-shaped default, while a healthy decision policy and
+    /// the upgrade itself stay idempotent.
+    #[tokio::test]
+    async fn upgrade_replaces_only_legacy_ceremony_policies() {
+        let (policies_ks, active_ks, _dir) = temp_keyspaces().await;
+
+        // A pre-migration boolean policy active for Join.
+        let legacy = "package vtc.join\nimport rego.v1\n\ndefault allow := false\n";
+        let legacy_id = Uuid::new_v4();
+        let sha = *compile_policy(legacy, legacy_id).unwrap().source_sha256();
+        let mut p = new_policy(
+            PolicyPurpose::Join,
+            legacy.to_string(),
+            sha,
+            "did:key:zOperator".into(),
+            1,
+        );
+        p.id = legacy_id;
+        p.activated_at = Some(Utc::now());
+        store_policy(&policies_ks, &p).await.unwrap();
+        set_active_policy_id(&active_ks, PolicyPurpose::Join, legacy_id)
+            .await
+            .unwrap();
+
+        // Fill the remaining purposes with the (decision-shaped)
+        // defaults. install_defaults skips Join — it has an active row.
+        install_defaults(&policies_ks, &active_ks).await.unwrap();
+        let removal_before = get_active_policy_id(&active_ks, PolicyPurpose::Removal)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let upgraded = upgrade_legacy_ceremony_defaults(&policies_ks, &active_ks)
+            .await
+            .unwrap();
+        assert_eq!(upgraded, 1, "only the legacy Join policy is upgraded");
+
+        // Join now points at a decision-shaped policy at a fresh version.
+        let join_after = get_active_policy_id(&active_ks, PolicyPurpose::Join)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_ne!(join_after, legacy_id, "Join active pointer moved forward");
+        let join_policy = get_policy(&policies_ks, join_after).await.unwrap().unwrap();
+        assert!(
+            yields_decision(&join_policy, "vtc.join"),
+            "upgraded Join policy yields a decision"
+        );
+        assert_eq!(join_policy.version, 2, "appended fail-forward");
+
+        // The healthy decision-shaped Removal policy is untouched.
+        let removal_after = get_active_policy_id(&active_ks, PolicyPurpose::Removal)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(removal_before, removal_after, "Removal default untouched");
+
+        // Idempotent — a second pass finds nothing to upgrade.
+        let again = upgrade_legacy_ceremony_defaults(&policies_ks, &active_ks)
+            .await
+            .unwrap();
+        assert_eq!(again, 0, "second upgrade pass is a no-op");
     }
 
     /// An operator-uploaded policy already pointed at by the active

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -227,6 +227,22 @@ pub async fn run(
         Err(e) => warn!("failed to install default policies: {e}"),
     }
 
+    // Self-heal a binary-upgrade-over-old-data state: a ceremony purpose
+    // whose active policy predates the decision-pipeline migration
+    // (defines `allow`, not `decision`) is non-functional — the routes
+    // evaluate `data.<pkg>.decision`. Replace those with the shipped
+    // decision-shaped defaults; operator decision-policies are untouched.
+    match crate::policy::default::upgrade_legacy_ceremony_defaults(
+        &policies_ks,
+        &active_policies_ks,
+    )
+    .await
+    {
+        Ok(0) => {}
+        Ok(n) => info!("upgraded {n} legacy ceremony policy(ies) to decision-shaped defaults"),
+        Err(e) => warn!("failed to upgrade legacy ceremony policies: {e}"),
+    }
+
     // M2.10 + M2.11: provision the two BitstringStatusLists.
     // Idempotent — only seeds decoys when the row is brand new.
     // Skipped when `public_url` is unset (pre-setup deployment) —

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -481,6 +481,43 @@ async fn test_does_not_mutate_state() {
     );
 }
 
+/// The shipped decision-shaped default policy, evaluated through the
+/// real `/test` endpoint with the query + facts the simulator sends,
+/// produces a four-valued decision object — proving the backend +
+/// default + wire shape are sound end-to-end (the simulator's
+/// "no decision" error is a non-decision-shaped *active* policy, not a
+/// backend bug).
+#[tokio::test]
+async fn shipped_directory_default_yields_a_decision_via_test() {
+    const DIRECTORY_DEFAULT: &str = include_str!("../policies/default/directory.rego");
+    let fix = build_fixture().await;
+    let uploaded = upload_policy(&fix, "directory", DIRECTORY_DEFAULT).await;
+    let id: Uuid = uploaded["id"].as_str().unwrap().parse().unwrap();
+
+    let req = auth_request(
+        "POST",
+        &format!("/v1/policies/{id}/test"),
+        TEST_TASK,
+        &fix.admin_token,
+        json!({
+            "query": "data.vtc.directory.decision",
+            "input": { "actor": { "role": "admin", "authenticated": true } }
+        }),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp.into_body()).await;
+    let decision = body
+        .pointer("/result/result/0/expressions/0/value")
+        .expect("decision query must yield a value");
+    assert_eq!(
+        decision["effect"], "allow",
+        "admin viewer → allow, got {decision}"
+    );
+    assert!(decision["with"]["fields"].is_array());
+}
+
 /// Upload + activate each emit one audit envelope. The audit
 /// keyspace gains exactly two rows (plus the boot-time
 /// `AuditKeyRotated::Initial` row from `ensure_initial`).


### PR DESCRIPTION
## Symptom

After the simulator was unblocked (#228), running it on **any** ceremony returns:

> The active policy produced no decision — it may still be the legacy boolean shape rather than a decision spine.

## Diagnosis

The error message was right. The backend is sound — I added `shipped_directory_default_yields_a_decision_via_test`, which uploads the **shipped** decision default, hits the real `/test` endpoint with the simulator's exact query (`data.vtc.directory.decision`) + facts, and gets back `{effect:"allow", with:{fields:[…]}}` in the precise shape the frontend plucks.

The problem is **stale active policies**. On an instance upgraded over an existing data store, the active policies are the **pre-migration boolean** ones (they define `allow`, not `decision`). `install_defaults` is idempotent — it only fills *missing* active pointers — so it never replaced them, even though the binary ships decision-shaped defaults. The routes now evaluate `data.<pkg>.decision`, which those policies don't define → undefined verdict → the simulator's "no decision".

## Fix

`upgrade_legacy_ceremony_defaults`, run at boot right after `install_defaults`:

- For each ceremony purpose (directory / join / removal / role_change), check whether the **active** policy yields a `decision` verdict (compile + evaluate `data.<pkg>.decision` against empty input, look for an `effect`).
- If it doesn't, it's a non-functional pre-migration leftover → replace it with the shipped decision-shaped default, **appended fail-forward** (new revision at `max_version+1`, active pointer moved — never an in-place rewrite).
- Operator-authored **decision** policies (which *do* define `decision`) are detected and left untouched.

So a broken instance self-heals on the next restart, with no operator action. (The user confirmed it's fine to create new decision-model defaults for this.)

## Verification

- `upgrade_replaces_only_legacy_ceremony_policies`: a legacy boolean Join policy is upgraded (decision-shaped, v2, fail-forward); a healthy decision Removal default is untouched; a second pass is a no-op.
- `shipped_directory_default_yields_a_decision_via_test`: end-to-end proof the backend + default produce a decision via `/test`.
- Full `vtc-service` suite green (33 suites); `cargo clippy --all-targets` clean; `cargo fmt`.

After this lands, redeploy/restart and the four ceremonies' simulator will produce verdicts. The boot log reports `upgraded N legacy ceremony policy(ies) to decision-shaped defaults`.
