### PR TITLE
chore(release): bump VTI crates for delegatedAny + step-up + legacy strips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+### Version bumps — delegatedAny + step-up + legacy-strip release
+
+Cuts the publish boundary for the accumulated breaking work documented below
+(delegatedAny + per-entry `stepUp.require`; the `atm/1.0`, passkey-vms `/1.0`,
+DID-template name-alias, and `pnm webvh` strips). Each is breaking — removed
+public API or message-type acceptance — so every changed crate takes a **minor**
+bump (each lands at exactly +1 minor over its published baseline):
+
+- `vta-sdk` 0.10.0 → **0.11.0** — dropped the deprecated passkey-vms `/1.0` and
+  `BUILTIN_{WEBVH,DID_HOSTING}_*` consts + `ProvisionAsk::{webvh,did_hosting}_*`
+  builders; DIDComm auth emits canonical `auth/{authenticate,refresh}/0.1`;
+  `acl` request/response types gain `step_up_require`.
+- `vti-common` 0.9.1 → **0.10.0** — `AclEntry.step_up_require` +
+  `delegated_any_approver_covers`; `new_pending_step_up` gained `approver_any`.
+- `vta-cli-common` 0.8.2 → **0.9.0** — `cmd_acl_{create,update}` gained a
+  `step_up_require` parameter.
+- `vta-service` **0.9.0** (publishes over 0.8.1) — delegatedAny + per-entry
+  override enforcement; `atm/1.0` and passkey-vms `/1.0` acceptance dropped.
+- `vtc-service` 0.8.1 → **0.9.0** — `atm/1.0` (DIDComm + SIOP) acceptance dropped.
+- `pnm-cli` / `cnm-cli` 0.8.1 → **0.9.0** — `--step-up-require` flag; the
+  `pnm webvh` alias removed.
+
+Internal `major.minor` pins updated across the workspace; the non-published
+consumers (`vta-mobile-core`, `didcomm-test`, `vta-enclave`) had their pins
+bumped to match. Publish order: `vta-sdk` → `vti-common` → `vta-cli-common`
+→ `vta-service` / `vtc-service` → `pnm-cli` / `cnm-cli`.
+
 ### Removed: vtc-service legacy `affinidi.com/atm/1.0` auth aliases (legacy strip)
 
 Completes the `atm/1.0` removal across both services (the VTA side landed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2339,7 +2339,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.0",
 ]
 
 [[package]]
@@ -3119,7 +3119,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.0",
 ]
 
 [[package]]
@@ -6480,7 +6480,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6502,7 +6502,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.0",
 ]
 
 [[package]]
@@ -9704,7 +9704,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9722,7 +9722,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.0",
  "x25519-dalek",
 ]
 
@@ -9761,7 +9761,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.0",
 ]
 
 [[package]]
@@ -9796,7 +9796,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9923,7 +9923,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.0",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9936,7 +9936,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10005,7 +10005,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.0",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -10015,7 +10015,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -10048,7 +10048,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10075,7 +10075,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.0",
  "vta-service",
  "vti-common",
 ]

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.8.1"
+version = "0.9.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["session"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.8" }
+vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["session"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.8.1"
+version = "0.9.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,12 +21,12 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
-vta-cli-common = { path = "../vta-cli-common", version = "0.8" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.8.2"
+version = "0.9.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.10", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.11", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -28,7 +28,7 @@ vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
 vta-service = { path = "../vta-service", version = "0.9", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.9", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.10", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -61,7 +61,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["session"] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -73,8 +73,8 @@ path = "src/main.rs"
 required-features = ["cli-synthesis"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.9", features = ["encryption", "passkey"] }
-vta-sdk = { path = "../vta-sdk", version = "0.10", features = ["didcomm", "sealed-transfer", "provision-integration"] }
+vti-common = { path = "../vti-common", version = "0.10", features = ["encryption", "passkey"] }
+vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["didcomm", "sealed-transfer", "provision-integration"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -94,7 +94,7 @@ trust-tasks-proof = { workspace = true }
 # generation, bundle opening). Used by `vta bootstrap request` /
 # `vta bootstrap open` so cold-start clients can run the offline flow
 # without depending on `pnm`.
-vta-cli-common = { path = "../vta-cli-common", version = "0.8" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
 affinidi-crypto = { workspace = true }
 # Low-level `Secret` type for loading the VTA's signing key at
 # provision time. Already transitively present via affinidi-tdk; made

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.8.1"
+version = "0.9.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -62,13 +62,13 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.9", features = [
+vti-common = { path = "../vti-common", version = "0.10", features = [
   "passkey",
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.
   "setup",
 ] }
-vta-sdk = { path = "../vta-sdk", version = "0.10", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.11", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -43,7 +43,7 @@ setup = ["dep:dialoguer"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.10", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.11", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }


### PR DESCRIPTION
Cuts the publish boundary for everything merged since the last release. **No code changes** — only crate versions, internal pins, `Cargo.lock`, and CHANGELOG.

## What's being released
- delegatedAny + per-entry `stepUp.require` (#329)
- legacy strips: passkey-vms `/1.0` (#330), `atm/1.0` auth (#331/#334), DID-template name aliases (#332), `pnm webvh` CLI (#333)

All breaking (removed public API / message-type acceptance) → **minor** bumps, each landing exactly +1 minor over its published baseline:

| crate | published | → |
|---|---|---|
| vta-sdk | 0.10.0 | **0.11.0** |
| vti-common | 0.9.1 | **0.10.0** |
| vta-cli-common | 0.8.1 | **0.9.0** |
| vta-service | 0.8.1 | **0.9.0** |
| vtc-service | 0.8.0 | **0.9.0** |
| pnm-cli / cnm-cli | 0.8.0 | **0.9.0** |

Internal `major.minor` pins updated workspace-wide (8× vta-sdk→0.11, 3× vti-common→0.10, 3× vta-cli-common→0.9). Non-published consumers (`vta-mobile-core`, `didcomm-test`, `vta-enclave`) had their pins bumped so the workspace still resolves; their own versions are unchanged (separate release cadence).

## Verification
- `VTC_SKIP_ADMIN_UI_BUILD=1 cargo check --workspace` ✅ (all pins resolve)
- `cargo deny check` ✅ (advisories/bans/licenses/sources ok — no dep-graph change)

## Publish (your manual step, after merge)
Order: `vta-sdk` → `vti-common` → `vta-cli-common` → `vta-service` / `vtc-service` → `pnm-cli` / `cnm-cli`.

⚠️ Deployment note (from #331): roll the browser plugin (vta-browser-plugin#70, merged) and any pnm/cnm clients onto these versions **with/before** the VTA, or their `atm/1.0` auth fails against the upgraded service.

`vta-mobile-core` now compiles against vta-sdk 0.11 — a fresh `vta-mobile-core` engine release (xcframework) is a separate follow-up if you want the iOS app on the new SDK.