### PR TITLE
feat(vtc): Phase 2 — DTG catalog adoption + VIC + schema store + issue-time validation (2.0–2.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3180,6 +3180,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtg-credentials"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b7131aa259ef04decb22060173d96b669cffbe172f0ad431f5cb36f1ad9569"
+dependencies = [
+ "affinidi-data-integrity",
+ "affinidi-secrets-resolver",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5130,6 +5145,8 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
+ "reqwest 0.13.4",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -7120,6 +7137,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.14",
@@ -9838,6 +9856,7 @@ dependencies = [
  "clap",
  "dialoguer",
  "didwebvh-rs",
+ "dtg-credentials",
  "ed25519-dalek",
  "fjall",
  "flate2",
@@ -9849,6 +9868,7 @@ dependencies = [
  "hkdf 0.13.0",
  "http-body-util",
  "include_dir",
+ "jsonschema",
  "jsonwebtoken",
  "keyring-core",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,9 @@ affinidi-messaging-didcomm-service = "0.3"
 # Decentralized Trust Graph Credentials
 dtg-credentials = "0.1.2"
 
+# JSON Schema validation (issue-time credentialSchema checks)
+jsonschema = "0.46"
+
 # Async runtime
 tokio = { version = "1", features = [
   "rt-multi-thread",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ affinidi-secrets-resolver = "0.5"
 affinidi-messaging-didcomm-service = "0.3"
 
 # Decentralized Trust Graph Credentials
-dtg-credentials = "0.1"
+dtg-credentials = "0.1.2"
 
 # Async runtime
 tokio = { version = "1", features = [

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -84,6 +84,10 @@ affinidi-messaging-didcomm-service = { workspace = true }
 affinidi-vc = { workspace = true }
 affinidi-data-integrity = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
+# DTG / Decentralized Trust Credentials catalog — canonical credential shapes
+# (Membership, Endorsement, Invitation, …). Phase 2 sources every issued
+# credential's shape from this catalog rather than hand-rolling each VC.
+dtg-credentials = { workspace = true }
 # Bitstring status list — privacy-preserving credential revocation
 # per W3C. Used by `crate::status_list` (Phase 2 M2.10).
 affinidi-status-list = { workspace = true }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -84,7 +84,7 @@ affinidi-messaging-didcomm-service = { workspace = true }
 affinidi-vc = { workspace = true }
 affinidi-data-integrity = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
-# DTG / Decentralized Trust Credentials catalog — canonical credential shapes
+# DTG (Decentralized Trust Graph) credentials catalog — canonical credential shapes
 # (Membership, Endorsement, Invitation, …). Phase 2 sources every issued
 # credential's shape from this catalog rather than hand-rolling each VC.
 dtg-credentials = { workspace = true }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -88,6 +88,8 @@ affinidi-secrets-resolver = { workspace = true }
 # (Membership, Endorsement, Invitation, …). Phase 2 sources every issued
 # credential's shape from this catalog rather than hand-rolling each VC.
 dtg-credentials = { workspace = true }
+# JSON Schema validation of issued credentials against their credentialSchema.
+jsonschema = { workspace = true }
 # Bitstring status list — privacy-preserving credential revocation
 # per W3C. Used by `crate::status_list` (Phase 2 M2.10).
 affinidi-status-list = { workspace = true }

--- a/vtc-service/src/credentials/custom_endorsement.rs
+++ b/vtc-service/src/credentials/custom_endorsement.rs
@@ -31,14 +31,12 @@
 //! - `claim` body fits the 8 KiB cap.
 //! - `type` is a non-empty string.
 
-use affinidi_vc::{CredentialBuilder, VerifiableCredential};
-use chrono::{Duration, Utc};
-use serde_json::{Map, Value as JsonValue, json};
+use affinidi_vc::VerifiableCredential;
+use chrono::Duration;
+use serde_json::Value as JsonValue;
 use vti_common::error::AppError;
 
 use super::LocalSigner;
-use super::VEC_CONTEXT_URL;
-use super::vec::VEC_TYPE;
 use super::vmc::CredentialStatusRef;
 
 /// 8 KiB cap on the `endorsement.claim` body. Mirrors the
@@ -131,76 +129,37 @@ pub async fn build_custom_endorsement(
         )));
     }
 
-    let now = Utc::now();
-    let valid_until = now + params.validity;
-
-    let endorsement = json!({
+    // Custom-endorsement shape: `credentialSubject.endorsement = { type, claim,
+    // communityDid }`, sourced through the DTC catalog (`issue_endorsement`),
+    // with the operator's required `credentialStatus`.
+    let endorsement = serde_json::json!({
         "type": params.endorsement_type,
         "claim": params.claim,
         "communityDid": signer.issuer_did(),
     });
 
-    let mut subject = Map::new();
-    subject.insert("id".into(), JsonValue::String(params.subject_did.clone()));
-    subject.insert("endorsement".into(), endorsement);
-
-    let mut vc = CredentialBuilder::v2()
-        .context(VEC_CONTEXT_URL)
-        .issuer_uri(signer.issuer_did().to_string())
-        .add_type(VEC_TYPE)
-        .valid_from(rfc3339(now))
-        .valid_until(rfc3339(valid_until))
-        .subject(subject)
-        .build()
-        .map_err(|e| AppError::Internal(format!("custom endorsement build: {e}")))?;
-
-    if let Some(id) = &params.id {
-        attach_top_level_id(&mut vc, id)?;
-    }
-    attach_credential_status(&mut vc, &params.status_ref)?;
-    signer.sign(&mut vc).await?;
-    Ok(vc)
-}
-
-fn rfc3339(t: chrono::DateTime<Utc>) -> String {
-    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
-}
-
-fn attach_top_level_id(vc: &mut VerifiableCredential, id: &str) -> Result<(), AppError> {
-    let mut as_value = serde_json::to_value(&*vc)
-        .map_err(|e| AppError::Internal(format!("custom endorsement -> value: {e}")))?;
-    as_value
-        .as_object_mut()
-        .ok_or_else(|| AppError::Internal("VC not an object".into()))?
-        .insert("id".into(), JsonValue::String(id.into()));
-    *vc = serde_json::from_value(as_value)
-        .map_err(|e| AppError::Internal(format!("value -> VC: {e}")))?;
-    Ok(())
-}
-
-fn attach_credential_status(
-    vc: &mut VerifiableCredential,
-    status_ref: &CredentialStatusRef,
-) -> Result<(), AppError> {
-    let mut as_value = serde_json::to_value(&*vc)
-        .map_err(|e| AppError::Internal(format!("custom endorsement -> value: {e}")))?;
-    as_value
-        .as_object_mut()
-        .ok_or_else(|| AppError::Internal("VC not an object".into()))?
-        .insert(
-            "credentialStatus".into(),
-            serde_json::to_value(status_ref)
-                .map_err(|e| AppError::Internal(format!("status_ref -> value: {e}")))?,
-        );
-    *vc = serde_json::from_value(as_value)
-        .map_err(|e| AppError::Internal(format!("value -> VC: {e}")))?;
-    Ok(())
+    let doc = super::dtc::issue_endorsement(
+        signer,
+        &params.subject_did,
+        endorsement,
+        params.id.as_deref(),
+        Some(&params.status_ref),
+        params.validity,
+    )
+    .await?;
+    serde_json::from_value(doc).map_err(|e| {
+        AppError::Internal(format!(
+            "DTC custom endorsement -> VerifiableCredential: {e}"
+        ))
+    })
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::vec::VEC_TYPE;
     use super::*;
     use affinidi_vc::SubjectValue;
+    use serde_json::json;
 
     const TEST_VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 

--- a/vtc-service/src/credentials/custom_endorsement.rs
+++ b/vtc-service/src/credentials/custom_endorsement.rs
@@ -130,7 +130,7 @@ pub async fn build_custom_endorsement(
     }
 
     // Custom-endorsement shape: `credentialSubject.endorsement = { type, claim,
-    // communityDid }`, sourced through the DTC catalog (`issue_endorsement`),
+    // communityDid }`, sourced through the DTG catalog (`issue_endorsement`),
     // with the operator's required `credentialStatus`.
     let endorsement = serde_json::json!({
         "type": params.endorsement_type,
@@ -138,7 +138,7 @@ pub async fn build_custom_endorsement(
         "communityDid": signer.issuer_did(),
     });
 
-    let doc = super::dtc::issue_endorsement(
+    let doc = super::dtg::issue_endorsement(
         signer,
         &params.subject_did,
         endorsement,
@@ -149,7 +149,7 @@ pub async fn build_custom_endorsement(
     .await?;
     serde_json::from_value(doc).map_err(|e| {
         AppError::Internal(format!(
-            "DTC custom endorsement -> VerifiableCredential: {e}"
+            "DTG custom endorsement -> VerifiableCredential: {e}"
         ))
     })
 }

--- a/vtc-service/src/credentials/custom_endorsement.rs
+++ b/vtc-service/src/credentials/custom_endorsement.rs
@@ -2,13 +2,13 @@
 //!
 //! ## Wire shape
 //!
-//! The VC carries the same `VerifiableEndorsementCredential`
+//! The VC carries the same catalog `EndorsementCredential`
 //! type as role VECs — wire-compatible. The discriminator
 //! lives on `endorsement.type`:
 //!
 //! ```json
 //! {
-//!   "type": ["VerifiableCredential", "VerifiableEndorsementCredential"],
+//!   "type": ["VerifiableCredential", "EndorsementCredential"],
 //!   "issuer": "did:webvh:vtc.example.com:abc",
 //!   "credentialSubject": {
 //!     "id": "<subject-did>",

--- a/vtc-service/src/credentials/dtc.rs
+++ b/vtc-service/src/credentials/dtc.rs
@@ -1,0 +1,261 @@
+//! Issue catalog credentials from the **DTG / Decentralized Trust Credentials**
+//! catalog (`dtg-credentials`) — task 2.0.
+//!
+//! Every credential the VTC mints (Membership, role/custom Endorsement,
+//! Invitation, …) gets its **canonical shape** here from the `dtg-credentials`
+//! catalog constructors (`new_vmc`, `new_vec`, `new_vic`, …) rather than being
+//! hand-rolled. The catalog fixes the `@context`, the `type` array, and the
+//! `credentialSubject` shape for each kind, so every issuer in the ecosystem
+//! mints the same wire form.
+//!
+//! ## Signing covers `id` + `credentialStatus`
+//!
+//! The catalog's `DTGCredential` models the VC body (`@context`, `type`,
+//! `issuer`, `validFrom`/`validUntil`, `credentialSubject`, `proof`) but **not**
+//! a top-level `id` or a `credentialStatus` block. Those are spliced onto the
+//! serialized body **before** signing, and the whole document is signed via
+//! [`LocalSigner::sign_doc`] — so the proof covers the status reference (a
+//! revoked credential can't have its `credentialStatus` stripped without
+//! breaking the signature). The result is the signed VC as a
+//! [`serde_json::Value`], the shape every downstream consumer (seal, store,
+//! `recognition`) already speaks.
+//!
+//! ## Keys stay in `LocalSigner`
+//!
+//! Issuance signs through the VTC's local issuer key ([`LocalSigner`]); the key
+//! is never exported. `issuer = signer.issuer_did()` for every credential.
+
+use chrono::{DateTime, Duration, Utc};
+use dtg_credentials::DTGCredential;
+use serde_json::Value;
+use vti_common::error::AppError;
+
+use crate::acl::VtcRole;
+
+use super::signer::LocalSigner;
+use super::vec::COMMUNITY_ROLE_ENDORSEMENT_TYPE;
+use super::vmc::CredentialStatusRef;
+
+/// `[validFrom, validUntil]` for a credential minted `now` with `validity`.
+fn window(validity: Duration) -> (DateTime<Utc>, DateTime<Utc>) {
+    let now = Utc::now();
+    (now, now + validity)
+}
+
+/// Serialize a catalog credential's body, splice the optional `id` +
+/// `credentialStatus`, and sign the whole document. Returns the signed VC JSON.
+async fn finalize(
+    signer: &LocalSigner,
+    dtg: DTGCredential,
+    id: Option<&str>,
+    status_ref: Option<&CredentialStatusRef>,
+) -> Result<Value, AppError> {
+    // The wire VC is the catalog's `DTGCommon` body; the `DTGCredential`
+    // wrapper's `type_`/`version` helpers are not part of the credential.
+    let mut doc = serde_json::to_value(dtg.credential())
+        .map_err(|e| AppError::Internal(format!("DTC credential -> value: {e}")))?;
+    let obj = doc
+        .as_object_mut()
+        .ok_or_else(|| AppError::Internal("DTC credential is not a JSON object".into()))?;
+
+    if let Some(id) = id {
+        obj.insert("id".into(), Value::String(id.to_string()));
+    }
+    if let Some(status_ref) = status_ref {
+        let status = serde_json::to_value(status_ref)
+            .map_err(|e| AppError::Internal(format!("credentialStatus -> value: {e}")))?;
+        obj.insert("credentialStatus".into(), status);
+    }
+
+    // Sign the full document (covers id + credentialStatus).
+    signer.sign_doc(&mut doc).await?;
+    Ok(doc)
+}
+
+/// Issue a signed **Membership** credential (VMC) as JSON.
+///
+/// `personhood = true` adds `PersonhoodCredential` to the `type` array (the
+/// catalog's convention) rather than a subject field.
+pub async fn issue_membership(
+    signer: &LocalSigner,
+    member_did: &str,
+    id: Option<&str>,
+    status_ref: Option<&CredentialStatusRef>,
+    validity: Duration,
+    personhood: bool,
+) -> Result<Value, AppError> {
+    let (valid_from, valid_until) = window(validity);
+    let dtg = DTGCredential::new_vmc(
+        signer.issuer_did().to_string(),
+        member_did.to_string(),
+        valid_from,
+        Some(valid_until),
+        personhood,
+    );
+    finalize(signer, dtg, id, status_ref).await
+}
+
+/// Issue a signed **role-grant** Endorsement credential (VEC) as JSON.
+///
+/// The endorsement carries `{ type: "CommunityRole", role, communityDid }` at
+/// `credentialSubject.endorsement` — the shape `recognition` parses for
+/// cross-community role verification.
+pub async fn issue_role(
+    signer: &LocalSigner,
+    member_did: &str,
+    role: &VtcRole,
+    id: Option<&str>,
+    status_ref: Option<&CredentialStatusRef>,
+    validity: Duration,
+) -> Result<Value, AppError> {
+    let endorsement = serde_json::json!({
+        "type": COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+        "role": role.to_string(),
+        "communityDid": signer.issuer_did(),
+    });
+    issue_endorsement(signer, member_did, endorsement, id, status_ref, validity).await
+}
+
+/// Issue a signed **Endorsement** credential (VEC) as JSON with a
+/// caller-supplied `endorsement` value at `credentialSubject.endorsement`.
+/// Used for both role grants ([`issue_role`]) and operator-defined custom
+/// endorsements.
+pub async fn issue_endorsement(
+    signer: &LocalSigner,
+    member_did: &str,
+    endorsement: Value,
+    id: Option<&str>,
+    status_ref: Option<&CredentialStatusRef>,
+    validity: Duration,
+) -> Result<Value, AppError> {
+    let (valid_from, valid_until) = window(validity);
+    let dtg = DTGCredential::new_vec(
+        signer.issuer_did().to_string(),
+        member_did.to_string(),
+        valid_from,
+        Some(valid_until),
+        endorsement,
+    );
+    finalize(signer, dtg, id, status_ref).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
+
+    const TEST_DID: &str = "did:web:acme.example";
+
+    fn signer() -> LocalSigner {
+        LocalSigner::from_ed25519_seed(TEST_DID.into(), &[7u8; 32])
+    }
+
+    /// Verify the issuer proof over the document (proof stripped), as every
+    /// downstream verifier does.
+    fn verify(doc: &Value, signer: &LocalSigner) -> Result<(), String> {
+        let proof: DataIntegrityProof =
+            serde_json::from_value(doc.get("proof").cloned().ok_or("no proof")?)
+                .map_err(|e| e.to_string())?;
+        let mut unsigned = doc.clone();
+        unsigned.as_object_mut().unwrap().remove("proof");
+        proof
+            .verify_with_public_key(&unsigned, signer.public_bytes(), VerifyOptions::new())
+            .map_err(|e| e.to_string())
+    }
+
+    #[tokio::test]
+    async fn membership_issues_with_catalog_shape_and_verifies() {
+        let s = signer();
+        let doc = issue_membership(
+            &s,
+            "did:key:zMember",
+            Some("urn:uuid:vmc-1"),
+            None,
+            Duration::days(30),
+            false,
+        )
+        .await
+        .expect("issue VMC");
+
+        verify(&doc, &s).expect("VMC proof verifies");
+        assert_eq!(doc["issuer"], TEST_DID);
+        assert_eq!(doc["id"], "urn:uuid:vmc-1");
+        assert_eq!(doc["credentialSubject"]["id"], "did:key:zMember");
+        let types: Vec<String> = serde_json::from_value(doc["type"].clone()).unwrap();
+        assert!(
+            types.iter().any(|t| t == "MembershipCredential"),
+            "{types:?}"
+        );
+        assert!(
+            !types.iter().any(|t| t == "PersonhoodCredential"),
+            "personhood was false"
+        );
+        assert!(
+            doc.get("credentialStatus").is_none(),
+            "no status_ref → no block"
+        );
+    }
+
+    #[tokio::test]
+    async fn personhood_membership_adds_type() {
+        let s = signer();
+        let doc = issue_membership(&s, "did:key:zM", None, None, Duration::days(30), true)
+            .await
+            .unwrap();
+        let types: Vec<String> = serde_json::from_value(doc["type"].clone()).unwrap();
+        assert!(
+            types.iter().any(|t| t == "PersonhoodCredential"),
+            "{types:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn role_vec_preserves_recognition_endorsement_shape() {
+        let s = signer();
+        let doc = issue_role(
+            &s,
+            "did:key:zMember",
+            &VtcRole::Admin,
+            Some("urn:uuid:vec-1"),
+            None,
+            Duration::days(30),
+        )
+        .await
+        .expect("issue role VEC");
+
+        verify(&doc, &s).expect("VEC proof verifies");
+        // The shape recognition/verify.rs parses: endorsement.{role,communityDid}.
+        let endorsement = &doc["credentialSubject"]["endorsement"];
+        assert_eq!(endorsement["type"], "CommunityRole");
+        assert_eq!(endorsement["role"], VtcRole::Admin.to_string());
+        assert_eq!(endorsement["communityDid"], TEST_DID);
+    }
+
+    #[tokio::test]
+    async fn credential_status_is_inside_the_signed_bytes() {
+        let s = signer();
+        let status = CredentialStatusRef::revocation("urn:uuid:list-1", 42);
+        let doc = issue_endorsement(
+            &s,
+            "did:key:zMember",
+            serde_json::json!({ "type": "CommunityRole", "role": "member" }),
+            None,
+            Some(&status),
+            Duration::days(30),
+        )
+        .await
+        .expect("issue VEC with status");
+
+        verify(&doc, &s).expect("VEC-with-status verifies");
+        assert!(doc.get("credentialStatus").is_some());
+
+        // Tampering with the status (e.g. removing it) breaks the proof —
+        // proving the status is covered by the signature.
+        let mut tampered = doc.clone();
+        tampered.as_object_mut().unwrap().remove("credentialStatus");
+        assert!(
+            verify(&tampered, &s).is_err(),
+            "stripping a signed credentialStatus must invalidate the proof"
+        );
+    }
+}

--- a/vtc-service/src/credentials/dtc.rs
+++ b/vtc-service/src/credentials/dtc.rs
@@ -139,6 +139,27 @@ pub async fn issue_endorsement(
     finalize(signer, dtg, id, status_ref).await
 }
 
+/// Issue a signed **Invitation** credential (VIC) as JSON to a `subject_did`
+/// that is **not** (yet) a member. The issue-to-unknown-holder transport
+/// (sealed + delivered out-of-band) is Phase 3; this is the issuance op. Pass a
+/// `status_ref` to make the invite revocable.
+pub async fn issue_invitation(
+    signer: &LocalSigner,
+    subject_did: &str,
+    id: Option<&str>,
+    status_ref: Option<&CredentialStatusRef>,
+    validity: Duration,
+) -> Result<Value, AppError> {
+    let (valid_from, valid_until) = window(validity);
+    let dtg = DTGCredential::new_vic(
+        signer.issuer_did().to_string(),
+        subject_did.to_string(),
+        valid_from,
+        Some(valid_until),
+    );
+    finalize(signer, dtg, id, status_ref).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,6 +250,35 @@ mod tests {
         assert_eq!(endorsement["type"], "CommunityRole");
         assert_eq!(endorsement["role"], VtcRole::Admin.to_string());
         assert_eq!(endorsement["communityDid"], TEST_DID);
+    }
+
+    #[tokio::test]
+    async fn invitation_issues_to_a_non_member_and_verifies() {
+        // A VIC is issued to a DID with no membership record (an invite); it
+        // verifies, carries the Invitation type, and is revocable.
+        let s = signer();
+        let status = CredentialStatusRef::revocation("urn:uuid:invite-list", 3);
+        let doc = issue_invitation(
+            &s,
+            "did:key:zInvitee",
+            Some("urn:uuid:vic-1"),
+            Some(&status),
+            Duration::days(7),
+        )
+        .await
+        .expect("issue VIC");
+
+        verify(&doc, &s).expect("VIC proof verifies");
+        assert_eq!(doc["credentialSubject"]["id"], "did:key:zInvitee");
+        let types: Vec<String> = serde_json::from_value(doc["type"].clone()).unwrap();
+        assert!(
+            types.iter().any(|t| t == "InvitationCredential"),
+            "{types:?}"
+        );
+        assert!(
+            doc.get("credentialStatus").is_some(),
+            "VIC must be revocable"
+        );
     }
 
     #[tokio::test]

--- a/vtc-service/src/credentials/dtg.rs
+++ b/vtc-service/src/credentials/dtg.rs
@@ -1,5 +1,5 @@
-//! Issue catalog credentials from the **DTG / Decentralized Trust Credentials**
-//! catalog (`dtg-credentials`) — task 2.0.
+//! Issue catalog credentials from the **DTG (Decentralized Trust Graph)**
+//! credentials catalog (`dtg-credentials`) — task 2.0.
 //!
 //! Every credential the VTC mints (Membership, role/custom Endorsement,
 //! Invitation, …) gets its **canonical shape** here from the `dtg-credentials`
@@ -53,10 +53,10 @@ async fn finalize(
     // The wire VC is the catalog's `DTGCommon` body; the `DTGCredential`
     // wrapper's `type_`/`version` helpers are not part of the credential.
     let mut doc = serde_json::to_value(dtg.credential())
-        .map_err(|e| AppError::Internal(format!("DTC credential -> value: {e}")))?;
+        .map_err(|e| AppError::Internal(format!("DTG credential -> value: {e}")))?;
     let obj = doc
         .as_object_mut()
-        .ok_or_else(|| AppError::Internal("DTC credential is not a JSON object".into()))?;
+        .ok_or_else(|| AppError::Internal("DTG credential is not a JSON object".into()))?;
 
     if let Some(id) = id {
         obj.insert("id".into(), Value::String(id.to_string()));

--- a/vtc-service/src/credentials/invitation.rs
+++ b/vtc-service/src/credentials/invitation.rs
@@ -36,6 +36,7 @@ pub const DEFAULT_INVITATION_VALIDITY: Duration = Duration::days(7);
 pub async fn issue_invitation(
     signer: &LocalSigner,
     status_lists_ks: &KeyspaceHandle,
+    schemas_ks: &KeyspaceHandle,
     subject_did: &str,
     validity: Duration,
 ) -> Result<Value, AppError> {
@@ -60,6 +61,12 @@ pub async fn issue_invitation(
     // Build first; persist the burned slot only on success.
     let vic =
         dtc::issue_invitation(signer, subject_did, Some(&id), Some(&status_ref), validity).await?;
+
+    // Issue-time schema validation (task 2.3): if an InvitationCredential schema
+    // is registered in the schema store, the VIC must conform before the slot is
+    // committed — so a non-conforming invite never burns a revocation slot.
+    crate::schemas::validate_issued(schemas_ks, &vic).await?;
+
     status_list::store_state(status_lists_ks, &row).await?;
 
     Ok(vic)
@@ -78,7 +85,8 @@ mod tests {
         LocalSigner::from_ed25519_seed(TEST_VTC_DID.into(), &[0xCC; 32])
     }
 
-    async fn provisioned_status_ks() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+    /// A provisioned revocation status list + an (empty) schemas keyspace.
+    async fn provisioned() -> (tempfile::TempDir, Store, KeyspaceHandle, KeyspaceHandle) {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open(&StoreConfig {
             data_dir: dir.path().to_path_buf(),
@@ -87,6 +95,7 @@ mod tests {
         let ks = store
             .keyspace("status_lists")
             .expect("status_lists keyspace");
+        let schemas_ks = store.keyspace("schemas").expect("schemas keyspace");
         let state = StatusListState::new(
             StatusPurpose::Revocation,
             format!("{TEST_VTC_DID}/v1/status-lists/revocation"),
@@ -94,12 +103,12 @@ mod tests {
         status_list::store_state(&ks, &state)
             .await
             .expect("seed list");
-        (dir, store, ks)
+        (dir, store, ks, schemas_ks)
     }
 
     #[tokio::test]
     async fn issues_a_revocable_vic_and_burns_a_slot() {
-        let (_dir, _store, ks) = provisioned_status_ks().await;
+        let (_dir, _store, ks, schemas_ks) = provisioned().await;
         let s = signer();
 
         let assigned_before = get_state(&ks, StatusPurpose::Revocation)
@@ -108,7 +117,7 @@ mod tests {
             .unwrap()
             .count_assigned();
 
-        let vic = issue_invitation(&s, &ks, "did:key:zInvitee", Duration::days(7))
+        let vic = issue_invitation(&s, &ks, &schemas_ks, "did:key:zInvitee", Duration::days(7))
             .await
             .expect("issue VIC");
 
@@ -147,10 +156,58 @@ mod tests {
         })
         .unwrap();
         let ks = store.keyspace("status_lists").unwrap();
+        let schemas_ks = store.keyspace("schemas").unwrap();
         let s = signer();
-        let err = issue_invitation(&s, &ks, "did:key:zInvitee", Duration::days(7))
+        let err = issue_invitation(&s, &ks, &schemas_ks, "did:key:zInvitee", Duration::days(7))
             .await
             .expect_err("must refuse without a provisioned list");
         assert!(matches!(err, AppError::Internal(_)), "{err:?}");
+    }
+
+    /// A registered InvitationCredential schema is enforced at issue time, and a
+    /// non-conforming invite never burns a revocation slot.
+    #[tokio::test]
+    async fn registered_schema_is_enforced_and_slot_not_burned_on_violation() {
+        use crate::schemas::{SchemaEntry, SchemaKind, store_schema};
+        let (_dir, _store, ks, schemas_ks) = provisioned().await;
+        let s = signer();
+
+        // Require a `invitedBy` subject field the catalog VIC subject ({id})
+        // never has → every VIC fails validation.
+        store_schema(
+            &schemas_ks,
+            &SchemaEntry {
+                type_uri: "InvitationCredential".into(),
+                dtc_type: Some("InvitationCredential".into()),
+                credential_schema: Some(serde_json::json!({
+                    "type": "object",
+                    "required": ["id", "invitedBy"]
+                })),
+                kind: SchemaKind::Issues,
+                description: None,
+                created_at: chrono::Utc::now(),
+                created_by_did: "did:key:zAdmin".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let before = get_state(&ks, StatusPurpose::Revocation)
+            .await
+            .unwrap()
+            .unwrap()
+            .count_assigned();
+
+        let err = issue_invitation(&s, &ks, &schemas_ks, "did:key:zInvitee", Duration::days(7))
+            .await
+            .expect_err("non-conforming VIC must be refused");
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+
+        let after = get_state(&ks, StatusPurpose::Revocation)
+            .await
+            .unwrap()
+            .unwrap()
+            .count_assigned();
+        assert_eq!(after, before, "a rejected VIC must not burn a slot");
     }
 }

--- a/vtc-service/src/credentials/invitation.rs
+++ b/vtc-service/src/credentials/invitation.rs
@@ -1,0 +1,156 @@
+//! Issue an **InvitationCredential** (VIC) to a non-member DID — task 2.1.
+//!
+//! The community invites an as-yet-unknown holder by issuing a VIC sealed to
+//! their key and delivered out-of-band (the relayer≠holder / air-gap pattern;
+//! the transport itself is Phase 3). This module is the **issuance op**: it
+//! allocates a revocation-list slot (so the invite is revocable), issues the
+//! VIC through the DTC catalog ([`super::dtc::issue_invitation`]) signed by the
+//! community's local key, and persists the status-list state only after the VIC
+//! builds — so a build failure never permanently burns a slot.
+
+use affinidi_status_list::StatusPurpose;
+use chrono::Duration;
+use serde_json::Value;
+use uuid::Uuid;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use crate::status_list;
+
+use super::dtc;
+use super::signer::LocalSigner;
+use super::vmc::CredentialStatusRef;
+
+/// Default validity for an invitation — short-lived, since an invite is a
+/// one-shot onboarding artifact.
+pub const DEFAULT_INVITATION_VALIDITY: Duration = Duration::days(7);
+
+/// Issue a revocable Invitation credential to `subject_did` (a non-member).
+///
+/// Allocates a slot in the community's **revocation** status list, issues the
+/// VIC via the catalog, and stores the updated status-list state. Returns the
+/// signed VIC as JSON.
+///
+/// Errors: [`AppError::Internal`] if the revocation list is not provisioned or
+/// is exhausted.
+pub async fn issue_invitation(
+    signer: &LocalSigner,
+    status_lists_ks: &KeyspaceHandle,
+    subject_did: &str,
+    validity: Duration,
+) -> Result<Value, AppError> {
+    let mut row = status_list::get_state(status_lists_ks, StatusPurpose::Revocation)
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal(
+                "revocation status list not provisioned — set `public_url` + restart".into(),
+            )
+        })?;
+
+    let slot = status_list::allocate(&mut row).ok_or_else(|| {
+        AppError::Internal(format!(
+            "revocation status list exhausted (capacity = {})",
+            row.capacity
+        ))
+    })?;
+
+    let status_ref = CredentialStatusRef::revocation(row.list_credential_id.clone(), slot);
+    let id = format!("urn:uuid:{}", Uuid::new_v4());
+
+    // Build first; persist the burned slot only on success.
+    let vic =
+        dtc::issue_invitation(signer, subject_did, Some(&id), Some(&status_ref), validity).await?;
+    status_list::store_state(status_lists_ks, &row).await?;
+
+    Ok(vic)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::status_list::{StatusListState, get_state};
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    const TEST_VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+
+    fn signer() -> LocalSigner {
+        LocalSigner::from_ed25519_seed(TEST_VTC_DID.into(), &[0xCC; 32])
+    }
+
+    async fn provisioned_status_ks() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store
+            .keyspace("status_lists")
+            .expect("status_lists keyspace");
+        let state = StatusListState::new(
+            StatusPurpose::Revocation,
+            format!("{TEST_VTC_DID}/v1/status-lists/revocation"),
+        );
+        status_list::store_state(&ks, &state)
+            .await
+            .expect("seed list");
+        (dir, store, ks)
+    }
+
+    #[tokio::test]
+    async fn issues_a_revocable_vic_and_burns_a_slot() {
+        let (_dir, _store, ks) = provisioned_status_ks().await;
+        let s = signer();
+
+        let assigned_before = get_state(&ks, StatusPurpose::Revocation)
+            .await
+            .unwrap()
+            .unwrap()
+            .count_assigned();
+
+        let vic = issue_invitation(&s, &ks, "did:key:zInvitee", Duration::days(7))
+            .await
+            .expect("issue VIC");
+
+        // Catalog Invitation type + revocable + subject is the invitee.
+        let types: Vec<String> = serde_json::from_value(vic["type"].clone()).unwrap();
+        assert!(
+            types.iter().any(|t| t == "InvitationCredential"),
+            "{types:?}"
+        );
+        assert_eq!(vic["credentialSubject"]["id"], "did:key:zInvitee");
+        assert!(
+            vic.get("credentialStatus").is_some(),
+            "VIC must be revocable"
+        );
+        s.verify(&serde_json::from_value(vic.clone()).unwrap())
+            .expect("VIC proof verifies");
+
+        // A slot was allocated + persisted.
+        let assigned_after = get_state(&ks, StatusPurpose::Revocation)
+            .await
+            .unwrap()
+            .unwrap()
+            .count_assigned();
+        assert_eq!(
+            assigned_after,
+            assigned_before + 1,
+            "issuing a VIC must burn exactly one revocation slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn refuses_when_revocation_list_not_provisioned() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("status_lists").unwrap();
+        let s = signer();
+        let err = issue_invitation(&s, &ks, "did:key:zInvitee", Duration::days(7))
+            .await
+            .expect_err("must refuse without a provisioned list");
+        assert!(matches!(err, AppError::Internal(_)), "{err:?}");
+    }
+}

--- a/vtc-service/src/credentials/invitation.rs
+++ b/vtc-service/src/credentials/invitation.rs
@@ -4,7 +4,7 @@
 //! their key and delivered out-of-band (the relayer≠holder / air-gap pattern;
 //! the transport itself is Phase 3). This module is the **issuance op**: it
 //! allocates a revocation-list slot (so the invite is revocable), issues the
-//! VIC through the DTC catalog ([`super::dtc::issue_invitation`]) signed by the
+//! VIC through the DTG catalog ([`super::dtg::issue_invitation`]) signed by the
 //! community's local key, and persists the status-list state only after the VIC
 //! builds — so a build failure never permanently burns a slot.
 
@@ -17,7 +17,7 @@ use vti_common::store::KeyspaceHandle;
 
 use crate::status_list;
 
-use super::dtc;
+use super::dtg;
 use super::signer::LocalSigner;
 use super::vmc::CredentialStatusRef;
 
@@ -60,7 +60,7 @@ pub async fn issue_invitation(
 
     // Build first; persist the burned slot only on success.
     let vic =
-        dtc::issue_invitation(signer, subject_did, Some(&id), Some(&status_ref), validity).await?;
+        dtg::issue_invitation(signer, subject_did, Some(&id), Some(&status_ref), validity).await?;
 
     // Issue-time schema validation (task 2.3): if an InvitationCredential schema
     // is registered in the schema store, the VIC must conform before the slot is
@@ -178,7 +178,7 @@ mod tests {
             &schemas_ks,
             &SchemaEntry {
                 type_uri: "InvitationCredential".into(),
-                dtc_type: Some("InvitationCredential".into()),
+                dtg_type: Some("InvitationCredential".into()),
                 credential_schema: Some(serde_json::json!({
                     "type": "object",
                     "required": ["id", "invitedBy"]

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -46,6 +46,7 @@
 
 pub mod custom_endorsement;
 pub mod dtc;
+pub mod invitation;
 pub mod signer;
 pub mod vec;
 pub mod vmc;

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -45,7 +45,7 @@
 //! pre-status-list state in tests.
 
 pub mod custom_endorsement;
-pub mod dtc;
+pub mod dtg;
 pub mod invitation;
 pub mod signer;
 pub mod vec;

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -45,6 +45,7 @@
 //! pre-status-list state in tests.
 
 pub mod custom_endorsement;
+pub mod dtc;
 pub mod signer;
 pub mod vec;
 pub mod vmc;

--- a/vtc-service/src/credentials/signer.rs
+++ b/vtc-service/src/credentials/signer.rs
@@ -103,8 +103,8 @@ impl LocalSigner {
     /// resulting `DataIntegrityProof` into its `proof` field.
     ///
     /// Unlike [`sign`](Self::sign) (a typed [`VerifiableCredential`]), this signs
-    /// a raw `serde_json::Value`. It's the signing surface for the DTC issuance
-    /// layer ([`super::dtc`]): a credential's canonical shape is sourced from the
+    /// a raw `serde_json::Value`. It's the signing surface for the DTG issuance
+    /// layer ([`super::dtg`]): a credential's canonical shape is sourced from the
     /// `dtg-credentials` catalog, then fields the catalog struct doesn't model
     /// (a top-level `id`, a `credentialStatus` block) are spliced **before**
     /// signing so the proof covers them. Any pre-existing `proof` is removed

--- a/vtc-service/src/credentials/signer.rs
+++ b/vtc-service/src/credentials/signer.rs
@@ -99,6 +99,32 @@ impl LocalSigner {
         Ok(())
     }
 
+    /// Sign an arbitrary JSON credential document **in place**, splicing the
+    /// resulting `DataIntegrityProof` into its `proof` field.
+    ///
+    /// Unlike [`sign`](Self::sign) (a typed [`VerifiableCredential`]), this signs
+    /// a raw `serde_json::Value`. It's the signing surface for the DTC issuance
+    /// layer ([`super::dtc`]): a credential's canonical shape is sourced from the
+    /// `dtg-credentials` catalog, then fields the catalog struct doesn't model
+    /// (a top-level `id`, a `credentialStatus` block) are spliced **before**
+    /// signing so the proof covers them. Any pre-existing `proof` is removed
+    /// first — a proof never covers itself.
+    pub async fn sign_doc(&self, doc: &mut serde_json::Value) -> Result<(), AppError> {
+        let obj = doc
+            .as_object_mut()
+            .ok_or_else(|| AppError::Internal("credential document is not a JSON object".into()))?;
+        obj.remove("proof");
+        let proof = DataIntegrityProof::sign(&*doc, &self.secret, SignOptions::new())
+            .await
+            .map_err(|e| AppError::Internal(format!("sign VC doc: {e}")))?;
+        let proof_value = serde_json::to_value(&proof)
+            .map_err(|e| AppError::Internal(format!("serialize VC doc proof: {e}")))?;
+        doc.as_object_mut()
+            .expect("doc was an object above")
+            .insert("proof".into(), proof_value);
+        Ok(())
+    }
+
     /// Verify a previously-signed VC against this signer's public
     /// key. Used by tests + the M2.13 renewal path that hands
     /// freshly-issued VCs to verifiers. Returns `Ok(())` on

--- a/vtc-service/src/credentials/vec.rs
+++ b/vtc-service/src/credentials/vec.rs
@@ -18,21 +18,18 @@
 //! and on every renewal (spec §6.3 step 2) so the external chain
 //! stays consistent.
 
-use affinidi_vc::{CredentialBuilder, VerifiableCredential};
-use chrono::{Duration, Utc};
-use serde_json::{Map, Value as JsonValue, json};
+use affinidi_vc::VerifiableCredential;
+use chrono::Duration;
 use vti_common::error::AppError;
 
 use crate::acl::VtcRole;
 
 use super::LocalSigner;
-use super::VEC_CONTEXT_URL;
 
-/// Type the VEC's `type` array carries alongside
-/// `VerifiableCredential`. Spec §6.1 names this credential the
-/// "Verifiable Endorsement Credential"; role grants are one
-/// canonical shape.
-pub const VEC_TYPE: &str = "VerifiableEndorsementCredential";
+/// The endorsement type the catalog stamps in the VEC's `type` array (alongside
+/// the universal `VerifiableCredential`). Sourced from the DTC catalog
+/// (`DTGCredentialType::Endorsement`).
+pub const VEC_TYPE: &str = "EndorsementCredential";
 
 /// `endorsement.type` value for a role-grant VEC. Custom
 /// endorsements (Phase 3+) use community-defined types.
@@ -85,59 +82,28 @@ pub async fn build_role_vec(
     signer: &LocalSigner,
     params: RoleVecParams,
 ) -> Result<VerifiableCredential, AppError> {
-    let now = Utc::now();
-    let valid_until = now + params.validity;
-
-    let endorsement = json!({
-        "type": COMMUNITY_ROLE_ENDORSEMENT_TYPE,
-        "role": params.role.to_string(),
-        "communityDid": signer.issuer_did(),
-    });
-
-    let mut subject = Map::new();
-    subject.insert("id".into(), JsonValue::String(params.member_did.clone()));
-    subject.insert("endorsement".into(), endorsement);
-
-    let mut vc = CredentialBuilder::v2()
-        .context(VEC_CONTEXT_URL)
-        .issuer_uri(signer.issuer_did().to_string())
-        .add_type(VEC_TYPE)
-        .valid_from(rfc3339(now))
-        .valid_until(rfc3339(valid_until))
-        .subject(subject)
-        .build()
-        .map_err(|e| AppError::Internal(format!("VEC build: {e}")))?;
-
-    if let Some(id) = &params.id {
-        attach_top_level_id(&mut vc, id)?;
-    }
-
-    signer.sign(&mut vc).await?;
-    Ok(vc)
-}
-
-/// Splice a top-level `id` onto the VC. Same JSON-round-trip
-/// trick the VMC builder uses for `credentialStatus`.
-fn attach_top_level_id(vc: &mut VerifiableCredential, id: &str) -> Result<(), AppError> {
-    let mut as_value =
-        serde_json::to_value(&*vc).map_err(|e| AppError::Internal(format!("VEC -> value: {e}")))?;
-    as_value
-        .as_object_mut()
-        .ok_or_else(|| AppError::Internal("VEC not an object".into()))?
-        .insert("id".into(), JsonValue::String(id.into()));
-    *vc = serde_json::from_value(as_value)
-        .map_err(|e| AppError::Internal(format!("value -> VEC: {e}")))?;
-    Ok(())
-}
-
-fn rfc3339(t: chrono::DateTime<Utc>) -> String {
-    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    // Canonical role-grant shape from the DTC catalog. `issue_role` keeps the
+    // `credentialSubject.endorsement.{type,role,communityDid}` shape that
+    // `recognition` parses. Role VECs carry no credentialStatus today
+    // (`status_ref = None`).
+    let doc = super::dtc::issue_role(
+        signer,
+        &params.member_did,
+        &params.role,
+        params.id.as_deref(),
+        None,
+        params.validity,
+    )
+    .await?;
+    serde_json::from_value(doc)
+        .map_err(|e| AppError::Internal(format!("DTC VEC -> VerifiableCredential: {e}")))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use affinidi_vc::SubjectValue;
+    use serde_json::{Map, Value as JsonValue};
 
     const TEST_VTC_DID: &str = "did:webvh:vtc.example.com:abc";
     const MEMBER_DID: &str = "did:key:zMember1";

--- a/vtc-service/src/credentials/vec.rs
+++ b/vtc-service/src/credentials/vec.rs
@@ -27,7 +27,7 @@ use crate::acl::VtcRole;
 use super::LocalSigner;
 
 /// The endorsement type the catalog stamps in the VEC's `type` array (alongside
-/// the universal `VerifiableCredential`). Sourced from the DTC catalog
+/// the universal `VerifiableCredential`). Sourced from the DTG catalog
 /// (`DTGCredentialType::Endorsement`).
 pub const VEC_TYPE: &str = "EndorsementCredential";
 
@@ -82,11 +82,11 @@ pub async fn build_role_vec(
     signer: &LocalSigner,
     params: RoleVecParams,
 ) -> Result<VerifiableCredential, AppError> {
-    // Canonical role-grant shape from the DTC catalog. `issue_role` keeps the
+    // Canonical role-grant shape from the DTG catalog. `issue_role` keeps the
     // `credentialSubject.endorsement.{type,role,communityDid}` shape that
     // `recognition` parses. Role VECs carry no credentialStatus today
     // (`status_ref = None`).
-    let doc = super::dtc::issue_role(
+    let doc = super::dtg::issue_role(
         signer,
         &params.member_did,
         &params.role,
@@ -96,7 +96,7 @@ pub async fn build_role_vec(
     )
     .await?;
     serde_json::from_value(doc)
-        .map_err(|e| AppError::Internal(format!("DTC VEC -> VerifiableCredential: {e}")))
+        .map_err(|e| AppError::Internal(format!("DTG VEC -> VerifiableCredential: {e}")))
 }
 
 #[cfg(test)]

--- a/vtc-service/src/credentials/vmc.rs
+++ b/vtc-service/src/credentials/vmc.rs
@@ -41,7 +41,7 @@ use vti_common::error::AppError;
 use super::LocalSigner;
 
 /// The membership type the catalog stamps in the VC's `type` array (alongside
-/// the universal `VerifiableCredential`). Sourced from the DTC catalog
+/// the universal `VerifiableCredential`). Sourced from the DTG catalog
 /// (`DTGCredentialType::Membership`).
 pub const VMC_TYPE: &str = "MembershipCredential";
 
@@ -146,15 +146,15 @@ impl VmcParams {
 /// `validFrom = now()`, `validUntil = now() + params.validity`.
 /// Returns the signed VC with `proof` attached.
 ///
-/// The credential's canonical shape comes from the DTC catalog
-/// ([`super::dtc::issue_membership`]); the signed JSON is carried as a
+/// The credential's canonical shape comes from the DTG catalog
+/// ([`super::dtg::issue_membership`]); the signed JSON is carried as a
 /// (lossless, JSON-backed) [`VerifiableCredential`] so every consumer is
 /// unchanged.
 pub async fn build_vmc(
     signer: &LocalSigner,
     params: VmcParams,
 ) -> Result<VerifiableCredential, AppError> {
-    let doc = super::dtc::issue_membership(
+    let doc = super::dtg::issue_membership(
         signer,
         &params.member_did,
         params.id.as_deref(),
@@ -164,7 +164,7 @@ pub async fn build_vmc(
     )
     .await?;
     serde_json::from_value(doc)
-        .map_err(|e| AppError::Internal(format!("DTC VMC -> VerifiableCredential: {e}")))
+        .map_err(|e| AppError::Internal(format!("DTG VMC -> VerifiableCredential: {e}")))
 }
 
 #[cfg(test)]
@@ -223,7 +223,7 @@ mod tests {
         assert_eq!((vu - vf).num_seconds(), validity.num_seconds());
     }
 
-    /// Personhood adds a `PersonhoodCredential` to the `type` array (the DTC
+    /// Personhood adds a `PersonhoodCredential` to the `type` array (the DTG
     /// catalog convention) rather than a `credentialSubject` field.
     #[tokio::test]
     async fn vmc_personhood_adds_personhood_type() {

--- a/vtc-service/src/credentials/vmc.rs
+++ b/vtc-service/src/credentials/vmc.rs
@@ -33,19 +33,17 @@
 //! tests can construct a VMC with `status_ref = None` to exercise
 //! the proof + validity-window paths in isolation.
 
-use affinidi_vc::{CredentialBuilder, VerifiableCredential};
-use chrono::{Duration, Utc};
+use affinidi_vc::VerifiableCredential;
+use chrono::Duration;
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value as JsonValue, json};
 use vti_common::error::AppError;
 
 use super::LocalSigner;
-use super::VMC_CONTEXT_URL;
 
-/// Type the VC's `type` array carries in addition to the
-/// universal `VerifiableCredential` value. Spec §6.1 names this
-/// credential the "Verifiable Membership Credential".
-pub const VMC_TYPE: &str = "VerifiableMembershipCredential";
+/// The membership type the catalog stamps in the VC's `type` array (alongside
+/// the universal `VerifiableCredential`). Sourced from the DTC catalog
+/// (`DTGCredentialType::Membership`).
+pub const VMC_TYPE: &str = "MembershipCredential";
 
 /// `credentialStatus` reference for a VMC. Mirrors the
 /// `BitstringStatusListEntry` shape per spec §6.2. M2.10 + M2.11
@@ -147,90 +145,32 @@ impl VmcParams {
 /// Build + sign a VMC. `issuer = signer.issuer_did()`,
 /// `validFrom = now()`, `validUntil = now() + params.validity`.
 /// Returns the signed VC with `proof` attached.
+///
+/// The credential's canonical shape comes from the DTC catalog
+/// ([`super::dtc::issue_membership`]); the signed JSON is carried as a
+/// (lossless, JSON-backed) [`VerifiableCredential`] so every consumer is
+/// unchanged.
 pub async fn build_vmc(
     signer: &LocalSigner,
     params: VmcParams,
 ) -> Result<VerifiableCredential, AppError> {
-    let now = Utc::now();
-    let valid_until = now + params.validity;
-
-    let mut subject = Map::new();
-    subject.insert("id".into(), JsonValue::String(params.member_did.clone()));
-    subject.insert("personhood".into(), JsonValue::Bool(params.personhood));
-
-    let mut vc = CredentialBuilder::v2()
-        .context(VMC_CONTEXT_URL)
-        .issuer_uri(signer.issuer_did().to_string())
-        .add_type(VMC_TYPE)
-        .valid_from(rfc3339(now))
-        .valid_until(rfc3339(valid_until))
-        .subject(subject)
-        .build()
-        .map_err(|e| AppError::Internal(format!("VMC build: {e}")))?;
-
-    if let Some(id) = &params.id {
-        attach_top_level_field(&mut vc, "id", JsonValue::String(id.clone()))?;
-    }
-
-    if let Some(status_ref) = &params.status_ref {
-        // `affinidi-vc` 0.1's typed VC doesn't expose a public
-        // `credentialStatus` setter (the type carries common
-        // fields; richer fields are operator-defined). Round-trip
-        // through JSON so we can splice the block in without
-        // forking the crate.
-        attach_credential_status(&mut vc, status_ref)?;
-    }
-
-    signer.sign(&mut vc).await?;
-    Ok(vc)
-}
-
-/// Splice a `credentialStatus` object onto the VC. Goes through
-/// JSON because the upstream typed `VerifiableCredential` doesn't
-/// expose the field as a builder method.
-fn attach_credential_status(
-    vc: &mut VerifiableCredential,
-    status_ref: &CredentialStatusRef,
-) -> Result<(), AppError> {
-    let status = serde_json::to_value(status_ref)
-        .map_err(|e| AppError::Internal(format!("credentialStatus -> value: {e}")))?;
-    attach_top_level_field(vc, "credentialStatus", status)
-}
-
-/// Splice an arbitrary top-level field onto the VC. Same
-/// JSON-round-trip trick used for `credentialStatus`; shared so
-/// the `id` setter doesn't duplicate the round-trip dance.
-fn attach_top_level_field(
-    vc: &mut VerifiableCredential,
-    key: &str,
-    value: JsonValue,
-) -> Result<(), AppError> {
-    let mut as_value =
-        serde_json::to_value(&*vc).map_err(|e| AppError::Internal(format!("VMC -> value: {e}")))?;
-    as_value
-        .as_object_mut()
-        .ok_or_else(|| AppError::Internal("VMC not an object".into()))?
-        .insert(key.to_string(), value);
-    *vc = serde_json::from_value(as_value)
-        .map_err(|e| AppError::Internal(format!("value -> VMC: {e}")))?;
-    Ok(())
-}
-
-/// Format a `DateTime<Utc>` as RFC 3339 — same shape the VTA SDK
-/// uses (`rfc3339(now)`), kept here so the VMC builder doesn't
-/// reach across crate boundaries for a one-liner.
-fn rfc3339(t: chrono::DateTime<Utc>) -> String {
-    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
-}
-
-#[allow(dead_code)]
-fn vmc_subject_template() -> JsonValue {
-    json!({ "id": "", "personhood": false })
+    let doc = super::dtc::issue_membership(
+        signer,
+        &params.member_did,
+        params.id.as_deref(),
+        params.status_ref.as_ref(),
+        params.validity,
+        params.personhood,
+    )
+    .await?;
+    serde_json::from_value(doc)
+        .map_err(|e| AppError::Internal(format!("DTC VMC -> VerifiableCredential: {e}")))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value as JsonValue;
 
     const TEST_VTC_DID: &str = "did:webvh:vtc.example.com:abc";
     const MEMBER_DID: &str = "did:key:zMember1";
@@ -283,18 +223,19 @@ mod tests {
         assert_eq!((vu - vf).num_seconds(), validity.num_seconds());
     }
 
-    /// Personhood flag propagates onto credentialSubject.
+    /// Personhood adds a `PersonhoodCredential` to the `type` array (the DTC
+    /// catalog convention) rather than a `credentialSubject` field.
     #[tokio::test]
-    async fn vmc_personhood_flag_set_in_credential_subject() {
+    async fn vmc_personhood_adds_personhood_type() {
         let signer = signer();
         let vc = build_vmc(&signer, VmcParams::new(MEMBER_DID).with_personhood(true))
             .await
             .unwrap();
-        let subject = match &vc.credential_subject {
-            affinidi_vc::SubjectValue::Single(m) => m.clone(),
-            affinidi_vc::SubjectValue::Multiple(v) => v[0].clone(),
-        };
-        assert_eq!(subject.get("personhood"), Some(&JsonValue::Bool(true)));
+        assert!(
+            vc.types.iter().any(|t| t == "PersonhoodCredential"),
+            "personhood=true must add the PersonhoodCredential type, got {:?}",
+            vc.types
+        );
     }
 
     /// A status_ref produces a `credentialStatus` block in the

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -39,6 +39,7 @@ pub mod registry;
 pub mod relationships;
 pub mod routes;
 pub mod routing;
+pub mod schemas;
 pub mod server;
 pub mod setup;
 pub mod status;

--- a/vtc-service/src/schemas/mod.rs
+++ b/vtc-service/src/schemas/mod.rs
@@ -1,0 +1,86 @@
+//! VTC schema store — the community's credential-type registry (task 2.2,
+//! `docs/05-design-notes/vti-credential-architecture.md` §8).
+//!
+//! A community declares the credential types it deals in:
+//!
+//! - **Issues** — the types this VTC *mints* (Invitation, Membership, Role, and
+//!   operator-defined endorsements), each bound to a DTC catalog type and an
+//!   optional JSON Schema (`credentialSchema`). Issuance consults this registry,
+//!   and issue-time validation (task 2.3) checks a minted credential against the
+//!   schema.
+//! - **Accepts** — the types/criteria the community recognises as *evidence*.
+//!   The Accepts half is expressed as a DCQL query over this registry and lands
+//!   in task 2.4.
+//!
+//! The store is one `schemas` keyspace, generalising the existing
+//! [`endorsement_types`](crate::endorsement_types) registry (same key-encoding
+//! discipline, broadened to every catalog type + an Issues/Accepts dimension).
+
+pub mod storage;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+pub use storage::{
+    SCHEMAS_PREFIX, delete_schema, get_schema, list_by_kind, list_schemas, schema_exists,
+    store_schema,
+};
+
+/// Maximum byte size of a `type_uri` (bounds the keyspace key length). Mirrors
+/// [`crate::endorsement_types::TYPE_URI_MAX_BYTES`].
+pub const TYPE_URI_MAX_BYTES: usize = 512;
+
+/// Whether a registered schema describes a credential type the community
+/// **Issues** (mints) or **Accepts** (recognises as evidence).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SchemaKind {
+    /// The VTC mints this credential type.
+    Issues,
+    /// The VTC recognises this credential type as evidence (task 2.4).
+    Accepts,
+}
+
+/// One registered credential-type schema in the community's schema store.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaEntry {
+    /// The credential type URI / `vct`. Primary key — URL-encoded into the key.
+    pub type_uri: String,
+    /// The DTC catalog type this binds to (a `DTGCredentialType` string, e.g.
+    /// `"MembershipCredential"`). `None` for community-defined endorsement types
+    /// that map onto the generic `EndorsementCredential`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dtc_type: Option<String>,
+    /// The JSON Schema (W3C `credentialSchema`) an issued/accepted credential
+    /// must conform to. Validated at issue time (task 2.3). `None` means
+    /// "registered, but no schema constraint".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_schema: Option<JsonValue>,
+    /// Issues (the VTC mints it) or Accepts (recognised as evidence).
+    pub kind: SchemaKind,
+    /// Free-form description shown in admin UIs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    /// Admin DID that registered the schema (audit correlation).
+    pub created_by_did: String,
+}
+
+impl SchemaEntry {
+    /// True when this entry is an `Issues` registration.
+    pub fn is_issues(&self) -> bool {
+        self.kind == SchemaKind::Issues
+    }
+}
+
+/// Whether `type_uri` is registered as an **Issues** type — the gate the
+/// issuance path consults ("only registered types may be minted").
+pub async fn is_issues_registered(ks: &KeyspaceHandle, type_uri: &str) -> Result<bool, AppError> {
+    Ok(get_schema(ks, type_uri)
+        .await?
+        .is_some_and(|s| s.is_issues()))
+}

--- a/vtc-service/src/schemas/mod.rs
+++ b/vtc-service/src/schemas/mod.rs
@@ -17,6 +17,9 @@
 //! discipline, broadened to every catalog type + an Issues/Accepts dimension).
 
 pub mod storage;
+pub mod validate;
+
+pub use validate::{validate_instance, validate_issued};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/vtc-service/src/schemas/mod.rs
+++ b/vtc-service/src/schemas/mod.rs
@@ -4,7 +4,7 @@
 //! A community declares the credential types it deals in:
 //!
 //! - **Issues** — the types this VTC *mints* (Invitation, Membership, Role, and
-//!   operator-defined endorsements), each bound to a DTC catalog type and an
+//!   operator-defined endorsements), each bound to a DTG catalog type and an
 //!   optional JSON Schema (`credentialSchema`). Issuance consults this registry,
 //!   and issue-time validation (task 2.3) checks a minted credential against the
 //!   schema.
@@ -53,11 +53,11 @@ pub enum SchemaKind {
 pub struct SchemaEntry {
     /// The credential type URI / `vct`. Primary key — URL-encoded into the key.
     pub type_uri: String,
-    /// The DTC catalog type this binds to (a `DTGCredentialType` string, e.g.
+    /// The DTG catalog type this binds to (a `DTGCredentialType` string, e.g.
     /// `"MembershipCredential"`). `None` for community-defined endorsement types
     /// that map onto the generic `EndorsementCredential`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dtc_type: Option<String>,
+    pub dtg_type: Option<String>,
     /// The JSON Schema (W3C `credentialSchema`) an issued/accepted credential
     /// must conform to. Validated at issue time (task 2.3). `None` means
     /// "registered, but no schema constraint".

--- a/vtc-service/src/schemas/storage.rs
+++ b/vtc-service/src/schemas/storage.rs
@@ -1,0 +1,183 @@
+//! CRUD helpers for [`super::SchemaEntry`] over the `schemas:` keyspace.
+//!
+//! Keys: `schemas:<percent-encoded-type-uri>` — the URI is percent-encoded so
+//! `:` / `/` in a type URI don't collide with the prefix delimiter (mirroring
+//! [`crate::endorsement_types::storage`]).
+
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::{SchemaEntry, SchemaKind};
+
+pub const SCHEMAS_PREFIX: &[u8] = b"schemas:";
+
+fn encode_uri(uri: &str) -> String {
+    let mut out = String::with_capacity(uri.len());
+    for b in uri.bytes() {
+        match b {
+            b':' | b'/' | b'%' => out.push_str(&format!("%{b:02x}")),
+            _ => out.push(b as char),
+        }
+    }
+    out
+}
+
+fn key(uri: &str) -> Vec<u8> {
+    let mut k = SCHEMAS_PREFIX.to_vec();
+    k.extend_from_slice(encode_uri(uri).as_bytes());
+    k
+}
+
+fn decode(bytes: &[u8]) -> Result<SchemaEntry, AppError> {
+    serde_json::from_slice(bytes)
+        .map_err(|e| AppError::Internal(format!("SchemaEntry decode: {e}")))
+}
+
+/// Fetch a registered schema by its type URI.
+pub async fn get_schema(
+    ks: &KeyspaceHandle,
+    type_uri: &str,
+) -> Result<Option<SchemaEntry>, AppError> {
+    match ks.get_raw(key(type_uri)).await? {
+        Some(bytes) => Ok(Some(decode(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+/// Fast existence check — avoids deserialising the row.
+pub async fn schema_exists(ks: &KeyspaceHandle, type_uri: &str) -> Result<bool, AppError> {
+    Ok(ks.get_raw(key(type_uri)).await?.is_some())
+}
+
+/// Register / overwrite a schema (keyed by `type_uri`).
+pub async fn store_schema(ks: &KeyspaceHandle, entry: &SchemaEntry) -> Result<(), AppError> {
+    ks.insert(
+        String::from_utf8(key(&entry.type_uri)).expect("ascii key"),
+        entry,
+    )
+    .await
+}
+
+/// Remove a registered schema.
+pub async fn delete_schema(ks: &KeyspaceHandle, type_uri: &str) -> Result<(), AppError> {
+    ks.remove(key(type_uri)).await
+}
+
+/// List all registered schemas (community config — not a privacy-sensitive
+/// enumeration). Ordered by key.
+pub async fn list_schemas(ks: &KeyspaceHandle) -> Result<Vec<SchemaEntry>, AppError> {
+    let mut pairs = ks.prefix_iter_raw(SCHEMAS_PREFIX.to_vec()).await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    pairs.iter().map(|(_, v)| decode(v)).collect()
+}
+
+/// List only the schemas of a given [`SchemaKind`] (e.g. all `Issues` types the
+/// admin UI offers, or all `Accepts` criteria for a ceremony).
+pub async fn list_by_kind(
+    ks: &KeyspaceHandle,
+    kind: SchemaKind,
+) -> Result<Vec<SchemaEntry>, AppError> {
+    Ok(list_schemas(ks)
+        .await?
+        .into_iter()
+        .filter(|s| s.kind == kind)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{SchemaKind, is_issues_registered};
+    use super::*;
+    use chrono::Utc;
+    use serde_json::json;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn temp_ks() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("schemas").unwrap();
+        (dir, store, ks)
+    }
+
+    fn membership_issues() -> SchemaEntry {
+        SchemaEntry {
+            type_uri: "https://openvtc.org/credentials/MembershipCredential".into(),
+            dtc_type: Some("MembershipCredential".into()),
+            credential_schema: Some(json!({
+                "type": "object",
+                "properties": { "id": { "type": "string" } },
+                "required": ["id"]
+            })),
+            kind: SchemaKind::Issues,
+            description: Some("Community membership".into()),
+            created_at: Utc::now(),
+            created_by_did: "did:key:zAdmin".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn store_get_list_delete_round_trip() {
+        let (_dir, _store, ks) = temp_ks().await;
+        let entry = membership_issues();
+
+        assert!(!schema_exists(&ks, &entry.type_uri).await.unwrap());
+        store_schema(&ks, &entry).await.unwrap();
+
+        // URI with `:` and `/` round-trips through the key encoding.
+        let got = get_schema(&ks, &entry.type_uri).await.unwrap().unwrap();
+        assert_eq!(got, entry);
+        assert!(schema_exists(&ks, &entry.type_uri).await.unwrap());
+
+        let all = list_schemas(&ks).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0], entry);
+
+        delete_schema(&ks, &entry.type_uri).await.unwrap();
+        assert!(get_schema(&ks, &entry.type_uri).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn is_issues_registered_only_for_issues_kind() {
+        let (_dir, _store, ks) = temp_ks().await;
+        let issues = membership_issues();
+        store_schema(&ks, &issues).await.unwrap();
+
+        let mut accepts = issues.clone();
+        accepts.type_uri = "https://openvtc.org/credentials/SomeEvidence".into();
+        accepts.kind = SchemaKind::Accepts;
+        store_schema(&ks, &accepts).await.unwrap();
+
+        assert!(is_issues_registered(&ks, &issues.type_uri).await.unwrap());
+        assert!(
+            !is_issues_registered(&ks, &accepts.type_uri).await.unwrap(),
+            "an Accepts type is not issuable"
+        );
+        assert!(
+            !is_issues_registered(&ks, "https://unknown").await.unwrap(),
+            "an unregistered type is not issuable"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_by_kind_partitions() {
+        let (_dir, _store, ks) = temp_ks().await;
+        store_schema(&ks, &membership_issues()).await.unwrap();
+        let mut accepts = membership_issues();
+        accepts.type_uri = "https://openvtc.org/credentials/Evidence".into();
+        accepts.kind = SchemaKind::Accepts;
+        store_schema(&ks, &accepts).await.unwrap();
+
+        assert_eq!(
+            list_by_kind(&ks, SchemaKind::Issues).await.unwrap().len(),
+            1
+        );
+        assert_eq!(
+            list_by_kind(&ks, SchemaKind::Accepts).await.unwrap().len(),
+            1
+        );
+    }
+}

--- a/vtc-service/src/schemas/storage.rs
+++ b/vtc-service/src/schemas/storage.rs
@@ -106,7 +106,7 @@ mod tests {
     fn membership_issues() -> SchemaEntry {
         SchemaEntry {
             type_uri: "https://openvtc.org/credentials/MembershipCredential".into(),
-            dtc_type: Some("MembershipCredential".into()),
+            dtg_type: Some("MembershipCredential".into()),
             credential_schema: Some(json!({
                 "type": "object",
                 "properties": { "id": { "type": "string" } },

--- a/vtc-service/src/schemas/validate.rs
+++ b/vtc-service/src/schemas/validate.rs
@@ -123,7 +123,7 @@ mod tests {
         let ks = store.keyspace("schemas").unwrap();
         let entry = SchemaEntry {
             type_uri: "MembershipCredential".into(),
-            dtc_type: Some("MembershipCredential".into()),
+            dtg_type: Some("MembershipCredential".into()),
             credential_schema: schema,
             kind: SchemaKind::Issues,
             description: None,

--- a/vtc-service/src/schemas/validate.rs
+++ b/vtc-service/src/schemas/validate.rs
@@ -1,0 +1,180 @@
+//! Issue-time JSON-Schema validation (task 2.3,
+//! `docs/05-design-notes/vti-credential-architecture.md` §8).
+//!
+//! When the VTC mints a credential whose type is registered in the
+//! [schema store](super) with a `credentialSchema`, the credential's
+//! `credentialSubject` is validated against that JSON Schema **before** the
+//! credential leaves the issuer. A non-conforming credential is refused
+//! ([`AppError::Validation`]).
+//!
+//! Validation is **opt-in by registration**: a credential whose type isn't
+//! registered, or whose registered entry carries no schema, passes unchecked
+//! (the separate "only registered types may be issued" gate is a follow-up).
+
+use serde_json::Value;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::get_schema;
+
+/// Validate a JSON `instance` against a JSON Schema `schema`.
+///
+/// Returns [`AppError::Validation`] on the first schema violation, or
+/// [`AppError::Internal`] if the schema document itself is not a valid JSON
+/// Schema.
+pub fn validate_instance(schema: &Value, instance: &Value) -> Result<(), AppError> {
+    let validator = jsonschema::validator_for(schema)
+        .map_err(|e| AppError::Internal(format!("invalid credentialSchema: {e}")))?;
+    if let Err(error) = validator.validate(instance) {
+        return Err(AppError::Validation(format!(
+            "credential does not conform to its registered schema: {error}"
+        )));
+    }
+    Ok(())
+}
+
+/// The credential's candidate type names (its `type` array minus the universal
+/// `VerifiableCredential`), in order — these are matched against schema-store
+/// `type_uri`s.
+fn candidate_types(credential: &Value) -> Vec<String> {
+    credential
+        .get("type")
+        .and_then(|t| t.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .filter(|t| *t != "VerifiableCredential")
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Validate a just-issued credential against the JSON Schema registered for its
+/// type, if any. The credential's `credentialSubject` is the validated instance.
+///
+/// No-op (`Ok`) when no candidate type is registered, or the registered entry
+/// has no `credentialSchema`.
+pub async fn validate_issued(
+    schemas_ks: &KeyspaceHandle,
+    credential: &Value,
+) -> Result<(), AppError> {
+    for type_uri in candidate_types(credential) {
+        let Some(entry) = get_schema(schemas_ks, &type_uri).await? else {
+            continue;
+        };
+        // Registered: enforce its schema if it has one, else accept.
+        return match &entry.credential_schema {
+            Some(schema) => {
+                let subject = credential.get("credentialSubject").unwrap_or(&Value::Null);
+                validate_instance(schema, subject)
+            }
+            None => Ok(()),
+        };
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{SchemaEntry, SchemaKind, store_schema};
+    use super::*;
+    use chrono::Utc;
+    use serde_json::json;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn membership_credential() -> Value {
+        json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": "did:web:acme",
+            "credentialSubject": { "id": "did:key:zMember", "tier": "gold" }
+        })
+    }
+
+    #[test]
+    fn validate_instance_accepts_and_rejects() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "id": { "type": "string" }, "tier": { "enum": ["gold", "silver"] } },
+            "required": ["id", "tier"]
+        });
+        // Conforming.
+        validate_instance(&schema, &json!({ "id": "x", "tier": "gold" })).expect("conforms");
+        // Missing required field.
+        assert!(matches!(
+            validate_instance(&schema, &json!({ "id": "x" })),
+            Err(AppError::Validation(_))
+        ));
+        // Out-of-enum value.
+        assert!(matches!(
+            validate_instance(&schema, &json!({ "id": "x", "tier": "bronze" })),
+            Err(AppError::Validation(_))
+        ));
+    }
+
+    async fn ks_with(schema: Option<Value>) -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("schemas").unwrap();
+        let entry = SchemaEntry {
+            type_uri: "MembershipCredential".into(),
+            dtc_type: Some("MembershipCredential".into()),
+            credential_schema: schema,
+            kind: SchemaKind::Issues,
+            description: None,
+            created_at: Utc::now(),
+            created_by_did: "did:key:zAdmin".into(),
+        };
+        store_schema(&ks, &entry).await.unwrap();
+        (dir, store, ks)
+    }
+
+    #[tokio::test]
+    async fn validate_issued_enforces_a_registered_schema() {
+        // Schema requires `tier` — the credential has it → passes.
+        let (_d, _s, ks) = ks_with(Some(json!({
+            "type": "object",
+            "required": ["id", "tier"]
+        })))
+        .await;
+        validate_issued(&ks, &membership_credential())
+            .await
+            .expect("conforming credential passes");
+
+        // Schema requires a field the credential lacks → rejected at issue.
+        let (_d2, _s2, ks2) = ks_with(Some(json!({
+            "type": "object",
+            "required": ["id", "endorsedBy"]
+        })))
+        .await;
+        assert!(matches!(
+            validate_issued(&ks2, &membership_credential()).await,
+            Err(AppError::Validation(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn validate_issued_is_a_noop_for_unregistered_or_schemaless() {
+        // Registered but no credentialSchema → accept.
+        let (_d, _s, ks) = ks_with(None).await;
+        validate_issued(&ks, &membership_credential())
+            .await
+            .expect("schemaless registration accepts");
+
+        // Unregistered type → accept (no gate here).
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let empty = store.keyspace("schemas").unwrap();
+        validate_issued(&empty, &membership_credential())
+            .await
+            .expect("unregistered type accepts");
+    }
+}

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -81,6 +81,9 @@ pub struct AppState {
     /// Operator-uploaded endorsement type registry (Phase 4
     /// M4.8.0). Only registered types are issuable.
     pub endorsement_types_ks: KeyspaceHandle,
+    /// Credential-type schema store (Phase 2 task 2.2): the Issues / Accepts
+    /// registry binding each type to a DTC catalog type + JSON Schema.
+    pub schemas_ks: KeyspaceHandle,
     /// Issued custom endorsement rows (Phase 4 M4.7).
     /// Tracked here for list + revoke surfaces; the VEC body
     /// itself is signed + returned at issuance time.
@@ -211,6 +214,7 @@ pub async fn run(
     let relationships_ks = store.keyspace("relationships")?;
     let relationships_by_did_ks = store.keyspace("relationships_by_did")?;
     let endorsement_types_ks = store.keyspace("endorsement_types")?;
+    let schemas_ks = store.keyspace("schemas")?;
     let endorsements_ks = store.keyspace("endorsements")?;
     let audit_ks = store.keyspace("audit")?;
     let audit_key_ks = store.keyspace("audit_key")?;
@@ -387,6 +391,7 @@ pub async fn run(
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
+        schemas_ks,
         endorsements_ks,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -82,7 +82,7 @@ pub struct AppState {
     /// M4.8.0). Only registered types are issuable.
     pub endorsement_types_ks: KeyspaceHandle,
     /// Credential-type schema store (Phase 2 task 2.2): the Issues / Accepts
-    /// registry binding each type to a DTC catalog type + JSON Schema.
+    /// registry binding each type to a DTG catalog type + JSON Schema.
     pub schemas_ks: KeyspaceHandle,
     /// Issued custom endorsement rows (Phase 4 M4.7).
     /// Tracked here for list + revoke surfaces; the VEC body

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -134,6 +134,7 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -120,6 +120,7 @@ async fn build_with(
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -193,6 +193,7 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -102,6 +102,7 @@ async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) 
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/ceremony_execute.rs
+++ b/vtc-service/tests/ceremony_execute.rs
@@ -109,6 +109,7 @@ async fn build_state() -> (AppState, tempfile::TempDir) {
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks,
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -103,6 +103,7 @@ async fn build() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/cookie_session.rs
+++ b/vtc-service/tests/cookie_session.rs
@@ -117,6 +117,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -105,6 +105,7 @@ async fn build() -> Fixture {
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks,
         registry_client: None,
         registry_health: RegistryHealth::new(),

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -104,6 +104,7 @@ async fn build_fixture(vtc_did: &str) -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/directory.rs
+++ b/vtc-service/tests/directory.rs
@@ -148,6 +148,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks,
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -303,6 +303,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -207,6 +207,7 @@ async fn build() -> Fixture {
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: RegistryHealth::new(),

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -118,6 +118,7 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -147,6 +147,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -210,6 +210,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -183,6 +183,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -82,6 +82,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/personhood.rs
+++ b/vtc-service/tests/personhood.rs
@@ -304,6 +304,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks,
         registry_client: None,
         registry_health: RegistryHealth::new(),

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -190,6 +190,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -109,6 +109,7 @@ async fn build() -> Fixture {
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks,
         registry_client: None,
         registry_health: RegistryHealth::new(),

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -217,6 +217,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: RegistryHealth::new(),

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -196,6 +196,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -190,6 +190,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -201,6 +201,7 @@ async fn build_fixture() -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -280,6 +280,7 @@ async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::Te
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/routing_modes.rs
+++ b/vtc-service/tests/routing_modes.rs
@@ -86,6 +86,7 @@ async fn build_router(routing: &RoutingConfig) -> (Router, tempfile::TempDir) {
         relationships_ks: store.keyspace("relationships").unwrap(),
         relationships_by_did_ks: store.keyspace("relationships_by_did").unwrap(),
         endorsement_types_ks: store.keyspace("endorsement_types").unwrap(),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: store.keyspace("endorsements").unwrap(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/status_lists.rs
+++ b/vtc-service/tests/status_lists.rs
@@ -123,6 +123,7 @@ async fn build_fixture(with_signer: bool) -> Fixture {
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks,
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -107,6 +107,7 @@ async fn build_fixture(holder_did: &str) -> Fixture {
         relationships_ks: ks!("relationships"),
         relationships_by_did_ks: ks!("relationships_by_did"),
         endorsement_types_ks: ks!("endorsement_types"),
+        schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: ks!("endorsements"),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),


### PR DESCRIPTION
Phase 2 of the credential architecture (spec §8/§9), tasks **2.0–2.3**, on `vtc-service`. Five commits, each independently green. **2.4 (Accepts as a DCQL query over the registry) is held for a follow-up PR.**

### 2.0 — Adopt the DTG catalog (`dtg-credentials`)
The VTC's hand-rolled VC builders are replaced by the `dtg-credentials` catalog (a declared-but-unused dep until now).
- `credentials/dtc.rs` — `issue_membership` / `issue_role` / `issue_endorsement` source each credential's canonical shape from the catalog (`new_vmc`/`new_vec`) and sign locally. `LocalSigner::sign_doc` signs the spliced JSON so `id` + `credentialStatus` are **covered by the proof** (a tamper test proves a signed status can't be stripped).
- `build_vmc`/`build_role_vec`/`build_custom_endorsement` now delegate to that layer and carry the signed result as a (lossless, JSON-backed) `VerifiableCredential` — so **every consumer is unchanged**. The `credentialSubject.endorsement.{type,role,communityDid}` shape is preserved, so cross-community `recognition` is unaffected.
- Wire-shape change (pre-wire, greenfield): catalog W3C VC 2.0 `@context` + type names (`MembershipCredential`/`EndorsementCredential`, `PersonhoodCredential` as a *type*).

### 2.1 — InvitationCredential (VIC)
`dtc::issue_invitation` (`new_vic`) + `credentials/invitation.rs::issue_invitation` — allocate a revocation slot, issue the VIC, persist the slot only after the VIC builds (a failure never burns a slot). Issue-to-unknown-holder transport is Phase 3.

### 2.2 — Schema store
`schemas` keyspace + `SchemaEntry { type_uri, dtc_type, credential_schema, kind: Issues|Accepts, … }` + CRUD (generalising `endorsement_types`) + `is_issues_registered`. Wired into `AppState`. (Accepts half = 2.4.)

### 2.3 — Issue-time JSON-Schema validation
`schemas/validate.rs` — validate a minted credential's `credentialSubject` against its registered `credentialSchema` (via `jsonschema 0.46`); opt-in by registration (no-op when unregistered/schemaless). Wired into the VIC op: a non-conforming invite is refused **before** the slot is committed.

### Verification
Full `vtc-service` suite (**433 lib + all integration**) green; `clippy --all-targets` + `cargo fmt --check` + `cargo deny` clean. All commits GPG + DCO signed.

### Deliberately deferred (follow-ups, before/with 2.4)
- The **"only registered Issues types may be minted" hard gate** + **default-type seeding** at community setup, and wiring `validate_issued` into the ceremony Admit + custom-endorsement paths (kept out here to avoid a seeding ripple across the ceremony engine + every test).
- **HTTP admin CRUD routes** for the schema store (thin layer over the storage CRUD).
- **2.4** — Accepts as a validated `DcqlQuery` over the registry (uses `affinidi-openid4vp` 0.1.2 from #343/#344).
