### PR TITLE
chore(deps): bump trust-tasks-rs + trust-tasks-proof to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -764,7 +764,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3200,7 +3200,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3449,7 +3449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4601,7 +4601,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5853,7 +5853,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6711,7 +6711,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6749,7 +6749,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7374,7 +7374,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7463,7 +7463,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7484,7 +7484,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8133,7 +8133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8616,7 +8616,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9248,9 +9248,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605c6641426e48cd3c1cee374c3f15b7615999e35b79783256795d6542fff16f"
+checksum = "89cd2a27ae877b61b1727675f5bc4959d54c7a6d842aef1623214243ec424e98"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10478,7 +10478,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Lockfile-only bump of `trust-tasks-rs` and `trust-tasks-proof` `0.2.0 → 0.2.1`, within the existing `0.2` (major.minor) pin. No `Cargo.toml` / source changes.

0.2.1 (spec repo `trustoverip/dtgwg-trust-tasks-tf` #82) regenerates the framework bindings and publishes the `vta/passkey-vms/*` task-family specs at `0.1`; `trust-tasks-proof` 0.2.1 carries the affinidi-crypto 0.2 backend already in our tree.

## Verification

- `cargo check --workspace` ✓
- `cargo fmt --all -- --check` ✓
- vta-sdk / vti-common / vta-service trust-task dispatcher + parity tests ✓ (0 failures)

## Heads-up (not addressed here): passkey-vms version drift

While checking the new specs I found a cross-repo version mismatch worth a coordination decision — **not a live break**, so I did not change it:

- The VTA implements passkey-vms at **`/1.0`** (`vta-sdk::trust_tasks` + `vta-service/.../trust_tasks/passkey_vms.rs`).
- The browser plugin also emits **`/1.0`** (`pnm-browser-plugin .../vta/protocol.ts`).
- The canonical registry just published the same specs (`enroll-challenge`, `enroll-submit`, `list`, `revoke`) at **`/0.1`**.

VTA ↔ plugin agree (1.0), so nothing is broken today — but the implementations and the canonical registry now disagree on the version label. Someone needs to decide whether the registry should be republished at 1.0 to match the shipped implementations, or the VTA + plugin should migrate/dual-accept 0.1. Flagging for a follow-up issue rather than guessing.