### PR TITLE
chore(auth): remove legacy affinidi.com/atm/1.0 auth aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Removed: legacy `affinidi.com/atm/1.0` auth aliases (legacy strip)
+
+The VTA's DIDComm auth path no longer accepts the legacy
+`affinidi.com/atm/1.0/authenticate` and `…/authenticate/refresh` message
+types — only the canonical `auth/authenticate/0.1` / `auth/refresh/0.1`
+Trust-Task URIs. In the same change the **vta-sdk** DIDComm auth path
+(`session.rs`, `auth_light.rs`) now *emits* the canonical types, so SDK
+clients move to canonical automatically.
+
+- **Deployment note (breaking):** a client still on the pre-canonical SDK
+  (emitting `atm/1.0`) fails auth against an upgraded VTA with
+  `unexpected message type`. Roll clients onto this SDK with/before the VTA.
+- **Follow-up:** `vtc-service` still dual-accepts `atm/1.0` (incl. its SIOP
+  envelope path); the SDK switch doesn't break it. Its `atm/1.0` removal is a
+  separate change (its SIOP path may have other clients).
+
 ### Removed: pre-spec `vta/passkey-vms/*/1.0` URIs (legacy strip)
 
 The pre-spec `…/1.0` passkey-vms task URIs — kept dual-accepted alongside the

--- a/vta-sdk/src/auth_light.rs
+++ b/vta-sdk/src/auth_light.rs
@@ -58,7 +58,7 @@ pub async fn challenge_response_light(
     // is async because `did:webvh` VTAs require an HTTP fetch + chain
     // verification; for `did:key:` VTAs the future resolves without I/O.
     let packed = didcomm_light::pack_auth_message(
-        "https://affinidi.com/atm/1.0/authenticate",
+        crate::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1,
         serde_json::json!({
             "challenge": challenge.challenge,
             "session_id": challenge.session_id,
@@ -119,7 +119,7 @@ pub async fn refresh_token_light(
     refresh_token: &str,
 ) -> Result<AuthResult, crate::error::VtaError> {
     let packed = didcomm_light::pack_auth_message(
-        "https://affinidi.com/atm/1.0/authenticate/refresh",
+        crate::trust_tasks::TASK_AUTH_REFRESH_0_1,
         serde_json::json!({
             "refresh_token": refresh_token,
         }),

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -951,7 +951,7 @@ pub async fn challenge_response(
     );
     let msg = Message::build(
         uuid::Uuid::new_v4().to_string(),
-        "https://affinidi.com/atm/1.0/authenticate".to_string(),
+        crate::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1.to_string(),
         serde_json::json!({
             "challenge": challenge.challenge,
             "session_id": challenge.session_id,

--- a/vta-service/src/routes/auth.rs
+++ b/vta-service/src/routes/auth.rs
@@ -161,17 +161,10 @@ pub async fn authenticate(
         .await
         .map_err(|e| AppError::Authentication(format!("failed to unpack message: {e}")))?;
 
-    // Accept both the legacy `affinidi.com/atm/1.0/authenticate`
-    // alias and the canonical
-    // `trusttasks.org/spec/auth/authenticate/0.1` Trust-Task URI.
-    // Closes L4 from the May 2026 security review during the
-    // canonical-task migration window. Drop the legacy alias one
-    // minor release after every client upgrades.
-    if !matches!(
-        msg.typ.as_str(),
-        "https://affinidi.com/atm/1.0/authenticate"
-            | "https://trusttasks.org/spec/auth/authenticate/0.1"
-    ) {
+    // Canonical Trust-Task URI only. The legacy
+    // `affinidi.com/atm/1.0/authenticate` alias was removed once the SDK's
+    // DIDComm auth path switched to emitting `auth/authenticate/0.1`.
+    if msg.typ.as_str() != "https://trusttasks.org/spec/auth/authenticate/0.1" {
         return Err(AppError::Authentication(format!(
             "unexpected message type: {}",
             msg.typ
@@ -358,11 +351,9 @@ pub async fn refresh(State(state): State<AppState>, body: String) -> Result<Resp
         .await
         .map_err(|e| AppError::Authentication(format!("failed to unpack message: {e}")))?;
 
-    if !matches!(
-        msg.typ.as_str(),
-        "https://affinidi.com/atm/1.0/authenticate/refresh"
-            | "https://trusttasks.org/spec/auth/refresh/0.1"
-    ) {
+    // Canonical Trust-Task URI only; the legacy
+    // `affinidi.com/atm/1.0/authenticate/refresh` alias was removed.
+    if msg.typ.as_str() != "https://trusttasks.org/spec/auth/refresh/0.1" {
         return Err(AppError::Authentication(format!(
             "unexpected message type: {}",
             msg.typ


### PR DESCRIPTION
Second legacy strip. Removes the legacy **`affinidi.com/atm/1.0`** DIDComm auth message-type aliases.

## What
The VTA dual-accepted `atm/1.0/{authenticate,authenticate/refresh}` alongside canonical `auth/{authenticate,refresh}/0.1`, and the **vta-sdk** DIDComm auth path still *emitted* `atm/1.0`. This:
- **vta-sdk** (`session.rs`, `auth_light.rs`): builds the authenticate/refresh DIDComm messages with the canonical `TASK_AUTH_AUTHENTICATE_0_1` / `TASK_AUTH_REFRESH_0_1` types.
- **vta-service** (`routes/auth.rs`): the authenticate + refresh handlers accept only the canonical URI; the `atm/1.0` arm is gone.

## Deployment ordering ⚠️ (you chose full-strip-now)
This is breaking by rollout order: a client still on the **pre-canonical SDK** (emitting `atm/1.0`) gets `unexpected message type` against an upgraded VTA. **Roll clients onto this SDK with/before the VTA upgrade.** (Recoverable — upgrade the client.)

## Scope + a deliberate follow-up
Scoped to **vta-sdk + vta-service**, which build/test fully here.
- **vtc-service** also dual-accepts `atm/1.0` (DIDComm auth **and** a separate SIOP `id_token` envelope path). The SDK switch does **not** break it (it already accepts canonical). I left its `atm/1.0` removal as a follow-up because (a) vtc-service's build script doesn't run in my sandbox so I can't verify it here, and (b) its SIOP path may have its own (non-vta-sdk) clients worth checking first. Flagged in CHANGELOG.

## Verification
- `cargo clippy -p vta-sdk -p vta-service --all-targets -- -D warnings` ✅
- `cargo test -p vta-sdk -p vta-service` ✅
Code-only (release PR bumps versions); CHANGELOG `[Unreleased]` records the breaking removal + deployment note.

Series: ~~passkey-vms /1.0 (#330)~~ · this · next: DID-template name aliases · `pnm webvh` CLI alias.