### PR TITLE
feat(vtc): route the credential-query push via the holder's own mediator

### DIFF
--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -220,9 +220,12 @@ pub async fn send_query(
 /// message id **is** `thread_id` (the thread root), so the holder's `present`
 /// reply threads back to the single-use challenge the VTC just issued.
 ///
-/// Uses the shared mediator (`config.messaging.mediator_did`) as the forward
-/// target — the common deployment where the VTC and holder share a mediator.
-/// Resolving the holder's own mediator from its DID document is a follow-up.
+/// The forward is addressed to the **holder's own mediator** (resolved from the
+/// holder's DID document) and sent through the **VTC's own mediator** — the
+/// mediator the VTC has a connection to. The VTC's mediator routes the forward
+/// onward to the holder's mediator, which delivers it. When the holder
+/// advertises no mediator, the VTC's own mediator is used as the forward target
+/// (the shared-mediator deployment).
 async fn push_credential_query(
     state: &AppState,
     holder_did: &str,
@@ -248,6 +251,14 @@ async fn push_credential_query(
         (vtc_did, mediator_did)
     };
 
+    // Resolve the holder's own mediator from its DID document; fall back to the
+    // VTC's mediator (shared-mediator deployment) when the holder has none.
+    let target_mediator = resolve_holder_mediator(state, holder_did)
+        .await
+        .unwrap_or_else(|| mediator_did.clone());
+
+    // The VTC sends through its OWN mediator (the profile's connection); the
+    // forward, addressed to the holder's mediator, is routed onward from there.
     let profile = Arc::new(
         ATMProfile::new(atm, None, vtc_did.clone(), Some(mediator_did.clone()))
             .await
@@ -279,7 +290,7 @@ async fn push_credential_query(
         false,
         &jwe,
         Some(thread_id),
-        &mediator_did,
+        &target_mediator,
         holder_did,
         None,
         None,
@@ -289,6 +300,27 @@ async fn push_credential_query(
     .map_err(|e| AppError::Internal(format!("mediator forward failed: {e}")))?;
 
     Ok(())
+}
+
+/// Resolve the holder's own DIDComm mediator from its DID document — the `did:`
+/// `uri` of its `DIDCommMessaging` service. Returns `None` when the holder
+/// advertises no mediator (so the caller routes through its own).
+async fn resolve_holder_mediator(state: &AppState, holder_did: &str) -> Option<String> {
+    let resolver = state.did_resolver.as_ref()?;
+    let resolved = resolver.resolve(holder_did).await.ok()?;
+    for svc in &resolved.doc.service {
+        if svc.type_.iter().any(|t| t == "DIDCommMessaging")
+            && let Some(mediator) = svc
+                .service_endpoint
+                .get_uris()
+                .into_iter()
+                .map(|u| u.trim_matches('"').to_string())
+                .find(|u| u.starts_with("did:"))
+        {
+            return Some(mediator);
+        }
+    }
+    None
 }
 
 /// Project a [`VerifiedPresentationSet`] into the verified ceremony


### PR DESCRIPTION
#273 addressed the query forward to the **shared** mediator. Now the VTC resolves the **holder's own mediator** from its DID document and addresses the forward to it, while still sending through the VTC's own mediator — which routes it onward. This delivers to a holder behind a *different* mediator, not just a shared one.

## What changed
- **`resolve_holder_mediator`** — resolves the holder DID via `state.did_resolver` and returns the `did:` `uri` of its `DIDCommMessaging` service (mirrors `vta-service`'s `status.rs` own-mediator extraction). `None` when the holder advertises no mediator.
- **`push_credential_query`** — the forward `target_did` is now the **holder's mediator** (fallback to the VTC's own mediator — the shared-mediator deployment — when the holder has none). The profile/connection stays the **VTC's own mediator**; the forward, addressed to the holder's mediator, is routed onward from there. `next_did = holder`.

This is the DIDComm routing model you described: *send to your own mediator with a forward wrapping, and let the mediator forward to the recipient's mediator if required.*

## Tests
Unchanged — the mediator-less fixture still returns `delivered: false` (no resolver/mediator), and the actual multi-mediator delivery is e2e (mediator harness).

## Verification
Full vtc-service suite passes (exit 0) · clippy clean · fmt clean · DCO + GPG signed.