### PR TITLE
chore(vtc): remove legacy affinidi.com/atm/1.0 auth aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Removed: vtc-service legacy `affinidi.com/atm/1.0` auth aliases (legacy strip)
+
+Completes the `atm/1.0` removal across both services (the VTA side landed
+earlier). `vtc-service/routes/auth.rs` now accepts only the canonical
+`auth/authenticate/0.1` / `auth/refresh/0.1` types — on the DIDComm
+authenticate + refresh paths **and** the SIOP `id_token` envelope path. All
+VTC clients already emit canonical: the browser plugin's SIOP login client
+(`siop/login-client.ts`) and vta-sdk / cnm-cli DIDComm auth.
+
 ### Removed: `pnm webvh …` CLI alias (legacy strip)
 
 The hidden `pnm webvh …` command alias (superseded by `pnm did-mgmt {servers,dids} …`)

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -98,11 +98,8 @@ async fn authenticate_siop(
     let Ok(env) = serde_json::from_str::<SiopAuthEnvelope>(body) else {
         return Ok(None);
     };
-    if !matches!(
-        env.typ.as_str(),
-        "https://affinidi.com/atm/1.0/authenticate"
-            | "https://trusttasks.org/spec/auth/authenticate/0.1"
-    ) || env.payload.id_token.is_empty()
+    if env.typ.as_str() != "https://trusttasks.org/spec/auth/authenticate/0.1"
+        || env.payload.id_token.is_empty()
     {
         return Ok(None);
     }
@@ -218,12 +215,9 @@ async fn authenticate_and_mint(
         .await
         .map_err(|e| AppError::Authentication(format!("failed to unpack message: {e}")))?;
 
-    // L4: accept both legacy and canonical Trust-Task URIs.
-    if !matches!(
-        msg.typ.as_str(),
-        "https://affinidi.com/atm/1.0/authenticate"
-            | "https://trusttasks.org/spec/auth/authenticate/0.1"
-    ) {
+    // Canonical Trust-Task URI only; the legacy `affinidi.com/atm/1.0`
+    // alias was removed (all VTC clients emit the canonical type).
+    if msg.typ.as_str() != "https://trusttasks.org/spec/auth/authenticate/0.1" {
         return Err(AppError::Authentication(format!(
             "unexpected message type: {}",
             msg.typ
@@ -720,11 +714,9 @@ pub async fn refresh(
         .await
         .map_err(|e| AppError::Authentication(format!("failed to unpack message: {e}")))?;
 
-    if !matches!(
-        msg.typ.as_str(),
-        "https://affinidi.com/atm/1.0/authenticate/refresh"
-            | "https://trusttasks.org/spec/auth/refresh/0.1"
-    ) {
+    // Canonical Trust-Task URI only; the legacy
+    // `affinidi.com/atm/1.0/authenticate/refresh` alias was removed.
+    if msg.typ.as_str() != "https://trusttasks.org/spec/auth/refresh/0.1" {
         return Err(AppError::Authentication(format!(
             "unexpected message type: {}",
             msg.typ


### PR DESCRIPTION
Completes the `atm/1.0` strip across **both** services — the VTA side landed in #331; this is the VTC half.

## What
`vtc-service/routes/auth.rs` now accepts only canonical `auth/authenticate/0.1` / `auth/refresh/0.1` at all three `atm/1.0` sites:
- DIDComm authenticate (line ~224)
- DIDComm refresh (line ~725)
- **SIOP `id_token` envelope** path (`authenticate_siop`, line ~103)

## Why it's safe (the thing I checked)
All VTC clients already emit canonical:
- **SIOP** — the browser plugin's `siop/login-client.ts` sends `TASK_AUTH_AUTHENTICATE = auth/authenticate/0.1` (verified). VTC's SIOP `atm/1.0` alias was already dead.
- **DIDComm authenticate/refresh** — vta-sdk / cnm-cli, canonical since the SDK switch (#331).

The browser plugin's *other* (VTA-targeting) authcrypt path still on `atm/1.0` is being fixed separately in **vta-browser-plugin#70** — it doesn't reach VTC, so it's orthogonal here.

## Verification
vtc-service's `build.rs` needs the admin-UI SPA; using the documented dev flag:
- `VTC_SKIP_ADMIN_UI_BUILD=1 cargo clippy -p vtc-service --all-targets -- -D warnings` ✅
- `VTC_SKIP_ADMIN_UI_BUILD=1 cargo test -p vtc-service` ✅ (all suites)

Code-only; minor bump at the release PR. CHANGELOG `[Unreleased]` updated.