### PR TITLE
feat(mobile-core): resolve_vta_endpoints — discover VTA URL + mediator from its DID

### DIFF
--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.4.0"
+version = "0.5.0"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR

--- a/vta-mobile-core/src/resolver.rs
+++ b/vta-mobile-core/src/resolver.rs
@@ -1,11 +1,11 @@
 //! DID resolution — wraps `affinidi-did-resolver-cache-sdk`.
 //!
 //! **Slice 3a.** The engine's first *async* export, proving the async-over-FFI
-//! path (`#[uniffi::export(async_runtime = "tokio")]`). Default config is
-//! **local**: `did:key` / `did:peer` resolve offline — which already covers the
-//! holder/relying-party key lookups needed to verify step-up proofs. Networked
-//! methods (`did:web` / `did:webvh`) need a network-mode config and are a
-//! follow-up.
+//! path (`#[uniffi::export(async_runtime = "tokio")]`). `did:key` / `did:peer`
+//! resolve offline; `did:web` / `did:webvh` resolve over the network (the SDK's
+//! default config handles all four — the same way the VTA reads service docs).
+//! [`resolve_vta_endpoints`] uses this to discover a VTA's REST + mediator
+//! endpoints from its DID alone.
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
@@ -34,8 +34,8 @@ async fn client() -> Result<&'static DIDCacheClient, FfiError> {
 ///
 /// Used to find a peer's verification keys (to verify a relying party's step-up
 /// proof) and key-agreement key (for DIDComm). `did:key` / `did:peer` resolve
-/// locally; other methods will require a network-mode resolver config
-/// (follow-up). The first async function exported across the FFI boundary.
+/// locally; `did:web` / `did:webvh` resolve over the network. The first async
+/// function exported across the FFI boundary.
 #[uniffi::export(async_runtime = "tokio")]
 pub async fn resolve_did(did: String) -> Result<String, FfiError> {
     let response = client()
@@ -48,6 +48,68 @@ pub async fn resolve_did(did: String) -> Result<String, FfiError> {
     serde_json::to_string(&response.doc).map_err(|e| FfiError::InvalidInput {
         reason: format!("could not serialize DID document: {e}"),
     })
+}
+
+/// The VTA's transport endpoints, discovered from its DID document — so a client
+/// can be configured with just the **VTA DID** instead of a hand-typed URL +
+/// mediator.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct VtaEndpoints {
+    /// REST base URL, from the `#vta-rest` (`VTARest`) service. `None` if the
+    /// VTA advertises no REST service.
+    pub rest_base_url: Option<String>,
+    /// Mediator DID, from the `#vta-didcomm` (`DIDCommMessaging`) service's
+    /// endpoint `uri`. `None` if the VTA advertises no DIDComm service.
+    pub mediator_did: Option<String>,
+}
+
+/// Resolve a VTA's DID and extract its transport endpoints (`#vta-rest` URL +
+/// `#vta-didcomm` mediator DID). The app uses this to auto-fill the connection
+/// from the DID alone. Resolves `did:key`/`did:peer` offline and `did:webvh`/
+/// `did:web` over the network (same resolver the VTA uses to read service docs).
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn resolve_vta_endpoints(did: String) -> Result<VtaEndpoints, FfiError> {
+    let doc_json = resolve_did(did).await?;
+    let doc: serde_json::Value = serde_json::from_str(&doc_json).map_err(|e| FfiError::Decode {
+        reason: format!("DID document is not valid JSON: {e}"),
+    })?;
+    Ok(parse_vta_endpoints(&doc))
+}
+
+/// Extract the VTA endpoints from a resolved DID document. Matches the VTA's own
+/// service shapes: `#vta-rest` (type `VTARest`) → REST URL; `#vta-didcomm`
+/// (type `DIDCommMessaging`) → mediator DID. Pure (no I/O) so it's unit-testable.
+fn parse_vta_endpoints(doc: &serde_json::Value) -> VtaEndpoints {
+    let mut rest_base_url = None;
+    let mut mediator_did = None;
+    if let Some(services) = doc.get("service").and_then(|s| s.as_array()) {
+        for svc in services {
+            let id = svc.get("id").and_then(|v| v.as_str()).unwrap_or_default();
+            let ty = svc.get("type").and_then(|v| v.as_str()).unwrap_or_default();
+            let endpoint = svc.get("serviceEndpoint");
+            if id.ends_with("#vta-rest") || ty == "VTARest" {
+                rest_base_url = endpoint_uri(endpoint);
+            } else if id.ends_with("#vta-didcomm") || ty == "DIDCommMessaging" {
+                mediator_did = endpoint_uri(endpoint);
+            }
+        }
+    }
+    VtaEndpoints {
+        rest_base_url,
+        mediator_did,
+    }
+}
+
+/// Pull a URI out of a `serviceEndpoint` value, which may be a bare string, an
+/// object with a `uri` field, or a single-element array of either (the shapes
+/// the VTA's own `document.rs` accepts).
+fn endpoint_uri(endpoint: Option<&serde_json::Value>) -> Option<String> {
+    match endpoint? {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Object(o) => o.get("uri").and_then(|v| v.as_str()).map(String::from),
+        serde_json::Value::Array(a) => a.first().and_then(|v| endpoint_uri(Some(v))),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -73,5 +135,69 @@ mod tests {
             .await
             .expect_err("a non-DID must fail");
         assert!(matches!(err, FfiError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn parses_vta_endpoints_from_a_did_document() {
+        // REST as a bare string; DIDComm as an object with `uri` + routingKeys —
+        // the two shapes the VTA emits.
+        let doc = serde_json::json!({
+            "id": "did:webvh:scid:vta.example:vta",
+            "service": [
+                { "id": "did:webvh:scid:vta.example:vta#vta-rest",
+                  "type": "VTARest",
+                  "serviceEndpoint": "https://vta.example/api" },
+                { "id": "did:webvh:scid:vta.example:vta#vta-didcomm",
+                  "type": "DIDCommMessaging",
+                  "serviceEndpoint": { "uri": "did:webvh:scid:m.example:mediator",
+                                       "routingKeys": [] } }
+            ]
+        });
+        let ep = parse_vta_endpoints(&doc);
+        assert_eq!(ep.rest_base_url.as_deref(), Some("https://vta.example/api"));
+        assert_eq!(
+            ep.mediator_did.as_deref(),
+            Some("did:webvh:scid:m.example:mediator")
+        );
+    }
+
+    #[test]
+    fn parses_vta_endpoints_tolerates_array_endpoint_and_missing_services() {
+        // REST endpoint as a single-element array (a shape the SDK accepts).
+        let doc = serde_json::json!({
+            "id": "did:web:vta.example",
+            "service": [
+                { "id": "did:web:vta.example#vta-rest", "type": "VTARest",
+                  "serviceEndpoint": ["https://vta.example/api"] }
+            ]
+        });
+        let ep = parse_vta_endpoints(&doc);
+        assert_eq!(ep.rest_base_url.as_deref(), Some("https://vta.example/api"));
+        assert_eq!(ep.mediator_did, None);
+
+        // No services at all → both None, no panic.
+        let empty = parse_vta_endpoints(&serde_json::json!({ "id": "did:key:z6Mk" }));
+        assert_eq!(empty.rest_base_url, None);
+        assert_eq!(empty.mediator_did, None);
+    }
+
+    /// Live network resolution of a real `did:webvh` — proves the engine's
+    /// resolver handles webvh (not just local methods). Ignored by default so
+    /// the offline suite stays green; run explicitly:
+    /// `cargo test -p vta-mobile-core -- --ignored resolves_webvh`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "network: resolves a live did:webvh"]
+    async fn resolves_webvh_over_the_network() {
+        let did =
+            "did:webvh:QmTS3a3H9Dk4ZMPAZ8jNWGeyPbuKrPbrPZcSbg8CJ6yynD:webvh.storm.ws:mediator";
+        let json = resolve_did(did.to_string())
+            .await
+            .expect("did:webvh resolves over the network");
+        let doc: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(doc["id"], did);
+        assert!(
+            doc.get("service").is_some(),
+            "the mediator's webvh doc advertises a service"
+        );
     }
 }


### PR DESCRIPTION
## What

Adds `resolve_vta_endpoints(did) -> { rest_base_url, mediator_did }` to the engine: resolve a VTA's DID, read its `#vta-rest` (REST URL) and `#vta-didcomm` (mediator DID) services. Lets the mobile app be configured with **just the VTA DID** instead of a hand-typed URL + mediator — the gap flagged during iOS testing ("shouldn't it get this from the DID?"). The browser plugin already does this; now the engine can too.

## Changes

- New FFI **`resolve_vta_endpoints`** + `VtaEndpoints { rest_base_url, mediator_did }`.
- `parse_vta_endpoints` mirrors the VTA's own service shapes (`document.rs`): type `VTARest` / `DIDCommMessaging`, id `#vta-rest` / `#vta-didcomm`; tolerates the three `serviceEndpoint` forms (bare string / `{ uri }` / single-element array).
- **Corrected the resolver docs:** `did:web` / `did:webvh` *do* resolve under the SDK's default config (the same way the VTA reads service docs) — the old "needs network-mode / follow-up" note was wrong.
- Version **0.4.0 → 0.5.0** (FFI addition).

## Verification

- `cargo fmt --check` clean; `cargo test -p vta-mobile-core` **38/38** offline (incl. 2 new pure parse tests); `cargo clippy --all-targets -- -D warnings` clean.
- **Live `did:webvh` resolution confirmed**: the `#[ignore]`d `resolves_webvh_over_the_network` test (run manually) resolves the demo mediator's webvh DID and reads its `service` array. This proves the engine resolves webvh in-process (no resolver service needed).

## Next

A `vta-mobile-core-v0.5.0` release, then the iOS app pins it and uses `resolve_vta_endpoints` to auto-fill URL + mediator from the VTA DID (removing the two manual fields).