### PR TITLE
spec(join): draft join-requests/accept (reciprocal VMC) + reconcile ceremony verb set

### DIFF
--- a/docs/05-design-notes/vtc-ceremony-protocol.md
+++ b/docs/05-design-notes/vtc-ceremony-protocol.md
@@ -156,3 +156,34 @@ response — one source of truth for the wire shape across all ceremonies.
   lighter read path? (Leaning: same envelope, exempt from threading fields.)
 - **Per-family rate-limit tuning** — join (unauth) needs the tightest bucket; member-triggered ceremonies inherit
   session auth.
+
+---
+
+## 9. Implementation status (2026-06)
+
+How the §2 verb set for the **join** family maps to what is built + specced
+today, so this proposal stays honest about the realized surface:
+
+| Verb (§2) | Realized as | Spec | Code |
+|---|---|---|---|
+| `request` | `join-requests/submit/1.0` | `trust-tasks/join-requests/submit` | `routes/join_requests/submit.rs` (REST + DIDComm) |
+| `present` | **`credential-exchange/present/1.0`** (reused; VTC = verifier) | `trust-tasks/credential-exchange/present` | `routes/join_requests/present.rs`, `messaging.rs` |
+| *(query side)* | **`credential-exchange/query/1.0`** (reused; VTC issues the DCQL query) | `trust-tasks/credential-exchange/query` | `routes/join_requests/present.rs::{prepare_join_query,send_query}` |
+| `resolve` | the existing admin REST `approve`/`reject` | `trust-tasks/join-requests/{approve,reject}` | `routes/join_requests/decide.rs` |
+| `accept` | `join-requests/accept/1.0` | `trust-tasks/join-requests/accept` *(this branch, Draft)* | **not yet implemented** — discharge `reciprocate_vmc` in `ceremony/execute.rs` + a route/DIDComm handler |
+| `manifest` | — | — | design-future |
+| `status` | join request `show` (`GET /v1/join-requests/{id}`) approximates it | `trust-tasks/join-requests/show` | `routes/join_requests/read.rs` |
+
+**Reconciliation note.** The §7 deliverable list implied
+`join-requests/{present,status}` as join-family verbs. In the build, the
+presentation exchange is the **generic `credential-exchange` family**
+(`query` + `present`), which the join verifier reuses — there are no
+`join-requests/present` / `join-requests/query` specs and none should be
+added (they would duplicate `credential-exchange/*`). `submit-receipt` /
+`accept-receipt` reply types are documented inline in their parent verb
+specs rather than as standalone entries.
+
+**Open decision (carried from §8):** whether to keep `present`/`query`
+under `credential-exchange` (current — favours one generic exchange family)
+or mint `join-requests` aliases (favours a self-contained per-ceremony
+surface). Current lean: keep the reuse; cross-reference from the join specs.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -205,6 +205,13 @@
       "rest": "POST /v1/join-requests/{id}/reject"
     },
     {
+      "id": "https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0",
+      "status": "Draft",
+      "path": "join-requests/accept/1.0",
+      "rest": "POST /v1/join-requests/{id}/accept",
+      "didcomm": "https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0"
+    },
+    {
       "id": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0",
       "status": "Draft",
       "path": "members/self-remove/1.0",

--- a/trust-tasks/join-requests/accept/1.0/schema.json
+++ b/trust-tasks/join-requests/accept/1.0/schema.json
@@ -1,0 +1,35 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Join Requests — Accept (reciprocal VMC)",
+  "type": "object",
+  "properties": {
+    "restRequest": {
+      "type": "object",
+      "required": ["memberDid", "vmcId", "vc", "signature"],
+      "properties": {
+        "memberDid": { "type": "string", "pattern": "^did:key:" },
+        "vmcId": { "type": "string" },
+        "vc": {},
+        "signature": { "type": "string", "pattern": "^[0-9a-fA-F]+$" }
+      }
+    },
+    "didcommBody": {
+      "type": "object",
+      "required": ["vmcId", "vc"],
+      "properties": {
+        "vmcId": { "type": "string" },
+        "vc": {}
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["requestId", "status"],
+      "properties": {
+        "requestId": { "type": "string", "format": "uuid" },
+        "status": { "type": "string", "enum": ["accepted"] },
+        "reciprocalVcId": { "type": "string" }
+      }
+    }
+  }
+}

--- a/trust-tasks/join-requests/accept/1.0/spec.md
+++ b/trust-tasks/join-requests/accept/1.0/spec.md
@@ -1,0 +1,136 @@
+---
+id: https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0
+title: VTC Join Requests — Accept (reciprocal VMC)
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/join-requests/{id}/accept
+  - didcomm: https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0
+---
+
+# VTC Join Requests — Accept (reciprocal VMC)
+
+The `accept` verb closes the join ceremony's **reciprocal step**: the
+newly-admitted member counter-signs the membership the VTC issued,
+forming the **bidirectional DTG membership edge**. It discharges the
+`reciprocate_vmc` obligation that the join `allow` carried (ceremony
+catalog §2; protocol §2 verb set; pipeline §11).
+
+A join `allow` issues the community → member half of the edge: the VTC
+mints the VMC + role VEC and (best-effort) delivers them to the
+applicant. That half alone is **one-directional** — the community
+asserts "this DID is a member," but the member has not yet asserted
+"I am a member of this community." `accept` carries the member's
+counter-assertion (the *reciprocal VMC*) back to the VTC, which records
+it and completes the edge.
+
+```
+… join-requests/request|present → allow {role, obligations:["reciprocate_vmc"]}
+   VTC issues VMC + role VEC to the member (community → member half)
+member ─join-requests/accept {reciprocal VMC, thread}─▶ VTC
+   VTC verifies + records the reciprocal edge (member → community half)
+```
+
+## Relationship to the existing flow
+
+- The `request` verb is the existing `join-requests/submit/1.0`
+  (protocol §4). `accept` carries the **same `thread_id`** the join
+  request minted, plus the `vmcId` of the VMC it reciprocates.
+- `accept` is valid only against a request whose membership has been
+  **issued** — i.e. the join verdict was `allow` (auto-admit on submit/
+  present) or an admin `approve` ran. It is rejected for a request in
+  `Pending`/`Deferred`/`Rejected` (no VMC to reciprocate) and is
+  idempotent once the edge is recorded (see Errors).
+
+## The reciprocal artifact
+
+The member's counter-assertion is a **member-issued Verifiable
+Credential** — the *reciprocal VMC* (`MembershipAcknowledgement`) —
+presented in a W3C Verifiable Presentation. The member is both issuer
+and holder; the credential subject is the **community** (`communityDid`)
+and asserts the member accepts membership under the issued `vmcId`.
+
+Using a VC/VP (not a bespoke signed struct) follows the workspace rule
+that holder → VTC authorization assertions are VPs and that the
+community's stored attestation half is a VC. The VTC verifies the VP's
+holder proof binds the member DID, then stores the reciprocal VC id on
+the Member row and emits the audit edge event.
+
+> **Decided:** the reciprocal artifact is the **VC/VP** form (per the
+> house rule that holder → VTC assertions are VPs), giving a standalone,
+> independently-verifiable member-side credential for the DTG edge. The
+> lighter alternative — a detached Ed25519 signature over `vmcId`,
+> mirroring the `submit` holder binding — was considered and rejected
+> because it produces only a binding proof, not a member-side credential.
+
+## Authentication
+
+Unauthenticated trigger; the reciprocal VP / DIDComm envelope **is** the
+auth, identically to `submit`:
+
+### DIDComm (preferred)
+
+The reply threads on the join `thread_id`. `memberDid` comes from the
+DIDComm `from` field (the authcrypt sender) — no separate signature in
+the body; the envelope binds the member. Body carries the reciprocal
+VC. The handler replies with an `accept-receipt/1.0` message
+(`threadId` + `status`).
+
+### REST holder binding (fallback)
+
+Request body carries `memberDid`, the reciprocal `vc`, and a
+hex-encoded Ed25519 signature over the domain-tagged
+(`vtc-join-accept/v1\0`) canonical JSON of the body minus `signature` —
+the same construction `submit` uses. `did:key` members only in 1.0
+(`did:webvh` resolution is a follow-up, as on `submit`).
+
+## Effects
+
+On a verified, in-state accept:
+
+1. Verify the reciprocal VP/VC holder proof binds `memberDid`, and that
+   `memberDid` matches the request's `applicantDid` and the VMC subject.
+2. Resolve the VMC referenced by `vmcId` against the member's current
+   `current_vmc_id`; reject a mismatch.
+3. Record the bidirectional edge: stamp the Member row with the
+   reciprocal VC id and an `acceptedAt` timestamp, marking the
+   `reciprocate_vmc` obligation discharged.
+4. Audit `MembershipReciprocated { requestId, memberDid, vmcId,
+   reciprocalVcId }` (new audit event — `vti-common::audit`).
+
+> **Decided:** membership (ACL + VMC) is **effective at admit**, before
+> `accept`. The edge is *pending reciprocation* until accept, with **no
+> functional restriction** on the member in the interim; an optional
+> reciprocation deadline is left to policy (not enforced by the host in
+> 1.0). The stricter alternatives — auto-revoke on a deadline, or gating
+> member capabilities until the edge is bidirectional — were considered
+> and deferred.
+
+## Errors
+
+- `400 Bad Request` — malformed VP / signature / non-`did:key` member,
+  or `memberDid` ≠ the request's applicant / VMC subject.
+- `404 Not Found` — request id unknown.
+- `409 Conflict` — request has no issued membership to reciprocate
+  (status is `Pending`/`Deferred`/`Rejected`), **or** `vmcId` does not
+  match the member's current VMC.
+- `429 Too Many Requests` — rate-limited (per-IP for REST,
+  per-sender-DID for DIDComm), same bucket as `submit`.
+
+Framework errors use the `trust-task-error` type, not a `deny` verdict
+(protocol §3): `accept` records an edge, it does not run the policy.
+
+## Idempotency
+
+A second `accept` that matches an already-recorded edge (same
+`memberDid` + `vmcId` + reciprocal VC) returns `200 OK` with
+`status: "accepted"` and does **not** re-stamp or re-audit. A
+*different* reciprocal VC for an already-reciprocated VMC is a `409`.
+
+## Audit
+
+`MembershipReciprocated { requestId, memberDid, vmcId, reciprocalVcId }`
+— correlatable with the `JoinRequestApproved` / `VmcIssued` events from
+the same `requestId`.


### PR DESCRIPTION
## What

Drafts the **`accept`** verb for the VTC join ceremony — the reciprocal step that closes the bidirectional DTG membership edge — and reconciles the ceremony protocol doc with the actually-built surface.

### `join-requests/accept/1.0` (new, Draft)
- `trust-tasks/join-requests/accept/1.0/{spec.md,schema.json}` + `index.json` entry.
- REST `POST /v1/join-requests/{id}/accept` + DIDComm type.
- Closes the reciprocal step: the admitted member counter-signs the issued VMC to form the bidirectional edge, discharging the `reciprocate_vmc` obligation a join `allow` carries (today the policy emits the obligation, the plan carries it, and `ceremony/execute.rs` drops it — `obligations: _`).

**Decisions locked (reviewed):**
1. Reciprocal artifact = **member-issued VC in a VP** (the "reciprocal VMC"/MembershipAcknowledgement), per the house rule that holder→VTC assertions are VPs — not a lightweight detached signature.
2. Membership is **effective at admit**; the edge is *pending reciprocation* until accept, with no host-enforced restriction/deadline in 1.0.

New audit event needed at impl time: `MembershipReciprocated`.

### Ceremony protocol reconciliation
`docs/05-design-notes/vtc-ceremony-protocol.md` gains an **Implementation status** section mapping the §2 join verb set to the built+specced reality: `present`/`query` are realized via the generic **`credential-exchange`** family (not `join-requests/present`), `resolve` = the admin approve/reject REST surface, `manifest` is design-future. Records that no `join-requests/present|query` specs should be added (they'd duplicate `credential-exchange/*`).

## Scope
Spec + design-doc only. No code, no bindings, no build impact (nothing in the cargo build reads `trust-tasks/`). Status: **Draft**.

## Follow-ups (not in this PR)
- Implement `accept`: SDK consts + discharge the obligation in `ceremony/execute.rs` + route/DIDComm handler + `MembershipReciprocated` audit event.
- Independent quick fix: DIDComm auto-admit path issues the VMC but the receipt only carries `{requestId,status}` — wire `deliver_membership_credentials` like the approve path.