### PR TITLE
chore(trust-tasks): remove pre-spec passkey-vms /1.0 URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Removed: pre-spec `vta/passkey-vms/*/1.0` URIs (legacy strip)
+
+The pre-spec `…/1.0` passkey-vms task URIs — kept dual-accepted alongside the
+canonical `…/0.1` during the browser plugin's migration — are removed. The
+plugin has been on `…/0.1` since vta-sdk 0.10, so the alias is no longer
+needed. A `…/1.0` document now falls through to `UnsupportedType`.
+
+- **vta-sdk**: dropped `TASK_PASSKEY_VMS_{ENROLL_CHALLENGE,ENROLL_SUBMIT,LIST,REVOKE}_1_0`
+  constants and their `ALL_URIS` entries. **Breaking** — bump at next release.
+- **vta-service**: the dispatcher matches only the `…/0.1` arms; the parity
+  harness now asserts the 0.1 URIs are dispatched.
+
 ### Built-in DID templates renamed `did-hosting-*` → `did-host-*` (capability-named)
 
 The three did-hosting built-in templates are renamed from service-named to

--- a/vta-sdk/src/protocols/did_management/passkey_vms.rs
+++ b/vta-sdk/src/protocols/did_management/passkey_vms.rs
@@ -29,7 +29,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// Trust-task payload for `spec/vta/passkey-vms/enroll-challenge/1.0`.
+/// Trust-task payload for `spec/vta/passkey-vms/enroll-challenge/0.1`.
 /// Requests a fresh WebAuthn registration challenge for a DID.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnrollPasskeyChallengeBody {
@@ -42,7 +42,7 @@ pub struct EnrollPasskeyChallengeBody {
     pub label: Option<String>,
 }
 
-/// Trust-task payload for `spec/vta/passkey-vms/list/1.0`.
+/// Trust-task payload for `spec/vta/passkey-vms/list/0.1`.
 /// Lists every passkey VM currently on a DID.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListPasskeyVmsBody {
@@ -50,7 +50,7 @@ pub struct ListPasskeyVmsBody {
     pub did: String,
 }
 
-/// Trust-task payload for `spec/vta/passkey-vms/revoke/1.0`.
+/// Trust-task payload for `spec/vta/passkey-vms/revoke/0.1`.
 /// Removes a passkey VM from a DID document via a WebVH log entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RevokePasskeyVmBody {
@@ -60,7 +60,7 @@ pub struct RevokePasskeyVmBody {
     pub fragment: String,
 }
 
-/// Trust-task payload for `spec/vta/passkey-vms/revoke/1.0` response —
+/// Trust-task payload for `spec/vta/passkey-vms/revoke/0.1` response —
 /// empty success body. Modelled as a struct so future additive fields
 /// don't bump the wire version.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -669,30 +669,6 @@ pub const TASK_PASSKEY_VMS_LIST_0_1: &str = "https://trusttasks.org/spec/vta/pas
 pub const TASK_PASSKEY_VMS_REVOKE_0_1: &str =
     "https://trusttasks.org/spec/vta/passkey-vms/revoke/0.1";
 
-/// `spec/vta/passkey-vms/enroll-challenge/1.0` — pre-spec version,
-/// retained during the plugin's migration window. Prefer
-/// [`TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1`].
-pub const TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0: &str =
-    "https://trusttasks.org/spec/vta/passkey-vms/enroll-challenge/1.0";
-
-/// `spec/vta/passkey-vms/enroll-submit/1.0` — pre-spec version,
-/// retained during the plugin's migration window. The handler appends
-/// the new VM to the DID document via a WebVH LogEntry and pushes to
-/// the configured mediator. Prefer
-/// [`TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1`].
-pub const TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0: &str =
-    "https://trusttasks.org/spec/vta/passkey-vms/enroll-submit/1.0";
-
-/// `spec/vta/passkey-vms/list/1.0` — pre-spec version, retained during
-/// the plugin's migration window. Prefer [`TASK_PASSKEY_VMS_LIST_0_1`].
-pub const TASK_PASSKEY_VMS_LIST_1_0: &str = "https://trusttasks.org/spec/vta/passkey-vms/list/1.0";
-
-/// `spec/vta/passkey-vms/revoke/1.0` — pre-spec version, retained
-/// during the plugin's migration window. Prefer
-/// [`TASK_PASSKEY_VMS_REVOKE_0_1`].
-pub const TASK_PASSKEY_VMS_REVOKE_1_0: &str =
-    "https://trusttasks.org/spec/vta/passkey-vms/revoke/1.0";
-
 // ─── Provision-integration (spec/vta/provision-integration/*) ───────────
 //
 // Feature-gated: handler requires `webvh` (DID-doc mutation + log
@@ -1129,10 +1105,6 @@ pub const ALL_URIS: &[&str] = &[
     TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1,
     TASK_PASSKEY_VMS_LIST_0_1,
     TASK_PASSKEY_VMS_REVOKE_0_1,
-    TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0,
-    TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0,
-    TASK_PASSKEY_VMS_LIST_1_0,
-    TASK_PASSKEY_VMS_REVOKE_1_0,
     // Provision-integration (feature-gated: webvh)
     TASK_PROVISION_INTEGRATION_REQUEST_1_0,
     // WebVH-DID-lifecycle slice (feature-gated: webvh)

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -132,10 +132,6 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1,
-    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0,
-    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0,
-    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_1_0,
-    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_1_0,
     // Provision-integration — requires `webvh`.
     vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_REQUEST_1_0,
     // WebVH-DID-lifecycle slice — requires `webvh`. The slice
@@ -523,27 +519,22 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         }
         // ─── Passkey-VMs slice (feature-gated: webvh + didcomm) ─────
         //
-        // Dual-accept canonical 0.1 + pre-spec 1.0 — identical payloads,
-        // so both versions share a handler and `success_response` echoes
-        // the request version into the reply (0.1 -> …/0.1#response).
+        // Canonical 0.1 only — the pre-spec 1.0 aliases were removed (the
+        // browser plugin migrated to 0.1; a 1.0 doc now gets UnsupportedType).
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
-        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1
-        | vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0 => {
+        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1 => {
             passkey_vms::handle_enroll_challenge(state, auth, doc).await
         }
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
-        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1
-        | vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0 => {
+        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1 => {
             passkey_vms::handle_enroll_submit(state, auth, doc).await
         }
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
-        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1
-        | vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_1_0 => {
+        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1 => {
             passkey_vms::handle_list(state, auth, doc).await
         }
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
-        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1
-        | vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_1_0 => {
+        vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1 => {
             passkey_vms::handle_revoke(state, auth, doc).await
         }
         // ─── Provision-integration (feature-gated: webvh) ────────────
@@ -732,39 +723,21 @@ mod tests {
         }
     }
 
-    /// Passkey-VMs dual-accept (#309): the canonical `…/0.1` URIs and
-    /// the retained pre-spec `…/1.0` URIs are both tracked by the
-    /// dispatcher, so a client on either version routes to the same
-    /// handler. `success_response` echoes the request type, so a 0.1
-    /// request replies `…/0.1#response`.
+    /// Passkey-VMs: the canonical `…/0.1` URIs are dispatched. The pre-spec
+    /// `…/1.0` aliases were removed (the browser plugin migrated to 0.1), so a
+    /// 1.0 document now falls through to `UnsupportedType`.
     #[test]
-    fn passkey_vms_dual_accepts_0_1_and_1_0() {
+    fn passkey_vms_0_1_dispatched() {
         let dispatched = aggregate_dispatched_uris();
         let tracked = |u: &&str| dispatched.contains(u) || KNOWN_FEATURE_GATED_URIS.contains(u);
-        for (v0_1, v1_0) in [
-            (
-                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1,
-                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0,
-            ),
-            (
-                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1,
-                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0,
-            ),
-            (
-                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
-                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_1_0,
-            ),
-            (
-                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1,
-                vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_1_0,
-            ),
+        for v0_1 in [
+            vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1,
+            vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1,
+            vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
+            vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1,
         ] {
             assert!(tracked(&v0_1), "canonical 0.1 URI not dispatched: {v0_1}");
-            assert!(tracked(&v1_0), "retained 1.0 URI not dispatched: {v1_0}");
-            assert!(
-                v0_1.ends_with("/0.1") && v1_0.ends_with("/1.0"),
-                "version-label mismatch for {v0_1} / {v1_0}"
-            );
+            assert!(v0_1.ends_with("/0.1"), "version-label mismatch for {v0_1}");
         }
     }
 

--- a/vta-service/src/routes/trust_tasks/passkey_vms.rs
+++ b/vta-service/src/routes/trust_tasks/passkey_vms.rs
@@ -106,19 +106,14 @@ fn passkey_vm_reject(doc: &TrustTask<Value>, err: PasskeyVmError) -> Response {
 /// `docs/05-design-notes/trust-task-feature-gating.md`.
 #[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
 pub(super) const DISPATCHED_URIS: &[&str] = &[
-    // Canonical 0.1 + retained pre-spec 1.0 (dual-accept; identical
-    // payloads, reply echoes the request version).
+    // Canonical 0.1 only — the pre-spec 1.0 aliases were removed.
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_0_1,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1,
-    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_1_0,
-    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_SUBMIT_1_0,
-    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_1_0,
-    vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_1_0,
 ];
 
-/// Handler for `spec/vta/passkey-vms/enroll-challenge/1.0`. Admin only
+/// Handler for `spec/vta/passkey-vms/enroll-challenge/0.1`. Admin only
 /// (enforced by the operation function).
 pub(super) async fn handle_enroll_challenge(
     state: &AppState,
@@ -145,7 +140,7 @@ pub(super) async fn handle_enroll_challenge(
     }
 }
 
-/// Handler for `spec/vta/passkey-vms/enroll-submit/1.0`. Admin only
+/// Handler for `spec/vta/passkey-vms/enroll-submit/0.1`. Admin only
 /// (enforced by the operation function). Appends the new VM to the
 /// DID document via a WebVH LogEntry; pushes the update to the
 /// configured mediator.
@@ -193,7 +188,7 @@ pub(super) async fn handle_enroll_submit(
     }
 }
 
-/// Handler for `spec/vta/passkey-vms/list/1.0`. Admin only (enforced
+/// Handler for `spec/vta/passkey-vms/list/0.1`. Admin only (enforced
 /// by the operation function).
 pub(super) async fn handle_list(
     state: &AppState,
@@ -210,7 +205,7 @@ pub(super) async fn handle_list(
     }
 }
 
-/// Handler for `spec/vta/passkey-vms/revoke/1.0`. Admin only (enforced
+/// Handler for `spec/vta/passkey-vms/revoke/0.1`. Admin only (enforced
 /// by the operation function). Removes the VM via a WebVH LogEntry
 /// and pushes the update to the mediator.
 pub(super) async fn handle_revoke(
@@ -343,7 +338,7 @@ mod tests {
                 "vta/passkey-vms/revoke",
             ),
             (
-                "https://trusttasks.org/spec/vta/passkey-vms/enroll-submit/1.0",
+                "https://trusttasks.org/spec/vta/passkey-vms/enroll-submit/0.1",
                 "vta/passkey-vms/enroll-submit",
             ),
         ] {


### PR DESCRIPTION
First of the legacy-API strips. Removes the **pre-spec `vta/passkey-vms/*/1.0`** task URIs that were dual-accepted alongside canonical `…/0.1` during the browser plugin's migration.

## Why it's safe now
The `…/1.0` URIs predate the published spec; the only client that ever used them is `pnm-browser-plugin`, which has been on `…/0.1` since vta-sdk 0.10. Confirmed: the browser plugin has **no** `/1.0` references. So the alias is dead.

## Changes
- **vta-sdk**: dropped `TASK_PASSKEY_VMS_{ENROLL_CHALLENGE,ENROLL_SUBMIT,LIST,REVOKE}_1_0` constants + their `ALL_URIS` entries. **Breaking** (removed public consts) → minor bump at next release.
- **vta-service**: dispatcher matches only the `…/0.1` arms; `DISPATCHED_URIS` + `KNOWN_FEATURE_GATED_URIS` trimmed; the dual-accept parity test rewritten to `passkey_vms_0_1_dispatched` (a `…/1.0` doc now → `UnsupportedType`). Stale `/1.0` doc comments corrected.

## Verification
- `cargo fmt` · `cargo clippy -p vta-sdk -p vta-service --all-targets -- -D warnings` ✅
- `cargo test -p vta-sdk -p vta-service` ✅ (incl. the dispatcher parity harness)

## Versioning
Code-only (no Cargo.toml bump) — matching this repo's convention of bumping in a dedicated release PR. CHANGELOG `[Unreleased]` notes the breaking removal; the next vta-sdk release is a **minor** bump.

Part of the legacy-strip series; next up: `atm/1.0` auth aliases, DID-template name aliases, `pnm webvh` CLI alias (separate PRs).