### PR TITLE
feat(vtc): drive the join decision from a verified presentation (close-the-join-loop, part 2)

### DIFF
--- a/vtc-service/src/routes/join_requests/mod.rs
+++ b/vtc-service/src/routes/join_requests/mod.rs
@@ -7,5 +7,6 @@
 //! Phase 2's policy surface).
 
 pub mod decide;
+pub mod present;
 pub mod read;
 pub mod submit;

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -1,0 +1,156 @@
+//! Credential-exchange `present` → join decision (close-the-join-loop, part 2).
+//!
+//! The VTA holder answers a verifier's DCQL query with an OID4VP `vp_token`
+//! (the map keyed by `credential_query_id` that
+//! `vta-service`'s `present_query` produces). This module is the VTC verifier's
+//! decision path: it **cryptographically verifies** the `vp_token`
+//! ([`crate::credentials::verify_vp_token`]), projects the verified set into the
+//! ceremony [`Presentation`] evidence shape, runs the active **join** policy, and
+//! realizes the verdict — auto-admitting (issuing the MembershipCredential) on
+//! `allow`, else queuing / rejecting like the VP submit path.
+//!
+//! Unlike the VP submit path (whose `presentation.verified` rests on a
+//! route-layer hex signature), here `verified` rests on the holder `kb-jwt`
+//! binding the verifier's `nonce` + audience — real VP cryptography.
+//!
+//! The DIDComm `credential-exchange/present` wire handler + the single-use
+//! presentation-challenge store (freshness / replay) that sources
+//! `expected_nonce` are the next slice; this operation takes the expected
+//! audience + nonce as parameters so it is transport-agnostic and testable.
+
+use chrono::{DateTime, Utc};
+use serde_json::{Value as JsonValue, json};
+
+use vti_common::error::AppError;
+
+use crate::ceremony::{Credential, CredentialStatus, Presentation};
+use crate::credentials::{VerifiedPresentationSet, verify_vp_token};
+use crate::join::JoinTransport;
+use crate::server::AppState;
+
+use super::submit::{JoinSubmitOutcome, decide_join, realize_join_verdict};
+
+/// Verify a presented OID4VP `vp_token`, run the join decision, and realize it.
+///
+/// `expected_aud` is this VTC's identity (the `domain`/`aud` the holder bound
+/// into the kb-jwt); `expected_nonce` is the single-use freshness value the VTC
+/// issued with its query. On success the applicant is the **proven holder** of
+/// the presentation. On `allow` the MembershipCredential is issued inline (the
+/// returned [`JoinSubmitOutcome::admit`]).
+pub async fn present_and_decide_join(
+    state: &AppState,
+    vp_token: &JsonValue,
+    expected_aud: &str,
+    expected_nonce: &str,
+    transport: JoinTransport,
+    now: DateTime<Utc>,
+) -> Result<JoinSubmitOutcome, AppError> {
+    // 1. Cryptographically verify every presentation in the vp_token. The holder
+    //    is proven (kb-jwt) and consistent across the set.
+    let set = verify_vp_token(vp_token, expected_aud, expected_nonce, now)?;
+    let applicant_did = set.holder.clone();
+
+    // 2. Project the verified set into the ceremony evidence shape.
+    let presentation = presentation_from_verified_set(&set);
+
+    // 3 + 4. Decide under the active join policy, then realize the verdict.
+    let verdict = decide_join(state, &applicant_did, presentation).await?;
+    let vp_claims = vp_claims_from_set(&set);
+    realize_join_verdict(
+        state,
+        &applicant_did,
+        vp_token.clone(),
+        vp_claims,
+        false,
+        JsonValue::Null,
+        verdict,
+        transport,
+    )
+    .await
+}
+
+/// Project a [`VerifiedPresentationSet`] into the verified ceremony
+/// [`Presentation`]. Crypto is already resolved, so `verified: true`. Issuer
+/// trust (TRQP) and status-list resolution stay `false` / `Valid` — both are
+/// follow-ups (the structured shape is what the policy decides over); the
+/// credential `type` is the SD-JWT-VC `vct`.
+fn presentation_from_verified_set(set: &VerifiedPresentationSet) -> Presentation {
+    let credentials = set
+        .presentations
+        .iter()
+        .map(|p| Credential {
+            credential_type: p
+                .vct
+                .clone()
+                .unwrap_or_else(|| "VerifiableCredential".to_string()),
+            issuer: p.issuer_did.clone(),
+            issuer_trusted: false,
+            status: CredentialStatus::Valid,
+            claims: p.claims.clone(),
+            // SD-JWT-VC carries expiry in `exp` (epoch seconds).
+            valid_until: p
+                .claims
+                .get("exp")
+                .and_then(JsonValue::as_i64)
+                .and_then(|s| DateTime::from_timestamp(s, 0)),
+        })
+        .collect();
+
+    Presentation {
+        verified: true,
+        holder: set.holder.clone(),
+        credentials,
+    }
+}
+
+/// The lossy `vp_claims` admin-display projection (mirrors the VP path's
+/// `extract_vp_claims`): the holder + a credential summary, persisted on the
+/// join-request row for the admin show.
+fn vp_claims_from_set(set: &VerifiedPresentationSet) -> JsonValue {
+    let credentials: Vec<JsonValue> = set
+        .presentations
+        .iter()
+        .map(|p| {
+            json!({
+                "issuer": p.issuer_did,
+                "type": p.vct,
+                "credentialSubject": p.claims,
+            })
+        })
+        .collect();
+    json!({ "holder": set.holder, "credentials": credentials })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn projects_a_verified_set_into_ceremony_presentation() {
+        use crate::credentials::VerifiedPresentation;
+
+        let set = VerifiedPresentationSet {
+            holder: "did:key:zHolder".into(),
+            presentations: vec![VerifiedPresentation {
+                issuer_did: "did:key:zIssuer".into(),
+                holder_did: "did:key:zHolder".into(),
+                vct: Some("https://openvtc.org/credentials/MembershipCredential".into()),
+                claims: json!({ "givenName": "Alice", "exp": 1_900_000_000 }),
+            }],
+        };
+
+        let p = presentation_from_verified_set(&set);
+        assert!(p.verified);
+        assert_eq!(p.holder, "did:key:zHolder");
+        assert_eq!(p.credentials.len(), 1);
+        assert_eq!(
+            p.credentials[0].credential_type,
+            "https://openvtc.org/credentials/MembershipCredential"
+        );
+        assert_eq!(p.credentials[0].issuer, "did:key:zIssuer");
+        assert!(!p.credentials[0].issuer_trusted);
+        assert_eq!(p.credentials[0].status, CredentialStatus::Valid);
+        assert!(p.credentials[0].valid_until.is_some());
+        assert_eq!(p.credentials[0].claims["givenName"], "Alice");
+    }
+}

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -161,11 +161,6 @@ pub async fn submit_inner(
     signature_hex: Option<&str>,
     transport: JoinTransport,
 ) -> Result<JoinSubmitOutcome, AppError> {
-    let audit_writer = state
-        .audit_writer
-        .as_ref()
-        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
-
     // 1. Holder binding (REST only).
     if let Some(hex_sig) = signature_hex {
         verify_holder_signature(&applicant_did, &vp, registry_consent, &extensions, hex_sig)?;
@@ -176,8 +171,36 @@ pub async fn submit_inner(
     // reads structured Facts instead (assembled below).
     let vp_claims = extract_vp_claims(&vp);
 
-    // 3. Decide: assemble verified Facts and run the active join policy.
-    let facts = assemble_join_facts(state, &applicant_did, &vp).await?;
+    // 3. Decide: assemble verified Facts (the route-layer holder-binding
+    // makes this presentation `verified`) and run the active join policy.
+    let presentation = presentation_from_vp(&applicant_did, &vp);
+    let verdict = decide_join(state, &applicant_did, presentation).await?;
+
+    // 4. Realize the verdict (store + audit + auto-admit on allow).
+    realize_join_verdict(
+        state,
+        &applicant_did,
+        vp,
+        vp_claims,
+        registry_consent,
+        extensions,
+        verdict,
+        transport,
+    )
+    .await
+}
+
+/// Assemble verified join [`Facts`] from a `presentation` and run the active
+/// join policy, returning the [`Verdict`]. The caller supplies a `presentation`
+/// it has already established as `verified` (route-layer holder-binding for the
+/// VP path; cryptographic `vp_token` verification for the credential-exchange
+/// path).
+pub(crate) async fn decide_join(
+    state: &AppState,
+    applicant_did: &str,
+    presentation: Presentation,
+) -> Result<Verdict, AppError> {
+    let facts = assemble_join_facts(state, applicant_did, presentation).await?;
     let verified = VerifiedFacts::assemble(facts)?;
     let policy = load_active_compiled(
         &state.active_policies_ks,
@@ -185,10 +208,29 @@ pub async fn submit_inner(
         PolicyPurpose::Join,
     )
     .await?;
-    let verdict = crate::ceremony::decide(&verified, &policy)?;
+    crate::ceremony::decide(&verified, &policy)
+}
 
-    // 4. Build the request + realize the verdict.
-    let mut request = JoinRequest::new(applicant_did.clone(), vp);
+/// Realize a join [`Verdict`]: build + persist the [`JoinRequest`], auto-admit on
+/// `allow` (the [`EffectPlan::Admit`] executor issues the VMC), and write the
+/// audit event. Shared by the VP submit and the credential-exchange present path.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn realize_join_verdict(
+    state: &AppState,
+    applicant_did: &str,
+    vp: JsonValue,
+    vp_claims: JsonValue,
+    registry_consent: bool,
+    extensions: JsonValue,
+    verdict: Verdict,
+    transport: JoinTransport,
+) -> Result<JoinSubmitOutcome, AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    let mut request = JoinRequest::new(applicant_did.to_string(), vp);
     request.vp_claims = vp_claims;
     request.registry_consent = registry_consent;
     request.extensions = extensions;
@@ -202,12 +244,12 @@ pub async fn submit_inner(
             // as the executor's `Conflict` → 409.
             let role = allow.role.clone().unwrap_or_else(|| "member".to_string());
             let plan = EffectPlan::Admit {
-                subject: applicant_did.clone(),
+                subject: applicant_did.to_string(),
                 role,
                 obligations: allow.obligations.clone(),
             };
             if let EffectOutcome::Admitted(creds) =
-                execute::apply(state, plan, &applicant_did).await?
+                execute::apply(state, plan, applicant_did).await?
             {
                 admit = Some(creds);
             }
@@ -225,11 +267,11 @@ pub async fn submit_inner(
     }
     store_join_request(&state.join_requests_ks, &request).await?;
 
-    // 5. Audit — Rejected for a policy deny; Submitted otherwise.
+    // Audit — Rejected for a policy deny; Submitted otherwise.
     if rejected {
         audit_writer
             .write(
-                &applicant_did,
+                applicant_did,
                 None,
                 AuditEvent::JoinRequestRejected(JoinRequestRejectedData {
                     request_id: request.id.to_string(),
@@ -240,7 +282,7 @@ pub async fn submit_inner(
     } else {
         audit_writer
             .write(
-                &applicant_did,
+                applicant_did,
                 None,
                 AuditEvent::JoinRequestSubmitted(JoinRequestData {
                     request_id: request.id.to_string(),
@@ -255,7 +297,7 @@ pub async fn submit_inner(
         applicant = %applicant_did,
         transport = transport.as_str(),
         verdict = verdict.effect(),
-        "join request submitted"
+        "join request realized"
     );
     Ok(JoinSubmitOutcome { request, admit })
 }
@@ -270,7 +312,7 @@ pub async fn submit_inner(
 async fn assemble_join_facts(
     state: &AppState,
     applicant_did: &str,
-    vp: &JsonValue,
+    presentation: Presentation,
 ) -> Result<Facts, AppError> {
     let community_did = load_profile(&state.community_ks)
         .await?
@@ -281,8 +323,9 @@ async fn assemble_join_facts(
     Ok(Facts {
         purpose: Purpose::Join,
         now: Utc::now(),
-        // The applicant proved holder-binding at the route layer; they
-        // are not (yet) a member, so they carry no community role.
+        // The applicant proved holder-binding (route-layer for the VP path,
+        // cryptographic kb-jwt for the credential-exchange path); they are not
+        // (yet) a member, so they carry no community role.
         actor: Actor {
             did: applicant_did.to_string(),
             role: None,
@@ -298,7 +341,7 @@ async fn assemble_join_facts(
         },
         evidence: Evidence {
             invitation: None,
-            presentation: Some(presentation_from_vp(applicant_did, vp)),
+            presentation: Some(presentation),
             request: None,
         },
         state: FactsState {

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -13,7 +13,7 @@ mod endorsement_types;
 mod endorsements;
 mod health;
 pub(crate) mod install;
-pub(crate) mod join_requests;
+pub mod join_requests;
 pub(crate) mod members;
 pub(crate) mod policies;
 pub mod recognise;

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -58,6 +58,7 @@ fn init_jwt_provider() {
 
 struct Fixture {
     router: axum::Router,
+    state: AppState,
     admin_token: String,
     acl_ks: KeyspaceHandle,
     members_ks: KeyspaceHandle,
@@ -231,10 +232,11 @@ async fn build_fixture() -> Fixture {
         supervisor: None,
     };
 
-    let router = routes::router().with_state(state);
+    let router = routes::router().with_state(state.clone());
 
     Fixture {
         router,
+        state,
         admin_token,
         acl_ks,
         members_ks,
@@ -981,4 +983,209 @@ async fn list_requires_authentication() {
     )
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// Credential-exchange present → join decision (close-the-join-loop, part 2)
+// ---------------------------------------------------------------------------
+
+/// Build a real SD-JWT-VC `MembershipCredential` presentation bound to
+/// `aud` + `nonce`, framed as an OID4VP DCQL `vp_token` map (keyed by
+/// credential-query id) — exactly the shape `vta-service`'s `present_query`
+/// emits. Returns `(holder_did, vp_token)`.
+fn build_membership_vp_token(
+    holder_seed: u8,
+    aud: &str,
+    nonce: &str,
+    now_ts: i64,
+) -> (String, Value) {
+    use affinidi_sd_jwt::error::SdJwtError;
+    use affinidi_sd_jwt::hasher::Sha256Hasher;
+    use affinidi_sd_jwt::holder::{KbJwtInput, present, select_disclosures};
+    use affinidi_sd_jwt::signer::JwtSigner;
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    struct SdSigner {
+        key: SigningKey,
+        kid: String,
+    }
+    impl JwtSigner for SdSigner {
+        fn algorithm(&self) -> &str {
+            "EdDSA"
+        }
+        fn key_id(&self) -> Option<&str> {
+            Some(&self.kid)
+        }
+        fn sign_jwt(&self, header: &Value, payload: &Value) -> Result<String, SdJwtError> {
+            let h = URL_SAFE_NO_PAD.encode(
+                serde_json::to_vec(header).map_err(|e| SdJwtError::Verification(e.to_string()))?,
+            );
+            let p = URL_SAFE_NO_PAD.encode(
+                serde_json::to_vec(payload).map_err(|e| SdJwtError::Verification(e.to_string()))?,
+            );
+            let input = format!("{h}.{p}");
+            let sig = self.key.sign(input.as_bytes());
+            Ok(format!(
+                "{input}.{}",
+                URL_SAFE_NO_PAD.encode(sig.to_bytes())
+            ))
+        }
+    }
+
+    let issuer = SigningKey::from_bytes(&[9u8; 32]);
+    let issuer_did =
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(issuer.verifying_key().as_bytes());
+    let issuer_signer = SdSigner {
+        key: SigningKey::from_bytes(&[9u8; 32]),
+        kid: format!("{issuer_did}#key-0"),
+    };
+
+    let holder = SigningKey::from_bytes(&[holder_seed; 32]);
+    let holder_vk = holder.verifying_key();
+    let holder_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(holder_vk.as_bytes());
+    let holder_signer = SdSigner {
+        key: SigningKey::from_bytes(&[holder_seed; 32]),
+        kid: format!(
+            "{holder_did}#{}",
+            holder_did.strip_prefix("did:key:").unwrap()
+        ),
+    };
+
+    let vct = "https://openvtc.org/credentials/MembershipCredential";
+    let claims = json!({
+        "iss": issuer_did, "sub": holder_did, "vct": vct,
+        "iat": now_ts, "exp": now_ts + 3600, "givenName": "Alice"
+    });
+    let frame = json!({ "_sd": ["givenName"] });
+    let hasher = Sha256Hasher;
+    let holder_jwk = json!({
+        "kty": "OKP", "crv": "Ed25519", "x": URL_SAFE_NO_PAD.encode(holder_vk.to_bytes())
+    });
+    let sd =
+        affinidi_sd_jwt::issuer::issue(&claims, &frame, &issuer_signer, &hasher, Some(&holder_jwk))
+            .unwrap();
+    let selected = select_disclosures(&sd, &["givenName"]);
+    let kb = KbJwtInput {
+        audience: aud,
+        nonce,
+        signer: &holder_signer,
+        iat: now_ts as u64,
+    };
+    let presentation = present(&sd, &selected, Some(&kb), &hasher).unwrap();
+    (
+        holder_did,
+        json!({ "membership": presentation.serialize() }),
+    )
+}
+
+const VTC_AUD: &str = "did:webvh:vtc.example.com:abc";
+
+/// A cryptographically-verified credential-exchange presentation drives the join
+/// decision: under an `allow` policy the holder is auto-admitted and the
+/// MembershipCredential is issued inline.
+#[tokio::test]
+async fn credential_exchange_present_auto_admits_under_allow_policy() {
+    use vtc_service::join::{JoinStatus, JoinTransport};
+    use vtc_service::routes::join_requests::present::present_and_decide_join;
+
+    let fix = build_fixture().await;
+    activate_join_policy(
+        &fix,
+        "package vtc.join\nimport rego.v1\n\n\
+         default decision := {\"effect\": \"allow\", \"with\": {\"role\": \"member\"}}\n",
+    )
+    .await;
+
+    let now = chrono::Utc::now();
+    let nonce = "vtc-issued-nonce-1";
+    let (holder_did, vp_token) = build_membership_vp_token(0x42, VTC_AUD, nonce, now.timestamp());
+
+    let outcome = present_and_decide_join(
+        &fix.state,
+        &vp_token,
+        VTC_AUD,
+        nonce,
+        JoinTransport::DIDComm,
+        now,
+    )
+    .await
+    .expect("present and decide");
+
+    assert_eq!(outcome.request.status, JoinStatus::Approved);
+    assert!(
+        outcome.admit.is_some(),
+        "MembershipCredential issued on allow"
+    );
+    // The proven holder is now a member.
+    let acl = vtc_service::acl::get_acl_entry(&fix.acl_ks, &holder_did)
+        .await
+        .unwrap()
+        .expect("auto-admitted holder has an ACL row");
+    assert_eq!(acl.role, VtcRole::Member);
+    assert!(
+        vtc_service::members::get_member(&fix.members_ks, &holder_did)
+            .await
+            .unwrap()
+            .is_some(),
+        "auto-admitted holder has a Member row"
+    );
+}
+
+/// Under the default join policy a verified presentation lands `pending` (the
+/// decision pipeline routed it; no auto-admit).
+#[tokio::test]
+async fn credential_exchange_present_defers_under_default_policy() {
+    use vtc_service::join::{JoinStatus, JoinTransport};
+    use vtc_service::routes::join_requests::present::present_and_decide_join;
+
+    let fix = build_fixture().await;
+    let now = chrono::Utc::now();
+    let nonce = "n";
+    let (_holder, vp_token) = build_membership_vp_token(0x43, VTC_AUD, nonce, now.timestamp());
+
+    let outcome = present_and_decide_join(
+        &fix.state,
+        &vp_token,
+        VTC_AUD,
+        nonce,
+        JoinTransport::DIDComm,
+        now,
+    )
+    .await
+    .expect("present and decide");
+
+    assert_eq!(outcome.request.status, JoinStatus::Pending);
+    assert!(outcome.admit.is_none());
+}
+
+/// A presentation bound to a different nonce than the verifier expects is
+/// refused — no decision runs (replay / wrong-challenge protection at the
+/// crypto layer).
+#[tokio::test]
+async fn credential_exchange_present_rejects_a_wrong_nonce() {
+    use vtc_service::join::JoinTransport;
+    use vtc_service::routes::join_requests::present::present_and_decide_join;
+
+    let fix = build_fixture().await;
+    let now = chrono::Utc::now();
+    let (_holder, vp_token) =
+        build_membership_vp_token(0x44, VTC_AUD, "right-nonce", now.timestamp());
+
+    let refused = matches!(
+        present_and_decide_join(
+            &fix.state,
+            &vp_token,
+            VTC_AUD,
+            "wrong-nonce",
+            JoinTransport::DIDComm,
+            now,
+        )
+        .await,
+        Err(vti_common::error::AppError::Validation(_))
+    );
+    assert!(
+        refused,
+        "a presentation bound to a different nonce must be refused"
+    );
 }


### PR DESCRIPTION
Part 1 (#267) added `verify_vp_token`. **Part 2 wires it into the join ceremony**: a cryptographically-verified credential-exchange presentation now runs the join decision and issues the MembershipCredential on `allow` — the **invite→hold→present→join** loop, end to end at the operation level.

## What changed
- **`present_and_decide_join(state, vp_token, expected_aud, expected_nonce, transport, now)`** — `verify_vp_token` (the proven holder *is* the applicant) → project the verified set into the ceremony `Presentation` → decide under the active join policy → realize (auto-admit + issue VMC on `allow`, else queue/reject). Unlike the VP submit path (whose `presentation.verified` rests on a route-layer hex signature), here `verified` rests on the holder **kb-jwt** binding the verifier's nonce + audience — real VP cryptography.
- **Refactored `submit_inner`** — extracted `decide_join` + `realize_join_verdict` (now shared by the VP submit path and the new present path) and made `assemble_join_facts` take the `Presentation` directly. **No behaviour change** to the existing path (its tests are unchanged and green).
- **`presentation_from_verified_set`** projects each verified presentation into a ceremony `Credential` (type = `vct`, issuer, claims, `valid_until` from `exp`). `issuer_trusted` / `status` stay `false` / `Valid` — TRQP issuer-trust + status-list resolution are follow-ups; the structured shape is what the policy decides over.

## Tests
- `credential_exchange_present_auto_admits_under_allow_policy` — a real SD-JWT-VC `vp_token` auto-admits: VMC issued inline, the proven holder gets ACL + Member rows.
- `credential_exchange_present_defers_under_default_policy` — lands `pending`.
- `credential_exchange_present_rejects_a_wrong_nonce` — refused before any decision (crypto-layer replay/wrong-challenge protection).
- `projects_a_verified_set_into_ceremony_presentation` — projection unit test.

## Verification
Full vtc-service suite passes (exit 0) · clippy clean · fmt clean · DCO + GPG signed. `routes::join_requests` widened to `pub` so the operation is reachable by the integration harness.

## Scope / next
The decision operation is transport- and freshness-agnostic (takes `expected_aud`/`expected_nonce`), so it's cleanly testable now. **Part 3** adds the wire + replay protection: the `credential-exchange/present` DIDComm handler + a single-use presentation-challenge store (the VTC issues the nonce with its DCQL query; the handler consumes it), plus DI-VP holder-proof verification.