### PR TITLE
chore(release): bump vta-sdk 0.11.0 → 0.11.1 (label-as-kid fix #337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### vta-sdk 0.11.0 → 0.11.1 — fix: never trust a key's label as its DIDComm kid
+
+Patch release cutting the publish boundary for the fix in #337. The published
+`0.11.0` `VtaClient::fetch_did_secrets_bundle` adopted a key's human-readable
+`label` as the bundle `key_id` whenever the label merely started with `did:` or
+contained `#`. A decorative label such as `"did:key:z6Mk… key-agreement key"`
+therefore silently overwrote the authoritative store `key_id`
+(`{did}#key-1`). A VTA-managed mediator registers its operating secrets under
+that clobbered kid, so a peer encrypting to the `keyAgreement` verification-method
+id published in the mediator's DID document matches no local secret — every
+inbound unpack (including `/authenticate`) fails with `No local secret matches
+any JWE recipient`, and the mediator boots clean but can never read a message.
+
+`select_secret_kid` now uses the authoritative store `key_id` when it is a
+verification-method id of the context DID, falls back to the `label` only when
+the label is *itself* a strict VM id (correct `{did}#` prefix, no embedded
+whitespace), and otherwise excludes the secret (e.g. an admin `did:key` minted
+into the context, or a free-text-labelled key) rather than corrupting the
+operating-secret set. The `label` is treated as human-readable metadata only.
+
+Patch bump — no public API change. Consumers pin `vta-sdk = "0.11"`, which
+`0.11.1` satisfies, so no dependent pin changes are required.
+
 ### Version bumps — delegatedAny + step-up + legacy-strip release
 
 Cuts the publish boundary for the accumulated breaking work documented below

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.11.0",
+ "vta-sdk 0.11.1",
 ]
 
 [[package]]
@@ -3119,7 +3119,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.11.0",
+ "vta-sdk 0.11.1",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.11.0",
+ "vta-sdk 0.11.1",
 ]
 
 [[package]]
@@ -9722,7 +9722,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.11.0",
+ "vta-sdk 0.11.1",
  "x25519-dalek",
 ]
 
@@ -9761,7 +9761,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.11.0",
+ "vta-sdk 0.11.1",
 ]
 
 [[package]]
@@ -9796,7 +9796,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9923,7 +9923,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.11.0",
+ "vta-sdk 0.11.1",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -10005,7 +10005,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.11.0",
+ "vta-sdk 0.11.1",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -10048,7 +10048,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.11.0",
+ "vta-sdk 0.11.1",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10075,7 +10075,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.11.0",
+ "vta-sdk 0.11.1",
  "vta-service",
  "vti-common",
 ]

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## What

Patch-bumps `vta-sdk` `0.11.0 → 0.11.1` to cut a publishable release of the fix in #337. The fix is already on `main` but unreleased, and crates.io `0.11.0` is buggy.

## Why

The published `0.11.0` `VtaClient::fetch_did_secrets_bundle` adopted a key's human-readable **`label`** as the bundle **`key_id`** whenever the label merely started with `did:` or contained `#`. A decorative label such as `"did:key:z6Mk… key-agreement key"` silently overwrote the authoritative store `key_id` (`{did}#key-1`).

A VTA-managed mediator registers its operating secrets under that clobbered kid. A peer then encrypts inbound DIDComm to the `keyAgreement` verification-method id published in the mediator's DID document, the mediator's exact-match recipient lookup finds no matching secret, and **every** inbound unpack — including the `/authenticate` handshake — fails with:

```
No local secret matches any JWE recipient
```

The mediator boots clean but can never read a single message. Diagnosed in the field against `webvh.storm.ws`: the VTA store held the correct `key_id`/`public_key` (`…mediator-2#key-1`), but the SDK delivered the decorative label as the kid.

#337's `select_secret_kid` is the real fix — it prefers the authoritative store `key_id`, falls back to the label only when the label is *itself* a strict VM id (correct `{did}#` prefix, no whitespace), and otherwise excludes the secret (e.g. an admin `did:key` minted into the context). The `label` is human-readable metadata only.

## Scope

- `vta-sdk/Cargo.toml`: `0.11.0 → 0.11.1`
- `CHANGELOG.md`: Unreleased entry
- `Cargo.lock`: workspace member synced

Patch bump — **no public API change**. All workspace consumers pin `vta-sdk = "0.11"`, which `0.11.1` satisfies, so **no dependent pin changes** are required. Downstream (e.g. `affinidi-tdk-rs` mediator, which pins crates.io `vta-sdk = "0.11"`) picks up the fix on the next `cargo update` once `0.11.1` is published.

## Verification

`cargo fmt -p vta-sdk` + `cargo check -p vta-sdk` green.