### PR TITLE
feat(vti-common): hierarchical context paths + ancestry-aware ACL gate (slice 1)

### DIFF
--- a/docs/05-design-notes/hierarchical-contexts.md
+++ b/docs/05-design-notes/hierarchical-contexts.md
@@ -1,0 +1,78 @@
+# Hierarchical trust contexts
+
+Status: design + in-progress (VTA first). Moves VTA trust contexts from a flat
+set to a **folder / sub-folder tree**, with **folder-level admin authority** —
+an admin of a parent context administers the whole subtree (create / remove
+sub-contexts, and manage their ACL, keys, and data).
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Hierarchy encoding | **The context identifier *is* its materialized path** (`acme/eng/team-a`) | Keeps the authorization gate **pure** — ancestry is a segment comparison on data already in the JWT, no store walk. See *Security rationale*. |
+| Ancestry test | **Segment-aware** prefix (`is_ancestor_or_self`) | A raw `starts_with` is wrong: `acme` must NOT match `acme-evil`. Compare path *segments*. |
+| Segment charset | Each segment is a [`validate_identifier`] value (`[A-Za-z0-9._-]`, ≤64 bytes) | `/` is the *only* separator and cannot appear in a segment → no `..` / slash-injection / empty-segment aliasing. |
+| Admin cascade | **Full subtree authority** | "More sophisticated context management overall" — an admin of a parent manages everything beneath it. |
+| Re-parenting (move a subtree) | **Disallowed initially** | The cost of a path-as-id model is that a move rewrites every descendant path + ACL ref. Rare; defer. |
+| Scope | **VTA first, VTC follows** | The key / ACL / BIP-32 machinery lives in the VTA; mirror to the VTC after. |
+
+## Security rationale (why path-encoded, not parent-pointer)
+
+The user's lens was *"most secure in the long run as we add stricter ACL
+management."* The authorization gate should be **pure, deterministic, and
+auditable**, with no dependency that can fail-open. A path-encoded identifier
+gives exactly that, where a parent-pointer model does not:
+
+- **Pure gate, no fail-open.** `has_context_access` stays a string/segment
+  comparison over `allowed_contexts` (already in the verified JWT). A
+  parent-pointer model has to *walk the store* to resolve ancestry inside the
+  security check — introducing: a store-error fail-open question, a DoS surface,
+  **cycle** risk (A→B→A loops), and TOCTOU between resolution and use.
+- **Scope is legible in the grant.** A grant for `acme/eng` self-evidently
+  authorizes that subtree. With pointers you must reconstruct a graph to know
+  what a grant covers — the opposite of auditable as rules get stricter.
+- **Stricter checks stay pure.** "deny deeper than N", "no cross-subtree
+  reference", "require a grant at each level" are all pure path operations
+  rather than store walks.
+
+The trade — cheap re-parenting + opaque ids — is worth losing for a gate with a
+materially smaller attack surface. Re-parenting is disallowed for now.
+
+## The path primitive (`vti-common::context_path`)
+
+Pure, store-free, the security foundation. Thoroughly tested against
+prefix-confusion and injection:
+
+- `validate_context_path(path)` — non-empty; split on `/`; every segment a valid
+  identifier; no empty / leading / trailing / doubled separators; depth ≤ MAX.
+- `is_ancestor_or_self(ancestor, descendant)` — `descendant`'s segments start
+  with `ancestor`'s segments (segment-aware; `acme` is **not** an ancestor of
+  `acme-evil`). This is what the ACL gate calls.
+- `parent_path(path) -> Option<&str>`, `depth(path) -> usize`.
+
+## ACL gate
+
+`AuthClaims::has_context_access(target)` becomes: super-admin, **or** any
+`allowed_contexts` entry `is_ancestor_or_self` of `target`. For today's flat
+(single-segment, childless) contexts this is **identical to the previous exact
+match**, so it is behaviour-preserving until sub-contexts exist.
+
+## BIP-32 nesting
+
+A sub-context's derivation base nests under its parent's: parent
+`m/26'/2'/<a>'` → child `m/26'/2'/<a>'/<b>'`, the path depth mirroring the
+context depth. The per-parent child index is counter-allocated under the parent.
+The context's immutable `base_path` stays the single source of truth for key
+derivation (unchanged contract; just deeper).
+
+## Slice plan
+
+1. **Path primitive + ACL gate** (this lands first) — `context_path` module +
+   `has_context_access`/`require_context` use `is_ancestor_or_self`. Pure,
+   behaviour-preserving for flat contexts, exhaustively tested.
+2. **Context model + nested creation** — `ContextRecord` carries its path +
+   parent; `create_context` accepts a parent, validates the parent exists +
+   caller is admin of it, allocates the nested BIP-32 base, enforces depth.
+3. **Subtree operations** — delete (cascade / refuse-non-empty), list-subtree,
+   and admin-of-parent authority over descendant ACL / keys.
+4. **VTC** — mirror the relevant parts to the community/context surface.

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -607,3 +607,91 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
 
     (router, ctx)
 }
+
+/// A **mock VTA** bound to an ephemeral local port — a real, listening HTTP
+/// server a test harness can drive over the wire, with no setup ceremony.
+///
+/// Wraps [`build_test_app`] (ephemeral in-memory state — no TEE/KMS, no mediator,
+/// no on-disk seed) and serves it on `127.0.0.1:<random-port>`. The server runs
+/// in a background task and shuts down when the `MockVta` is dropped (or via
+/// [`shutdown`](Self::shutdown)).
+///
+/// ```no_run
+/// # async fn demo() {
+/// use vta_service::test_support::MockVta;
+/// let mock = MockVta::start().await;
+/// let base = mock.base_url();              // e.g. http://127.0.0.1:54321
+/// // … point a client at `base`, or seed ACL/sessions via `mock.ctx` …
+/// mock.shutdown().await;
+/// # }
+/// ```
+pub struct MockVta {
+    base_url: String,
+    /// The bootstrapped app context (keyspaces, JWT keys, config) so a harness
+    /// can seed ACL rows / sessions before driving the API. Owns the temp data
+    /// dir — kept alive for the lifetime of the `MockVta`.
+    pub ctx: TestAppContext,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl MockVta {
+    /// Start a mock VTA on a random loopback port and return once it is bound
+    /// and serving.
+    pub async fn start() -> MockVta {
+        let (router, ctx) = build_test_app().await;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral loopback port");
+        let addr = listener.local_addr().expect("resolve local addr");
+        let base_url = format!("http://{addr}");
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            // `ConnectInfo<SocketAddr>` is required — the unauth routes carry the
+            // per-source-IP rate limiter, same as production.
+            let _ = axum::serve(
+                listener,
+                router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+        });
+
+        MockVta {
+            base_url,
+            ctx,
+            shutdown: Some(tx),
+            handle: Some(handle),
+        }
+    }
+
+    /// The base URL to point a client at (e.g. `http://127.0.0.1:54321`).
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Stop the server and wait for it to wind down gracefully.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for MockVta {
+    fn drop(&mut self) {
+        // Signal graceful shutdown; abort as a backstop if the task is still up.
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -1,0 +1,64 @@
+//! The `MockVta` test-harness helper: a real, listening VTA on a random
+//! loopback port that any HTTP client can drive — verified here by hitting the
+//! unauthenticated `GET /health` over the wire (raw TCP, no client dep).
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use vta_service::test_support::MockVta;
+
+/// Minimal HTTP/1.1 GET over a fresh TCP connection; returns the raw response.
+async fn http_get(addr: &str, path: &str) -> String {
+    let mut stream = TcpStream::connect(addr).await.expect("connect to mock VTA");
+    let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .expect("read response");
+    String::from_utf8_lossy(&response).into_owned()
+}
+
+#[tokio::test]
+async fn mock_vta_serves_health_over_http() {
+    let mock = MockVta::start().await;
+    let addr = mock
+        .base_url()
+        .strip_prefix("http://")
+        .expect("base_url is http://")
+        .to_string();
+
+    let response = http_get(&addr, "/health").await;
+
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "expected 200 from /health, got:\n{response}"
+    );
+    // The health handler returns a JSON status body.
+    assert!(
+        response.contains("status"),
+        "expected a status body, got:\n{response}"
+    );
+
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_vta_gates_authenticated_routes() {
+    let mock = MockVta::start().await;
+    let addr = mock.base_url().strip_prefix("http://").unwrap().to_string();
+
+    // An authenticated route without a token must not be served as 200 — the
+    // mock is a real VTA, auth gates and all.
+    let response = http_get(&addr, "/keys").await;
+    assert!(
+        !response.starts_with("HTTP/1.1 200"),
+        "an unauthenticated /keys must not return 200, got:\n{}",
+        response.lines().next().unwrap_or("")
+    );
+
+    mock.shutdown().await;
+}

--- a/vti-common/src/auth/extractor.rs
+++ b/vti-common/src/auth/extractor.rs
@@ -181,10 +181,22 @@ impl AuthClaims {
         self.role == Role::Admin && self.allowed_contexts.is_empty()
     }
 
-    /// Returns `true` if the caller has access to the given context,
-    /// either as a super admin or by explicit context assignment.
+    /// Returns `true` if the caller has access to the given context — as a super
+    /// admin, or because one of their `allowed_contexts` is `context_id` itself
+    /// **or an ancestor of it** (folder-level authority: admin of a parent
+    /// context covers the whole subtree).
+    ///
+    /// Ancestry is the segment-aware
+    /// [`is_ancestor_or_self`](crate::context_path::is_ancestor_or_self) — a
+    /// pure, store-free check over the verified JWT's contexts. For today's flat
+    /// (single-segment, childless) contexts this is identical to the previous
+    /// exact match.
     pub fn has_context_access(&self, context_id: &str) -> bool {
-        self.is_super_admin() || self.allowed_contexts.iter().any(|c| c == context_id)
+        self.is_super_admin()
+            || self
+                .allowed_contexts
+                .iter()
+                .any(|allowed| crate::context_path::is_ancestor_or_self(allowed, context_id))
     }
 
     /// Check that the caller has access to the given context.
@@ -435,8 +447,45 @@ fn cookie_token(parts: &Parts, name: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "cli-synthesis")]
     use super::*;
+
+    #[test]
+    fn has_context_access_grants_the_subtree_to_a_parent_admin() {
+        // A context admin scoped to `acme/eng` (not super-admin — the list is
+        // non-empty), so ancestry applies.
+        let claims = AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: vec!["acme/eng".into()],
+            ..Default::default()
+        };
+        assert!(!claims.is_super_admin());
+
+        // Self + every descendant.
+        assert!(claims.has_context_access("acme/eng"));
+        assert!(claims.has_context_access("acme/eng/team-a"));
+        assert!(claims.has_context_access("acme/eng/team-a/squad-1"));
+
+        // NOT the parent, a sibling, or a prefix-confusion look-alike.
+        assert!(!claims.has_context_access("acme"));
+        assert!(!claims.has_context_access("acme/ops"));
+        assert!(!claims.has_context_access("acme/engineering"));
+
+        assert!(claims.require_context("acme/eng/team-a").is_ok());
+        assert!(claims.require_context("acme/ops").is_err());
+    }
+
+    #[test]
+    fn flat_context_grant_is_exact_match_only() {
+        // A single-segment grant with no sub-contexts behaves exactly as before.
+        let claims = AuthClaims {
+            role: Role::Reader,
+            allowed_contexts: vec!["prod-mediator".into()],
+            ..Default::default()
+        };
+        assert!(claims.has_context_access("prod-mediator"));
+        assert!(!claims.has_context_access("prod-mediator-2"));
+        assert!(!claims.has_context_access("other"));
+    }
 
     #[cfg(feature = "cli-synthesis")]
     #[test]

--- a/vti-common/src/context_path.rs
+++ b/vti-common/src/context_path.rs
@@ -1,0 +1,214 @@
+//! Hierarchical trust-context paths — the security foundation for
+//! folder/sub-folder contexts (`docs/05-design-notes/hierarchical-contexts.md`).
+//!
+//! A context identifier **is** its materialized path: slash-separated segments,
+//! e.g. `acme/eng/team-a`. The authorization gate
+//! ([`crate::auth`]'s `has_context_access`) decides "admin of a parent → access
+//! to descendants" with [`is_ancestor_or_self`] — a **pure, store-free**
+//! segment comparison over data already in the verified JWT.
+//!
+//! ## Why this is store-free (and why that matters)
+//! Resolving ancestry without a store walk keeps the security gate pure: no
+//! fail-open on a store error, no DoS surface, no parent-pointer **cycles**, no
+//! TOCTOU. The cost — re-parenting rewrites a subtree's paths — is deferred
+//! (moves are disallowed initially).
+//!
+//! ## The one footgun, handled
+//! A raw `str::starts_with` is **wrong**: `acme` would "contain" `acme-evil`.
+//! Ancestry here is **segment-aware**, and `/` is the *only* separator — it
+//! cannot appear inside a segment (each segment is a
+//! [`validate_identifier`](crate::identifier::validate_identifier) value), so
+//! there is no `..` / slash-injection / empty-segment aliasing.
+
+use crate::error::AppError;
+use crate::identifier::validate_identifier;
+
+/// Maximum nesting depth (number of path segments). Bounds derivation depth and
+/// keeps ancestry checks cheap; deep trees are an anti-pattern, not a need.
+pub const MAX_CONTEXT_DEPTH: usize = 8;
+
+/// The path separator. A context identifier is segments joined by this; it never
+/// appears inside a segment.
+pub const SEPARATOR: char = '/';
+
+/// Validate a context path: non-empty, ≤ [`MAX_CONTEXT_DEPTH`] segments, every
+/// segment a valid identifier, and no empty / leading / trailing / doubled
+/// separators.
+pub fn validate_context_path(value: &str) -> Result<(), AppError> {
+    if value.is_empty() {
+        return Err(AppError::Validation(
+            "context path must not be empty".into(),
+        ));
+    }
+    if value.starts_with(SEPARATOR) || value.ends_with(SEPARATOR) {
+        return Err(AppError::Validation(format!(
+            "context path must not start or end with '{SEPARATOR}'"
+        )));
+    }
+
+    let segments: Vec<&str> = value.split(SEPARATOR).collect();
+    if segments.len() > MAX_CONTEXT_DEPTH {
+        return Err(AppError::Validation(format!(
+            "context path is {} levels deep; maximum is {MAX_CONTEXT_DEPTH}",
+            segments.len()
+        )));
+    }
+    for segment in &segments {
+        // An empty segment means a leading/trailing/doubled separator — `split`
+        // yields `""` for each. (The leading/trailing case is caught above; this
+        // catches `a//b`.)
+        if segment.is_empty() {
+            return Err(AppError::Validation(
+                "context path must not contain an empty segment ('//')".into(),
+            ));
+        }
+        validate_identifier("context path segment", segment)?;
+    }
+    Ok(())
+}
+
+/// Split a path into its segments. The path is assumed
+/// [validated](validate_context_path); for an arbitrary string this still
+/// returns the slash-split parts.
+fn segments(path: &str) -> impl Iterator<Item = &str> {
+    path.split(SEPARATOR)
+}
+
+/// Whether `ancestor` is `descendant` itself or an ancestor of it — the test the
+/// ACL gate uses for "admin of a parent context covers the subtree".
+///
+/// **Segment-aware:** `descendant`'s segments must *begin with* `ancestor`'s
+/// segments, segment-for-segment. So `acme` is an ancestor of `acme/eng` but
+/// **not** of `acme-evil`, and `acme/eng` is not an ancestor of `acme/engineering`.
+///
+/// Inputs are compared as-is; callers gate creation through
+/// [`validate_context_path`], so malformed paths simply fail to match.
+pub fn is_ancestor_or_self(ancestor: &str, descendant: &str) -> bool {
+    // Empty strings never participate (an empty `allowed_contexts` entry must
+    // not grant access; super-admin is handled separately by the gate).
+    if ancestor.is_empty() || descendant.is_empty() {
+        return false;
+    }
+    let mut anc = segments(ancestor);
+    let mut desc = segments(descendant);
+    loop {
+        match anc.next() {
+            // Ancestor exhausted: descendant began with all of it → ancestor-or-self.
+            None => return true,
+            Some(a) => match desc.next() {
+                // Descendant ran out first, or a segment differs → not an ancestor.
+                None => return false,
+                Some(d) if a != d => return false,
+                Some(_) => continue,
+            },
+        }
+    }
+}
+
+/// The parent path (one segment shorter), or `None` for a top-level (single
+/// segment) path.
+pub fn parent_path(path: &str) -> Option<&str> {
+    path.rsplit_once(SEPARATOR).map(|(parent, _)| parent)
+}
+
+/// The depth (segment count) of a path. A top-level context is depth 1.
+pub fn depth(path: &str) -> usize {
+    if path.is_empty() {
+        return 0;
+    }
+    path.split(SEPARATOR).count()
+}
+
+/// Build a child path under `parent` by appending a single `segment`. The
+/// `segment` must be one valid identifier — it cannot itself contain a separator
+/// (else it would silently add *several* levels) — and the resulting path must
+/// validate (depth included).
+pub fn child_path(parent: &str, segment: &str) -> Result<String, AppError> {
+    // Reject a `segment` that is empty or contains the separator: `child_path`
+    // adds exactly one level.
+    validate_identifier("context path segment", segment)?;
+    let candidate = format!("{parent}{SEPARATOR}{segment}");
+    validate_context_path(&candidate)?;
+    Ok(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_good_paths() {
+        for p in ["acme", "acme/eng", "acme/eng/team-a", "a.b_c/d-e", "x/y/z"] {
+            assert!(validate_context_path(p).is_ok(), "{p} should be valid");
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_paths() {
+        assert!(validate_context_path("").is_err()); // empty
+        assert!(validate_context_path("/acme").is_err()); // leading separator
+        assert!(validate_context_path("acme/").is_err()); // trailing separator
+        assert!(validate_context_path("acme//eng").is_err()); // doubled separator
+        assert!(validate_context_path("acme/ev il").is_err()); // space in a segment
+        // `..` is a *legal* segment name (only alnum/`.`/`_`/`-`), but it can't
+        // escape anything: `/` is the sole separator and can't appear in a
+        // segment, so `..` is just a literal child named "..". The dangerous
+        // forms (slash / empty-segment injection) above are all rejected.
+        assert!(validate_context_path("acme/..").is_ok());
+    }
+
+    #[test]
+    fn enforces_max_depth() {
+        let deep = (0..=MAX_CONTEXT_DEPTH)
+            .map(|i| format!("s{i}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        assert!(
+            validate_context_path(&deep).is_err(),
+            "{deep} exceeds max depth"
+        );
+        let ok = (0..MAX_CONTEXT_DEPTH)
+            .map(|i| format!("s{i}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        assert!(validate_context_path(&ok).is_ok());
+    }
+
+    #[test]
+    fn ancestry_is_segment_aware_not_string_prefix() {
+        // Self.
+        assert!(is_ancestor_or_self("acme", "acme"));
+        assert!(is_ancestor_or_self("acme/eng", "acme/eng"));
+        // True ancestry.
+        assert!(is_ancestor_or_self("acme", "acme/eng"));
+        assert!(is_ancestor_or_self("acme", "acme/eng/team-a"));
+        assert!(is_ancestor_or_self("acme/eng", "acme/eng/team-a"));
+        // The prefix-confusion attack: string-prefix but NOT a segment ancestor.
+        assert!(!is_ancestor_or_self("acme", "acme-evil"));
+        assert!(!is_ancestor_or_self("acme/eng", "acme/engineering"));
+        assert!(!is_ancestor_or_self("ac", "acme"));
+        // Descendant is shorter / a sibling.
+        assert!(!is_ancestor_or_self("acme/eng", "acme"));
+        assert!(!is_ancestor_or_self("acme/eng", "acme/ops"));
+        // Empty never matches.
+        assert!(!is_ancestor_or_self("", "acme"));
+        assert!(!is_ancestor_or_self("acme", ""));
+    }
+
+    #[test]
+    fn parent_and_depth() {
+        assert_eq!(parent_path("acme"), None);
+        assert_eq!(parent_path("acme/eng"), Some("acme"));
+        assert_eq!(parent_path("acme/eng/team-a"), Some("acme/eng"));
+        assert_eq!(depth("acme"), 1);
+        assert_eq!(depth("acme/eng/team-a"), 3);
+        assert_eq!(depth(""), 0);
+    }
+
+    #[test]
+    fn child_path_builds_and_validates() {
+        assert_eq!(child_path("acme", "eng").unwrap(), "acme/eng");
+        assert!(child_path("acme", "ev/il").is_err()); // separator in the new segment
+        assert!(child_path("acme", "").is_err()); // empty segment
+    }
+}

--- a/vti-common/src/lib.rs
+++ b/vti-common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod acl;
 pub mod audit;
 pub mod auth;
 pub mod config;
+pub mod context_path;
 pub mod error;
 pub mod idempotency;
 pub mod identifier;


### PR DESCRIPTION
## Hierarchical contexts — slice 1: path primitive + ancestry-aware ACL gate

The security foundation for moving VTA trust contexts from a flat set to a
**folder / sub-folder tree** with **folder-level admin authority** (admin of a
parent administers the whole subtree). Design note + decisions:
`docs/05-design-notes/hierarchical-contexts.md`.

### The encoding decision (you asked me to advise, optimising for long-run ACL security)
**The context identifier *is* its materialized path** (`acme/eng/team-a`), not a
parent-pointer. Why this is the more secure choice as ACL gets stricter:
- **The authorization gate stays pure & store-free.** Ancestry is a segment
  comparison over data already in the verified JWT. A parent-pointer model forces
  the gate to *walk the store* — introducing fail-open-on-error questions, a DoS
  surface, parent **cycles** (A→B→A), and TOCTOU. A pure gate has none of these.
- **Scope is legible in the grant** — a grant for `acme/eng` self-evidently
  covers that subtree; no pointer-graph reconstruction to audit it.
- **Future stricter checks stay pure** (depth caps, no-cross-subtree, per-level
  grants) instead of store walks.
The trade — re-parenting rewrites a subtree's paths — is deferred (moves
disallowed initially).

### What's in this slice
- **`vti-common::context_path`** (pure, the security primitive):
  - `validate_context_path` — segments are valid identifiers; `/` is the *only*
    separator (so no `..` / slash / empty-segment injection); depth-bounded.
  - `is_ancestor_or_self` — **segment-aware**: `acme` is an ancestor of `acme/eng`
    but **NOT** of `acme-evil` (the prefix-confusion footgun, handled).
  - `parent_path` / `depth` / `child_path`.
- **`AuthClaims::has_context_access`** now grants `context_id` itself **or any
  ancestor** in `allowed_contexts`. **Behaviour-preserving** for today's flat
  (single-segment, childless) contexts — identical to the prior exact match, so
  this is safe to land before sub-contexts exist.

### Verification
Tests cover the prefix-confusion attack, injection, depth bound, and the gate
(parent-admin reaches the subtree but not parent/sibling/look-alike; flat grant =
exact match). **213 vti-common + 623 vta-service** lib tests pass; clippy clean
(default + `cli-synthesis`); vtc builds. DCO-signed.

### Next slices (per the design note)
2. `ContextRecord` carries its path + parent; `create_context` accepts a parent
   (validates it exists + caller is admin of it), allocates the **nested BIP-32
   base**, enforces depth.
3. Subtree ops (delete cascade/refuse-non-empty, list-subtree) + parent-admin
   authority over descendant ACL/keys.
4. VTC mirror.
