### PR TITLE
spec(join): draft join-requests/manifest + status verbs

### DIFF
--- a/docs/05-design-notes/vtc-ceremony-protocol.md
+++ b/docs/05-design-notes/vtc-ceremony-protocol.md
@@ -170,9 +170,9 @@ today, so this proposal stays honest about the realized surface:
 | `present` | **`credential-exchange/present/1.0`** (reused; VTC = verifier) | `trust-tasks/credential-exchange/present` | `routes/join_requests/present.rs`, `messaging.rs` |
 | *(query side)* | **`credential-exchange/query/1.0`** (reused; VTC issues the DCQL query) | `trust-tasks/credential-exchange/query` | `routes/join_requests/present.rs::{prepare_join_query,send_query}` |
 | `resolve` | the existing admin REST `approve`/`reject` | `trust-tasks/join-requests/{approve,reject}` | `routes/join_requests/decide.rs` |
-| `accept` | `join-requests/accept/1.0` | `trust-tasks/join-requests/accept` *(this branch, Draft)* | **not yet implemented** — discharge `reciprocate_vmc` in `ceremony/execute.rs` + a route/DIDComm handler |
-| `manifest` | — | — | design-future |
-| `status` | join request `show` (`GET /v1/join-requests/{id}`) approximates it | `trust-tasks/join-requests/show` | `routes/join_requests/read.rs` |
+| `accept` | `join-requests/accept/1.0` | `trust-tasks/join-requests/accept` | `routes/join_requests/accept.rs` + `messaging.rs` (REST + DIDComm) — discharges `reciprocate_vmc` |
+| `manifest` | `join-requests/manifest/1.0` | `trust-tasks/join-requests/manifest` *(this branch, Draft)* | **not yet implemented** — `GET /v1/join-requests/manifest` over `schemas::accepts::list_accepts` |
+| `status` | `join-requests/status/1.0` | `trust-tasks/join-requests/status` *(this branch, Draft)* | **not yet implemented** — applicant-facing holder-bound poll; the admin-only `show` (`routes/join_requests/read.rs`) remains the staff view |
 
 **Reconciliation note.** The §7 deliverable list implied
 `join-requests/{present,status}` as join-family verbs. In the build, the

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -212,6 +212,20 @@
       "didcomm": "https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0"
     },
     {
+      "id": "https://trusttasks.org/openvtc/vtc/join-requests/manifest/1.0",
+      "status": "Draft",
+      "path": "join-requests/manifest/1.0",
+      "rest": "GET /v1/join-requests/manifest",
+      "didcomm": "https://trusttasks.org/openvtc/vtc/join-requests/manifest/1.0"
+    },
+    {
+      "id": "https://trusttasks.org/openvtc/vtc/join-requests/status/1.0",
+      "status": "Draft",
+      "path": "join-requests/status/1.0",
+      "rest": "POST /v1/join-requests/{id}/status",
+      "didcomm": "https://trusttasks.org/openvtc/vtc/join-requests/status/1.0"
+    },
+    {
       "id": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0",
       "status": "Draft",
       "path": "members/self-remove/1.0",

--- a/trust-tasks/join-requests/manifest/1.0/schema.json
+++ b/trust-tasks/join-requests/manifest/1.0/schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/join-requests/manifest/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Join Requests — Manifest (discovery)",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "object",
+      "required": ["communityDid", "criteria"],
+      "properties": {
+        "communityDid": { "type": "string" },
+        "criteria": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "presentationDefinition"],
+            "properties": {
+              "id": { "type": "string" },
+              "description": { "type": "string" },
+              "presentationDefinition": {}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/trust-tasks/join-requests/manifest/1.0/spec.md
+++ b/trust-tasks/join-requests/manifest/1.0/spec.md
@@ -1,0 +1,75 @@
+---
+id: https://trusttasks.org/openvtc/vtc/join-requests/manifest/1.0
+title: VTC Join Requests — Manifest (discovery)
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/join-requests/manifest
+  - didcomm: https://trusttasks.org/openvtc/vtc/join-requests/manifest/1.0
+---
+
+# VTC Join Requests — Manifest (discovery)
+
+The `manifest` verb is the join ceremony's **pre-submit discovery** step
+(protocol §2 verb set). A prospective applicant asks the VTC *what it
+needs to present to join* — the community's evidence requirements — so
+the applicant can assemble a presentation before opening a thread with
+`request` (= `submit`) or answering a `present`.
+
+`manifest` is a **read**: it opens no thread, mints no challenge, and
+writes nothing. It is the public face of the community's registered
+**Accepts criteria** (`schemas::accepts`) — each criterion is a named
+DCQL **Presentation Definition** over registered credential types, plus
+a human description.
+
+## Authentication
+
+Unauthenticated — manifest is public discovery (the "how do I join this
+community" page). Rate-limited per the unauth bucket (`vtc-mvp.md` §9.6).
+It returns only the community's *stated requirements*, never any
+applicant or member data.
+
+## Response
+
+```jsonc
+{
+  "communityDid": "did:webvh:…",          // this VTC's DID (the would-be VMC issuer)
+  "criteria": [
+    {
+      "id": "join-evidence",               // criterion id to cite on the present/query thread
+      "description": "Present a witness credential from a recognised notary.",
+      "presentationDefinition": { /* DCQL query */ }
+    }
+  ]
+}
+```
+
+- `criteria` is the community's registered Accepts set
+  (`schemas::accepts::list_accepts`). Each entry's
+  `presentationDefinition` is the criterion's DCQL query; `id` is the
+  value a holder cites when the VTC sends a `credential-exchange/query`
+  for that criterion (see `present`).
+- An empty `criteria` array means the community has registered no
+  evidence requirement — joining is gated by the active `join.rego`
+  alone (e.g. open-join or manual review), with no credential to
+  pre-assemble.
+
+> **Decided (review):** 1.0 returns **all** registered Accepts criteria;
+> there is no per-criterion "purpose" tag yet, so manifest does not
+> distinguish join criteria from those used by other ceremonies. A
+> `purpose`/scope tag on `AcceptsCriterion` (so manifest can return only
+> the join-relevant subset, and name a default) is a follow-up.
+
+## Errors
+
+- `429 Too Many Requests` — rate-limited (per-IP for REST,
+  per-sender-DID for DIDComm).
+
+Framework errors use the `trust-task-error` type, not a verdict
+(protocol §3) — `manifest` runs no policy.
+
+## Audit
+
+None — `manifest` is a stateless public read.

--- a/trust-tasks/join-requests/status/1.0/schema.json
+++ b/trust-tasks/join-requests/status/1.0/schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/join-requests/status/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC Join Requests — Status (applicant poll)",
+  "type": "object",
+  "properties": {
+    "restRequest": {
+      "type": "object",
+      "required": ["applicantDid", "signature"],
+      "properties": {
+        "applicantDid": { "type": "string", "pattern": "^did:key:" },
+        "signature": { "type": "string", "pattern": "^[0-9a-fA-F]+$" }
+      }
+    },
+    "didcommBody": {
+      "type": "object",
+      "required": ["requestId"],
+      "properties": {
+        "requestId": { "type": "string", "format": "uuid" }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["requestId", "status"],
+      "properties": {
+        "requestId": { "type": "string", "format": "uuid" },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "deferred", "approved", "rejected", "withdrawn"]
+        },
+        "needs": { "type": "array", "items": { "type": "string" } },
+        "presentationDefinition": {}
+      }
+    }
+  }
+}

--- a/trust-tasks/join-requests/status/1.0/spec.md
+++ b/trust-tasks/join-requests/status/1.0/spec.md
@@ -1,0 +1,87 @@
+---
+id: https://trusttasks.org/openvtc/vtc/join-requests/status/1.0
+title: VTC Join Requests — Status (applicant poll)
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: POST /v1/join-requests/{id}/status
+  - didcomm: https://trusttasks.org/openvtc/vtc/join-requests/status/1.0
+---
+
+# VTC Join Requests — Status (applicant poll)
+
+The `status` verb lets an **applicant poll their own join request**
+while it is in flight (protocol §2 verb set: "poll a thread in
+`Pending`/`Deferred`"). It is the applicant-facing counterpart to the
+admin-only `show` (`GET /v1/join-requests/{id}`, `AdminAuth`): same
+underlying row, but `status` is authenticated by the *applicant's holder
+binding*, returns only non-sensitive lifecycle fields, and never exposes
+the stored VP or moderator notes.
+
+It is the universal fallback for the async paths: after a `refer`
+(→ `Pending`, awaiting an admin `approve`/`reject`) or a `request_more`
+(→ `Deferred`, awaiting more evidence over `present`), a DIDComm-reachable
+applicant may be pushed the outcome, but `status` is always available to
+poll.
+
+## Authentication
+
+Holder-bound to the request's `applicantDid`, identically to `submit` /
+`accept` — the request is not public, so a leaked/guessed `requestId`
+alone must not reveal its state.
+
+### DIDComm (preferred)
+
+`applicantDid` is the DIDComm `from` field (authcrypt sender). The body
+carries `requestId` (no URL path over DIDComm). The handler rejects a
+sender that is not the request's applicant.
+
+### REST holder binding
+
+`POST /v1/join-requests/{id}/status` — a POST (not GET) because the read
+is holder-authenticated. Body carries `applicantDid` and a hex-encoded
+Ed25519 `signature` over the domain-tagged (`vtc-join-status/v1\0`)
+canonical JSON `{ applicantDid, requestId }`. `did:key` applicants only
+in 1.0 (as on `submit`). The signer must match the request's applicant.
+
+> **Decided (review):** `status` is holder-authenticated (not an
+> unauthenticated capability-URL keyed by the unguessable `requestId`).
+> The family is uniformly holder-bound; a poll that leaks lifecycle state
+> on a guessed/shared id is avoided. The cost is a POST-for-read on the
+> REST path.
+
+## Response
+
+```jsonc
+{
+  "requestId": "urn:uuid:…",
+  "status": "pending" | "deferred" | "approved" | "rejected" | "withdrawn",
+  // present only when status == "deferred" (a request_more verdict):
+  "needs": ["agreed:code-of-conduct"],
+  "presentationDefinition": { /* DCQL — what to present next over `present` */ }
+}
+```
+
+- `needs` + `presentationDefinition` are projected from the request's
+  stored `policy_decision` (the `request_more` verdict
+  `realize_join_verdict` persisted). Absent for every other status.
+- `approved` does **not** re-deliver credentials — the VMC + role VEC
+  were delivered at admit (and returned inline on a REST auto-admit).
+  `status` reports the disposition only.
+
+## Errors
+
+- `400 Bad Request` — malformed / non-`did:key` applicant; signer ≠ the
+  request's applicant.
+- `404 Not Found` — request id unknown.
+- `429 Too Many Requests` — rate-limited.
+
+Framework errors use the `trust-task-error` type (protocol §3) —
+`status` runs no policy.
+
+## Audit
+
+None — a holder reading their own request's lifecycle is not an
+audit-significant state change.


### PR DESCRIPTION
## What

Completes the join ceremony's protocol §2 verb set with the two remaining **read** verbs (Draft specs). With `request`(submit) / `present`+`query`(via credential-exchange) / `resolve`(approve+reject) / `accept` already built, this adds `manifest` and `status`.

### `join-requests/manifest/1.0` — pre-submit discovery
`GET /v1/join-requests/manifest` (unauth) + DIDComm. Returns the community's registered **Accepts criteria** — each a named DCQL **Presentation Definition** + human description — plus the community DID, so a prospective applicant can assemble a presentation before opening a thread. Sourced from `schemas::accepts::list_accepts`. Stateless public read, no audit.

- *Decided (review):* 1.0 returns all criteria; a per-criterion `purpose`/scope tag (to return only join-relevant ones + a default) is a follow-up, since `AcceptsCriterion` has no purpose field yet.

### `join-requests/status/1.0` — applicant poll
`POST /v1/join-requests/{id}/status` (holder-bound) + DIDComm (authcrypt sender = applicant). The applicant-facing counterpart to the admin-only `show`: returns the lifecycle `status` and, when `Deferred`, the `needs`/`presentationDefinition` projected from the stored `request_more` verdict. Returns no VP/notes.

- *Decided (review):* holder-authenticated (not an unauthenticated capability-URL on the unguessable `requestId`), for consistency with the rest of the family — at the cost of a POST-for-read on REST.

## Scope
Spec + protocol-doc only (3 spec files + 2 `index.json` entries + the §9 status table). No code, no build impact. Follows the spec-first rhythm of #315.

## Follow-up
Implement both (the table marks them "not yet implemented"): `manifest` over `list_accepts`; `status` as a holder-bound poll reusing submit's signing construction (domain tag `vtc-join-status/v1\0`).