### PR TITLE
feat(step-up): runtime step-up policy management

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -133,6 +133,15 @@ pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1: &str =
 pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2: &str =
     "https://trusttasks.org/spec/auth/step-up/approve-response/0.2";
 
+/// `spec/auth/step-up/policy/0.2` — an administrator setting the maintainer's
+/// AAL2 step-up policy (per-operation-class floors + the master `enabled`
+/// switch). The maintainer validates, refuses a self-lockout, applies it
+/// atomically, and returns the effective (canonicalized) policy. Authorized to
+/// a super-admin; ships disabled. There is no 0.1 management wire form (the
+/// policy was config-only before), so only 0.2 is dispatched.
+pub const TASK_AUTH_STEP_UP_POLICY_0_2: &str =
+    "https://trusttasks.org/spec/auth/step-up/policy/0.2";
+
 // ─── Device slice (spec/device/*) ────────────────────────────────────────
 // Canonical Trust Task registry shapes (dtgwg `device/*`). Companion/Service
 // lifecycle on the VTA: register a device, heartbeat, list, disable, wipe, and
@@ -1029,6 +1038,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2,
+    TASK_AUTH_STEP_UP_POLICY_0_2,
     // Device slice
     TASK_DEVICE_REGISTER_0_1,
     TASK_DEVICE_REGISTER_0_2,

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -47,6 +47,7 @@ pub mod protocol;
 pub mod provision_integration;
 pub mod seeds;
 pub mod step_up_approval;
+pub mod step_up_policy;
 pub mod vault;
 
 use crate::store::KeyspaceHandle;

--- a/vta-service/src/operations/step_up_policy.rs
+++ b/vta-service/src/operations/step_up_policy.rs
@@ -1,0 +1,273 @@
+//! Runtime management of the VTA's AAL2 step-up policy (`auth/step-up/policy`).
+//!
+//! The *gate* (the resolution algorithm + `RequireStepUp` extractor) already
+//! lives in [`crate::routes::trust_tasks::step_up`]. This module is the
+//! *management* half: validating, canonicalizing, and durably applying a new
+//! [`StepUpPolicy`], so an operator can change the VTA's posture at runtime
+//! instead of editing the config TOML and restarting.
+//!
+//! Two callers share [`set_step_up_policy`]:
+//! - the wire path — the `auth/step-up/policy/0.2` trust-task handler
+//!   (`routes::trust_tasks::step_up_policy`), authorized by a super-admin bearer;
+//! - the **break-glass** path — the offline `vta step-up policy` CLI (direct
+//!   config access, no wire auth), which the spec REQUIRES so an over-strict
+//!   policy can be recovered without traversing the step-up gate.
+//!
+//! Persistence mirrors the runtime-service-management ops: mutate the live
+//! `RwLock<AppConfig>` and rewrite the config file (`AppConfig::save`), so the
+//! change is both immediate and durable across restarts.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tokio::sync::RwLock;
+
+use trust_tasks_rs::specs::auth::step_up::policy::v0_2 as policy;
+use vti_common::acl::list_acl_entries;
+use vti_common::auth::step_up::{StepUpFloor, StepUpMode, StepUpPolicy, op_class};
+use vti_common::store::KeyspaceHandle;
+
+use crate::config::AppConfig;
+
+/// Why setting a step-up policy was refused. Maps to the spec's `auth/step-up/policy`
+/// error codes (the wire handler renders these as `trust-task-error`s; the CLI
+/// prints them).
+#[derive(Debug, thiserror::Error)]
+pub enum SetPolicyError {
+    /// A floor names an operation-class the maintainer does not gate
+    /// (`unknownOperation`). Carries the offending slug.
+    #[error("unknown operation-class '{0}': not a gated operation (or '*')")]
+    UnknownOperation(String),
+    /// Enabling would leave a `delegated` floor with no party able to satisfy it
+    /// — no `AclEntry` carries a `stepUp.approver` — locking out every
+    /// administrator (`lockoutRefused`).
+    #[error("{0}")]
+    LockoutRefused(String),
+    /// Reading the ACL (for the lockout check) failed.
+    #[error("acl read failed: {0}")]
+    Store(String),
+    /// Persisting the policy to the config file failed.
+    #[error("policy persistence failed: {0}")]
+    Persistence(String),
+}
+
+/// Validate, canonicalize, durably persist, and live-apply `requested`.
+///
+/// On success returns the **effective** (canonicalized) policy the maintainer
+/// now holds — floors deduplicated by operation, last occurrence winning,
+/// first-seen order preserved (mirrors the spec's `#response`).
+///
+/// Steps (spec §Conformance consumer rules 2–4):
+/// 1. `unknownOperation` — every `floor.operation` is `*` or a gated op-class.
+/// 2. canonicalize the floors.
+/// 3. `lockoutRefused` — refuse enabling a delegated floor when no approver
+///    exists anywhere in the ACL (only when `enabled`).
+/// 4. apply atomically: update the live config + rewrite the config file.
+pub async fn set_step_up_policy(
+    config: &Arc<RwLock<AppConfig>>,
+    acl_ks: &KeyspaceHandle,
+    requested: StepUpPolicy,
+) -> Result<StepUpPolicy, SetPolicyError> {
+    // 1. unknownOperation.
+    for floor in &requested.floors {
+        if !op_class::is_recognized(&floor.operation) {
+            return Err(SetPolicyError::UnknownOperation(floor.operation.clone()));
+        }
+    }
+
+    // 2. canonicalize.
+    let effective = canonicalize(requested);
+
+    // 3. lockoutRefused (only relevant when enabling enforcement).
+    if effective.enabled {
+        lockout_check(&effective, acl_ks).await?;
+    }
+
+    // 4. apply atomically: live config + durable file.
+    {
+        let mut cfg = config.write().await;
+        cfg.auth.step_up = effective.clone();
+        cfg.save()
+            .map_err(|e| SetPolicyError::Persistence(e.to_string()))?;
+    }
+
+    Ok(effective)
+}
+
+/// Deduplicate floors by `operation` (last occurrence wins) while preserving
+/// first-seen order. `enabled` is carried through unchanged. Per-floor
+/// `allow_aal1_if_non_escalating` is already a materialized `bool` on
+/// [`StepUpFloor`](vti_common::auth::step_up::StepUpFloor), so "defaults
+/// materialized" needs no extra work here.
+fn canonicalize(policy: StepUpPolicy) -> StepUpPolicy {
+    let mut order: Vec<String> = Vec::new();
+    let mut by_op: HashMap<String, vti_common::auth::step_up::StepUpFloor> = HashMap::new();
+    for floor in policy.floors {
+        if !by_op.contains_key(&floor.operation) {
+            order.push(floor.operation.clone());
+        }
+        by_op.insert(floor.operation.clone(), floor);
+    }
+    let floors = order
+        .into_iter()
+        .map(|op| by_op.remove(&op).expect("op was just inserted"))
+        .collect();
+    StepUpPolicy {
+        enabled: policy.enabled,
+        floors,
+    }
+}
+
+/// Anti-lockout (spec §Security → *Anti-lockout*).
+///
+/// A `self` (or `none`) floor is always satisfiable: any `did:key` holder can
+/// sign a did-signed approve-response for its **own** session with the key it
+/// already holds, so enabling a `self` floor can never brick anyone. A
+/// `delegated`/`delegatedAny` floor, however, can only be satisfied if some
+/// party carries a `stepUp.approver` the request can be routed to. If enabling
+/// would gate any operation-class at a delegated mode while **no** `AclEntry`
+/// carries an approver, every administrator is locked out — refuse, prompting
+/// the operator to register an approver first.
+///
+/// This is conservative (it refuses if *no* approver exists anywhere, rather
+/// than reasoning per-principal), which is the safe direction for an
+/// anti-lockout guard; the offline break-glass path remains the ultimate
+/// recovery if a policy ever does over-constrain.
+async fn lockout_check(
+    policy: &StepUpPolicy,
+    acl_ks: &KeyspaceHandle,
+) -> Result<(), SetPolicyError> {
+    let needs_delegate = policy
+        .floors
+        .iter()
+        .any(|f| matches!(f.mode, StepUpMode::Delegated | StepUpMode::DelegatedAny));
+    if !needs_delegate {
+        return Ok(());
+    }
+
+    let entries = list_acl_entries(acl_ks)
+        .await
+        .map_err(|e| SetPolicyError::Store(e.to_string()))?;
+    let any_approver = entries
+        .iter()
+        .any(|e| e.step_up_approver.as_deref().is_some_and(|a| !a.is_empty()));
+    if !any_approver {
+        return Err(SetPolicyError::LockoutRefused(
+            "enabling a delegated floor would lock out all administrators: no AclEntry \
+             carries a stepUp.approver. Register an approver (acl create/update \
+             --step-up-approver), then enable."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+// ── conversions between the `auth/step-up/policy/0.2` wire binding and the
+//    VTA's internal `StepUpPolicy` (shared by the trust-task handler and the
+//    REST surface) ─────────────────────────────────────────────────────────
+
+fn floormode_to_mode(m: policy::FloorMode) -> StepUpMode {
+    match m {
+        policy::FloorMode::None => StepUpMode::None,
+        policy::FloorMode::Self_ => StepUpMode::SelfApprove,
+        policy::FloorMode::Delegated => StepUpMode::Delegated,
+        policy::FloorMode::DelegatedAny => StepUpMode::DelegatedAny,
+    }
+}
+
+fn mode_to_floormode(m: StepUpMode) -> policy::FloorMode {
+    match m {
+        StepUpMode::None => policy::FloorMode::None,
+        StepUpMode::SelfApprove => policy::FloorMode::Self_,
+        StepUpMode::Delegated => policy::FloorMode::Delegated,
+        StepUpMode::DelegatedAny => policy::FloorMode::DelegatedAny,
+    }
+}
+
+/// Convert a parsed `auth/step-up/policy/0.2` payload to the internal policy.
+pub fn policy_from_payload(p: &policy::Payload) -> StepUpPolicy {
+    StepUpPolicy {
+        enabled: p.enabled,
+        floors: p
+            .floors
+            .iter()
+            .map(|f| StepUpFloor {
+                operation: f.operation.clone(),
+                mode: floormode_to_mode(f.mode),
+                allow_aal1_if_non_escalating: f.allow_aal1_if_non_escalating.unwrap_or(false),
+            })
+            .collect(),
+    }
+}
+
+/// Parse a policy JSON value (the `0.2` payload shape — camelCase `mode`
+/// values + `allowAal1IfNonEscalating`) into the internal policy. Used by the
+/// REST `PUT /step-up/policy` surface. Returns a human-readable error on a
+/// malformed body.
+pub fn policy_from_value(v: &Value) -> Result<StepUpPolicy, String> {
+    let payload: policy::Payload =
+        serde_json::from_value(v.clone()).map_err(|e| format!("invalid step-up policy: {e}"))?;
+    Ok(policy_from_payload(&payload))
+}
+
+/// Render a policy as the canonical `0.2` response value: every floor's
+/// `allowAal1IfNonEscalating` materialized, mode values in camelCase
+/// (`delegatedAny`). Shared by the trust-task `#response`, the REST `PUT`
+/// result, and the `GET /step-up/policy` read.
+pub fn effective_response(p: &StepUpPolicy) -> Value {
+    let resp = policy::Response {
+        enabled: p.enabled,
+        ext: None,
+        floors: p
+            .floors
+            .iter()
+            .map(|f| policy::Floor {
+                operation: f.operation.clone(),
+                mode: mode_to_floormode(f.mode),
+                allow_aal1_if_non_escalating: Some(f.allow_aal1_if_non_escalating),
+            })
+            .collect(),
+    };
+    serde_json::to_value(resp).unwrap_or(Value::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn floor(op: &str, mode: StepUpMode) -> StepUpFloor {
+        StepUpFloor {
+            operation: op.to_string(),
+            mode,
+            allow_aal1_if_non_escalating: false,
+        }
+    }
+
+    #[test]
+    fn canonicalize_dedupes_last_wins_preserving_order() {
+        let p = StepUpPolicy {
+            enabled: true,
+            floors: vec![
+                floor("acl/grant", StepUpMode::SelfApprove),
+                floor("*", StepUpMode::SelfApprove),
+                floor("acl/grant", StepUpMode::Delegated), // later wins
+            ],
+        };
+        let c = canonicalize(p);
+        // First-seen order: acl/grant, then *.
+        assert_eq!(c.floors.len(), 2);
+        assert_eq!(c.floors[0].operation, "acl/grant");
+        assert_eq!(c.floors[0].mode, StepUpMode::Delegated); // last occurrence won
+        assert_eq!(c.floors[1].operation, "*");
+    }
+
+    #[test]
+    fn op_class_recognition() {
+        assert!(op_class::is_recognized("*"));
+        assert!(op_class::is_recognized("acl/grant"));
+        assert!(op_class::is_recognized("key/revoke"));
+        assert!(!op_class::is_recognized("acl/teleport"));
+        assert!(!op_class::is_recognized(""));
+    }
+}

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -20,6 +20,7 @@ pub mod keys;
 mod passkey_vms;
 #[cfg(feature = "webvh")]
 mod protocol;
+mod step_up;
 pub(crate) mod trust_tasks;
 mod vta;
 
@@ -327,6 +328,11 @@ pub fn router_with_cors(allowed_origins: &[String], trust_xff: bool) -> Router<A
         .route(
             "/contexts/{id}/did-templates/{name}/render",
             post(did_templates::render_context_handler),
+        )
+        // Step-up policy management (read posture; super-admin set).
+        .route(
+            "/step-up/policy",
+            get(step_up::get_step_up_policy).put(step_up::put_step_up_policy),
         )
         // ACL routes (flattened for consistency)
         .route("/acl", get(acl::list_acl).post(acl::create_acl))

--- a/vta-service/src/routes/step_up.rs
+++ b/vta-service/src/routes/step_up.rs
@@ -1,0 +1,58 @@
+//! REST surface for step-up **policy** management.
+//!
+//! - `GET /step-up/policy` — read the maintainer's current (effective) policy
+//!   (any manage-level caller, so operators can inspect posture).
+//! - `PUT /step-up/policy` — set the policy (super-admin only).
+//!
+//! Both reuse [`crate::operations::step_up_policy`], so the REST and the
+//! `auth/step-up/policy/0.2` trust-task wire forms agree on validation,
+//! canonicalization, persistence, and response shape. This convenience path is
+//! what the SDK / `pnm` use; DIDComm / Trust-Task clients use the dispatched
+//! trust-task instead.
+
+use axum::Json;
+use axum::extract::State;
+use serde_json::Value;
+
+use vti_common::auth::extractor::{ManageAuth, SuperAdminAuth};
+use vti_common::error::AppError;
+
+use crate::operations::step_up_policy::{
+    SetPolicyError, effective_response, policy_from_value, set_step_up_policy,
+};
+use crate::server::AppState;
+
+/// GET /step-up/policy — read the current effective step-up policy.
+pub async fn get_step_up_policy(
+    _auth: ManageAuth,
+    State(state): State<AppState>,
+) -> Result<Json<Value>, AppError> {
+    let policy = state.config.read().await.auth.step_up.clone();
+    Ok(Json(effective_response(&policy)))
+}
+
+/// PUT /step-up/policy — set the step-up policy (super-admin). Body is the
+/// `0.2` policy payload shape (`{ enabled, floors: [...] }`).
+pub async fn put_step_up_policy(
+    _auth: SuperAdminAuth,
+    State(state): State<AppState>,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, AppError> {
+    let requested = policy_from_value(&body).map_err(AppError::Validation)?;
+    let effective = set_step_up_policy(&state.config, &state.acl_ks, requested)
+        .await
+        .map_err(set_policy_error_to_app)?;
+    Ok(Json(effective_response(&effective)))
+}
+
+/// Map a policy-set failure onto the HTTP error surface:
+/// `unknownOperation` → 400, `lockoutRefused` → 409, store/persist → 500.
+fn set_policy_error_to_app(e: SetPolicyError) -> AppError {
+    match e {
+        SetPolicyError::UnknownOperation(op) => AppError::Validation(format!(
+            "unknown operation-class '{op}' (not a gated op or '*')"
+        )),
+        SetPolicyError::LockoutRefused(msg) => AppError::Conflict(msg),
+        SetPolicyError::Store(m) | SetPolicyError::Persistence(m) => AppError::Config(m),
+    }
+}

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -61,6 +61,7 @@ mod passkey_vms;
 mod provision_integration;
 mod seeds;
 mod step_up;
+mod step_up_policy;
 pub(crate) use step_up::{
     AclChangeRoleOp, AclGrantOp, AclRevokeOp, AclSwapKeyOp, ContextDeleteOp, RequireStepUp,
 };
@@ -210,6 +211,7 @@ fn aggregate_dispatched_uris() -> Vec<&'static str> {
     v.extend(management::DISPATCHED_URIS);
     v.extend(seeds::DISPATCHED_URIS);
     v.extend(step_up::DISPATCHED_URIS);
+    v.extend(step_up_policy::DISPATCHED_URIS);
     v.extend(vault::DISPATCHED_URIS);
     // Feature-gated slices add their `v.extend(slice::DISPATCHED_URIS)`
     // here under `#[cfg(feature = "...")]`. The corresponding URIs
@@ -373,6 +375,9 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1
         | vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2 => {
             step_up::handle_approve_response(state, auth, doc).await
+        }
+        vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_POLICY_0_2 => {
+            step_up_policy::handle_set_step_up_policy(state, auth, doc).await
         }
         // ─── ACL slice ────────────────────────────────────────────────
         vta_sdk::trust_tasks::TASK_ACL_LIST_1_0 => acl::handle_list(state, auth, doc).await,

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -842,15 +842,14 @@ pub(super) async fn require_step_up(
 
 /// Stable operation-class identifiers used to resolve step-up floors.
 /// These are the gated VTA operations; they mirror the canonical
-/// `acl/*` / `context/*` / `key/*` slugs the `auth/step-up/policy/0.1`
-/// spec uses for its `Floor.operation`.
+/// `acl/*` / `context/*` / `key/*` slugs the `auth/step-up/policy` spec uses for
+/// its `Floor.operation`. Re-exported from [`vti_common::auth::step_up::op_class`]
+/// so the gate and the policy-management `unknownOperation` check share one
+/// source of truth.
 pub mod op {
-    pub const ACL_GRANT: &str = "acl/grant";
-    pub const ACL_CHANGE_ROLE: &str = "acl/change-role";
-    pub const ACL_REVOKE: &str = "acl/revoke";
-    pub const ACL_SWAP_KEY: &str = "acl/swap-key";
-    pub const CONTEXT_DELETE: &str = "context/delete";
-    pub const KEY_REVOKE: &str = "key/revoke";
+    pub use vti_common::auth::step_up::op_class::{
+        ACL_CHANGE_ROLE, ACL_GRANT, ACL_REVOKE, ACL_SWAP_KEY, CONTEXT_DELETE, KEY_REVOKE,
+    };
 }
 
 /// Compile-time operation-class marker for the [`RequireStepUp`] extractor.

--- a/vta-service/src/routes/trust_tasks/step_up_policy.rs
+++ b/vta-service/src/routes/trust_tasks/step_up_policy.rs
@@ -1,0 +1,92 @@
+//! `auth/step-up/policy/0.2` — runtime step-up policy management (the wire half).
+//!
+//! Authorizes a super-admin bearer, converts the policy payload to the VTA's
+//! internal `StepUpPolicy`, and delegates validation + persistence to
+//! [`crate::operations::step_up_policy`]. Returns the effective (canonicalized)
+//! policy as a `#response`, or a `trust-task-error` with the spec's
+//! `notAuthorized` / `unknownOperation` / `lockoutRefused` codes.
+//!
+//! Authorization is the super-admin **bearer** (not a step-up gate — gating the
+//! policy-set on a step-up would be circular: you could never enable the gate
+//! that requires an approver). The spec's `proof` requirement is satisfied by
+//! the authenticated caller; full TT-proof verification lands with the
+//! session-pubkey binding (dispatcher Phase 3), as for every other mutating arm.
+
+use axum::response::Response;
+use serde_json::{Value, json};
+
+use trust_tasks_rs::specs::auth::step_up::policy::v0_2 as policy;
+use trust_tasks_rs::{RejectReason, TrustTask};
+
+use vti_common::auth::AuthClaims;
+
+use crate::operations::step_up_policy::{
+    SetPolicyError, effective_response, policy_from_payload, set_step_up_policy,
+};
+use crate::server::AppState;
+
+use super::helpers::{reject_with, success_response};
+
+/// URIs this slice dispatches (aggregated by the dispatcher parity harness).
+#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
+pub(super) const DISPATCHED_URIS: &[&str] = &[vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_POLICY_0_2];
+
+fn policy_failure(code: &str, details: Option<Value>) -> RejectReason {
+    RejectReason::TaskFailed {
+        reason: code.to_string(),
+        details,
+    }
+}
+
+/// Handle `auth/step-up/policy/0.2`: set the maintainer's step-up policy.
+pub(super) async fn handle_set_step_up_policy(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    // Authz: only a super-admin may change the VTA's security posture.
+    if !auth.is_super_admin() {
+        return reject_with(
+            &doc,
+            policy_failure("auth/step-up/policy:not_authorized", None),
+        );
+    }
+
+    // Parse the 0.2 payload.
+    let payload: policy::Payload = match serde_json::from_value(doc.payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return reject_with(
+                &doc,
+                RejectReason::MalformedRequest {
+                    reason: format!("payload parse: {e}"),
+                },
+            );
+        }
+    };
+    let requested = policy_from_payload(&payload);
+
+    match set_step_up_policy(&state.config, &state.acl_ks, requested).await {
+        Ok(effective) => success_response(&doc, effective_response(&effective)),
+        Err(SetPolicyError::UnknownOperation(op)) => reject_with(
+            &doc,
+            policy_failure(
+                "auth/step-up/policy:unknown_operation",
+                Some(json!({ "operation": op })),
+            ),
+        ),
+        Err(SetPolicyError::LockoutRefused(msg)) => reject_with(
+            &doc,
+            policy_failure(
+                "auth/step-up/policy:lockout_refused",
+                Some(json!({ "message": msg })),
+            ),
+        ),
+        Err(e @ (SetPolicyError::Store(_) | SetPolicyError::Persistence(_))) => reject_with(
+            &doc,
+            RejectReason::InternalError {
+                reason: e.to_string(),
+            },
+        ),
+    }
+}

--- a/vta-service/tests/step_up_policy.rs
+++ b/vta-service/tests/step_up_policy.rs
@@ -1,0 +1,295 @@
+//! Integration tests for runtime **step-up policy management** — the REST
+//! `GET`/`PUT /step-up/policy` surface and the `auth/step-up/policy/0.2`
+//! trust-task, exercised through the real router → bearer auth → operation →
+//! config persistence path.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vta_service::test_support::build_test_app;
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+
+/// The recipient DID `build_test_app` configures as the VTA's own `vta_did`.
+const TEST_VTA_DID: &str = "did:key:z6MkTestVTA";
+
+/// Store an authenticated session and mint a bearer token for `did` with the
+/// given role / contexts. Empty `contexts` + `admin` role ⇒ super-admin.
+async fn token_for(
+    ctx: &vta_service::test_support::TestAppContext,
+    did: &str,
+    session_id: &str,
+    role: &str,
+    contexts: Vec<String>,
+) -> String {
+    let session = Session {
+        session_id: session_id.to_string(),
+        did: did.to_string(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".to_string()],
+        acr: "aal1".to_string(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+    let claims = ctx.jwt_keys.new_claims(
+        did.to_string(),
+        session_id.to_string(),
+        role.to_string(),
+        contexts,
+        900,
+        false,
+    );
+    ctx.jwt_keys.encode(&claims).unwrap()
+}
+
+async fn put_policy(router: &axum::Router, token: &str, body: Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/step-up/policy")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+#[tokio::test]
+async fn super_admin_sets_and_reads_self_policy_via_rest() {
+    let (router, ctx) = build_test_app().await;
+    let token = token_for(&ctx, "did:key:z6MkSuper", "sess-su-1", "admin", vec![]).await;
+
+    // Set a `self` floor — never a lockout risk, so it applies with no approver.
+    let (status, body) = put_policy(
+        &router,
+        &token,
+        json!({ "enabled": true, "floors": [{ "operation": "*", "mode": "self" }] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["enabled"], true, "{body}");
+    assert_eq!(body["floors"][0]["operation"], "*", "{body}");
+    assert_eq!(body["floors"][0]["mode"], "self", "{body}");
+    // Default materialized on the response.
+    assert_eq!(
+        body["floors"][0]["allowAal1IfNonEscalating"], false,
+        "{body}"
+    );
+
+    // The live config now reflects it (so the gate enforces it).
+    assert!(ctx.config.read().await.auth.step_up.enabled);
+
+    // GET reads the same effective policy back.
+    let req = Request::builder()
+        .method("GET")
+        .uri("/step-up/policy")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let got: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(got["enabled"], true);
+    assert_eq!(got["floors"][0]["mode"], "self");
+}
+
+#[tokio::test]
+async fn enabling_delegated_floor_without_approver_is_lockout_refused() {
+    let (router, ctx) = build_test_app().await;
+    let token = token_for(&ctx, "did:key:z6MkSuper", "sess-su-2", "admin", vec![]).await;
+
+    let (status, body) = put_policy(
+        &router,
+        &token,
+        json!({ "enabled": true, "floors": [{ "operation": "acl/grant", "mode": "delegated" }] }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "expected lockoutRefused: {body}"
+    );
+    assert!(
+        serde_json::to_string(&body).unwrap().contains("approver"),
+        "error should explain the missing approver: {body}"
+    );
+    // Refused → prior (disabled) policy still in force.
+    assert!(!ctx.config.read().await.auth.step_up.enabled);
+}
+
+#[tokio::test]
+async fn unknown_operation_is_rejected() {
+    let (router, _ctx) = build_test_app().await;
+    let token = token_for(&_ctx, "did:key:z6MkSuper", "sess-su-3", "admin", vec![]).await;
+
+    let (status, body) = put_policy(
+        &router,
+        &token,
+        json!({ "enabled": true, "floors": [{ "operation": "acl/teleport", "mode": "self" }] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+}
+
+#[tokio::test]
+async fn enabling_delegated_floor_with_an_approver_succeeds() {
+    let (router, ctx) = build_test_app().await;
+    let token = token_for(&ctx, "did:key:z6MkSuper", "sess-su-5", "admin", vec![]).await;
+
+    // Register an ACL entry that carries a delegated approver (allowed at AAL1
+    // while the policy is still disabled). Now a delegated floor is satisfiable.
+    let create = json!({
+        "did": "did:key:z6MkSomeUser",
+        "role": "application",
+        "step_up_approver": "did:key:z6MkApproverPhone"
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/acl")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&create).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "acl create should succeed at AAL1"
+    );
+
+    // Enabling the delegated floor now passes the lockout check.
+    let (status, body) = put_policy(
+        &router,
+        &token,
+        json!({ "enabled": true, "floors": [{ "operation": "acl/grant", "mode": "delegated" }] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["floors"][0]["mode"], "delegated", "{body}");
+    assert!(ctx.config.read().await.auth.step_up.enabled);
+}
+
+#[tokio::test]
+async fn non_super_admin_cannot_set_policy() {
+    let (router, ctx) = build_test_app().await;
+    // Admin role but scoped to a context ⇒ NOT super-admin.
+    let token = token_for(
+        &ctx,
+        "did:key:z6MkScopedAdmin",
+        "sess-scoped-1",
+        "admin",
+        vec!["ctx1".to_string()],
+    )
+    .await;
+
+    let (status, _body) = put_policy(
+        &router,
+        &token,
+        json!({ "enabled": true, "floors": [{ "operation": "*", "mode": "self" }] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(!ctx.config.read().await.auth.step_up.enabled);
+}
+
+#[tokio::test]
+async fn trust_task_path_sets_policy() {
+    let (router, ctx) = build_test_app().await;
+    let token = token_for(&ctx, "did:key:z6MkSuper", "sess-su-4", "admin", vec![]).await;
+
+    let doc = json!({
+        "id": "stepup-policy-itest-1",
+        "type": "https://trusttasks.org/spec/auth/step-up/policy/0.2",
+        "issuer": "did:key:z6MkSuper",
+        "recipient": TEST_VTA_DID,
+        "payload": {
+            "enabled": true,
+            "floors": [
+                { "operation": "*", "mode": "self" },
+                { "operation": "acl/swap-key", "mode": "self", "allowAal1IfNonEscalating": true }
+            ]
+        }
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(
+        v["type"], "https://trusttasks.org/spec/auth/step-up/policy/0.2#response",
+        "{v}"
+    );
+    assert_eq!(v["payload"]["enabled"], true, "{v}");
+    // Canonicalized: the swap-key carve-out is materialized.
+    let floors = v["payload"]["floors"].as_array().expect("floors array");
+    assert!(
+        floors
+            .iter()
+            .any(|f| f["operation"] == "acl/swap-key" && f["allowAal1IfNonEscalating"] == true),
+        "{v}"
+    );
+    assert!(ctx.config.read().await.auth.step_up.enabled);
+}
+
+#[tokio::test]
+async fn non_super_admin_trust_task_is_not_authorized() {
+    let (router, ctx) = build_test_app().await;
+    let token = token_for(
+        &ctx,
+        "did:key:z6MkScopedAdmin",
+        "sess-scoped-2",
+        "admin",
+        vec!["ctx1".to_string()],
+    )
+    .await;
+
+    let doc = json!({
+        "id": "stepup-policy-itest-2",
+        "type": "https://trusttasks.org/spec/auth/step-up/policy/0.2",
+        "issuer": "did:key:z6MkScopedAdmin",
+        "recipient": TEST_VTA_DID,
+        "payload": { "enabled": true, "floors": [{ "operation": "*", "mode": "self" }] }
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_ne!(status, StatusCode::OK, "{v}");
+    assert!(
+        serde_json::to_string(&v)
+            .unwrap()
+            .contains("not_authorized"),
+        "{v}"
+    );
+    assert!(!ctx.config.read().await.auth.step_up.enabled);
+}

--- a/vti-common/src/auth/step_up.rs
+++ b/vti-common/src/auth/step_up.rs
@@ -54,6 +54,37 @@ pub struct PendingStepUp {
     pub expires_at: u64,
 }
 
+/// Canonical operation-class slugs the VTA gates with a step-up floor.
+///
+/// A policy `floor.operation` MUST be one of these or `*` (the catch-all);
+/// anything else is rejected as `unknownOperation` when a policy is set. Single
+/// source of truth shared by the gate (`routes::trust_tasks::step_up::op`
+/// re-exports these) and the policy-management validation.
+pub mod op_class {
+    pub const ACL_GRANT: &str = "acl/grant";
+    pub const ACL_CHANGE_ROLE: &str = "acl/change-role";
+    pub const ACL_REVOKE: &str = "acl/revoke";
+    pub const ACL_SWAP_KEY: &str = "acl/swap-key";
+    pub const CONTEXT_DELETE: &str = "context/delete";
+    pub const KEY_REVOKE: &str = "key/revoke";
+
+    /// Every recognized operation-class (excludes the `*` catch-all).
+    pub const ALL: &[&str] = &[
+        ACL_GRANT,
+        ACL_CHANGE_ROLE,
+        ACL_REVOKE,
+        ACL_SWAP_KEY,
+        CONTEXT_DELETE,
+        KEY_REVOKE,
+    ];
+
+    /// Whether `operation` is a floor target the maintainer recognizes: a known
+    /// op-class or the `*` catch-all.
+    pub fn is_recognized(operation: &str) -> bool {
+        operation == "*" || ALL.contains(&operation)
+    }
+}
+
 /// Step-up enforcement mode for an operation-class — the assurance the
 /// relying party requires before the operation runs. Mirrors the
 /// `auth/step-up/policy/0.1` `FloorMode`. Strictness (least → most):


### PR DESCRIPTION
Adds a runtime management surface for the VTA's AAL2 step-up policy, per the merged `auth/step-up/policy/0.2` spec. Previously the policy (`[auth.step_up]`) was **config-only** — changing posture meant editing the TOML and restarting (the friction behind the earlier "enable via config + restart" step). Now an operator can set/read it on a live VTA.

## Core operation — `operations/step_up_policy::set_step_up_policy`
1. **`unknownOperation`** — every `floor.operation` is `*` or a gated op-class. The canonical slugs now live in `vti_common::auth::step_up::op_class` and the gate's `op` module re-exports them → one source of truth.
2. **canonicalize** — dedupe floors by `operation` (last wins, order-stable), `allowAal1IfNonEscalating` materialized.
3. **`lockoutRefused`** — refuse enabling a `delegated`/`delegatedAny` floor when no `AclEntry` carries a `stepUp.approver`. A `self` floor is always satisfiable (a holder signs for its own session with its own key), so it never locks out.
4. **apply atomically** — update the live `RwLock<AppConfig>` + rewrite the config file (`AppConfig::save`), mirroring the runtime-service-management ops.

## Two surfaces, one op
- **Trust-task** `auth/step-up/policy/0.2` (dispatched arm) — super-admin bearer; reject codes `notAuthorized` / `unknownOperation` / `lockoutRefused`; effective (canonicalized) policy as `#response`. Works over REST `/api/trust-tasks` **and** DIDComm.
- **REST** `GET /step-up/policy` (read posture; manage-level) + `PUT /step-up/policy` (set; super-admin) — the convenience path the SDK/`pnm` will use (PR2).

## Authorization
Super-admin **bearer** — deliberately *not* a step-up gate. Gating the policy-set on a step-up would be circular (you could never enable a gate that requires an approver). The spec's `proof` requirement is satisfied by the authenticated caller, consistent with every other mutating trust-task arm (full TT-proof verification lands with the dispatcher's session-pubkey binding, Phase 3).

## Tests
- Op units: canonicalize (dedupe/last-wins/order), op-class recognition.
- Integration (`tests/step_up_policy.rs`, 7): self set + `GET` read-back + live-config reflects it; `lockoutRefused` **with and without** an approver (the positive path seeds an ACL approver first); `unknownOperation` → 400; non-super-admin `PUT` → 403; trust-task path → `#response`; non-super-admin trust-task → `not_authorized`.
- Regression: vta-service lib **675/675**, `step_up_approve_response` **5/5**, vti-common **214/214**. `cargo fmt` + `clippy --all-targets` + `cargo deny` clean.

## Scope / next
No new deps; no version bumps (internal behavioral change; the `vta-sdk` addition is an additive const). **PR2** wires the operator CLI: `pnm step-up policy show/set/disable` (via SDK over the new REST surface), the offline `vta step-up policy …` **break-glass** path (spec MUST — direct config, bypasses the gate), and `--step-up-approver` on `pnm acl create/update` (unblocks the delegated end-to-end test).