### PR TITLE
feat(vtc): deliver the re-minted role VEC on role change + share delivery machinery

### DIFF
--- a/vtc-service/src/credentials/delivery.rs
+++ b/vtc-service/src/credentials/delivery.rs
@@ -1,0 +1,220 @@
+//! Deliver issued credentials to a holder's wallet over DIDComm.
+//!
+//! When the VTC issues a credential to a member — at join auto-admit, at
+//! admin-approve, or when a role change re-mints the role VEC — the holder needs
+//! to actually *receive* it. The REST surfaces return the credential inline in
+//! their response (for out-of-band hand-off), but a holder that interacted over
+//! DIDComm, or one that's offline at approval/role-change time, has no inline
+//! channel. This module pushes each credential to the holder over DIDComm.
+//!
+//! Each credential is wrapped in a `credential-exchange/issue` message — the same
+//! one-way-deposit shape the holder's VTA receives via its
+//! `handle_credential_issue` handler — packed authcrypt **to the proven holder**
+//! (never the relayer) and forwarded via the holder's own mediator (resolved from
+//! its DID document, falling back to the VTC's mediator for the shared-mediator
+//! deployment). Sending is **best-effort**: the credential is already issued and
+//! persisted, so the caller logs a delivery failure rather than unwinding the
+//! decision.
+
+use std::sync::Arc;
+
+use affinidi_messaging_didcomm::Message;
+use affinidi_openid4vci::issuer::create_credential_response;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_vc::VerifiableCredential;
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+use vta_sdk::protocols::credential_exchange::{ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody};
+use vti_common::error::AppError;
+
+use crate::ceremony::AdmitOutcome;
+use crate::server::AppState;
+
+/// Deliver the credentials a holder earned by being admitted — the
+/// MembershipCredential and role EndorsementCredential of an [`AdmitOutcome`] —
+/// into the holder's wallet over DIDComm. See [`deliver_credentials`].
+pub(crate) async fn deliver_membership_credentials(
+    state: &AppState,
+    holder_did: &str,
+    admit: &AdmitOutcome,
+) -> Result<(), AppError> {
+    deliver_credentials(state, holder_did, &[&admit.vmc, &admit.role_vec]).await
+}
+
+/// Deliver each of `credentials` to `holder_did` over DIDComm, one
+/// `credential-exchange/issue` message apiece.
+///
+/// Packed authcrypt **to the proven holder** (not a relayer) and forwarded via
+/// the holder's own mediator. Best-effort by nature (mediator delivery is
+/// end-to-end): the first failure is returned so the caller can log it, but the
+/// credentials are already issued and persisted — a failure must not unwind the
+/// decision that issued them.
+pub(crate) async fn deliver_credentials(
+    state: &AppState,
+    holder_did: &str,
+    credentials: &[&VerifiableCredential],
+) -> Result<(), AppError> {
+    for credential in credentials {
+        let credential_json = serde_json::to_value(credential)
+            .map_err(|e| AppError::Internal(format!("issued credential serialise: {e}")))?;
+        let body = issue_message_body(credential_json)?;
+        // A fresh thread per delivered credential — `issue` is a one-way deposit,
+        // not a request/response, so it needs no correlation to a prior thread.
+        let msg_id = Uuid::new_v4().to_string();
+        push_to_holder(state, holder_did, &msg_id, CREDENTIAL_ISSUE_TYPE, body).await?;
+    }
+    Ok(())
+}
+
+/// Wrap an issued credential JSON value in a `credential-exchange/issue` body —
+/// the exact shape the holder's VTA extracts in its `handle_credential_issue` →
+/// `store_issued_credential` path (`credential_response.credential`, here a W3C
+/// Data-Integrity VC object). `sealed` is `None`: the holder is a proven,
+/// resolvable DID, so the message is authcrypt-encrypted to it rather than
+/// HPKE-sealed (sealing is the unknown-holder / invite case).
+fn issue_message_body(credential_json: JsonValue) -> Result<JsonValue, AppError> {
+    let issue = IssueBody {
+        credential_response: Some(create_credential_response(credential_json, None, None)),
+        sealed: None,
+    };
+    serde_json::to_value(&issue)
+        .map_err(|e| AppError::Internal(format!("issue body serialise: {e}")))
+}
+
+/// Pack `body` as a DIDComm message (`msg_id` / `msg_type`) authcrypt to
+/// `holder_did`, wrap it in a mediator forward, and send it.
+///
+/// The forward is addressed to the **holder's own mediator** (resolved from the
+/// holder's DID document) and sent through the **VTC's own mediator** — the
+/// mediator the VTC has a connection to. The VTC's mediator routes the forward
+/// onward to the holder's mediator, which delivers it. When the holder advertises
+/// no mediator, the VTC's own mediator is used as the forward target (the
+/// shared-mediator deployment). Shared by the credential-query push and the
+/// issued-credential delivery.
+pub(crate) async fn push_to_holder(
+    state: &AppState,
+    holder_did: &str,
+    msg_id: &str,
+    msg_type: &str,
+    body: JsonValue,
+) -> Result<(), AppError> {
+    let atm = state
+        .atm
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("messaging (ATM) not configured".into()))?;
+
+    let (vtc_did, mediator_did) = {
+        let config = state.config.read().await;
+        let vtc_did = config
+            .vtc_did
+            .clone()
+            .ok_or_else(|| AppError::Internal("VTC DID not configured".into()))?;
+        let mediator_did = config
+            .messaging
+            .as_ref()
+            .map(|m| m.mediator_did.clone())
+            .ok_or_else(|| AppError::Internal("no mediator configured for messaging".into()))?;
+        (vtc_did, mediator_did)
+    };
+
+    // Resolve the holder's own mediator from its DID document; fall back to the
+    // VTC's mediator (shared-mediator deployment) when the holder has none.
+    let target_mediator = resolve_holder_mediator(state, holder_did)
+        .await
+        .unwrap_or_else(|| mediator_did.clone());
+
+    // The VTC sends through its OWN mediator (the profile's connection); the
+    // forward, addressed to the holder's mediator, is routed onward from there.
+    let profile = Arc::new(
+        ATMProfile::new(atm, None, vtc_did.clone(), Some(mediator_did.clone()))
+            .await
+            .map_err(|e| AppError::Internal(format!("ATM profile setup failed: {e}")))?,
+    );
+    atm.profile_enable_websocket(&profile)
+        .await
+        .map_err(|e| AppError::Internal(format!("mediator websocket failed: {e}")))?;
+
+    let msg = Message::build(msg_id.to_string(), msg_type.to_string(), body)
+        .from(vtc_did.clone())
+        .to(holder_did.to_string())
+        .finalize();
+
+    let (jwe, _meta) = atm
+        .pack_encrypted(&msg, holder_did, Some(&vtc_did), None)
+        .await
+        .map_err(|e| AppError::Internal(format!("pack_encrypted failed: {e}")))?;
+
+    atm.forward_and_send_message(
+        &profile,
+        false,
+        &jwe,
+        Some(msg_id),
+        &target_mediator,
+        holder_did,
+        None,
+        None,
+        false,
+    )
+    .await
+    .map_err(|e| AppError::Internal(format!("mediator forward failed: {e}")))?;
+
+    Ok(())
+}
+
+/// Resolve the holder's own DIDComm mediator from its DID document — the `did:`
+/// `uri` of its `DIDCommMessaging` service. Returns `None` when the holder
+/// advertises no mediator (so the caller routes through its own).
+async fn resolve_holder_mediator(state: &AppState, holder_did: &str) -> Option<String> {
+    let resolver = state.did_resolver.as_ref()?;
+    let resolved = resolver.resolve(holder_did).await.ok()?;
+    for svc in &resolved.doc.service {
+        if svc.type_.iter().any(|t| t == "DIDCommMessaging")
+            && let Some(mediator) = svc
+                .service_endpoint
+                .get_uris()
+                .into_iter()
+                .map(|u| u.trim_matches('"').to_string())
+                .find(|u| u.starts_with("did:"))
+        {
+            return Some(mediator);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn issue_message_body_matches_the_vta_receive_shape() {
+        // A W3C-DI MembershipCredential as the VTC issues it.
+        let vmc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": "did:web:vtc.example",
+            "credentialSubject": { "id": "did:key:zHolder", "community": "acme" },
+            "proof": { "type": "DataIntegrityProof", "cryptosuite": "eddsa-jcs-2022" },
+        });
+
+        let body = issue_message_body(vmc.clone()).expect("wrap issue body");
+
+        // The holder's VTA parses exactly this with IssueBody, then reads
+        // `credential_response.credential` (a DI VC object) in store_issued_credential.
+        let issue: IssueBody = serde_json::from_value(body).expect("parse as IssueBody");
+        assert!(
+            issue.sealed.is_none(),
+            "a proven holder gets authcrypt, not a seal"
+        );
+        let credential = issue
+            .credential_response
+            .expect("credential_response present")
+            .credential
+            .expect("credential present");
+        assert_eq!(
+            credential, vmc,
+            "the delivered credential round-trips intact"
+        );
+    }
+}

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -45,6 +45,7 @@
 //! pre-status-list state in tests.
 
 pub mod custom_endorsement;
+pub mod delivery;
 pub mod dtg;
 pub mod exchange;
 pub mod invitation;

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -372,12 +372,9 @@ async fn credential_present_handler(
     // delivery failure is logged (the holder/admin can re-fetch), not fatal.
     if let Some(admit) = outcome.admit.as_deref() {
         let holder_did = outcome.request.applicant_did.clone();
-        if let Err(e) = crate::routes::join_requests::present::deliver_membership_credentials(
-            &state,
-            &holder_did,
-            admit,
-        )
-        .await
+        if let Err(e) =
+            crate::credentials::delivery::deliver_membership_credentials(&state, &holder_did, admit)
+                .await
         {
             warn!(holder = %holder_did, request = %outcome.request.id, error = %e, "membership-credential delivery failed; credential is issued and can be re-delivered");
         } else {

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -94,7 +94,7 @@ pub async fn approve(
     // its mediator. Best-effort: the credentials are already issued and are also
     // returned inline below for out-of-band hand-off, so a delivery failure (no
     // mediator, unreachable holder) is logged, not fatal.
-    if let Err(e) = crate::routes::join_requests::present::deliver_membership_credentials(
+    if let Err(e) = crate::credentials::delivery::deliver_membership_credentials(
         &state,
         &req.applicant_did,
         &creds,

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -21,12 +21,7 @@
 //! [`send_query`]): the VTC issues the challenge and builds the DCQL query (from
 //! a registered Accepts criterion) the holder answers.
 
-use std::sync::Arc;
-
-use affinidi_messaging_didcomm::Message;
-use affinidi_openid4vci::issuer::create_credential_response;
 use affinidi_openid4vp::DcqlQuery;
-use affinidi_tdk::messaging::profiles::ATMProfile;
 use axum::Json;
 use axum::extract::State;
 use chrono::{DateTime, Utc};
@@ -34,14 +29,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 use tracing::{info, warn};
 use uuid::Uuid;
-use vta_sdk::protocols::credential_exchange::{
-    ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody, QUERY as CREDENTIAL_QUERY_TYPE, QueryBody,
-};
+use vta_sdk::protocols::credential_exchange::{QUERY as CREDENTIAL_QUERY_TYPE, QueryBody};
 
 use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
 
-use crate::ceremony::{AdmitOutcome, Credential, CredentialStatus, Presentation};
+use crate::ceremony::{Credential, CredentialStatus, Presentation};
 use crate::credentials::present_challenge::{self, DEFAULT_CHALLENGE_TTL};
 use crate::credentials::{VerifiedPresentation, VerifiedPresentationSet, verify_vp_token};
 use crate::join::JoinTransport;
@@ -240,155 +233,14 @@ async fn push_credential_query(
     let body = serde_json::to_value(query)
         .map_err(|e| AppError::Internal(format!("query serialise: {e}")))?;
     // The message id is the thread root; the holder replies with `thid = thread_id`.
-    push_to_holder(state, holder_did, thread_id, CREDENTIAL_QUERY_TYPE, body).await
-}
-
-/// Deliver the credentials a holder earned by joining — the MembershipCredential
-/// and role EndorsementCredential — into the holder's wallet over DIDComm.
-///
-/// On a DIDComm auto-admit the VTC issues the VMC + role VEC (the
-/// [`AdmitOutcome`]) and stores its own copy, but the holder, who only received
-/// a join receipt, never gets the credential it just earned. (The REST submit
-/// path returns them inline in the response; the DIDComm path has no inline
-/// channel.) Each credential is wrapped in a `credential-exchange/issue` message
-/// — the same one-way-deposit shape the holder's VTA receives via its
-/// `handle_credential_issue` handler — packed authcrypt **to the proven holder**
-/// (not the relayer) and forwarded via the holder's own mediator.
-///
-/// Best-effort by nature (mediator delivery is end-to-end): a failure is returned
-/// so the caller can log it, but it must not unwind the admit — the credential is
-/// already issued and persisted, and an admin can re-deliver.
-pub(crate) async fn deliver_membership_credentials(
-    state: &AppState,
-    holder_did: &str,
-    admit: &AdmitOutcome,
-) -> Result<(), AppError> {
-    for credential in [&admit.vmc, &admit.role_vec] {
-        let credential_json = serde_json::to_value(credential)
-            .map_err(|e| AppError::Internal(format!("issued credential serialise: {e}")))?;
-        let body = issue_message_body(credential_json)?;
-        // A fresh thread per delivered credential — `issue` is a one-way deposit,
-        // not a request/response, so it needs no correlation to a prior thread.
-        let msg_id = Uuid::new_v4().to_string();
-        push_to_holder(state, holder_did, &msg_id, CREDENTIAL_ISSUE_TYPE, body).await?;
-    }
-    Ok(())
-}
-
-/// Wrap an issued credential JSON value in a `credential-exchange/issue` body —
-/// the exact shape the holder's VTA extracts in its `handle_credential_issue` →
-/// `store_issued_credential` path (`credential_response.credential`, here a W3C
-/// Data-Integrity VC object). `sealed` is `None`: the holder is a proven,
-/// resolvable DID, so the message is authcrypt-encrypted to it rather than
-/// HPKE-sealed (sealing is the unknown-holder / invite case).
-fn issue_message_body(credential_json: JsonValue) -> Result<JsonValue, AppError> {
-    let issue = IssueBody {
-        credential_response: Some(create_credential_response(credential_json, None, None)),
-        sealed: None,
-    };
-    serde_json::to_value(&issue)
-        .map_err(|e| AppError::Internal(format!("issue body serialise: {e}")))
-}
-
-/// Pack `body` as a DIDComm message (`msg_id` / `msg_type`) authcrypt to
-/// `holder_did`, wrap it in a mediator forward, and send it.
-///
-/// The forward is addressed to the **holder's own mediator** (resolved from the
-/// holder's DID document) and sent through the **VTC's own mediator** — the
-/// mediator the VTC has a connection to. The VTC's mediator routes the forward
-/// onward to the holder's mediator, which delivers it. When the holder advertises
-/// no mediator, the VTC's own mediator is used as the forward target (the
-/// shared-mediator deployment). Shared by the query push and the issued-credential
-/// delivery.
-async fn push_to_holder(
-    state: &AppState,
-    holder_did: &str,
-    msg_id: &str,
-    msg_type: &str,
-    body: serde_json::Value,
-) -> Result<(), AppError> {
-    let atm = state
-        .atm
-        .as_ref()
-        .ok_or_else(|| AppError::Internal("messaging (ATM) not configured".into()))?;
-
-    let (vtc_did, mediator_did) = {
-        let config = state.config.read().await;
-        let vtc_did = config
-            .vtc_did
-            .clone()
-            .ok_or_else(|| AppError::Internal("VTC DID not configured".into()))?;
-        let mediator_did = config
-            .messaging
-            .as_ref()
-            .map(|m| m.mediator_did.clone())
-            .ok_or_else(|| AppError::Internal("no mediator configured for messaging".into()))?;
-        (vtc_did, mediator_did)
-    };
-
-    // Resolve the holder's own mediator from its DID document; fall back to the
-    // VTC's mediator (shared-mediator deployment) when the holder has none.
-    let target_mediator = resolve_holder_mediator(state, holder_did)
-        .await
-        .unwrap_or_else(|| mediator_did.clone());
-
-    // The VTC sends through its OWN mediator (the profile's connection); the
-    // forward, addressed to the holder's mediator, is routed onward from there.
-    let profile = Arc::new(
-        ATMProfile::new(atm, None, vtc_did.clone(), Some(mediator_did.clone()))
-            .await
-            .map_err(|e| AppError::Internal(format!("ATM profile setup failed: {e}")))?,
-    );
-    atm.profile_enable_websocket(&profile)
-        .await
-        .map_err(|e| AppError::Internal(format!("mediator websocket failed: {e}")))?;
-
-    let msg = Message::build(msg_id.to_string(), msg_type.to_string(), body)
-        .from(vtc_did.clone())
-        .to(holder_did.to_string())
-        .finalize();
-
-    let (jwe, _meta) = atm
-        .pack_encrypted(&msg, holder_did, Some(&vtc_did), None)
-        .await
-        .map_err(|e| AppError::Internal(format!("pack_encrypted failed: {e}")))?;
-
-    atm.forward_and_send_message(
-        &profile,
-        false,
-        &jwe,
-        Some(msg_id),
-        &target_mediator,
+    crate::credentials::delivery::push_to_holder(
+        state,
         holder_did,
-        None,
-        None,
-        false,
+        thread_id,
+        CREDENTIAL_QUERY_TYPE,
+        body,
     )
     .await
-    .map_err(|e| AppError::Internal(format!("mediator forward failed: {e}")))?;
-
-    Ok(())
-}
-
-/// Resolve the holder's own DIDComm mediator from its DID document — the `did:`
-/// `uri` of its `DIDCommMessaging` service. Returns `None` when the holder
-/// advertises no mediator (so the caller routes through its own).
-async fn resolve_holder_mediator(state: &AppState, holder_did: &str) -> Option<String> {
-    let resolver = state.did_resolver.as_ref()?;
-    let resolved = resolver.resolve(holder_did).await.ok()?;
-    for svc in &resolved.doc.service {
-        if svc.type_.iter().any(|t| t == "DIDCommMessaging")
-            && let Some(mediator) = svc
-                .service_endpoint
-                .get_uris()
-                .into_iter()
-                .map(|u| u.trim_matches('"').to_string())
-                .find(|u| u.starts_with("did:"))
-        {
-            return Some(mediator);
-        }
-    }
-    None
 }
 
 /// Project a [`VerifiedPresentationSet`] into the verified ceremony
@@ -563,37 +415,6 @@ mod tests {
                 "did:webvh:stranger.example"
             )
             .await
-        );
-    }
-
-    #[test]
-    fn issue_message_body_matches_the_vta_receive_shape() {
-        // A W3C-DI MembershipCredential as the VTC issues it.
-        let vmc = json!({
-            "@context": ["https://www.w3.org/ns/credentials/v2"],
-            "type": ["VerifiableCredential", "MembershipCredential"],
-            "issuer": "did:web:vtc.example",
-            "credentialSubject": { "id": "did:key:zHolder", "community": "acme" },
-            "proof": { "type": "DataIntegrityProof", "cryptosuite": "eddsa-jcs-2022" },
-        });
-
-        let body = issue_message_body(vmc.clone()).expect("wrap issue body");
-
-        // The holder's VTA parses exactly this with IssueBody, then reads
-        // `credential_response.credential` (a DI VC object) in store_issued_credential.
-        let issue: IssueBody = serde_json::from_value(body).expect("parse as IssueBody");
-        assert!(
-            issue.sealed.is_none(),
-            "a proven holder gets authcrypt, not a seal"
-        );
-        let credential = issue
-            .credential_response
-            .expect("credential_response present")
-            .credential
-            .expect("credential present");
-        assert_eq!(
-            credential, vmc,
-            "the delivered credential round-trips intact"
         );
     }
 

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -17,6 +17,7 @@ use axum::extract::{Path, State};
 use chrono::Utc;
 use serde::Deserialize;
 use serde_json::{Value as JsonValue, json};
+use tracing::warn;
 
 use vti_common::audit::{AuditEvent, MemberUpdatedData, RoleChangedData};
 
@@ -215,6 +216,22 @@ async fn role_change_via_pipeline(
             "remint effect did not produce an outcome".into(),
         ));
     };
+
+    // Deliver the re-minted role VEC to the member's wallet over DIDComm so it
+    // can present its updated role. Best-effort: the VEC is already issued and
+    // persisted (the old one is short-lived and expires on its own validUntil —
+    // role VECs carry no status entry), so a delivery failure is logged, not
+    // fatal.
+    if let Err(e) =
+        crate::credentials::delivery::deliver_credentials(state, subject_did, &[&outcome.role_vec])
+            .await
+    {
+        warn!(
+            subject = %subject_did,
+            error = %e,
+            "role-VEC delivery failed on role change; the credential is issued and can be re-delivered"
+        );
+    }
 
     Ok(RoleChangeResult {
         previous_role: outcome.previous_role.to_string(),


### PR DESCRIPTION
## What

A role change (`PATCH /v1/members/{did}`) runs the role-change ceremony, which re-mints the member's role VEC at the new role and stores it on the VTC — but the route returned only `{previousRole, newRole}`. The member **never received its updated role credential**, so it couldn't present the new role.

The old role VEC carries no status entry and expires on its 30-day `validUntil` (existing design — role VECs are short-lived rather than status-list-revocable), so this is purely a **delivery** gap, not a revocation one.

## How

Deliver the re-minted role VEC to the member over DIDComm, best-effort — the same model as the auto-admit (#279) and admin-approve (#280) paths. The credential is already issued and persisted, so a delivery failure (no mediator, unreachable holder) is logged, not fatal.

### Shared delivery module

The DIDComm credential-delivery machinery was introduced in #279 and reused by #280. With a **third caller** (role change) — and now across a *second* route tree (`routes/members/`) — it no longer belongs in `routes/join_requests/present.rs`. Extracted to **`crate::credentials::delivery`**:

- `deliver_membership_credentials(&AdmitOutcome)` — admit + approve paths (VMC + role VEC).
- `deliver_credentials(&[&VerifiableCredential])` — the new general entry; role change delivers just the role VEC.
- `push_to_holder` — now genuinely shared (also backs `present.rs`'s `push_credential_query`).
- `issue_message_body`, `resolve_holder_mediator`, and the issue-body unit test moved along.

No behaviour change for the existing two callers — pure relocation plus the new role-change entry point.

## Tests

The wire-shape unit test (`issue_message_body_matches_the_vta_receive_shape`) moved with the code and still passes. Existing join + role-change integration tests run mediator-less, so delivery fails soft (logged, non-fatal) and their assertions are unchanged.

`cargo fmt`, `cargo clippy -p vtc-service --all-targets` (clean), full `vtc-service` suite, and `cargo deny` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)