### PR TITLE
chore(deps): adopt affinidi-crypto 0.2 (vta-sdk 0.9.11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-bbs"
-version = "0.1.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59631d7fb6461fdb9a118888d056b501d50198720d36036bb826d53b91829c13"
+checksum = "4d24778bfb29be2a2fbdf25d0d03a65188c8a1a5d567719cb786ebab18ff2965"
 dependencies = [
  "bls12_381_plus",
  "elliptic-curve",
@@ -119,13 +119,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-crypto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a56253d8878db88e02d70a0472ec7e346412a4dcf14b84a77cca096ecbbf4f0"
+dependencies = [
+ "aes 0.8.4",
+ "affinidi-encoding",
+ "base58",
+ "base64 0.22.1",
+ "cbc 0.1.2",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac 0.12.1",
+ "k256",
+ "multibase",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror 2.0.18",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "affinidi-data-integrity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40e3bfdabfb46690fe58cea0801d4b43d15949ee34a92290b68d9447bbb616a5"
 dependencies = [
- "affinidi-bbs",
- "affinidi-crypto",
+ "affinidi-crypto 0.1.12",
  "affinidi-did-common",
  "affinidi-rdf-encoding",
  "affinidi-secrets-resolver",
@@ -143,12 +171,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "affinidi-did-authentication"
-version = "0.3.5"
+name = "affinidi-data-integrity"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f6dddb1c766bd2907802b2d9f6c47b511531664e5715828a667c7cf57cef9d"
+checksum = "be2413307935cc2126c9fc4890a0e38ed69329638b93590a936a2d5bd11a50d8"
 dependencies = [
- "affinidi-crypto",
+ "affinidi-bbs",
+ "affinidi-crypto 0.2.0",
+ "affinidi-did-common",
+ "affinidi-rdf-encoding",
+ "affinidi-secrets-resolver",
+ "async-trait",
+ "chrono",
+ "ciborium",
+ "ed25519-dalek",
+ "hmac 0.12.1",
+ "multibase",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "affinidi-did-authentication"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6b7f65487eeb0332943dfb1b7140a9e0657b65c90fc6ae89c3291bd793e291"
+dependencies = [
+ "affinidi-crypto 0.2.0",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
@@ -167,11 +221,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-common"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe027b966094b1a10afedc57c3eb947f1ce9aa9e46eaed439afae873676d325"
+checksum = "4caccbd04e9f77b067659c9ac0312c4dfface553fe2375ceb7ed1affec550061"
 dependencies = [
- "affinidi-crypto",
+ "affinidi-crypto 0.2.0",
  "affinidi-encoding",
  "base64 0.22.1",
  "serde",
@@ -184,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3ef1475ae7fb0378b08e530fc3180f96c2a1a778d60aa9f5ce70b068f3979d"
+checksum = "81bf73e3580e63f3877c10e7648f42b0082eaa4ba8f2ea6e2c16ce5921b2e415"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-traits",
@@ -278,11 +332,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a20a4728d64691ee53bb7af10721050fea21bee3eba2f48f6c3556ce66617f5"
+checksum = "116a97f0ee592f0fa7cda8c30b2c757175ea4a28d9bbf3b800be7e13d1740b02"
 dependencies = [
- "affinidi-crypto",
+ "affinidi-crypto 0.2.0",
  "base64ct",
  "ed25519-dalek",
  "k256",
@@ -325,7 +379,7 @@ version = "0.15.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "584360aaac36240a40e671a9725ffec8c99bdebd4c0e11a29806ca0396d358b4"
 dependencies = [
- "affinidi-crypto",
+ "affinidi-crypto 0.1.12",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
@@ -375,7 +429,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.1",
+ "vta-sdk 0.9.9",
 ]
 
 [[package]]
@@ -417,11 +471,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.6"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536aa87c41fcfb795574e5b6d7275dcfd94599cf20442e62f2acefdcb976bef5"
+checksum = "1e03b90fdf586d88f396350f555b5569f66eee86c1d17f69ada41f6d58ee479b"
 dependencies = [
- "affinidi-crypto",
+ "affinidi-crypto 0.2.0",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-encoding",
@@ -559,11 +613,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f5b82eb03c6356e54c041739aaad4bd1a8c25cf19e9b0e9690a32014c3e956"
+checksum = "a5df3f588537611ef80a97ddfaa9fef3d8070553fab051a44e974e66781eff64"
 dependencies = [
- "affinidi-crypto",
+ "affinidi-crypto 0.2.0",
  "affinidi-encoding",
  "ahash 0.8.12",
  "base58",
@@ -599,12 +653,12 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa8f1cc1d16a7e58b3ecae5d2bc8cd31169923ec531fe0559982e0507619451"
+checksum = "a5245bc666e4270a5706472ab283b10c48f44d3b9c7f0e04303e7e28409e8cd0"
 dependencies = [
- "affinidi-crypto",
- "affinidi-data-integrity",
+ "affinidi-crypto 0.2.0",
+ "affinidi-data-integrity 0.7.1",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
@@ -624,11 +678,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325cf3d04813a5ae8ce92bf4363a4e4da561ce71dd1aca06638ebe9ec0830a52"
+checksum = "6f9612ab9d79a96d32cc80707d9a4f97d9bbf07d78adc0876ccaa9ca2b9b8b92"
 dependencies = [
- "affinidi-data-integrity",
+ "affinidi-data-integrity 0.7.1",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
@@ -779,6 +833,15 @@ dependencies = [
  "keyring-core",
  "log",
  "security-framework",
+]
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1032,9 +1095,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.17"
+version = "1.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1136,10 +1199,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.108.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c07c0605c62c02a7ca33ee4f9db8ec0d9085e38bf74b1f02d7e357646e3b63f"
+checksum = "217276b3d948ec05b2726d66b2c9013567ca42751052c287ec45800ee81799c9"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -1160,10 +1224,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.106.0"
+version = "1.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6fa2aa029a7298bc3d863c253fe6745dac677620f20c337b6ca7cc208f7201"
+checksum = "63da8ec2dca98a68d8bcba971abae5f06e2c9c0017f43097d1ff92cff96adc54"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -1184,10 +1249,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.100.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2719d4a5e5e147bb9e9b77490df6ece750df1094968aa857b09b618a1881a"
+checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -1208,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.102.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30d254992d56ef19f430396e5765b11e0f5bd21a7a557cb12fca1c8c18b9636"
+checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1233,10 +1299,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.105.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f4f8065fe615dbed9096458ba98dda6d641553ffd5aedd27e37e65211aca9f"
+checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -1258,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -1312,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1342,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -1398,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1438,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1811,9 +1878,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitmaps"
@@ -1983,6 +2050,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytecount"
@@ -2168,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2317,7 +2390,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.10",
+ "vta-sdk 0.9.11",
 ]
 
 [[package]]
@@ -2522,6 +2595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,7 +2640,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -3091,16 +3170,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.10",
+ "vta-sdk 0.9.11",
 ]
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854fcce63deb51e3baac8a5fddc5512c9f437e3ff81c78a78bd08f931672f7ce"
+checksum = "46448d8c4137746b88b66ef7bdfd67b13a981208703936879af11bdecf742519"
 dependencies = [
- "affinidi-data-integrity",
+ "affinidi-data-integrity 0.7.1",
  "affinidi-did-common",
  "affinidi-secrets-resolver",
  "ahash 0.8.12",
@@ -3201,7 +3280,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59b7131aa259ef04decb22060173d96b669cffbe172f0ad431f5cb36f1ad9569"
 dependencies = [
- "affinidi-data-integrity",
+ "affinidi-data-integrity 0.6.1",
  "affinidi-secrets-resolver",
  "chrono",
  "serde",
@@ -3485,6 +3564,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -3911,9 +3996,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd4f8c914f230834828771125168eaa39bc6602e32cb0316ceeff2add10d449"
+checksum = "4595b69c95c727ac896a4f2f16d0cdaa6f547de0bc5d64dbe9201487fc3226d5"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -3940,11 +4025,10 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d597e9e4758fc778a60d8c28a8677629675ae40d8652ec000ae5f53f5ae7ec"
+checksum = "4f60f45dd97ff91cedfcb6b2b9f860d3d84739386c3557027687c52cc0e698fd"
 dependencies = [
- "base64 0.22.1",
  "bytes",
  "futures",
  "google-cloud-rpc",
@@ -3960,9 +4044,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3e4d09e162fb71314e2c91879bdd495c1f8a1f69e71ccbae5767b8b6c833d6"
+checksum = "78e0d5b25e5714321efc3ea48a1457bcd943ba85fe7a0e80e97d989f3c9aea17"
 dependencies = [
  "bytes",
  "futures",
@@ -3991,9 +4075,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v1"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab83affdded409153d2e616174054a780705016c288e43221a0d6a22dd78671"
+checksum = "70a245c548c002e22d1644e88d9b7d6c32183b335e63510a1bb8580045c3282d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4009,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-location"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd181e470051464f49e47f00010e08f586ee2def8ade486352978b1312d4b58"
+checksum = "20a6d8ac73bb9d78fff74be261bf5b17dba4a49a12b41cd3b5abbc173c0771e4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4039,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-secretmanager-v1"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a610ccf84829bb73c391e86a0387c87a1826e53d76fd518de475907bce57b3de"
+checksum = "3d92326f99f56001667b63a773583c85c0fe50b53d6891805630085c1f611770"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4071,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5daa3084991800bcc5333d7e77bb19259a02b34ee35f35c27b49d602732306e"
+checksum = "88e0186e2221bf82c5296500251b4650b111172c324984159a0de9f6bcaa18a5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4229,6 +4313,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -5352,6 +5441,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5366,7 +5461,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5452,9 +5547,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "loom"
@@ -5471,18 +5566,12 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -5767,7 +5856,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5780,7 +5869,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5996,7 +6085,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -6045,9 +6134,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6059,21 +6148,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
 ]
@@ -6133,12 +6223,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6405,7 +6533,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "pnm-cli"
 version = "0.8.0"
 dependencies = [
- "affinidi-crypto",
+ "affinidi-crypto 0.2.0",
  "affinidi-did-resolver-cache-sdk",
  "base64 0.22.1",
  "chrono",
@@ -6425,7 +6553,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.10",
+ "vta-sdk 0.9.11",
 ]
 
 [[package]]
@@ -6613,9 +6741,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
+checksum = "3a3db184a8b66cfe87f0263a1de147a6b554c864d1767c6f7fa4eb0e5497b565"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -6815,9 +6943,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -6825,21 +6953,25 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
+ "critical-section",
+ "hashbrown 0.17.1",
  "indoc",
  "itertools",
  "kasuari",
- "lru 0.16.4",
+ "lru",
+ "palette",
+ "serde",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -6849,9 +6981,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -6861,9 +6993,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -6871,9 +7003,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -6881,17 +7013,18 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
+ "serde",
  "strum",
  "time",
  "unicode-segmentation",
@@ -6910,7 +7043,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6969,7 +7102,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7070,7 +7203,7 @@ dependencies = [
  "ipnet",
  "jsonschema",
  "lazy_static",
- "lru 0.18.0",
+ "lru",
  "msvc_spectre_libs",
  "num-bigint",
  "num-traits",
@@ -7288,7 +7421,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -7325,9 +7458,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -7568,7 +7701,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7741,9 +7874,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -7761,9 +7894,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -8374,18 +8507,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -8476,7 +8609,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -8566,7 +8699,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
@@ -8993,7 +9126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -9085,9 +9218,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -9149,12 +9282,12 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d150451ef1284688183bc514f41970233719f83a56ee3b9df21b7b6ca3d3b1a0"
+checksum = "c0138696d9a4d052ee0c7d780a7ba28d469c41dc3157312ae222c9e54d484fe9"
 dependencies = [
- "affinidi-crypto",
- "affinidi-data-integrity",
+ "affinidi-crypto 0.2.0",
+ "affinidi-data-integrity 0.7.1",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
  "async-trait",
@@ -9313,9 +9446,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -9568,9 +9701,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "varint-rs"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f54a172d0620933a27a4360d3db3e2ae0dd6cceae9730751a036bbf182c4b23"
+checksum = "bfa6c38708f6257f1ec2ca7e5a11f9bbf58a27d7060078b6b333624968183d96"
 
 [[package]]
 name = "vaultrs"
@@ -9624,7 +9757,7 @@ name = "vta-cli-common"
 version = "0.8.1"
 dependencies = [
  "aes-gcm",
- "affinidi-crypto",
+ "affinidi-crypto 0.2.0",
  "base64 0.22.1",
  "chrono",
  "dialoguer",
@@ -9639,7 +9772,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.10",
+ "vta-sdk 0.9.11",
  "x25519-dalek",
 ]
 
@@ -9662,8 +9795,8 @@ dependencies = [
 name = "vta-mobile-core"
 version = "0.3.0"
 dependencies = [
- "affinidi-crypto",
- "affinidi-data-integrity",
+ "affinidi-crypto 0.2.0",
+ "affinidi-data-integrity 0.7.1",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -9676,18 +9809,20 @@ dependencies = [
  "tokio",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.9.10",
+ "vta-sdk 0.9.11",
 ]
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.1"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858ad5093e72c21153d50ec4aa7d361b9b5d356bdb1af2c4016734d0c66ae9b1"
+checksum = "95b83da57520fdbcf3a7ae45532ff020bb3e732abd6be691ffaf198fb514b612"
 dependencies = [
- "affinidi-crypto",
+ "affinidi-crypto 0.1.12",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
  "affinidi-tdk",
  "base64 0.22.1",
  "chrono",
@@ -9709,11 +9844,11 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "affinidi-bbs",
- "affinidi-crypto",
- "affinidi-data-integrity",
+ "affinidi-crypto 0.2.0",
+ "affinidi-data-integrity 0.7.1",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-openid4vci",
@@ -9758,13 +9893,13 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
  "affinidi-bbs",
- "affinidi-crypto",
- "affinidi-data-integrity",
+ "affinidi-crypto 0.2.0",
+ "affinidi-data-integrity 0.7.1",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
@@ -9836,7 +9971,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.10",
+ "vta-sdk 0.9.11",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9852,8 +9987,8 @@ name = "vtc-service"
 version = "0.8.0"
 dependencies = [
  "affinidi-bbs",
- "affinidi-crypto",
- "affinidi-data-integrity",
+ "affinidi-crypto 0.2.0",
+ "affinidi-data-integrity 0.7.1",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
@@ -9918,7 +10053,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.10",
+ "vta-sdk 0.9.11",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9961,7 +10096,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.10",
+ "vta-sdk 0.9.11",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9988,7 +10123,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.10",
+ "vta-sdk 0.9.11",
  "vta-service",
  "vti-common",
 ]
@@ -10160,7 +10295,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -10877,7 +11012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -11013,9 +11148,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,14 +96,11 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3b42d67853904ddcbf3e69dc9522b7088f1557b50e6e49b07d5469b30ed6d93"
 dependencies = [
- "aes 0.8.4",
  "affinidi-encoding",
  "base58",
  "base64 0.22.1",
- "cbc 0.1.2",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac 0.12.1",
  "k256",
  "multibase",
  "p256",
@@ -112,7 +109,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "subtle",
  "thiserror 2.0.18",
  "x25519-dalek",
  "zeroize",
@@ -375,11 +371,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.15.13"
+version = "0.15.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584360aaac36240a40e671a9725ffec8c99bdebd4c0e11a29806ca0396d358b4"
+checksum = "550c4325d3e325d3062c2135419d99668987b4f6c6f1063d047b11ea2c248404"
 dependencies = [
- "affinidi-crypto 0.1.12",
+ "affinidi-crypto 0.2.0",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
@@ -429,7 +425,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.9",
+ "vta-sdk 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -9814,36 +9810,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b83da57520fdbcf3a7ae45532ff020bb3e732abd6be691ffaf198fb514b612"
-dependencies = [
- "affinidi-crypto 0.1.12",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "getrandom 0.4.2",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.9.11"
 dependencies = [
  "affinidi-bbs",
@@ -9889,6 +9855,36 @@ dependencies = [
  "wiremock",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72e9ca533c5452a06b69fa4fd0e1c15d0d146c8fbe06c78b20211cf0c0ebc05"
+dependencies = [
+ "affinidi-crypto 0.2.0",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,30 +92,6 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b42d67853904ddcbf3e69dc9522b7088f1557b50e6e49b07d5469b30ed6d93"
-dependencies = [
- "affinidi-encoding",
- "base58",
- "base64 0.22.1",
- "ed25519-dalek",
- "getrandom 0.2.17",
- "k256",
- "multibase",
- "p256",
- "p384",
- "rand_core 0.6.4",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "affinidi-crypto"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a56253d8878db88e02d70a0472ec7e346412a4dcf14b84a77cca096ecbbf4f0"
@@ -145,35 +121,12 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e3bfdabfb46690fe58cea0801d4b43d15949ee34a92290b68d9447bbb616a5"
-dependencies = [
- "affinidi-crypto 0.1.12",
- "affinidi-did-common",
- "affinidi-rdf-encoding",
- "affinidi-secrets-resolver",
- "async-trait",
- "chrono",
- "ed25519-dalek",
- "multibase",
- "serde",
- "serde_json",
- "serde_json_canonicalizer",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "affinidi-data-integrity"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2413307935cc2126c9fc4890a0e38ed69329638b93590a936a2d5bd11a50d8"
 dependencies = [
  "affinidi-bbs",
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "affinidi-did-common",
  "affinidi-rdf-encoding",
  "affinidi-secrets-resolver",
@@ -198,7 +151,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df6b7f65487eeb0332943dfb1b7140a9e0657b65c90fc6ae89c3291bd793e291"
 dependencies = [
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
@@ -221,7 +174,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4caccbd04e9f77b067659c9ac0312c4dfface553fe2375ceb7ed1affec550061"
 dependencies = [
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "affinidi-encoding",
  "base64 0.22.1",
  "serde",
@@ -332,7 +285,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "116a97f0ee592f0fa7cda8c30b2c757175ea4a28d9bbf3b800be7e13d1740b02"
 dependencies = [
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "base64ct",
  "ed25519-dalek",
  "k256",
@@ -375,7 +328,7 @@ version = "0.15.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "550c4325d3e325d3062c2135419d99668987b4f6c6f1063d047b11ea2c248404"
 dependencies = [
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
@@ -471,7 +424,7 @@ version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e03b90fdf586d88f396350f555b5569f66eee86c1d17f69ada41f6d58ee479b"
 dependencies = [
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-encoding",
@@ -613,7 +566,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5df3f588537611ef80a97ddfaa9fef3d8070553fab051a44e974e66781eff64"
 dependencies = [
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "affinidi-encoding",
  "ahash 0.8.12",
  "base58",
@@ -653,8 +606,8 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5245bc666e4270a5706472ab283b10c48f44d3b9c7f0e04303e7e28409e8cd0"
 dependencies = [
- "affinidi-crypto 0.2.0",
- "affinidi-data-integrity 0.7.1",
+ "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
@@ -678,7 +631,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f9612ab9d79a96d32cc80707d9a4f97d9bbf07d78adc0876ccaa9ca2b9b8b92"
 dependencies = [
- "affinidi-data-integrity 0.7.1",
+ "affinidi-data-integrity",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
@@ -800,7 +753,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -811,7 +764,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2877,7 +2830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3175,7 +3128,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46448d8c4137746b88b66ef7bdfd67b13a981208703936879af11bdecf742519"
 dependencies = [
- "affinidi-data-integrity 0.7.1",
+ "affinidi-data-integrity",
  "affinidi-did-common",
  "affinidi-secrets-resolver",
  "ahash 0.8.12",
@@ -3247,7 +3200,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3272,11 +3225,11 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b7131aa259ef04decb22060173d96b669cffbe172f0ad431f5cb36f1ad9569"
+checksum = "8ac7fa3bbea7023541deabdc0301959bc0ac18dcdde3871a460ac7c9f8435862"
 dependencies = [
- "affinidi-data-integrity 0.6.1",
+ "affinidi-data-integrity",
  "affinidi-secrets-resolver",
  "chrono",
  "serde",
@@ -3496,7 +3449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4648,7 +4601,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5900,7 +5853,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6529,7 +6482,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "pnm-cli"
 version = "0.8.0"
 dependencies = [
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
  "base64 0.22.1",
  "chrono",
@@ -6758,7 +6711,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6796,7 +6749,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7421,7 +7374,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7510,7 +7463,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7531,7 +7484,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8180,7 +8133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8663,7 +8616,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9282,8 +9235,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0138696d9a4d052ee0c7d780a7ba28d469c41dc3157312ae222c9e54d484fe9"
 dependencies = [
- "affinidi-crypto 0.2.0",
- "affinidi-data-integrity 0.7.1",
+ "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
  "async-trait",
@@ -9753,7 +9706,7 @@ name = "vta-cli-common"
 version = "0.8.1"
 dependencies = [
  "aes-gcm",
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "base64 0.22.1",
  "chrono",
  "dialoguer",
@@ -9791,8 +9744,8 @@ dependencies = [
 name = "vta-mobile-core"
 version = "0.3.0"
 dependencies = [
- "affinidi-crypto 0.2.0",
- "affinidi-data-integrity 0.7.1",
+ "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -9813,8 +9766,8 @@ name = "vta-sdk"
 version = "0.9.11"
 dependencies = [
  "affinidi-bbs",
- "affinidi-crypto 0.2.0",
- "affinidi-data-integrity 0.7.1",
+ "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-openid4vci",
@@ -9863,7 +9816,7 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c72e9ca533c5452a06b69fa4fd0e1c15d0d146c8fbe06c78b20211cf0c0ebc05"
 dependencies = [
- "affinidi-crypto 0.2.0",
+ "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-openid4vci",
@@ -9894,8 +9847,8 @@ dependencies = [
  "aes 0.9.1",
  "aes-gcm",
  "affinidi-bbs",
- "affinidi-crypto 0.2.0",
- "affinidi-data-integrity 0.7.1",
+ "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
@@ -9983,8 +9936,8 @@ name = "vtc-service"
 version = "0.8.0"
 dependencies = [
  "affinidi-bbs",
- "affinidi-crypto 0.2.0",
- "affinidi-data-integrity 0.7.1",
+ "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
@@ -10525,7 +10478,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ affinidi-tdk = "0.7"
 # Raw crypto primitives (ed25519↔x25519 conversion, did:key helpers). Pulled
 # directly so sealed-transfer can use `affinidi_crypto::did_key::*` without
 # going through the higher-level Secret wrapper in secrets-resolver.
-affinidi-crypto = "0.1.12"
+affinidi-crypto = "0.2"
 # W3C VC Data Model 2.0 + Data Integrity proofs. Used by the
 # provision-integration flow (VP-framed bootstrap request, VC-issued
 # admin authorization). See CLAUDE.md "Authorization claims" principle.
 affinidi-vc = "0.1"
-affinidi-data-integrity = "0.6.1"
+affinidi-data-integrity = "0.7"
 affinidi-status-list = "0.1.3"
 
 # Credential formats for the credential-centric VTI architecture
@@ -80,7 +80,7 @@ affinidi-status-list = "0.1.3"
 # to avoid a duplicate-version split.
 affinidi-sd-jwt-vc = "0.1.1"
 affinidi-sd-jwt = "0.1.2"
-affinidi-bbs = "0.1.1"
+affinidi-bbs = "0.2"
 affinidi-openid4vp = "0.1.2"
 affinidi-openid4vci = "0.1.2"
 affinidi-secrets-resolver = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ affinidi-secrets-resolver = "0.5"
 affinidi-messaging-didcomm-service = "0.3"
 
 # Decentralized Trust Graph Credentials
-dtg-credentials = "0.1.2"
+dtg-credentials = "0.1.3"
 
 # JSON Schema validation (issue-time credentialSchema checks)
 jsonschema = "0.46"

--- a/vta-cli-common/src/render.rs
+++ b/vta-cli-common/src/render.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    buffer::Buffer,
+    buffer::{Buffer, CellDiffOption},
     layout::Rect,
     style::{Color, Modifier},
     widgets::Widget,
@@ -312,7 +312,7 @@ pub fn print_widget(widget: impl Widget, height: u16) {
 
         for x in 0..width {
             let cell = &buf[(x, y)];
-            if cell.skip {
+            if cell.diff_option == CellDiffOption::Skip {
                 continue;
             }
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.10"
+version = "0.9.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.8.3"
+version = "0.8.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## What

Move the whole workspace to **affinidi-crypto 0.2** — the tree now resolves to a **single** `affinidi-crypto 0.2.0` and `affinidi-data-integrity 0.7.1` (no duplicate-version split).

| crate | from | to |
|---|---|---|
| affinidi-crypto | 0.1.12 | **0.2.0** |
| affinidi-data-integrity | 0.6.1 | 0.7.1 |
| affinidi-bbs | 0.1.1 | 0.2.2 |
| affinidi-tdk | 0.7.3 | 0.7.4 |
| affinidi-tdk-common | 0.6.2 | 0.6.3 |
| affinidi-secrets-resolver | 0.5.6 | 0.5.7 |
| affinidi-messaging-mediator | 0.15.13 | 0.15.14 |
| didwebvh-rs | 0.5.3 | 0.5.4 |
| dtg-credentials | 0.1.2 | 0.1.3 |

Plus a full `cargo update` for the rest of the tree.

**Version bumps:** `vta-sdk` 0.9.10 → **0.9.11** (published to crates.io on crypto 0.2), `vta-service` 0.8.3 → **0.8.4**.

**Drive-by:** ratatui 0.30 deprecated `Cell::skip` → `vta-cli-common::render` now reads `cell.diff_option == CellDiffOption::Skip`.

## Sequencing (now complete)

This needed the producer crates to publish on crypto 0.2 first. Order was: publish `vta-sdk 0.9.11` (crypto 0.2) → `affinidi-messaging-mediator 0.15.14` republished on crypto 0.2 → `dtg-credentials 0.1.3` onto data-integrity 0.7. Each removed a crypto-0.1 holdout; the last one collapsed the tree to a single crypto version.

## Verification

- `cargo build --workspace` — clean
- `clippy --workspace --all-targets -- -D warnings` — clean
- e2e suite green (client_didcomm 41, didcomm_session 17, transient_handshake 11, rollback, state_op_matrix)
- vtc-service 489 + vta-service 667 lib tests — green
- `cargo deny check` — ok
- single `affinidi-crypto 0.2.0` in the tree (verified)
