### PR TITLE
feat(vta): MockVta — a one-call listening VTA for test harnesses

### DIFF
--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -607,3 +607,91 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
 
     (router, ctx)
 }
+
+/// A **mock VTA** bound to an ephemeral local port — a real, listening HTTP
+/// server a test harness can drive over the wire, with no setup ceremony.
+///
+/// Wraps [`build_test_app`] (ephemeral in-memory state — no TEE/KMS, no mediator,
+/// no on-disk seed) and serves it on `127.0.0.1:<random-port>`. The server runs
+/// in a background task and shuts down when the `MockVta` is dropped (or via
+/// [`shutdown`](Self::shutdown)).
+///
+/// ```no_run
+/// # async fn demo() {
+/// use vta_service::test_support::MockVta;
+/// let mock = MockVta::start().await;
+/// let base = mock.base_url();              // e.g. http://127.0.0.1:54321
+/// // … point a client at `base`, or seed ACL/sessions via `mock.ctx` …
+/// mock.shutdown().await;
+/// # }
+/// ```
+pub struct MockVta {
+    base_url: String,
+    /// The bootstrapped app context (keyspaces, JWT keys, config) so a harness
+    /// can seed ACL rows / sessions before driving the API. Owns the temp data
+    /// dir — kept alive for the lifetime of the `MockVta`.
+    pub ctx: TestAppContext,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl MockVta {
+    /// Start a mock VTA on a random loopback port and return once it is bound
+    /// and serving.
+    pub async fn start() -> MockVta {
+        let (router, ctx) = build_test_app().await;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral loopback port");
+        let addr = listener.local_addr().expect("resolve local addr");
+        let base_url = format!("http://{addr}");
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            // `ConnectInfo<SocketAddr>` is required — the unauth routes carry the
+            // per-source-IP rate limiter, same as production.
+            let _ = axum::serve(
+                listener,
+                router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+        });
+
+        MockVta {
+            base_url,
+            ctx,
+            shutdown: Some(tx),
+            handle: Some(handle),
+        }
+    }
+
+    /// The base URL to point a client at (e.g. `http://127.0.0.1:54321`).
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Stop the server and wait for it to wind down gracefully.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for MockVta {
+    fn drop(&mut self) {
+        // Signal graceful shutdown; abort as a backstop if the task is still up.
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -1,0 +1,64 @@
+//! The `MockVta` test-harness helper: a real, listening VTA on a random
+//! loopback port that any HTTP client can drive — verified here by hitting the
+//! unauthenticated `GET /health` over the wire (raw TCP, no client dep).
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use vta_service::test_support::MockVta;
+
+/// Minimal HTTP/1.1 GET over a fresh TCP connection; returns the raw response.
+async fn http_get(addr: &str, path: &str) -> String {
+    let mut stream = TcpStream::connect(addr).await.expect("connect to mock VTA");
+    let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .expect("read response");
+    String::from_utf8_lossy(&response).into_owned()
+}
+
+#[tokio::test]
+async fn mock_vta_serves_health_over_http() {
+    let mock = MockVta::start().await;
+    let addr = mock
+        .base_url()
+        .strip_prefix("http://")
+        .expect("base_url is http://")
+        .to_string();
+
+    let response = http_get(&addr, "/health").await;
+
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "expected 200 from /health, got:\n{response}"
+    );
+    // The health handler returns a JSON status body.
+    assert!(
+        response.contains("status"),
+        "expected a status body, got:\n{response}"
+    );
+
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_vta_gates_authenticated_routes() {
+    let mock = MockVta::start().await;
+    let addr = mock.base_url().strip_prefix("http://").unwrap().to_string();
+
+    // An authenticated route without a token must not be served as 200 — the
+    // mock is a real VTA, auth gates and all.
+    let response = http_get(&addr, "/keys").await;
+    assert!(
+        !response.starts_with("HTTP/1.1 200"),
+        "an unauthenticated /keys must not return 200, got:\n{}",
+        response.lines().next().unwrap_or("")
+    );
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
## MockVta — a one-call listening VTA for test harnesses

The first of the two requested features: spin up a VTA for tests with no
ceremony. `test_support::MockVta` is a **real, listening VTA on a random
loopback port** that any HTTP client can drive.

### Surface
- **`MockVta::start().await`** — wraps `build_test_app` (ephemeral in-memory state:
  no TEE/KMS, no mediator, no on-disk seed), binds `127.0.0.1:0`, and serves it in
  a background task. Returns once bound.
- **`base_url()`** — e.g. `http://127.0.0.1:54321`, to point a client at.
- **`ctx`** — the bootstrapped app context (keyspaces, JWT keys, config) so a
  harness can seed ACL rows / sessions before driving the API.
- Graceful **shutdown on `shutdown().await` or `Drop`** (abort backstop).

It serves through `into_make_service_with_connect_info::<SocketAddr>` so the
unauthenticated routes keep their **per-source-IP rate limiter** — i.e. it
behaves like a real VTA, auth gates and all, not a stub.

### Scope
Feature-gated behind `test-support` (and `cfg(test)`); the production/default
build is **unaffected** (verified). Builds on the existing `build_test_app`
scaffolding rather than duplicating AppState wiring.

### Verification
2 integration tests over **real HTTP** (raw TCP, no client dependency added):
`/health` returns 200 with a status body; an unauthenticated `/keys` is *not*
served as 200. `cargo clippy --features test-support` clean; `cargo fmt`; default
build green. DCO-signed.

### Follow-ups (noted, not in this slice)
A pre-seeded admin DID + a token-mint helper would make "spin up and
authenticate" a one-liner; `ctx` already exposes the keyspaces to do it by hand.
A `vta mock` binary subcommand could expose the same for non-Rust harnesses.
