### PR TITLE
fix(vtc): member role in heal scan + admin-remove Trust-Task

### DIFF
--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -39,8 +39,6 @@ const TRUST_TASK_SHOW =
   "https://trusttasks.org/openvtc/vtc/members/show/1.0";
 const TRUST_TASK_PROMOTE =
   "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0";
-const TRUST_TASK_ADMIN_REMOVE =
-  "https://trusttasks.org/openvtc/vtc/members/admin-remove/1.0";
 
 interface MemberRow {
   did: string;
@@ -122,8 +120,14 @@ async function adminRemove(args: {
   reason: string;
 }): Promise<void> {
   // DELETE accepts an optional `{reason}` body on the server.
+  // `/members/{did}` collapses GET + PATCH + DELETE under the single
+  // `members/show/1.0` Trust Task at the router (per-method selectors are
+  // deferred infra), so the DELETE must send that task — sending
+  // `members/admin-remove/1.0` trips the exact-match soft-gate
+  // (`TrustTaskMismatch`, 415). The standalone admin-remove Trust Task still
+  // exists on disk for the soft-gate surface.
   await deleteJson<unknown>(`/v1/members/${encodeURIComponent(args.did)}`, {
-    trustTask: TRUST_TASK_ADMIN_REMOVE,
+    trustTask: TRUST_TASK_SHOW,
     body: { reason: args.reason || null },
   });
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -741,15 +741,19 @@ pub async fn run(
 /// bootstrap that crashed between PasskeyUser and AdminEntry).
 async fn heal_missing_admin_entries(state: &AppState) -> Result<(), AppError> {
     use chrono::Utc;
-    use vti_common::acl::list_acl_entries;
     use vti_common::auth::passkey::store::get_passkey_user_by_did;
 
     use crate::acl::admin::{AdminEntry, RegisteredPasskey, get_admin_entry, store_admin_entry};
+    // Use the VTC's own ACL type (`VtcRole`), not `vti_common`'s `Role`. The
+    // VTC stores `VtcAclEntry`, whose role set includes `Member` (written by a
+    // join admit); deserializing those rows via `vti_common::acl` fails with
+    // "unknown variant `member`" once any member exists.
+    use crate::acl::{VtcRole, list_acl_entries};
 
     let admins = list_acl_entries(&state.acl_ks).await?;
     let mut healed = 0usize;
     for acl_entry in admins {
-        if acl_entry.role != vti_common::acl::Role::Admin {
+        if acl_entry.role != VtcRole::Admin {
             continue;
         }
         if get_admin_entry(&state.passkey_ks, &acl_entry.did)


### PR DESCRIPTION
Two VTC bugs that surface once a real **member** exists (i.e. once the join flow actually works end-to-end):

## 1. Startup warning — heal scan can't read a member
```
WARN admin-entry heal scan failed: serialization error: unknown variant `member`,
expected one of `admin`,`initiator`,`application`,`reader`,`monitor`
```
`heal_missing_admin_entries` read ACL rows via `vti_common::acl::list_acl_entries` (whose `Role` has no `member`), but the VTC stores `crate::acl::VtcAclEntry` — whose `VtcRole` includes `Member`, written by a join admit. → use the VTC's own `crate::acl::list_acl_entries` + `VtcRole::Admin`.

## 2. Admin 'Remove member' → `TrustTaskMismatch` (415)
`/members/{did}` collapses GET + PATCH + DELETE under the single `members/show/1.0` Trust Task at the router (per-method selectors are deferred infra — see the route comment), but the admin UI sent `members/admin-remove/1.0` for the DELETE → exact-match soft-gate failure. The admin UI's own comment already says `members/show/1.0` covers all three methods; the DELETE just wasn't following it. → send `TRUST_TASK_SHOW` (as GET/PATCH do); drop the unused `TRUST_TASK_ADMIN_REMOVE` const. The standalone `members/admin-remove/1.0` Trust Task stays on disk for the soft-gate surface.

## Verification
`cargo check`/`fmt`/`clippy` clean (vtc-service); admin-ui `tsc -b` + vite build clean. Not runtime-tested, but both are narrow, well-understood fixes. Please confirm: VTC restart no longer warns, and admin Remove member succeeds.

Built in an isolated worktree off `main` (the primary checkout is on a parallel step-up branch).