### PR TITLE
fix(vta-service): mediator wizard ships a usable WS endpoint and secret bundle

### DIFF
--- a/vta-sdk/src/client/secrets.rs
+++ b/vta-sdk/src/client/secrets.rs
@@ -1,6 +1,7 @@
 //! Convenience methods for paginating + bundling key secrets via [`VtaClient`].
 
 use super::VtaClient;
+use crate::did_secrets::select_secret_kid;
 use crate::error::VtaError;
 
 impl VtaClient {
@@ -102,50 +103,9 @@ impl VtaClient {
     }
 }
 
-/// Decide the verification-method id (kid) to publish for a context secret
-/// in a [`DidSecretsBundle`](crate::did_secrets::DidSecretsBundle), or
-/// `None` if the secret must be excluded.
-///
-/// The kid a VTA-managed mediator matches inbound JWE recipients against
-/// must be a verification-method id of the bundle's DID (`{did}#...`).
-/// Rules, in order:
-///
-/// 1. If the store's `record_key_id` is already a VM id of `did`, use it.
-///    Every DID-operating-key flow stores exactly this
-///    (`save_entity_key_records` → `{did}#key-0` / `#key-1`), so this is
-///    the common path.
-/// 2. Otherwise, if the human `label` is *itself* a strict VM id of `did`
-///    (correct prefix, no embedded whitespace), adopt it. Covers generic
-///    `/keys` records whose id defaults to a derivation path while the
-///    label carries the VM id.
-/// 3. Otherwise the secret is not a verification method of this DID — an
-///    admin `did:key` minted into the same context, or a free-text label
-///    such as `"<did:key> signing key"`. Exclude it.
-///
-/// Rule 3 is the fix for the storm.ws outage: the previous logic adopted
-/// the label as the kid whenever it merely *started with* `did:` or
-/// *contained* `#`, so a decorative label like
-/// `"did:key:z6Mkr4J… signing key"` silently overwrote the correct
-/// `{did}#key-1` kid. The mediator then found no local secret matching the
-/// recipient kid published in its own DID document and failed every unpack
-/// with `No local secret matches any JWE recipient`.
-fn select_secret_kid(did: &str, record_key_id: &str, label: Option<&str>) -> Option<String> {
-    let vm_prefix = format!("{did}#");
-    if record_key_id.starts_with(&vm_prefix) {
-        return Some(record_key_id.to_string());
-    }
-    if let Some(label) = label
-        && label.starts_with(&vm_prefix)
-        && !label.chars().any(char::is_whitespace)
-    {
-        return Some(label.to_string());
-    }
-    None
-}
-
 #[cfg(test)]
 mod tests {
-    use super::select_secret_kid;
+    use crate::did_secrets::select_secret_kid;
 
     const DID: &str =
         "did:webvh:QmQjq4GHRH9fwSXCg4884kxpCMT5EUqHB9XY2U7aXisP8R:webvh.storm.ws:mediator-2";

--- a/vta-sdk/src/did_secrets.rs
+++ b/vta-sdk/src/did_secrets.rs
@@ -65,6 +65,51 @@ impl From<crate::client::GetKeySecretResponse> for SecretEntry {
     }
 }
 
+/// Decide the verification-method id (kid) to publish for a context secret
+/// in a [`DidSecretsBundle`], or `None` if the secret must be excluded.
+///
+/// The kid a VTA-managed mediator matches inbound JWE recipients against
+/// must be a verification-method id of the bundle's DID (`{did}#...`).
+/// Rules, in order:
+///
+/// 1. If the store's `record_key_id` is already a VM id of `did`, use it.
+///    Every DID-operating-key flow stores exactly this
+///    (`save_entity_key_records` → `{did}#key-0` / `#key-1`), so this is
+///    the common path.
+/// 2. Otherwise, if the human `label` is *itself* a strict VM id of `did`
+///    (correct prefix, no embedded whitespace), adopt it. Covers generic
+///    `/keys` records whose id defaulted to a derivation path while the
+///    label carries the VM id.
+/// 3. Otherwise the secret is not a verification method of this DID — an
+///    admin `did:key` minted into the same context, or a free-text label
+///    such as `"<did:key> signing key"`. Exclude it.
+///
+/// Rule 3 is the fix for the storm.ws outage (PR #337): the previous
+/// logic adopted the label as the kid whenever it merely *started with*
+/// `did:` or *contained* `#`, so a decorative label like
+/// `"did:key:z6Mkr4J… signing key"` silently overwrote the correct
+/// `{did}#key-1` kid. The mediator then found no local secret matching
+/// the recipient kid published in its own DID document and failed every
+/// unpack with `No local secret matches any JWE recipient`.
+///
+/// Shared between the online SDK path (`VtaClient::fetch_did_secrets_bundle`)
+/// and the offline VTA-service path
+/// (`vta_service::operations::export::build_did_secrets_bundle`) so the
+/// two cannot drift.
+pub fn select_secret_kid(did: &str, record_key_id: &str, label: Option<&str>) -> Option<String> {
+    let vm_prefix = format!("{did}#");
+    if record_key_id.starts_with(&vm_prefix) {
+        return Some(record_key_id.to_string());
+    }
+    if let Some(label) = label
+        && label.starts_with(&vm_prefix)
+        && !label.chars().any(char::is_whitespace)
+    {
+        return Some(label.to_string());
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vta-service/src/keys/mod.rs
+++ b/vta-service/src/keys/mod.rs
@@ -304,7 +304,13 @@ pub async fn derive_entity_keys(
 
 /// Store entity key records using DID verification method IDs as key_ids.
 ///
-/// Signing key → `{did}#key-0`, key-agreement key → `{did}#key-1`.
+/// Signing key → `{did}#key-0`, key-agreement key → `{did}#key-1`. The
+/// `label` field is also stored as the VM id rather than the freeform
+/// description carried in `derived.{signing,ka}_label`: belt-and-braces
+/// for downstream code that historically adopted the label as the kid
+/// (see [`vta_sdk::did_secrets::select_secret_kid`] rule #2). A reader
+/// that confuses label and id can no longer break decryption — both
+/// agree.
 pub async fn save_entity_key_records(
     did: &str,
     derived: &DerivedEntityKeys,
@@ -312,24 +318,26 @@ pub async fn save_entity_key_records(
     context_id: Option<&str>,
     seed_id: Option<u32>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let signing_vm_id = format!("{did}#key-0");
+    let ka_vm_id = format!("{did}#key-1");
     save_key_record(
         keys_ks,
-        &format!("{did}#key-0"),
+        &signing_vm_id,
         &derived.signing_path,
         KeyType::Ed25519,
         &derived.signing_pub,
-        &derived.signing_label,
+        &signing_vm_id,
         context_id,
         seed_id,
     )
     .await?;
     save_key_record(
         keys_ks,
-        &format!("{did}#key-1"),
+        &ka_vm_id,
         &derived.ka_path,
         KeyType::X25519,
         &derived.ka_pub,
-        &derived.ka_label,
+        &ka_vm_id,
         context_id,
         seed_id,
     )

--- a/vta-service/src/operations/export.rs
+++ b/vta-service/src/operations/export.rs
@@ -29,7 +29,7 @@ use vta_sdk::context_provision::ContextProvisionBundle;
 #[cfg(feature = "webvh")]
 use vta_sdk::context_provision::ProvisionedDid;
 use vta_sdk::credentials::CredentialBundle;
-use vta_sdk::did_secrets::{DidSecretsBundle, SecretEntry};
+use vta_sdk::did_secrets::{DidSecretsBundle, SecretEntry, select_secret_kid};
 use vta_sdk::keys::KeyStatus;
 
 /// Dependencies for the offline state-assembly helpers.
@@ -52,9 +52,12 @@ pub struct ExportDeps<'a> {
 /// keys in the local store and loading each secret.
 ///
 /// Mirrors [`vta_sdk::client::VtaClient::fetch_did_secrets_bundle`] —
-/// same traversal (context → active keys → secret per key), same label-
-/// based key-id mapping (if a key's label looks like a DID verification
-/// method id, use it as the `SecretEntry.key_id`).
+/// same traversal (context → active keys → secret per key), same kid
+/// selection via [`vta_sdk::did_secrets::select_secret_kid`]. Secrets
+/// that aren't verification methods of the context DID (admin `did:key`
+/// rolled into the same context, free-text-labelled records) are
+/// excluded; including them would corrupt the operating-secret set the
+/// mediator matches inbound JWE recipients against.
 pub async fn build_did_secrets_bundle(
     deps: &ExportDeps<'_>,
     auth: &AuthClaims,
@@ -103,20 +106,33 @@ pub async fn build_did_secrets_bundle(
                 channel,
             )
             .await?;
-            // Label-as-key-id convention: setup wizard + provisioning
-            // flows set labels to DID verification method ids so the
-            // bundle installs verbatim without consumer-side mapping.
-            let key_id = match key.label.as_deref() {
-                Some(label) if label.contains('#') || label.starts_with("did:") => {
-                    label.to_string()
+            // The kid a mediator matches inbound JWE recipients against MUST be
+            // a verification-method id of *this* context's DID. Resolve it from
+            // the authoritative store key_id (falling back to the label only
+            // when the label is itself a strict VM id); drop anything that
+            // isn't a VM id of `did`. Identical contract to the online
+            // `VtaClient::fetch_did_secrets_bundle` — shared helper.
+            match select_secret_kid(&did, &secret.key_id, key.label.as_deref()) {
+                Some(key_id) => secrets.push(SecretEntry {
+                    key_id,
+                    key_type: secret.key_type,
+                    private_key_multibase: secret.private_key_multibase,
+                }),
+                None => {
+                    debug!(
+                        channel,
+                        %context_id,
+                        %did,
+                        key_id = %secret.key_id,
+                        label = key.label.as_deref().unwrap_or(""),
+                        "excluding secret from did-secrets bundle: not a verification \
+                         method of the context DID (e.g. an admin did:key minted into \
+                         this context, or a free-text-labelled key). Including it would \
+                         corrupt the DIDComm operating-secret set and break the \
+                         mediator's exact-match recipient lookup."
+                    );
                 }
-                _ => secret.key_id,
-            };
-            secrets.push(SecretEntry {
-                key_id,
-                key_type: secret.key_type,
-                private_key_multibase: secret.private_key_multibase,
-            });
+            }
         }
         offset += page.keys.len() as u64;
         if offset >= page.total {

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -506,11 +506,25 @@ pub async fn apply_inputs(inputs: WizardInputs) -> Result<(), Box<dyn std::error
         } => {
             let _med_ctx =
                 create_seed_context(&contexts_ks, context, "DIDComm Messaging Mediator").await?;
-            // Operator-supplied vars first; then `URL` (and any auto-derived
+            // Operator-supplied vars first; then `URL` (and the auto-derived
             // `WS_URL`) so the wizard's notion of the endpoint always wins
-            // even if an operator typo'd it under template_vars.
+            // even if an operator typo'd it under template_vars. `WS_URL`
+            // is required by the `didcomm-mediator` template since it
+            // started advertising HTTP + WSS in a single `#service` block.
             let mut effective_vars: HashMap<String, serde_json::Value> = template_vars.clone();
             effective_vars.insert("URL".into(), json!(url));
+            let ws_url = if let Some(rest) = url.strip_prefix("https://") {
+                format!("wss://{rest}")
+            } else if let Some(rest) = url.strip_prefix("http://") {
+                format!("ws://{rest}")
+            } else {
+                return Err(format!(
+                    "messaging.url '{url}' must start with http:// or https:// so the \
+                     wizard can derive WS_URL"
+                )
+                .into());
+            };
+            effective_vars.insert("WS_URL".into(), json!(ws_url));
 
             // `url` is the DIDComm endpoint; `webvh_url` is the DID-document
             // hosting URL. They are usually the same host but are semantically

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -513,7 +513,11 @@ pub async fn apply_inputs(inputs: WizardInputs) -> Result<(), Box<dyn std::error
             // started advertising HTTP + WSS in a single `#service` block.
             let mut effective_vars: HashMap<String, serde_json::Value> = template_vars.clone();
             effective_vars.insert("URL".into(), json!(url));
-            let ws_url = if let Some(rest) = url.strip_prefix("https://") {
+            // Mirror the mediator-setup convention: `{base}/ws` for the
+            // WebSocket upgrade alongside `{base}/` for HTTP DIDComm.
+            // Defined in `affinidi-messaging-mediator/tools/mediator-setup/
+            // src/generators/did_peer.rs::websocket_service_uri`.
+            let scheme_swapped = if let Some(rest) = url.strip_prefix("https://") {
                 format!("wss://{rest}")
             } else if let Some(rest) = url.strip_prefix("http://") {
                 format!("ws://{rest}")
@@ -524,6 +528,7 @@ pub async fn apply_inputs(inputs: WizardInputs) -> Result<(), Box<dyn std::error
                 )
                 .into());
             };
+            let ws_url = format!("{}/ws", scheme_swapped.trim_end_matches('/'));
             effective_vars.insert("WS_URL".into(), json!(ws_url));
 
             // `url` is the DIDComm endpoint; `webvh_url` is the DID-document

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -1251,6 +1251,20 @@ fn prompt_optional_mediator_host() -> Result<Option<String>, Box<dyn std::error:
     Ok(if host.is_empty() { None } else { Some(host) })
 }
 
+/// Best-effort default for the mediator's WebSocket endpoint, derived
+/// from the HTTP endpoint by swapping the scheme. The operator can
+/// override it interactively; this just spares them retyping the host
+/// for the common case where HTTP and WSS share a hostname.
+fn default_ws_url_from_http(http_url: &str) -> String {
+    if let Some(rest) = http_url.strip_prefix("https://") {
+        format!("wss://{rest}")
+    } else if let Some(rest) = http_url.strip_prefix("http://") {
+        format!("ws://{rest}")
+    } else {
+        String::new()
+    }
+}
+
 /// Prompt for an optional comma-separated list of routing-key DIDs
 /// for the `didcomm-mediator` template's `ROUTING_KEYS` variable.
 /// Used when this mediator forwards traffic through an upstream
@@ -1338,6 +1352,18 @@ async fn configure_messaging(
 
             let mediator_url: String = Input::new().with_prompt("Mediator URL").interact_text()?;
 
+            // The didcomm-mediator template advertises a WebSocket
+            // transport in the same `#service` block; required by the
+            // template since the HTTP + WSS dual-transport change.
+            // Default to the HTTP URL with the scheme swapped — operators
+            // can override when WS is hosted elsewhere.
+            let ws_default = default_ws_url_from_http(&mediator_url);
+            let mut ws_prompt = Input::new().with_prompt("Mediator WebSocket URL");
+            if !ws_default.is_empty() {
+                ws_prompt = ws_prompt.default(ws_default);
+            }
+            let mediator_ws_url: String = ws_prompt.interact_text()?;
+
             let mediator_host = prompt_optional_mediator_host()?;
 
             // Optional ROUTING_KEYS escape hatch (mediator chains). The
@@ -1362,6 +1388,7 @@ async fn configure_messaging(
             let mut template_vars: std::collections::HashMap<String, serde_json::Value> =
                 std::collections::HashMap::new();
             template_vars.insert("URL".into(), json!(mediator_url));
+            template_vars.insert("WS_URL".into(), json!(mediator_ws_url));
             if !routing_keys.is_empty() {
                 template_vars.insert("ROUTING_KEYS".into(), json!(routing_keys));
             }

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -1252,17 +1252,25 @@ fn prompt_optional_mediator_host() -> Result<Option<String>, Box<dyn std::error:
 }
 
 /// Best-effort default for the mediator's WebSocket endpoint, derived
-/// from the HTTP endpoint by swapping the scheme. The operator can
-/// override it interactively; this just spares them retyping the host
-/// for the common case where HTTP and WSS share a hostname.
+/// from the HTTP endpoint by swapping the scheme and appending `/ws`.
+/// Mirrors the canonical convention in
+/// `affinidi-messaging-mediator/tools/mediator-setup` (the mediator
+/// serves HTTP DIDComm at `{base}/` and the WebSocket upgrade at
+/// `{base}/ws`). Operators can override interactively when their
+/// reverse proxy routes WS elsewhere.
 fn default_ws_url_from_http(http_url: &str) -> String {
-    if let Some(rest) = http_url.strip_prefix("https://") {
-        format!("wss://{rest}")
+    let (scheme_swapped, scheme_ok) = if let Some(rest) = http_url.strip_prefix("https://") {
+        (format!("wss://{rest}"), true)
     } else if let Some(rest) = http_url.strip_prefix("http://") {
-        format!("ws://{rest}")
+        (format!("ws://{rest}"), true)
     } else {
-        String::new()
+        (String::new(), false)
+    };
+    if !scheme_ok {
+        return String::new();
     }
+    let trimmed = scheme_swapped.trim_end_matches('/');
+    format!("{trimmed}/ws")
 }
 
 /// Prompt for an optional comma-separated list of routing-key DIDs


### PR DESCRIPTION
## Summary

  Two follow-on fixes to the `vta setup` mediator-DID flow so a freshly-minted mediator boots with the right WebSocket endpoint and a complete secret bundle. Both interactive and `--from <toml>` setup paths are kept in sync.

  ### 1. `WS_URL` defaults now end in `/ws`

  The wizard's derived `WS_URL` did the scheme swap (`https` -> `wss`) but stopped there. The Affinidi mediator's WebSocket endpoint is canonically at `{base}/ws` alongside HTTP DIDComm at `{base}/`, so emitting `wss://host/mediator/v1` produces a DID doc that nginx 404s on every WS upgrade.

  - `default_ws_url_from_http` trims any trailing slash and appends `/ws`.
  - TOML setup applies the same `/ws` suffix when deriving `WS_URL` from `messaging.url`, so both paths agree.

  Confirmed against a live deployment: with the suffix the upgrade reaches the mediator and gets a 401 "Missing credentials" — same path, just no token — which is the expected protocol response.

  ### 2. Mediator wizard secret-bundle gaps

  The interactive mediator-DID flow could not actually render the `didcomm-mediator` builtin: the template started requiring `WS_URL` (commit 666dbd1) and neither setup path supplied it. The offline export also kept a copy of the pre-#337 label-as-kid
  defect that the SDK fixed for the online path. Together these meant a freshly-minted mediator could ship with no operating secrets the mediator-setup guard would accept.

  - Interactive setup prompts for `WS_URL`, defaulting to the HTTP URL with the scheme swapped.
  - TOML setup derives `WS_URL` from `messaging.url` the same way; non-http(s) URLs error early with guidance.
  - `select_secret_kid` moves from a private `client::secrets` fn into `vta_sdk::did_secrets` as `pub`, so the online and offline bundle builders share one implementation and cannot drift again.
  - `vta_service::operations::export::build_did_secrets_bundle` now calls `select_secret_kid` instead of its own `label.contains('#') || label.starts_with("did:")` check. Non-VM-id secrets are excluded with a `debug!` line; same contract as the SDK path.
  - `save_entity_key_records` writes the VM id as both `key_id` and `label`, instead of the freeform "<label> signing key" / "<label> key-agreement key". Belt-and-braces against #337-style regressions.

  ## Test plan

  - [x] `cargo test -p vta-service --lib` (677 pass)
  - [x] `cargo test -p vta-sdk --lib --features client` (152 pass, incl. the 5 `select_secret_kid` regression tests at their new location)
  - [x] `cargo clippy -p vta-sdk -p vta-service` clean
  - [x] `cargo fmt --check` clean
  - [x] Live-deployment check: WS upgrade reaches mediator and returns 401 "Missing credentials" instead of nginx 404.
  - [x] Re-run `vta setup` end-to-end against a clean store and confirm the rendered `didcomm-mediator` document carries the `/ws` WebSocket service and the saved secrets all have VM-id kids.
