### PR TITLE
chore(vta-sdk): gate provision-integration-only imports in client/bootstrap.rs

### DIFF
--- a/vta-sdk/src/client/bootstrap.rs
+++ b/vta-sdk/src/client/bootstrap.rs
@@ -1,6 +1,12 @@
 //! Bootstrap / provision-integration methods on [`VtaClient`].
 
-use super::{Transport, VtaClient};
+use super::VtaClient;
+// `Transport` + `VtaError` are only used by `provision_integration`, which is
+// gated on the `provision-integration` feature — gate the imports to match so
+// they aren't reported unused in builds without it (e.g. `client,session`).
+#[cfg(feature = "provision-integration")]
+use super::Transport;
+#[cfg(feature = "provision-integration")]
 use crate::error::VtaError;
 
 impl VtaClient {


### PR DESCRIPTION
Closes #297.

`Transport` and `VtaError` in `client/bootstrap.rs` are used only by `provision_integration`, which is gated on the `provision-integration` feature — so builds without it (e.g. `client,session`) reported them as unused imports. Rather than delete them (they're needed when the feature is on), this gates the two imports on the same feature. `VtaClient` stays unconditional (the impl block always needs it).

Verified: the `unused import` warnings are gone under `--features client,session`; compiles clean with `provision-integration` enabled and in the default build. `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)