### PR TITLE
feat(cli): step-up policy commands + delegated approver flag

### DIFF
--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1059,7 +1059,8 @@ async fn main() {
                 .transpose()
             {
                 Ok(expires_at) => {
-                    acl::cmd_acl_create(&client, did, role, label, contexts, expires_at).await
+                    // cnm does not expose the delegated step-up approver flag.
+                    acl::cmd_acl_create(&client, did, role, label, contexts, expires_at, None).await
                 }
                 Err(e) => Err(format!("--expires: {e}").into()),
             },
@@ -1068,7 +1069,7 @@ async fn main() {
                 role,
                 label,
                 contexts,
-            } => acl::cmd_acl_update(&client, &did, role, label, contexts).await,
+            } => acl::cmd_acl_update(&client, &did, role, label, contexts, None).await,
             AclCommands::Delete { did } => acl::cmd_acl_delete(&client, &did).await,
         },
         Commands::AuthCredential { command } => match command {

--- a/docs/02-vta/step-up-policy.md
+++ b/docs/02-vta/step-up-policy.md
@@ -1,0 +1,125 @@
+# Step-up Policy & Delegated AAL2
+
+Operator guide for the VTA's **AAL2 step-up policy** — when (and how) a
+session must elevate to a higher assurance level before a gated operation
+runs — and for wiring a **delegated approver** (e.g. a holder's phone) that
+ratifies those step-ups out-of-band.
+
+Spec: `auth/step-up/policy/0.2`, `auth/step-up/approve-request/0.2`,
+`auth/step-up/approve-response/0.2` (in `dtgwg-trust-tasks-tf`).
+
+The policy **ships disabled** — a fresh VTA has no registered approver, so
+enforcing a gate that requires one would brick onboarding. You enable it
+deliberately, after registering at least one approver.
+
+## Concepts
+
+- **Floor** — a per-operation-class minimum mode. Operation-classes:
+  `acl/grant`, `acl/change-role`, `acl/revoke`, `acl/swap-key`,
+  `context/delete`, `key/revoke`, or `*` (catch-all).
+- **Mode** — `none` (AAL1, no step-up) < `self` < `delegated-any` < `delegated`.
+  - `self` — the caller elevates its own session with its own key.
+  - `delegated` — a **separate** approver named on the caller's ACL entry
+    (`stepUp.approver`) must ratify.
+- **Override** — a per-entry `stepUp.require` may only *raise* the floor for
+  that subject, never lower it.
+- **Carve-out** — `allowAal1IfNonEscalating: true` admits a non-escalating
+  self-service request (key rotation / authenticator enrolment) at AAL1 even
+  when the floor demands AAL2, so a holder with no authenticator yet can still
+  bootstrap.
+
+## Manage the policy (online, `pnm`)
+
+Requires a **super-admin** session.
+
+```bash
+# Inspect current posture.
+pnm step-up policy show
+
+# Enable from a JSON document (the auth/step-up/policy/0.2 payload shape).
+pnm step-up policy set --from policy.json     # or `--from -` to read stdin
+
+# Disable — revert to AAL1 everywhere.
+pnm step-up policy disable
+```
+
+`policy.json`:
+
+```json
+{
+  "enabled": true,
+  "floors": [
+    { "operation": "*", "mode": "self" },
+    { "operation": "acl/grant", "mode": "delegated" },
+    { "operation": "acl/swap-key", "mode": "self", "allowAal1IfNonEscalating": true }
+  ]
+}
+```
+
+The VTA validates (`unknownOperation` for an unrecognized op-class), refuses a
+**self-lockout** (`lockoutRefused` — enabling a `delegated` floor when no ACL
+entry carries a `stepUp.approver`), canonicalizes the floors, and returns the
+effective policy. The change is applied live and persisted to the config file.
+
+## Set a delegated approver
+
+The approver is the `stepUp.approver` on the **subject's** ACL entry — the VID
+the VTA addresses the approve-request to when a `delegated` floor applies.
+
+```bash
+# At grant time:
+pnm acl create --did <subject-did> --role application \
+               --step-up-approver <approver-did>
+
+# Or on an existing entry (empty string clears it):
+pnm acl update <subject-did> --step-up-approver <approver-did>
+```
+
+## Break-glass (offline, `vta`)
+
+If an over-strict policy locks every remote credential out, recover **locally**
+— direct config access, no wire auth, no step-up gate. The daemon must be
+stopped (exclusive store lock).
+
+```bash
+vta step-up policy show       # alias of `vta step-up show`
+vta step-up disable           # the recovery lever — always permitted
+vta step-up set-floor --operation acl/grant --mode self
+vta step-up enable
+```
+
+Offline `vta acl update <did> --step-up-approver <approver-did>` likewise sets
+an approver without the wire path.
+
+## Full delegated end-to-end loop
+
+A **requester** at AAL1 hits a `delegated`-gated operation; the VTA delegates
+approval to the requester's registered approver (e.g. the iOS holder); the
+approver ratifies over DIDComm; the requester's session elevates to AAL2.
+
+1. **Register the approver** on the requester's entry:
+   ```bash
+   pnm acl create --did <requester-did> --role application \
+                  --step-up-approver <ios-holder-did>
+   ```
+2. **Enable a delegated floor** (now lockout-safe — an approver exists):
+   ```bash
+   echo '{"enabled":true,"floors":[{"operation":"acl/grant","mode":"delegated"}]}' \
+     | pnm step-up policy set --from -
+   ```
+3. **Approver listens**: the iOS holder authenticates and taps *Listen for
+   step-ups* (or stays push-registered). It connects to the VTA's mediator.
+4. **Trigger**: the requester (AAL1) performs the gated op (e.g. `pnm acl
+   create …` as the requester). The VTA returns a `403` step-up challenge,
+   buffers an `auth/step-up/approve-request` to the approver's mediator, and
+   (if a wake channel is registered) sends a push.
+5. **Ratify**: the iOS holder drains the request and signs an
+   `auth/step-up/approve-response` (issuer = the holder, subject = the
+   requester). The VTA verifies the gate against the holder's key, confirms the
+   holder is the subject's authorized approver, and **elevates the requester's
+   session to AAL2**.
+6. The requester refreshes its token (`/auth/refresh`) to mint an AAL2 access
+   token and retries the operation, which now passes.
+
+> The whole loop runs on canonical DIDs over DIDComm — no bespoke side channel.
+> See `docs/05-design-notes/mobile-agent-architecture.md` for the holder side.

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -122,6 +122,12 @@ pub(crate) enum Commands {
         command: AclCommands,
     },
 
+    /// AAL2 step-up policy management (when/how operations require elevation)
+    StepUp {
+        #[command(subcommand)]
+        command: StepUpCommands,
+    },
+
     /// Generate auth credentials for applications and services
     AuthCredential {
         #[command(subcommand)]
@@ -1574,6 +1580,11 @@ pub(crate) enum AclCommands {
         /// Without this flag the entry is permanent.
         #[arg(long)]
         expires: Option<String>,
+        /// DID of the delegated AAL2 step-up approver for this subject
+        /// (`stepUp.approver`) — the VID that ratifies the subject's step-ups
+        /// when policy `mode: delegated` applies (e.g. the holder's phone).
+        #[arg(long)]
+        step_up_approver: Option<String>,
     },
     /// Update an ACL entry
     Update {
@@ -1588,12 +1599,43 @@ pub(crate) enum AclCommands {
         /// New comma-separated context IDs
         #[arg(long, value_delimiter = ',')]
         contexts: Option<Vec<String>>,
+        /// Set the delegated step-up approver VID (`stepUp.approver`). Pass an
+        /// empty string to clear it; omit to leave it unchanged.
+        #[arg(long)]
+        step_up_approver: Option<String>,
     },
     /// Delete an ACL entry
     Delete {
         /// DID of the entry to delete
         did: String,
     },
+}
+
+/// `pnm step-up …` — manage the VTA's AAL2 step-up posture.
+#[derive(Subcommand)]
+pub(crate) enum StepUpCommands {
+    /// Manage the system-wide step-up policy.
+    Policy {
+        #[command(subcommand)]
+        command: PolicyCommands,
+    },
+}
+
+/// `pnm step-up policy …`
+#[derive(Subcommand)]
+pub(crate) enum PolicyCommands {
+    /// Show the current effective step-up policy.
+    Show,
+    /// Set the policy from a JSON file (the `auth/step-up/policy/0.2` payload
+    /// shape: `{ "enabled": bool, "floors": [{ "operation", "mode",
+    /// "allowAal1IfNonEscalating"? }] }`). Use `-` to read from stdin.
+    Set {
+        /// Path to the policy JSON (or `-` for stdin).
+        #[arg(long)]
+        from: String,
+    },
+    /// Disable enforcement — revert to AAL1 everywhere (the shipping default).
+    Disable,
 }
 
 #[derive(Subcommand)]

--- a/pnm-cli/src/commands/acl.rs
+++ b/pnm-cli/src/commands/acl.rs
@@ -18,9 +18,19 @@ pub(crate) async fn run(
             label,
             contexts,
             expires,
+            step_up_approver,
         } => match resolve_expires_at(expires.as_deref()) {
             Ok(expires_at) => {
-                acl::cmd_acl_create(client, did, role, label, contexts, expires_at).await
+                acl::cmd_acl_create(
+                    client,
+                    did,
+                    role,
+                    label,
+                    contexts,
+                    expires_at,
+                    step_up_approver,
+                )
+                .await
             }
             Err(e) => Err(e),
         },
@@ -29,7 +39,8 @@ pub(crate) async fn run(
             role,
             label,
             contexts,
-        } => acl::cmd_acl_update(client, &did, role, label, contexts).await,
+            step_up_approver,
+        } => acl::cmd_acl_update(client, &did, role, label, contexts, step_up_approver).await,
         AclCommands::Delete { did } => acl::cmd_acl_delete(client, &did).await,
     }
 }

--- a/pnm-cli/src/commands/mod.rs
+++ b/pnm-cli/src/commands/mod.rs
@@ -21,5 +21,6 @@ pub(crate) mod health;
 pub(crate) mod keys;
 pub(crate) mod services;
 pub(crate) mod setup;
+pub(crate) mod step_up;
 pub(crate) mod vta;
 pub(crate) mod webvh;

--- a/pnm-cli/src/commands/step_up.rs
+++ b/pnm-cli/src/commands/step_up.rs
@@ -1,0 +1,36 @@
+//! `pnm step-up …` dispatch — thin shim over the shared step-up commands.
+
+use std::io::Read;
+
+use vta_cli_common::commands::step_up as su;
+use vta_sdk::prelude::*;
+
+use crate::cli::{PolicyCommands, StepUpCommands};
+
+pub(crate) async fn run(
+    client: &VtaClient,
+    command: StepUpCommands,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match command {
+        StepUpCommands::Policy { command } => match command {
+            PolicyCommands::Show => su::cmd_policy_show(client).await,
+            PolicyCommands::Set { from } => {
+                let policy = read_policy(&from)?;
+                su::cmd_policy_set(client, policy).await
+            }
+            PolicyCommands::Disable => su::cmd_policy_disable(client).await,
+        },
+    }
+}
+
+/// Read a policy JSON document from a file path, or stdin when `from` is `-`.
+fn read_policy(from: &str) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let contents = if from == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf)?;
+        buf
+    } else {
+        std::fs::read_to_string(from).map_err(|e| format!("--from {from}: {e}"))?
+    };
+    serde_json::from_str(&contents).map_err(|e| format!("--from {from}: invalid JSON: {e}").into())
+}

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -251,6 +251,7 @@ async fn main() {
         Commands::Services { command } => commands::services::run(&client, command).await,
         Commands::Contexts { command } => commands::contexts::run(&client, command).await,
         Commands::Acl { command } => commands::acl::run(&client, command).await,
+        Commands::StepUp { command } => commands::step_up::run(&client, command).await,
         Commands::AuthCredential { command } => {
             commands::auth_credential::run(&client, command).await
         }

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -150,6 +150,7 @@ pub async fn cmd_acl_create(
     label: Option<String>,
     contexts: Vec<String>,
     expires_at: Option<u64>,
+    step_up_approver: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_role(&role)?;
     let mut req = CreateAclRequest::new(did, role).contexts(contexts);
@@ -158,6 +159,9 @@ pub async fn cmd_acl_create(
     }
     if let Some(secs) = expires_at {
         req = req.expires_at(secs);
+    }
+    if let Some(ref approver) = step_up_approver {
+        req = req.step_up_approver(approver.clone());
     }
     let entry = client.create_acl(req).await?;
     println!("ACL entry created:");
@@ -170,6 +174,9 @@ pub async fn cmd_acl_create(
         println!("  Label:      {label}");
     }
     println!("  Contexts:   {}", format_contexts(&entry.allowed_contexts));
+    if let Some(approver) = &step_up_approver {
+        println!("  Step-up approver: {approver}");
+    }
     match entry.expires_at {
         Some(secs) => println!(
             "  Expires at: {} ({})",
@@ -187,6 +194,7 @@ pub async fn cmd_acl_update(
     role: Option<String>,
     label: Option<String>,
     contexts: Option<Vec<String>>,
+    step_up_approver: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(ref r) = role {
         validate_role(r)?;
@@ -195,6 +203,7 @@ pub async fn cmd_acl_update(
         role,
         label,
         allowed_contexts: contexts,
+        step_up_approver: step_up_approver.clone(),
     };
     let entry = client.update_acl(did, req).await?;
     println!("ACL entry updated:");
@@ -207,6 +216,13 @@ pub async fn cmd_acl_update(
         println!("  Label:    {label}");
     }
     println!("  Contexts: {}", format_contexts(&entry.allowed_contexts));
+    if let Some(approver) = &step_up_approver {
+        if approver.is_empty() {
+            println!("  Step-up approver: (cleared)");
+        } else {
+            println!("  Step-up approver: {approver}");
+        }
+    }
     Ok(())
 }
 

--- a/vta-cli-common/src/commands/mod.rs
+++ b/vta-cli-common/src/commands/mod.rs
@@ -6,5 +6,6 @@ pub mod credentials;
 pub mod did_templates;
 pub mod keys;
 pub mod services;
+pub mod step_up;
 pub mod webvh;
 pub mod webvh_edit;

--- a/vta-cli-common/src/commands/step_up.rs
+++ b/vta-cli-common/src/commands/step_up.rs
@@ -1,0 +1,71 @@
+//! `… step-up policy` operator commands (online, via the VTA REST surface).
+//!
+//! Thin wrappers over [`VtaClient::get_step_up_policy`] /
+//! [`VtaClient::set_step_up_policy`]. The policy JSON is the `0.2` shape
+//! (`{ enabled, floors: [{ operation, mode, allowAal1IfNonEscalating }] }`).
+
+use serde_json::Value;
+use vta_sdk::prelude::*;
+
+/// `step-up policy show` — print the maintainer's current effective policy.
+pub async fn cmd_policy_show(client: &VtaClient) -> Result<(), Box<dyn std::error::Error>> {
+    let policy = client.get_step_up_policy().await?;
+    print_policy(&policy);
+    Ok(())
+}
+
+/// `step-up policy set` — apply `policy` (the `0.2` payload) and print the
+/// effective (canonicalized) result the maintainer now holds.
+pub async fn cmd_policy_set(
+    client: &VtaClient,
+    policy: Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let effective = client.set_step_up_policy(policy).await?;
+    println!("Step-up policy updated:");
+    print_policy(&effective);
+    Ok(())
+}
+
+/// `step-up policy disable` — revert to AAL1 everywhere (the shipping default).
+pub async fn cmd_policy_disable(client: &VtaClient) -> Result<(), Box<dyn std::error::Error>> {
+    let effective = client
+        .set_step_up_policy(serde_json::json!({ "enabled": false, "floors": [] }))
+        .await?;
+    println!("Step-up policy disabled (AAL1 everywhere):");
+    print_policy(&effective);
+    Ok(())
+}
+
+/// Pretty-print a `0.2` policy value.
+pub fn print_policy(p: &Value) {
+    let enabled = p.get("enabled").and_then(Value::as_bool).unwrap_or(false);
+    println!(
+        "  Enforcement: {}",
+        if enabled {
+            "ENABLED"
+        } else {
+            "disabled (AAL1 everywhere)"
+        }
+    );
+    let floors = p.get("floors").and_then(Value::as_array);
+    match floors {
+        Some(floors) if !floors.is_empty() => {
+            println!("  Floors:");
+            for f in floors {
+                let op = f.get("operation").and_then(Value::as_str).unwrap_or("?");
+                let mode = f.get("mode").and_then(Value::as_str).unwrap_or("?");
+                let carve = f
+                    .get("allowAal1IfNonEscalating")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let suffix = if carve {
+                    "  (AAL1 carve-out for non-escalating self-service)"
+                } else {
+                    ""
+                };
+                println!("    {op:<18} → {mode}{suffix}");
+            }
+        }
+        _ => println!("  Floors: (none)"),
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -541,6 +541,62 @@ impl VtaClient {
         }
     }
 
+    // ── Step-up policy ──────────────────────────────────────────────
+
+    /// `GET /step-up/policy` — read the maintainer's current effective step-up
+    /// policy (the `0.2` shape: `{ enabled, floors }`). REST-only in the SDK;
+    /// over DIDComm send the `auth/step-up/policy/0.2` trust-task instead.
+    pub async fn get_step_up_policy(&self) -> Result<serde_json::Value, VtaError> {
+        match &self.transport {
+            Transport::Rest {
+                client,
+                base_url,
+                auth,
+            } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
+                let req = client.get(format!("{base_url}/step-up/policy"));
+                let resp = Self::with_auth_token(req, &token).send().await?;
+                Self::handle_response(resp).await
+            }
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(
+                "step-up policy read is REST-only in the SDK".into(),
+            )),
+        }
+    }
+
+    /// `PUT /step-up/policy` — set the step-up policy (super-admin). `policy` is
+    /// the `0.2` payload (`{ enabled, floors }`); returns the effective
+    /// (canonicalized) policy. REST-only; over DIDComm send the
+    /// `auth/step-up/policy/0.2` trust-task instead.
+    pub async fn set_step_up_policy(
+        &self,
+        policy: serde_json::Value,
+    ) -> Result<serde_json::Value, VtaError> {
+        match &self.transport {
+            Transport::Rest {
+                client,
+                base_url,
+                auth,
+            } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
+                let req = client
+                    .put(format!("{base_url}/step-up/policy"))
+                    .json(&policy);
+                let resp = Self::with_auth_token(req, &token).send().await?;
+                Self::handle_response(resp).await
+            }
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(
+                "step-up policy set is REST-only in the SDK; send the \
+                 auth/step-up/policy/0.2 trust-task over DIDComm instead"
+                    .into(),
+            )),
+        }
+    }
+
     // ── Discovery ──────────────────────────────────────────────────
 
     /// Discover VTA capabilities: enabled features, services, WebVH servers,
@@ -720,10 +776,13 @@ mod tests {
             label: None,
             allowed_contexts: vec!["vta".into()],
             expires_at: None,
+            step_up_approver: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["did"], "did:key:z6Mk123");
         assert_eq!(json["role"], "admin");
+        // Omitted approver must not appear on the wire.
+        assert!(json.get("step_up_approver").is_none());
         assert!(!json.as_object().unwrap().contains_key("label"));
         assert_eq!(json["allowed_contexts"], serde_json::json!(["vta"]));
     }
@@ -734,6 +793,7 @@ mod tests {
             role: None,
             label: None,
             allowed_contexts: None,
+            step_up_approver: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         let obj = json.as_object().unwrap();

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -333,6 +333,10 @@ pub struct CreateAclRequest {
     /// if the admin never claims it via `pnm setup` + rotation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
+    /// VID authorized to ratify a **delegated** AAL2 step-up for this subject
+    /// (the subject's `stepUp.approver`). Omit for no delegated approver.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub step_up_approver: Option<String>,
 }
 
 impl CreateAclRequest {
@@ -343,6 +347,7 @@ impl CreateAclRequest {
             label: None,
             allowed_contexts: Vec::new(),
             expires_at: None,
+            step_up_approver: None,
         }
     }
     pub fn label(mut self, label: impl Into<String>) -> Self {
@@ -355,6 +360,11 @@ impl CreateAclRequest {
     }
     pub fn expires_at(mut self, unix_secs: u64) -> Self {
         self.expires_at = Some(unix_secs);
+        self
+    }
+    /// Set the delegated step-up approver VID (`stepUp.approver`).
+    pub fn step_up_approver(mut self, approver: impl Into<String>) -> Self {
+        self.step_up_approver = Some(approver.into());
         self
     }
 }
@@ -384,6 +394,10 @@ pub struct UpdateAclRequest {
     pub label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_contexts: Option<Vec<String>>,
+    /// Set the delegated step-up approver VID (`Some` sets — pass an empty
+    /// string to clear; `None` leaves the current value unchanged).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub step_up_approver: Option<String>,
 }
 
 // ── WebVH server types ──────────────────────────────────────────────

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -640,6 +640,7 @@ async fn update_acl_patches() {
         role: Some("reader".into()),
         label: None,
         allowed_contexts: Some(vec!["ctx-b".into()]),
+        step_up_approver: None,
     };
     let resp = c.update_acl("did:key:zAdmin", req).await.unwrap();
     assert_eq!(resp.did, "did:key:zAdmin");

--- a/vta-service/src/acl_cli.rs
+++ b/vta-service/src/acl_cli.rs
@@ -70,9 +70,12 @@ pub async fn run_acl_update(
     role: Option<String>,
     label: Option<String>,
     contexts: Option<Vec<String>>,
+    step_up_approver: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if role.is_none() && label.is_none() && contexts.is_none() {
-        return Err("nothing to update — specify --role, --label, or --contexts".into());
+    if role.is_none() && label.is_none() && contexts.is_none() && step_up_approver.is_none() {
+        return Err(
+            "nothing to update — specify --role, --label, --contexts, or --step-up-approver".into(),
+        );
     }
 
     let new_role = role.map(|r| Role::parse(&r)).transpose()?;
@@ -93,6 +96,14 @@ pub async fn run_acl_update(
     }
     if let Some(contexts) = contexts {
         entry.allowed_contexts = contexts;
+    }
+    if let Some(approver) = step_up_approver {
+        // Empty string clears the delegated approver; any value sets it.
+        entry.step_up_approver = if approver.is_empty() {
+            None
+        } else {
+            Some(approver)
+        };
     }
 
     store_acl_entry(&acl_ks, &entry).await?;

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1161,6 +1161,11 @@ enum AclCommands {
         /// New context list (comma-separated; omit flag to keep unchanged)
         #[arg(long, value_delimiter = ',')]
         contexts: Option<Vec<String>>,
+        /// Set the delegated step-up approver VID (`stepUp.approver`). Empty
+        /// string clears it; omit to keep unchanged. Break-glass: direct store
+        /// write, no wire auth.
+        #[arg(long)]
+        step_up_approver: Option<String>,
     },
     /// Delete an ACL entry
     Delete {
@@ -1601,7 +1606,18 @@ async fn main() {
                     role,
                     label,
                     contexts,
-                } => acl_cli::run_acl_update(cli.config, did, role, label, contexts).await,
+                    step_up_approver,
+                } => {
+                    acl_cli::run_acl_update(
+                        cli.config,
+                        did,
+                        role,
+                        label,
+                        contexts,
+                        step_up_approver,
+                    )
+                    .await
+                }
                 AclCommands::Delete { did, yes } => {
                     acl_cli::run_acl_delete(cli.config, did, yes).await
                 }


### PR DESCRIPTION
The operator CLI for the runtime step-up policy surface (#325) and the delegated-approver field — so the full delegated AAL2 loop is driveable with first-class commands instead of curl. This is the last piece of the delegated step-up arc.

## SDK (`vta-sdk`)
- `VtaClient::get_step_up_policy` / `set_step_up_policy` — REST `GET`/`PUT /step-up/policy`. REST-only (the canonical DIDComm path is the `auth/step-up/policy/0.2` trust-task); a pure-DIDComm session gets a clear `UnsupportedTransport`.
- `CreateAclRequest` / `UpdateAclRequest` gain `step_up_approver` — additive, `skip_serializing_if` (omitted ⇒ absent on the wire) — plus a `CreateAclRequest::step_up_approver(...)` builder.

## pnm
- `pnm step-up policy show | set --from <file|-> | disable` (super-admin). `show` pretty-prints the floors; `set` reads a JSON policy doc (file or stdin); `disable` reverts to AAL1.
- `pnm acl create|update --step-up-approver <did>` — set (or clear, via `""`) the subject's `stepUp.approver`. Shared impls in `vta-cli-common`; `cnm` passes `None` (no flag exposed there).

## Offline break-glass
The `vta step-up …` surface (Show/Enable/Disable/SetFloor/RemoveFloor — direct config, bypasses the gate) **already existed** and satisfies the spec's break-glass requirement, so no change there. Added `vta acl update --step-up-approver` to round out the offline path.

## Docs
`docs/02-vta/step-up-policy.md` — operator guide (online + break-glass) **and the full delegated end-to-end runbook**: register approver → enable a delegated floor → approver listens → requester triggers the gated op → ratify over DIDComm → requester's session elevates to AAL2.

## Verification
- `cargo fmt` + `clippy --all-targets` + `cargo deny` clean.
- `vta-sdk` 65 tests green; PR1 policy integration still **7/7**; all four CLIs build.
- New commands smoke-checked via `--help` (`pnm step-up policy`, `pnm acl create --step-up-approver`, `vta step-up`).
- No version bumps (not a publish; the `vta-sdk` additions are additive).

## Arc complete
With this merged, delegated AAL2 step-up is operable end-to-end: spec (dtgwg #83) → VTA intake (#324) → iOS ratify (#11) → policy management (#325) → **this CLI layer**. The runbook in the new doc is the on-device test you can now run with first-class commands.