### PR TITLE
chore: bump vta-sdk to 0.9.8 to publish the DIDComm shutdown guardrails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,7 +2315,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.7",
+ "vta-sdk 0.9.8",
 ]
 
 [[package]]
@@ -3089,7 +3089,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.7",
+ "vta-sdk 0.9.8",
 ]
 
 [[package]]
@@ -6423,7 +6423,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.7",
+ "vta-sdk 0.9.8",
 ]
 
 [[package]]
@@ -9637,7 +9637,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.7",
+ "vta-sdk 0.9.8",
  "x25519-dalek",
 ]
 
@@ -9674,7 +9674,7 @@ dependencies = [
  "tokio",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.9.7",
+ "vta-sdk 0.9.8",
 ]
 
 [[package]]
@@ -9707,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9834,7 +9834,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.7",
+ "vta-sdk 0.9.8",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9916,7 +9916,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.7",
+ "vta-sdk 0.9.8",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9959,7 +9959,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.7",
+ "vta-sdk 0.9.8",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9986,7 +9986,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.7",
+ "vta-sdk 0.9.8",
  "vta-service",
  "vti-common",
 ]

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.7"
+version = "0.9.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
`vta-sdk 0.9.7` (the latest published) predates #292, which added the DIDComm session shutdown guardrails (warn-on-drop leak guard, `VtaClient::with_didcomm` scoped API, loud docs). This bumps `0.9.7 → 0.9.8` so the fix publishes for downstream consumers (e.g. the openvtc client that tripped the original session-leak bug).

**Patch bump** — the change is additive (new method + non-breaking behaviour). Every workspace dependent pins `vta-sdk "0.9"` (major.minor), so `0.9.8` satisfies all pins with **no cascade re-pin** (a `0.10` would have broken every `"0.9"` pin). Lock diff is just the `vta-sdk` version reference.

Closes the publish gap for #292 / #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)