### PR TITLE
feat(bbs): bbs-2023 holder-binding (pseudonyms) + standards-track migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-bbs"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d24778bfb29be2a2fbdf25d0d03a65188c8a1a5d567719cb786ebab18ff2965"
+checksum = "4fdebb15bb1c2d336032ba371544478c8e3a240a3292134b99960542e2d80175"
 dependencies = [
  "bls12_381_plus",
  "elliptic-curve",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.7.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2413307935cc2126c9fc4890a0e38ed69329638b93590a936a2d5bd11a50d8"
+checksum = "d3ac6d3b8f244b0531a14dfde22a90d0468e5e759b682fdc4bd41600d53a0b3a"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-rdf-encoding"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327366e7191a875eddcf0131e2b008e97fce1ba971e0442ac1835492316c0b2f"
+checksum = "0159f4425bb7ee85d27ad530c6011db6b23e39777e28eb7391db01371984e7e5"
 dependencies = [
  "serde",
  "serde_json",
@@ -753,7 +753,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -764,7 +764,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3200,7 +3200,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3449,7 +3449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4601,7 +4601,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5853,7 +5853,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6711,7 +6711,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6749,7 +6749,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7374,7 +7374,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7463,7 +7463,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7484,7 +7484,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8133,7 +8133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8616,7 +8616,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10478,7 +10478,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ affinidi-status-list = "0.1.3"
 # to avoid a duplicate-version split.
 affinidi-sd-jwt-vc = "0.1.1"
 affinidi-sd-jwt = "0.1.2"
-affinidi-bbs = "0.2"
+affinidi-bbs = "0.3"
 affinidi-openid4vp = "0.1.2"
 affinidi-openid4vci = "0.1.2"
 affinidi-secrets-resolver = "0.5"

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -1359,7 +1359,7 @@ mod tests {
     #[tokio::test]
     async fn receives_a_bbs_vc_from_a_did_key_issuer() {
         use affinidi_bbs as bbs;
-        use affinidi_data_integrity::bbs_2023::sign_vc_base;
+        use affinidi_data_integrity::bbs_2023_transform::sign_base_document;
 
         let (_dir, _store, vault) = fresh_vault();
 
@@ -1369,19 +1369,24 @@ mod tests {
         let pk = bbs::sk_to_pk(&sk);
         let issuer_did = affinidi_crypto::bls12381::g2_pub_to_did_key(&pk.to_bytes());
         let vc = json!({
-            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2"
+            ],
             "type": ["VerifiableCredential", "MembershipCredential"],
             "issuer": issuer_did,
             "validFrom": "2020-01-01T00:00:00Z",
             "credentialSubject": { "id": "did:key:zMember", "givenName": "Alice" }
         });
         let mandatory = ["/@context", "/type", "/issuer", "/credentialSubject/id"];
-        let signed = sign_vc_base(
+        let signed = sign_base_document(
             &vc,
             &mandatory,
             &format!("{issuer_did}#bbs-key-0"),
+            "2020-01-01T00:00:00Z",
             &sk,
             &pk,
+            b"ops-bbs-test-hmac-key-32-bytes!!",
         )
         .unwrap();
 

--- a/vta-service/src/vault/bbs.rs
+++ b/vta-service/src/vault/bbs.rs
@@ -3,28 +3,43 @@
 //! The vault's SD-JWT-VC / eddsa-jcs-2022 paths are always built; BBS pulls in
 //! the BLS12-381 curve (`affinidi-bbs`) + the `bbs-2023` Data-Integrity
 //! cryptosuite, so it lives behind the `bbs` feature. The document-level
-//! sign/derive/verify is delegated to
-//! [`affinidi_data_integrity::bbs_2023`] — per the workspace principle, proof
-//! handling is the library's job, not hand-rolled here.
+//! derive/verify is delegated to the standards-track
+//! [`affinidi_data_integrity::bbs_2023_transform`] (W3C vc-di-bbs, RDF-canonical)
+//! — per the workspace principle, proof handling is the library's job, not
+//! hand-rolled here. (The earlier `bbs_2023` module is an affinidi-internal,
+//! non-interoperable encoding and is now deprecated upstream.)
+//!
+//! A vc-di-bbs soundness bug in the document layer (a holder could present
+//! forged disclosed values) was found during this work and fixed upstream in
+//! `affinidi-data-integrity` 0.7.5 / `affinidi-rdf-encoding` 0.1.5
+//! (affinidi-tdk-rs#381) — the fix adds JSON-LD **safe mode**, so every claim
+//! term MUST be defined by the credential's `@context` (no silent `@vocab`
+//! drop). The regression is pinned by `tampered_disclosure_is_rejected_upstream_381`.
+//! Note: BBS issuer *signing* remains separately **audit-gated** (#294).
 //!
 //! ## Scope (audit gate)
 //!
 //! The VTA is a credential **holder/verifier**, not an issuer, so issuer
-//! *signing* (`sign_vc_base`) is deliberately **not** exposed from this module
-//! — BBS issuance stays audit-gated. This module covers the holder side:
+//! *signing* (`sign_base_document`) is deliberately **not** exposed from this
+//! module — BBS issuance stays audit-gated. This module covers the holder side:
 //! **receive** ([`receive_bbs`] — verify the issuer base proof, then store),
 //! **present** ([`present_bbs`] — consent-gated selective disclosure), and the
 //! G2 issuer-key resolution ([`resolve_bbs_issuer_key`]) the wire layer uses.
 
 use affinidi_bbs::PublicKey;
-use affinidi_data_integrity::bbs_2023;
+use affinidi_data_integrity::bbs_2023_transform as bbs_tx;
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
-use super::model::{CredentialFormat, CredentialStatus, StoredCredential};
+use super::model::{
+    BBS_PROVER_NYM_TAG, BBS_SECRET_PROVER_BLIND_TAG, CredentialFormat, CredentialStatus,
+    StoredCredential,
+};
 use super::receive::{Provenance, di_temporal_valid, extract_types, infer_purpose};
 use super::storage;
 
@@ -166,13 +181,16 @@ pub async fn receive_bbs(
     let vc: Value = serde_json::from_slice(vc_json)
         .map_err(|e| AppError::Validation(format!("malformed BBS VC JSON: {e}")))?;
 
-    // Verify the issuer base proof before trusting any bytes. The empty pointer
-    // `""` is a prefix of every claim pointer, so this discloses everything; a
-    // full-disclosure derived proof verifies iff the base signature is valid.
+    // Verify the issuer base proof before trusting any bytes. The cryptosuite
+    // exposes no standalone "verify base", so we derive a **full-disclosure**
+    // proof and verify it: a full-disclosure derived proof verifies iff the base
+    // BBS signature is valid over every message, so a tampered claim — mandatory
+    // or not — is rejected. The `""` root JSON pointer selects every statement
+    // (`select_json_ld` returns the whole document for an empty path).
     const BASE_CHECK_NONCE: &[u8] = b"vta-vault-base-check";
-    let full = bbs_2023::derive_vc(&vc, &[""], BASE_CHECK_NONCE, &pk)
+    let full = bbs_tx::create_derived_proof(&vc, &[""], BASE_CHECK_NONCE, &pk)
         .map_err(|e| AppError::Validation(format!("BBS base proof is malformed: {e}")))?;
-    if !bbs_2023::verify_vc_derived(&full, BASE_CHECK_NONCE, &pk)
+    if !bbs_tx::verify_derived_proof(&full, &pk)
         .map_err(|e| AppError::Validation(format!("BBS base proof verification failed: {e}")))?
     {
         return Err(AppError::Validation(
@@ -183,8 +201,22 @@ pub async fn receive_bbs(
     // Temporal validity over W3C VC 2.0 `validFrom` / `validUntil`.
     di_temporal_valid(&vc, now)?;
 
-    // --- map verified VC → StoredCredential envelope (mirrors receive_di_vc) ---
-    let types = extract_types(&vc);
+    let cred = build_stored_bbs(&vc, id, vc_json, source, now);
+    storage::put(vault, &cred).await?;
+    Ok(cred)
+}
+
+/// Map a verified BBS VC into a [`StoredCredential`] envelope (mirrors
+/// `receive_di_vc`). Pure metadata extraction — the caller has already verified
+/// the issuer proof and temporal validity.
+fn build_stored_bbs(
+    vc: &Value,
+    id: &str,
+    vc_json: &[u8],
+    source: Provenance,
+    now: DateTime<Utc>,
+) -> StoredCredential {
+    let types = extract_types(vc);
     let subject_did = vc
         .get("credentialSubject")
         .and_then(|s| s.get("id"))
@@ -205,7 +237,7 @@ pub async fn receive_bbs(
         .and_then(Value::as_str)
         .map(str::to_string);
 
-    let cred = StoredCredential {
+    StoredCredential {
         id: id.to_string(),
         format: CredentialFormat::Bbs2023,
         types,
@@ -221,7 +253,75 @@ pub async fn receive_bbs(
         source,
         tags: std::collections::BTreeMap::new(),
         body: vc_json.to_vec(),
-    };
+    }
+}
+
+/// Receive a BBS (`bbs-2023`) **pseudonym** base-proof credential — one issued in
+/// **holder-binding** mode, where the issuer blind-signed the holder's link-secret
+/// commitment ([`affinidi_bbs::nym_commit`]).
+///
+/// Same envelope mapping as [`receive_bbs`], but additionally persists the
+/// holder's pseudonym secrets (`prover_nym`, `secret_prover_blind`, generated by
+/// the holder at the commitment step) under the reserved
+/// [`BBS_PROVER_NYM_TAG`] / [`BBS_SECRET_PROVER_BLIND_TAG`] tags, so the holder
+/// can later derive a per-verifier pseudonym presentation ([`present_bbs`]).
+///
+/// **Base-proof verification:** the cryptosuite exposes no standalone "verify
+/// base", so we derive a *full-disclosure pseudonym* proof with the holder's
+/// secrets under a fixed check context and verify it — which succeeds iff the
+/// issuer's blind signature over the committed messages is valid.
+#[allow(clippy::too_many_arguments)]
+pub async fn receive_bbs_pseudonym(
+    vault: &KeyspaceHandle,
+    id: &str,
+    vc_json: &[u8],
+    issuer_pub: &[u8],
+    prover_nym: &[u8],
+    secret_prover_blind: &[u8],
+    source: Provenance,
+    now: DateTime<Utc>,
+) -> Result<StoredCredential, AppError> {
+    if id.trim().is_empty() {
+        return Err(AppError::Validation(
+            "credential id must be non-empty".to_string(),
+        ));
+    }
+    let pk = g2_public_key(issuer_pub)?;
+    let vc: Value = serde_json::from_slice(vc_json)
+        .map_err(|e| AppError::Validation(format!("malformed BBS VC JSON: {e}")))?;
+
+    // Verify the issuer pseudonym base proof under a fixed check context (any
+    // stable verifier id works — we only care that the signature is valid).
+    const BASE_CHECK_NONCE: &[u8] = b"vta-vault-base-check";
+    const BASE_CHECK_VERIFIER: &str = "vta-vault-base-check";
+    let full = bbs_tx::create_pseudonym_derived_proof(
+        &vc,
+        &[""],
+        BASE_CHECK_NONCE,
+        &pk,
+        prover_nym,
+        secret_prover_blind,
+        BASE_CHECK_VERIFIER,
+    )
+    .map_err(|e| AppError::Validation(format!("BBS pseudonym base proof is malformed: {e}")))?;
+    if !bbs_tx::verify_pseudonym_derived_proof(&full, &pk, BASE_CHECK_VERIFIER).map_err(|e| {
+        AppError::Validation(format!("BBS pseudonym base proof verification failed: {e}"))
+    })? {
+        return Err(AppError::Validation(
+            "BBS issuer pseudonym base proof did not verify".to_string(),
+        ));
+    }
+    di_temporal_valid(&vc, now)?;
+
+    let mut cred = build_stored_bbs(&vc, id, vc_json, source, now);
+    cred.tags.insert(
+        BBS_PROVER_NYM_TAG.to_string(),
+        URL_SAFE_NO_PAD.encode(prover_nym),
+    );
+    cred.tags.insert(
+        BBS_SECRET_PROVER_BLIND_TAG.to_string(),
+        URL_SAFE_NO_PAD.encode(secret_prover_blind),
+    );
     storage::put(vault, &cred).await?;
     Ok(cred)
 }
@@ -283,10 +383,61 @@ pub async fn present_bbs(
         .collect();
     let selective_refs: Vec<&str> = selective.iter().map(String::as_str).collect();
 
-    let derived = bbs_2023::derive_vc(&vc, &selective_refs, nonce.as_bytes(), &pk)
-        .map_err(|e| AppError::Validation(format!("BBS selective disclosure failed: {e}")))?;
+    // Holder-binding (pseudonym) mode iff the stored credential carries the
+    // holder's pseudonym secrets (set at blind issuance by
+    // [`receive_bbs_pseudonym`]). Then we derive a *per-verifier pseudonym* proof
+    // bound to `aud` (the verifier context), so the verifier learns the presenter
+    // **is** the subject — without sacrificing cross-verifier unlinkability.
+    // Otherwise the basic, possession-based derived proof (anyone holding the
+    // credential can present as the disclosed subject).
+    let derived = match holder_pseudonym_secrets(&cred)? {
+        Some((prover_nym, secret_prover_blind)) => bbs_tx::create_pseudonym_derived_proof(
+            &vc,
+            &selective_refs,
+            nonce.as_bytes(),
+            &pk,
+            &prover_nym,
+            &secret_prover_blind,
+            aud,
+        )
+        .map_err(|e| AppError::Validation(format!("BBS holder-bound disclosure failed: {e}")))?,
+        None => bbs_tx::create_derived_proof(&vc, &selective_refs, nonce.as_bytes(), &pk)
+            .map_err(|e| AppError::Validation(format!("BBS selective disclosure failed: {e}")))?,
+    };
     serde_json::to_string(&derived)
         .map_err(|e| AppError::Internal(format!("serialise BBS presentation: {e}")))
+}
+
+/// Read the holder's BBS pseudonym secrets from a stored credential's reserved
+/// tags, returning `(prover_nym, secret_prover_blind)` as raw bytes when the
+/// credential was issued in holder-binding mode, or `None` for a
+/// possession-based bbs-2023 credential.
+///
+/// Errors if exactly one secret is present (a corrupt half-pair — both are
+/// required to derive a pseudonym) or a value is not valid base64url.
+fn holder_pseudonym_secrets(
+    cred: &StoredCredential,
+) -> Result<Option<(Vec<u8>, Vec<u8>)>, AppError> {
+    let decode = |k: &str, v: &str| {
+        URL_SAFE_NO_PAD
+            .decode(v)
+            .map_err(|e| AppError::Validation(format!("bbs `{k}` tag is not base64url: {e}")))
+    };
+    match (
+        cred.tags.get(BBS_PROVER_NYM_TAG),
+        cred.tags.get(BBS_SECRET_PROVER_BLIND_TAG),
+    ) {
+        (None, None) => Ok(None),
+        (Some(nym), Some(blind)) => Ok(Some((
+            decode(BBS_PROVER_NYM_TAG, nym)?,
+            decode(BBS_SECRET_PROVER_BLIND_TAG, blind)?,
+        ))),
+        _ => Err(AppError::Validation(
+            "bbs-2023 credential has only one of the two pseudonym holder secrets — both \
+             `bbs:prover_nym` and `bbs:secret_prover_blind` are required for holder binding"
+                .into(),
+        )),
+    }
 }
 
 /// RFC 6901 token escaping (`~` -> `~0`, `/` -> `~1`) for a claim name embedded
@@ -295,16 +446,88 @@ fn rfc6901_escape(token: &str) -> String {
     token.replace('~', "~0").replace('/', "~1")
 }
 
+/// Test-only: issue a `bbs-2023` **pseudonym** base-proof credential — the
+/// audit-gated *issuer* side, exercised only in tests (production issuer signing
+/// stays out of this crate per the module's "audit gate" scope).
+///
+/// Runs the blind-issuance handshake: the holder commits a `prover_nym` link
+/// secret ([`affinidi_bbs::nym_commit`]) and the issuer blind-signs it
+/// ([`bbs_tx::create_pseudonym_base_proof_value`]) with `signer_nym_entropy`
+/// mixed in. Returns `(base_document, prover_nym, secret_prover_blind)` — the
+/// latter two are the holder secrets to pass to [`receive_bbs_pseudonym`].
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn issue_bbs_pseudonym_for_test(
+    vc: &Value,
+    mandatory: &[&str],
+    verification_method: &str,
+    created: &str,
+    sk: &affinidi_bbs::SecretKey,
+    pk: &PublicKey,
+    hmac_key: &[u8],
+    prover_nym_bytes: &[u8; 32],
+    signer_nym_entropy_bytes: &[u8; 32],
+) -> (Value, Vec<u8>, Vec<u8>) {
+    use affinidi_bbs as bbs;
+    // Holder side: commit the link secret.
+    let prover_nym =
+        bbs::hash::scalar_from_bytes(prover_nym_bytes).expect("prover_nym is a valid scalar");
+    let (commitment_with_proof, secret_prover_blind) =
+        bbs::nym_commit(prover_nym, &[], bbs::Ciphersuite::default()).expect("nym_commit");
+    let secret_prover_blind_bytes = bbs::hash::scalar_to_bytes(&secret_prover_blind);
+
+    // Issuer side: blind-sign the commitment into a pseudonym base proof. Build
+    // the proof object exactly as `sign_base_document` does for the basic suite.
+    let context = vc.get("@context").cloned().expect("vc has @context");
+    let proof_config = serde_json::json!({
+        "type": "DataIntegrityProof",
+        "cryptosuite": "bbs-2023",
+        "created": created,
+        "verificationMethod": verification_method,
+        "proofPurpose": "assertionMethod",
+        "@context": context,
+    });
+    let proof_value = bbs_tx::create_pseudonym_base_proof_value(
+        vc,
+        &proof_config,
+        mandatory,
+        sk,
+        pk,
+        hmac_key,
+        &commitment_with_proof,
+        signer_nym_entropy_bytes,
+    )
+    .expect("create pseudonym base proof");
+    let mut proof = proof_config;
+    let obj = proof.as_object_mut().unwrap();
+    obj.remove("@context");
+    obj.insert("proofValue".to_string(), Value::String(proof_value));
+    let mut base = vc.clone();
+    base.as_object_mut()
+        .unwrap()
+        .insert("proof".to_string(), proof);
+
+    (
+        base,
+        prover_nym_bytes.to_vec(),
+        secret_prover_blind_bytes.to_vec(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use affinidi_bbs as bbs;
-    use affinidi_data_integrity::bbs_2023::sign_vc_base;
+    use affinidi_data_integrity::bbs_2023_transform::sign_base_document;
     use serde_json::json;
     use vti_common::config::StoreConfig;
     use vti_common::store::Store;
 
     const MANDATORY: &[&str] = &["/@context", "/type", "/issuer", "/credentialSubject/id"];
+    /// Per-credential HMAC key (32 bytes) — carried inside the base proofValue so
+    /// the holder can derive presentations. Fixed here for deterministic tests.
+    const TEST_HMAC: &[u8; 32] = b"vta-bbs-test-hmac-key-32-bytes!!";
+    const TEST_CREATED: &str = "2020-01-01T00:00:00Z";
 
     fn fresh_vault() -> (tempfile::TempDir, Store, KeyspaceHandle) {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -330,7 +553,10 @@ mod tests {
         let (sk, pk) = issuer_keys();
         let did = issuer_did(&pk);
         let mut vc = json!({
-            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2"
+            ],
             "type": ["VerifiableCredential", "MembershipCredential"],
             "issuer": did,
             "validFrom": "2020-01-01T00:00:00Z",
@@ -340,7 +566,8 @@ mod tests {
             vc["validUntil"] = json!(u);
         }
         let vm = format!("{did}#bbs-key-0");
-        let signed = sign_vc_base(&vc, MANDATORY, &vm, &sk, &pk).unwrap();
+        let signed =
+            sign_base_document(&vc, MANDATORY, &vm, TEST_CREATED, &sk, &pk, TEST_HMAC).unwrap();
         (serde_json::to_vec(&signed).unwrap(), pk)
     }
 
@@ -377,6 +604,99 @@ mod tests {
         );
     }
 
+    /// Soundness regression for **affinidi-tdk-rs#381** (fixed in
+    /// `affinidi-data-integrity` 0.7.5 / `affinidi-rdf-encoding` 0.1.5).
+    ///
+    /// A holder must not be able to change a signed attribute and have the
+    /// derived proof verify. The fix added JSON-LD **safe mode**, so the document
+    /// layer now enforces the disclosed-value ↔ proof binding two ways, both
+    /// covered here:
+    /// 1. **defined terms** (examples `@vocab`): the value is in the signed RDF
+    ///    dataset, so tampering it makes `verify_derived_proof` return `false`;
+    /// 2. **undefined terms** (bare `credentials/v2`): expansion is refused
+    ///    outright, so a forged value can't even be derived.
+    ///
+    /// The raw `affinidi-bbs` primitive was always sound (asserted here too).
+    #[test]
+    fn tampered_disclosure_is_rejected_upstream_381() {
+        let (sk, pk) = issuer_keys();
+        let did = issuer_did(&pk);
+
+        // Raw primitive: tampered disclosure is correctly REJECTED.
+        let sig = bbs::sign(&sk, &pk, b"hdr", &[b"m0".as_ref(), b"gold"]).unwrap();
+        let proof = bbs::proof_gen(
+            &pk,
+            &sig,
+            b"hdr",
+            b"ph",
+            &[b"m0".as_ref(), b"platinum"],
+            &[1],
+        )
+        .unwrap();
+        assert!(
+            !bbs::proof_verify(&pk, &proof, b"hdr", b"ph", &[b"platinum".as_ref()], &[1]).unwrap(),
+            "raw affinidi-bbs must reject a tampered disclosure"
+        );
+
+        // (1) Defined terms (examples @vocab) → value is in the signed dataset.
+        let vc = json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2"
+            ],
+            "type": ["VerifiableCredential", "ExampleMembershipCredential"],
+            "issuer": did,
+            "credentialSubject": { "id": "did:key:zMember", "memberLevel": "gold" }
+        });
+        let base = sign_base_document(
+            &vc,
+            MANDATORY,
+            &format!("{did}#bbs-key-0"),
+            TEST_CREATED,
+            &sk,
+            &pk,
+            TEST_HMAC,
+        )
+        .unwrap();
+        // Honest derive verifies.
+        let honest =
+            bbs_tx::create_derived_proof(&base, &["/credentialSubject/memberLevel"], b"n", &pk)
+                .unwrap();
+        assert!(bbs_tx::verify_derived_proof(&honest, &pk).unwrap());
+        // Tamper the base, re-derive disclosing the forged value → verify REJECTS.
+        let mut tampered = base.clone();
+        tampered["credentialSubject"]["memberLevel"] = json!("platinum");
+        let forged =
+            bbs_tx::create_derived_proof(&tampered, &["/credentialSubject/memberLevel"], b"n", &pk)
+                .expect("derive (defined terms)");
+        assert!(
+            !bbs_tx::verify_derived_proof(&forged, &pk).unwrap_or(false),
+            "REGRESSION (affinidi-tdk-rs#381): bbs_2023_transform accepted a forged disclosed value"
+        );
+
+        // (2) Undefined terms (bare credentials/v2) → safe mode refuses expansion,
+        // so a credential whose claims aren't in its @context can't be signed at all.
+        let undefined = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential"],
+            "issuer": did,
+            "credentialSubject": { "id": "did:key:zMember", "memberLevel": "gold" }
+        });
+        assert!(
+            sign_base_document(
+                &undefined,
+                MANDATORY,
+                &format!("{did}#bbs-key-0"),
+                TEST_CREATED,
+                &sk,
+                &pk,
+                TEST_HMAC,
+            )
+            .is_err(),
+            "safe mode must refuse a credential with @context-undefined claim terms"
+        );
+    }
+
     #[tokio::test]
     async fn rejects_an_expired_bbs_credential() {
         let (_dir, _store, vault) = fresh_vault();
@@ -404,5 +724,131 @@ mod tests {
         let did = issuer_did(&pk);
         let resolved = g2_issuer_key_from_did_key(&did).expect("resolve G2 did:key");
         assert_eq!(resolved.to_bytes(), pk.to_bytes());
+    }
+
+    // ---- holder-binding (pseudonym) ------------------------------------------
+
+    /// A bbs-2023 **pseudonym** base-proof VC + the holder's `(prover_nym,
+    /// secret_prover_blind)` raw-byte secrets.
+    fn pseudonym_bbs_vc() -> (Vec<u8>, bbs::PublicKey, [u8; 32], Vec<u8>) {
+        let (sk, pk) = issuer_keys();
+        let did = issuer_did(&pk);
+        let vc = json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2"
+            ],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": did,
+            "validFrom": "2020-01-01T00:00:00Z",
+            "credentialSubject": { "id": "did:key:zMember", "givenName": "Alice", "memberLevel": "gold" }
+        });
+        let vm = format!("{did}#bbs-key-0");
+        let prover_nym = [0x11u8; 32];
+        let entropy = [0x22u8; 32];
+        let (base, nym, blind) = issue_bbs_pseudonym_for_test(
+            &vc,
+            MANDATORY,
+            &vm,
+            TEST_CREATED,
+            &sk,
+            &pk,
+            TEST_HMAC,
+            &prover_nym,
+            &entropy,
+        );
+        assert_eq!(nym, prover_nym.to_vec());
+        (serde_json::to_vec(&base).unwrap(), pk, prover_nym, blind)
+    }
+
+    #[tokio::test]
+    async fn receives_and_stores_a_pseudonym_bbs_credential() {
+        let (_dir, _store, vault) = fresh_vault();
+        let (vc, pk, nym, blind) = pseudonym_bbs_vc();
+        let cred = receive_bbs_pseudonym(
+            &vault,
+            "bbs-nym",
+            &vc,
+            &pk.to_bytes(),
+            &nym,
+            &blind,
+            None,
+            Utc::now(),
+        )
+        .await
+        .expect("receive pseudonym BBS VC");
+        assert_eq!(cred.format, CredentialFormat::Bbs2023);
+        assert!(
+            cred.tags.contains_key(BBS_PROVER_NYM_TAG)
+                && cred.tags.contains_key(BBS_SECRET_PROVER_BLIND_TAG),
+            "holder pseudonym secrets must be persisted"
+        );
+        let stored = storage::get(&vault, "bbs-nym")
+            .await
+            .unwrap()
+            .expect("stored");
+        assert_eq!(
+            stored.tags.get(BBS_PROVER_NYM_TAG),
+            cred.tags.get(BBS_PROVER_NYM_TAG),
+            "secrets round-trip through the store"
+        );
+        // The decoded secrets must be the holder's originals.
+        assert_eq!(
+            holder_pseudonym_secrets(&stored).unwrap(),
+            Some((nym.to_vec(), blind))
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_pseudonym_base_with_wrong_holder_secret() {
+        let (_dir, _store, vault) = fresh_vault();
+        let (vc, pk, _nym, blind) = pseudonym_bbs_vc();
+        let wrong_nym = [0x33u8; 32];
+        let err = receive_bbs_pseudonym(
+            &vault,
+            "bbs-bad",
+            &vc,
+            &pk.to_bytes(),
+            &wrong_nym,
+            &blind,
+            None,
+            Utc::now(),
+        )
+        .await
+        .expect_err("a wrong holder link secret must fail the base check");
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        assert!(
+            storage::get(&vault, "bbs-bad").await.unwrap().is_none(),
+            "a rejected credential must not be stored"
+        );
+    }
+
+    #[test]
+    fn half_a_pseudonym_secret_pair_is_an_error() {
+        // A credential carrying only one of the two reserved secret tags must not
+        // be silently treated as possession-based.
+        let mut cred = StoredCredential {
+            id: "x".into(),
+            format: CredentialFormat::Bbs2023,
+            types: vec![],
+            schema_id: None,
+            community_did: None,
+            subject_did: None,
+            issuer_did: None,
+            purpose: None,
+            status: CredentialStatus::Valid,
+            valid_from: None,
+            valid_until: None,
+            received_at: Utc::now().to_rfc3339(),
+            source: None,
+            tags: std::collections::BTreeMap::new(),
+            body: vec![],
+        };
+        assert_eq!(holder_pseudonym_secrets(&cred).unwrap(), None);
+        cred.tags.insert(
+            BBS_PROVER_NYM_TAG.to_string(),
+            URL_SAFE_NO_PAD.encode([1u8; 32]),
+        );
+        assert!(holder_pseudonym_secrets(&cred).is_err());
     }
 }

--- a/vta-service/src/vault/model.rs
+++ b/vta-service/src/vault/model.rs
@@ -24,6 +24,13 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Reserved [`StoredCredential::tags`] key holding the BBS pseudonym holder
+/// link secret (`prover_nym`), base64url-no-pad. See [`StoredCredential::tags`].
+pub const BBS_PROVER_NYM_TAG: &str = "bbs:prover_nym";
+/// Reserved [`StoredCredential::tags`] key holding the BBS pseudonym
+/// `secret_prover_blind`, base64url-no-pad. See [`StoredCredential::tags`].
+pub const BBS_SECRET_PROVER_BLIND_TAG: &str = "bbs:secret_prover_blind";
+
 /// Proof / serialization format of the stored credential body. Stored as a
 /// tag so the (later) receive/present/status code can dispatch to the right
 /// format verifier without this format-agnostic layer needing to understand
@@ -166,6 +173,15 @@ pub struct StoredCredential {
     pub source: Option<String>,
     /// Holder-applied labels. Not indexed in this task (search by tag is a
     /// later DCQL concern); carried so the round-trip is lossless.
+    ///
+    /// Two **reserved** keys carry the BBS pseudonym holder secrets for a
+    /// `bbs-2023` credential issued in **holder-binding** mode (see
+    /// [`crate::vault::bbs`]): [`BBS_PROVER_NYM_TAG`] (the holder's link secret
+    /// `prover_nym`) and [`BBS_SECRET_PROVER_BLIND_TAG`] (`secret_prover_blind`),
+    /// both base64url-no-pad. They are present only for pseudonym credentials and
+    /// are co-encrypted at rest with the rest of the record. Storing them here —
+    /// rather than as format-specific columns — keeps this layer format-agnostic
+    /// (§5: "a new format never requires a storage-schema change").
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub tags: std::collections::BTreeMap<String, String>,
     /// The credential itself — **opaque bytes**, encrypted at rest. This

--- a/vta-service/src/vault/present.rs
+++ b/vta-service/src/vault/present.rs
@@ -631,7 +631,9 @@ mod tests {
     async fn present_bbs_discloses_only_consented_claims() {
         use crate::vault::bbs::{present_bbs, receive_bbs};
         use affinidi_bbs as bbs;
-        use affinidi_data_integrity::bbs_2023::{sign_vc_base, verify_vc_derived};
+        use affinidi_data_integrity::bbs_2023_transform::{
+            sign_base_document, verify_derived_proof,
+        };
 
         let (_dir, _store, vault) = fresh_vault();
         let (holder_did, _kb, consent_key, _vk) = holder(7);
@@ -643,7 +645,10 @@ mod tests {
         let pk = bbs::sk_to_pk(&sk);
         let issuer_did = affinidi_crypto::bls12381::g2_pub_to_did_key(&pk.to_bytes());
         let vc = json!({
-            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2"
+            ],
             "type": ["VerifiableCredential", "MembershipCredential"],
             "issuer": issuer_did,
             "validFrom": "2020-01-01T00:00:00Z",
@@ -655,12 +660,14 @@ mod tests {
             }
         });
         let mandatory = ["/@context", "/type", "/issuer", "/credentialSubject/id"];
-        let signed = sign_vc_base(
+        let signed = sign_base_document(
             &vc,
             &mandatory,
             &format!("{issuer_did}#bbs-key-0"),
+            "2020-01-01T00:00:00Z",
             &sk,
             &pk,
+            b"present-bbs-test-hmac-key-32byte",
         )
         .unwrap();
         let body = serde_json::to_vec(&signed).unwrap();
@@ -711,10 +718,124 @@ mod tests {
             "mandatory subject id disclosed"
         );
 
-        // The derived proof verifies against the issuer key + the verifier nonce.
+        // The derived proof verifies against the issuer key. (The standards-track
+        // verify authenticates the presentation header embedded in the proof; the
+        // verifier binds that header to its own challenge — covered in the VTC
+        // join verifier tests, not here.)
         assert!(
-            verify_vc_derived(&derived, nonce.as_bytes(), &pk).unwrap(),
+            verify_derived_proof(&derived, &pk).unwrap(),
             "BBS derived presentation must verify"
+        );
+    }
+
+    #[cfg(feature = "bbs")]
+    #[tokio::test]
+    async fn present_bbs_holder_bound_is_per_verifier_pseudonymous() {
+        use crate::vault::bbs::{issue_bbs_pseudonym_for_test, present_bbs, receive_bbs_pseudonym};
+        use affinidi_bbs as bbs;
+        use affinidi_data_integrity::bbs_2023_transform::verify_pseudonym_derived_proof;
+
+        let (_dir, _store, vault) = fresh_vault();
+        let (holder_did, _kb, consent_key, _vk) = holder(9);
+        let verifier = "did:web:acme-verifier.example";
+        let now = Utc::now();
+
+        // Issue a pseudonym (holder-binding) base-proof VC bound to the holder.
+        let sk = bbs::keygen(b"present-nym-issuer-key-material!!", b"").unwrap();
+        let pk = bbs::sk_to_pk(&sk);
+        let issuer_did = affinidi_crypto::bls12381::g2_pub_to_did_key(&pk.to_bytes());
+        let vc = json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2"
+            ],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": issuer_did,
+            "validFrom": "2020-01-01T00:00:00Z",
+            "credentialSubject": { "id": holder_did, "givenName": "Alice", "dateOfBirth": "1990-01-01" }
+        });
+        let mandatory = ["/@context", "/type", "/issuer", "/credentialSubject/id"];
+        let vm = format!("{issuer_did}#bbs-key-0");
+        let (base, nym, blind) = issue_bbs_pseudonym_for_test(
+            &vc,
+            &mandatory,
+            &vm,
+            "2020-01-01T00:00:00Z",
+            &sk,
+            &pk,
+            b"present-nym-test-hmac-key-32byte",
+            &[0x11u8; 32],
+            &[0x22u8; 32],
+        );
+        let body = serde_json::to_vec(&base).unwrap();
+        receive_bbs_pseudonym(
+            &vault,
+            "nym-cred",
+            &body,
+            &pk.to_bytes(),
+            &nym,
+            &blind,
+            None,
+            now,
+        )
+        .await
+        .expect("receive pseudonym base proof");
+
+        // Consent to disclose only givenName.
+        let rec = create_consent(
+            &vault,
+            &grant(
+                &holder_did,
+                "nym-cred",
+                verifier,
+                vec!["givenName".into()],
+                now + Duration::hours(1),
+            ),
+            &consent_key,
+        )
+        .await
+        .unwrap();
+
+        let pres = present_bbs(
+            &vault,
+            "nym-cred",
+            &rec.identifier,
+            &pk.to_bytes(),
+            "verifier-nonce-nym",
+            verifier,
+            None,
+            now,
+        )
+        .await
+        .expect("present holder-bound BBS");
+        let derived: Value = serde_json::from_str(&pres).unwrap();
+
+        // It is a *pseudonym* derived proof (`0xd95d09`), not a basic one.
+        let pv = derived["proof"]["proofValue"].as_str().unwrap();
+        let (_b, bytes) = multibase::decode(pv).unwrap();
+        assert_eq!(
+            &bytes[..3],
+            &[0xd9, 0x5d, 0x09],
+            "holder-binding must emit a pseudonym derived proof"
+        );
+
+        // Verifies under the verifier it was bound to ...
+        assert!(
+            verify_pseudonym_derived_proof(&derived, &pk, verifier).unwrap(),
+            "pseudonym proof must verify for its bound verifier"
+        );
+        // ... and NOT under a different verifier id (per-verifier binding).
+        assert!(
+            !verify_pseudonym_derived_proof(&derived, &pk, "did:web:someone-else.example")
+                .unwrap_or(false),
+            "a pseudonym proof must not verify under a different verifier id"
+        );
+
+        // Disclosure is still minimised.
+        assert_eq!(derived["credentialSubject"]["givenName"], "Alice");
+        assert!(
+            derived["credentialSubject"].get("dateOfBirth").is_none(),
+            "an unconsented claim must be redacted"
         );
     }
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -16,7 +16,7 @@ setup = ["dep:dialoguer", "dep:didwebvh-rs", "dep:url"]
 # BBS+ (`bbs-2023`) verifier support — lets the join verifier accept
 # selectively-disclosed bbs-2023 presentations. Pulls in the BLS12-381 curve
 # (`affinidi-bbs`) + the `bbs-2023` Data-Integrity cryptosuite. Off by default.
-bbs = ["dep:affinidi-bbs", "affinidi-data-integrity/bbs-2023"]
+bbs = ["dep:affinidi-bbs", "dep:ciborium", "affinidi-data-integrity/bbs-2023"]
 # Public community website (§12.1). Filesystem-backed static
 # hosting at `website.root_dir`. Default-on so MVP `cargo run`
 # serves a site; operators who host externally can compile it
@@ -169,6 +169,10 @@ hkdf = { workspace = true }
 x25519-dalek = { workspace = true }
 zeroize = { version = "1", features = ["derive"] }
 multibase = { workspace = true }
+# CBOR decode for the bbs-2023 derived proofValue (extracting the embedded
+# presentation header + pseudonym tag in the verifier). Optional, pulled in by
+# the `bbs` feature; also a dev-dependency for non-bbs test parsing.
+ciborium = { version = "0.2", optional = true }
 # Rego policy interpreter (Phase 2 M2.1). Hosted in `crate::policy`.
 # Spec §3-J + §7: regorus runs in-process; no external OPA sidecar.
 regorus = { workspace = true }

--- a/vtc-service/src/ceremony/evaluate.rs
+++ b/vtc-service/src/ceremony/evaluate.rs
@@ -128,6 +128,7 @@ cred_trusted(t) if {
                         issuer: "did:webvh:notary.example".into(),
                         issuer_trusted,
                         status: CredentialStatus::Valid,
+                        holder_bound: true,
                         claims: json!({}),
                         valid_until: None,
                     }],

--- a/vtc-service/src/ceremony/facts.rs
+++ b/vtc-service/src/ceremony/facts.rs
@@ -258,6 +258,15 @@ pub struct Credential {
     pub issuer_trusted: bool,
     /// Resolved revocation/suspension state from the status list.
     pub status: CredentialStatus,
+    /// Host verdict: did the presenter **cryptographically prove control of
+    /// the holder key** (so the presenter *is* the subject), versus mere
+    /// possession of the credential? True for SD-JWT-VC (`kb-jwt`), DI VP
+    /// (holder proof), and holder-bound **bbs-2023 pseudonym** proofs; false
+    /// for a basic, possession-based bbs-2023 derived proof. A policy can
+    /// `require` this for sensitive communities (low-assurance flows may accept
+    /// possession-based holdership).
+    #[serde(default)]
+    pub holder_bound: bool,
     /// The credential's subject claims, verbatim. Free-form; policies
     /// read specific claim paths.
     #[serde(default)]
@@ -346,6 +355,7 @@ mod tests {
                         issuer: "did:webvh:notary.example".into(),
                         issuer_trusted: true,
                         status: CredentialStatus::Valid,
+                        holder_bound: true,
                         claims: json!({ "kind": "proximity" }),
                         valid_until: None,
                     }],
@@ -368,7 +378,7 @@ mod tests {
                     "verified": true,
                     "holder": "did:key:z6MkHuman",
                     "credentials": [
-                        { "type": "WitnessCredential", "issuer": "did:webvh:notary.example", "issuer_trusted": true, "status": "valid", "claims": { "kind": "proximity" } }
+                        { "type": "WitnessCredential", "issuer": "did:webvh:notary.example", "issuer_trusted": true, "status": "valid", "holder_bound": true, "claims": { "kind": "proximity" } }
                     ]
                 },
                 "request": { "agreements": {} }

--- a/vtc-service/src/ceremony/verify.rs
+++ b/vtc-service/src/ceremony/verify.rs
@@ -188,6 +188,7 @@ mod tests {
                 issuer: "did:webvh:notary.example".into(),
                 issuer_trusted: true,
                 status: CredentialStatus::Valid,
+                holder_bound: true,
                 claims: json!({}),
                 valid_until: None,
             }],

--- a/vtc-service/src/credentials/exchange.rs
+++ b/vtc-service/src/credentials/exchange.rs
@@ -283,6 +283,13 @@ pub struct VerifiedPresentation {
     pub vct: Option<String>,
     /// The disclosed claims (issuer-protected claims + the revealed subset).
     pub claims: Value,
+    /// Whether the presenter **cryptographically proved control of the holder
+    /// key** (so the presenter *is* the subject), versus mere possession of the
+    /// credential. True for SD-JWT-VC (`kb-jwt`), DI VP (holder proof), and
+    /// holder-bound **bbs-2023 pseudonym** proofs; **false** for a basic
+    /// (possession-based) bbs-2023 derived proof. A join policy can require this
+    /// (see the `holder_bound` fact) for sensitive communities.
+    pub holder_bound: bool,
     /// The raw `credentialStatus` entry (W3C `BitstringStatusListEntry`) or
     /// SD-JWT-VC IETF `status` object, captured at verify time so the join
     /// verifier can resolve revocation. `None` when the credential opted into no
@@ -580,6 +587,9 @@ pub async fn verify_presentation(
         issuer_did,
         holder_did,
         vct,
+        // SD-JWT-VC carries a mandatory holder `kb-jwt` — the presenter proved
+        // control of the holder key.
+        holder_bound: true,
         claims: result.claims,
         credential_status,
     })
@@ -655,7 +665,7 @@ pub async fn verify_vp_token(
         // **string** is one SD-JWT-VC presentation.
         let verified: Vec<VerifiedPresentation> = if entry.is_object() {
             if is_bbs_2023_presentation(entry) {
-                verify_bbs_dispatch(entry, expected_nonce, did_resolver, now).await?
+                verify_bbs_dispatch(entry, expected_aud, expected_nonce, did_resolver, now).await?
             } else {
                 verify_di_vp(entry, expected_aud, expected_nonce, did_resolver, now).await?
             }
@@ -814,6 +824,9 @@ async fn verify_di_vp(
             issuer_did,
             holder_did: holder_did.clone(),
             vct,
+            // A DI VP carries a holder `DataIntegrityProof` — the presenter proved
+            // control of the holder key.
+            holder_bound: true,
             claims: vc.get("credentialSubject").cloned().unwrap_or(Value::Null),
             credential_status,
         });
@@ -838,6 +851,7 @@ fn is_bbs_2023_presentation(entry: &Value) -> bool {
 /// when the crate was built without the `bbs` feature.
 async fn verify_bbs_dispatch(
     entry: &Value,
+    expected_aud: &str,
     expected_nonce: &str,
     did_resolver: Option<&affinidi_did_resolver_cache_sdk::DIDCacheClient>,
     now: DateTime<Utc>,
@@ -845,12 +859,12 @@ async fn verify_bbs_dispatch(
     #[cfg(feature = "bbs")]
     {
         Ok(vec![
-            verify_bbs_presentation(entry, expected_nonce, did_resolver, now).await?,
+            verify_bbs_presentation(entry, expected_aud, expected_nonce, did_resolver, now).await?,
         ])
     }
     #[cfg(not(feature = "bbs"))]
     {
-        let _ = (entry, expected_nonce, did_resolver, now);
+        let _ = (entry, expected_aud, expected_nonce, did_resolver, now);
         Err(AppError::Validation(
             "a bbs-2023 presentation was received but this VTC was built without the `bbs` \
              feature"
@@ -859,8 +873,63 @@ async fn verify_bbs_dispatch(
     }
 }
 
+/// Inspect a `bbs-2023` **derived** proofValue: returns its embedded
+/// `presentationHeader` and whether it is a **pseudonym** (holder-bound) proof.
+///
+/// The standards-track `verify_derived_proof` / `verify_pseudonym_derived_proof`
+/// authenticate against the header carried *inside* the proof rather than a
+/// verifier-supplied one, so the verifier must extract it to bind freshness. The
+/// derived proofValue is `multibase-base64url("u" || 0xd95d0{3,9} ||
+/// CBOR([...]))`; `0xd95d03` is a basic derived proof and `0xd95d09` a pseudonym
+/// (holder-bound) one. The presentation header is element index 4 of the CBOR
+/// array in both forms.
+#[cfg(feature = "bbs")]
+fn bbs_inspect_derived_proof(vc: &Value) -> Result<(Vec<u8>, bool), AppError> {
+    let pv = vc
+        .get("proof")
+        .and_then(|p| p.get("proofValue"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| AppError::Validation("bbs-2023 presentation has no `proofValue`".into()))?;
+    let (_base, bytes) = multibase::decode(pv).map_err(|e| {
+        AppError::Validation(format!("bbs-2023 `proofValue` is not multibase: {e}"))
+    })?;
+    // 0xd95d03 = basic derived, 0xd95d09 = pseudonym derived. Reject base proofs
+    // (0xd95d02 / 0xd95d08) and anything else — only a *disclosure* proof is a
+    // presentation.
+    if bytes.len() < 3 || bytes[0] != 0xd9 || bytes[1] != 0x5d {
+        return Err(AppError::Validation(
+            "bbs-2023 `proofValue` is not a derived (disclosure) proof".into(),
+        ));
+    }
+    let is_pseudonym = match bytes[2] {
+        0x03 => false,
+        0x09 => true,
+        _ => {
+            return Err(AppError::Validation(
+                "bbs-2023 `proofValue` is not a derived (disclosure) proof".into(),
+            ));
+        }
+    };
+    let value: ciborium::value::Value = ciborium::from_reader(&bytes[3..]).map_err(|e| {
+        AppError::Validation(format!("bbs-2023 `proofValue` CBOR is malformed: {e}"))
+    })?;
+    let header = value
+        .as_array()
+        .and_then(|arr| arr.get(4))
+        .and_then(ciborium::value::Value::as_bytes)
+        .ok_or_else(|| {
+            AppError::Validation("bbs-2023 derived `proofValue` has no presentationHeader".into())
+        })?;
+    Ok((header.clone(), is_pseudonym))
+}
+
 /// Verify a **bbs-2023 derived-proof** presentation and project it into a
 /// [`VerifiedPresentation`].
+///
+/// Requires `affinidi-data-integrity` ≥ 0.7.5 (the vc-di-bbs disclosed-value
+/// soundness fix, affinidi-tdk-rs#381): every claim term in a presented VC must
+/// be defined by its `@context` (JSON-LD safe mode), else verification refuses
+/// it. BBS issuer *signing* remains separately audit-gated (#294).
 ///
 /// The derived proof (the disclosed VC's `proof`) proves the holder possesses a
 /// credential validly issued by the VC `issuer` and discloses only the revealed
@@ -868,22 +937,27 @@ async fn verify_bbs_dispatch(
 /// The issuer's BLS12-381 G2 key resolves from its DID (the proof's
 /// `verificationMethod`, bound to `issuer`).
 ///
-/// **Holder semantics (deliberate):** unlike SD-JWT-VC (kb-jwt) or DI VP
-/// (holder proof), a basic bbs-2023 derived proof carries **no holder-key
-/// binding** — it is unlinkable and possession-based. The applicant
-/// (`holder_did`) is therefore taken to be the **disclosed `credentialSubject.id`**
-/// (which a well-formed presentation discloses as a mandatory claim). The join
-/// policy decides whether possession-based holdership is acceptable; stronger
-/// holder binding (BBS pseudonyms) is a follow-up.
+/// **Holder semantics — two modes, by proof kind:**
+/// - A **basic** derived proof (`0xd95d03`) carries **no holder-key binding** —
+///   it is unlinkable and possession-based. The applicant (`holder_did`) is taken
+///   to be the **disclosed `credentialSubject.id`** (a mandatory-disclosed claim),
+///   and [`VerifiedPresentation::holder_bound`] is `false`.
+/// - A **pseudonym** derived proof (`0xd95d09`) is holder-bound: the holder proves
+///   knowledge of the link secret committed at issuance, bound to a per-verifier
+///   context. We verify it against `expected_aud` as the `verifier_id` (so the
+///   pseudonym is stable per verifier, unlinkable across verifiers), and
+///   `holder_bound` is `true`. The join policy can require this for sensitive
+///   communities (see the `holder_bound` fact).
 #[cfg(feature = "bbs")]
 async fn verify_bbs_presentation(
     vc: &Value,
+    expected_aud: &str,
     expected_nonce: &str,
     did_resolver: Option<&affinidi_did_resolver_cache_sdk::DIDCacheClient>,
     now: DateTime<Utc>,
 ) -> Result<VerifiedPresentation, AppError> {
     use affinidi_bbs::PublicKey;
-    use affinidi_data_integrity::bbs_2023;
+    use affinidi_data_integrity::bbs_2023_transform;
 
     let issuer_did = vc
         .get("issuer")
@@ -909,10 +983,26 @@ async fn verify_bbs_presentation(
     let pk = PublicKey::from_bytes(&g2)
         .map_err(|e| AppError::Validation(format!("bbs-2023 issuer key is invalid: {e}")))?;
 
-    // Verify the derived proof binds the verifier's nonce (presentation header).
-    if !bbs_2023::verify_vc_derived(vc, expected_nonce.as_bytes(), &pk)
-        .map_err(|e| AppError::Validation(format!("bbs-2023 presentation did not verify: {e}")))?
-    {
+    // Freshness / anti-replay: the standards-track verify authenticates the
+    // presentation header *embedded* in the derived proof, not a verifier-supplied
+    // one — so we read that header back out and bind it to the challenge this
+    // verifier issued. Without this check a proof minted for any other challenge
+    // would verify cryptographically. The same inspection tells us whether this is
+    // a holder-bound *pseudonym* proof (`0xd95d09`) or a basic one (`0xd95d03`).
+    let (header, holder_bound) = bbs_inspect_derived_proof(vc)?;
+    if header != expected_nonce.as_bytes() {
+        return Err(AppError::Validation(
+            "bbs-2023 presentation header does not match the expected challenge".into(),
+        ));
+    }
+    let verified = if holder_bound {
+        // Pseudonym proof: verify the per-verifier holder binding against `aud`.
+        bbs_2023_transform::verify_pseudonym_derived_proof(vc, &pk, expected_aud)
+    } else {
+        bbs_2023_transform::verify_derived_proof(vc, &pk)
+    }
+    .map_err(|e| AppError::Validation(format!("bbs-2023 presentation did not verify: {e}")))?;
+    if !verified {
         return Err(AppError::Validation(
             "bbs-2023 presentation proof did not verify".into(),
         ));
@@ -946,6 +1036,9 @@ async fn verify_bbs_presentation(
         issuer_did,
         holder_did,
         vct,
+        // `true` only for a pseudonym (holder-bound) proof; a basic derived proof
+        // is possession-based.
+        holder_bound,
         claims: vc.get("credentialSubject").cloned().unwrap_or(Value::Null),
         credential_status,
     })
@@ -2007,13 +2100,18 @@ mod tests {
     #[cfg(feature = "bbs")]
     fn bbs_derived_presentation(nonce: &str, subject: &str, disclose: &[&str]) -> (Value, String) {
         use affinidi_bbs as bbs;
-        use affinidi_data_integrity::bbs_2023::{derive_vc, sign_vc_base};
+        use affinidi_data_integrity::bbs_2023_transform::{
+            create_derived_proof, sign_base_document,
+        };
 
         let sk = bbs::keygen(b"vtc-bbs-verify-key-material-32by", b"").unwrap();
         let pk = bbs::sk_to_pk(&sk);
         let issuer_did = affinidi_crypto::bls12381::g2_pub_to_did_key(&pk.to_bytes());
         let vc = json!({
-            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2"
+            ],
             "type": ["VerifiableCredential", "MembershipCredential"],
             "issuer": issuer_did,
             "validFrom": "2020-01-01T00:00:00Z",
@@ -2021,15 +2119,17 @@ mod tests {
             "credentialSubject": { "id": subject, "memberLevel": "gold", "secret": "hidden" }
         });
         let mandatory = ["/@context", "/type", "/issuer", "/credentialSubject/id"];
-        let base = sign_vc_base(
+        let base = sign_base_document(
             &vc,
             &mandatory,
             &format!("{issuer_did}#bbs-key-0"),
+            "2020-01-01T00:00:00Z",
             &sk,
             &pk,
+            b"vtc-bbs-test-hmac-key-32-bytes!!",
         )
         .unwrap();
-        let derived = derive_vc(&base, disclose, nonce.as_bytes(), &pk).unwrap();
+        let derived = create_derived_proof(&base, disclose, nonce.as_bytes(), &pk).unwrap();
         (derived, issuer_did)
     }
 
@@ -2056,6 +2156,119 @@ mod tests {
         assert!(
             p.claims.get("secret").is_none(),
             "an undisclosed claim must not appear"
+        );
+        assert!(
+            !p.holder_bound,
+            "a basic bbs-2023 proof is possession-based, not holder-bound"
+        );
+    }
+
+    /// A bbs-2023 **pseudonym** (holder-bound) presentation bound to `verifier_id`.
+    #[cfg(feature = "bbs")]
+    fn bbs_pseudonym_presentation(
+        nonce: &str,
+        subject: &str,
+        verifier_id: &str,
+        disclose: &[&str],
+    ) -> (Value, String) {
+        use affinidi_bbs as bbs;
+        use affinidi_data_integrity::bbs_2023_transform as tx;
+
+        let sk = bbs::keygen(b"vtc-nym-verify-key-material-32by", b"").unwrap();
+        let pk = bbs::sk_to_pk(&sk);
+        let issuer_did = affinidi_crypto::bls12381::g2_pub_to_did_key(&pk.to_bytes());
+        let vc = json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2"
+            ],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": issuer_did,
+            "validFrom": "2020-01-01T00:00:00Z",
+            "validUntil": "2100-01-01T00:00:00Z",
+            "credentialSubject": { "id": subject, "memberLevel": "gold", "secret": "hidden" }
+        });
+        let mandatory = ["/@context", "/type", "/issuer", "/credentialSubject/id"];
+
+        // Holder commits a link secret; issuer blind-signs the pseudonym base.
+        let prover_nym_bytes = [0x11u8; 32];
+        let prover_nym = bbs::hash::scalar_from_bytes(&prover_nym_bytes).unwrap();
+        let (commitment, secret_prover_blind) =
+            bbs::nym_commit(prover_nym, &[], bbs::Ciphersuite::default()).unwrap();
+        let blind_bytes = bbs::hash::scalar_to_bytes(&secret_prover_blind);
+        let proof_config = json!({
+            "type": "DataIntegrityProof",
+            "cryptosuite": "bbs-2023",
+            "created": "2020-01-01T00:00:00Z",
+            "verificationMethod": format!("{issuer_did}#bbs-key-0"),
+            "proofPurpose": "assertionMethod",
+            "@context": vc["@context"].clone(),
+        });
+        let proof_value = tx::create_pseudonym_base_proof_value(
+            &vc,
+            &proof_config,
+            &mandatory,
+            &sk,
+            &pk,
+            b"vtc-nym-test-hmac-key-32-bytes!!",
+            &commitment,
+            &[0x22u8; 32],
+        )
+        .unwrap();
+        let mut proof = proof_config;
+        let obj = proof.as_object_mut().unwrap();
+        obj.remove("@context");
+        obj.insert("proofValue".into(), json!(proof_value));
+        let mut base = vc.clone();
+        base.as_object_mut().unwrap().insert("proof".into(), proof);
+
+        // Holder derives a per-verifier pseudonym proof bound to `verifier_id`.
+        let derived = tx::create_pseudonym_derived_proof(
+            &base,
+            disclose,
+            nonce.as_bytes(),
+            &pk,
+            &prover_nym_bytes,
+            &blind_bytes,
+            verifier_id,
+        )
+        .unwrap();
+        (derived, issuer_did)
+    }
+
+    #[cfg(feature = "bbs")]
+    #[tokio::test]
+    async fn verify_vp_token_accepts_a_holder_bound_bbs_pseudonym() {
+        let nonce = "vtc-challenge-xyz";
+        let subject = "did:key:zApplicant";
+        let aud = "did:web:vtc.example";
+        let (derived, _issuer) =
+            bbs_pseudonym_presentation(nonce, subject, aud, &["/credentialSubject/memberLevel"]);
+        let vp_token = json!({ "membership": derived });
+
+        // Verifies and is reported as holder-bound when aud matches the verifier id.
+        let set = verify_vp_token(&vp_token, aud, nonce, None, Utc::now())
+            .await
+            .expect("a holder-bound bbs-2023 pseudonym must verify");
+        assert_eq!(set.holder, subject);
+        assert!(
+            set.presentations[0].holder_bound,
+            "a pseudonym proof must be reported holder-bound"
+        );
+
+        // ... and is REJECTED for a different verifier (per-verifier binding):
+        // `aud` is the pseudonym `verifier_id`, so a different VTC can't accept it.
+        assert!(
+            verify_vp_token(
+                &vp_token,
+                "did:web:other-vtc.example",
+                nonce,
+                None,
+                Utc::now()
+            )
+            .await
+            .is_err(),
+            "a pseudonym proof must not verify for a different verifier id"
         );
     }
 

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -311,6 +311,7 @@ fn credential_from_verified(
         issuer: p.issuer_did.clone(),
         issuer_trusted,
         status,
+        holder_bound: p.holder_bound,
         claims: p.claims.clone(),
         // SD-JWT-VC carries expiry in `exp` (epoch seconds).
         valid_until: p
@@ -474,6 +475,7 @@ mod tests {
             issuer_did: "did:key:zIssuer".into(),
             holder_did: "did:key:zHolder".into(),
             vct: Some("https://openvtc.org/credentials/MembershipCredential".into()),
+            holder_bound: true,
             claims: json!({ "givenName": "Alice", "exp": 1_900_000_000 }),
             credential_status: None,
         }

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -408,6 +408,11 @@ fn credential_from_vc(vc: &JsonValue) -> Option<Credential> {
         issuer,
         issuer_trusted: false,
         status: CredentialStatus::Valid,
+        // This raw-VC path does not verify a *per-credential* holder-key binding
+        // (no `kb-jwt` / holder proof / pseudonym check like the vp_token path) —
+        // so we don't claim one. Fail-safe: a policy requiring holder binding will
+        // (correctly) not be satisfied by these.
+        holder_bound: false,
         claims: obj
             .get("credentialSubject")
             .cloned()


### PR DESCRIPTION
Implements #295 — per-verifier **holder binding** for `bbs-2023` presentations, on the standards-track W3C vc-di-bbs document layer. All behind the off-by-default `bbs` feature.

## What's here
- **Deps**: `affinidi-bbs` 0.3, `affinidi-data-integrity` **0.7.5**, `affinidi-rdf-encoding` **0.1.5**.
- **Standards-track migration**: receive / present / verify moved off the deprecated, non-interoperable internal `bbs_2023` encoding onto `bbs_2023_transform` (RDF-canonical, offline via bundled contexts).
- **Freshness binding**: the new verify authenticates the presentation header *embedded* in the derived proof, so the VTC verifier extracts that header and binds it to its own challenge (anti-replay).
- **Holder-binding pseudonyms (end-to-end)**: `receive_bbs_pseudonym` + `present_bbs` per-verifier mode (`verifier_id = aud`); holder secrets stored in reserved vault tags (`bbs:prover_nym` / `bbs:secret_prover_blind`); `verify_bbs_presentation` detects the `0xd95d09` pseudonym proof and verifies it via `verify_pseudonym_derived_proof`. Per-verifier unlinkability is tested (rejected for a different verifier id).
- **Join policy**: `holder_bound` is now a ceremony `Credential` fact — a Rego policy can `require input.presentation.credentials[_].holder_bound` for sensitive communities. SD-JWT-VC / DI VP / bbs-pseudonym ⇒ `true`; possession-based bbs-basic and the DIDComm raw-VC path ⇒ `false` (fail-safe).

## Soundness note (upstream)
A vc-di-bbs soundness bug — a holder could present **forged disclosed values** — was found during this work and **fixed upstream** in data-integrity 0.7.5 / rdf-encoding 0.1.5 (**affinidi/affinidi-tdk-rs#381**) via JSON-LD **safe mode**: every claim term must now be defined by the credential's `@context`. Pinned by the regression test `tampered_disclosure_is_rejected_upstream_381`. (Test VCs therefore use `credentials/examples/v2`; real issuers must use defining contexts.)

## Scope / gates
- Issuer signing (incl. pseudonym base proofs) stays **test-only / audit-gated** under #294 — this PR is holder + verifier only.

## Checks
- Tests: vta-service **685** passed, vtc-service **493** passed (0 ignored).
- `cargo clippy` clean (with and without `bbs`); `cargo fmt` clean; `cargo deny` ok; `cargo check --workspace` clean.

Refs #295, #294, affinidi/affinidi-tdk-rs#381.

> Note: this branch was developed in a worktree; the repo's global `CARGO_TARGET_DIR=~/.cargo/target` is shared across worktrees — build BBS tests with `CARGO_TARGET_DIR=./target` for trustworthy (non-stale) results.