### PR TITLE
docs(vti): credential architecture spec — invite, hold, present, join

### DIFF
--- a/docs/05-design-notes/vti-credential-architecture-plan.md
+++ b/docs/05-design-notes/vti-credential-architecture-plan.md
@@ -18,14 +18,21 @@ lies.
 
 | Repo | Owns |
 |---|---|
-| **`affinidi-tdk-rs`** (external; published crates) | the credential *crypto + formats*: SD-JWT-VC, BBS+ (`affinidi-bbs`), the `bbs-2023` Data Integrity cryptosuite, BLS12-381 keys. |
+| **`affinidi-tdk-rs`** (external; published crates) | the credential *crypto + formats* — **already built + validated**: `affinidi-sd-jwt`/`-vc`, `affinidi-bbs` (BBS over `bls12_381_plus`), `affinidi-data-integrity::bbs_2023`, `affinidi-openid4vp`/`-vci`. One net-new gap: **DCQL**. |
 | **`verifiable-trust-infrastructure`** (this workspace) | everything that *uses* credentials: the VTA store, VTC schema store + issuer, the exchange protocol, role-by-VC + the verified-assertion cache, the ceremony integration, plugin UX. |
 
-**Coordination rule:** a this-repo phase that consumes a new format
-cannot start until that format is available as a published/path/git dep
-from `affinidi-tdk-rs`. The plan front-loads the format work (Phase 0a)
-and keeps the format-agnostic this-repo work (the store's model/index)
-able to start in parallel.
+> **Re-baseline (validated):** the credential foundation the spec once
+> said to "build from scratch" **already exists in the TDK and passes its
+> tests** (`cargo test` exit 0 across the crates). Phase 0 is therefore
+> **validate + adopt**, not build — the BBS curve is `bls12_381_plus`
+> (keep `affinidi-bbs`, not `arkworks`), and the only net-new TDK work is
+> **DCQL**. This collapses the original Phase 0a/0b into a short adoption
+> step and moves the real work to DCQL + Phases 1–6.
+
+**Coordination rule:** a this-repo phase that consumes a TDK format wires
+it as a dep (the crates are `publish.workspace = true` — crates.io, like
+the `affinidi-vc = "0.1"` deps VTI already uses; path/git to the local
+TDK for unreleased changes like DCQL).
 
 ---
 
@@ -33,14 +40,14 @@ able to start in parallel.
 
 ```
                  ┌─────────────────────────── (affinidi-tdk-rs) ───────────────────────────┐
-   Phase 0a  SD-JWT-VC ──────────────┐
-   Phase 0b  BBS foundation ─────────┤  (additive: a new format + cryptosuite; never blocks 1–6)
-                                     │
-                 └─────────────────── │ ───────── (verifiable-trust-infrastructure) ────────┘
-                                     ▼
+   Phase 0   validate + adopt SD-JWT-VC + BBS (DONE: tests green) ─┐
+   Phase 0c  DCQL  (the one net-new TDK build) ───────────────────┤
+                                                                  │
+                 └────────────────────────────────────────────────│── (verifiable-trust-infrastructure) ──┘
+                                                                  ▼
    Phase 1   VTA credential store    │   1.1–1.3 (model / receive / search) are FORMAT-AGNOSTIC →
-             ────────────────────────┘   can start NOW, parallel to 0a.
-                                         1.4–1.6 (present / mint / status) need a format (0a).
+             ────────────────────────┘   can start NOW (adopt SD-JWT-VC at 1.4).
+                                         1.4–1.6 (present / mint / status) wire the adopted format.
                                      ▼
    Phase 2   DTC catalog + VTC schema store + VIC
                                      ▼
@@ -54,13 +61,13 @@ able to start in parallel.
 ```
 
 **What can start immediately, in parallel:**
-- **Track A (affinidi-tdk-rs):** Phase 0a (SD-JWT-VC). Phase 0b (BBS) on
-  its own audited track.
+- **Track A (affinidi-tdk-rs):** Phase 0c (DCQL) — the one net-new TDK
+  build. (Phase 0 adopt = already validated; BBS audit on its own track.)
 - **Track B (this repo):** Phase 1 tasks **1.1–1.3** — the
   `StoredCredential` model, the `vault` keyspace + index, and local
   DCQL-shaped search — are format-agnostic (they index opaque credential
-  bodies + metadata) and don't need 0a. They converge with 0a at task 1.4
-  (present), which needs a real format verifier/presenter.
+  bodies + metadata). They converge with the adopted SD-JWT-VC at task 1.4
+  (present).
 
 ---
 
@@ -74,40 +81,40 @@ search, then present.
 
 ---
 
-## Phase 0a — SD-JWT-VC  (repo: `affinidi-tdk-rs`)
+## Phase 0 — Validate + adopt the TDK formats  (repo: `affinidi-tdk-rs`; mostly DONE)
 
-**Goal:** a selective-disclosure credential format with no new curve —
-runs on the existing Ed25519/JOSE — so the this-repo phases can build on
-it immediately. **Home:** a new `affinidi-sd-jwt` crate (mirrors the
-`affinidi-bbs` isolation decision; keeps the disclosure machinery out of
-the base crypto crate). *Final home is an `affinidi-tdk-rs` repo call.*
+The credential foundation already exists and passes its tests. Validated
+`cargo test` (exit 0) across `affinidi-sd-jwt` (90), `affinidi-sd-jwt-vc`
+(11), `affinidi-bbs` (52, BBS over `bls12_381_plus`),
+`affinidi-data-integrity` (incl. `bbs_2023`), `affinidi-openid4vp`/`-vci`.
 
-Slices (detail in the tasks doc): SD-JWT core round-trip → selective
-disclosure → key binding (`kb-jwt`) → the SD-JWT-VC profile (`vct`/`cnf`/
-`status`) → IETF interop fixtures → the public `issue/present/verify` API.
+Remaining adoption work (small): wire the crates as VTI deps; confirm the
+SD-JWT-VC profile carries `vct`/`cnf`/`status`; confirm/add a BLS12-381 G2
+verification-method representation for `#bbs-key-0` in the
+did:key/did:webvh layer; schedule the **BBS security audit** (the crate is
+unit-tested, not yet independently audited) as a gate before BBS signs
+anything real.
 
-**CHECKPOINT 0a:** `affinidi-sd-jwt` exposes `issue` / `present` (select
-+ bind) / `verify` (returns the disclosed claim set + holder DID), green
-against the IETF SD-JWT examples. *This is the gate that unblocks Phase 1
+**CHECKPOINT 0:** the TDK credential crates wired as VTI deps; a smoke
+test issues + verifies an SD-JWT-VC from this workspace. *Unblocks Phase 1
 present/mint and Phase 3.*
 
 ---
 
-## Phase 0b — BBS foundation  (repo: `affinidi-tdk-rs`; gated, parallel, audited)
+## Phase 0c — DCQL  (repo: `affinidi-tdk-rs`; the one net-new build)
 
-**Goal:** unlinkable claim-level selective disclosure as a W3C Data
-Integrity cryptosuite. **Net-new** — the dependency tree has no BLS today.
+**Goal:** the Digital Credentials Query Language — the privacy-first,
+"no fishing" query model (§7). `affinidi-openid4vp` uses the older DIF
+Presentation Exchange (`PresentationDefinition`/`InputDescriptor`) today;
+DCQL is absent across the whole TDK.
 
-Milestones: adopt `arkworks`/`ark-bls12-381` → BLS12-381 G2 keygen +
-`affinidi-crypto` trait impls (`#bbs-key-0`) → `bbs-2023` sign/verify vs
-IRTF test vectors → `bbs-2023` proofgen/proofverify (selective disclosure)
-vs IRTF vectors → the `bbs-2023` Data Integrity cryptosuite in
-`affinidi-data-integrity` → Ed25519 holder binding → **security review**.
+Slices: a DCQL query/credential-set model → a local match engine against
+held credentials → mapping onto both the SD-JWT-VC and BBS formats →
+integration with the OID4VP authorization request/response.
 
-**CHECKPOINT 0b:** IRTF test vectors pass + end-to-end issue/disclose/
-verify; **audited before any real signing.** Additive — adding BBS+ to
-the credential layer is a new format registration, so 0b never blocks 0a
-or 1–6.
+**CHECKPOINT 0c:** a DCQL query selects matching credentials (SD-JWT-VC +
+BBS) and produces an OID4VP presentation. *Unblocks the VTA local search
+(1.3) and the exchange (Phase 3).*
 
 ---
 

--- a/docs/05-design-notes/vti-credential-architecture-plan.md
+++ b/docs/05-design-notes/vti-credential-architecture-plan.md
@@ -1,0 +1,211 @@
+# VTI Credential Architecture — implementation plan
+
+**Phase:** PLAN (spec-driven). Companion to
+`vti-credential-architecture.md` (the SPECIFY artifact, PR #230) and
+`vti-credential-architecture-tasks.md` (the task checklist).
+
+This plan turns the spec into a dependency-ordered, vertically-sliced
+build. Phase 0a (SD-JWT-VC) and Phase 1 (VTA credential store) are
+detailed to task level; later phases are milestone-level and get their
+own PLAN pass before they start.
+
+---
+
+## Two repositories
+
+The work spans two repos. Get the boundary right or the dependency graph
+lies.
+
+| Repo | Owns |
+|---|---|
+| **`affinidi-tdk-rs`** (external; published crates) | the credential *crypto + formats*: SD-JWT-VC, BBS+ (`affinidi-bbs`), the `bbs-2023` Data Integrity cryptosuite, BLS12-381 keys. |
+| **`verifiable-trust-infrastructure`** (this workspace) | everything that *uses* credentials: the VTA store, VTC schema store + issuer, the exchange protocol, role-by-VC + the verified-assertion cache, the ceremony integration, plugin UX. |
+
+**Coordination rule:** a this-repo phase that consumes a new format
+cannot start until that format is available as a published/path/git dep
+from `affinidi-tdk-rs`. The plan front-loads the format work (Phase 0a)
+and keeps the format-agnostic this-repo work (the store's model/index)
+able to start in parallel.
+
+---
+
+## Dependency graph
+
+```
+                 ┌─────────────────────────── (affinidi-tdk-rs) ───────────────────────────┐
+   Phase 0a  SD-JWT-VC ──────────────┐
+   Phase 0b  BBS foundation ─────────┤  (additive: a new format + cryptosuite; never blocks 1–6)
+                                     │
+                 └─────────────────── │ ───────── (verifiable-trust-infrastructure) ────────┘
+                                     ▼
+   Phase 1   VTA credential store    │   1.1–1.3 (model / receive / search) are FORMAT-AGNOSTIC →
+             ────────────────────────┘   can start NOW, parallel to 0a.
+                                         1.4–1.6 (present / mint / status) need a format (0a).
+                                     ▼
+   Phase 2   DTC catalog + VTC schema store + VIC
+                                     ▼
+   Phase 3   credential-exchange protocol  (Trust-Tasks ⊃ OID4VCI/OID4VP + DCQL)
+                                     ▼
+   Phase 4   role-by-VC + verified-assertion cache + VP-based /auth
+                                     ▼
+   Phase 5   join ceremony integration  (plugs into the existing decision pipeline)
+                                     ▼
+   Phase 6   browser plugin UX  (Digital Credentials API)
+```
+
+**What can start immediately, in parallel:**
+- **Track A (affinidi-tdk-rs):** Phase 0a (SD-JWT-VC). Phase 0b (BBS) on
+  its own audited track.
+- **Track B (this repo):** Phase 1 tasks **1.1–1.3** — the
+  `StoredCredential` model, the `vault` keyspace + index, and local
+  DCQL-shaped search — are format-agnostic (they index opaque credential
+  bodies + metadata) and don't need 0a. They converge with 0a at task 1.4
+  (present), which needs a real format verifier/presenter.
+
+---
+
+## Vertical slicing principle
+
+Every task is **one complete path**, not a horizontal layer. For SD-JWT
+that means "issue → disclose → verify a credential with N claims" as a
+single slice, not "all issuance, then all verification." For the store it
+means "store + index + retrieve one credential end-to-end" before adding
+search, then present.
+
+---
+
+## Phase 0a — SD-JWT-VC  (repo: `affinidi-tdk-rs`)
+
+**Goal:** a selective-disclosure credential format with no new curve —
+runs on the existing Ed25519/JOSE — so the this-repo phases can build on
+it immediately. **Home:** a new `affinidi-sd-jwt` crate (mirrors the
+`affinidi-bbs` isolation decision; keeps the disclosure machinery out of
+the base crypto crate). *Final home is an `affinidi-tdk-rs` repo call.*
+
+Slices (detail in the tasks doc): SD-JWT core round-trip → selective
+disclosure → key binding (`kb-jwt`) → the SD-JWT-VC profile (`vct`/`cnf`/
+`status`) → IETF interop fixtures → the public `issue/present/verify` API.
+
+**CHECKPOINT 0a:** `affinidi-sd-jwt` exposes `issue` / `present` (select
++ bind) / `verify` (returns the disclosed claim set + holder DID), green
+against the IETF SD-JWT examples. *This is the gate that unblocks Phase 1
+present/mint and Phase 3.*
+
+---
+
+## Phase 0b — BBS foundation  (repo: `affinidi-tdk-rs`; gated, parallel, audited)
+
+**Goal:** unlinkable claim-level selective disclosure as a W3C Data
+Integrity cryptosuite. **Net-new** — the dependency tree has no BLS today.
+
+Milestones: adopt `arkworks`/`ark-bls12-381` → BLS12-381 G2 keygen +
+`affinidi-crypto` trait impls (`#bbs-key-0`) → `bbs-2023` sign/verify vs
+IRTF test vectors → `bbs-2023` proofgen/proofverify (selective disclosure)
+vs IRTF vectors → the `bbs-2023` Data Integrity cryptosuite in
+`affinidi-data-integrity` → Ed25519 holder binding → **security review**.
+
+**CHECKPOINT 0b:** IRTF test vectors pass + end-to-end issue/disclose/
+verify; **audited before any real signing.** Additive — adding BBS+ to
+the credential layer is a new format registration, so 0b never blocks 0a
+or 1–6.
+
+---
+
+## Phase 1 — VTA credential store  (repo: this workspace, `vta-service`)
+
+**Goal:** promote the `vault` keyspace from M1 read-only stub to a real
+credential store: receive, index, search (DCQL, local), present, mint —
+the data plane the spec §5 describes.
+
+Slices (detail in the tasks doc):
+1. `StoredCredential` model + `vault` storage + index (by type / community
+   / issuer / purpose / status). **Format-agnostic — start now.**
+2. Receive (verify-minimally → index → store).
+3. Local DCQL search → **descriptors only** (the no-enumeration invariant).
+4. Present (stored cred + holder-signed consent → SD-JWT-VC presentation).
+5. Mint (VTA issues its own SD-JWT-VC).
+6. Status refresh (revoked/expired excluded from search/present).
+
+**CHECKPOINT 1:** the VTA stores, searches, presents, and mints SD-JWT-VC
+credentials end-to-end, with the no-wallet-enumeration invariant enforced
+by a test. *Unblocks Phase 3.*
+
+---
+
+## Phases 2–6 — milestones (own PLAN pass before each starts)
+
+- **Phase 2 — DTC catalog + VTC schema store + VIC** (this repo:
+  `vtc-service`, `dtg-credentials`). Adopt `dtg-credentials`; port VMC/VEC
+  onto DTC; build the `schemas` keyspace + registry (issues + accepts,
+  JSON Schema + DTC binding, admin CRUD); add the InvitationCredential
+  (VIC); validate issued credentials against their schema at issue time.
+  *Checkpoint: each catalog type issues against its schema.*
+
+- **Phase 3 — credential-exchange protocol** (this repo: `vta-sdk`,
+  `vta-service`, `vtc-service`). The `credential-exchange/*` Trust Task
+  family wrapping OID4VCI (offer/request/issue) + OID4VP (query/present) +
+  DCQL; issuer, verifier, and holder sides; relayer≠holder +
+  `sealed_transfer` for secret-bearing issuance. *Checkpoint: VTC↔VTA
+  issue + query + present.*
+
+- **Phase 4 — role-by-VC + verified-assertion cache + VP-based `/auth`**
+  (this repo: `vti-common`, `vtc-service`). The `verified_assertions`
+  keyspace + record (TTL + invalidation); `/auth/challenge` (DCQL) +
+  `/auth` (verify VP → write assertion → mint a derived JWT); extractors
+  read the assertion record, not the JWT role; revocation/role-change
+  invalidates the record; ceremony Admit/Remint/Depart issue/revoke Role
+  VCs + update the cache; ACL → derived index. *Checkpoint: admin proven
+  by a held Role VC; revocation invalidates within the window.*
+
+- **Phase 5 — join ceremony integration** (this repo: `vtc-service`).
+  The "join" ceremony sends a DCQL query from the schema store's required
+  evidence; the holder presents; the ceremony assembles Facts from the
+  verified VP → `decide()` → `execute()`; allow → issue the
+  MembershipCredential (+ Role VC) back via the exchange; deny → the
+  decision-trace reason; refer → the moderator queue; request_more → a
+  DCQL loop. *Checkpoint: the spec §12 flow end-to-end (allow + deny).*
+
+- **Phase 6 — browser plugin UX** (browser plugin, `vta-mobile-core`).
+  Digital Credentials API → OID4VP; plain-English consent (reuse the
+  ceremony English renderer) + per-claim disclosure; the device-side
+  holder-binding signature; invite→join progress UI. *Checkpoint: Alice
+  completes invite→join in the plugin.*
+
+---
+
+## Checkpoints / review gates
+
+Each phase is its own PR (or PR series) and ends at a checkpoint that
+**verifies** the slice with a test, not a "looks right." Cross-repo gate:
+a `affinidi-tdk-rs` format must be released (path/git dep wired into this
+workspace) before the this-repo phase that consumes it merges.
+
+```
+0a ─gate─▶ 1 ─gate─▶ 2 ─gate─▶ 3 ─gate─▶ 4 ─gate─▶ 5 ─gate─▶ 6
+0b ─(audited, additive, joins at the credential-format registry)─▶
+```
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| BBS scheme correctness/audit (highest) | IRTF test vectors + external audit before real signing; isolated in `affinidi-bbs`; SD-JWT-VC carries the near-term path so 1–6 don't wait on it. |
+| Cross-repo coupling stalls this-repo work | Front-load 0a; keep 1.1–1.3 format-agnostic so Track B starts immediately. |
+| Privacy invariant regressions | Each phase carries the invariant tests (no enumeration, consent-before-disclosure, claim minimisation) as acceptance criteria, not afterthoughts. |
+| Role-by-VC breaks the hot path | The verified-assertion cache keeps authz synchronous; Phase 4 ships the cache before flipping extractors off the JWT role. |
+| Scope creep across 7 phases | Only 0a + 1 are task-level now; 2–6 get their own PLAN pass at their gate. |
+
+---
+
+## Immediate next actions
+
+1. **Track A:** confirm the `affinidi-sd-jwt` crate home in
+   `affinidi-tdk-rs`, then start Phase 0a task 0a.1.
+2. **Track B (this repo):** start Phase 1 tasks **1.1–1.3** in parallel —
+   they need no upstream format.
+3. Park Phase 0b on the audited track; it joins later without blocking.
+
+See `vti-credential-architecture-tasks.md` for the task checklist with
+acceptance criteria, verification steps, and file targets.

--- a/docs/05-design-notes/vti-credential-architecture-tasks.md
+++ b/docs/05-design-notes/vti-credential-architecture-tasks.md
@@ -10,62 +10,75 @@ Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
 
 ---
 
-## Phase 0a — SD-JWT-VC  (Repo: `tdk`, new crate `affinidi-sd-jwt`)
+## Phase 0 — Validate + adopt TDK formats  (Repo: `tdk` + `vti`)
 
-- [ ] **0a.1 — SD-JWT core round-trip.** Build an SD-JWT (issuer JWT with
-  an `_sd` digest array + appended `~`-separated disclosures), serialize,
-  parse, and verify the issuer signature + recompute every disclosure
-  digest.
-  - Acceptance: a credential with all claims disclosed verifies; flipping
-    one byte of a disclosure or the signature fails verification.
-  - Verify: unit tests (`cargo test -p affinidi-sd-jwt`).
-  - Files: `affinidi-sd-jwt/src/{lib,sd_jwt,disclosure,hash}.rs`.
+> The SD-JWT/-VC + BBS + `bbs_2023` crates already exist and pass tests —
+> "build from scratch" was wrong. This phase **adopts** them.
 
-- [ ] **0a.2 — Selective disclosure.** Holder presents a *subset* of
-  disclosures; verifier returns only revealed claims; undisclosed claims
-  are absent and unrecoverable from the digests.
-  - Acceptance: present `{a}` of `{a,b,c}` → verifier sees `a`, never
-    `b`/`c`; the digests of `b`/`c` reveal nothing.
-  - Verify: unit test asserting the disclosed set and the absence of the
-    rest.
-  - Files: `affinidi-sd-jwt/src/present.rs`, `verify.rs`.
+- [x] **0.1 — Validate the foundation builds + passes.** `cargo test -p
+  affinidi-bbs -p affinidi-sd-jwt -p affinidi-sd-jwt-vc -p
+  affinidi-data-integrity -p affinidi-openid4vp`.
+  - Acceptance: exit 0. **DONE** (validated).
+  - Verify: ✅ exit 0.
 
-- [ ] **0a.3 — Key binding (`kb-jwt`).** Holder appends a `kb-jwt` over
-  `(sd_hash, aud, nonce, iat)` signed by the holder key (`cnf`); verifier
-  enforces it.
-  - Acceptance: a presentation with no / wrong / replayed (stale
-    `nonce`/`aud`) `kb-jwt` is rejected; a correct one passes and yields
-    the bound holder DID.
-  - Verify: unit tests for each rejection case + the happy path.
-  - Files: `affinidi-sd-jwt/src/key_binding.rs`, `verify.rs`.
+- [ ] **0.2 — Wire the crates as VTI deps.** Add `affinidi-sd-jwt-vc`,
+  `affinidi-bbs`, `affinidi-data-integrity` (bbs_2023), `affinidi-openid4vp`
+  to the VTI workspace (crates.io versions, or path/git to the local TDK
+  for unreleased DCQL).
+  - Acceptance: a VTI smoke test issues + verifies an SD-JWT-VC.
+  - Verify: `cargo test` in `vta-sdk`/`vti-common` smoke module.
+  - Files: `Cargo.toml` (workspace deps), a smoke test.
 
-- [ ] **0a.4 — SD-JWT-VC profile.** Add the VC profile fields: `vct`
-  (credential type), `iss`, `cnf`, `status`, `iat`/`exp`; map to the
-  workspace VC semantics.
-  - Acceptance: a typed SD-JWT-VC issues + verifies carrying
-    `vct`+`cnf`+`status`; an unknown/absent `vct` is surfaced to the
-    caller.
-  - Verify: unit test + a committed fixture credential.
-  - Files: `affinidi-sd-jwt/src/vc.rs`, `fixtures/`.
+- [ ] **0.3 — Confirm SD-JWT-VC profile completeness.** Verify
+  `affinidi-sd-jwt-vc` carries `vct` / `cnf` / `status`; fill any gap
+  upstream (TDK).
+  - Acceptance: a typed SD-JWT-VC with `vct`+`cnf`+`status` round-trips.
+  - Verify: unit test (TDK).
 
-- [ ] **0a.5 — IETF interop fixtures.** Validate against the published
-  SD-JWT / SD-JWT-VC examples (known-answer tests).
-  - Acceptance: the IETF example issuance + presentation verify;
-    digests/disclosures match byte-for-byte where the spec fixes them.
-  - Verify: KAT tests over `fixtures/ietf/`.
-  - Files: `affinidi-sd-jwt/tests/interop.rs`, `fixtures/ietf/`.
+- [ ] **0.4 — BLS12-381 G2 verification method.** Confirm/add a
+  `#bbs-key-0` representation in the did:key/did:webvh layer for the BBS
+  issuer key.
+  - Acceptance: a `did:webvh` doc resolves a BLS12-381 G2 VM usable by the
+    `bbs_2023` verifier.
+  - Verify: resolve + verify test (TDK).
 
-- [ ] **0a.6 — Public API + docs.** Stabilise `issue(claims, sd_paths,
-  issuer_key)`, `present(sd_jwt, reveal, holder_key, nonce, aud)`,
-  `verify(presentation, trusted_issuer) -> {claims, holder_did}`.
-  - Acceptance: the three-call flow runs in a doctest; the API is what the
-    VTA store (1.4/1.5) and the exchange (P3) will consume.
-  - Verify: doctest + `cargo doc` clean.
-  - Files: `affinidi-sd-jwt/src/lib.rs` (public surface).
+- [ ] **0.5 — Schedule the BBS security audit** (gate before BBS signs
+  anything real; SD-JWT-VC carries the near-term path meanwhile).
 
-- [ ] **CHECKPOINT 0a** — crate green end-to-end (issue → disclose →
-  verify + binding) + IETF fixtures pass; wired as a path/git dep into
-  this workspace. *Gate: unblocks 1.4–1.6 and Phase 3.*
+- [ ] **CHECKPOINT 0** — TDK formats wired into VTI; SD-JWT-VC
+  issue/verify smoke test green. *Gate: unblocks 1.4–1.6 + Phase 3.*
+
+---
+
+## Phase 0c — DCQL  (Repo: `tdk`, `affinidi-openid4vp`; the one net-new build)
+
+- [ ] **0c.1 — DCQL query model.** The DCQL `credentials` / `claims` /
+  `credential_sets` query structures (serde).
+  - Acceptance: parse/serialize the DCQL spec examples.
+  - Verify: unit tests over spec fixtures.
+  - Files: `affinidi-openid4vp/src/dcql/{model,parse}.rs`.
+
+- [ ] **0c.2 — Local match engine.** Match a DCQL query against a set of
+  held credentials → the satisfying credential(s)/claims, or no-match.
+  - Acceptance: a query for "InvitationCredential with claim X" selects
+    only matching held creds; returns descriptors, never the whole set.
+  - Verify: unit tests incl. a negative (no-fishing) case.
+  - Files: `affinidi-openid4vp/src/dcql/match.rs`.
+
+- [ ] **0c.3 — Format mapping.** Map DCQL onto **SD-JWT-VC** and **BBS**
+  credentials (the `format`/`meta` selectors).
+  - Acceptance: a DCQL query targets each format and disclosures honour
+    the requested claims.
+  - Verify: per-format unit tests.
+
+- [ ] **0c.4 — OID4VP integration.** Carry DCQL in the authorization
+  request/response alongside (or instead of) DIF PE.
+  - Acceptance: a DCQL authorization request → a conforming `vp_token`.
+  - Verify: round-trip test.
+  - Files: `affinidi-openid4vp/src/authorization*.rs`.
+
+- [ ] **CHECKPOINT 0c** — a DCQL query selects + presents SD-JWT-VC and
+  BBS credentials over OID4VP. *Gate: unblocks VTA search (1.3) + Phase 3.*
 
 ---
 
@@ -129,20 +142,22 @@ Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
 
 ---
 
-## Phase 0b — BBS foundation  (Repo: `tdk`, new crate `affinidi-bbs`; gated/audited)
+## Phase 0b — BBS (Repo: `tdk`, existing `affinidi-bbs`; adopt + audit)
 
-- [ ] 0b.1 — Adopt `ark-bls12-381`; BLS12-381 G2 keygen; implement
-  `affinidi-crypto` key/DID/multikey traits (`#bbs-key-0`, multicodec
-  `0xeb`).
-- [ ] 0b.2 — `bbs-2023` sign/verify vs IRTF test vectors.
-- [ ] 0b.3 — `bbs-2023` proofgen/proofverify (selective disclosure) vs
-  IRTF vectors.
-- [ ] 0b.4 — `bbs-2023` Data Integrity cryptosuite in
-  `affinidi-data-integrity`.
-- [ ] 0b.5 — Ed25519 holder binding for BBS presentations.
-- [ ] 0b.6 — **Security review** before any real signing.
-- [ ] CHECKPOINT 0b — IRTF vectors pass + e2e issue/disclose/verify;
-  audited. Additive to the credential-format registry.
+> `affinidi-bbs` (BBS over `bls12_381_plus`, 52 tests) + the `bbs_2023` DI
+> cryptosuite **already exist** — superseding the original "build on
+> arkworks" tasks. Remaining is adoption + the audit.
+
+- [x] 0b.1 — BBS sign/verify + proofgen/proofverify exist & pass (52
+  tests). **DONE.**
+- [x] 0b.2 — `bbs_2023` Data Integrity cryptosuite exists in
+  `affinidi-data-integrity`. **DONE.**
+- [ ] 0b.3 — Ed25519 holder binding for BBS presentations (confirm/wire
+  at integration).
+- [ ] 0b.4 — **Independent security review** before BBS signs anything
+  real. *(the one real gate)*
+- [ ] CHECKPOINT 0b — adopted as a registered credential format; audited
+  before real signing. Additive — never blocks SD-JWT-VC or 1–6.
 
 ---
 
@@ -218,6 +233,7 @@ Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
 
 ## Start here (parallel)
 
-- **Track A (`tdk`):** 0a.1 → … → CHECKPOINT 0a. (0b on the audited track.)
-- **Track B (`vti`):** 1.1 → 1.2 → 1.3 now (format-agnostic); converge
-  with 0a at 1.4.
+- **Track A (`tdk`):** Phase 0c (DCQL) — 0c.1 → … (the one net-new build).
+  Phase 0 adopt = validated; BBS audit on its own track.
+- **Track B (`vti`):** 1.1 → 1.2 → 1.3 now (format-agnostic); + 0.2 (wire
+  the TDK formats as deps); converge at 1.4 (present with SD-JWT-VC).

--- a/docs/05-design-notes/vti-credential-architecture-tasks.md
+++ b/docs/05-design-notes/vti-credential-architecture-tasks.md
@@ -1,0 +1,223 @@
+# VTI Credential Architecture — task checklist
+
+Companion to `vti-credential-architecture-plan.md`. Phase 0a + Phase 1 are
+task-level (vertical slices, each one complete path). Phases 0b + 2–6 are
+milestone-level and get a full task pass at their gate.
+
+Legend — **Repo:** `tdk` = `affinidi-tdk-rs`, `vti` = this workspace.
+Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
+**Files** (targets).
+
+---
+
+## Phase 0a — SD-JWT-VC  (Repo: `tdk`, new crate `affinidi-sd-jwt`)
+
+- [ ] **0a.1 — SD-JWT core round-trip.** Build an SD-JWT (issuer JWT with
+  an `_sd` digest array + appended `~`-separated disclosures), serialize,
+  parse, and verify the issuer signature + recompute every disclosure
+  digest.
+  - Acceptance: a credential with all claims disclosed verifies; flipping
+    one byte of a disclosure or the signature fails verification.
+  - Verify: unit tests (`cargo test -p affinidi-sd-jwt`).
+  - Files: `affinidi-sd-jwt/src/{lib,sd_jwt,disclosure,hash}.rs`.
+
+- [ ] **0a.2 — Selective disclosure.** Holder presents a *subset* of
+  disclosures; verifier returns only revealed claims; undisclosed claims
+  are absent and unrecoverable from the digests.
+  - Acceptance: present `{a}` of `{a,b,c}` → verifier sees `a`, never
+    `b`/`c`; the digests of `b`/`c` reveal nothing.
+  - Verify: unit test asserting the disclosed set and the absence of the
+    rest.
+  - Files: `affinidi-sd-jwt/src/present.rs`, `verify.rs`.
+
+- [ ] **0a.3 — Key binding (`kb-jwt`).** Holder appends a `kb-jwt` over
+  `(sd_hash, aud, nonce, iat)` signed by the holder key (`cnf`); verifier
+  enforces it.
+  - Acceptance: a presentation with no / wrong / replayed (stale
+    `nonce`/`aud`) `kb-jwt` is rejected; a correct one passes and yields
+    the bound holder DID.
+  - Verify: unit tests for each rejection case + the happy path.
+  - Files: `affinidi-sd-jwt/src/key_binding.rs`, `verify.rs`.
+
+- [ ] **0a.4 — SD-JWT-VC profile.** Add the VC profile fields: `vct`
+  (credential type), `iss`, `cnf`, `status`, `iat`/`exp`; map to the
+  workspace VC semantics.
+  - Acceptance: a typed SD-JWT-VC issues + verifies carrying
+    `vct`+`cnf`+`status`; an unknown/absent `vct` is surfaced to the
+    caller.
+  - Verify: unit test + a committed fixture credential.
+  - Files: `affinidi-sd-jwt/src/vc.rs`, `fixtures/`.
+
+- [ ] **0a.5 — IETF interop fixtures.** Validate against the published
+  SD-JWT / SD-JWT-VC examples (known-answer tests).
+  - Acceptance: the IETF example issuance + presentation verify;
+    digests/disclosures match byte-for-byte where the spec fixes them.
+  - Verify: KAT tests over `fixtures/ietf/`.
+  - Files: `affinidi-sd-jwt/tests/interop.rs`, `fixtures/ietf/`.
+
+- [ ] **0a.6 — Public API + docs.** Stabilise `issue(claims, sd_paths,
+  issuer_key)`, `present(sd_jwt, reveal, holder_key, nonce, aud)`,
+  `verify(presentation, trusted_issuer) -> {claims, holder_did}`.
+  - Acceptance: the three-call flow runs in a doctest; the API is what the
+    VTA store (1.4/1.5) and the exchange (P3) will consume.
+  - Verify: doctest + `cargo doc` clean.
+  - Files: `affinidi-sd-jwt/src/lib.rs` (public surface).
+
+- [ ] **CHECKPOINT 0a** — crate green end-to-end (issue → disclose →
+  verify + binding) + IETF fixtures pass; wired as a path/git dep into
+  this workspace. *Gate: unblocks 1.4–1.6 and Phase 3.*
+
+---
+
+## Phase 1 — VTA credential store  (Repo: `vti`, `vta-service`)
+
+- [ ] **1.1 — `StoredCredential` model + `vault` storage + index.**
+  *(format-agnostic — start now, parallel to 0a)*
+  - Acceptance: store + get by id; prefix-scan the index by `type`,
+    `community_did`, `issuer_did`, `purpose`, `status`. Encrypted at rest
+    (existing per-keyspace AES-GCM).
+  - Verify: unit tests (`cargo test -p vta-service ... vault`).
+  - Files: `vta-service/src/vault/{model,storage,index}.rs`, `server.rs`
+    (keyspace wiring; `vault` already exists).
+
+- [ ] **1.2 — Receive a credential.** An operation that verifies-minimally
+  (issuer signature via the format verifier + not-expired), indexes, and
+  stores.
+  - Acceptance: receiving a valid SD-JWT-VC (from 0a) stores + indexes it;
+    a tampered/expired one is rejected and not stored.
+  - Verify: integration test (store, then re-fetch + index hit).
+  - Files: `vta-service/src/operations/vault/receive.rs`,
+    `vta-service/src/routes/vault.rs` (+ DIDComm handler).
+
+- [ ] **1.3 — Local DCQL search → descriptors only.** Match stored
+  credentials by `{type, claims, issuer, purpose}`; return **descriptors**
+  (never bulk bodies across a trust boundary). **No "list all" endpoint.**
+  - Acceptance: a DCQL query for "InvitationCredential for community X"
+    returns the matching descriptor; there is no endpoint that enumerates
+    the wallet (asserted by a test that the only query path requires a
+    DCQL filter).
+  - Verify: unit tests for matching + a **negative** test enforcing the
+    no-enumeration invariant.
+  - Files: `vta-service/src/vault/query.rs` (DCQL match engine).
+
+- [ ] **1.4 — Present.** Build a presentation from a stored credential +
+  a holder-signed consent/selection → an SD-JWT-VC presentation with
+  `kb-jwt`.
+  - Acceptance: presenting a consented credential yields a verifiable
+    presentation (disclosing only the requested claims); without a valid
+    consent token the VTA refuses. *(needs 0a)*
+  - Verify: integration test (present → verify via `affinidi-sd-jwt`).
+  - Files: `vta-service/src/operations/vault/present.rs`, `routes/vault.rs`.
+
+- [ ] **1.5 — Mint.** The VTA issues its own SD-JWT-VC via the format
+  issuer + the VTA signing key (the signing oracle path).
+  - Acceptance: a VTA-minted credential verifies; the issuer key never
+    leaves the VTA.
+  - Verify: integration test (mint → verify).
+  - Files: `vta-service/src/operations/vault/mint.rs`.
+
+- [ ] **1.6 — Status refresh.** Poll/refresh status-list state; mark
+  revoked/expired so search + present exclude them.
+  - Acceptance: a credential whose status-list bit is set is excluded from
+    search results and refused for presentation.
+  - Verify: unit test flipping a status bit → excluded.
+  - Files: `vta-service/src/vault/status.rs`.
+
+- [ ] **CHECKPOINT 1** — VTA stores / searches / presents / mints
+  SD-JWT-VC end-to-end; the no-enumeration + consent-before-presentation
+  invariants are test-enforced. *Gate: unblocks Phase 3.*
+
+---
+
+## Phase 0b — BBS foundation  (Repo: `tdk`, new crate `affinidi-bbs`; gated/audited)
+
+- [ ] 0b.1 — Adopt `ark-bls12-381`; BLS12-381 G2 keygen; implement
+  `affinidi-crypto` key/DID/multikey traits (`#bbs-key-0`, multicodec
+  `0xeb`).
+- [ ] 0b.2 — `bbs-2023` sign/verify vs IRTF test vectors.
+- [ ] 0b.3 — `bbs-2023` proofgen/proofverify (selective disclosure) vs
+  IRTF vectors.
+- [ ] 0b.4 — `bbs-2023` Data Integrity cryptosuite in
+  `affinidi-data-integrity`.
+- [ ] 0b.5 — Ed25519 holder binding for BBS presentations.
+- [ ] 0b.6 — **Security review** before any real signing.
+- [ ] CHECKPOINT 0b — IRTF vectors pass + e2e issue/disclose/verify;
+  audited. Additive to the credential-format registry.
+
+---
+
+## Phase 2 — DTC catalog + VTC schema store + VIC  (Repo: `vti` + `dtg-credentials`)
+
+- [ ] 2.1 — Adopt `dtg-credentials`; port VMC/VEC onto DTC types (thin
+  wrappers).
+- [ ] 2.2 — VTC `schemas` keyspace + registry (issues + accepts; JSON
+  Schema + DTC binding) + admin CRUD.
+- [ ] 2.3 — InvitationCredential (VIC) builder (DTC).
+- [ ] 2.4 — Issue-time schema validation for every issued credential.
+- [ ] CHECKPOINT 2 — each catalog type issues against its schema.
+
+---
+
+## Phase 3 — credential-exchange protocol  (Repo: `vti`: `vta-sdk` + `vta-service` + `vtc-service`)
+
+- [ ] 3.1 — `credential-exchange/*` Trust Task message types
+  (`offer`/`request`/`issue` + `query`/`present`) wrapping OID4VCI/OID4VP
+  bodies + DCQL — in `vta-sdk/src/protocols/credential_exchange/`.
+- [ ] 3.2 — Issuer side (VTC): `offer → issue` (OID4VCI).
+- [ ] 3.3 — Verifier side (VTC): `query (DCQL) → present (OID4VP)`
+  verification.
+- [ ] 3.4 — Holder side (VTA): handle `offer→request→store`;
+  `query→consent→present`.
+- [ ] 3.5 — relayer≠holder + `sealed_transfer` for secret-bearing
+  issuance.
+- [ ] CHECKPOINT 3 — VTC↔VTA issue + query + present round-trips.
+
+---
+
+## Phase 4 — role-by-VC + verified-assertion cache + VP-based `/auth`  (Repo: `vti`: `vti-common` + `vtc-service`)
+
+- [ ] 4.1 — `verified_assertions` keyspace + record (roles/contexts/
+  membership/proof_refs/verified_at/expires_at/invalidated) + TTL.
+- [ ] 4.2 — `/auth/challenge` (DCQL) + `/auth` (verify VP → write
+  assertion → mint a JWT derived from it).
+- [ ] 4.3 — Auth extractors (`AdminAuth`/`ManageAuth`/`StepUpAuth`) read
+  the assertion record, not the JWT `role`.
+- [ ] 4.4 — Revocation/role-change → invalidate the record (push) + TTL
+  (pull); define the max staleness window.
+- [ ] 4.5 — Ceremony `Admit`/`Remint`/`Depart` issue/revoke Role VCs +
+  update the cache; ACL → derived index.
+- [ ] CHECKPOINT 4 — admin proven by a held Role VC; revocation
+  invalidates within the window.
+
+---
+
+## Phase 5 — join ceremony integration  (Repo: `vti`: `vtc-service`)
+
+- [ ] 5.1 — "join" ceremony emits a DCQL query from the schema store's
+  required evidence.
+- [ ] 5.2 — Holder presents → ceremony assembles `Facts` from the
+  verified VP → `decide()` → `execute()`.
+- [ ] 5.3 — Allow → issue MembershipCredential (+ Role VC) back via the
+  exchange; deny → decision-trace reason; refer → moderator queue;
+  request_more → DCQL loop.
+- [ ] CHECKPOINT 5 — the spec §12 invite→join flow end-to-end (allow +
+  deny).
+
+---
+
+## Phase 6 — browser plugin UX  (Repo: browser plugin + `vta-mobile-core`)
+
+- [ ] 6.1 — Digital Credentials API → OID4VP request handling.
+- [ ] 6.2 — Plain-English consent (reuse the ceremony English renderer) +
+  per-claim disclosure.
+- [ ] 6.3 — Device-side holder-binding signature + invite→join progress
+  UI.
+- [ ] CHECKPOINT 6 — Alice completes invite→join in the plugin.
+
+---
+
+## Start here (parallel)
+
+- **Track A (`tdk`):** 0a.1 → … → CHECKPOINT 0a. (0b on the audited track.)
+- **Track B (`vti`):** 1.1 → 1.2 → 1.3 now (format-agnostic); converge
+  with 0a at 1.4.

--- a/docs/05-design-notes/vti-credential-architecture.md
+++ b/docs/05-design-notes/vti-credential-architecture.md
@@ -1,0 +1,500 @@
+# VTI Credential Architecture — invite, hold, present, join
+
+**Status:** SPECIFY (spec-driven). Awaiting review before PLAN → TASKS →
+IMPLEMENT. Greenfield: breaking changes are in scope where they make the
+architecture better. Security and privacy are the gating constraints.
+
+This is the shared source of truth for turning VTI into a
+credential-centric system: the VTA becomes a holder's credential agent
+(store + wallet + signer), the VTC becomes an issuer + verifier + schema
+authority, and trust between nodes moves as Verifiable Credentials over a
+privacy-preserving exchange protocol. The motivating user journey is
+**invite → hold → present → join**.
+
+---
+
+## 0. Locked decisions (design-review forks)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Exchange wire protocol | **Trust Tasks wrap OID4VCI (issuance) + OID4VP (query/presentation)**; DCQL is the query language. The same OID4VP shapes are exposable to the browser via the W3C Digital Credentials API. |
+| D2 | Role / session auth model | **Hybrid**: the VC is the source of truth; a fast local *verified-assertion record* (TTL + invalidation) backs every hot-path authorization check. Re-prove only on invalidation. |
+| D3 | Credential type layer | **Adopt `dtg-credentials` (DTC)** as the canonical type catalog; the bespoke VMC/VEC become thin wrappers (or are retired) onto DTC types. |
+| D4 | Selective disclosure | **Claim-level from the start.** Primary: **BBS+ (`bbs-2023` Data Integrity cryptosuite)** — stays inside W3C VCDM + Data Integrity, adds unlinkable selective disclosure. SD-JWT-VC is the interop alternative. |
+
+---
+
+## 1. Objective
+
+Build the credential plane that lets a community **invite** a prospective
+member, lets that member **hold** the invitation in their own agent, and
+lets them **present** it to **join** — with the community then **issuing**
+a membership credential, and all subsequent authority (membership, roles,
+admin) **proven by held credentials** rather than asserted by a name in a
+server-side list.
+
+### Users
+
+- **Alice** — a prospective then actual member. Holds credentials in her
+  VTA; drives consent through the browser plugin (or mobile).
+- **Community operator** — runs the VTC; defines which credentials the
+  community issues and accepts (schemas), and the join ceremony.
+- **Integrations / other VTI nodes** — exchange credentials VTA↔VTC and
+  VTA↔VTA.
+
+### Success criteria (testable)
+
+1. A VTC can issue an **InvitationCredential** to an arbitrary DID that is
+   **not yet a member** (the holder is unknown to the community), and the
+   holder can store it in their VTA.
+2. A holder's VTA can **store, index, search (by type/criteria), and
+   present** credentials, and **mint** its own.
+3. A verifier can request a credential by **DCQL** and receive **only**
+   what the holder consents to — there is **no API that enumerates a
+   holder's wallet** across a trust boundary ("no fishing").
+4. Presentation supports **claim-level selective disclosure** — Alice can
+   prove "holds a valid InvitationCredential for community X" without
+   revealing unrelated claims or unrelated credentials.
+5. **Authorization is credential-derived**: `admin` (and every role) is
+   proven by a held **Role credential**, not by an ACL naming the DID.
+6. **Session auth** is established by presenting a VP once; subsequent
+   requests hit a **fast local verified-assertion record**; proof is
+   re-requested only when that record is invalidated (revocation, role
+   change, expiry).
+7. The end-to-end **invite → join** flow works through the existing
+   ceremony decision pipeline, including a legible **deny reason** on
+   failure.
+
+---
+
+## 2. Principles
+
+- **A credential is the unit of trust.** Membership, roles, invitations,
+  endorsements, personhood — all are VCs. Everything server-side is a
+  *projection* of credentials, never the source of truth.
+- **The VTA is the holder's agent.** It stores the holder's VCs (the
+  `vault`), signs/presents on the holder's behalf, and mints VCs the
+  holder issues. Key custody and consent live on the device (browser
+  plugin / mobile-core); the VTA never presents without consent.
+- **The VTC is issuer + verifier + schema authority.** It is *not* a
+  wallet. It declares what it issues and accepts, issues credentials, and
+  verifies presented ones.
+- **The ACL becomes a cache.** The authoritative statement "Alice is an
+  admin of context X" is a Role credential Alice holds. The VTC keeps a
+  derived, fast, local *verified-assertion record* for the hot path, with
+  a TTL and explicit invalidation.
+- **Privacy is default-deny on disclosure.** A verifier asks for a
+  *specific* credential/claims; the holder matches locally and consents
+  per request. Unlinkability where the crypto allows it.
+- **Reuse the rails.** Trust Tasks (envelope/auth/choreography),
+  `sealed_transfer` (secret-bearing parts), the ceremony decision
+  pipeline (Facts→Verdict→Effect), status lists (revocation), and the
+  `affinidi-*` issue/verify stack are kept; the credential *data plane*
+  and the *proof format* are the new work.
+
+---
+
+## 3. The credential catalog (DTC)
+
+Adopt `dtg-credentials` (DTC) as the canonical type layer. The community
+catalog (a superset of `docs/05-design-notes/vtc-mvp.md` §6.1):
+
+| Credential | Issuer | Subject | Purpose | Selective disclosure |
+|---|---|---|---|---|
+| **InvitationCredential (VIC)** | community (or member with `can_invite`) | a (possibly unknown) DID | authorizes a join | yes — prove validity without revealing inviter graph |
+| **MembershipCredential (VMC)** | community | member | "is a member of X" | yes — prove membership without other claims |
+| **RoleCredential (Role VEC)** | community | member | proves a role (admin/moderator/issuer/member/custom) | yes |
+| **EndorsementCredential (VEC)** | community or issuer-role member | member | community-defined claims | yes |
+| **RecognitionCredential (VRC)** | member (self-issued) | another member | peer trust edge | n/a (Phase 3) |
+| **PersonhoodCredential** | personhood oracle / community | member | Sybil resistance | yes |
+
+`vtc-service/src/credentials/{vmc,vec}.rs` become thin adapters over DTC
+types (or are retired). The JSON-LD `@context` documents live under
+`https://openvtc.org/contexts/` and are `include_str!`-baked for offline
+verification.
+
+**Capabilities as credentials.** `can_invite` (delegated invitation) and
+issuer authority are themselves credentials/claims, not ACL flags — this
+is what lets invitation trees and delegated issuance work without a
+central list.
+
+---
+
+## 4. Proof format — selective disclosure
+
+The workspace today issues W3C VCDM 2.0 credentials with Data Integrity
+proofs (`eddsa-jcs-2022`). To get claim-level selective disclosure
+(D4) **from the start**:
+
+- **Primary: BBS+ via the `bbs-2023` Data Integrity cryptosuite.** Keeps
+  the W3C VCDM + Data Integrity + JSON-LD model already in place — a VC is
+  still a VC, just signed with a different cryptosuite. The holder derives
+  a *proof* that discloses a chosen subset of claims, and BBS+ gives
+  **unlinkable** presentations (two presentations of the same credential
+  can't be correlated by the proof).
+  - **Implication:** the issuer (VTC, and a VTA minting its own) needs a
+    **BLS12-381 G2** assertion key in addition to its Ed25519 key. The
+    holder's **key binding** can remain Ed25519 (`did:key`/`did:webvh`),
+    bound into the derived proof.
+- **Holder binding** is mandatory on presentation: the derived proof is
+  bound to a fresh holder-key signature over the verifier's nonce
+  (prevents replay / credential lifting).
+- **`eddsa-jcs-2022` is retained** for credentials where selective
+  disclosure adds nothing (e.g. status-list credentials, internal
+  authorization VCs) and for the holder key-binding signature.
+- **SD-JWT-VC** is the documented alternative if interop with the
+  SD-JWT-VC ecosystem (OID4VC profiles, mDL-adjacent wallets) is needed;
+  it would run as a *second* presentation format the verifier accepts,
+  not a replacement.
+
+> **Risk (must spike first):** Rust BBS+/`bbs-2023` library maturity and
+> the BLS key management on the issuer. This is the highest-risk
+> dependency in the spec; Phase 0 is a spike that proves issue →
+> selectively-disclose → verify end-to-end before anything else is built.
+> Fallback path if the spike fails: ship SD-JWT-VC as primary instead.
+
+---
+
+## 5. The VTA credential store (`vault` promotion)
+
+The VTA already has a `vault` keyspace (M1 read-only stub). Promote it to
+a first-class credential store. Each stored credential carries an indexed
+envelope so the holder's agent can search **by type/criteria** without
+parsing every credential:
+
+```
+StoredCredential {
+  id,                       // local handle
+  format,                   // "bbs-2023" | "eddsa-jcs-2022" | "sd-jwt-vc"
+  types: [..],              // VC type tags (InvitationCredential, ...)
+  schema_id,                // → VTC schema store / catalog entry
+  community_did,            // which community / context this is for
+  subject_did,              // the holder DID this VC is about
+  issuer_did,
+  purpose,                  // invite | membership | role | endorsement | personhood
+  status,                   // valid | expired | revoked | unknown
+  valid_from, valid_until,
+  received_at, source,      // provenance
+  tags: {..},               // holder-applied labels
+  body,                     // the VC itself (encrypted at rest)
+}
+```
+
+VTA capabilities (the missing data plane):
+
+- **Receive** a VC → verify minimally (issuer signature, not-expired),
+  index, store (encrypted).
+- **Search** locally by `{type, community, issuer, purpose, schema,
+  status, claims}` — this is the DCQL match engine, **local only**.
+- **Present** → build a VP / derived proof (BBS+ selective disclosure)
+  on demand, signed with the holder key (device callback / signing
+  oracle), **gated by consent**.
+- **Mint** → the VTA issues its own VCs (generalize the existing
+  `DataIntegrityProof` issuer surface; add BBS+).
+- **Track validity** → poll/refresh status-list state; mark
+  revoked/expired so search can exclude them.
+
+Encryption at rest reuses the existing per-keyspace AES-256-GCM.
+
+---
+
+## 6. Exchange protocols — Trust Tasks wrapping OID4VCI / OID4VP
+
+A `credential-exchange/*` Trust Task family. The **Trust Task is the
+transport + auth + choreography envelope**; the **body is OID4VCI/OID4VP**.
+
+### Issuance (OID4VCI inside a Trust Task)
+
+```
+issuer → holder:  credential-exchange/offer/1.0      { credential_offer }   (OID4VCI)
+holder → issuer:  credential-exchange/request/1.0    { credential_request } (OID4VCI, key-binding proof)
+issuer → holder:  credential-exchange/issue/1.0      { credential }         (the VC, sealed if secret-bearing)
+```
+
+### Presentation (OID4VP + DCQL inside a Trust Task)
+
+```
+verifier → holder: credential-exchange/query/1.0     { dcql_query, nonce, purpose }  (OID4VP)
+holder   → verifier: credential-exchange/present/1.0 { vp_token }                    (OID4VP, derived proof + holder binding)
+```
+
+Why wrap rather than adopt OID4VP raw:
+
+- Trust Tasks already give **sender authentication** (authcrypt /
+  DI-signed), **threading**, **relayer≠holder** (the air-gap onboarding
+  pattern from provision-integration), and a uniform audit envelope.
+- OID4VP/VCI give **standard, wallet-interoperable** request/response
+  shapes and let the **browser plugin** speak the same bytes via the
+  **W3C Digital Credentials API** (`navigator.credentials.get({digital})`
+  with a DCQL request) — no bespoke plugin protocol.
+- New protocol → new Trust Task type + handler, exactly the existing
+  extension pattern (`vta-sdk/src/protocols/*`, `messaging/handlers.rs`).
+
+`purpose` on every query is mandatory and **shown to the holder** (purpose
+binding); the verifier cannot ask for a credential without stating why.
+
+---
+
+## 7. Privacy-first discovery (DCQL)
+
+- The verifier sends a **DCQL query** — "a credential of type
+  `InvitationCredential` for community `X` issued by a trusted issuer,
+  disclosing claims `{a, b}`." It never receives, and there is no endpoint
+  that returns, the holder's credential list.
+- The holder's VTA runs the DCQL match **locally** over its `vault`
+  index, producing candidate credentials.
+- The **browser plugin** renders the request in plain English (reuse the
+  ceremony's English-rendering approach) — *what* is being asked, *which*
+  of Alice's credentials would satisfy it, *what claims* would be
+  disclosed, and *why* (purpose) — and Alice **consents per credential**.
+- Only on consent does the VTA build the **selectively-disclosed** VP and
+  send it. Unmatched / unconsented credentials never leave the agent and
+  are never even acknowledged to the verifier.
+
+This is the "no fishing" guarantee at two layers: **no enumeration**
+(DCQL targets specific credentials) and **claim minimisation** (BBS+
+discloses only the requested claims).
+
+---
+
+## 8. VTC schema store
+
+A `schemas` keyspace + registry. The community declares:
+
+- **Issues** — the credential types this VTC mints (Invitation,
+  Membership, Role, plus operator-defined endorsement types), each with a
+  JSON Schema (`credentialSchema`) and a DTC type binding.
+- **Accepts** — the credential types/criteria the community recognises as
+  evidence, expressed so a ceremony's required evidence is a **DCQL query
+  over the schema store** (this is the "manifest" / Presentation
+  Definition from the join-ceremony design, now concrete).
+
+The schema store is the single source for: what a join requires, what the
+admin UI offers operators to issue, and what the DCQL queries reference.
+Validation of an incoming VC against its `credentialSchema` happens at
+verify time (a new step alongside signature + status + issuer-trust).
+
+---
+
+## 9. Issuing to a DID — unknown (invite) vs member-only
+
+- **Invite (unknown holder).** The community issues an
+  InvitationCredential to a DID that is **not a member**. This is the
+  relayer≠holder / air-gap pattern already used by provision-integration:
+  the credential is sealed to the holder's key and delivered out-of-band
+  (link, QR, DIDComm), and the holder need not have an account first.
+  Delegated invites (`can_invite`) let an authorised member issue.
+- **Member-only.** Membership, Role, and Endorsement credentials are
+  issued only to an established member DID (gated by the
+  verified-assertion record, §10).
+
+Issuance always goes through the **schema store** (the type must be
+registered as "issues") and the **status-list allocator** (so every
+issued credential is revocable).
+
+---
+
+## 10. Role-by-VC + the verified-assertion cache (hybrid auth)
+
+This replaces the ACL-name-as-truth model.
+
+- **Source of truth:** a held **Role credential** ("Alice holds a
+  `RoleCredential{role: admin, community: X}` issued by X"). There is no
+  ACL row that *names* Alice an admin.
+- **Hot-path cache — the verified-assertion record:**
+
+  ```
+  VerifiedAssertion {
+    did,
+    community_did,
+    roles: [admin, ...],          // proven by presented Role VCs
+    contexts: [..],
+    membership: { vmc_id, status },
+    proof_refs: [credential ids + presentation nonce],
+    verified_at,
+    expires_at,                   // TTL — short for high-assurance roles
+    invalidated: bool,            // flipped on revocation / role change
+  }
+  ```
+
+  Built when the holder presents a VP (at login or step-up). Every gated
+  route reads this record **synchronously** — no per-request credential
+  verification, no async I/O on the hot path.
+
+- **Invalidation:** a status-list revocation event, a role-change
+  ceremony, or TTL expiry flips `invalidated` / drops the record. The
+  next request gets a `re-present required` and the holder re-proves. This
+  is requirement #8 verbatim: *simple fast local lookup; only when
+  invalidated do you request proof again.*
+
+- **What changes in code:** the `VtcAclEntry.role` field stops being
+  authoritative; the auth extractors (`AdminAuth`, `ManageAuth`,
+  `StepUpAuth`) read the verified-assertion record instead of a JWT role
+  burned from the ACL. The ceremony `Admit`/`Remint`/`Depart` effects
+  issue/revoke Role VCs and update the cache rather than writing an ACL
+  role.
+
+---
+
+## 11. Session authentication via VP
+
+Generalise the existing challenge-response so the credential **is** the
+authentication:
+
+```
+POST /auth/challenge   → { nonce, dcql_query }     // "present membership (+ role) for X"
+POST /auth/            → { vp_token }               // selectively-disclosed VP, holder-bound
+   → verify: signature + holder binding + status + issuer trust + schema
+   → write VerifiedAssertion (roles/contexts/membership)
+   → mint session JWT whose role/contexts are DERIVED from the assertion
+POST /auth/refresh     → rotates the bearer; re-checks the assertion isn't invalidated
+```
+
+The JWT stays as the session bearer (fast stateless transport of "who +
+what"), but it is now a **cache of a cache** — derived from the
+verified-assertion record, which is derived from credentials. Token TTLs
+stay short for high-assurance roles (existing aal2 pattern).
+
+---
+
+## 12. The end-to-end flow (invite → join)
+
+```
+1. Operator (VTC) issues InvitationCredential to did:alice
+   └ credential-exchange/offer → issue ; sealed to alice's key ; alice unknown to community
+2. Alice stores it in her VTA
+   └ browser plugin → VTA vault.store ; indexed { type: Invitation, community: X, purpose: invite }
+3. Alice opens community, clicks "Join"
+   └ VTC starts the join ceremony
+4. VTC → Alice: credential-exchange/query (DCQL)  "InvitationCredential for X (+ schema-required evidence)"
+   └ Alice's VTA matches locally ; plugin shows request + purpose + claims to disclose
+5. Alice consents per credential
+   └ VTA builds selectively-disclosed, holder-bound VP → credential-exchange/present
+6. VTC verifies → assembles ceremony Facts → decide() → execute()
+   ├ Allow  → issue MembershipCredential (+ Role VC) back to Alice ; write VerifiedAssertion
+   ├ Deny   → return the decision-trace reason (the "why this verdict" UX)
+   ├ Refer  → moderator queue (existing) ; refer→queue link
+   └ RequestMore → DCQL for the missing evidence (the request_more loop)
+7. Alice is a member: her authority is now the held Membership + Role VCs.
+```
+
+Every wire step is a `credential-exchange/*` Trust Task; every decision is
+the ceremony pipeline already built; every failure is a legible verdict.
+
+---
+
+## 13. Browser plugin UX
+
+The plugin is the consent + key + legibility surface:
+
+- Speaks **OID4VP via the W3C Digital Credentials API** to the same query
+  shapes the Trust Tasks carry.
+- Renders the DCQL request in **plain English** (reuse the ceremony
+  English renderer): what, which credential, which claims, why.
+- Drives **per-credential, per-claim consent** and the **holder-binding**
+  signature (device key).
+- Shows held credentials, their validity/revocation status, and the
+  invite→join progress (mirrors the ceremony pipeline visual).
+
+---
+
+## 14. Security & privacy invariants (do not relax)
+
+1. **No wallet enumeration across a trust boundary.** No endpoint returns
+   a holder's credential list. Discovery is DCQL-targeted only.
+2. **Consent before disclosure.** The VTA never presents a credential
+   without explicit, purpose-bound holder consent.
+3. **Claim minimisation.** Presentations disclose only the DCQL-requested
+   claims (BBS+ selective disclosure); unlinkable where the suite allows.
+4. **Holder binding mandatory.** Every presentation is bound to a fresh
+   holder signature over the verifier nonce — no replay, no lifting.
+5. **Every issued credential is revocable** (status-list entry) and
+   re-verified for status at presentation time.
+6. **Issuer trust is explicit.** A verifier accepts a credential only
+   from an issuer its policy/trust-registry trusts (reuse Phase-3
+   recognition).
+7. **Secret-bearing transfers stay sealed.** Any credential carrying key
+   material moves via `sealed_transfer` (HPKE), never plaintext.
+8. **The verified-assertion cache is authoritative only as a cache.** It
+   must be invalidatable within one revocation propagation cycle; it
+   never outlives the credential it projects.
+
+---
+
+## 15. Data model (keyspaces)
+
+| Keyspace | Node | New/changed | Holds |
+|---|---|---|---|
+| `vault` | VTA | **promote** (was M1 stub) | StoredCredential envelopes + index |
+| `schemas` | VTC | **new** | issued + accepted credential schemas (DTC + JSON Schema) |
+| `verified_assertions` | VTC (+VTA) | **new** | the hot-path auth cache (§10) |
+| `acl` | VTC | **repurpose** | from "role source of truth" → derived index / legacy gate |
+| `status_lists` | VTC | reuse | revocation/suspension |
+| `sealed_nonces` | VTA | reuse | anti-replay for sealed transfers |
+| credential-exchange threads | both | **new** (or reuse join_requests) | in-flight exchange state |
+
+---
+
+## 16. Boundaries
+
+- **Always:** issue through the schema store + status-list allocator;
+  require purpose on every DCQL query; require holder binding on every
+  presentation; verify signature + status + issuer-trust + schema before
+  trusting any VC; gate every disclosure on consent.
+- **Ask first:** introducing a second proof format (SD-JWT-VC); changing
+  the BLS/BBS key management on issuers; widening what the
+  verified-assertion cache trusts; any endpoint that returns more than one
+  credential at a time.
+- **Never:** an endpoint that enumerates a holder's wallet; presenting a
+  credential without consent; disclosing claims beyond the DCQL request;
+  treating the ACL/JWT role as authoritative over a revoked credential;
+  emitting plaintext secret-bearing credentials.
+
+---
+
+## 17. Open questions
+
+1. **BBS+ library maturity (highest risk).** Does a production-grade
+   `bbs-2023` Data Integrity implementation exist for Rust, with the
+   `affinidi-*` stack? Phase 0 spike decides BBS+ vs SD-JWT-VC-primary.
+2. **Issuer BLS key lifecycle.** How are BLS12-381 issuer keys minted,
+   stored (the VTC `LocalSigner`), and rotated alongside the Ed25519 key?
+3. **Trust-registry binding for issuer trust** — reuse Phase-3
+   recognition, or a dedicated trusted-issuer policy per credential type?
+4. **Verified-assertion invalidation propagation** — push (revocation
+   event → cache flip) vs pull (TTL + status re-check). Likely both;
+   what's the max staleness window?
+5. **Where does the VTA wallet run for a browser-only Alice?** Hosted VTA
+   vs in-plugin lightweight agent vs both — affects key custody.
+6. **OID4VP profile** — which DCQL/credential-format profile to target for
+   external-wallet interop (and is that a near-term goal or future)?
+
+---
+
+## 18. Phased plan (PLAN preview — not yet TASKS)
+
+- **Phase 0 — Spike (gating):** prove BBS+ (`bbs-2023`) issue →
+  selective-disclose → verify + holder binding in Rust. Decide proof
+  format. *Verify: a passing end-to-end crypto test.*
+- **Phase 1 — Credential store:** promote the VTA `vault` to a real
+  store (receive/store/index/search/present/mint). *Verify: store + DCQL
+  local search + present round-trip.*
+- **Phase 2 — DTC catalog + schema store:** adopt `dtg-credentials`;
+  build the VTC `schemas` registry; port VMC/VEC; add InvitationCredential.
+  *Verify: issue each catalog type against its schema.*
+- **Phase 3 — Exchange protocol:** the `credential-exchange/*` Trust Task
+  family wrapping OID4VCI/OID4VP + DCQL. *Verify: VTC↔VTA issue + query +
+  present.*
+- **Phase 4 — Role-by-VC + verified-assertion cache:** rebuild auth so
+  roles are credential-derived; ACL → cache; VP-based `/auth`. *Verify:
+  admin proven by a held Role VC; revocation invalidates within the
+  window.*
+- **Phase 5 — Join ceremony integration:** wire the exchange + cache into
+  the existing ceremony pipeline (invite → DCQL → present → decide →
+  issue membership). *Verify: the §12 flow end-to-end, allow + deny.*
+- **Phase 6 — Browser plugin UX:** Digital Credentials API, plain-English
+  consent, per-claim disclosure, progress UI. *Verify: Alice completes
+  invite→join in the plugin.*
+
+Each phase is its own PR(s) and its own review gate. PLAN → TASKS expand
+each into discrete, verifiable tasks before implementation.

--- a/docs/05-design-notes/vti-credential-architecture.md
+++ b/docs/05-design-notes/vti-credential-architecture.md
@@ -184,13 +184,21 @@ both; DCQL `format` selectors say which a given query wants.
      arithmetic.
   3. **Implement `bbs-2023`** (keygen / sign / proofgen / proofverify per
      `draft-irtf-cfrg-bbs-signatures`) on `ark-bls12-381` — clean-room,
-     validated against the IRTF **test vectors**. Home: extend
-     `affinidi-crypto` or a new `affinidi-bbs` crate.
+     validated against the IRTF **test vectors**. Home: a **new
+     `affinidi-bbs` crate** (D-locked) that *depends on `affinidi-crypto`*
+     for the shared key/DID/multikey abstractions — keeps `affinidi-crypto`
+     curve-free and the audit-pending BLS code **structurally isolated**
+     (BBS is linked iff a build depends on `affinidi-bbs`, with no
+     workspace feature-unification surprises). The BLS12-381 G2 key type
+     lives here too.
   4. **Add a `bbs-2023` Data Integrity cryptosuite** to
      `affinidi-data-integrity` so a BBS VC is still a normal W3C
      Data-Integrity VC (parallel to `eddsa-jcs-2022`).
-  5. **Add BLS12-381 G2 key support** to `affinidi-crypto`'s key/DID layer
-     (the issuer `#bbs-key-0` verification method).
+  5. **BLS12-381 G2 key support** — `affinidi-bbs` defines the G2 key
+     type + multicodec (`0xeb`) and implements `affinidi-crypto`'s shared
+     key/DID/multikey traits, so the issuer `#bbs-key-0` verification
+     method plugs into the existing did:key/did:webvh machinery without
+     putting the curve in `affinidi-crypto`.
   This turns the library-maturity risk into a reusable asset, at the cost
   of an **implement-and-audit-a-cryptographic-scheme** obligation: BBS+
   must be security-reviewed before it signs anything real.
@@ -530,9 +538,9 @@ The plugin is the consent + key + legibility surface:
    external-wallet interop (and is that a near-term goal or future)?
 7. ~~Pairing-library choice~~ **RESOLVED: `arkworks` / `ark-bls12-381`.**
    ~~Which proof format~~ **RESOLVED: implement BOTH SD-JWT-VC and BBS+.**
-   Remaining: confirm the BBS home (`affinidi-crypto` vs new
-   `affinidi-bbs`) and **who audits** the BBS scheme before it signs real
-   credentials.
+   ~~BBS home~~ **RESOLVED: a new `affinidi-bbs` crate** (depends on
+   `affinidi-crypto`; curve stays out of the base crate). Remaining:
+   **who audits** the BBS scheme before it signs real credentials.
 
 ---
 
@@ -544,8 +552,8 @@ The plugin is the consent + key + legibility surface:
   verify + key-binding end-to-end.* Phases 1–6 build on this immediately.
 - **Phase 0b — BBS foundation (gated, parallel; net-new — the TDK has no
   BLS today):** adopt `arkworks`/`ark-bls12-381`; implement `bbs-2023`
-  (extend `affinidi-crypto` or new `affinidi-bbs`) and pass the IRTF BBS
-  test vectors; add a `bbs-2023` Data Integrity cryptosuite to
+  in a new **`affinidi-bbs`** crate (depends on `affinidi-crypto`) and
+  pass the IRTF BBS test vectors; add a `bbs-2023` Data Integrity cryptosuite to
   `affinidi-data-integrity`; add BLS12-381 G2 key support + the issuer
   `#bbs-key-0` verification method on a `did:webvh` doc; prove issue →
   selectively-disclose → verify + Ed25519 holder binding. *Verify: IRTF

--- a/docs/05-design-notes/vti-credential-architecture.md
+++ b/docs/05-design-notes/vti-credential-architecture.md
@@ -72,10 +72,12 @@ server-side list.
 - **A credential is the unit of trust.** Membership, roles, invitations,
   endorsements, personhood — all are VCs. Everything server-side is a
   *projection* of credentials, never the source of truth.
-- **The VTA is the holder's agent.** It stores the holder's VCs (the
-  `vault`), signs/presents on the holder's behalf, and mints VCs the
-  holder issues. Key custody and consent live on the device (browser
-  plugin / mobile-core); the VTA never presents without consent.
+- **The VTA is the holder's agent — always.** It stores the holder's VCs
+  (the `vault`), holds the holder's keys, signs/presents on the holder's
+  behalf, and mints VCs the holder issues. **There is no browser-only
+  holder:** the browser plugin / mobile-core is the UX + consent surface
+  and is *always backed by a VTA*. Consent originates on the device; the
+  VTA never presents without it.
 - **The VTC is issuer + verifier + schema authority.** It is *not* a
   wallet. It declares what it issues and accepts, issues credentials, and
   verifies presented ones.
@@ -132,10 +134,40 @@ proofs (`eddsa-jcs-2022`). To get claim-level selective disclosure
   a *proof* that discloses a chosen subset of claims, and BBS+ gives
   **unlinkable** presentations (two presentations of the same credential
   can't be correlated by the proof).
-  - **Implication:** the issuer (VTC, and a VTA minting its own) needs a
-    **BLS12-381 G2** assertion key in addition to its Ed25519 key. The
-    holder's **key binding** can remain Ed25519 (`did:key`/`did:webvh`),
-    bound into the derived proof.
+- **DID keys: we ADD a key, we do not change one.** BBS runs over
+  BLS12-381 (a pairing-friendly curve, ≠ Ed25519), but the impact is
+  asymmetric:
+  - **Holders (Alice): no change at all.** Proof derivation (selective
+    disclosure) is a *public* operation on the issuer's signature — the
+    holder needs **no BLS key** to receive a credential or derive a
+    disclosure proof. Holder binding stays an **Ed25519** signature over
+    the verifier nonce (her existing `did:key`/`did:webvh`). Her DID +
+    keys are untouched.
+  - **Issuers (VTC, and a VTA that mints BBS credentials): add one
+    verification method.** A **BLS12-381 G2** assertion key
+    (`#bbs-key-0`, `Bls12381G2Key2020` / multicodec `0xeb`) **alongside**
+    the existing Ed25519 `#key-0`. Because issuers are **`did:webvh`**
+    (multi-key DID documents), this is purely additive — the DID
+    identifier is unchanged and Ed25519 is not rotated.
+  - **Caveat:** `did:key` is single-key, so an *ephemeral `did:key`
+    issuer* can't carry a BLS key; only durable `did:webvh` issuers mint
+    BBS credentials. `eddsa-jcs-2022` stays for anything a `did:key`
+    signs. The workspace's "default to Ed25519 `did:key`" principle thus
+    *expands* (issuer DID docs also carry a BLS G2 key) — it doesn't break.
+  - **Optional later:** cryptographically *unlinkable* holder binding
+    (inside the ZKP) uses the BBS **pseudonym/commitment** extension with
+    a wallet-managed BLS **link secret** — still **not** the holder's DID
+    key, just a blinding scalar the wallet holds. Start without it.
+- **Implementation: own it in `affinidi-tdk-rs`.** Rather than depend on
+  an external BBS crate of uncertain maturity, implement the `bbs-2023`
+  scheme as a reusable library in `affinidi-tdk-rs` — but **on top of a
+  vetted BLS12-381 pairing library** (`blstrs` / `arkworks`), never
+  hand-rolling curve arithmetic. BBS is fully specified
+  (`draft-irtf-cfrg-bbs-signatures`) and ships official **test vectors**,
+  so a clean-room implementation is verifiable. This turns the
+  library-maturity risk into a reusable asset, at the cost of an
+  **implement-and-audit-a-cryptographic-scheme** obligation: it must be
+  security-reviewed before it signs anything real.
 - **Holder binding** is mandatory on presentation: the derived proof is
   bound to a fresh holder-key signature over the verifier's nonce
   (prevents replay / credential lifting).
@@ -147,11 +179,12 @@ proofs (`eddsa-jcs-2022`). To get claim-level selective disclosure
   it would run as a *second* presentation format the verifier accepts,
   not a replacement.
 
-> **Risk (must spike first):** Rust BBS+/`bbs-2023` library maturity and
-> the BLS key management on the issuer. This is the highest-risk
-> dependency in the spec; Phase 0 is a spike that proves issue →
-> selectively-disclose → verify end-to-end before anything else is built.
-> Fallback path if the spike fails: ship SD-JWT-VC as primary instead.
+> **Risk (must spike first):** owning a `bbs-2023` implementation +
+> issuer BLS key management is the highest-risk dependency in the spec.
+> Phase 0 is a spike that **implements `bbs-2023` in `affinidi-tdk-rs`,
+> passes the IRTF test vectors, then proves issue → selectively-disclose
+> → verify (+ Ed25519 holder binding) end-to-end** before anything else
+> is built. Fallback if the spike stalls: ship SD-JWT-VC as primary.
 
 ---
 
@@ -464,18 +497,29 @@ The plugin is the consent + key + legibility surface:
 4. **Verified-assertion invalidation propagation** — push (revocation
    event → cache flip) vs pull (TTL + status re-check). Likely both;
    what's the max staleness window?
-5. **Where does the VTA wallet run for a browser-only Alice?** Hosted VTA
-   vs in-plugin lightweight agent vs both — affects key custody.
+5. ~~Where does the VTA wallet run for a browser-only Alice?~~
+   **RESOLVED:** there is no browser-only holder — the plugin is always
+   backed by a VTA, which holds the wallet + keys. (Open sub-question:
+   does the plugin also hold a device-side key for holder binding, or
+   does the VTA hold it? Lean device-side for the binding signature, VTA
+   for the credential store.)
 6. **OID4VP profile** — which DCQL/credential-format profile to target for
    external-wallet interop (and is that a near-term goal or future)?
+7. **BBS implementation home + audit** — confirm `affinidi-tdk-rs` is the
+   right home, the pairing-library choice (`blstrs` vs `arkworks`), and
+   who audits the scheme before it signs real credentials.
 
 ---
 
 ## 18. Phased plan (PLAN preview — not yet TASKS)
 
-- **Phase 0 — Spike (gating):** prove BBS+ (`bbs-2023`) issue →
-  selective-disclose → verify + holder binding in Rust. Decide proof
-  format. *Verify: a passing end-to-end crypto test.*
+- **Phase 0 — Spike (gating):** implement `bbs-2023` in `affinidi-tdk-rs`
+  over a vetted BLS12-381 pairing crate; pass the IRTF BBS test vectors;
+  add the issuer BLS G2 verification method to a `did:webvh` doc; prove
+  issue → selectively-disclose → verify + Ed25519 holder binding. Decide
+  proof format (BBS+ vs SD-JWT-VC fallback). *Verify: IRTF test vectors
+  pass + a passing end-to-end issue/disclose/verify test. Security review
+  scheduled before any real signing.*
 - **Phase 1 — Credential store:** promote the VTA `vault` to a real
   store (receive/store/index/search/present/mint). *Verify: store + DCQL
   local search + present round-trip.*

--- a/docs/05-design-notes/vti-credential-architecture.md
+++ b/docs/05-design-notes/vti-credential-architecture.md
@@ -20,7 +20,7 @@ privacy-preserving exchange protocol. The motivating user journey is
 | D1 | Exchange wire protocol | **Trust Tasks wrap OID4VCI (issuance) + OID4VP (query/presentation)**; DCQL is the query language. The same OID4VP shapes are exposable to the browser via the W3C Digital Credentials API. |
 | D2 | Role / session auth model | **Hybrid**: the VC is the source of truth; a fast local *verified-assertion record* (TTL + invalidation) backs every hot-path authorization check. Re-prove only on invalidation. |
 | D3 | Credential type layer | **Adopt `dtg-credentials` (DTC)** as the canonical type catalog; the bespoke VMC/VEC become thin wrappers (or are retired) onto DTC types. |
-| D4 | Selective disclosure | **Implement BOTH, claim-level from the start.** **SD-JWT-VC** (no new curve, ships first, broad OID4VP interop) **and** **BBS+** (`bbs-2023` Data Integrity cryptosuite, unlinkable). The BLS12-381 foundation uses **`arkworks` / `ark-bls12-381`**. Both owned in `affinidi-tdk-rs`. |
+| D4 | Selective disclosure | **BOTH, claim-level — and ALREADY BUILT in the TDK** (`affinidi-sd-jwt`/`-vc`, `affinidi-bbs`, the `bbs_2023` DI cryptosuite — validated, tests green). So this is **adopt, not build**. BBS curve = **`bls12_381_plus`** (the existing `affinidi-bbs`; supersedes the earlier `arkworks` call). One net-new TDK gap: **DCQL** (add to `affinidi-openid4vp`, which uses DIF PE today). |
 
 ---
 
@@ -171,37 +171,34 @@ both; DCQL `format` selectors say which a given query wants.
     (inside the ZKP) uses the BBS **pseudonym/commitment** extension with
     a wallet-managed BLS **link secret** — still **not** the holder's DID
     key, just a blinding scalar the wallet holds. Start without it.
-- **Implementation: own it in `affinidi-tdk-rs` — starting from zero.**
-  Confirmed against `Cargo.lock`: there is **no BBS+ and no BLS12-381
-  curve anywhere in the dependency tree today**. The Affinidi crypto we
-  pull (`affinidi-crypto`, `affinidi-data-integrity` `eddsa-jcs-2022`,
-  `affinidi-secrets-resolver`) is entirely Ed25519/X25519. So this is
-  net-new foundational work, layered into `affinidi-tdk-rs`:
-  1. **SD-JWT-VC** (no curve) — salted-hash disclosures + JWT + `kb-jwt`
-     over the existing Ed25519/JOSE. Lower effort; **ships first**.
-  2. **Adopt `arkworks` / `ark-bls12-381`** (D-locked, pure-Rust pairing
-     library) as the BLS12-381 foundation. Never hand-roll curve
-     arithmetic.
-  3. **Implement `bbs-2023`** (keygen / sign / proofgen / proofverify per
-     `draft-irtf-cfrg-bbs-signatures`) on `ark-bls12-381` — clean-room,
-     validated against the IRTF **test vectors**. Home: a **new
-     `affinidi-bbs` crate** (D-locked) that *depends on `affinidi-crypto`*
-     for the shared key/DID/multikey abstractions — keeps `affinidi-crypto`
-     curve-free and the audit-pending BLS code **structurally isolated**
-     (BBS is linked iff a build depends on `affinidi-bbs`, with no
-     workspace feature-unification surprises). The BLS12-381 G2 key type
-     lives here too.
-  4. **Add a `bbs-2023` Data Integrity cryptosuite** to
-     `affinidi-data-integrity` so a BBS VC is still a normal W3C
-     Data-Integrity VC (parallel to `eddsa-jcs-2022`).
-  5. **BLS12-381 G2 key support** — `affinidi-bbs` defines the G2 key
-     type + multicodec (`0xeb`) and implements `affinidi-crypto`'s shared
-     key/DID/multikey traits, so the issuer `#bbs-key-0` verification
-     method plugs into the existing did:key/did:webvh machinery without
-     putting the curve in `affinidi-crypto`.
-  This turns the library-maturity risk into a reusable asset, at the cost
-  of an **implement-and-audit-a-cryptographic-scheme** obligation: BBS+
-  must be security-reviewed before it signs anything real.
+- **Implementation: ADOPT — the TDK already has it (validated).** The
+  earlier "build from scratch" framing was wrong: the `Cargo.lock` grep
+  came back empty only because *this workspace doesn't depend on the
+  credential crates yet*. They exist and pass their suites (validated
+  `cargo test`, exit 0):
+  | TDK crate | LOC | tests | what it is |
+  |---|---|---|---|
+  | `affinidi-sd-jwt` | ~2.3k | 90 | SD-JWT core (issuer/holder/verifier, key binding) |
+  | `affinidi-sd-jwt-vc` | ~0.5k | 11 | the SD-JWT-VC profile (`SdJwtVc`, `issue`, `verify_temporal`) |
+  | `affinidi-bbs` | ~2.1k | 52 | BBS over **BLS12-381 (`bls12_381_plus`)**, IETF `draft-irtf-cfrg-bbs-signatures` |
+  | `affinidi-data-integrity` | ~3k | ✓ | includes **`bbs_2023.rs`** — the DI cryptosuite, parallel to `eddsa-jcs-2022` |
+  | `affinidi-openid4vp` / `-vci` | ~0.8k ea | 13 | OID4VP/VCI (**DIF Presentation Exchange today, not DCQL**) |
+
+  So the BBS curve is **`bls12_381_plus`** (D-revised — the original
+  `arkworks` call predated finding `affinidi-bbs`; we keep the existing,
+  tested crate rather than rewrite it). The crates are
+  `publish.workspace = true` (crates.io-publishable, like the
+  `affinidi-vc = "0.1"` deps VTI already uses), so VTI **adopts them as
+  dependencies** — no new TDK crate, no `arkworks`.
+  - **The one net-new TDK gap is DCQL** (D-locked). `affinidi-openid4vp`
+    uses the older DIF Presentation Exchange (`PresentationDefinition` /
+    `InputDescriptor`); DCQL is absent across the whole TDK. We add a DCQL
+    query + match module to `affinidi-openid4vp`.
+  - **Still to confirm during adoption:** SD-JWT-VC profile completeness
+    (`vct` / `cnf` / `status`); a BLS12-381 G2 verification-method
+    representation for `#bbs-key-0` in the did:key/did:webvh layer.
+  - **BBS audit** remains a gate before BBS signs anything real (the crate
+    is implemented + unit-tested, not yet independently audited).
 - **Holder binding** is mandatory on presentation (both formats): bound to
   a fresh holder-key signature over the verifier nonce — `kb-jwt` for
   SD-JWT-VC, an Ed25519 binding (or the BBS pseudonym extension later) for
@@ -210,12 +207,13 @@ both; DCQL `format` selectors say which a given query wants.
   disclosure adds nothing (status-list credentials, internal authorization
   VCs) and for the holder key-binding signature.
 
-> **Sequencing (de-risked):** SD-JWT-VC has no curve dependency, so
-> Phases 1–6 build on it **in parallel** while the BLS/BBS foundation
-> matures — and because the credential layer abstracts over format, adding
-> BBS+ later is additive (a new format + cryptosuite), not a rewrite. BBS+
-> is the gated, security-reviewed track; SD-JWT-VC is the unblock-now
-> track. Both land; neither blocks the other.
+> **Sequencing (de-risked — the foundation is already built):** both
+> formats exist + pass tests in the TDK, so Phase 0 is *validate + adopt*,
+> not *build*. Integrate **SD-JWT-VC first** (simplest to wire — JOSE over
+> Ed25519); **BBS+ is additive** (register a second format + the
+> `bbs_2023` cryptosuite) and gated only by its independent **security
+> audit** before real signing. The one net-new TDK build is **DCQL**.
+> Neither blocks the VTA/VTC integration (Phases 1–6).
 
 ---
 
@@ -518,9 +516,11 @@ The plugin is the consent + key + legibility surface:
 
 ## 17. Open questions
 
-1. **BBS+ library maturity (highest risk).** Does a production-grade
-   `bbs-2023` Data Integrity implementation exist for Rust, with the
-   `affinidi-*` stack? Phase 0 spike decides BBS+ vs SD-JWT-VC-primary.
+1. ~~BBS+ library maturity (highest risk)~~ **RESOLVED: it exists +
+   passes tests.** `affinidi-bbs` (BBS over `bls12_381_plus`, 52 tests) +
+   `affinidi-data-integrity::bbs_2023` are implemented and validated
+   (`cargo test` exit 0). Remaining real risk is the **independent
+   security audit** before BBS signs anything real — not existence.
 2. **Issuer BLS key lifecycle.** How are BLS12-381 issuer keys minted,
    stored (the VTC `LocalSigner`), and rotated alongside the Ed25519 key?
 3. **Trust-registry binding for issuer trust** — reuse Phase-3
@@ -536,30 +536,30 @@ The plugin is the consent + key + legibility surface:
    for the credential store.)
 6. **OID4VP profile** — which DCQL/credential-format profile to target for
    external-wallet interop (and is that a near-term goal or future)?
-7. ~~Pairing-library choice~~ **RESOLVED: `arkworks` / `ark-bls12-381`.**
-   ~~Which proof format~~ **RESOLVED: implement BOTH SD-JWT-VC and BBS+.**
-   ~~BBS home~~ **RESOLVED: a new `affinidi-bbs` crate** (depends on
-   `affinidi-crypto`; curve stays out of the base crate). Remaining:
-   **who audits** the BBS scheme before it signs real credentials.
+7. ~~Pairing-library choice~~ **RESOLVED: `bls12_381_plus`** — keep the
+   existing, tested `affinidi-bbs` (the earlier `arkworks` + new-crate
+   plan predated finding it). ~~Proof format~~ **RESOLVED: BOTH, and both
+   already built.** ~~BBS home~~ **RESOLVED: existing `affinidi-bbs`.**
+   Remaining: **who audits** BBS before real signing.
+8. **DCQL shape** — confirm the DCQL profile/version to implement in
+   `affinidi-openid4vp`, and how it maps onto both SD-JWT-VC and BBS
+   credential formats.
 
 ---
 
 ## 18. Phased plan (PLAN preview — not yet TASKS)
 
-- **Phase 0a — SD-JWT-VC (unblocks everything; no curve):** implement
-  SD-JWT-VC (salted-hash disclosures + `kb-jwt`) in `affinidi-tdk-rs` over
-  the existing Ed25519/JOSE. *Verify: issue → selectively-disclose →
-  verify + key-binding end-to-end.* Phases 1–6 build on this immediately.
-- **Phase 0b — BBS foundation (gated, parallel; net-new — the TDK has no
-  BLS today):** adopt `arkworks`/`ark-bls12-381`; implement `bbs-2023`
-  in a new **`affinidi-bbs`** crate (depends on `affinidi-crypto`) and
-  pass the IRTF BBS test vectors; add a `bbs-2023` Data Integrity cryptosuite to
-  `affinidi-data-integrity`; add BLS12-381 G2 key support + the issuer
-  `#bbs-key-0` verification method on a `did:webvh` doc; prove issue →
-  selectively-disclose → verify + Ed25519 holder binding. *Verify: IRTF
-  test vectors pass + end-to-end issue/disclose/verify. **Security review
-  before any real signing.*** Adding BBS+ to the credential layer is
-  additive (new format + cryptosuite), so it doesn't block 0a or 1–6.
+- **Phase 0 — Validate + adopt the TDK formats (mostly DONE).** The
+  credential foundation already exists and passes its tests (`affinidi-sd-jwt`,
+  `affinidi-sd-jwt-vc`, `affinidi-bbs` on `bls12_381_plus`, the `bbs_2023`
+  DI cryptosuite). *Verify: ✅ `cargo test` exit 0 across the crates.*
+  Remaining adoption tasks: wire them as VTI deps; confirm the SD-JWT-VC
+  profile (`vct`/`cnf`/`status`) + a BLS12-381 G2 verification method for
+  `#bbs-key-0`; schedule the **BBS security audit** before real signing.
+- **Phase 0c — DCQL (the one net-new TDK build):** add a DCQL query +
+  match module to `affinidi-openid4vp` (it uses DIF Presentation Exchange
+  today). *Verify: a DCQL query matches/selects credentials against the
+  SD-JWT-VC + BBS formats.* Unblocks the privacy-first discovery (§7).
 - **Phase 1 — Credential store:** promote the VTA `vault` to a real
   store (receive/store/index/search/present/mint). *Verify: store + DCQL
   local search + present round-trip.*

--- a/docs/05-design-notes/vti-credential-architecture.md
+++ b/docs/05-design-notes/vti-credential-architecture.md
@@ -158,16 +158,27 @@ proofs (`eddsa-jcs-2022`). To get claim-level selective disclosure
     (inside the ZKP) uses the BBS **pseudonym/commitment** extension with
     a wallet-managed BLS **link secret** — still **not** the holder's DID
     key, just a blinding scalar the wallet holds. Start without it.
-- **Implementation: own it in `affinidi-tdk-rs`.** Rather than depend on
-  an external BBS crate of uncertain maturity, implement the `bbs-2023`
-  scheme as a reusable library in `affinidi-tdk-rs` — but **on top of a
-  vetted BLS12-381 pairing library** (`blstrs` / `arkworks`), never
-  hand-rolling curve arithmetic. BBS is fully specified
-  (`draft-irtf-cfrg-bbs-signatures`) and ships official **test vectors**,
-  so a clean-room implementation is verifiable. This turns the
-  library-maturity risk into a reusable asset, at the cost of an
-  **implement-and-audit-a-cryptographic-scheme** obligation: it must be
-  security-reviewed before it signs anything real.
+- **Implementation: own it in `affinidi-tdk-rs` — starting from zero.**
+  Confirmed against `Cargo.lock`: there is **no BBS+ and no BLS12-381
+  curve anywhere in the dependency tree today**. The Affinidi crypto we
+  pull (`affinidi-crypto`, `affinidi-data-integrity` `eddsa-jcs-2022`,
+  `affinidi-secrets-resolver`) is entirely Ed25519/X25519. So this is
+  net-new foundational work, layered into `affinidi-tdk-rs`:
+  1. **Adopt** a vetted BLS12-381 pairing crate (`blstrs` — `blst`-backed,
+     fast, audited C core; or `arkworks`/`ark-bls12-381` — pure Rust).
+     Never hand-roll curve arithmetic.
+  2. **Implement `bbs-2023`** (keygen / sign / proofgen / proofverify per
+     `draft-irtf-cfrg-bbs-signatures`) — clean-room, validated against the
+     IRTF **test vectors**. Home: extend `affinidi-crypto` or a new
+     `affinidi-bbs` crate.
+  3. **Add a `bbs-2023` Data Integrity cryptosuite** to
+     `affinidi-data-integrity` so a BBS VC is still a normal W3C
+     Data-Integrity VC (parallel to `eddsa-jcs-2022`).
+  4. **Add BLS12-381 G2 key support** to `affinidi-crypto`'s key/DID layer
+     (the issuer `#bbs-key-0` verification method).
+  This turns the library-maturity risk into a reusable asset, at the cost
+  of an **implement-and-audit-a-cryptographic-scheme** obligation: it must
+  be security-reviewed before it signs anything real.
 - **Holder binding** is mandatory on presentation: the derived proof is
   bound to a fresh holder-key signature over the verifier's nonce
   (prevents replay / credential lifting).
@@ -513,9 +524,12 @@ The plugin is the consent + key + legibility surface:
 
 ## 18. Phased plan (PLAN preview — not yet TASKS)
 
-- **Phase 0 — Spike (gating):** implement `bbs-2023` in `affinidi-tdk-rs`
-  over a vetted BLS12-381 pairing crate; pass the IRTF BBS test vectors;
-  add the issuer BLS G2 verification method to a `did:webvh` doc; prove
+- **Phase 0 — BBS foundation + spike (gating; net-new, the TDK has no
+  BLS today):** adopt a BLS12-381 pairing crate into `affinidi-tdk-rs`;
+  implement `bbs-2023` (extend `affinidi-crypto` or new `affinidi-bbs`)
+  and pass the IRTF BBS test vectors; add a `bbs-2023` Data Integrity
+  cryptosuite to `affinidi-data-integrity`; add BLS12-381 G2 key support +
+  the issuer `#bbs-key-0` verification method on a `did:webvh` doc; prove
   issue → selectively-disclose → verify + Ed25519 holder binding. Decide
   proof format (BBS+ vs SD-JWT-VC fallback). *Verify: IRTF test vectors
   pass + a passing end-to-end issue/disclose/verify test. Security review

--- a/docs/05-design-notes/vti-credential-architecture.md
+++ b/docs/05-design-notes/vti-credential-architecture.md
@@ -20,7 +20,7 @@ privacy-preserving exchange protocol. The motivating user journey is
 | D1 | Exchange wire protocol | **Trust Tasks wrap OID4VCI (issuance) + OID4VP (query/presentation)**; DCQL is the query language. The same OID4VP shapes are exposable to the browser via the W3C Digital Credentials API. |
 | D2 | Role / session auth model | **Hybrid**: the VC is the source of truth; a fast local *verified-assertion record* (TTL + invalidation) backs every hot-path authorization check. Re-prove only on invalidation. |
 | D3 | Credential type layer | **Adopt `dtg-credentials` (DTC)** as the canonical type catalog; the bespoke VMC/VEC become thin wrappers (or are retired) onto DTC types. |
-| D4 | Selective disclosure | **Claim-level from the start.** Primary: **BBS+ (`bbs-2023` Data Integrity cryptosuite)** — stays inside W3C VCDM + Data Integrity, adds unlinkable selective disclosure. SD-JWT-VC is the interop alternative. |
+| D4 | Selective disclosure | **Implement BOTH, claim-level from the start.** **SD-JWT-VC** (no new curve, ships first, broad OID4VP interop) **and** **BBS+** (`bbs-2023` Data Integrity cryptosuite, unlinkable). The BLS12-381 foundation uses **`arkworks` / `ark-bls12-381`**. Both owned in `affinidi-tdk-rs`. |
 
 ---
 
@@ -126,14 +126,27 @@ central list.
 
 The workspace today issues W3C VCDM 2.0 credentials with Data Integrity
 proofs (`eddsa-jcs-2022`). To get claim-level selective disclosure
-(D4) **from the start**:
+(D4) **from the start**, we implement **both** SD-JWT-VC and BBS+ as
+first-class formats — the credential layer abstracts over *format*, not
+just over DI cryptosuite. They are complementary, not redundant:
 
-- **Primary: BBS+ via the `bbs-2023` Data Integrity cryptosuite.** Keeps
-  the W3C VCDM + Data Integrity + JSON-LD model already in place — a VC is
-  still a VC, just signed with a different cryptosuite. The holder derives
-  a *proof* that discloses a chosen subset of claims, and BBS+ gives
-  **unlinkable** presentations (two presentations of the same credential
-  can't be correlated by the proof).
+- **SD-JWT-VC** (IETF) — selective disclosure via **salted-hash
+  disclosures over a JWT**, with a key-binding JWT (`kb-jwt`) for holder
+  binding. *Needs no new curve* — it runs on the **Ed25519/JOSE** we
+  already have, so it can ship first and unblock the VTA/VTC layers
+  (Phases 1–6). Broadest **OID4VP / wallet ecosystem interop** (the
+  `dc+sd-jwt` format). A distinct serialization from W3C-DI VCs (not a DI
+  cryptosuite), so the credential-handling layer must span both shapes.
+- **BBS+** via the **`bbs-2023` Data Integrity cryptosuite** — keeps the
+  W3C VCDM + Data Integrity + JSON-LD model; the holder derives a *proof*
+  disclosing a chosen subset of claims, and BBS+ adds **unlinkable**
+  presentations (two presentations of the same credential can't be
+  correlated). This is the stronger-privacy format and the reason for the
+  BLS curve work below.
+
+The two share one contract: disclose **only** the DCQL-requested claims,
+mandatory holder binding, status-list revocability. The verifier accepts
+both; DCQL `format` selectors say which a given query wants.
 - **DID keys: we ADD a key, we do not change one.** BBS runs over
   BLS12-381 (a pairing-friendly curve, ≠ Ed25519), but the impact is
   asymmetric:
@@ -164,38 +177,37 @@ proofs (`eddsa-jcs-2022`). To get claim-level selective disclosure
   pull (`affinidi-crypto`, `affinidi-data-integrity` `eddsa-jcs-2022`,
   `affinidi-secrets-resolver`) is entirely Ed25519/X25519. So this is
   net-new foundational work, layered into `affinidi-tdk-rs`:
-  1. **Adopt** a vetted BLS12-381 pairing crate (`blstrs` — `blst`-backed,
-     fast, audited C core; or `arkworks`/`ark-bls12-381` — pure Rust).
-     Never hand-roll curve arithmetic.
-  2. **Implement `bbs-2023`** (keygen / sign / proofgen / proofverify per
-     `draft-irtf-cfrg-bbs-signatures`) — clean-room, validated against the
-     IRTF **test vectors**. Home: extend `affinidi-crypto` or a new
-     `affinidi-bbs` crate.
-  3. **Add a `bbs-2023` Data Integrity cryptosuite** to
+  1. **SD-JWT-VC** (no curve) — salted-hash disclosures + JWT + `kb-jwt`
+     over the existing Ed25519/JOSE. Lower effort; **ships first**.
+  2. **Adopt `arkworks` / `ark-bls12-381`** (D-locked, pure-Rust pairing
+     library) as the BLS12-381 foundation. Never hand-roll curve
+     arithmetic.
+  3. **Implement `bbs-2023`** (keygen / sign / proofgen / proofverify per
+     `draft-irtf-cfrg-bbs-signatures`) on `ark-bls12-381` — clean-room,
+     validated against the IRTF **test vectors**. Home: extend
+     `affinidi-crypto` or a new `affinidi-bbs` crate.
+  4. **Add a `bbs-2023` Data Integrity cryptosuite** to
      `affinidi-data-integrity` so a BBS VC is still a normal W3C
      Data-Integrity VC (parallel to `eddsa-jcs-2022`).
-  4. **Add BLS12-381 G2 key support** to `affinidi-crypto`'s key/DID layer
+  5. **Add BLS12-381 G2 key support** to `affinidi-crypto`'s key/DID layer
      (the issuer `#bbs-key-0` verification method).
   This turns the library-maturity risk into a reusable asset, at the cost
-  of an **implement-and-audit-a-cryptographic-scheme** obligation: it must
-  be security-reviewed before it signs anything real.
-- **Holder binding** is mandatory on presentation: the derived proof is
-  bound to a fresh holder-key signature over the verifier's nonce
-  (prevents replay / credential lifting).
+  of an **implement-and-audit-a-cryptographic-scheme** obligation: BBS+
+  must be security-reviewed before it signs anything real.
+- **Holder binding** is mandatory on presentation (both formats): bound to
+  a fresh holder-key signature over the verifier nonce — `kb-jwt` for
+  SD-JWT-VC, an Ed25519 binding (or the BBS pseudonym extension later) for
+  BBS+. Prevents replay / credential lifting.
 - **`eddsa-jcs-2022` is retained** for credentials where selective
-  disclosure adds nothing (e.g. status-list credentials, internal
-  authorization VCs) and for the holder key-binding signature.
-- **SD-JWT-VC** is the documented alternative if interop with the
-  SD-JWT-VC ecosystem (OID4VC profiles, mDL-adjacent wallets) is needed;
-  it would run as a *second* presentation format the verifier accepts,
-  not a replacement.
+  disclosure adds nothing (status-list credentials, internal authorization
+  VCs) and for the holder key-binding signature.
 
-> **Risk (must spike first):** owning a `bbs-2023` implementation +
-> issuer BLS key management is the highest-risk dependency in the spec.
-> Phase 0 is a spike that **implements `bbs-2023` in `affinidi-tdk-rs`,
-> passes the IRTF test vectors, then proves issue → selectively-disclose
-> → verify (+ Ed25519 holder binding) end-to-end** before anything else
-> is built. Fallback if the spike stalls: ship SD-JWT-VC as primary.
+> **Sequencing (de-risked):** SD-JWT-VC has no curve dependency, so
+> Phases 1–6 build on it **in parallel** while the BLS/BBS foundation
+> matures — and because the credential layer abstracts over format, adding
+> BBS+ later is additive (a new format + cryptosuite), not a rewrite. BBS+
+> is the gated, security-reviewed track; SD-JWT-VC is the unblock-now
+> track. Both land; neither blocks the other.
 
 ---
 
@@ -516,24 +528,30 @@ The plugin is the consent + key + legibility surface:
    for the credential store.)
 6. **OID4VP profile** — which DCQL/credential-format profile to target for
    external-wallet interop (and is that a near-term goal or future)?
-7. **BBS implementation home + audit** — confirm `affinidi-tdk-rs` is the
-   right home, the pairing-library choice (`blstrs` vs `arkworks`), and
-   who audits the scheme before it signs real credentials.
+7. ~~Pairing-library choice~~ **RESOLVED: `arkworks` / `ark-bls12-381`.**
+   ~~Which proof format~~ **RESOLVED: implement BOTH SD-JWT-VC and BBS+.**
+   Remaining: confirm the BBS home (`affinidi-crypto` vs new
+   `affinidi-bbs`) and **who audits** the BBS scheme before it signs real
+   credentials.
 
 ---
 
 ## 18. Phased plan (PLAN preview — not yet TASKS)
 
-- **Phase 0 — BBS foundation + spike (gating; net-new, the TDK has no
-  BLS today):** adopt a BLS12-381 pairing crate into `affinidi-tdk-rs`;
-  implement `bbs-2023` (extend `affinidi-crypto` or new `affinidi-bbs`)
-  and pass the IRTF BBS test vectors; add a `bbs-2023` Data Integrity
-  cryptosuite to `affinidi-data-integrity`; add BLS12-381 G2 key support +
-  the issuer `#bbs-key-0` verification method on a `did:webvh` doc; prove
-  issue → selectively-disclose → verify + Ed25519 holder binding. Decide
-  proof format (BBS+ vs SD-JWT-VC fallback). *Verify: IRTF test vectors
-  pass + a passing end-to-end issue/disclose/verify test. Security review
-  scheduled before any real signing.*
+- **Phase 0a — SD-JWT-VC (unblocks everything; no curve):** implement
+  SD-JWT-VC (salted-hash disclosures + `kb-jwt`) in `affinidi-tdk-rs` over
+  the existing Ed25519/JOSE. *Verify: issue → selectively-disclose →
+  verify + key-binding end-to-end.* Phases 1–6 build on this immediately.
+- **Phase 0b — BBS foundation (gated, parallel; net-new — the TDK has no
+  BLS today):** adopt `arkworks`/`ark-bls12-381`; implement `bbs-2023`
+  (extend `affinidi-crypto` or new `affinidi-bbs`) and pass the IRTF BBS
+  test vectors; add a `bbs-2023` Data Integrity cryptosuite to
+  `affinidi-data-integrity`; add BLS12-381 G2 key support + the issuer
+  `#bbs-key-0` verification method on a `did:webvh` doc; prove issue →
+  selectively-disclose → verify + Ed25519 holder binding. *Verify: IRTF
+  test vectors pass + end-to-end issue/disclose/verify. **Security review
+  before any real signing.*** Adding BBS+ to the credential layer is
+  additive (new format + cryptosuite), so it doesn't block 0a or 1–6.
 - **Phase 1 — Credential store:** promote the VTA `vault` to a real
   store (receive/store/index/search/present/mint). *Verify: store + DCQL
   local search + present round-trip.*


### PR DESCRIPTION
## What

Spec-driven design review (**SPECIFY** phase) for the credential-centric redesign: the VTA becomes a holder's credential agent (store + wallet + signer), the VTC becomes an issuer + verifier + schema authority, and all authority (membership, roles, admin) is **proven by held credentials** rather than named in a server-side list. Motivating journey: **invite → hold → present → join**.

Docs-only — one design note: `docs/05-design-notes/vti-credential-architecture.md`. Awaiting review before PLAN → TASKS → IMPLEMENT.

## Locked decisions (from the design-review forks)

| | Decision |
|---|---|
| **Exchange** | Trust Tasks **wrap** OID4VCI (issue) + OID4VP (query/present); **DCQL** is the query language; same shapes exposed to the browser via the W3C Digital Credentials API. |
| **Auth** | **Hybrid** — the VC is the source of truth; a fast local **verified-assertion record** (TTL + invalidation) backs hot-path checks. The ACL becomes that cache. |
| **Types** | Adopt **`dtg-credentials` (DTC)**; VMC/VEC become thin wrappers. |
| **Privacy** | **Claim-level selective disclosure from the start** — primary **BBS+ (`bbs-2023`)**, SD-JWT-VC as interop alternative. |

## Grounded in what exists

Maps reuse vs gaps from a workspace sweep: reuse `affinidi-vc`/`-data-integrity`/`-status-list`, the `LocalSigner` path, `sealed_transfer`, Trust Tasks, and the ceremony decision pipeline; **promote** the VTA `vault` keyspace (today an M1 read-only stub) to a real credential store; **new** work is the credential data plane, the `schemas` store, the `verified_assertions` cache, the `credential-exchange/*` protocol, and the BBS+ proof format.

## Biggest risk, called out

BBS+/`bbs-2023` Rust library maturity + issuer BLS12-381 key management is the highest-risk dependency. **Phase 0 is a spike** that proves issue → selectively-disclose → verify before anything else; fallback is SD-JWT-VC-primary.

## Covers

Objective + testable success criteria, principles, the DTC catalog, the proof-format decision, the VTA store data model, the Trust-Task-wrapped OID4VCI/OID4VP exchange, DCQL privacy-first discovery, the VTC schema store, issue-to-unknown-DID (invite) vs member-only, role-by-VC + the verified-assertion cache, VP-based session auth, the end-to-end invite→join sequence, browser-plugin UX, security/privacy invariants, keyspace data model, Always/Ask-first/Never boundaries, open questions, and a 7-phase plan.
