### PR TITLE
feat(cred): VTA vault credential store — model + storage + index (task 1.1)

### DIFF
--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -32,6 +32,7 @@ pub mod status;
 pub mod store;
 #[cfg(feature = "tee")]
 pub mod tee;
+pub mod vault;
 #[cfg(feature = "webvh")]
 pub mod webvh_auth;
 #[cfg(feature = "webvh")]

--- a/vta-service/src/vault/index.rs
+++ b/vta-service/src/vault/index.rs
@@ -1,0 +1,175 @@
+//! Secondary index over the credential vault, keyed by
+//! `{type, community_did, issuer_did, purpose, status}` (task 1.1).
+//!
+//! ## Design: key-only index rows
+//!
+//! The `vault` keyspace is encrypted at rest (AES-256-GCM on the *value*),
+//! but fjall **keys stay plaintext** so prefix scans work. We exploit that:
+//! each index entry is a key-only row whose key encodes
+//! `idx:<field>:<value>:<id>` and whose value is a single sentinel byte.
+//! A prefix scan on `idx:<field>:<value>:` therefore yields the ids of
+//! every credential indexed under that `(field, value)` pair — without
+//! decrypting (or even touching) any credential body.
+//!
+//! The credential body and its metadata live only in the primary record
+//! (`super::storage`, key `cred:<id>`), which *is* value-encrypted. The
+//! index keys carry only routing metadata (a DID, a type tag, a status
+//! token), never the body — consistent with the privacy invariants in
+//! `vti-credential-architecture.md` §14.
+//!
+//! ## Key namespace, and why it is disjoint from the password vault
+//!
+//! The same `vault` keyspace already holds the password-manager
+//! `VaultEntry` records under the `vault:` prefix
+//! (`vti_common::vault`). The credential store uses the disjoint prefixes
+//! `cred:` (primary) and `idx:` (this index), so the two never collide.
+//! See [`super::storage`] for the primary-key helpers.
+
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::model::{IndexField, StoredCredential};
+
+/// Prefix for every secondary-index row in the credential vault. Disjoint
+/// from `cred:` (primary records) and `vault:` (password manager).
+pub(crate) const INDEX_PREFIX: &str = "idx:";
+
+/// Single-byte sentinel stored as the value of every index row. The row's
+/// information content is entirely in its key; the value exists only
+/// because fjall requires one.
+const SENTINEL: &[u8] = b"1";
+
+/// Byte that separates the `value` segment from the `id` segment in an
+/// index key. A NUL is used deliberately: it cannot appear in a DID, a VC
+/// type tag, or a status/purpose token, so it is an unambiguous boundary
+/// even when one value is a colon-extended prefix of another (e.g.
+/// `did:web:acme` vs `did:web:acme:team`). Using `:` here would let the
+/// former's scan prefix falsely match the latter's rows.
+const VALUE_ID_SEP: u8 = 0x00;
+
+/// `idx:<field>:<value>\0<id>` — the full key for one index entry.
+///
+/// `field` is a fixed token; `value` is caller data (a type tag, a DID, a
+/// status token) and may itself contain `:`. The `\0` boundary
+/// ([`VALUE_ID_SEP`]) makes the `(field, value)` prefix exact regardless of
+/// the `value`'s contents. The id is appended last so two credentials
+/// sharing a `(field, value)` get distinct keys.
+fn index_key(field: IndexField, value: &str, id: &str) -> Vec<u8> {
+    let mut k = format!("{INDEX_PREFIX}{}:{value}", field.token()).into_bytes();
+    k.push(VALUE_ID_SEP);
+    k.extend_from_slice(id.as_bytes());
+    k
+}
+
+/// `idx:<field>:<value>\0` — the prefix that selects exactly the ids indexed
+/// under `(field, value)`. The trailing `\0` is load-bearing: it pins the
+/// end of the `value` segment, so `did:web:acme` never matches
+/// `did:web:acme:team`'s rows (those start with `…acme:team\0`).
+fn scan_prefix(field: IndexField, value: &str) -> Vec<u8> {
+    let mut p = format!("{INDEX_PREFIX}{}:{value}", field.token()).into_bytes();
+    p.push(VALUE_ID_SEP);
+    p
+}
+
+/// Recover the trailing `<id>` segment from a full index key produced by
+/// [`index_key`] — everything after the `\0` boundary.
+fn id_from_index_key(key: &[u8]) -> Option<String> {
+    let sep = key.iter().rposition(|&b| b == VALUE_ID_SEP)?;
+    let id = &key[sep + 1..];
+    if id.is_empty() {
+        return None;
+    }
+    std::str::from_utf8(id).ok().map(|s| s.to_string())
+}
+
+/// Insert every index entry for `cred`. Idempotent: re-inserting the same
+/// credential overwrites the same sentinel rows. Call **after** writing the
+/// primary record.
+pub(crate) async fn insert_for(
+    vault: &KeyspaceHandle,
+    cred: &StoredCredential,
+) -> Result<(), AppError> {
+    for (field, value) in cred.index_terms() {
+        vault
+            .insert_raw(index_key(field, &value, &cred.id), SENTINEL.to_vec())
+            .await?;
+    }
+    Ok(())
+}
+
+/// Remove every index entry that `cred` would have produced. Used both by
+/// delete and by the update path (remove-old then insert-new), so a status
+/// or community change never leaves a stale index row pointing at the
+/// credential under its previous value.
+pub(crate) async fn remove_for(
+    vault: &KeyspaceHandle,
+    cred: &StoredCredential,
+) -> Result<(), AppError> {
+    for (field, value) in cred.index_terms() {
+        vault.remove(index_key(field, &value, &cred.id)).await?;
+    }
+    Ok(())
+}
+
+/// Scan the index for every credential id stored under `(field, value)`.
+///
+/// This is the **only** discovery primitive the vault exposes: it requires
+/// an explicit field *and* value — there is no "give me everything" mode.
+/// That is deliberate (no-wallet-enumeration, §14): a caller must already
+/// know what it is looking for, mirroring the DCQL-targeted discovery model
+/// the later tasks build on top of this index.
+///
+/// Returns ids in fjall key order; duplicates are not possible (the id is
+/// part of the unique key). The credential bodies are **not** touched —
+/// callers resolve ids to records via [`super::storage::get`] only for the
+/// ids they actually need.
+pub(crate) async fn scan(
+    vault: &KeyspaceHandle,
+    field: IndexField,
+    value: &str,
+) -> Result<Vec<String>, AppError> {
+    let rows = vault.prefix_iter_raw(scan_prefix(field, value)).await?;
+    let mut ids = Vec::with_capacity(rows.len());
+    for (key, _sentinel) in rows {
+        if let Some(id) = id_from_index_key(&key) {
+            ids.push(id);
+        }
+    }
+    Ok(ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_key_layout_is_field_value_nul_id() {
+        let k = index_key(IndexField::IssuerDid, "did:web:acme", "cred-1");
+        let mut expected = b"idx:issuer:did:web:acme".to_vec();
+        expected.push(0x00);
+        expected.extend_from_slice(b"cred-1");
+        assert_eq!(k, expected);
+    }
+
+    #[test]
+    fn scan_prefix_pins_value_with_nul() {
+        let p = scan_prefix(IndexField::CommunityDid, "did:web:acme");
+        let mut expected = b"idx:community:did:web:acme".to_vec();
+        expected.push(0x00);
+        assert_eq!(p, expected);
+    }
+
+    #[test]
+    fn colon_extended_value_is_not_a_false_prefix_match() {
+        // `did:web:acme` must NOT prefix-match `did:web:acme:team`'s key.
+        let scan = scan_prefix(IndexField::CommunityDid, "did:web:acme");
+        let sibling = index_key(IndexField::CommunityDid, "did:web:acme:team", "x");
+        assert!(!sibling.starts_with(&scan));
+    }
+
+    #[test]
+    fn id_recovered_after_nul_even_when_value_has_colons() {
+        let k = index_key(IndexField::CommunityDid, "did:web:acme:team", "ulid-xyz");
+        assert_eq!(id_from_index_key(&k).as_deref(), Some("ulid-xyz"));
+    }
+}

--- a/vta-service/src/vault/mod.rs
+++ b/vta-service/src/vault/mod.rs
@@ -1,0 +1,47 @@
+//! VTA credential vault — the format-agnostic credential store
+//! (`docs/05-design-notes/vti-credential-architecture.md` §5, task 1.1).
+//!
+//! This is the credential-architecture data plane the VTA grows in Phase 1:
+//! it stores the W3C / SD-JWT-VC credentials a holder *holds* (invitations,
+//! memberships, roles, endorsements, …), indexed so the holder's agent can
+//! find them by `{type, community_did, issuer_did, purpose, status}` without
+//! parsing every body.
+//!
+//! ## Not the password vault
+//!
+//! `vti_common::vault` is a *different* vault: the password-manager
+//! `VaultEntry` records (site logins, OAuth tokens, passkeys) used by
+//! Companions to authenticate against external sites. Both stores share the
+//! single `vault` keyspace but use disjoint key namespaces:
+//!
+//! | Namespace | Owner | Holds |
+//! |-----------|-------|-------|
+//! | `vault:<id>`     | `vti_common::vault` | password-manager `VaultEntry` |
+//! | `cred:<id>`      | this module         | `StoredCredential` (the body, encrypted) |
+//! | `idx:<field>:…`  | this module         | credential secondary index (key-only) |
+//!
+//! ## Scope of task 1.1 (and what is deliberately absent)
+//!
+//! This module is **format-agnostic** and does **no cryptography**: it
+//! stores opaque credential bodies plus an indexed metadata envelope, with
+//! encryption-at-rest delegated to the keyspace's AES-256-GCM wrapper. It
+//! does **not** verify issuer signatures (task 1.2 receive), search via DCQL
+//! (1.3), build presentations or disclose claims (1.4 present), mint (1.5),
+//! or resolve status lists (1.6).
+//!
+//! It also exposes **no wallet-enumeration primitive** — there is no
+//! `list_all`. The only discovery path is [`storage::find_by_index`], which
+//! requires an explicit indexed field *and* value. This is the storage-layer
+//! expression of the no-enumeration invariant
+//! (`vti-credential-architecture.md` §14); the route/operation layers built
+//! on top in later tasks must preserve it (DCQL-targeted discovery only,
+//! never "return the whole set").
+
+pub mod index;
+pub mod model;
+pub mod storage;
+
+pub use model::{
+    CredentialFormat, CredentialPurpose, CredentialStatus, IndexField, StoredCredential,
+};
+pub use storage::{delete, find_by_index, get, put};

--- a/vta-service/src/vault/model.rs
+++ b/vta-service/src/vault/model.rs
@@ -1,0 +1,224 @@
+//! `StoredCredential` — the format-agnostic credential envelope held by the
+//! VTA `vault` (credential store, distinct from the password-manager
+//! `VaultEntry` in `vti_common::vault`).
+//!
+//! Task 1.1 of the VTI credential architecture
+//! (`docs/05-design-notes/vti-credential-architecture.md` §5). This module
+//! is **format-agnostic**: the credential body is stored as opaque bytes
+//! plus an indexed metadata envelope. **No cryptographic verification,
+//! signing, presentation, or disclosure happens here** — those land in
+//! later tasks (1.2 receive, 1.4 present, 1.5 mint, 1.6 status). This
+//! module only models + indexes what the holder already holds.
+//!
+//! Security/privacy invariants this module upholds
+//! (`vti-credential-architecture.md` §14):
+//! - The credential body (`body`) is opaque to the store and encrypted at
+//!   rest via the keyspace's AES-256-GCM wrapper. This module never parses
+//!   it, never logs it, and never re-emits it.
+//! - There is **no "list all" surface** in this module. Reads are by `id`
+//!   ([`super::storage::get`]) or by an explicit, single-field index
+//!   prefix scan ([`super::index`]). The no-wallet-enumeration invariant is
+//!   enforced at the route/operation layer (no endpoint returns the whole
+//!   set), and this module deliberately gives that layer only targeted
+//!   primitives to build on.
+
+use serde::{Deserialize, Serialize};
+
+/// Proof / serialization format of the stored credential body. Stored as a
+/// tag so the (later) receive/present/status code can dispatch to the right
+/// format verifier without this format-agnostic layer needing to understand
+/// any of them. Open-ended via [`CredentialFormat::Other`] so a new format
+/// never requires a storage-schema change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CredentialFormat {
+    /// BBS+ Data-Integrity proof (`bbs-2023`) — selective disclosure.
+    Bbs2023,
+    /// Ed25519 JCS Data-Integrity proof (`eddsa-jcs-2022`).
+    EddsaJcs2022,
+    /// IETF SD-JWT-VC.
+    SdJwtVc,
+    /// Forward-compatibility escape hatch — carries the raw tag verbatim so
+    /// an unknown format round-trips losslessly.
+    #[serde(untagged)]
+    Other(String),
+}
+
+/// Lifecycle / validity status of a stored credential. Set to
+/// [`CredentialStatus::Unknown`] at store time (this task does no status
+/// resolution); task 1.6 refreshes it from the status list so search and
+/// present can exclude revoked/expired credentials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CredentialStatus {
+    /// Believed valid (signature/not-expired checks are the caller's job in
+    /// later tasks; this layer treats the tag as opaque metadata).
+    Valid,
+    /// Past its `valid_until` or otherwise time-expired.
+    Expired,
+    /// Status-list bit set / explicitly revoked.
+    Revoked,
+    /// Not yet resolved against a status list. The default at store time.
+    Unknown,
+}
+
+impl CredentialStatus {
+    /// Stable wire/index token for this status. Used to build the `status`
+    /// secondary-index key; kept in sync with the serde `rename_all`.
+    pub fn as_index_token(&self) -> &'static str {
+        match self {
+            CredentialStatus::Valid => "valid",
+            CredentialStatus::Expired => "expired",
+            CredentialStatus::Revoked => "revoked",
+            CredentialStatus::Unknown => "unknown",
+        }
+    }
+}
+
+/// Purpose of the credential — the semantic role it plays in the trust
+/// fabric. Indexed so a (later) DCQL match can target "an invite for
+/// community X" without parsing every body. Open-ended via
+/// [`CredentialPurpose::Other`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CredentialPurpose {
+    Invite,
+    Membership,
+    Role,
+    Endorsement,
+    Personhood,
+    #[serde(untagged)]
+    Other(String),
+}
+
+impl CredentialPurpose {
+    /// Stable token used in the `purpose` secondary-index key.
+    pub fn as_index_token(&self) -> String {
+        match self {
+            CredentialPurpose::Invite => "invite".to_string(),
+            CredentialPurpose::Membership => "membership".to_string(),
+            CredentialPurpose::Role => "role".to_string(),
+            CredentialPurpose::Endorsement => "endorsement".to_string(),
+            CredentialPurpose::Personhood => "personhood".to_string(),
+            CredentialPurpose::Other(s) => s.clone(),
+        }
+    }
+}
+
+/// A credential the holder has stored on this VTA, plus the indexed
+/// metadata envelope that lets the holder's agent search **by criteria**
+/// without parsing every body. Field-for-field per
+/// `vti-credential-architecture.md` §5.
+///
+/// `body` is the credential itself, treated as **opaque bytes** by this
+/// layer. It is encrypted at rest by the keyspace AES-256-GCM wrapper
+/// (the whole record is serialized then encrypted before it hits fjall).
+/// The metadata fields are co-encrypted in the record value; the *index
+/// keys* (built by [`super::index`]) carry only the indexed field values,
+/// which are routing metadata, never the credential body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredCredential {
+    /// Local handle — the holder-agent-assigned id (ULID recommended).
+    /// Unique within this vault. Used as the primary key.
+    pub id: String,
+    /// Proof / serialization format of `body`.
+    pub format: CredentialFormat,
+    /// VC `type` tags (e.g. `InvitationCredential`). Multiple tags are
+    /// each indexed independently so a match on any one tag finds the
+    /// credential.
+    #[serde(default)]
+    pub types: Vec<String>,
+    /// Reference into the VTC schema store / catalog entry, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_id: Option<String>,
+    /// Which community / context this credential is for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub community_did: Option<String>,
+    /// The holder DID this VC is about (credential subject).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_did: Option<String>,
+    /// Issuer DID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issuer_did: Option<String>,
+    /// Semantic purpose (invite / membership / role / …).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<CredentialPurpose>,
+    /// Lifecycle status. Defaults to `Unknown` at store time; refreshed by
+    /// the status task (1.6).
+    pub status: CredentialStatus,
+    /// RFC 3339 validity window start, when the body declares one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_from: Option<String>,
+    /// RFC 3339 validity window end, when the body declares one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<String>,
+    /// RFC 3339 timestamp the credential was received/stored.
+    pub received_at: String,
+    /// Free-form provenance string (e.g. the exchange thread / source DID).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Holder-applied labels. Not indexed in this task (search by tag is a
+    /// later DCQL concern); carried so the round-trip is lossless.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub tags: std::collections::BTreeMap<String, String>,
+    /// The credential itself — **opaque bytes**, encrypted at rest. This
+    /// layer never parses, verifies, signs, or discloses it. Stored as a
+    /// byte vector; the format-agnostic store makes no assumption about
+    /// whether it is a UTF-8 JWT, CBOR, or anything else.
+    pub body: Vec<u8>,
+}
+
+impl StoredCredential {
+    /// The set of `(field, value)` pairs this credential is indexed under.
+    /// Drives both index insertion and removal so the two can never drift.
+    /// Only **present** (`Some`) fields are emitted — a credential with no
+    /// issuer DID simply isn't reachable via an issuer-DID scan.
+    ///
+    /// Each `types` tag is emitted as its own `type` entry (a credential
+    /// with two type tags is reachable by either).
+    pub(crate) fn index_terms(&self) -> Vec<(IndexField, String)> {
+        let mut terms = Vec::new();
+        for t in &self.types {
+            terms.push((IndexField::Type, t.clone()));
+        }
+        if let Some(c) = &self.community_did {
+            terms.push((IndexField::CommunityDid, c.clone()));
+        }
+        if let Some(i) = &self.issuer_did {
+            terms.push((IndexField::IssuerDid, i.clone()));
+        }
+        if let Some(p) = &self.purpose {
+            terms.push((IndexField::Purpose, p.as_index_token()));
+        }
+        terms.push((IndexField::Status, self.status.as_index_token().to_string()));
+        terms
+    }
+}
+
+/// The fields the vault maintains a secondary index over, per task 1.1:
+/// `{type, community_did, issuer_did, purpose, status}`. Each variant maps
+/// to a stable token used in the index key namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexField {
+    Type,
+    CommunityDid,
+    IssuerDid,
+    Purpose,
+    Status,
+}
+
+impl IndexField {
+    /// Stable token used as the field segment of an index key. Changing one
+    /// of these is a storage-format break (it orphans existing index rows),
+    /// so they are deliberately terse and fixed.
+    pub fn token(&self) -> &'static str {
+        match self {
+            IndexField::Type => "type",
+            IndexField::CommunityDid => "community",
+            IndexField::IssuerDid => "issuer",
+            IndexField::Purpose => "purpose",
+            IndexField::Status => "status",
+        }
+    }
+}

--- a/vta-service/src/vault/storage.rs
+++ b/vta-service/src/vault/storage.rs
@@ -1,0 +1,382 @@
+//! Primary persistence for the credential vault (task 1.1).
+//!
+//! Stores [`StoredCredential`] records under the `cred:<id>` key namespace
+//! in the `vault` keyspace and keeps the secondary index ([`super::index`])
+//! in lock-step on every mutation. The whole record value — including the
+//! opaque credential body — is encrypted at rest by the keyspace's
+//! AES-256-GCM wrapper when the deployment supplies a storage key.
+//!
+//! This layer is format-agnostic and does **no** cryptographic work: it
+//! does not verify issuer signatures, check status lists, or disclose
+//! claims. Those are later tasks. It also exposes **no enumeration
+//! primitive** — there is no `list_all`; discovery is index-scan-only
+//! (`vti-credential-architecture.md` §14).
+
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::index;
+use super::model::{IndexField, StoredCredential};
+
+/// Primary-key prefix for credential records. Disjoint from `idx:` (the
+/// secondary index) and `vault:` (the password-manager `VaultEntry` records
+/// that share this keyspace).
+const RECORD_PREFIX: &str = "cred:";
+
+/// `cred:<id>` — the primary key for one stored credential.
+fn record_key(id: &str) -> Vec<u8> {
+    format!("{RECORD_PREFIX}{id}").into_bytes()
+}
+
+/// Store (create or overwrite) a credential and (re)build its index entries.
+///
+/// On overwrite, the *previous* record's index terms are removed first so a
+/// changed `status` / `community_did` / etc. never leaves a stale index row
+/// pointing at this id under its old value. The record value is encrypted
+/// at rest; the index keys carry only routing metadata, never the body.
+///
+/// The credential `id` must be non-empty (it is the primary key); an empty
+/// id is rejected rather than silently writing to `cred:`.
+pub async fn put(vault: &KeyspaceHandle, cred: &StoredCredential) -> Result<(), AppError> {
+    if cred.id.trim().is_empty() {
+        return Err(AppError::Validation(
+            "StoredCredential.id must be non-empty".to_string(),
+        ));
+    }
+
+    // Remove the prior record's index terms before re-indexing, so an
+    // update that changes an indexed field doesn't orphan the old row.
+    if let Some(prev) = get(vault, &cred.id).await? {
+        index::remove_for(vault, &prev).await?;
+    }
+
+    vault.insert(record_key(&cred.id), cred).await?;
+    index::insert_for(vault, cred).await?;
+    Ok(())
+}
+
+/// Fetch a credential by its local id. Returns `Ok(None)` for an absent id
+/// so callers map to their own not-found / permission-denied policy. The
+/// returned record includes the decrypted opaque body — callers that only
+/// need metadata should still treat the body as opaque.
+pub async fn get(vault: &KeyspaceHandle, id: &str) -> Result<Option<StoredCredential>, AppError> {
+    vault.get(record_key(id)).await
+}
+
+/// Delete a credential by id and tear down all of its index entries.
+/// Idempotent: deleting an absent id is a no-op (returns `Ok`).
+pub async fn delete(vault: &KeyspaceHandle, id: &str) -> Result<(), AppError> {
+    if let Some(prev) = get(vault, id).await? {
+        index::remove_for(vault, &prev).await?;
+    }
+    vault.remove(record_key(id)).await?;
+    Ok(())
+}
+
+/// Resolve every credential indexed under `(field, value)` to its full
+/// record. This is the targeted search primitive: it requires an explicit
+/// field **and** value, scans the index for matching ids, then loads only
+/// those records. There is intentionally no variant that returns every
+/// credential — see `vti-credential-architecture.md` §14.
+///
+/// An index row whose primary record has since vanished (a torn write, or a
+/// race) is skipped rather than erroring, so a stale index entry can never
+/// wedge a search.
+pub async fn find_by_index(
+    vault: &KeyspaceHandle,
+    field: IndexField,
+    value: &str,
+) -> Result<Vec<StoredCredential>, AppError> {
+    let ids = index::scan(vault, field, value).await?;
+    let mut out = Vec::with_capacity(ids.len());
+    for id in ids {
+        if let Some(rec) = get(vault, &id).await? {
+            out.push(rec);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::model::{CredentialFormat, CredentialPurpose, CredentialStatus};
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    /// A fresh tempdir-backed store plus a `vault` keyspace handle. The
+    /// `TempDir` and `Store` are returned so the caller keeps the fjall
+    /// files (and DB handle) alive for the duration of the test. When `key`
+    /// is `Some`, the returned handle is wrapped in the AES-256-GCM at-rest
+    /// layer; the underlying store is unchanged, so a second *plain* handle
+    /// can be opened on the same keyspace to read the on-disk ciphertext.
+    fn fresh_vault(key: Option<[u8; 32]>) -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store.keyspace("vault").expect("vault keyspace");
+        let ks = match key {
+            Some(k) => ks.with_encryption(k),
+            None => ks,
+        };
+        (dir, store, ks)
+    }
+
+    fn sample(id: &str) -> StoredCredential {
+        StoredCredential {
+            id: id.to_string(),
+            format: CredentialFormat::SdJwtVc,
+            types: vec!["VerifiableCredential".into(), "InvitationCredential".into()],
+            schema_id: Some("schema:invite:1".into()),
+            community_did: Some("did:web:acme".into()),
+            subject_did: Some("did:key:zAlice".into()),
+            issuer_did: Some("did:web:issuer.example".into()),
+            purpose: Some(CredentialPurpose::Invite),
+            status: CredentialStatus::Unknown,
+            valid_from: Some("2026-01-01T00:00:00Z".into()),
+            valid_until: Some("2027-01-01T00:00:00Z".into()),
+            received_at: "2026-06-03T00:00:00Z".into(),
+            source: Some("exchange:thread-42".into()),
+            tags: std::collections::BTreeMap::from([("label".into(), "alice-invite".into())]),
+            body: b"opaque.credential.bytes".to_vec(),
+        }
+    }
+
+    #[tokio::test]
+    async fn store_then_get_by_id_round_trips() {
+        let (_dir, _store, vault) = fresh_vault(None);
+        let cred = sample("cred-1");
+        put(&vault, &cred).await.unwrap();
+
+        let got = get(&vault, "cred-1").await.unwrap().expect("present");
+        assert_eq!(got, cred, "full record round-trips byte-for-byte");
+
+        // Absent id → None, never an error (caller maps to not-found).
+        assert!(get(&vault, "nope").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn prefix_scan_index_hits_each_indexed_field() {
+        let (_dir, _store, vault) = fresh_vault(None);
+        put(&vault, &sample("cred-1")).await.unwrap();
+
+        // type (both tags reachable)
+        let by_type = find_by_index(&vault, IndexField::Type, "InvitationCredential")
+            .await
+            .unwrap();
+        assert_eq!(by_type.len(), 1);
+        assert_eq!(by_type[0].id, "cred-1");
+        assert_eq!(
+            find_by_index(&vault, IndexField::Type, "VerifiableCredential")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // community_did
+        assert_eq!(
+            find_by_index(&vault, IndexField::CommunityDid, "did:web:acme")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        // issuer_did
+        assert_eq!(
+            find_by_index(&vault, IndexField::IssuerDid, "did:web:issuer.example")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        // purpose
+        assert_eq!(
+            find_by_index(&vault, IndexField::Purpose, "invite")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        // status (defaults to unknown at store time)
+        assert_eq!(
+            find_by_index(&vault, IndexField::Status, "unknown")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // A value that matches nothing returns empty, never an error.
+        assert!(
+            find_by_index(&vault, IndexField::IssuerDid, "did:web:other")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn index_scans_isolate_distinct_credentials() {
+        let (_dir, _store, vault) = fresh_vault(None);
+
+        let mut a = sample("cred-a");
+        a.issuer_did = Some("did:web:issuer-a".into());
+        a.community_did = Some("did:web:acme".into());
+
+        let mut b = sample("cred-b");
+        b.issuer_did = Some("did:web:issuer-b".into());
+        b.community_did = Some("did:web:acme".into());
+
+        put(&vault, &a).await.unwrap();
+        put(&vault, &b).await.unwrap();
+
+        // Shared community → both.
+        let mut shared = find_by_index(&vault, IndexField::CommunityDid, "did:web:acme")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect::<Vec<_>>();
+        shared.sort();
+        assert_eq!(shared, vec!["cred-a", "cred-b"]);
+
+        // Distinct issuer → exactly one each.
+        let only_a = find_by_index(&vault, IndexField::IssuerDid, "did:web:issuer-a")
+            .await
+            .unwrap();
+        assert_eq!(only_a.len(), 1);
+        assert_eq!(only_a[0].id, "cred-a");
+    }
+
+    #[tokio::test]
+    async fn update_reindexes_and_drops_stale_rows() {
+        let (_dir, _store, vault) = fresh_vault(None);
+        let mut cred = sample("cred-1");
+        put(&vault, &cred).await.unwrap();
+
+        // Initially indexed under status=unknown.
+        assert_eq!(
+            find_by_index(&vault, IndexField::Status, "unknown")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // Flip status → revoked and re-store.
+        cred.status = CredentialStatus::Revoked;
+        put(&vault, &cred).await.unwrap();
+
+        // Old status row is gone; new one is present. No double-counting.
+        assert!(
+            find_by_index(&vault, IndexField::Status, "unknown")
+                .await
+                .unwrap()
+                .is_empty(),
+            "stale status=unknown index row must be removed on update"
+        );
+        assert_eq!(
+            find_by_index(&vault, IndexField::Status, "revoked")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_removes_record_and_all_index_rows() {
+        let (_dir, _store, vault) = fresh_vault(None);
+        put(&vault, &sample("cred-1")).await.unwrap();
+
+        delete(&vault, "cred-1").await.unwrap();
+
+        assert!(get(&vault, "cred-1").await.unwrap().is_none());
+        for (field, value) in [
+            (IndexField::Type, "InvitationCredential"),
+            (IndexField::CommunityDid, "did:web:acme"),
+            (IndexField::IssuerDid, "did:web:issuer.example"),
+            (IndexField::Purpose, "invite"),
+            (IndexField::Status, "unknown"),
+        ] {
+            assert!(
+                find_by_index(&vault, field, value)
+                    .await
+                    .unwrap()
+                    .is_empty(),
+                "index row for {field:?}={value} must be gone after delete"
+            );
+        }
+
+        // Deleting an absent id is a no-op.
+        delete(&vault, "cred-1").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn empty_id_is_rejected() {
+        let (_dir, _store, vault) = fresh_vault(None);
+        let cred = sample("");
+        let err = put(&vault, &cred).await.unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn body_is_encrypted_at_rest() {
+        // With an at-rest key, the opaque body must not appear in cleartext
+        // anywhere in the keyspace's stored value bytes. Scanning the raw
+        // (still-encrypted) record value proves the AES-GCM wrapper engaged.
+        let key = [7u8; 32];
+        let (_dir, store, vault) = fresh_vault(Some(key));
+        assert!(vault.is_encrypted());
+
+        let cred = sample("cred-secret");
+        put(&vault, &cred).await.unwrap();
+
+        // Read the SAME keyspace through a second handle that has NO
+        // encryption key. `get_raw` only decrypts when its handle carries a
+        // key, so this plain handle returns the actual on-disk ciphertext —
+        // the genuine "at rest" bytes, not a decrypted view.
+        let plain = store.keyspace("vault").expect("plain vault handle");
+        assert!(!plain.is_encrypted());
+        let raw = plain
+            .get_raw(record_key("cred-secret"))
+            .await
+            .unwrap()
+            .expect("raw record present");
+        // Neither the opaque body nor any plaintext metadata (the id, the
+        // issuer DID) may appear in the ciphertext.
+        assert!(
+            !contains_subslice(&raw, b"opaque.credential.bytes"),
+            "credential body must be ciphertext at rest, found cleartext"
+        );
+        assert!(
+            !contains_subslice(&raw, b"cred-secret"),
+            "record metadata must be ciphertext at rest, found cleartext id"
+        );
+        assert!(
+            !contains_subslice(&raw, b"did:web:issuer.example"),
+            "record metadata must be ciphertext at rest, found cleartext issuer DID"
+        );
+
+        // Through the decrypting handle the body round-trips intact.
+        let got = get(&vault, "cred-secret").await.unwrap().expect("present");
+        assert_eq!(got.body, b"opaque.credential.bytes".to_vec());
+
+        // And searches still work over the encrypted store (index keys are
+        // plaintext metadata; only the value is encrypted).
+        assert_eq!(
+            find_by_index(&vault, IndexField::Purpose, "invite")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
+    }
+}


### PR DESCRIPTION
## What (credential architecture — task 1.1)

Promotes the VTA `vault` keyspace from M1 read-only stub to a real credential store's **storage + index layer**. Format-agnostic: stores opaque credential bodies + metadata, no crypto (that arrives in 1.2+).

- `vault/model.rs` — `StoredCredential` envelope `{ id, format, types[], schema_id, community_did, subject_did, issuer_did, purpose, status, valid_from/until, received_at, source, tags, body }`.
- `vault/storage.rs` — store/get/put/delete; **encrypted at rest** via the existing per-keyspace AES-256-GCM (a `body_is_encrypted_at_rest` test reads on-disk ciphertext through a keyless handle and asserts the body + issuer DID are absent in cleartext).
- `vault/index.rs` — prefix-scan index by `{type, community_did, issuer_did, purpose, status}`; a single `index_terms()` drives insert+remove so they can't drift; NUL separator prevents colon-extended DID false prefix matches.

## Verification

39 `vault::` tests green (store+get, prefix-scan each field, round-trip, update-reindex, delete, empty-id rejection, encrypted-at-rest); `cargo fmt --check` + `cargo clippy -p vta-service --lib` clean. (Verified on the branch — an earlier IDE diagnostic was stale cross-worktree noise.)

## Security review (agent-skills:security-auditor) — **approve**, with carried-forward findings

No leak: the module never logs and never parses the body. The no-enumeration invariant is upheld at this layer (no `list_all`; the only discovery primitive requires an explicit field+value). **Findings to honour downstream (not in 1.1):**
- `find_by_index` is a de-facto enumeration primitive — **tasks 1.2–1.4 MUST gate it** so no route scans a low-cardinality field or returns >1 credential (§16 "Ask first").
- Index *keys* carry plaintext routing metadata at rest (issuer/community DIDs) — bodies/claims are encrypted, index tokens are not (inherent to fjall prefix scans, same as the existing password vault). A future task may want HMAC'd index tokens if a disk-capture adversary inferring the issuer graph is in scope.
- `StoredCredential` derives `Debug` — add a redacting impl before route handlers consume the body in 1.2+.

> Generated by the `credential-phase` workflow (build → adversarial security review); branch verified locally before this PR.
