### PR TITLE
feat(cred): adopt TDK credential formats + SD-JWT-VC smoke (task 0.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-bbs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59631d7fb6461fdb9a118888d056b501d50198720d36036bb826d53b91829c13"
+dependencies = [
+ "bls12_381_plus",
+ "elliptic-curve",
+ "ff",
+ "group",
+ "hex",
+ "rand 0.9.4",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
 name = "affinidi-crypto"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +124,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce7f611e7bcad221aee953b8ef91d23e0f18ef319c711211357f03f14f63450"
 dependencies = [
+ "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-did-common",
  "affinidi-rdf-encoding",
@@ -453,6 +471,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-oid4vc-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a76fb08084e1686e548bd43ede194f203d539575bee4eaf48c730a1cd7fd7de"
+dependencies = [
+ "base64 0.22.1",
+ "p256",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "affinidi-openid4vp"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84ea087067358f7010e75fa9fb335d823b812b95c2f34dbf1807caca6a0a9705"
+dependencies = [
+ "affinidi-oid4vc-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "affinidi-rdf-encoding"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +508,35 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "affinidi-sd-jwt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f71ae9d530bef6f384bc68feea57ed1b32f786ace4cc3e82951de8242f4217b6"
+dependencies = [
+ "base64 0.22.1",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "affinidi-sd-jwt-vc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c85a1cd2ffb74ee591912a8145f5a83369d2a25aaec2a15163664e15fba6538"
+dependencies = [
+ "affinidi-sd-jwt",
+ "chrono",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -1733,6 +1809,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1883,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bls12_381_plus"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa37cf2a8c96054d2dc3d708efe35cc0347014af0d30b86c736b4388ff8491c"
+dependencies = [
+ "arrayref",
+ "elliptic-curve",
+ "ff",
+ "group",
+ "hex",
+ "pairing",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2679,7 +2786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3360,6 +3467,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -3551,6 +3659,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -5986,6 +6100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6541,6 +6664,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -8345,6 +8474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9542,10 +9677,14 @@ dependencies = [
 name = "vta-sdk"
 version = "0.9.6"
 dependencies = [
+ "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
+ "affinidi-openid4vp",
+ "affinidi-sd-jwt",
+ "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "affinidi-vc",
@@ -10726,6 +10865,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,27 @@ affinidi-crypto = "0.1"
 affinidi-vc = "0.1"
 affinidi-data-integrity = "0.6"
 affinidi-status-list = "0.1"
+
+# Credential formats for the credential-centric VTI architecture
+# (docs/05-design-notes/vti-credential-architecture.md). All published on
+# crates.io and validated upstream in the TDK:
+#   - affinidi-sd-jwt-vc  — SD-JWT-VC issue/verify (IETF draft-ietf-oauth-sd-jwt-vc).
+#     Near-term credential path; runs on existing Ed25519/JOSE, no new curve.
+#   - affinidi-bbs        — BBS+ signatures over bls12_381_plus (IETF
+#     draft-irtf-cfrg-bbs-signatures). The unlinkable, selective-disclosure
+#     track. Gated on an independent security audit before signing real
+#     credentials (tasks §0.5).
+#   - affinidi-openid4vp  — OID4VP presentation exchange (DCQL lands upstream
+#     in a later task; this is the published base).
+# The `bbs-2023` Data Integrity cryptosuite lives behind the
+# `affinidi-data-integrity` `bbs-2023` feature, enabled per-consumer where the
+# BBS proof path is wired. If you path-override these to the local TDK for an
+# unreleased change (e.g. DCQL), override the whole interdependent set together
+# to avoid a duplicate-version split.
+affinidi-sd-jwt-vc = "0.1.1"
+affinidi-sd-jwt = "0.1.2"
+affinidi-bbs = "0.1.1"
+affinidi-openid4vp = "0.1.1"
 affinidi-secrets-resolver = "0.5"
 affinidi-messaging-didcomm-service = "0.3"
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -186,6 +186,20 @@ ed25519-dalek = { workspace = true }
 affinidi-crypto = { workspace = true }
 getrandom = "0.4"
 base64 = { workspace = true }
+# Credential-format smoke test (tests/sd_jwt_vc_smoke.rs): exercises the
+# adopted TDK SD-JWT-VC issue/verify path end-to-end as part of wiring the
+# credential crates into the workspace (vti-credential-architecture §0.2).
+# Dev-only — the published SDK does not depend on these yet.
+affinidi-sd-jwt-vc = { workspace = true }
+affinidi-sd-jwt = { workspace = true }
+# The remaining adopted credential crates. Referenced from
+# tests/cred_formats_build.rs purely so `cargo test -p vta-sdk` compiles and
+# link-checks them as part of §0.2 ("the new deps build cleanly"), including
+# the BBS+ Data Integrity cryptosuite behind the `bbs-2023` feature. Functional
+# BBS / OID4VP-DCQL integration is later-phase work.
+affinidi-bbs = { workspace = true }
+affinidi-openid4vp = { workspace = true }
+affinidi-data-integrity = { workspace = true, features = ["bbs-2023"] }
 
 [lints]
 workspace = true

--- a/vta-sdk/tests/cred_formats_build.rs
+++ b/vta-sdk/tests/cred_formats_build.rs
@@ -1,0 +1,88 @@
+//! Dependency-wiring build/link check for the adopted TDK credential crates
+//! that are not the near-term path (vti-credential-architecture §0.2 —
+//! "the new deps build cleanly").
+//!
+//! SD-JWT-VC (the near-term format) has its own functional smoke test in
+//! `sd_jwt_vc_smoke.rs`. This file pins that the *rest* of the adopted set —
+//! `affinidi-bbs`, the `bbs-2023` Data Integrity cryptosuite, and
+//! `affinidi-openid4vp` — compile and link inside the workspace and that their
+//! key entry points are reachable. It is intentionally light on behaviour:
+//! BBS+ and OID4VP/DCQL integration are later-phase, audit-gated work.
+
+/// The `affinidi-data-integrity` `bbs-2023` feature must activate the BBS+
+/// Data Integrity cryptosuite. Naming the (feature-gated) variant proves the
+/// feature is wired through the workspace dependency.
+#[test]
+fn bbs_2023_cryptosuite_is_wired() {
+    use affinidi_data_integrity::crypto_suites::CryptoSuite;
+
+    let suite = CryptoSuite::try_from("bbs-2023").expect("bbs-2023 cryptosuite must resolve");
+    assert!(matches!(suite, CryptoSuite::Bbs2023));
+}
+
+/// `affinidi-bbs` must link and round-trip: keygen → sign → verify, then a
+/// zero-knowledge selective-disclosure proof over a subset of messages. This
+/// is the unlinkable-disclosure primitive the credential plane will later use;
+/// here it just confirms the crate is usable from the workspace.
+#[test]
+fn bbs_sign_verify_and_selective_disclosure_round_trip() {
+    // Deterministic key material (>= 32 bytes) keeps the test reproducible.
+    let sk = affinidi_bbs::keygen(&[9u8; 32], b"vti-cred-0.2-smoke").expect("bbs keygen");
+    let pk = affinidi_bbs::sk_to_pk(&sk);
+
+    let header = b"vti-smoke-header";
+    let messages: [&[u8]; 3] = [b"community", b"member_handle", b"tier"];
+
+    let sig = affinidi_bbs::sign(&sk, &pk, header, &messages).expect("bbs sign");
+    assert!(
+        affinidi_bbs::verify(&pk, &sig, header, &messages).expect("bbs verify"),
+        "freshly-signed BBS signature must verify"
+    );
+
+    // Disclose only message index 0 ("community"); keep the rest hidden.
+    let presentation_header = b"verifier-nonce";
+    let disclosed_indexes = [0usize];
+    let disclosed_messages: [&[u8]; 1] = [messages[0]];
+
+    let proof = affinidi_bbs::proof_gen(
+        &pk,
+        &sig,
+        header,
+        presentation_header,
+        &messages,
+        &disclosed_indexes,
+    )
+    .expect("bbs proof_gen");
+
+    assert!(
+        affinidi_bbs::proof_verify(
+            &pk,
+            &proof,
+            header,
+            presentation_header,
+            &disclosed_messages,
+            &disclosed_indexes,
+        )
+        .expect("bbs proof_verify"),
+        "selective-disclosure proof for the disclosed subset must verify"
+    );
+}
+
+/// `affinidi-openid4vp` must link and its presentation-exchange types must be
+/// constructable / serializable. (DCQL is the one net-new TDK gap and lands in
+/// a later task; this just pins that the published base is wired in.)
+#[test]
+fn openid4vp_types_are_reachable() {
+    use affinidi_openid4vp::types::PresentationDefinition;
+
+    let pd = PresentationDefinition {
+        id: "vti-cred-0.2-smoke".to_string(),
+        name: None,
+        purpose: None,
+        input_descriptors: Vec::new(),
+        submission_requirements: None,
+        format: None,
+    };
+    let json = serde_json::to_string(&pd).expect("serialize PresentationDefinition");
+    assert!(json.contains("vti-cred-0.2-smoke"));
+}

--- a/vta-sdk/tests/sd_jwt_vc_smoke.rs
+++ b/vta-sdk/tests/sd_jwt_vc_smoke.rs
@@ -1,0 +1,245 @@
+//! Smoke test for the adopted TDK credential formats
+//! (vti-credential-architecture §0.2 — "Wire the crates as VTI deps").
+//!
+//! This proves the SD-JWT-VC issue → verify path works end-to-end inside the
+//! VTI workspace using a *real* asymmetric (EdDSA / Ed25519) signer, not the
+//! upstream HMAC test helper. SD-JWT-VC is the near-term credential format
+//! (runs on the existing Ed25519/JOSE stack, no new curve) and unblocks the
+//! later VTA-vault / credential-exchange work.
+//!
+//! Security/privacy invariants this test pins (spec §14):
+//!   - Claim minimisation: selectively-disclosed claims never appear in the
+//!     cleartext JWT body — only their salted digests do.
+//!   - Issuer authenticity: a tampered issuer signature is rejected.
+//!
+//! NOTE: this is an *adoption* smoke test for the dependency wiring. It does
+//! not establish any VTI endpoint, does not enumerate a wallet, and does not
+//! present/disclose without an explicit (here, test-driven) caller decision.
+
+use affinidi_sd_jwt::hasher::Sha256Hasher;
+use affinidi_sd_jwt::signer::{JwtSigner, JwtVerifier};
+use affinidi_sd_jwt::verifier::{VerificationOptions, verify};
+use affinidi_sd_jwt::{SdJwt, error::SdJwtError};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde_json::{Value, json};
+
+/// A production-shape EdDSA (Ed25519) JWT signer.
+///
+/// Signs the compact JWS signing input (`header_b64.payload_b64`) with an
+/// Ed25519 key and emits the full compact JWS. This is the same algorithm
+/// (`EdDSA`) the rest of the workspace signs with, so the smoke test exercises
+/// a realistic issuer rather than the HMAC test stub shipped in the TDK.
+struct EddsaSigner {
+    key: SigningKey,
+    kid: String,
+}
+
+impl JwtSigner for EddsaSigner {
+    fn algorithm(&self) -> &str {
+        "EdDSA"
+    }
+
+    fn key_id(&self) -> Option<&str> {
+        Some(&self.kid)
+    }
+
+    fn sign_jwt(&self, header: &Value, payload: &Value) -> Result<String, SdJwtError> {
+        let header_b64 = URL_SAFE_NO_PAD.encode(
+            serde_json::to_string(header)
+                .map_err(|e| SdJwtError::Verification(e.to_string()))?
+                .as_bytes(),
+        );
+        let payload_b64 = URL_SAFE_NO_PAD.encode(
+            serde_json::to_string(payload)
+                .map_err(|e| SdJwtError::Verification(e.to_string()))?
+                .as_bytes(),
+        );
+        let signing_input = format!("{header_b64}.{payload_b64}");
+        let sig: Signature = self.key.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        Ok(format!("{signing_input}.{sig_b64}"))
+    }
+}
+
+/// The matching EdDSA verifier: checks the `alg` header is `EdDSA`, verifies
+/// the Ed25519 signature over the signing input, and returns the decoded
+/// payload. A bad signature or wrong `alg` is rejected.
+struct EddsaVerifier {
+    key: VerifyingKey,
+}
+
+impl JwtVerifier for EddsaVerifier {
+    fn verify_jwt(&self, jws: &str) -> Result<Value, SdJwtError> {
+        let parts: Vec<&str> = jws.split('.').collect();
+        if parts.len() != 3 {
+            return Err(SdJwtError::Verification("malformed compact JWS".into()));
+        }
+        let (header_b64, payload_b64, sig_b64) = (parts[0], parts[1], parts[2]);
+
+        // Validate the algorithm header before touching the signature.
+        let header_bytes = URL_SAFE_NO_PAD
+            .decode(header_b64)
+            .map_err(|e| SdJwtError::Verification(e.to_string()))?;
+        let header: Value = serde_json::from_slice(&header_bytes)
+            .map_err(|e| SdJwtError::Verification(e.to_string()))?;
+        if header.get("alg").and_then(Value::as_str) != Some("EdDSA") {
+            return Err(SdJwtError::Verification(
+                "unexpected alg (want EdDSA)".into(),
+            ));
+        }
+
+        // Verify the signature over `header_b64.payload_b64`.
+        let signing_input = format!("{header_b64}.{payload_b64}");
+        let sig_bytes = URL_SAFE_NO_PAD
+            .decode(sig_b64)
+            .map_err(|e| SdJwtError::Verification(e.to_string()))?;
+        let sig = Signature::from_slice(&sig_bytes)
+            .map_err(|e| SdJwtError::Verification(e.to_string()))?;
+        self.key
+            .verify(signing_input.as_bytes(), &sig)
+            .map_err(|_| SdJwtError::Verification("Ed25519 signature invalid".into()))?;
+
+        // Signature good — decode and return the payload.
+        let payload_bytes = URL_SAFE_NO_PAD
+            .decode(payload_b64)
+            .map_err(|e| SdJwtError::Verification(e.to_string()))?;
+        serde_json::from_slice(&payload_bytes).map_err(|e| SdJwtError::Verification(e.to_string()))
+    }
+}
+
+fn issuer_keypair() -> (EddsaSigner, EddsaVerifier) {
+    // Deterministic key so the test is reproducible without an RNG dependency.
+    let secret = [7u8; 32];
+    let signing = SigningKey::from_bytes(&secret);
+    let verifying = signing.verifying_key();
+    (
+        EddsaSigner {
+            key: signing,
+            kid: "did:example:community#key-0".to_string(),
+        },
+        EddsaVerifier { key: verifying },
+    )
+}
+
+#[test]
+fn issue_and_verify_sd_jwt_vc_end_to_end() {
+    let hasher = Sha256Hasher;
+    let (signer, verifier) = issuer_keypair();
+
+    // A community-membership-shaped credential. Every member-identifying claim
+    // is selectively disclosable so the holder can later prove "is a member of
+    // community X" without leaking the rest.
+    let claims = json!({
+        "community": "did:web:community.example",
+        "member_handle": "alice",
+        "joined_at": "2026-06-03T00:00:00Z",
+        "tier": "founding",
+    });
+    let frame = json!({
+        "_sd": ["community", "member_handle", "joined_at", "tier"],
+    });
+
+    let vc = affinidi_sd_jwt_vc::issue(
+        "https://openvtc.org/credentials/MembershipCredential",
+        "did:example:community",
+        Some("did:example:alice"),
+        &claims,
+        &frame,
+        &signer,
+        &hasher,
+        None,
+        1_700_000_000,
+        Some(1_900_000_000),
+    )
+    .expect("issue SD-JWT-VC");
+
+    // The protected VC claims live in cleartext in the JWT body...
+    let body = vc.payload().expect("decode payload");
+    assert_eq!(
+        body["vct"],
+        "https://openvtc.org/credentials/MembershipCredential"
+    );
+    assert_eq!(body["iss"], "did:example:community");
+    assert_eq!(body["sub"], "did:example:alice");
+    assert_eq!(body["iat"], 1_700_000_000);
+    assert_eq!(body["exp"], 1_900_000_000);
+
+    // ...but the selectively-disclosed member claims MUST NOT (claim
+    // minimisation, spec §14.3). Only their salted digests are in `_sd`.
+    for hidden in ["community", "member_handle", "joined_at", "tier"] {
+        assert!(
+            body.get(hidden).is_none(),
+            "disclosable claim `{hidden}` leaked into the cleartext JWT body"
+        );
+    }
+    assert_eq!(vc.sd_jwt.disclosures.len(), 4);
+
+    // Round-trip through the compact serialization a real holder would store.
+    let serialized = vc.serialize();
+    let parsed = SdJwt::parse(&serialized, &hasher).expect("parse serialized SD-JWT-VC");
+
+    // Issuer-side verification: check the Ed25519 signature and reconstruct
+    // the full claim set from the disclosures the holder chose to present.
+    let opts = VerificationOptions::default();
+    let result = verify(&parsed, &verifier, &hasher, &opts, None).expect("verify issuer signature");
+    assert!(result.is_verified());
+
+    // Every disclosed claim is recovered with its original value.
+    assert_eq!(result.claims["community"], "did:web:community.example");
+    assert_eq!(result.claims["member_handle"], "alice");
+    assert_eq!(result.claims["tier"], "founding");
+    assert_eq!(
+        result.claims["vct"],
+        "https://openvtc.org/credentials/MembershipCredential"
+    );
+
+    // Temporal validity holds inside the window and is rejected outside it.
+    affinidi_sd_jwt_vc::verify_temporal(&result.claims, 1_800_000_000)
+        .expect("inside validity window");
+    assert!(
+        affinidi_sd_jwt_vc::verify_temporal(&result.claims, 2_000_000_000).is_err(),
+        "expired credential must fail temporal verification"
+    );
+}
+
+#[test]
+fn tampered_issuer_signature_is_rejected() {
+    let hasher = Sha256Hasher;
+    let (signer, verifier) = issuer_keypair();
+
+    let claims = json!({ "tier": "founding" });
+    let frame = json!({ "_sd": ["tier"] });
+
+    let vc = affinidi_sd_jwt_vc::issue(
+        "https://openvtc.org/credentials/MembershipCredential",
+        "did:example:community",
+        None,
+        &claims,
+        &frame,
+        &signer,
+        &hasher,
+        None,
+        1_700_000_000,
+        None,
+    )
+    .expect("issue SD-JWT-VC");
+
+    // Flip the final signature byte of the issuer JWS — verification must fail.
+    let mut jws = vc.sd_jwt.jws.clone();
+    let last = jws.pop().expect("non-empty jws");
+    let swapped = if last == 'A' { 'B' } else { 'A' };
+    jws.push(swapped);
+
+    let forged = SdJwt {
+        jws,
+        disclosures: vc.sd_jwt.disclosures.clone(),
+        kb_jwt: vc.sd_jwt.kb_jwt.clone(),
+    };
+
+    let opts = VerificationOptions::default();
+    let err = verify(&forged, &verifier, &hasher, &opts, None)
+        .expect_err("tampered signature must be rejected");
+    assert!(matches!(err, SdJwtError::Verification(_)));
+}


### PR DESCRIPTION
## What (credential architecture — task 0.2)

Adopts the already-built TDK credential-format crates into the workspace and proves the path end-to-end. First implementation step of the credential architecture spec (#230); the foundation already exists in `affinidi-tdk-rs` (validated), so this is **adopt, not build**.

- Workspace deps: `affinidi-sd-jwt-vc 0.1.1`, `affinidi-sd-jwt 0.1.2`, `affinidi-bbs 0.1.1`, `affinidi-openid4vp 0.1.1` (crates.io; published `affinidi-data-integrity 0.6.0` already carries `bbs-2023`). Comment documents the path-override convention for the later unreleased DCQL work.
- Added as **dev-deps in `vta-sdk`** (published SDK artifact unchanged).
- `sd_jwt_vc_smoke.rs` — issue→serialize→verify an SD-JWT-VC with a real Ed25519 issuer; pins §14 **claim minimisation** (disclosable claims absent from the cleartext JWT) + **issuer authenticity** (tampered sig rejected).
- `cred_formats_build.rs` — `bbs-2023` reachable, BBS ZK selective-disclosure round-trip, OID4VP PresentationDefinition.

## Verification

`cargo fmt --check`, build/check across the SDK graph, `cargo test -p vta-sdk` (5 new), `cargo clippy --tests`, **`cargo deny`** — all clean. No `rsa` reintroduced.

## Security review (agent-skills:security-auditor) — **approve**

Dev-deps + tests only; no production surface / endpoint / enumeration path / shipped key material. `cargo tree --no-dev-dependencies` confirms the credential crates don't reach downstream consumers. BBS stays **audit-gated** before real signing.

> Generated by the `credential-phase` workflow (build → adversarial security review); branch verified locally before this PR.
