### PR TITLE
fix(webvh): restore absent-path → auto-assign; add explicit WebvhPathMode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,7 +2315,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.6",
+ "vta-sdk 0.9.7",
 ]
 
 [[package]]
@@ -3089,7 +3089,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.6",
+ "vta-sdk 0.9.7",
 ]
 
 [[package]]
@@ -6423,7 +6423,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.6",
+ "vta-sdk 0.9.7",
 ]
 
 [[package]]
@@ -9619,7 +9619,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9637,7 +9637,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.6",
+ "vta-sdk 0.9.7",
  "x25519-dalek",
 ]
 
@@ -9674,7 +9674,7 @@ dependencies = [
  "tokio",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.9.6",
+ "vta-sdk 0.9.7",
 ]
 
 [[package]]
@@ -9707,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9756,7 +9756,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -9833,7 +9833,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.6",
+ "vta-sdk 0.9.7",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9914,7 +9914,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.6",
+ "vta-sdk 0.9.7",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9957,7 +9957,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.6",
+ "vta-sdk 0.9.7",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9984,7 +9984,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.6",
+ "vta-sdk 0.9.7",
  "vta-service",
  "vti-common",
 ]

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -522,6 +522,9 @@ pub async fn cmd_context_provision(
             server_id: opts.server_id,
             url: opts.did_url,
             path: None,
+            // No explicit path-mode override; the absent legacy `path`
+            // resolves to auto-assign server-side.
+            path_mode: None,
             // Context-bootstrap path: no per-DID domain override.
             // The server's caller-default → system-default resolves.
             domain: None,

--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -381,6 +381,10 @@ pub async fn cmd_webvh_did_create_with_files(
         server_id,
         url,
         path,
+        // The `--path` value travels in the legacy `path` field, which
+        // resolves to the right mode server-side (absent → auto-assign,
+        // `.well-known` → root, else explicit).
+        path_mode: None,
         domain,
         label,
         portable,

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.6"
+version = "0.9.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -411,8 +411,16 @@ pub struct CreateDidWebvhRequest {
     pub server_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// Legacy path selector. Prefer [`path_mode`](Self::path_mode), which
+    /// distinguishes the `.well-known` root, an explicit label, and
+    /// server-side auto-assignment. Retained for wire back-compat.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    /// Explicit path-selection mode for server-managed DIDs. When set it
+    /// overrides [`path`](Self::path); absent falls back to `path`. See
+    /// [`crate::protocols::did_management::create::WebvhPathMode`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path_mode: Option<crate::protocols::did_management::create::WebvhPathMode>,
     /// Optional explicit hosting domain on the target server. See
     /// [`crate::protocols::did_management::create::CreateDidWebvhBody::domain`].
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/vta-sdk/src/protocols/did_management/create.rs
+++ b/vta-sdk/src/protocols/did_management/create.rs
@@ -1,6 +1,90 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// How the `<path>` segment of a server-managed `did:webvh` is chosen.
+///
+/// Only meaningful when a hosting server is selected (`server_id` is
+/// set). A serverless DID always resolves at
+/// `<host>/.well-known/did.jsonl` and ignores this — serverless mode is
+/// selected by the *absence* of `server_id`, not by this enum. The three
+/// variants map onto the hosting server's `check-name` / `create_did`
+/// path contract:
+///
+/// - [`WebvhPathMode::WellKnown`] → the reserved `.well-known` root slot
+///   (`<host>/.well-known/did.jsonl`). Admin-gated on the host.
+/// - [`WebvhPathMode::Explicit`] → an operator-chosen label
+///   (`<host>/<path>/did.jsonl`).
+/// - [`WebvhPathMode::AutoAssign`] → the host allocates a path (it mints
+///   a fresh mnemonic). This is the default.
+///
+/// `AutoAssign` is the default because that is the long-standing
+/// "no path given → the server assigns one" contract: the setup wizard's
+/// "leave blank → server-assigned" prompt, and the SDK's
+/// `webvh_path_from_url` deriving *no path* from empty / `.well-known` /
+/// bare-origin URLs. An absent path has never meant the `.well-known`
+/// root on a hosting server — that is the serverless case.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(tag = "mode", content = "path", rename_all = "snake_case")]
+pub enum WebvhPathMode {
+    /// Root DID at the host: resolves at `<host>/.well-known/did.jsonl`.
+    WellKnown,
+    /// Operator-chosen path label: `<host>/<path>/did.jsonl`.
+    Explicit(String),
+    /// Let the hosting server allocate the path.
+    #[default]
+    AutoAssign,
+}
+
+impl WebvhPathMode {
+    /// The path string to hand the hosting server's `check-name` /
+    /// `create_did` call. `Some(".well-known")` / `Some(label)` reserve a
+    /// specific slot; `None` tells the host to allocate one (the
+    /// auto-assign contract — the host mints a mnemonic).
+    ///
+    /// Returning `None` for [`AutoAssign`](WebvhPathMode::AutoAssign) is
+    /// load-bearing: the DIDComm/REST clients must *omit* the `path` wire
+    /// field for auto-assign. Sending an empty string instead makes the
+    /// host reject it with `e.p.did.path-invalid` ("path must not be
+    /// empty"), since the host validates a present-but-empty path.
+    pub fn to_request_path(&self) -> Option<&str> {
+        match self {
+            WebvhPathMode::WellKnown => Some(".well-known"),
+            WebvhPathMode::Explicit(p) => Some(p),
+            WebvhPathMode::AutoAssign => None,
+        }
+    }
+
+    /// Resolve the effective mode from the new explicit `path_mode` field
+    /// and the legacy `path: Option<String>` field. `path_mode` wins when
+    /// present; otherwise the legacy `path` is interpreted (via
+    /// `From<Option<String>>`) so pre-enum callers keep working.
+    pub fn resolve(path_mode: Option<WebvhPathMode>, legacy_path: Option<String>) -> Self {
+        path_mode.unwrap_or_else(|| WebvhPathMode::from(legacy_path))
+    }
+}
+
+impl From<Option<String>> for WebvhPathMode {
+    fn from(path: Option<String>) -> Self {
+        match path {
+            None => WebvhPathMode::AutoAssign,
+            Some(p) => WebvhPathMode::from(p),
+        }
+    }
+}
+
+impl From<String> for WebvhPathMode {
+    fn from(path: String) -> Self {
+        match path.trim() {
+            // Empty / whitespace-only is auto-assign, not an explicit
+            // empty path — an explicit "" would be rejected by the host.
+            // Mirrors `webvh_path_from_url`'s empty → no-path derivation.
+            "" => WebvhPathMode::AutoAssign,
+            ".well-known" => WebvhPathMode::WellKnown,
+            trimmed => WebvhPathMode::Explicit(trimmed.to_string()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateDidWebvhBody {
     pub context_id: String,
@@ -8,8 +92,18 @@ pub struct CreateDidWebvhBody {
     pub server_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// Legacy path selector. Prefer [`path_mode`](Self::path_mode) for
+    /// new callers — it distinguishes the `.well-known` root, an explicit
+    /// label, and server-side auto-assignment. Kept for wire back-compat:
+    /// when `path_mode` is absent, this is interpreted as `None`/empty →
+    /// auto-assign, `".well-known"` → root, else explicit (see
+    /// [`WebvhPathMode::resolve`]).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    /// Explicit path-selection mode for server-managed DIDs. When set it
+    /// overrides [`path`](Self::path). Absent → fall back to `path`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_mode: Option<WebvhPathMode>,
     /// Optional explicit hosting domain on the target server. When
     /// the server hosts multiple tenant domains, the caller may
     /// supply this to direct the new DID at a specific one;
@@ -107,5 +201,95 @@ impl std::fmt::Debug for CreateDidWebvhResultBody {
             .field("did_document", &self.did_document)
             .field("log_entry", &self.log_entry)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod webvh_path_mode_tests {
+    use super::WebvhPathMode;
+
+    /// The wire path the host's `check-name`/`create_did` receives.
+    /// `AutoAssign → None` is load-bearing: the clients omit the field,
+    /// which is the only form the host treats as "allocate one for me".
+    #[test]
+    fn to_request_path_maps_each_mode() {
+        assert_eq!(
+            WebvhPathMode::WellKnown.to_request_path(),
+            Some(".well-known")
+        );
+        assert_eq!(
+            WebvhPathMode::Explicit("alice".into()).to_request_path(),
+            Some("alice")
+        );
+        assert_eq!(WebvhPathMode::AutoAssign.to_request_path(), None);
+    }
+
+    /// Default is auto-assign — the long-standing "no path → server
+    /// assigns one" contract. An absent path has never meant `.well-known`.
+    #[test]
+    fn default_is_auto_assign() {
+        assert_eq!(WebvhPathMode::default(), WebvhPathMode::AutoAssign);
+    }
+
+    /// Legacy `path: Option<String>` interpretation: None/empty →
+    /// auto-assign, `.well-known` → root, else explicit (trimmed).
+    #[test]
+    fn from_legacy_path() {
+        assert_eq!(WebvhPathMode::from(None), WebvhPathMode::AutoAssign);
+        assert_eq!(
+            WebvhPathMode::from(Some("   ".to_string())),
+            WebvhPathMode::AutoAssign
+        );
+        assert_eq!(
+            WebvhPathMode::from(Some(".well-known".to_string())),
+            WebvhPathMode::WellKnown
+        );
+        assert_eq!(
+            WebvhPathMode::from(Some("  alice ".to_string())),
+            WebvhPathMode::Explicit("alice".into())
+        );
+    }
+
+    /// `resolve`: explicit `path_mode` wins; otherwise fall back to the
+    /// legacy `path`.
+    #[test]
+    fn resolve_prefers_explicit_mode() {
+        // Explicit mode set → legacy path ignored.
+        assert_eq!(
+            WebvhPathMode::resolve(Some(WebvhPathMode::AutoAssign), Some("alice".into())),
+            WebvhPathMode::AutoAssign
+        );
+        // No mode → interpret legacy path.
+        assert_eq!(
+            WebvhPathMode::resolve(None, Some("alice".into())),
+            WebvhPathMode::Explicit("alice".into())
+        );
+        assert_eq!(
+            WebvhPathMode::resolve(None, None),
+            WebvhPathMode::AutoAssign
+        );
+    }
+
+    /// Adjacently-tagged serde shape, and that it round-trips.
+    #[test]
+    fn serde_round_trips() {
+        for mode in [
+            WebvhPathMode::WellKnown,
+            WebvhPathMode::Explicit("alice".into()),
+            WebvhPathMode::AutoAssign,
+        ] {
+            let json = serde_json::to_value(&mode).unwrap();
+            let back: WebvhPathMode = serde_json::from_value(json).unwrap();
+            assert_eq!(mode, back);
+        }
+        // Pin the explicit wire shape.
+        assert_eq!(
+            serde_json::to_value(WebvhPathMode::Explicit("alice".into())).unwrap(),
+            serde_json::json!({ "mode": "explicit", "path": "alice" })
+        );
+        assert_eq!(
+            serde_json::to_value(WebvhPathMode::AutoAssign).unwrap(),
+            serde_json::json!({ "mode": "auto_assign" })
+        );
     }
 }

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -943,6 +943,7 @@ async fn create_did_webvh_posts() {
         server_id: Some("s1".into()),
         url: None,
         path: None,
+        path_mode: None,
         domain: None,
         label: None,
         portable: false,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -7,6 +7,7 @@ use serde_json::json;
 use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 
 use vta_sdk::did_secrets::{DidSecretsBundle, SecretEntry};
+use vta_sdk::protocols::did_management::create::WebvhPathMode;
 
 use crate::config::AppConfig;
 use crate::keys::seed_store::create_seed_store;
@@ -148,7 +149,8 @@ pub async fn run_create_did_webvh(
         context_id: args.context.clone(),
         server_id: None,
         url: Some(url_str.clone()),
-        path: None,
+        // Serverless (`server_id: None`) ignores `path_mode`.
+        path_mode: WebvhPathMode::default(),
         domain: None,
         label: Some(label.to_string()),
         portable,

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -55,7 +55,7 @@ use affinidi_tdk::secrets_resolver::secrets::Secret;
 use crate::didcomm_bridge::DIDCommBridge;
 
 use vta_sdk::protocols::did_management::{
-    create::{CreateDidWebvhBody, CreateDidWebvhResultBody},
+    create::{CreateDidWebvhBody, CreateDidWebvhResultBody, WebvhPathMode},
     delete::DeleteDidWebvhResultBody,
 };
 use vta_sdk::webvh::{WebvhDidRecord, WebvhServerRecord};
@@ -131,7 +131,11 @@ pub struct CreateDidWebvhParams {
     pub context_id: String,
     pub server_id: Option<String>,
     pub url: Option<String>,
-    pub path: Option<String>,
+    /// How to choose the server-managed DID's `<path>` segment. Drives
+    /// the host's `check-name`/`create_did` call (`WellKnown` →
+    /// `.well-known`, `Explicit` → label, `AutoAssign` → host allocates).
+    /// Ignored in serverless mode (`server_id` is `None`).
+    pub path_mode: WebvhPathMode,
     /// Optional explicit hosting domain on the target server.
     /// Honored only for server-managed DIDs (when `server_id` is set);
     /// ignored in serverless mode. Resolution chain on the remote:
@@ -183,7 +187,9 @@ impl From<CreateDidWebvhBody> for CreateDidWebvhParams {
             context_id: body.context_id,
             server_id: body.server_id,
             url: body.url,
-            path: body.path,
+            // Explicit `path_mode` wins; otherwise interpret the legacy
+            // `path` field so pre-enum wire callers keep working.
+            path_mode: WebvhPathMode::resolve(body.path_mode, body.path),
             domain: body.domain,
             label: body.label,
             portable: body.portable.unwrap_or(true),
@@ -627,7 +633,7 @@ pub async fn create_did_webvh(
         // supplied override (pnm CLI `--domain`). When omitted, the
         // remote resolves via caller's ACL default → system default.
         let uri_response = transport
-            .request_uri(params.path.as_deref(), params.domain.as_deref())
+            .request_uri(params.path_mode.to_request_path(), params.domain.as_deref())
             .await?;
 
         // Validate the URL

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -664,7 +664,7 @@ mod pre_rotation_e2e_tests {
                 context_id: context_id.into(),
                 server_id: None,
                 url: Some("https://example.com/.well-known/did/did.jsonl".into()),
-                path: None,
+                path_mode: vta_sdk::protocols::did_management::create::WebvhPathMode::default(),
                 domain: None,
                 label: Some("e2e".into()),
                 portable: true,

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -417,7 +417,12 @@ pub async fn provision_integration(
                 context_id: context.clone(),
                 server_id: params_server_id,
                 url: params_url,
-                path: webvh_path,
+                // `webvh_path` is `None` when the operator gave no path
+                // (or only `.well-known`/bare URL): server-managed mode
+                // then auto-assigns. An explicit label maps to `Explicit`.
+                path_mode: vta_sdk::protocols::did_management::create::WebvhPathMode::from(
+                    webvh_path,
+                ),
                 // Explicit tenant domain when the caller set
                 // `WEBVH_DOMAIN` (multi-tenant hosting server); `None`
                 // lets the remote resolve to its caller-default / system

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1096,7 +1096,8 @@ async fn create_simple_webvh_did(
         context_id: context_id.to_string(),
         server_id: None,
         url: Some(url_str),
-        path: None,
+        // Serverless (`server_id: None`) ignores `path_mode`.
+        path_mode: vta_sdk::protocols::did_management::create::WebvhPathMode::default(),
         domain: None,
         label: Some(label.to_string()),
         portable,

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -1106,7 +1106,8 @@ async fn build_wizard_did(
         context_id: context_id.to_string(),
         server_id: None,
         url: Some(url_str.clone()),
-        path: None,
+        // Serverless (`server_id: None`) ignores `path_mode`.
+        path_mode: vta_sdk::protocols::did_management::create::WebvhPathMode::default(),
         domain: None,
         label: Some(label.to_string()),
         portable,

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use vta_sdk::protocols::did_management::create::WebvhPathMode;
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
@@ -163,7 +164,9 @@ pub async fn run_create_did(
         context_id: context_id.clone(),
         server_id: Some(server_id),
         url: None,
-        path,
+        // `--path <p>` → explicit; `--path .well-known` → root; absent
+        // → server auto-assigns.
+        path_mode: WebvhPathMode::from(path),
         // CLI-driven flow: no per-DID domain selection here. Wired
         // via `--domain` in pnm-cli's surface.
         domain: None,

--- a/vta-service/src/webvh_didcomm.rs
+++ b/vta-service/src/webvh_didcomm.rs
@@ -73,6 +73,32 @@ const TASK_DID_DELETE_RESPONSE: &str =
 const TASK_DID_PROBLEM_REPORT: &str =
     "https://trusttasks.org/spec/did-management/did/problem-report/0.1";
 
+/// Build the `did/check-name/0.1` reservation body.
+///
+/// `path == None` is the auto-assign case: the `path` field is OMITTED
+/// entirely so the host runs its server-generated-mnemonic branch. A
+/// present-but-empty path is rejected by the host with
+/// `e.p.did.path-invalid` ("path must not be empty"), so an absent path
+/// must never be coerced to `""` — that coercion was the regression this
+/// pins. Mirrors the REST `request_uri`, which omits the field for `None`.
+fn build_check_name_body(
+    path: Option<&str>,
+    domain: Option<&str>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut body = serde_json::Map::new();
+    if let Some(p) = path {
+        body.insert("path".to_string(), serde_json::Value::String(p.to_string()));
+    }
+    body.insert("reserve".to_string(), serde_json::Value::Bool(true));
+    if let Some(d) = domain {
+        body.insert(
+            "domain".to_string(),
+            serde_json::Value::String(d.to_string()),
+        );
+    }
+    body
+}
+
 /// DIDComm-based client for communicating with a WebVH server.
 ///
 /// Routes messages through the DIDComm service's listener connection,
@@ -107,24 +133,7 @@ impl<'a> WebvhDIDCommClient<'a> {
         path: Option<&str>,
         domain: Option<&str>,
     ) -> Result<RequestUriResponse, AppError> {
-        let mut body = serde_json::Map::new();
-        // check-name requires a path; the legacy `request_uri` mode
-        // also accepted an absent path (server-generated mnemonic).
-        // We preserve that behaviour by passing empty string when the
-        // caller wants the host to mint one — the remote interprets
-        // an empty path under `reserve: true` as "pick a mnemonic
-        // for me."
-        body.insert(
-            "path".to_string(),
-            serde_json::Value::String(path.unwrap_or("").to_string()),
-        );
-        body.insert("reserve".to_string(), serde_json::Value::Bool(true));
-        if let Some(d) = domain {
-            body.insert(
-                "domain".to_string(),
-                serde_json::Value::String(d.to_string()),
-            );
-        }
+        let body = build_check_name_body(path, domain);
 
         let response = self
             .bridge
@@ -319,5 +328,50 @@ impl<'a> WebvhDIDCommClient<'a> {
             )
             .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_check_name_body;
+    use serde_json::json;
+
+    /// Regression for `e.p.did.path-invalid`: auto-assign (`path == None`)
+    /// must OMIT the `path` field, not send `""`. The host rejects a
+    /// present-but-empty path; only an absent one triggers
+    /// server-side mnemonic generation.
+    #[test]
+    fn auto_assign_omits_path() {
+        let body = build_check_name_body(None, None);
+        assert!(
+            !body.contains_key("path"),
+            "auto-assign must omit `path`; got {body:?}"
+        );
+        assert_eq!(body.get("reserve"), Some(&json!(true)));
+    }
+
+    /// An explicit label travels verbatim under `reserve: true`.
+    #[test]
+    fn explicit_path_is_sent() {
+        let body = build_check_name_body(Some("alice"), None);
+        assert_eq!(body.get("path"), Some(&json!("alice")));
+        assert_eq!(body.get("reserve"), Some(&json!(true)));
+    }
+
+    /// `.well-known` (the root-DID marker) is sent as a normal path —
+    /// the host's `create_did` treats it as the reserved root slot.
+    #[test]
+    fn well_known_is_sent_as_path() {
+        let body = build_check_name_body(Some(".well-known"), None);
+        assert_eq!(body.get("path"), Some(&json!(".well-known")));
+    }
+
+    /// The optional `domain` rides along only when present.
+    #[test]
+    fn domain_included_only_when_present() {
+        let with = build_check_name_body(Some("alice"), Some("acme.example.com"));
+        assert_eq!(with.get("domain"), Some(&json!("acme.example.com")));
+        let without = build_check_name_body(Some("alice"), None);
+        assert!(!without.contains_key("domain"));
     }
 }

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -1521,6 +1521,38 @@ async fn create_did_webvh_rejects_both_document_and_log() {
     assert_eq!(status, StatusCode::BAD_REQUEST, "expected 400: {body}");
 }
 
+/// The new `path_mode` wire field deserializes and threads through
+/// `CreateDidWebvhBody` → `CreateDidWebvhParams` without breaking the
+/// serverless create path. (Serverless ignores the mode — `server_id`
+/// selects `.well-known` self-hosting — but the field must still be
+/// accepted so server-managed callers can set it.) Pins back-compat for
+/// the `WebvhPathMode` addition.
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn create_did_webvh_accepts_path_mode_field() {
+    let (app, ctx) = TestApp::new().await;
+    let token = setup_webvh_context(&app, &ctx, "test-path-mode").await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/webvh/dids",
+            &token,
+            json!({
+                "context_id": "test-path-mode",
+                "url": "https://example.com/.well-known/did/did.jsonl",
+                "path_mode": { "mode": "auto_assign" },
+                "set_primary": false,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "create with explicit path_mode: {status} {body}"
+    );
+    assert!(body["did"].as_str().is_some(), "response has did");
+}
+
 #[cfg(feature = "webvh")]
 #[tokio::test]
 async fn create_did_webvh_template_mode() {


### PR DESCRIPTION
## Symptom

Creating a persona's `did:webvh` via the VTA's webvh server (the openvtc setup flow's "create DID via server" step, with no explicit path) failed after a recent VTA update with:

```
server error (500): bad gateway:
e.p.did.path-invalid: validation error: [path] path must not be empty
```

## Root cause

`vta-service/src/webvh_didcomm.rs::request_uri` coerced an absent path to `""` in its `did/check-name/0.1` reservation body:

```rust
body.insert("path", Value::String(path.unwrap_or("").to_string()));  // None → ""
```

The hosting server (`affinidi-webvh-service`) validates a **present-but-empty** path and rejects it; only an **absent** path triggers its server-generated-mnemonic (auto-assign) branch. The pre-regression DIDComm client and the REST client (which never regressed) both omit the field for `None`. Regression introduced by `bf8df009` ("did-management 0.1 surface"). **The host was always correct — the VTA client sent the wrong shape.**

Fix: omit `path` when `None`, mirroring the REST client.

## Note on the "three modes"

An **absent path means auto-assign** (the server picks), per the setup wizard (*"leave blank → server-assigned"*) and pre-regression behaviour — **not** `.well-known`. `.well-known` is the **serverless** case (`server_id: None`, self-hosted at the URL). The fix preserves this, so existing DIDs don't change where they resolve.

## Schema gap → `WebvhPathMode`

Added an explicit `WebvhPathMode { WellKnown, Explicit(String), AutoAssign }` so the three modes are first-class instead of being smuggled through `Option<String>`:

| Mode | Resolves at |
|------|-------------|
| `WellKnown` | `<host>/.well-known/did.jsonl` (admin-gated root on host) |
| `Explicit(label)` | `<host>/<label>/did.jsonl` |
| `AutoAssign` (default) | host allocates a mnemonic |

- Wire types (`CreateDidWebvhBody`/`Request`): additive optional `path_mode` next to the now-legacy `path` (same back-compat pattern as the existing `domain` field), resolved via `WebvhPathMode::resolve`.
- Internal `CreateDidWebvhParams`: `path: Option<String>` → `path_mode: WebvhPathMode`, consumed at the single `request_uri` call via `to_request_path()`.

## Verification

- New unit tests: `WebvhPathMode` contract + serde; `build_check_name_body` **omits `path` for auto-assign** (regression pin); REST `POST /webvh/dids` accepts `path_mode`.
- Existing `webvh_path_from_url_*` contract tests unchanged.
- `cargo test`: vta-service **850 passed / 0 failed**, vta-sdk + vta-cli-common green. `cargo fmt` + `clippy` clean.

## Impact on other consumers of this flow

- **did-hosting service** (`affinidi-webvh-service`): server-side, **unchanged/unaffected** — already handles absent / `.well-known` / explicit correctly.
- **Mediator setup** (`affinidi-tdk-rs`): only references `CreateDidWebvhRequest` in a doc comment, **never constructs it** — unaffected.
- **openvtc**: its `create_persona_did` (`server_id: Some`, `path: None`) now correctly auto-assigns. When it upgrades to vta-sdk `0.9.7` it needs `path_mode: None` added to that struct literal (no `Default` derive on the request). _Owner updating separately._

## Versions

Patch bumps keep `vta-sdk` in `0.9.x` (safe for the mediator's `^0.9` pin): `vta-sdk 0.9.6→0.9.7`, `vta-service 0.8.1→0.8.2`, `vta-cli-common 0.8.0→0.8.1`. Internal `major.minor` pins unchanged.