### PR TITLE
feat(provision-integration): dual-accept 0.2; retire legacy FPN URI (#306)

### DIFF
--- a/docs/02-vta/provision-integration.md
+++ b/docs/02-vta/provision-integration.md
@@ -422,8 +422,16 @@ DIDComm session. The integration calls
 which packs an authcrypt'd DIDComm message carrying the same VP and
 parses the same sealed-bundle response.
 
-Protocol URI:
-`https://firstperson.network/protocols/provision-integration/1.0/provision-integration`.
+Protocol URI (canonical Trust Task registry), two versions accepted:
+`https://trusttasks.org/spec/provision/integration/0.1` and
+`https://trusttasks.org/spec/provision/integration/0.2`. The VTA
+dual-accepts both and replies under the matching `#response` URI. The
+0.2 wire form differs only in camelCase enum casing (notably the signed
+VP's `ask.type`, e.g. `templateBootstrap`); the handler verifies the VP
+over the bytes as received so the holder's casing survives. The legacy
+`firstperson.network/protocols/provision-integration/1.0/*` URI was
+retired now that the browser plugin and Rust CLIs target the canonical
+registry.
 
 The VTA's DIDComm handler enforces a **dual check**:
 `auth_from_message` verifies the authcrypt sender + ACL entry, AND

--- a/docs/05-design-notes/trust-task-uri-registry.md
+++ b/docs/05-design-notes/trust-task-uri-registry.md
@@ -598,6 +598,18 @@ Two mechanisms, split by whether the payload is signed:
 - **Declarative** — **passkey-login** start/finish are REST-routed flat JSON
   whose VTA-facing types carry no renamed enum, so a 0.2 client is structurally
   identical; the 0.2 URIs are simply declared REST-routed.
+- **As-received VP verify** — **`provision/integration`** is not on the
+  trust-task dispatcher; it has its own DIDComm message-type route
+  (`vta_sdk::protocols::provision_integration_management`) and a REST endpoint.
+  Its payload carries a **signed VP** whose `ask.type` is camelCased in 0.2
+  (`templateBootstrap` / `adminRotation`) *inside* the proof coverage, so the
+  bytes MUST NOT be re-cased. The handler verifies the proof over the VP
+  **exactly as received** (`BootstrapRequest::verify_value`) rather than
+  re-serialising the typed struct, and the `BootstrapAsk` enum carries
+  deserialize aliases for both casings. Both `…/0.1` and `…/0.2` route to the
+  same handler; `result_uri_for` picks the matching `#response`. The legacy
+  `firstperson.network` provision URI was retired here (the other
+  `firstperson.network` management protocols are untouched).
 
 **Adding the next 0.2 spec:** add the `*_0_2` const + `ALL_URIS` entry in
 `vta-sdk::trust_tasks` and `#[deprecate]` the 0.1; for an edge-transform spec,

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -875,7 +875,7 @@ async fn with_didcomm_sequential_cycles_for_same_did_do_not_duel() {
 /// the mock VTA does not trip the LeakGuard."
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn provision_admin_rotation_didcomm_shuts_session_down_on_error() {
-    use vta_sdk::protocols::provision_integration_management::PROVISION_INTEGRATION;
+    use vta_sdk::protocols::provision_integration_management::CANONICAL_PROVISION_INTEGRATION;
     use vta_sdk::provision_client::{ProvisionAsk, provision_admin_rotation_via_didcomm};
 
     common::init_tracing();
@@ -885,7 +885,7 @@ async fn provision_admin_rotation_didcomm_shuts_session_down_on_error() {
     let (mediator, responder) = TestVtaResponder::spawn_with_mediator(
         vec![setup_did.clone()],
         |msg_type: &str, _body: &Value| {
-            if msg_type == PROVISION_INTEGRATION {
+            if msg_type == CANONICAL_PROVISION_INTEGRATION {
                 // Deny — exercises the runner's error path, which must
                 // still shut the session down before returning.
                 ResponderReply::problem_report("e.p.msg.forbidden", "denied for test")

--- a/vta-sdk/src/protocols/provision_integration_management.rs
+++ b/vta-sdk/src/protocols/provision_integration_management.rs
@@ -16,57 +16,59 @@
 //! [`crate::provision_integration::http::ProvisionIntegrationRequest`]
 //! and [`crate::provision_integration::http::ProvisionIntegrationResponse`].
 //!
-//! Two URI shapes are accepted on the wire, both routed to the same
-//! handler:
+//! Two canonical Trust Task URI versions are accepted on the wire, both
+//! routed to the same handler:
 //!
-//! * The legacy FPN-private URI ([`PROVISION_INTEGRATION`]) — what every
-//!   existing client targets today.
-//! * The canonical Trust Task URI
-//!   ([`CANONICAL_PROVISION_INTEGRATION`]) — landed in
-//!   `dtgwg-trust-tasks-tf` PR #51 as
-//!   `https://trusttasks.org/spec/provision/integration/0.1`. Clients
-//!   migrating to the canonical registry target this URI.
+//! * [`CANONICAL_PROVISION_INTEGRATION`] — `provision/integration/0.1`,
+//!   landed in `dtgwg-trust-tasks-tf` PR #51.
+//! * [`CANONICAL_PROVISION_INTEGRATION_0_2`] —
+//!   `provision/integration/0.2`. Same VP/bundle wire body; the 0.2 delta
+//!   is camelCase enum casing (e.g. the VP's `ask.type`), which the typed
+//!   verifier accommodates by checking the proof over the bytes as
+//!   received — see
+//!   [`crate::provision_integration::BootstrapRequest::verify_value`].
 //!
-//! The handler emits the response under whichever URI the request came
-//! in with — a caller using the canonical URI receives a canonical
-//! response (`#response` fragment), a caller using the FPN URI receives
-//! the legacy `…-result` URI. That keeps both clients working without
-//! either having to know about the other.
+//! The handler emits the response under whichever version the request
+//! came in with — a 0.1 request gets the `0.1#response` URI, a 0.2 request
+//! the `0.2#response` URI — so both clients work without either knowing
+//! about the other.
+//!
+//! The legacy `firstperson.network` provision-integration URI was retired
+//! once consumers (the browser plugin, the Rust CLIs) moved to the
+//! canonical registry. The other `firstperson.network` management
+//! protocols are unaffected.
 
-pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/provision-integration/1.0";
-
-/// Inbound VP + provisioning options. Legacy FPN-private URI.
-pub const PROVISION_INTEGRATION: &str =
-    "https://firstperson.network/protocols/provision-integration/1.0/provision-integration";
-
-/// Outbound sealed bundle + summary. Legacy FPN-private URI.
-pub const PROVISION_INTEGRATION_RESULT: &str =
-    "https://firstperson.network/protocols/provision-integration/1.0/provision-integration-result";
-
-/// Inbound VP + provisioning options — canonical Trust Task URI. Same
-/// wire body as [`PROVISION_INTEGRATION`]; accepting both is the spec
-/// migration step #51 of `dtgwg-trust-tasks-tf` set up.
+/// Inbound VP + provisioning options — canonical Trust Task URI, v0.1.
 pub const CANONICAL_PROVISION_INTEGRATION: &str =
     "https://trusttasks.org/spec/provision/integration/0.1";
 
-/// Outbound sealed bundle + summary — canonical Trust Task URI.
+/// Outbound sealed bundle + summary — canonical Trust Task URI, v0.1.
 /// Per SPEC.md §4.4.1 of `dtgwg-trust-tasks-tf`, success responses are
 /// emitted under the request URI with a `#response` fragment.
 pub const CANONICAL_PROVISION_INTEGRATION_RESULT: &str =
     "https://trusttasks.org/spec/provision/integration/0.1#response";
 
+/// Inbound VP + provisioning options — canonical Trust Task URI, v0.2.
+/// Same wire body as v0.1; the 0.2 spec uses camelCase enum casing
+/// (notably the signed VP's `ask.type`). Verification runs over the
+/// as-received bytes so the holder's casing survives.
+pub const CANONICAL_PROVISION_INTEGRATION_0_2: &str =
+    "https://trusttasks.org/spec/provision/integration/0.2";
+
+/// Outbound sealed bundle + summary — canonical Trust Task URI, v0.2.
+pub const CANONICAL_PROVISION_INTEGRATION_0_2_RESULT: &str =
+    "https://trusttasks.org/spec/provision/integration/0.2#response";
+
 /// Match the result URI to whichever request URI the caller used.
 /// Centralised here so the routing decision lives next to the URI
-/// constants — handlers downstream just call this and don't need to
-/// know which URIs are alias-equivalent.
+/// constants — handlers downstream just call this. The 0.2 request URI
+/// maps to the 0.2 `#response`; the 0.1 request URI (the only other shape
+/// the router advertises) maps to the 0.1 `#response`.
 pub fn result_uri_for(request_uri: &str) -> &'static str {
-    if request_uri == CANONICAL_PROVISION_INTEGRATION {
-        CANONICAL_PROVISION_INTEGRATION_RESULT
+    if request_uri == CANONICAL_PROVISION_INTEGRATION_0_2 {
+        CANONICAL_PROVISION_INTEGRATION_0_2_RESULT
     } else {
-        // Default to the legacy URI for any URI that's not the canonical
-        // one. Today the only other accepted shape is the FPN-private
-        // URI; future additions widen this match.
-        PROVISION_INTEGRATION_RESULT
+        CANONICAL_PROVISION_INTEGRATION_RESULT
     }
 }
 
@@ -90,7 +92,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn result_uri_for_canonical_request_emits_canonical_response() {
+    fn result_uri_for_v0_1_request_emits_v0_1_response() {
         assert_eq!(
             result_uri_for(CANONICAL_PROVISION_INTEGRATION),
             CANONICAL_PROVISION_INTEGRATION_RESULT
@@ -98,31 +100,30 @@ mod tests {
     }
 
     #[test]
-    fn result_uri_for_legacy_request_emits_legacy_response() {
+    fn result_uri_for_v0_2_request_emits_v0_2_response() {
         assert_eq!(
-            result_uri_for(PROVISION_INTEGRATION),
-            PROVISION_INTEGRATION_RESULT
+            result_uri_for(CANONICAL_PROVISION_INTEGRATION_0_2),
+            CANONICAL_PROVISION_INTEGRATION_0_2_RESULT
         );
     }
 
-    /// Unknown / future URIs default to the legacy result URI.  The router
-    /// only advertises the two URIs we know about, so this branch is
-    /// unreachable in production — but exercising it pins the fallback so
-    /// a future widening doesn't silently change the default response
-    /// shape for an already-deployed client.
+    /// Unknown / future URIs default to the 0.1 result URI. The router
+    /// only advertises the 0.1 and 0.2 URIs, so this branch is unreachable
+    /// in production — but exercising it pins the fallback so a future
+    /// widening doesn't silently change the default response shape.
     #[test]
-    fn result_uri_for_unknown_request_defaults_to_legacy() {
+    fn result_uri_for_unknown_request_defaults_to_v0_1() {
         assert_eq!(
             result_uri_for("https://example.invalid/something-else"),
-            PROVISION_INTEGRATION_RESULT
+            CANONICAL_PROVISION_INTEGRATION_RESULT
         );
     }
 
-    /// The canonical Trust Task URI MUST be exactly the value declared in
-    /// `dtgwg-trust-tasks-tf` PR #51's `payload.schema.json` `$id`. Pin
-    /// the string so a refactor here can't drift away from the registry.
+    /// The canonical Trust Task URIs MUST be exactly the values declared
+    /// in `dtgwg-trust-tasks-tf`'s `payload.schema.json` `$id`. Pin the
+    /// strings so a refactor here can't drift away from the registry.
     #[test]
-    fn canonical_uri_matches_registry() {
+    fn canonical_uris_match_registry() {
         assert_eq!(
             CANONICAL_PROVISION_INTEGRATION,
             "https://trusttasks.org/spec/provision/integration/0.1"
@@ -130,6 +131,14 @@ mod tests {
         assert_eq!(
             CANONICAL_PROVISION_INTEGRATION_RESULT,
             "https://trusttasks.org/spec/provision/integration/0.1#response"
+        );
+        assert_eq!(
+            CANONICAL_PROVISION_INTEGRATION_0_2,
+            "https://trusttasks.org/spec/provision/integration/0.2"
+        );
+        assert_eq!(
+            CANONICAL_PROVISION_INTEGRATION_0_2_RESULT,
+            "https://trusttasks.org/spec/provision/integration/0.2#response"
         );
     }
 }

--- a/vta-sdk/src/provision_integration/didcomm.rs
+++ b/vta-sdk/src/provision_integration/didcomm.rs
@@ -30,7 +30,7 @@
 use crate::didcomm_session::DIDCommSession;
 use crate::error::VtaError;
 use crate::protocols::provision_integration_management::{
-    PROVISION_INTEGRATION, PROVISION_INTEGRATION_RESULT,
+    CANONICAL_PROVISION_INTEGRATION, CANONICAL_PROVISION_INTEGRATION_RESULT,
 };
 
 use super::BootstrapRequest;
@@ -91,9 +91,9 @@ pub async fn provision_integration_didcomm(
 
     session
         .send_and_wait::<ProvisionIntegrationResponse>(
-            PROVISION_INTEGRATION,
+            CANONICAL_PROVISION_INTEGRATION,
             body,
-            PROVISION_INTEGRATION_RESULT,
+            CANONICAL_PROVISION_INTEGRATION_RESULT,
             DEFAULT_TIMEOUT_SECS,
         )
         .await

--- a/vta-sdk/src/provision_integration/http.rs
+++ b/vta-sdk/src/provision_integration/http.rs
@@ -59,11 +59,19 @@ fn is_false(b: &bool) -> bool {
 
 /// Producer assertion mode on the returned sealed bundle. Mirrors the
 /// server's `AssertionMode`.
+///
+/// Serialises kebab-case (`did-signed` / `pinned-only`, the 0.1 wire
+/// form). The camelCase aliases accept the `provision/integration/0.2`
+/// wire form (`didSigned` / `pinnedOnly`) on the way in. This field is
+/// outside the signed VP, so an alias is sufficient — no as-received
+/// verification needed.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum AssertionMode {
     #[default]
+    #[serde(alias = "didSigned")]
     DidSigned,
+    #[serde(alias = "pinnedOnly")]
     PinnedOnly,
 }
 

--- a/vta-sdk/src/provision_integration/request.rs
+++ b/vta-sdk/src/provision_integration/request.rs
@@ -89,6 +89,13 @@ pub enum BootstrapAsk {
     /// (plus the integration DID's keys, did.jsonl, VC, trust bundle)
     /// in a [`SealedPayloadV1::TemplateBootstrap`](crate::sealed_transfer::SealedPayloadV1)
     /// bundle.
+    ///
+    /// The `templateBootstrap` alias accepts the
+    /// `provision/integration/0.2` camelCase tag; serialisation keeps the
+    /// 0.1 `TemplateBootstrap` form. The tag is inside the signed VP, so
+    /// verification must run over the wire bytes — see
+    /// [`BootstrapRequest::verify_value`].
+    #[serde(alias = "templateBootstrap")]
     TemplateBootstrap(TemplateBootstrapAsk),
     /// Admin-DID rotation only — no integration DID minted. The VTA
     /// renders `admin_template`, mints a fresh long-term admin DID,
@@ -103,6 +110,10 @@ pub enum BootstrapAsk {
     ///
     /// [`SealedPayloadV1::AdminRotation`]:
     /// crate::sealed_transfer::SealedPayloadV1::AdminRotation
+    ///
+    /// The `adminRotation` alias accepts the `provision/integration/0.2`
+    /// camelCase tag; serialisation keeps the 0.1 `AdminRotation` form.
+    #[serde(alias = "adminRotation")]
     AdminRotation(AdminRotationAsk),
 }
 
@@ -250,25 +261,63 @@ impl BootstrapRequest {
 
     /// Verify the proof + freshness + structure, returning the typestate
     /// form that downstream handlers consume.
+    ///
+    /// Re-serialises `self` and delegates to [`verify_value`]. Use this for
+    /// Rust-internal round-trips where this crate both built and verifies
+    /// the request. **Network handlers MUST call [`verify_value`] with the
+    /// bytes exactly as received** — re-serialising the typed struct
+    /// re-imposes this crate's wire casing and would reject any holder
+    /// (e.g. a 0.2 client) whose signed casing differs.
+    ///
+    /// [`verify_value`]: Self::verify_value
     pub fn verify(self) -> Result<VerifiedBootstrapRequest, ProvisionIntegrationError> {
+        let value = serde_json::to_value(&self)
+            .map_err(|e| ProvisionIntegrationError::Parse(format!("serialize VP: {e}")))?;
+        Self::verify_value(value)
+    }
+
+    /// Verify a bootstrap VP from its JSON **exactly as received on the
+    /// wire**, returning the typestate form downstream handlers consume.
+    ///
+    /// The Data Integrity proof covers the JCS canonicalisation of the VP
+    /// with `proof` removed. Verifying against the bytes as received —
+    /// rather than re-serialising the typed [`BootstrapRequest`] — means a
+    /// holder whose wire casing differs from this crate's serde output
+    /// still verifies. Concretely, a `provision/integration/0.2` client
+    /// signs `ask.type` as camelCase (`templateBootstrap`); re-serialising
+    /// the typed enum would re-impose the 0.1 `TemplateBootstrap` casing
+    /// and break the proof. JCS preserves string *values*, so the signed
+    /// casing survives canonicalisation and the proof checks out — while
+    /// the typed view (built via the `BootstrapAsk` aliases) still drives
+    /// downstream business logic on a normalised enum.
+    pub fn verify_value(
+        value: Value,
+    ) -> Result<VerifiedBootstrapRequest, ProvisionIntegrationError> {
+        // Typed view for structural fields + downstream business logic.
+        // `deny_unknown_fields` still rejects smuggled fields; the
+        // `BootstrapAsk` aliases accept both 0.1 (`TemplateBootstrap`) and
+        // 0.2 (`templateBootstrap`) tag casings.
+        let req: BootstrapRequest = serde_json::from_value(value.clone())
+            .map_err(|e| ProvisionIntegrationError::Parse(format!("parse VP: {e}")))?;
+
         // Structure checks first (cheap, deterministic).
-        if !self.types.iter().any(|t| t == "VerifiablePresentation") {
+        if !req.types.iter().any(|t| t == "VerifiablePresentation") {
             return Err(ProvisionIntegrationError::InvalidClaim(
                 "type array must include 'VerifiablePresentation'".into(),
             ));
         }
-        if !self.types.iter().any(|t| t == "BootstrapRequest") {
+        if !req.types.iter().any(|t| t == "BootstrapRequest") {
             return Err(ProvisionIntegrationError::InvalidClaim(
                 "type array must include 'BootstrapRequest'".into(),
             ));
         }
 
         // Holder DID must be a decodable did:key (Ed25519).
-        let holder_ed_pub = did_key_helpers::did_key_to_ed25519_pub(&self.holder)
+        let holder_ed_pub = did_key_helpers::did_key_to_ed25519_pub(&req.holder)
             .map_err(|e| ProvisionIntegrationError::HolderMismatch(format!("holder: {e}")))?;
 
-        // Parse the proof out.
-        let proof: DataIntegrityProof = serde_json::from_value(self.proof.clone())
+        // Parse the proof out (typed view carries the same proof bytes).
+        let proof: DataIntegrityProof = serde_json::from_value(req.proof.clone())
             .map_err(|e| ProvisionIntegrationError::BadProof(format!("parse proof: {e}")))?;
 
         // Cryptosuite check — only JCS is accepted here. If we add RDFC
@@ -290,17 +339,16 @@ impl BootstrapRequest {
             .ok_or_else(|| {
                 ProvisionIntegrationError::HolderMismatch("verificationMethod missing '#'".into())
             })?;
-        if vm_did != self.holder {
+        if vm_did != req.holder {
             return Err(ProvisionIntegrationError::HolderMismatch(format!(
                 "verificationMethod DID '{}' does not match holder '{}'",
-                vm_did, self.holder
+                vm_did, req.holder
             )));
         }
 
-        // Verify the proof against the document with `proof` stripped —
-        // same shape that was signed.
-        let mut signing_doc = serde_json::to_value(&self)
-            .map_err(|e| ProvisionIntegrationError::Parse(format!("re-serialize VP: {e}")))?;
+        // Verify the proof against the VP as received, with `proof`
+        // stripped — the exact shape the holder signed.
+        let mut signing_doc = value;
         if let Some(obj) = signing_doc.as_object_mut() {
             obj.remove("proof");
         }
@@ -312,7 +360,7 @@ impl BootstrapRequest {
         // Freshness (±5min skew).
         let now = Utc::now();
         let skew = Duration::minutes(5);
-        let vu = self
+        let vu = req
             .valid_until
             .parse::<DateTime<Utc>>()
             .map_err(|e| ProvisionIntegrationError::Parse(format!("validUntil: {e}")))?;
@@ -322,7 +370,7 @@ impl BootstrapRequest {
             )));
         }
 
-        Ok(VerifiedBootstrapRequest { inner: self })
+        Ok(VerifiedBootstrapRequest { inner: req })
     }
 }
 
@@ -1197,6 +1245,78 @@ mod tests {
         // unrelated structural bug.
         let (vp, _) = build_valid_vp().await;
         vp.verify().expect("fixture VP verifies");
+    }
+
+    /// Build a `provision/integration/0.2`-shape VP: identical to a 0.1
+    /// VP except `ask.type` is camelCase (`templateBootstrap`), signed
+    /// over that exact wire form. A 0.2 holder (e.g. the browser plugin)
+    /// signs camelCase; this proves `verify_value` checks the proof
+    /// against the bytes as received rather than this crate's serde
+    /// re-rendering. Returns the signed VP JSON + holder DID.
+    async fn build_valid_camelcase_vp() -> (Value, String) {
+        use base64::Engine;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
+
+        let (seed, client_did) = sample_client_did(0xD2);
+        let vm_id = did_key_to_vm(&client_did).expect("vm id");
+        let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed));
+        signer.id = vm_id;
+
+        let now = Utc::now();
+        let mut doc = serde_json::json!({
+            "@context": [VC_V2_CONTEXT_URL, BOOTSTRAP_CONTEXT_URL],
+            "type": ["VerifiablePresentation", "BootstrapRequest"],
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "holder": client_did,
+            "nonce": B64URL.encode([0xD2u8; 16]),
+            "validUntil": rfc3339(now + Duration::hours(1)),
+            "label": "v0.2-camelcase-fixture",
+            // 0.2 wire form: camelCase tag, inside the signed VP.
+            "ask": {
+                "type": "templateBootstrap",
+                "template": {
+                    "name": "didcomm-mediator",
+                    "vars": { "URL": "https://mediator.example.com" }
+                }
+            }
+        });
+
+        let sign_options = SignOptions::new()
+            .with_proof_purpose("authentication")
+            .with_created(now);
+        let proof = DataIntegrityProof::sign(&doc, &signer, sign_options)
+            .await
+            .expect("sign camelCase VP");
+        doc.as_object_mut()
+            .unwrap()
+            .insert("proof".into(), serde_json::to_value(&proof).unwrap());
+        (doc, client_did)
+    }
+
+    #[tokio::test]
+    async fn verify_value_accepts_v0_2_camelcase_ask() {
+        // A 0.2 holder signs `ask.type` as camelCase. Verifying over the
+        // wire bytes (not the re-serialised typed struct) must accept it,
+        // and the typed view must normalise to the `TemplateBootstrap`
+        // variant for downstream business logic.
+        let (doc, holder) = build_valid_camelcase_vp().await;
+        let verified = BootstrapRequest::verify_value(doc).expect("0.2 camelCase VP verifies");
+        assert_eq!(verified.holder(), holder);
+        assert!(matches!(verified.ask(), BootstrapAsk::TemplateBootstrap(_)));
+    }
+
+    #[tokio::test]
+    async fn verify_value_rejects_tampered_v0_2_ask() {
+        // Mutating the camelCase ask after signing must still fail the
+        // proof — the as-received path is not a casing loophole that
+        // skips integrity.
+        let (mut doc, _) = build_valid_camelcase_vp().await;
+        doc["ask"]["template"]["name"] = Value::String("swapped-template".into());
+        let err = BootstrapRequest::verify_value(doc).unwrap_err();
+        assert!(
+            matches!(err, ProvisionIntegrationError::BadProof(_)),
+            "tampered 0.2 ask must yield BadProof, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1429,10 +1429,28 @@ pub async fn handle_provision_integration(
 ) -> HandlerResult {
     let auth = app_try!(auth_from_message(&message, &state.acl_ks).await);
 
+    // Capture the VP exactly as received, before `message.body` is moved
+    // into the typed deserialize. Verification must run over the holder's
+    // signed bytes: a `provision/integration/0.2` client signs camelCase
+    // `ask.type` *inside* the VP, and re-serialising the typed struct
+    // would re-impose 0.1 casing and reject the proof. See
+    // `BootstrapRequest::verify_value`.
+    let request_raw = message.body.get("request").cloned();
+
     let body: vta_sdk::protocols::provision_integration_management::request::ProvisionIntegrationRequest =
         serde_json::from_value(message.body).map_err(handler_err)?;
 
-    let verified = match body.request.verify() {
+    let request_raw = match request_raw {
+        Some(v) => v,
+        None => {
+            return Ok(Some(app_err_to_response(AppError::Validation(
+                "provision-integration request missing 'request' field".into(),
+            ))));
+        }
+    };
+
+    let verified = match vta_sdk::provision_integration::BootstrapRequest::verify_value(request_raw)
+    {
         Ok(v) => v,
         Err(e) => {
             return Ok(Some(app_err_to_response(AppError::Validation(format!(

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -471,19 +471,20 @@ pub fn build_handler(
     // Provision-integration — always available; vta-service depends
     // on vta-sdk with the `provision-integration` feature enabled.
     //
-    // Both the legacy FPN-private URI and the canonical Trust Task URI
-    // route to the same handler; the handler reads the inbound `typ`
-    // and emits the matching response URI (`…-result` for the legacy
-    // shape, `#response` fragment for the canonical shape). Existing
-    // clients on the FPN URI keep working unchanged; new clients can
-    // target the canonical registry without coordinating a URI flip.
+    // Both canonical Trust Task versions (0.1 and 0.2) route to the same
+    // handler; the handler reads the inbound `typ` and emits the matching
+    // `#response` URI (`result_uri_for`). The 0.2 wire form differs only
+    // in camelCase enum casing — including the signed VP's `ask.type`, so
+    // the handler verifies over the bytes as received. The legacy
+    // `firstperson.network` provision URI was retired now that the browser
+    // plugin and Rust CLIs all target the canonical registry.
     router = router
         .route(
-            provision_integration_management::PROVISION_INTEGRATION,
+            provision_integration_management::CANONICAL_PROVISION_INTEGRATION,
             handler_fn(handlers::handle_provision_integration),
         )?
         .route(
-            provision_integration_management::CANONICAL_PROVISION_INTEGRATION,
+            provision_integration_management::CANONICAL_PROVISION_INTEGRATION_0_2,
             handler_fn(handlers::handle_provision_integration),
         )?;
 


### PR DESCRIPTION
Closes #306.

## What

Adds `provision/integration/0.2` to the VTA's accept surface alongside `0.1`, and removes the legacy `firstperson.network` provision-integration URI now that its only consumers — the browser plugin (`pnm-browser-plugin`, on canonical `0.1`) and the Rust SDK client — target the canonical registry.

**Scope is provision-integration only.** The other ~12 `firstperson.network` management protocols (key/context/did/acl/seed/…) are the live DIDComm wire format for `pnm-cli`/`cnm-cli` and are deliberately left untouched.

## The interesting bit: verifying a signed VP across a casing change

`provision/integration/0.2` is camelCase, and the change reaches the VP's `ask.type` (`templateBootstrap` / `adminRotation`) — which is **inside the signed VP**. The proof signs the JCS canonicalisation of the VP, so re-casing before verification breaks the signature.

The existing verifier reconstructed its signing input by **re-serialising the typed struct** (`serde_json::to_value(&self)`), which re-imposes this crate's 0.1 PascalCase. That only ever worked because every client (including the plugin on 0.1) happened to emit Rust's serde casing.

**Root-cause fix:** verify the proof over the VP *exactly as received*.

- `BootstrapRequest::verify_value(Value)` verifies against the wire bytes; `verify(self)` delegates to it. The typed view (via new `BootstrapAsk` camelCase deserialize aliases) still drives downstream logic on a normalised enum. JCS preserves string values, so a 0.2 holder's camelCase signature verifies and **0.1 is unaffected**.
- `AssertionMode` gains camelCase aliases (`didSigned`/`pinnedOnly`) — outside the signed VP, so an alias suffices.
- The DIDComm handler verifies over the raw `request` value and selects the response URI via `result_uri_for` (`0.1 → 0.1#response`, `0.2 → 0.2#response`). REST stays 0.1 (its consumers are the Rust CLIs).
- Rust SDK DIDComm client emits canonical `0.1` (behaviour-preserving de-FPN). Router drops the FPN arm, adds the 0.2 arm.

## Acceptance (#306)

- ✅ A `provision/integration/0.2` request is handled and replies `…/0.2#response` (router 0.2 arm + `result_uri_for` + `verify_value`, unit-covered end-to-end).
- ✅ `0.1` (canonical) keeps working. The legacy FPN type is **removed** (not just deprecated) per the cleanup ask — safe because no consumer still emits it.

## Tests

New SDK coverage: a genuinely camelCase-signed (0.2-shape) VP verifies; a tampered 0.2 ask still rejects with `BadProof`; `result_uri_for` 0.1↔0.2 mapping. The full existing VP mutation/tamper suite stays green.

`cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, and vta-sdk/vta-service/e2e provision tests all pass locally.

## Not in scope

- REST `/bootstrap/provision-integration` stays 0.1-only (its callers are Rust CLIs on 0.1).
- The separate `spec/vta/provision-integration/request/1.0` trust-task-dispatcher surface is untouched.
- Browser-plugin migration to 0.2 is a follow-up on its side; this PR *enables* it.