### PR TITLE
docs: credential-architecture "getting ready for join" presentation

### DIFF
--- a/docs/05-design-notes/credential-architecture-presentation.html
+++ b/docs/05-design-notes/credential-architecture-presentation.html
@@ -285,7 +285,7 @@
     <table>
       <thead><tr><th>Format</th><th>Standard</th><th>Selective disclosure</th><th>Status</th></tr></thead>
       <tbody>
-        <tr><td><code>SdJwtVc</code></td><td>IETF SD-JWT-VC + kb-jwt</td><td>Per-claim (salted disclosures)</td><td><span class="st live">first-class · live</span></td></tr>
+        <tr><td><code>SdJwtVc</code></td><td>IETF SD-JWT-VC + kb-jwt</td><td>Per-claim (selective-disclosures)</td><td><span class="st live">first-class · live</span></td></tr>
         <tr><td><code>EddsaJcs2022</code></td><td>W3C Data Integrity (eddsa-jcs-2022)</td><td>Whole-credential, holder-bound VP</td><td><span class="st live">first-class · live</span></td></tr>
         <tr><td><code>Bbs2023</code></td><td>W3C DI · BBS+ (BLS12-381)</td><td>Per-claim + <em>unlinkable</em></td><td><span class="st gated">additive · audit-gated</span></td></tr>
         <tr><td><code>Zkp</code></td><td>Circom · BabyJubJub-EdDSA + Poseidon</td><td>ZK predicates (future circuit)</td><td><span class="st gated">additive · Phase-0 gate</span></td></tr>

--- a/docs/05-design-notes/credential-architecture-presentation.html
+++ b/docs/05-design-notes/credential-architecture-presentation.html
@@ -1,0 +1,444 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Credential-Centric VTI — Getting Ready for Join</title>
+<style>
+  :root{
+    --bg:#0b1020; --bg2:#121a33; --panel:#16203f; --panel2:#1b2750;
+    --ink:#e8edff; --muted:#9aa7d4; --line:#2b3766;
+    --a:#5eead4;     /* teal  */
+    --b:#a78bfa;     /* violet*/
+    --c:#fbbf24;     /* amber */
+    --d:#60a5fa;     /* blue  */
+    --e:#fb7185;     /* rose  */
+    --ok:#34d399; --warn:#fbbf24; --gate:#fb7185;
+    --r:14px; --shadow:0 18px 50px rgba(0,0,0,.45);
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Inter,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%}
+  body{
+    background:radial-gradient(1200px 700px at 80% -10%,#1a244a 0%,var(--bg) 55%) fixed;
+    color:var(--ink); font-family:var(--sans); -webkit-font-smoothing:antialiased;
+  }
+  .deck{height:100vh;width:100vw;overflow:hidden;position:relative}
+  .slide{
+    position:absolute;inset:0;display:none;flex-direction:column;
+    padding:54px 7vw 80px; overflow:auto;
+    animation:fade .45s ease both;
+  }
+  .slide.on{display:flex}
+  @keyframes fade{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
+  h1,h2,h3{margin:0;line-height:1.1;font-weight:800;letter-spacing:-.02em}
+  h1{font-size:clamp(34px,5vw,68px)}
+  h2{font-size:clamp(26px,3.4vw,44px)}
+  .kicker{font-family:var(--mono);font-size:13px;letter-spacing:.22em;text-transform:uppercase;color:var(--a);margin-bottom:14px}
+  .sub{color:var(--muted);font-size:clamp(15px,1.5vw,20px);max-width:60ch;margin-top:16px;line-height:1.5}
+  p{line-height:1.55}
+  .grid{display:grid;gap:18px}
+  .card{background:linear-gradient(180deg,var(--panel),var(--bg2));border:1px solid var(--line);border-radius:var(--r);padding:20px 22px;box-shadow:var(--shadow)}
+  .card h3{font-size:19px;margin-bottom:8px}
+  .card p,.card li{color:var(--muted);font-size:14.5px;line-height:1.5}
+  .tag{display:inline-block;font-family:var(--mono);font-size:11.5px;padding:3px 9px;border-radius:999px;border:1px solid var(--line);color:var(--muted);background:#0e1530}
+  .pill{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;padding:5px 11px;border-radius:999px;border:1px solid var(--line)}
+  .dot{width:8px;height:8px;border-radius:50%}
+  .accent-a{color:var(--a)} .accent-b{color:var(--b)} .accent-c{color:var(--c)} .accent-d{color:var(--d)} .accent-e{color:var(--e)}
+  .b-a{border-color:rgba(94,234,212,.5)} .b-b{border-color:rgba(167,139,250,.5)} .b-c{border-color:rgba(251,191,36,.5)} .b-d{border-color:rgba(96,165,250,.5)}
+  code,.mono{font-family:var(--mono)}
+  .muted{color:var(--muted)}
+  /* nav */
+  .nav{position:fixed;bottom:22px;left:0;right:0;display:flex;justify-content:center;align-items:center;gap:18px;z-index:20}
+  .nav button{background:var(--panel2);color:var(--ink);border:1px solid var(--line);border-radius:10px;padding:8px 14px;font-size:14px;cursor:pointer;font-family:var(--mono)}
+  .nav button:hover{border-color:var(--a)}
+  .count{font-family:var(--mono);font-size:13px;color:var(--muted);min-width:62px;text-align:center}
+  .progress{position:fixed;top:0;left:0;height:3px;background:linear-gradient(90deg,var(--a),var(--b),var(--c));z-index:30;transition:width .35s}
+  .foot{position:fixed;bottom:24px;right:28px;font-family:var(--mono);font-size:11px;color:var(--muted);z-index:20;letter-spacing:.1em}
+  .hint{position:fixed;bottom:24px;left:28px;font-family:var(--mono);font-size:11px;color:var(--muted);z-index:20}
+  /* flow journey */
+  .journey{display:grid;grid-template-columns:repeat(4,1fr);gap:0;margin-top:30px;align-items:stretch}
+  .step{position:relative;padding:22px 20px;border:1px solid var(--line);background:linear-gradient(180deg,var(--panel),var(--bg2));margin-right:-1px}
+  .step:first-child{border-radius:var(--r) 0 0 var(--r)}
+  .step:last-child{border-radius:0 var(--r) var(--r) 0;margin-right:0}
+  .step .n{font-family:var(--mono);font-size:12px;color:var(--bg);font-weight:800;width:26px;height:26px;border-radius:50%;display:grid;place-items:center}
+  .step h3{font-size:20px;margin:12px 0 6px}
+  .step p{font-size:13.5px;color:var(--muted)}
+  .step .role{font-family:var(--mono);font-size:11px;margin-top:12px;color:var(--ink)}
+  .arrowrow{display:flex;justify-content:space-around;color:var(--muted);font-size:22px;margin:6px 0 0}
+  /* before/after */
+  .ba{display:grid;grid-template-columns:1fr 64px 1fr;gap:0;align-items:stretch;margin-top:26px}
+  .ba .col{border:1px solid var(--line);border-radius:var(--r);padding:24px;background:linear-gradient(180deg,var(--panel),var(--bg2))}
+  .ba .mid{display:grid;place-items:center;font-size:34px;color:var(--a)}
+  .ba h3{font-size:16px;text-transform:uppercase;letter-spacing:.12em;margin-bottom:16px}
+  .ba ul{margin:0;padding-left:18px}
+  .ba li{margin:9px 0;color:var(--muted);font-size:14.5px;line-height:1.45}
+  .before h3{color:var(--muted)} .after h3{color:var(--a)}
+  /* sequence diagram */
+  .seq{margin-top:26px;border:1px solid var(--line);border-radius:var(--r);padding:24px 20px;background:#0d1430;overflow:auto}
+  .lanes{display:grid;gap:0;font-family:var(--mono);font-size:12.5px}
+  .lanes .actors{display:grid;margin-bottom:6px}
+  .lanes .actors span{text-align:center;font-weight:700;padding:8px;border:1px solid var(--line);border-radius:8px;background:var(--panel2);margin:0 6px}
+  .msg{display:grid;align-items:center;margin:0;padding:7px 0;border-bottom:1px dashed #233063}
+  .msg:last-child{border-bottom:0}
+  .msg .lbl{grid-column:1/-1;color:var(--muted);font-size:11.5px;padding:2px 8px}
+  .msg .arrow{height:2px;background:var(--d);position:relative;align-self:center;margin:0 8px}
+  .msg .arrow.rev{background:var(--a)}
+  .msg .arrow::after{content:"";position:absolute;right:-1px;top:-4px;border:5px solid transparent;border-left-color:var(--d)}
+  .msg .arrow.rev::after{right:auto;left:-1px;border-left-color:transparent;border-right-color:var(--a)}
+  .msg .arrow.gate{background:var(--gate)} .msg .arrow.gate::after{border-left-color:var(--gate)}
+  /* table */
+  table{border-collapse:collapse;width:100%;margin-top:22px;font-size:14px}
+  th,td{text-align:left;padding:12px 14px;border-bottom:1px solid var(--line)}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+  td .st{font-family:var(--mono);font-size:11px;padding:3px 8px;border-radius:6px}
+  .live{background:rgba(52,211,153,.15);color:var(--ok);border:1px solid rgba(52,211,153,.4)}
+  .gated{background:rgba(251,113,133,.13);color:var(--gate);border:1px solid rgba(251,113,133,.4)}
+  .planned{background:rgba(251,191,36,.12);color:var(--warn);border:1px solid rgba(251,191,36,.4)}
+  /* standards chips */
+  .chips{display:flex;flex-wrap:wrap;gap:12px;margin-top:24px}
+  .chip{border:1px solid var(--line);border-radius:12px;padding:14px 16px;background:linear-gradient(180deg,var(--panel),var(--bg2));min-width:200px;flex:1 1 220px}
+  .chip .s{font-family:var(--mono);font-size:11px;color:var(--a);letter-spacing:.12em}
+  .chip .t{font-weight:700;margin-top:5px;font-size:15px}
+  .chip .d{color:var(--muted);font-size:12.5px;margin-top:4px}
+  /* roadmap */
+  .road{display:flex;gap:0;margin-top:30px;align-items:stretch}
+  .phase{flex:1;border:1px solid var(--line);padding:18px 16px;background:linear-gradient(180deg,var(--panel),var(--bg2));margin-right:-1px}
+  .phase:first-child{border-radius:var(--r) 0 0 var(--r)}
+  .phase:last-child{border-radius:0 var(--r) var(--r) 0;margin-right:0}
+  .phase .ph{font-family:var(--mono);font-size:11px;color:var(--c);letter-spacing:.12em}
+  .phase h3{font-size:16px;margin:8px 0 8px}
+  .phase ul{margin:0;padding-left:16px} .phase li{color:var(--muted);font-size:12.5px;margin:5px 0}
+  .barwrap{margin-top:6px}
+  .bar{height:9px;border-radius:6px;background:#0e1530;overflow:hidden;border:1px solid var(--line)}
+  .bar > span{display:block;height:100%;background:linear-gradient(90deg,var(--a),var(--b))}
+  .lead{font-size:clamp(17px,1.8vw,22px);line-height:1.5;max-width:64ch}
+  .two{grid-template-columns:1fr 1fr}
+  .three{grid-template-columns:1fr 1fr 1fr}
+  .four{grid-template-columns:repeat(4,1fr)}
+  .card.center{display:grid;place-content:center;text-align:center}
+  .slide.closing{justify-content:center;align-items:center;text-align:center}
+  .slide.closing h1,.slide.closing .sub{margin-left:auto;margin-right:auto}
+  .big-num{font-size:54px;font-weight:800;font-family:var(--mono)}
+  .legend{display:flex;gap:18px;flex-wrap:wrap;margin-top:18px;font-size:12.5px;color:var(--muted)}
+  .legend span{display:inline-flex;align-items:center;gap:7px}
+  a{color:var(--a)}
+  @media (max-width:880px){
+    .journey,.road{grid-template-columns:1fr;display:grid}
+    .ba{grid-template-columns:1fr}.ba .mid{transform:rotate(90deg)}
+    .two,.three,.four{grid-template-columns:1fr}
+  }
+  @media print{
+    .slide{display:flex!important;position:relative;height:auto;page-break-after:always;animation:none}
+    .nav,.foot,.hint,.progress{display:none}
+    body,.deck{height:auto;overflow:visible}
+  }
+</style>
+</head>
+<body>
+<div class="progress" id="bar"></div>
+<div class="deck" id="deck">
+
+  <!-- 1 — TITLE -->
+  <section class="slide on">
+    <div class="kicker">Verifiable Trust Infrastructure · Design Note</div>
+    <h1>Getting Ready for Join</h1>
+    <h2 style="margin-top:10px;color:var(--muted);font-weight:600">A credential-centric redesign of the VTA &amp; VTC</h2>
+    <p class="sub">From an ACL-and-keys world to one where a community member <strong class="accent-a">holds</strong> credentials, <strong class="accent-b">presents</strong> them, and <strong class="accent-c">joins</strong> — over open standards (W3C VC, SD-JWT-VC, OpenID4VCI / OpenID4VP, DCQL, DIDComm).</p>
+    <div class="legend">
+      <span><i class="dot" style="background:var(--ok)"></i>Shipped &amp; merged</span>
+      <span><i class="dot" style="background:var(--gate)"></i>Gated (audit / Phase-0)</span>
+      <span><i class="dot" style="background:var(--warn)"></i>Planned</span>
+    </div>
+    <div style="margin-top:34px;display:flex;gap:10px;flex-wrap:wrap">
+      <span class="pill b-a"><i class="dot" style="background:var(--a)"></i>VTA = credential agent</span>
+      <span class="pill b-b"><i class="dot" style="background:var(--b)"></i>VTC = issuer · verifier · schema authority</span>
+      <span class="pill b-d"><i class="dot" style="background:var(--d)"></i>invite → hold → present → join</span>
+    </div>
+  </section>
+
+  <!-- 2 — THE SHIFT -->
+  <section class="slide">
+    <div class="kicker">Executive summary</div>
+    <h2>The shift in one sentence</h2>
+    <p class="lead" style="margin-top:22px">We moved authorization from <strong class="accent-e">"a row in an ACL + a role in a JWT"</strong> to <strong class="accent-a">"a verifiable credential the member holds and presents"</strong> — so trust is portable, standards-native, privacy-preserving, and re-verifiable by anyone, not just by us.</p>
+    <div class="grid three" style="margin-top:34px">
+      <div class="card b-a"><h3 class="accent-a">Portable</h3><p>Membership and roles become W3C Verifiable Credentials the holder carries — usable beyond a single VTA/VTC, by external verifiers that show up later.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Standards-native</h3><p>Issuance and presentation ride OpenID4VCI / OpenID4VP + DCQL, wrapped in Trust Tasks over DIDComm. No bespoke signature schemes.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Privacy-preserving</h3><p>Selective disclosure (SD-JWT-VC, BBS+), per-disclosure consent records, and a vault with <em>no enumeration</em> primitive.</p></div>
+    </div>
+  </section>
+
+  <!-- 3 — BEFORE / AFTER -->
+  <section class="slide">
+    <div class="kicker">Before &nbsp;→&nbsp; After</div>
+    <h2>What changed architecturally</h2>
+    <div class="ba">
+      <div class="col before">
+        <h3>Before — ACL &amp; keys</h3>
+        <ul>
+          <li><strong>VTA</strong> = key manager (BIP-32, signing oracle) + an ACL keyspace.</li>
+          <li><strong>Authorization</strong> = an ACL entry + a <code>role</code> claim baked into a JWT.</li>
+          <li><strong>Join</strong> = bespoke: applicant submits a VP, an admin approves, the membership credential is handed back <em>inline in the HTTP response</em>.</li>
+          <li>Credentials existed (VMC / VEC) but were <em>point-to-point artifacts</em> — not held, not queryable, not re-presentable.</li>
+          <li>No wallet · no selective disclosure · no DCQL · no OID4VCI/VP.</li>
+        </ul>
+      </div>
+      <div class="mid">⟶</div>
+      <div class="col after">
+        <h3>After — hold &amp; present</h3>
+        <ul>
+          <li><strong>VTA</strong> = credential agent with a <strong class="accent-a">format-agnostic vault</strong> (hold) + receive / match / present.</li>
+          <li><strong>Authorization</strong> = a <strong class="accent-b">held Role VC</strong> → a verified-assertion cache; the ACL becomes a <em>derived index</em>.</li>
+          <li><strong>Join</strong> = invite (issue) → hold → present (DCQL) → join (verify → admit → issue), all over standards.</li>
+          <li>Credentials are first-class: stored encrypted-at-rest, indexed, queryable, selectively disclosed.</li>
+          <li><strong>DIDComm-first</strong> transport (authcrypt = intrinsic sender auth); REST fallback.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 4 — THE JOURNEY -->
+  <section class="slide">
+    <div class="kicker">The flow we built toward</div>
+    <h2>“Getting ready for join” — the member journey</h2>
+    <p class="sub">A prospective member is invited, holds the invitation, presents it on demand, and is admitted — each arrow a standards-based protocol message.</p>
+    <div class="journey">
+      <div class="step"><span class="n" style="background:var(--a)">1</span><h3 class="accent-a">Invite</h3><p>The VTC <strong>issues</strong> an invitation / membership credential offer to the prospect's DID — an OpenID4VCI pre-authorized offer.</p><div class="role">VTC → holder · <span class="muted">offer</span></div></div>
+      <div class="step"><span class="n" style="background:var(--d)">2</span><h3 class="accent-d">Hold</h3><p>The VTA <strong>redeems</strong> with a key-binding proof, receives the credential, and stores it in the vault (format-agnostic, encrypted).</p><div class="role">holder ⇄ VTC · <span class="muted">request → issue</span></div></div>
+      <div class="step"><span class="n" style="background:var(--b)">3</span><h3 class="accent-b">Present</h3><p>At join, the VTC verifier sends a <strong>DCQL query</strong>. The VTA matches over its vault (no enumeration), gates on consent, builds a selectively-disclosed VP.</p><div class="role">VTC → holder → VTC · <span class="muted">query → present</span></div></div>
+      <div class="step"><span class="n" style="background:var(--c)">4</span><h3 class="accent-c">Join</h3><p>The VTC <strong>verifies</strong> the VP (holder binding · status · issuer trust · DCQL satisfaction) → admits → issues VMC + Role VEC. The member now holds those too.</p><div class="role">VTC · <span class="muted">verify → admit → issue</span></div></div>
+    </div>
+    <p class="muted" style="margin-top:18px;font-size:13px">Every step is the <strong>same credential machinery</strong> — issuance is presentation's mirror image. Build it once, reuse it for invites, memberships, roles, endorsements.</p>
+  </section>
+
+  <!-- 5 — ROADMAP / WHAT SHIPPED -->
+  <section class="slide">
+    <div class="kicker">Delivery</div>
+    <h2>What shipped, phase by phase</h2>
+    <div class="road">
+      <div class="phase"><div class="ph">PHASE 0</div><h3>SD-JWT-VC unblocker</h3><ul><li>SD-JWT-VC + kb-jwt (TDK)</li><li>DCQL query model + matcher</li><li>Key-proof layer + Ed25519 JWS</li></ul><div class="barwrap"><div class="bar"><span style="width:100%"></span></div></div></div>
+      <div class="phase"><div class="ph">PHASE 1</div><h3>VTA vault</h3><ul><li>Format-agnostic store</li><li>receive · query · mint</li><li>present · status · consent</li></ul><div class="barwrap"><div class="bar"><span style="width:100%"></span></div></div></div>
+      <div class="phase"><div class="ph">PHASE 2</div><h3>VTC schema authority</h3><ul><li>DTG credential catalog</li><li>schema register + validate</li><li><code>accepts</code> · seeded defaults</li></ul><div class="barwrap"><div class="bar"><span style="width:100%"></span></div></div></div>
+      <div class="phase"><div class="ph">PHASE 3</div><h3>Exchange protocol</h3><ul><li>Issue: offer→request→issue</li><li>Hold: holder-receive</li><li>Present: DCQL match over vault</li></ul><div class="barwrap"><div class="bar"><span style="width:78%"></span></div></div></div>
+      <div class="phase"><div class="ph">PHASE 4–5</div><h3>Role-by-VC · join</h3><ul><li>Verified-assertion cache</li><li>VP-based <code>/auth</code></li><li>Ceremony integration</li></ul><div class="barwrap"><div class="bar"><span style="width:12%"></span></div></div></div>
+    </div>
+    <div class="grid four" style="margin-top:26px">
+      <div class="card center"><div class="big-num accent-a">13</div><p>PRs merged in the credential line (this stream)</p></div>
+      <div class="card center"><div class="big-num accent-b">4</div><p>credential formats the vault abstracts over</p></div>
+      <div class="card center"><div class="big-num accent-c">10+</div><p>open standards adopted, not invented</p></div>
+      <div class="card center"><div class="big-num accent-d">1</div><p>upstream crate hardened (affinidi-tdk-rs)</p></div>
+    </div>
+  </section>
+
+  <!-- 6 — ISSUANCE SEQUENCE -->
+  <section class="slide">
+    <div class="kicker">Flow 1 · Issuance</div>
+    <h2>OpenID4VCI over DIDComm — <span class="mono accent-a">offer → request → issue</span></h2>
+    <div class="seq">
+      <div class="lanes">
+        <div class="actors" style="grid-template-columns:1fr 1fr 1fr">
+          <span class="accent-b">VTC (issuer)</span><span class="accent-a">VTA (holder)</span><span class="accent-c">Vault</span>
+        </div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">① <code>credential-exchange/offer</code> — pre-authorized code (doubles as the proof nonce)</div><div style="grid-column:1/3" class="arrow"></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">② <code>credential-exchange/request</code> — holder signs an OID4VCI <em>key-binding proof</em> (EdDSA, bound to its did:key)</div><div></div><div style="grid-column:1/3" class="arrow rev"></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">③ Issuer <strong>verifies the proof</strong> → proven holder DID must equal the credential's subject (else <code>Forbidden</code>)</div><div class="arrow gate" style="grid-column:1/2"></div><div></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">④ <code>credential-exchange/issue</code> — the credential (single-use offer consumed on success only)</div><div style="grid-column:1/3" class="arrow"></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">⑤ Holder infers format, stores via the format-agnostic <code>vault::receive</code> (encrypted at rest)</div><div></div><div style="grid-column:2/4" class="arrow"></div></div>
+      </div>
+    </div>
+    <div class="grid three" style="margin-top:22px">
+      <div class="card b-a"><h3 class="accent-a">Holder binding is the gate</h3><p>A credential is released only to a party that proves possession of the subject key — the heart of OID4VCI, and the part every implementation otherwise hand-rolls.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Relayer ≠ holder is safe</h3><p>The DIDComm authcrypt sender authenticates the relayer; the inner key-binding proof authenticates the holder. The two may differ (air-gapped onboarding) with no escalation.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Single-use, DoS-resistant</h3><p>The pending offer is consumed <em>only</em> on a successful issue — a forged or wrong-party request can't burn the legitimate holder's offer.</p></div>
+    </div>
+  </section>
+
+  <!-- 7 — PRESENTATION SEQUENCE -->
+  <section class="slide">
+    <div class="kicker">Flow 2 · Presentation</div>
+    <h2>OpenID4VP + DCQL — <span class="mono accent-b">query → match → present</span></h2>
+    <div class="seq">
+      <div class="lanes">
+        <div class="actors" style="grid-template-columns:1fr 1fr 1fr">
+          <span class="accent-b">VTC (verifier)</span><span class="accent-a">VTA (holder)</span><span class="accent-c">Vault</span>
+        </div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">① <code>credential-exchange/query</code> — DCQL query + nonce + <strong>mandatory purpose</strong> (shown to the holder)</div><div style="grid-column:1/3" class="arrow"></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">② Holder gathers candidates by the <code>vct</code>/type index — <strong>no wallet enumeration</strong></div><div></div><div style="grid-column:2/4" class="arrow"></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">③ <code>DcqlQuery::match_credentials</code> → which held credentials satisfy it + the claim paths to disclose</div><div></div><div style="grid-column:2/3;justify-self:center" class="tag">match</div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">④ <strong>Consent gate</strong> (ISO/IEC 27560 + DPV) + selectively-disclosed <code>present</code> → <code>vp_token</code></div><div></div><div class="arrow gate" style="grid-column:2/3"></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">⑤ <code>credential-exchange/present</code> — holder-bound VP; verifier checks binding · status · issuer trust · DCQL</div><div></div><div style="grid-column:1/3" class="arrow rev"></div></div>
+      </div>
+    </div>
+    <div class="grid two" style="margin-top:22px">
+      <div class="card b-a"><h3 class="accent-a">No-enumeration is a feature</h3><p>The vault exposes no “list everything.” Discovery is only via an indexed field + value, so a query with no discriminator returns <em>nothing</em> — the holder never blind-scans its wallet to answer a verifier.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Disclose exactly what was consented</h3><p>The reveal set <em>is</em> the consent record's personal-data list. SD-JWT-VC redacts to the consented subset; plain DI refuses to over-disclose.</p></div>
+    </div>
+  </section>
+
+  <!-- 8 — FORMAT-AGNOSTIC VAULT -->
+  <section class="slide">
+    <div class="kicker">Design decision · the keystone</div>
+    <h2>One vault, every credential format</h2>
+    <p class="sub">The vault and the exchange abstract over credential <em>format</em>, driven by the DCQL <code>format</code> selector. Adding a format never touches the storage schema — every wire op depends on this bridge.</p>
+    <table>
+      <thead><tr><th>Format</th><th>Standard</th><th>Selective disclosure</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td><code>SdJwtVc</code></td><td>IETF SD-JWT-VC + kb-jwt</td><td>Per-claim (salted disclosures)</td><td><span class="st live">first-class · live</span></td></tr>
+        <tr><td><code>EddsaJcs2022</code></td><td>W3C Data Integrity (eddsa-jcs-2022)</td><td>Whole-credential, holder-bound VP</td><td><span class="st live">first-class · live</span></td></tr>
+        <tr><td><code>Bbs2023</code></td><td>W3C DI · BBS+ (BLS12-381)</td><td>Per-claim + <em>unlinkable</em></td><td><span class="st gated">additive · audit-gated</span></td></tr>
+        <tr><td><code>Zkp</code></td><td>Circom · BabyJubJub-EdDSA + Poseidon</td><td>ZK predicates (future circuit)</td><td><span class="st gated">additive · Phase-0 gate</span></td></tr>
+        <tr><td><code>Other(tag)</code></td><td>forward-compat escape hatch</td><td>—</td><td><span class="st planned">round-trips losslessly</span></td></tr>
+      </tbody>
+    </table>
+    <p class="muted" style="margin-top:18px;font-size:13px"><strong>Decision (Option C):</strong> SD-JWT-VC + W3C-DI are first-class now; BBS+ slots in once its audit clears; a second ZKP option (Circom) is gated behind packaging + a trusted setup. The enum is <em>additive</em> — a new variant is a new arm, never a migration.</p>
+  </section>
+
+  <!-- 9 — STANDARDS STACK -->
+  <section class="slide">
+    <div class="kicker">Adopt, don't invent</div>
+    <h2>The standards we stand on</h2>
+    <div class="chips">
+      <div class="chip"><div class="s">W3C</div><div class="t">Verifiable Credentials 2.0</div><div class="d">Data Integrity · eddsa-jcs-2022 · bbs-2023 cryptosuites</div></div>
+      <div class="chip"><div class="s">IETF</div><div class="t">SD-JWT-VC</div><div class="d">Selective disclosure + kb-jwt holder binding</div></div>
+      <div class="chip"><div class="s">OpenID</div><div class="t">OpenID4VCI</div><div class="d">Credential issuance · pre-authorized-code · key-proof</div></div>
+      <div class="chip"><div class="s">OpenID</div><div class="t">OpenID4VP + DCQL</div><div class="d">Presentation + Digital Credentials Query Language</div></div>
+      <div class="chip"><div class="s">DIF</div><div class="t">DIDComm v2</div><div class="d">authcrypt · intrinsic sender authentication</div></div>
+      <div class="chip"><div class="s">W3C</div><div class="t">DIDs</div><div class="d">did:key · did:webvh · did:web</div></div>
+      <div class="chip"><div class="s">trusttasks.org</div><div class="t">Trust Tasks</div><div class="d">The transport / auth / threading envelope</div></div>
+      <div class="chip"><div class="s">IRTF CFRG</div><div class="t">BBS Signatures</div><div class="d">Unlinkable selective disclosure · BLS12-381</div></div>
+      <div class="chip"><div class="s">ISO/IEC · W3C</div><div class="t">27560 + DPV</div><div class="d">Consent records · per-disclosure authorization</div></div>
+      <div class="chip"><div class="s">IETF RFC</div><div class="t">8037 · 7519 · 7638</div><div class="d">EdDSA JWS · JWT · JWK Thumbprint</div></div>
+      <div class="chip"><div class="s">HPKE</div><div class="t">RFC 9180</div><div class="d">Sealed transfer of secret-bearing bundles</div></div>
+      <div class="chip"><div class="s">Circom</div><div class="t">BabyJubJub · Poseidon</div><div class="d">ZK commitment primitives (gated option)</div></div>
+    </div>
+  </section>
+
+  <!-- 10 — DESIGN DECISIONS -->
+  <section class="slide">
+    <div class="kicker">The decisions behind it</div>
+    <h2>Principles we committed to</h2>
+    <div class="grid three">
+      <div class="card b-a"><h3 class="accent-a">Trust Tasks wrap OID4VCI/VP</h3><p>The Trust Task is the envelope (transport · auth · threading · relayer); the body is OID4VCI / OID4VP + DCQL. We never default to "a REST endpoint + a bespoke signature scheme."</p></div>
+      <div class="card b-b"><h3 class="accent-b">DIDComm first</h3><p>Authcrypt gives intrinsic sender authentication — unpacking yields a cryptographically-proven sender DID. REST is the fallback for parties that can't speak DIDComm.</p></div>
+      <div class="card b-c"><h3 class="accent-c">VC/VP for authorization</h3><p>When the VTA attests authorization it issues a W3C VC; when a holder presents, it's a VP. No signing a JSON struct with a key and calling it auth.</p></div>
+      <div class="card b-d"><h3 class="accent-d">Typestate for verified forms</h3><p>A wire form exposes <code>.verify()</code> returning a distinct <code>Verified*</code> type. Forgetting to verify doesn't compile — it's the wrong type.</p></div>
+      <div class="card b-a"><h3 class="accent-a">Default to DIDs</h3><p>Every public-key surface is a <code>did:key</code>, not a raw pubkey. HPKE still works on X25519 internally — derived on demand inside the cipher layer.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Crypto-agnostic, DID-resolution-with-the-caller</h3><p>The upstream key-proof layer verifies signatures via traits and surfaces the claimed key id — DID-method coupling stays out of the crate.</p></div>
+    </div>
+  </section>
+
+  <!-- 11 — SECURITY MODEL -->
+  <section class="slide">
+    <div class="kicker">Security model</div>
+    <h2>Where the guarantees live</h2>
+    <div class="grid two">
+      <div class="card b-d"><h3 class="accent-d">Holder key-binding proof</h3><p>OID4VCI <code>openid4vci-proof+jwt</code>: verify <code>typ</code>/<code>alg</code>, resolve the <code>kid</code> did:key, check the EdDSA signature (<code>verify_strict</code>), <code>aud</code>, freshness, and the <strong>c_nonce replay binding</strong>. Issuance releases only to the proven subject.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Consent-gated disclosure</h3><p>A signed consent record (ISO/IEC 27560 + DPV) authorizes a verifier + claim set. The reveal set <em>is</em> the consent; revoked / temporally-invalid credentials are refused before any disclosure.</p></div>
+      <div class="card b-b"><h3 class="accent-b">No-enumeration vault</h3><p>There is no "list all" primitive — discovery is targeted index lookups only. A query with no discriminator yields nothing. Privacy by construction.</p></div>
+      <div class="card b-a"><h3 class="accent-a">Sealed transfer</h3><p>Every secret-bearing bundle is HPKE-sealed to a consumer <code>client_did</code>, ASCII-armored, with a producer assertion + out-of-band SHA-256 digest. Hardcoded suite, domain-bound info string.</p></div>
+    </div>
+    <p class="muted" style="margin-top:18px;font-size:13px">Each of these was traced against forgery, replay (time + nonce), wrong-key, wrong-audience, alg-confusion, <code>alg=none</code>, and relayer-escalation attacks during review.</p>
+  </section>
+
+  <!-- 12 — CAPABILITIES MATRIX -->
+  <section class="slide">
+    <div class="kicker">New capabilities</div>
+    <h2>What the VTA &amp; VTC can do now</h2>
+    <table>
+      <thead><tr><th>Capability</th><th>Before</th><th>After</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Hold credentials</strong></td><td class="muted">—</td><td>Format-agnostic vault, encrypted at rest, indexed</td></tr>
+        <tr><td><strong>Receive issued credentials</strong></td><td class="muted">inline HTTP response</td><td>OpenID4VCI over DIDComm, holder-key-bound</td></tr>
+        <tr><td><strong>Issue with proof-of-possession</strong></td><td class="muted">sign &amp; hand over</td><td>Key-binding proof verified before release</td></tr>
+        <tr><td><strong>Query / match held credentials</strong></td><td class="muted">—</td><td>DCQL over the vault, no enumeration</td></tr>
+        <tr><td><strong>Selective disclosure</strong></td><td class="muted">—</td><td>SD-JWT-VC per-claim · BBS+ unlinkable (gated)</td></tr>
+        <tr><td><strong>Per-disclosure consent</strong></td><td class="muted">—</td><td>ISO/IEC 27560 + DPV consent records</td></tr>
+        <tr><td><strong>Schema authority</strong></td><td class="muted">implicit</td><td>VTC DTG catalog · register · validate · accepts</td></tr>
+        <tr><td><strong>ZK option</strong></td><td class="muted">—</td><td>Circom (BabyJubJub + Poseidon), Phase-0 gated</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- 13 — UPSTREAM -->
+  <section class="slide">
+    <div class="kicker">Giving back</div>
+    <h2>Upstream: hardening <span class="mono">affinidi-tdk-rs</span></h2>
+    <p class="sub">The security-critical proof handling shouldn't be re-implemented by every consumer. We moved it upstream where SIOPv2 / OID4VCI / OID4VP all benefit.</p>
+    <div class="grid two" style="margin-top:8px">
+      <div class="card b-a"><h3 class="accent-a">Key-binding proof layer (openid4vci)</h3><p><code>build_key_proof_jwt</code> (wallet) + <code>KeyProof::parse → verify</code> (issuer). Crypto-agnostic: signature via the <code>JwtSigner</code>/<code>JwtVerifier</code> traits; <strong>DID resolution stays with the caller</strong>. Enforces aud, c_nonce, freshness; rejects <code>alg=none</code>.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Ed25519 JWS + ergonomics (oid4vc-core)</h3><p><code>EdDsaSigner</code>/<code>EdDsaVerifier</code> (RFC 8037, <code>verify_strict</code>) — the missing companion to the P-256 impl, since the stack is Ed25519-<code>did:key</code> first. Plus a string-or-array <code>Audience</code> helper.</p></div>
+    </div>
+    <p class="muted" style="margin-top:18px;font-size:13px">Reviewed end-to-end against the bypass classes; <code>validate_credential_request</code> now documents that it is a <em>structural</em> check only — closing a real footgun where it returned <code>Ok</code> for a forged proof.</p>
+  </section>
+
+  <!-- 14 — WHAT'S NEXT -->
+  <section class="slide">
+    <div class="kicker">The road ahead</div>
+    <h2>What's next</h2>
+    <div class="grid two">
+      <div class="card b-c"><h3 class="accent-c">Finish presentation (3.5c / 3.4)</h3><p>Consent-gate + selectively-disclosed <code>present</code> → <code>vp_token</code>; the <code>query → present</code> handler; the VTC verifier that emits the query and verifies the returned presentation.</p></div>
+      <div class="card b-d"><h3 class="accent-d">Sealed &amp; descriptors (3.6 / 3.7)</h3><p>Sealed issuance to an unknown holder (the invite / air-gap case) via <code>sealed_transfer</code>; hand-authored Trust-Task descriptors for the family.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Role-by-VC &amp; the cache (Phase 4)</h3><p>A <code>verified_assertions</code> keyspace; VP-based <code>/auth</code>; auth extractors read the assertion record, not the JWT role. Revocation invalidates within a window.</p></div>
+      <div class="card b-a"><h3 class="accent-a">Join ceremony integration (Phase 5)</h3><p>Admit / Remint / Depart issue &amp; revoke Role VCs and update the cache — closing the loop from "present" to "joined."</p></div>
+    </div>
+    <p class="muted" style="margin-top:20px;font-size:13px">Also queued: a one-command <strong>mock VTA</strong> for test harnesses, and <strong>hierarchical (folder) trust contexts</strong> with folder-level admin.</p>
+  </section>
+
+  <!-- 15 — CLOSE -->
+  <section class="slide closing">
+    <div class="kicker" style="color:var(--b)">Getting ready for join</div>
+    <h1 style="max-width:18ch;margin:0 auto">Trust you can hold,<br>present, and carry.</h1>
+    <p class="sub" style="margin:22px auto 0">Membership stopped being a row in our database and became a credential in the member's wallet — issued, held, queried, selectively disclosed, and verified over open standards.</p>
+    <div style="margin-top:30px;display:flex;gap:10px;flex-wrap:wrap;justify-content:center">
+      <span class="pill b-a"><i class="dot" style="background:var(--ok)"></i>Vault · receive · match — live</span>
+      <span class="pill b-c"><i class="dot" style="background:var(--gate)"></i>BBS+ · ZKP — gated &amp; additive</span>
+      <span class="pill b-b"><i class="dot" style="background:var(--warn)"></i>present · role-by-VC — next</span>
+    </div>
+    <p class="muted mono" style="margin-top:34px;font-size:11.5px">docs/05-design-notes/credential-architecture-presentation.html · companion to vti-credential-architecture.md</p>
+  </section>
+
+</div>
+
+<div class="nav">
+  <button id="prev">◀ Prev</button>
+  <span class="count" id="count">1 / 15</span>
+  <button id="next">Next ▶</button>
+</div>
+<div class="hint">← → · Space · Home/End</div>
+<div class="foot">VTI · CREDENTIAL ARCHITECTURE</div>
+
+<script>
+  var slides = Array.prototype.slice.call(document.querySelectorAll('.slide'));
+  var i = 0;
+  var bar = document.getElementById('bar');
+  var count = document.getElementById('count');
+  function show(n){
+    i = Math.max(0, Math.min(slides.length-1, n));
+    slides.forEach(function(s,k){ s.classList.toggle('on', k===i); });
+    count.textContent = (i+1)+' / '+slides.length;
+    bar.style.width = ((i+1)/slides.length*100)+'%';
+    var on = slides[i]; if(on) on.scrollTop = 0;
+    location.hash = i+1;
+  }
+  document.getElementById('next').onclick = function(){ show(i+1); };
+  document.getElementById('prev').onclick = function(){ show(i-1); };
+  document.addEventListener('keydown', function(e){
+    if(e.key==='ArrowRight'||e.key===' '||e.key==='PageDown'){ show(i+1); e.preventDefault(); }
+    else if(e.key==='ArrowLeft'||e.key==='PageUp'){ show(i-1); e.preventDefault(); }
+    else if(e.key==='Home'){ show(0); }
+    else if(e.key==='End'){ show(slides.length-1); }
+  });
+  // deep-link + swipe
+  var start=null;
+  document.addEventListener('touchstart',function(e){start=e.touches[0].clientX;},{passive:true});
+  document.addEventListener('touchend',function(e){
+    if(start===null)return; var dx=e.changedTouches[0].clientX-start;
+    if(Math.abs(dx)>50){ show(i + (dx<0?1:-1)); } start=null;
+  },{passive:true});
+  var h = parseInt(location.hash.replace('#',''),10);
+  show(isNaN(h)?0:h-1);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Design presentation — credential-centric "getting ready for join"

A self-contained HTML slide deck (`docs/05-design-notes/credential-architecture-presentation.html`)
that tells the story of the credential-architecture work end-to-end.

### Contents (15 slides)
- **The shift** — ACL-and-keys → hold-and-present, in one sentence.
- **Before / After** — side-by-side architecture comparison.
- **The journey** — invite → hold → present → join, each arrow a standards-based message.
- **Roadmap** — Phases 0–5, what shipped, with progress bars + a delivery scoreboard.
- **Two sequence flows** — OpenID4VCI `offer→request→issue` and OpenID4VP+DCQL `query→match→present`.
- **Format-agnostic vault** — the credential-format table + the Option-C decision.
- **Standards stack** — the 10+ open standards we adopt (not invent).
- **Design decisions** + **security model** (key-binding proof, consent, no-enumeration, sealed).
- **Capabilities matrix** (before/after), **upstream contributions**, **what's next**.

### Build notes
- **Fully self-contained / offline** — inline CSS + JS, hand-rolled CSS/SVG diagrams and sequence
  flows (no Mermaid/CDN), so it renders anywhere including air-gapped review.
- Keyboard (← → · Space · Home/End), swipe, deep-link (`#n`), progress bar, and `@media print` support.
- Rendered + visually verified via headless Chrome (title + the layout-heavy sequence slide).

Companion to `vti-credential-architecture.md`.
