### PR TITLE
feat(cred): complete Phase-3 tail — W3C-DI present, deferred approval, sealed issuance, TT descriptors

### DIFF
--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -225,6 +225,23 @@ pub async fn run_open(
             println!();
             println!("Install via the provision-integration flow on the integration host.");
         }
+        SealedPayloadV1::IssuedCredential(c) => {
+            println!("Payload: IssuedCredential");
+            println!("  Issuer DID: {}", c.issuer_did);
+            if let Some(ref label) = c.label {
+                println!("  Label:      {label}");
+            }
+            let kind = if c.credential.is_string() {
+                "SD-JWT-VC (compact)"
+            } else {
+                "W3C Data-Integrity VC"
+            };
+            println!("  Format:     {kind}");
+            println!();
+            println!(
+                "Receive this credential into the holder vault via the credential-exchange flow."
+            );
+        }
     }
 
     Ok(())
@@ -528,6 +545,7 @@ fn variant_name(p: &SealedPayloadV1) -> &'static str {
         SealedPayloadV1::RawPrivateKey(_) => "RawPrivateKey",
         SealedPayloadV1::TemplateBootstrap(_) => "TemplateBootstrap",
         SealedPayloadV1::AdminRotation(_) => "AdminRotation",
+        SealedPayloadV1::IssuedCredential(_) => "IssuedCredential",
     }
 }
 

--- a/trust-tasks/credential-exchange/index.json
+++ b/trust-tasks/credential-exchange/index.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://trusttasks.org/manifest/v1.json",
+  "version": 1,
+  "org": "spec",
+  "domain": "credential-exchange",
+  "description": "Canonical credential-exchange Trust Task family (spec §6). The Trust Task is the transport / auth / threading / relayer envelope; the body is OID4VCI (issuance) or OID4VP + DCQL (presentation). Format-agnostic: SD-JWT-VC, W3C Data-Integrity, or BBS+. Published under trusttasks.org/spec/ (cross-org canonical), not org-scoped.",
+  "tasks": [
+    {
+      "id": "https://trusttasks.org/spec/credential-exchange/offer/1.0",
+      "status": "Draft",
+      "path": "offer/1.0",
+      "didcomm": "https://trusttasks.org/spec/credential-exchange/offer/1.0"
+    },
+    {
+      "id": "https://trusttasks.org/spec/credential-exchange/request/1.0",
+      "status": "Draft",
+      "path": "request/1.0",
+      "didcomm": "https://trusttasks.org/spec/credential-exchange/request/1.0"
+    },
+    {
+      "id": "https://trusttasks.org/spec/credential-exchange/issue/1.0",
+      "status": "Draft",
+      "path": "issue/1.0",
+      "didcomm": "https://trusttasks.org/spec/credential-exchange/issue/1.0"
+    },
+    {
+      "id": "https://trusttasks.org/spec/credential-exchange/query/1.0",
+      "status": "Draft",
+      "path": "query/1.0",
+      "didcomm": "https://trusttasks.org/spec/credential-exchange/query/1.0"
+    },
+    {
+      "id": "https://trusttasks.org/spec/credential-exchange/present/1.0",
+      "status": "Draft",
+      "path": "present/1.0",
+      "didcomm": "https://trusttasks.org/spec/credential-exchange/present/1.0"
+    }
+  ]
+}

--- a/trust-tasks/credential-exchange/issue/1.0/schema.json
+++ b/trust-tasks/credential-exchange/issue/1.0/schema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://trusttasks.org/spec/credential-exchange/issue/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Credential Exchange — Issue",
+  "description": "issuer → holder. The issued credential — cleartext for a known holder, or a sealed bundle for an unknown / invite holder. Exactly one of credential_response or sealed.",
+  "type": "object",
+  "properties": {
+    "didcommBody": {
+      "type": "object",
+      "oneOf": [
+        { "required": ["credential_response"] },
+        { "required": ["sealed"] }
+      ],
+      "properties": {
+        "credential_response": {
+          "description": "Cleartext OID4VCI Credential Response. The `credential` is a JSON string (SD-JWT-VC compact) or a JSON object (W3C Data-Integrity VC with its proof). The holder infers the format from the value shape."
+        },
+        "sealed": {
+          "type": "string",
+          "description": "An armored vta-sdk sealed-transfer bundle (SealedPayloadV1::IssuedCredential). Used when the credential is secret-bearing or issued to an unknown holder (invite / air-gap). Only the holder can open it; an out-of-band SHA-256 digest pins integrity."
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/credential-exchange/issue/1.0/spec.md
+++ b/trust-tasks/credential-exchange/issue/1.0/spec.md
@@ -1,0 +1,55 @@
+---
+id: https://trusttasks.org/spec/credential-exchange/issue/1.0
+title: Credential Exchange — Issue
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - didcomm: https://trusttasks.org/spec/credential-exchange/issue/1.0
+---
+
+# Credential Exchange — Issue
+
+`issuer → holder`. The issuer delivers the credential. The body
+carries **exactly one** of two shapes:
+
+- `credential_response` — the cleartext OID4VCI Credential Response,
+  for a **known** holder over an authenticated channel.
+- `sealed` — an armored [sealed-transfer](../../../../docs/02-vta/provision-integration.md)
+  bundle, for a **secret-bearing** credential or an **unknown holder**
+  (the invite / air-gap case). Only the holder can open it.
+
+## Cleartext path
+
+The `credential` inside `credential_response` is **format-agnostic**:
+
+- a JSON **string** → SD-JWT-VC compact serialization;
+- a JSON **object** with a `proof` → a W3C Data-Integrity VC.
+
+The holder infers the format from the value shape and receives it
+into its vault (`receive_issued_credential`). The issuer `did:key` is
+resolved locally for the Data-Integrity path; a `did:webvh` / `did:web`
+issuer needs resolver-based key resolution (a follow-up slice).
+
+## Sealed path (invite / unknown holder)
+
+`sealed` is an armored `SealedPayloadV1::IssuedCredential` bundle
+(HPKE X25519-HKDF-SHA256 + ChaCha20-Poly1305) sealed to the holder's
+X25519 derivation — derived from the `did:key` the invite pinned. The
+holder opens it with `receive_sealed_issued_credential`, supplying the
+matching X25519 secret and the **out-of-band SHA-256 digest** (digest
+pinning is mandatory — there is no TOFU). The bundle's producer
+assertion (`DidSigned` / `Attested` / `PinnedOnly`) is verified per
+the sealed-transfer contract.
+
+## Authentication
+
+DIDComm authcrypt authenticates the **issuer**. For the sealed path,
+the bundle additionally binds to the holder's key: a relayer that
+forwards the bundle cannot open it.
+
+## Threading
+
+Replies on the [`request/1.0`](../../request/1.0) /
+[`offer/1.0`](../../offer/1.0) thread (`thid`).

--- a/trust-tasks/credential-exchange/offer/1.0/schema.json
+++ b/trust-tasks/credential-exchange/offer/1.0/schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://trusttasks.org/spec/credential-exchange/offer/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Credential Exchange — Offer",
+  "description": "issuer → holder. An OID4VCI credential offer carried as the Trust Task body.",
+  "type": "object",
+  "properties": {
+    "didcommBody": {
+      "type": "object",
+      "required": ["credential_offer"],
+      "properties": {
+        "credential_offer": {
+          "description": "An OID4VCI Credential Offer object (RFC-shaped by affinidi-openid4vci)."
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/credential-exchange/offer/1.0/spec.md
+++ b/trust-tasks/credential-exchange/offer/1.0/spec.md
@@ -1,0 +1,41 @@
+---
+id: https://trusttasks.org/spec/credential-exchange/offer/1.0
+title: Credential Exchange — Offer
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - didcomm: https://trusttasks.org/spec/credential-exchange/offer/1.0
+---
+
+# Credential Exchange — Offer
+
+`issuer → holder`. The first step of the issuance leg: the issuer
+offers a credential. The Trust Task is the transport / auth /
+threading envelope; the body is an **OID4VCI Credential Offer**.
+
+## Body
+
+`{ credential_offer }` — an OID4VCI Credential Offer object. The
+holder reads the offer to learn which credential(s) are on offer and
+which grant / authorization flow to use, then replies with
+[`request/1.0`](../../request/1.0).
+
+## Authentication
+
+The DIDComm authcrypt envelope authenticates the **issuer** (the
+`from` DID is the proven sender). No in-body signature.
+
+## Format-agnostic
+
+Nothing here is format-specific. The credential format (SD-JWT-VC,
+W3C Data-Integrity, BBS+) is negotiated by the credential
+configuration referenced in the offer and finalised by the DCQL
+`format` selector at presentation time.
+
+## Threading
+
+The offer opens a thread; `request/1.0` and `issue/1.0` reply on it
+(`thid`). Relayer ≠ holder is permitted (the air-gap onboarding
+pattern): the envelope sender may relay on the holder's behalf.

--- a/trust-tasks/credential-exchange/present/1.0/schema.json
+++ b/trust-tasks/credential-exchange/present/1.0/schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://trusttasks.org/spec/credential-exchange/present/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Credential Exchange — Present",
+  "description": "holder → verifier. The OID4VP vp_token carrying the selectively-disclosed, holder-bound presentation.",
+  "type": "object",
+  "properties": {
+    "didcommBody": {
+      "type": "object",
+      "required": ["vp_token"],
+      "properties": {
+        "vp_token": {
+          "description": "The OID4VP vp_token. Format-agnostic: a JSON string (SD-JWT-VC + kb-jwt holder binding) or a JSON object (W3C Data-Integrity VP with the holder's eddsa-jcs-2022 proof). Carries exactly the consented claims; the nonce + verifier audience are bound by the holder proof."
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/credential-exchange/present/1.0/spec.md
+++ b/trust-tasks/credential-exchange/present/1.0/spec.md
@@ -1,0 +1,52 @@
+---
+id: https://trusttasks.org/spec/credential-exchange/present/1.0
+title: Credential Exchange — Present
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - didcomm: https://trusttasks.org/spec/credential-exchange/present/1.0
+---
+
+# Credential Exchange — Present
+
+`holder → verifier`. The holder answers a [`query/1.0`](../../query/1.0)
+with a presentation. The body is an **OID4VP `vp_token`** — a
+selectively-disclosed, holder-bound presentation of the matched
+credential.
+
+## Body
+
+`{ vp_token }` — **format-agnostic**:
+
+- a JSON **string** → an SD-JWT-VC presentation: exactly the consented
+  disclosures + a mandatory **kb-jwt** holder binding over the
+  verifier `nonce` + `aud`.
+- a JSON **object** → a W3C Data-Integrity VP. Plain `eddsa-jcs-2022`
+  has no claim-level selective disclosure, so the whole credential is
+  disclosed — and the present gate refuses unless the credential's
+  claims are a **subset of the consented reveal set** (never
+  over-discloses). The holder signs the VP (carrying `nonce` +
+  `domain`) with its `eddsa-jcs-2022` key.
+
+## Consent gate
+
+Every disclosure is gated by a persisted, signed
+[consent record](../../../../docs/05-design-notes/vti-credential-architecture.md)
+(ISO/IEC 27560 + W3C DPV). The gate discloses exactly the consented
+claims and refuses a revoked / expired credential or an over-broad
+request.
+
+## Holder binding & freshness
+
+Holder binding is mandatory. The verifier `nonce` (freshness) and
+audience are bound by the holder proof (the kb-jwt for SD-JWT-VC, the
+DI proof's `nonce` + `domain` for W3C), so replay and audience
+substitution are cryptographically prevented.
+
+## Threading
+
+Replies on the [`query/1.0`](../../query/1.0) thread (`thid`). For a
+deferred query, the holder re-presents on the same thread once the
+out-of-band approval lands.

--- a/trust-tasks/credential-exchange/query/1.0/schema.json
+++ b/trust-tasks/credential-exchange/query/1.0/schema.json
@@ -1,0 +1,26 @@
+{
+  "$id": "https://trusttasks.org/spec/credential-exchange/query/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Credential Exchange — Query",
+  "description": "verifier → holder. An OID4VP DCQL query with a freshness nonce and a mandatory, holder-shown purpose.",
+  "type": "object",
+  "properties": {
+    "didcommBody": {
+      "type": "object",
+      "required": ["dcql_query", "nonce", "purpose"],
+      "properties": {
+        "dcql_query": {
+          "description": "An OID4VP DCQL query (affinidi-openid4vp). Per-credential format + meta (vct_values / type_values) + claims constraints."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Verifier freshness nonce — bound into the holder presentation."
+        },
+        "purpose": {
+          "type": "string",
+          "description": "The verifier's stated reason, MANDATORY and shown to the holder (purpose binding). A verifier cannot ask without stating why."
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/credential-exchange/query/1.0/spec.md
+++ b/trust-tasks/credential-exchange/query/1.0/spec.md
@@ -1,0 +1,52 @@
+---
+id: https://trusttasks.org/spec/credential-exchange/query/1.0
+title: Credential Exchange — Query
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - didcomm: https://trusttasks.org/spec/credential-exchange/query/1.0
+---
+
+# Credential Exchange — Query
+
+`verifier → holder`. The verifier asks the holder to present a
+credential. The body is an **OID4VP DCQL query** + a freshness
+`nonce` + a **mandatory `purpose`** shown to the holder.
+
+## Body
+
+`{ dcql_query, nonce, purpose }`:
+
+- `dcql_query` — the DCQL query. Per-credential `format` selector
+  (`dc+sd-jwt`, `ldp_vc`, …), `meta` type discriminator
+  (`vct_values` for SD-JWT-VC, `type_values` for W3C), and `claims`
+  paths.
+- `nonce` — verifier freshness, bound into the presentation.
+- `purpose` — **mandatory, never optional**, and shown to the holder.
+  Purpose binding: a verifier cannot ask for a credential without
+  stating why.
+
+## Privacy — no wallet enumeration
+
+The holder gathers candidates **only** via the type index named by
+the query's `meta` discriminator — there is no enumeration primitive.
+A query carrying no `vct_values` / `type_values` contributes no
+candidates, so the holder never blind-scans its whole wallet to
+answer a query.
+
+## Consent
+
+A matched query is gated by the holder's consent policy. A **trusted**
+verifier is auto-consented and the holder replies immediately with
+[`present/1.0`](../../present/1.0); any other verifier **defers** —
+the query is persisted for an out-of-band approval, and the verifier
+is told consent is required. Approval mints a query-scoped consent
+record and re-presents on-thread.
+
+## Authentication
+
+DIDComm authcrypt authenticates the **verifier** (the `from` DID).
+The holder presents its **own** held credentials with its own
+authority; the consent policy is the gate.

--- a/trust-tasks/credential-exchange/request/1.0/schema.json
+++ b/trust-tasks/credential-exchange/request/1.0/schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://trusttasks.org/spec/credential-exchange/request/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Credential Exchange — Request",
+  "description": "holder → issuer. An OID4VCI credential request carrying the holder's key-binding proof.",
+  "type": "object",
+  "properties": {
+    "didcommBody": {
+      "type": "object",
+      "required": ["credential_request"],
+      "properties": {
+        "credential_request": {
+          "description": "An OID4VCI Credential Request object. Carries the holder key-binding proof (openid4vci-proof+jwt) binding the issued credential to the holder's key."
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/credential-exchange/request/1.0/spec.md
+++ b/trust-tasks/credential-exchange/request/1.0/spec.md
@@ -1,0 +1,34 @@
+---
+id: https://trusttasks.org/spec/credential-exchange/request/1.0
+title: Credential Exchange — Request
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - didcomm: https://trusttasks.org/spec/credential-exchange/request/1.0
+---
+
+# Credential Exchange — Request
+
+`holder → issuer`. The holder asks for the offered credential. The
+body is an **OID4VCI Credential Request** carrying the holder's
+**key-binding proof**.
+
+## Body
+
+`{ credential_request }` — an OID4VCI Credential Request. The
+embedded proof (`openid4vci-proof+jwt`) binds the credential to a key
+the holder controls; the issuer mints the credential against that
+key (the `cnf` for SD-JWT-VC, the `credentialSubject.id` for W3C DI).
+
+## Authentication
+
+DIDComm authcrypt authenticates the **holder** (the `from` DID is the
+proven sender). The key-binding proof is an additional, credential-
+level binding — distinct from the envelope sender authentication.
+
+## Threading
+
+Replies on the [`offer/1.0`](../../offer/1.0) thread (`thid`). The
+issuer answers with [`issue/1.0`](../../issue/1.0).

--- a/vta-cli-common/src/sealed_consumer.rs
+++ b/vta-cli-common/src/sealed_consumer.rs
@@ -336,6 +336,11 @@ pub fn extract_admin_credential(
              flow to install"
                 .into(),
         ),
+        SealedPayloadV1::IssuedCredential(_) => Err(
+            "IssuedCredential payloads carry a holder credential, not an admin CredentialBundle \
+             — receive it into the holder vault via the credential-exchange flow"
+                .into(),
+        ),
     }
 }
 

--- a/vta-sdk/src/sealed_transfer/bundle.rs
+++ b/vta-sdk/src/sealed_transfer/bundle.rs
@@ -55,6 +55,35 @@ pub enum SealedPayloadV1 {
     /// only needs to roll the ephemeral setup `did:key` over to a
     /// long-term admin identity at the VTA.
     AdminRotation(Box<super::template_bootstrap::AdminRotationPayload>),
+    /// An issued credential sealed for an invite / unknown-holder (spec §6,
+    /// task 3.6). The issuer seals a freshly-minted credential to the holder's
+    /// known `did:key`; the holder opens it and receives it into its vault. See
+    /// [`IssuedCredentialBundle`].
+    IssuedCredential(Box<IssuedCredentialBundle>),
+}
+
+/// An issued credential sealed for delivery to a holder the issuer cannot yet
+/// reach over DIDComm — the **invite / unknown-holder** issuance case (spec
+/// §6, task 3.6). The issuer mints the credential bound to the holder's known
+/// `did:key` (from the invite), seals it to that holder's X25519 derivation,
+/// and frames it in armor. The holder opens it with the same derived key and
+/// receives it into its vault via the format-agnostic receive path.
+///
+/// The `credential` carries the issued credential exactly as an OID4VCI
+/// credential response does — a JSON **string** for an SD-JWT-VC compact
+/// serialization, or a JSON **object** for a W3C Data-Integrity VC (with its
+/// `proof`). The holder infers the format from the value shape, identically to
+/// the over-DIDComm `credential-exchange/issue` path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IssuedCredentialBundle {
+    /// The issued credential — an SD-JWT-VC compact string or a W3C DI VC object.
+    pub credential: serde_json::Value,
+    /// The issuer DID, recorded as provenance on the stored credential.
+    pub issuer_did: String,
+    /// Optional human label / context hint shown to the holder at open time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 /// A single raw private key transferred inside a sealed bundle. The

--- a/vta-sdk/src/sealed_transfer/mod.rs
+++ b/vta-sdk/src/sealed_transfer/mod.rs
@@ -21,8 +21,9 @@ pub mod template_bootstrap;
 pub mod verify;
 
 pub use bundle::{
-    ArmoredChunk, AssertionProof, AttestationQuoteAssertion, DidSignedAssertion, LabeledKey,
-    ProducerAssertion, RawPrivateKey, SealedBundle, SealedPayloadV1,
+    ArmoredChunk, AssertionProof, AttestationQuoteAssertion, DidSignedAssertion,
+    IssuedCredentialBundle, LabeledKey, ProducerAssertion, RawPrivateKey, SealedBundle,
+    SealedPayloadV1,
 };
 pub use chunk::{ChunkPlaintext, MAX_PAYLOAD_FRAGMENT, VERSION};
 pub use error::SealedTransferError;

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -340,6 +340,19 @@ fn print_opened(
                 "  \x1b[1;33m⚠ VC verification not yet wired for AdminRotation — relying on digest pinning.\x1b[0m"
             );
         }
+        SealedPayloadV1::IssuedCredential(c) => {
+            println!("Payload: IssuedCredential");
+            println!("  Issuer DID: {}", c.issuer_did);
+            if let Some(ref label) = c.label {
+                println!("  Label:      {label}");
+            }
+            let kind = if c.credential.is_string() {
+                "SD-JWT-VC (compact)"
+            } else {
+                "W3C Data-Integrity VC"
+            };
+            println!("  Format:     {kind}");
+        }
     }
     Ok(())
 }
@@ -762,7 +775,6 @@ fn to_context_response(
 /// record directly to the local keystore. When `--admin-did` is set,
 /// also writes an admin ACL entry scoped to the new context, mirroring
 /// the online `pnm contexts create --admin-did` shorthand.
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_arguments)]
 pub async fn run_context_create(
     config_path: Option<PathBuf>,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1932,22 +1932,41 @@ pub async fn handle_credential_query(
             response(credential_exchange::PRESENT, &present_body)
         }
         PresentOutcome::ConsentRequired {
-            claims, purpose, ..
+            credential_id,
+            claims,
+            purpose,
+            ..
         } => {
+            // Persist the deferral so an out-of-band approval can re-present. The
+            // thread id is the approval handle the verifier (and the holder's
+            // approval UI) refer to.
+            let approval_id = message.thid.clone().unwrap_or_else(|| message.id.clone());
+            app_try!(
+                operations::credential_exchange::defer_presentation(
+                    &app_state.vault_ks,
+                    &approval_id,
+                    &verifier_did,
+                    &credential_id,
+                    claims.clone(),
+                    &body,
+                    chrono::Utc::now(),
+                )
+                .await
+            );
             info!(
                 verifier = %verifier_did,
+                approval_id = %approval_id,
                 ?claims,
                 %purpose,
-                "credential query deferred — holder consent required"
+                "credential query deferred — holder consent required (pending approval persisted)"
             );
-            // Deferred-approval store + re-present loop is a follow-up; signal
-            // the verifier that holder consent is required.
+            // Signal the verifier that holder consent is required; once approved
+            // out-of-band, the holder re-presents on this thread.
             Ok(Some(DIDCommResponse::problem_report(
-                ProblemReport::bad_request(
+                ProblemReport::bad_request(format!(
                     "presentation requires holder consent (verifier not trusted); \
-                     an out-of-band approval is needed"
-                        .to_string(),
-                ),
+                     an out-of-band approval is needed (pending `{approval_id}`)"
+                )),
             )))
         }
     }

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -67,8 +67,8 @@ pub async fn receive_issued_credential(
 ) -> Result<StoredCredential, AppError> {
     if issue.sealed.is_some() {
         return Err(AppError::Validation(
-            "sealed credential issuance (unknown-holder / invite) is not yet wired \
-             (sealed-issuance slice 3.6)"
+            "this issue message carries a `sealed` bundle — open it with \
+             `receive_sealed_issued_credential` (the holder's X25519 key is required)"
                 .into(),
         ));
     }
@@ -79,6 +79,21 @@ pub async fn receive_issued_credential(
         .and_then(|r| r.credential.as_ref())
         .ok_or_else(|| AppError::Validation("issue message carries no credential".to_string()))?;
 
+    store_issued_credential(vault_ks, credential, source, now).await
+}
+
+/// Store an issued credential value (the OID4VCI `credential` field shape) into
+/// the holder's vault, inferring the format from the value: a JSON **string** is
+/// an SD-JWT-VC compact serialization; a JSON **object** with a `proof` is a W3C
+/// Data-Integrity VC. Shared by the plaintext over-DIDComm path
+/// ([`receive_issued_credential`]) and the sealed invite path
+/// ([`receive_sealed_issued_credential`]).
+async fn store_issued_credential(
+    vault_ks: &KeyspaceHandle,
+    credential: &Value,
+    source: Option<String>,
+    now: DateTime<Utc>,
+) -> Result<StoredCredential, AppError> {
     let id = format!("urn:uuid:{}", Uuid::new_v4());
 
     match credential {
@@ -125,6 +140,91 @@ pub async fn receive_issued_credential(
                 .to_string(),
         )),
     }
+}
+
+/// Open a **sealed** issued credential (the invite / unknown-holder case, spec
+/// §6 task 3.6) and receive it into the holder's vault.
+///
+/// The issuer minted the credential bound to this holder's `did:key` and sealed
+/// it to the holder's X25519 derivation via [`vta_sdk::sealed_transfer`]. The
+/// holder opens it with `holder_x25519_secret` (derived from the same key the
+/// invite pinned) and stores the credential through the format-agnostic path.
+///
+/// `expect_digest` is the out-of-band SHA-256 digest pinning (mandatory in
+/// practice — see the sealed-transfer invariants): we require a pinned digest so
+/// a party that merely knows the holder pubkey cannot inject a bundle.
+pub async fn receive_sealed_issued_credential(
+    vault_ks: &KeyspaceHandle,
+    armored: &str,
+    holder_x25519_secret: &[u8; 32],
+    expect_digest: Option<&str>,
+    source: Option<String>,
+    now: DateTime<Utc>,
+) -> Result<StoredCredential, AppError> {
+    use vta_sdk::sealed_transfer::{SealedPayloadV1, armor, open_bundle};
+
+    let bundles = armor::decode(armored)
+        .map_err(|e| AppError::Validation(format!("sealed issuance armor decode failed: {e}")))?;
+    let bundle = bundles.into_iter().next().ok_or_else(|| {
+        AppError::Validation("sealed issuance carried no armored bundle".to_string())
+    })?;
+
+    let opened = open_bundle(holder_x25519_secret, &bundle, expect_digest)
+        .map_err(|e| AppError::Validation(format!("sealed issuance open failed: {e}")))?;
+
+    let credential_bundle = match opened.payload {
+        SealedPayloadV1::IssuedCredential(boxed) => *boxed,
+        other => {
+            return Err(AppError::Validation(format!(
+                "sealed bundle is not an issued credential (got {other:?})"
+            )));
+        }
+    };
+
+    // Provenance: the sealed issuer DID, unless the caller supplied one.
+    let source = source.or(Some(credential_bundle.issuer_did.clone()));
+    store_issued_credential(vault_ks, &credential_bundle.credential, source, now).await
+}
+
+/// Seal a freshly-issued credential for an invite / unknown holder (spec §6 task
+/// 3.6, the **issuer** half). Mints an HPKE-sealed, armored bundle the holder
+/// opens with [`receive_sealed_issued_credential`].
+///
+/// `holder_did` is the holder's `did:key` from the invite — the credential was
+/// minted bound to it, and the bundle is sealed to its X25519 derivation.
+/// `bundle_id` is the single-use nonce; `producer` asserts who issued (typically
+/// `DidSigned` by the issuer). Returns `(armored_text, sha256_digest)` — the
+/// digest is communicated out-of-band for the holder's `expect_digest` pin.
+pub async fn seal_issued_credential(
+    holder_did: &str,
+    credential: Value,
+    issuer_did: &str,
+    label: Option<String>,
+    bundle_id: [u8; 16],
+    producer: vta_sdk::sealed_transfer::ProducerAssertion,
+    nonce_store: &dyn vta_sdk::sealed_transfer::NonceStore,
+) -> Result<(String, String), AppError> {
+    use vta_sdk::sealed_transfer::{
+        IssuedCredentialBundle, SealedPayloadV1, armor, bundle_digest, seal_payload,
+    };
+
+    // The holder's X25519 sealing target, derived from its Ed25519 `did:key`.
+    let holder_ed = affinidi_crypto::did_key::did_key_to_ed25519_pub(holder_did)
+        .map_err(|e| AppError::Validation(format!("holder DID is not an Ed25519 did:key: {e}")))?;
+    let holder_x = affinidi_crypto::did_key::ed25519_pub_to_x25519_bytes(&holder_ed)
+        .map_err(|e| AppError::Internal(format!("holder X25519 derivation failed: {e}")))?;
+
+    let payload = SealedPayloadV1::IssuedCredential(Box::new(IssuedCredentialBundle {
+        credential,
+        issuer_did: issuer_did.to_string(),
+        label,
+    }));
+
+    let bundle = seal_payload(&holder_x, bundle_id, producer, &payload, nonce_store)
+        .await
+        .map_err(|e| AppError::Internal(format!("sealing issued credential failed: {e}")))?;
+    let digest = bundle_digest(&bundle);
+    Ok((armor::encode(&bundle), digest))
 }
 
 /// The issuer DID from a VC `issuer` field — a string, or an object with `id`.
@@ -352,13 +452,16 @@ fn meta_type_values(meta: Option<&serde_json::Map<String, Value>>) -> Vec<String
 /// - `verifier_aud` is the verifier identity the holder `kb-jwt` binds to (the
 ///   DIDComm sender); `iat_unix` stamps the kb-jwt.
 ///
-/// `NotFound` when nothing the holder holds satisfies the query. This slice
-/// presents **SD-JWT-VC** matches; a W3C Data-Integrity present path (a
-/// different holder-key abstraction) is a follow-up.
+/// `NotFound` when nothing the holder holds satisfies the query. Presents both
+/// **SD-JWT-VC** (via `holder_signer`, the kb-jwt) and **W3C Data-Integrity**
+/// (via `holder_secret`, the holder DI key) matches — the two abstractions of
+/// the same derived holder key.
+#[allow(clippy::too_many_arguments)]
 pub async fn present_for_query(
     vault: &KeyspaceHandle,
     query: &QueryBody,
     holder_signer: &dyn affinidi_sd_jwt::signer::JwtSigner,
+    holder_secret: &Secret,
     consent_record_id: &str,
     verifier_aud: &str,
     iat_unix: u64,
@@ -395,10 +498,27 @@ pub async fn present_for_query(
             .await?;
             Value::String(compact)
         }
+        CredentialFormat::EddsaJcs2022 => {
+            // W3C Data-Integrity VP: the holder signs an `eddsa-jcs-2022` proof
+            // over the matched VC with the same derived holder key (here as a
+            // raw `Secret`, not the kb-jwt abstraction). The VP is a JSON object,
+            // not a compact string — carry it through as structured JSON.
+            let vp = vault::present_di_vc(
+                vault,
+                &first.credential_id,
+                consent_record_id,
+                holder_secret,
+                &query.nonce,
+                verifier_aud,
+                now,
+            )
+            .await?;
+            serde_json::from_str(&vp).unwrap_or(Value::String(vp))
+        }
         other => {
             return Err(AppError::Validation(format!(
-                "present_for_query currently presents SD-JWT-VC; presenting {other:?} via DCQL \
-                 is a follow-up slice"
+                "present_for_query presents SD-JWT-VC and W3C Data-Integrity; presenting \
+                 {other:?} via DCQL is a follow-up slice"
             )));
         }
     };
@@ -523,6 +643,7 @@ pub async fn present_or_defer(
         vault,
         query,
         holder_signer,
+        holder_consent_key,
         &record.identifier,
         verifier_did,
         now.timestamp() as u64,
@@ -583,6 +704,236 @@ pub async fn present_query(
         now,
     )
     .await
+}
+
+/// Deferred-approval store (task 3.5d, the defer half) — when
+/// [`present_or_defer`] returns [`PresentOutcome::ConsentRequired`] for an
+/// untrusted verifier, the wire layer persists a [`PendingPresentation`] here.
+/// An out-of-band approval ([`approve_pending_presentation`]) mints the
+/// query-scoped consent and re-presents; a denial ([`deny_pending_presentation`])
+/// records the refusal. The holder's own [`pending::list`] is the approval
+/// surface a UI drives.
+///
+/// Records live in the `vault` keyspace under the disjoint `pending-present:`
+/// namespace (alongside `cred:` / `consent:` / `vault:`), encrypted at rest by
+/// the keyspace wrapper.
+pub mod pending {
+    use super::*;
+
+    /// Primary-key prefix. Disjoint from `cred:` / `idx:` / `consent:` / `vault:`.
+    const PREFIX: &str = "pending-present:";
+
+    fn key(id: &str) -> Vec<u8> {
+        format!("{PREFIX}{id}").into_bytes()
+    }
+
+    /// Where a deferred presentation stands.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum PendingStatus {
+        /// Awaiting the holder's out-of-band approval.
+        Pending,
+        /// Approved — the `vp_token` was produced and sent.
+        Approved,
+        /// Denied by the holder; no presentation was made.
+        Denied,
+    }
+
+    /// A verifier's query the holder deferred, persisted until an out-of-band
+    /// approval mints consent and re-presents. Carries the **whole query** so the
+    /// re-present is byte-faithful (same nonce, same claims).
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    pub struct PendingPresentation {
+        /// The approval id — the DIDComm thread id, so the verifier can be told
+        /// "your request `<id>` is pending" and a later present replies on-thread.
+        pub id: String,
+        /// The verifier that asked (the authcrypt sender). The presentation, once
+        /// approved, binds to this audience.
+        pub verifier_did: String,
+        /// The held credential that would satisfy the query (informational — the
+        /// approve path re-matches to be robust to vault changes).
+        pub credential_id: String,
+        /// The claims the query asks to disclose — what the approver authorizes.
+        pub claims: Vec<String>,
+        /// The verifier's stated purpose, shown to the approver.
+        pub purpose: String,
+        /// The full query, stored so [`approve_pending_presentation`] re-presents
+        /// faithfully (same nonce + claim set).
+        pub query: QueryBody,
+        /// Lifecycle state.
+        pub status: PendingStatus,
+        /// When the deferral was recorded.
+        pub created_at: DateTime<Utc>,
+        /// After this the deferral is stale — approval refuses (the verifier's
+        /// nonce is no longer fresh).
+        pub expires_at: DateTime<Utc>,
+    }
+
+    /// Persist (or overwrite) a pending-presentation record.
+    pub async fn put(vault: &KeyspaceHandle, record: &PendingPresentation) -> Result<(), AppError> {
+        vault.insert(key(&record.id), record).await
+    }
+
+    /// Load one pending-presentation record.
+    pub async fn get(
+        vault: &KeyspaceHandle,
+        id: &str,
+    ) -> Result<Option<PendingPresentation>, AppError> {
+        vault.get(key(id)).await
+    }
+
+    /// The holder's own local approval surface — every pending-presentation
+    /// record. Scans only this VTA's `pending-present:` namespace; never a
+    /// cross-trust-boundary enumeration.
+    pub async fn list(vault: &KeyspaceHandle) -> Result<Vec<PendingPresentation>, AppError> {
+        let raw = vault.prefix_iter_raw(PREFIX.as_bytes().to_vec()).await?;
+        let mut out = Vec::with_capacity(raw.len());
+        for (_k, v) in raw {
+            out.push(
+                serde_json::from_slice(&v)
+                    .map_err(|e| AppError::Internal(format!("pending record decode: {e}")))?,
+            );
+        }
+        Ok(out)
+    }
+}
+
+/// Record a deferred presentation for later out-of-band approval. Called by the
+/// wire layer when [`present_query`] returns [`PresentOutcome::ConsentRequired`].
+/// `id` is the request/thread id the verifier can poll on.
+pub async fn defer_presentation(
+    vault: &KeyspaceHandle,
+    id: &str,
+    verifier_did: &str,
+    credential_id: &str,
+    claims: Vec<String>,
+    query: &QueryBody,
+    now: DateTime<Utc>,
+) -> Result<pending::PendingPresentation, AppError> {
+    let record = pending::PendingPresentation {
+        id: id.to_string(),
+        verifier_did: verifier_did.to_string(),
+        credential_id: credential_id.to_string(),
+        claims,
+        purpose: query.purpose.clone(),
+        query: query.clone(),
+        status: pending::PendingStatus::Pending,
+        created_at: now,
+        // The verifier's nonce ages out; keep the approval window bounded.
+        expires_at: now + chrono::Duration::hours(24),
+    };
+    pending::put(vault, &record).await?;
+    Ok(record)
+}
+
+/// Approve a deferred presentation: mint the query-scoped consent the holder is
+/// authorizing and **re-present**. ACL-gated via `auth` (the same holder-key
+/// gate as [`present_query`]). Marks the record `Approved` and returns the
+/// `vp_token`.
+///
+/// Refuses a record that isn't `Pending` (already approved / denied) or whose
+/// deferral window has lapsed (`expires_at` past — the verifier's nonce is stale).
+pub async fn approve_pending_presentation(
+    vault: &KeyspaceHandle,
+    keys_ks: &KeyspaceHandle,
+    seed_store: &Arc<dyn SeedStore>,
+    auth: &AuthClaims,
+    id: &str,
+    now: DateTime<Utc>,
+) -> Result<PresentBody, AppError> {
+    let mut record = pending::get(vault, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("no pending presentation `{id}`")))?;
+
+    if record.status != pending::PendingStatus::Pending {
+        return Err(AppError::Validation(format!(
+            "pending presentation `{id}` is {:?}, not awaiting approval",
+            record.status
+        )));
+    }
+    if now >= record.expires_at {
+        return Err(AppError::Validation(format!(
+            "pending presentation `{id}` expired at {} — the verifier must re-ask",
+            record.expires_at
+        )));
+    }
+
+    // Re-match the stored query to find the credential + subject (robust to vault
+    // changes since the deferral — mirrors `present_query`).
+    let matched = match_vault(vault, &record.query.dcql_query).await?;
+    let first = matched.into_iter().next().ok_or_else(|| {
+        AppError::NotFound("no held credential satisfies the deferred query".to_string())
+    })?;
+    let stored = vault::storage::get(vault, &first.credential_id)
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal(format!(
+                "matched credential `{}` is gone",
+                first.credential_id
+            ))
+        })?;
+    let subject = stored.subject_did.as_deref().ok_or_else(|| {
+        AppError::Validation("matched credential has no subject DID to present".into())
+    })?;
+
+    // ACL-gated holder key for that subject.
+    let keys = resolve_holder_keys(keys_ks, seed_store, auth, subject).await?;
+
+    // Mint the query-scoped consent the approver is authorizing.
+    let claims: Vec<String> = first
+        .disclosed_paths
+        .iter()
+        .filter_map(|path| path.last().cloned())
+        .collect();
+    let consent_record = consent::create(
+        vault,
+        &ConsentGrant {
+            holder_did: subject,
+            credential_id: &first.credential_id,
+            verifier_did: &record.verifier_did,
+            purpose: &record.query.purpose,
+            claims,
+            valid_until: now + chrono::Duration::minutes(5),
+        },
+        &keys.consent_secret,
+    )
+    .await?;
+
+    let present = present_for_query(
+        vault,
+        &record.query,
+        &keys.signer,
+        &keys.consent_secret,
+        &consent_record.identifier,
+        &record.verifier_did,
+        now.timestamp() as u64,
+        now,
+    )
+    .await?;
+
+    record.status = pending::PendingStatus::Approved;
+    pending::put(vault, &record).await?;
+    Ok(present)
+}
+
+/// Deny a deferred presentation — the holder refuses disclosure. Records the
+/// refusal (no presentation is made) and returns the updated record.
+pub async fn deny_pending_presentation(
+    vault: &KeyspaceHandle,
+    id: &str,
+) -> Result<pending::PendingPresentation, AppError> {
+    let mut record = pending::get(vault, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("no pending presentation `{id}`")))?;
+    if record.status != pending::PendingStatus::Pending {
+        return Err(AppError::Validation(format!(
+            "pending presentation `{id}` is {:?}, not awaiting approval",
+            record.status
+        )));
+    }
+    record.status = pending::PendingStatus::Denied;
+    pending::put(vault, &record).await?;
+    Ok(record)
 }
 
 /// Map a stored credential format to its DCQL `format` selector, or `None` if
@@ -717,13 +1068,104 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refuses_a_sealed_bundle_for_now() {
+    async fn refuses_a_sealed_bundle_on_the_plaintext_path() {
         let (_dir, _store, vault) = fresh_vault();
+        // The plaintext receive path now redirects a `sealed` bundle to the
+        // dedicated opener rather than claiming it is unimplemented.
         let body = issue_body(Value::Null, Some("-----BEGIN VTA SEALED-----…".into()));
         let err = receive_issued_credential(&vault, &body, None, Utc::now())
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("receive_sealed_issued_credential")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn seal_then_receive_an_issued_credential_round_trips() {
+        use vta_sdk::sealed_transfer::{
+            AssertionProof, InMemoryNonceStore, ProducerAssertion, ed25519_seed_to_x25519_secret,
+        };
+
+        let (_dir, _store, vault) = fresh_vault();
+
+        // Issuer mints an SD-JWT-VC bound to the holder's did:key (seed [5;32]).
+        let holder_seed = [5u8; 32];
+        let holder_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(
+            &SigningKey::from_bytes(&holder_seed)
+                .verifying_key()
+                .to_bytes(),
+        );
+        let issuer = SigningKey::from_bytes(&[9u8; 32]);
+        let issuer_did =
+            affinidi_crypto::did_key::ed25519_pub_to_did_key(issuer.verifying_key().as_bytes());
+        let issuer_signer = EddsaSigner {
+            key: issuer,
+            kid: format!("{issuer_did}#key-0"),
+        };
+        let compact = crate::vault::mint::mint_sd_jwt_vc(
+            &crate::vault::mint::MintRequest {
+                vct: MEMBERSHIP_VCT,
+                issuer_did: &issuer_did,
+                subject_did: &holder_did,
+                claims: &json!({ "givenName": "Alice" }),
+                disclosable: &["givenName"],
+                iat: 1_700_000_000,
+                exp: Some(1_900_000_000),
+            },
+            &issuer_signer,
+        )
+        .unwrap();
+
+        // Issuer seals it to the holder (PinnedOnly + out-of-band digest).
+        let nonce_store = InMemoryNonceStore::new();
+        let producer = ProducerAssertion {
+            producer_did: issuer_did.clone(),
+            proof: AssertionProof::PinnedOnly,
+        };
+        let (armored, digest) = seal_issued_credential(
+            &holder_did,
+            Value::String(compact),
+            &issuer_did,
+            Some("Acme membership".into()),
+            [7u8; 16],
+            producer,
+            &nonce_store,
+        )
+        .await
+        .expect("seal issued credential");
+
+        // Holder opens it with its X25519 derivation + the OOB digest pin.
+        let holder_x = ed25519_seed_to_x25519_secret(&holder_seed);
+        let stored = receive_sealed_issued_credential(
+            &vault,
+            &armored,
+            &holder_x,
+            Some(&digest),
+            None,
+            Utc::now(),
+        )
+        .await
+        .expect("receive sealed issued credential");
+
+        assert_eq!(stored.format, CredentialFormat::SdJwtVc);
+        assert_eq!(stored.subject_did.as_deref(), Some(holder_did.as_str()));
+        // Provenance defaults to the sealed issuer DID.
+        assert_eq!(stored.source.as_deref(), Some(issuer_did.as_str()));
+
+        // A wrong out-of-band digest is rejected (no TOFU).
+        let bad = receive_sealed_issued_credential(
+            &vault,
+            &armored,
+            &holder_x,
+            Some("deadbeef"),
+            None,
+            Utc::now(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(bad, AppError::Validation(_)), "{bad:?}");
     }
 
     #[tokio::test]
@@ -972,6 +1414,7 @@ mod tests {
             &vault,
             &query,
             &kb_signer,
+            &consent_key,
             &rec.identifier,
             verifier,
             now.timestamp() as u64,
@@ -999,7 +1442,7 @@ mod tests {
     async fn present_for_query_is_not_found_when_nothing_matches() {
         let (_dir, _store, vault) = fresh_vault();
         let _stored = mint_and_store(&vault).await;
-        let (_did, kb_signer, _key) = subject_holder();
+        let (_did, kb_signer, consent_key) = subject_holder();
 
         let query = QueryBody {
             dcql_query: DcqlQuery::from_json(&json!({
@@ -1017,6 +1460,7 @@ mod tests {
             &vault,
             &query,
             &kb_signer,
+            &consent_key,
             "consent-x",
             "did:web:v",
             0,
@@ -1025,6 +1469,107 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(err, AppError::NotFound(_)), "{err:?}");
+    }
+
+    /// Store a plain W3C-DI VC (`EddsaJcs2022`) bound to `subject_did`, indexed
+    /// under `MembershipCredential` so a `type_values` DCQL query gathers it.
+    async fn store_di_membership(vault: &KeyspaceHandle, id: &str, subject_did: &str) {
+        let vc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": "did:web:issuer.example",
+            "credentialSubject": { "id": subject_did, "givenName": "Alice" },
+        });
+        let cred = crate::vault::model::StoredCredential {
+            id: id.to_string(),
+            format: CredentialFormat::EddsaJcs2022,
+            types: vec!["MembershipCredential".into()],
+            schema_id: None,
+            community_did: None,
+            subject_did: Some(subject_did.to_string()),
+            issuer_did: Some("did:web:issuer.example".into()),
+            purpose: None,
+            status: crate::vault::model::CredentialStatus::Valid,
+            valid_from: None,
+            valid_until: None,
+            received_at: "2026-01-01T00:00:00Z".into(),
+            source: None,
+            tags: Default::default(),
+            body: serde_json::to_vec(&vc).unwrap(),
+        };
+        crate::vault::storage::put(vault, &cred)
+            .await
+            .expect("put DI VC");
+    }
+
+    #[tokio::test]
+    async fn present_for_query_presents_a_w3c_di_vc_as_a_json_vp() {
+        use crate::vault::consent::{ConsentGrant, create as create_consent};
+
+        let (_dir, _store, vault) = fresh_vault();
+        let (subject_did, _kb_signer, holder_secret) = subject_holder();
+        let verifier = "did:web:acme-verifier.example";
+        let now = Utc::now();
+
+        store_di_membership(&vault, "di-membership", &subject_did).await;
+
+        // Plain DI cannot redact, so consent must cover the whole subject.
+        let rec = create_consent(
+            &vault,
+            &ConsentGrant {
+                holder_did: &subject_did,
+                credential_id: "di-membership",
+                verifier_did: verifier,
+                purpose: "join the Acme community",
+                claims: vec!["givenName".into()],
+                valid_until: now + chrono::Duration::hours(1),
+            },
+            &holder_secret,
+        )
+        .await
+        .expect("create consent");
+
+        // A `ldp_vc` DCQL query selecting the DI credential by W3C `type_values`.
+        let query = QueryBody {
+            dcql_query: DcqlQuery::from_json(&json!({
+                "credentials": [{
+                    "id": "membership",
+                    "format": "ldp_vc",
+                    "meta": { "type_values": ["MembershipCredential"] },
+                    "claims": [{ "path": ["credentialSubject", "givenName"] }]
+                }]
+            }))
+            .unwrap(),
+            nonce: "verifier-nonce-di".into(),
+            purpose: "join the Acme community".into(),
+        };
+
+        // The kb-jwt signer is unused on the DI arm — pass the subject's anyway.
+        let (_d, kb_signer, _k) = subject_holder();
+        let present = present_for_query(
+            &vault,
+            &query,
+            &kb_signer,
+            &holder_secret,
+            &rec.identifier,
+            verifier,
+            now.timestamp() as u64,
+            now,
+        )
+        .await
+        .expect("present DI for query");
+
+        // The DI vp_token is a JSON VP object (not a compact string), holder-bound.
+        let vp = present.vp_token.as_object().expect("JSON-object vp_token");
+        assert_eq!(vp["type"][0], "VerifiablePresentation");
+        assert_eq!(vp["holder"], subject_did);
+        assert_eq!(vp["nonce"], "verifier-nonce-di");
+        assert_eq!(vp["domain"], verifier);
+        assert_eq!(
+            vp["verifiableCredential"][0]["credentialSubject"]["givenName"],
+            "Alice"
+        );
+        assert!(vp.contains_key("proof"), "holder VP proof must be present");
     }
 
     // ── present_or_defer: consent policy ──
@@ -1245,5 +1790,243 @@ mod tests {
         .await
         .unwrap();
         assert!(matches!(deferred, PresentOutcome::ConsentRequired { .. }));
+    }
+
+    // ── deferred approval store (task 3.5d, the defer half) ──
+
+    /// Full holder fixture: a VTA-derived subject key (context `acme`) registered
+    /// in `keys_ks` + an SD-JWT-VC bound to it stored in the vault. Returns the
+    /// pieces `present_query` / `approve_pending_presentation` need.
+    async fn holder_fixture() -> (
+        tempfile::TempDir,
+        KeyspaceHandle,
+        KeyspaceHandle,
+        Arc<dyn SeedStore>,
+        String,
+    ) {
+        use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
+        use vta_sdk::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = vti_common::store::Store::open(&vti_common::config::StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let vault = store.keyspace("vault").unwrap();
+        let keys_ks = store.keyspace("keys").unwrap();
+
+        let seed = vec![42u8; 64];
+        let seed_store: Arc<dyn SeedStore> =
+            Arc::new(crate::test_support::TestSeedStore(seed.clone()));
+        let path = "m/26'/2'/0'/0'";
+        let bip32 = ExtendedSigningKey::from_seed(&seed).unwrap();
+        let derived = bip32
+            .derive(&path.parse::<DerivationPath>().unwrap())
+            .unwrap();
+        let subject_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(
+            derived.signing_key.verifying_key().as_bytes(),
+        );
+        let multibase = subject_did.strip_prefix("did:key:").unwrap();
+        let key_id = format!("{subject_did}#{multibase}");
+        keys_ks
+            .insert(
+                crate::keys::store_key(&key_id),
+                &KeyRecord {
+                    key_id: key_id.clone(),
+                    derivation_path: path.into(),
+                    key_type: KeyType::Ed25519,
+                    status: KeyStatus::Active,
+                    public_key: multibase.into(),
+                    label: None,
+                    context_id: Some("acme".into()),
+                    seed_id: None,
+                    origin: KeyOrigin::Derived,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let issuer = SigningKey::from_bytes(&[9u8; 32]);
+        let issuer_did =
+            affinidi_crypto::did_key::ed25519_pub_to_did_key(issuer.verifying_key().as_bytes());
+        let issuer_signer = EddsaSigner {
+            key: issuer,
+            kid: format!("{issuer_did}#key-0"),
+        };
+        let compact = crate::vault::mint::mint_sd_jwt_vc(
+            &crate::vault::mint::MintRequest {
+                vct: MEMBERSHIP_VCT,
+                issuer_did: &issuer_did,
+                subject_did: &subject_did,
+                claims: &json!({ "givenName": "Alice" }),
+                disclosable: &["givenName"],
+                iat: 1_700_000_000,
+                exp: Some(1_900_000_000),
+            },
+            &issuer_signer,
+        )
+        .unwrap();
+        receive_issued_credential(
+            &vault,
+            &issue_body(Value::String(compact), None),
+            None,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+
+        (dir, vault, keys_ks, seed_store, subject_did)
+    }
+
+    #[tokio::test]
+    async fn defer_then_approve_presents_and_marks_approved() {
+        use crate::acl::Role;
+
+        let (_dir, vault, keys_ks, seed_store, _subject) = holder_fixture().await;
+        let verifier = "did:web:stranger.example";
+        let now = Utc::now();
+        let auth = AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: Vec::new(),
+            ..Default::default()
+        };
+        let query = membership_query();
+
+        // 1. Untrusted verifier defers → no presentation yet, but a pending record.
+        let outcome = present_query(
+            &vault,
+            &keys_ks,
+            &seed_store,
+            &auth,
+            &query,
+            verifier,
+            &ConsentPolicy::default(),
+            now,
+        )
+        .await
+        .expect("present_query");
+        let credential_id = match outcome {
+            PresentOutcome::ConsentRequired {
+                credential_id,
+                claims,
+                ..
+            } => {
+                let rec = defer_presentation(
+                    &vault,
+                    "req-1",
+                    verifier,
+                    &credential_id,
+                    claims,
+                    &query,
+                    now,
+                )
+                .await
+                .expect("defer");
+                assert_eq!(rec.status, pending::PendingStatus::Pending);
+                credential_id
+            }
+            other => panic!("expected ConsentRequired, got {other:?}"),
+        };
+
+        // It shows up on the holder's local approval surface.
+        let list = pending::list(&vault).await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "req-1");
+        assert_eq!(list[0].credential_id, credential_id);
+
+        // 2. Out-of-band approval mints consent + re-presents.
+        let present =
+            approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-1", now)
+                .await
+                .expect("approve");
+        let token = present.vp_token.as_str().expect("compact vp_token");
+        let parsed =
+            affinidi_sd_jwt::SdJwt::parse(token, &affinidi_sd_jwt::hasher::Sha256Hasher).unwrap();
+        assert_eq!(parsed.disclosures.len(), 1);
+        assert!(parsed.kb_jwt.is_some(), "holder kb-jwt must be present");
+
+        // The record is now Approved, and a second approval refuses.
+        assert_eq!(
+            pending::get(&vault, "req-1").await.unwrap().unwrap().status,
+            pending::PendingStatus::Approved
+        );
+        let twice =
+            approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-1", now)
+                .await
+                .unwrap_err();
+        assert!(matches!(twice, AppError::Validation(_)), "{twice:?}");
+    }
+
+    #[tokio::test]
+    async fn deny_marks_denied_and_blocks_approval() {
+        use crate::acl::Role;
+
+        let (_dir, vault, keys_ks, seed_store, _subject) = holder_fixture().await;
+        let verifier = "did:web:stranger.example";
+        let now = Utc::now();
+        let query = membership_query();
+
+        defer_presentation(
+            &vault,
+            "req-2",
+            verifier,
+            "urn:cred:1",
+            vec!["givenName".into()],
+            &query,
+            now,
+        )
+        .await
+        .expect("defer");
+
+        let denied = deny_pending_presentation(&vault, "req-2")
+            .await
+            .expect("deny");
+        assert_eq!(denied.status, pending::PendingStatus::Denied);
+
+        // A denied record cannot then be approved.
+        let auth = AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: Vec::new(),
+            ..Default::default()
+        };
+        let err = approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-2", now)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn approve_refuses_an_expired_deferral() {
+        use crate::acl::Role;
+
+        let (_dir, vault, keys_ks, seed_store, _subject) = holder_fixture().await;
+        let query = membership_query();
+        let created = Utc::now() - chrono::Duration::hours(48);
+
+        // A deferral recorded 48h ago — past the 24h window.
+        defer_presentation(
+            &vault,
+            "req-3",
+            "did:web:stranger.example",
+            "urn:cred:1",
+            vec!["givenName".into()],
+            &query,
+            created,
+        )
+        .await
+        .expect("defer");
+
+        let auth = AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: Vec::new(),
+            ..Default::default()
+        };
+        let err =
+            approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-3", Utc::now())
+                .await
+                .unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
     }
 }


### PR DESCRIPTION
Closes the four remaining Phase-3 (credential-exchange) slices in one pass. Branched from the merged #263.

## 1. W3C Data-Integrity present path (3.5c)
`present_for_query` now dispatches `EddsaJcs2022 → vault::present_di_vc`, returning the holder-bound VP as **structured JSON** (vs. the SD-JWT-VC compact string). `holder_secret` is threaded through `present_or_defer` — the two abstractions of the same derived holder key. Test covers a JSON-VP round-trip with `nonce`/`domain` binding.

## 2. Deferred-approval store (3.5d, the defer half)
New `pending` store in the vault keyspace (`pending-present:` namespace), disjoint from `cred:` / `consent:` / `vault:`:
- `PendingPresentation` + `pending::{put,get,list}` (the holder's local approval surface).
- `defer_presentation` persists a deferred query; `approve_pending_presentation` re-matches, ACL-gated holder-key resolves, mints a query-scoped consent, re-presents, and marks `Approved`; `deny_pending_presentation` records the refusal.
- Expiry-gated (24h — the verifier nonce ages out).
- Wired into `handle_credential_query`'s `ConsentRequired` arm — the DIDComm thread id is the approval handle returned to the verifier.
- Tests: approve→present, deny→block, expired→refuse.

## 3. Sealed issuance (3.6, invite / unknown-holder)
- Additive `SealedPayloadV1::IssuedCredential(IssuedCredentialBundle)` variant — **no existing variant reshaped** (per the sealed-transfer invariant).
- `seal_issued_credential` (issuer half) seals a minted credential to the holder's X25519 derivation from its `did:key`; `receive_sealed_issued_credential` (holder half) opens with the holder secret + **mandatory OOB digest pin** and stores via the shared `store_issued_credential` helper (refactored out of `receive_issued_credential`).
- Display/reject arms added to every exhaustive `SealedPayloadV1` match (`bootstrap_cli`, `pnm bootstrap`, and the `cli-common` extractor rejects it as a non-admin payload).
- Round-trip test (seal → open → vault), plus a wrong-digest rejection.

## 4. Trust-Task descriptors (3.7)
Hand-authored `trust-tasks/credential-exchange/` family: `index.json` + `schema.json`/`spec.md` for **offer, request, issue, query, present** under the canonical `trusttasks.org/spec/` namespace.

## Verification
- vta-service (642) + vta-sdk (236) lib tests pass.
- clippy clean (also dropped a pre-existing duplicate-attribute warning in `bootstrap_cli`).
- cargo deny green (advisories / bans / licenses / sources ok).
- Full workspace builds.
- DCO-signed + GPG-signed.

## Notes
Crate versions intentionally unbumped — history shows bumps land in dedicated `chore(release):` PRs, and these additive SDK changes are all consumed within the workspace.