### PR TITLE
feat(step-up): accept a delegated approver's approve-response (issuer != subject)

### DIFF
--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -66,16 +66,17 @@ pub(super) enum GateError {
 
 /// Verify the **did-signed** gate on an approve-response document.
 ///
-/// `expected_subject` is the session's subject (the handler has already checked
-/// it equals the payload `subject` and the document `issuer`). Here we bind the
-/// *cryptographic* identity: the proof's `verificationMethod` DID MUST equal it,
-/// and the `eddsa-jcs-2022` signature MUST verify under that `did:key`.
+/// `expected_signer` is the document `issuer` — the approver (the subject in
+/// self step-up, the authorized delegated approver otherwise; the handler
+/// authorizes which one it is before calling). Here we bind the *cryptographic*
+/// identity: the proof's `verificationMethod` DID MUST equal the signer, and the
+/// `eddsa-jcs-2022` signature MUST verify under that `did:key`.
 ///
 /// `did:key` resolution is local (no I/O); the mobile holder key is always a
 /// `did:key`, matching the engine's signing side.
 pub(super) async fn verify_did_signed_gate(
     doc: &TrustTask<Value>,
-    expected_subject: &str,
+    expected_signer: &str,
 ) -> Result<(), GateError> {
     let proof = doc.proof.as_ref().ok_or(GateError::NoGate)?;
 
@@ -86,11 +87,12 @@ pub(super) async fn verify_did_signed_gate(
         .and_then(|v| serde_json::from_value(v).ok())
         .ok_or_else(|| GateError::ProofInvalid("not a Data Integrity proof".to_string()))?;
 
-    // Bind identity: the signing key's DID must be the subject. The resolver
-    // confirms the signature is by this verificationMethod; this check ties
-    // that VM to the subject so a valid proof by a *different* DID can't elevate.
+    // Bind identity: the signing key's DID must be the signer (the document
+    // `issuer`). The resolver confirms the signature is by this
+    // verificationMethod; this check ties that VM to the issuer so a valid proof
+    // by some *other* DID can't stand in for the approver.
     let vm_did = di.verification_method.split('#').next().unwrap_or_default();
-    if vm_did != expected_subject {
+    if vm_did != expected_signer {
         return Err(GateError::SubjectMismatch);
     }
 
@@ -142,7 +144,7 @@ fn gate_err_to_reject(e: GateError) -> RejectReason {
 /// any verification failure.
 async fn verify_webauthn_gate(
     state: &AppState,
-    subject: &str,
+    approver: &str,
     challenge: &str,
     assertion: &approve_response::AssertionResponse,
 ) -> Result<(), RejectReason> {
@@ -177,9 +179,11 @@ async fn verify_webauthn_gate(
 
     let credential_id = dec(&assertion.id).map_err(|_| invalid())?;
 
-    // Resolve credential.id → the subject's passkey VM (spec: resolve the
-    // credential to a subject and verify it equals the session's subject).
-    let vms = enumerate_passkey_vms(&resolver, subject)
+    // Resolve credential.id → the approver's passkey VM (spec: resolve the
+    // credential to the approver, whom the handler has already authorized for
+    // the subject — the subject itself in self mode, the delegated approver
+    // otherwise).
+    let vms = enumerate_passkey_vms(&resolver, approver)
         .await
         .map_err(|e| RejectReason::InternalError {
             reason: format!("passkey VM enumeration: {e}"),
@@ -206,10 +210,18 @@ async fn verify_webauthn_gate(
 /// Handler for `auth/step-up/approve-response/0.1` **and** `/0.2`.
 ///
 /// Consumes the approver's ratification of a pending step-up and, on a verified
-/// gate, elevates the (caller's own) session's `amr`/`acr`. Follows the spec's
+/// gate, elevates the *subject's* session `amr`/`acr`. Follows the spec's
 /// relying-party conformance rules; the bearer JWT (`auth`) identifies the
-/// caller, and the approve-response's gate (did-signed proof or webauthn
-/// assertion) is the second factor.
+/// caller (the approver, who signs and submits the document as itself), and the
+/// approve-response's gate (did-signed proof or webauthn assertion) is the
+/// second factor.
+///
+/// Self **and** delegated: the document `issuer`/signer is the *approver*, which
+/// is the subject in self step-up (`issuer == subject`) or a distinct party in
+/// delegated step-up (`issuer == AclEntry.stepUp.approver`, recorded on the
+/// pending step-up at mint). The gate is verified against the issuer key; the
+/// issuer is authorized against the recorded approver before the subject's
+/// session is elevated.
 ///
 /// Dual-accept: 0.2 differs from 0.1 only in the `evidence.kind` discriminator
 /// value (`did-signed`→`didSigned`). Because the approver signs the payload,
@@ -244,19 +256,23 @@ pub(super) async fn handle_approve_response(
     let session_id = payload.session_id.to_string();
     let challenge = payload.challenge.to_string();
 
-    // 2. Subject binding: the document issuer AND the bearer caller must be the
-    //    subject (same-session step-up — the caller elevates their own session).
-    if doc.issuer.as_deref() != Some(subject.as_str()) {
+    // 2. Signer self-consistency: the approver signs the document and submits it
+    //    as itself, so the bearer caller MUST be the document `issuer`. Whether
+    //    that issuer is the subject (self) or a distinct authorized approver
+    //    (delegated) is decided in step 4b, once the consumed pending step-up
+    //    tells us who the relying party addressed the request to. The proof VM
+    //    is bound to `issuer` in the gate step (4/5).
+    let Some(issuer) = doc.issuer.as_deref().map(str::to_string) else {
         return reject_with(
             &doc,
             step_up_failure("auth/step-up/approve-response:subject_mismatch"),
         );
-    }
-    if auth.did != subject {
+    };
+    if auth.did != issuer {
         return reject_with(
             &doc,
             RejectReason::PermissionDenied {
-                reason: "caller is not the subject of this step-up".to_string(),
+                reason: "the approve-response issuer must be the authenticated caller".to_string(),
             },
         );
     }
@@ -293,10 +309,28 @@ pub(super) async fn handle_approve_response(
         );
     }
 
-    // 4. A `denied` decision is a signed refusal — verify the did-signed gate,
-    //    audit, and elevate nothing.
+    // 4b. Authorize the signer. The relying party elevates only for the approver
+    //     it addressed the request to: the subject itself (self), or the
+    //     delegated approver recorded on the pending step-up at mint. An
+    //     in-flight record written before the `approver` field existed has it
+    //     empty → fall back to self (issuer MUST equal subject). The gate (4/5)
+    //     proves the proof VM == issuer; this ties that issuer to the step-up.
+    let authorized_signer = if pending.approver.is_empty() {
+        subject.as_str()
+    } else {
+        pending.approver.as_str()
+    };
+    if issuer != authorized_signer {
+        return reject_with(
+            &doc,
+            step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
+        );
+    }
+
+    // 4. A `denied` decision is a signed refusal — verify the did-signed gate
+    //    (against the approver/issuer key), audit, and elevate nothing.
     if payload.decision == approve_response::PayloadDecision::Denied {
-        if let Err(e) = verify_did_signed_gate(&doc, &subject).await {
+        if let Err(e) = verify_did_signed_gate(&doc, &issuer).await {
             return reject_with(&doc, gate_err_to_reject(e));
         }
         audit!(
@@ -314,16 +348,18 @@ pub(super) async fn handle_approve_response(
         );
     }
 
-    // 5. Approved — verify exactly one cryptographic gate.
+    // 5. Approved — verify exactly one cryptographic gate, bound to the
+    //    *signer* (the issuer/approver), which is the subject in self mode and
+    //    the authorized delegated approver otherwise.
     let factor: &str = match payload.evidence.as_ref() {
         None | Some(approve_response::Evidence::DidSigned) => {
-            if let Err(e) = verify_did_signed_gate(&doc, &subject).await {
+            if let Err(e) = verify_did_signed_gate(&doc, &issuer).await {
                 return reject_with(&doc, gate_err_to_reject(e));
             }
             "did"
         }
         Some(approve_response::Evidence::Webauthn(assertion)) => {
-            match verify_webauthn_gate(state, &subject, &challenge, assertion).await {
+            match verify_webauthn_gate(state, &issuer, &challenge, assertion).await {
                 Ok(()) => "passkey",
                 Err(reason) => return reject_with(&doc, reason),
             }
@@ -439,6 +475,11 @@ async fn mint_pending_step_up(
         challenge.clone(),
         session_id,
         subject,
+        // The authorized signer of the eventual approve-response: the subject
+        // itself for `self`, or the delegated approver the request is addressed
+        // to. `handle_approve_response` checks the document `issuer` against
+        // this, so a delegated approver (issuer != subject) can elevate.
+        recipient,
         STEP_UP_TARGET_ACR,
         acceptable.clone(),
         STEP_UP_TTL_SECS,
@@ -973,6 +1014,8 @@ mod tests {
         let pending = get_pending_step_up(&ks, challenge).await.unwrap().unwrap();
         assert_eq!(pending.session_id, "sess-9");
         assert_eq!(pending.subject, "did:key:zHolder");
+        // self-approval recorded the subject as its own authorized approver.
+        assert_eq!(pending.approver, "did:key:zHolder");
         assert_eq!(pending.target_acr, "aal2");
         assert_eq!(
             pending.acceptable_evidence,

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -74,6 +74,7 @@ async fn did_signed_approve_response_elevates_session_to_aal2() {
         challenge.clone(),
         session_id.clone(),
         did.clone(),
+        did.clone(), // self step-up: approver == subject
         "aal2",
         vec!["did-signed".to_string()],
         300,
@@ -202,6 +203,7 @@ async fn did_signed_approve_response_0_2_elevates_session_to_aal2() {
         challenge.clone(),
         session_id.clone(),
         did.clone(),
+        did.clone(), // self step-up: approver == subject
         "aal2",
         vec!["did-signed".to_string()],
         300,
@@ -369,4 +371,281 @@ async fn trust_task_acl_mutation_requires_step_up() {
         details["approveRequest"]["payload"]["targetAcr"], "aal2",
         "{v}"
     );
+}
+
+/// Delegated step-up: a distinct, authorized approver (`issuer != subject`)
+/// ratifies and the *subject's* session elevates. Mirrors the VTA's
+/// `mode: delegated` flow — the approve-request was addressed to the subject's
+/// `AclEntry.stepUp.approver`, recorded on the pending step-up at mint. The
+/// approver signs with its own key and authenticates as itself.
+#[tokio::test]
+async fn delegated_approve_response_elevates_the_subjects_session() {
+    let (router, ctx) = build_test_app().await;
+
+    // The subject: an AAL1 session being elevated (the requester).
+    let subject = "did:key:z6MkDelegatedSubject".to_string();
+    let session_id = "sess-delegated-1".to_string();
+    let challenge = "RGVsZWdhdGVkU3RlcFVwQ2hhbGxlbmdlWFla".to_string();
+    let subject_session = Session {
+        session_id: session_id.clone(),
+        did: subject.clone(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".to_string()],
+        acr: "aal1".to_string(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &subject_session)
+        .await
+        .unwrap();
+
+    // The approver: a *different* principal with its own key, session, token.
+    let approver_sk = SigningKey::from_bytes(&[21u8; 32]);
+    let (approver_did, approver_mb) = did_key(&approver_sk);
+    let approver_vm = format!("{approver_did}#{approver_mb}");
+    let approver_session_id = "sess-approver-1".to_string();
+    let approver_session = Session {
+        session_id: approver_session_id.clone(),
+        did: approver_did.clone(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".to_string()],
+        acr: "aal1".to_string(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &approver_session)
+        .await
+        .unwrap();
+    let approver_claims = ctx.jwt_keys.new_claims(
+        approver_did.clone(),
+        approver_session_id.clone(),
+        "admin".to_string(),
+        vec![],
+        900,
+        false,
+    );
+    let approver_token = ctx.jwt_keys.encode(&approver_claims).unwrap();
+
+    // Pending step-up: subject == requester, approver == the delegate.
+    let pending = new_pending_step_up(
+        challenge.clone(),
+        session_id.clone(),
+        subject.clone(),
+        approver_did.clone(), // delegated: approver != subject
+        "aal2",
+        vec!["did-signed".to_string()],
+        300,
+    );
+    store_pending_step_up(&ctx.sessions_ks, &pending)
+        .await
+        .unwrap();
+
+    // The approver signs: issuer == approver, payload.subject == the requester.
+    let doc_json = json!({
+        "id": "approve-resp-delegated-1",
+        "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
+        "issuer": approver_did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {
+            "subject": subject,
+            "sessionId": session_id,
+            "challenge": challenge,
+            "decision": "approved",
+            "grantedAcr": "aal2",
+        },
+    });
+    let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
+    let mut di = DataIntegrityProof {
+        type_: "DataIntegrityProof".to_string(),
+        cryptosuite: CryptoSuite::EddsaJcs2022,
+        created: Some("2026-05-31T00:00:00Z".to_string()),
+        verification_method: approver_vm,
+        proof_purpose: "assertionMethod".to_string(),
+        proof_value: None,
+        context: None,
+    };
+    let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
+    di.proof_value = Some(multibase::encode(
+        Base::Base58Btc,
+        approver_sk.sign(&input).to_bytes(),
+    ));
+    doc.proof = Some(serde_json::from_value::<Proof>(serde_json::to_value(&di).unwrap()).unwrap());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {approver_token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(status, StatusCode::OK, "expected 200, got {status}: {v}");
+    assert_eq!(v["payload"]["status"], "elevated", "{v}");
+    assert_eq!(v["payload"]["session"]["acr"], "aal2", "{v}");
+    // The elevated session is the SUBJECT's — not the approver's.
+    assert_eq!(v["payload"]["session"]["subject"], subject, "{v}");
+
+    let stored = get_session(&ctx.sessions_ks, &session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.acr, "aal2");
+    // The approver's own session is untouched by ratifying for someone else.
+    let approver_stored = get_session(&ctx.sessions_ks, &approver_session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(approver_stored.acr, "aal1");
+}
+
+/// An approver the relying party did NOT authorize for the subject is rejected
+/// (`approver_unauthorized`) and elevates nothing — even with a perfectly valid
+/// signature over the document. The pending step-up records approver B; a
+/// different valid signer C tries to ratify the subject's session.
+#[tokio::test]
+async fn unauthorized_approver_cannot_elevate() {
+    let (router, ctx) = build_test_app().await;
+
+    let subject = "did:key:z6MkUnauthSubject".to_string();
+    let session_id = "sess-unauth-1".to_string();
+    let challenge = "VW5hdXRob3JpemVkQXBwcm92ZXJDaGFsbFha".to_string();
+    let subject_session = Session {
+        session_id: session_id.clone(),
+        did: subject.clone(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".to_string()],
+        acr: "aal1".to_string(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &subject_session)
+        .await
+        .unwrap();
+
+    // The pending step-up authorizes a specific approver (B).
+    let authorized = "did:key:z6MkAuthorizedApprover".to_string();
+    let pending = new_pending_step_up(
+        challenge.clone(),
+        session_id.clone(),
+        subject.clone(),
+        authorized.clone(),
+        "aal2",
+        vec!["did-signed".to_string()],
+        300,
+    );
+    store_pending_step_up(&ctx.sessions_ks, &pending)
+        .await
+        .unwrap();
+
+    // A DIFFERENT signer (C) — valid key, session, token — attempts to ratify.
+    let rogue_sk = SigningKey::from_bytes(&[33u8; 32]);
+    let (rogue_did, rogue_mb) = did_key(&rogue_sk);
+    let rogue_vm = format!("{rogue_did}#{rogue_mb}");
+    let rogue_session_id = "sess-rogue-1".to_string();
+    let rogue_session = Session {
+        session_id: rogue_session_id.clone(),
+        did: rogue_did.clone(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".to_string()],
+        acr: "aal1".to_string(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &rogue_session)
+        .await
+        .unwrap();
+    let rogue_claims = ctx.jwt_keys.new_claims(
+        rogue_did.clone(),
+        rogue_session_id.clone(),
+        "admin".to_string(),
+        vec![],
+        900,
+        false,
+    );
+    let rogue_token = ctx.jwt_keys.encode(&rogue_claims).unwrap();
+
+    // C signs its own well-formed approve-response for the subject's session.
+    let doc_json = json!({
+        "id": "approve-resp-rogue-1",
+        "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
+        "issuer": rogue_did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {
+            "subject": subject,
+            "sessionId": session_id,
+            "challenge": challenge,
+            "decision": "approved",
+            "grantedAcr": "aal2",
+        },
+    });
+    let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
+    let mut di = DataIntegrityProof {
+        type_: "DataIntegrityProof".to_string(),
+        cryptosuite: CryptoSuite::EddsaJcs2022,
+        created: Some("2026-05-31T00:00:00Z".to_string()),
+        verification_method: rogue_vm,
+        proof_purpose: "assertionMethod".to_string(),
+        proof_value: None,
+        context: None,
+    };
+    let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
+    di.proof_value = Some(multibase::encode(
+        Base::Base58Btc,
+        rogue_sk.sign(&input).to_bytes(),
+    ));
+    doc.proof = Some(serde_json::from_value::<Proof>(serde_json::to_value(&di).unwrap()).unwrap());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {rogue_token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    // Rejected with the authorization failure; nothing elevated.
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "unauthorized approver must not elevate: {v}"
+    );
+    assert!(
+        serde_json::to_string(&v)
+            .unwrap()
+            .contains("approver_unauthorized"),
+        "expected approver_unauthorized, got: {v}"
+    );
+    let stored = get_session(&ctx.sessions_ks, &session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.acr, "aal1", "subject session must remain AAL1");
 }

--- a/vti-common/src/auth/step_up.rs
+++ b/vti-common/src/auth/step_up.rs
@@ -27,8 +27,21 @@ pub struct PendingStepUp {
     /// The session being elevated.
     pub session_id: String,
     /// The VID whose session is being elevated; the approve-response's
-    /// `subject` (and proof VM DID / credential subject) MUST equal this.
+    /// `subject` MUST equal this.
     pub subject: String,
+    /// The VID authorized to *sign* the approve-response — the document
+    /// `issuer` / proof VM DID (or credential subject) the relying party will
+    /// accept. Equals [`Self::subject`] for **self** step-up; the delegated
+    /// `AclEntry.stepUp.approver` the request was addressed to for
+    /// **delegated** step-up. The relying party elevates only when the signer
+    /// equals this.
+    ///
+    /// `#[serde(default)]` so an in-flight record written before this field
+    /// existed deserializes with an empty approver; the handler treats an empty
+    /// approver as self (issuer MUST equal subject), preserving the prior
+    /// contract for the ≤TTL window after a deploy.
+    #[serde(default)]
+    pub approver: String,
     /// The acr the relying party requested. The elevated session MUST reach
     /// at least this, else `acr_unsatisfied`.
     pub target_acr: String,
@@ -215,6 +228,7 @@ pub fn new_pending_step_up(
     challenge: impl Into<String>,
     session_id: impl Into<String>,
     subject: impl Into<String>,
+    approver: impl Into<String>,
     target_acr: impl Into<String>,
     acceptable_evidence: Vec<String>,
     ttl_secs: u64,
@@ -224,6 +238,7 @@ pub fn new_pending_step_up(
         challenge: challenge.into(),
         session_id: session_id.into(),
         subject: subject.into(),
+        approver: approver.into(),
         target_acr: target_acr.into(),
         acceptable_evidence,
         created_at,
@@ -253,6 +268,7 @@ mod tests {
             challenge: challenge.to_string(),
             session_id: "sess-1".to_string(),
             subject: "did:key:zHolder".to_string(),
+            approver: "did:key:zHolder".to_string(),
             target_acr: "aal2".to_string(),
             acceptable_evidence: vec!["did-signed".into(), "webauthn".into()],
             created_at: 1000,
@@ -321,12 +337,33 @@ mod tests {
             "VHJhbnNmZXJDb25maXJtTm9uY2VYWQ",
             "sess-1",
             "did:key:zHolder",
+            "did:key:zApprover",
             "aal2",
             vec!["webauthn".into()],
             300,
         );
         assert_eq!(p.expires_at, p.created_at + 300);
         assert_eq!(p.target_acr, "aal2");
+        assert_eq!(p.approver, "did:key:zApprover");
+    }
+
+    #[test]
+    fn legacy_record_without_approver_defaults_empty() {
+        // A record serialized before `approver` existed must still deserialize
+        // (serde default) with an empty approver — the handler treats that as
+        // self (issuer MUST equal subject), preserving the prior contract.
+        let legacy = r#"{
+            "challenge":"VHJhbnNmZXJDb25maXJtTm9uY2VYWQ",
+            "session_id":"sess-1",
+            "subject":"did:key:zHolder",
+            "target_acr":"aal2",
+            "acceptable_evidence":["did-signed"],
+            "created_at":1000,
+            "expires_at":2000
+        }"#;
+        let p: PendingStepUp = serde_json::from_str(legacy).expect("legacy record deserializes");
+        assert_eq!(p.approver, "");
+        assert_eq!(p.subject, "did:key:zHolder");
     }
 
     fn floor(op: &str, mode: StepUpMode) -> StepUpFloor {


### PR DESCRIPTION
Implements the VTA side of delegated AAL2 step-up, per spec **dtgwg #83** (merged). The delivery half was already built (the gate routes the approve-request to the subject's `AclEntry.stepUp.approver` and buffers it to the mediator + push); the **intake** was still self-only and rejected a delegated approver three ways.

## The gap

`handle_approve_response` required `doc.issuer == subject`, `auth.did == subject`, and verified the did-signed gate against the **subject's** key. A delegated approver (its own DID ≠ subject) could never ratify — so `mode: delegated` could be *requested* but never *completed*.

## Change

Decouple the **signer** (approver = document `issuer` = proof VM) from the **subject** (whose session elevates), and authorize the signer against the approver the relying party bound at request time.

- **`vti-common`** — `PendingStepUp` gains an `approver` field (the authorized signer), set at mint via `new_pending_step_up`. `#[serde(default)]` so an in-flight record written before the upgrade deserializes with an empty approver, which the handler treats as **self** (issuer must equal subject) — safe across the ≤TTL deploy window.
- **`vta-service` `mint_pending_step_up`** — records the request `recipient` as `approver` (the subject for `self`, the delegated approver otherwise).
- **`handle_approve_response`** — restructured:
  1. require `auth.did == issuer` (the approver signs and submits as itself);
  2. consume the pending step-up;
  3. **authorize**: `issuer == pending.approver` (empty ⇒ fall back to subject = self), else `approver_unauthorized`;
  4. verify the gate (did-signed / webauthn) against the **issuer/approver** key;
  5. still elevate the **subject's** session (`pending.session_id`).

## Tests

- Unit: the minted pending records the approver (self case).
- Integration (`tests/step_up_approve_response.rs`):
  - `delegated_approve_response_elevates_the_subjects_session` — a distinct approver ratifies; the **subject's** session goes AAL2; the approver's own session is untouched.
  - `unauthorized_approver_cannot_elevate` — a different valid signer (good signature, wrong approver) is rejected with `approver_unauthorized` and nothing elevates.
  - Existing self + 0.2 paths unchanged and still green.

## CI

`cargo fmt` + `cargo clippy --all-targets` + `cargo test` (vti-common step_up unit + vta-service integration: 5/5) + `cargo deny` — all clean. No new dependencies. No version bumps (internal crates; reaches prod via VTA redeploy).

## Follow-up

iOS ratify path: when a received approve-request's `subject` ≠ the holder's own DID, build the approve-response with `issuer_did = own DID`, `subject = request.subject` (the engine builder already supports issuer ≠ subject) — next PR.