### PR TITLE
feat(vtc): credential-exchange/query send side — issue the challenge + build the DCQL query

### DIFF
--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -10,22 +10,34 @@
 //! `allow`, else queuing / rejecting like the VP submit path.
 //!
 //! Unlike the VP submit path (whose `presentation.verified` rests on a
-//! route-layer hex signature), here `verified` rests on the holder `kb-jwt`
-//! binding the verifier's `nonce` + audience — real VP cryptography.
+//! route-layer hex signature), here `verified` rests on the holder `kb-jwt` /
+//! DI holder proof binding the verifier's `nonce` + audience — real VP
+//! cryptography. [`present_and_decide_join`] takes the expected audience + nonce
+//! as parameters so it is transport-agnostic; the DIDComm
+//! `credential-exchange/present` handler (`messaging.rs`) sources them from the
+//! single-use presentation challenge it consumes.
 //!
-//! The DIDComm `credential-exchange/present` wire handler + the single-use
-//! presentation-challenge store (freshness / replay) that sources
-//! `expected_nonce` are the next slice; this operation takes the expected
-//! audience + nonce as parameters so it is transport-agnostic and testable.
+//! This module also hosts the **query send side** ([`prepare_join_query`] +
+//! [`send_query`]): the VTC issues the challenge and builds the DCQL query (from
+//! a registered Accepts criterion) the holder answers.
 
+use affinidi_openid4vp::DcqlQuery;
+use axum::Json;
+use axum::extract::State;
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
+use vta_sdk::protocols::credential_exchange::QueryBody;
 
+use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
 
 use crate::ceremony::{Credential, CredentialStatus, Presentation};
+use crate::credentials::present_challenge::{self, DEFAULT_CHALLENGE_TTL};
 use crate::credentials::{VerifiedPresentationSet, verify_vp_token};
 use crate::join::JoinTransport;
+use crate::schemas::accepts::get_accepts;
 use crate::server::AppState;
 
 use super::submit::{JoinSubmitOutcome, decide_join, realize_join_verdict};
@@ -75,6 +87,106 @@ pub async fn present_and_decide_join(
         transport,
     )
     .await
+}
+
+// ---------------------------------------------------------------------------
+// Query send side (close-the-join-loop, part B): the VTC issues the challenge
+// and builds the DCQL query the holder answers.
+// ---------------------------------------------------------------------------
+
+/// Prepare a `credential-exchange/query` for a join: load the registered Accepts
+/// DCQL criterion `criterion_id` (Phase 2 — the community's acceptance rule),
+/// issue a **single-use presentation challenge** keyed by `thread_id` and bound
+/// to the VTC's own DID, and assemble the [`QueryBody`] (the DCQL query + the
+/// freshness nonce + a purpose shown to the holder).
+///
+/// The holder presents on this `thread_id`; the
+/// `credential-exchange/present` handler consumes the challenge to recover the
+/// nonce + audience and verify the presentation.
+pub async fn prepare_join_query(
+    state: &AppState,
+    thread_id: &str,
+    criterion_id: &str,
+    now: DateTime<Utc>,
+) -> Result<QueryBody, AppError> {
+    let vtc_did = state.config.read().await.vtc_did.clone().ok_or_else(|| {
+        AppError::Internal("VTC DID not configured — cannot bind a presentation challenge".into())
+    })?;
+
+    let criterion = get_accepts(&state.schemas_ks, criterion_id)
+        .await?
+        .ok_or_else(|| {
+            AppError::NotFound(format!("no Accepts criterion `{criterion_id}` registered"))
+        })?;
+    let dcql_query = DcqlQuery::from_json(&criterion.query).map_err(|e| {
+        AppError::Internal(format!(
+            "registered Accepts criterion `{criterion_id}` is not a valid DCQL query: {e}"
+        ))
+    })?;
+
+    let nonce = present_challenge::issue(
+        &state.join_requests_ks,
+        thread_id,
+        &vtc_did,
+        DEFAULT_CHALLENGE_TTL,
+        now,
+    )
+    .await?;
+
+    let purpose = criterion
+        .description
+        .unwrap_or_else(|| format!("join: present credentials satisfying `{criterion_id}`"));
+    Ok(QueryBody {
+        dcql_query,
+        nonce,
+        purpose,
+    })
+}
+
+/// `POST /v1/join-requests/query` request — ask the VTC to prepare a join query
+/// for `holderDid` from the named Accepts criterion.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendQueryRequest {
+    /// The holder the query is for (delivered to it over DIDComm by the VTC or a
+    /// relayer — relayer ≠ holder is supported; the holder still proves binding).
+    pub holder_did: String,
+    /// The registered Accepts criterion whose DCQL query to send.
+    pub criterion_id: String,
+}
+
+/// `POST /v1/join-requests/query` response — the prepared query to deliver, and
+/// the thread the holder presents on.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendQueryResponse {
+    /// The DIDComm thread id the holder must reply on (the challenge is keyed by
+    /// it; the `present` handler consumes it).
+    pub thread_id: String,
+    /// Echoed for the caller's correlation.
+    pub holder_did: String,
+    /// The `credential-exchange/query` body to deliver to the holder.
+    pub query: QueryBody,
+}
+
+/// `POST /v1/join-requests/query` (admin) — prepare a `credential-exchange/query`
+/// for `holderDid` from the Accepts criterion `criterionId`: issue the single-use
+/// challenge and return the [`QueryBody`] to deliver. The VTC relays it over
+/// DIDComm (or an out-of-band relayer delivers it — relayer ≠ holder is
+/// supported); the holder presents on the returned `threadId`, and the
+/// `credential-exchange/present` handler consumes the challenge.
+pub async fn send_query(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Json(body): Json<SendQueryRequest>,
+) -> Result<Json<SendQueryResponse>, AppError> {
+    let thread_id = Uuid::new_v4().to_string();
+    let query = prepare_join_query(&state, &thread_id, &body.criterion_id, Utc::now()).await?;
+    Ok(Json(SendQueryResponse {
+        thread_id,
+        holder_did: body.holder_did,
+        query,
+    }))
 }
 
 /// Project a [`VerifiedPresentationSet`] into the verified ceremony

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -683,6 +683,14 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             post(join_requests::decide::reject),
             join_reject,
         )
+        // Credential-exchange query send (admin): prepare a DCQL query + issue a
+        // single-use presentation challenge for a holder. Plain admin route (no
+        // Trust-Task descriptor) — the holder answers over the credential-exchange
+        // DIDComm `present` surface.
+        .route_exempt(
+            "/join-requests/query",
+            post(join_requests::present::send_query),
+        )
         // Policies (Phase 2 M2.3). Three POST endpoints, three
         // Trust Tasks. `upload` mints + persists; `activate` flips
         // the per-purpose active pointer; `test` evaluates a stored

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1261,3 +1261,95 @@ async fn credential_exchange_present_over_a_single_use_challenge_closes_the_loop
         "a replayed presentation finds no challenge"
     );
 }
+
+/// The query-send side: an admin asks the VTC to prepare a credential-exchange
+/// query from a registered Accepts criterion. The VTC issues a single-use
+/// challenge (bound to its own DID) and returns the DCQL `QueryBody` to deliver;
+/// the challenge is then consumable on the returned thread.
+#[tokio::test]
+async fn admin_query_send_prepares_a_dcql_query_and_issues_a_challenge() {
+    use vtc_service::credentials::present_challenge::consume;
+    use vtc_service::schemas::accepts::{AcceptsCriterion, store_accepts};
+
+    let fix = build_fixture().await;
+
+    // A `type_values` DCQL query references no `vct_values` types, so it stores
+    // without registering schemas first.
+    let criterion = AcceptsCriterion {
+        id: "join-evidence".into(),
+        query: json!({
+            "credentials": [{
+                "id": "membership",
+                "format": "ldp_vc",
+                "meta": { "type_values": ["MembershipCredential"] }
+            }]
+        }),
+        description: Some("present a MembershipCredential to join".into()),
+        created_at: chrono::Utc::now(),
+        created_by_did: ADMIN_DID.into(),
+    };
+    store_accepts(&fix.state.schemas_ks, &criterion)
+        .await
+        .expect("store accepts criterion");
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests/query",
+        "x",
+        Some(&fix.admin_token),
+        Some(json!({ "holderDid": "did:key:zHolder", "criterionId": "join-evidence" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    let thread_id = body["threadId"].as_str().expect("threadId").to_string();
+    assert_eq!(body["holderDid"], "did:key:zHolder");
+    assert!(
+        body["query"]["dcql_query"]["credentials"].is_array(),
+        "DCQL query present: {body}"
+    );
+    let nonce = body["query"]["nonce"].as_str().expect("nonce").to_string();
+    assert_eq!(
+        body["query"]["purpose"],
+        "present a MembershipCredential to join"
+    );
+
+    // The single-use challenge is consumable on that thread, bound to the VTC DID.
+    let challenge = consume(&fix.state.join_requests_ks, &thread_id, chrono::Utc::now())
+        .await
+        .expect("consume challenge");
+    assert_eq!(challenge.aud, VTC_AUD);
+    assert_eq!(challenge.nonce, nonce);
+}
+
+/// An unregistered criterion id is a 404 (no challenge issued).
+#[tokio::test]
+async fn admin_query_send_404s_an_unknown_criterion() {
+    let fix = build_fixture().await;
+    let (status, _body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests/query",
+        "x",
+        Some(&fix.admin_token),
+        Some(json!({ "holderDid": "did:key:zHolder", "criterionId": "does-not-exist" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// The query-send route is admin-gated.
+#[tokio::test]
+async fn admin_query_send_requires_admin() {
+    let fix = build_fixture().await;
+    let (status, _body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests/query",
+        "x",
+        None,
+        Some(json!({ "holderDid": "did:key:zHolder", "criterionId": "join-evidence" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
The VTC can now **initiate** the present→join loop: it builds the DCQL query the holder must answer and issues the single-use challenge that anchors freshness. (Third of the four follow-ups; PR C = the VTA holder offer→request leg.)

## What changed
- **`prepare_join_query(state, thread_id, criterion_id, now) -> QueryBody`** — loads the registered **Accepts DCQL criterion** (Phase 2 #241 — the community's acceptance rule), issues a `present_challenge` keyed by `thread_id` and bound to the VTC's own DID, and assembles `QueryBody { dcql_query, nonce, purpose }`. The holder presents on that thread; the `credential-exchange/present` handler (#269) consumes the challenge. This connects the schema-store **Accepts** criterion to the wire query.
- **`POST /v1/join-requests/query`** (admin) — `{ holderDid, criterionId }` → prepare + return `{ threadId, holderDid, query }`. The VTC relays the query over DIDComm, or an out-of-band relayer delivers it (**relayer ≠ holder** is supported; the holder still proves binding). Plain admin route (`route_exempt`).

## Tests
- An admin query-send prepares the DCQL query from a registered criterion + issues a challenge **consumable on the returned thread** (bound to the VTC DID).
- An unknown criterion is `404`.
- The route is admin-gated (`401` without a token).

## Verification
Full vtc-service suite passes (exit 0) · clippy clean · fmt clean · DCO + GPG signed.

## Design note
The route returns the prepared `QueryBody` + `threadId` for delivery rather than blocking on an outbound mediator push — the relayer-delivery model is supported and keeps this testable without a live mediator (the actual DIDComm push is e2e-territory, like the `present` handler). The security-critical part — the VTC issuing the single-use, audience-bound challenge — is fully here and tested.

## The loop, now both directions
```
VTC: prepare_join_query (Accepts criterion → DCQL) + issue challenge  ──query──▶  holder
holder presents vp_token (binds nonce + aud)                          ──present─▶  VTC
VTC: consume challenge → verify_vp_token → decide → allow ⇒ issue MembershipCredential
```