### PR TITLE
feat(vta): hierarchical contexts slice 2 — nested creation + BIP-32 nesting + --parent CLI

### DIFF
--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -340,7 +340,8 @@ enum ContextCommands {
     },
     /// Create a new application context
     Create {
-        /// Context slug (lowercase alphanumeric + hyphens)
+        /// Context slug (lowercase alphanumeric + hyphens). When `--parent` is
+        /// set this is the leaf segment; the full id becomes `<parent>/<id>`.
         #[arg(long)]
         id: String,
         /// Human-readable name
@@ -349,6 +350,11 @@ enum ContextCommands {
         /// Optional description
         #[arg(long)]
         description: Option<String>,
+        /// Parent context path to nest under (e.g. `acme/eng`). Creates a
+        /// sub-context — requires admin of the parent. Omit for a top-level
+        /// context (super-admin only).
+        #[arg(long)]
+        parent: Option<String>,
         /// DID to grant admin access to (must start with `did:`). When set,
         /// creates an ACL entry with role=admin scoped to this context.
         #[arg(long)]
@@ -976,6 +982,7 @@ async fn main() {
                 id,
                 name,
                 description,
+                parent,
                 admin_did,
                 admin_label,
                 admin_expires,
@@ -996,7 +1003,7 @@ async fn main() {
                     expires_at,
                     expires_duration: admin_expires.clone(),
                 };
-                contexts::cmd_context_create(&client, &id, &name, description, admin).await
+                contexts::cmd_context_create(&client, &id, &name, description, parent, admin).await
             }
             ContextCommands::Update {
                 id,

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1365,7 +1365,8 @@ pub(crate) enum ContextCommands {
     /// it — useful when the DID was minted on a fresh `pnm setup` and you
     /// want an automatic safety window.
     Create {
-        /// Context slug (lowercase alphanumeric + hyphens)
+        /// Context slug (lowercase alphanumeric + hyphens). When `--parent` is
+        /// set this is the leaf segment; the full id becomes `<parent>/<id>`.
         #[arg(long)]
         id: String,
         /// Human-readable name
@@ -1374,6 +1375,11 @@ pub(crate) enum ContextCommands {
         /// Optional description
         #[arg(long)]
         description: Option<String>,
+        /// Parent context path to nest under (e.g. `acme/eng`). Creates a
+        /// sub-context — requires admin of the parent. Omit for a top-level
+        /// context (super-admin only).
+        #[arg(long)]
+        parent: Option<String>,
         /// DID to grant admin access to (must start with `did:`). When set,
         /// creates an ACL entry with role=admin scoped to this context.
         #[arg(long)]

--- a/pnm-cli/src/commands/contexts.rs
+++ b/pnm-cli/src/commands/contexts.rs
@@ -17,11 +17,14 @@ pub(crate) async fn run(
             id,
             name,
             description,
+            parent,
             admin_did,
             admin_label,
             admin_expires,
         } => match resolve_admin_acl_options(admin_did, admin_label, admin_expires.as_deref()) {
-            Ok(admin) => contexts::cmd_context_create(client, &id, &name, description, admin).await,
+            Ok(admin) => {
+                contexts::cmd_context_create(client, &id, &name, description, parent, admin).await
+            }
             Err(e) => Err(e),
         },
         ContextCommands::Update {

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -237,15 +237,22 @@ pub async fn cmd_context_create(
     id: &str,
     name: &str,
     description: Option<String>,
+    parent: Option<String>,
     admin: AdminAclOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use crate::render::{RESET, YELLOW};
     use vta_sdk::error::VtaError;
 
+    // The full context path the server will assign (`<parent>/<id>` when nested)
+    // — used for the conflict hint before `resp` exists.
+    let effective_id = parent
+        .as_ref()
+        .map_or_else(|| id.to_string(), |p| format!("{p}/{id}"));
     let req = CreateContextRequest {
         id: id.to_string(),
         name: name.to_string(),
         description,
+        parent,
     };
     let resp = match client.create_context(req).await {
         Ok(r) => r,
@@ -258,13 +265,14 @@ pub async fn cmd_context_create(
             let did = admin.did.as_deref().unwrap_or_default();
             let bin = crate::render::bin_name();
             eprintln!(
-                "{YELLOW}\u{26a0}{RESET}  Context '{id}' already exists — skipping context creation."
+                "{YELLOW}\u{26a0}{RESET}  Context '{effective_id}' already exists — skipping context creation."
             );
             eprintln!();
             eprintln!("  The --admin-did was NOT added. To grant admin access to an existing");
             eprintln!("  context, use the ACL command directly:");
             eprintln!();
-            let mut hint = format!("    {bin} acl create --did {did} --role admin --contexts {id}");
+            let mut hint =
+                format!("    {bin} acl create --did {did} --role admin --contexts {effective_id}");
             if let Some(label) = admin.label.as_deref() {
                 hint.push_str(&format!(" --label '{label}'"));
             }
@@ -297,8 +305,10 @@ pub async fn cmd_context_create(
             )
             .into());
         }
+        // Scope the admin grant to the **full path** the server assigned
+        // (`<parent>/<id>` for a sub-context), not the leaf.
         let mut acl_req =
-            vta_sdk::client::CreateAclRequest::new(did, "admin").contexts(vec![id.to_string()]);
+            vta_sdk::client::CreateAclRequest::new(did, "admin").contexts(vec![resp.id.clone()]);
         if let Some(label) = admin.label.as_deref() {
             acl_req = acl_req.label(label);
         }

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -151,10 +151,16 @@ pub struct WrappingKeyResponse {
 #[derive(Debug, Serialize)]
 #[must_use]
 pub struct CreateContextRequest {
+    /// The new context's id. A leaf segment when [`parent`](Self::parent) is set
+    /// (the full path becomes `<parent>/<id>`); a top-level segment otherwise.
     pub id: String,
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Parent context path to nest under, or `None` for a top-level context.
+    /// Top-level creation is super-admin only; nesting requires admin of `parent`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
 }
 
 impl CreateContextRequest {
@@ -163,10 +169,16 @@ impl CreateContextRequest {
             id: id.into(),
             name: name.into(),
             description: None,
+            parent: None,
         }
     }
     pub fn description(mut self, desc: impl Into<String>) -> Self {
         self.description = Some(desc.into());
+        self
+    }
+    /// Nest the new context under `parent` (its full path becomes `<parent>/<id>`).
+    pub fn parent(mut self, parent: impl Into<String>) -> Self {
+        self.parent = Some(parent.into());
         self
     }
 }

--- a/vta-sdk/src/contexts.rs
+++ b/vta-sdk/src/contexts.rs
@@ -3,10 +3,19 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextRecord {
+    /// The context's materialized path identifier — slash-separated segments
+    /// (e.g. `acme/eng/team-a`). A top-level context is a single segment.
     pub id: String,
     pub name: String,
     pub did: Option<String>,
     pub description: Option<String>,
+    /// The parent context's id, or `None` for a top-level context. Together
+    /// with [`id`](Self::id) this records the tree; absent on legacy (flat)
+    /// records, which deserialize as top-level.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    /// BIP-32 derivation base for this context's keys. For a sub-context this
+    /// nests under the parent's base (`{parent.base_path}/<child>'`).
     pub base_path: String,
     pub index: u32,
     pub created_at: DateTime<Utc>,

--- a/vta-sdk/src/protocols/context_management/create.rs
+++ b/vta-sdk/src/protocols/context_management/create.rs
@@ -3,10 +3,15 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateContextBody {
+    /// Leaf segment when `parent` is set (full path = `<parent>/<id>`), else a
+    /// top-level segment.
     pub id: String,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Parent context path to nest under, or `None` for a top-level context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -15,6 +20,9 @@ pub struct CreateContextResultBody {
     pub name: String,
     pub did: Option<String>,
     pub description: Option<String>,
+    /// Parent context id, or `None` for a top-level context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
     pub base_path: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -763,11 +763,13 @@ fn to_context_response(
 /// also writes an admin ACL entry scoped to the new context, mirroring
 /// the online `pnm contexts create --admin-did` shorthand.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub async fn run_context_create(
     config_path: Option<PathBuf>,
     id: String,
     name: Option<String>,
     description: Option<String>,
+    parent: Option<String>,
     admin_did: Option<String>,
     admin_label: Option<String>,
     admin_expires: Option<String>,
@@ -789,6 +791,7 @@ pub async fn run_context_create(
         &id,
         display_name,
         description,
+        parent,
         "vta-context-create",
     )
     .await?;
@@ -815,10 +818,14 @@ pub async fn run_context_create(
             format!("vta-context-create:{}", auth.did),
         )
         .with_label(admin_label)
-        .with_contexts(vec![id.clone()])
+        // Scope to the full path the operation assigned (`<parent>/<id>` nested).
+        .with_contexts(vec![record.id.clone()])
         .with_expires_at(expires_at);
         crate::acl::store_acl_entry(&acl_ks, &entry).await?;
-        eprintln!("Admin ACL entry created for {did} (context: {id}).");
+        eprintln!(
+            "Admin ACL entry created for {did} (context: {}).",
+            record.id
+        );
     }
 
     store.persist().await?;
@@ -1271,6 +1278,7 @@ mod tests {
             &auth,
             "existing-ctx",
             "existing-ctx".into(),
+            None,
             None,
             "test-setup",
         )

--- a/vta-service/src/contexts/mod.rs
+++ b/vta-service/src/contexts/mod.rs
@@ -37,11 +37,19 @@ pub async fn list_contexts(ks: &KeyspaceHandle) -> Result<Vec<ContextRecord>, Ap
 
 /// Allocate the next context index and return `(index, base_path)`.
 ///
-/// The counter is stored in the contexts keyspace under `ctx_counter`.
-/// Returns the next available index and the corresponding BIP-32 base path
-/// `m/26'/2'/N'`.
-pub async fn allocate_context_index(ks: &KeyspaceHandle) -> Result<(u32, String), AppError> {
-    let counter_key = "ctx_counter";
+/// Allocate the next BIP-32 base path under `base_prefix`, bumping the counter
+/// at `counter_key`.
+///
+/// Top-level contexts use [`CONTEXT_KEY_BASE`] + the legacy `ctx_counter` key
+/// (so existing indices are preserved). A sub-context passes its **parent's**
+/// `base_path` as the prefix and a **per-parent** counter key, so each parent
+/// allocates its children independently and the derivation path nests:
+/// `{parent.base_path}/<child>'`.
+pub async fn allocate_context_index(
+    ks: &KeyspaceHandle,
+    base_prefix: &str,
+    counter_key: &str,
+) -> Result<(u32, String), AppError> {
     let current: u32 = match ks.get_raw(counter_key).await? {
         Some(bytes) => {
             let arr: [u8; 4] = bytes
@@ -51,19 +59,19 @@ pub async fn allocate_context_index(ks: &KeyspaceHandle) -> Result<(u32, String)
         }
         None => 0,
     };
-    let base_path = format!("{CONTEXT_KEY_BASE}/{current}'");
+    let base_path = format!("{base_prefix}/{current}'");
     ks.insert_raw(counter_key, (current + 1).to_le_bytes().to_vec())
         .await?;
     Ok((current, base_path))
 }
 
-/// Create a new application context and store it.
+/// Create a new top-level application context and store it.
 pub async fn create_context(
     contexts_ks: &KeyspaceHandle,
     id: &str,
     name: &str,
 ) -> Result<ContextRecord, Box<dyn std::error::Error>> {
-    let (index, base_path) = allocate_context_index(contexts_ks)
+    let (index, base_path) = allocate_context_index(contexts_ks, CONTEXT_KEY_BASE, "ctx_counter")
         .await
         .map_err(|e| format!("{e}"))?;
     let now = Utc::now();
@@ -72,6 +80,7 @@ pub async fn create_context(
         name: name.to_string(),
         did: None,
         description: None,
+        parent: None,
         base_path,
         index,
         created_at: now,

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -585,6 +585,10 @@ enum ContextCommands {
         /// Free-form description.
         #[arg(long)]
         description: Option<String>,
+        /// Parent context path to nest under (e.g. `acme/eng`). Creates a
+        /// sub-context; omit for a top-level context.
+        #[arg(long)]
+        parent: Option<String>,
         /// DID to grant admin access to (must start with `did:`). When
         /// set, atomically creates an ACL entry with role=admin scoped
         /// to this context.
@@ -1524,6 +1528,7 @@ async fn main() {
                     id,
                     name,
                     description,
+                    parent,
                     admin_did,
                     admin_label,
                     admin_expires,
@@ -1533,6 +1538,7 @@ async fn main() {
                         id,
                         name,
                         description,
+                        parent,
                         admin_did,
                         admin_label,
                         admin_expires,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -383,7 +383,9 @@ pub async fn handle_create_context(
     Extension(state): Extension<Arc<VtaState>>,
 ) -> HandlerResult {
     let auth = app_try!(auth_from_message(&message, &state.acl_ks).await);
-    app_try!(auth.require_super_admin());
+    // Admin role required; `create_context` enforces the finer gate (super-admin
+    // for a top-level context, admin-of-parent for a sub-context).
+    app_try!(auth.require_admin());
     let body: vta_sdk::protocols::context_management::create::CreateContextBody =
         serde_json::from_value(message.body).map_err(handler_err)?;
     let result = app_try!(
@@ -393,6 +395,7 @@ pub async fn handle_create_context(
             &body.id,
             body.name,
             body.description,
+            body.parent,
             "didcomm",
         )
         .await

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -490,6 +490,7 @@ mod tests {
                     name: (*id).into(),
                     did: None,
                     description: None,
+                    parent: None,
                     base_path: format!("m/26'/2'/{i}'"),
                     index: i as u32,
                     created_at: now,

--- a/vta-service/src/operations/contexts.rs
+++ b/vta-service/src/operations/contexts.rs
@@ -52,35 +52,85 @@ fn to_result_body(r: &ContextRecord) -> CreateContextResultBody {
         name: r.name.clone(),
         did: r.did.clone(),
         description: r.description.clone(),
+        parent: r.parent.clone(),
         base_path: r.base_path.clone(),
         created_at: r.created_at,
         updated_at: r.updated_at,
     }
 }
 
+/// Create a context — top-level, or a sub-context nested under `parent`.
+///
+/// `id` is the **leaf** segment; when `parent` is set the stored id is the full
+/// path `<parent>/<id>` (`docs/05-design-notes/hierarchical-contexts.md`).
+///
+/// **Authorization:**
+/// - **top-level** (`parent` is `None`) — super-admin only (unchanged).
+/// - **sub-context** (`parent` is `Some`) — the parent must exist and the caller
+///   must be **admin of it** (folder-level authority: `require_context(parent)`
+///   passes for an admin scoped to the parent or any ancestor, and for a
+///   super-admin). The route gates the admin *role*; this gates the *scope*.
+///
+/// The sub-context's BIP-32 base nests under the parent's, and the path depth is
+/// bounded by [`vti_common::context_path::child_path`].
 pub async fn create_context(
     contexts_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     id: &str,
     name: String,
     description: Option<String>,
+    parent: Option<String>,
     channel: &str,
 ) -> Result<CreateContextResultBody, AppError> {
-    auth.require_super_admin()?;
+    // The leaf id is always a single slug segment.
     validate_slug(id)?;
 
-    if get_context(contexts_ks, id).await?.is_some() {
-        return Err(AppError::Conflict(format!("context already exists: {id}")));
+    let (full_id, parent_field, base_prefix, counter_key) = match &parent {
+        None => {
+            // Top-level context creation stays super-admin only.
+            auth.require_super_admin()?;
+            (
+                id.to_string(),
+                None,
+                crate::contexts::CONTEXT_KEY_BASE.to_string(),
+                "ctx_counter".to_string(),
+            )
+        }
+        Some(parent_id) => {
+            // Sub-context: the parent must exist and the caller must be admin of
+            // it. `require_context` is the segment-aware ancestry gate; the route
+            // already required the admin role.
+            let parent_ctx = get_context(contexts_ks, parent_id).await?.ok_or_else(|| {
+                AppError::NotFound(format!("parent context not found: {parent_id}"))
+            })?;
+            auth.require_context(parent_id)?;
+            // Full path = `<parent>/<id>`; validates segment + total depth.
+            let full = vti_common::context_path::child_path(parent_id, id)?;
+            (
+                full,
+                Some(parent_id.clone()),
+                parent_ctx.base_path.clone(),
+                format!("ctx_counter:{parent_id}"),
+            )
+        }
+    };
+
+    if get_context(contexts_ks, &full_id).await?.is_some() {
+        return Err(AppError::Conflict(format!(
+            "context already exists: {full_id}"
+        )));
     }
 
-    let (index, base_path) = allocate_context_index(contexts_ks).await?;
+    let (index, base_path) =
+        allocate_context_index(contexts_ks, &base_prefix, &counter_key).await?;
 
     let now = Utc::now();
     let record = ContextRecord {
-        id: id.to_string(),
+        id: full_id,
         name,
         did: None,
         description,
+        parent: parent_field,
         base_path,
         index,
         created_at: now,
@@ -89,7 +139,7 @@ pub async fn create_context(
 
     store_context(contexts_ks, &record).await?;
 
-    info!(channel, id = %record.id, index, "context created");
+    info!(channel, id = %record.id, parent = ?record.parent, index, "context created");
     Ok(to_result_body(&record))
 }
 
@@ -362,4 +412,136 @@ async fn collect_context_resources(
     preview.did_templates = templates.into_iter().map(|r| r.template.name).collect();
 
     Ok(preview)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::Role;
+    use crate::auth::AuthClaims;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn fresh_contexts() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("contexts").unwrap();
+        (dir, store, ks)
+    }
+
+    fn super_admin() -> AuthClaims {
+        AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: Vec::new(), // empty = super-admin
+            ..Default::default()
+        }
+    }
+
+    fn admin_of(context: &str) -> AuthClaims {
+        AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: vec![context.to_string()],
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn creates_a_top_level_context() {
+        let (_d, _s, ks) = fresh_contexts();
+        let r = create_context(&ks, &super_admin(), "acme", "Acme".into(), None, None, "t")
+            .await
+            .expect("create top-level");
+        assert_eq!(r.id, "acme");
+        assert_eq!(r.parent, None);
+        assert_eq!(r.base_path, "m/26'/2'/0'");
+    }
+
+    #[tokio::test]
+    async fn top_level_creation_requires_super_admin() {
+        let (_d, _s, ks) = fresh_contexts();
+        // A context-admin (non-super) cannot create a top-level context.
+        let err = create_context(&ks, &admin_of("acme"), "ops", "Ops".into(), None, None, "t")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn admin_of_parent_creates_a_nested_context_with_nested_base_path() {
+        let (_d, _s, ks) = fresh_contexts();
+        let parent = create_context(&ks, &super_admin(), "acme", "Acme".into(), None, None, "t")
+            .await
+            .unwrap();
+
+        // An admin scoped to `acme` nests `eng` under it.
+        let child = create_context(
+            &ks,
+            &admin_of("acme"),
+            "eng",
+            "Engineering".into(),
+            None,
+            Some("acme".into()),
+            "t",
+        )
+        .await
+        .expect("nest under acme");
+
+        assert_eq!(child.id, "acme/eng");
+        assert_eq!(child.parent.as_deref(), Some("acme"));
+        // The child's BIP-32 base nests under the parent's.
+        assert_eq!(child.base_path, format!("{}/0'", parent.base_path));
+    }
+
+    #[tokio::test]
+    async fn nesting_requires_admin_of_the_parent() {
+        let (_d, _s, ks) = fresh_contexts();
+        create_context(&ks, &super_admin(), "acme", "Acme".into(), None, None, "t")
+            .await
+            .unwrap();
+        create_context(
+            &ks,
+            &super_admin(),
+            "other",
+            "Other".into(),
+            None,
+            None,
+            "t",
+        )
+        .await
+        .unwrap();
+
+        // An admin of `acme` cannot nest under `other`.
+        let err = create_context(
+            &ks,
+            &admin_of("acme"),
+            "team",
+            "Team".into(),
+            None,
+            Some("other".into()),
+            "t",
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn nesting_under_a_missing_parent_is_not_found() {
+        let (_d, _s, ks) = fresh_contexts();
+        let err = create_context(
+            &ks,
+            &super_admin(),
+            "eng",
+            "Engineering".into(),
+            None,
+            Some("ghost".into()),
+            "t",
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)), "{err:?}");
+    }
 }

--- a/vta-service/src/operations/provision_integration/preconditions.rs
+++ b/vta-service/src/operations/provision_integration/preconditions.rs
@@ -158,6 +158,7 @@ pub async fn ensure_target_context_or_create(
         context,
         context.to_string(),
         None,
+        None, // top-level context (provisioning never nests)
         "provision-integration",
     )
     .await?;

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -19,6 +19,9 @@ pub struct CreateContextRequest {
     pub id: String,
     pub name: String,
     pub description: Option<String>,
+    /// Parent context path to nest under, or absent for a top-level context.
+    #[serde(default)]
+    pub parent: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -43,9 +46,11 @@ pub async fn list_contexts_handler(
     Ok(Json(result))
 }
 
-/// POST /contexts — create a new context. Auth: Super Admin only.
+/// POST /contexts — create a context. Auth: **admin** (the operation enforces
+/// the finer gate — super-admin for a top-level context, admin-of-parent for a
+/// sub-context).
 pub async fn create_context_handler(
-    auth: SuperAdminAuth,
+    auth: AdminAuth,
     State(state): State<AppState>,
     Json(req): Json<CreateContextRequest>,
 ) -> Result<(StatusCode, Json<CreateContextResultBody>), AppError> {
@@ -55,6 +60,7 @@ pub async fn create_context_handler(
         &req.id,
         req.name,
         req.description,
+        req.parent,
         "rest",
     )
     .await?;

--- a/vta-service/src/routes/trust_tasks/contexts.rs
+++ b/vta-service/src/routes/trust_tasks/contexts.rs
@@ -57,7 +57,9 @@ pub(super) async fn handle_create(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> Response {
-    if let Err(e) = auth.require_super_admin() {
+    // Admin role required; `create_context` enforces the finer gate (super-admin
+    // for a top-level context, admin-of-parent for a sub-context).
+    if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
     let req: CreateContextBody = match parse_payload(&doc) {
@@ -70,6 +72,7 @@ pub(super) async fn handle_create(
         &req.id,
         req.name,
         req.description,
+        req.parent,
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -463,6 +463,7 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
                 name: "ctx1".into(),
                 did: None,
                 description: None,
+                parent: None,
                 base_path: "m/26'/2'/0'".into(),
                 index: 0,
                 created_at: now,


### PR DESCRIPTION
## Hierarchical contexts — slice 2: nested creation + BIP-32 nesting + `--parent`

Builds on the path/ancestry foundation (slice 1, #257). You can now create a
**sub-context** under a parent, and the CLI got the `--parent` flag you flagged.

### Server (`vta-service`)
- **`create_context(id, parent, …)`** — top-level stays **super-admin only**; a
  sub-context requires the parent to exist **and the caller to be admin of it**
  (`require_context(parent)`, the segment-aware ancestry gate). The leaf `id` +
  `parent` form the full path `<parent>/<id>` via `context_path::child_path`
  (segment + depth validated).
- **BIP-32 nesting** — a sub-context's base nests under the parent's
  (`{parent.base_path}/<child>'`) with a **per-parent** counter; top-level keeps
  the legacy `ctx_counter` + base, so **existing indices are preserved**.
- **All three create wire paths** (REST, DIDComm, Trust-Task) now require the
  admin **role** and let the operation enforce the finer **scope** gate — so a
  context-admin can create sub-contexts, but only within their own subtree. The
  REST handler moves `SuperAdminAuth` → `AdminAuth` accordingly (the operation
  still enforces super-admin for top-level).

### Wire / SDK (`vta-sdk`)
`ContextRecord` + `CreateContextRequest` / `CreateContextBody` / `…ResultBody`
carry `parent` (serde-default, **back-compatible** — legacy flat records
deserialize as top-level).

### CLI
`--parent` on **`pnm contexts create`**, **`cnm contexts create`**, and the
offline **`vta contexts create`**. The optional admin-ACL grant scopes to the
**full assigned path** (`<parent>/<id>`), not the leaf.

### Verification
5 operation tests: top-level create; super-admin-only for top-level; nested by a
parent-admin (asserts the **nested base_path** + full id + parent); nesting
requires admin-of-parent (else `Forbidden`); missing parent → `NotFound`.
**628 vta-service** lib tests pass; clippy + `cargo deny` clean; full workspace
builds. DCO-signed.

### Next (slice 3 / 4)
3. Subtree ops — delete (cascade vs refuse-non-empty), list-subtree, and the
   parent-admin authority over descendant ACL/keys (the gate already grants it;
   the ops surface it).
4. VTC mirror.
