### PR TITLE
fix(join): deliver credentials over DIDComm on auto-admit

### DIFF
--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -42,7 +42,7 @@ use chrono::Utc;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use vti_common::audit::{AuditEvent, JoinRequestData, JoinRequestRejectedData};
@@ -251,6 +251,26 @@ pub(crate) async fn realize_join_verdict(
             if let EffectOutcome::Admitted(creds) =
                 execute::apply(state, plan, applicant_did).await?
             {
+                // Deliver the issued VMC + role VEC to the applicant's wallet
+                // over DIDComm — mirrors the approve path. Best-effort: the
+                // credentials are already issued (and returned inline on the
+                // REST path), so a delivery failure (no mediator, unreachable
+                // holder) is logged, not fatal. This closes the gap where a
+                // DIDComm auto-admit issued credentials but never sent them —
+                // the receipt only carries the request id + status.
+                if let Err(e) = crate::credentials::delivery::deliver_membership_credentials(
+                    state,
+                    applicant_did,
+                    &creds,
+                )
+                .await
+                {
+                    warn!(
+                        applicant = %applicant_did,
+                        error = %e,
+                        "membership-credential delivery failed on auto-admit; credentials issued",
+                    );
+                }
                 admit = Some(creds);
             }
             request.status = JoinStatus::Approved;


### PR DESCRIPTION
## Problem

The policy **auto-admit** path (`realize_join_verdict`, shared by the DIDComm `submit` and `present` handlers) issued the VMC + role VEC but never delivered them. The DIDComm receipt only carries `{requestId, status}`, so a DIDComm applicant whose join policy returned `allow` got `approved` back but **never received its membership credentials**.

Only the admin `approve` path actually delivered — and its own comment references "the auto-admit path" as if delivery happened there too. It didn't.

## Fix

On the `Allow` arm of `realize_join_verdict`, call `deliver_membership_credentials` best-effort right after the admit effect issues them — mirroring `approve`:
- Failure (no mediator, unreachable holder) is **logged, not fatal**.
- The REST path still returns the credentials inline as well.

One file, +21/-1.

## Tests / CI

Green in an isolated worktree off `main`: `cargo fmt --check`, `clippy --all-targets` (no warnings), full `cargo test -p vtc-service`, `cargo deny`. The existing auto-admit tests (`rest_submit_under_allow_policy_auto_admits`, `credential_exchange_present_auto_admits_under_allow_policy`) confirm the path stays non-fatal with the no-mediator fixture. End-to-end DIDComm delivery is exercised by the mediator harness (vti-e2e-tests), per the join test module's convention.