### PR TITLE
feat(vta-sdk): credential-exchange Trust Task message types — Phase 3 kickoff (task 3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-openid4vci"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4a082c3bc08f810d89dcbdba0349e429a9df3e3af54d5ea68b1f10806b7522"
+dependencies = [
+ "affinidi-oid4vc-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "affinidi-openid4vp"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9700,6 +9714,7 @@ dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
  "affinidi-sd-jwt-vc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ affinidi-sd-jwt-vc = "0.1.1"
 affinidi-sd-jwt = "0.1.2"
 affinidi-bbs = "0.1.1"
 affinidi-openid4vp = "0.1.2"
+affinidi-openid4vci = "0.1.2"
 affinidi-secrets-resolver = "0.5"
 affinidi-messaging-didcomm-service = "0.3"
 

--- a/docs/05-design-notes/vti-credential-architecture-tasks.md
+++ b/docs/05-design-notes/vti-credential-architecture-tasks.md
@@ -293,17 +293,72 @@ Dependency order: **2.0 → (2.1 ∥ 2.2) → 2.3 → 2.4**. 2.4 is gated on the
 
 ## Phase 3 — credential-exchange protocol  (Repo: `vti`: `vta-sdk` + `vta-service` + `vtc-service`)
 
-- [ ] 3.1 — `credential-exchange/*` Trust Task message types
-  (`offer`/`request`/`issue` + `query`/`present`) wrapping OID4VCI/OID4VP
-  bodies + DCQL — in `vta-sdk/src/protocols/credential_exchange/`.
-- [ ] 3.2 — Issuer side (VTC): `offer → issue` (OID4VCI).
-- [ ] 3.3 — Verifier side (VTC): `query (DCQL) → present (OID4VP)`
-  verification.
-- [ ] 3.4 — Holder side (VTA): handle `offer→request→store`;
-  `query→consent→present`.
-- [ ] 3.5 — relayer≠holder + `sealed_transfer` for secret-bearing
-  issuance.
-- [ ] CHECKPOINT 3 — VTC↔VTA issue + query + present round-trips.
+**Re-baseline (grounding survey + format decision).** Key facts: the Phase-1
+credential vault (`vta-service/src/vault/`) is **pure library — not yet wired
+to any wire route** (net-new exposure here). VTC↔VTA **already speak DIDComm**
+via a shared mediator (the `join_requests` flow is the precedent; prefer
+DIDComm). `provision-integration` is the working template for relayer≠holder +
+`sealed_transfer` + dual REST/DIDComm. `affinidi-openid4vp` is already a dep
+(carries DCQL); `affinidi-openid4vci` is **net-new** (added in 3.0). Trust-Task
+URIs are validated newtypes — the `trust-tasks/` descriptors + `index.json` are
+hand-maintained convention (not runtime-required).
+
+**Format decision (user, Option C — full format-agnostic bridge).** The vault +
+exchange abstract over credential **format**, driven by the DCQL `format`
+selector: **SD-JWT-VC** (Phase-1 path) + **W3C Data-Integrity** (what the VTC's
+DTG issuance emits) are first-class now; **BBS+** slots in additively once its
+security audit clears (Phase 0b gate). This makes the **format-agnostic vault
+(3.1) the keystone** — every wire op depends on it.
+
+Dependency order: **3.0 → 3.1 → (3.2 ∥ 3.3) issuance → (3.4 ∥ 3.5) presentation
+→ 3.6 → 3.7**.
+
+- [x] **3.0 — `credential-exchange/*` Trust Task message types.** *(this PR.)*
+  Add `affinidi-openid4vci`; the `offer`/`request`/`issue` + `query`/`present`
+  URIs + body shapes wrapping OID4VCI/OID4VP + DCQL, format-agnostic.
+  - Files: `vta-sdk/src/protocols/credential_exchange.rs`. Branch:
+    `feat/cred-3.0-exchange-types`.
+
+- [ ] **3.1 — Format-agnostic vault (the bridge).** Generalise the vault's
+  `receive` + `present` to dispatch on `StoredCredential.format`: SD-JWT-VC
+  (existing) **and** W3C-DI VC (verify DI proof / build a DI VP, holder-bound).
+  `query`/`match` is already format-aware (DCQL `format` → `CandidateCredential.
+  format`). BBS+ left as an additive variant (audit-gated).
+  - Acceptance: receive + present a W3C-DI VC and an SD-JWT-VC through one
+    format-dispatching surface; the DCQL `format` selector picks correctly.
+  - Files: `vta-service/src/vault/{receive,present}.rs` (+ a `format` dispatch).
+
+- [ ] **3.2 — Issuer side (VTC): `offer → request → issue` (OID4VCI).** VTC
+  emits an offer, validates the request's key-binding proof, issues the
+  credential (calls `credentials::dtg::issue_*` / an SD-JWT-VC issuer per the
+  negotiated format), **sealed** for an unknown holder (the invite case). REST
+  + DIDComm handler (extend `vtc-service/src/messaging.rs`). *(needs 3.0)*
+
+- [ ] **3.3 — Holder side (VTA): `offer → request → store`.** VTA handles an
+  inbound offer, builds the OID4VCI request (key-binding proof), receives the
+  issued credential, stores it via the format-agnostic vault (3.1). *(needs
+  3.0 + 3.1)*
+
+- [ ] **3.4 — Verifier side (VTC): `query (DCQL) → verify present (OID4VP)`.**
+  VTC emits a `query` (DCQL + nonce + mandatory `purpose`), receives a
+  `vp_token`, verifies the presentation (holder binding + status + issuer trust
+  + DCQL satisfaction). *(needs 3.0)*
+
+- [ ] **3.5 — Holder side (VTA): `query → consent → present`.** VTA runs
+  `DcqlQuery::match_credentials` locally over the vault, gates on a per-credential
+  consent record (§7a), builds the selectively-disclosed VP via the
+  format-dispatching `present`, returns the `vp_token`. *(needs 3.0 + 3.1)*
+
+- [ ] **3.6 — relayer≠holder + `sealed_transfer` for issuance.** A new
+  `SealedPayloadV1` variant (additive) for a sealed issued credential; reuse the
+  provision-integration auth onion (relayer authenticated outer, holder VP
+  inner, bundle HPKE-sealed to the holder).
+
+- [ ] **3.7 — Trust-Task descriptors + `index.json`** for the
+  `credential-exchange/*` family (hand-authored; trusttasks.org + soft-gate).
+
+- [ ] CHECKPOINT 3 — VTC↔VTA **issue + query + present** round-trips end-to-end
+  across both credential formats.
 
 ---
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -109,6 +109,10 @@ test-support = ["session"]
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+# OID4VP (+ DCQL) and OID4VCI — the body formats wrapped by the
+# `protocols::credential_exchange` Trust Task family (Phase 3, always compiled).
+affinidi-openid4vp = { workspace = true }
+affinidi-openid4vci = { workspace = true }
 base64 = { workspace = true }
 multibase = { workspace = true }
 thiserror = { workspace = true }
@@ -198,7 +202,6 @@ affinidi-sd-jwt = { workspace = true }
 # the BBS+ Data Integrity cryptosuite behind the `bbs-2023` feature. Functional
 # BBS / OID4VP-DCQL integration is later-phase work.
 affinidi-bbs = { workspace = true }
-affinidi-openid4vp = { workspace = true }
 affinidi-data-integrity = { workspace = true, features = ["bbs-2023"] }
 
 [lints]

--- a/vta-sdk/src/protocols/credential_exchange.rs
+++ b/vta-sdk/src/protocols/credential_exchange.rs
@@ -1,0 +1,159 @@
+//! `credential-exchange/*` Trust Task family — Phase 3 (spec §6).
+//!
+//! The **Trust Task is the transport / auth / threading / relayer envelope**;
+//! the **body is OID4VCI** (issuance) or **OID4VP + DCQL** (presentation). This
+//! module is the *message-type layer* both sides build on: the versioned URIs +
+//! the request/response body shapes. Handlers (issuer/verifier on the VTC,
+//! holder on the VTA) land in later Phase 3 slices.
+//!
+//! ```text
+//! Issuance (OID4VCI):
+//!   issuer → holder    credential-exchange/offer/1.0     { credential_offer }
+//!   holder → issuer    credential-exchange/request/1.0   { credential_request }   (key-binding proof)
+//!   issuer → holder    credential-exchange/issue/1.0     { credential_response | sealed }
+//!
+//! Presentation (OID4VP + DCQL):
+//!   verifier → holder  credential-exchange/query/1.0     { dcql_query, nonce, purpose }
+//!   holder → verifier  credential-exchange/present/1.0   { vp_token }
+//! ```
+//!
+//! **Format-agnostic** (spec D4): the issued `credential` and the `vp_token`
+//! carry whichever credential format — SD-JWT-VC, W3C Data-Integrity, or BBS+ —
+//! the DCQL `format` selector negotiated. Nothing here is format-specific.
+//!
+//! `purpose` on a [`QueryBody`] is **mandatory** and shown to the holder
+//! (purpose binding): a verifier cannot ask for a credential without stating
+//! why.
+
+use affinidi_openid4vci::{CredentialOffer, CredentialRequest, CredentialResponse};
+use affinidi_openid4vp::DcqlQuery;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ── Canonical Trust Task URIs (trusttasks.org/spec form) ──
+
+/// issuer → holder: a credential offer.
+pub const OFFER: &str = "https://trusttasks.org/spec/credential-exchange/offer/1.0";
+/// holder → issuer: a credential request.
+pub const REQUEST: &str = "https://trusttasks.org/spec/credential-exchange/request/1.0";
+/// issuer → holder: the issued credential.
+pub const ISSUE: &str = "https://trusttasks.org/spec/credential-exchange/issue/1.0";
+/// verifier → holder: a DCQL query.
+pub const QUERY: &str = "https://trusttasks.org/spec/credential-exchange/query/1.0";
+/// holder → verifier: a presentation.
+pub const PRESENT: &str = "https://trusttasks.org/spec/credential-exchange/present/1.0";
+
+/// `offer/1.0` — issuer → holder. An OID4VCI credential offer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OfferBody {
+    pub credential_offer: CredentialOffer,
+}
+
+/// `request/1.0` — holder → issuer. An OID4VCI credential request carrying the
+/// holder's key-binding proof.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestBody {
+    pub credential_request: CredentialRequest,
+}
+
+/// `issue/1.0` — issuer → holder. Exactly one of:
+///
+/// - `credential_response` — the cleartext OID4VCI response (the issued
+///   credential), for a known holder over an authenticated channel; or
+/// - `sealed` — an armored [`crate::sealed_transfer`] bundle, when the
+///   credential is secret-bearing or issued to an **unknown holder** (the
+///   invite / air-gap case): only the holder can open it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueBody {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_response: Option<CredentialResponse>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sealed: Option<String>,
+}
+
+/// `query/1.0` — verifier → holder. A DCQL query + freshness nonce + a
+/// **mandatory** `purpose` shown to the holder.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryBody {
+    pub dcql_query: DcqlQuery,
+    pub nonce: String,
+    /// The verifier's stated reason for the request — shown to the holder
+    /// (purpose binding). Never optional.
+    pub purpose: String,
+}
+
+/// `present/1.0` — holder → verifier. The OID4VP `vp_token` carrying the
+/// selectively-disclosed, holder-bound presentation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PresentBody {
+    pub vp_token: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn query_body_round_trips_with_a_dcql_query() {
+        let dcql = DcqlQuery::from_json(&json!({
+            "credentials": [{
+                "id": "membership",
+                "format": "dc+sd-jwt",
+                "meta": { "vct_values": ["https://openvtc.org/credentials/MembershipCredential"] }
+            }]
+        }))
+        .unwrap();
+        let body = QueryBody {
+            dcql_query: dcql,
+            nonce: "n-123".into(),
+            purpose: "join the Acme community".into(),
+        };
+        let wire = serde_json::to_string(&body).unwrap();
+        let back: QueryBody = serde_json::from_str(&wire).unwrap();
+        assert_eq!(back.nonce, "n-123");
+        assert_eq!(back.purpose, "join the Acme community");
+        assert_eq!(back.dcql_query.credentials.len(), 1);
+    }
+
+    #[test]
+    fn issue_body_carries_a_sealed_bundle() {
+        let body = IssueBody {
+            credential_response: None,
+            sealed: Some("-----BEGIN VTA SEALED-----\n…\n-----END VTA SEALED-----".into()),
+        };
+        let wire = serde_json::to_value(&body).unwrap();
+        assert!(wire.get("sealed").is_some());
+        assert!(
+            wire.get("credentialResponse").is_none() && wire.get("credential_response").is_none(),
+            "absent cleartext response is omitted: {wire}"
+        );
+        let back: IssueBody = serde_json::from_value(wire).unwrap();
+        assert!(back.sealed.is_some() && back.credential_response.is_none());
+    }
+
+    #[test]
+    fn present_body_round_trips() {
+        let body = PresentBody {
+            vp_token: json!("<jws>~<disclosure>~<kb-jwt>"),
+        };
+        let back: PresentBody =
+            serde_json::from_str(&serde_json::to_string(&body).unwrap()).unwrap();
+        assert_eq!(back.vp_token, json!("<jws>~<disclosure>~<kb-jwt>"));
+    }
+
+    #[test]
+    fn uris_are_versioned_and_distinct() {
+        let all = [OFFER, REQUEST, ISSUE, QUERY, PRESENT];
+        for u in all {
+            assert!(u.starts_with("https://trusttasks.org/spec/credential-exchange/"));
+            assert!(u.ends_with("/1.0"));
+        }
+        // all distinct
+        for (i, a) in all.iter().enumerate() {
+            for b in &all[i + 1..] {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -4,6 +4,7 @@ pub mod audit_management;
 pub mod auth;
 pub mod backup_management;
 pub mod context_management;
+pub mod credential_exchange;
 pub mod did_management;
 pub mod did_template_management;
 pub mod discovery;


### PR DESCRIPTION
Kicks off **Phase 3** — the credential-exchange wire protocol (spec §6: a `credential-exchange/*` Trust Task family wrapping OID4VCI for issuance and OID4VP+DCQL for presentation). This first slice is the SDK **message-type layer** both the issuer/verifier (VTC) and holder (VTA) sides build on.

### What's here
- `vta-sdk/src/protocols/credential_exchange.rs`:
  - URIs: `offer` / `request` / `issue` (OID4VCI) + `query` / `present` (OID4VP+DCQL), versioned `…/1.0`.
  - Bodies: `OfferBody`/`RequestBody` (OID4VCI), `IssueBody` (either a cleartext OID4VCI `credential_response` **or** an armored `sealed_transfer` bundle — the unknown-holder / invite case), `QueryBody { dcql_query, nonce, purpose }` (`purpose` mandatory — purpose binding), `PresentBody { vp_token }`.
  - **Format-agnostic** (spec D4): the issued credential + `vp_token` carry whichever format the DCQL `format` selector negotiated.
- Adds `affinidi-openid4vci` 0.1.2; promotes it + `affinidi-openid4vp` from vta-sdk **dev-deps → normal deps** (the new module is always-compiled lib code).
- **Phase 3 task breakdown** (tasks doc) expanded for the chosen **Option C — full format-agnostic bridge**: the format-agnostic vault (3.1) is the keystone; SD-JWT-VC + W3C Data-Integrity first-class now, BBS+ additive once its audit clears.

### Tests
4: `QueryBody` round-trips with a real `DcqlQuery`; `IssueBody` sealed variant omits the cleartext response; `PresentBody` round-trips; URIs versioned + distinct. `clippy --all-targets` / `fmt` / `cargo deny` clean; `vta-service` (the main consumer) builds with the promoted deps.

### Next (this phase)
3.1 the format-agnostic vault (receive/present dispatch on `format`: SD-JWT-VC + W3C-DI) — the keystone — then issuance (3.2/3.3) and presentation (3.4/3.5) over DIDComm (the `join_requests` precedent), relayer≠holder sealing (3.6), and the Trust-Task descriptors (3.7).