### PR TITLE
feat(vtc): hierarchical contexts slice 4 — ancestry-aware ACL filter + closeout

### DIFF
--- a/docs/05-design-notes/hierarchical-contexts.md
+++ b/docs/05-design-notes/hierarchical-contexts.md
@@ -76,3 +76,14 @@ derivation (unchanged contract; just deeper).
 3. **Subtree operations** — delete (cascade / refuse-non-empty), list-subtree,
    and admin-of-parent authority over descendant ACL / keys.
 4. **VTC** — mirror the relevant parts to the community/context surface.
+
+   **Finding (on investigation):** the VTC is **not** the key authority — it
+   never creates contexts or derives keys, and has **no `require_context`
+   authorization gate**. It only *references* VTA context ids as ACL metadata
+   (`VtcAclEntry.allowed_contexts`), used in a single place: the
+   `GET /acl?context=…` list filter. So there is no context *model* to make
+   hierarchical. The only consistent change is that list filter, which is now
+   **ancestry-aware** (an entry scoped to an ancestor of the queried context is
+   relevant to it), reusing `vti_common::context_path::is_ancestor_or_self`. The
+   hierarchical-contexts feature is therefore **complete on the VTA**, where the
+   context model, BIP-32 derivation, and authorization gate live.

--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -61,8 +61,15 @@ pub async fn list_acl(
     let entries: Vec<AclEntryResponse> = all_entries
         .into_iter()
         .filter(|e| is_acl_entry_visible(&auth.0, &as_vti_acl_entry(e)))
+        // Hierarchy-aware: an entry scoped to an *ancestor* of `ctx` grants
+        // access to `ctx`, so it's relevant to a query for `ctx`
+        // (`docs/05-design-notes/hierarchical-contexts.md`). For flat ids this
+        // is identical to an exact match.
         .filter(|e| match &query.context {
-            Some(ctx) => e.allowed_contexts.contains(ctx),
+            Some(ctx) => e
+                .allowed_contexts
+                .iter()
+                .any(|allowed| vti_common::context_path::is_ancestor_or_self(allowed, ctx)),
             None => true,
         })
         .map(AclEntryResponse::from)


### PR DESCRIPTION
## Hierarchical contexts — slice 4 (VTC): ancestry-aware ACL filter + closeout

This closes out the hierarchical-contexts feature — and the honest finding is
that **the VTC has almost nothing to mirror.**

### Finding
The VTC is **not** the key authority: it never creates contexts or derives keys,
and has **no `require_context` authorization gate**. It only *references* VTA
context ids as ACL metadata (`VtcAclEntry.allowed_contexts`), and that metadata
is used in exactly one place — the `GET /acl?context=…` list filter. There is no
context *model* to make hierarchical.

### Change
The one consistent improvement: that list filter is now **hierarchy-aware** — an
entry scoped to an **ancestor** of the queried context is relevant to it (it
grants access there), via the shared
`vti_common::context_path::is_ancestor_or_self`. For flat ids this is identical
to the previous exact match, so it's behaviour-preserving today.

### Verification
vtc-service builds; clippy clean; 35 acl tests pass. Design note updated with the
finding. DCO-signed.

### Feature status — complete
- #257 slice 1 — path primitive + ancestry-aware ACL gate (vti-common).
- #258 slice 2 — nested creation + BIP-32 nesting + `--parent` CLI (VTA + CLIs).
- #259 slice 3 — subtree delete + folder-admin authority (VTA).
- this   slice 4 — VTC ancestry-aware ACL filter + closeout.

Hierarchical trust contexts are now fully delivered on the VTA (where the model,
key derivation, and authorization live), with the VTC's one context-aware
surface made consistent.
