### PR TITLE
feat(vtc): credential-exchange/present DIDComm handler + single-use challenge (close-the-join-loop, part 3)

### DIFF
--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -48,6 +48,7 @@ pub mod custom_endorsement;
 pub mod dtg;
 pub mod exchange;
 pub mod invitation;
+pub mod present_challenge;
 pub mod signer;
 pub mod vec;
 pub mod vmc;

--- a/vtc-service/src/credentials/present_challenge.rs
+++ b/vtc-service/src/credentials/present_challenge.rs
@@ -1,0 +1,188 @@
+//! Single-use presentation challenge — the freshness / replay anchor for the
+//! credential-exchange `present` → join loop (close-the-join-loop, part 3).
+//!
+//! The VTC generates a nonce when it sends a `credential-exchange/query`, keyed
+//! by the query's DIDComm thread id, and binds it to the audience the holder
+//! must echo (the VTC's own DID). The holder presents on that thread; the
+//! `present` handler [`consume`]s the challenge:
+//!
+//! - **single-use** — the record is removed on consume, so a replayed
+//!   `vp_token` on the same thread finds no challenge and is refused;
+//! - **TTL-bounded** — a stale challenge (the nonce aged out) is refused.
+//!
+//! Stored in the `join_requests` keyspace under a disjoint `present-challenge:`
+//! prefix (the same keyspace the credx-pending issuance store uses; the prefixes
+//! never collide).
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// Primary-key prefix. Disjoint from `join_requests:` and `credx-pending:`.
+const PREFIX: &str = "present-challenge:";
+
+/// Default lifetime of a presentation challenge.
+pub const DEFAULT_CHALLENGE_TTL: Duration = Duration::minutes(5);
+
+fn key(thread_id: &str) -> Vec<u8> {
+    format!("{PREFIX}{thread_id}").into_bytes()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PresentChallenge {
+    nonce: String,
+    aud: String,
+    expires_at: DateTime<Utc>,
+}
+
+/// The freshness `nonce` + `aud` a holder must have bound into its presentation,
+/// recovered by [`consume`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsumedChallenge {
+    /// The single-use nonce the holder's kb-jwt must echo.
+    pub nonce: String,
+    /// The verifier identity (the VTC DID) the holder's kb-jwt must name.
+    pub aud: String,
+}
+
+/// Issue a single-use presentation challenge for `thread_id`, bound to `aud`
+/// (the verifier identity the holder's kb-jwt must name). Returns the
+/// freshly-generated nonce to place in the outgoing `credential-exchange/query`.
+pub async fn issue(
+    ks: &KeyspaceHandle,
+    thread_id: &str,
+    aud: &str,
+    ttl: Duration,
+    now: DateTime<Utc>,
+) -> Result<String, AppError> {
+    let nonce = Uuid::new_v4().to_string();
+    let rec = PresentChallenge {
+        nonce: nonce.clone(),
+        aud: aud.to_string(),
+        expires_at: now + ttl,
+    };
+    ks.insert(key(thread_id), &rec).await?;
+    Ok(nonce)
+}
+
+/// Consume the challenge for `thread_id`. **Single-use**: the record is removed
+/// before the expiry check, so a replayed presentation on the same thread finds
+/// no challenge. Errors if absent (unknown / already-consumed) or expired.
+pub async fn consume(
+    ks: &KeyspaceHandle,
+    thread_id: &str,
+    now: DateTime<Utc>,
+) -> Result<ConsumedChallenge, AppError> {
+    let rec: PresentChallenge = ks.get(key(thread_id)).await?.ok_or_else(|| {
+        AppError::Validation(format!(
+            "no presentation challenge for thread `{thread_id}` (unknown or already consumed)"
+        ))
+    })?;
+    // Remove first — single-use, even on the expired path.
+    ks.remove(key(thread_id)).await?;
+    if now >= rec.expires_at {
+        return Err(AppError::Validation(format!(
+            "presentation challenge for thread `{thread_id}` expired at {}",
+            rec.expires_at
+        )));
+    }
+    Ok(ConsumedChallenge {
+        nonce: rec.nonce,
+        aud: rec.aud,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn fresh_ks() -> (tempfile::TempDir, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("join_requests").unwrap();
+        (dir, ks)
+    }
+
+    #[tokio::test]
+    async fn issue_then_consume_round_trips() {
+        let (_dir, ks) = fresh_ks();
+        let now = Utc::now();
+        let nonce = issue(
+            &ks,
+            "thread-1",
+            "did:web:vtc.example",
+            DEFAULT_CHALLENGE_TTL,
+            now,
+        )
+        .await
+        .unwrap();
+
+        let consumed = consume(&ks, "thread-1", now).await.unwrap();
+        assert_eq!(consumed.nonce, nonce);
+        assert_eq!(consumed.aud, "did:web:vtc.example");
+    }
+
+    #[tokio::test]
+    async fn consume_is_single_use() {
+        let (_dir, ks) = fresh_ks();
+        let now = Utc::now();
+        issue(
+            &ks,
+            "thread-1",
+            "did:web:vtc.example",
+            DEFAULT_CHALLENGE_TTL,
+            now,
+        )
+        .await
+        .unwrap();
+
+        consume(&ks, "thread-1", now).await.expect("first consume");
+        // A replay on the same thread finds no challenge.
+        let err = consume(&ks, "thread-1", now).await.unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("already consumed")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_rejects_an_expired_challenge() {
+        let (_dir, ks) = fresh_ks();
+        let issued_at = Utc::now() - Duration::minutes(10);
+        issue(
+            &ks,
+            "thread-1",
+            "did:web:vtc.example",
+            DEFAULT_CHALLENGE_TTL,
+            issued_at,
+        )
+        .await
+        .unwrap();
+
+        let err = consume(&ks, "thread-1", Utc::now()).await.unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("expired")),
+            "{err:?}"
+        );
+        // Even expired, it was consumed (single-use cleanup).
+        let again = consume(&ks, "thread-1", Utc::now()).await.unwrap_err();
+        assert!(matches!(&again, AppError::Validation(m) if m.contains("already consumed")));
+    }
+
+    #[tokio::test]
+    async fn consume_rejects_an_unknown_thread() {
+        let (_dir, ks) = fresh_ks();
+        let err = consume(&ks, "never-issued", Utc::now()).await.unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("unknown")),
+            "{err:?}"
+        );
+    }
+}

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -13,9 +13,10 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use vta_sdk::protocols::credential_exchange::PRESENT as CREDENTIAL_PRESENT_TYPE;
 use vta_sdk::protocols::credential_exchange::REQUEST as CREDENTIAL_REQUEST_TYPE;
 use vta_sdk::protocols::credential_exchange::{
-    ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody, RequestBody,
+    ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody, PresentBody, RequestBody,
 };
 use vta_sdk::protocols::join_requests::{
     JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitBody,
@@ -109,6 +110,12 @@ pub async fn run_didcomm_service(
             r.route(
                 CREDENTIAL_REQUEST_TYPE,
                 handler_fn(credential_request_handler),
+            )
+        })
+        .and_then(|r| {
+            r.route(
+                CREDENTIAL_PRESENT_TYPE,
+                handler_fn(credential_present_handler),
             )
         }) {
         Ok(r) => r,
@@ -309,6 +316,67 @@ async fn credential_request_handler(
         .map_err(|e| DIDCommServiceError::Internal(format!("issue serialise: {e}")))?;
     Ok(Some(
         DIDCommResponse::new(CREDENTIAL_ISSUE_TYPE, issue_body).thid(message.id),
+    ))
+}
+
+/// `credential-exchange/present/1.0` over DIDComm (close-the-join-loop, part 3).
+///
+/// The holder answers the VTC's DCQL query with an OID4VP `vp_token`. The present
+/// replies on the query's thread (`thid`); the VTC consumes the **single-use
+/// presentation challenge** keyed by that thread
+/// ([`crate::credentials::present_challenge`]) to recover the expected nonce +
+/// audience (freshness / replay), cryptographically verifies the `vp_token`, runs
+/// the join decision, and — on `allow` — admits the proven holder and issues the
+/// MembershipCredential. Replies with a join receipt (request id + status).
+///
+/// The DIDComm `from` (authcrypt sender) authenticates the *relayer*; the
+/// **holder kb-jwt** inside the `vp_token` authenticates the *holder* and binds
+/// the verifier's nonce + audience — so a relayer ≠ holder is safe (it cannot
+/// forge the kb-jwt), mirroring the request-handler onion.
+async fn credential_present_handler(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<AppState>,
+) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let body: PresentBody = serde_json::from_value(message.body.clone())
+        .map_err(|e| DIDCommServiceError::Internal(format!("malformed present body: {e}")))?;
+
+    // The present replies on the query's thread; the challenge is keyed by it.
+    let thread_id = message.thid.clone().ok_or_else(|| {
+        DIDCommServiceError::Internal(
+            "present carries no thread id (thid) to correlate its challenge".into(),
+        )
+    })?;
+
+    let now = chrono::Utc::now();
+    let challenge =
+        crate::credentials::present_challenge::consume(&state.join_requests_ks, &thread_id, now)
+            .await
+            .map_err(|e| DIDCommServiceError::Internal(format!("present challenge: {e}")))?;
+
+    let outcome = crate::routes::join_requests::present::present_and_decide_join(
+        &state,
+        &body.vp_token,
+        &challenge.aud,
+        &challenge.nonce,
+        JoinTransport::DIDComm,
+        now,
+    )
+    .await
+    .map_err(|e| DIDCommServiceError::Internal(format!("present decision: {e}")))?;
+
+    let status = serde_json::to_value(outcome.request.status)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_default();
+    let receipt = JoinRequestSubmitReceiptBody {
+        request_id: outcome.request.id,
+        status,
+    };
+    let receipt_body = serde_json::to_value(&receipt)
+        .map_err(|e| DIDCommServiceError::Internal(format!("receipt serialise: {e}")))?;
+    Ok(Some(
+        DIDCommResponse::new(JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, receipt_body).thid(message.id),
     ))
 }
 

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1189,3 +1189,75 @@ async fn credential_exchange_present_rejects_a_wrong_nonce() {
         "a presentation bound to a different nonce must be refused"
     );
 }
+
+/// The wire freshness model end to end: the VTC issues a single-use challenge
+/// (nonce keyed by the query's thread), the holder presents bound to it, the
+/// `present` handler consumes the challenge and decides — and a replay on the
+/// same thread is refused (single-use). Exercises the same path the
+/// `credential-exchange/present` DIDComm handler drives.
+#[tokio::test]
+async fn credential_exchange_present_over_a_single_use_challenge_closes_the_loop() {
+    use vtc_service::credentials::present_challenge::{DEFAULT_CHALLENGE_TTL, consume, issue};
+    use vtc_service::join::{JoinStatus, JoinTransport};
+    use vtc_service::routes::join_requests::present::present_and_decide_join;
+
+    let fix = build_fixture().await;
+    activate_join_policy(
+        &fix,
+        "package vtc.join\nimport rego.v1\n\n\
+         default decision := {\"effect\": \"allow\", \"with\": {\"role\": \"member\"}}\n",
+    )
+    .await;
+
+    let now = chrono::Utc::now();
+    let thread = "query-thread-1";
+
+    // VTC issues the single-use challenge it sent with its DCQL query.
+    let nonce = issue(
+        &fix.state.join_requests_ks,
+        thread,
+        VTC_AUD,
+        DEFAULT_CHALLENGE_TTL,
+        now,
+    )
+    .await
+    .expect("issue challenge");
+
+    // Holder presents bound to (aud, nonce).
+    let (holder_did, vp_token) = build_membership_vp_token(0x45, VTC_AUD, &nonce, now.timestamp());
+
+    // Handler: consume the challenge (freshness/replay), then decide.
+    let challenge = consume(&fix.state.join_requests_ks, thread, now)
+        .await
+        .expect("consume challenge");
+    assert_eq!(challenge.nonce, nonce);
+    assert_eq!(challenge.aud, VTC_AUD);
+
+    let outcome = present_and_decide_join(
+        &fix.state,
+        &vp_token,
+        &challenge.aud,
+        &challenge.nonce,
+        JoinTransport::DIDComm,
+        now,
+    )
+    .await
+    .expect("present and decide");
+    assert_eq!(outcome.request.status, JoinStatus::Approved);
+    assert!(outcome.admit.is_some(), "VMC issued on allow");
+    assert!(
+        vtc_service::acl::get_acl_entry(&fix.acl_ks, &holder_did)
+            .await
+            .unwrap()
+            .is_some(),
+        "admitted holder has an ACL row"
+    );
+
+    // Replay: the challenge for this thread is gone — single-use.
+    assert!(
+        consume(&fix.state.join_requests_ks, thread, now)
+            .await
+            .is_err(),
+        "a replayed presentation finds no challenge"
+    );
+}


### PR DESCRIPTION
Wires Part 2's decision operation (#268) to the wire and adds replay protection. The **invite→hold→present→join** loop now closes over DIDComm.

## What changed
- **`present_challenge` store** (single-use, TTL) — the VTC issues a nonce keyed by the query's DIDComm thread id, bound to the audience the holder must echo. `consume` **removes the record before the expiry check**, so a replayed `vp_token` on the same thread finds no challenge and is refused; a stale nonce ages out. Stored in the `join_requests` keyspace under a disjoint `present-challenge:` prefix (alongside `credx-pending:`).
- **`credential-exchange/present/1.0` DIDComm handler** — the present replies on the query's thread (`thid`); the VTC consumes the challenge (freshness / replay) to recover the expected nonce + audience, then runs `present_and_decide_join` (verify → decide → admit + issue VMC on `allow`). Replies with a join receipt (request id + status). The authcrypt sender authenticates the *relayer*; the holder kb-jwt inside the `vp_token` authenticates the *holder* — relayer ≠ holder is safe (it can't forge the kb-jwt).

## Tests
- Challenge store: round-trip · single-use (replay refused) · expired · unknown-thread (4 unit tests).
- `credential_exchange_present_over_a_single_use_challenge_closes_the_loop` — a wire-level integration test: issue a challenge → present bound to it → consume + decide (auto-admit + VMC, holder gets an ACL row) → confirm a replay on the same thread is refused.

## Verification
Full vtc-service suite passes (exit 0) · clippy clean · fmt clean · DCO + GPG signed.

## The loop, end to end
```
VTC issues challenge (nonce, keyed by query thread)  ──query──▶  VTA holder
VTA presents vp_token (kb-jwt binds nonce+aud)       ──present─▶  VTC
VTC: consume challenge (single-use) → verify_vp_token → decide → allow ⇒ issue MembershipCredential
```

## Scope / next (optional)
- The `credential-exchange/query` **send** side (the VTC issuing the challenge alongside an outbound DCQL query, as part of join initiation) — this PR provides `present_challenge::issue` that the send path will call.
- **W3C Data-Integrity VP** holder-proof verification (`verify_vp_token` currently defers DI-VP entries; SD-JWT-VC is fully wired).