### PR TITLE
feat(mobile-core): adopt the push gateway model (push/register + device/set-wake)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9742,7 +9742,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/docs/05-design-notes/mobile-agent-architecture.md
+++ b/docs/05-design-notes/mobile-agent-architecture.md
@@ -4,14 +4,23 @@
 **PNM** apps) to another language/runtime — e.g. **Dart/Flutter**, Kotlin
 Multiplatform, React Native, or a fully-native rewrite.
 
-**Status:** descriptive snapshot of `vta-mobile-core` v0.3.0 (the shared engine)
+**Status:** descriptive snapshot of `vta-mobile-core` v0.3.1 (the shared engine)
 and the design decisions behind it, as of 2026-06. The engine is built
 incrementally; "Build-out slices" below maps what exists today. This doc is the
 **contract + standards** a second implementation must honour to be wire- and
 custody-compatible. It is not a line-by-line transliteration guide.
 
+> **Two wire-form notes for this revision.** (1) **Push** has moved to the
+> *gateway / trigger / device* model — a separate push gateway, the `push/*`
+> Trust-Task control plane, and Web Push via VAPID (§4.8). The engine's
+> `push.rs` still builds the older mediator `set-device-info` messages (§3.9);
+> bringing it onto the gateway model is a tracked follow-up (§10), so a **new
+> client should target the gateway model directly**. (2) The Trust-Tasks
+> **framework is at 0.2** — lowerCamelCase field names; 0.1 and 0.2 wire forms
+> coexist and the VTA dual-accepts (§4.2).
+
 > Nothing here is platform-secret. Every wire format is a published standard
-> (Trust Tasks, DIDComm v2, W3C Data Integrity, WebAuthn, Aries push). The value
+> (Trust Tasks, DIDComm v2, W3C Data Integrity, WebAuthn, Web Push/VAPID). The value
 > of this document is that it tells you *exactly which* standards, *which*
 > parameters, and *which* invariants, so you don't have to reverse-engineer them.
 
@@ -245,7 +254,15 @@ approver uses it to pull VTA-pushed step-up requests off its mediator.
 | `receive_next` | `async (timeout_secs) -> Option<String /*unpacked message JSON*/>` | Wait up to `timeout_secs` for the next inbound message (the application Trust Task rides in `body`); `None` on timeout. Poll again to continue. |
 | `shutdown` | `async ()` | Close the live-delivery WebSocket. |
 
-### 3.9 Push registration (`push`)
+### 3.9 Push registration (`push`) — ⚠ superseded mechanism, see §4.8
+
+> **The engine's current push surface predates the gateway model.** It builds
+> the older Aries `set-device-info` / `delete-device-info` DIDComm messages the
+> agent sends to its **mediator**, and returns `Unimplemented` for Web Push. The
+> deployed architecture is now the *gateway / trigger / device* model with the
+> `push/*` Trust-Task control plane (§4.8); a new client should implement
+> **that**, not these calls. Bringing the engine onto the gateway model is a
+> tracked follow-up (§10). Documented here for completeness.
 
 Builds the DIDComm message **core** (`{type, body}`) the agent sends to its
 **mediator** to register/clear its push channel. Native adds envelope headers
@@ -327,6 +344,17 @@ https://trusttasks.org/spec/{namespace}/{op-path}/{major}.{minor}
   separate identifiers; the router does **no** version-family matching.
 - A `#response` document echoes the request: type gets a `#response` suffix,
   issuer/recipient swap, `threadId` = request id.
+
+**Framework version (0.1 vs 0.2).** The Trust-Tasks framework is at **0.2**. The
+wire change that matters to a client: payload field names are **lowerCamelCase**
+(e.g. `sessionId`, `issuedAt`, and enum *values* like `oauthTokens`), and **0.1
+and 0.2 documents coexist** — the VTA *dual-accepts* both (an edge transform
+normalises enum case for bearer-authed ops; signed-payload ops carry typed
+0.1/0.2 handlers). Emit **0.2** for new clients; the type-URI minor version
+(`/0.2`) selects it. Not every op is at 0.2 yet (e.g. parts of the `auth/*` set
+the Authenticator uses are still `0.1`) — check the spec/registry per op rather
+than assuming a uniform version. Tooling: `trust-tasks-rs` **0.2.1**,
+`@openvtc/trust-tasks` **0.2.1**.
 
 The full VTA URI catalogue (~79 ops: auth, keys, seeds, contexts, acl, audit,
 attestation, services, webvh, did-templates, backup, …) is in
@@ -478,23 +506,78 @@ Pinned details:
   `signature`, `credential_id`, optional `userHandle`).
 - Native APIs: **`ASAuthorization`** (iOS) / **Credential Manager** (Android).
   Flutter: `webauthn`/passkey plugins or platform channels to those APIs.
-- Passkeys are also enrollable as DID verification methods
-  (`spec/vta/passkey-vms/*`) — a PNM concern, see the URI registry.
+- Passkeys are also enrollable as DID verification methods via the
+  **`vta/passkey-vms/*`** Trust-Task family (`enroll-challenge`, `enroll-submit`,
+  `list`, `revoke`; published `0.1`) — a PNM concern, see the URI registry. The
+  VTA carries `/0.1` alongside legacy `/1.0` consts during the client-migration
+  window, with a spec-compliant error taxonomy (`permissionDenied`,
+  `fragmentNotFound`, `invalidAttestation` + `details.reason`).
 
-### 4.8 Push wake-up (APNs / FCM)
+### 4.8 Push wake-up — the gateway / trigger / device model
 
-- Binding: `https://trusttasks.org/binding/push/0.1`, adopting **Aries RFC 0699
-  (APNs)** and **RFC 0734 (FCM)** as DIDComm v2 messages.
-- Protocols: `https://didcomm.org/push-notifications-apns/1.0` and
-  `…-fcm/1.0`, verbs `set-device-info` / `delete-device-info`.
-- APNs body: `{ device_token, service: "apns"|"apns_sandbox", topic }`.
-  FCM body: `{ device_token, service: "fcm" }`.
-- **The push itself is contentless** — it only wakes the app. The app then opens
-  its `MediatorSession` and pulls the actual (encrypted) Trust Task via message
-  pickup. Push never carries Trust-Task content. Honour this — it's a privacy
-  and security property, not an optimisation.
-- Web Push (RFC 8030) is **not** done via DIDComm `set-device-info`
-  (`Unimplemented`).
+Binding: `https://trusttasks.org/binding/push/0.1`. A backgrounded app can't
+hold a mediator WebSocket open across OS suspension, so something must wake it.
+The wake is a **contentless doorbell**; the real (encrypted) Trust Task is still
+pulled from the mediator over DIDComm pickup once awake. **Push never carries
+Trust-Task content** — honour this; it's a privacy/security property, not an
+optimisation (the payload transits Apple/Google/a Web Push service and may be
+logged or shown on a lock screen).
+
+**Three roles** (keeping them distinct is the whole design):
+
+| Role | Holds | Does |
+|---|---|---|
+| **Push gateway** | the *app's* platform push credentials (APNs auth key, FCM service account, Web Push VAPID key) + a `handle → token` map | the only party that can deliver a push for this app. Issues an **opaque `WakeHandle`** for a registered token, enforces a VTA-provisioned allowlist, relays the contentless push. Operated by the **app publisher** (the Matrix-Sygnal topology). A separate service: `vti-push-gateway`, reachable over DIDComm (preferred) or HTTPS. |
+| **Trigger** | a `WakeHandle` (opaque handle + gateway address) | decides *when* to wake. Either the device's **mediator** (queue-driven — it alone knows the device is offline with messages waiting) or its **VTA** (policy-driven — e.g. a step-up it's delegating to this device). A device MAY authorize both. |
+| **Device** | its platform push token | registers the token with the gateway, gets a handle, conveys that handle (never the token) to its VTA. |
+
+Why a gateway and not the mediator: APNs/FCM credentials are bound to the
+**app**, not to any server operator — only the app publisher can push to the
+app. A generic shared mediator doesn't hold those keys. So the gateway is a
+necessary third service; the only open question is *who may ask it to wake a
+device*, answered by a per-device, **VTA-owned allowlist**.
+
+**Control plane = the `push/*` Trust-Task family** (addressed to the gateway,
+over DIDComm authcrypt — preferred, the sender is authenticated intrinsically —
+or HTTPS with a did-signed body):
+
+| Trust Task | Parties | Purpose |
+|---|---|---|
+| `push/register` (`0.1`/`0.2`) | device → gateway | register a push token (APNs/FCM/Web Push); returns `{ wakeHandle: { gateway, handle } }`. **Unauthenticated** — the handle is opaque and useless until provisioned. |
+| `push/provision` (`0.1`) | controller VTA → gateway | set the handle's trigger allowlist: `{ handle, policy: { allowedTriggers: [did, …] } }`. |
+| `push/wake` (`0.1`) | trigger → gateway | request a contentless wake: `{ handle, v: 1, mediator, urgency }`. The gateway checks the allowlist, resolves handle → token, pushes. |
+
+The device conveys its handle to the VTA with the **`device/set-wake`**
+(`0.1`/`0.2`) Trust Task — `{ wakeHandle?, pushPlatform?, suggestedTriggers? }`
+→ `{ pushCapable, triggerPolicy? }`, proof-REQUIRED. The VTA owns the allowlist
+and provisions the gateway on the device's behalf; omitting `wakeHandle` clears
+the channel (device becomes non-wakeable).
+
+**Contentless wake payload** (gateway → device) carries *only* `{ v: 1,
+mediator, count?, urgency? }` — never a handle, never task content. Treat every
+field as an untrusted hint; the authoritative message set comes from
+authenticated mediator pickup.
+
+**End-to-end:** device `push/register` → gateway → handle → `device/set-wake`
+→ VTA → `push/provision` → gateway. Later, a trigger (the VTA on a step-up, or
+the mediator on a queued message) → `push/wake` → gateway → contentless push →
+device wakes → opens `MediatorSession` → drains the real `approve-request` →
+returns `approve-response` (§4.6).
+
+**Per-platform delivery:**
+- **APNs / FCM** — the gateway holds the app's Apple/Google credentials and
+  delivers natively (token shapes mirror the `PushRegistration` schema).
+- **Web Push (RFC 8030/8291 + RFC 8292 VAPID)** — self-hostable, no
+  Apple/Google account; the gateway signs with its own VAPID keypair (**ES256 /
+  p256**, not RSA — consistent with the workspace's no-`rsa` policy). This is
+  what the browser-plugin PNM already runs against `vti-push-gateway`. *(Web
+  Push was previously declared out-of-band / unimplemented; under the gateway
+  model it is a first-class platform.)*
+
+> **Engine status:** `vta-mobile-core` v0.3.1 does **not** yet speak the `push/*`
+> family — its `push.rs` still builds the older mediator `set-device-info` path
+> (§3.9). Implement the gateway model above (it's the one the gateway + browser
+> plugin run); the engine catch-up is tracked in §10.
 
 ---
 
@@ -604,8 +687,10 @@ engine was built:
    slice; strongly prefer reusing the Rust core here.
 9. **Mediator session.** Challenge-auth + message-pickup 3.0 over WebSocket; the
    `receive_next` poll loop.
-10. **Push.** `set-device-info`/`delete-device-info` message cores; native APNs/FCM
-    receipt → open mediator session → pull the real (encrypted) Trust Task.
+10. **Push (gateway model, §4.8).** `push/register` to the gateway → handle;
+    `device/set-wake` to convey it to the VTA; native APNs/FCM/Web-Push receipt
+    → open mediator session → pull the real (encrypted) Trust Task. (The engine's
+    legacy `set-device-info` path is superseded — don't port it.)
 
 ---
 
@@ -626,8 +711,12 @@ engine was built:
 - Auth `IS_PROOF_REQUIRED` matrix: challenge=no, authenticate=yes, refresh=no,
   whoami=yes, revoke=yes.
 - Refresh **preserves AAL**; `aal2` access tokens get the shorter TTL.
-- Push wake-ups are **contentless**; Trust-Task content only ever travels
-  encrypted via mediator pickup.
+- Push wake-ups are **contentless** (`{ v, mediator, count?, urgency? }` only);
+  Trust-Task content only ever travels encrypted via mediator pickup. The raw
+  push token never leaves the gateway — triggers and the VTA hold only the
+  opaque `WakeHandle`. Possession of a handle is **not** authority to wake; the
+  VTA-owned allowlist, enforced by the gateway on every `push/wake`, is the
+  control.
 - DIDComm is the **preferred** transport for every inter-component flow; REST is
   the fallback for parties that can't speak it (and `auth/*` supports both).
 - Sealed-transfer (PNM bundles) uses the hard-pinned HPKE suite + info string +
@@ -668,6 +757,14 @@ engine was built:
   largely *not yet* in `vta-mobile-core` — it's specced in the URI registry and
   implemented in the CLIs (`vta-sdk`, `vta-cli-common`). A full PNM port pulls
   from those.
+- **Push: the engine is behind the architecture.** The deployed push model is
+  the gateway / trigger / device design with the `push/*` Trust-Task control
+  plane and Web Push/VAPID (§4.8); `vta-mobile-core` v0.3.1 still builds the
+  older mediator `set-device-info` messages (§3.9) and returns `Unimplemented`
+  for Web Push. Adopting the gateway model in the engine (build `push/register` +
+  `device/set-wake`, support Web Push) is the tracked follow-up. A new client
+  should implement the gateway model directly rather than the engine's current
+  push surface.
 - `resolve_did` is local-methods-only today; `did:web`/`did:webvh` need
   network-mode resolver config.
 - Tier-1 (key-agreement in the enclave) is a future hardening; the FFI is

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.3.1"
+version = "0.4.0"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR

--- a/vta-mobile-core/src/push.rs
+++ b/vta-mobile-core/src/push.rs
@@ -1,20 +1,47 @@
-//! Push registration — builds the DIDComm `set-device-info` / `delete-device-info`
-//! messages a backgrounded mobile agent sends to its **mediator** to register or
-//! clear its push channel (push wake-up binding,
-//! `https://trusttasks.org/binding/push/0.1`; adopts Aries RFC 0699 APNs /
-//! 0734 FCM as DIDComm v2 messages).
+//! Push wake-up — the **gateway / trigger / device** model
+//! (push wake-up binding, `https://trusttasks.org/binding/push/0.1`).
 //!
-//! The engine builds the message core (`{type, body}`); the native layer adds
-//! envelope headers (`id`/`from`/`to`) and authcrypt-packs it onto the live
-//! DIDComm channel. These messages only tell the mediator *where* to push — the
-//! wake-up push itself is contentless and never carries Trust Task content.
+//! A backgrounded mobile agent can't hold a mediator WebSocket open across OS
+//! suspension, so it must be *woken*. The wake is a **contentless doorbell**; the
+//! real (encrypted) Trust Task is still pulled from the mediator over DIDComm
+//! pickup once the app is awake. Push never carries Trust-Task content.
+//!
+//! Three roles (see the binding): the **push gateway** holds the app's platform
+//! push credentials (APNs / FCM / Web Push) and the `handle → token` map and is
+//! the only party that can deliver a push; a **trigger** (the device's mediator
+//! or its VTA) asks the gateway to wake a handle; the **device** registers its
+//! token with the gateway and conveys the resulting opaque handle to its VTA.
+//!
+//! This module builds the two Trust Task documents the **device** sends; transport
+//! (HTTPS for a URL gateway, or DIDComm authcrypt for a DID gateway / the VTA's
+//! mediator) is the native layer's job, exactly as for the `auth/*` documents:
+//!
+//! 1. `build_push_register` → `push/register` to the **gateway**: register a
+//!    platform token, get back an opaque [`WakeHandle`]. **No proof** — register
+//!    is unauthenticated; the handle is opaque and useless until the controller
+//!    VTA provisions a trigger for it. The raw token never leaves the gateway.
+//! 2. `parse_push_register_response` → read the issued [`WakeHandle`].
+//! 3. `build_device_set_wake` → `device/set-wake` to the **VTA**: convey the
+//!    handle so the VTA can own the trigger allowlist and provision the gateway.
+//!    **Proof-REQUIRED** — holder-signed via the native [`Signer`] (the VTA
+//!    binds the wake channel to the subject). Omitting the handle clears the
+//!    channel (the device becomes non-wakeable).
+//! 4. `parse_device_set_wake_response` → whether the device is now push-capable
+//!    and the effective allowlist the VTA provisioned.
+//!
+//! `push/provision` and `push/wake` are *not* device operations (they are
+//! VTA→gateway and trigger→gateway respectively), so they are not built here.
+
+use chrono::DateTime;
+use trust_tasks_rs::specs::device::set_wake::v0_2 as set_wake;
+use trust_tasks_rs::specs::push::register::v0_2 as register;
+use trust_tasks_rs::{Payload, TrustTask};
 
 use crate::error::FfiError;
+use crate::keys::Signer;
+use crate::proof::attach_did_signed_proof;
 
-const APNS_PROTOCOL: &str = "https://didcomm.org/push-notifications-apns/1.0";
-const FCM_PROTOCOL: &str = "https://didcomm.org/push-notifications-fcm/1.0";
-
-/// Which APNs environment issued the token — the mediator routes to the matching
+/// Which APNs environment issued the token — the gateway routes to the matching
 /// Apple endpoint.
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum ApnsEnvironment {
@@ -22,8 +49,10 @@ pub enum ApnsEnvironment {
     Production,
 }
 
-/// A device's platform push channel — the body of a `set-device-info` message.
-/// Mirrors the `PushRegistration` shape in the device-binding shared schema.
+/// A device's platform push channel — the token the device registers with its
+/// push **gateway** (`push/register`). The gateway holds it in exchange for an
+/// opaque [`WakeHandle`]; the raw token never leaves the gateway. Mirrors the
+/// `PushRegistration` shape in the device-binding shared schema.
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum PushRegistration {
     /// Apple Push Notification service.
@@ -34,10 +63,8 @@ pub enum PushRegistration {
     },
     /// Firebase Cloud Messaging.
     Fcm { token: String },
-    /// Web Push (RFC 8030). Carried out-of-band, not via a DIDComm
-    /// `set-device-info` — the Aries push-notification protocols cover APNs/FCM
-    /// only. Present here so the type mirrors the schema; building a message for
-    /// it returns [`FfiError::Unimplemented`].
+    /// Web Push (RFC 8030 endpoint + RFC 8291 encryption keys). Self-hostable
+    /// via the gateway's VAPID keypair — no Apple/Google account required.
     WebPush {
         endpoint: String,
         p256dh: String,
@@ -45,8 +72,8 @@ pub enum PushRegistration {
     },
 }
 
-/// The platform discriminator, for messages whose body carries no token
-/// (e.g. `delete-device-info`).
+/// The platform discriminator, for the advisory `pushPlatform` hint on
+/// `device/set-wake` (the VTA never sees the token).
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum PushPlatform {
     Apns,
@@ -54,140 +81,405 @@ pub enum PushPlatform {
     WebPush,
 }
 
-/// Builds the DIDComm `set-device-info` message (`{type, body}` JSON) the agent
-/// sends to its mediator to register or refresh its push channel. The native
-/// layer adds envelope headers and authcrypt-packs it before sending.
+/// Envelope fields the native layer supplies for a push / device Trust Task
+/// (`id` / `issued_at` — the native layer owns identifiers and the clock).
+/// `issuer` / `recipient` are optional because `push/register` is unauthenticated
+/// and a REST gateway is addressed by URL (no recipient DID); `device/set-wake`
+/// sets both (issuer = device holder DID, recipient = the VTA DID).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct PushEnvelope {
+    pub id: String,
+    pub issued_at: String,
+    pub issuer: Option<String>,
+    pub recipient: Option<String>,
+}
+
+/// The opaque gateway-issued reference to a device's push channel. Reveals no
+/// platform token. `gateway` is a DID (DIDComm gateway) or an https URL (REST
+/// gateway); the device conveys this — never the token — to its VTA.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct WakeHandle {
+    pub gateway: String,
+    pub handle: String,
+}
+
+/// Outcome of a `device/set-wake` — whether the device now has a usable wake
+/// channel, and the effective trigger allowlist the VTA provisioned (absent when
+/// the channel was cleared).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct SetWakeOutcome {
+    pub push_capable: bool,
+    pub allowed_triggers: Option<Vec<String>>,
+}
+
+/// Build an unauthenticated `push/register/0.2` document the device sends to its
+/// push **gateway** to register a platform token. **No proof** — the handle is
+/// opaque and only becomes usable once the `controller_vta_did` provisions a
+/// trigger for it. `controller_vta_did` is the DID of the VTA permitted to
+/// provision this handle's allowlist (the device conveys the handle there next
+/// via [`build_device_set_wake`]).
 #[uniffi::export]
-pub fn build_set_device_info(registration: PushRegistration) -> Result<String, FfiError> {
-    let (protocol, body) = match registration {
+pub fn build_push_register(
+    env: PushEnvelope,
+    registration: PushRegistration,
+    controller_vta_did: String,
+) -> Result<String, FfiError> {
+    let payload = register::Payload {
+        registration: to_wire_registration(registration)?,
+        controller_vta_did: register::PayloadControllerVtaDid::try_from(controller_vta_did)
+            .map_err(conv)?,
+        ext: None,
+    };
+    serialize(&envelope_doc(&env, payload)?)
+}
+
+/// Parse a `push/register/0.2#response` — the opaque [`WakeHandle`] the gateway
+/// issued for the registered token.
+#[uniffi::export]
+pub fn parse_push_register_response(json: String) -> Result<WakeHandle, FfiError> {
+    let doc: TrustTask<register::Response> = serde_json::from_str(&json).map_err(decode)?;
+    Ok(WakeHandle {
+        gateway: doc.payload.wake_handle.gateway.to_string(),
+        handle: doc.payload.wake_handle.handle.to_string(),
+    })
+}
+
+/// Build a signed `device/set-wake/0.2` the device sends to its **VTA** to convey
+/// the opaque [`WakeHandle`] it obtained from the gateway. The VTA owns the
+/// trigger allowlist and provisions the gateway on the device's behalf.
+/// **Proof-REQUIRED** — holder-signed via the native [`Signer`], so the VTA binds
+/// the wake channel to the subject. Pass `wake_handle: None` to **clear** the
+/// channel (the VTA empties the gateway allowlist; the device becomes
+/// non-wakeable). `push_platform` and `suggested_triggers` are advisory hints the
+/// VTA MAY ignore (it never sees the token; it owns the final allowlist).
+#[uniffi::export]
+pub fn build_device_set_wake(
+    env: PushEnvelope,
+    wake_handle: Option<WakeHandle>,
+    push_platform: Option<PushPlatform>,
+    suggested_triggers: Vec<String>,
+    signer: Box<dyn Signer>,
+) -> Result<String, FfiError> {
+    let wake_handle = wake_handle
+        .map(|h| -> Result<set_wake::WakeHandle, FfiError> {
+            Ok(set_wake::WakeHandle {
+                gateway: set_wake::WakeHandleGateway::try_from(h.gateway).map_err(conv)?,
+                handle: set_wake::WakeHandleHandle::try_from(h.handle).map_err(conv)?,
+            })
+        })
+        .transpose()?;
+    let push_platform = push_platform.map(|p| match p {
+        PushPlatform::Apns => set_wake::PayloadPushPlatform::Apns,
+        PushPlatform::Fcm => set_wake::PayloadPushPlatform::Fcm,
+        PushPlatform::WebPush => set_wake::PayloadPushPlatform::Webpush,
+    });
+    // Empty → omit (the field skip-serializes when absent).
+    let suggested_triggers = if suggested_triggers.is_empty() {
+        None
+    } else {
+        Some(
+            suggested_triggers
+                .into_iter()
+                .map(set_wake::PayloadSuggestedTriggersItem::try_from)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(conv)?,
+        )
+    };
+    let payload = set_wake::Payload {
+        wake_handle,
+        push_platform,
+        suggested_triggers,
+        ext: None,
+    };
+    let mut doc = envelope_doc(&env, payload)?;
+    attach_did_signed_proof(&mut doc, &*signer, &env.issued_at)?;
+    serialize(&doc)
+}
+
+/// Parse a `device/set-wake/0.2#response` — whether the device is now
+/// push-capable and the effective allowlist the VTA provisioned to the gateway.
+#[uniffi::export]
+pub fn parse_device_set_wake_response(json: String) -> Result<SetWakeOutcome, FfiError> {
+    let doc: TrustTask<set_wake::Response> = serde_json::from_str(&json).map_err(decode)?;
+    Ok(SetWakeOutcome {
+        push_capable: doc.payload.push_capable,
+        allowed_triggers: doc
+            .payload
+            .trigger_policy
+            .map(|p| p.allowed_triggers.iter().map(|t| t.to_string()).collect()),
+    })
+}
+
+/// Map the FFI [`PushRegistration`] to the wire `push/register` registration.
+fn to_wire_registration(reg: PushRegistration) -> Result<register::PushRegistration, FfiError> {
+    Ok(match reg {
         PushRegistration::Apns {
             token,
             topic,
             environment,
-        } => {
-            let service = match environment {
-                ApnsEnvironment::Sandbox => "apns_sandbox",
-                ApnsEnvironment::Production => "apns",
-            };
-            (
-                APNS_PROTOCOL,
-                serde_json::json!({
-                    "device_token": token,
-                    "service": service,
-                    "topic": topic,
-                }),
-            )
-        }
-        PushRegistration::Fcm { token } => (
-            FCM_PROTOCOL,
-            serde_json::json!({ "device_token": token, "service": "fcm" }),
-        ),
-        PushRegistration::WebPush { .. } => {
-            return Err(FfiError::Unimplemented {
-                what: "web push registration uses RFC 8030 directly, not a DIDComm \
-                       set-device-info message; APNs/FCM only"
-                    .to_string(),
-            });
-        }
-    };
-    message(protocol, "set-device-info", body)
-}
-
-/// Builds the DIDComm `delete-device-info` message to unregister this device's
-/// push channel (e.g. on logout).
-#[uniffi::export]
-pub fn build_delete_device_info(platform: PushPlatform) -> Result<String, FfiError> {
-    let protocol = match platform {
-        PushPlatform::Apns => APNS_PROTOCOL,
-        PushPlatform::Fcm => FCM_PROTOCOL,
-        PushPlatform::WebPush => {
-            return Err(FfiError::Unimplemented {
-                what: "web push is not registered via DIDComm set-device-info".to_string(),
-            });
-        }
-    };
-    message(protocol, "delete-device-info", serde_json::json!({}))
-}
-
-/// Assemble the `{type, body}` DIDComm message core and serialize it.
-fn message(protocol: &str, verb: &str, body: serde_json::Value) -> Result<String, FfiError> {
-    let msg = serde_json::json!({
-        "type": format!("{protocol}/{verb}"),
-        "body": body,
-    });
-    serde_json::to_string(&msg).map_err(|e| FfiError::InvalidInput {
-        reason: format!("failed to serialize push message: {e}"),
+        } => register::PushRegistration::Apns {
+            token: register::PushRegistrationToken::try_from(token).map_err(conv)?,
+            topic: register::PushRegistrationTopic::try_from(topic).map_err(conv)?,
+            environment: Some(match environment {
+                ApnsEnvironment::Sandbox => register::PushRegistrationEnvironment::Sandbox,
+                ApnsEnvironment::Production => register::PushRegistrationEnvironment::Production,
+            }),
+        },
+        PushRegistration::Fcm { token } => register::PushRegistration::Fcm {
+            token: register::PushRegistrationToken::try_from(token).map_err(conv)?,
+        },
+        PushRegistration::WebPush {
+            endpoint,
+            p256dh,
+            auth,
+        } => register::PushRegistration::Webpush {
+            endpoint,
+            keys: register::PushRegistrationKeys {
+                auth: register::PushRegistrationKeysAuth::try_from(auth).map_err(conv)?,
+                p256dh: register::PushRegistrationKeysP256dh::try_from(p256dh).map_err(conv)?,
+            },
+        },
     })
+}
+
+/// Build the request envelope (issuer/recipient/issuedAt) for a push payload.
+fn envelope_doc<P: Payload>(env: &PushEnvelope, payload: P) -> Result<TrustTask<P>, FfiError> {
+    let issued_at = DateTime::parse_from_rfc3339(&env.issued_at)
+        .map_err(|e| FfiError::InvalidInput {
+            reason: format!("issued_at is not an RFC 3339 timestamp: {e}"),
+        })?
+        .with_timezone(&chrono::Utc);
+    let mut doc = TrustTask::for_payload(env.id.clone(), payload);
+    doc.issuer = env.issuer.clone();
+    doc.recipient = env.recipient.clone();
+    doc.issued_at = Some(issued_at);
+    Ok(doc)
+}
+
+fn serialize<P: serde::Serialize>(doc: &TrustTask<P>) -> Result<String, FfiError> {
+    serde_json::to_string(doc).map_err(|e| FfiError::InvalidInput {
+        reason: format!("failed to serialize push document: {e}"),
+    })
+}
+
+fn conv<E: ::std::fmt::Display>(e: E) -> FfiError {
+    FfiError::InvalidInput {
+        reason: e.to_string(),
+    }
+}
+
+fn decode<E: ::std::fmt::Display>(e: E) -> FfiError {
+    FfiError::Decode {
+        reason: format!("not a valid push document: {e}"),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn env() -> PushEnvelope {
+        PushEnvelope {
+            id: "push-1".to_string(),
+            issued_at: "2026-05-30T10:00:00Z".to_string(),
+            issuer: Some("did:key:zDevice".to_string()),
+            recipient: None,
+        }
+    }
+
+    /// A test `Signer` standing in for the native enclave, with a `did:key`
+    /// derived from an Ed25519 test key.
+    fn enclave_signer(seed: u8) -> (Box<dyn Signer>, ed25519_dalek::VerifyingKey, String) {
+        use ed25519_dalek::{Signer as _, SigningKey};
+        use multibase::Base;
+
+        let sk = SigningKey::from_bytes(&[seed; 32]);
+        let pk = sk.verifying_key();
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(pk.as_bytes());
+        let mb = multibase::encode(Base::Base58Btc, mc);
+        let did = format!("did:key:{mb}");
+
+        struct EnclaveStub {
+            sk: SigningKey,
+            did: String,
+        }
+        impl Signer for EnclaveStub {
+            fn did(&self) -> String {
+                self.did.clone()
+            }
+            fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>, FfiError> {
+                Ok(self.sk.sign(&payload).to_bytes().to_vec())
+            }
+        }
+        (Box::new(EnclaveStub { sk, did }), pk, mb)
+    }
+
     #[test]
-    fn apns_set_device_info_shape() {
-        let json = build_set_device_info(PushRegistration::Apns {
-            token: "abc123".to_string(),
-            topic: "org.openvtc.vta.agent".to_string(),
-            environment: ApnsEnvironment::Production,
-        })
+    fn push_register_has_no_proof_right_type_and_payload() {
+        let json = build_push_register(
+            env(),
+            PushRegistration::Apns {
+                token: "abc123".to_string(),
+                topic: "org.openvtc.vta.agent".to_string(),
+                environment: ApnsEnvironment::Production,
+            },
+            "did:web:vta.example".to_string(),
+        )
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "https://trusttasks.org/spec/push/register/0.2");
+        assert_eq!(v["issuer"], "did:key:zDevice");
+        // No recipient (a REST gateway is addressed by URL, out-of-band).
+        assert!(v.get("recipient").is_none());
+        assert_eq!(v["payload"]["controllerVtaDid"], "did:web:vta.example");
+        assert_eq!(v["payload"]["registration"]["platform"], "apns");
+        assert_eq!(v["payload"]["registration"]["token"], "abc123");
         assert_eq!(
-            v["type"],
-            "https://didcomm.org/push-notifications-apns/1.0/set-device-info"
+            v["payload"]["registration"]["topic"],
+            "org.openvtc.vta.agent"
         );
-        assert_eq!(v["body"]["device_token"], "abc123");
-        assert_eq!(v["body"]["service"], "apns");
-        assert_eq!(v["body"]["topic"], "org.openvtc.vta.agent");
+        assert_eq!(v["payload"]["registration"]["environment"], "production");
+        // register is unauthenticated — IS_PROOF_REQUIRED == false.
+        assert!(v.get("proof").is_none());
     }
 
     #[test]
-    fn apns_sandbox_maps_to_service() {
-        let json = build_set_device_info(PushRegistration::Apns {
-            token: "t".to_string(),
-            topic: "x".to_string(),
-            environment: ApnsEnvironment::Sandbox,
-        })
+    fn push_register_webpush_maps_endpoint_and_keys() {
+        let json = build_push_register(
+            env(),
+            PushRegistration::WebPush {
+                endpoint: "https://push.example/x".to_string(),
+                p256dh: "p256dh-key".to_string(),
+                auth: "auth-secret".to_string(),
+            },
+            "did:web:vta.example".to_string(),
+        )
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["body"]["service"], "apns_sandbox");
+        let reg = &v["payload"]["registration"];
+        assert_eq!(reg["platform"], "webpush");
+        assert_eq!(reg["endpoint"], "https://push.example/x");
+        assert_eq!(reg["keys"]["p256dh"], "p256dh-key");
+        assert_eq!(reg["keys"]["auth"], "auth-secret");
     }
 
     #[test]
-    fn fcm_set_device_info_shape() {
-        let json = build_set_device_info(PushRegistration::Fcm {
-            token: "fcm-tok".to_string(),
-        })
+    fn parses_push_register_response_wake_handle() {
+        let json = r#"{
+          "id": "r-1",
+          "type": "https://trusttasks.org/spec/push/register/0.2#response",
+          "issuer": "did:web:gateway.example",
+          "recipient": "did:key:zDevice",
+          "payload": {
+            "wakeHandle": { "gateway": "https://gw.example", "handle": "z6MkHandle" }
+          }
+        }"#;
+        let h = parse_push_register_response(json.to_string()).unwrap();
+        assert_eq!(h.gateway, "https://gw.example");
+        assert_eq!(h.handle, "z6MkHandle");
+    }
+
+    #[test]
+    fn device_set_wake_is_signed_carries_handle_and_verifies() {
+        let (signer, pk, mb) = enclave_signer(7);
+        let did = signer.did();
+        let e = PushEnvelope {
+            id: "sw-1".to_string(),
+            issued_at: "2026-05-30T10:00:00Z".to_string(),
+            issuer: Some(did.clone()),
+            recipient: Some("did:web:vta.example".to_string()),
+        };
+        let json = build_device_set_wake(
+            e,
+            Some(WakeHandle {
+                gateway: "https://gw.example".to_string(),
+                handle: "z6MkHandle".to_string(),
+            }),
+            Some(PushPlatform::WebPush),
+            vec!["did:web:mediator.example".to_string()],
+            signer,
+        )
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "https://trusttasks.org/spec/device/set-wake/0.2");
+        assert_eq!(v["payload"]["wakeHandle"]["gateway"], "https://gw.example");
+        assert_eq!(v["payload"]["wakeHandle"]["handle"], "z6MkHandle");
+        assert_eq!(v["payload"]["pushPlatform"], "webpush");
         assert_eq!(
-            v["type"],
-            "https://didcomm.org/push-notifications-fcm/1.0/set-device-info"
+            v["payload"]["suggestedTriggers"][0],
+            "did:web:mediator.example"
         );
-        assert_eq!(v["body"]["service"], "fcm");
-        assert_eq!(v["body"]["device_token"], "fcm-tok");
+
+        // device/set-wake is IS_PROOF_REQUIRED == true — holder-signed.
+        let doc: TrustTask<set_wake::Payload> = serde_json::from_str(&json).unwrap();
+        let proof = doc.proof.clone().expect("set-wake must be signed");
+        let di: affinidi_data_integrity::DataIntegrityProof =
+            serde_json::from_value(serde_json::to_value(&proof).unwrap()).unwrap();
+        assert_eq!(di.verification_method, format!("{did}#{mb}"));
+        let mut unsigned = doc;
+        unsigned.proof = None;
+        di.verify_with_public_key(
+            &unsigned,
+            pk.as_bytes(),
+            affinidi_data_integrity::VerifyOptions::default(),
+        )
+        .expect("the set-wake proof must verify against the holder key");
     }
 
     #[test]
-    fn delete_device_info_shape() {
-        let json = build_delete_device_info(PushPlatform::Fcm).unwrap();
+    fn device_set_wake_clear_omits_handle_and_optional_fields() {
+        let (signer, _pk, _mb) = enclave_signer(8);
+        let e = PushEnvelope {
+            id: "sw-2".to_string(),
+            issued_at: "2026-05-30T10:00:00Z".to_string(),
+            issuer: Some(signer.did()),
+            recipient: Some("did:web:vta.example".to_string()),
+        };
+        let json = build_device_set_wake(e, None, None, vec![], signer).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(
-            v["type"],
-            "https://didcomm.org/push-notifications-fcm/1.0/delete-device-info"
-        );
-        assert!(v["body"].as_object().unwrap().is_empty());
+        // Clearing the channel: no handle, and the advisory fields skip-serialize.
+        assert!(v["payload"].get("wakeHandle").is_none());
+        assert!(v["payload"].get("pushPlatform").is_none());
+        assert!(v["payload"].get("suggestedTriggers").is_none());
+        // Still holder-signed.
+        assert!(v.get("proof").is_some());
     }
 
     #[test]
-    fn webpush_set_device_info_is_unimplemented() {
-        let err = build_set_device_info(PushRegistration::WebPush {
-            endpoint: "https://push.example/x".to_string(),
-            p256dh: "k".to_string(),
-            auth: "a".to_string(),
-        })
-        .unwrap_err();
-        assert!(matches!(err, FfiError::Unimplemented { .. }));
+    fn parses_device_set_wake_response_with_policy() {
+        let json = r#"{
+          "id": "swr-1",
+          "type": "https://trusttasks.org/spec/device/set-wake/0.2#response",
+          "issuer": "did:web:vta.example",
+          "recipient": "did:key:zDevice",
+          "payload": {
+            "pushCapable": true,
+            "triggerPolicy": { "allowedTriggers": ["did:web:mediator.example", "did:web:vta.example"] }
+          }
+        }"#;
+        let o = parse_device_set_wake_response(json.to_string()).unwrap();
+        assert!(o.push_capable);
+        assert_eq!(
+            o.allowed_triggers.unwrap(),
+            vec![
+                "did:web:mediator.example".to_string(),
+                "did:web:vta.example".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_device_set_wake_response_cleared() {
+        let json = r#"{
+          "id": "swr-2",
+          "type": "https://trusttasks.org/spec/device/set-wake/0.2#response",
+          "issuer": "did:web:vta.example",
+          "recipient": "did:key:zDevice",
+          "payload": { "pushCapable": false }
+        }"#;
+        let o = parse_device_set_wake_response(json.to_string()).unwrap();
+        assert!(!o.push_capable);
+        assert!(o.allowed_triggers.is_none());
     }
 }


### PR DESCRIPTION
## What

Brings `vta-mobile-core`'s push surface onto the **gateway / trigger / device** model, the engine catch-up flagged in the re-implementation spec (#313).

## Why

The engine's `push.rs` was the *superseded* mechanism: it built the older Aries `set-device-info`/`delete-device-info` DIDComm messages to the **mediator**, and returned `Unimplemented` for Web Push. The deployed architecture is the gateway model — a separate `vti-push-gateway`, the `push/*` Trust-Task control plane, `device/set-wake` to convey the opaque `WakeHandle`, and Web Push via VAPID (the browser-plugin PNM already uses it). The engine led a client to build the wrong thing.

Implements against the existing `trust-tasks-rs` 0.2 specs — **no spec change**.

## Changes

Device-side gateway-model Trust Tasks (replacing the mediator `set-device-info` path):

- **`build_push_register`** → `push/register/0.2` to the gateway (unauthenticated; **no proof**). Maps the FFI `PushRegistration` (apns/fcm/webpush) to the wire type; **Web Push is now first-class** (endpoint + RFC 8291 keys), not `Unimplemented`.
- **`parse_push_register_response`** → the opaque `WakeHandle { gateway, handle }`.
- **`build_device_set_wake`** → `device/set-wake/0.2` to the VTA, **holder-signed** via the native `Signer` (proof-REQUIRED). Conveys the handle; `None` clears the channel. `push_platform` + `suggested_triggers` are advisory.
- **`parse_device_set_wake_response`** → `{ push_capable, allowed_triggers? }`.

Kept the `PushRegistration` / `PushPlatform` / `ApnsEnvironment` FFI enums (reused). **Removed** `build_set_device_info` / `build_delete_device_info` + the Aries push-notification protocol plumbing — no consumer (iOS push is unwired). `push/provision` + `push/wake` are not device ops, so not built here.

**Version:** minor bump `0.3.1 → 0.4.0` (FFI surface change; pre-1.0).

## CI

- `cargo fmt -p vta-mobile-core --check` clean
- `cargo test -p vta-mobile-core` — **36/36**
- `cargo clippy -p vta-mobile-core --all-targets -- -D warnings` clean
- `cargo deny check` ok

(Cross-compile/bindgen runs in the `mobile-artifacts` CI job; the host build exercises the `#[uniffi::export]` macros.)

## Follow-ups

- Once #313 merges, flip its doc notes ("engine is behind / tracked follow-up", "v0.3.1") to **done** at v0.4.0.
- A `vta-mobile-core-v0.4.0` release tag is needed before the iOS/Android shells can consume the new surface.