### PR TITLE
chore(pnm): remove deprecated 'pnm webvh' CLI alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Removed: `pnm webvh …` CLI alias (legacy strip)
+
+The hidden `pnm webvh …` command alias (superseded by `pnm did-mgmt {servers,dids} …`)
+is removed — invoking it now errors as an unknown command. The internal
+`WebvhCommands` dispatch type stays; the new `did-mgmt` surface still converts
+into it (`DidMgmtCommands → WebvhCommands → commands::webvh::run`), so the
+command implementations are unchanged. Stale `pnm webvh …` hints in operator
+output / `--help` updated to the `pnm did-mgmt …` forms.
+
 ### Removed: legacy DID-template name aliases `webvh-*` / `did-hosting-*` (legacy strip)
 
 Both prior template-name generations are dropped; only the capability-named

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -159,15 +159,6 @@ pub(crate) enum Commands {
         command: DidMgmtCommands,
     },
 
-    /// DEPRECATED — renamed to `pnm did-mgmt <subcommand>`. Still
-    /// dispatched for one release; switch your scripts before the
-    /// alias is removed in the next minor.
-    #[command(hide = true)]
-    Webvh {
-        #[command(subcommand)]
-        command: WebvhCommands,
-    },
-
     /// Audit log management
     Audit {
         #[command(subcommand)]
@@ -711,7 +702,7 @@ pub(crate) enum WebvhCommands {
         /// The serverless WebVH DID to promote.
         #[arg(long)]
         did: String,
-        /// Registered server id (from `pnm webvh add-server`).
+        /// Registered server id (from `pnm did-mgmt servers add`).
         #[arg(long)]
         server: String,
         /// Take over a slot owned by a different DID. Honoured only
@@ -735,7 +726,7 @@ pub(crate) enum WebvhCommands {
     /// create-did` / `register-did` before the first call. The
     /// system default is flagged with `(default)`.
     ListDomains {
-        /// Registered server id (from `pnm webvh add-server`).
+        /// Registered server id (from `pnm did-mgmt servers add`).
         #[arg(long)]
         server: String,
     },

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -256,15 +256,6 @@ async fn main() {
             commands::auth_credential::run(&client, command).await
         }
         Commands::DidMgmt { command } => commands::webvh::run(&client, command.into()).await,
-        Commands::Webvh { command } => {
-            eprintln!(
-                "\x1b[1;33mwarning:\x1b[0m `pnm webvh …` has been renamed to \
-                 `pnm did-mgmt {{servers,dids}} …`. The old name is accepted for \
-                 one release and will be removed in the next minor. \
-                 See `pnm did-mgmt --help`."
-            );
-            commands::webvh::run(&client, command).await
-        }
         Commands::Audit { command } => commands::audit::run(&client, command).await,
         Commands::Backup { command } => commands::backup::run(&client, command).await,
         Commands::Keys { command } => commands::keys::run(&client, command).await,

--- a/vta-cli-common/src/commands/services.rs
+++ b/vta-cli-common/src/commands/services.rs
@@ -387,7 +387,7 @@ pub fn print_serverless_hint(serverless: bool, vta_did: &str) {
     }
     println!();
     println!("  This VTA's DID is self-hosted. Fetch the updated log:");
-    println!("    pnm webvh did-log {vta_did} --out did.jsonl");
+    println!("    pnm did-mgmt dids get-log {vta_did} --out did.jsonl");
     println!("  then redeploy did.jsonl to your host. Until you do,");
     println!("  resolvers will keep returning the prior version.");
 }

--- a/vta-cli-common/src/commands/webvh_edit.rs
+++ b/vta-cli-common/src/commands/webvh_edit.rs
@@ -39,7 +39,7 @@ pub enum EditFlowError {
         "the edited document changed the DID identifier (`{prior}` → `{edited}`). \
          The DID id is a permanent commitment from the first LogEntry; mutating it \
          would invalidate every existing reference to the DID. Re-run the editor \
-         with the original `id` restored, or use `pnm webvh create-did` to mint a \
+         with the original `id` restored, or use `pnm did-mgmt dids create` to mint a \
          new DID instead."
     )]
     DidIdChanged { prior: String, edited: String },


### PR DESCRIPTION
Final legacy strip in the series. Removes the hidden **`pnm webvh …`** command alias (superseded by `pnm did-mgmt {servers,dids} …`).

## What
- `pnm-cli/src/cli.rs`: removed the `Commands::Webvh` clap variant.
- `pnm-cli/src/main.rs`: removed its dispatch arm (the one that printed a yellow deprecation note and forwarded). `pnm webvh …` now errors as an unknown command.
- Updated the remaining user-facing `pnm webvh …` references to `pnm did-mgmt …`: a printed recovery hint (`services.rs`), an edit-DID error message (`webvh_edit.rs`), and two clap `--help` strings (`cli.rs`).

## Kept on purpose
The internal `WebvhCommands` enum and `commands::webvh::run` **stay** — the new `did-mgmt` surface converts into them (`DidMgmtCommands → WebvhCommands → commands::webvh::run`), so they're the live dispatch backbone, not dead alias code. Command behaviour is unchanged; only the old *name* is gone.

## Verification
- `cargo clippy -p pnm-cli -p cnm-cli -p vta-cli-common --all-targets -- -D warnings` ✅
- `cargo test -p pnm-cli -p cnm-cli -p vta-cli-common` ✅

Completes the legacy-strip series: ~~passkey-vms /1.0 (#330)~~ · ~~atm/1.0 (#331)~~ · ~~template name aliases (#332)~~ · this.