### PR TITLE
feat(vta): receive BBS (bbs-2023) credentials into the vault (feature `bbs`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383822b5aa105040ae6debb29d0321cbb5ad8f755d2c050e437c923434aa72c8"
+checksum = "181b6e6fe074cf7ef7c39c24a4eed69781d1872387269409e4cf6e6e507c0d76"
 dependencies = [
  "aes 0.8.4",
  "affinidi-encoding",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce7f611e7bcad221aee953b8ef91d23e0f18ef319c711211357f03f14f63450"
+checksum = "40e3bfdabfb46690fe58cea0801d4b43d15949ee34a92290b68d9447bbb616a5"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-encoding"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0d6ba1e7fc9bde231c5c7d6e10f29b6822f93e20000dce2a4647d8de8c8d9a"
+checksum = "8b0faa57ab55df6fad876ac64a223532a9bb159b393d88b66887c1ae42c33f52"
 dependencies = [
  "bs58 0.5.1",
  "serde",
@@ -2800,7 +2800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9760,6 +9760,7 @@ version = "0.8.2"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
+ "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ affinidi-tdk = "0.7"
 # Raw crypto primitives (ed25519↔x25519 conversion, did:key helpers). Pulled
 # directly so sealed-transfer can use `affinidi_crypto::did_key::*` without
 # going through the higher-level Secret wrapper in secrets-resolver.
-affinidi-crypto = "0.1"
+affinidi-crypto = "0.1.11"
 # W3C VC Data Model 2.0 + Data Integrity proofs. Used by the
 # provision-integration flow (VP-framed bootstrap request, VC-issued
 # admin authorization). See CLAUDE.md "Authorization claims" principle.
 affinidi-vc = "0.1"
-affinidi-data-integrity = "0.6"
+affinidi-data-integrity = "0.6.1"
 affinidi-status-list = "0.1.3"
 
 # Credential formats for the credential-centric VTI architecture

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -16,6 +16,11 @@ rest = []
 didcomm = []
 webvh = ["dep:didwebvh-rs", "dep:url", "dep:reqwest"]
 setup = ["webvh", "dep:tempfile"]
+# BBS+ (`bbs-2023`) credential support in the vault — pulls in the BLS12-381
+# curve (`affinidi-bbs`) + the `bbs-2023` Data-Integrity cryptosuite. Off by
+# default; the holder/verifier paths (receive, present, verify) build behind
+# it. Issuer signing stays audit-gated (not exposed from the VTA).
+bbs = ["dep:affinidi-bbs", "affinidi-data-integrity/bbs-2023"]
 # Enables the offline CLI command helpers (bootstrap_cli, webvh_cli) that
 # synthesize super-admin `AuthClaims` without wire-level verification. The
 # local `vta` binary enables this; the enclave binary does not (its
@@ -107,6 +112,8 @@ affinidi-data-integrity = { workspace = true }
 # and not pulled in here.
 affinidi-sd-jwt-vc = { workspace = true }
 affinidi-sd-jwt = { workspace = true }
+# BBS+ primitives + G2 issuer keys — only under the `bbs` feature.
+affinidi-bbs = { workspace = true, optional = true }
 # DCQL matcher — the holder runs a verifier's DCQL query over held credentials
 # (`credential-exchange/query`, task 3.5). Same crate vta-sdk's QueryBody uses.
 affinidi-openid4vp = { workspace = true }

--- a/vta-service/src/vault/bbs.rs
+++ b/vta-service/src/vault/bbs.rs
@@ -1,0 +1,255 @@
+//! BBS+ (`bbs-2023`) credential support for the vault — feature-gated `bbs`.
+//!
+//! The vault's SD-JWT-VC / eddsa-jcs-2022 paths are always built; BBS pulls in
+//! the BLS12-381 curve (`affinidi-bbs`) + the `bbs-2023` Data-Integrity
+//! cryptosuite, so it lives behind the `bbs` feature. The document-level
+//! sign/derive/verify is delegated to
+//! [`affinidi_data_integrity::bbs_2023`] — per the workspace principle, proof
+//! handling is the library's job, not hand-rolled here.
+//!
+//! ## Scope (audit gate)
+//!
+//! The VTA is a credential **holder/verifier**, not an issuer, so issuer
+//! *signing* (`sign_vc_base`) is deliberately **not** exposed from this module
+//! — BBS issuance stays audit-gated. This module covers **receive** (verify the
+//! issuer's base proof, then store) plus issuer-key resolution. The holder
+//! **present** (selective-disclosure derive) lands in a follow-up.
+
+use affinidi_bbs::PublicKey;
+use affinidi_data_integrity::bbs_2023;
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use super::model::{CredentialFormat, CredentialStatus, StoredCredential};
+use super::receive::{Provenance, di_temporal_valid, extract_types, infer_purpose};
+use super::storage;
+
+/// Compressed BLS12-381 G2 public key length.
+const BLS12381_G2_LEN: usize = 96;
+
+/// Parse a 96-byte compressed BLS12-381 G2 key into a BBS [`PublicKey`]
+/// (validates the point is on-curve, in-subgroup, non-identity).
+pub fn g2_public_key(bytes: &[u8]) -> Result<PublicKey, AppError> {
+    let arr: [u8; BLS12381_G2_LEN] = bytes.try_into().map_err(|_| {
+        AppError::Validation(format!(
+            "BBS issuer key must be {BLS12381_G2_LEN} bytes (compressed G2), got {}",
+            bytes.len()
+        ))
+    })?;
+    PublicKey::from_bytes(&arr)
+        .map_err(|e| AppError::Validation(format!("invalid BBS issuer key: {e}")))
+}
+
+/// Resolve a BBS issuer's G2 public key from a `did:key` issuer (the whole DID
+/// *is* the key, multicodec `0xeb`). `did:webvh` / `did:web` issuers are
+/// resolved from a DID-document verification method by the wire layer, which
+/// passes the 96 bytes to [`receive_bbs`] — keeping this module network-free,
+/// like the eddsa-jcs path.
+pub fn g2_issuer_key_from_did_key(issuer_did: &str) -> Result<PublicKey, AppError> {
+    let bytes = affinidi_crypto::bls12381::did_key_to_g2_pub(issuer_did).map_err(|e| {
+        AppError::Validation(format!("issuer `{issuer_did}` is not a BBS did:key: {e}"))
+    })?;
+    g2_public_key(&bytes)
+}
+
+/// Receive a BBS (`bbs-2023`) **base-proof** credential into the vault.
+///
+/// Verifies the issuer's base proof, checks temporal validity, then stores the
+/// base-proof VC verbatim (the holder keeps it to derive selective-disclosure
+/// presentations later). `issuer_pub` is the caller-resolved 96-byte compressed
+/// G2 key — the vault stays network-free, mirroring `receive_di_vc`.
+///
+/// **Base-proof verification:** the cryptosuite exposes no standalone
+/// "verify base", so we confirm the issuer signature by deriving a
+/// full-disclosure proof and verifying it — a full-disclosure derived proof
+/// verifies iff the base BBS signature is valid over every message.
+pub async fn receive_bbs(
+    vault: &KeyspaceHandle,
+    id: &str,
+    vc_json: &[u8],
+    issuer_pub: &[u8],
+    source: Provenance,
+    now: DateTime<Utc>,
+) -> Result<StoredCredential, AppError> {
+    if id.trim().is_empty() {
+        return Err(AppError::Validation(
+            "credential id must be non-empty".to_string(),
+        ));
+    }
+    let pk = g2_public_key(issuer_pub)?;
+    let vc: Value = serde_json::from_slice(vc_json)
+        .map_err(|e| AppError::Validation(format!("malformed BBS VC JSON: {e}")))?;
+
+    // Verify the issuer base proof before trusting any bytes. The empty pointer
+    // `""` is a prefix of every claim pointer, so this discloses everything; a
+    // full-disclosure derived proof verifies iff the base signature is valid.
+    const BASE_CHECK_NONCE: &[u8] = b"vta-vault-base-check";
+    let full = bbs_2023::derive_vc(&vc, &[""], BASE_CHECK_NONCE, &pk)
+        .map_err(|e| AppError::Validation(format!("BBS base proof is malformed: {e}")))?;
+    if !bbs_2023::verify_vc_derived(&full, BASE_CHECK_NONCE, &pk)
+        .map_err(|e| AppError::Validation(format!("BBS base proof verification failed: {e}")))?
+    {
+        return Err(AppError::Validation(
+            "BBS issuer base proof did not verify".to_string(),
+        ));
+    }
+
+    // Temporal validity over W3C VC 2.0 `validFrom` / `validUntil`.
+    di_temporal_valid(&vc, now)?;
+
+    // --- map verified VC → StoredCredential envelope (mirrors receive_di_vc) ---
+    let types = extract_types(&vc);
+    let subject_did = vc
+        .get("credentialSubject")
+        .and_then(|s| s.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let issuer_did = vc.get("issuer").and_then(|i| {
+        i.as_str()
+            .map(str::to_string)
+            .or_else(|| i.get("id").and_then(Value::as_str).map(str::to_string))
+    });
+    let purpose = infer_purpose(&types);
+    let valid_from = vc
+        .get("validFrom")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let valid_until = vc
+        .get("validUntil")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    let cred = StoredCredential {
+        id: id.to_string(),
+        format: CredentialFormat::Bbs2023,
+        types,
+        schema_id: None,
+        community_did: None,
+        subject_did,
+        issuer_did,
+        purpose,
+        status: CredentialStatus::Valid,
+        valid_from,
+        valid_until,
+        received_at: now.to_rfc3339(),
+        source,
+        tags: std::collections::BTreeMap::new(),
+        body: vc_json.to_vec(),
+    };
+    storage::put(vault, &cred).await?;
+    Ok(cred)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_bbs as bbs;
+    use affinidi_data_integrity::bbs_2023::sign_vc_base;
+    use serde_json::json;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    const MANDATORY: &[&str] = &["/@context", "/type", "/issuer", "/credentialSubject/id"];
+
+    fn fresh_vault() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store.keyspace("vault").expect("vault keyspace");
+        (dir, store, ks)
+    }
+
+    fn issuer_keys() -> (bbs::SecretKey, bbs::PublicKey) {
+        let sk = bbs::keygen(b"vta-bbs-test-key-material-32byte", b"").unwrap();
+        let pk = bbs::sk_to_pk(&sk);
+        (sk, pk)
+    }
+
+    fn issuer_did(pk: &bbs::PublicKey) -> String {
+        affinidi_crypto::bls12381::g2_pub_to_did_key(&pk.to_bytes())
+    }
+
+    fn signed_bbs_vc(valid_until: Option<&str>) -> (Vec<u8>, bbs::PublicKey) {
+        let (sk, pk) = issuer_keys();
+        let did = issuer_did(&pk);
+        let mut vc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": did,
+            "validFrom": "2020-01-01T00:00:00Z",
+            "credentialSubject": { "id": "did:key:zMember", "givenName": "Alice", "memberLevel": "gold" }
+        });
+        if let Some(u) = valid_until {
+            vc["validUntil"] = json!(u);
+        }
+        let vm = format!("{did}#bbs-key-0");
+        let signed = sign_vc_base(&vc, MANDATORY, &vm, &sk, &pk).unwrap();
+        (serde_json::to_vec(&signed).unwrap(), pk)
+    }
+
+    #[tokio::test]
+    async fn receives_and_stores_a_valid_bbs_credential() {
+        let (_dir, _store, vault) = fresh_vault();
+        let (vc, pk) = signed_bbs_vc(Some("2100-01-01T00:00:00Z"));
+        let cred = receive_bbs(&vault, "bbs-1", &vc, &pk.to_bytes(), None, Utc::now())
+            .await
+            .expect("receive valid BBS VC");
+        assert_eq!(cred.format, CredentialFormat::Bbs2023);
+        assert_eq!(cred.subject_did.as_deref(), Some("did:key:zMember"));
+        assert!(cred.types.contains(&"MembershipCredential".to_string()));
+        assert!(
+            storage::get(&vault, "bbs-1").await.unwrap().is_some(),
+            "credential must be stored"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_a_tampered_bbs_credential() {
+        let (_dir, _store, vault) = fresh_vault();
+        let (vc, pk) = signed_bbs_vc(None);
+        let mut v: Value = serde_json::from_slice(&vc).unwrap();
+        v["credentialSubject"]["memberLevel"] = json!("platinum"); // tamper post-sign
+        let tampered = serde_json::to_vec(&v).unwrap();
+        let err = receive_bbs(&vault, "bbs-x", &tampered, &pk.to_bytes(), None, Utc::now())
+            .await
+            .expect_err("a tampered BBS VC must be rejected");
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        assert!(
+            storage::get(&vault, "bbs-x").await.unwrap().is_none(),
+            "a rejected credential must not be stored"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_an_expired_bbs_credential() {
+        let (_dir, _store, vault) = fresh_vault();
+        let (vc, pk) = signed_bbs_vc(Some("2001-01-01T00:00:00Z"));
+        let err = receive_bbs(&vault, "bbs-exp", &vc, &pk.to_bytes(), None, Utc::now())
+            .await
+            .expect_err("an expired BBS VC must be rejected");
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn rejects_a_wrong_issuer_key() {
+        let (_dir, _store, vault) = fresh_vault();
+        let (vc, _pk) = signed_bbs_vc(None);
+        let other = bbs::sk_to_pk(&bbs::keygen(b"another-bbs-key-material-32bytes", b"").unwrap());
+        let err = receive_bbs(&vault, "bbs-w", &vc, &other.to_bytes(), None, Utc::now())
+            .await
+            .expect_err("verification under the wrong issuer key must fail");
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+    }
+
+    #[test]
+    fn resolves_g2_issuer_key_from_did_key() {
+        let (_sk, pk) = issuer_keys();
+        let did = issuer_did(&pk);
+        let resolved = g2_issuer_key_from_did_key(&did).expect("resolve G2 did:key");
+        assert_eq!(resolved.to_bytes(), pk.to_bytes());
+    }
+}

--- a/vta-service/src/vault/mod.rs
+++ b/vta-service/src/vault/mod.rs
@@ -49,6 +49,8 @@
 //! on top in later tasks must preserve it (DCQL-targeted discovery only,
 //! never "return the whole set").
 
+#[cfg(feature = "bbs")]
+pub mod bbs;
 pub mod consent;
 pub mod di_verify;
 pub mod index;

--- a/vta-service/src/vault/receive.rs
+++ b/vta-service/src/vault/receive.rs
@@ -399,9 +399,22 @@ pub async fn receive(
             })?;
             receive_di_vc(vault, id, body, pubkey, source, now).await
         }
-        CredentialFormat::Bbs2023 => Err(AppError::Validation(
-            "BBS+ receive is audit-gated (Phase 0b) and not yet supported".to_string(),
-        )),
+        CredentialFormat::Bbs2023 => {
+            #[cfg(feature = "bbs")]
+            {
+                let pubkey = issuer_pub.ok_or_else(|| {
+                    AppError::Validation(
+                        "a BBS (bbs-2023) credential needs a caller-resolved 96-byte G2 issuer key"
+                            .to_string(),
+                    )
+                })?;
+                super::bbs::receive_bbs(vault, id, body, pubkey, source, now).await
+            }
+            #[cfg(not(feature = "bbs"))]
+            Err(AppError::Validation(
+                "BBS+ receive requires the `bbs` feature (audit-gated, Phase 0b)".to_string(),
+            ))
+        }
         CredentialFormat::Zkp => Err(AppError::Validation(
             "ZKP receive is Phase-0-gated and not yet supported (commitment primitives \
              + Circom/Groth16 verifier not yet wired)"
@@ -416,7 +429,7 @@ pub async fn receive(
 /// True iff `now` lies within a W3C VC 2.0 `validFrom`/`validUntil` window.
 /// Either bound may be absent; a malformed RFC-3339 bound is a hard error
 /// (default-deny — never store a credential whose window can't be evaluated).
-fn di_temporal_valid(vc: &Value, now: DateTime<Utc>) -> Result<(), AppError> {
+pub(super) fn di_temporal_valid(vc: &Value, now: DateTime<Utc>) -> Result<(), AppError> {
     if let Some(from) = vc.get("validFrom").and_then(Value::as_str) {
         let from = from.parse::<DateTime<Utc>>().map_err(|e| {
             AppError::Validation(format!("`validFrom` ({from}) is not RFC-3339: {e}"))
@@ -447,7 +460,7 @@ fn di_temporal_valid(vc: &Value, now: DateTime<Utc>) -> Result<(), AppError> {
 /// JSON-LD-style `type` / `vc.type` arrays a richer credential carries, so a
 /// match on either the SD-JWT-VC `vct` or a classic VC `type` tag finds the
 /// credential. Duplicates are de-duplicated; order is preserved.
-fn extract_types(claims: &Value) -> Vec<String> {
+pub(super) fn extract_types(claims: &Value) -> Vec<String> {
     let mut types: Vec<String> = Vec::new();
     let mut push_unique = |s: String| {
         if !s.is_empty() && !types.contains(&s) {
@@ -489,7 +502,7 @@ fn collect_type_field(field: Option<&Value>, push: &mut impl FnMut(String)) {
 /// without the caller having to classify it. Matching is case-insensitive and
 /// substring-based against the known catalog families; an unrecognised type
 /// leaves `purpose` unset (rather than guessing wrong).
-fn infer_purpose(types: &[String]) -> Option<CredentialPurpose> {
+pub(super) fn infer_purpose(types: &[String]) -> Option<CredentialPurpose> {
     for t in types {
         let lower = t.to_ascii_lowercase();
         if lower.contains("invitation") || lower.contains("invite") {


### PR DESCRIPTION
## What

The first slice of BBS+ in the VTI vault. The vault could store SD-JWT-VC and eddsa-jcs-2022 credentials, but its `Bbs2023` arm was an audit-gated error. This un-gates **receiving** BBS credentials, behind a new off-by-default `bbs` cargo feature.

Built on the now-published TDK foundation: `affinidi-crypto 0.1.11` (BLS12-381 G2 `did:key`, #346) and `affinidi-data-integrity 0.6.1` (document-level bbs-2023 sign/derive/verify, #347).

## How

New feature-gated `vault/bbs.rs`:
- **`receive_bbs`** — verifies the issuer's base proof, checks temporal validity, and stores the base-proof VC (the holder keeps it to derive selective-disclosure presentations later). Mirrors `receive_di_vc`: a caller-resolved 96-byte G2 key, vault stays network-free.
  - Base-proof verification **delegates to the library** (per the workspace's don't-hand-roll-proofs principle): since bbs-2023 has no standalone "verify base", a full-disclosure `derive_vc` + `verify_vc_derived` confirms the base BBS signature is valid over every message.
- **`g2_public_key` / `g2_issuer_key_from_did_key`** — G2 issuer-key handling; `did:key` resolves locally via `affinidi_crypto::bls12381`, `did:webvh` VMs resolve in the wire layer (which passes the bytes), like the eddsa path.

`receive()` routes `Bbs2023` → `receive_bbs` under the feature; without it the audit-gated error remains.

## Audit gate respected

Issuer **signing** (`sign_vc_base`) is deliberately **not** exposed from the VTA — it's a holder/verifier. BBS issuance stays audit-gated.

## Tests (under `bbs`)

Valid receive + store; tampered, expired, and wrong-issuer-key credentials all rejected and not stored; G2 `did:key` resolution round-trip. `cargo fmt`, `clippy --all-targets` (clean on **both** default and `--features bbs`), the full default suite, and `cargo deny` all pass. Default (no-`bbs`) build unchanged.

## Note

`affinidi-crypto 0.1.11` loosely pins `affinidi-encoding = "0.1"` but uses a `0.1.4` symbol; the lock is pinned to `encoding 0.1.4` here. Upstream follow-up: `affinidi-crypto` should pin `affinidi-encoding >= 0.1.4` and republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)