### PR TITLE
feat: DIDComm status endpoint + PNM health mediator discovery

### DIFF
--- a/cnm-cli/src/auth.rs
+++ b/cnm-cli/src/auth.rs
@@ -120,5 +120,5 @@ pub async fn connect(
     url_override: Option<&str>,
     keyring_key: &str,
 ) -> Result<vta_sdk::client::VtaClient, Box<dyn std::error::Error>> {
-    store().connect(keyring_key, url_override).await
+    store().connect(keyring_key, url_override, None).await
 }

--- a/docs/02-vta/runtime-service-management.md
+++ b/docs/02-vta/runtime-service-management.md
@@ -65,6 +65,26 @@ nature (DIDComm isn't running yet at first-enable).
 | Show in-flight drain entries | `pnm services didcomm drain list` |
 | Per-mediator traffic + sender attribution | `pnm services report [--since <rfc3339>] [--until <rfc3339>] [--format json|table]` |
 
+#### DIDComm status endpoint (`GET /services/didcomm`)
+
+`pnm services list` reports the advertised service array from the VTA's
+DID document. For DID methods with no resolvable service block (e.g.
+`did:key`), the mediator can't be discovered that way, so the VTA also
+exposes `GET /services/didcomm`, returning `{ enabled, mediator_did,
+websocket_status }` straight from runtime config. `pnm health` falls back
+to it to discover the mediator DID for those methods. Like every operation
+here, it is **super-admin** gated — parity with `pnm services list`, which
+exposes the same `mediator_did`.
+
+> **Caveat — `websocket_status` is server-path-only.** The live mediator
+> connection state (`connected` / `connecting` / `disconnected`) is tracked
+> only on the axum server path (`run()`). TEE / Nitro-Enclave front-ends
+> build their `AppState` via `build_app_state()`, which never wires the
+> listener event logger, so `websocket_status` there always reports
+> `disconnected` even when the mediator connection is healthy. Treat the
+> field as authoritative only on non-TEE deployments; use `enabled` +
+> `mediator_did` for configuration discovery on all deployments.
+
 ### Mutate REST
 
 | Task | Command |

--- a/pnm-cli/src/auth.rs
+++ b/pnm-cli/src/auth.rs
@@ -194,13 +194,19 @@ pub async fn show_token(keyring_key: &str) -> Result<(), Box<dyn std::error::Err
 
 /// Connect to the VTA using the preferred transport (DIDComm or REST).
 ///
-/// If `url_override` is provided, always uses REST.
-/// Otherwise resolves the VTA DID and prefers DIDComm when available.
+/// Transport selection priority:
+/// 1. `mediator_did_hint` from config → DIDComm (pinned).
+/// 2. VTA DID doc DIDCommMessaging service → DIDComm (resolved).
+/// 3. `url_override` + REST discovery → DIDComm if available.
+/// 4. `url_override` → REST-only fallback.
 pub async fn connect(
     url_override: Option<&str>,
+    mediator_did_hint: Option<&str>,
     keyring_key: &str,
 ) -> Result<vta_sdk::client::VtaClient, Box<dyn std::error::Error>> {
-    store().connect(keyring_key, url_override).await
+    store()
+        .connect(keyring_key, url_override, mediator_did_hint)
+        .await
 }
 
 #[cfg(test)]

--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -360,6 +360,7 @@ pub async fn run_connect(
             name: slug.clone(),
             vta_did: Some(credential.vta_did.clone()),
             url: None,
+            mediator_did: None,
         },
     );
     if pnm_config.default_vta.is_none() {

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -214,6 +214,11 @@ pub(crate) enum SetupCommands {
         /// VTA REST URL (required for did:key DIDs that cannot advertise a service endpoint).
         #[arg(long)]
         vta_url: Option<String>,
+
+        /// Mediator DID for DIDComm transport. When set, PNM uses DIDComm
+        /// without needing to discover the mediator from the DID doc or REST.
+        #[arg(long)]
+        mediator_did: Option<String>,
     },
 }
 

--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -181,9 +181,39 @@ pub(crate) async fn run(
             vta_sdk::session::resolve_mediator_did(vta_did).await
         };
 
+        let mediator_result = match mediator_result {
+            Ok(Some(mediator_did)) => Ok(Some((mediator_did, false))),
+            Ok(None) => {
+                // DID document has no DIDCommMessaging service (e.g. did:key).
+                // Fallback: query VTA's REST status endpoint for mediator info.
+                if let Some(url) = effective_rest_url.as_deref() {
+                    match auth::ensure_authenticated(url, keyring_key).await {
+                        Ok(token) => {
+                            let client = VtaClient::new(url);
+                            client.set_token_async(token).await;
+                            match client.didcomm_status().await {
+                                Ok(status) if status.enabled => {
+                                    Ok(status.mediator_did.map(|did| (did, true)))
+                                }
+                                Ok(_) => Ok(None),
+                                Err(_) => Ok(None),
+                            }
+                        }
+                        Err(_) => Ok(None),
+                    }
+                } else {
+                    Ok(None)
+                }
+            }
+            Err(e) => Err(e),
+        };
+
         match mediator_result {
-            Ok(Some(mediator_did)) => {
+            Ok(Some((mediator_did, via_status_endpoint))) => {
                 println!("  {CYAN}{:<13}{RESET} {mediator_did}", "DID");
+                if via_status_endpoint {
+                    println!("                {DIM}discovered via /services/didcomm{RESET}");
+                }
 
                 // Resolve mediator DID document (uses cached resolver)
                 if let Some(ref resolver) = did_resolver {

--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -196,10 +196,16 @@ pub(crate) async fn run(
                                     Ok(status.mediator_did.map(|did| (did, true)))
                                 }
                                 Ok(_) => Ok(None),
-                                Err(_) => Ok(None),
+                                Err(e) => {
+                                    println!("  {DIM}(status check failed: {e}){RESET}");
+                                    Ok(None)
+                                }
                             }
                         }
-                        Err(_) => Ok(None),
+                        Err(e) => {
+                            println!("  {DIM}(auth for status check failed: {e}){RESET}");
+                            Ok(None)
+                        }
                     }
                 } else {
                     Ok(None)

--- a/pnm-cli/src/commands/setup.rs
+++ b/pnm-cli/src/commands/setup.rs
@@ -29,6 +29,7 @@ pub(crate) async fn run(
                 slug,
                 vta_did: Some(vta_did),
                 vta_url,
+                mediator_did,
             }),
             None,
         ) => {
@@ -37,6 +38,7 @@ pub(crate) async fn run(
                 &slug,
                 &vta_did,
                 vta_url.as_deref(),
+                mediator_did.as_deref(),
             )
             .await
         }

--- a/pnm-cli/src/config.rs
+++ b/pnm-cli/src/config.rs
@@ -35,6 +35,11 @@ pub struct VtaConfig {
     /// from the DID document.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// Explicit mediator DID for DIDComm transport. When set, PNM uses
+    /// DIDComm without needing to discover the mediator from the DID doc
+    /// or REST endpoint. Useful for did:key VTAs or airgapped setups.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mediator_did: Option<String>,
 }
 
 /// Returns `~/.config/pnm/`, creating it if it doesn't exist.
@@ -76,6 +81,7 @@ pub fn load_config() -> Result<PnmConfig, Box<dyn std::error::Error>> {
                 name: "Default VTA".to_string(),
                 vta_did: None,
                 url: None,
+                mediator_did: None,
             },
         );
         config.default_vta = Some("default".to_string());
@@ -178,6 +184,7 @@ mod tests {
                 name: "Personal VTA".into(),
                 vta_did: Some("did:web:vta.example.com".into()),
                 url: None,
+                mediator_did: None,
             },
         );
         config.vtas.insert(
@@ -186,6 +193,7 @@ mod tests {
                 name: "Work VTA".into(),
                 vta_did: Some("did:webvh:abc:work.example.com:vta".into()),
                 url: None,
+                mediator_did: None,
             },
         );
 
@@ -255,6 +263,7 @@ vta_did = "did:web:vta.example.com"
                 name: "Personal".into(),
                 vta_did: None,
                 url: None,
+                mediator_did: None,
             },
         );
         let (slug, vta) = resolve_vta(Some("personal"), &config).unwrap();
@@ -274,6 +283,7 @@ vta_did = "did:web:vta.example.com"
                 name: "Work".into(),
                 vta_did: None,
                 url: None,
+                mediator_did: None,
             },
         );
         let (slug, _) = resolve_vta(None, &config).unwrap();

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -212,9 +212,10 @@ async fn main() {
     // Build client
     // For did:key VTAs, use the persisted URL as fallback (DID has no service endpoint).
     let effective_url_override = url_override.as_deref().or(vta_config.url.as_deref());
+    let mediator_did_hint = vta_config.mediator_did.as_deref();
 
     let client = if needs_auth {
-        match auth::connect(effective_url_override, &keyring_key).await {
+        match auth::connect(effective_url_override, mediator_did_hint, &keyring_key).await {
             Ok(c) => c,
             Err(e) => {
                 vta_cli_common::render::print_cli_error(e.as_ref());

--- a/pnm-cli/src/setup.rs
+++ b/pnm-cli/src/setup.rs
@@ -317,6 +317,7 @@ pub async fn continue_non_tee_setup_non_interactive(
     slug: &str,
     vta_did: &str,
     vta_url: Option<&str>,
+    mediator_did: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let keyring_key = vta_keyring_key(slug);
     let (name, existing_did) = require_pending(config, slug, &keyring_key)?;
@@ -341,6 +342,15 @@ pub async fn continue_non_tee_setup_non_interactive(
     };
 
     finalize_session(config, slug, &name, vta_did, &existing_did, vta_url, true)?;
+
+    // Persist mediator_did if provided
+    if let Some(med_did) = mediator_did {
+        if let Some(vta_cfg) = config.vtas.get_mut(slug) {
+            vta_cfg.mediator_did = Some(med_did.to_string());
+        }
+        save_config(config)?;
+    }
+
     Ok(())
 }
 
@@ -366,6 +376,7 @@ fn persist_pending(
             name: name.to_string(),
             vta_did: None,
             url: None,
+            mediator_did: None,
         },
     );
     if config.default_vta.is_none() || config.vtas.len() == 1 {
@@ -393,6 +404,7 @@ fn finalize_session(
             name: name.to_string(),
             vta_did: Some(vta_did.to_string()),
             url: vta_url.map(|u| u.trim_end_matches('/').to_string()),
+            mediator_did: None,
         },
     );
     if config.default_vta.is_none() || config.vtas.len() == 1 {
@@ -575,6 +587,7 @@ async fn setup_tee(config: &mut PnmConfig) -> Result<(), Box<dyn std::error::Err
             name: name.clone(),
             vta_did: Some(vta_did.clone()),
             url: None,
+            mediator_did: None,
         },
     );
     if config.default_vta.is_none() || config.vtas.len() == 1 {
@@ -614,6 +627,7 @@ mod tests {
                 name: slug.to_string(),
                 vta_did: vta_did.map(str::to_string),
                 url: None,
+                mediator_did: None,
             },
         );
         config.vtas = vtas;

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -518,6 +518,7 @@ async fn update_acl_via_didcomm() {
         role: Some("reader".into()),
         label: None,
         allowed_contexts: None,
+        step_up_approver: None,
     };
     client.update_acl("did:key:zAdmin", req).await.unwrap();
 

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -519,6 +519,7 @@ async fn update_acl_via_didcomm() {
         label: None,
         allowed_contexts: None,
         step_up_approver: None,
+        step_up_require: None,
     };
     client.update_acl("did:key:zAdmin", req).await.unwrap();
 

--- a/vta-cli-common/src/commands/services.rs
+++ b/vta-cli-common/src/commands/services.rs
@@ -14,21 +14,15 @@
 //! see the migration cue in pnm-cli/cnm-cli for the
 //! retired-command UX.
 
-use serde::Deserialize;
 use vta_sdk::client::VtaClient;
 use vta_sdk::error::VtaError;
 use vta_sdk::protocol::services::{
     DisableRestRequest, EnableRestRequest, RollbackDidcommRequest, RollbackRestRequest,
     UpdateRestRequest,
 };
-use vta_sdk::protocol::{DisableDidcommRequest, EnableDidcommRequest, UpdateDidcommRequest};
-
-#[derive(Debug, Deserialize)]
-struct EnableDidcommConflictBody {
-    error: String,
-    #[serde(default)]
-    mediator_did: Option<String>,
-}
+use vta_sdk::protocol::{
+    DisableDidcommRequest, EnableDidcommConflictBody, EnableDidcommRequest, UpdateDidcommRequest,
+};
 
 // ── services list ──────────────────────────────────────────────────
 

--- a/vta-cli-common/src/commands/services.rs
+++ b/vta-cli-common/src/commands/services.rs
@@ -14,12 +14,21 @@
 //! see the migration cue in pnm-cli/cnm-cli for the
 //! retired-command UX.
 
+use serde::Deserialize;
 use vta_sdk::client::VtaClient;
+use vta_sdk::error::VtaError;
 use vta_sdk::protocol::services::{
     DisableRestRequest, EnableRestRequest, RollbackDidcommRequest, RollbackRestRequest,
     UpdateRestRequest,
 };
 use vta_sdk::protocol::{DisableDidcommRequest, EnableDidcommRequest, UpdateDidcommRequest};
+
+#[derive(Debug, Deserialize)]
+struct EnableDidcommConflictBody {
+    error: String,
+    #[serde(default)]
+    mediator_did: Option<String>,
+}
 
 // ── services list ──────────────────────────────────────────────────
 
@@ -178,7 +187,22 @@ pub async fn cmd_services_didcomm_enable(
     let mut req = EnableDidcommRequest::new(&mediator_did);
     req.force = force;
     req.handshake_timeout_secs = handshake_timeout_secs;
-    let resp = client.enable_didcomm(req).await?;
+    let resp = match client.enable_didcomm(req).await {
+        Ok(resp) => resp,
+        Err(VtaError::Conflict(body)) => {
+            if let Ok(conflict) = serde_json::from_str::<EnableDidcommConflictBody>(&body)
+                && conflict.error == "didcomm_already_enabled"
+            {
+                println!("DIDComm already enabled.");
+                if let Some(mediator_did) = conflict.mediator_did {
+                    println!("  Mediator DID:   {mediator_did}");
+                }
+                return Ok(());
+            }
+            return Err(VtaError::Conflict(body).into());
+        }
+        Err(e) => return Err(e.into()),
+    };
     println!("DIDComm enabled.");
     println!("  Mediator DID:   {}", resp.mediator_did);
     if !resp.mediator_endpoint.is_empty() {

--- a/vta-cli-common/src/render.rs
+++ b/vta-cli-common/src/render.rs
@@ -180,7 +180,15 @@ pub fn print_cli_error(err: &(dyn std::error::Error + 'static)) {
                 eprintln!("{RED}\u{2717}{RESET} Not found: {msg}");
             }
             VtaError::Conflict(msg) => {
-                eprintln!("{RED}\u{2717}{RESET} Conflict: {msg}");
+                // The SDK preserves the full 409 JSON body so programmatic
+                // callers can extract structured fields (e.g. `mediator_did`).
+                // For humans, surface the `message` (or `error`) field rather
+                // than dumping the raw JSON; fall back to the raw text for
+                // non-JSON bodies.
+                eprintln!(
+                    "{RED}\u{2717}{RESET} Conflict: {}",
+                    extract_human_message(msg)
+                );
             }
             VtaError::Gone(msg) => {
                 let bin = bin_name();
@@ -294,6 +302,25 @@ pub fn print_cli_error(err: &(dyn std::error::Error + 'static)) {
         eprintln!("  {DIM}caused by: {s}{RESET}");
         source = s.source();
     }
+}
+
+/// Pull a human-readable line out of a (possibly JSON) error body.
+///
+/// The SDK hands `VtaError::Conflict` the *raw* 409 response body so that
+/// programmatic callers can deserialize structured fields. For terminal
+/// output we don't want to dump JSON at the operator, so prefer the body's
+/// `message` field, then its `error` field, and only fall back to the raw
+/// text when the body isn't the expected JSON shape.
+fn extract_human_message(body: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| {
+            v.get("message")
+                .or_else(|| v.get("error"))
+                .and_then(|m| m.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| body.to_string())
 }
 
 // ── Ratatui rendering helpers ───────────────────────────────────────
@@ -419,4 +446,34 @@ pub fn print_section(title: &str) {
         "\n{DIM}──{RESET} {BOLD}{title}{RESET} {DIM}{}{RESET}",
         "─".repeat(pad)
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_human_message;
+
+    #[test]
+    fn prefers_message_field() {
+        let body = r#"{"error":"didcomm_already_enabled","message":"DIDComm is already enabled.","mediator_did":"did:peer:2.med"}"#;
+        assert_eq!(extract_human_message(body), "DIDComm is already enabled.");
+    }
+
+    #[test]
+    fn falls_back_to_error_field_when_no_message() {
+        let body = r#"{"error":"duplicate_key"}"#;
+        assert_eq!(extract_human_message(body), "duplicate_key");
+    }
+
+    #[test]
+    fn falls_back_to_raw_text_for_non_json() {
+        let body = "plain conflict text";
+        assert_eq!(extract_human_message(body), "plain conflict text");
+    }
+
+    #[test]
+    fn falls_back_to_raw_text_when_fields_missing() {
+        // Valid JSON but neither `message` nor `error` present → raw text.
+        let body = r#"{"detail":"something"}"#;
+        assert_eq!(extract_human_message(body), body);
+    }
 }

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -140,11 +140,14 @@ impl VtaClient {
             Ok(resp.json::<T>().await?)
         } else {
             let status = resp.status();
-            let body = resp
-                .json::<ErrorResponse>()
-                .await
-                .map(|e| e.error)
-                .unwrap_or_else(|_| "unknown error".to_string());
+            let text = resp.text().await?;
+            // For 409 Conflict, preserve the full JSON body so callers can
+            // extract structured details (e.g. EnableDidcommConflictBody).
+            // Other error codes only need the `error` field string.
+            if status == reqwest::StatusCode::CONFLICT {
+                return Err(VtaError::Conflict(text));
+            }
+            let body = Self::extract_error_message(&text);
             Err(VtaError::from_http(status, body))
         }
     }
@@ -154,13 +157,27 @@ impl VtaClient {
             Ok(())
         } else {
             let status = resp.status();
-            let body = resp
-                .json::<ErrorResponse>()
-                .await
-                .map(|e| e.error)
-                .unwrap_or_else(|_| "unknown error".to_string());
+            let text = resp.text().await?;
+            if status == reqwest::StatusCode::CONFLICT {
+                return Err(VtaError::Conflict(text));
+            }
+            let body = Self::extract_error_message(&text);
             Err(VtaError::from_http(status, body))
         }
+    }
+
+    /// Extract the `error` field from a JSON response body, or fall back to
+    /// "unknown error" with the raw text appended for diagnostics.
+    fn extract_error_message(text: &str) -> String {
+        serde_json::from_str::<ErrorResponse>(text)
+            .map(|e| e.error)
+            .unwrap_or_else(|_| {
+                if text.is_empty() {
+                    "unknown error".to_string()
+                } else {
+                    format!("unknown error: {text}")
+                }
+            })
     }
 }
 

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -167,15 +167,25 @@ impl VtaClient {
     }
 
     /// Extract the `error` field from a JSON response body, or fall back to
-    /// "unknown error" with the raw text appended for diagnostics.
+    /// "unknown error" with the raw text appended for diagnostics. The raw text
+    /// is truncated so a large non-JSON body (e.g. a 1 MB proxy error page)
+    /// can't bloat the error string that propagates into CLI output and logs.
     fn extract_error_message(text: &str) -> String {
+        /// Max characters of raw body to surface in the fallback message.
+        const MAX_RAW_LEN: usize = 256;
         serde_json::from_str::<ErrorResponse>(text)
             .map(|e| e.error)
             .unwrap_or_else(|_| {
                 if text.is_empty() {
                     "unknown error".to_string()
                 } else {
-                    format!("unknown error: {text}")
+                    let truncated: String = text.chars().take(MAX_RAW_LEN).collect();
+                    let ellipsis = if truncated.len() < text.len() {
+                        "…"
+                    } else {
+                        ""
+                    };
+                    format!("unknown error: {truncated}{ellipsis}")
                 }
             })
     }

--- a/vta-sdk/src/protocol/mod.rs
+++ b/vta-sdk/src/protocol/mod.rs
@@ -77,6 +77,16 @@ pub struct EnableDidcommResponse {
     pub serverless: bool,
 }
 
+/// Response body for `GET /services/didcomm`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DidcommStatusResponse {
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mediator_did: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_status: Option<String>,
+}
+
 /// Request body for `POST /services/didcomm/disable`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DisableDidcommRequest {
@@ -130,19 +140,75 @@ impl VtaClient {
         &self,
         req: EnableDidcommRequest,
     ) -> Result<EnableDidcommResponse, VtaError> {
-        // REST-only by nature. Calling this over DIDComm transport
-        // will surface as a 404 from the upstream message router,
-        // which the rpc() layer turns into a `VtaError::Protocol`.
-        // That's the right behaviour — the operation is logically
-        // not available over DIDComm transport.
-        self.rpc(
-            "services-management/1.0/enable-not-available-via-didcomm",
-            serde_json::to_value(&req)?,
-            "services-management/1.0/enable-not-available-via-didcomm-result",
-            30,
-            |c, url| c.post(format!("{url}/services/didcomm/enable")).json(&req),
-        )
-        .await
+        #[derive(Debug, Deserialize)]
+        struct EnableDidcommConflictBody {
+            error: String,
+            #[serde(default)]
+            mediator_did: Option<String>,
+        }
+
+        match &self.transport {
+            crate::client::Transport::Rest {
+                client,
+                base_url,
+                auth,
+            } => {
+                crate::client::VtaClient::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
+                let req = client
+                    .post(format!("{base_url}/services/didcomm/enable"))
+                    .json(&req);
+                let resp = crate::client::VtaClient::with_auth_token(req, &token)
+                    .send()
+                    .await?;
+
+                if resp.status().is_success() {
+                    return Ok(resp.json::<EnableDidcommResponse>().await?);
+                }
+
+                let status = resp.status();
+                let text = resp.text().await?;
+                if status == reqwest::StatusCode::CONFLICT
+                    && let Ok(body) = serde_json::from_str::<EnableDidcommConflictBody>(&text)
+                    && body.error == "didcomm_already_enabled"
+                    && body.mediator_did.is_some()
+                {
+                    return Err(VtaError::Conflict(text));
+                }
+
+                let body = serde_json::from_str::<crate::client::ErrorResponse>(&text)
+                    .map(|e| e.error)
+                    .unwrap_or(text);
+                Err(VtaError::from_http(status, body))
+            }
+            #[cfg(feature = "session")]
+            crate::client::Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(
+                "enable_didcomm is REST-only".into(),
+            )),
+        }
+    }
+
+    /// Read the current DIDComm runtime status. Auth: any authenticated role.
+    pub async fn didcomm_status(&self) -> Result<DidcommStatusResponse, VtaError> {
+        match &self.transport {
+            crate::client::Transport::Rest {
+                client,
+                base_url,
+                auth,
+            } => {
+                crate::client::VtaClient::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
+                let req = client.get(format!("{base_url}/services/didcomm"));
+                let resp = crate::client::VtaClient::with_auth_token(req, &token)
+                    .send()
+                    .await?;
+                crate::client::VtaClient::handle_response(resp).await
+            }
+            #[cfg(feature = "session")]
+            crate::client::Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(
+                "didcomm status is REST-only in the SDK".into(),
+            )),
+        }
     }
 
     /// Disable DIDComm. Refuses if REST is also disabled

--- a/vta-sdk/src/protocol/mod.rs
+++ b/vta-sdk/src/protocol/mod.rs
@@ -87,6 +87,15 @@ pub struct DidcommStatusResponse {
     pub websocket_status: Option<String>,
 }
 
+/// Body returned by the server on `409 Conflict` from
+/// `POST /services/didcomm/enable` when DIDComm is already active.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EnableDidcommConflictBody {
+    pub error: String,
+    #[serde(default)]
+    pub mediator_did: Option<String>,
+}
+
 /// Request body for `POST /services/didcomm/disable`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DisableDidcommRequest {
@@ -140,46 +149,19 @@ impl VtaClient {
         &self,
         req: EnableDidcommRequest,
     ) -> Result<EnableDidcommResponse, VtaError> {
-        #[derive(Debug, Deserialize)]
-        struct EnableDidcommConflictBody {
-            error: String,
-            #[serde(default)]
-            mediator_did: Option<String>,
-        }
-
         match &self.transport {
             crate::client::Transport::Rest {
                 client,
                 base_url,
                 auth,
             } => {
-                crate::client::VtaClient::ensure_token_valid(client, base_url, auth).await?;
+                Self::ensure_token_valid(client, base_url, auth).await?;
                 let token = auth.lock().await.token.clone();
                 let req = client
                     .post(format!("{base_url}/services/didcomm/enable"))
                     .json(&req);
-                let resp = crate::client::VtaClient::with_auth_token(req, &token)
-                    .send()
-                    .await?;
-
-                if resp.status().is_success() {
-                    return Ok(resp.json::<EnableDidcommResponse>().await?);
-                }
-
-                let status = resp.status();
-                let text = resp.text().await?;
-                if status == reqwest::StatusCode::CONFLICT
-                    && let Ok(body) = serde_json::from_str::<EnableDidcommConflictBody>(&text)
-                    && body.error == "didcomm_already_enabled"
-                    && body.mediator_did.is_some()
-                {
-                    return Err(VtaError::Conflict(text));
-                }
-
-                let body = serde_json::from_str::<crate::client::ErrorResponse>(&text)
-                    .map(|e| e.error)
-                    .unwrap_or(text);
-                Err(VtaError::from_http(status, body))
+                let resp = Self::with_auth_token(req, &token).send().await?;
+                Self::handle_response(resp).await
             }
             #[cfg(feature = "session")]
             crate::client::Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(

--- a/vta-sdk/src/protocol/mod.rs
+++ b/vta-sdk/src/protocol/mod.rs
@@ -170,7 +170,8 @@ impl VtaClient {
         }
     }
 
-    /// Read the current DIDComm runtime status. Auth: any authenticated role.
+    /// Read the current DIDComm runtime status. Auth: super-admin (parity with
+    /// `GET /services` / `list_services`, which exposes the same `mediator_did`).
     pub async fn didcomm_status(&self) -> Result<DidcommStatusResponse, VtaError> {
         match &self.transport {
             crate::client::Transport::Rest {

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -609,9 +609,14 @@ impl SessionStore {
     /// Transport selection priority:
     /// 1. If `mediator_did_hint` is provided → DIDComm (pinned, no discovery).
     /// 2. If VTA DID doc has DIDCommMessaging service → DIDComm (resolved).
-    /// 3. If `url_override` is provided → try REST discovery of mediator,
-    ///    fall back to REST-only if DIDComm unavailable.
+    /// 3. If `url_override` is provided → authenticate over REST, then ask the
+    ///    VTA's status endpoint whether DIDComm is live and prefer it if so.
     /// 4. REST-only (from DID doc or url_override).
+    ///
+    /// Note `url_override` is a *fallback hint*, not a force-REST switch: a VTA
+    /// DID that resolves to a DIDComm endpoint (priority 2) still uses DIDComm
+    /// even when `--url` is supplied. The override only takes effect when DID
+    /// resolution yields nothing usable (e.g. `did:key`).
     pub async fn connect(
         &self,
         key: &str,
@@ -668,9 +673,19 @@ impl SessionStore {
             }
         }
 
-        // Priority 3: URL override — try /services/didcomm discovery, fall back to REST
+        // Priority 3 & 4: URL override. Authenticate over REST first (needed for
+        // either outcome), then ask the *authenticated* status endpoint whether
+        // DIDComm is live. `GET /services/didcomm` is super-admin-gated, so an
+        // unauthenticated probe can never succeed — discovery must reuse the
+        // token we just obtained. Prefer DIDComm if available, otherwise keep
+        // the REST client we already built.
         if let Some(url) = url_override {
-            if let Some(mediator_did) = discover_mediator_from_rest(url).await {
+            let token = self.ensure_authenticated(url, key).await?;
+            let rest_client = crate::client::VtaClient::new(url);
+            rest_client.set_token(token);
+
+            // Priority 3: DIDComm discovery via the authenticated status endpoint.
+            if let Some(mediator_did) = discover_mediator_via_status(&rest_client).await {
                 debug!(mediator_did = %mediator_did, "connecting via DIDComm (REST discovery)");
                 let client = crate::client::VtaClient::connect_didcomm(
                     &session.client_did,
@@ -683,12 +698,9 @@ impl SessionStore {
                 return Ok(client);
             }
 
-            // Priority 4: REST-only fallback
+            // Priority 4: REST-only fallback.
             debug!(url, "connecting via REST (URL override)");
-            let token = self.ensure_authenticated(url, key).await?;
-            let client = crate::client::VtaClient::new(url);
-            client.set_token(token);
-            return Ok(client);
+            return Ok(rest_client);
         }
 
         Err(format!("Could not determine transport for VTA DID: {session_vta_did}").into())
@@ -1120,55 +1132,28 @@ pub async fn resolve_vta_endpoint(
     }
 }
 
-/// Attempt to discover a mediator DID by calling `GET {url}/services/didcomm`.
+/// Best-effort: ask an already-authenticated VTA whether DIDComm is enabled
+/// and, if so, return its mediator DID.
 ///
-/// This is a best-effort fallback for DIDs without service endpoints (e.g. did:key).
-/// Returns `None` if the endpoint is unreachable, returns disabled, or fails.
-async fn discover_mediator_from_rest(url: &str) -> Option<String> {
-    let endpoint = format!("{}/services/didcomm", url.trim_end_matches('/'));
-    debug!(endpoint = %endpoint, "attempting DIDComm discovery via REST");
-
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .ok()?;
-
-    let resp = client.get(&endpoint).send().await.ok()?;
-
-    // The endpoint exists even with REST "disabled" but may require auth.
-    // For unauthenticated discovery, we only get the enabled status from
-    // the health-like response. If 401, we know the endpoint exists and
-    // DIDComm is likely configured — try the /health endpoint instead.
-    if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
-        // Try /health which is unauthenticated and may contain didcomm info
-        let health_url = format!("{}/health", url.trim_end_matches('/'));
-        let health_resp = client.get(&health_url).send().await.ok()?;
-        let body: serde_json::Value = health_resp.json().await.ok()?;
-        return body
-            .get("mediator_did")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+/// Used as a fallback for DID methods with no resolvable service block (e.g.
+/// `did:key`), where the only way to learn the mediator is to ask the running
+/// VTA over REST. `GET /services/didcomm` is super-admin-gated, so this *must*
+/// run on a client that already carries a valid token — an unauthenticated
+/// probe always 401s. Returns `None` if DIDComm is disabled, the caller lacks
+/// permission, or the endpoint errs; every one of those simply means "fall
+/// back to REST".
+async fn discover_mediator_via_status(client: &crate::client::VtaClient) -> Option<String> {
+    match client.didcomm_status().await {
+        Ok(status) if status.enabled => status.mediator_did,
+        Ok(_) => {
+            debug!("DIDComm not enabled on VTA (status discovery)");
+            None
+        }
+        Err(e) => {
+            debug!(error = %e, "DIDComm status discovery failed; falling back to REST");
+            None
+        }
     }
-
-    if !resp.status().is_success() {
-        return None;
-    }
-
-    let body: serde_json::Value = resp.json().await.ok()?;
-
-    // Check if DIDComm is enabled
-    let enabled = body
-        .get("enabled")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    if !enabled {
-        debug!("DIDComm not enabled on VTA (REST discovery)");
-        return None;
-    }
-
-    body.get("mediator_did")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
 }
 
 /// Resolve a VTA DID to discover its service URL.

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -606,38 +606,45 @@ impl SessionStore {
 
     /// Connect to a VTA using the preferred transport (DIDComm or REST).
     ///
-    /// 1. Loads session from store (client DID, private key, VTA DID).
-    /// 2. If `url_override` is provided, uses REST directly.
-    /// 3. Otherwise resolves the VTA DID to discover DIDComm or REST endpoints.
-    /// 4. For DIDComm: encryption provides auth (no JWT needed).
-    /// 5. For REST: performs challenge-response to obtain a JWT.
+    /// Transport selection priority:
+    /// 1. If `mediator_did_hint` is provided → DIDComm (pinned, no discovery).
+    /// 2. If VTA DID doc has DIDCommMessaging service → DIDComm (resolved).
+    /// 3. If `url_override` is provided → try REST discovery of mediator,
+    ///    fall back to REST-only if DIDComm unavailable.
+    /// 4. REST-only (from DID doc or url_override).
     pub async fn connect(
         &self,
         key: &str,
         url_override: Option<&str>,
+        mediator_did_hint: Option<&str>,
     ) -> Result<crate::client::VtaClient, Box<dyn std::error::Error>> {
         let session = self.load_session(key).ok_or(
             "Not authenticated.\n\nTo authenticate, import a credential:\n  <cli> auth login <credential-string>",
         )?;
 
-        // URL override: always use REST
-        if let Some(url) = url_override {
-            debug!(url, "using REST transport (URL override)");
-            let token = self.ensure_authenticated(url, key).await?;
-            let client = crate::client::VtaClient::new(url);
-            client.set_token(token);
+        let session_vta_did = require_vta_did(&session)?.to_string();
+
+        // Priority 1: Explicit mediator DID from config → DIDComm directly
+        if let Some(mediator_did) = mediator_did_hint {
+            debug!(mediator_did, "connecting via DIDComm (config mediator_did)");
+            let client = crate::client::VtaClient::connect_didcomm(
+                &session.client_did,
+                &session.private_key,
+                &session_vta_did,
+                mediator_did,
+                url_override.map(|s| s.to_string()),
+            )
+            .await?;
             return Ok(client);
         }
 
-        let session_vta_did = require_vta_did(&session)?.to_string();
-
-        // Resolve VTA DID for transport selection
-        match resolve_vta_endpoint(&session_vta_did).await? {
-            VtaEndpoint::DIDComm {
+        // Priority 2: Resolve VTA DID for transport selection
+        match resolve_vta_endpoint(&session_vta_did).await {
+            Ok(VtaEndpoint::DIDComm {
                 vta_did,
                 mediator_did,
                 rest_url,
-            } => {
+            }) => {
                 debug!("connecting via DIDComm");
                 let client = crate::client::VtaClient::connect_didcomm(
                     &session.client_did,
@@ -647,16 +654,44 @@ impl SessionStore {
                     rest_url,
                 )
                 .await?;
-                Ok(client)
+                return Ok(client);
             }
-            VtaEndpoint::Rest { url } => {
-                debug!(url = %url, "connecting via REST");
+            Ok(VtaEndpoint::Rest { url }) => {
+                debug!(url = %url, "connecting via REST (from DID doc)");
                 let token = self.ensure_authenticated(&url, key).await?;
                 let client = crate::client::VtaClient::new(&url);
                 client.set_token(token);
-                Ok(client)
+                return Ok(client);
+            }
+            Err(e) => {
+                debug!(error = %e, "DID resolution failed, trying URL-based fallback");
             }
         }
+
+        // Priority 3: URL override — try /services/didcomm discovery, fall back to REST
+        if let Some(url) = url_override {
+            if let Some(mediator_did) = discover_mediator_from_rest(url).await {
+                debug!(mediator_did = %mediator_did, "connecting via DIDComm (REST discovery)");
+                let client = crate::client::VtaClient::connect_didcomm(
+                    &session.client_did,
+                    &session.private_key,
+                    &session_vta_did,
+                    &mediator_did,
+                    Some(url.to_string()),
+                )
+                .await?;
+                return Ok(client);
+            }
+
+            // Priority 4: REST-only fallback
+            debug!(url, "connecting via REST (URL override)");
+            let token = self.ensure_authenticated(url, key).await?;
+            let client = crate::client::VtaClient::new(url);
+            client.set_token(token);
+            return Ok(client);
+        }
+
+        Err(format!("Could not determine transport for VTA DID: {session_vta_did}").into())
     }
 }
 
@@ -1083,6 +1118,57 @@ pub async fn resolve_vta_endpoint(
         debug!(url = %url, "falling back to URL from DID string");
         Ok(VtaEndpoint::Rest { url })
     }
+}
+
+/// Attempt to discover a mediator DID by calling `GET {url}/services/didcomm`.
+///
+/// This is a best-effort fallback for DIDs without service endpoints (e.g. did:key).
+/// Returns `None` if the endpoint is unreachable, returns disabled, or fails.
+async fn discover_mediator_from_rest(url: &str) -> Option<String> {
+    let endpoint = format!("{}/services/didcomm", url.trim_end_matches('/'));
+    debug!(endpoint = %endpoint, "attempting DIDComm discovery via REST");
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .ok()?;
+
+    let resp = client.get(&endpoint).send().await.ok()?;
+
+    // The endpoint exists even with REST "disabled" but may require auth.
+    // For unauthenticated discovery, we only get the enabled status from
+    // the health-like response. If 401, we know the endpoint exists and
+    // DIDComm is likely configured — try the /health endpoint instead.
+    if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+        // Try /health which is unauthenticated and may contain didcomm info
+        let health_url = format!("{}/health", url.trim_end_matches('/'));
+        let health_resp = client.get(&health_url).send().await.ok()?;
+        let body: serde_json::Value = health_resp.json().await.ok()?;
+        return body
+            .get("mediator_did")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+    }
+
+    if !resp.status().is_success() {
+        return None;
+    }
+
+    let body: serde_json::Value = resp.json().await.ok()?;
+
+    // Check if DIDComm is enabled
+    let enabled = body
+        .get("enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if !enabled {
+        debug!("DIDComm not enabled on VTA (REST discovery)");
+        return None;
+    }
+
+    body.get("mediator_did")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
 }
 
 /// Resolve a VTA DID to discover its service URL.

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1545,6 +1545,31 @@ async fn malformed_error_body_falls_back_to_raw_text() {
     }
 }
 
+#[tokio::test]
+async fn oversized_error_body_is_truncated() {
+    // A large non-JSON body (e.g. a proxy error page) must not bloat the
+    // error string. The fallback truncates the raw text and marks it with `…`.
+    let server = MockServer::start().await;
+    let huge = "x".repeat(10_000);
+    Mock::given(method("GET"))
+        .and(path("/config"))
+        .respond_with(ResponseTemplate::new(500).set_body_string(huge))
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let err = c.get_config().await.unwrap_err();
+    match err {
+        VtaError::Server { status, body } => {
+            assert_eq!(status, 500);
+            // "unknown error: " (15) + 256 chars + "…" — far smaller than 10k.
+            assert!(body.len() < 600, "body not truncated: {} bytes", body.len());
+            assert!(body.starts_with("unknown error: x"));
+            assert!(body.ends_with('…'), "expected truncation marker");
+        }
+        other => panic!("expected Server, got {other:?}"),
+    }
+}
+
 // ── Connection/transport ────────────────────────────────────────────
 
 #[tokio::test]

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1527,7 +1527,7 @@ async fn http_418_maps_to_other() {
 }
 
 #[tokio::test]
-async fn malformed_error_body_falls_back_to_unknown() {
+async fn malformed_error_body_falls_back_to_raw_text() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/config"))
@@ -1539,7 +1539,7 @@ async fn malformed_error_body_falls_back_to_unknown() {
     match err {
         VtaError::Server { status, body } => {
             assert_eq!(status, 500);
-            assert_eq!(body, "unknown error");
+            assert_eq!(body, "unknown error: not json");
         }
         other => panic!("expected Server, got {other:?}"),
     }

--- a/vta-sdk/tests/protocol_rest.rs
+++ b/vta-sdk/tests/protocol_rest.rs
@@ -58,7 +58,10 @@ async fn enable_didcomm_409_maps_to_conflict() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/services/didcomm/enable"))
-        .respond_with(ResponseTemplate::new(409).set_body_json(json!({"error": "already on"})))
+        .respond_with(ResponseTemplate::new(409).set_body_json(json!({
+            "error": "didcomm_already_enabled",
+            "mediator_did": "did:peer:2.med"
+        })))
         .mount(&server)
         .await;
     let c = client(&server).await;
@@ -67,6 +70,34 @@ async fn enable_didcomm_409_maps_to_conflict() {
         .await
         .unwrap_err();
     assert!(err.is_conflict(), "got {err:?}");
+    match err {
+        VtaError::Conflict(body) => {
+            let body: Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(body["mediator_did"], "did:peer:2.med");
+        }
+        other => panic!("expected conflict, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn didcomm_status_gets_and_decodes_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/services/didcomm"))
+        .and(auth())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "enabled": true,
+            "mediator_did": "did:peer:2.med",
+            "websocket_status": "connected"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let resp = c.didcomm_status().await.unwrap();
+    assert!(resp.enabled);
+    assert_eq!(resp.mediator_did.as_deref(), Some("did:peer:2.med"));
+    assert_eq!(resp.websocket_status.as_deref(), Some("connected"));
 }
 
 // ── disable_didcomm ─────────────────────────────────────────────────

--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -635,11 +635,12 @@ async fn resolve_vta_endpoint_unparseable_did_errors() {
 }
 
 #[tokio::test]
-async fn connect_url_override_skips_resolution() {
-    // SessionStore::connect with a URL override goes straight to the
-    // REST path — never calls resolve_vta_endpoint. Verifies that even
-    // a session bound to an unresolvable did:key VTA still connects
-    // when the operator passes `--url`.
+async fn connect_url_override_falls_back_to_rest() {
+    // A session bound to an unresolvable did:key VTA still connects over
+    // REST when the operator passes `--url`. Resolution (priority 2) yields
+    // nothing usable for a did:key, and the authenticated DIDComm-status
+    // discovery (priority 3) finds no live mediator (the status endpoint
+    // isn't mounted → errors → None), so connect falls back to REST-only.
     let server = MockServer::start().await;
     mount_challenge(&server).await;
     mount_authenticate(&server, now_secs() + 3600).await;

--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -565,7 +565,7 @@ async fn connect_with_url_override_uses_rest_and_attaches_token() {
     let (vta_did, _) = did_key_from_seed(0x20);
     s.store_direct("k", &did, &pk, &vta_did).unwrap();
 
-    let client = s.connect("k", Some(&server.uri())).await.unwrap();
+    let client = s.connect("k", Some(&server.uri()), None).await.unwrap();
     // Round-trip an authenticated call to prove the token was attached.
     client.get_config().await.unwrap();
 }
@@ -660,7 +660,7 @@ async fn connect_url_override_skips_resolution() {
         .await;
 
     let client = s
-        .connect("k", Some(&server.uri()))
+        .connect("k", Some(&server.uri()), None)
         .await
         .expect("connect with url override");
     client.get_config().await.unwrap();
@@ -671,7 +671,7 @@ async fn connect_url_override_skips_resolution() {
 #[tokio::test]
 async fn connect_errors_when_no_session() {
     let s = store();
-    let err = match s.connect("missing", Some("http://localhost")).await {
+    let err = match s.connect("missing", Some("http://localhost"), None).await {
         Ok(_) => panic!("expected connect to fail with no session"),
         Err(e) => e,
     };

--- a/vta-service/src/operations/protocol/list.rs
+++ b/vta-service/src/operations/protocol/list.rs
@@ -76,12 +76,39 @@ pub async fn list_services(
             didcomm_enabled: cfg.services.didcomm,
             webauthn_enabled: cfg.services.webauthn,
             vta_did: cfg.vta_did.clone(),
+            mediator_did: cfg
+                .messaging
+                .as_ref()
+                .map(|m| m.mediator_did.clone())
+                .filter(|did| !did.is_empty()),
+            public_url: cfg.public_url.clone(),
         }
     };
 
     let vta_did = cfg_view
         .vta_did
         .ok_or(ListServicesError::VtaDidNotConfigured)?;
+
+    // For non-webvh DIDs (e.g. did:key), there is no on-chain DID document
+    // to inspect. Report service state from config only.
+    if !vta_did.starts_with("did:webvh:") {
+        let services = vec![
+            ServiceState::Didcomm {
+                enabled: cfg_view.didcomm_enabled && cfg_view.mediator_did.is_some(),
+                mediator_did: cfg_view.mediator_did,
+                routing_keys: Vec::new(),
+            },
+            ServiceState::Rest {
+                enabled: cfg_view.rest_enabled,
+                url: cfg_view.public_url.clone(),
+            },
+            ServiceState::Webauthn {
+                enabled: cfg_view.webauthn_enabled,
+                url: None,
+            },
+        ];
+        return Ok(ServicesListResponse { services });
+    }
 
     let _record = webvh_store::get_did(webvh_ks, &vta_did)
         .await?
@@ -128,6 +155,8 @@ struct ConfigView {
     didcomm_enabled: bool,
     webauthn_enabled: bool,
     vta_did: Option<String>,
+    mediator_did: Option<String>,
+    public_url: Option<String>,
 }
 
 impl From<crate::operations::protocol::document::CurrentDocumentError> for ListServicesError {
@@ -210,6 +239,65 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ListServicesError::VtaDidNotConfigured));
+    }
+
+    /// `list_services` succeeds for did:key VTAs (no webvh record)
+    /// by returning service state from config only.
+    #[tokio::test]
+    async fn returns_config_state_for_did_key_vta() {
+        use crate::test_support::test_app_config;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = test_app_config(dir.path().into());
+        cfg.services.rest = false;
+        cfg.services.didcomm = true;
+        cfg.services.webauthn = false;
+        cfg.vta_did = Some("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK".into());
+        cfg.public_url = Some("https://vta.example.com".into());
+        cfg.messaging = Some(crate::config::MessagingConfig {
+            mediator_did: "did:peer:2.MEDIATOR".into(),
+            mediator_url: "ws://mediator:7037".into(),
+            mediator_host: None,
+        });
+        cfg.config_path = dir.path().join("vta.toml");
+        let config = Arc::new(RwLock::new(cfg));
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        let webvh_ks = store.keyspace("webvh").unwrap();
+        let super_admin = AuthClaims::unsafe_local_cli_super_admin("test");
+
+        let response = list_services(&config, &webvh_ks, &super_admin)
+            .await
+            .unwrap();
+
+        assert_eq!(response.services.len(), 3);
+        match &response.services[0] {
+            ServiceState::Didcomm {
+                enabled,
+                mediator_did,
+                ..
+            } => {
+                assert!(enabled);
+                assert_eq!(mediator_did.as_deref(), Some("did:peer:2.MEDIATOR"));
+            }
+            other => panic!("expected DIDComm first; got {other:?}"),
+        }
+        match &response.services[1] {
+            ServiceState::Rest { enabled, url } => {
+                assert!(!enabled, "REST is disabled in config");
+                assert_eq!(url.as_deref(), Some("https://vta.example.com"));
+            }
+            other => panic!("expected REST second; got {other:?}"),
+        }
+        match &response.services[2] {
+            ServiceState::Webauthn { enabled, url } => {
+                assert!(!enabled);
+                assert!(url.is_none());
+            }
+            other => panic!("expected WebAuthn third; got {other:?}"),
+        }
     }
 
     /// Drives production `list_services` end-to-end against an

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -388,6 +388,10 @@ pub fn router_with_cors(allowed_origins: &[String], trust_xff: bool) -> Router<A
             post(protocol::enable_didcomm_handler),
         )
         .route(
+            "/services/didcomm",
+            get(protocol::get_didcomm_status_handler),
+        )
+        .route(
             "/services/didcomm/disable",
             post(protocol::disable_didcomm_handler),
         )

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -194,7 +194,7 @@ pub async fn get_didcomm_status_handler(
     _auth: AuthClaims,
     State(state): State<AppState>,
 ) -> Json<DidcommStatusResponse> {
-    let (enabled, mediator_did) = {
+    let (configured, mediator_did) = {
         let config = state.config.read().await;
         (
             config.services.didcomm,
@@ -206,6 +206,13 @@ pub async fn get_didcomm_status_handler(
         )
     };
 
+    // DIDComm is "enabled" only when the feature is compiled in, the config
+    // flag is set, AND a mediator is registered — consistent with GET /services.
+    #[cfg(feature = "didcomm")]
+    let enabled = configured && mediator_did.is_some();
+    #[cfg(not(feature = "didcomm"))]
+    let enabled = false;
+
     if !enabled {
         return Json(DidcommStatusResponse {
             enabled: false,
@@ -214,17 +221,22 @@ pub async fn get_didcomm_status_handler(
         });
     }
 
-    let websocket_status = state
-        .didcomm_websocket_status
-        .read()
-        .await
-        .as_str()
-        .to_string();
+    #[cfg(feature = "didcomm")]
+    let websocket_status = Some(
+        state
+            .didcomm_websocket_status
+            .read()
+            .await
+            .as_str()
+            .to_string(),
+    );
+    #[cfg(not(feature = "didcomm"))]
+    let websocket_status: Option<String> = None;
 
     Json(DidcommStatusResponse {
         enabled: true,
         mediator_did,
-        websocket_status: Some(websocket_status),
+        websocket_status,
     })
 }
 

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -15,7 +15,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 
-use crate::auth::SuperAdminAuth;
+use crate::auth::{AuthClaims, SuperAdminAuth};
 use crate::messaging::handshake::{AlwaysOkProver, HandshakeError, HandshakeStage};
 use crate::operations::protocol::OpContext;
 use crate::operations::protocol::disable_didcomm::DisableTransport as DidcommTransport;
@@ -54,6 +54,7 @@ use crate::operations::protocol::update_webauthn::{
     UpdateWebauthnError, UpdateWebauthnParams, update_webauthn,
 };
 use crate::server::AppState;
+use vta_sdk::protocol::DidcommStatusResponse;
 
 /// Default trust-ping round-trip timeout for first-enable when the
 /// caller doesn't specify `handshake_timeout_secs`. Spec default 10s.
@@ -107,6 +108,12 @@ pub async fn enable_didcomm_handler(
     State(state): State<AppState>,
     Json(req): Json<EnableDidcommRequest>,
 ) -> Result<Json<EnableDidcommResponse>, EnableDidcommHttpError> {
+    if state.config.read().await.services.didcomm {
+        return Err(EnableDidcommHttpError::AlreadyEnabled {
+            mediator_did: current_didcomm_mediator_did(&state).await,
+        });
+    }
+
     let bridge = Arc::clone(&state.didcomm_bridge);
     let did_resolver = state
         .did_resolver
@@ -137,7 +144,7 @@ pub async fn enable_didcomm_handler(
 
     let prover = AlwaysOkProver;
 
-    let result = enable_didcomm(
+    let result = match enable_didcomm(
         &state.config,
         &state.keys_ks,
         &state.imported_ks,
@@ -162,7 +169,16 @@ pub async fn enable_didcomm_handler(
         &state.webvh_auth_locks,
         "rest",
     )
-    .await?;
+    .await
+    {
+        Ok(result) => result,
+        Err(EnableDidcommError::DidcommAlreadyEnabled) => {
+            return Err(EnableDidcommHttpError::AlreadyEnabled {
+                mediator_did: current_didcomm_mediator_did(&state).await,
+            });
+        }
+        Err(e) => return Err(EnableDidcommHttpError::Op(e)),
+    };
 
     Ok(Json(EnableDidcommResponse {
         new_version_id: result.new_version_id,
@@ -173,11 +189,62 @@ pub async fn enable_didcomm_handler(
     }))
 }
 
+/// `GET /services/didcomm` — current DIDComm runtime status. Auth: any role.
+pub async fn get_didcomm_status_handler(
+    _auth: AuthClaims,
+    State(state): State<AppState>,
+) -> Json<DidcommStatusResponse> {
+    let (enabled, mediator_did) = {
+        let config = state.config.read().await;
+        (
+            config.services.didcomm,
+            config
+                .messaging
+                .as_ref()
+                .map(|m| m.mediator_did.clone())
+                .filter(|did| !did.is_empty()),
+        )
+    };
+
+    if !enabled {
+        return Json(DidcommStatusResponse {
+            enabled: false,
+            mediator_did: None,
+            websocket_status: None,
+        });
+    }
+
+    let websocket_status = state
+        .didcomm_websocket_status
+        .read()
+        .await
+        .as_str()
+        .to_string();
+
+    Json(DidcommStatusResponse {
+        enabled: true,
+        mediator_did,
+        websocket_status: Some(websocket_status),
+    })
+}
+
+async fn current_didcomm_mediator_did(state: &AppState) -> Option<String> {
+    state
+        .config
+        .read()
+        .await
+        .messaging
+        .as_ref()
+        .map(|m| m.mediator_did.clone())
+        .filter(|did| !did.is_empty())
+}
+
 /// HTTP error wrapper for `EnableDidcommError` that maps each typed
 /// variant to an appropriate status code + suggested-fix body.
 #[derive(Debug)]
 pub enum EnableDidcommHttpError {
     Op(EnableDidcommError),
+    AlreadyEnabled { mediator_did: Option<String> },
     DidResolverUnavailable,
 }
 
@@ -191,6 +258,8 @@ impl From<EnableDidcommError> for EnableDidcommHttpError {
 struct ErrorBody {
     error: &'static str,
     message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mediator_did: Option<String>,
     /// Operator-facing suggested fix. Per CLAUDE.md, we surface the
     /// corrected command rather than just the HTTP status.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -203,11 +272,25 @@ struct ErrorBody {
 impl IntoResponse for EnableDidcommHttpError {
     fn into_response(self) -> Response {
         let (status, body) = match self {
+            Self::AlreadyEnabled { mediator_did } => (
+                StatusCode::CONFLICT,
+                ErrorBody {
+                    error: "didcomm_already_enabled",
+                    message: "DIDComm is already enabled.".into(),
+                    mediator_did,
+                    suggested_fix: Some(
+                        "Use `pnm services didcomm update --mediator-did <did>` to change the active mediator."
+                            .into(),
+                    ),
+                    stage: None,
+                },
+            ),
             Self::Op(EnableDidcommError::DidcommAlreadyEnabled) => (
                 StatusCode::CONFLICT,
                 ErrorBody {
                     error: "didcomm_already_enabled",
                     message: "DIDComm is already enabled.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Use `pnm services didcomm update --mediator-did <did>` to change the active mediator."
                             .into(),
@@ -220,6 +303,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_not_configured",
                     message: "VTA DID is not configured.".into(),
+                    mediator_did: None,
                     suggested_fix: Some("Run `vta setup` to configure the VTA's DID first.".into()),
                     stage: None,
                 },
@@ -229,6 +313,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_record_missing",
                     message: format!("VTA DID `{did}` has no webvh record on disk."),
+                    mediator_did: None,
                     suggested_fix: Some("Re-run `vta setup` — local state appears corrupted.".into()),
                     stage: None,
                 },
@@ -238,6 +323,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_log_missing",
                     message: format!("VTA DID `{did}` has no published log."),
+                    mediator_did: None,
                     suggested_fix: Some("Re-run `vta setup` — local state appears corrupted.".into()),
                     stage: None,
                 },
@@ -247,6 +333,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_log_empty",
                     message: "VTA DID log is empty.".into(),
+                    mediator_did: None,
                     suggested_fix: Some("Re-run `vta setup` — local state appears corrupted.".into()),
                     stage: None,
                 },
@@ -256,6 +343,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "mediator_handshake_failed",
                     message: format!("mediator handshake failed: {cause}"),
+                    mediator_did: None,
                     suggested_fix: Some(match stage {
                         HandshakeStage::Resolve =>
                             "Check the mediator DID is correct and reachable from this VTA.".into(),
@@ -271,6 +359,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "document_patch_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -280,6 +369,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "webvh_update_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -289,6 +379,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "config_persistence_failed",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Check the VTA's config file is writable; the LogEntry was published \
                          but config persistence failed — fix permissions and retry."
@@ -302,6 +393,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "registry_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -311,6 +403,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "forbidden",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: Some("This operation requires super-admin privileges.".into()),
                     stage: None,
                 },
@@ -320,6 +413,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "storage_failed",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -329,6 +423,7 @@ impl IntoResponse for EnableDidcommHttpError {
                 ErrorBody {
                     error: "did_resolver_unavailable",
                     message: "DID resolver is not initialised on this VTA.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Configure `resolver_url` or run with the local resolver.".into(),
                     ),
@@ -451,6 +546,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "didcomm_not_enabled",
                     message: "DIDComm is not currently enabled.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Enable DIDComm first: `pnm services didcomm enable --mediator-did <did>` \
                          (online) or `vta services didcomm enable --mediator-did <did>` \
@@ -465,6 +561,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "no_protocol_remaining",
                     message: "Cannot disable DIDComm — REST is also disabled. The VTA would have no protocol surface left.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Enable REST first: `pnm services rest enable --url <url>` (online) \
                          or `vta services rest enable --url <url>` (offline, daemon stopped). \
@@ -485,6 +582,7 @@ impl IntoResponse for DisableDidcommHttpError {
                     message: format!(
                         "drain ttl {requested}s outside allowed range [{min}s, {max}s]"
                     ),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Either retry over REST transport (`--transport rest`) for a sub-1h TTL, or pick a TTL within bounds (1h–30d).".into(),
                     ),
@@ -496,6 +594,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_not_configured",
                     message: "VTA DID is not configured.".into(),
+                    mediator_did: None,
                     suggested_fix: Some("Run `vta setup` to configure the VTA's DID first.".into()),
                     stage: None,
                 },
@@ -505,6 +604,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_record_missing",
                     message: format!("VTA DID `{did}` has no webvh record on disk."),
+                    mediator_did: None,
                     suggested_fix: Some("Re-run `vta setup` — local state appears corrupted.".into()),
                     stage: None,
                 },
@@ -514,6 +614,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_log_missing",
                     message: format!("VTA DID `{did}` has no published log."),
+                    mediator_did: None,
                     suggested_fix: Some("Re-run `vta setup` — local state appears corrupted.".into()),
                     stage: None,
                 },
@@ -523,6 +624,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_log_empty",
                     message: "VTA DID log is empty.".into(),
+                    mediator_did: None,
                     suggested_fix: Some("Re-run `vta setup` — local state appears corrupted.".into()),
                     stage: None,
                 },
@@ -532,6 +634,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "no_active_mediator",
                     message: "DIDComm is enabled but the DID document has no `#vta-didcomm` service entry.".into(),
+                    mediator_did: None,
                     suggested_fix: Some("On-disk state is inconsistent — re-run `vta setup`.".into()),
                     stage: None,
                 },
@@ -541,6 +644,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "document_patch_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -550,6 +654,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "webvh_update_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -559,6 +664,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "config_persistence_failed",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Check the VTA's config file is writable and retry.".into(),
                     ),
@@ -570,6 +676,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "registry_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -579,6 +686,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "forbidden",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: Some("This operation requires super-admin privileges.".into()),
                     stage: None,
                 },
@@ -588,6 +696,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "storage_failed",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -597,6 +706,7 @@ impl IntoResponse for DisableDidcommHttpError {
                 ErrorBody {
                     error: "did_resolver_unavailable",
                     message: "DID resolver is not initialised on this VTA.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Configure `resolver_url` or run with the local resolver.".into(),
                     ),
@@ -751,6 +861,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                     message:
                         "DIDComm is not currently enabled — there is no active mediator to migrate from."
                             .into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Use `pnm services didcomm enable --mediator-did <did>` first.".into(),
                     ),
@@ -768,6 +879,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                     message: format!(
                         "drain ttl {requested}s outside allowed range [{min}s, {max}s]"
                     ),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Pick a TTL within bounds (1h–30d over DIDComm transport, 0s–30d over REST).".into(),
                     ),
@@ -779,6 +891,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "same_as_active",
                     message: format!("`{did}` is already the active mediator — nothing to migrate."),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -788,6 +901,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "already_draining",
                     message: format!("`{did}` is currently in drain state."),
+                    mediator_did: None,
                     suggested_fix: Some(format!(
                         "Run `pnm services didcomm drain cancel --mediator-did {did}` first, or use `pnm services didcomm rollback` to fail-forward to a state where `{did}` is active."
                     )),
@@ -799,6 +913,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_not_configured",
                     message: "VTA DID is not configured.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Run `vta setup` to configure the VTA's DID first.".into(),
                     ),
@@ -810,6 +925,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_record_missing",
                     message: format!("VTA DID `{did}` has no webvh record on disk."),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Re-run `vta setup` — local state appears corrupted.".into(),
                     ),
@@ -821,6 +937,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_log_missing",
                     message: format!("VTA DID `{did}` has no published log."),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Re-run `vta setup` — local state appears corrupted.".into(),
                     ),
@@ -832,6 +949,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "vta_did_log_empty",
                     message: "VTA DID log is empty.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Re-run `vta setup` — local state appears corrupted.".into(),
                     ),
@@ -845,6 +963,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                     message:
                         "DIDComm is enabled but the DID document has no `#vta-didcomm` service entry."
                             .into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "On-disk state is inconsistent — re-run `vta setup`.".into(),
                     ),
@@ -857,6 +976,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                     ErrorBody {
                         error: "mediator_handshake_failed",
                         message: format!("mediator handshake failed: {cause}"),
+                        mediator_did: None,
                         suggested_fix: Some(match stage {
                             HandshakeStage::Resolve => {
                                 "Check the mediator DID is correct and reachable.".into()
@@ -875,6 +995,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "document_patch_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -884,6 +1005,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "webvh_update_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -893,6 +1015,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "config_persistence_failed",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Check the VTA's config file is writable; the LogEntry was published. Fix permissions and retry."
                             .into(),
@@ -905,6 +1028,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "registry_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -914,6 +1038,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "forbidden",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: Some(
                         "This operation requires super-admin privileges.".into(),
                     ),
@@ -925,6 +1050,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "storage_failed",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -934,6 +1060,7 @@ impl IntoResponse for UpdateDidcommHttpError {
                 ErrorBody {
                     error: "did_resolver_unavailable",
                     message: "DID resolver is not initialised on this VTA.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Configure `resolver_url` or run with the local resolver.".into(),
                     ),
@@ -1002,6 +1129,7 @@ impl IntoResponse for DrainCancelHttpError {
                 ErrorBody {
                     error: "forbidden",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: Some("This operation requires super-admin privileges.".into()),
                     stage: None,
                 },
@@ -1028,6 +1156,7 @@ impl IntoResponse for DrainCancelHttpError {
                     ErrorBody {
                         error: code,
                         message: e.to_string(),
+                        mediator_did: None,
                         suggested_fix: fix,
                         stage: None,
                     },
@@ -1099,6 +1228,7 @@ impl IntoResponse for MediatorReportHttpError {
                 ErrorBody {
                     error: "forbidden",
                     message: e,
+                    mediator_did: None,
                     suggested_fix: Some("This operation requires super-admin privileges.".into()),
                     stage: None,
                 },
@@ -1108,6 +1238,7 @@ impl IntoResponse for MediatorReportHttpError {
                 ErrorBody {
                     error: "telemetry_query_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -1117,6 +1248,7 @@ impl IntoResponse for MediatorReportHttpError {
                 ErrorBody {
                     error: "bad_timestamp",
                     message: format!("invalid RFC 3339 timestamp: {e}"),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Use RFC 3339 / ISO 8601 like `2026-04-29T15:00:00Z`.".into(),
                     ),
@@ -1408,6 +1540,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "service_already_enabled",
                     message: "REST is already enabled.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Use `pnm services rest update --url <url>` to change the URL.".into(),
                     ),
@@ -1419,6 +1552,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "invalid_url",
                     message: msg,
+                    mediator_did: None,
                     suggested_fix: Some(
                         "URL must be https://, parsable, with no fragment or userinfo.".into(),
                     ),
@@ -1432,6 +1566,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "service_not_present",
                     message: "REST is not currently enabled.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Run `pnm services rest enable --url <url>` first.".into(),
                     ),
@@ -1443,6 +1578,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "invalid_url",
                     message: msg,
+                    mediator_did: None,
                     suggested_fix: Some(
                         "URL must be https://, parsable, with no fragment or userinfo.".into(),
                     ),
@@ -1456,6 +1592,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "service_not_present",
                     message: "REST is not currently enabled — nothing to disable.".into(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -1465,6 +1602,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "last_service_refused",
                     message: "Refusing to disable REST — DIDComm is also off, so the VTA would have no advertised services.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Run `pnm services didcomm enable --mediator-did <did>` first, then retry."
                             .into(),
@@ -1484,6 +1622,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "auth",
                     message: msg,
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Super-admin role required for service-management operations.".into(),
                     ),
@@ -1497,6 +1636,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "vta_did_not_configured",
                     message: "VTA DID is not configured.".into(),
+                    mediator_did: None,
                     suggested_fix: Some("Run `vta setup` to configure the VTA's DID first.".into()),
                     stage: None,
                 },
@@ -1508,6 +1648,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "webvh_update_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -1519,6 +1660,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "document_patch_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -1550,6 +1692,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "storage_error",
                     message: "Internal storage / log-replay failure.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Re-run `vta setup` if local state appears corrupted.".into(),
                     ),
@@ -1562,6 +1705,7 @@ impl IntoResponse for RestServiceHttpError {
                 ErrorBody {
                     error: "did_resolver_unavailable",
                     message: "DID resolver not available on this VTA.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Confirm the resolver is configured and running, then retry.".into(),
                     ),
@@ -1787,6 +1931,7 @@ impl IntoResponse for RollbackRestHttpError {
                 ErrorBody {
                     error: "no_prior_mutation",
                     message: "No prior REST mutation to roll back from.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Use `pnm services rest enable / update / disable` directly instead."
                             .into(),
@@ -1802,6 +1947,7 @@ impl IntoResponse for RollbackRestHttpError {
                         "Rolling back this REST mutation would leave the VTA with no advertised \
                          services. Enable DIDComm first and retry."
                             .into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Run `pnm services didcomm enable --mediator-did <did>`, then retry rollback."
                             .into(),
@@ -1814,6 +1960,7 @@ impl IntoResponse for RollbackRestHttpError {
                 ErrorBody {
                     error: "rollback_failed",
                     message: other.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -1823,6 +1970,7 @@ impl IntoResponse for RollbackRestHttpError {
                 ErrorBody {
                     error: "did_resolver_unavailable",
                     message: "DID resolver not available on this VTA.".into(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -1852,6 +2000,7 @@ impl IntoResponse for RollbackDidcommHttpError {
                 ErrorBody {
                     error: "no_prior_mutation",
                     message: "No prior DIDComm mutation to roll back from.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Use `pnm services didcomm enable / update / disable` directly instead."
                             .into(),
@@ -1869,6 +2018,7 @@ impl IntoResponse for RollbackDidcommHttpError {
                         "Rolling back this DIDComm mutation would leave the VTA with no advertised \
                          services. Enable REST first and retry."
                             .into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Run `pnm services rest enable --url <url>`, then retry rollback.".into(),
                     ),
@@ -1880,6 +2030,7 @@ impl IntoResponse for RollbackDidcommHttpError {
                 ErrorBody {
                     error: "rollback_failed",
                     message: other.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -1889,6 +2040,7 @@ impl IntoResponse for RollbackDidcommHttpError {
                 ErrorBody {
                     error: "did_resolver_unavailable",
                     message: "DID resolver not available on this VTA.".into(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -1934,6 +2086,7 @@ impl IntoResponse for ListServicesHttpError {
                 ErrorBody {
                     error: "vta_did_not_configured",
                     message: "VTA DID is not configured.".into(),
+                    mediator_did: None,
                     suggested_fix: Some("Run `vta setup` to configure the VTA's DID first.".into()),
                     stage: None,
                 },
@@ -1943,6 +2096,7 @@ impl IntoResponse for ListServicesHttpError {
                 ErrorBody {
                     error: "auth",
                     message: msg,
+                    mediator_did: None,
                     suggested_fix: Some("Super-admin role required for service inspection.".into()),
                     stage: None,
                 },
@@ -1952,6 +2106,7 @@ impl IntoResponse for ListServicesHttpError {
                 ErrorBody {
                     error: "list_failed",
                     message: other.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -1992,6 +2147,7 @@ impl IntoResponse for ListDrainHttpError {
                 ErrorBody {
                     error: "auth",
                     message: msg,
+                    mediator_did: None,
                     suggested_fix: Some("Super-admin role required for service inspection.".into()),
                     stage: None,
                 },
@@ -2001,6 +2157,7 @@ impl IntoResponse for ListDrainHttpError {
                 ErrorBody {
                     error: "list_drain_failed",
                     message: other.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -2218,6 +2375,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "service_already_enabled",
                     message: "WebAuthn is already enabled.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Use `pnm services webauthn update --url <url>` to change it.".into(),
                     ),
@@ -2230,6 +2388,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "invalid_url",
                     message: msg,
+                    mediator_did: None,
                     suggested_fix: Some("URL must be https://, parsable, with no fragment.".into()),
                     stage: None,
                 },
@@ -2240,6 +2399,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "service_not_present",
                     message: "WebAuthn is not currently enabled.".into(),
+                    mediator_did: None,
                     suggested_fix: Some(
                         "Run `pnm services webauthn enable --url <url>` first.".into(),
                     ),
@@ -2254,6 +2414,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "last_service_refused",
                     message: "Refusing — at least one transport must remain advertised.".into(),
+                    mediator_did: None,
                     suggested_fix: Some("Enable REST or DIDComm before disabling WebAuthn.".into()),
                     stage: None,
                 },
@@ -2263,6 +2424,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "no_prior_mutation",
                     message: "No prior `services webauthn` mutation to roll back.".into(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -2272,6 +2434,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "did_resolver_unavailable",
                     message: "DID resolver not configured.".into(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -2281,6 +2444,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "enable_webauthn_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -2290,6 +2454,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "update_webauthn_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -2299,6 +2464,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "disable_webauthn_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },
@@ -2308,6 +2474,7 @@ impl IntoResponse for WebauthnServiceHttpError {
                 ErrorBody {
                     error: "rollback_webauthn_failed",
                     message: e.to_string(),
+                    mediator_did: None,
                     suggested_fix: None,
                     stage: None,
                 },

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -15,7 +15,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 
-use crate::auth::{AuthClaims, SuperAdminAuth};
+use crate::auth::SuperAdminAuth;
 use crate::messaging::handshake::{AlwaysOkProver, HandshakeError, HandshakeStage};
 use crate::operations::protocol::OpContext;
 use crate::operations::protocol::disable_didcomm::DisableTransport as DidcommTransport;
@@ -189,9 +189,12 @@ pub async fn enable_didcomm_handler(
     }))
 }
 
-/// `GET /services/didcomm` — current DIDComm runtime status. Auth: any role.
+/// `GET /services/didcomm` — current DIDComm runtime status. Auth: super-admin,
+/// for parity with `GET /services` (`list_services`), which exposes the same
+/// `mediator_did`. Gating both the same way avoids a reader-role caller learning
+/// the mediator DID here that it cannot obtain from the sibling list endpoint.
 pub async fn get_didcomm_status_handler(
-    _auth: AuthClaims,
+    _auth: SuperAdminAuth,
     State(state): State<AppState>,
 ) -> Json<DidcommStatusResponse> {
     let (configured, mediator_did) = {

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -696,6 +696,7 @@ async fn resolve_step_up(
 
 /// Trust Task `type` of a step-up approve-request (also the DIDComm message
 /// `type` used when pushing one to an approver).
+#[cfg(feature = "didcomm")]
 const STEP_UP_APPROVE_REQUEST_TYPE: &str =
     "https://trusttasks.org/spec/auth/step-up/approve-request/0.1";
 
@@ -724,7 +725,7 @@ async fn maybe_push_step_up(
     state: &AppState,
     recipient: &str,
     caller_did: &str,
-    approve_request: &Value,
+    #[cfg_attr(not(feature = "didcomm"), allow(unused))] approve_request: &Value,
 ) {
     if recipient == caller_did {
         return; // self mode — the caller satisfies its own step-up.
@@ -736,6 +737,7 @@ async fn maybe_push_step_up(
             cfg.messaging.as_ref().map(|m| m.mediator_did.as_str()),
         )
     };
+    #[cfg_attr(not(feature = "didcomm"), allow(unused))]
     let Some(mediator_did) = mediator_did else {
         tracing::debug!(
             approver = %recipient,

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -743,24 +743,27 @@ async fn maybe_push_step_up(
         );
         return;
     };
-    let pending = crate::messaging::registry::PendingResponse {
-        recipient_did: recipient.to_string(),
-        message_type: STEP_UP_APPROVE_REQUEST_TYPE.to_string(),
-        body: approve_request.clone(),
-        thread_id: approve_request
-            .get("id")
-            .and_then(|v| v.as_str())
-            .map(str::to_string),
-    };
-    if let Err(e) = state
-        .mediator_registry
-        .buffer_outbound(&mediator_did, pending)
-        .await
+    #[cfg(feature = "didcomm")]
     {
-        tracing::warn!(
-            error = %e, approver = %recipient, mediator = %mediator_did,
-            "failed to buffer delegated step-up push; relay fallback applies"
-        );
+        let pending = crate::messaging::registry::PendingResponse {
+            recipient_did: recipient.to_string(),
+            message_type: STEP_UP_APPROVE_REQUEST_TYPE.to_string(),
+            body: approve_request.clone(),
+            thread_id: approve_request
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        };
+        if let Err(e) = state
+            .mediator_registry
+            .buffer_outbound(&mediator_did, pending)
+            .await
+        {
+            tracing::warn!(
+                error = %e, approver = %recipient, mediator = %mediator_did,
+                "failed to buffer delegated step-up push; relay fallback applies"
+            );
+        }
     }
 
     // VTA-trigger: wake the approver's device via its push gateway so a

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -169,6 +169,7 @@ pub struct AppState {
     pub ka_vm_id: Option<String>,
     #[cfg(feature = "didcomm")]
     pub didcomm_bridge: Arc<DIDCommBridge>,
+    pub didcomm_websocket_status: Arc<RwLock<DidcommWebsocketStatus>>,
     pub jwt_keys: Option<Arc<JwtKeys>>,
     pub atm: Option<ATM>,
     pub tee: Option<TeeContext>,
@@ -177,6 +178,25 @@ pub struct AppState {
     /// Prometheus metrics handle for rendering `/metrics` endpoint.
     #[cfg(feature = "rest")]
     pub metrics_handle: Option<crate::metrics::PrometheusHandle>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DidcommWebsocketStatus {
+    Connected,
+    Connecting,
+    #[default]
+    Disconnected,
+}
+
+impl DidcommWebsocketStatus {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Connected => "connected",
+            Self::Connecting => "connecting",
+            Self::Disconnected => "disconnected",
+        }
+    }
 }
 
 impl AuthState for AppState {
@@ -309,6 +329,7 @@ pub async fn build_app_state(
         ka_vm_id: auth.ka_vm_id,
         #[cfg(feature = "didcomm")]
         didcomm_bridge: Arc::new(DIDCommBridge::placeholder()),
+        didcomm_websocket_status: Arc::new(RwLock::new(DidcommWebsocketStatus::Disconnected)),
 
         jwt_keys: auth.jwt_keys,
         atm: auth.atm,
@@ -628,6 +649,7 @@ pub async fn run(
             ka_vm_id: auth.ka_vm_id.clone(),
             #[cfg(feature = "didcomm")]
             didcomm_bridge: didcomm_bridge.clone(),
+            didcomm_websocket_status: Arc::new(RwLock::new(DidcommWebsocketStatus::Disconnected)),
             jwt_keys: auth.jwt_keys,
             atm: auth.atm,
             tee: tee_context.clone(),
@@ -722,6 +744,10 @@ pub async fn run(
                         .await
                     {
                         Ok(service) => {
+                            {
+                                let mut status = app_state.didcomm_websocket_status.write().await;
+                                *status = DidcommWebsocketStatus::Connecting;
+                            }
                             // Wait for the mediator connection before accepting traffic.
                             // Race the wait against shutdown so a Ctrl-C while the
                             // mediator is unreachable doesn't park us here for the full
@@ -732,19 +758,31 @@ pub async fn run(
                                     Duration::from_secs(30),
                                 ) => {
                                     if let Err(e) = res {
+                                        let mut status = app_state.didcomm_websocket_status.write().await;
+                                        *status = DidcommWebsocketStatus::Disconnected;
                                         warn!("DIDComm listener not connected after 30s: {e}");
+                                    } else {
+                                        let mut status = app_state.didcomm_websocket_status.write().await;
+                                        *status = DidcommWebsocketStatus::Connected;
                                     }
                                 }
                                 _ = didcomm_shutdown.cancelled() => {
+                                    let mut status = app_state.didcomm_websocket_status.write().await;
+                                    *status = DidcommWebsocketStatus::Disconnected;
                                     info!("shutdown received before mediator connected");
                                 }
                             }
                             didcomm_bridge.set_service(service.clone());
-                            spawn_event_logger(service.clone());
+                            spawn_event_logger(
+                                service.clone(),
+                                Arc::clone(&app_state.didcomm_websocket_status),
+                            );
                             info!("DIDComm service started");
                             Some(service)
                         }
                         Err(e) => {
+                            let mut status = app_state.didcomm_websocket_status.write().await;
+                            *status = DidcommWebsocketStatus::Disconnected;
                             warn!("failed to start DIDComm service: {e}");
                             None
                         }
@@ -1412,7 +1450,10 @@ fn decode_jwt_key(b64: &str) -> Result<JwtKeys, AppError> {
 
 /// Spawn a background task that logs DIDComm listener lifecycle events.
 #[cfg(feature = "didcomm")]
-fn spawn_event_logger(service: DIDCommService) {
+fn spawn_event_logger(
+    service: DIDCommService,
+    websocket_status: Arc<RwLock<DidcommWebsocketStatus>>,
+) {
     use affinidi_messaging_didcomm_service::ListenerEvent;
 
     let mut rx = service.subscribe();
@@ -1420,9 +1461,11 @@ fn spawn_event_logger(service: DIDCommService) {
         loop {
             match rx.recv().await {
                 Ok(ListenerEvent::Connected { listener_id }) => {
+                    *websocket_status.write().await = DidcommWebsocketStatus::Connected;
                     info!(listener = %listener_id, "DIDComm listener connected to mediator");
                 }
                 Ok(ListenerEvent::Disconnected { listener_id, error }) => {
+                    *websocket_status.write().await = DidcommWebsocketStatus::Disconnected;
                     warn!(
                         listener = %listener_id,
                         error = error.as_deref().unwrap_or("none"),
@@ -1434,6 +1477,7 @@ fn spawn_event_logger(service: DIDCommService) {
                     attempt,
                     delay,
                 }) => {
+                    *websocket_status.write().await = DidcommWebsocketStatus::Connecting;
                     info!(
                         listener = %listener_id,
                         attempt,

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -169,6 +169,10 @@ pub struct AppState {
     pub ka_vm_id: Option<String>,
     #[cfg(feature = "didcomm")]
     pub didcomm_bridge: Arc<DIDCommBridge>,
+    /// WebSocket connection status of the DIDComm listener. Only meaningful
+    /// on the axum server path (`run()`); `build_app_state()` (TEE
+    /// front-ends) never wires the event logger that updates this field.
+    #[cfg(feature = "didcomm")]
     pub didcomm_websocket_status: Arc<RwLock<DidcommWebsocketStatus>>,
     pub jwt_keys: Option<Arc<JwtKeys>>,
     pub atm: Option<ATM>,
@@ -329,6 +333,7 @@ pub async fn build_app_state(
         ka_vm_id: auth.ka_vm_id,
         #[cfg(feature = "didcomm")]
         didcomm_bridge: Arc::new(DIDCommBridge::placeholder()),
+        #[cfg(feature = "didcomm")]
         didcomm_websocket_status: Arc::new(RwLock::new(DidcommWebsocketStatus::Disconnected)),
 
         jwt_keys: auth.jwt_keys,
@@ -649,6 +654,7 @@ pub async fn run(
             ka_vm_id: auth.ka_vm_id.clone(),
             #[cfg(feature = "didcomm")]
             didcomm_bridge: didcomm_bridge.clone(),
+            #[cfg(feature = "didcomm")]
             didcomm_websocket_status: Arc::new(RwLock::new(DidcommWebsocketStatus::Disconnected)),
             jwt_keys: auth.jwt_keys,
             atm: auth.atm,

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -580,6 +580,9 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
         ka_vm_id: None,
         #[cfg(feature = "didcomm")]
         didcomm_bridge: Arc::new(DIDCommBridge::placeholder()),
+        didcomm_websocket_status: Arc::new(tokio::sync::RwLock::new(
+            crate::server::DidcommWebsocketStatus::Disconnected,
+        )),
         jwt_keys: Some(jwt_keys.clone()),
         atm: None,
         tee: None,

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -580,6 +580,7 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
         ka_vm_id: None,
         #[cfg(feature = "didcomm")]
         didcomm_bridge: Arc::new(DIDCommBridge::placeholder()),
+        #[cfg(feature = "didcomm")]
         didcomm_websocket_status: Arc::new(tokio::sync::RwLock::new(
             crate::server::DidcommWebsocketStatus::Disconnected,
         )),

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -329,10 +329,22 @@ async fn didcomm_status_requires_auth() {
 
 #[cfg(feature = "webvh")]
 #[tokio::test]
+async fn didcomm_status_forbids_non_super_admin() {
+    // Parity with `GET /services` (list_services): both are super-admin-gated
+    // since they expose the same `mediator_did`. A reader-role caller is rejected.
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx.auth_token("did:key:z6MkTest", "reader", vec![]).await;
+    let (status, _) = app.request(get_auth("/services/didcomm", &token)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
 async fn didcomm_status_returns_disabled_when_not_enabled() {
     let (app, ctx) = TestApp::new().await;
     ctx.inner.config.write().await.services.didcomm = false;
-    let token = ctx.auth_token("did:key:z6MkTest", "reader", vec![]).await;
+    // admin + empty contexts == super-admin
+    let token = ctx.auth_token("did:key:z6MkTest", "admin", vec![]).await;
     let (status, body) = app.request(get_auth("/services/didcomm", &token)).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, json!({ "enabled": false }));

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -319,6 +319,46 @@ async fn health_details_returns_version_with_auth() {
     assert!(body["version"].is_string());
 }
 
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn didcomm_status_requires_auth() {
+    let (app, _ctx) = TestApp::new().await;
+    let (status, _) = app.request(get("/services/didcomm")).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn didcomm_status_returns_disabled_when_not_enabled() {
+    let (app, ctx) = TestApp::new().await;
+    ctx.inner.config.write().await.services.didcomm = false;
+    let token = ctx.auth_token("did:key:z6MkTest", "reader", vec![]).await;
+    let (status, body) = app.request(get_auth("/services/didcomm", &token)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, json!({ "enabled": false }));
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn didcomm_status_returns_mediator_and_websocket_state_when_enabled() {
+    let (app, ctx) = TestApp::new().await;
+    {
+        let mut config = ctx.inner.config.write().await;
+        config.services.didcomm = true;
+        config.messaging = Some(vti_common::config::MessagingConfig {
+            mediator_url: "wss://mediator.example.com".into(),
+            mediator_did: "did:peer:2.med".into(),
+            mediator_host: None,
+        });
+    }
+    let token = ctx.auth_token("did:key:z6MkTest", "admin", vec![]).await;
+    let (status, body) = app.request(get_auth("/services/didcomm", &token)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["enabled"], true);
+    assert_eq!(body["mediator_did"], "did:peer:2.med");
+    assert_eq!(body["websocket_status"], "disconnected");
+}
+
 // ── Auth: missing/invalid token ────────────────────────────────────
 
 #[tokio::test]
@@ -3116,18 +3156,15 @@ async fn enable_didcomm_non_super_admin_returns_403() {
 async fn enable_didcomm_already_enabled_returns_409_with_suggested_fix() {
     let (app, ctx) = TestApp::new().await;
     let token = ctx.auth_token("did:key:z6MkSuper", "admin", vec![]).await;
-    // Flip services.didcomm = true via PATCH /config equivalent.
-    // The test fixture's config doesn't expose a setter for
-    // services, so we construct a fresh app where DIDComm starts
-    // already-enabled by default.
-    //
-    // Workaround: send the request anyway; the operation reads
-    // config.services.didcomm and refuses. Default is `false` so
-    // this test instead asserts the non-already-enabled refusal
-    // path (vta_did mismatch). We re-target this case to verify a
-    // distinct refusal: the test fixture's vta_did is `did:key:...`
-    // which has no webvh record, so the operation surfaces
-    // VtaDidRecordMissing as 500 with a re-run-setup suggested fix.
+    {
+        let mut config = ctx.inner.config.write().await;
+        config.services.didcomm = true;
+        config.messaging = Some(vti_common::config::MessagingConfig {
+            mediator_url: "wss://mediator.example.com".into(),
+            mediator_did: "did:peer:2.med".into(),
+            mediator_host: None,
+        });
+    }
     let (status, body) = app
         .request(post_auth(
             "/services/didcomm/enable",
@@ -3135,16 +3172,9 @@ async fn enable_didcomm_already_enabled_returns_409_with_suggested_fix() {
             json!({ "mediator_did": "did:key:z6MkBogus" }),
         ))
         .await;
-    // The TestApp's vta_did is `did:key:z6MkTestVTA` (not a webvh
-    // DID), so the precondition check fires before the handshake:
-    // either DidcommAlreadyEnabled (409) if services.didcomm is
-    // ever flipped, or VtaDidRecordMissing (500) given the fresh
-    // fixture. Either way, the route surfaces a typed error body
-    // with a suggested_fix string per CLAUDE.md.
-    assert!(
-        status == StatusCode::CONFLICT || status == StatusCode::INTERNAL_SERVER_ERROR,
-        "expected 409 or 500, got {status}: {body}"
-    );
+    assert_eq!(status, StatusCode::CONFLICT, "unexpected body: {body}");
+    assert_eq!(body["error"], "didcomm_already_enabled");
+    assert_eq!(body["mediator_did"], "did:peer:2.med");
     assert!(
         body.get("suggested_fix").and_then(|v| v.as_str()).is_some(),
         "operator-friendly suggested_fix string is required, body: {body}"


### PR DESCRIPTION
## Changes

### 1. `GET /services/didcomm` status endpoint (VTA)
Returns `{enabled, mediator_did, websocket_status}` for DIDComm configuration discovery. Allows PNM and other clients to discover mediator connection status without requiring DID document resolution — works for all DID methods (did:key, did:web, did:webvh).

### 2. PNM health fallback to `/services/didcomm`
When VTA DID document has no DIDCommMessaging service (e.g. did:key), PNM health now falls back to `GET /services/didcomm` to discover the mediator DID. Enables mediator health checks for all DID methods. Fallback errors are surfaced in diagnostics output (not silently swallowed).

### 3. Fix `GET /services` (list all) 500 for did:key VTAs
`list_services()` unconditionally read the webvh on-chain DID document, causing a 500 `list_failed` error for did:key VTAs (which have no webvh record). Now short-circuits for non-webvh DIDs and returns service state from AppConfig:
- DIDComm: enabled flag + `messaging.mediator_did`
- REST: enabled flag + `public_url`  
- WebAuthn: enabled flag (no URL from config)

### 4. SDK: preserve full 409 Conflict body
`handle_response` now returns `VtaError::Conflict(raw_json_text)` for all 409 responses, preserving structured details (e.g. `mediator_did`) for callers. `enable_didcomm` simplified to use `handle_response` directly — no more hand-rolled request path. Body-read errors are propagated with `?` instead of `unwrap_or_default`.

### 5. Consolidate `EnableDidcommConflictBody`
Single public definition in `vta-sdk::protocol`, removed duplicate from `vta-cli-common`. CLI imports from SDK.

### 6. Feature-gate `didcomm_websocket_status` on `AppState`
Field gated behind `#[cfg(feature = "didcomm")]` — it is only written on the DIDComm path and read by `GET /services/didcomm`. Added doc comment noting it is only meaningful on the axum server path. The `enabled` field in the status response is also gated: always `false` on no-didcomm builds.

### Drive-by fixes (additive, required for CI)
- **`step_up.rs` feature gate**: `STEP_UP_APPROVE_REQUEST_TYPE` const and the `buffer_outbound` block gated behind `#[cfg(feature = "didcomm")]`. Fixes Feature combos CI job (`aws-secrets,keyring,rest` and `azure-secrets,keyring,rest`). Warning-free under `--no-default-features`.
- **e2e test fields**: Added `step_up_approver: None` and `step_up_require: None` to `UpdateAclRequest` in `client_didcomm.rs` (required after rebase onto main which includes #329 and #326).

## Testing
- E2E verified with deployed VTA (AWS) + local docker-compose harness
- `pnm services list` confirmed working for did:key VTAs
- `pnm services didcomm enable` (already enabled) returns friendly 409 message with mediator DID
- Unit test added: `returns_config_state_for_did_key_vta`
- All 6 existing list/list_drain unit tests pass
- All feature combos compile warning-free: default, `aws-secrets,keyring,rest`, `azure-secrets,keyring,rest`, `tee,rest,didcomm`
- SDK integration tests pass (14/14 including `enable_didcomm_409_maps_to_conflict`)
- clippy clean, fmt clean