### PR TITLE
feat(vta): verify the status-list credential's own issuer signature

### DIFF
--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -122,7 +122,8 @@ async fn store_issued_credential(
         // issuer's signing key (binding it to the credential `issuer`) and store
         // via the DI path. The vault stays network-free — resolution happens here.
         Value::Object(_) if credential.get("proof").is_some() => {
-            let issuer_pub = resolve_di_issuer_key(did_resolver, credential).await?;
+            let issuer_pub =
+                crate::vault::di_verify::resolve_di_issuer_key(did_resolver, credential).await?;
             let body = serde_json::to_vec(credential)
                 .map_err(|e| AppError::Internal(format!("credential -> bytes: {e}")))?;
             vault::receive(
@@ -304,137 +305,6 @@ pub async fn build_credential_request_for_offer(
     let credential_request =
         affinidi_openid4vci::wallet::build_sd_jwt_vc_request(&vct, Some(proof_jwt));
     Ok(RequestBody { credential_request })
-}
-
-/// The issuer DID from a VC `issuer` field — a string, or an object with `id`.
-fn issuer_str(issuer: &Value) -> Option<String> {
-    issuer
-        .as_str()
-        .map(str::to_string)
-        .or_else(|| issuer.get("id").and_then(Value::as_str).map(str::to_string))
-}
-
-/// Resolve the Ed25519 public key a Data-Integrity VC's proof is signed with,
-/// **binding it to the credential `issuer`**.
-///
-/// The proof's `verificationMethod` names the signing key; its base DID MUST be
-/// the credential `issuer` — otherwise a key belonging to some *other* DID could
-/// sign a credential that claims a different issuer (issuer spoofing). `did:key`
-/// issuers resolve locally with no I/O even when a resolver is configured;
-/// `did:webvh` / `did:web` issuers are resolved through `did_resolver`, which
-/// must then be present.
-async fn resolve_di_issuer_key(
-    did_resolver: Option<&DIDCacheClient>,
-    credential: &Value,
-) -> Result<Vec<u8>, AppError> {
-    let issuer_did = credential
-        .get("issuer")
-        .and_then(issuer_str)
-        .ok_or_else(|| AppError::Validation("Data-Integrity credential has no `issuer`".into()))?;
-
-    let vm = credential
-        .get("proof")
-        .and_then(|p| p.get("verificationMethod"))
-        .and_then(Value::as_str)
-        .ok_or_else(|| {
-            AppError::Validation("Data-Integrity proof has no `verificationMethod`".into())
-        })?;
-
-    // Binding: the signing key MUST belong to the stated issuer.
-    let vm_base = vm.split('#').next().unwrap_or_default();
-    if vm_base != issuer_did {
-        return Err(AppError::Validation(format!(
-            "DI proof verificationMethod `{vm}` is not under the credential issuer \
-             `{issuer_did}` — refusing a credential signed by a key outside the issuer DID"
-        )));
-    }
-
-    // `did:key` is its own key — resolve locally, no network even if configured.
-    if issuer_did.starts_with("did:key:") {
-        return affinidi_crypto::did_key::did_key_to_ed25519_pub(&issuer_did)
-            .map(|k| k.to_vec())
-            .map_err(|e| {
-                AppError::Validation(format!(
-                    "issuer `{issuer_did}` is not a resolvable did:key: {e}"
-                ))
-            });
-    }
-
-    let resolver = did_resolver.ok_or_else(|| {
-        AppError::Validation(format!(
-            "resolving issuer `{issuer_did}` needs a DID resolver, but none is configured — \
-             configure the DID cache client to receive Data-Integrity credentials from \
-             did:webvh / did:web issuers"
-        ))
-    })?;
-    resolve_vm_ed25519(resolver, &issuer_did, vm).await
-}
-
-/// Resolve a DID's verification method to its Ed25519 public-key bytes via the
-/// DID cache. Mirrors the DID-document JSON navigation in
-/// [`crate::operations::passkey_login::VtaVmResolver`] but yields raw Ed25519
-/// bytes for Data-Integrity verification. Only `publicKeyMultibase`
-/// (Multikey-encoded) Ed25519 VMs are supported.
-async fn resolve_vm_ed25519(
-    resolver: &DIDCacheClient,
-    did: &str,
-    vm: &str,
-) -> Result<Vec<u8>, AppError> {
-    let resolved = resolver
-        .resolve(did)
-        .await
-        .map_err(|e| AppError::Validation(format!("issuer DID `{did}` did not resolve: {e}")))?;
-
-    // Serialise to JSON for shape-agnostic navigation (the DID-Core JSON shape is
-    // the stable contract, decoupled from the resolver's struct version).
-    let doc: Value = serde_json::to_value(&resolved.doc)
-        .map_err(|e| AppError::Internal(format!("issuer DID document serialise failed: {e}")))?;
-
-    let vms = doc
-        .get("verificationMethod")
-        .and_then(Value::as_array)
-        .ok_or_else(|| {
-            AppError::Validation(format!(
-                "issuer DID `{did}` has no verificationMethod array"
-            ))
-        })?;
-
-    // VM ids can be absolute (`did:webvh:...#key-0`) or relative (`#key-0`).
-    let relative = vm
-        .split_once('#')
-        .map(|(_, frag)| format!("#{frag}"))
-        .unwrap_or_default();
-    let entry = vms
-        .iter()
-        .find(|e| {
-            let id = e.get("id").and_then(Value::as_str).unwrap_or("");
-            id == vm || id == relative
-        })
-        .ok_or_else(|| {
-            AppError::Validation(format!(
-                "verificationMethod `{vm}` not found in issuer DID `{did}`"
-            ))
-        })?;
-
-    let multibase = entry
-        .get("publicKeyMultibase")
-        .and_then(Value::as_str)
-        .ok_or_else(|| {
-            AppError::Validation(format!(
-                "verificationMethod `{vm}` has no publicKeyMultibase (only Multikey-encoded \
-                 Ed25519 VMs are supported)"
-            ))
-        })?;
-
-    // A `z`-prefixed Ed25519 Multikey is exactly the `did:key` suffix — reuse the
-    // canonical decoder, which also rejects a non-Ed25519 multicodec.
-    affinidi_crypto::did_key::did_key_to_ed25519_pub(&format!("did:key:{multibase}"))
-        .map(|k| k.to_vec())
-        .map_err(|e| {
-            AppError::Validation(format!(
-                "verificationMethod `{vm}` is not an Ed25519 Multikey: {e}"
-            ))
-        })
 }
 
 // ── Holder-side DCQL match (Phase 3, task 3.5: query → match) ──

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -300,8 +300,8 @@ pub async fn build_app_state(
         wrapping_cache: crate::keys::wrapping::WrappingKeyCache::new(),
         config: Arc::new(RwLock::new(config)),
         seed_store,
-        did_resolver: auth.did_resolver,
-        status_list_resolver: crate::vault::status::default_status_resolver(),
+        did_resolver: auth.did_resolver.clone(),
+        status_list_resolver: crate::vault::status::default_status_resolver(auth.did_resolver),
         secrets_resolver: auth.secrets_resolver,
         #[cfg(feature = "didcomm")]
         signing_vm_id: auth.signing_vm_id,
@@ -619,8 +619,8 @@ pub async fn run(
             wrapping_cache,
             config: Arc::new(RwLock::new(config.clone())),
             seed_store: seed_store.clone(),
-            did_resolver: auth.did_resolver,
-            status_list_resolver: crate::vault::status::default_status_resolver(),
+            did_resolver: auth.did_resolver.clone(),
+            status_list_resolver: crate::vault::status::default_status_resolver(auth.did_resolver),
             secrets_resolver: auth.secrets_resolver.clone(),
             #[cfg(feature = "didcomm")]
             signing_vm_id: auth.signing_vm_id.clone(),

--- a/vta-service/src/vault/di_verify.rs
+++ b/vta-service/src/vault/di_verify.rs
@@ -1,0 +1,151 @@
+//! Shared Data-Integrity issuer-key resolution.
+//!
+//! Resolving the Ed25519 public key that signed a W3C Data-Integrity credential
+//! — **bound to the credential's stated `issuer`** — is needed in more than one
+//! place: receiving a DI credential into the vault
+//! ([`crate::operations::credential_exchange`]) and verifying a
+//! `BitstringStatusListCredential`'s own issuer signature before trusting it
+//! ([`crate::vault::status`]). Both share the same binding rule (the signing key
+//! MUST belong to the stated issuer — otherwise a key from some *other* DID could
+//! sign a credential claiming a different issuer) and the same resolution path
+//! (`did:key` locally, `did:webvh` / `did:web` via the DID cache).
+//!
+//! Consistent with the vault's dependency-injection style, the DID resolver is a
+//! **caller-supplied parameter** — these helpers never own a network client; for
+//! `did:key` issuers no I/O happens at all, and for `did:webvh` / `did:web` the
+//! injected resolver does the lookup.
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use serde_json::Value;
+use vti_common::error::AppError;
+
+/// The issuer DID of a credential — its `issuer` field as a string, or the `id`
+/// of an `issuer` object. Returns `None` when the credential has no `issuer`.
+pub(crate) fn credential_issuer(credential: &Value) -> Option<String> {
+    let issuer = credential.get("issuer")?;
+    issuer
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| issuer.get("id").and_then(Value::as_str).map(str::to_string))
+}
+
+/// Resolve the Ed25519 public key a Data-Integrity VC's proof is signed with,
+/// **binding it to the credential `issuer`**.
+///
+/// The proof's `verificationMethod` names the signing key; its base DID MUST be
+/// the credential `issuer` — otherwise a key belonging to some *other* DID could
+/// sign a credential that claims a different issuer (issuer spoofing). `did:key`
+/// issuers resolve locally with no I/O even when a resolver is configured;
+/// `did:webvh` / `did:web` issuers are resolved through `did_resolver`, which
+/// must then be present.
+pub(crate) async fn resolve_di_issuer_key(
+    did_resolver: Option<&DIDCacheClient>,
+    credential: &Value,
+) -> Result<Vec<u8>, AppError> {
+    let issuer_did = credential_issuer(credential)
+        .ok_or_else(|| AppError::Validation("Data-Integrity credential has no `issuer`".into()))?;
+
+    let vm = credential
+        .get("proof")
+        .and_then(|p| p.get("verificationMethod"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            AppError::Validation("Data-Integrity proof has no `verificationMethod`".into())
+        })?;
+
+    // Binding: the signing key MUST belong to the stated issuer.
+    let vm_base = vm.split('#').next().unwrap_or_default();
+    if vm_base != issuer_did {
+        return Err(AppError::Validation(format!(
+            "DI proof verificationMethod `{vm}` is not under the credential issuer \
+             `{issuer_did}` — refusing a credential signed by a key outside the issuer DID"
+        )));
+    }
+
+    // `did:key` is its own key — resolve locally, no network even if configured.
+    if issuer_did.starts_with("did:key:") {
+        return affinidi_crypto::did_key::did_key_to_ed25519_pub(&issuer_did)
+            .map(|k| k.to_vec())
+            .map_err(|e| {
+                AppError::Validation(format!(
+                    "issuer `{issuer_did}` is not a resolvable did:key: {e}"
+                ))
+            });
+    }
+
+    let resolver = did_resolver.ok_or_else(|| {
+        AppError::Validation(format!(
+            "resolving issuer `{issuer_did}` needs a DID resolver, but none is configured — \
+             configure the DID cache client to receive Data-Integrity credentials from \
+             did:webvh / did:web issuers"
+        ))
+    })?;
+    resolve_vm_ed25519(resolver, &issuer_did, vm).await
+}
+
+/// Resolve a DID's verification method to its Ed25519 public-key bytes via the
+/// DID cache. Mirrors the DID-document JSON navigation in
+/// [`crate::operations::passkey_login::VtaVmResolver`] but yields raw Ed25519
+/// bytes for Data-Integrity verification. Only `publicKeyMultibase`
+/// (Multikey-encoded) Ed25519 VMs are supported.
+async fn resolve_vm_ed25519(
+    resolver: &DIDCacheClient,
+    did: &str,
+    vm: &str,
+) -> Result<Vec<u8>, AppError> {
+    let resolved = resolver
+        .resolve(did)
+        .await
+        .map_err(|e| AppError::Validation(format!("issuer DID `{did}` did not resolve: {e}")))?;
+
+    // Serialise to JSON for shape-agnostic navigation (the DID-Core JSON shape is
+    // the stable contract, decoupled from the resolver's struct version).
+    let doc: Value = serde_json::to_value(&resolved.doc)
+        .map_err(|e| AppError::Internal(format!("issuer DID document serialise failed: {e}")))?;
+
+    let vms = doc
+        .get("verificationMethod")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "issuer DID `{did}` has no verificationMethod array"
+            ))
+        })?;
+
+    // VM ids can be absolute (`did:webvh:...#key-0`) or relative (`#key-0`).
+    let relative = vm
+        .split_once('#')
+        .map(|(_, frag)| format!("#{frag}"))
+        .unwrap_or_default();
+    let entry = vms
+        .iter()
+        .find(|e| {
+            let id = e.get("id").and_then(Value::as_str).unwrap_or("");
+            id == vm || id == relative
+        })
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "verificationMethod `{vm}` not found in issuer DID `{did}`"
+            ))
+        })?;
+
+    let multibase = entry
+        .get("publicKeyMultibase")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "verificationMethod `{vm}` has no publicKeyMultibase (only Multikey-encoded \
+                 Ed25519 VMs are supported)"
+            ))
+        })?;
+
+    // A `z`-prefixed Ed25519 Multikey is exactly the `did:key` suffix — reuse the
+    // canonical decoder, which also rejects a non-Ed25519 multicodec.
+    affinidi_crypto::did_key::did_key_to_ed25519_pub(&format!("did:key:{multibase}"))
+        .map(|k| k.to_vec())
+        .map_err(|e| {
+            AppError::Validation(format!(
+                "verificationMethod `{vm}` is not an Ed25519 Multikey: {e}"
+            ))
+        })
+}

--- a/vta-service/src/vault/mod.rs
+++ b/vta-service/src/vault/mod.rs
@@ -50,6 +50,7 @@
 //! never "return the whole set").
 
 pub mod consent;
+pub mod di_verify;
 pub mod index;
 pub mod mint;
 pub mod model;

--- a/vta-service/src/vault/present.rs
+++ b/vta-service/src/vault/present.rs
@@ -1464,6 +1464,7 @@ mod tests {
         async fn resolve(
             &self,
             _url: &str,
+            _expected_issuer: Option<&str>,
         ) -> Result<super::super::status::ResolvedStatusList, AppError> {
             use affinidi_status_list::{BitstringStatusList, StatusPurpose};
             let mut list = BitstringStatusList::new(1024, StatusPurpose::Revocation);

--- a/vta-service/src/vault/status.rs
+++ b/vta-service/src/vault/status.rs
@@ -51,10 +51,13 @@
 //!   [`CredentialStatus::Valid`]. A `revocation`-purpose set bit is terminal:
 //!   once revoked, a subsequent clear read does **not** un-revoke it.
 
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use serde::{Deserialize, Serialize};
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
+#[cfg(feature = "webvh")]
+use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions, crypto_suites::CryptoSuite};
 #[cfg(feature = "webvh")]
 use affinidi_status_list::DEFAULT_BITSTRING_SIZE;
 use affinidi_status_list::{BitstringStatusList, StatusPurpose};
@@ -103,53 +106,71 @@ pub struct ResolvedStatusList {
 /// The default live status resolver wired into a running VTA: an HTTP resolver
 /// when the `webvh` feature (which pulls in `reqwest`) is built, else `None` —
 /// in which case the present path falls back to the stored status tag.
-pub fn default_status_resolver() -> Option<std::sync::Arc<dyn StatusListResolver>> {
+///
+/// `did_resolver` resolves the status-list credential's issuer key for the
+/// signature check (`did:webvh` / `did:web` issuers; `did:key` resolves
+/// locally). It is unused in the non-`webvh` build.
+pub fn default_status_resolver(
+    did_resolver: Option<DIDCacheClient>,
+) -> Option<std::sync::Arc<dyn StatusListResolver>> {
     #[cfg(feature = "webvh")]
     {
-        Some(std::sync::Arc::new(HttpStatusListResolver::new()))
+        Some(std::sync::Arc::new(HttpStatusListResolver::new(
+            did_resolver,
+        )))
     }
     #[cfg(not(feature = "webvh"))]
     {
+        let _ = did_resolver;
         None
     }
 }
 
 /// Production [`StatusListResolver`]: HTTP-fetches the `BitstringStatusListCredential`
-/// an issuer (e.g. the VTC) publishes at the entry URL and decodes its
-/// `credentialSubject` (`encodedList` + `statusPurpose`), using the standard list
-/// size ([`DEFAULT_BITSTRING_SIZE`], the W3C minimum the issuers allocate).
+/// an issuer (e.g. the VTC) publishes at the entry URL, **verifies its issuer
+/// Data-Integrity signature**, and decodes its `credentialSubject`
+/// (`encodedList` + `statusPurpose`), using the standard list size
+/// ([`DEFAULT_BITSTRING_SIZE`], the W3C minimum the issuers allocate).
 ///
-/// NOTE (hardening follow-up): this does **not** yet verify the status-list
-/// credential's own issuer signature — a holder should ideally verify it before
-/// trusting the list (needs issuer-key resolution). The present gate falls back
-/// to the stored tag on any resolver error, so an outage does not block
-/// presentation.
+/// Signature verification (eddsa-jcs-2022) is mandatory: the proof's
+/// `verificationMethod` is bound to the list credential's own `issuer`, and —
+/// when an `expected_issuer` is supplied — that `issuer` is bound to the issuer
+/// of the credential whose status is being checked. This closes the
+/// fail-open hole where anyone able to serve the status-list URL could forge a
+/// (terminal) revocation of a valid credential, or hide a real one. A resolver
+/// error (fetch failure, bad signature, issuer mismatch) leaves the present gate
+/// to fall back to the stored tag, so an outage does not block presentation but a
+/// *forged* list is rejected rather than trusted.
 #[cfg(feature = "webvh")]
 pub struct HttpStatusListResolver {
     http: reqwest::Client,
+    /// Resolves the status-list credential's issuer key (`did:webvh` / `did:web`
+    /// via the cache; `did:key` is resolved locally without it). `None` is
+    /// tolerated for `did:key`-issued lists only — a `did:webvh` list then fails
+    /// closed (resolver error → stored-tag fallback).
+    did_resolver: Option<DIDCacheClient>,
 }
 
 #[cfg(feature = "webvh")]
 impl HttpStatusListResolver {
-    /// A resolver over a fresh HTTP client.
-    pub fn new() -> Self {
+    /// A resolver over a fresh HTTP client, using `did_resolver` for issuer-key
+    /// resolution of the status-list credential's signature.
+    pub fn new(did_resolver: Option<DIDCacheClient>) -> Self {
         Self {
             http: reqwest::Client::new(),
+            did_resolver,
         }
-    }
-}
-
-#[cfg(feature = "webvh")]
-impl Default for HttpStatusListResolver {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
 #[cfg(feature = "webvh")]
 #[async_trait::async_trait]
 impl StatusListResolver for HttpStatusListResolver {
-    async fn resolve(&self, url: &str) -> Result<ResolvedStatusList, AppError> {
+    async fn resolve(
+        &self,
+        url: &str,
+        expected_issuer: Option<&str>,
+    ) -> Result<ResolvedStatusList, AppError> {
         let body: serde_json::Value = self
             .http
             .get(url)
@@ -161,6 +182,12 @@ impl StatusListResolver for HttpStatusListResolver {
             .json()
             .await
             .map_err(|e| AppError::Internal(format!("status list `{url}` is not JSON: {e}")))?;
+
+        // Verify the list credential's own issuer signature BEFORE trusting any
+        // of its bytes (issuer key bound to the list's `issuer`), then bind that
+        // issuer to the credential's issuer when known.
+        verify_status_list_signature(self.did_resolver.as_ref(), &body, expected_issuer, url)
+            .await?;
 
         let subject = body.get("credentialSubject").ok_or_else(|| {
             AppError::Validation(format!("status list `{url}` has no credentialSubject"))
@@ -189,6 +216,80 @@ impl StatusListResolver for HttpStatusListResolver {
     }
 }
 
+/// Verify a fetched `BitstringStatusListCredential`'s own issuer signature and,
+/// when `expected_issuer` is known, bind its `issuer` to the credential whose
+/// status is being checked.
+///
+/// 1. **Issuer binding (within the list):** [`crate::vault::di_verify`] resolves
+///    the proof's signing key, requiring its `verificationMethod` to belong to
+///    the list credential's own `issuer` (no cross-DID signing).
+/// 2. **Issuer binding (to the checked credential):** when `expected_issuer` is
+///    `Some`, the list's `issuer` MUST equal it — a validly-signed but unrelated
+///    issuer's list cannot be substituted.
+/// 3. **Signature:** the `eddsa-jcs-2022` proof is verified over the list
+///    credential with `proof` removed (BBS+ is audit-gated and rejected here).
+///
+/// Any failure is an error — the caller treats a resolver error as
+/// "leave the stored status unchanged" (fail-safe to the stored tag).
+#[cfg(feature = "webvh")]
+async fn verify_status_list_signature(
+    did_resolver: Option<&DIDCacheClient>,
+    list_credential: &serde_json::Value,
+    expected_issuer: Option<&str>,
+    url: &str,
+) -> Result<(), AppError> {
+    use crate::vault::di_verify::{credential_issuer, resolve_di_issuer_key};
+
+    // Bind the list's self-asserted issuer to the credential's issuer first —
+    // cheap, and it rejects a substituted (even if validly-signed) list outright.
+    let list_issuer = credential_issuer(list_credential).ok_or_else(|| {
+        AppError::Validation(format!("status list `{url}` has no `issuer` to verify"))
+    })?;
+    if let Some(expected) = expected_issuer
+        && list_issuer != expected
+    {
+        return Err(AppError::Validation(format!(
+            "status list `{url}` issuer `{list_issuer}` is not the credential's issuer \
+             `{expected}` — refusing a substituted status list"
+        )));
+    }
+
+    // Resolve the signing key (bound to the list's own issuer) and verify the
+    // eddsa-jcs-2022 proof over the credential with `proof` removed.
+    let issuer_pub = resolve_di_issuer_key(did_resolver, list_credential).await?;
+
+    let proof_val = list_credential.get("proof").cloned().ok_or_else(|| {
+        AppError::Validation(format!("status list `{url}` has no `proof` to verify"))
+    })?;
+    let proof: DataIntegrityProof = serde_json::from_value(proof_val).map_err(|e| {
+        AppError::Validation(format!("status list `{url}` has an unparseable proof: {e}"))
+    })?;
+    if !matches!(proof.cryptosuite, CryptoSuite::EddsaJcs2022) {
+        return Err(AppError::Validation(format!(
+            "status list `{url}` proof cryptosuite {:?} is unsupported \
+             (expected eddsa-jcs-2022; BBS+ is audit-gated)",
+            proof.cryptosuite
+        )));
+    }
+
+    // JCS is presence-sensitive: strip `proof` exactly as the issuer did at
+    // signing time.
+    let mut signing_doc = list_credential.clone();
+    signing_doc
+        .as_object_mut()
+        .ok_or_else(|| AppError::Validation(format!("status list `{url}` is not a JSON object")))?
+        .remove("proof");
+    proof
+        .verify_with_public_key(&signing_doc, &issuer_pub, VerifyOptions::new())
+        .map_err(|e| {
+            AppError::Validation(format!(
+                "status list `{url}` issuer signature verification failed: {e}"
+            ))
+        })?;
+
+    Ok(())
+}
+
 /// Resolves a status-list-credential URL to its decoded-ready bitstring.
 ///
 /// Injected so tests provide a mock (no network) and production wires the
@@ -198,12 +299,25 @@ impl StatusListResolver for HttpStatusListResolver {
 pub trait StatusListResolver: Send + Sync {
     /// Fetch and return the status list referenced by `url`.
     ///
-    /// Implementations should verify the status-list *credential's* own issuer
+    /// Implementations MUST verify the status-list *credential's* own issuer
     /// signature before returning (the holder must not trust an unverified
-    /// list); that verification is out of scope for this module, which only
-    /// decodes and reads the bit. Returns an error the caller can surface or
-    /// retry; on error this module leaves the stored status unchanged.
-    async fn resolve(&self, url: &str) -> Result<ResolvedStatusList, AppError>;
+    /// list) — otherwise anyone who can serve `url` could forge a revocation
+    /// (terminal!) of a valid credential, or hide a real one. When
+    /// `expected_issuer` is `Some`, the implementation MUST also bind the
+    /// resolved list's `issuer` to it (the issuer of the credential whose
+    /// status is being checked), so a *validly-signed but unrelated* list
+    /// can't be substituted. `expected_issuer` is `None` only when the held
+    /// credential records no issuer; binding is then skipped (signature
+    /// verification still applies).
+    ///
+    /// Returns an error the caller can surface or retry; on error this module
+    /// leaves the stored status unchanged (the present gate falls back to the
+    /// stored tag — fail-safe).
+    async fn resolve(
+        &self,
+        url: &str,
+        expected_issuer: Option<&str>,
+    ) -> Result<ResolvedStatusList, AppError>;
 }
 
 /// Extract the `credentialStatus` `BitstringStatusListEntry` from a stored
@@ -416,7 +530,14 @@ pub async fn refresh_status<R: StatusListResolver + ?Sized>(
         return Ok(RefreshOutcome::NotTracked);
     };
 
-    let resolved = resolver.resolve(&status_ref.status_list_credential).await?;
+    // Bind the resolved list to this credential's issuer: the issuer that issued
+    // the credential is the only party allowed to publish its status list.
+    let resolved = resolver
+        .resolve(
+            &status_ref.status_list_credential,
+            cred.issuer_did.as_deref(),
+        )
+        .await?;
 
     // Enforce the declared-purpose binding (W3C vc-bitstring-status-list §). When
     // the credential's entry declares a `statusPurpose`, it MUST match the
@@ -562,7 +683,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl StatusListResolver for MockResolver {
-        async fn resolve(&self, _url: &str) -> Result<ResolvedStatusList, AppError> {
+        async fn resolve(
+            &self,
+            _url: &str,
+            _expected_issuer: Option<&str>,
+        ) -> Result<ResolvedStatusList, AppError> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(self.list.clone())
         }
@@ -574,7 +699,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl StatusListResolver for ErrResolver {
-        async fn resolve(&self, _url: &str) -> Result<ResolvedStatusList, AppError> {
+        async fn resolve(
+            &self,
+            _url: &str,
+            _expected_issuer: Option<&str>,
+        ) -> Result<ResolvedStatusList, AppError> {
             Err(AppError::Internal("status list unreachable".to_string()))
         }
     }
@@ -919,5 +1048,117 @@ mod tests {
         c.body = serde_json::to_vec(&body).unwrap();
         let err = extract_status_ref(&c).unwrap_err();
         assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    // ---- status-list-credential signature verification (webvh) ----------
+    //
+    // The production resolver MUST verify the list credential's own issuer
+    // signature and bind it to the checked credential's issuer, so a forged
+    // list served at the entry URL is rejected rather than trusted (a forged
+    // revocation is terminal — this is the hole these tests close).
+
+    #[cfg(feature = "webvh")]
+    mod signature {
+        use super::*;
+        use affinidi_crypto::did_key::ed25519_pub_to_did_key;
+        use affinidi_data_integrity::{
+            DataIntegrityProof as DiProof, SignOptions, crypto_suites::CryptoSuite as Suite,
+        };
+        use affinidi_secrets_resolver::secrets::Secret;
+
+        /// Build + eddsa-jcs-2022-sign a `BitstringStatusListCredential` issued
+        /// by a `did:key` derived from `seed`. Returns `(credential, issuer_did)`.
+        async fn signed_status_list(seed: u8, purpose: &str) -> (serde_json::Value, String) {
+            // The signing key and the issuer `did:key` must be the same key:
+            // generate once to read the public bytes + form the did:key, then
+            // re-generate with the matching verificationMethod id (deterministic
+            // from the seed, so the key is identical).
+            let probe = Secret::generate_ed25519(None, Some(&[seed; 32]));
+            let pub_bytes: [u8; 32] = probe.get_public_bytes().try_into().unwrap();
+            let issuer_did = ed25519_pub_to_did_key(&pub_bytes);
+            let vm_id = format!("{issuer_did}#key-0");
+            let secret = Secret::generate_ed25519(Some(&vm_id), Some(&[seed; 32]));
+
+            let encoded = encoded_list_with(Some(7), parse_purpose(purpose).unwrap());
+            let mut cred = serde_json::json!({
+                "@context": ["https://www.w3.org/ns/credentials/v2"],
+                "type": ["VerifiableCredential", "BitstringStatusListCredential"],
+                "issuer": issuer_did,
+                "credentialSubject": {
+                    "type": "BitstringStatusList",
+                    "statusPurpose": purpose,
+                    "encodedList": encoded,
+                },
+            });
+            let proof = DiProof::sign(
+                &cred,
+                &secret,
+                SignOptions::new()
+                    .with_proof_purpose("assertionMethod")
+                    .with_cryptosuite(Suite::EddsaJcs2022),
+            )
+            .await
+            .expect("sign status list");
+            cred["proof"] = serde_json::to_value(&proof).unwrap();
+            (cred, issuer_did)
+        }
+
+        #[tokio::test]
+        async fn valid_signature_and_matching_issuer_passes() {
+            let (cred, issuer) = signed_status_list(11, "revocation").await;
+            // did:key issuer → resolved locally, no DID resolver needed.
+            verify_status_list_signature(None, &cred, Some(&issuer), "https://x/sl")
+                .await
+                .expect("a correctly-signed, issuer-matched list must verify");
+        }
+
+        #[tokio::test]
+        async fn no_expected_issuer_still_verifies_the_signature() {
+            let (cred, _issuer) = signed_status_list(12, "revocation").await;
+            // Binding is skipped (the held credential recorded no issuer), but the
+            // signature is still checked.
+            verify_status_list_signature(None, &cred, None, "https://x/sl")
+                .await
+                .expect("signature must still verify when binding is skipped");
+        }
+
+        #[tokio::test]
+        async fn substituted_issuer_is_rejected() {
+            let (cred, _issuer) = signed_status_list(13, "revocation").await;
+            // A validly-signed list, but from a different issuer than the
+            // credential's → refused (substitution attack).
+            let err = verify_status_list_signature(
+                None,
+                &cred,
+                Some("did:key:zStranger"),
+                "https://x/sl",
+            )
+            .await
+            .expect_err("a list whose issuer != the credential's must be refused");
+            assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        }
+
+        #[tokio::test]
+        async fn tampered_list_fails_the_signature() {
+            let (mut cred, issuer) = signed_status_list(14, "revocation").await;
+            // Flip the encoded bitstring after signing (e.g. a forged all-clear) —
+            // the JCS proof no longer verifies.
+            cred["credentialSubject"]["encodedList"] =
+                serde_json::json!(encoded_list_with(None, StatusPurpose::Revocation));
+            let err = verify_status_list_signature(None, &cred, Some(&issuer), "https://x/sl")
+                .await
+                .expect_err("a tampered list must fail signature verification");
+            assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        }
+
+        #[tokio::test]
+        async fn unsigned_list_is_rejected() {
+            let (mut cred, issuer) = signed_status_list(15, "revocation").await;
+            cred.as_object_mut().unwrap().remove("proof");
+            let err = verify_status_list_signature(None, &cred, Some(&issuer), "https://x/sl")
+                .await
+                .expect_err("an unsigned list must be refused");
+            assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        }
     }
 }


### PR DESCRIPTION
## What

`HttpStatusListResolver` (the production live-status resolver, #274) fetched a `BitstringStatusListCredential` and read its `encodedList` / `statusPurpose` **without verifying the issuer signature**. That's a fail-open hole: anyone able to serve the status-list URL could forge the list —

- a forged **all-clear** hides a real revocation (a revoked credential keeps presenting), and
- a forged **all-set** forges a **terminal** revocation of a *valid* credential (revocation is terminal, so this is a permanent DoS on a good credential).

This closes the hole flagged as the #274 follow-up.

## How

Verify the list credential's `eddsa-jcs-2022` issuer signature before trusting any of its bytes, with two bindings:

1. **Within the list** — the proof's `verificationMethod` must belong to the list credential's own `issuer` (no cross-DID signing).
2. **To the checked credential** — when the held credential records an issuer, the list's `issuer` must equal it, so a *validly-signed but unrelated* issuer's list can't be substituted.

`StatusListResolver::resolve` gains an `expected_issuer` parameter; `refresh_status` passes the credential's `issuer_did`. `HttpStatusListResolver` now holds an `Option<DIDCacheClient>` (`did:key` resolves locally, `did:webvh`/`did:web` via the cache), wired from `default_status_resolver(did_resolver)` at both `AppState` build sites.

**Fail-safe preserved**: a resolver error (fetch failure, bad signature, issuer mismatch) still falls back to the stored status tag at the present gate — an outage doesn't block presentation, but a *forged* list is now rejected rather than trusted.

### Refactor

Extracted `resolve_di_issuer_key` + `resolve_vm_ed25519` (and `credential_issuer`) out of `operations/credential_exchange.rs` into a new `vault/di_verify.rs` (`pub(crate)`), now shared by DI receive and status-list verification — same issuer-binding rule, one implementation.

## Tests

New `vault::status::tests::signature` (webvh-gated): valid signature + matching issuer passes; no-expected-issuer still verifies the signature (binding skipped); substituted issuer, tampered `encodedList`, and unsigned list all rejected.

`cargo fmt`, `cargo clippy -p vta-service --all-targets` (default **and** `--no-default-features --features rest,didcomm`, both clean), full `vta-service` suite, and `cargo deny` all pass. `vta-enclave` has no references to the changed surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)