### PR TITLE
feat(join): implement join-requests/accept (reciprocal VMC)

### DIFF
--- a/trust-tasks/join-requests/accept/1.0/schema.json
+++ b/trust-tasks/join-requests/accept/1.0/schema.json
@@ -16,8 +16,9 @@
     },
     "didcommBody": {
       "type": "object",
-      "required": ["vmcId", "vc"],
+      "required": ["requestId", "vmcId", "vc"],
       "properties": {
+        "requestId": { "type": "string", "format": "uuid" },
         "vmcId": { "type": "string" },
         "vc": {}
       }

--- a/trust-tasks/join-requests/accept/1.0/spec.md
+++ b/trust-tasks/join-requests/accept/1.0/spec.md
@@ -47,16 +47,33 @@ member ─join-requests/accept {reciprocal VMC, thread}─▶ VTC
 ## The reciprocal artifact
 
 The member's counter-assertion is a **member-issued Verifiable
-Credential** — the *reciprocal VMC* (`MembershipAcknowledgement`) —
-presented in a W3C Verifiable Presentation. The member is both issuer
-and holder; the credential subject is the **community** (`communityDid`)
-and asserts the member accepts membership under the issued `vmcId`.
+Credential** — the *reciprocal VMC* (`MembershipAcknowledgement`). The
+member is the issuer; the credential subject is the **community** (this
+VTC — the DID that issued the VMC) and asserts the member accepts
+membership under the issued `vmcId`. Concrete 1.0 shape:
 
-Using a VC/VP (not a bespoke signed struct) follows the workspace rule
-that holder → VTC authorization assertions are VPs and that the
-community's stored attestation half is a VC. The VTC verifies the VP's
-holder proof binds the member DID, then stores the reciprocal VC id on
-the Member row and emits the audit edge event.
+```jsonc
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2"],
+  "type": ["VerifiableCredential", "MembershipAcknowledgement"],
+  "id": "urn:uuid:…",                  // recorded as the member's reciprocalVcId
+  "issuer": "did:key:z…member",        // MUST equal memberDid
+  "credentialSubject": {
+    "id": "did:webvh:…community",       // MUST equal this VTC's DID (the VMC issuer)
+    "reciprocates": "urn:uuid:…vmc"     // MUST equal the member's current VMC id
+  },
+  "proof": { "type": "DataIntegrityProof", "cryptosuite": "eddsa-jcs-2022",
+             "proofPurpose": "assertionMethod", "verificationMethod": "did:key:z…member#…" }
+}
+```
+
+The `eddsa-jcs-2022` issuer proof IS the counter-signature: for a
+`did:key` member (Phase 1) the VTC verifies it directly against the
+member's `did:key` (no resolver), binding `verificationMethod` to
+`memberDid`. Using a VC (not a bespoke signed struct) follows the
+workspace rule that holder → VTC authorization assertions are VC/VP. The
+VTC records the VC's `id` on the Member row and emits the audit edge
+event.
 
 > **Decided:** the reciprocal artifact is the **VC/VP** form (per the
 > house rule that holder → VTC assertions are VPs), giving a standalone,
@@ -72,11 +89,12 @@ auth, identically to `submit`:
 
 ### DIDComm (preferred)
 
-The reply threads on the join `thread_id`. `memberDid` comes from the
-DIDComm `from` field (the authcrypt sender) — no separate signature in
-the body; the envelope binds the member. Body carries the reciprocal
-VC. The handler replies with an `accept-receipt/1.0` message
-(`threadId` + `status`).
+`memberDid` comes from the DIDComm `from` field (the authcrypt sender) —
+no separate signature in the body; the envelope binds the member. The
+body carries `requestId` (no URL path over DIDComm), `vmcId`, and the
+reciprocal `vc`. The handler replies with an `accept-receipt/1.0`
+message (`requestId` + `status` + `reciprocalVcId`), threaded (`thid`)
+on the accept message id.
 
 ### REST holder binding (fallback)
 

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -42,6 +42,48 @@ pub struct JoinRequestSubmitReceiptBody {
 }
 
 // ---------------------------------------------------------------------------
+// Accept — reciprocal VMC (join ceremony close, join-requests/accept/1.0)
+// ---------------------------------------------------------------------------
+
+/// DIDComm message `type` for a join-request accept: the admitted
+/// member counter-signs the issued VMC to form the bidirectional DTG
+/// membership edge. `memberDid` comes from the DIDComm `from` field.
+pub const JOIN_REQUEST_ACCEPT_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0";
+
+/// DIDComm `type` for the VTC's accept reply (the reciprocation
+/// receipt). Carried as a `thid` reply to the accept message id.
+pub const JOIN_REQUEST_ACCEPT_RECEIPT_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/join-requests/accept-receipt/1.0";
+
+/// Body of the accept message. `memberDid` comes from the DIDComm
+/// `from` field (the authcrypt sender) — the envelope binds the member,
+/// so no separate signature is needed. `vc` is the member-issued
+/// reciprocal VC (a DI VC whose issuer is the member); `vmcId` names the
+/// VMC it reciprocates.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestAcceptBody {
+    /// The join request being reciprocated. Over REST this is the
+    /// `{id}` path segment; over DIDComm (no path) it travels in the
+    /// body. The member learns it from the submit receipt's `requestId`.
+    pub request_id: Uuid,
+    pub vmc_id: String,
+    pub vc: JsonValue,
+}
+
+/// Body of the accept receipt message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestAcceptReceiptBody {
+    pub request_id: Uuid,
+    /// Status string. `"accepted"` once the reciprocal edge is recorded.
+    pub status: String,
+    /// `id` of the recorded member-issued reciprocal VC.
+    pub reciprocal_vc_id: String,
+}
+
+// ---------------------------------------------------------------------------
 // Self-remove (M1.11.1 DIDComm twin)
 // ---------------------------------------------------------------------------
 

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -97,6 +97,18 @@ pub struct Member {
     /// timestamp persists.
     #[serde(default)]
     pub personhood_asserted_at: Option<DateTime<Utc>>,
+    /// `id` of the member-issued reciprocal VC that closed the
+    /// bidirectional DTG membership edge (`join-requests/accept/1.0`).
+    /// `None` until the member discharges the `reciprocate_vmc`
+    /// obligation; `Some(_)` marks the edge reciprocated. The
+    /// membership (ACL + VMC) is effective at admit regardless — this
+    /// is the member → community half of the edge.
+    #[serde(default)]
+    pub reciprocal_vc_id: Option<String>,
+    /// Timestamp the reciprocation was recorded. Paired with
+    /// [`Self::reciprocal_vc_id`]; `None` until accept.
+    #[serde(default)]
+    pub accepted_at: Option<DateTime<Utc>>,
 }
 
 impl Member {
@@ -121,7 +133,18 @@ impl Member {
             removed_at: None,
             personhood: false,
             personhood_asserted_at: None,
+            reciprocal_vc_id: None,
+            accepted_at: None,
         }
+    }
+
+    /// Record the member-issued reciprocal VC that closes the
+    /// bidirectional membership edge (`join-requests/accept/1.0`),
+    /// stamping the time. Idempotent at the call site — the accept
+    /// flow guards against re-recording a different VC.
+    pub fn record_reciprocation(&mut self, reciprocal_vc_id: impl Into<String>) {
+        self.reciprocal_vc_id = Some(reciprocal_vc_id.into());
+        self.accepted_at = Some(Utc::now());
     }
 
     /// Returns `true` if this Member has been tombstoned or marked
@@ -149,6 +172,10 @@ impl Member {
         // evidence.
         self.personhood = false;
         self.personhood_asserted_at = None;
+        // The reciprocal edge is bound to the wiped VMC — drop it too;
+        // a re-admitted member reciprocates afresh.
+        self.reciprocal_vc_id = None;
+        self.accepted_at = None;
     }
 
     /// Mark the row historical — keep all fields verbatim, just

--- a/vtc-service/src/members/storage.rs
+++ b/vtc-service/src/members/storage.rs
@@ -201,6 +201,8 @@ mod tests {
             removed_at: None,
             personhood: false,
             personhood_asserted_at: None,
+            reciprocal_vc_id: None,
+            accepted_at: None,
         };
         let json = serde_json::to_value(&m).unwrap();
         assert!(json["joinedAt"].is_string());
@@ -230,6 +232,8 @@ mod tests {
             removed_at: None,
             personhood: true,
             personhood_asserted_at: Some(now),
+            reciprocal_vc_id: None,
+            accepted_at: None,
         };
         let json = serde_json::to_value(&m).unwrap();
         assert_eq!(json["personhood"], true);

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -19,14 +19,16 @@ use vta_sdk::protocols::credential_exchange::{
     ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody, PresentBody, RequestBody,
 };
 use vta_sdk::protocols::join_requests::{
-    JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitBody,
-    JoinRequestSubmitReceiptBody, MEMBER_SELF_REMOVE_RECEIPT_TYPE, MEMBER_SELF_REMOVE_TYPE,
-    SelfRemoveBody, SelfRemoveReceiptBody,
+    JOIN_REQUEST_ACCEPT_RECEIPT_TYPE, JOIN_REQUEST_ACCEPT_TYPE, JOIN_REQUEST_SUBMIT_RECEIPT_TYPE,
+    JOIN_REQUEST_SUBMIT_TYPE, JoinRequestAcceptBody, JoinRequestAcceptReceiptBody,
+    JoinRequestSubmitBody, JoinRequestSubmitReceiptBody, MEMBER_SELF_REMOVE_RECEIPT_TYPE,
+    MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody, SelfRemoveReceiptBody,
 };
 
 use crate::config::AppConfig;
 use crate::join::JoinTransport;
 use crate::members::Disposition;
+use crate::routes::join_requests::accept::accept_inner;
 use crate::routes::join_requests::submit::submit_inner;
 use crate::routes::members::remove::remove_inner;
 use crate::server::AppState;
@@ -98,6 +100,12 @@ pub async fn run_didcomm_service(
             r.route(
                 JOIN_REQUEST_SUBMIT_TYPE,
                 handler_fn(join_request_submit_handler),
+            )
+        })
+        .and_then(|r| {
+            r.route(
+                JOIN_REQUEST_ACCEPT_TYPE,
+                handler_fn(join_request_accept_handler),
             )
         })
         .and_then(|r| {
@@ -231,6 +239,48 @@ async fn join_request_submit_handler(
         .map_err(|e| DIDCommServiceError::Internal(format!("receipt serialise: {e}")))?;
     Ok(Some(
         DIDCommResponse::new(JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, body).thid(message.id),
+    ))
+}
+
+/// `join-requests/accept/1.0` over DIDComm — the reciprocal step.
+///
+/// The member DID is the DIDComm `from` field (authcrypt sender), so no
+/// separate holder-binding signature is needed (`signature_hex = None`).
+/// The body carries the `requestId` (no path over DIDComm), the `vmcId`,
+/// and the member-issued reciprocal `vc`. Calls into the same
+/// `accept_inner` the REST endpoint uses; replies with an accept receipt.
+async fn join_request_accept_handler(
+    ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<AppState>,
+) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let member_did = ctx.sender_did.clone().ok_or_else(|| {
+        DIDCommServiceError::Internal("join-request accept has no DIDComm sender".into())
+    })?;
+    let body: JoinRequestAcceptBody = serde_json::from_value(message.body.clone())
+        .map_err(|e| DIDCommServiceError::Internal(format!("malformed join-accept body: {e}")))?;
+
+    let outcome = accept_inner(
+        &state,
+        body.request_id,
+        member_did,
+        body.vmc_id,
+        body.vc,
+        None,
+        JoinTransport::DIDComm,
+    )
+    .await
+    .map_err(|e| DIDCommServiceError::Internal(format!("accept failed: {e}")))?;
+
+    let receipt = JoinRequestAcceptReceiptBody {
+        request_id: outcome.request_id,
+        status: "accepted".to_string(),
+        reciprocal_vc_id: outcome.reciprocal_vc_id,
+    };
+    let body = serde_json::to_value(&receipt)
+        .map_err(|e| DIDCommServiceError::Internal(format!("receipt serialise: {e}")))?;
+    Ok(Some(
+        DIDCommResponse::new(JOIN_REQUEST_ACCEPT_RECEIPT_TYPE, body).thid(message.id),
     ))
 }
 

--- a/vtc-service/src/routes/join_requests/accept.rs
+++ b/vtc-service/src/routes/join_requests/accept.rs
@@ -1,0 +1,386 @@
+//! `POST /v1/join-requests/{id}/accept` — the reciprocal step
+//! (`join-requests/accept/1.0`) + a shared `accept_inner` the DIDComm
+//! handler calls into.
+//!
+//! A join `allow` issues the community → member half of the membership
+//! edge (the VMC). `accept` carries the member's counter-assertion — a
+//! member-issued **reciprocal VC** — back to the VTC, which verifies it
+//! and records the bidirectional DTG edge, discharging the
+//! `reciprocate_vmc` obligation. Membership (ACL + VMC) is already
+//! effective at admit; this completes the edge.
+//!
+//! ## Auth
+//!
+//! Unauthenticated trigger; the reciprocal VC + the request binding ARE
+//! the auth (spec §Authentication), mirroring `submit`:
+//! - REST carries an Ed25519 holder-binding `signature` over the
+//!   canonical body (domain tag [`JOIN_ACCEPT_DOMAIN_TAG`]).
+//! - DIDComm omits it — the authcrypt sender binds `memberDid`
+//!   (`signature_hex = None`).
+//!
+//! The reciprocal VC itself is a DI VC self-issued by the member
+//! (`did:key`, Phase 1) — its `eddsa-jcs-2022` issuer proof IS the
+//! counter-signature, verified directly against the member's `did:key`.
+
+use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::info;
+use uuid::Uuid;
+
+use vti_common::audit::{AuditEvent, MembershipReciprocatedData};
+use vti_common::error::AppError;
+
+use crate::join::{JoinStatus, JoinTransport, get_join_request};
+use crate::members::{get_member, store_member};
+use crate::server::AppState;
+
+/// Domain tag prefixing the REST holder-binding signature payload.
+/// Distinct from `submit`'s tag so an accept signature can never be
+/// replayed as a submission.
+pub const JOIN_ACCEPT_DOMAIN_TAG: &[u8] = b"vtc-join-accept/v1\0";
+
+/// `type` array value the reciprocal VC must carry.
+const RECIPROCAL_VC_TYPE: &str = "MembershipAcknowledgement";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcceptRequestBody {
+    pub member_did: String,
+    pub vmc_id: String,
+    /// Member-issued reciprocal VC (DI VC; issuer = `memberDid`).
+    pub vc: JsonValue,
+    /// Hex-encoded Ed25519 signature over the canonical body.
+    pub signature: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcceptResponse {
+    pub request_id: Uuid,
+    pub status: String,
+    pub reciprocal_vc_id: String,
+}
+
+/// What [`accept_inner`] recorded.
+pub struct AcceptOutcome {
+    pub request_id: Uuid,
+    pub reciprocal_vc_id: String,
+    /// `false` when the edge was already recorded with this same VC —
+    /// the call was a no-op (idempotent re-accept), so the caller skips
+    /// re-auditing.
+    pub recorded: bool,
+}
+
+pub async fn accept(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<AcceptRequestBody>,
+) -> Result<(StatusCode, Json<AcceptResponse>), AppError> {
+    let outcome = accept_inner(
+        &state,
+        id,
+        body.member_did,
+        body.vmc_id,
+        body.vc,
+        Some(&body.signature),
+        JoinTransport::Rest,
+    )
+    .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(AcceptResponse {
+            request_id: outcome.request_id,
+            status: "accepted".to_string(),
+            reciprocal_vc_id: outcome.reciprocal_vc_id,
+        }),
+    ))
+}
+
+/// Shared decide → record spine for REST + DIDComm.
+///
+/// `signature_hex` is `Some` for REST (explicit holder binding) and
+/// `None` for DIDComm (the authcrypt sender already authenticated
+/// `member_did`).
+pub async fn accept_inner(
+    state: &AppState,
+    id: Uuid,
+    member_did: String,
+    vmc_id: String,
+    vc: JsonValue,
+    signature_hex: Option<&str>,
+    transport: JoinTransport,
+) -> Result<AcceptOutcome, AppError> {
+    // 1. Holder binding (REST only).
+    if let Some(hex_sig) = signature_hex {
+        verify_holder_signature(&member_did, &vmc_id, &vc, hex_sig)?;
+    }
+
+    // 2. The join request must exist and have an issued membership to
+    // reciprocate (verdict was `allow`/approve → status Approved).
+    let req = get_join_request(&state.join_requests_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("join request not found: {id}")))?;
+    if req.status != JoinStatus::Approved {
+        return Err(AppError::Conflict(format!(
+            "join request {id} is {:?}; only an Approved request has a VMC to reciprocate",
+            req.status
+        )));
+    }
+    if req.applicant_did != member_did {
+        return Err(AppError::Validation(format!(
+            "memberDid does not match the join request applicant ({})",
+            req.applicant_did
+        )));
+    }
+
+    // 3. The member must exist and `vmcId` must name their current VMC.
+    let mut member = get_member(&state.members_ks, &member_did)
+        .await?
+        .filter(|m| !m.is_removed())
+        .ok_or_else(|| AppError::NotFound(format!("no active member: {member_did}")))?;
+    if member.current_vmc_id.as_deref() != Some(vmc_id.as_str()) {
+        return Err(AppError::Conflict(format!(
+            "vmcId does not match the member's current VMC ({:?})",
+            member.current_vmc_id
+        )));
+    }
+
+    // 4. Verify the reciprocal VC (the counter-signature itself). The
+    // community DID the member acknowledges is this VTC's DID — the
+    // issuer of the VMC being reciprocated.
+    let community_did = state
+        .config
+        .read()
+        .await
+        .vtc_did
+        .clone()
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| {
+            AppError::Internal("VTC DID not configured — cannot bind a reciprocal VC".into())
+        })?;
+    let reciprocal_vc_id = verify_reciprocal_vc(&vc, &member_did, &vmc_id, &community_did)?;
+
+    // 5. Idempotency: a re-accept with the same VC is a no-op; a
+    // different VC for an already-reciprocated VMC is a conflict.
+    if let Some(existing) = member.reciprocal_vc_id.as_deref() {
+        if existing == reciprocal_vc_id {
+            return Ok(AcceptOutcome {
+                request_id: id,
+                reciprocal_vc_id,
+                recorded: false,
+            });
+        }
+        return Err(AppError::Conflict(format!(
+            "membership already reciprocated with a different VC ({existing})"
+        )));
+    }
+
+    // 6. Record the bidirectional edge.
+    member.record_reciprocation(reciprocal_vc_id.clone());
+    store_member(&state.members_ks, &member).await?;
+
+    // 7. Audit.
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+    audit_writer
+        .write(
+            &member_did,
+            Some(&member_did),
+            AuditEvent::MembershipReciprocated(MembershipReciprocatedData {
+                request_id: id.to_string(),
+                vmc_id: vmc_id.clone(),
+                reciprocal_vc_id: reciprocal_vc_id.clone(),
+            }),
+        )
+        .await?;
+
+    info!(
+        request_id = %id,
+        member = %member_did,
+        vmc_id = %vmc_id,
+        reciprocal_vc_id = %reciprocal_vc_id,
+        transport = transport.as_str(),
+        "membership reciprocated"
+    );
+
+    Ok(AcceptOutcome {
+        request_id: id,
+        reciprocal_vc_id,
+        recorded: true,
+    })
+}
+
+/// Verify the member-issued reciprocal VC and return its top-level `id`.
+///
+/// Checks: `issuer == member_did`; `type` includes
+/// [`RECIPROCAL_VC_TYPE`]; `credentialSubject.id == community_did`;
+/// `credentialSubject.reciprocates == vmc_id`; and the
+/// `eddsa-jcs-2022` issuer proof (purpose `assertionMethod`, key bound
+/// to `member_did`) verifies against the member's `did:key`.
+fn verify_reciprocal_vc(
+    vc: &JsonValue,
+    member_did: &str,
+    vmc_id: &str,
+    community_did: &str,
+) -> Result<String, AppError> {
+    let obj = vc
+        .as_object()
+        .ok_or_else(|| AppError::Validation("reciprocal vc is not a JSON object".into()))?;
+
+    // Issuer must be the member (self-issued counter-signature).
+    let issuer = match obj.get("issuer") {
+        Some(JsonValue::String(s)) => s.clone(),
+        Some(JsonValue::Object(o)) => o
+            .get("id")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        _ => String::new(),
+    };
+    if issuer != member_did {
+        return Err(AppError::Validation(format!(
+            "reciprocal vc issuer `{issuer}` is not the member `{member_did}`"
+        )));
+    }
+
+    // Type discriminator.
+    let has_type = obj
+        .get("type")
+        .and_then(JsonValue::as_array)
+        .is_some_and(|a| {
+            a.iter()
+                .filter_map(JsonValue::as_str)
+                .any(|t| t == RECIPROCAL_VC_TYPE)
+        });
+    if !has_type {
+        return Err(AppError::Validation(format!(
+            "reciprocal vc `type` must include `{RECIPROCAL_VC_TYPE}`"
+        )));
+    }
+
+    // Subject: acknowledges THIS community + the specific VMC.
+    let subject = obj.get("credentialSubject").and_then(JsonValue::as_object);
+    let subject_id = subject
+        .and_then(|s| s.get("id"))
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    if subject_id != community_did {
+        return Err(AppError::Validation(format!(
+            "reciprocal vc subject `{subject_id}` is not this community `{community_did}`"
+        )));
+    }
+    let reciprocates = subject
+        .and_then(|s| s.get("reciprocates"))
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    if reciprocates != vmc_id {
+        return Err(AppError::Validation(format!(
+            "reciprocal vc `reciprocates` ({reciprocates}) does not name the member's VMC ({vmc_id})"
+        )));
+    }
+
+    // Cryptographic counter-signature: the member's issuer proof.
+    let proof_val = obj
+        .get("proof")
+        .ok_or_else(|| AppError::Validation("reciprocal vc has no issuer `proof`".into()))?;
+    let proof: DataIntegrityProof = serde_json::from_value(proof_val.clone()).map_err(|e| {
+        AppError::Validation(format!("reciprocal vc proof is not Data-Integrity: {e}"))
+    })?;
+    if proof.proof_purpose != "assertionMethod" {
+        return Err(AppError::Validation(format!(
+            "reciprocal vc proof purpose is `{}`, expected `assertionMethod`",
+            proof.proof_purpose
+        )));
+    }
+    if proof
+        .verification_method
+        .split('#')
+        .next()
+        .unwrap_or_default()
+        != member_did
+    {
+        return Err(AppError::Validation(format!(
+            "reciprocal vc proof verificationMethod `{}` is not under the member `{member_did}`",
+            proof.verification_method
+        )));
+    }
+
+    let pub_bytes = affinidi_crypto::did_key::did_key_to_ed25519_pub(member_did)
+        .map_err(|e| AppError::Validation(format!("member_did is not a parseable did:key: {e}")))?;
+    let mut unsigned = vc.clone();
+    if let Some(o) = unsigned.as_object_mut() {
+        o.remove("proof");
+    }
+    proof
+        .verify_with_public_key(&unsigned, &pub_bytes, VerifyOptions::new())
+        .map_err(|e| {
+            AppError::Validation(format!("reciprocal vc issuer proof did not verify: {e}"))
+        })?;
+
+    obj.get("id")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| AppError::Validation("reciprocal vc is missing a top-level `id`".into()))
+}
+
+/// Verify the Ed25519 holder-binding signature over the canonical body
+/// (`memberDid` + `vmcId` + `vc`), domain-tagged. Mirrors `submit`.
+fn verify_holder_signature(
+    member_did: &str,
+    vmc_id: &str,
+    vc: &JsonValue,
+    signature_hex: &str,
+) -> Result<(), AppError> {
+    let pubkey_bytes = affinidi_crypto::did_key::did_key_to_ed25519_pub(member_did)
+        .map_err(|e| AppError::Validation(format!("member_did is not a parseable did:key: {e}")))?;
+    let verifying = VerifyingKey::from_bytes(&pubkey_bytes)
+        .map_err(|e| AppError::Validation(format!("member_did decodes to an invalid key: {e}")))?;
+
+    let payload = canonical_payload(member_did, vmc_id, vc)?;
+    let signing_bytes = signing_bytes(&payload);
+
+    let raw_sig = hex::decode(signature_hex)
+        .map_err(|e| AppError::Validation(format!("signature is not hex: {e}")))?;
+    let signature = Signature::from_slice(&raw_sig).map_err(|e| {
+        AppError::Validation(format!("signature is not a 64-byte Ed25519 value: {e}"))
+    })?;
+
+    verifying
+        .verify(&signing_bytes, &signature)
+        .map_err(|e| AppError::Validation(format!("holder-binding signature failed: {e}")))?;
+    Ok(())
+}
+
+/// Canonical signing payload — typed struct, field order pinned by the
+/// derive (both sides build it identically).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalPayload<'a> {
+    member_did: &'a str,
+    vmc_id: &'a str,
+    vc: &'a JsonValue,
+}
+
+fn canonical_payload(member_did: &str, vmc_id: &str, vc: &JsonValue) -> Result<Vec<u8>, AppError> {
+    serde_json::to_vec(&CanonicalPayload {
+        member_did,
+        vmc_id,
+        vc,
+    })
+    .map_err(|e| AppError::Internal(format!("canonical payload serialize: {e}")))
+}
+
+fn signing_bytes(payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(JOIN_ACCEPT_DOMAIN_TAG.len() + payload.len());
+    buf.extend_from_slice(JOIN_ACCEPT_DOMAIN_TAG);
+    buf.extend_from_slice(payload);
+    buf
+}

--- a/vtc-service/src/routes/join_requests/mod.rs
+++ b/vtc-service/src/routes/join_requests/mod.rs
@@ -6,6 +6,7 @@
 //! (Phase 1 simplification — Moderator-tier admission lands in
 //! Phase 2's policy surface).
 
+pub mod accept;
 pub mod decide;
 pub mod present;
 pub mod read;

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -252,6 +252,8 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             .expect("static Trust-Task URL");
     let join_reject = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0")
         .expect("static Trust-Task URL");
+    let join_accept = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0")
+        .expect("static Trust-Task URL");
     // Policies (Phase 2 M2.3). Three distinct Trust Tasks for the
     // three POST endpoints — upload, activate, test — so SIEM
     // filters + soft-gate consumers can target each precisely.
@@ -682,6 +684,14 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             "/join-requests/{id}/reject",
             post(join_requests::decide::reject),
             join_reject,
+        )
+        // Accept (unauth — the reciprocal VC + holder binding are the
+        // auth, like submit): the member counter-signs the issued VMC to
+        // close the bidirectional edge.
+        .route_with_task(
+            "/join-requests/{id}/accept",
+            post(join_requests::accept::accept),
+            join_accept,
         )
         // Credential-exchange query send (admin): prepare a DCQL query + issue a
         // single-use presentation challenge for a holder. Plain admin route (no

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -37,12 +37,21 @@ use vtc_service::server::AppState;
 /// test. Keeping a single-line copy here is cheaper than widening
 /// the module's visibility for one test.
 const JOIN_REQUEST_SUBMIT_DOMAIN_TAG: &[u8] = b"vtc-join-request/v1\0";
+/// Mirror of `routes::join_requests::accept::JOIN_ACCEPT_DOMAIN_TAG`.
+const JOIN_ACCEPT_DOMAIN_TAG: &[u8] = b"vtc-join-accept/v1\0";
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const SUBMIT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0";
 const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0";
 const APPROVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0";
 const REJECT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0";
+const ACCEPT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0";
+/// The VTC DID the fixture configures — the issuer of every VMC and the
+/// community a reciprocal VC must acknowledge.
+const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+/// Member seed shared by `applicant_pair` (so a `LocalSigner` over the
+/// same seed signs reciprocal VCs that verify against the member did:key).
+const MEMBER_SEED: [u8; 32] = [0xCD; 32];
 const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
 const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
 
@@ -1355,4 +1364,229 @@ async fn admin_query_send_requires_admin() {
     )
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// Accept — reciprocal VMC (join-requests/accept/1.0)
+// ---------------------------------------------------------------------------
+
+/// Submit then admin-approve an applicant, returning
+/// `(member sk, member_did, request_id, vmc_id)`.
+async fn admit_member(fix: &Fixture) -> (SigningKey, String, Uuid, String) {
+    let (sk, member_did) = applicant_pair();
+    let vp = json!({});
+    let sig = sign_holder_payload(&sk, &member_did, &vp, false, &Value::Null);
+    let (_, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({ "applicantDid": member_did, "vp": vp, "signature": sig })),
+    )
+    .await;
+    let id = Uuid::parse_str(body["requestId"].as_str().unwrap()).unwrap();
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/approve"),
+        APPROVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "approve failed: {body}");
+    let vmc_id = body["vmc"]["id"].as_str().unwrap().to_string();
+    (sk, member_did, id, vmc_id)
+}
+
+/// Build + sign a member-issued reciprocal VC (the counter-signature).
+async fn build_reciprocal_vc(
+    member_did: &str,
+    vmc_id: &str,
+    community_did: &str,
+    id: &str,
+) -> Value {
+    let signer = vtc_service::credentials::LocalSigner::from_ed25519_seed(
+        member_did.to_string(),
+        &MEMBER_SEED,
+    );
+    let mut vc = json!({
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
+        "type": ["VerifiableCredential", "MembershipAcknowledgement"],
+        "id": id,
+        "issuer": member_did,
+        "credentialSubject": { "id": community_did, "reciprocates": vmc_id },
+    });
+    signer.sign_doc(&mut vc).await.expect("sign reciprocal vc");
+    vc
+}
+
+/// Holder-binding signature over the canonical accept body. Mirrors
+/// `routes::join_requests::accept`'s construction.
+fn sign_accept_payload(sk: &SigningKey, member_did: &str, vmc_id: &str, vc: &Value) -> String {
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Payload<'a> {
+        member_did: &'a str,
+        vmc_id: &'a str,
+        vc: &'a Value,
+    }
+    let payload = serde_json::to_vec(&Payload {
+        member_did,
+        vmc_id,
+        vc,
+    })
+    .unwrap();
+    let mut signing = Vec::with_capacity(JOIN_ACCEPT_DOMAIN_TAG.len() + payload.len());
+    signing.extend_from_slice(JOIN_ACCEPT_DOMAIN_TAG);
+    signing.extend_from_slice(&payload);
+    hex::encode(sk.sign(&signing).to_bytes())
+}
+
+async fn post_accept(
+    fix: &Fixture,
+    id: Uuid,
+    member_did: &str,
+    vmc_id: &str,
+    vc: &Value,
+    signature: &str,
+) -> (StatusCode, Value) {
+    send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/accept"),
+        ACCEPT_TASK,
+        None,
+        Some(json!({
+            "memberDid": member_did,
+            "vmcId": vmc_id,
+            "vc": vc,
+            "signature": signature,
+        })),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn accept_records_the_reciprocal_edge() {
+    let fix = build_fixture().await;
+    let (sk, member_did, id, vmc_id) = admit_member(&fix).await;
+    let recip_id = "urn:uuid:recip-1";
+    let vc = build_reciprocal_vc(&member_did, &vmc_id, VTC_DID, recip_id).await;
+    let sig = sign_accept_payload(&sk, &member_did, &vmc_id, &vc);
+
+    let (status, body) = post_accept(&fix, id, &member_did, &vmc_id, &vc, &sig).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["status"], "accepted");
+    assert_eq!(body["reciprocalVcId"], recip_id);
+
+    let member = get_member(&fix.members_ks, &member_did)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(member.reciprocal_vc_id.as_deref(), Some(recip_id));
+    assert!(member.accepted_at.is_some(), "accepted_at stamped");
+}
+
+#[tokio::test]
+async fn accept_is_idempotent_for_the_same_vc() {
+    let fix = build_fixture().await;
+    let (sk, member_did, id, vmc_id) = admit_member(&fix).await;
+    let vc = build_reciprocal_vc(&member_did, &vmc_id, VTC_DID, "urn:uuid:recip-1").await;
+    let sig = sign_accept_payload(&sk, &member_did, &vmc_id, &vc);
+
+    let (s1, _) = post_accept(&fix, id, &member_did, &vmc_id, &vc, &sig).await;
+    assert_eq!(s1, StatusCode::OK);
+    let (s2, b2) = post_accept(&fix, id, &member_did, &vmc_id, &vc, &sig).await;
+    assert_eq!(
+        s2,
+        StatusCode::OK,
+        "re-accept of the same VC is a no-op: {b2}"
+    );
+    assert_eq!(b2["reciprocalVcId"], "urn:uuid:recip-1");
+}
+
+#[tokio::test]
+async fn accept_conflicts_on_a_different_vc_after_reciprocation() {
+    let fix = build_fixture().await;
+    let (sk, member_did, id, vmc_id) = admit_member(&fix).await;
+    let vc1 = build_reciprocal_vc(&member_did, &vmc_id, VTC_DID, "urn:uuid:recip-1").await;
+    let sig1 = sign_accept_payload(&sk, &member_did, &vmc_id, &vc1);
+    let (s1, _) = post_accept(&fix, id, &member_did, &vmc_id, &vc1, &sig1).await;
+    assert_eq!(s1, StatusCode::OK);
+
+    let vc2 = build_reciprocal_vc(&member_did, &vmc_id, VTC_DID, "urn:uuid:recip-2").await;
+    let sig2 = sign_accept_payload(&sk, &member_did, &vmc_id, &vc2);
+    let (s2, _) = post_accept(&fix, id, &member_did, &vmc_id, &vc2, &sig2).await;
+    assert_eq!(s2, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn accept_rejects_a_wrong_holder_signature() {
+    let fix = build_fixture().await;
+    let (_sk, member_did, id, vmc_id) = admit_member(&fix).await;
+    let vc = build_reciprocal_vc(&member_did, &vmc_id, VTC_DID, "urn:uuid:recip-1").await;
+    let other = SigningKey::from_bytes(&[0xEE; 32]);
+    let bad_sig = sign_accept_payload(&other, &member_did, &vmc_id, &vc);
+
+    let (status, _) = post_accept(&fix, id, &member_did, &vmc_id, &vc, &bad_sig).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn accept_conflicts_when_not_yet_approved() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+    let (sk, member_did) = applicant_pair();
+    // No VMC exists yet; build a placeholder vc — the status guard fires first.
+    let vc = build_reciprocal_vc(&member_did, "urn:uuid:none", VTC_DID, "urn:uuid:recip-1").await;
+    let sig = sign_accept_payload(&sk, &member_did, "urn:uuid:none", &vc);
+
+    let (status, _) = post_accept(&fix, id, &member_did, "urn:uuid:none", &vc, &sig).await;
+    assert_eq!(status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn accept_conflicts_on_vmc_id_mismatch() {
+    let fix = build_fixture().await;
+    let (sk, member_did, id, _vmc_id) = admit_member(&fix).await;
+    let wrong = "urn:uuid:not-the-current-vmc";
+    let vc = build_reciprocal_vc(&member_did, wrong, VTC_DID, "urn:uuid:recip-1").await;
+    let sig = sign_accept_payload(&sk, &member_did, wrong, &vc);
+
+    let (status, _) = post_accept(&fix, id, &member_did, wrong, &vc, &sig).await;
+    assert_eq!(status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn accept_rejects_a_reciprocal_vc_for_another_community() {
+    let fix = build_fixture().await;
+    let (sk, member_did, id, vmc_id) = admit_member(&fix).await;
+    // Subject acknowledges a different community than this VTC.
+    let vc = build_reciprocal_vc(
+        &member_did,
+        &vmc_id,
+        "did:web:evil.example",
+        "urn:uuid:recip-1",
+    )
+    .await;
+    let sig = sign_accept_payload(&sk, &member_did, &vmc_id, &vc);
+
+    let (status, _) = post_accept(&fix, id, &member_did, &vmc_id, &vc, &sig).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn accept_rejects_a_tampered_reciprocal_vc() {
+    let fix = build_fixture().await;
+    let (sk, member_did, id, vmc_id) = admit_member(&fix).await;
+    let mut vc = build_reciprocal_vc(&member_did, &vmc_id, VTC_DID, "urn:uuid:recip-1").await;
+    // Mutate the signed `id` after signing — the issuer proof no longer covers it.
+    vc["id"] = json!("urn:uuid:swapped");
+    let sig = sign_accept_payload(&sk, &member_did, &vmc_id, &vc);
+
+    let (status, _) = post_accept(&fix, id, &member_did, &vmc_id, &vc, &sig).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
 }

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -146,6 +146,13 @@ pub enum AuditEvent {
     /// tombstoned with the DID retained, or kept historical.
     MemberRemoved(MemberRemovedData),
 
+    /// A member discharged the `reciprocate_vmc` obligation: they
+    /// counter-signed the issued VMC with a member-issued reciprocal
+    /// VC, completing the bidirectional DTG membership edge
+    /// (`join-requests/accept/1.0`). The audit envelope's
+    /// `target_did` carries the member.
+    MembershipReciprocated(MembershipReciprocatedData),
+
     /// `POST /v1/policies` accepted an upload, compiled the source,
     /// and persisted a new revision. The row is **not yet active** —
     /// activation is a separate event. Spec §7.1; Phase 2 M2.3.
@@ -534,6 +541,25 @@ pub struct PolicyUploadedData {
     pub sha256: String,
     /// Per-purpose monotone counter the upload landed under.
     pub version: u32,
+}
+
+/// Payload for [`AuditEvent::MembershipReciprocated`].
+///
+/// The audit envelope's `target_did` already carries the member; this
+/// adds the join request that admitted them, the VMC they reciprocated,
+/// and the id of the member-issued reciprocal VC, so an investigator can
+/// chain "admitted → reciprocated" without scanning the members keyspace.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MembershipReciprocatedData {
+    /// UUID of the JoinRequest the reciprocation closes.
+    pub request_id: String,
+    /// `id` of the VMC the member reciprocated (the community → member
+    /// half of the edge).
+    pub vmc_id: String,
+    /// `id` of the member-issued reciprocal VC (the member → community
+    /// half).
+    pub reciprocal_vc_id: String,
 }
 
 /// Payload for [`AuditEvent::VmcIssued`] + [`AuditEvent::VecIssued`].

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -37,11 +37,12 @@ pub use event::{
     CustomEndorsementIssuedData, CustomEndorsementRevokedData, DidRotatedData,
     EmergencyBootstrapData, EndorsementTypeDeletedData, EndorsementTypeRegisteredData,
     JoinRequestData, JoinRequestRejectedData, MemberAddedData, MemberRemovedData,
-    MemberUpdatedData, MembershipRenewedData, PersonhoodAssertedData, PersonhoodRevokedData,
-    PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER, RegistryRecordPolicyOverrideData,
-    RegistryStatusChangedData, RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData,
-    StatusListFlippedData, VrcPublishedData, VrcRevokedData, WebsiteBundleDeployedData,
-    WebsiteFileDeletedData, WebsiteFileWrittenData, WebsiteGenerationRolledBackData,
+    MemberUpdatedData, MembershipReciprocatedData, MembershipRenewedData, PersonhoodAssertedData,
+    PersonhoodRevokedData, PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER,
+    RegistryRecordPolicyOverrideData, RegistryStatusChangedData, RegistrySyncOutcomeData,
+    RestartRequestedData, RoleChangedData, StatusListFlippedData, VrcPublishedData, VrcRevokedData,
+    WebsiteBundleDeployedData, WebsiteFileDeletedData, WebsiteFileWrittenData,
+    WebsiteGenerationRolledBackData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## What

Implements the **`accept`** verb spec'd in #315 — the reciprocal step that closes the VTC join ceremony's bidirectional DTG membership edge.

A join `allow` issues the community → member half (the VMC). `accept` carries the member's counter-assertion — a member-issued **reciprocal VC** (`MembershipAcknowledgement`) — which the VTC verifies and records, discharging the `reciprocate_vmc` obligation the policy emits (previously parsed, carried in the plan, then dropped at `ceremony/execute.rs`).

## Surface
- **REST** `POST /v1/join-requests/{id}/accept` + **DIDComm** `join-requests/accept/1.0` (authcrypt sender = member), sharing one `accept_inner` spine.
- **Auth** mirrors `submit`: REST Ed25519 holder binding over the domain-tagged (`vtc-join-accept/v1\0`) body; DIDComm authcrypt sender (no body signature).
- **Reciprocal VC verification:** issuer == `memberDid`; type includes `MembershipAcknowledgement`; `credentialSubject.id` == this VTC (the VMC issuer); `credentialSubject.reciprocates` == the member's current VMC; `eddsa-jcs-2022` issuer proof (purpose `assertionMethod`, VM bound to the member `did:key`) verified directly against the `did:key` (Phase 1, no resolver — same constraint as `submit`).
- **Cross-checks:** request is `Approved`, applicant == member, `vmcId` == member's current VMC. **Idempotent** (same VC → no-op 200; different VC for a reciprocated VMC → 409).
- `Member` gains `reciprocal_vc_id` + `accepted_at` (cleared on tombstone). New audit event `MembershipReciprocated`. SDK wire types added.

## Spec sync
The merged #315 spec is refined to pin the concrete reciprocal-VC shape and note the DIDComm body carries `requestId` (no URL path over DIDComm). Decisions from #315 hold: VC/VP form; membership effective at admit, edge pending (no host-enforced deadline in 1.0).

## Tests
8 integration tests in `tests/join_requests.rs`: happy path, idempotent re-accept, different-VC conflict, wrong holder signature, not-yet-approved, vmcId mismatch, wrong-community subject, tampered proof.

## CI
Green in an isolated worktree off `main`: `cargo fmt --check`, `clippy --all-targets` (no warnings), `cargo test -p vtc-service` (489 lib + join suite 23→31), `vti-common`/`vta-sdk` tests, `cargo deny`.

## Follow-ups (not here)
- DIDComm auto-admit delivery: the submit/present auto-admit path issues the VMC but its receipt only carries `{requestId,status}` — wire `deliver_membership_credentials` like the approve path.
- `did:webvh` members (Phase 1 is `did:key` only, as on `submit`).