### PR TITLE
feat(trust-tasks): 0.2 dual-accept (device/vault/passkey/step-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9128,9 +9128,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab965205a434071ff814f009d0e1f9421abd81d022fb1cd1bd0f389f9970413f"
+checksum = "8300322fc155f22289bd800eb2152ef300c99471bd71f2daa975aa6e7798b526"
 dependencies = [
  "axum",
  "chrono",
@@ -9147,9 +9147,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30796be1898deae785ac1f29861fa4b902f407968ec2f4703232e0d8bec11a0c"
+checksum = "d150451ef1284688183bc514f41970233719f83a56ee3b9df21b7b6ca3d3b1a0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9164,9 +9164,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e7dbafd9c86e62361207636907e71ffc74ffb2585ffec958ce8d95933de7a1"
+checksum = "605c6641426e48cd3c1cee374c3f15b7615999e35b79783256795d6542fff16f"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,7 +2315,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.10",
 ]
 
 [[package]]
@@ -3089,7 +3089,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.10",
 ]
 
 [[package]]
@@ -6423,7 +6423,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.10",
 ]
 
 [[package]]
@@ -9637,7 +9637,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.10",
  "x25519-dalek",
 ]
 
@@ -9674,7 +9674,7 @@ dependencies = [
  "tokio",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.10",
 ]
 
 [[package]]
@@ -9707,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9756,7 +9756,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -9834,7 +9834,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.10",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9916,7 +9916,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.10",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9959,7 +9959,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.10",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9986,7 +9986,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.10",
  "vta-service",
  "vti-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,14 +163,15 @@ jsonwebtoken = { version = "10", default-features = false, features = ["use_pem"
 aws-lc-rs = "1.16"
 
 # Trust-Tasks framework — wire-envelope for the trust-task migration
-# initiative (docs/05-design-notes/trust-task-uri-registry.md). Now
-# on crates.io at 0.1.1 (DTGWG PR #36 merged + published 2026-05-24);
-# the `[patch.crates-io]` git pin that lived here through the
-# pre-publish window is gone. Bump to 0.1.x in lockstep with
-# affinidi-webvh-service when upstream publishes new patch releases.
-trust-tasks-rs = { version = "0.1", default-features = false }
-trust-tasks-https = { version = "0.1", default-features = false, features = ["server", "client", "jwt"] }
-trust-tasks-proof = { version = "0.1", default-features = false, features = ["affinidi"] }
+# initiative (docs/05-design-notes/trust-task-uri-registry.md). On
+# crates.io; the `[patch.crates-io]` git pin that lived here through
+# the pre-publish window is gone. 0.2 adds `v0_2` spec modules
+# (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
+# `v0_1` modules — the VTA dual-accepts both during the migration.
+# Bump in lockstep with affinidi-webvh-service when upstream publishes.
+trust-tasks-rs = { version = "0.2", default-features = false }
+trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
+trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }
 
 # Axum extras (typed headers for Bearer auth)
 axum-extra = { version = "0.12", features = ["typed-header"] }

--- a/docs/05-design-notes/trust-task-uri-registry.md
+++ b/docs/05-design-notes/trust-task-uri-registry.md
@@ -560,3 +560,53 @@ here so they're not relitigated per-slice.
 - [ ] **0.2h** — propagate URI consts into `vta-sdk::trust_tasks::specs` (mirrors the `did_hosting_tasks.rs` pattern); add the cross-crate parity harness referenced as T9 in webvh-service.
 - [ ] **0.2i** — add `LOAD-BEARING` comment on the public `/did/{did}/log` route handler explaining the WebVH resolver failover invariant (so a future "tidy-up" PR doesn't quietly remove it).
 - [ ] **0.2j** — pin `BundleDescriptor` schema (Phase 3.7 design item; not blocking lighthouse).
+
+## 0.2 dual-accept migration (2026-06)
+
+The upstream Trust-Tasks framework published **0.2** of a set of specs. The
+only wire change from 0.1 is the minor-version bump in the `type` URI plus a
+fixed set of enum **values** switching kebab-case → camelCase (`vault-read` →
+`vaultRead`, `apple-app-attest` → `appleAppAttest`, …); Rust struct shapes are
+unchanged. The VTA **dual-accepts** both versions during a migration window:
+the `*_0_1` URI constants are `#[deprecated]` (still served; removed in a
+future release) and each gained a `*_0_2` successor.
+
+Specs with no upstream 0.2 stay on 0.1 untouched: `auth/{authenticate,refresh,
+challenge,revoke-session,whoami,sessions/list}`, `device/{disable,wipe}`,
+`vault/delete`, and all `did-management/*`. The VTA's own `*/1.0` URIs (acl,
+contexts, keys, seeds, audit, config, …) are not framework specs and are
+unaffected.
+
+Two mechanisms, split by whether the payload is signed:
+
+- **Edge transform** (`routes/trust_tasks/wire_v0_2.rs`) — for
+  bearer-authenticated specs with no signature over the payload: **device/***
+  and **vault/***. An inbound 0.2 request is down-converted (enum values →
+  kebab at the spec's declared enum field *paths*), retyped to the canonical
+  0.1 URI, dispatched through the existing 0.1 handler unchanged, and the
+  response up-converted (→ camelCase at the response enum paths, retyped to
+  `…/0.2#response`). `kebabize`/`camelize` are deterministic inverses;
+  transforms are **path-targeted** so opaque / free-text values (JWEs, DIDs,
+  labels) are never rewritten even if they coincidentally equal an enum token.
+  This delivers full per-version camelCase **without** modifying the
+  `vti_common` vault types.
+- **Typed handler** — for signed payloads (**`auth/step-up/approve-response`**,
+  where the approver signs the document). The bytes MUST NOT be mutated, so the
+  handler parses its v0_1 typed payload from a *copy* whose only renamed field
+  (`evidence.kind`) is normalised, while proof verification and the echoed
+  response use the original signed 0.2 document.
+- **Declarative** — **passkey-login** start/finish are REST-routed flat JSON
+  whose VTA-facing types carry no renamed enum, so a 0.2 client is structurally
+  identical; the 0.2 URIs are simply declared REST-routed.
+
+**Adding the next 0.2 spec:** add the `*_0_2` const + `ALL_URIS` entry in
+`vta-sdk::trust_tasks` and `#[deprecate]` the 0.1; for an edge-transform spec,
+add a `WireSpecV02` entry (with request/response enum-path tables) +
+`WIRE_V0_2_URIS` entry and a JSON round-trip test; for a signed spec, add a
+typed dispatch arm. The parity harness fails until the new 0.2 URI is tracked.
+
+**Client migration (mobile / companions):** the VTA accepting 0.2 *enables*
+clients to emit 0.2; it does not require them to. `vta-mobile-core` keeps
+emitting 0.1 approve-response (and the VTA keeps emitting 0.1 approve-request)
+so field clients interoperate with not-yet-upgraded peers. Client 0.2 emission
+is a fleet-rollout-gated follow-up.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.9"
+version = "0.9.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -91,21 +91,47 @@ pub const TASK_AUTH_SESSIONS_LIST_0_1: &str = "https://trusttasks.org/spec/auth/
 /// `spec/auth/passkey/login/start/0.1` — begin a WebAuthn assertion
 /// ceremony. Same wire form serves initial login AND AAL step-up via the
 /// payload's `purpose` field.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (the `purpose` \
+    enum uses the camelCase `stepUp` value). The VTA still accepts 0.1 during \
+    the migration window but it will be removed in a future release — prefer \
+    TASK_AUTH_PASSKEY_LOGIN_START_0_2.")]
 pub const TASK_AUTH_PASSKEY_LOGIN_START_0_1: &str =
     "https://trusttasks.org/spec/auth/passkey/login/start/0.1";
+
+/// `spec/auth/passkey/login/start/0.2` — successor to
+/// [`TASK_AUTH_PASSKEY_LOGIN_START_0_1`]; `purpose: stepUp` (camelCase).
+pub const TASK_AUTH_PASSKEY_LOGIN_START_0_2: &str =
+    "https://trusttasks.org/spec/auth/passkey/login/start/0.2";
 
 /// `spec/auth/passkey/login/finish/0.1` — submit the WebAuthn assertion.
 /// On success the consumer issues a session (for `purpose: login`) or
 /// elevates an existing session's acr (for `purpose: step-up`).
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form. The VTA still \
+    accepts 0.1 during the migration window but it will be removed in a future \
+    release — prefer TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2.")]
 pub const TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1: &str =
     "https://trusttasks.org/spec/auth/passkey/login/finish/0.1";
+
+/// `spec/auth/passkey/login/finish/0.2` — successor to
+/// [`TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1`].
+pub const TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2: &str =
+    "https://trusttasks.org/spec/auth/passkey/login/finish/0.2";
 
 /// `spec/auth/step-up/approve-response/0.1` — an approver's signed
 /// ratification of a pending AAL step-up. The relying party verifies the
 /// carried gate (did-signed Data Integrity proof, or a WebAuthn assertion)
 /// and elevates the session's `amr`/`acr`.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (the evidence \
+    enum uses the camelCase `didSigned` value). The VTA still accepts 0.1 \
+    during the migration window but it will be removed in a future release — \
+    prefer TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2.")]
 pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1: &str =
     "https://trusttasks.org/spec/auth/step-up/approve-response/0.1";
+
+/// `spec/auth/step-up/approve-response/0.2` — successor to
+/// [`TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1`]; camelCase `didSigned` evidence.
+pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2: &str =
+    "https://trusttasks.org/spec/auth/step-up/approve-response/0.2";
 
 // ─── Device slice (spec/device/*) ────────────────────────────────────────
 // Canonical Trust Task registry shapes (dtgwg `device/*`). Companion/Service
@@ -114,24 +140,53 @@ pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1: &str =
 
 /// `device/register/0.1` — a Companion/Service claims its DeviceBinding after
 /// the provision-integration + acl/swap-key bootstrap.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (camelCase enum \
+    values). The VTA still accepts 0.1 during the migration window but it will \
+    be removed in a future release — prefer TASK_DEVICE_REGISTER_0_2.")]
 pub const TASK_DEVICE_REGISTER_0_1: &str = "https://trusttasks.org/spec/device/register/0.1";
+
+/// `device/register/0.2` — successor to [`TASK_DEVICE_REGISTER_0_1`]; identical
+/// Rust shape, camelCase enum values on the wire.
+pub const TASK_DEVICE_REGISTER_0_2: &str = "https://trusttasks.org/spec/device/register/0.2";
 
 /// `device/heartbeat/0.1` — periodic check-in; refreshes `lastSeenAt` and
 /// delivers queued operations.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (camelCase enum \
+    values). The VTA still accepts 0.1 during the migration window but it will \
+    be removed in a future release — prefer TASK_DEVICE_HEARTBEAT_0_2.")]
 pub const TASK_DEVICE_HEARTBEAT_0_1: &str = "https://trusttasks.org/spec/device/heartbeat/0.1";
 
+/// `device/heartbeat/0.2` — successor to [`TASK_DEVICE_HEARTBEAT_0_1`].
+pub const TASK_DEVICE_HEARTBEAT_0_2: &str = "https://trusttasks.org/spec/device/heartbeat/0.2";
+
 /// `device/list/0.1` — list the maintainer's registered devices.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (camelCase enum \
+    values). The VTA still accepts 0.1 during the migration window but it will \
+    be removed in a future release — prefer TASK_DEVICE_LIST_0_2.")]
 pub const TASK_DEVICE_LIST_0_1: &str = "https://trusttasks.org/spec/device/list/0.1";
 
+/// `device/list/0.2` — successor to [`TASK_DEVICE_LIST_0_1`]. The `capabilityFilter`
+/// (`Capability`) enum carries camelCase values on the wire.
+pub const TASK_DEVICE_LIST_0_2: &str = "https://trusttasks.org/spec/device/list/0.2";
+
 /// `device/disable/0.1` — disable a device (cannot authenticate; record kept).
+/// No 0.2 spec exists upstream; this stays on 0.1.
 pub const TASK_DEVICE_DISABLE_0_1: &str = "https://trusttasks.org/spec/device/disable/0.1";
 
-/// `device/wipe/0.1` — issue a wipe instruction for a device.
+/// `device/wipe/0.1` — issue a wipe instruction for a device. No 0.2 spec
+/// exists upstream; this stays on 0.1.
 pub const TASK_DEVICE_WIPE_0_1: &str = "https://trusttasks.org/spec/device/wipe/0.1";
 
 /// `device/set-wake/0.1` — the device conveys its opaque push `WakeHandle` to
 /// the VTA, which owns the trigger allowlist and provisions the push gateway.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form. The VTA still \
+    accepts 0.1 during the migration window but it will be removed in a future \
+    release — prefer TASK_DEVICE_SET_WAKE_0_2.")]
 pub const TASK_DEVICE_SET_WAKE_0_1: &str = "https://trusttasks.org/spec/device/set-wake/0.1";
+
+/// `device/set-wake/0.2` — successor to [`TASK_DEVICE_SET_WAKE_0_1`]. No enum
+/// values changed; the bump is the canonical-version alignment.
+pub const TASK_DEVICE_SET_WAKE_0_2: &str = "https://trusttasks.org/spec/device/set-wake/0.2";
 
 // ─── ACL slice (spec/vta/acl/*) ──────────────────────────────────────────
 
@@ -292,25 +347,53 @@ pub const TASK_DISCOVERY_CAPABILITIES_1_0: &str =
 /// material is never returned by this task. Auth: any caller with the
 /// derived `VaultRead` capability (i.e. role ∈ {Admin, Initiator,
 /// Application, Reader}).
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (secretKind and \
+    related enums use camelCase values). The VTA still accepts 0.1 during the \
+    migration window but it will be removed in a future release — prefer \
+    TASK_VAULT_LIST_0_2.")]
 pub const TASK_VAULT_LIST_0_1: &str = "https://trusttasks.org/spec/vault/list/0.1";
+
+/// `spec/vault/list/0.2` — successor to [`TASK_VAULT_LIST_0_1`]; camelCase
+/// enum values (e.g. `secretKind: oauthTokens`).
+pub const TASK_VAULT_LIST_0_2: &str = "https://trusttasks.org/spec/vault/list/0.2";
 
 /// `spec/vault/get/0.1` — fetch the metadata view of a single entry by
 /// id. Same auth as vault/list.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (response enums \
+    use camelCase values). The VTA still accepts 0.1 during the migration \
+    window but it will be removed in a future release — prefer TASK_VAULT_GET_0_2.")]
 pub const TASK_VAULT_GET_0_1: &str = "https://trusttasks.org/spec/vault/get/0.1";
+
+/// `spec/vault/get/0.2` — successor to [`TASK_VAULT_GET_0_1`].
+pub const TASK_VAULT_GET_0_2: &str = "https://trusttasks.org/spec/vault/get/0.2";
 
 /// `spec/vault/upsert/0.1` — create a new vault entry or update an
 /// existing one. Secret material rides inside a pluggable cipher
 /// envelope (see vault/_shared/0.1/sealed-envelope). Auth: VaultWrite.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (secretKind / \
+    sealed-envelope / target enums use camelCase values). The VTA still \
+    accepts 0.1 during the migration window but it will be removed in a future \
+    release — prefer TASK_VAULT_UPSERT_0_2.")]
 pub const TASK_VAULT_UPSERT_0_1: &str = "https://trusttasks.org/spec/vault/upsert/0.1";
 
+/// `spec/vault/upsert/0.2` — successor to [`TASK_VAULT_UPSERT_0_1`].
+pub const TASK_VAULT_UPSERT_0_2: &str = "https://trusttasks.org/spec/vault/upsert/0.2";
+
 /// `spec/vault/delete/0.1` — tombstone an entry with a maintainer-defined
-/// grace window. Auth: VaultWrite.
+/// grace window. Auth: VaultWrite. No 0.2 spec exists upstream; stays on 0.1.
 pub const TASK_VAULT_DELETE_0_1: &str = "https://trusttasks.org/spec/vault/delete/0.1";
 
 /// `spec/vault/release/0.1` — release the cleartext secret material of an
 /// entry inside a pluggable cipher envelope sealed to the requesting
 /// consumer. Auth: FillRelease.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (secretKind / \
+    sealed-envelope / step-up-proof enums use camelCase values). The VTA still \
+    accepts 0.1 during the migration window but it will be removed in a future \
+    release — prefer TASK_VAULT_RELEASE_0_2.")]
 pub const TASK_VAULT_RELEASE_0_1: &str = "https://trusttasks.org/spec/vault/release/0.1";
+
+/// `spec/vault/release/0.2` — successor to [`TASK_VAULT_RELEASE_0_1`].
+pub const TASK_VAULT_RELEASE_0_2: &str = "https://trusttasks.org/spec/vault/release/0.2";
 
 /// `spec/vault/proxy-login/0.1` — the VTA performs an authentication at
 /// the third-party site on the holder's behalf using the entry's secret
@@ -318,7 +401,14 @@ pub const TASK_VAULT_RELEASE_0_1: &str = "https://trusttasks.org/spec/vault/rele
 /// localStorage) wrapped in a pluggable cipher envelope sealed to the
 /// requesting consumer. The long-term credential never leaves the VTA.
 /// Auth: ProxyLogin.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (site-target / \
+    step-up-proof enums use camelCase values). The VTA still accepts 0.1 \
+    during the migration window but it will be removed in a future release — \
+    prefer TASK_VAULT_PROXY_LOGIN_0_2.")]
 pub const TASK_VAULT_PROXY_LOGIN_0_1: &str = "https://trusttasks.org/spec/vault/proxy-login/0.1";
+
+/// `spec/vault/proxy-login/0.2` — successor to [`TASK_VAULT_PROXY_LOGIN_0_1`].
+pub const TASK_VAULT_PROXY_LOGIN_0_2: &str = "https://trusttasks.org/spec/vault/proxy-login/0.2";
 
 /// `spec/vault/sign-trust-task/0.1` — the VTA attaches an eddsa-jcs-2022
 /// Data Integrity proof to a Trust Task envelope, signing as the
@@ -328,8 +418,17 @@ pub const TASK_VAULT_PROXY_LOGIN_0_1: &str = "https://trusttasks.org/spec/vault/
 /// consumer needs to issue follow-up tasks during a proxy-login'd
 /// session and the RP expects them signed by the session DID.
 /// Auth: SignTrustTask capability.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form (step-up-proof \
+    enums use camelCase values). The VTA still accepts 0.1 during the \
+    migration window but it will be removed in a future release — prefer \
+    TASK_VAULT_SIGN_TRUST_TASK_0_2.")]
 pub const TASK_VAULT_SIGN_TRUST_TASK_0_1: &str =
     "https://trusttasks.org/spec/vault/sign-trust-task/0.1";
+
+/// `spec/vault/sign-trust-task/0.2` — successor to
+/// [`TASK_VAULT_SIGN_TRUST_TASK_0_1`].
+pub const TASK_VAULT_SIGN_TRUST_TASK_0_2: &str =
+    "https://trusttasks.org/spec/vault/sign-trust-task/0.2";
 
 // ─── DID-management slice (spec/did-management/*) ────────────────────────
 //
@@ -879,6 +978,12 @@ pub const TASK_ATTESTATION_REPORT_1_0: &str =
 /// Every URI registered in this module — handy for the dispatcher's
 /// parity harness and for operator tooling that wants to enumerate
 /// the VTA's wire surface programmatically.
+///
+/// Lists both the deprecated `*_0_1` URIs (still dual-accepted) and their
+/// `*_0_2` successors — the VTA's live wire surface is the union during the
+/// migration window. `#[allow(deprecated)]` because naming the 0.1 constants
+/// here is intentional, not a migration miss.
+#[allow(deprecated)]
 pub const ALL_URIS: &[&str] = &[
     // Auth slice
     TASK_AUTH_CHALLENGE_0_1,
@@ -888,14 +993,21 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_WHOAMI_0_1,
     TASK_AUTH_SESSIONS_LIST_0_1,
     TASK_AUTH_PASSKEY_LOGIN_START_0_1,
+    TASK_AUTH_PASSKEY_LOGIN_START_0_2,
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
+    TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
+    TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2,
     // Device slice
     TASK_DEVICE_REGISTER_0_1,
+    TASK_DEVICE_REGISTER_0_2,
     TASK_DEVICE_HEARTBEAT_0_1,
+    TASK_DEVICE_HEARTBEAT_0_2,
     TASK_DEVICE_LIST_0_1,
+    TASK_DEVICE_LIST_0_2,
     TASK_DEVICE_DISABLE_0_1,
     TASK_DEVICE_SET_WAKE_0_1,
+    TASK_DEVICE_SET_WAKE_0_2,
     // ACL slice
     TASK_ACL_LIST_1_0,
     TASK_ACL_CREATE_1_0,
@@ -927,14 +1039,20 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUDIT_UPDATE_RETENTION_1_0,
     // Discovery
     TASK_DISCOVERY_CAPABILITIES_1_0,
-    // Vault slice (public 0.1 spec)
+    // Vault slice (0.1 + 0.2 dual-accept; delete is 0.1-only upstream)
     TASK_VAULT_LIST_0_1,
+    TASK_VAULT_LIST_0_2,
     TASK_VAULT_GET_0_1,
+    TASK_VAULT_GET_0_2,
     TASK_VAULT_UPSERT_0_1,
+    TASK_VAULT_UPSERT_0_2,
     TASK_VAULT_DELETE_0_1,
     TASK_VAULT_RELEASE_0_1,
+    TASK_VAULT_RELEASE_0_2,
     TASK_VAULT_PROXY_LOGIN_0_1,
+    TASK_VAULT_PROXY_LOGIN_0_2,
     TASK_VAULT_SIGN_TRUST_TASK_0_1,
+    TASK_VAULT_SIGN_TRUST_TASK_0_2,
     // DID-management slice (canonical spec/did-management/*)
     TASK_DID_MANAGEMENT_DID_REGISTER_0_1,
     TASK_DID_MANAGEMENT_DID_PUBLISH_0_1,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -993,11 +993,12 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_WHOAMI_0_1,
     TASK_AUTH_SESSIONS_LIST_0_1,
     TASK_AUTH_PASSKEY_LOGIN_START_0_1,
-    TASK_AUTH_PASSKEY_LOGIN_START_0_2,
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
-    TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
-    TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2,
+    // NOTE: the auth 0.2 successors (passkey-login start/finish, step-up
+    // approve-response) join ALL_URIS when their dual-accept handling lands
+    // in vta-service — the dispatcher parity harness requires every listed
+    // URI to be served.
     // Device slice
     TASK_DEVICE_REGISTER_0_1,
     TASK_DEVICE_REGISTER_0_2,
@@ -1039,20 +1040,15 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUDIT_UPDATE_RETENTION_1_0,
     // Discovery
     TASK_DISCOVERY_CAPABILITIES_1_0,
-    // Vault slice (0.1 + 0.2 dual-accept; delete is 0.1-only upstream)
+    // Vault slice (delete is 0.1-only upstream). The vault 0.2 successors
+    // join ALL_URIS when the vault dual-accept slice lands in vta-service.
     TASK_VAULT_LIST_0_1,
-    TASK_VAULT_LIST_0_2,
     TASK_VAULT_GET_0_1,
-    TASK_VAULT_GET_0_2,
     TASK_VAULT_UPSERT_0_1,
-    TASK_VAULT_UPSERT_0_2,
     TASK_VAULT_DELETE_0_1,
     TASK_VAULT_RELEASE_0_1,
-    TASK_VAULT_RELEASE_0_2,
     TASK_VAULT_PROXY_LOGIN_0_1,
-    TASK_VAULT_PROXY_LOGIN_0_2,
     TASK_VAULT_SIGN_TRUST_TASK_0_1,
-    TASK_VAULT_SIGN_TRUST_TASK_0_2,
     // DID-management slice (canonical spec/did-management/*)
     TASK_DID_MANAGEMENT_DID_REGISTER_0_1,
     TASK_DID_MANAGEMENT_DID_PUBLISH_0_1,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -993,12 +993,13 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_WHOAMI_0_1,
     TASK_AUTH_SESSIONS_LIST_0_1,
     TASK_AUTH_PASSKEY_LOGIN_START_0_1,
+    TASK_AUTH_PASSKEY_LOGIN_START_0_2,
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
+    TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
-    // NOTE: the auth 0.2 successors (passkey-login start/finish, step-up
-    // approve-response) join ALL_URIS when their dual-accept handling lands
-    // in vta-service — the dispatcher parity harness requires every listed
-    // URI to be served.
+    // NOTE: step-up approve-response 0.2 joins ALL_URIS when its typed
+    // dual-accept handler lands in vta-service — the dispatcher parity harness
+    // requires every listed URI to be served.
     // Device slice
     TASK_DEVICE_REGISTER_0_1,
     TASK_DEVICE_REGISTER_0_2,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -997,9 +997,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
-    // NOTE: step-up approve-response 0.2 joins ALL_URIS when its typed
-    // dual-accept handler lands in vta-service — the dispatcher parity harness
-    // requires every listed URI to be served.
+    TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2,
     // Device slice
     TASK_DEVICE_REGISTER_0_1,
     TASK_DEVICE_REGISTER_0_2,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -1040,15 +1040,20 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUDIT_UPDATE_RETENTION_1_0,
     // Discovery
     TASK_DISCOVERY_CAPABILITIES_1_0,
-    // Vault slice (delete is 0.1-only upstream). The vault 0.2 successors
-    // join ALL_URIS when the vault dual-accept slice lands in vta-service.
+    // Vault slice (0.1 + 0.2 dual-accept; delete is 0.1-only upstream)
     TASK_VAULT_LIST_0_1,
+    TASK_VAULT_LIST_0_2,
     TASK_VAULT_GET_0_1,
+    TASK_VAULT_GET_0_2,
     TASK_VAULT_UPSERT_0_1,
+    TASK_VAULT_UPSERT_0_2,
     TASK_VAULT_DELETE_0_1,
     TASK_VAULT_RELEASE_0_1,
+    TASK_VAULT_RELEASE_0_2,
     TASK_VAULT_PROXY_LOGIN_0_1,
+    TASK_VAULT_PROXY_LOGIN_0_2,
     TASK_VAULT_SIGN_TRUST_TASK_0_1,
+    TASK_VAULT_SIGN_TRUST_TASK_0_2,
     // DID-management slice (canonical spec/did-management/*)
     TASK_DID_MANAGEMENT_DID_REGISTER_0_1,
     TASK_DID_MANAGEMENT_DID_PUBLISH_0_1,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.8.2"
+version = "0.8.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/routes/trust_tasks/device.rs
+++ b/vta-service/src/routes/trust_tasks/device.rs
@@ -22,7 +22,9 @@ use crate::server::AppState;
 use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
 
 /// URIs handled by this slice. Aggregated by the dispatcher's parity harness.
-#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
+/// `#[allow(deprecated)]`: the 0.1 URIs remain dual-accepted during the
+/// migration (their 0.2 counterparts are edge-transformed in `wire_v0_2`).
+#[allow(dead_code, deprecated)] // consumed by the dispatcher's test-only parity harness
 pub(super) const DISPATCHED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_1,
     vta_sdk::trust_tasks::TASK_DEVICE_HEARTBEAT_0_1,

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -92,6 +92,14 @@ const REST_ROUTED: &[&str] = &[
     vta_sdk::trust_tasks::TASK_AUTH_REFRESH_0_1,
     vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_START_0_1,
     vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
+    // Passkey-login 0.2: the only 0.1→0.2 delta in the spec is the `purpose`
+    // enum value (`step-up`→`stepUp`), and the VTA's flat-JSON request/response
+    // types (`PasskeyLoginStart/FinishRequest`, `…StartResponse`) don't carry
+    // `purpose` at all — so a 0.2 client sends structurally identical JSON to
+    // the same `/auth/passkey-login/*` handlers. Dual-accept is purely
+    // declarative here; no edge transform needed.
+    vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_START_0_2,
+    vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2,
     // Attestation (unauth — TEE proofs are publicly verifiable by design)
     vta_sdk::trust_tasks::TASK_ATTESTATION_STATUS_1_0,
     vta_sdk::trust_tasks::TASK_ATTESTATION_REPORT_1_0,

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -362,7 +362,12 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         vta_sdk::trust_tasks::TASK_AUTH_SESSIONS_LIST_0_1 => {
             auth::handle_sessions_list(state, auth, doc).await
         }
-        vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1 => {
+        // Dual-accept: both versions route to the same typed handler, which
+        // normalises the `evidence.kind` discriminator on a copy (the signed
+        // document is never mutated). Not edge-transformed in `wire_v0_2`
+        // because the payload carries the approver's signature.
+        vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1
+        | vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2 => {
             step_up::handle_approve_response(state, auth, doc).await
         }
         // ─── ACL slice ────────────────────────────────────────────────

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -67,6 +67,7 @@ pub(crate) use step_up::{
 mod vault;
 #[cfg(feature = "webvh")]
 mod webvh;
+mod wire_v0_2;
 
 use helpers::{body_parse_error_response, method_not_found, reject_with};
 #[cfg(feature = "didcomm")]
@@ -81,7 +82,9 @@ use trust_tasks_rs::RejectReason;
 /// arm. The corresponding handlers live in `routes::auth` (passkey
 /// login, legacy challenge/authenticate/refresh) and
 /// `routes::attestation` (TEE status / report).
-#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
+// `#[allow(deprecated)]`: this intentionally names the deprecated passkey-login
+// 0.1 URIs — they remain REST-routed and dual-accepted during the migration.
+#[allow(dead_code, deprecated)] // consumed by the dispatcher's test-only parity harness
 const REST_ROUTED: &[&str] = &[
     // Auth (pre-login — no session, can't pass AuthClaims)
     vta_sdk::trust_tasks::TASK_AUTH_CHALLENGE_0_1,
@@ -283,6 +286,22 @@ pub(crate) async fn dispatch_trust_task_core(
     let _ = auth;
 
     // 4. Dispatch by type URI.
+    //
+    // 0.2 dual-accept: bearer-authed specs whose only 0.1→0.2 delta is
+    // enum-value casing are down-converted to their canonical 0.1 form,
+    // dispatched through the existing 0.1 handler, and the response
+    // up-converted back to 0.2 (see `wire_v0_2`). Signed-payload specs are NOT
+    // routed here — they have typed 0.2 arms in `dispatch_typed`.
+    let type_uri = doc.type_uri.to_string();
+    if let Some(spec) = wire_v0_2::lookup_0_2(&type_uri) {
+        let mut doc = doc;
+        wire_v0_2::downconvert_request(&mut doc.payload, spec);
+        if let Ok(uri_0_1) = spec.uri_0_1.parse() {
+            doc.type_uri = uri_0_1;
+        }
+        let resp = dispatch_typed(state, auth, doc).await;
+        return wire_v0_2::upconvert_response(resp, spec).await;
+    }
     dispatch_typed(state, auth, doc).await
 }
 
@@ -311,6 +330,12 @@ pub(crate) fn reject_trust_task(body: &[u8], reason: RejectReason) -> Response {
 ///
 /// Unknown URIs fall through to `method_not_found` which returns
 /// `unsupported_type` per the framework's status table.
+///
+/// `#[allow(deprecated)]`: the device / vault / step-up / passkey arms match on
+/// the deprecated `*_0_1` URI constants on purpose — the VTA keeps serving 0.1
+/// during the migration. The 0.2 counterparts arrive pre-down-converted (see
+/// `wire_v0_2`) so they match the same arms.
+#[allow(deprecated)]
 async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Value>) -> Response {
     let type_uri = doc.type_uri.to_string();
 
@@ -620,6 +645,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // names the dual-accepted passkey-login 0.1 URIs on purpose
     fn phase_2_uri_registry_present() {
         // Compile-time check: every URI we route in `dispatch_typed`
         // is declared in `vta-sdk::trust_tasks`. If a URI gets renamed
@@ -660,13 +686,18 @@ mod tests {
             let in_dispatched = dispatched.contains(declared);
             let in_rest_routed = REST_ROUTED.contains(declared);
             let in_feature_gated = KNOWN_FEATURE_GATED_URIS.contains(declared);
+            // 0.2 dual-accept URIs are served via the `wire_v0_2` edge
+            // transform (down-convert → 0.1 handler → up-convert), not a
+            // dedicated `dispatch_typed` arm, so they're tracked here.
+            let in_wire_v0_2 = wire_v0_2::WIRE_V0_2_URIS.contains(declared);
 
             assert!(
-                in_dispatched || in_rest_routed || in_feature_gated,
+                in_dispatched || in_rest_routed || in_feature_gated || in_wire_v0_2,
                 "vta-sdk declares URI `{declared}` but it is not tracked in this dispatcher — \
                  either (a) add it to a slice's `DISPATCHED_URIS` const and wire a match arm, \
-                 (b) add it to `REST_ROUTED` if it lives on a dedicated REST route, or \
-                 (c) add it to `KNOWN_FEATURE_GATED_URIS` with a comment explaining the gating"
+                 (b) add it to `REST_ROUTED` if it lives on a dedicated REST route, \
+                 (c) add it to `KNOWN_FEATURE_GATED_URIS` with a comment explaining the gating, or \
+                 (d) register it in `wire_v0_2::WIRE_V0_2_URIS` if it's an edge-transformed 0.2 URI"
             );
         }
     }

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -43,7 +43,9 @@ use vti_common::store::KeyspaceHandle;
 use super::helpers::{parse_payload, reject_with, success_response};
 
 /// URIs dispatched by this slice (aggregated by the dispatcher's parity harness).
-#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
+/// `#[allow(deprecated)]`: approve-response 0.1 stays dual-accepted during the
+/// migration; the 0.2 form gets a typed arm (signed payload — not edge-transformed).
+#[allow(dead_code, deprecated)] // consumed by the dispatcher's test-only parity harness
 pub(super) const DISPATCHED_URIS: &[&str] =
     &[vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1];
 

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -40,14 +40,16 @@ use vti_common::auth::step_up::{
 };
 use vti_common::store::KeyspaceHandle;
 
-use super::helpers::{parse_payload, reject_with, success_response};
+use super::helpers::{reject_with, success_response};
 
 /// URIs dispatched by this slice (aggregated by the dispatcher's parity harness).
 /// `#[allow(deprecated)]`: approve-response 0.1 stays dual-accepted during the
 /// migration; the 0.2 form gets a typed arm (signed payload — not edge-transformed).
 #[allow(dead_code, deprecated)] // consumed by the dispatcher's test-only parity harness
-pub(super) const DISPATCHED_URIS: &[&str] =
-    &[vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1];
+pub(super) const DISPATCHED_URIS: &[&str] = &[
+    vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
+    vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2,
+];
 
 /// Why a step-up gate failed to verify. Maps to the spec's approve-response
 /// error codes in the handler.
@@ -201,22 +203,42 @@ async fn verify_webauthn_gate(
         .map_err(|_| invalid())
 }
 
-/// Handler for `auth/step-up/approve-response/0.1`.
+/// Handler for `auth/step-up/approve-response/0.1` **and** `/0.2`.
 ///
 /// Consumes the approver's ratification of a pending step-up and, on a verified
 /// gate, elevates the (caller's own) session's `amr`/`acr`. Follows the spec's
 /// relying-party conformance rules; the bearer JWT (`auth`) identifies the
 /// caller, and the approve-response's gate (did-signed proof or webauthn
 /// assertion) is the second factor.
+///
+/// Dual-accept: 0.2 differs from 0.1 only in the `evidence.kind` discriminator
+/// value (`did-signed`→`didSigned`). Because the approver signs the payload,
+/// the document MUST NOT be mutated; instead the typed (v0_1) parse runs over a
+/// down-converted *copy*, while proof verification and the echoed response use
+/// the original `doc` — so a 0.2 request verifies against its 0.2 bytes and
+/// receives a `…/0.2#response`. (`kebabize` is idempotent on already-kebab
+/// values, so the down-convert is a no-op for a genuine 0.1 request — one code
+/// path serves both versions.)
 pub(super) async fn handle_approve_response(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> Response {
-    // 1. Parse the typed payload.
-    let payload: approve_response::Payload = match parse_payload(&doc) {
-        Ok(p) => p,
-        Err(r) => return r,
+    // 1. Parse the typed payload from a version-normalised copy (see above).
+    let payload: approve_response::Payload = {
+        let mut payload_value = doc.payload.clone();
+        super::wire_v0_2::kebabize_paths(&mut payload_value, &["evidence.kind"]);
+        match serde_json::from_value(payload_value) {
+            Ok(p) => p,
+            Err(e) => {
+                return reject_with(
+                    &doc,
+                    RejectReason::MalformedRequest {
+                        reason: format!("payload parse: {e}"),
+                    },
+                );
+            }
+        }
     };
     let subject = payload.subject.to_string();
     let session_id = payload.session_id.to_string();

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -40,8 +40,9 @@ use super::helpers::{app_error_to_reject, parse_payload, reject_with, success_re
 use trust_tasks_rs::RejectReason;
 
 /// URIs handled by this slice. Aggregated by the dispatcher's parity
-/// harness.
-#[allow(dead_code)]
+/// harness. `#[allow(deprecated)]`: the 0.1 URIs remain dual-accepted during
+/// the migration (their 0.2 counterparts are edge-transformed in `wire_v0_2`).
+#[allow(dead_code, deprecated)]
 pub(super) const DISPATCHED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_VAULT_LIST_0_1,
     vta_sdk::trust_tasks::TASK_VAULT_GET_0_1,

--- a/vta-service/src/routes/trust_tasks/wire_v0_2.rs
+++ b/vta-service/src/routes/trust_tasks/wire_v0_2.rs
@@ -234,6 +234,17 @@ pub(super) fn downconvert_request(payload: &mut Value, spec: &WireSpecV02) {
     apply_paths(payload, spec.request_paths, kebabize);
 }
 
+/// Down-convert (camel→kebab) the enum values at `paths` in `payload`.
+///
+/// Exposed for the **typed** slices (e.g. step-up) whose payload is signed:
+/// they can't mutate the document itself (it would void the proof), so they
+/// down-convert a *copy* of the payload purely to parse it with the v0_1
+/// types, while proof verification and the echoed response still use the
+/// original 0.2 document.
+pub(super) fn kebabize_paths(payload: &mut Value, paths: &[&str]) {
+    apply_paths(payload, paths, kebabize);
+}
+
 /// Maximum response body we'll re-read to up-convert. Trust-Task responses are
 /// small; the workspace-wide 1 MB request cap bounds the inputs that produce
 /// them. Generous headroom over that.

--- a/vta-service/src/routes/trust_tasks/wire_v0_2.rs
+++ b/vta-service/src/routes/trust_tasks/wire_v0_2.rs
@@ -87,6 +87,51 @@ pub(super) const WIRE_SPECS_V0_2: &[WireSpecV02] = &[
         request_paths: &[],
         response_paths: &[],
     },
+    // ── vault slice ─────────────────────────────────────────────────
+    // SecretKind (`oauth-tokens`, `did-self-issued`, …) and the SiteTarget
+    // `kind` discriminator (`web-origin`, `ios-app`, `android-app`) carry the
+    // renamed values. `sealedSecret`/`sealedSessionBlob` envelope tags
+    // (`didcomm-authcrypt`, …) are NOT renamed in 0.2, and the JWE / step-up
+    // proof / signed-envelope payloads are opaque — none are on enum paths, so
+    // they pass through byte-exact.
+    WireSpecV02 {
+        uri_0_1: "https://trusttasks.org/spec/vault/list/0.1",
+        uri_0_2: "https://trusttasks.org/spec/vault/list/0.2",
+        request_paths: &["secretKind"],
+        response_paths: &["entries.*.secretKind", "entries.*.targets.*.kind"],
+    },
+    WireSpecV02 {
+        uri_0_1: "https://trusttasks.org/spec/vault/get/0.1",
+        uri_0_2: "https://trusttasks.org/spec/vault/get/0.2",
+        request_paths: &[],
+        response_paths: &["entry.secretKind", "entry.targets.*.kind"],
+    },
+    WireSpecV02 {
+        uri_0_1: "https://trusttasks.org/spec/vault/upsert/0.1",
+        uri_0_2: "https://trusttasks.org/spec/vault/upsert/0.2",
+        request_paths: &["secretKind", "targets.*.kind"],
+        response_paths: &["entry.secretKind", "entry.targets.*.kind"],
+    },
+    WireSpecV02 {
+        uri_0_1: "https://trusttasks.org/spec/vault/release/0.1",
+        uri_0_2: "https://trusttasks.org/spec/vault/release/0.2",
+        request_paths: &["target.kind"],
+        response_paths: &["secretKind"],
+    },
+    WireSpecV02 {
+        uri_0_1: "https://trusttasks.org/spec/vault/proxy-login/0.1",
+        uri_0_2: "https://trusttasks.org/spec/vault/proxy-login/0.2",
+        request_paths: &["target.kind"],
+        response_paths: &[],
+    },
+    WireSpecV02 {
+        // Request/response carry the unsigned/signed Trust-Task envelope verbatim
+        // (signed bytes — must not be mutated); no SecretKind/SiteTarget fields.
+        uri_0_1: "https://trusttasks.org/spec/vault/sign-trust-task/0.1",
+        uri_0_2: "https://trusttasks.org/spec/vault/sign-trust-task/0.2",
+        request_paths: &[],
+        response_paths: &[],
+    },
 ];
 
 /// Every 0.2 URI handled by the edge transform — consumed by the dispatcher's
@@ -97,6 +142,12 @@ pub(super) const WIRE_V0_2_URIS: &[&str] = &[
     "https://trusttasks.org/spec/device/heartbeat/0.2",
     "https://trusttasks.org/spec/device/list/0.2",
     "https://trusttasks.org/spec/device/set-wake/0.2",
+    "https://trusttasks.org/spec/vault/list/0.2",
+    "https://trusttasks.org/spec/vault/get/0.2",
+    "https://trusttasks.org/spec/vault/upsert/0.2",
+    "https://trusttasks.org/spec/vault/release/0.2",
+    "https://trusttasks.org/spec/vault/proxy-login/0.2",
+    "https://trusttasks.org/spec/vault/sign-trust-task/0.2",
 ];
 
 /// Look up the edge-transform spec for an inbound type URI, if it's a
@@ -384,6 +435,63 @@ mod tests {
             "https://trusttasks.org/spec/trust-task-error/0.1"
         );
         assert_eq!(v["payload"]["code"], "permission_denied");
+    }
+
+    #[test]
+    fn vault_upsert_request_downconverts_secretkind_and_target() {
+        let spec = lookup_0_2("https://trusttasks.org/spec/vault/upsert/0.2").unwrap();
+        let mut payload = serde_json::json!({
+            "contextId": "personal",
+            "label": "did-self-issued", // free-text label that LOOKS like a token
+            "secretKind": "didSelfIssued",
+            "targets": [
+                { "kind": "webOrigin", "origin": "https://example.com" },
+                { "kind": "iosApp", "bundleId": "com.example.app" },
+                { "kind": "did", "did": "did:web:rp.example" }
+            ]
+        });
+        downconvert_request(&mut payload, spec);
+        assert_eq!(payload["secretKind"], "did-self-issued");
+        assert_eq!(payload["targets"][0]["kind"], "web-origin");
+        assert_eq!(payload["targets"][1]["kind"], "ios-app");
+        assert_eq!(payload["targets"][2]["kind"], "did"); // single word, no-op
+        // SiteTarget variant fields stay camelCase (not on enum paths).
+        assert_eq!(payload["targets"][1]["bundleId"], "com.example.app");
+        // Free-text label is NOT an enum path — untouched.
+        assert_eq!(payload["label"], "did-self-issued");
+    }
+
+    #[tokio::test]
+    async fn vault_list_response_upconverts_nested_enums() {
+        let spec = lookup_0_2("https://trusttasks.org/spec/vault/list/0.2").unwrap();
+        let doc = serde_json::json!({
+            "id": "urn:uuid:9",
+            "type": "https://trusttasks.org/spec/vault/list/0.1#response",
+            "payload": {
+                "entries": [
+                    { "id": "v1", "label": "oauth-tokens", "secretKind": "oauth-tokens",
+                      "targets": [ { "kind": "ios-app", "bundleId": "x" } ] }
+                ],
+                "truncated": false
+            }
+        });
+        let resp = Response::builder()
+            .status(200)
+            .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+            .unwrap();
+        let out = upconvert_response(resp, spec).await;
+        let bytes = axum::body::to_bytes(out.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            v["type"],
+            "https://trusttasks.org/spec/vault/list/0.2#response"
+        );
+        assert_eq!(v["payload"]["entries"][0]["secretKind"], "oauthTokens");
+        assert_eq!(v["payload"]["entries"][0]["targets"][0]["kind"], "iosApp");
+        // Free-text label coinciding with a token stays put.
+        assert_eq!(v["payload"]["entries"][0]["label"], "oauth-tokens");
     }
 
     #[test]

--- a/vta-service/src/routes/trust_tasks/wire_v0_2.rs
+++ b/vta-service/src/routes/trust_tasks/wire_v0_2.rs
@@ -1,0 +1,399 @@
+//! Trust-Task **0.2 dual-accept** edge transform.
+//!
+//! The 0.2 wire form of a spec differs from 0.1 in exactly two ways: the
+//! `TYPE_URI` minor bumps to `/0.2`, and a fixed set of enum *values* switch
+//! from kebab-case to camelCase (`vault-read` → `vaultRead`,
+//! `apple-app-attest` → `appleAppAttest`, …). The Rust struct shapes are
+//! otherwise identical.
+//!
+//! For specs whose payload is **not** signed (bearer-authenticated:
+//! device/*, vault/*, passkey login) we exploit that by reusing the existing
+//! 0.1 handlers unchanged:
+//!
+//! 1. **Down-convert** an inbound 0.2 request — rewrite the enum values at the
+//!    spec's known enum field paths back to kebab ([`kebabize`]), and retype
+//!    the envelope to the 0.1 URI — then dispatch it through the ordinary 0.1
+//!    machinery.
+//! 2. **Up-convert** the handler's (kebab) response — rewrite the enum values
+//!    at the response's known enum field paths to camel ([`camelize`]) and
+//!    retype the response document to `…/0.2#response`.
+//!
+//! Why path-targeted and not a blanket value rewrite: a free-text field
+//! (a display name, a label) could coincidentally equal an enum token. By
+//! transforming only at the declared enum paths we never touch opaque or
+//! free-text values (JWEs, DIDs, labels).
+//!
+//! `kebabize`/`camelize` are deterministic inverses and each is idempotent on
+//! its own target form, so a path that happens to carry an unchanged
+//! single-word value (`mediator`, `companion`) is a safe no-op.
+//!
+//! **Not** used for specs whose payload carries a signature over the document
+//! (e.g. `auth/step-up/approve-response`, where the approver signs the
+//! payload) — mutating those bytes would void the proof, so they get genuine
+//! version-matched typed handlers instead.
+
+use axum::body::Body;
+use axum::response::Response;
+use serde_json::Value;
+
+/// One spec's 0.1 ⇄ 0.2 mapping. Paths are `.`-separated and relative to the
+/// document `payload`; a `*` segment fans out over every array element or
+/// object value.
+pub(super) struct WireSpecV02 {
+    /// Canonical 0.1 type URI the 0.2 request is down-converted to.
+    pub uri_0_1: &'static str,
+    /// 0.2 type URI this entry matches on the wire.
+    pub uri_0_2: &'static str,
+    /// Enum field paths in the **request** payload (down-converted camel→kebab).
+    pub request_paths: &'static [&'static str],
+    /// Enum field paths in the **response** payload (up-converted kebab→camel).
+    pub response_paths: &'static [&'static str],
+}
+
+/// Registry of dual-accepted, edge-transformed specs. Signed-payload specs
+/// (step-up) are intentionally absent — they get typed handlers.
+pub(super) const WIRE_SPECS_V0_2: &[WireSpecV02] = &[
+    // ── device slice ────────────────────────────────────────────────
+    WireSpecV02 {
+        uri_0_1: "https://trusttasks.org/spec/device/register/0.1",
+        uri_0_2: "https://trusttasks.org/spec/device/register/0.2",
+        request_paths: &["consumerKind.serviceKind", "attestation.kind"],
+        response_paths: &["binding.consumerKind.serviceKind", "binding.capabilities.*"],
+    },
+    WireSpecV02 {
+        uri_0_1: "https://trusttasks.org/spec/device/heartbeat/0.1",
+        uri_0_2: "https://trusttasks.org/spec/device/heartbeat/0.2",
+        request_paths: &[],
+        response_paths: &["queuedOperations.*.kind", "syncHint"],
+    },
+    WireSpecV02 {
+        uri_0_1: "https://trusttasks.org/spec/device/list/0.1",
+        uri_0_2: "https://trusttasks.org/spec/device/list/0.2",
+        request_paths: &[
+            "capabilityFilter",
+            "consumerKindFilter",
+            "formFactorFilter",
+            "serviceKindFilter",
+        ],
+        response_paths: &[
+            "devices.*.consumerKind.serviceKind",
+            "devices.*.capabilities.*",
+        ],
+    },
+    WireSpecV02 {
+        // No enum fields in either direction — pure minor-version bump.
+        uri_0_1: "https://trusttasks.org/spec/device/set-wake/0.1",
+        uri_0_2: "https://trusttasks.org/spec/device/set-wake/0.2",
+        request_paths: &[],
+        response_paths: &[],
+    },
+];
+
+/// Every 0.2 URI handled by the edge transform — consumed by the dispatcher's
+/// parity harness (these are "tracked" without a `dispatch_typed` arm).
+#[allow(dead_code)] // consumed by the test-only parity harness
+pub(super) const WIRE_V0_2_URIS: &[&str] = &[
+    "https://trusttasks.org/spec/device/register/0.2",
+    "https://trusttasks.org/spec/device/heartbeat/0.2",
+    "https://trusttasks.org/spec/device/list/0.2",
+    "https://trusttasks.org/spec/device/set-wake/0.2",
+];
+
+/// Look up the edge-transform spec for an inbound type URI, if it's a
+/// dual-accepted 0.2 URI.
+pub(super) fn lookup_0_2(type_uri: &str) -> Option<&'static WireSpecV02> {
+    WIRE_SPECS_V0_2.iter().find(|s| s.uri_0_2 == type_uri)
+}
+
+/// kebab-case → camelCase (`apple-app-attest` → `appleAppAttest`). Idempotent
+/// on already-camel input; a no-op on hyphen-free single words.
+fn camelize(s: &str) -> String {
+    let mut parts = s.split('-');
+    let mut out = String::new();
+    if let Some(first) = parts.next() {
+        out.push_str(first);
+    }
+    for p in parts {
+        let mut chars = p.chars();
+        if let Some(f) = chars.next() {
+            out.extend(f.to_uppercase());
+            out.push_str(chars.as_str());
+        }
+    }
+    out
+}
+
+/// camelCase → kebab-case (`appleAppAttest` → `apple-app-attest`). Idempotent
+/// on already-kebab input; a no-op on hyphen-free single words.
+fn kebabize(s: &str) -> String {
+    let mut out = String::new();
+    for ch in s.chars() {
+        if ch.is_ascii_uppercase() {
+            out.push('-');
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Apply `f` to every string value reached by the `.`-separated `path`
+/// (with `*` fanning out over arrays / object values).
+fn apply_at_path(v: &mut Value, segments: &[&str], f: fn(&str) -> String) {
+    match segments.split_first() {
+        None => {
+            if let Value::String(s) = v {
+                *s = f(s);
+            }
+        }
+        Some((&"*", rest)) => match v {
+            Value::Array(items) => {
+                for it in items.iter_mut() {
+                    apply_at_path(it, rest, f);
+                }
+            }
+            Value::Object(map) => {
+                for val in map.values_mut() {
+                    apply_at_path(val, rest, f);
+                }
+            }
+            _ => {}
+        },
+        Some((seg, rest)) => {
+            if let Value::Object(map) = v
+                && let Some(child) = map.get_mut(*seg)
+            {
+                apply_at_path(child, rest, f);
+            }
+        }
+    }
+}
+
+fn apply_paths(payload: &mut Value, paths: &[&str], f: fn(&str) -> String) {
+    for path in paths {
+        let segments: Vec<&str> = path.split('.').collect();
+        apply_at_path(payload, &segments, f);
+    }
+}
+
+/// Down-convert a 0.2 request `payload` in place — rewrite the enum values at
+/// `spec.request_paths` to kebab so the existing 0.1 handler parses it.
+pub(super) fn downconvert_request(payload: &mut Value, spec: &WireSpecV02) {
+    apply_paths(payload, spec.request_paths, kebabize);
+}
+
+/// Maximum response body we'll re-read to up-convert. Trust-Task responses are
+/// small; the workspace-wide 1 MB request cap bounds the inputs that produce
+/// them. Generous headroom over that.
+const MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+
+/// Up-convert a handler's response: retype `…/0.1#response` → `…/0.2#response`
+/// and rewrite the response payload's enum values to camel. Error/reject
+/// documents (a different `type`) are passed through with only the type
+/// prefix swapped, since their payload carries no spec enums.
+pub(super) async fn upconvert_response(resp: Response, spec: &WireSpecV02) -> Response {
+    let (parts, body) = resp.into_parts();
+    let bytes = match axum::body::to_bytes(body, MAX_RESPONSE_BYTES).await {
+        Ok(b) => b,
+        Err(_) => {
+            // Body couldn't be buffered (shouldn't happen for our in-memory
+            // responses). Nothing left to send — surface an empty body.
+            return Response::from_parts(parts, Body::empty());
+        }
+    };
+    let mut doc: Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        // Not JSON (shouldn't happen) — pass the original bytes through.
+        Err(_) => return Response::from_parts(parts, Body::from(bytes)),
+    };
+
+    // Retype the response document. A success response echoes the (now 0.1)
+    // request type with a `#response` fragment; rejects carry their own error
+    // type and are left as-is apart from a 0.1→0.2 prefix swap if present.
+    let mut is_success_response = false;
+    if let Some(Value::String(t)) = doc.get_mut("type")
+        && let Some(fragment) = t.strip_prefix(spec.uri_0_1)
+    {
+        is_success_response = fragment == "#response";
+        *t = format!("{}{}", spec.uri_0_2, fragment);
+    }
+
+    if is_success_response && let Some(payload) = doc.get_mut("payload") {
+        apply_paths(payload, spec.response_paths, camelize);
+    }
+
+    let new_bytes = serde_json::to_vec(&doc).unwrap_or_else(|_| bytes.to_vec());
+    Response::from_parts(parts, Body::from(new_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn casing_transforms_are_inverse_and_idempotent() {
+        for (kebab, camel) in [
+            ("vault-read", "vaultRead"),
+            ("apple-app-attest", "appleAppAttest"),
+            ("did-self-issued", "didSelfIssued"),
+            ("full-resync-required", "fullResyncRequired"),
+            ("webauthn-uv", "webauthnUv"),
+        ] {
+            assert_eq!(camelize(kebab), camel, "camelize({kebab})");
+            assert_eq!(kebabize(camel), kebab, "kebabize({camel})");
+            // Idempotent on the target form.
+            assert_eq!(camelize(camel), camel);
+            assert_eq!(kebabize(kebab), kebab);
+        }
+        // Single words are no-ops in both directions.
+        for w in ["mediator", "companion", "sign", "browser"] {
+            assert_eq!(camelize(w), w);
+            assert_eq!(kebabize(w), w);
+        }
+    }
+
+    #[test]
+    fn apply_at_path_fans_out_over_arrays_and_objects() {
+        let mut v = serde_json::json!({
+            "devices": [
+                { "consumerKind": { "serviceKind": "ai-agent" }, "capabilities": ["vault-read", "sign"] },
+                { "consumerKind": { "serviceKind": "mediator" }, "capabilities": ["proxy-login"] }
+            ]
+        });
+        apply_paths(
+            &mut v,
+            &[
+                "devices.*.consumerKind.serviceKind",
+                "devices.*.capabilities.*",
+            ],
+            camelize,
+        );
+        assert_eq!(v["devices"][0]["consumerKind"]["serviceKind"], "aiAgent");
+        assert_eq!(v["devices"][0]["capabilities"][0], "vaultRead");
+        assert_eq!(v["devices"][0]["capabilities"][1], "sign");
+        assert_eq!(v["devices"][1]["consumerKind"]["serviceKind"], "mediator");
+        assert_eq!(v["devices"][1]["capabilities"][0], "proxyLogin");
+    }
+
+    #[test]
+    fn free_text_at_non_enum_path_is_untouched() {
+        // A display name that coincidentally looks like a token must not be
+        // rewritten — it isn't on an enum path.
+        let mut v = serde_json::json!({
+            "binding": { "displayName": "vault-read", "capabilities": ["vault-read"] }
+        });
+        apply_paths(&mut v, &["binding.capabilities.*"], camelize);
+        assert_eq!(
+            v["binding"]["displayName"], "vault-read",
+            "free text untouched"
+        );
+        assert_eq!(
+            v["binding"]["capabilities"][0], "vaultRead",
+            "enum value upcased"
+        );
+    }
+
+    #[test]
+    fn device_list_request_downconverts_enums() {
+        // A 0.2 device/list request carries camelCase enum values; after
+        // down-convert the existing v0_1 handler must see kebab.
+        let spec = lookup_0_2("https://trusttasks.org/spec/device/list/0.2").unwrap();
+        let mut payload = serde_json::json!({
+            "capabilityFilter": "vaultRead",
+            "serviceKindFilter": "aiAgent",
+            "consumerKindFilter": "service",
+            "includeDisabled": false
+        });
+        downconvert_request(&mut payload, spec);
+        assert_eq!(payload["capabilityFilter"], "vault-read");
+        assert_eq!(payload["serviceKindFilter"], "ai-agent");
+        assert_eq!(payload["consumerKindFilter"], "service"); // unchanged single word
+        assert_eq!(payload["includeDisabled"], false); // non-enum untouched
+    }
+
+    #[tokio::test]
+    async fn device_list_response_upconverts_and_retypes() {
+        // The v0_1 handler echoes a `…/device/list/0.1#response` doc with
+        // kebab enum values; up-convert must retype to 0.2 and camelCase the
+        // enum values at the declared response paths.
+        let spec = lookup_0_2("https://trusttasks.org/spec/device/list/0.2").unwrap();
+        let doc = serde_json::json!({
+            "id": "urn:uuid:1",
+            "type": "https://trusttasks.org/spec/device/list/0.1#response",
+            "issuer": "did:web:vta",
+            "recipient": "did:key:zClient",
+            "payload": {
+                "devices": [
+                    { "deviceId": "d1", "displayName": "vault-read",
+                      "consumerKind": { "kind": "service", "serviceKind": "ai-agent" },
+                      "capabilities": ["vault-read", "sign"] }
+                ],
+                "truncated": false
+            }
+        });
+        let body = serde_json::to_vec(&doc).unwrap();
+        let resp = Response::builder()
+            .status(200)
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        let out = upconvert_response(resp, spec).await;
+        let bytes = axum::body::to_bytes(out.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(
+            v["type"],
+            "https://trusttasks.org/spec/device/list/0.2#response"
+        );
+        assert_eq!(
+            v["payload"]["devices"][0]["consumerKind"]["serviceKind"],
+            "aiAgent"
+        );
+        assert_eq!(v["payload"]["devices"][0]["capabilities"][0], "vaultRead");
+        assert_eq!(v["payload"]["devices"][0]["capabilities"][1], "sign");
+        // A free-text field that coincidentally equals an enum token must NOT
+        // be rewritten — it isn't on a declared response path.
+        assert_eq!(v["payload"]["devices"][0]["displayName"], "vault-read");
+    }
+
+    #[tokio::test]
+    async fn upconvert_passes_through_reject_documents() {
+        // A reject carries a different `type`; up-convert must not camelCase
+        // its payload, only (harmlessly) leave it intact.
+        let spec = lookup_0_2("https://trusttasks.org/spec/device/list/0.2").unwrap();
+        let doc = serde_json::json!({
+            "id": "urn:uuid:2",
+            "type": "https://trusttasks.org/spec/trust-task-error/0.1",
+            "payload": { "code": "permission_denied", "reason": "nope" }
+        });
+        let resp = Response::builder()
+            .status(403)
+            .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+            .unwrap();
+        let out = upconvert_response(resp, spec).await;
+        let bytes = axum::body::to_bytes(out.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            v["type"],
+            "https://trusttasks.org/spec/trust-task-error/0.1"
+        );
+        assert_eq!(v["payload"]["code"], "permission_denied");
+    }
+
+    #[test]
+    fn registry_uris_are_consistent() {
+        // Every spec's 0.2 URI is in the parity list, and 0.1/0.2 differ only
+        // by the minor version.
+        for spec in WIRE_SPECS_V0_2 {
+            assert!(WIRE_V0_2_URIS.contains(&spec.uri_0_2), "{}", spec.uri_0_2);
+            assert_eq!(spec.uri_0_1.replace("/0.1", "/0.2"), spec.uri_0_2);
+            assert!(lookup_0_2(spec.uri_0_2).is_some());
+        }
+    }
+}

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -157,6 +157,120 @@ async fn did_signed_approve_response_elevates_session_to_aal2() {
     assert_ne!(status2, StatusCode::OK, "replay must not elevate again");
 }
 
+/// Dual-accept: the **0.2** approve-response carries the camelCase
+/// `evidence.kind` (`didSigned`) and a `…/0.2` type URI. The VTA must accept
+/// it, verify the approver's signature over the *0.2* bytes (the document is
+/// never down-converted), elevate the session, and reply with a
+/// `…/0.2#response`.
+#[tokio::test]
+async fn did_signed_approve_response_0_2_elevates_session_to_aal2() {
+    let (router, ctx) = build_test_app().await;
+
+    let sk = SigningKey::from_bytes(&[11u8; 32]);
+    let (did, mb) = did_key(&sk);
+    let vm = format!("{did}#{mb}");
+    let session_id = "sess-stepup-0-2".to_string();
+    let challenge = "U3RlcFVwMHgyQ2hhbGxlbmdlVmFsdWVYWQ".to_string();
+
+    let session = Session {
+        session_id: session_id.clone(),
+        did: did.clone(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".to_string()],
+        acr: "aal1".to_string(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+
+    let claims = ctx.jwt_keys.new_claims(
+        did.clone(),
+        session_id.clone(),
+        "admin".to_string(),
+        vec![],
+        900,
+        false,
+    );
+    let token = ctx.jwt_keys.encode(&claims).unwrap();
+
+    let pending = new_pending_step_up(
+        challenge.clone(),
+        session_id.clone(),
+        did.clone(),
+        "aal2",
+        vec!["did-signed".to_string()],
+        300,
+    );
+    store_pending_step_up(&ctx.sessions_ks, &pending)
+        .await
+        .unwrap();
+
+    // 0.2 document: camelCase `evidence.kind` + the /0.2 type URI. The signature
+    // covers THIS (0.2) form — the VTA must not mutate it before verifying.
+    let doc_json = json!({
+        "id": "approve-resp-itest-0-2",
+        "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.2",
+        "issuer": did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {
+            "subject": did,
+            "sessionId": session_id,
+            "challenge": challenge,
+            "decision": "approved",
+            "grantedAcr": "aal2",
+            "evidence": { "kind": "didSigned" },
+        },
+    });
+    let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
+    let mut di = DataIntegrityProof {
+        type_: "DataIntegrityProof".to_string(),
+        cryptosuite: CryptoSuite::EddsaJcs2022,
+        created: Some("2026-05-31T00:00:00Z".to_string()),
+        verification_method: vm,
+        proof_purpose: "assertionMethod".to_string(),
+        proof_value: None,
+        context: None,
+    };
+    let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
+    di.proof_value = Some(multibase::encode(
+        Base::Base58Btc,
+        sk.sign(&input).to_bytes(),
+    ));
+    doc.proof = Some(serde_json::from_value::<Proof>(serde_json::to_value(&di).unwrap()).unwrap());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(status, StatusCode::OK, "expected 200, got {status}: {v}");
+    // The response document echoes the 0.2 type with a #response fragment.
+    assert_eq!(
+        v["type"], "https://trusttasks.org/spec/auth/step-up/approve-response/0.2#response",
+        "0.2 request must yield a 0.2 response: {v}"
+    );
+    assert_eq!(v["payload"]["status"], "elevated", "{v}");
+    assert_eq!(v["payload"]["session"]["acr"], "aal2", "{v}");
+
+    let stored = get_session(&ctx.sessions_ks, &session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.acr, "aal2");
+}
+
 /// The trust-task analogue of the REST step-up `403`: an AAL1 caller invoking
 /// an AAL2-gated trust-task operation (here `acl/create`) is rejected with a
 /// reject that *carries the approve-request* in its `details`. The caller has


### PR DESCRIPTION
## What

The upstream Trust-Tasks framework published **0.2** of a set of specs. The VTA now **dual-accepts** 0.1 and 0.2 during a migration window: the 0.1 URI constants are `#[deprecated]` (still served; removed in a future release) and each gained a `*_0_2` successor.

The only 0.1→0.2 wire change is the `type` minor bump plus a fixed set of enum **values** switching kebab→camel (`vault-read`→`vaultRead`, `apple-app-attest`→`appleAppAttest`, …); Rust shapes are unchanged.

Specs with **no** upstream 0.2 are untouched and stay on 0.1: `auth/{authenticate,refresh,challenge,revoke-session,whoami,sessions/list}`, `device/{disable,wipe}`, `vault/delete`, all `did-management/*`, and the VTA's own `*/1.0` URIs.

## Mechanism (split by whether the payload is signed)

| Specs | Mechanism |
|---|---|
| **device/\*** (register/heartbeat/list/set-wake), **vault/\*** (list/get/upsert/release/proxy-login/sign-trust-task) | **Edge transform** (`routes/trust_tasks/wire_v0_2.rs`): bearer-authed, no signature over the payload → down-convert the 0.2 request's enum values to kebab at the spec's declared enum **paths**, retype to the 0.1 URI, run the existing 0.1 handler **unchanged**, up-convert the response (→camel + `…/0.2#response`). |
| **auth/step-up/approve-response** | **Typed handler**: the approver signs the payload, so the document is never mutated — parse the v0_1 typed payload from a *copy* whose `evidence.kind` is normalised; verify the proof + echo the response over the original 0.2 doc. |
| **passkey-login** start/finish | **Declarative**: REST-routed flat JSON whose VTA-facing types carry no renamed enum → a 0.2 client is structurally identical; the 0.2 URIs are declared REST-routed. |

`kebabize`/`camelize` are deterministic inverses; transforms are **path-targeted** so opaque/free-text values (JWEs, DIDs, labels) are never rewritten even if they coincidentally equal an enum token. This delivers full per-version camelCase **without** modifying the `vti_common` vault types (smaller blast radius than a type-level serde change).

## Notable

- **trust-tasks-rs/https/proof 0.1 → 0.2** (0.2 retains all `v0_1` modules; non-breaking).
- **Client migration is enabled, not forced.** `vta-mobile-core` keeps emitting 0.1 approve-response and the VTA keeps emitting 0.1 approve-request, so field clients interoperate with not-yet-upgraded peers. Client 0.2 emission is a fleet-rollout-gated follow-up.
- vta-sdk 0.9.9→0.9.10, vta-service 0.8.2→0.8.3 (dependents pin major.minor).
- Design note: `docs/05-design-notes/trust-task-uri-registry.md` §"0.2 dual-accept migration".

## Tests

- `wire_v0_2` unit + round-trip tests: device/list + vault/list/upsert request down-convert & response up-convert, `/0.2#response` retype, reject pass-through, **free-text-token safety**, registry consistency.
- New integration test: a **signed 0.2** step-up approve-response (camelCase `evidence.kind`, `/0.2` type) → proof verified over the 0.2 bytes → session elevated → `/0.2#response`.
- Full vta-service integration suite (170+ tests) green — no regression.
- clippy `-D warnings` clean (vta-sdk, vta-service); workspace builds all-features; `cargo deny` clean; fmt clean.

## How to add the next 0.2 spec

Add the `*_0_2` const + `ALL_URIS` entry and `#[deprecate]` the 0.1 in `vta-sdk::trust_tasks`; then either a `WireSpecV02` entry + path tables + round-trip test (edge transform) or a typed dispatch arm (signed). The parity harness fails until the new 0.2 URI is tracked.
