### PR TITLE
feat(vta): credential-exchange/query DIDComm handler — present over the wire

### DIFF
--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -35,6 +35,12 @@ pub struct AppConfig {
     pub audit: AuditConfig,
     #[serde(default)]
     pub secrets: SecretsConfig,
+    /// Verifier DIDs the holder **auto-consents** to when answering a
+    /// `credential-exchange/query` (`present_or_defer`'s `ConsentPolicy`). Any
+    /// verifier not listed **defers** to an out-of-band approval. Default empty
+    /// (defer everything) — a safe default; operators trust specific verifiers.
+    #[serde(default)]
+    pub trusted_presentation_verifiers: Vec<String>,
     #[cfg(feature = "tee")]
     #[serde(default)]
     pub tee: TeeConfig,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1871,6 +1871,88 @@ pub async fn handle_credential_issue(
     Ok(None)
 }
 
+/// `credential-exchange/query` over DIDComm (Phase 3) — the holder answers a
+/// verifier's DCQL query with a presentation.
+///
+/// The authcrypt sender is the **verifier**. The VTA presents its **own** held
+/// credentials, so it acts with its own authority (super-admin over its own
+/// contexts) — the **consent policy** (trusted verifiers from config) is the
+/// gate. `present_query` does match → ACL-gated holder-key resolution →
+/// consent-policy → present. A **trusted** verifier gets a `present` reply with
+/// the `vp_token`; any other **defers** (the pending-approval persistence + the
+/// re-present loop is a follow-up).
+pub async fn handle_credential_query(
+    ctx: HandlerContext,
+    message: Message,
+    Extension(app_state): Extension<AppState>,
+) -> HandlerResult {
+    let verifier_did = ctx
+        .sender_did
+        .clone()
+        .ok_or_else(|| handler_err("credential query has no authcrypt sender"))?;
+    let body: credential_exchange::QueryBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+
+    // Trusted-verifier policy + the VTA's own identity, from config.
+    let (policy, vta_did) = {
+        let config = app_state.config.read().await;
+        (
+            operations::credential_exchange::ConsentPolicy::trusting(
+                config.trusted_presentation_verifiers.clone(),
+            ),
+            config.vta_did.clone().unwrap_or_else(|| "vta:self".into()),
+        )
+    };
+    // The VTA presents its own held credentials — its own authority.
+    let auth = crate::auth::AuthClaims {
+        did: vta_did,
+        role: Role::Admin,
+        allowed_contexts: Vec::new(),
+        ..Default::default()
+    };
+
+    let outcome = app_try!(
+        operations::credential_exchange::present_query(
+            &app_state.vault_ks,
+            &app_state.keys_ks,
+            &app_state.seed_store,
+            &auth,
+            &body,
+            &verifier_did,
+            &policy,
+            chrono::Utc::now(),
+        )
+        .await
+    );
+
+    use operations::credential_exchange::PresentOutcome;
+    match outcome {
+        PresentOutcome::Presented(present_body) => {
+            info!(verifier = %verifier_did, "presented a vp_token via DIDComm");
+            response(credential_exchange::PRESENT, &present_body)
+        }
+        PresentOutcome::ConsentRequired {
+            claims, purpose, ..
+        } => {
+            info!(
+                verifier = %verifier_did,
+                ?claims,
+                %purpose,
+                "credential query deferred — holder consent required"
+            );
+            // Deferred-approval store + re-present loop is a follow-up; signal
+            // the verifier that holder consent is required.
+            Ok(Some(DIDCommResponse::problem_report(
+                ProblemReport::bad_request(
+                    "presentation requires holder consent (verifier not trusted); \
+                     an out-of-band approval is needed"
+                        .to_string(),
+                ),
+            )))
+        }
+    }
+}
+
 pub async fn handle_unknown(_ctx: HandlerContext, message: Message) -> HandlerResult {
     let from = message.from.as_deref().unwrap_or("unknown");
     let thid = message.thid.as_deref().unwrap_or("none");

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -346,6 +346,12 @@ pub fn build_handler(
         .route(
             credential_exchange::ISSUE,
             handler_fn(handlers::handle_credential_issue),
+        )?
+        // Credential exchange — holder answers a verifier's DCQL query with a
+        // presentation (spec §6 / task 3.5). Uses `AppState` for vault + keys.
+        .route(
+            credential_exchange::QUERY,
+            handler_fn(handlers::handle_credential_query),
         )?;
 
     // WebVH handlers (feature-gated)

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -618,6 +618,7 @@ pub async fn apply_inputs(inputs: WizardInputs) -> Result<(), Box<dyn std::error
 
     // 13. Save AppConfig.
     let config = AppConfig {
+        trusted_presentation_verifiers: Vec::new(),
         vta_did: vta_did.clone(),
         vta_name: inputs.vta_name.clone(),
         public_url: inputs.public_url.clone(),
@@ -949,6 +950,7 @@ fn scratch_config_for_seed_store(
     config_path: PathBuf,
 ) -> AppConfig {
     AppConfig {
+        trusted_presentation_verifiers: Vec::new(),
         vta_did: None,
         vta_name: None,
         public_url: None,

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -699,6 +699,7 @@ pub async fn run_setup_wizard(
     } else {
         // All other backends: store via the seed store
         let seed_store = create_seed_store(&AppConfig {
+            trusted_presentation_verifiers: Vec::new(),
             vta_did: None,
             vta_name: None,
             public_url: None,
@@ -738,6 +739,7 @@ pub async fn run_setup_wizard(
 
     // Create a temporary AppConfig for the seed store (config hasn't been saved yet)
     let mut wizard_config = AppConfig {
+        trusted_presentation_verifiers: Vec::new(),
         vta_did: None,
         vta_name: None,
         public_url: public_url.clone(),
@@ -820,6 +822,7 @@ pub async fn run_setup_wizard(
 
     // 15. Save config
     let config = AppConfig {
+        trusted_presentation_verifiers: Vec::new(),
         vta_did,
         vta_name,
         public_url: public_url.clone(),

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -109,6 +109,7 @@ pub async fn open_test_store() -> TestStore {
 /// their defaults.
 pub fn test_app_config(data_dir: PathBuf) -> AppConfig {
     AppConfig {
+        trusted_presentation_verifiers: Vec::new(),
         vta_did: None,
         vta_name: None,
         public_url: None,


### PR DESCRIPTION
## `credential-exchange/query` DIDComm handler — present over the wire

The **final connector**: the holder now answers a verifier's DCQL query with a
presentation **over DIDComm**, closing the credential round-trip end-to-end on
the wire — `issue → hold → match → consent → present → verify`.

### What's new
- **`handle_credential_query`** — the authcrypt sender is the **verifier**. The
  VTA presents its **own** held credentials, so it acts with its own authority
  (super-admin over its own contexts) and the **consent policy is the gate**. It
  drives **`present_query`** (#262): `match_vault` → ACL-gated holder-key
  resolution (#261) → `present_or_defer` (#255).
  - **Trusted** verifier → a `credential-exchange/present` reply carrying the `vp_token`.
  - Any other → a problem-report signalling holder consent is required.
- **Route** `credential_exchange::QUERY` registered alongside `ISSUE`.
- **`AppConfig.trusted_presentation_verifiers`** (`Vec<String>`, **default empty
  = defer-all** — a safe default) feeds the `ConsentPolicy`.

### Why this slice is thin (and safe)
The hard, security-critical logic is already built and tested: the holder-key
ACL gate (#261) and the full `present_query` path with its capstone integration
test (#262). This adds only the DIDComm wrapper (parse → build the VTA's auth +
policy → `present_query` → reply), the route, and the config field.

### Verification
**637 vta-service** lib tests pass; `cargo clippy` (`-D warnings`) + `cargo deny`
clean; full workspace builds. DCO-signed.

### Deferred (the deferred-path's other half)
On `ConsentRequired` the handler replies with a problem-report for now; the
**pending-approval store + the approval→re-present loop** (so a deferred
presentation can complete after an out-of-band approval) is a focused follow-up.

### Milestone
With this, the **whole "getting ready for join" credential machinery is real
end-to-end over DIDComm** — a member's VTA can be issued a credential, hold it,
and present it on a verifier's query, all over authcrypt.
