### PR TITLE
feat(vta): receive BBS credentials over the credential-exchange/issue path

### DIFF
--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -118,6 +118,38 @@ async fn store_issued_credential(
             )
             .await
         }
+        // A JSON object with a `bbs-2023` proof → a BBS base-proof VC. Resolve the
+        // issuer's G2 key (bound to the credential `issuer`) and store via the BBS
+        // path. Behind the `bbs` feature; without it a bbs-2023 credential is
+        // refused cleanly.
+        Value::Object(_) if is_bbs_2023_credential(credential) => {
+            #[cfg(feature = "bbs")]
+            {
+                let issuer_pub =
+                    crate::vault::bbs::resolve_bbs_issuer_key(did_resolver, credential).await?;
+                let body = serde_json::to_vec(credential)
+                    .map_err(|e| AppError::Internal(format!("credential -> bytes: {e}")))?;
+                vault::receive(
+                    vault_ks,
+                    &id,
+                    &CredentialFormat::Bbs2023,
+                    &body,
+                    Some(&issuer_pub),
+                    source,
+                    now,
+                )
+                .await
+            }
+            #[cfg(not(feature = "bbs"))]
+            {
+                let _ = did_resolver;
+                Err(AppError::Validation(
+                    "received a bbs-2023 credential but this VTA was built without the `bbs` \
+                     feature"
+                        .to_string(),
+                ))
+            }
+        }
         // A JSON object carrying a `proof` → a W3C Data-Integrity VC. Resolve the
         // issuer's signing key (binding it to the credential `issuer`) and store
         // via the DI path. The vault stays network-free — resolution happens here.
@@ -143,6 +175,17 @@ async fn store_issued_credential(
                 .to_string(),
         )),
     }
+}
+
+/// True iff `credential` is a `bbs-2023` VC — a JSON object whose
+/// `proof.cryptosuite` is `bbs-2023`. Pure JSON inspection, so it routes to the
+/// BBS path (or a clean error) even without the `bbs` feature.
+fn is_bbs_2023_credential(credential: &Value) -> bool {
+    credential
+        .get("proof")
+        .and_then(|p| p.get("cryptosuite"))
+        .and_then(Value::as_str)
+        == Some("bbs-2023")
 }
 
 /// Open a **sealed** issued credential (the invite / unknown-holder case, spec
@@ -1309,6 +1352,45 @@ mod tests {
             .await
             .expect("receive did:key DI VC");
         assert_eq!(cred.format, CredentialFormat::EddsaJcs2022);
+        assert_eq!(cred.issuer_did.as_deref(), Some(issuer_did.as_str()));
+    }
+
+    #[cfg(feature = "bbs")]
+    #[tokio::test]
+    async fn receives_a_bbs_vc_from_a_did_key_issuer() {
+        use affinidi_bbs as bbs;
+        use affinidi_data_integrity::bbs_2023::sign_vc_base;
+
+        let (_dir, _store, vault) = fresh_vault();
+
+        // A real bbs-2023 base-proof VC from a did:key (G2) issuer — the issuer
+        // DID is the key, so the issuer-binding holds and resolution is local.
+        let sk = bbs::keygen(b"ops-bbs-issuer-key-material-32by", b"").unwrap();
+        let pk = bbs::sk_to_pk(&sk);
+        let issuer_did = affinidi_crypto::bls12381::g2_pub_to_did_key(&pk.to_bytes());
+        let vc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": issuer_did,
+            "validFrom": "2020-01-01T00:00:00Z",
+            "credentialSubject": { "id": "did:key:zMember", "givenName": "Alice" }
+        });
+        let mandatory = ["/@context", "/type", "/issuer", "/credentialSubject/id"];
+        let signed = sign_vc_base(
+            &vc,
+            &mandatory,
+            &format!("{issuer_did}#bbs-key-0"),
+            &sk,
+            &pk,
+        )
+        .unwrap();
+
+        // No resolver needed — the did:key G2 issuer resolves locally.
+        let cred =
+            receive_issued_credential(&vault, &issue_body(signed, None), None, None, Utc::now())
+                .await
+                .expect("receive did:key BBS VC over the issue path");
+        assert_eq!(cred.format, CredentialFormat::Bbs2023);
         assert_eq!(cred.issuer_did.as_deref(), Some(issuer_did.as_str()));
     }
 

--- a/vta-service/src/vault/bbs.rs
+++ b/vta-service/src/vault/bbs.rs
@@ -11,12 +11,14 @@
 //!
 //! The VTA is a credential **holder/verifier**, not an issuer, so issuer
 //! *signing* (`sign_vc_base`) is deliberately **not** exposed from this module
-//! — BBS issuance stays audit-gated. This module covers **receive** (verify the
-//! issuer's base proof, then store) plus issuer-key resolution. The holder
-//! **present** (selective-disclosure derive) lands in a follow-up.
+//! — BBS issuance stays audit-gated. This module covers the holder side:
+//! **receive** ([`receive_bbs`] — verify the issuer base proof, then store),
+//! **present** ([`present_bbs`] — consent-gated selective disclosure), and the
+//! G2 issuer-key resolution ([`resolve_bbs_issuer_key`]) the wire layer uses.
 
 use affinidi_bbs::PublicKey;
 use affinidi_data_integrity::bbs_2023;
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use vti_common::error::AppError;
@@ -52,6 +54,88 @@ pub fn g2_issuer_key_from_did_key(issuer_did: &str) -> Result<PublicKey, AppErro
         AppError::Validation(format!("issuer `{issuer_did}` is not a BBS did:key: {e}"))
     })?;
     g2_public_key(&bytes)
+}
+
+/// Resolve a BBS issuer's 96-byte compressed G2 public key from a credential,
+/// **binding the proof's `verificationMethod` to the credential `issuer`** (so a
+/// key under some other DID can't sign a credential claiming a different issuer).
+///
+/// `did:key` issuers resolve locally; `did:webvh` / `did:web` issuers resolve
+/// through `did_resolver` (the verification method's `publicKeyMultibase`, a
+/// `0xeb` Multikey). The G2 analog of
+/// [`crate::vault::di_verify::resolve_di_issuer_key`] — used by the wire layer
+/// (`store_issued_credential`) to receive a BBS credential delivered over
+/// DIDComm.
+pub async fn resolve_bbs_issuer_key(
+    did_resolver: Option<&DIDCacheClient>,
+    credential: &Value,
+) -> Result<[u8; BLS12381_G2_LEN], AppError> {
+    let issuer_did = crate::vault::di_verify::credential_issuer(credential)
+        .ok_or_else(|| AppError::Validation("bbs-2023 credential has no `issuer`".into()))?;
+    let vm = credential
+        .get("proof")
+        .and_then(|p| p.get("verificationMethod"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| AppError::Validation("bbs-2023 proof has no `verificationMethod`".into()))?;
+    if vm.split('#').next().unwrap_or_default() != issuer_did {
+        return Err(AppError::Validation(format!(
+            "bbs-2023 proof verificationMethod `{vm}` is not under the credential issuer \
+             `{issuer_did}`"
+        )));
+    }
+
+    if issuer_did.starts_with("did:key:") {
+        return affinidi_crypto::bls12381::did_key_to_g2_pub(&issuer_did).map_err(|e| {
+            AppError::Validation(format!("issuer `{issuer_did}` is not a BBS did:key: {e}"))
+        });
+    }
+    let resolver = did_resolver.ok_or_else(|| {
+        AppError::Validation(format!(
+            "resolving issuer `{issuer_did}` needs a DID resolver for did:webvh / did:web BBS \
+             issuers"
+        ))
+    })?;
+    let resolved = resolver.resolve(&issuer_did).await.map_err(|e| {
+        AppError::Validation(format!("issuer DID `{issuer_did}` did not resolve: {e}"))
+    })?;
+    let doc: Value = serde_json::to_value(&resolved.doc)
+        .map_err(|e| AppError::Internal(format!("issuer DID document serialise failed: {e}")))?;
+    let vms = doc
+        .get("verificationMethod")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "issuer DID `{issuer_did}` has no verificationMethod array"
+            ))
+        })?;
+    let relative = vm
+        .split_once('#')
+        .map(|(_, f)| format!("#{f}"))
+        .unwrap_or_default();
+    let entry = vms
+        .iter()
+        .find(|e| {
+            let id = e.get("id").and_then(Value::as_str).unwrap_or("");
+            id == vm || id == relative
+        })
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "verificationMethod `{vm}` not found in issuer DID `{issuer_did}`"
+            ))
+        })?;
+    let multibase = entry
+        .get("publicKeyMultibase")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "verificationMethod `{vm}` has no publicKeyMultibase (BLS12-381 G2 Multikey)"
+            ))
+        })?;
+    affinidi_crypto::bls12381::did_key_to_g2_pub(&format!("did:key:{multibase}")).map_err(|e| {
+        AppError::Validation(format!(
+            "verificationMethod `{vm}` is not a BLS12-381 G2 Multikey: {e}"
+        ))
+    })
 }
 
 /// Receive a BBS (`bbs-2023`) **base-proof** credential into the vault.


### PR DESCRIPTION
## What

Wires BBS into the holder's **over-DIDComm receive** flow. `store_issued_credential` routed any object-with-proof to the eddsa-jcs DI resolver — so a `bbs-2023` credential delivered via `credential-exchange/issue` would fail (its issuer key is a BLS12-381 G2 key, not Ed25519). With #285 the vault could *store* a BBS credential, but nothing on the wire path could *route* one to it.

## How

A `bbs-2023` branch **before** the generic DI branch in `store_issued_credential`: detect `proof.cryptosuite == bbs-2023` (pure JSON, so non-`bbs` builds reject it cleanly), resolve the issuer's G2 key, and store via the format-agnostic `vault::receive` (`Bbs2023`).

New **`vault::bbs::resolve_bbs_issuer_key`** — the G2 analog of `di_verify::resolve_di_issuer_key`: binds the proof `verificationMethod` to the credential `issuer` (no cross-DID signing), `did:key` local, `did:webvh`/`did:web` via the DID-doc VM `publicKeyMultibase` (`0xeb` Multikey). Reuses `di_verify::credential_issuer`.

So a VTA can now receive a BBS credential from an external (`did:key` or `did:webvh`) issuer **end-to-end over DIDComm** — completing the holder receive surface for both formats. Issuer signing stays audit-gated.

## Test (feature `bbs`)

A `did:key` G2 issuer signs a `bbs-2023` VC, delivered through the issue path → stored as `Bbs2023` with the correct issuer DID. (Mirrors the existing `receives_a_di_vc_from_a_did_key_issuer` test.)

`cargo fmt`, `clippy --all-targets` clean on **both** default and `--features bbs`, the full default suite, and `cargo deny` all pass; no lock change. Also refreshed the `vault/bbs.rs` module doc (present landed alongside receive in #286).

🤖 Generated with [Claude Code](https://claude.com/claude-code)