### PR TITLE
feat(step-up): delegatedAny + per-entry stepUp.require enforcement

### DIFF
--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1059,8 +1059,9 @@ async fn main() {
                 .transpose()
             {
                 Ok(expires_at) => {
-                    // cnm does not expose the delegated step-up approver flag.
-                    acl::cmd_acl_create(&client, did, role, label, contexts, expires_at, None).await
+                    // cnm does not expose the per-entry step-up flags.
+                    acl::cmd_acl_create(&client, did, role, label, contexts, expires_at, None, None)
+                        .await
                 }
                 Err(e) => Err(format!("--expires: {e}").into()),
             },
@@ -1069,7 +1070,7 @@ async fn main() {
                 role,
                 label,
                 contexts,
-            } => acl::cmd_acl_update(&client, &did, role, label, contexts, None).await,
+            } => acl::cmd_acl_update(&client, &did, role, label, contexts, None, None).await,
             AclCommands::Delete { did } => acl::cmd_acl_delete(&client, &did).await,
         },
         Commands::AuthCredential { command } => match command {

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1585,6 +1585,10 @@ pub(crate) enum AclCommands {
         /// when policy `mode: delegated` applies (e.g. the holder's phone).
         #[arg(long)]
         step_up_approver: Option<String>,
+        /// Per-entry step-up override (`self` | `delegated`) raising the system
+        /// floor for this subject (`stepUp.require`). Omit for none.
+        #[arg(long)]
+        step_up_require: Option<String>,
     },
     /// Update an ACL entry
     Update {
@@ -1603,6 +1607,10 @@ pub(crate) enum AclCommands {
         /// empty string to clear it; omit to leave it unchanged.
         #[arg(long)]
         step_up_approver: Option<String>,
+        /// Set the per-entry step-up override (`self` | `delegated`). Pass an
+        /// empty string to clear it; omit to leave it unchanged.
+        #[arg(long)]
+        step_up_require: Option<String>,
     },
     /// Delete an ACL entry
     Delete {

--- a/pnm-cli/src/commands/acl.rs
+++ b/pnm-cli/src/commands/acl.rs
@@ -19,6 +19,7 @@ pub(crate) async fn run(
             contexts,
             expires,
             step_up_approver,
+            step_up_require,
         } => match resolve_expires_at(expires.as_deref()) {
             Ok(expires_at) => {
                 acl::cmd_acl_create(
@@ -29,6 +30,7 @@ pub(crate) async fn run(
                     contexts,
                     expires_at,
                     step_up_approver,
+                    step_up_require,
                 )
                 .await
             }
@@ -40,7 +42,19 @@ pub(crate) async fn run(
             label,
             contexts,
             step_up_approver,
-        } => acl::cmd_acl_update(client, &did, role, label, contexts, step_up_approver).await,
+            step_up_require,
+        } => {
+            acl::cmd_acl_update(
+                client,
+                &did,
+                role,
+                label,
+                contexts,
+                step_up_approver,
+                step_up_require,
+            )
+            .await
+        }
         AclCommands::Delete { did } => acl::cmd_acl_delete(client, &did).await,
     }
 }

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -151,6 +151,7 @@ pub async fn cmd_acl_create(
     contexts: Vec<String>,
     expires_at: Option<u64>,
     step_up_approver: Option<String>,
+    step_up_require: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_role(&role)?;
     let mut req = CreateAclRequest::new(did, role).contexts(contexts);
@@ -162,6 +163,9 @@ pub async fn cmd_acl_create(
     }
     if let Some(ref approver) = step_up_approver {
         req = req.step_up_approver(approver.clone());
+    }
+    if let Some(ref require) = step_up_require {
+        req = req.step_up_require(require.clone());
     }
     let entry = client.create_acl(req).await?;
     println!("ACL entry created:");
@@ -176,6 +180,9 @@ pub async fn cmd_acl_create(
     println!("  Contexts:   {}", format_contexts(&entry.allowed_contexts));
     if let Some(approver) = &step_up_approver {
         println!("  Step-up approver: {approver}");
+    }
+    if let Some(require) = &step_up_require {
+        println!("  Step-up require:  {require}");
     }
     match entry.expires_at {
         Some(secs) => println!(
@@ -195,6 +202,7 @@ pub async fn cmd_acl_update(
     label: Option<String>,
     contexts: Option<Vec<String>>,
     step_up_approver: Option<String>,
+    step_up_require: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(ref r) = role {
         validate_role(r)?;
@@ -204,6 +212,7 @@ pub async fn cmd_acl_update(
         label,
         allowed_contexts: contexts,
         step_up_approver: step_up_approver.clone(),
+        step_up_require: step_up_require.clone(),
     };
     let entry = client.update_acl(did, req).await?;
     println!("ACL entry updated:");
@@ -221,6 +230,13 @@ pub async fn cmd_acl_update(
             println!("  Step-up approver: (cleared)");
         } else {
             println!("  Step-up approver: {approver}");
+        }
+    }
+    if let Some(require) = &step_up_require {
+        if require.is_empty() {
+            println!("  Step-up require:  (cleared)");
+        } else {
+            println!("  Step-up require:  {require}");
         }
     }
     Ok(())

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -777,6 +777,7 @@ mod tests {
             allowed_contexts: vec!["vta".into()],
             expires_at: None,
             step_up_approver: None,
+            step_up_require: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["did"], "did:key:z6Mk123");
@@ -794,6 +795,7 @@ mod tests {
             label: None,
             allowed_contexts: None,
             step_up_approver: None,
+            step_up_require: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         let obj = json.as_object().unwrap();

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -313,6 +313,11 @@ pub struct AclEntryResponse {
     /// defaults to `None` for backward compat.
     #[serde(default)]
     pub expires_at: Option<u64>,
+    /// Per-entry step-up override (`"self"` | `"delegated"`) raising the system
+    /// floor for this subject. `None` = no override. `#[serde(default)]` for
+    /// pre-existing entries on the wire.
+    #[serde(default)]
+    pub step_up_require: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -337,6 +342,10 @@ pub struct CreateAclRequest {
     /// (the subject's `stepUp.approver`). Omit for no delegated approver.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub step_up_approver: Option<String>,
+    /// Per-entry step-up override (`"self"` | `"delegated"`) raising the system
+    /// floor for this subject. Omit for none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub step_up_require: Option<String>,
 }
 
 impl CreateAclRequest {
@@ -348,6 +357,7 @@ impl CreateAclRequest {
             allowed_contexts: Vec::new(),
             expires_at: None,
             step_up_approver: None,
+            step_up_require: None,
         }
     }
     pub fn label(mut self, label: impl Into<String>) -> Self {
@@ -365,6 +375,12 @@ impl CreateAclRequest {
     /// Set the delegated step-up approver VID (`stepUp.approver`).
     pub fn step_up_approver(mut self, approver: impl Into<String>) -> Self {
         self.step_up_approver = Some(approver.into());
+        self
+    }
+    /// Set the per-entry step-up override (`stepUp.require`: `"self"` |
+    /// `"delegated"`), which raises the system floor for this subject.
+    pub fn step_up_require(mut self, require: impl Into<String>) -> Self {
+        self.step_up_require = Some(require.into());
         self
     }
 }
@@ -398,6 +414,10 @@ pub struct UpdateAclRequest {
     /// string to clear; `None` leaves the current value unchanged).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub step_up_approver: Option<String>,
+    /// Per-entry step-up override (`"self"` | `"delegated"`): `Some` sets — pass
+    /// an empty string to clear; `None` leaves the current value unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub step_up_require: Option<String>,
 }
 
 // ── WebVH server types ──────────────────────────────────────────────

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -17,6 +17,10 @@ pub struct CreateAclBody {
     /// `step_up_approver`. `None` = no delegated approver configured.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step_up_approver: Option<String>,
+    /// Per-entry step-up override (`"self"` | `"delegated"`) raising the system
+    /// floor for this subject. Stored as `step_up_require`. `None` = no override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_up_require: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,4 +38,8 @@ pub struct CreateAclResultBody {
     /// subject, if any (echoes the stored `step_up_approver`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step_up_approver: Option<String>,
+    /// The per-entry step-up override the maintainer now holds for this subject,
+    /// if any (echoes the stored `step_up_require`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_up_require: Option<String>,
 }

--- a/vta-sdk/src/protocols/acl_management/update.rs
+++ b/vta-sdk/src/protocols/acl_management/update.rs
@@ -16,6 +16,10 @@ pub struct UpdateAclBody {
     /// approver isn't expressible here, consistent with `label`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step_up_approver: Option<String>,
+    /// Set the per-entry step-up override (`"self"` | `"delegated"`). `Some`
+    /// sets it; `None` leaves it unchanged (consistent with the other fields).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_up_require: Option<String>,
 }
 
 pub type UpdateAclResultBody = CreateAclResultBody;

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -641,6 +641,7 @@ async fn update_acl_patches() {
         label: None,
         allowed_contexts: Some(vec!["ctx-b".into()]),
         step_up_approver: None,
+        step_up_require: None,
     };
     let resp = c.update_acl("did:key:zAdmin", req).await.unwrap();
     assert_eq!(resp.did, "did:key:zAdmin");

--- a/vta-service/src/acl_cli.rs
+++ b/vta-service/src/acl_cli.rs
@@ -71,11 +71,17 @@ pub async fn run_acl_update(
     label: Option<String>,
     contexts: Option<Vec<String>>,
     step_up_approver: Option<String>,
+    step_up_require: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if role.is_none() && label.is_none() && contexts.is_none() && step_up_approver.is_none() {
-        return Err(
-            "nothing to update — specify --role, --label, --contexts, or --step-up-approver".into(),
-        );
+    if role.is_none()
+        && label.is_none()
+        && contexts.is_none()
+        && step_up_approver.is_none()
+        && step_up_require.is_none()
+    {
+        return Err("nothing to update — specify --role, --label, --contexts, \
+             --step-up-approver, or --step-up-require"
+            .into());
     }
 
     let new_role = role.map(|r| Role::parse(&r)).transpose()?;
@@ -103,6 +109,14 @@ pub async fn run_acl_update(
             None
         } else {
             Some(approver)
+        };
+    }
+    if let Some(require) = step_up_require {
+        // Empty string clears the per-entry override; otherwise parse + validate.
+        entry.step_up_require = if require.trim().is_empty() {
+            None
+        } else {
+            crate::operations::acl::parse_step_up_require(Some(&require))?
         };
     }
 

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1166,6 +1166,10 @@ enum AclCommands {
         /// write, no wire auth.
         #[arg(long)]
         step_up_approver: Option<String>,
+        /// Set the per-entry step-up override (`self` | `delegated`;
+        /// `stepUp.require`). Empty string clears it; omit to keep unchanged.
+        #[arg(long)]
+        step_up_require: Option<String>,
     },
     /// Delete an ACL entry
     Delete {
@@ -1607,6 +1611,7 @@ async fn main() {
                     label,
                     contexts,
                     step_up_approver,
+                    step_up_require,
                 } => {
                     acl_cli::run_acl_update(
                         cli.config,
@@ -1615,6 +1620,7 @@ async fn main() {
                         label,
                         contexts,
                         step_up_approver,
+                        step_up_require,
                     )
                     .await
                 }

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -544,6 +544,7 @@ pub async fn handle_create_acl(
             body.allowed_contexts,
             body.expires_at,
             body.step_up_approver,
+            body.step_up_require,
             "didcomm",
         )
         .await
@@ -684,6 +685,7 @@ pub async fn handle_update_acl(
                 label: body.label,
                 allowed_contexts: body.allowed_contexts,
                 step_up_approver: body.step_up_approver,
+                step_up_require: body.step_up_require,
             },
             "didcomm",
         )

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -16,6 +16,7 @@ use crate::auth::session::now_epoch;
 use crate::contexts::get_context;
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
+use vti_common::auth::step_up::StepUpMode;
 
 pub struct UpdateAclParams {
     pub role: Option<Role>,
@@ -23,6 +24,38 @@ pub struct UpdateAclParams {
     pub allowed_contexts: Option<Vec<String>>,
     /// `Some` sets the delegated step-up approver; `None` leaves it unchanged.
     pub step_up_approver: Option<String>,
+    /// `Some` sets the per-entry step-up override (empty string clears); `None`
+    /// leaves it unchanged.
+    pub step_up_require: Option<String>,
+}
+
+/// Parse a wire `stepUp.require` value into a [`StepUpMode`]. Only `self` and
+/// `delegated` are valid per-entry overrides (the spec's enum); an override is
+/// additive and a per-subject relaxation to `delegated-any` is not meaningful.
+/// `None`/empty ⇒ no override.
+pub fn parse_step_up_require(s: Option<&str>) -> Result<Option<StepUpMode>, AppError> {
+    match s.map(str::trim) {
+        None | Some("") => Ok(None),
+        Some("self") => Ok(Some(StepUpMode::SelfApprove)),
+        Some("delegated") => Ok(Some(StepUpMode::Delegated)),
+        Some(other) => Err(AppError::Validation(format!(
+            "invalid stepUp.require '{other}': must be 'self' or 'delegated'"
+        ))),
+    }
+}
+
+/// Render a stored [`StepUpMode`] override as its wire token for echo in
+/// responses (`self` / `delegated`).
+fn step_up_require_to_wire(m: Option<StepUpMode>) -> Option<String> {
+    m.map(|m| {
+        match m {
+            StepUpMode::SelfApprove => "self",
+            StepUpMode::Delegated => "delegated",
+            StepUpMode::DelegatedAny => "delegated-any",
+            StepUpMode::None => "none",
+        }
+        .to_string()
+    })
 }
 
 /// Compute the symmetric difference of two context lists — every
@@ -81,6 +114,7 @@ fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
         created_by: e.created_by.clone(),
         expires_at: e.expires_at,
         step_up_approver: e.step_up_approver.clone(),
+        step_up_require: step_up_require_to_wire(e.step_up_require),
     }
 }
 
@@ -96,12 +130,14 @@ pub async fn create_acl(
     allowed_contexts: Vec<String>,
     expires_at: Option<u64>,
     step_up_approver: Option<String>,
+    step_up_require: Option<String>,
     channel: &str,
 ) -> Result<CreateAclResultBody, AppError> {
     auth.require_manage()?;
     validate_role_assignment(auth, &role)?;
     validate_acl_modification(auth, &allowed_contexts)?;
     require_contexts_exist(contexts_ks, &allowed_contexts).await?;
+    let step_up_require = parse_step_up_require(step_up_require.as_deref())?;
 
     if get_acl_entry(acl_ks, did).await?.is_some() {
         return Err(AppError::Conflict(format!(
@@ -113,7 +149,8 @@ pub async fn create_acl(
         .with_label(label)
         .with_contexts(allowed_contexts)
         .with_expires_at(expires_at)
-        .with_step_up_approver(step_up_approver);
+        .with_step_up_approver(step_up_approver)
+        .with_step_up_require(step_up_require);
 
     store_acl_entry(acl_ks, &entry).await?;
 
@@ -213,6 +250,14 @@ pub async fn update_acl(
     }
     if let Some(approver) = params.step_up_approver {
         entry.step_up_approver = Some(approver);
+    }
+    if let Some(require) = params.step_up_require {
+        // Empty string clears the override; otherwise parse + validate.
+        entry.step_up_require = if require.trim().is_empty() {
+            None
+        } else {
+            parse_step_up_require(Some(&require))?
+        };
     }
     if let Some(allowed_contexts) = params.allowed_contexts {
         // Validate the *symmetric difference* of (old, new), not just
@@ -525,6 +570,38 @@ mod tests {
     }
 
     #[test]
+    fn parse_step_up_require_accepts_self_and_delegated_only() {
+        assert_eq!(parse_step_up_require(None).unwrap(), None);
+        assert_eq!(parse_step_up_require(Some("")).unwrap(), None);
+        assert_eq!(parse_step_up_require(Some("  ")).unwrap(), None);
+        assert_eq!(
+            parse_step_up_require(Some("self")).unwrap(),
+            Some(StepUpMode::SelfApprove)
+        );
+        assert_eq!(
+            parse_step_up_require(Some("delegated")).unwrap(),
+            Some(StepUpMode::Delegated)
+        );
+        // `delegated-any` / `none` / junk are not valid per-entry overrides.
+        assert!(parse_step_up_require(Some("delegated-any")).is_err());
+        assert!(parse_step_up_require(Some("none")).is_err());
+        assert!(parse_step_up_require(Some("nope")).is_err());
+    }
+
+    #[test]
+    fn step_up_require_round_trips_to_wire() {
+        assert_eq!(step_up_require_to_wire(None), None);
+        assert_eq!(
+            step_up_require_to_wire(Some(StepUpMode::SelfApprove)).as_deref(),
+            Some("self")
+        );
+        assert_eq!(
+            step_up_require_to_wire(Some(StepUpMode::Delegated)).as_deref(),
+            Some("delegated")
+        );
+    }
+
+    #[test]
     fn symmetric_difference_handles_typical_cases() {
         let s = symmetric_difference_contexts(&["a".into(), "b".into()], &["a".into(), "c".into()]);
         let mut s = s;
@@ -572,6 +649,7 @@ mod tests {
                 role: None,
                 label: None,
                 step_up_approver: None,
+                step_up_require: None,
                 allowed_contexts: Some(vec!["ctx-a".into()]),
             },
             "test",
@@ -606,6 +684,7 @@ mod tests {
                 role: None,
                 label: None,
                 step_up_approver: None,
+                step_up_require: None,
                 allowed_contexts: Some(vec!["ctx-a".into()]),
             },
             "test",
@@ -637,6 +716,7 @@ mod tests {
                 role: None,
                 label: None,
                 step_up_approver: None,
+                step_up_require: None,
                 allowed_contexts: Some(vec!["ctx-a".into(), "ctx-b".into()]),
             },
             "test",
@@ -678,6 +758,7 @@ mod tests {
             vec!["ctx-typo".into()],
             None,
             None,
+            None,
             "test",
         )
         .await
@@ -709,6 +790,7 @@ mod tests {
             Role::Admin,
             None,
             vec!["ctx-real".into()],
+            None,
             None,
             None,
             "test",
@@ -800,6 +882,7 @@ mod tests {
                 role: None,
                 label: None,
                 step_up_approver: None,
+                step_up_require: None,
                 allowed_contexts: Some(vec!["ctx-a".into(), "ctx-ghost".into()]),
             },
             "test",

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -594,6 +594,7 @@ pub async fn provision_integration(
         vec![context.clone()],
         None,
         None,
+        None,
         "provision-integration",
     )
     .await
@@ -861,6 +862,7 @@ async fn provision_admin_rotation(
         Role::Admin,
         request.label().map(str::to_string),
         vec![context.to_string()],
+        None,
         None,
         None,
         "provision-integration",

--- a/vta-service/src/operations/step_up_policy.rs
+++ b/vta-service/src/operations/step_up_policy.rs
@@ -138,25 +138,42 @@ async fn lockout_check(
     policy: &StepUpPolicy,
     acl_ks: &KeyspaceHandle,
 ) -> Result<(), SetPolicyError> {
-    let needs_delegate = policy
+    let needs_delegated = policy
         .floors
         .iter()
-        .any(|f| matches!(f.mode, StepUpMode::Delegated | StepUpMode::DelegatedAny));
-    if !needs_delegate {
+        .any(|f| matches!(f.mode, StepUpMode::Delegated));
+    let needs_delegated_any = policy
+        .floors
+        .iter()
+        .any(|f| matches!(f.mode, StepUpMode::DelegatedAny));
+    if !needs_delegated && !needs_delegated_any {
         return Ok(());
     }
 
     let entries = list_acl_entries(acl_ks)
         .await
         .map_err(|e| SetPolicyError::Store(e.to_string()))?;
-    let any_approver = entries
-        .iter()
-        .any(|e| e.step_up_approver.as_deref().is_some_and(|a| !a.is_empty()));
-    if !any_approver {
+
+    // `delegated` needs a bound approver routed to via `stepUp.approver`.
+    if needs_delegated
+        && !entries
+            .iter()
+            .any(|e| e.step_up_approver.as_deref().is_some_and(|a| !a.is_empty()))
+    {
         return Err(SetPolicyError::LockoutRefused(
             "enabling a delegated floor would lock out all administrators: no AclEntry \
              carries a stepUp.approver. Register an approver (acl create/update \
              --step-up-approver), then enable."
+                .to_string(),
+        ));
+    }
+
+    // `delegated-any` is satisfiable by any admin meeting the criterion, so it
+    // needs at least one admin entry to exist to ratify.
+    if needs_delegated_any && !entries.iter().any(|e| e.is_admin()) {
+        return Err(SetPolicyError::LockoutRefused(
+            "enabling a delegated-any floor would lock out all administrators: no admin \
+             AclEntry exists to ratify. Register an admin, then enable."
                 .to_string(),
         ));
     }

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -45,6 +45,10 @@ pub struct CreateAclRequest {
     /// (the approve-request `recipient`). Omit for no delegated approver.
     #[serde(default)]
     pub step_up_approver: Option<String>,
+    /// Per-entry step-up override (`"self"` | `"delegated"`) raising the system
+    /// floor for this subject. Omit for none.
+    #[serde(default)]
+    pub step_up_require: Option<String>,
 }
 
 /// POST /acl — create a new ACL entry for a DID. Auth: Admin or Initiator.
@@ -68,6 +72,7 @@ pub async fn create_acl(
         req.allowed_contexts,
         req.expires_at,
         req.step_up_approver,
+        req.step_up_require,
         "rest",
     )
     .await?;
@@ -92,6 +97,10 @@ pub struct UpdateAclRequest {
     /// Set the delegated step-up approver VID (`Some` sets; `None` leaves).
     #[serde(default)]
     pub step_up_approver: Option<String>,
+    /// Set the per-entry step-up override (`"self"` | `"delegated"`; empty
+    /// string clears; `None` leaves unchanged).
+    #[serde(default)]
+    pub step_up_require: Option<String>,
 }
 
 /// PATCH /acl/{did} — update role, label, or allowed contexts for an ACL entry.
@@ -115,6 +124,7 @@ pub async fn update_acl(
             label: req.label,
             allowed_contexts: req.allowed_contexts,
             step_up_approver: req.step_up_approver,
+            step_up_require: req.step_up_require,
         },
         "rest",
     )

--- a/vta-service/src/routes/trust_tasks/acl.rs
+++ b/vta-service/src/routes/trust_tasks/acl.rs
@@ -100,6 +100,7 @@ pub(super) async fn handle_create(
         req.allowed_contexts,
         req.expires_at,
         req.step_up_approver,
+        req.step_up_require,
         TRANSPORT_TRUST_TASK,
     )
     .await
@@ -174,6 +175,7 @@ pub(super) async fn handle_update(
             label: req.label,
             allowed_contexts: req.allowed_contexts,
             step_up_approver: req.step_up_approver,
+            step_up_require: req.step_up_require,
         },
         TRANSPORT_TRUST_TASK,
     )

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -34,7 +34,7 @@ use crate::operations::passkey_login::{
     VtaVmResolver, enumerate_passkey_vms, verify_passkey_login,
 };
 use crate::server::AppState;
-use vti_common::acl::get_acl_entry;
+use vti_common::acl::{delegated_any_approver_covers, get_acl_entry};
 use vti_common::auth::step_up::{
     ConsumeOutcome, StepUpMode, consume_pending_step_up, new_pending_step_up, store_pending_step_up,
 };
@@ -309,22 +309,53 @@ pub(super) async fn handle_approve_response(
         );
     }
 
-    // 4b. Authorize the signer. The relying party elevates only for the approver
-    //     it addressed the request to: the subject itself (self), or the
-    //     delegated approver recorded on the pending step-up at mint. An
-    //     in-flight record written before the `approver` field existed has it
-    //     empty → fall back to self (issuer MUST equal subject). The gate (4/5)
-    //     proves the proof VM == issuer; this ties that issuer to the step-up.
-    let authorized_signer = if pending.approver.is_empty() {
-        subject.as_str()
+    // 4b. Authorize the signer. The gate (4/5) proves the proof VM == issuer;
+    //     this ties that issuer to the step-up the relying party minted.
+    if pending.approver_any {
+        // delegated-any: no single bound approver. The issuer must meet the
+        // maintainer's criterion — an admin whose contexts cover the subject's
+        // (super-admin covers all). Expired approver entries can't ratify.
+        let now = now_epoch();
+        let issuer_entry = match get_acl_entry(&state.acl_ks, &issuer).await {
+            Ok(Some(e)) if !e.is_expired(now) => e,
+            _ => {
+                return reject_with(
+                    &doc,
+                    step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
+                );
+            }
+        };
+        let subject_entry = match get_acl_entry(&state.acl_ks, &subject).await {
+            Ok(Some(e)) => e,
+            _ => {
+                return reject_with(
+                    &doc,
+                    step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
+                );
+            }
+        };
+        if !delegated_any_approver_covers(&issuer_entry, &subject_entry) {
+            return reject_with(
+                &doc,
+                step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
+            );
+        }
     } else {
-        pending.approver.as_str()
-    };
-    if issuer != authorized_signer {
-        return reject_with(
-            &doc,
-            step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
-        );
+        // self / delegated: the relying party elevates only for the approver it
+        // addressed the request to — the subject itself (self) or the delegated
+        // approver recorded at mint. An in-flight record written before the
+        // `approver` field existed has it empty → fall back to self.
+        let authorized_signer = if pending.approver.is_empty() {
+            subject.as_str()
+        } else {
+            pending.approver.as_str()
+        };
+        if issuer != authorized_signer {
+            return reject_with(
+                &doc,
+                step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
+            );
+        }
     }
 
     // 4. A `denied` decision is a signed refusal — verify the did-signed gate
@@ -459,6 +490,7 @@ async fn mint_pending_step_up(
     vta_did: &str,
     subject: &str,
     recipient: &str,
+    approver_any: bool,
     session_id: &str,
     reason: &str,
 ) -> Result<Value, ()> {
@@ -477,9 +509,10 @@ async fn mint_pending_step_up(
         subject,
         // The authorized signer of the eventual approve-response: the subject
         // itself for `self`, or the delegated approver the request is addressed
-        // to. `handle_approve_response` checks the document `issuer` against
-        // this, so a delegated approver (issuer != subject) can elevate.
+        // to. Empty for `delegated-any` (authorization is by criterion, not a
+        // bound approver — `approver_any` selects that path).
         recipient,
+        approver_any,
         STEP_UP_TARGET_ACR,
         acceptable.clone(),
         STEP_UP_TTL_SECS,
@@ -489,13 +522,10 @@ async fn mint_pending_step_up(
         return Err(());
     }
 
-    Ok(json!({
+    let mut doc = json!({
         "id": format!("urn:uuid:{}", Uuid::new_v4()),
         "type": "https://trusttasks.org/spec/auth/step-up/approve-request/0.1",
         "issuer": vta_did,
-        // `recipient` is the approver the request is addressed to: the subject
-        // itself for `self` mode, or the configured delegated approver.
-        "recipient": recipient,
         "payload": {
             "subject": subject,
             "sessionId": session_id,
@@ -505,7 +535,14 @@ async fn mint_pending_step_up(
             "acceptableEvidence": acceptable,
             "ttl": STEP_UP_TTL_SECS,
         },
-    }))
+    });
+    // Address the request to the approver for `self`/`delegated`; `delegated-any`
+    // has no single recipient (any qualifying admin may ratify), so the field is
+    // omitted and the carried request is relayed to an eligible approver.
+    if !approver_any && !recipient.is_empty() {
+        doc["recipient"] = json!(recipient);
+    }
+    Ok(doc)
 }
 
 /// Mint a pending step-up and return the REST `403` that *carries the
@@ -519,23 +556,31 @@ pub(crate) async fn issue_step_up_challenge(
     vta_did: &str,
     subject: &str,
     recipient: &str,
+    approver_any: bool,
     session_id: &str,
     reason: &str,
 ) -> Response {
-    let approve_request =
-        match mint_pending_step_up(sessions_ks, vta_did, subject, recipient, session_id, reason)
-            .await
-        {
-            Ok(ar) => ar,
-            Err(()) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    [(axum::http::header::CONTENT_TYPE, "application/json")],
-                    br#"{"error":"internal_error"}"#.to_vec(),
-                )
-                    .into_response();
-            }
-        };
+    let approve_request = match mint_pending_step_up(
+        sessions_ks,
+        vta_did,
+        subject,
+        recipient,
+        approver_any,
+        session_id,
+        reason,
+    )
+    .await
+    {
+        Ok(ar) => ar,
+        Err(()) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                br#"{"error":"internal_error"}"#.to_vec(),
+            )
+                .into_response();
+        }
+    };
     // Backward-compatible with the prior 403 shape (`error` + `requiredAcr`),
     // plus the carried approve-request a step-up-aware client acts on.
     let body = json!({
@@ -579,8 +624,13 @@ enum StepUpDecision {
     /// non-escalation carve-out applied).
     Allow,
     /// Gated — mint an approve-request addressed to `recipient` (the subject
-    /// itself for `self` mode, or the delegated approver).
+    /// itself for `self` mode, or the delegated approver for `delegated`).
     Require { recipient: String },
+    /// Gated under `delegated-any`: any approver meeting the maintainer's
+    /// criterion (an admin covering the subject's contexts) may ratify. The
+    /// approve-request is addressed to no single party; authorization happens at
+    /// approve-response time against the actual issuer.
+    RequireAny,
     /// Gated, but no usable step-up method exists (a `delegated` floor with no
     /// approver on the caller's entry) — fail closed.
     Deny,
@@ -597,13 +647,30 @@ async fn resolve_step_up(
     caller_did: &str,
     is_non_escalating: bool,
 ) -> StepUpDecision {
-    let (mode, allow_carveout) = {
+    let (floor_mode, allow_carveout) = {
         let cfg = state.config.read().await;
         match cfg.auth.step_up.floor_record(op_class) {
             None => return StepUpDecision::Allow,
             Some(f) => (f.mode, f.allow_aal1_if_non_escalating),
         }
     };
+
+    // Compose the system floor with the caller's per-entry override
+    // (`stepUp.require`), additive-only: the effective mode is the strictest of
+    // the two. The caller's entry is also where a `delegated` approver lives, so
+    // fetch it once.
+    let entry = get_acl_entry(&state.acl_ks, caller_did)
+        .await
+        .ok()
+        .flatten();
+    let override_mode = entry
+        .as_ref()
+        .and_then(|e| e.step_up_require)
+        .unwrap_or(StepUpMode::None);
+    let mode = floor_mode.strictest(override_mode);
+
+    // The non-escalation carve-out is a structural exemption for self-service
+    // rotation/enrolment; it applies to the resolved requirement.
     if !mode.requires_aal2() || (allow_carveout && is_non_escalating) {
         return StepUpDecision::Allow;
     }
@@ -612,20 +679,18 @@ async fn resolve_step_up(
         StepUpMode::SelfApprove => StepUpDecision::Require {
             recipient: caller_did.to_string(),
         },
-        // Delegated (and delegated-any, until a broader approver criterion is
-        // defined) route to the caller's configured approver; absent one, fail
-        // closed rather than let the subject self-approve a delegated gate.
-        StepUpMode::Delegated | StepUpMode::DelegatedAny => {
-            match get_acl_entry(&state.acl_ks, caller_did).await {
-                Ok(Some(entry)) => match entry.step_up_approver {
-                    Some(approver) => StepUpDecision::Require {
-                        recipient: approver,
-                    },
-                    None => StepUpDecision::Deny,
-                },
-                _ => StepUpDecision::Deny,
-            }
-        }
+        // Delegated routes to the caller's single configured approver; absent
+        // one, fail closed rather than let the subject self-approve a delegated
+        // gate.
+        StepUpMode::Delegated => match entry.and_then(|e| e.step_up_approver) {
+            Some(approver) => StepUpDecision::Require {
+                recipient: approver,
+            },
+            None => StepUpDecision::Deny,
+        },
+        // Delegated-any: no single approver — any admin meeting the criterion
+        // may ratify (checked at approve-response time against the issuer).
+        StepUpMode::DelegatedAny => StepUpDecision::RequireAny,
     }
 }
 
@@ -787,9 +852,10 @@ pub(super) async fn require_step_up(
     // Trust-task gated ops (grant, change-role, revoke, context-delete,
     // key-revoke) are all escalating — they never qualify for the
     // non-escalation carve-out.
-    let recipient = match resolve_step_up(state, op_class, &auth.did, false).await {
+    let (recipient, approver_any) = match resolve_step_up(state, op_class, &auth.did, false).await {
         StepUpDecision::Allow => return None,
-        StepUpDecision::Require { recipient } => recipient,
+        StepUpDecision::Require { recipient } => (recipient, false),
+        StepUpDecision::RequireAny => (String::new(), true),
         StepUpDecision::Deny => {
             return Some(reject_with(
                 doc,
@@ -815,6 +881,7 @@ pub(super) async fn require_step_up(
         &vta_did,
         &auth.did,
         &recipient,
+        approver_any,
         &auth.session_id,
         "this operation requires a stepped-up (AAL2) session",
     )
@@ -823,8 +890,11 @@ pub(super) async fn require_step_up(
         Ok(approve_request) => {
             // Delegated mode: proactively push the approve-request to the
             // approver's device over DIDComm. Best-effort — the carried
-            // `approveRequest` below remains the relay fallback.
-            maybe_push_step_up(state, &recipient, &auth.did, &approve_request).await;
+            // `approveRequest` below remains the relay fallback. Skipped for
+            // `delegated-any` (no single approver device to target).
+            if !approver_any {
+                maybe_push_step_up(state, &recipient, &auth.did, &approve_request).await;
+            }
             RejectReason::TaskFailed {
                 reason: "auth:step_up_required".to_string(),
                 details: Some(json!({
@@ -914,10 +984,11 @@ impl<O: StepUpOp> FromRequestParts<AppState> for RequireStepUp<O> {
         // Resolve the floor for this route's operation-class, honoring the
         // non-escalation carve-out (`O::IS_NON_ESCALATING`) and, for delegated
         // modes, routing to the caller's configured approver.
-        let recipient =
+        let (recipient, approver_any) =
             match resolve_step_up(state, O::OP_CLASS, &claims.did, O::IS_NON_ESCALATING).await {
                 StepUpDecision::Allow => return Ok(RequireStepUp(std::marker::PhantomData)),
-                StepUpDecision::Require { recipient } => recipient,
+                StepUpDecision::Require { recipient } => (recipient, false),
+                StepUpDecision::RequireAny => (String::new(), true),
                 StepUpDecision::Deny => return Err(step_up_denied_response()),
             };
         let vta_did = state
@@ -932,6 +1003,7 @@ impl<O: StepUpOp> FromRequestParts<AppState> for RequireStepUp<O> {
             &vta_did,
             &claims.did,
             &recipient,
+            approver_any,
             &claims.session_id,
             "this operation requires a stepped-up (AAL2) session",
         )
@@ -985,6 +1057,7 @@ mod tests {
             "did:key:zHolder",
             // self-approval: recipient == subject
             "did:key:zHolder",
+            false,
             "sess-9",
             "rotate keys",
         )

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -75,6 +75,7 @@ async fn did_signed_approve_response_elevates_session_to_aal2() {
         session_id.clone(),
         did.clone(),
         did.clone(), // self step-up: approver == subject
+        false,       // approver_any (self/delegated single-approver path)
         "aal2",
         vec!["did-signed".to_string()],
         300,
@@ -204,6 +205,7 @@ async fn did_signed_approve_response_0_2_elevates_session_to_aal2() {
         session_id.clone(),
         did.clone(),
         did.clone(), // self step-up: approver == subject
+        false,       // approver_any (self/delegated single-approver path)
         "aal2",
         vec!["did-signed".to_string()],
         300,
@@ -442,6 +444,7 @@ async fn delegated_approve_response_elevates_the_subjects_session() {
         session_id.clone(),
         subject.clone(),
         approver_did.clone(), // delegated: approver != subject
+        false,                // approver_any (self/delegated single-approver path)
         "aal2",
         vec!["did-signed".to_string()],
         300,
@@ -548,6 +551,7 @@ async fn unauthorized_approver_cannot_elevate() {
         session_id.clone(),
         subject.clone(),
         authorized.clone(),
+        false, // approver_any (self/delegated single-approver path)
         "aal2",
         vec!["did-signed".to_string()],
         300,

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::auth::extractor::AuthClaims;
+use crate::auth::step_up::StepUpMode;
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
 
@@ -301,6 +302,17 @@ pub struct AclEntry {
     /// `#[serde(default)]` so pre-existing rows deserialise as `None`.
     #[serde(default)]
     pub step_up_approver: Option<String>,
+    /// Per-entry step-up override raising the system floor for *this* subject —
+    /// the spec's `AclEntry.stepUp.require`. ADDITIVE-ONLY: the effective mode
+    /// is the strictest of (system floor, this override), so an override weaker
+    /// than the floor is ignored (see [`StepUpMode::strictest`]). Restricted to
+    /// `self` / `delegated` (a per-subject override never relaxes to
+    /// `delegated-any`); the ACL op layer rejects other values.
+    ///
+    /// `#[serde(default)]` so pre-existing rows deserialise as `None` (no
+    /// override; the system floor applies unchanged).
+    #[serde(default)]
+    pub step_up_require: Option<StepUpMode>,
 }
 
 impl AclEntry {
@@ -326,6 +338,7 @@ impl AclEntry {
             device: None,
             version: 0,
             step_up_approver: None,
+            step_up_require: None,
         }
     }
 
@@ -376,6 +389,24 @@ impl AclEntry {
     pub fn with_step_up_approver(mut self, approver: Option<String>) -> Self {
         self.step_up_approver = approver;
         self
+    }
+
+    /// Set the per-entry step-up override (`stepUp.require`).
+    pub fn with_step_up_require(mut self, require: Option<StepUpMode>) -> Self {
+        self.step_up_require = require;
+        self
+    }
+
+    /// Whether this entry is an admin (`Role::Admin`).
+    pub fn is_admin(&self) -> bool {
+        matches!(self.role, Role::Admin)
+    }
+
+    /// Whether this entry is a **super-admin**: an admin with no context
+    /// restriction (empty `allowed_contexts` ⇒ unrestricted), mirroring
+    /// [`AuthClaims::is_super_admin`].
+    pub fn is_super_admin(&self) -> bool {
+        self.is_admin() && self.allowed_contexts.is_empty()
     }
 
     /// Set the optimistic-concurrency version (defaults to 0).
@@ -565,6 +596,36 @@ pub fn validate_acl_modification(
     Ok(())
 }
 
+/// Authorization predicate for **`delegated-any`** step-up: may `approver`
+/// ratify an AAL2 step-up for `subject`?
+///
+/// The criterion is **context-scoped admin**:
+/// - a **super-admin** approver (admin, no context restriction) may ratify for
+///   any subject — including cross-context and global subjects;
+/// - a **context-admin** approver may ratify only for a context-scoped subject
+///   **all** of whose contexts it administers (`subject.allowed_contexts ⊆
+///   approver.allowed_contexts`). A context admin can never ratify for a global
+///   (super-admin-equivalent, empty-context) subject — only a super-admin can.
+///
+/// Non-admins never qualify. Expiry is the caller's responsibility (it should
+/// skip an expired approver entry before calling this).
+pub fn delegated_any_approver_covers(approver: &AclEntry, subject: &AclEntry) -> bool {
+    if !approver.is_admin() {
+        return false;
+    }
+    if approver.allowed_contexts.is_empty() {
+        return true; // super-admin: covers all contexts
+    }
+    // Context admin: the subject must itself be context-scoped, and every one of
+    // its contexts must fall within the approver's. A global subject (empty
+    // contexts) requires a super-admin approver, handled by the branch above.
+    !subject.allowed_contexts.is_empty()
+        && subject
+            .allowed_contexts
+            .iter()
+            .all(|c| approver.allowed_contexts.contains(c))
+}
+
 /// Check whether an ACL entry is visible to the caller.
 ///
 /// Super admins see all entries. Context admins only see entries whose
@@ -577,6 +638,87 @@ pub fn is_acl_entry_visible(caller: &AuthClaims, entry: &AclEntry) -> bool {
         .allowed_contexts
         .iter()
         .any(|ctx| caller.has_context_access(ctx))
+}
+
+#[cfg(test)]
+mod delegated_any_tests {
+    use super::*;
+
+    fn admin(contexts: &[&str]) -> AclEntry {
+        AclEntry::new("did:key:zApprover", Role::Admin, "did:key:zCreator")
+            .with_contexts(contexts.iter().map(|s| s.to_string()).collect())
+    }
+    fn subject(role: Role, contexts: &[&str]) -> AclEntry {
+        AclEntry::new("did:key:zSubject", role, "did:key:zCreator")
+            .with_contexts(contexts.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn super_admin_covers_any_subject() {
+        let sa = admin(&[]); // empty contexts ⇒ super-admin
+        assert!(delegated_any_approver_covers(
+            &sa,
+            &subject(Role::Admin, &["ctx-a"])
+        ));
+        assert!(delegated_any_approver_covers(
+            &sa,
+            &subject(Role::Reader, &[])
+        )); // global subject
+        assert!(delegated_any_approver_covers(
+            &sa,
+            &subject(Role::Application, &["ctx-a", "ctx-b"])
+        ));
+    }
+
+    #[test]
+    fn context_admin_covers_only_within_its_contexts() {
+        let ca = admin(&["ctx-a", "ctx-b"]);
+        // Subject fully within → covered.
+        assert!(delegated_any_approver_covers(
+            &ca,
+            &subject(Role::Reader, &["ctx-a"])
+        ));
+        assert!(delegated_any_approver_covers(
+            &ca,
+            &subject(Role::Reader, &["ctx-a", "ctx-b"])
+        ));
+        // Subject in a context the admin doesn't administer → NOT covered.
+        assert!(!delegated_any_approver_covers(
+            &ca,
+            &subject(Role::Reader, &["ctx-c"])
+        ));
+        assert!(!delegated_any_approver_covers(
+            &ca,
+            &subject(Role::Reader, &["ctx-a", "ctx-c"])
+        ));
+    }
+
+    #[test]
+    fn context_admin_never_covers_a_global_subject() {
+        // A global (empty-context, super-admin-equivalent) subject needs a
+        // super-admin approver; a context admin must never ratify for it.
+        let ca = admin(&["ctx-a"]);
+        assert!(!delegated_any_approver_covers(
+            &ca,
+            &subject(Role::Admin, &[])
+        ));
+    }
+
+    #[test]
+    fn non_admins_never_qualify() {
+        for role in [
+            Role::Initiator,
+            Role::Application,
+            Role::Reader,
+            Role::Monitor,
+        ] {
+            let not_admin = AclEntry::new("did:key:zX", role, "did:key:zC");
+            assert!(!delegated_any_approver_covers(
+                &not_admin,
+                &subject(Role::Reader, &["ctx-a"])
+            ));
+        }
+    }
 }
 
 #[cfg(test)]

--- a/vti-common/src/auth/step_up.rs
+++ b/vti-common/src/auth/step_up.rs
@@ -42,6 +42,14 @@ pub struct PendingStepUp {
     /// contract for the ≤TTL window after a deploy.
     #[serde(default)]
     pub approver: String,
+    /// `true` for **`delegated-any`** mode: the approve-response is authorized
+    /// not against a single bound [`Self::approver`] but against the relying
+    /// party's approver *criterion* (the issuer must be an admin covering the
+    /// subject's contexts — see `acl::delegated_any_approver_covers`).
+    /// [`Self::approver`] is empty in this mode. `#[serde(default)]` so older
+    /// records deserialize as `false` (the self/delegated single-approver path).
+    #[serde(default)]
+    pub approver_any: bool,
     /// The acr the relying party requested. The elevated session MUST reach
     /// at least this, else `acr_unsatisfied`.
     pub target_acr: String,
@@ -260,6 +268,7 @@ pub fn new_pending_step_up(
     session_id: impl Into<String>,
     subject: impl Into<String>,
     approver: impl Into<String>,
+    approver_any: bool,
     target_acr: impl Into<String>,
     acceptable_evidence: Vec<String>,
     ttl_secs: u64,
@@ -270,6 +279,7 @@ pub fn new_pending_step_up(
         session_id: session_id.into(),
         subject: subject.into(),
         approver: approver.into(),
+        approver_any,
         target_acr: target_acr.into(),
         acceptable_evidence,
         created_at,
@@ -300,6 +310,7 @@ mod tests {
             session_id: "sess-1".to_string(),
             subject: "did:key:zHolder".to_string(),
             approver: "did:key:zHolder".to_string(),
+            approver_any: false,
             target_acr: "aal2".to_string(),
             acceptable_evidence: vec!["did-signed".into(), "webauthn".into()],
             created_at: 1000,
@@ -369,6 +380,7 @@ mod tests {
             "sess-1",
             "did:key:zHolder",
             "did:key:zApprover",
+            false,
             "aal2",
             vec!["webauthn".into()],
             300,
@@ -376,6 +388,7 @@ mod tests {
         assert_eq!(p.expires_at, p.created_at + 300);
         assert_eq!(p.target_acr, "aal2");
         assert_eq!(p.approver, "did:key:zApprover");
+        assert!(!p.approver_any);
     }
 
     #[test]


### PR DESCRIPTION
Rounds out the step-up policy engine. The spec (`auth/step-up/policy/0.2` + `acl/_shared`) already defined both `delegatedAny` and the per-entry `stepUp.require` override, and `vti-common` had the `StepUpMode` model — but two **enforcement** gaps remained. This closes them. One PR, as requested.

## Gap 1 — per-entry `stepUp.require` override (was unwired)
`AclEntry` carried `step_up_approver` but no `step_up_require`, and `resolve_step_up` used only the system floor — `StepUpMode::strictest()` existed but was never called.
- Add `step_up_require: Option<StepUpMode>` to `AclEntry` (restricted to `self`|`delegated`; the op layer rejects others).
- `resolve_step_up` now composes `floor.strictest(entry.require)` (additive-only — an override may raise, never lower).
- Threaded through **every** ACL config surface (matching how `step_up_approver` was done): REST + trust-task + DIDComm bodies, `vta-sdk` `Create`/`UpdateAclRequest` (+ builder) & `AclEntryResponse`, `operations::acl` create/update + result body, `pnm`/`cnm` CLI `--step-up-require`, and the offline `vta acl update` break-glass path.

## Gap 2 — `delegatedAny` (was stubbed to behave like `delegated`)
The old code routed `delegatedAny` to the caller's single configured approver with a *"until a broader approver criterion is defined"* TODO.
- **Criterion = context-scoped admin** (your call): `acl::delegated_any_approver_covers` — a **super-admin** covers all subjects; a **context-admin** covers only subjects all of whose contexts it administers; a context-admin **never** covers a global (empty-context) subject; non-admins never qualify.
- New `RequireAny` gate decision (no single recipient). `PendingStepUp` gains `approver_any` so `handle_approve_response` authorizes the **actual issuer** against the criterion (with an expiry check) instead of one bound approver.
- The approve-request omits `recipient` under `delegatedAny` and skips the single-device proactive push (relay fallback applies).
- `lockout_check` split: a `delegated` floor still needs a configured `stepUp.approver`; a `delegatedAny` floor needs at least one admin entry to ratify.

## Tests
- `delegated_any_approver_covers`: super-admin / context-within / context-outside / global-subject / non-admin.
- `parse_step_up_require` (self/delegated only; rejects `delegated-any`/`none`/junk) + wire round-trip.
- Existing step-up unit + integration suites updated for the new field/param.

## Checks
- `cargo fmt` ✅
- `cargo clippy -p vti-common -p vta-sdk -p vta-service -p vta-cli-common -p pnm-cli -p cnm-cli --all-targets -- -D warnings` ✅
- `cargo test` (same crates) ✅ — all green
- `cargo deny check` ✅ (advisories/bans/licenses/sources ok; no new deps)

## Spec
Pairs with **dtgwg-trust-tasks-tf #84** — a prose clarification of the `approve-response/0.2` authorization rule to include the `delegatedAny` branch (rule 4 previously only covered self+delegated). No binding change, no version bump (same reasoning as #83).

Branched fresh off main, DCO-signed, no GPG.