### PR TITLE
feat(vta): holder offer→request leg — answer a credential offer with a key-binding proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9765,6 +9765,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
+ "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
  "affinidi-sd-jwt-vc",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -110,6 +110,9 @@ affinidi-sd-jwt = { workspace = true }
 # DCQL matcher — the holder runs a verifier's DCQL query over held credentials
 # (`credential-exchange/query`, task 3.5). Same crate vta-sdk's QueryBody uses.
 affinidi-openid4vp = { workspace = true }
+# OID4VCI offer/request types + wallet builders — the holder `offer → request`
+# leg (task 3.2). Same crate vta-sdk's OfferBody / RequestBody use.
+affinidi-openid4vci = { workspace = true }
 # Holder-side status refresh for held credentials (task 1.6): decode the
 # issuer's BitstringStatusList and read the bit at the credential's index.
 affinidi-status-list = { workspace = true }

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -41,6 +41,13 @@ pub struct AppConfig {
     /// (defer everything) — a safe default; operators trust specific verifiers.
     #[serde(default)]
     pub trusted_presentation_verifiers: Vec<String>,
+    /// The VTA-managed holder identity (a registered derived `subject_did`) the
+    /// VTA **auto-accepts** offered credentials for: when set, an inbound
+    /// `credential-exchange/offer` is answered with a `request` binding the new
+    /// credential to this DID. Default unset — the VTA does **not** accept
+    /// unsolicited offers (a safe default; opt in by naming the holder identity).
+    #[serde(default)]
+    pub credential_holder_did: Option<String>,
     #[cfg(feature = "tee")]
     #[serde(default)]
     pub tee: TeeConfig,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1872,6 +1872,74 @@ pub async fn handle_credential_issue(
     Ok(None)
 }
 
+/// `credential-exchange/offer` over DIDComm (Phase 3, task 3.2) — the holder side
+/// of the issuance negotiation: an issuer offered a credential, and the VTA
+/// answers with a `request` carrying a key-binding proof.
+///
+/// **Opt-in**: the VTA accepts an offer only when `credential_holder_did` is
+/// configured — the registered VTA-managed holder identity the new credential
+/// binds to. With it unset (the default), an unsolicited offer is declined; the
+/// VTA does not auto-request credentials from arbitrary issuers. When set, the
+/// VTA acts with its own authority, signs an `openid4vci-proof+jwt` bound to that
+/// holder key + the offer's issuer/pre-auth code, and replies `request/1.0`
+/// on-thread. The issuer's redeem path returns the credential via `issue/1.0`,
+/// which [`handle_credential_issue`] receives.
+pub async fn handle_credential_offer(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(app_state): Extension<AppState>,
+) -> HandlerResult {
+    let body: credential_exchange::OfferBody =
+        serde_json::from_value(message.body).map_err(handler_err)?;
+
+    let subject_did = match app_state.config.read().await.credential_holder_did.clone() {
+        Some(did) => did,
+        None => {
+            info!(
+                from = message.from.as_deref().unwrap_or("unknown"),
+                "credential offer received but no credential_holder_did configured — declining"
+            );
+            return Ok(Some(DIDCommResponse::problem_report(
+                ProblemReport::bad_request(
+                    "this VTA does not accept unsolicited credential offers \
+                     (no credential_holder_did configured)"
+                        .to_string(),
+                ),
+            )));
+        }
+    };
+
+    // The VTA accepts on its own behalf (super-admin over its own contexts); the
+    // holder-key resolution is still ACL-gated to the subject's context.
+    let auth = crate::auth::AuthClaims {
+        role: Role::Admin,
+        allowed_contexts: Vec::new(),
+        ..Default::default()
+    };
+
+    let request = app_try!(
+        operations::credential_exchange::build_credential_request_for_offer(
+            &app_state.keys_ks,
+            &app_state.seed_store,
+            &auth,
+            &body.credential_offer,
+            &subject_did,
+            chrono::Utc::now(),
+        )
+        .await
+    );
+
+    let request_body = serde_json::to_value(&request).map_err(handler_err)?;
+    info!(
+        from = message.from.as_deref().unwrap_or("unknown"),
+        subject = %subject_did,
+        "answered credential offer with a request"
+    );
+    Ok(Some(
+        DIDCommResponse::new(credential_exchange::REQUEST, request_body).thid(message.id),
+    ))
+}
+
 /// `credential-exchange/query` over DIDComm (Phase 3) — the holder answers a
 /// verifier's DCQL query with a presentation.
 ///

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -352,6 +352,12 @@ pub fn build_handler(
         .route(
             credential_exchange::QUERY,
             handler_fn(handlers::handle_credential_query),
+        )?
+        // Credential exchange — holder answers an issuer's offer with a request
+        // (spec §6 / task 3.2). Opt-in via `credential_holder_did`.
+        .route(
+            credential_exchange::OFFER,
+            handler_fn(handlers::handle_credential_offer),
         )?;
 
     // WebVH handlers (feature-gated)

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -40,7 +40,7 @@ use affinidi_secrets_resolver::secrets::Secret;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use uuid::Uuid;
-use vta_sdk::protocols::credential_exchange::{IssueBody, PresentBody, QueryBody};
+use vta_sdk::protocols::credential_exchange::{IssueBody, PresentBody, QueryBody, RequestBody};
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
@@ -235,6 +235,75 @@ pub async fn seal_issued_credential(
         .map_err(|e| AppError::Internal(format!("sealing issued credential failed: {e}")))?;
     let digest = bundle_digest(&bundle);
     Ok((armor::encode(&bundle), digest))
+}
+
+/// Build a `credential-exchange/request` from a received OID4VCI **offer** — the
+/// holder side of the issuance negotiation (spec §6, task 3.2). This is the
+/// `offer → request` leg: the issuer offered a credential, and the holder asks
+/// for it, proving control of the key the credential will bind to.
+///
+/// Resolves the **ACL-gated** VTA-managed holder key for `subject_did` (the same
+/// derived-key model as the present path — `auth` gates which context's key may
+/// be used), signs an `openid4vci-proof+jwt` key-binding proof — `iss` + `kid` =
+/// the holder, `aud` = the offer's `credential_issuer`, `nonce` = the offer's
+/// **pre-authorized code** (the issuer's freshness value the redeem path looks
+/// up), `iat` = `now` — and wraps it in a `CredentialRequest`. The issued
+/// credential binds to `subject_did`; the holder later presents it under the same
+/// key.
+pub async fn build_credential_request_for_offer(
+    keys_ks: &KeyspaceHandle,
+    seed_store: &Arc<dyn SeedStore>,
+    auth: &AuthClaims,
+    offer: &affinidi_openid4vci::CredentialOffer,
+    subject_did: &str,
+    now: DateTime<Utc>,
+) -> Result<RequestBody, AppError> {
+    use affinidi_sd_jwt::signer::JwtSigner;
+
+    // The pre-authorized code is the issuer-issued freshness value the holder
+    // commits to (the VTC redeem path looks the pending issuance up by it).
+    let pre_auth_code = offer
+        .grants
+        .as_ref()
+        .and_then(|g| g.pre_authorized_code.as_ref())
+        .map(|c| c.pre_authorized_code.clone())
+        .ok_or_else(|| {
+            AppError::Validation("credential offer has no pre-authorized-code grant".into())
+        })?;
+
+    // The credential the offer advertises (its configuration id doubles as the
+    // requested `vct` for the SD-JWT-VC format).
+    let vct = offer
+        .credential_configuration_ids
+        .first()
+        .cloned()
+        .ok_or_else(|| {
+            AppError::Validation("credential offer names no credential_configuration_ids".into())
+        })?;
+
+    // ACL-gated holder key for the subject the credential will bind to.
+    let keys = resolve_holder_keys(keys_ks, seed_store, auth, subject_did).await?;
+    let kid = keys.signer.key_id().unwrap_or(subject_did).to_string();
+
+    let header = serde_json::json!({
+        "typ": "openid4vci-proof+jwt",
+        "alg": "EdDSA",
+        "kid": kid,
+    });
+    let payload = serde_json::json!({
+        "iss": subject_did,
+        "aud": offer.credential_issuer,
+        "iat": now.timestamp(),
+        "nonce": pre_auth_code,
+    });
+    let proof_jwt = keys
+        .signer
+        .sign_jwt(&header, &payload)
+        .map_err(|e| AppError::Internal(format!("signing key-binding proof failed: {e}")))?;
+
+    let credential_request =
+        affinidi_openid4vci::wallet::build_sd_jwt_vc_request(&vct, Some(proof_jwt));
+    Ok(RequestBody { credential_request })
 }
 
 /// The issuer DID from a VC `issuer` field — a string, or an object with `id`.
@@ -2033,6 +2102,121 @@ mod tests {
         .unwrap();
 
         (dir, vault, keys_ks, seed_store, subject_did)
+    }
+
+    #[tokio::test]
+    async fn build_credential_request_for_offer_signs_a_keybinding_proof() {
+        use crate::acl::Role;
+        use base64::Engine;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use ed25519_dalek::Verifier;
+        use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
+
+        let (_dir, _vault, keys_ks, seed_store, subject_did) = holder_fixture().await;
+        let auth = AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: Vec::new(),
+            ..Default::default()
+        };
+        let now = Utc::now();
+
+        let offer = affinidi_openid4vci::wallet::parse_credential_offer(
+            r#"{
+                "credential_issuer": "did:webvh:vtc.example",
+                "credential_configuration_ids": ["https://openvtc.org/credentials/MembershipCredential"],
+                "grants": {
+                    "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+                        "pre-authorized_code": "code-abc-123"
+                    }
+                }
+            }"#,
+        )
+        .expect("parse offer");
+
+        let request = build_credential_request_for_offer(
+            &keys_ks,
+            &seed_store,
+            &auth,
+            &offer,
+            &subject_did,
+            now,
+        )
+        .await
+        .expect("build credential request");
+
+        let req = request.credential_request;
+        assert_eq!(
+            req.vct.as_deref(),
+            Some("https://openvtc.org/credentials/MembershipCredential")
+        );
+        let proof = req.proof.expect("key-binding proof present");
+        assert_eq!(proof.proof_type, "jwt");
+
+        // Decode the openid4vci-proof+jwt and check its bindings.
+        let parts: Vec<&str> = proof.jwt.split('.').collect();
+        assert_eq!(parts.len(), 3, "compact JWS");
+        let header: Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[0]).unwrap()).unwrap();
+        let payload: Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+        assert_eq!(header["typ"], "openid4vci-proof+jwt");
+        assert_eq!(header["alg"], "EdDSA");
+        assert!(
+            header["kid"].as_str().unwrap().starts_with(&subject_did),
+            "kid names the holder"
+        );
+        assert_eq!(payload["iss"], subject_did);
+        assert_eq!(payload["aud"], "did:webvh:vtc.example");
+        assert_eq!(
+            payload["nonce"], "code-abc-123",
+            "bound to the pre-auth code"
+        );
+
+        // The signature verifies under the holder's ACL-gated derived key.
+        let signing_input = format!("{}.{}", parts[0], parts[1]);
+        let sig = ed25519_dalek::Signature::from_slice(&URL_SAFE_NO_PAD.decode(parts[2]).unwrap())
+            .unwrap();
+        let derived = ExtendedSigningKey::from_seed(&[42u8; 64])
+            .unwrap()
+            .derive(&"m/26'/2'/0'/0'".parse::<DerivationPath>().unwrap())
+            .unwrap();
+        derived
+            .signing_key
+            .verifying_key()
+            .verify(signing_input.as_bytes(), &sig)
+            .expect("key-binding proof signature verifies under the holder key");
+    }
+
+    #[tokio::test]
+    async fn build_credential_request_for_offer_refuses_an_offer_without_a_code() {
+        use crate::acl::Role;
+
+        let (_dir, _vault, keys_ks, seed_store, subject_did) = holder_fixture().await;
+        let auth = AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: Vec::new(),
+            ..Default::default()
+        };
+        // No `grants` → no pre-authorized code.
+        let offer = affinidi_openid4vci::wallet::parse_credential_offer(
+            r#"{ "credential_issuer": "did:webvh:vtc.example", "credential_configuration_ids": ["x"] }"#,
+        )
+        .expect("parse offer");
+
+        let err = build_credential_request_for_offer(
+            &keys_ks,
+            &seed_store,
+            &auth,
+            &offer,
+            &subject_did,
+            Utc::now(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("pre-authorized")),
+            "{err:?}"
+        );
     }
 
     #[tokio::test]

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -619,6 +619,7 @@ pub async fn apply_inputs(inputs: WizardInputs) -> Result<(), Box<dyn std::error
     // 13. Save AppConfig.
     let config = AppConfig {
         trusted_presentation_verifiers: Vec::new(),
+        credential_holder_did: None,
         vta_did: vta_did.clone(),
         vta_name: inputs.vta_name.clone(),
         public_url: inputs.public_url.clone(),
@@ -951,6 +952,7 @@ fn scratch_config_for_seed_store(
 ) -> AppConfig {
     AppConfig {
         trusted_presentation_verifiers: Vec::new(),
+        credential_holder_did: None,
         vta_did: None,
         vta_name: None,
         public_url: None,

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -700,6 +700,7 @@ pub async fn run_setup_wizard(
         // All other backends: store via the seed store
         let seed_store = create_seed_store(&AppConfig {
             trusted_presentation_verifiers: Vec::new(),
+            credential_holder_did: None,
             vta_did: None,
             vta_name: None,
             public_url: None,
@@ -740,6 +741,7 @@ pub async fn run_setup_wizard(
     // Create a temporary AppConfig for the seed store (config hasn't been saved yet)
     let mut wizard_config = AppConfig {
         trusted_presentation_verifiers: Vec::new(),
+        credential_holder_did: None,
         vta_did: None,
         vta_name: None,
         public_url: public_url.clone(),
@@ -823,6 +825,7 @@ pub async fn run_setup_wizard(
     // 15. Save config
     let config = AppConfig {
         trusted_presentation_verifiers: Vec::new(),
+        credential_holder_did: None,
         vta_did,
         vta_name,
         public_url: public_url.clone(),

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -110,6 +110,7 @@ pub async fn open_test_store() -> TestStore {
 pub fn test_app_config(data_dir: PathBuf) -> AppConfig {
     AppConfig {
         trusted_presentation_verifiers: Vec::new(),
+        credential_holder_did: None,
         vta_did: None,
         vta_name: None,
         public_url: None,


### PR DESCRIPTION
Completes the issuance negotiation: the VTA holder receives an OID4VCI credential **offer** and answers with a **request** proving control of the key the credential will bind to. The issuer's redeem path then returns the credential via `issue/1.0`, which `handle_credential_issue` already receives. (Last of the four credential-exchange completion items.)

## What changed
- **`build_credential_request_for_offer(keys_ks, seed_store, auth, offer, subject_did, now) -> RequestBody`** — resolves the **ACL-gated** VTA-managed holder key for `subject_did` (same derived-key model as the present path — `auth` gates which context's key may be used), signs an `openid4vci-proof+jwt` key-binding proof (`iss` + `kid` = holder, `aud` = the offer's `credential_issuer`, `nonce` = the offer's **pre-authorized code**, `iat` = now), and wraps it in a `CredentialRequest` via the `affinidi-openid4vci` wallet builder. Added `affinidi-openid4vci` as a direct vta-service dep.
- **`handle_credential_offer`** DIDComm handler — **opt-in** via the new `credential_holder_did` config field. When **unset** (the default), an unsolicited offer is **declined** (the VTA does not auto-request credentials from arbitrary issuers — a safe default). When set, it binds the new credential to that identity and replies `request/1.0` on-thread. Registered on the credential-exchange `OFFER` type.

## Tests
- The proof binds `iss`/`kid` = holder, `aud` = issuer, `nonce` = pre-auth code, and its **signature verifies under the ACL-gated derived holder key**.
- An offer without a pre-authorized code is refused.

## Verification
644 vta-service lib tests pass · clippy clean · fmt clean · workspace builds · DCO + GPG signed.

## The full issuance + presentation loop
```
issuer → offer/1.0 → VTA holder
VTA: resolve_holder_keys (ACL-gated) → sign openid4vci-proof+jwt → request/1.0 → issuer
issuer: redeem (verify proof binds subject) → issue/1.0 → VTA   (handle_credential_issue receives)
…later: VTC query → VTA present → VTC verify + decide → MembershipCredential
```

## Notes
The handler is **opt-in** because auto-accepting any offer is a footgun — the operator names the holder identity (`credential_holder_did`) the VTA accepts credentials for. The substantive logic (`build_credential_request_for_offer`) is transport-agnostic and fully unit-tested.