### PR TITLE
fix(vta-sdk): shut down provision-runner DIDComm sessions on every path (#300)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,7 +2315,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.8",
+ "vta-sdk 0.9.9",
 ]
 
 [[package]]
@@ -3089,7 +3089,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.8",
+ "vta-sdk 0.9.9",
 ]
 
 [[package]]
@@ -6423,7 +6423,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.8",
+ "vta-sdk 0.9.9",
 ]
 
 [[package]]
@@ -9637,7 +9637,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.8",
+ "vta-sdk 0.9.9",
  "x25519-dalek",
 ]
 
@@ -9674,7 +9674,7 @@ dependencies = [
  "tokio",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.9.8",
+ "vta-sdk 0.9.9",
 ]
 
 [[package]]
@@ -9707,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9834,7 +9834,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.8",
+ "vta-sdk 0.9.9",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9916,7 +9916,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.8",
+ "vta-sdk 0.9.9",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9959,7 +9959,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.8",
+ "vta-sdk 0.9.9",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9986,7 +9986,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.8",
+ "vta-sdk 0.9.9",
  "vta-service",
  "vti-common",
 ]

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -25,7 +25,7 @@ affinidi-messaging-test-mediator = "0.2"
 # state (in-memory keyspaces, default `AppConfig`, bootstrap helpers)
 # from outside the crate.
 vta-service = { path = "../../vta-service", features = ["test-support", "didcomm", "webvh", "rest"] }
-vta-sdk = { path = "../../vta-sdk", features = ["client", "didcomm", "session", "sealed-transfer", "provision-integration"] }
+vta-sdk = { path = "../../vta-sdk", features = ["client", "didcomm", "session", "sealed-transfer", "provision-integration", "provision-client"] }
 vti-common = { path = "../../vti-common" }
 
 affinidi-tdk = { workspace = true }

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -858,3 +858,64 @@ async fn with_didcomm_sequential_cycles_for_same_did_do_not_duel() {
     mediator.shutdown();
     mediator.join().await.expect("mediator joins");
 }
+
+// ── Provision runner shuts its session down on the error path (#300) ──
+
+/// The `provision_client` DIDComm runner opens its own setup-key
+/// [`DIDCommSession`] internally (not via [`VtaClient`]), so it owns the
+/// `shutdown()` obligation. Before the fix it dropped the session on the
+/// error path, tripping the `LeakGuard` `debug_assert!` (#292/#300) in
+/// debug builds.
+///
+/// Drive one provisioning flight whose VTA denies the request
+/// (`e.p.msg.forbidden`): the round-trip returns `Err`, and the runner
+/// must still have shut the session down — reaching this assertion at
+/// all (no `LeakGuard` panic) is the regression check. The acceptance
+/// criterion in #300 is exactly "a debug-build provisioning run against
+/// the mock VTA does not trip the LeakGuard."
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn provision_admin_rotation_didcomm_shuts_session_down_on_error() {
+    use vta_sdk::protocols::provision_integration_management::PROVISION_INTEGRATION;
+    use vta_sdk::provision_client::{ProvisionAsk, provision_admin_rotation_via_didcomm};
+
+    common::init_tracing();
+    // The setup DID the operator would have enrolled via `pnm acl create`.
+    let (setup_did, setup_priv) = did_key_from_seed(0x11);
+
+    let (mediator, responder) = TestVtaResponder::spawn_with_mediator(
+        vec![setup_did.clone()],
+        |msg_type: &str, _body: &Value| {
+            if msg_type == PROVISION_INTEGRATION {
+                // Deny — exercises the runner's error path, which must
+                // still shut the session down before returning.
+                ResponderReply::problem_report("e.p.msg.forbidden", "denied for test")
+            } else {
+                ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+            }
+        },
+    )
+    .await
+    .expect("responder + mediator spawn");
+
+    let ask = ProvisionAsk::vta_admin_rotated("test-context");
+    let result = provision_admin_rotation_via_didcomm(
+        &setup_did,
+        &setup_priv,
+        responder.did(),
+        mediator.did(),
+        &ask,
+    )
+    .await;
+
+    // The VTA denied the request, so the round-trip fails — but reaching
+    // this line (no LeakGuard panic from a dropped, un-shut-down session)
+    // is the actual regression assertion for #300.
+    assert!(
+        result.is_err(),
+        "expected the denying VTA to fail the round-trip"
+    );
+
+    responder.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins");
+}

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.8"
+version = "0.9.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/provision_client/runner_didcomm.rs
+++ b/vta-sdk/src/provision_client/runner_didcomm.rs
@@ -52,14 +52,26 @@ pub async fn provision_via_didcomm(
         .await
         .map_err(|e| ProvisionError::SessionOpen(e.to_string()))?;
 
-    let vp = ask.to_builder().sign_with(&seed, setup_did).await?;
-    let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
-
-    let response =
-        provision_integration_didcomm(&session, vp, Some(ask.context.clone()), None, None, false)
-            .await?;
-
-    response_to_result(&seed, nonce, response)
+    // Run the round-trip, then shut the session down on EVERY path (Ok or Err)
+    // before returning — a dropped, un-shut-down session leaks a reconnecting
+    // mediator connection (see `DIDCommSession`).
+    let result = async {
+        let vp = ask.to_builder().sign_with(&seed, setup_did).await?;
+        let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
+        let response = provision_integration_didcomm(
+            &session,
+            vp,
+            Some(ask.context.clone()),
+            None,
+            None,
+            false,
+        )
+        .await?;
+        response_to_result(&seed, nonce, response)
+    }
+    .await;
+    session.shutdown().await;
+    result
 }
 
 /// Run the DIDComm leg of the auth check.
@@ -173,6 +185,9 @@ pub(crate) async fn run_didcomm_attempt(
                 }
             };
 
+            // Preflight is done; the flight (`run_provision_flight`) opens a
+            // fresh session, so close this one rather than leak it.
+            session.shutdown().await;
             AttemptOutcome::PreflightOk {
                 rest_url,
                 mediator_did,
@@ -184,32 +199,25 @@ pub(crate) async fn run_didcomm_attempt(
             // stop there. The setup DID *is* the long-term admin DID
             // (no rotation) — the session open is the authenticated
             // proof that the operator's `pnm acl create` landed.
-            match DIDCommSession::connect(&setup_did, &setup_privkey_mb, &vta_did, &mediator_did)
-                .await
+            // Bind the session out of the match before any `.await`, so the
+            // `Result`'s non-`Send` error payload isn't held across the
+            // `shutdown().await` below (that would make this future non-`Send`
+            // and break `tokio::spawn` in the runner) — same shape as the
+            // AdminRotated probe arm.
+            let session = match DIDCommSession::connect(
+                &setup_did,
+                &setup_privkey_mb,
+                &vta_did,
+                &mediator_did,
+            )
+            .await
             {
-                Ok(_session) => {
+                Ok(session) => {
                     let _ = tx.send(VtaEvent::CheckDone(
                         DiagCheck::AuthenticateDIDComm,
                         DiagStatus::Ok(format!("DIDComm session as {setup_did}")),
                     ));
-                    let _ = tx.send(VtaEvent::CheckDone(
-                        DiagCheck::ListWebvhServers,
-                        DiagStatus::Skipped(
-                            "AdminOnly — no VTA-minted DID so no webvh host needed".into(),
-                        ),
-                    ));
-                    let _ = tx.send(VtaEvent::CheckDone(
-                        DiagCheck::ProvisionIntegration,
-                        DiagStatus::Skipped(
-                            "AdminOnly — setup did:key is the long-term admin credential; \
-                             no template render, no rollover"
-                                .into(),
-                        ),
-                    ));
-                    AttemptOutcome::Connected(VtaReply::AdminOnly(AdminCredentialReply {
-                        admin_did: setup_did,
-                        admin_private_key_mb: setup_privkey_mb,
-                    }))
+                    session
                 }
                 Err(e) => {
                     let msg = e.to_string();
@@ -225,14 +233,34 @@ pub(crate) async fn run_didcomm_attempt(
                         DiagCheck::ProvisionIntegration,
                         DiagStatus::Skipped("session did not open".into()),
                     ));
-                    AttemptOutcome::PreAuthFailure(format!(
+                    return AttemptOutcome::PreAuthFailure(format!(
                         "Could not open an authenticated DIDComm session to the VTA. \
-                         Confirm the `pnm acl create` command ran successfully for \
-                         this DID and that the VTA's mediator service is reachable. \
-                         ({msg})"
-                    ))
+                             Confirm the `pnm acl create` command ran successfully for \
+                             this DID and that the VTA's mediator service is reachable. \
+                             ({msg})"
+                    ));
                 }
-            }
+            };
+
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ListWebvhServers,
+                DiagStatus::Skipped("AdminOnly — no VTA-minted DID so no webvh host needed".into()),
+            ));
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ProvisionIntegration,
+                DiagStatus::Skipped(
+                    "AdminOnly — setup did:key is the long-term admin credential; \
+                     no template render, no rollover"
+                        .into(),
+                ),
+            ));
+            // The session open *was* the auth proof for AdminOnly — close it
+            // now (no round-trip follows).
+            session.shutdown().await;
+            AttemptOutcome::Connected(VtaReply::AdminOnly(AdminCredentialReply {
+                admin_did: setup_did,
+                admin_private_key_mb: setup_privkey_mb,
+            }))
         }
         VtaIntent::AdminRotated => {
             // AdminRotated: open a DIDComm session, then run the
@@ -244,7 +272,7 @@ pub(crate) async fn run_didcomm_attempt(
             // map to PreAuthFailure (different transport may succeed).
             // Once auth completes, the round-trip itself becomes
             // post-auth.
-            let _ = match DIDCommSession::connect(
+            let probe_session = match DIDCommSession::connect(
                 &setup_did,
                 &setup_privkey_mb,
                 &vta_did,
@@ -281,6 +309,11 @@ pub(crate) async fn run_didcomm_attempt(
                     ));
                 }
             };
+
+            // The probe only proved auth; close it before the round-trip below
+            // opens its own session for the SAME DID (two live sessions for one
+            // DID duel on the mediator), and so it doesn't leak.
+            probe_session.shutdown().await;
 
             let _ = tx.send(VtaEvent::CheckDone(
                 DiagCheck::ListWebvhServers,
@@ -349,14 +382,24 @@ pub async fn provision_admin_rotation_via_didcomm(
         .await
         .map_err(|e| ProvisionError::SessionOpen(e.to_string()))?;
 
-    let vp = ask.to_builder().sign_with(&seed, setup_did).await?;
-    let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
-
-    let response =
-        provision_integration_didcomm(&session, vp, Some(ask.context.clone()), None, None, false)
-            .await?;
-
-    crate::provision_client::result::admin_rotation_response_to_reply(&seed, nonce, response)
+    // Shut the session down on every path (Ok or Err) before returning.
+    let result = async {
+        let vp = ask.to_builder().sign_with(&seed, setup_did).await?;
+        let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
+        let response = provision_integration_didcomm(
+            &session,
+            vp,
+            Some(ask.context.clone()),
+            None,
+            None,
+            false,
+        )
+        .await?;
+        crate::provision_client::result::admin_rotation_response_to_reply(&seed, nonce, response)
+    }
+    .await;
+    session.shutdown().await;
+    result
 }
 
 /// FullSetup provision flight — runs after the preflight


### PR DESCRIPTION
## What

Fixes #300 — the `provision_client` DIDComm runner leaked its setup-key sessions.

The runner opens its own `DIDCommSession` (separate from `VtaClient`), so it owns the `shutdown()` obligation introduced with the `LeakGuard` in #292. It was dropping those sessions instead of shutting them down, so:

- a **debug** build tripped the `LeakGuard` `debug_assert!` (panic at `didcomm_session.rs`), and
- a **release** build leaked a reconnecting mediator connection.

## Fix

Close the session on every exit path at all five sites in `runner_didcomm.rs`:

| Site | Change |
|---|---|
| `provision_via_didcomm` | Wrap sign → round-trip → decode in an inner async block; `shutdown().await` on Ok **and** Err before returning. |
| `provision_admin_rotation_via_didcomm` | Same wrap-and-shutdown pattern. |
| `run_didcomm_attempt` **FullSetup** | Shut the preflight session down before returning `PreflightOk` (the flight opens a fresh session). |
| `run_didcomm_attempt` **AdminOnly** | Bind the session out of the match, shut it down after emitting the checklist events. Binding first also keeps the `Result`'s non-`Send` error payload from spanning `shutdown().await` (which would make the future non-`Send` and break `tokio::spawn`). |
| `run_didcomm_attempt` **AdminRotated** | Shut the auth probe down before the round-trip opens its own session for the same DID (two live sessions for one DID duel on the mediator). |

## Test

New e2e regression test `provision_admin_rotation_didcomm_shuts_session_down_on_error` drives one AdminRotation flight against the mock mediator + a denying VTA responder. The round-trip returns `Err`; the runner must still have shut its session down, so **reaching the assertion at all** (no `LeakGuard` panic) is the check. This is exactly the path the REST-mocked provision tests miss — which is why CI didn't catch the leak. Enables the `provision-client` feature on the e2e crate so the runner entry points are reachable.

## Verification

- `cargo test -p vti-e2e-tests --test client_didcomm` — 41 passed
- `cargo clippy -p vta-sdk --features client,session,provision-integration,provision-client,sealed-transfer --all-targets` — clean
- `cargo deny check` — advisories/bans/licenses/sources ok
- `cargo build -p vta-sdk` (default features) — clean

Closes #300
