### PR TITLE
feat(vta): present BBS (bbs-2023) credentials with selective disclosure

### DIFF
--- a/vta-service/src/vault/bbs.rs
+++ b/vta-service/src/vault/bbs.rs
@@ -142,6 +142,75 @@ pub async fn receive_bbs(
     Ok(cred)
 }
 
+/// Build a consent-gated, **selectively-disclosed** BBS (`bbs-2023`)
+/// presentation of a stored credential — the holder's side of selective
+/// disclosure.
+///
+/// Gating is the shared [`super::present::gate_present`] (subject binding,
+/// per-credential consent, live status, temporal — same as the SD-JWT / DI
+/// paths). Unlike the eddsa-jcs path (which is whole-credential), BBS discloses
+/// **exactly** the consent record's reveal set (`dpv:hasPersonalData`) as
+/// `credentialSubject` claims, plus the issuer's mandatory claims — it redacts
+/// everything else, so there's no over-disclosure.
+///
+/// `issuer_pub` is the caller-resolved 96-byte G2 key (deriving a proof needs
+/// the issuer key); `nonce` is the verifier's presentation challenge (bound into
+/// the proof for freshness). Returns the derived VC as a JSON string.
+#[allow(clippy::too_many_arguments)]
+pub async fn present_bbs(
+    vault: &KeyspaceHandle,
+    credential_id: &str,
+    consent_record_id: &str,
+    issuer_pub: &[u8],
+    nonce: &str,
+    aud: &str,
+    status_resolver: Option<&dyn super::status::StatusListResolver>,
+    now: DateTime<Utc>,
+) -> Result<String, AppError> {
+    let (cred, record) = super::present::gate_present(
+        vault,
+        credential_id,
+        consent_record_id,
+        aud,
+        status_resolver,
+        now,
+    )
+    .await?;
+
+    if cred.format != CredentialFormat::Bbs2023 {
+        return Err(AppError::Validation(format!(
+            "credential `{credential_id}` is not a bbs-2023 credential (format {:?}); \
+             cannot present via present_bbs",
+            cred.format
+        )));
+    }
+    let pk = g2_public_key(issuer_pub)?;
+    let vc: Value = serde_json::from_slice(&cred.body)
+        .map_err(|e| AppError::Validation(format!("stored BBS VC body is not JSON: {e}")))?;
+
+    // Disclose EXACTLY the consented claims (the reveal set) as `credentialSubject`
+    // pointers; BBS redacts the rest, so the gate's claim-scope check is enforced
+    // cryptographically rather than by a whole-credential guard.
+    let selective: Vec<String> = record
+        .process
+        .personal_data
+        .iter()
+        .map(|name| format!("/credentialSubject/{}", rfc6901_escape(name)))
+        .collect();
+    let selective_refs: Vec<&str> = selective.iter().map(String::as_str).collect();
+
+    let derived = bbs_2023::derive_vc(&vc, &selective_refs, nonce.as_bytes(), &pk)
+        .map_err(|e| AppError::Validation(format!("BBS selective disclosure failed: {e}")))?;
+    serde_json::to_string(&derived)
+        .map_err(|e| AppError::Internal(format!("serialise BBS presentation: {e}")))
+}
+
+/// RFC 6901 token escaping (`~` -> `~0`, `/` -> `~1`) for a claim name embedded
+/// in a JSON pointer.
+fn rfc6901_escape(token: &str) -> String {
+    token.replace('~', "~0").replace('/', "~1")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vta-service/src/vault/present.rs
+++ b/vta-service/src/vault/present.rs
@@ -187,7 +187,7 @@ pub async fn present_sd_jwt_vc(
 /// unexpired, §13), the **`Valid`** status (§14.5), and **temporal** validity.
 /// Returns the credential + record; the caller builds the format-specific,
 /// consent-scoped presentation.
-async fn gate_present(
+pub(super) async fn gate_present(
     vault: &KeyspaceHandle,
     credential_id: &str,
     consent_record_id: &str,
@@ -622,6 +622,100 @@ mod tests {
         assert!(result.is_verified(), "kb-jwt must verify");
         assert_eq!(result.kb_verified, Some(true));
         result.claims
+    }
+
+    // ---- BBS+ selective disclosure (feature `bbs`) ----------------------
+
+    #[cfg(feature = "bbs")]
+    #[tokio::test]
+    async fn present_bbs_discloses_only_consented_claims() {
+        use crate::vault::bbs::{present_bbs, receive_bbs};
+        use affinidi_bbs as bbs;
+        use affinidi_data_integrity::bbs_2023::{sign_vc_base, verify_vc_derived};
+
+        let (_dir, _store, vault) = fresh_vault();
+        let (holder_did, _kb, consent_key, _vk) = holder(7);
+        let verifier = "did:web:acme-verifier.example";
+        let now = Utc::now();
+
+        // Issuer signs a BBS base-proof VC bound to the holder as subject.
+        let sk = bbs::keygen(b"present-bbs-issuer-key-material!!", b"").unwrap();
+        let pk = bbs::sk_to_pk(&sk);
+        let issuer_did = affinidi_crypto::bls12381::g2_pub_to_did_key(&pk.to_bytes());
+        let vc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": issuer_did,
+            "validFrom": "2020-01-01T00:00:00Z",
+            "credentialSubject": {
+                "id": holder_did,
+                "givenName": "Alice",
+                "memberSince": "2020",
+                "dateOfBirth": "1990-01-01"
+            }
+        });
+        let mandatory = ["/@context", "/type", "/issuer", "/credentialSubject/id"];
+        let signed = sign_vc_base(
+            &vc,
+            &mandatory,
+            &format!("{issuer_did}#bbs-key-0"),
+            &sk,
+            &pk,
+        )
+        .unwrap();
+        let body = serde_json::to_vec(&signed).unwrap();
+        receive_bbs(&vault, "bbs-cred", &body, &pk.to_bytes(), None, now)
+            .await
+            .expect("receive BBS base proof");
+
+        // Consent to disclose ONLY givenName + memberSince (NOT dateOfBirth).
+        let rec = create_consent(
+            &vault,
+            &grant(
+                &holder_did,
+                "bbs-cred",
+                verifier,
+                vec!["givenName".into(), "memberSince".into()],
+                now + Duration::hours(1),
+            ),
+            &consent_key,
+        )
+        .await
+        .unwrap();
+
+        let nonce = "verifier-nonce-bbs";
+        let pres = present_bbs(
+            &vault,
+            "bbs-cred",
+            &rec.identifier,
+            &pk.to_bytes(),
+            nonce,
+            verifier,
+            None,
+            now,
+        )
+        .await
+        .expect("present BBS");
+
+        let derived: Value = serde_json::from_str(&pres).unwrap();
+        let cs = &derived["credentialSubject"];
+        assert_eq!(cs["givenName"], "Alice");
+        assert_eq!(cs["memberSince"], "2020");
+        assert!(
+            cs.get("dateOfBirth").is_none(),
+            "dateOfBirth was not consented and MUST be redacted by BBS"
+        );
+        assert_eq!(
+            cs["id"],
+            holder_did.as_str(),
+            "mandatory subject id disclosed"
+        );
+
+        // The derived proof verifies against the issuer key + the verifier nonce.
+        assert!(
+            verify_vc_derived(&derived, nonce.as_bytes(), &pk).unwrap(),
+            "BBS derived presentation must verify"
+        );
     }
 
     // ---- ACCEPTANCE: happy path -----------------------------------------


### PR DESCRIPTION
## What

Second BBS+ slice in the VTA vault (after #285's receive). Adds the holder **present** path: `present_bbs` derives a consent-gated, selectively-disclosed `bbs-2023` presentation of a stored credential.

## How

- Reuses the shared **`gate_present`** (subject binding, per-credential consent, live status re-check, temporal — the same security gate as the SD-JWT-VC and DI paths; promoted to `pub(super)`).
- Unlike the eddsa-jcs path (whole-credential, refuses if any claim is out of the reveal set), BBS discloses **exactly** the consent record's reveal set (`dpv:hasPersonalData`) as `credentialSubject` claims plus the issuer's mandatory claims, and **cryptographically redacts the rest** via `affinidi-data-integrity`'s `derive_vc` (#347). Claim-scope is enforced by the proof itself, not a whole-credential over-disclosure guard.
- `issuer_pub` is the caller-resolved 96-byte G2 key (deriving a proof needs the issuer key); `nonce` is the verifier's presentation challenge, bound into the derived proof for freshness.

## Audit gate

Issuer **signing** (`sign_vc_base`) remains unexposed from the VTA — holder/verifier only.

## Test (feature `bbs`)

End-to-end, reusing the existing consent test infrastructure: an issuer signs a BBS VC for the holder, `receive_bbs` stores it, a consent record authorizes **only** `givenName` + `memberSince`, and `present_bbs` discloses exactly those — `dateOfBirth` is redacted, the mandatory subject `id` is kept, and the derived proof verifies against the issuer key + nonce.

`cargo fmt`, `clippy --all-targets` clean on **both** default and `--features bbs`, the full default suite, and `cargo deny` all pass. No lock change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)