### PR TITLE
docs(vta-sdk): fix stale DIDCommSession::connect WebSocket doc (#302)

### DIFF
--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -104,9 +104,15 @@ impl DIDCommSession {
 
     /// Connect to a VTA via DIDComm through a mediator.
     ///
-    /// Sets up the ATM and profile for REST-based messaging. Does NOT open a
-    /// WebSocket — all communication goes through the mediator's REST API,
-    /// avoiding connection storms when the CLI is invoked repeatedly.
+    /// Opens a **persistent, auto-reconnecting WebSocket** to the mediator for
+    /// streaming response delivery (`profile_enable_websocket` below) — without
+    /// it the ATM can only REST-poll and may miss responses that arrive after
+    /// the initial send returns. Because the mediator enforces one socket per
+    /// DID, callers MUST reuse a single session per DID and [`shutdown`] it
+    /// rather than connecting per operation; overlapping sessions for the same
+    /// DID duel on the mediator and drop in-flight messages (see #302).
+    ///
+    /// [`shutdown`]: Self::shutdown
     pub async fn connect(
         client_did: &str,
         private_key_multibase: &str,


### PR DESCRIPTION
## What

`DIDCommSession::connect`'s rustdoc claimed it *"Does NOT open a WebSocket — all communication goes through the mediator's REST API"*. That's wrong: the method body calls `profile_enable_websocket` ("WebSocket mode"), and the struct-level doc already describes a live, auto-reconnecting connection. The stale claim was the exact confusion that seeded #302.

This replaces it with the actual behavior **plus the one-socket-per-DID contract** — callers MUST reuse a single session per DID and `shutdown()` it rather than connecting per operation, since overlapping sessions duel on the mediator and drop in-flight messages.

## Scope

Doc-only change (no code/behavior change).

## Context

This is the in-repo remainder of #302. The session-churn root cause was already hardened across #292 / #296 / #299 / #300 / #301. The remaining transport-layer item — the mediator closing a replaced WebSocket without draining/redelivering in-flight messages — is **not in this workspace** (`affinidi-messaging-mediator`) and is tracked upstream at affinidi/affinidi-tdk-rs#374.

Closes #302.