### PR TITLE
fix(mobile-core): mediator WebSocket TLS on iOS (bundle webpki roots)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8891,6 +8891,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -9742,7 +9743,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9756,6 +9757,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.0"
+version = "0.6.1"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -62,6 +62,15 @@ affinidi-messaging-didcomm = "0.15"
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
 vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["session"] }
+# iOS has no native trust store that `rustls-native-certs` can read, so the
+# mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
+# "no native root CA certificates found". Declaring tokio-tungstenite here with
+# `rustls-tls-webpki-roots` turns that feature on graph-wide (features are
+# additive): tokio-tungstenite then treats empty native certs as non-fatal and
+# adds the bundled Mozilla webpki roots — so `wss://` works on iOS. We don't use
+# the crate directly (`use tokio_tungstenite as _` in lib.rs); it's a feature
+# enabler matched to the version affinidi-messaging-sdk already pulls.
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 # Test-only Ed25519 signing for the did-signed verify round-trip (stands in for

--- a/vta-mobile-core/src/lib.rs
+++ b/vta-mobile-core/src/lib.rs
@@ -28,6 +28,11 @@
 
 uniffi::setup_scaffolding!();
 
+// Pulled only to enable tokio-tungstenite's `rustls-tls-webpki-roots` feature
+// graph-wide (see Cargo.toml) so the mediator WebSocket works on iOS, which has
+// no native trust store. Not called directly.
+use tokio_tungstenite as _;
+
 pub mod api;
 mod error;
 mod proof;


### PR DESCRIPTION
## Root cause (captured via `init_logging` on-device)

The mediator `wss://` connect failed with:
```
WebSocket connection failed: IO error: no native root CA certificates found (errors: [])
```
…while webvh resolution and REST `list_messages` (`200 OK`) succeeded. So it wasn't a blanket TLS failure: **REST goes through `reqwest` (which has webpki roots); the WebSocket transport (`tokio-tungstenite`, via `affinidi-messaging-sdk`) used `rustls-native-certs` only — and iOS has no native trust store for it to read** → empty roots → fatal.

## Fix

`tokio-tungstenite`'s `tls.rs` makes empty native certs **non-fatal and adds the bundled Mozilla `webpki-roots`** *iff* its `rustls-tls-webpki-roots` feature is enabled:
```rust
#[cfg(not(feature = "rustls-tls-webpki-roots"))]
if certs.is_empty() { return Err("no native root CA certificates found"); }
#[cfg(feature = "rustls-tls-webpki-roots")]
{ root_store.extend(webpki_roots::TLS_SERVER_ROOTS...); }
```
Cargo features are additive, so the engine declares `tokio-tungstenite` (the same 0.29 the SDK already pulls) with `rustls-tls-webpki-roots`, enabling it graph-wide for the affinidi WebSocket. Not called directly — `use tokio_tungstenite as _` in `lib.rs` documents it as a feature enabler. Scoped to the mobile build (`vta-mobile-core` is excluded from default-members, so server builds are unaffected).

## Verification

- `cargo tree -i tokio-tungstenite -e features` → both `rustls-tls-native-roots` **and** `rustls-tls-webpki-roots` now active.
- Live **host** mediator connect still works (no regression).
- `cargo fmt --check` + `clippy --all-targets -D warnings` clean.
- **iOS device** verification after the v0.6.1 release (pin bump) — this is the exact code path that logged the error.

Version 0.6.0 → 0.6.1.