### PR TITLE
feat(join): implement join-requests/manifest + status verbs

### DIFF
--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -84,6 +84,76 @@ pub struct JoinRequestAcceptReceiptBody {
 }
 
 // ---------------------------------------------------------------------------
+// Manifest — pre-submit discovery (join-requests/manifest/1.0)
+// ---------------------------------------------------------------------------
+
+/// DIDComm message `type` for a join-request manifest request: discover
+/// the community's join evidence requirements. Read; empty request body.
+pub const JOIN_REQUEST_MANIFEST_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/join-requests/manifest/1.0";
+
+/// DIDComm `type` for the VTC's manifest reply.
+pub const JOIN_REQUEST_MANIFEST_RESPONSE_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/join-requests/manifest-response/1.0";
+
+/// One community evidence requirement — a named DCQL Presentation
+/// Definition the applicant may present against.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestCriterion {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub presentation_definition: JsonValue,
+}
+
+/// Manifest response: the community's join evidence requirements.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestManifestResponseBody {
+    pub community_did: String,
+    pub criteria: Vec<ManifestCriterion>,
+}
+
+// ---------------------------------------------------------------------------
+// Status — applicant poll (join-requests/status/1.0)
+// ---------------------------------------------------------------------------
+
+/// DIDComm message `type` for an applicant status poll. `applicantDid`
+/// is the DIDComm `from` field (authcrypt sender).
+pub const JOIN_REQUEST_STATUS_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/join-requests/status/1.0";
+
+/// DIDComm `type` for the VTC's status reply.
+pub const JOIN_REQUEST_STATUS_RESPONSE_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/join-requests/status-response/1.0";
+
+/// Body of the status message (DIDComm). Over REST the `{id}` is the
+/// path segment; over DIDComm it travels here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestStatusBody {
+    pub request_id: Uuid,
+}
+
+/// Status response: the request's lifecycle, plus (when `deferred`) what
+/// the applicant must present next.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestStatusResponseBody {
+    pub request_id: Uuid,
+    /// `pending` | `deferred` | `approved` | `rejected` | `withdrawn`.
+    pub status: String,
+    /// Outstanding requirements — present only for a `deferred` request.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub needs: Vec<String>,
+    /// The DCQL the applicant should answer over `present` — present only
+    /// for a `deferred` request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub presentation_definition: Option<JsonValue>,
+}
+
+// ---------------------------------------------------------------------------
 // Self-remove (M1.11.1 DIDComm twin)
 // ---------------------------------------------------------------------------
 

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -19,16 +19,21 @@ use vta_sdk::protocols::credential_exchange::{
     ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody, PresentBody, RequestBody,
 };
 use vta_sdk::protocols::join_requests::{
-    JOIN_REQUEST_ACCEPT_RECEIPT_TYPE, JOIN_REQUEST_ACCEPT_TYPE, JOIN_REQUEST_SUBMIT_RECEIPT_TYPE,
+    JOIN_REQUEST_ACCEPT_RECEIPT_TYPE, JOIN_REQUEST_ACCEPT_TYPE,
+    JOIN_REQUEST_MANIFEST_RESPONSE_TYPE, JOIN_REQUEST_MANIFEST_TYPE,
+    JOIN_REQUEST_STATUS_RESPONSE_TYPE, JOIN_REQUEST_STATUS_TYPE, JOIN_REQUEST_SUBMIT_RECEIPT_TYPE,
     JOIN_REQUEST_SUBMIT_TYPE, JoinRequestAcceptBody, JoinRequestAcceptReceiptBody,
-    JoinRequestSubmitBody, JoinRequestSubmitReceiptBody, MEMBER_SELF_REMOVE_RECEIPT_TYPE,
-    MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody, SelfRemoveReceiptBody,
+    JoinRequestStatusBody, JoinRequestSubmitBody, JoinRequestSubmitReceiptBody,
+    MEMBER_SELF_REMOVE_RECEIPT_TYPE, MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody,
+    SelfRemoveReceiptBody,
 };
 
 use crate::config::AppConfig;
 use crate::join::JoinTransport;
 use crate::members::Disposition;
 use crate::routes::join_requests::accept::accept_inner;
+use crate::routes::join_requests::manifest::manifest_inner;
+use crate::routes::join_requests::status::status_inner;
 use crate::routes::join_requests::submit::submit_inner;
 use crate::routes::members::remove::remove_inner;
 use crate::server::AppState;
@@ -106,6 +111,18 @@ pub async fn run_didcomm_service(
             r.route(
                 JOIN_REQUEST_ACCEPT_TYPE,
                 handler_fn(join_request_accept_handler),
+            )
+        })
+        .and_then(|r| {
+            r.route(
+                JOIN_REQUEST_MANIFEST_TYPE,
+                handler_fn(join_request_manifest_handler),
+            )
+        })
+        .and_then(|r| {
+            r.route(
+                JOIN_REQUEST_STATUS_TYPE,
+                handler_fn(join_request_status_handler),
             )
         })
         .and_then(|r| {
@@ -281,6 +298,51 @@ async fn join_request_accept_handler(
         .map_err(|e| DIDCommServiceError::Internal(format!("receipt serialise: {e}")))?;
     Ok(Some(
         DIDCommResponse::new(JOIN_REQUEST_ACCEPT_RECEIPT_TYPE, body).thid(message.id),
+    ))
+}
+
+/// `join-requests/manifest/1.0` over DIDComm — pre-submit discovery.
+///
+/// A read: the empty request body returns the community's join evidence
+/// requirements. No sender authentication needed (manifest is public).
+async fn join_request_manifest_handler(
+    _ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<AppState>,
+) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let manifest = manifest_inner(&state)
+        .await
+        .map_err(|e| DIDCommServiceError::Internal(format!("manifest failed: {e}")))?;
+    let body = serde_json::to_value(&manifest)
+        .map_err(|e| DIDCommServiceError::Internal(format!("manifest serialise: {e}")))?;
+    Ok(Some(
+        DIDCommResponse::new(JOIN_REQUEST_MANIFEST_RESPONSE_TYPE, body).thid(message.id),
+    ))
+}
+
+/// `join-requests/status/1.0` over DIDComm — applicant poll.
+///
+/// `applicantDid` is the DIDComm `from` field (authcrypt sender), so no
+/// separate holder-binding signature is needed (`signature_hex = None`).
+/// The body carries the `requestId`.
+async fn join_request_status_handler(
+    ctx: HandlerContext,
+    message: Message,
+    Extension(state): Extension<AppState>,
+) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let applicant_did = ctx.sender_did.clone().ok_or_else(|| {
+        DIDCommServiceError::Internal("join-request status has no DIDComm sender".into())
+    })?;
+    let body: JoinRequestStatusBody = serde_json::from_value(message.body.clone())
+        .map_err(|e| DIDCommServiceError::Internal(format!("malformed status body: {e}")))?;
+
+    let resp = status_inner(&state, body.request_id, applicant_did, None)
+        .await
+        .map_err(|e| DIDCommServiceError::Internal(format!("status failed: {e}")))?;
+    let body = serde_json::to_value(&resp)
+        .map_err(|e| DIDCommServiceError::Internal(format!("status serialise: {e}")))?;
+    Ok(Some(
+        DIDCommResponse::new(JOIN_REQUEST_STATUS_RESPONSE_TYPE, body).thid(message.id),
     ))
 }
 

--- a/vtc-service/src/routes/join_requests/manifest.rs
+++ b/vtc-service/src/routes/join_requests/manifest.rs
@@ -1,0 +1,52 @@
+//! `GET /v1/join-requests/manifest` — pre-submit discovery
+//! (`join-requests/manifest/1.0`) + a shared `manifest_inner` the
+//! DIDComm handler calls into.
+//!
+//! Returns the community's registered Accepts criteria — each a named
+//! DCQL Presentation Definition — plus this VTC's DID, so a prospective
+//! applicant can assemble a presentation before opening a thread. A
+//! stateless, unauthenticated public read: no thread, no challenge, no
+//! audit.
+
+use axum::Json;
+use axum::extract::State;
+
+use vta_sdk::protocols::join_requests::{JoinRequestManifestResponseBody, ManifestCriterion};
+use vti_common::error::AppError;
+
+use crate::schemas::accepts::list_accepts;
+use crate::server::AppState;
+
+pub async fn manifest(
+    State(state): State<AppState>,
+) -> Result<Json<JoinRequestManifestResponseBody>, AppError> {
+    Ok(Json(manifest_inner(&state).await?))
+}
+
+/// Shared discovery read for REST + DIDComm: the community's join
+/// evidence requirements.
+pub async fn manifest_inner(state: &AppState) -> Result<JoinRequestManifestResponseBody, AppError> {
+    let community_did = state
+        .config
+        .read()
+        .await
+        .vtc_did
+        .clone()
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| AppError::Internal("VTC DID not configured".into()))?;
+
+    let criteria = list_accepts(&state.schemas_ks)
+        .await?
+        .into_iter()
+        .map(|c| ManifestCriterion {
+            id: c.id,
+            description: c.description,
+            presentation_definition: c.query,
+        })
+        .collect();
+
+    Ok(JoinRequestManifestResponseBody {
+        community_did,
+        criteria,
+    })
+}

--- a/vtc-service/src/routes/join_requests/mod.rs
+++ b/vtc-service/src/routes/join_requests/mod.rs
@@ -8,6 +8,8 @@
 
 pub mod accept;
 pub mod decide;
+pub mod manifest;
 pub mod present;
 pub mod read;
+pub mod status;
 pub mod submit;

--- a/vtc-service/src/routes/join_requests/status.rs
+++ b/vtc-service/src/routes/join_requests/status.rs
@@ -1,0 +1,153 @@
+//! `POST /v1/join-requests/{id}/status` — applicant-facing poll
+//! (`join-requests/status/1.0`) + a shared `status_inner` the DIDComm
+//! handler calls into.
+//!
+//! The applicant polls their own request's lifecycle while it is in
+//! flight (after a `refer` → `Pending`, or a `request_more` →
+//! `Deferred`). It is the holder-authenticated counterpart to the
+//! admin-only `show`: it returns only non-sensitive lifecycle fields
+//! (never the stored VP), and — when `Deferred` — what the applicant
+//! must present next, projected from the stored `request_more` verdict.
+//!
+//! ## Auth
+//!
+//! Holder-bound to the request's `applicantDid`, like `submit`/`accept`:
+//! - REST carries an Ed25519 `signature` over the domain-tagged
+//!   ([`JOIN_STATUS_DOMAIN_TAG`]) canonical `{ applicantDid, requestId }`.
+//! - DIDComm omits it — the authcrypt sender binds `applicantDid`
+//!   (`signature_hex = None`).
+
+use axum::Json;
+use axum::extract::{Path, State};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use vta_sdk::protocols::join_requests::JoinRequestStatusResponseBody;
+use vti_common::error::AppError;
+
+use crate::ceremony::Verdict;
+use crate::join::{JoinStatus, get_join_request};
+use crate::server::AppState;
+
+/// Domain tag prefixing the REST holder-binding signature payload.
+/// Distinct from `submit`/`accept` so a status signature can't be
+/// replayed against another verb.
+pub const JOIN_STATUS_DOMAIN_TAG: &[u8] = b"vtc-join-status/v1\0";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusRequestBody {
+    pub applicant_did: String,
+    /// Hex-encoded Ed25519 signature over the canonical body.
+    pub signature: String,
+}
+
+pub async fn status(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<StatusRequestBody>,
+) -> Result<Json<JoinRequestStatusResponseBody>, AppError> {
+    let resp = status_inner(&state, id, body.applicant_did, Some(&body.signature)).await?;
+    Ok(Json(resp))
+}
+
+/// Shared poll for REST + DIDComm.
+///
+/// `signature_hex` is `Some` for REST (explicit holder binding) and
+/// `None` for DIDComm (the authcrypt sender already authenticated
+/// `applicant_did`).
+pub async fn status_inner(
+    state: &AppState,
+    id: Uuid,
+    applicant_did: String,
+    signature_hex: Option<&str>,
+) -> Result<JoinRequestStatusResponseBody, AppError> {
+    if let Some(hex_sig) = signature_hex {
+        verify_holder_signature(&applicant_did, id, hex_sig)?;
+    }
+
+    let req = get_join_request(&state.join_requests_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("join request not found: {id}")))?;
+    if req.applicant_did != applicant_did {
+        return Err(AppError::Validation(
+            "applicantDid does not match the join request applicant".into(),
+        ));
+    }
+
+    // Project the outstanding requirements only for a Deferred request
+    // (a `request_more` verdict the daemon persisted on `policy_decision`).
+    let (needs, presentation_definition) = if req.status == JoinStatus::Deferred {
+        match req
+            .policy_decision
+            .and_then(|pd| serde_json::from_value::<Verdict>(pd).ok())
+        {
+            Some(Verdict::RequestMore(rm)) => (rm.needs, Some(rm.presentation_definition)),
+            _ => (Vec::new(), None),
+        }
+    } else {
+        (Vec::new(), None)
+    };
+
+    Ok(JoinRequestStatusResponseBody {
+        request_id: id,
+        status: req.status.to_string(),
+        needs,
+        presentation_definition,
+    })
+}
+
+/// Verify the Ed25519 holder-binding signature over the canonical body
+/// (`applicantDid` + `requestId`), domain-tagged.
+fn verify_holder_signature(
+    applicant_did: &str,
+    request_id: Uuid,
+    signature_hex: &str,
+) -> Result<(), AppError> {
+    let pubkey_bytes =
+        affinidi_crypto::did_key::did_key_to_ed25519_pub(applicant_did).map_err(|e| {
+            AppError::Validation(format!("applicantDid is not a parseable did:key: {e}"))
+        })?;
+    let verifying = VerifyingKey::from_bytes(&pubkey_bytes).map_err(|e| {
+        AppError::Validation(format!("applicantDid decodes to an invalid key: {e}"))
+    })?;
+
+    let payload = canonical_payload(applicant_did, request_id)?;
+    let signing_bytes = signing_bytes(&payload);
+
+    let raw_sig = hex::decode(signature_hex)
+        .map_err(|e| AppError::Validation(format!("signature is not hex: {e}")))?;
+    let signature = Signature::from_slice(&raw_sig).map_err(|e| {
+        AppError::Validation(format!("signature is not a 64-byte Ed25519 value: {e}"))
+    })?;
+
+    verifying
+        .verify(&signing_bytes, &signature)
+        .map_err(|e| AppError::Validation(format!("holder-binding signature failed: {e}")))?;
+    Ok(())
+}
+
+/// Canonical signing payload — typed struct, field order pinned by the
+/// derive (both sides build it identically).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalPayload<'a> {
+    applicant_did: &'a str,
+    request_id: String,
+}
+
+fn canonical_payload(applicant_did: &str, request_id: Uuid) -> Result<Vec<u8>, AppError> {
+    serde_json::to_vec(&CanonicalPayload {
+        applicant_did,
+        request_id: request_id.to_string(),
+    })
+    .map_err(|e| AppError::Internal(format!("canonical payload serialize: {e}")))
+}
+
+fn signing_bytes(payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(JOIN_STATUS_DOMAIN_TAG.len() + payload.len());
+    buf.extend_from_slice(JOIN_STATUS_DOMAIN_TAG);
+    buf.extend_from_slice(payload);
+    buf
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -254,6 +254,11 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
         .expect("static Trust-Task URL");
     let join_accept = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0")
         .expect("static Trust-Task URL");
+    let join_manifest =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/manifest/1.0")
+            .expect("static Trust-Task URL");
+    let join_status = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/status/1.0")
+        .expect("static Trust-Task URL");
     // Policies (Phase 2 M2.3). Three distinct Trust Tasks for the
     // three POST endpoints — upload, activate, test — so SIEM
     // filters + soft-gate consumers can target each precisely.
@@ -692,6 +697,21 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             "/join-requests/{id}/accept",
             post(join_requests::accept::accept),
             join_accept,
+        )
+        // Manifest (unauth public discovery): the community's join
+        // evidence requirements. Static `manifest` segment takes
+        // precedence over the `{id}` show route.
+        .route_with_task(
+            "/join-requests/manifest",
+            get(join_requests::manifest::manifest),
+            join_manifest,
+        )
+        // Status (unauth — holder binding in the body): the applicant
+        // polls their own request's lifecycle.
+        .route_with_task(
+            "/join-requests/{id}/status",
+            post(join_requests::status::status),
+            join_status,
         )
         // Credential-exchange query send (admin): prepare a DCQL query + issue a
         // single-use presentation challenge for a holder. Plain admin route (no

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -46,6 +46,10 @@ const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/show/1
 const APPROVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0";
 const REJECT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0";
 const ACCEPT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0";
+const MANIFEST_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/manifest/1.0";
+const STATUS_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/status/1.0";
+/// Mirror of `routes::join_requests::status::JOIN_STATUS_DOMAIN_TAG`.
+const JOIN_STATUS_DOMAIN_TAG: &[u8] = b"vtc-join-status/v1\0";
 /// The VTC DID the fixture configures — the issuer of every VMC and the
 /// community a reciprocal VC must acknowledge.
 const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
@@ -1589,4 +1593,193 @@ async fn accept_rejects_a_tampered_reciprocal_vc() {
 
     let (status, _) = post_accept(&fix, id, &member_did, &vmc_id, &vc, &sig).await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// Manifest — pre-submit discovery (join-requests/manifest/1.0)
+// ---------------------------------------------------------------------------
+
+async fn store_join_criterion(fix: &Fixture) {
+    use vtc_service::schemas::accepts::{AcceptsCriterion, store_accepts};
+    let criterion = AcceptsCriterion {
+        id: "join-evidence".into(),
+        query: json!({
+            "credentials": [{
+                "id": "membership",
+                "format": "ldp_vc",
+                "meta": { "type_values": ["MembershipCredential"] }
+            }]
+        }),
+        description: Some("present a MembershipCredential to join".into()),
+        created_at: chrono::Utc::now(),
+        created_by_did: ADMIN_DID.into(),
+    };
+    store_accepts(&fix.state.schemas_ks, &criterion)
+        .await
+        .expect("store accepts criterion");
+}
+
+#[tokio::test]
+async fn manifest_lists_registered_criteria() {
+    let fix = build_fixture().await;
+    store_join_criterion(&fix).await;
+
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/join-requests/manifest",
+        MANIFEST_TASK,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["communityDid"], VTC_DID);
+    let criteria = body["criteria"].as_array().unwrap();
+    assert_eq!(criteria.len(), 1);
+    assert_eq!(criteria[0]["id"], "join-evidence");
+    assert!(criteria[0]["presentationDefinition"]["credentials"].is_array());
+    assert_eq!(
+        criteria[0]["description"],
+        "present a MembershipCredential to join"
+    );
+}
+
+#[tokio::test]
+async fn manifest_is_empty_when_no_criteria_registered() {
+    let fix = build_fixture().await;
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/join-requests/manifest",
+        MANIFEST_TASK,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["communityDid"], VTC_DID);
+    assert_eq!(body["criteria"].as_array().unwrap().len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Status — applicant poll (join-requests/status/1.0)
+// ---------------------------------------------------------------------------
+
+/// Holder-binding signature over the canonical status body. Mirrors
+/// `routes::join_requests::status`'s construction.
+fn sign_status_payload(sk: &SigningKey, applicant_did: &str, request_id: Uuid) -> String {
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Payload<'a> {
+        applicant_did: &'a str,
+        request_id: String,
+    }
+    let payload = serde_json::to_vec(&Payload {
+        applicant_did,
+        request_id: request_id.to_string(),
+    })
+    .unwrap();
+    let mut signing = Vec::with_capacity(JOIN_STATUS_DOMAIN_TAG.len() + payload.len());
+    signing.extend_from_slice(JOIN_STATUS_DOMAIN_TAG);
+    signing.extend_from_slice(&payload);
+    hex::encode(sk.sign(&signing).to_bytes())
+}
+
+async fn post_status(
+    fix: &Fixture,
+    id: Uuid,
+    applicant_did: &str,
+    signature: &str,
+) -> (StatusCode, Value) {
+    send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/status"),
+        STATUS_TASK,
+        None,
+        Some(json!({ "applicantDid": applicant_did, "signature": signature })),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn status_returns_pending_for_the_applicant() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+    let (sk, applicant_did) = applicant_pair();
+    let sig = sign_status_payload(&sk, &applicant_did, id);
+
+    let (status, body) = post_status(&fix, id, &applicant_did, &sig).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["requestId"], id.to_string());
+    assert_eq!(body["status"], "pending");
+    assert!(body.get("needs").is_none() || body["needs"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn status_rejects_a_wrong_signer() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+    let (_sk, applicant_did) = applicant_pair();
+    let other = SigningKey::from_bytes(&[0xEE; 32]);
+    let bad_sig = sign_status_payload(&other, &applicant_did, id);
+
+    let (status, _) = post_status(&fix, id, &applicant_did, &bad_sig).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn status_404_for_an_unknown_request() {
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let unknown = Uuid::new_v4();
+    let sig = sign_status_payload(&sk, &applicant_did, unknown);
+
+    let (status, _) = post_status(&fix, unknown, &applicant_did, &sig).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn status_deferred_returns_needs_and_presentation_definition() {
+    let fix = build_fixture().await;
+    // A join policy that defers, asking for more evidence.
+    activate_join_policy(
+        &fix,
+        r#"
+package vtc.join
+import future.keywords.if
+default decision := {"effect": "deny", "with": {"code": "closed"}}
+decision := {"effect": "request_more", "with": {
+    "needs": ["agreed:code-of-conduct"],
+    "presentation_definition": {"id": "pd-coc"}
+}} if { true }
+"#,
+    )
+    .await;
+
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({});
+    let submit_sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let (_, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({ "applicantDid": applicant_did, "vp": vp, "signature": submit_sig })),
+    )
+    .await;
+    assert_eq!(
+        body["status"], "deferred",
+        "expected request_more → deferred: {body}"
+    );
+    let id = Uuid::parse_str(body["requestId"].as_str().unwrap()).unwrap();
+
+    let sig = sign_status_payload(&sk, &applicant_did, id);
+    let (status, body) = post_status(&fix, id, &applicant_did, &sig).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(body["status"], "deferred");
+    assert_eq!(body["needs"][0], "agreed:code-of-conduct");
+    assert_eq!(body["presentationDefinition"]["id"], "pd-coc");
 }


### PR DESCRIPTION
## What

Implements the two read verbs spec'd in #318, completing the join ceremony's protocol §2 verb set.

### `manifest` — pre-submit discovery
`GET /v1/join-requests/manifest` (unauth) + DIDComm `join-requests/manifest/1.0`. Returns the community's registered **Accepts criteria** (each a named DCQL Presentation Definition + description) plus the VTC DID, via `schemas::accepts::list_accepts`. Stateless public read — no thread, no challenge, no audit. Shared `manifest_inner` for both transports.

### `status` — applicant poll
`POST /v1/join-requests/{id}/status` (holder-bound) + DIDComm `join-requests/status/1.0` (authcrypt sender). The applicant-facing counterpart to the admin-only `show`: returns the lifecycle `status` and, when `Deferred`, the `needs`/`presentationDefinition` projected from the stored `request_more` verdict (`policy_decision`). REST holder binding is an Ed25519 signature over the domain-tagged (`vtc-join-status/v1\0`) `{applicantDid, requestId}`; signer must match the request's applicant. Returns no VP/notes. Shared `status_inner`.

SDK wire types + consts added (`JoinRequestManifestResponseBody`/`ManifestCriterion`, `JoinRequestStatusBody`/`...ResponseBody`).

## Tests
6 integration tests: manifest lists registered criteria / empty-when-none; status returns pending for the applicant / rejects wrong signer / 404 unknown / **deferred returns needs + presentationDefinition** (end-to-end through a request_more join policy). Join suite 31→37.

## CI
Green in an isolated worktree, rebased on current `main` (#319): `cargo fmt --check`, `clippy --all-targets` (no warnings), full `cargo test -p vtc-service`, `cargo deny`.

## Notes
- Decisions from #318 hold: manifest returns all criteria (no purpose tag yet); status is holder-authenticated (POST-for-read on REST).
- With this, the join §2 verbs are all built: `manifest` · `request`(submit) · `present`+query (credential-exchange) · `status` · `resolve`(approve/reject) · `accept`.