### PR TITLE
feat(passkey-vms): /0.1 dual-accept + 0.1 error taxonomy; release vta-sdk 0.10.0 (#309, #308)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.9.11",
 ]
 
 [[package]]
@@ -2326,7 +2326,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2339,7 +2339,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.11",
+ "vta-sdk 0.10.0",
 ]
 
 [[package]]
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -3119,7 +3119,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.9.11",
+ "vta-sdk 0.10.0",
 ]
 
 [[package]]
@@ -6480,7 +6480,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6502,7 +6502,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.9.11",
+ "vta-sdk 0.10.0",
 ]
 
 [[package]]
@@ -9703,7 +9703,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9721,13 +9721,13 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.9.11",
+ "vta-sdk 0.10.0",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "vta-enclave"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9742,7 +9742,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9758,12 +9758,42 @@ dependencies = [
  "tokio",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.9.11",
+ "vta-sdk 0.10.0",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72e9ca533c5452a06b69fa4fd0e1c15d0d146c8fbe06c78b20211cf0c0ebc05"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.10.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9811,38 +9841,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "vta-sdk"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72e9ca533c5452a06b69fa4fd0e1c15d0d146c8fbe06c78b20211cf0c0ebc05"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "getrandom 0.4.2",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "vta-service"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -9920,7 +9920,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.9.11",
+ "vta-sdk 0.10.0",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9933,7 +9933,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10002,7 +10002,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.9.11",
+ "vta-sdk 0.10.0",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -10012,7 +10012,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -10045,7 +10045,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.9.11",
+ "vta-sdk 0.10.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10072,7 +10072,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.9.11",
+ "vta-sdk 0.10.0",
  "vta-service",
  "vti-common",
 ]

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["session"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.8" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/docs/05-design-notes/trust-task-uri-registry.md
+++ b/docs/05-design-notes/trust-task-uri-registry.md
@@ -610,6 +610,15 @@ Two mechanisms, split by whether the payload is signed:
   same handler; `result_uri_for` picks the matching `#response`. The legacy
   `firstperson.network` provision URI was retired here (the other
   `firstperson.network` management protocols are untouched).
+- **Version-label dual-accept** — **`vta/passkey-vms/*`** shipped at `/1.0`
+  before the registry published it; the canonical version is `/0.1` (#308/#309).
+  The payload/response shapes are byte-identical across the two — only the URI
+  version label differs — so the four dispatch arms accept `…/0.1 | …/1.0` and
+  `success_response` (`doc.respond_with`) echoes the request version into the
+  reply. No edge transform, no typed-handler copy: just both URIs in
+  `ALL_URIS` / the slice `DISPATCHED_URIS` / `KNOWN_FEATURE_GATED_URIS`.
+  Retirement plan: drop the `…/1.0` URIs once the browser plugin cuts over to
+  `…/0.1` (it currently emits `/1.0`).
 
 **Adding the next 0.2 spec:** add the `*_0_2` const + `ALL_URIS` entry in
 `vta-sdk::trust_tasks` and `#[deprecate]` the 0.1; for an edge-transform spec,

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.9", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.10", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 # `vta-enclave` is a Linux-only Nitro Enclave binary (vsock-store depends
 # on `tokio-vsock`). Publishing to crates.io would surface "fails on
@@ -27,7 +27,7 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.8", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.9", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.9", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.3.0"
+version = "0.3.1"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -57,7 +57,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["session"] }
 
 [dev-dependencies]
 # Test-only Ed25519 signing for the did-signed verify round-trip (stands in for

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.11"
+version = "0.10.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -623,33 +623,64 @@ pub const TASK_MANAGEMENT_RELOAD_SERVICES_1_0: &str =
 // URIs are declared unconditionally here so client SDKs can probe;
 // the dispatcher's `KNOWN_FEATURE_GATED_URIS` allowlist tracks them
 // for builds where the features are off.
+//
+// Versioning: the canonical registry publishes this family at `0.1`
+// (framework 0.2). The `…/1.0` URIs predate the published spec; they
+// are retained for a deprecation window so the browser plugin (still
+// on `/1.0`) keeps working. Payload/response shapes are byte-identical
+// across the two versions — only the URI version label differs — so
+// the VTA dual-accepts both and replies under whichever version the
+// request used (`success_response` echoes the request type). Prefer
+// the `…_0_1` constants in new code. Retirement plan: drop the `…_1_0`
+// URIs once the plugin has cut over to `…/0.1`.
 
-/// `spec/vta/passkey-vms/enroll-challenge/1.0` — request a fresh
-/// WebAuthn registration challenge for a DID. Payload:
+/// `spec/vta/passkey-vms/enroll-challenge/0.1` — request a fresh
+/// WebAuthn registration challenge for a DID (canonical version).
+/// Payload:
 /// [`crate::protocols::did_management::passkey_vms::EnrollPasskeyChallengeBody`].
 /// Auth: Admin role on the DID's context.
+pub const TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1: &str =
+    "https://trusttasks.org/spec/vta/passkey-vms/enroll-challenge/0.1";
+
+/// `spec/vta/passkey-vms/enroll-submit/0.1` — finalise enrolment with
+/// the browser-supplied attestation bundle (canonical version).
+/// Payload:
+/// [`crate::protocols::did_management::passkey_vms::EnrollPasskeySubmitBody`].
+pub const TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1: &str =
+    "https://trusttasks.org/spec/vta/passkey-vms/enroll-submit/0.1";
+
+/// `spec/vta/passkey-vms/list/0.1` — list every passkey VM currently
+/// published on a DID (canonical version). Payload:
+/// [`crate::protocols::did_management::passkey_vms::ListPasskeyVmsBody`].
+pub const TASK_PASSKEY_VMS_LIST_0_1: &str = "https://trusttasks.org/spec/vta/passkey-vms/list/0.1";
+
+/// `spec/vta/passkey-vms/revoke/0.1` — remove a passkey VM by fragment
+/// (canonical version). Payload:
+/// [`crate::protocols::did_management::passkey_vms::RevokePasskeyVmBody`].
+pub const TASK_PASSKEY_VMS_REVOKE_0_1: &str =
+    "https://trusttasks.org/spec/vta/passkey-vms/revoke/0.1";
+
+/// `spec/vta/passkey-vms/enroll-challenge/1.0` — pre-spec version,
+/// retained during the plugin's migration window. Prefer
+/// [`TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1`].
 pub const TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0: &str =
     "https://trusttasks.org/spec/vta/passkey-vms/enroll-challenge/1.0";
 
-/// `spec/vta/passkey-vms/enroll-submit/1.0` — finalise enrolment with
-/// the browser-supplied attestation bundle. Payload:
-/// [`crate::protocols::did_management::passkey_vms::EnrollPasskeySubmitBody`].
-/// Auth: Admin role on the DID's context. The handler appends the
-/// new VM to the DID document via a WebVH LogEntry and pushes to the
-/// configured mediator.
+/// `spec/vta/passkey-vms/enroll-submit/1.0` — pre-spec version,
+/// retained during the plugin's migration window. The handler appends
+/// the new VM to the DID document via a WebVH LogEntry and pushes to
+/// the configured mediator. Prefer
+/// [`TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1`].
 pub const TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0: &str =
     "https://trusttasks.org/spec/vta/passkey-vms/enroll-submit/1.0";
 
-/// `spec/vta/passkey-vms/list/1.0` — list every passkey VM currently
-/// published on a DID. Payload:
-/// [`crate::protocols::did_management::passkey_vms::ListPasskeyVmsBody`].
-/// Auth: Admin role on the DID's context.
+/// `spec/vta/passkey-vms/list/1.0` — pre-spec version, retained during
+/// the plugin's migration window. Prefer [`TASK_PASSKEY_VMS_LIST_0_1`].
 pub const TASK_PASSKEY_VMS_LIST_1_0: &str = "https://trusttasks.org/spec/vta/passkey-vms/list/1.0";
 
-/// `spec/vta/passkey-vms/revoke/1.0` — remove a passkey VM by fragment.
-/// Payload:
-/// [`crate::protocols::did_management::passkey_vms::RevokePasskeyVmBody`].
-/// Auth: Admin role on the DID's context.
+/// `spec/vta/passkey-vms/revoke/1.0` — pre-spec version, retained
+/// during the plugin's migration window. Prefer
+/// [`TASK_PASSKEY_VMS_REVOKE_0_1`].
 pub const TASK_PASSKEY_VMS_REVOKE_1_0: &str =
     "https://trusttasks.org/spec/vta/passkey-vms/revoke/1.0";
 
@@ -1082,7 +1113,12 @@ pub const ALL_URIS: &[&str] = &[
     TASK_CONFIG_UPDATE_1_0,
     // Management slice
     TASK_MANAGEMENT_RELOAD_SERVICES_1_0,
-    // Passkey-VMs slice (feature-gated: webvh + didcomm)
+    // Passkey-VMs slice (feature-gated: webvh + didcomm). Dual-accept
+    // canonical 0.1 + retained pre-spec 1.0.
+    TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1,
+    TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1,
+    TASK_PASSKEY_VMS_LIST_0_1,
+    TASK_PASSKEY_VMS_REVOKE_0_1,
     TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0,
     TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0,
     TASK_PASSKEY_VMS_LIST_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.8.4"
+version = "0.9.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -74,7 +74,7 @@ required-features = ["cli-synthesis"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.9", features = ["encryption", "passkey"] }
-vta-sdk = { path = "../vta-sdk", version = "0.9", features = ["didcomm", "sealed-transfer", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["didcomm", "sealed-transfer", "provision-integration"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*

--- a/vta-service/src/operations/passkey_vms/errors.rs
+++ b/vta-service/src/operations/passkey_vms/errors.rs
@@ -34,6 +34,16 @@ pub enum PasskeyVmError {
     /// associated with the ceremony.
     #[error("DID not found or not VTA-managed")]
     DidNotFound,
+    /// Caller is authenticated but lacks the admin role required to
+    /// mutate this DID's passkey VMs. Distinct from the internal-error
+    /// bucket so it renders as a 403 `permissionDenied`, not a 500.
+    #[error("admin role required")]
+    PermissionDenied(String),
+    /// Revoke target fragment is not present on the DID document. The
+    /// spec distinguishes this from `didNotFound` so a client can tell
+    /// "wrong DID" from "already gone".
+    #[error("passkey verification-method fragment not found")]
+    FragmentNotFound,
     /// Two passkeys with the same WebAuthn credential id can't share
     /// the same DID — fragment collision.
     #[error("passkey already enrolled on this DID")]
@@ -71,6 +81,10 @@ impl From<PasskeyVmError> for AppError {
             }
             PasskeyVmError::Multikey(e) => AppError::Validation(format!("multikey: {e}")),
             PasskeyVmError::DidNotFound => AppError::NotFound("DID not managed by this VTA".into()),
+            PasskeyVmError::PermissionDenied(msg) => AppError::Forbidden(msg),
+            PasskeyVmError::FragmentNotFound => {
+                AppError::NotFound("passkey verification-method fragment not found".into())
+            }
             PasskeyVmError::AlreadyEnrolled => {
                 AppError::Conflict("passkey already enrolled".into())
             }

--- a/vta-service/src/operations/passkey_vms/mod.rs
+++ b/vta-service/src/operations/passkey_vms/mod.rs
@@ -182,7 +182,7 @@ pub async fn start_enrollment(
         .map_err(|e| PasskeyVmError::Persistence(format!("get_did: {e}")))?
         .ok_or(PasskeyVmError::DidNotFound)?;
     auth.require_admin()
-        .map_err(|e| PasskeyVmError::Internal(format!("admin required: {e}")))?;
+        .map_err(|e| PasskeyVmError::PermissionDenied(format!("admin required: {e}")))?;
     auth.require_context(&record.context_id)
         .map_err(|_| PasskeyVmError::DidNotFound)?;
 
@@ -257,7 +257,7 @@ pub async fn finish_enrollment(
         .map_err(|e| PasskeyVmError::Persistence(format!("get_did: {e}")))?
         .ok_or(PasskeyVmError::DidNotFound)?;
     auth.require_admin()
-        .map_err(|e| PasskeyVmError::Internal(format!("admin required: {e}")))?;
+        .map_err(|e| PasskeyVmError::PermissionDenied(format!("admin required: {e}")))?;
     auth.require_context(&record.context_id)
         .map_err(|_| PasskeyVmError::DidNotFound)?;
 
@@ -455,7 +455,7 @@ pub async fn revoke_passkey(
         .map_err(|e| PasskeyVmError::Persistence(format!("get_did: {e}")))?
         .ok_or(PasskeyVmError::DidNotFound)?;
     auth.require_admin()
-        .map_err(|e| PasskeyVmError::Internal(format!("admin required: {e}")))?;
+        .map_err(|e| PasskeyVmError::PermissionDenied(format!("admin required: {e}")))?;
     auth.require_context(&record.context_id)
         .map_err(|_| PasskeyVmError::DidNotFound)?;
 
@@ -577,7 +577,9 @@ fn remove_vm_from_document(current: &Value, vm_id: &str) -> Result<Value, Passke
         }
     }
     if !removed {
-        return Err(PasskeyVmError::DidNotFound);
+        // The fragment isn't on the document — distinct from "DID not
+        // found" so revoke can emit `revoke:fragmentNotFound` (#308).
+        return Err(PasskeyVmError::FragmentNotFound);
     }
     for field in ["authentication", "assertionMethod", "keyAgreement"] {
         if let Some(arr) = obj.get_mut(field).and_then(|v| v.as_array_mut()) {
@@ -702,5 +704,25 @@ mod tests {
         let auths = new["authentication"].as_array().unwrap();
         assert_eq!(auths.len(), 1);
         assert_eq!(auths[0], "did:webvh:example.com:abc#key-0");
+    }
+
+    #[test]
+    fn remove_vm_absent_fragment_is_fragment_not_found() {
+        // Revoking a fragment that isn't on the document must surface as
+        // FragmentNotFound (→ `revoke:fragmentNotFound`), not DidNotFound.
+        let doc = serde_json::json!({
+            "verificationMethod": [{
+                "id": "did:webvh:example.com:abc#key-0",
+                "type": "Multikey",
+                "controller": "did:webvh:example.com:abc",
+                "publicKeyMultibase": "zK"
+            }]
+        });
+        let err =
+            remove_vm_from_document(&doc, "did:webvh:example.com:abc#passkey-missing").unwrap_err();
+        assert!(
+            matches!(err, PasskeyVmError::FragmentNotFound),
+            "expected FragmentNotFound, got {err:?}"
+        );
     }
 }

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -127,6 +127,10 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     // slice module's `DISPATCHED_URIS` lists the same URIs and is
     // aggregated by the parity harness when both features are on; this
     // allowlist covers builds where either feature is off.
+    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1,
+    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1,
+    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
+    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_1_0,
@@ -513,20 +517,28 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
             did_templates::handle_context_render(state, auth, doc).await
         }
         // ─── Passkey-VMs slice (feature-gated: webvh + didcomm) ─────
+        //
+        // Dual-accept canonical 0.1 + pre-spec 1.0 — identical payloads,
+        // so both versions share a handler and `success_response` echoes
+        // the request version into the reply (0.1 -> …/0.1#response).
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
-        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0 => {
+        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1
+        | vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0 => {
             passkey_vms::handle_enroll_challenge(state, auth, doc).await
         }
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
-        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0 => {
+        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1
+        | vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0 => {
             passkey_vms::handle_enroll_submit(state, auth, doc).await
         }
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
-        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_1_0 => {
+        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1
+        | vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_1_0 => {
             passkey_vms::handle_list(state, auth, doc).await
         }
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
-        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_1_0 => {
+        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1
+        | vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_1_0 => {
             passkey_vms::handle_revoke(state, auth, doc).await
         }
         // ─── Provision-integration (feature-gated: webvh) ────────────
@@ -711,6 +723,42 @@ mod tests {
                  (b) add it to `REST_ROUTED` if it lives on a dedicated REST route, \
                  (c) add it to `KNOWN_FEATURE_GATED_URIS` with a comment explaining the gating, or \
                  (d) register it in `wire_v0_2::WIRE_V0_2_URIS` if it's an edge-transformed 0.2 URI"
+            );
+        }
+    }
+
+    /// Passkey-VMs dual-accept (#309): the canonical `…/0.1` URIs and
+    /// the retained pre-spec `…/1.0` URIs are both tracked by the
+    /// dispatcher, so a client on either version routes to the same
+    /// handler. `success_response` echoes the request type, so a 0.1
+    /// request replies `…/0.1#response`.
+    #[test]
+    fn passkey_vms_dual_accepts_0_1_and_1_0() {
+        let dispatched = aggregate_dispatched_uris();
+        let tracked = |u: &&str| dispatched.contains(u) || KNOWN_FEATURE_GATED_URIS.contains(u);
+        for (v0_1, v1_0) in [
+            (
+                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1,
+                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0,
+            ),
+            (
+                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1,
+                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0,
+            ),
+            (
+                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
+                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_1_0,
+            ),
+            (
+                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1,
+                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_1_0,
+            ),
+        ] {
+            assert!(tracked(&v0_1), "canonical 0.1 URI not dispatched: {v0_1}");
+            assert!(tracked(&v1_0), "retained 1.0 URI not dispatched: {v1_0}");
+            assert!(
+                v0_1.ends_with("/0.1") && v1_0.ends_with("/1.0"),
+                "version-label mismatch for {v0_1} / {v1_0}"
             );
         }
     }

--- a/vta-service/src/routes/trust_tasks/passkey_vms.rs
+++ b/vta-service/src/routes/trust_tasks/passkey_vms.rs
@@ -19,7 +19,7 @@
 
 use axum::response::Response;
 use serde_json::Value;
-use trust_tasks_rs::TrustTask;
+use trust_tasks_rs::{ErrorPayload, StandardCode, TrustTask, TrustTaskCode};
 use vta_sdk::protocols::did_management::passkey_vms::{
     EnrollPasskeyChallengeBody, EnrollPasskeySubmitBody, ListPasskeyVmsBody, RevokePasskeyVmBody,
     RevokePasskeyVmResponse,
@@ -28,9 +28,78 @@ use vta_sdk::protocols::did_management::passkey_vms::{
 use crate::auth::AuthClaims;
 use crate::error::AppError;
 use crate::operations;
+use crate::operations::passkey_vms::PasskeyVmError;
 use crate::server::AppState;
 
-use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
+use super::helpers::{
+    TRANSPORT_TRUST_TASK, app_error_to_reject, error_response, parse_payload, success_response,
+};
+
+// ── Error mapping (#308) ────────────────────────────────────────────
+//
+// Map `PasskeyVmError` onto the published 0.1 error taxonomy: framework
+// **standard** codes for auth / availability / internal failures, and
+// **extended** `<task-slug>:<local>` codes (camelCase, framework 0.2)
+// for the task-specific failures — with `details.reason` on the
+// `invalidAttestation` family. The slug is sourced from the incoming
+// document's type URI, so the same variant (e.g. DidNotFound) is
+// namespaced to whichever task raised it, and 0.1/1.0 share one mapping.
+
+/// Pure error→code mapping (tested in isolation). Returns the trust-task
+/// code plus an optional `details.reason` value.
+fn passkey_vm_code(slug: &str, err: &PasskeyVmError) -> (TrustTaskCode, Option<&'static str>) {
+    let ext = |local: &str| {
+        TrustTaskCode::new_extended(slug, local)
+            .expect("passkey-vms extended code is grammar-valid")
+    };
+    match err {
+        // Standard framework codes.
+        PasskeyVmError::PermissionDenied(_) => (StandardCode::PermissionDenied.into(), None),
+        PasskeyVmError::NotAvailable(_) => (StandardCode::Unavailable.into(), None),
+        PasskeyVmError::Persistence(_)
+        | PasskeyVmError::Internal(_)
+        | PasskeyVmError::Update(_) => (StandardCode::InternalError.into(), None),
+        // Extended, task-namespaced codes.
+        PasskeyVmError::UnknownCeremony => (ext("unknownCeremony"), None),
+        PasskeyVmError::CeremonyDidMismatch => (ext("ceremonyDidMismatch"), None),
+        PasskeyVmError::InvalidAttestation(_) => (ext("invalidAttestation"), Some("unparseable")),
+        PasskeyVmError::WebauthnFinishFailed(_) => (
+            ext("invalidAttestation"),
+            Some("webauthnVerificationFailed"),
+        ),
+        PasskeyVmError::Multikey(_) => (ext("invalidAttestation"), Some("unsupportedAlgorithm")),
+        PasskeyVmError::PublicKeyMismatch => (ext("publicKeyMismatch"), None),
+        PasskeyVmError::AlreadyEnrolled | PasskeyVmError::FragmentCollision(_) => {
+            (ext("alreadyEnrolled"), None)
+        }
+        PasskeyVmError::DidNotFound => (ext("didNotFound"), None),
+        PasskeyVmError::FragmentNotFound => (ext("fragmentNotFound"), None),
+    }
+}
+
+/// Task slug (`vta/passkey-vms/<op>`) from the incoming document's type
+/// URI, for namespacing extended codes. Falls back to the family slug
+/// if the shape is unexpected (the document arrived via dispatch, so a
+/// known URI is the norm).
+fn slug_from_doc(doc: &TrustTask<Value>) -> String {
+    let uri = doc.type_uri.to_string();
+    uri.strip_prefix("https://trusttasks.org/spec/")
+        .and_then(|rest| rest.rsplit_once('/'))
+        .map(|(slug, _ver)| slug.to_string())
+        .unwrap_or_else(|| "vta/passkey-vms".to_string())
+}
+
+/// Render a `PasskeyVmError` as a spec-taxonomy trust-task error response,
+/// namespaced to the task that raised it.
+fn passkey_vm_reject(doc: &TrustTask<Value>, err: PasskeyVmError) -> Response {
+    let slug = slug_from_doc(doc);
+    let (code, reason) = passkey_vm_code(&slug, &err);
+    let mut payload = ErrorPayload::new(code).with_message(err.to_string());
+    if let Some(r) = reason {
+        payload = payload.with_details(serde_json::json!({ "reason": r }));
+    }
+    error_response(doc.reject_with(format!("urn:uuid:{}", uuid::Uuid::new_v4()), payload))
+}
 
 /// URIs handled by this slice. Aggregated by the dispatcher's parity
 /// harness — see the feature-gating convention in
@@ -72,7 +141,7 @@ pub(super) async fn handle_enroll_challenge(
     .await
     {
         Ok(body) => success_response(&doc, body),
-        Err(e) => app_error_to_reject(&doc, AppError::from(e)),
+        Err(e) => passkey_vm_reject(&doc, e),
     }
 }
 
@@ -120,7 +189,7 @@ pub(super) async fn handle_enroll_submit(
     .await
     {
         Ok(body) => success_response(&doc, body),
-        Err(e) => app_error_to_reject(&doc, AppError::from(e)),
+        Err(e) => passkey_vm_reject(&doc, e),
     }
 }
 
@@ -137,7 +206,7 @@ pub(super) async fn handle_list(
     };
     match operations::passkey_vms::list_passkeys(&state.webvh_ks, auth, &req.did).await {
         Ok(body) => success_response(&doc, body),
-        Err(e) => app_error_to_reject(&doc, AppError::from(e)),
+        Err(e) => passkey_vm_reject(&doc, e),
     }
 }
 
@@ -182,6 +251,105 @@ pub(super) async fn handle_revoke(
     .await
     {
         Ok(()) => success_response(&doc, RevokePasskeyVmResponse::default()),
-        Err(e) => app_error_to_reject(&doc, AppError::from(e)),
+        Err(e) => passkey_vm_reject(&doc, e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trust_tasks_rs::TypeUri;
+
+    #[test]
+    fn standard_codes_map_to_framework_codes() {
+        let s = "vta/passkey-vms/enroll-submit";
+        assert!(matches!(
+            passkey_vm_code(s, &PasskeyVmError::PermissionDenied("x".into())).0,
+            TrustTaskCode::Standard(StandardCode::PermissionDenied)
+        ));
+        assert!(matches!(
+            passkey_vm_code(s, &PasskeyVmError::NotAvailable("x".into())).0,
+            TrustTaskCode::Standard(StandardCode::Unavailable)
+        ));
+        assert!(matches!(
+            passkey_vm_code(s, &PasskeyVmError::Internal("x".into())).0,
+            TrustTaskCode::Standard(StandardCode::InternalError)
+        ));
+    }
+
+    #[test]
+    fn extended_codes_are_task_namespaced() {
+        let submit = "vta/passkey-vms/enroll-submit";
+        assert_eq!(
+            passkey_vm_code(submit, &PasskeyVmError::UnknownCeremony)
+                .0
+                .to_string(),
+            "vta/passkey-vms/enroll-submit:unknownCeremony"
+        );
+        assert_eq!(
+            passkey_vm_code(submit, &PasskeyVmError::CeremonyDidMismatch)
+                .0
+                .to_string(),
+            "vta/passkey-vms/enroll-submit:ceremonyDidMismatch"
+        );
+        assert_eq!(
+            passkey_vm_code(submit, &PasskeyVmError::PublicKeyMismatch)
+                .0
+                .to_string(),
+            "vta/passkey-vms/enroll-submit:publicKeyMismatch"
+        );
+        assert_eq!(
+            passkey_vm_code(submit, &PasskeyVmError::AlreadyEnrolled)
+                .0
+                .to_string(),
+            "vta/passkey-vms/enroll-submit:alreadyEnrolled"
+        );
+        // DidNotFound takes the emitting task's slug.
+        assert_eq!(
+            passkey_vm_code("vta/passkey-vms/list", &PasskeyVmError::DidNotFound)
+                .0
+                .to_string(),
+            "vta/passkey-vms/list:didNotFound"
+        );
+        // fragmentNotFound is revoke-only and distinct from didNotFound.
+        assert_eq!(
+            passkey_vm_code("vta/passkey-vms/revoke", &PasskeyVmError::FragmentNotFound)
+                .0
+                .to_string(),
+            "vta/passkey-vms/revoke:fragmentNotFound"
+        );
+    }
+
+    #[test]
+    fn invalid_attestation_family_carries_details_reason() {
+        let s = "vta/passkey-vms/enroll-submit";
+        let (code, reason) = passkey_vm_code(s, &PasskeyVmError::InvalidAttestation("x".into()));
+        assert_eq!(
+            code.to_string(),
+            "vta/passkey-vms/enroll-submit:invalidAttestation"
+        );
+        assert_eq!(reason, Some("unparseable"));
+        assert_eq!(
+            passkey_vm_code(s, &PasskeyVmError::WebauthnFinishFailed("x".into())).1,
+            Some("webauthnVerificationFailed")
+        );
+    }
+
+    #[test]
+    fn slug_is_derived_from_type_uri_for_both_versions() {
+        for (uri, want) in [
+            (
+                "https://trusttasks.org/spec/vta/passkey-vms/revoke/0.1",
+                "vta/passkey-vms/revoke",
+            ),
+            (
+                "https://trusttasks.org/spec/vta/passkey-vms/enroll-submit/1.0",
+                "vta/passkey-vms/enroll-submit",
+            ),
+        ] {
+            let type_uri: TypeUri = uri.parse().unwrap();
+            let doc = TrustTask::new("urn:uuid:1", type_uri, serde_json::json!({}));
+            assert_eq!(slug_from_doc(&doc), want);
+        }
     }
 }

--- a/vta-service/src/routes/trust_tasks/passkey_vms.rs
+++ b/vta-service/src/routes/trust_tasks/passkey_vms.rs
@@ -37,6 +37,12 @@ use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, s
 /// `docs/05-design-notes/trust-task-feature-gating.md`.
 #[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
 pub(super) const DISPATCHED_URIS: &[&str] = &[
+    // Canonical 0.1 + retained pre-spec 1.0 (dual-accept; identical
+    // payloads, reply echoes the request version).
+    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1,
+    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1,
+    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
+    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_1_0,

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -68,7 +68,7 @@ vti-common = { path = "../vti-common", version = "0.9", features = [
   # the wizard calls into.
   "setup",
 ] }
-vta-sdk = { path = "../vta-sdk", version = "0.9", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.10", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -43,7 +43,7 @@ setup = ["dep:dialoguer"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.9", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.10", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }


### PR DESCRIPTION
Closes #309. Closes #308.

Three related pieces of the `vta/passkey-vms/*` registry alignment, plus the version bump needed to publish the result. They touch the same handlers / crate, so they ship together.

## Part 1 — adopt canonical `/0.1`, dual-accept alongside `/1.0` (#309)

`vta/passkey-vms/*` shipped at `/1.0` before the registry published it; the canonical version is `/0.1` (`dtgwg-trust-tasks-tf` #81; bindings in `trust-tasks-rs` 0.2.1, adopted in #311). The VTA now **dual-accepts both**.

Payloads/responses are **byte-identical** across versions — the Rust wire types already serde-rename to the published 0.1 lowerCamelCase names and `RevokePasskeyVmResponse` is `{}` — so only the URI version label differs. The simplest dual-accept shape: declarative, no edge transform.

- `TASK_PASSKEY_VMS_*_0_1` constants + `ALL_URIS`; `_1_0` retained for the plugin's migration window (documented retirement plan).
- Each dispatch arm matches `…/0.1 | …/1.0`; `success_response` (`doc.respond_with`) echoes the request type, so a `0.1` request replies `…/0.1#response`. 0.1 URIs added to `DISPATCHED_URIS` + `KNOWN_FEATURE_GATED_URIS` (parity harness).

## Part 2 — map errors to the 0.1 spec taxonomy (#308)

Trust-task error responses now use the published spec's codes instead of generic framework codes:

- **New `PasskeyVmError::PermissionDenied`** — admin-check failures previously collapsed into `Internal` and rendered as **500 `internalError`**. They now map to the standard **`permissionDenied` (403)**. A real bug fix, not just relabelling.
- **New `PasskeyVmError::FragmentNotFound`** — revoking a fragment not on the document was reported as `didNotFound`; the spec distinguishes them, so revoke now emits **`vta/passkey-vms/revoke:fragmentNotFound`**.
- **`passkey_vm_code`/`passkey_vm_reject`** — standard codes for permission/availability/internal, and extended `vta/passkey-vms/<op>:<local>` codes (camelCase) for task-specific failures. The slug is derived from the request type URI, so the same variant is namespaced to the emitting task and 0.1/1.0 share one mapping. The `invalidAttestation` family carries `details.reason` ∈ {`unparseable`, `webauthnVerificationFailed`, `unsupportedAlgorithm`}.
- #308 items 2 (field naming) & 4 (revoke `{}` body) needed no change — verified against the published 0.1 schemas.

Mapping (per #308's table):

| `PasskeyVmError` | code |
|---|---|
| admin check fails (`PermissionDenied`) | `permissionDenied` (403) |
| `NotAvailable` | `unavailable` (503) |
| `UnknownCeremony` / `CeremonyDidMismatch` / `PublicKeyMismatch` | `…/enroll-submit:<local>` |
| `InvalidAttestation`/`WebauthnFinishFailed`/`Multikey` | `…/enroll-submit:invalidAttestation` + `details.reason` |
| `AlreadyEnrolled` / `FragmentCollision` | `…/enroll-submit:alreadyEnrolled` |
| `DidNotFound` | `…/<task>:didNotFound` |
| absent fragment (`FragmentNotFound`) | `…/revoke:fragmentNotFound` |
| `Persistence`/`Internal`/`Update` | `internalError` (500) |

## Part 3 — release bump so `vta-sdk` can be published

`vta-sdk` was still `0.9.11` — identical to crates.io — so it couldn't be published, and #310's removal of the FPN provision consts (`PROTOCOL_BASE`, `PROVISION_INTEGRATION`, `PROVISION_INTEGRATION_RESULT`) made it a **breaking** change. Bumped semver-correctly with the required pin cascade:

- `vta-sdk` **0.9.11 → 0.10.0** (breaking removal + additive 0.2 provision / `verify_value` / passkey-vms 0.1 surface).
- `vta-service` **0.8.4 → 0.9.0** (adds public `PasskeyVmError` variants + consumes the breaking vta-sdk) → `vta-enclave`'s `vta-service` pin `0.8`→`0.9`.
- Every internal `vta-sdk = "0.9"` pin → `"0.10"` (vti-common, vta-cli-common, vta-service, vtc-service, pnm-cli, cnm-cli, vta-mobile-core, didcomm-test).
- Patch bumps for the pin-only dependents (vti-common 0.9.1, vta-cli-common 0.8.2, vtc-service 0.8.1, pnm-cli 0.8.1, cnm-cli 0.8.1, vta-enclave 0.7.1, vta-mobile-core 0.3.1, didcomm-test 0.6.1); their major.minor consumer pins still resolve, so no further churn.

`cargo update -w` + `cargo check --workspace` clean. The duplicate `vta-sdk 0.9.11` left in `Cargo.lock` is an external edge (`affinidi-messaging-mediator` → published vta-sdk, e2e dev-deps only) and is unaffected.

## Tests

- Dual-accept routing (both versions, 0.1 → `#response` at 0.1), with and without `webvh,didcomm`.
- Error mapping: standard codes, extended task-namespacing, `details.reason`, slug derivation for both versions, absent-fragment → `FragmentNotFound`.
- Full `vta-service` suite (`webvh,didcomm`) green; `fmt` + `clippy --workspace -- -D warnings` (default **and** `webvh,didcomm`) clean.

## Follow-ups (separate repos / out of scope)

- Browser plugin `/1.0 → /0.1` cutover (`OpenVTC/vta-browser-plugin`, ~4-line change) — dual-accept means no lockstep deploy needed.
- After merge, `vta-sdk` is publishable: `cargo publish -p vta-sdk`.