### PR TITLE
docs(cred): land stranded credential-arch doc updates (§7a per-credential consent, Phase 2 breakdown, DTG)

### DIFF
--- a/docs/05-design-notes/vti-credential-architecture-plan.md
+++ b/docs/05-design-notes/vti-credential-architecture-plan.md
@@ -49,7 +49,7 @@ TDK for unreleased changes like DCQL).
              ────────────────────────┘   can start NOW (adopt SD-JWT-VC at 1.4).
                                          1.4–1.6 (present / mint / status) wire the adopted format.
                                      ▼
-   Phase 2   DTC catalog + VTC schema store + VIC
+   Phase 2   DTG catalog + VTC schema store + VIC
                                      ▼
    Phase 3   credential-exchange protocol  (Trust-Tasks ⊃ OID4VCI/OID4VP + DCQL)
                                      ▼
@@ -141,10 +141,10 @@ by a test. *Unblocks Phase 3.*
 
 ## Phases 2–6 — milestones (own PLAN pass before each starts)
 
-- **Phase 2 — DTC catalog + VTC schema store + VIC** (this repo:
+- **Phase 2 — DTG catalog + VTC schema store + VIC** (this repo:
   `vtc-service`, `dtg-credentials`). Adopt `dtg-credentials`; port VMC/VEC
-  onto DTC; build the `schemas` keyspace + registry (issues + accepts,
-  JSON Schema + DTC binding, admin CRUD); add the InvitationCredential
+  onto DTG; build the `schemas` keyspace + registry (issues + accepts,
+  JSON Schema + DTG binding, admin CRUD); add the InvitationCredential
   (VIC); validate issued credentials against their schema at issue time.
   *Checkpoint: each catalog type issues against its schema.*
 

--- a/docs/05-design-notes/vti-credential-architecture-tasks.md
+++ b/docs/05-design-notes/vti-credential-architecture-tasks.md
@@ -21,7 +21,7 @@ Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
   - Acceptance: exit 0. **DONE** (validated).
   - Verify: ✅ exit 0.
 
-- [ ] **0.2 — Wire the crates as VTI deps.** Add `affinidi-sd-jwt-vc`,
+- [x] **0.2 — Wire the crates as VTI deps.** Add `affinidi-sd-jwt-vc`,
   `affinidi-bbs`, `affinidi-data-integrity` (bbs_2023), `affinidi-openid4vp`
   to the VTI workspace (crates.io versions, or path/git to the local TDK
   for unreleased DCQL).
@@ -84,7 +84,7 @@ Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
 
 ## Phase 1 — VTA credential store  (Repo: `vti`, `vta-service`)
 
-- [ ] **1.1 — `StoredCredential` model + `vault` storage + index.**
+- [x] **1.1 — `StoredCredential` model + `vault` storage + index.**
   *(format-agnostic — start now, parallel to 0a)*
   - Acceptance: store + get by id; prefix-scan the index by `type`,
     `community_did`, `issuer_did`, `purpose`, `status`. Encrypted at rest
@@ -93,7 +93,7 @@ Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
   - Files: `vta-service/src/vault/{model,storage,index}.rs`, `server.rs`
     (keyspace wiring; `vault` already exists).
 
-- [ ] **1.2 — Receive a credential.** An operation that verifies-minimally
+- [x] **1.2 — Receive a credential.** An operation that verifies-minimally
   (issuer signature via the format verifier + not-expired), indexes, and
   stores.
   - Acceptance: receiving a valid SD-JWT-VC (from 0a) stores + indexes it;
@@ -102,7 +102,7 @@ Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
   - Files: `vta-service/src/operations/vault/receive.rs`,
     `vta-service/src/routes/vault.rs` (+ DIDComm handler).
 
-- [ ] **1.3 — Local DCQL search → descriptors only.** Match stored
+- [x] **1.3 — Local DCQL search → descriptors only.** Match stored
   credentials by `{type, claims, issuer, purpose}`; return **descriptors**
   (never bulk bodies across a trust boundary). **No "list all" endpoint.**
   - Acceptance: a DCQL query for "InvitationCredential for community X"
@@ -113,23 +113,48 @@ Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
     no-enumeration invariant.
   - Files: `vta-service/src/vault/query.rs` (DCQL match engine).
 
-- [ ] **1.4 — Present.** Build a presentation from a stored credential +
-  a holder-signed consent/selection → an SD-JWT-VC presentation with
-  `kb-jwt`.
-  - Acceptance: presenting a consented credential yields a verifiable
-    presentation (disclosing only the requested claims); without a valid
-    consent token the VTA refuses. *(needs 0a)*
-  - Verify: integration test (present → verify via `affinidi-sd-jwt`).
-  - Files: `vta-service/src/operations/vault/present.rs`, `routes/vault.rs`.
+- [x] **1.3.5 — Consent records (ISO/IEC 27560 + DPV).** *(PR #235 merged; consent bound per-credential via `dct:source` in #237.)* A `ConsentRecord`
+  type serializing to the 27560/DPV JSON-LD shape (§7a) + a `consent`
+  keyspace (create / get / withdraw / list) + the status event log +
+  validity. **Non-repudiation from day one:** every record carries a
+  holder `eddsa-jcs-2022` Data Integrity proof signed with the holder's
+  **VTA-managed** key (a signed consent receipt). Withdraw appends a
+  signed `dpv:ConsentWithdrawn` event.
+  - Acceptance: create a signed consent record (verifies; carries
+    dataSubject/recipient/purpose/personalData/validity); withdraw flips
+    it to ConsentWithdrawn (re-signed) and it no longer authorizes; an
+    expired record authorizes nothing; `list`/`get` is the holder's own
+    surface (no cross-boundary enumeration). cargo fmt/build/test/clippy/
+    deny clean.
+  - Verify: unit + integration tests over the consent keyspace.
+  - Files: `vta-service/src/vault/consent.rs` (new) + `vault/mod.rs`;
+    `affinidi-data-integrity` as a normal `vta-service` dep (signing).
+  - Branch: `feat/cred-1.3.5-consent-records`. *(prerequisite for 1.4)*
 
-- [ ] **1.5 — Mint.** The VTA issues its own SD-JWT-VC via the format
+- [x] **1.4 — Present (consent-gated).** *(PR #237.)* Build a holder-bound,
+  selectively-disclosed presentation from a stored credential — a
+  **library op** (the wire surface is Phase 3). Signature:
+  `present(credential_id, consent_record_id, nonce, aud)`.
+  - Acceptance: checks the consent record is *given* / unexpired /
+    signature-valid / matches the verifier (`hasRecipient`), derives the
+    reveal set from `hasPersonalData`, produces an SD-JWT-VC presentation
+    disclosing **only** those claims + a `kb-jwt` signed by the
+    **VTA-held holder signer** (injected `&dyn JwtSigner`); refuses a
+    revoked/expired credential or a missing/withdrawn consent record;
+    a NEGATIVE test proves the disclosed set never exceeds the consented
+    set. *(needs 1.3.5 + 0.2)*
+  - Verify: integration test (present → verify via `affinidi-sd-jwt`).
+  - Files: `vta-service/src/vault/present.rs` (new) + `vault/mod.rs`.
+  - Branch: `feat/cred-1.4-vault-present`.
+
+- [x] **1.5 — Mint.** *(PR #236 merged.)* The VTA issues its own SD-JWT-VC via the format
   issuer + the VTA signing key (the signing oracle path).
   - Acceptance: a VTA-minted credential verifies; the issuer key never
     leaves the VTA.
   - Verify: integration test (mint → verify).
   - Files: `vta-service/src/operations/vault/mint.rs`.
 
-- [ ] **1.6 — Status refresh.** Poll/refresh status-list state; mark
+- [x] **1.6 — Status refresh.** *(PR #238.)* Poll/refresh status-list state; mark
   revoked/expired so search + present exclude them.
   - Acceptance: a credential whose status-list bit is set is excluded from
     search results and refused for presentation.
@@ -161,15 +186,108 @@ Each task: **Acceptance** (true when done) · **Verify** (evidence) ·
 
 ---
 
-## Phase 2 — DTC catalog + VTC schema store + VIC  (Repo: `vti` + `dtg-credentials`)
+## Phase 2 — DTG catalog + VTC schema store + VIC  (Repo: `vti` + `dtg-credentials`)
 
-- [ ] 2.1 — Adopt `dtg-credentials`; port VMC/VEC onto DTC types (thin
-  wrappers).
-- [ ] 2.2 — VTC `schemas` keyspace + registry (issues + accepts; JSON
-  Schema + DTC binding) + admin CRUD.
-- [ ] 2.3 — InvitationCredential (VIC) builder (DTC).
-- [ ] 2.4 — Issue-time schema validation for every issued credential.
-- [ ] CHECKPOINT 2 — each catalog type issues against its schema.
+**Re-baseline (codebase survey, 2026-06).** Phase 2 is smaller than the
+milestone implied — much already exists in `vtc-service`:
+
+- **`dtg-credentials` 0.1.2** (the DTG catalog, a declared-but-**unused**
+  crates.io dep) already ships `create::{new_vmc, new_vrc, new_vec,
+  new_vic, new_vpc, new_vwc, new_rcard}` over `DTGCredential` / `DTGCommon`
+  / `DTGCredentialType{Membership, Relationship, **Invitation**, Persona,
+  Endorsement, Witness, RCard}` (W3C VC 2.0, `verify_proof_with_public_key`).
+  **`new_vic` IS the InvitationCredential** — VIC is adopt-not-build.
+- VTC's current credential builders are **hand-rolled and bypass** the
+  catalog: `credentials/{vmc.rs (build_vmc), vec.rs (build_role_vec),
+  custom_endorsement.rs}` + `credentials/signer.rs (LocalSigner)`. "Port
+  onto DTG" = swap these to `dtg_credentials::create::new_*` signed by the
+  existing `LocalSigner`. Callers to update: `ceremony/execute.rs` (Admit →
+  membership), `endorsements/`.
+- An **`endorsement_types` registry already exists** (`EndorsementType
+  {type_uri, claim_schema: Option<JsonValue>, description, created_at,
+  created_by_did}` + `storage::{get,store,delete,list,exists}_type` over a
+  keyspace) — the proven pattern the `schemas` registry generalises.
+- A **`status_lists` keyspace + `status_list/mod.rs` allocator already
+  exists** → "every issued credential revocable" reuses it (and this is the
+  VTC-side answer to the Phase 1 task 1.5 follow-up). `vmc.rs` already
+  attaches `credentialStatus` via `CredentialStatusRef::revocation`.
+- **No `schemas` keyspace yet** (net-new). DCQL types for the "accepts"
+  half now exist in `affinidi-openid4vp` 0.1.2 (#343 + #344).
+
+Dependency order: **2.0 → (2.1 ∥ 2.2) → 2.3 → 2.4**. 2.4 is gated on the
+`affinidi-openid4vp` 0.1.2 publish landing on crates.io.
+
+- [ ] **2.0 — Adopt `dtg-credentials` (DTG catalog).** Wire `dtg-credentials`
+  as a real `vtc-service` dep; add a thin `credentials::dtc` layer that
+  builds + signs a `DTGCredential` of a given type via the existing
+  `LocalSigner` (issuer key never exported). Port `build_vmc`→`new_vmc`,
+  `build_role_vec`→`new_vrc`/`new_vec`, `build_custom_endorsement`→`new_vec`;
+  update the `ceremony/execute.rs` + `endorsements/` callers.
+  - Acceptance: each ported type issues and `verify_proof_with_public_key`
+    verifies; issuer key stays in `LocalSigner`; existing ceremony Admit
+    still issues a (now DTG) membership. The VC wire shape changes — a
+    pre-wire breaking change (greenfield, OK); update affected tests.
+  - Verify: unit + the ceremony Admit integration test.
+  - Files: `vtc-service/src/credentials/{dtc.rs (new), vmc.rs, vec.rs,
+    custom_endorsement.rs, mod.rs}`, `ceremony/execute.rs`,
+    `endorsements/mod.rs`; root `Cargo.toml` (`dtg-credentials` → used).
+  - Branch: `feat/cred-2.0-adopt-dtc`.
+
+- [ ] **2.1 — InvitationCredential (VIC).** Issue a VIC to a **non-member**
+  DID via `dtg_credentials::create::new_vic` + `LocalSigner` + a status-list
+  allocation (revocable). Library op (the OOB/sealed delivery transport is
+  Phase 3; reuses the relayer≠holder / `sealed_transfer` pattern). Optional
+  delegated-invite gate (`can_invite`) deferred to Phase 5.
+  - Acceptance: a VTC issues a VIC to a DID with no membership record; it
+    verifies; it carries a `credentialStatus` and can be revoked.
+  - Verify: unit test (issue VIC to unknown DID → verify + revoke).
+  - Files: `vtc-service/src/credentials/invitation.rs (new)` + `mod.rs`;
+    `status_list/` (reuse). *(needs 2.0)*
+  - Branch: `feat/cred-2.1-invitation`.
+
+- [ ] **2.2 — Schema store: the `schemas` keyspace + Issues registry.** A
+  `schemas` keyspace + `SchemaEntry{type_uri, dtc_type (DTGCredentialType
+  binding), credential_schema (JSON Schema), kind: Issues, description,
+  created_*}` + CRUD, generalising the `endorsement_types` registry. The
+  **Issues** half: the types this VTC mints, each with a JSON Schema + DTG
+  binding. Admin CRUD endpoints/CLI.
+  - Acceptance: register an Issues type with a schema; `list`/`get`/`delete`
+    round-trip; issuance (2.0/2.1) consults it (issue refused if the type
+    isn't registered as Issues).
+  - Verify: unit + integration over the `schemas` keyspace.
+  - Files: `vtc-service/src/schemas/{mod.rs, storage.rs, registry.rs}
+    (new)`; `routes`/`*_cli` for admin CRUD. *(needs 2.0)*
+  - Branch: `feat/cred-2.2-schema-store`.
+
+- [ ] **2.3 — Issue-time schema validation.** When issuing any catalog
+    credential, validate the produced VC against its registered
+    `credentialSchema` (JSON Schema). Reuse an existing JSON-Schema validator
+    crate (check the tree first — likely already present; else add one).
+  - Acceptance: a credential whose subject violates its schema is rejected
+    at issue; a conforming one passes. Wired into 2.0/2.1 issue paths.
+  - Verify: unit (conforming pass / violating reject) per catalog type.
+  - Files: `vtc-service/src/schemas/validate.rs (new)`, hooked into
+    `credentials/dtc.rs`. *(needs 2.2)*
+  - Branch: `feat/cred-2.3-issue-validation`.
+
+- [ ] **2.4 — Schema store: Accepts (DCQL over the registry).** The
+    **Accepts** half: criteria the community recognises as evidence,
+    expressed as an `affinidi_openid4vp::DcqlQuery` whose `meta.vct_values`
+    reference registered schema-store types. This is what a ceremony's
+    required-evidence becomes (the join "manifest", now concrete).
+  - Acceptance: store an Accepts criterion as a **validated** `DcqlQuery`
+    that references only registered types (reject dangling type refs);
+    round-trips; retrievable for a ceremony to run via
+    `DcqlQuery::match_credentials` (Phase 5).
+  - Verify: unit (valid DCQL accepted; one referencing an unregistered type
+    rejected).
+  - Files: `vtc-service/src/schemas/accepts.rs (new)`; dep
+    `affinidi-openid4vp = "0.1.2"`. *(needs 2.2; gated on #344 publish)*
+  - Branch: `feat/cred-2.4-accepts-dcql`.
+
+- [ ] CHECKPOINT 2 — each catalog type issues against its schema; a VIC
+  issues to a non-member; an Accepts criterion is a DCQL query over the
+  registry.
 
 ---
 

--- a/docs/05-design-notes/vti-credential-architecture.md
+++ b/docs/05-design-notes/vti-credential-architecture.md
@@ -19,7 +19,7 @@ privacy-preserving exchange protocol. The motivating user journey is
 |---|---|---|
 | D1 | Exchange wire protocol | **Trust Tasks wrap OID4VCI (issuance) + OID4VP (query/presentation)**; DCQL is the query language. The same OID4VP shapes are exposable to the browser via the W3C Digital Credentials API. |
 | D2 | Role / session auth model | **Hybrid**: the VC is the source of truth; a fast local *verified-assertion record* (TTL + invalidation) backs every hot-path authorization check. Re-prove only on invalidation. |
-| D3 | Credential type layer | **Adopt `dtg-credentials` (DTC)** as the canonical type catalog; the bespoke VMC/VEC become thin wrappers (or are retired) onto DTC types. |
+| D3 | Credential type layer | **Adopt `dtg-credentials` (DTG)** as the canonical type catalog; the bespoke VMC/VEC become thin wrappers (or are retired) onto DTG types. |
 | D4 | Selective disclosure | **BOTH, claim-level — and ALREADY BUILT in the TDK** (`affinidi-sd-jwt`/`-vc`, `affinidi-bbs`, the `bbs_2023` DI cryptosuite — validated, tests green). So this is **adopt, not build**. BBS curve = **`bls12_381_plus`** (the existing `affinidi-bbs`; supersedes the earlier `arkworks` call). One net-new TDK gap: **DCQL** (add to `affinidi-openid4vp`, which uses DIF PE today). |
 
 ---
@@ -96,9 +96,9 @@ server-side list.
 
 ---
 
-## 3. The credential catalog (DTC)
+## 3. The credential catalog (DTG)
 
-Adopt `dtg-credentials` (DTC) as the canonical type layer. The community
+Adopt `dtg-credentials` (DTG) as the canonical type layer. The community
 catalog (a superset of `docs/05-design-notes/vtc-mvp.md` §6.1):
 
 | Credential | Issuer | Subject | Purpose | Selective disclosure |
@@ -110,7 +110,7 @@ catalog (a superset of `docs/05-design-notes/vtc-mvp.md` §6.1):
 | **RecognitionCredential (VRC)** | member (self-issued) | another member | peer trust edge | n/a (Phase 3) |
 | **PersonhoodCredential** | personhood oracle / community | member | Sybil resistance | yes |
 
-`vtc-service/src/credentials/{vmc,vec}.rs` become thin adapters over DTC
+`vtc-service/src/credentials/{vmc,vec}.rs` become thin adapters over DTG
 types (or are retired). The JSON-LD `@context` documents live under
 `https://openvtc.org/contexts/` and are `include_str!`-baked for offline
 verification.
@@ -319,13 +319,76 @@ discloses only the requested claims).
 
 ---
 
+## 7a. Consent records (ISO/IEC 27560 + W3C DPV)
+
+Consent is a **first-class, persisted, signed, withdrawable, auditable
+record** — not an ephemeral parameter. Every disclosure is gated by a
+**consent record** modelled on **ISO/IEC 27560** (consent record
+structure) expressed with the **W3C DPV** vocabulary
+(`w3c.github.io/dpv/guides/consent-27560`). This makes the
+consent-before-disclosure + purpose-binding invariants (§14) enforced by
+a real artifact, and gives the holder a provable, revocable record of
+what they shared and why.
+
+**Shape** (a pragmatic 27560/DPV subset — the essential fields with DPV
+terms + `@context`, not the full DPV ontology; the richer purpose/
+processing taxonomy can layer in later):
+
+```jsonld
+{
+  "@context": ["https://w3id.org/dpv", ...],
+  "@type": "dpv:ConsentRecord",
+  "dct:identifier": "<record id>",
+  "dct:conformsTo": "<27560/DPV schema>",
+  "dpv:hasDataSubject": "<holder DID>",
+  "dpv:hasProcess": {
+    "@type": "dpv:Process",
+    "dpv:hasPurpose":      "<verifier's stated purpose>",
+    "dct:source":          "<credential id>",            // the held credential this consent is FOR (per-credential, §13)
+    "dpv:hasPersonalData": ["<claim a>", "<claim b>"],   // the reveal set (claim names OF that credential)
+    "dpv:hasRecipient":    "<verifier DID>",
+    "dpv:hasProcessing":   "dpv:Disclose",
+    "dpv:hasStorageCondition": { "dct:valid": "<expiry>" }
+  },
+  "dpv:hasStatus": { "@type": "dpv:ConsentGiven", "dct:date": "<ts>" },
+  "proof": { /* eddsa-jcs-2022 Data Integrity, signed by the holder */ }
+}
+```
+
+**Non-repudiation from day one.** The record carries a holder
+`eddsa-jcs-2022` Data Integrity proof — signed with the holder's
+**VTA-managed** key (keys are always VTA-managed). So a consent record is
+a **signed consent receipt**: the holder cannot later deny it, and any
+party can verify it offline.
+
+**Lifecycle** (a `consent` keyspace, VTA-side):
+- **create** — on the holder's authorization (the device/plugin captures
+  the decision; the VTA constructs + signs + stores the record).
+- **withdraw** — appends a signed `dpv:ConsentWithdrawn` status event;
+  the record stays (audit trail) but no longer authorizes disclosure.
+- **get / list** — the holder's own audit surface (never a
+  cross-boundary enumeration).
+- **validity** — `dct:valid` / storage-condition expiry; an expired or
+  withdrawn record authorizes nothing.
+
+**Gating.** A presentation (§ present) takes a consent-record id, checks
+it is **given, unexpired, signature-valid, bound to the credential being
+presented (`dct:source`), whose `dpv:hasDataSubject` is that credential's
+subject, and matches the verifier (`hasRecipient`)**, derives the reveal
+set from `hasPersonalData`, and discloses **only** those claims. Consent
+is **per-credential** (§13): a record captured for one credential never
+authorizes disclosing a different one, even when claim names overlap. No
+valid consent record → no disclosure.
+
+---
+
 ## 8. VTC schema store
 
 A `schemas` keyspace + registry. The community declares:
 
 - **Issues** — the credential types this VTC mints (Invitation,
   Membership, Role, plus operator-defined endorsement types), each with a
-  JSON Schema (`credentialSchema`) and a DTC type binding.
+  JSON Schema (`credentialSchema`) and a DTG type binding.
 - **Accepts** — the credential types/criteria the community recognises as
   evidence, expressed so a ceremony's required evidence is a **DCQL query
   over the schema store** (this is the "manifest" / Presentation
@@ -488,7 +551,7 @@ The plugin is the consent + key + legibility surface:
 | Keyspace | Node | New/changed | Holds |
 |---|---|---|---|
 | `vault` | VTA | **promote** (was M1 stub) | StoredCredential envelopes + index |
-| `schemas` | VTC | **new** | issued + accepted credential schemas (DTC + JSON Schema) |
+| `schemas` | VTC | **new** | issued + accepted credential schemas (DTG + JSON Schema) |
 | `verified_assertions` | VTC (+VTA) | **new** | the hot-path auth cache (§10) |
 | `acl` | VTC | **repurpose** | from "role source of truth" → derived index / legacy gate |
 | `status_lists` | VTC | reuse | revocation/suspension |
@@ -528,12 +591,13 @@ The plugin is the consent + key + legibility surface:
 4. **Verified-assertion invalidation propagation** — push (revocation
    event → cache flip) vs pull (TTL + status re-check). Likely both;
    what's the max staleness window?
-5. ~~Where does the VTA wallet run for a browser-only Alice?~~
-   **RESOLVED:** there is no browser-only holder — the plugin is always
-   backed by a VTA, which holds the wallet + keys. (Open sub-question:
-   does the plugin also hold a device-side key for holder binding, or
-   does the VTA hold it? Lean device-side for the binding signature, VTA
-   for the credential store.)
+5. ~~Where does the VTA wallet run for a browser-only Alice? / device vs
+   VTA holder-binding key?~~ **RESOLVED:** there is no browser-only
+   holder — the plugin is always backed by a VTA. **Keys are *always*
+   VTA-managed** — including the holder's `kb-jwt` binding key and the key
+   that signs consent receipts. The plugin captures consent + authorizes;
+   the VTA holds the keys and signs. (A device-held binding key is out of
+   scope — not a future enhancement.)
 6. **OID4VP profile** — which DCQL/credential-format profile to target for
    external-wallet interop (and is that a near-term goal or future)?
 7. ~~Pairing-library choice~~ **RESOLVED: `bls12_381_plus`** — keep the
@@ -563,7 +627,7 @@ The plugin is the consent + key + legibility surface:
 - **Phase 1 — Credential store:** promote the VTA `vault` to a real
   store (receive/store/index/search/present/mint). *Verify: store + DCQL
   local search + present round-trip.*
-- **Phase 2 — DTC catalog + schema store:** adopt `dtg-credentials`;
+- **Phase 2 — DTG catalog + schema store:** adopt `dtg-credentials`;
   build the VTC `schemas` registry; port VMC/VEC; add InvitationCredential.
   *Verify: issue each catalog type against its schema.*
 - **Phase 3 — Exchange protocol:** the `credential-exchange/*` Trust Task


### PR DESCRIPTION
#230 (the credential-architecture spec) merged before three later doc commits landed, so they never reached `main`. This brings them forward in one clean pass (just the three `docs/05-design-notes/vti-credential-architecture{,-plan,-tasks}.md` files):

- **§7a — per-credential consent.** The consent-record shape gains `dct:source` (the held credential a consent is *for*) and the gating paragraph requires the consent's `dpv:hasDataSubject` to be the presented credential's subject — matching the #237 code (the two MEDIUM auth-scoping fixes).
- **Phase 2 task-level breakdown (2.0–2.4)** with the `dtg-credentials` re-baseline: adopt-not-build (the catalog already ships `new_vic`), reuse the existing `endorsement_types` registry + `status_lists` allocator. Replaces the old milestone-level stub.
- **Checklist:** 1.3.5 / 1.4 / 1.5 / 1.6 marked done with their PR refs (#235/#237/#236/#238).
- **DTC → DTG** throughout, to match the `dtg-credentials` crate (and the #239 code rename).

Docs-only; no code. The implementation these describe is already merged (Phase 1: #232–#238; Phase 2: #239; DCQL: #343/#344 in `affinidi-tdk-rs`).