### PR TITLE
feat(vta): live status re-check at present time (§14.5)

### DIFF
--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1989,6 +1989,7 @@ pub async fn handle_credential_query(
             &body,
             &verifier_did,
             &policy,
+            app_state.status_list_resolver.as_deref(),
             chrono::Utc::now(),
         )
         .await

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -644,6 +644,7 @@ async fn present_single(
     nonce: &str,
     verifier_aud: &str,
     iat_unix: u64,
+    status_resolver: Option<&dyn crate::vault::status::StatusListResolver>,
     now: DateTime<Utc>,
 ) -> Result<Value, AppError> {
     match &stored.format {
@@ -656,6 +657,7 @@ async fn present_single(
                 nonce,
                 verifier_aud,
                 iat_unix,
+                status_resolver,
                 now,
             )
             .await?;
@@ -671,6 +673,7 @@ async fn present_single(
                 holder_secret,
                 nonce,
                 verifier_aud,
+                status_resolver,
                 now,
             )
             .await?;
@@ -692,6 +695,7 @@ async fn present_single(
 /// When a credential query asked for `multiple` candidates and more than one
 /// satisfied it, that id maps to an **array** of presentations; otherwise to the
 /// single presentation value.
+#[allow(clippy::too_many_arguments)]
 async fn present_matched_set(
     vault: &KeyspaceHandle,
     keys_ks: &KeyspaceHandle,
@@ -700,6 +704,7 @@ async fn present_matched_set(
     matches: &[HeldMatch],
     query: &QueryBody,
     verifier_did: &str,
+    status_resolver: Option<&dyn crate::vault::status::StatusListResolver>,
     now: DateTime<Utc>,
 ) -> Result<PresentBody, AppError> {
     // Accumulate per credential-query id; collapse to a value (1) or array (>1).
@@ -750,6 +755,7 @@ async fn present_matched_set(
             &query.nonce,
             verifier_did,
             now.timestamp() as u64,
+            status_resolver,
             now,
         )
         .await?;
@@ -856,6 +862,7 @@ pub async fn present_query(
     query: &QueryBody,
     verifier_did: &str,
     policy: &ConsentPolicy,
+    status_resolver: Option<&dyn crate::vault::status::StatusListResolver>,
     now: DateTime<Utc>,
 ) -> Result<PresentOutcome, AppError> {
     let matched = match_vault(vault, &query.dcql_query).await?;
@@ -882,6 +889,7 @@ pub async fn present_query(
         &matched,
         query,
         verifier_did,
+        status_resolver,
         now,
     )
     .await?;
@@ -1028,12 +1036,14 @@ pub async fn defer_presentation(
 ///
 /// Refuses a record that isn't `Pending` (already approved / denied) or whose
 /// deferral window has lapsed (`expires_at` past — the verifier's nonce is stale).
+#[allow(clippy::too_many_arguments)]
 pub async fn approve_pending_presentation(
     vault: &KeyspaceHandle,
     keys_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     auth: &AuthClaims,
     id: &str,
+    status_resolver: Option<&dyn crate::vault::status::StatusListResolver>,
     now: DateTime<Utc>,
 ) -> Result<PresentBody, AppError> {
     let mut record = pending::get(vault, id)
@@ -1069,6 +1079,7 @@ pub async fn approve_pending_presentation(
         &matched,
         &record.query,
         &record.verifier_did,
+        status_resolver,
         now,
     )
     .await?;
@@ -1648,6 +1659,7 @@ mod tests {
             "verifier-nonce-1",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -1741,6 +1753,7 @@ mod tests {
             "verifier-nonce-di",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -1878,6 +1891,7 @@ mod tests {
             &query,
             verifier,
             &ConsentPolicy::trusting([verifier]),
+            None,
             now,
         )
         .await
@@ -1906,6 +1920,7 @@ mod tests {
             &query,
             "did:web:stranger.example",
             &ConsentPolicy::default(),
+            None,
             now,
         )
         .await
@@ -1992,6 +2007,7 @@ mod tests {
             &query,
             verifier,
             &ConsentPolicy::trusting([verifier]),
+            None,
             now,
         )
         .await
@@ -2242,6 +2258,7 @@ mod tests {
             &query,
             verifier,
             &ConsentPolicy::default(),
+            None,
             now,
         )
         .await
@@ -2269,7 +2286,7 @@ mod tests {
 
         // 2. Out-of-band approval mints consent + re-presents.
         let present =
-            approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-1", now)
+            approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-1", None, now)
                 .await
                 .expect("approve");
         // vp_token is the OID4VP DCQL map keyed by credential-query id.
@@ -2287,7 +2304,7 @@ mod tests {
             pending::PendingStatus::Approved
         );
         let twice =
-            approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-1", now)
+            approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-1", None, now)
                 .await
                 .unwrap_err();
         assert!(matches!(twice, AppError::Validation(_)), "{twice:?}");
@@ -2322,9 +2339,10 @@ mod tests {
             allowed_contexts: Vec::new(),
             ..Default::default()
         };
-        let err = approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-2", now)
-            .await
-            .unwrap_err();
+        let err =
+            approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-2", None, now)
+                .await
+                .unwrap_err();
         assert!(matches!(err, AppError::Validation(_)), "{err:?}");
     }
 
@@ -2358,10 +2376,17 @@ mod tests {
             allowed_contexts: Vec::new(),
             ..Default::default()
         };
-        let err =
-            approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-3", Utc::now())
-                .await
-                .unwrap_err();
+        let err = approve_pending_presentation(
+            &vault,
+            &keys_ks,
+            &seed_store,
+            &auth,
+            "req-3",
+            None,
+            Utc::now(),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, AppError::Validation(_)), "{err:?}");
     }
 }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -151,6 +151,11 @@ pub struct AppState {
     pub config: Arc<RwLock<AppConfig>>,
     pub seed_store: Arc<dyn SeedStore>,
     pub did_resolver: Option<DIDCacheClient>,
+    /// Live status-list resolver for the present path: when set, the holder
+    /// **re-resolves** a credential's revocation status at present time rather
+    /// than trusting the stored tag (§14.5). `None` falls back to the stored
+    /// status (the pre-live behaviour).
+    pub status_list_resolver: Option<Arc<dyn crate::vault::status::StatusListResolver>>,
     pub secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
     /// Verification-method id for the VTA's signing key (e.g.
     /// `{did}#key-0`). Populated by `init_auth`. Needed by the
@@ -296,6 +301,7 @@ pub async fn build_app_state(
         config: Arc::new(RwLock::new(config)),
         seed_store,
         did_resolver: auth.did_resolver,
+        status_list_resolver: crate::vault::status::default_status_resolver(),
         secrets_resolver: auth.secrets_resolver,
         #[cfg(feature = "didcomm")]
         signing_vm_id: auth.signing_vm_id,
@@ -614,6 +620,7 @@ pub async fn run(
             config: Arc::new(RwLock::new(config.clone())),
             seed_store: seed_store.clone(),
             did_resolver: auth.did_resolver,
+            status_list_resolver: crate::vault::status::default_status_resolver(),
             secrets_resolver: auth.secrets_resolver.clone(),
             #[cfg(feature = "didcomm")]
             signing_vm_id: auth.signing_vm_id.clone(),

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -572,6 +572,7 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
         did_resolver: DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
             .await
             .ok(),
+        status_list_resolver: None,
         secrets_resolver: None,
         #[cfg(feature = "didcomm")]
         signing_vm_id: None,

--- a/vta-service/src/vault/present.rs
+++ b/vta-service/src/vault/present.rs
@@ -97,6 +97,7 @@ use super::storage;
 ///   outside its `valid_from`/`valid_until` window ([`AppError::Forbidden`]);
 /// - the credential is not an SD-JWT-VC, or its stored body is malformed
 ///   ([`AppError::Validation`]).
+#[allow(clippy::too_many_arguments)]
 pub async fn present_sd_jwt_vc(
     vault: &KeyspaceHandle,
     credential_id: &str,
@@ -105,12 +106,21 @@ pub async fn present_sd_jwt_vc(
     nonce: &str,
     aud: &str,
     iat_unix: u64,
+    status_resolver: Option<&dyn super::status::StatusListResolver>,
     now: DateTime<Utc>,
 ) -> Result<String, AppError> {
     // Consent + subject-binding + authorization + status + temporal gate. Shared
     // with the Data-Integrity path ([`present_di_vc`]) — the single source of
     // truth for the security-critical disclosure gate.
-    let (cred, record) = gate_present(vault, credential_id, consent_record_id, aud, now).await?;
+    let (cred, record) = gate_present(
+        vault,
+        credential_id,
+        consent_record_id,
+        aud,
+        status_resolver,
+        now,
+    )
+    .await?;
 
     if cred.format != CredentialFormat::SdJwtVc {
         return Err(AppError::Validation(format!(
@@ -182,6 +192,7 @@ async fn gate_present(
     credential_id: &str,
     consent_record_id: &str,
     aud: &str,
+    status_resolver: Option<&dyn super::status::StatusListResolver>,
     now: DateTime<Utc>,
 ) -> Result<(super::model::StoredCredential, consent::ConsentRecord), AppError> {
     let cred = storage::get(vault, credential_id)
@@ -226,6 +237,32 @@ async fn gate_present(
         )));
     }
 
+    // Live status re-check (§14.5): when a resolver is configured, re-resolve the
+    // credential's status list **now** rather than trusting the stored tag — so a
+    // credential revoked since receive is refused at present time. `refresh_status`
+    // persists any change; re-read to gate on the live status.
+    //
+    // Resilient: a transient fetch failure (status-list host unreachable) falls
+    // back to the stored tag rather than blocking every presentation — fail-open
+    // on a fetch error, but fail-closed on a successfully-fetched `revoked` bit.
+    let cred = if let Some(resolver) = status_resolver {
+        match super::status::refresh_status(vault, credential_id, resolver).await {
+            Ok(_) => storage::get(vault, credential_id).await?.ok_or_else(|| {
+                AppError::NotFound(format!("credential `{credential_id}` not found"))
+            })?,
+            Err(e) => {
+                tracing::warn!(
+                    credential_id,
+                    error = %e,
+                    "live status re-check failed; falling back to the stored status"
+                );
+                cred
+            }
+        }
+    } else {
+        cred
+    };
+
     // Never present a revoked / temporally-invalid credential (§14.5).
     if cred.status != CredentialStatus::Valid {
         return Err(AppError::Forbidden(format!(
@@ -257,6 +294,7 @@ async fn gate_present(
 ///
 /// `holder_secret` is the holder's VTA-managed DI signing key. Returns the VP as
 /// a JSON string.
+#[allow(clippy::too_many_arguments)]
 pub async fn present_di_vc(
     vault: &KeyspaceHandle,
     credential_id: &str,
@@ -264,9 +302,18 @@ pub async fn present_di_vc(
     holder_secret: &Secret,
     nonce: &str,
     aud: &str,
+    status_resolver: Option<&dyn super::status::StatusListResolver>,
     now: DateTime<Utc>,
 ) -> Result<String, AppError> {
-    let (cred, record) = gate_present(vault, credential_id, consent_record_id, aud, now).await?;
+    let (cred, record) = gate_present(
+        vault,
+        credential_id,
+        consent_record_id,
+        aud,
+        status_resolver,
+        now,
+    )
+    .await?;
 
     if cred.format != CredentialFormat::EddsaJcs2022 {
         return Err(AppError::Validation(format!(
@@ -630,6 +677,7 @@ mod tests {
             nonce,
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -714,6 +762,7 @@ mod tests {
             nonce,
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -803,6 +852,7 @@ mod tests {
             "n",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -865,6 +915,7 @@ mod tests {
             "n",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -907,6 +958,7 @@ mod tests {
             "n",
             "did:web:acme-verifier.example",
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -968,6 +1020,7 @@ mod tests {
             "n",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -1026,6 +1079,7 @@ mod tests {
             "n",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -1083,6 +1137,7 @@ mod tests {
             "n",
             "did:web:evil-verifier.example", // mismatched aud
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -1140,6 +1195,7 @@ mod tests {
             "n",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -1198,6 +1254,7 @@ mod tests {
             "n",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -1255,6 +1312,7 @@ mod tests {
             "the-right-nonce",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -1312,6 +1370,7 @@ mod tests {
             "n",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await
@@ -1361,6 +1420,121 @@ mod tests {
         storage::put(vault, &cred).await.expect("put DI VC");
     }
 
+    /// A held DI VC carrying a W3C `BitstringStatusListEntry` at `index`,
+    /// stored with the `Valid` tag (as if status hadn't been re-checked since
+    /// receive).
+    async fn di_put_with_status(vault: &KeyspaceHandle, id: &str, subject_did: &str, index: usize) {
+        let vc = serde_json::json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": "did:web:issuer.example",
+            "credentialSubject": { "id": subject_did, "givenName": "Alice" },
+            "credentialStatus": {
+                "type": "BitstringStatusListEntry",
+                "statusPurpose": "revocation",
+                "statusListIndex": index.to_string(),
+                "statusListCredential": "https://issuer.example/status/1",
+            },
+        });
+        let cred = StoredCredential {
+            id: id.to_string(),
+            format: CredentialFormat::EddsaJcs2022,
+            types: vec!["MembershipCredential".into()],
+            schema_id: None,
+            community_did: None,
+            subject_did: Some(subject_did.to_string()),
+            issuer_did: Some("did:web:issuer.example".into()),
+            purpose: None,
+            status: CredentialStatus::Valid,
+            valid_from: None,
+            valid_until: None,
+            received_at: "2026-01-01T00:00:00Z".into(),
+            source: None,
+            tags: Default::default(),
+            body: serde_json::to_vec(&vc).unwrap(),
+        };
+        storage::put(vault, &cred).await.expect("put DI VC");
+    }
+
+    /// A live status resolver whose list marks `revoked` index as revoked.
+    struct RevokedAt(usize);
+
+    #[async_trait::async_trait]
+    impl super::super::status::StatusListResolver for RevokedAt {
+        async fn resolve(
+            &self,
+            _url: &str,
+        ) -> Result<super::super::status::ResolvedStatusList, AppError> {
+            use affinidi_status_list::{BitstringStatusList, StatusPurpose};
+            let mut list = BitstringStatusList::new(1024, StatusPurpose::Revocation);
+            list.set(self.0, true).unwrap();
+            Ok(super::super::status::ResolvedStatusList {
+                encoded_list: list.encode().unwrap(),
+                size: 1024,
+                status_purpose: StatusPurpose::Revocation,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn gate_present_live_status_refuses_a_since_revoked_credential() {
+        let (_dir, _store, vault) = fresh_vault();
+        let (holder_did, _kb, holder_secret, _vk) = holder(7);
+        let verifier = "did:web:acme-verifier.example";
+        let now = Utc::now();
+
+        // Stored with the Valid tag, status index 5.
+        di_put_with_status(&vault, "di-rev", &holder_did, 5).await;
+        let rec = create_consent(
+            &vault,
+            &grant(
+                &holder_did,
+                "di-rev",
+                verifier,
+                vec!["givenName".into()],
+                now + chrono::Duration::hours(1),
+            ),
+            &holder_secret,
+        )
+        .await
+        .unwrap();
+
+        // No resolver → the stored tag (Valid) is trusted → the gate passes.
+        gate_present(&vault, "di-rev", &rec.identifier, verifier, None, now)
+            .await
+            .expect("stored-tag gate passes");
+
+        // Live resolver whose list does NOT revoke index 5 → the gate re-resolves
+        // and still passes.
+        gate_present(
+            &vault,
+            "di-rev",
+            &rec.identifier,
+            verifier,
+            Some(&RevokedAt(999)),
+            now,
+        )
+        .await
+        .expect("live gate passes when the list says valid");
+
+        // Live resolver whose list **revokes** index 5 → the gate re-resolves and
+        // refuses, even though the stored tag still said Valid.
+        let err = gate_present(
+            &vault,
+            "di-rev",
+            &rec.identifier,
+            verifier,
+            Some(&RevokedAt(5)),
+            now,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Forbidden(m) if m.contains("not valid")),
+            "{err:?}"
+        );
+    }
+
     #[tokio::test]
     async fn present_di_vc_produces_a_verifiable_holder_bound_vp() {
         let (_dir, _store, vault) = fresh_vault();
@@ -1396,6 +1570,7 @@ mod tests {
             &holder_secret,
             "nonce-1",
             verifier,
+            None,
             now,
         )
         .await
@@ -1463,6 +1638,7 @@ mod tests {
             &holder_secret,
             "n",
             verifier,
+            None,
             now,
         )
         .await
@@ -1513,6 +1689,7 @@ mod tests {
             &holder_secret,
             "n",
             verifier,
+            None,
             now,
         )
         .await

--- a/vta-service/src/vault/status.rs
+++ b/vta-service/src/vault/status.rs
@@ -55,6 +55,8 @@ use serde::{Deserialize, Serialize};
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
+#[cfg(feature = "webvh")]
+use affinidi_status_list::DEFAULT_BITSTRING_SIZE;
 use affinidi_status_list::{BitstringStatusList, StatusPurpose};
 
 use super::model::{CredentialStatus, StoredCredential};
@@ -98,13 +100,102 @@ pub struct ResolvedStatusList {
     pub status_purpose: StatusPurpose,
 }
 
+/// The default live status resolver wired into a running VTA: an HTTP resolver
+/// when the `webvh` feature (which pulls in `reqwest`) is built, else `None` —
+/// in which case the present path falls back to the stored status tag.
+pub fn default_status_resolver() -> Option<std::sync::Arc<dyn StatusListResolver>> {
+    #[cfg(feature = "webvh")]
+    {
+        Some(std::sync::Arc::new(HttpStatusListResolver::new()))
+    }
+    #[cfg(not(feature = "webvh"))]
+    {
+        None
+    }
+}
+
+/// Production [`StatusListResolver`]: HTTP-fetches the `BitstringStatusListCredential`
+/// an issuer (e.g. the VTC) publishes at the entry URL and decodes its
+/// `credentialSubject` (`encodedList` + `statusPurpose`), using the standard list
+/// size ([`DEFAULT_BITSTRING_SIZE`], the W3C minimum the issuers allocate).
+///
+/// NOTE (hardening follow-up): this does **not** yet verify the status-list
+/// credential's own issuer signature — a holder should ideally verify it before
+/// trusting the list (needs issuer-key resolution). The present gate falls back
+/// to the stored tag on any resolver error, so an outage does not block
+/// presentation.
+#[cfg(feature = "webvh")]
+pub struct HttpStatusListResolver {
+    http: reqwest::Client,
+}
+
+#[cfg(feature = "webvh")]
+impl HttpStatusListResolver {
+    /// A resolver over a fresh HTTP client.
+    pub fn new() -> Self {
+        Self {
+            http: reqwest::Client::new(),
+        }
+    }
+}
+
+#[cfg(feature = "webvh")]
+impl Default for HttpStatusListResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "webvh")]
+#[async_trait::async_trait]
+impl StatusListResolver for HttpStatusListResolver {
+    async fn resolve(&self, url: &str) -> Result<ResolvedStatusList, AppError> {
+        let body: serde_json::Value = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| AppError::Internal(format!("status list fetch `{url}` failed: {e}")))?
+            .error_for_status()
+            .map_err(|e| AppError::Internal(format!("status list `{url}` returned an error: {e}")))?
+            .json()
+            .await
+            .map_err(|e| AppError::Internal(format!("status list `{url}` is not JSON: {e}")))?;
+
+        let subject = body.get("credentialSubject").ok_or_else(|| {
+            AppError::Validation(format!("status list `{url}` has no credentialSubject"))
+        })?;
+        let encoded_list = subject
+            .get("encodedList")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| AppError::Validation(format!("status list `{url}` has no encodedList")))?
+            .to_string();
+        let purpose_str = subject
+            .get("statusPurpose")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                AppError::Validation(format!("status list `{url}` has no statusPurpose"))
+            })?;
+        let status_purpose = parse_purpose(purpose_str).ok_or_else(|| {
+            AppError::Validation(format!(
+                "status list `{url}` has unknown statusPurpose `{purpose_str}`"
+            ))
+        })?;
+        Ok(ResolvedStatusList {
+            encoded_list,
+            size: DEFAULT_BITSTRING_SIZE,
+            status_purpose,
+        })
+    }
+}
+
 /// Resolves a status-list-credential URL to its decoded-ready bitstring.
 ///
-/// Injected so tests provide a mock (no network) and production wires an
-/// HTTP-fetching, list-credential-verifying implementation. The single method
-/// is `async` so a real resolver can perform I/O.
+/// Injected so tests provide a mock (no network) and production wires the
+/// HTTP-fetching [`HttpStatusListResolver`]. The single method is `async` so a
+/// real resolver can perform I/O.
 #[async_trait::async_trait]
-pub trait StatusListResolver {
+pub trait StatusListResolver: Send + Sync {
     /// Fetch and return the status list referenced by `url`.
     ///
     /// Implementations should verify the status-list *credential's* own issuer

--- a/vta-service/tests/vault_present.rs
+++ b/vta-service/tests/vault_present.rs
@@ -268,6 +268,7 @@ async fn present_discloses_only_consented_claims_with_kb_jwt_end_to_end() {
         nonce,
         verifier,
         now.timestamp() as u64,
+        None,
         now,
     )
     .await
@@ -319,6 +320,7 @@ async fn present_refused_for_missing_withdrawn_and_expired_consent() {
         "n",
         verifier,
         now.timestamp() as u64,
+        None,
         now,
     )
     .await
@@ -351,6 +353,7 @@ async fn present_refused_for_missing_withdrawn_and_expired_consent() {
         "n",
         verifier,
         now.timestamp() as u64,
+        None,
         now,
     )
     .await
@@ -379,6 +382,7 @@ async fn present_refused_for_missing_withdrawn_and_expired_consent() {
         "n",
         verifier,
         now.timestamp() as u64,
+        None,
         now,
     )
     .await
@@ -451,6 +455,7 @@ async fn present_refused_for_revoked_or_temporally_invalid_credential() {
             "n",
             verifier,
             now.timestamp() as u64,
+            None,
             now,
         )
         .await


### PR DESCRIPTION
The holder present path trusted the **stored** status tag (set at receive). Now it **re-resolves a credential's revocation status live** at present time, so a credential revoked *since* receive is refused before disclosure.

## What changed
- **`gate_present` takes `Option<&dyn StatusListResolver>`** — when set, it calls `refresh_status` (re-resolves the credential's status list, persists any change) and re-reads the credential before the status check. **Resilient**: a transient fetch failure falls back to the stored tag (fail-open on a fetch error, **fail-closed on a successfully-fetched `revoked` bit**), so a status-list outage doesn't block every presentation.
- **Threaded the resolver** through `present_sd_jwt_vc` / `present_di_vc` / `present_single` / `present_matched_set` / `present_query` / `approve_pending_presentation`; the `credential-exchange/query` handler passes `AppState.status_list_resolver`.
- **`AppState.status_list_resolver: Option<Arc<dyn StatusListResolver>>`** — wired via `vault::status::default_status_resolver()`: `Some(HttpStatusListResolver)` under the `webvh` feature (which pulls `reqwest`), else `None`.
- **`HttpStatusListResolver`** (webvh-gated) — fetches the `BitstringStatusListCredential` the issuer publishes, decodes `credentialSubject.{encodedList, statusPurpose}`, size = `DEFAULT_BITSTRING_SIZE`.
- `StatusListResolver` gains `Send + Sync` (for the `Arc<dyn>` in `AppState`).

## Tests
- `gate_present_live_status_refuses_a_since_revoked_credential` — under a live resolver whose list **revokes** the credential's index, the gate refuses it (Forbidden), while `None` (stored tag) and a not-revoked list both pass. Proves the live re-check end to end.
- All existing present tests pass with `None` (stored-tag behaviour unchanged).

## Verification
645 vta-service lib tests pass · clippy clean (`--all-targets`) · fmt clean · workspace builds · DCO + GPG signed.

## Notes
- **Behaviour by default**: live-status is on when the `webvh` feature is built (the production default); the gate's fail-open-on-fetch-error keeps it deployable even if the status-list host is unreachable.
- **Hardening follow-up**: `HttpStatusListResolver` does not yet verify the status-list *credential's own* issuer signature (needs issuer-key resolution). A holder should ideally verify it before trusting the list; the fail-open-on-error gate makes the current behaviour safe in the meantime.