### PR TITLE
feat(mobile-core): init_logging + live mediator connect test (iOS diagnostics)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9742,7 +9742,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9756,6 +9756,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
  "vta-sdk 0.10.0",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.5.0"
+version = "0.6.0"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -48,6 +48,10 @@ multibase = { workspace = true }
 affinidi-crypto = { workspace = true }
 # Async runtime for the FFI async exports + a process-wide resolver cell.
 tokio = { workspace = true }
+# Opt-in log subscriber for `init_logging` — pipes the engine's + the affinidi
+# stack's `tracing` output to stderr (the Xcode console on iOS / logcat-adjacent
+# on Android) so on-device network/DIDComm failures are diagnosable.
+tracing-subscriber = { workspace = true }
 # DID resolution. Default config is local (did:key / did:peer resolve offline);
 # networked methods (did:web / did:webvh) need network-mode config — later.
 affinidi-did-resolver-cache-sdk = { workspace = true }

--- a/vta-mobile-core/src/api.rs
+++ b/vta-mobile-core/src/api.rs
@@ -4,9 +4,39 @@
 //! re-exported from a sibling module). Slice 1 keeps the surface minimal and
 //! synchronous to prove the build + bindgen pipeline end to end.
 
+use std::sync::Once;
+
 use base64::Engine as _;
 
 use crate::error::FfiError;
+
+static LOG_INIT: Once = Once::new();
+
+/// Install a log subscriber that writes the engine's — and its dependencies'
+/// (`affinidi-messaging-sdk`, `vta-sdk`, the DID resolver, `reqwest`/`rustls`) —
+/// `tracing` output to **stderr**, which the **Xcode console** surfaces on iOS
+/// (and is visible via the device log on Android). Call once at app launch;
+/// idempotent and safe to call again.
+///
+/// `directives` is an `EnvFilter` string, e.g. `"info"` or, to debug a stuck
+/// mediator/DIDComm connection,
+/// `"info,vta_mobile_core=debug,vta_sdk=debug,affinidi_messaging_sdk=debug"`.
+/// Without this, the engine's libraries log to a no-op and on-device failures
+/// (TLS handshakes, mediator round-trips) are invisible — only the FFI error
+/// string survives.
+#[uniffi::export]
+pub fn init_logging(directives: String) {
+    LOG_INIT.call_once(|| {
+        let filter = tracing_subscriber::EnvFilter::try_new(&directives)
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+        // `try_init` so a host that already installed a subscriber isn't clobbered.
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .with_ansi(false)
+            .try_init();
+    });
+}
 
 /// Engine build/version metadata. A trivial record so the host app can confirm
 /// the FFI bridge is live and log which engine build it loaded.

--- a/vta-mobile-core/src/mediator.rs
+++ b/vta-mobile-core/src/mediator.rs
@@ -69,3 +69,50 @@ impl MediatorSession {
         self.inner.shutdown().await;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Live: connect a fresh `did:key` holder to a real mediator and poll once,
+    /// reproducing exactly what the iOS app's `connectMediator` does — on the
+    /// host, to isolate iOS-specific failures from the affinidi-ATM client path.
+    /// Ignored by default (network + a real mediator). Run:
+    /// `cargo test -p vta-mobile-core -- --ignored connects_to_mediator --nocapture`
+    /// Override the mediator with `VTA_TEST_MEDIATOR`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "network: connects to a live mediator as a fresh did:key"]
+    async fn connects_to_mediator_as_fresh_did_key() {
+        use ed25519_dalek::SigningKey;
+        use multibase::Base;
+
+        let seed = [7u8; 32];
+        let sk = SigningKey::from_bytes(&seed);
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(sk.verifying_key().as_bytes());
+        let holder_did = format!("did:key:{}", multibase::encode(Base::Base58Btc, &mc));
+
+        let mediator = std::env::var("VTA_TEST_MEDIATOR").unwrap_or_else(|_| {
+            "did:webvh:QmTS3a3H9Dk4ZMPAZ8jNWGeyPbuKrPbrPZcSbg8CJ6yynD:webvh.storm.ws:mediator"
+                .to_string()
+        });
+
+        eprintln!("connecting holder={holder_did} → mediator={mediator}");
+        let session = MediatorSession::connect(
+            holder_did.clone(),
+            seed.to_vec(),
+            holder_did, // vta_did is unused for the connect itself; a valid did:key
+            mediator,
+        )
+        .await
+        .expect("connect to the mediator as a fresh did:key");
+
+        eprintln!("connected; polling once (5s)…");
+        let got = session
+            .receive_next(5)
+            .await
+            .expect("receive_next should not error");
+        eprintln!("receive_next → {got:?}");
+        session.shutdown().await;
+    }
+}


### PR DESCRIPTION
## Why

The iOS app's mediator connect (`connectMediator`) fails — "command timed out" (and, with a stale mediator value, a swallowed "No Mediator is configured"). But the **exact same `MediatorSession::connect` succeeds on the desktop host** (new test connects a fresh `did:key` to a live mediator and receives the `messagepickup/3.0/status`). So:

- The affinidi-ATM client path is correct.
- The failure is **iOS-runtime-specific** — and it's the first use of the **engine's own Rust networking** on-device (iOS REST auth goes through Swift `URLSession`, not the engine). The affinidi SDK pins **`rustls-tls-native-roots`**, so the prime suspect is **Rust TLS roots on iOS** — but the FFI error is too coarse to confirm.

## Changes

- **`init_logging(directives)`** — installs a `tracing_subscriber` fmt layer to **stderr** (the **Xcode console** on iOS) so the engine + `affinidi-messaging-sdk` + `vta-sdk` + `reqwest`/`rustls` `tracing` output is visible on-device. Idempotent (`Once` + `try_init`). Without it those libraries log to nothing and on-device network failures are invisible. The app will call this at launch.
- **`mediator::tests::connects_to_mediator_as_fresh_did_key`** — ignored, network; reproduces `connectMediator` on the host (passed against the demo mediator). Plus `resolver::tests::resolves_webvh_over_the_network` from #319.
- Version **0.5.0 → 0.6.0** (FFI addition).

## Verification

`cargo fmt --check` clean · `cargo build -p vta-mobile-core` ok · `cargo clippy --all-targets -- -D warnings` clean · 38 offline tests pass · the host mediator test passed live.

## Next

Cut `vta-mobile-core-v0.6.0`, the app calls `initLogging("info,vta_mobile_core=debug,vta_sdk=debug,affinidi_messaging_sdk=debug")` at launch, re-run the mediator connect on-device, and read the real error from the Xcode console — then fix precisely (likely a webpki-roots / TLS-on-iOS change).