### PR TITLE
fix: serialise every store counter and one-shot creation race (P0.4)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -25,13 +25,13 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   (wire-facing bypass) — PR: #341 (in review)
 - `[~]` **P0.4** (S) Shared locked counter allocator; fix
   `allocate_context_index` race (same-subtree key derivation) —
-  implemented on branch `fix/p0.4-counter-races` (stacked on P0.3 #341,
-  PR opens after #341 merges). Delivered: `vti-common/src/store/counter.rs`
-  (app-level lock so the vsock backend is covered too); allocate_path +
-  allocate_context_index delegate; `insert_raw_if_absent` closes the KEK
-  salt race; ROTATE_LOCK serialises seed rotation; create_context claims
-  its record atomically at both layers. Concurrency regression tests for
-  all four — PR: ____
+  implemented on branch `fix/p0.4-counter-races`. Delivered:
+  `vti-common/src/store/counter.rs` (app-level lock so the vsock backend
+  is covered too); allocate_path + allocate_context_index delegate;
+  `insert_raw_if_absent` closes the KEK salt race; ROTATE_LOCK serialises
+  seed rotation; create_context claims its record atomically at both
+  layers; concurrency regression tests for all four —
+  PR: #342 (stacked on #341)
 - `[ ]` **P0.5** (L) Backup/restore: export counters (no BIP-32 path reuse),
   full `AclEntry` round-trip, import-in-progress sentinel — PR: ____
 - `[ ]` **P0.6** (S) TEE seed rotation: reject or persist (no silent key loss) — PR: ____

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -22,14 +22,16 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   closures (take_raw/swap) were NOT actually atomic — added a shared
   per-keyspace write lock in LocalStore + `insert_if_absent` primitive +
   concurrency regression tests; also validated `rename_key`'s new id
-  (wire-facing bypass) — PR: ____
+  (wire-facing bypass) — PR: #341 (in review)
 - `[~]` **P0.4** (S) Shared locked counter allocator; fix
-  `allocate_context_index` race (same-subtree key derivation) — next up
-  after P0.3. Scoped during P0.3: new `vti-common/src/store/counter.rs`
-  (app-level lock so the vsock backend is covered too, like ALLOC_LOCK);
-  delegate allocate_path + allocate_context_index; `insert_raw_if_absent`
-  for the KEK salt race; ROTATE_LOCK around operations::seeds::rotate_seed
-  (gen N+1 race); insert_if_absent for the create_context record — PR: ____
+  `allocate_context_index` race (same-subtree key derivation) —
+  implemented on branch `fix/p0.4-counter-races` (stacked on P0.3 #341,
+  PR opens after #341 merges). Delivered: `vti-common/src/store/counter.rs`
+  (app-level lock so the vsock backend is covered too); allocate_path +
+  allocate_context_index delegate; `insert_raw_if_absent` closes the KEK
+  salt race; ROTATE_LOCK serialises seed rotation; create_context claims
+  its record atomically at both layers. Concurrency regression tests for
+  all four — PR: ____
 - `[ ]` **P0.5** (L) Backup/restore: export counters (no BIP-32 path reuse),
   full `AclEntry` round-trip, import-in-progress sentinel — PR: ____
 - `[ ]` **P0.6** (S) TEE seed rotation: reject or persist (no silent key loss) — PR: ____

--- a/vta-service/src/contexts/mod.rs
+++ b/vta-service/src/contexts/mod.rs
@@ -19,6 +19,17 @@ pub async fn store_context(ks: &KeyspaceHandle, record: &ContextRecord) -> Resul
     ks.insert(ctx_key(&record.id), record).await
 }
 
+/// Store a NEW context record, claiming the id atomically. Returns
+/// `false` (storing nothing) when the id is already taken — creation
+/// paths must treat that as a Conflict, never overwrite: last-writer-
+/// wins on a context record silently re-points its BIP-32 base path.
+pub async fn store_new_context(
+    ks: &KeyspaceHandle,
+    record: &ContextRecord,
+) -> Result<bool, AppError> {
+    ks.insert_if_absent(ctx_key(&record.id), record).await
+}
+
 /// Delete a context by ID.
 pub async fn delete_context(ks: &KeyspaceHandle, id: &str) -> Result<(), AppError> {
     ks.remove(ctx_key(id)).await
@@ -50,18 +61,11 @@ pub async fn allocate_context_index(
     base_prefix: &str,
     counter_key: &str,
 ) -> Result<(u32, String), AppError> {
-    let current: u32 = match ks.get_raw(counter_key).await? {
-        Some(bytes) => {
-            let arr: [u8; 4] = bytes
-                .try_into()
-                .map_err(|_| AppError::Internal("corrupt context counter".into()))?;
-            u32::from_le_bytes(arr)
-        }
-        None => 0,
-    };
+    // Serialised via the shared counter allocator: two concurrent
+    // context creations handed the same index would share an entire
+    // BIP-32 subtree — identical private keys across trust boundaries.
+    let current = vti_common::store::counter::allocate_u32(ks, counter_key).await?;
     let base_path = format!("{base_prefix}/{current}'");
-    ks.insert_raw(counter_key, (current + 1).to_le_bytes().to_vec())
-        .await?;
     Ok((current, base_path))
 }
 
@@ -86,11 +90,93 @@ pub async fn create_context(
         created_at: now,
         updated_at: now,
     };
-    store_context(contexts_ks, &record)
+    if !store_new_context(contexts_ks, &record)
         .await
-        .map_err(|e| format!("{e}"))?;
+        .map_err(|e| format!("{e}"))?
+    {
+        // The allocated counter slot is intentionally left as a gap —
+        // counters skip forward on a lost race, they never reuse.
+        return Err(format!("context already exists: {id}").into());
+    }
     Ok(record)
 }
 
 /// Base path for application context keys.
 pub const CONTEXT_KEY_BASE: &str = "m/26'/2'";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use vti_common::config::StoreConfig;
+
+    fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        (store.keyspace("contexts").expect("keyspace"), dir)
+    }
+
+    /// Regression test for the context-index race: N concurrent
+    /// allocations must yield N distinct base paths. Two contexts
+    /// handed the same index would share an entire BIP-32 subtree —
+    /// identical private keys across trust boundaries.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn allocate_context_index_is_collision_free_under_concurrency() {
+        let (ks, _dir) = temp_ks();
+
+        let n = 64usize;
+        let mut handles = Vec::with_capacity(n);
+        for _ in 0..n {
+            let ks = ks.clone();
+            handles.push(tokio::spawn(async move {
+                allocate_context_index(&ks, CONTEXT_KEY_BASE, "ctx_counter")
+                    .await
+                    .expect("alloc")
+            }));
+        }
+        let mut paths = std::collections::HashSet::with_capacity(n);
+        for h in handles {
+            let (_, base_path) = h.await.expect("join");
+            assert!(
+                paths.insert(base_path.clone()),
+                "duplicate context base path {base_path}"
+            );
+        }
+        assert_eq!(paths.len(), n);
+    }
+
+    /// Concurrent creates with the same id: exactly one may win; the
+    /// losers must not overwrite the winner's record (last-writer-wins
+    /// would silently re-point the context's BIP-32 base path).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_same_id_creates_admit_exactly_one() {
+        let (ks, _dir) = temp_ks();
+
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let ks = ks.clone();
+            handles.push(tokio::spawn(async move {
+                create_context(&ks, "contested", "Contested").await.ok()
+            }));
+        }
+        let mut winners = Vec::new();
+        for h in handles {
+            if let Some(rec) = h.await.expect("join") {
+                winners.push(rec);
+            }
+        }
+        assert_eq!(winners.len(), 1, "exactly one same-id create may win");
+
+        let stored = get_context(&ks, "contested")
+            .await
+            .expect("get")
+            .expect("record exists");
+        assert_eq!(
+            stored.base_path, winners[0].base_path,
+            "stored record must be the winner's — no overwrite by losers"
+        );
+    }
+}

--- a/vta-service/src/keys/imported.rs
+++ b/vta-service/src/keys/imported.rs
@@ -32,16 +32,30 @@ fn build_aad(key_id: &str, key_type: &str) -> Vec<u8> {
 }
 
 /// Get or create the KEK salt. Returns the 32-byte salt.
+///
+/// The first-ever creation is claimed via `insert_raw_if_absent`: two
+/// concurrent first imports must converge on ONE salt. The loser of
+/// the race reads the winner's salt back — a plain insert here would
+/// overwrite the winner's salt and leave its just-encrypted secret
+/// permanently undecryptable.
 pub async fn get_or_create_salt(keys_ks: &KeyspaceHandle) -> Result<Vec<u8>, AppError> {
     if let Some(existing) = keys_ks.get_raw(KEK_SALT_KEY).await? {
         return Ok(existing);
     }
-    // Generate a new random salt
+    // Generate a new random salt and try to claim the slot.
     use aes_gcm::aead::rand_core::RngCore;
     let mut salt = vec![0u8; 32];
     aes_gcm::aead::OsRng.fill_bytes(&mut salt);
-    keys_ks.insert_raw(KEK_SALT_KEY, salt.clone()).await?;
-    Ok(salt)
+    if keys_ks
+        .insert_raw_if_absent(KEK_SALT_KEY, salt.clone())
+        .await?
+    {
+        return Ok(salt);
+    }
+    keys_ks
+        .get_raw(KEK_SALT_KEY)
+        .await?
+        .ok_or_else(|| AppError::Internal("KEK salt vanished after losing creation race".into()))
 }
 
 /// Store the KEK salt (used during backup restore).
@@ -263,6 +277,36 @@ mod tests {
         };
         let store = Store::open(&config).unwrap();
         (store, dir)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn get_or_create_salt_converges_on_one_salt_under_concurrency() {
+        // Two concurrent first imports must agree on a single KEK salt:
+        // a lost overwrite here makes the winner's just-encrypted secret
+        // permanently undecryptable.
+        let (store, _dir) = temp_store();
+
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let ks = store.keyspace("keys").unwrap();
+            handles.push(tokio::spawn(async move {
+                get_or_create_salt(&ks).await.expect("salt")
+            }));
+        }
+        let mut salts = Vec::new();
+        for h in handles {
+            salts.push(h.await.expect("join"));
+        }
+        let persisted = get_salt(&store.keyspace("keys").unwrap())
+            .await
+            .unwrap()
+            .expect("salt persisted");
+        for s in &salts {
+            assert_eq!(
+                s, &persisted,
+                "every concurrent caller must observe the persisted salt"
+            );
+        }
     }
 
     #[tokio::test]

--- a/vta-service/src/keys/paths.rs
+++ b/vta-service/src/keys/paths.rs
@@ -1,44 +1,24 @@
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
-use std::sync::LazyLock;
-use tokio::sync::Mutex;
 use tracing::debug;
+use vti_common::store::counter;
 
 /// Construct a full derivation path from a base and index.
 pub fn path_at(base: &str, index: u32) -> String {
     format!("{base}/{index}'")
 }
 
-/// Serializes the read-increment-write of path counters across the
-/// process. The fjall store has no atomic increment primitive, so two
-/// concurrent `allocate_path` callers would otherwise observe the same
-/// counter value and be handed identical BIP-32 derivation paths —
-/// producing two `KeyRecord`s that share a private key. Allocation is
-/// infrequent and the section is short, so a single global lock is
-/// acceptable; per-base sharding would be a refinement only if this
-/// becomes a hot path.
-static ALLOC_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
 /// Allocate the next sequential derivation path from a group's counter.
 ///
-/// Reads the current counter for `base` from the keys keyspace,
-/// constructs `{base}/{N}'`, increments the counter, and returns the path.
+/// Allocation goes through [`vti_common::store::counter::allocate_u32`],
+/// which serialises the read-increment-write process-wide. Two
+/// concurrent callers handed the same counter value would receive
+/// identical BIP-32 derivation paths — two `KeyRecord`s sharing a
+/// private key — so collision-freedom here is load-bearing.
 pub async fn allocate_path(keys_ks: &KeyspaceHandle, base: &str) -> Result<String, AppError> {
-    let _guard = ALLOC_LOCK.lock().await;
     let counter_key = format!("path_counter:{base}");
-    let current: u32 = match keys_ks.get_raw(counter_key.as_str()).await? {
-        Some(bytes) => {
-            let arr: [u8; 4] = bytes
-                .try_into()
-                .map_err(|_| AppError::Internal("corrupt path counter".into()))?;
-            u32::from_le_bytes(arr)
-        }
-        None => 0,
-    };
+    let current = counter::allocate_u32(keys_ks, &counter_key).await?;
     let path = path_at(base, current);
-    keys_ks
-        .insert_raw(counter_key, (current + 1).to_le_bytes().to_vec())
-        .await?;
     debug!(base, path = %path, "derivation path allocated");
     Ok(path)
 }

--- a/vta-service/src/operations/contexts.rs
+++ b/vta-service/src/operations/contexts.rs
@@ -137,7 +137,16 @@ pub async fn create_context(
         updated_at: now,
     };
 
-    store_context(contexts_ks, &record).await?;
+    // Atomic claim: the early exists-check above is the friendly fast
+    // path, but two concurrent creates with the same id both pass it.
+    // The loser's counter slot stays as a gap — safe; record overwrite
+    // would not be (it re-points the context's BIP-32 base path).
+    if !crate::contexts::store_new_context(contexts_ks, &record).await? {
+        return Err(AppError::Conflict(format!(
+            "context already exists: {}",
+            record.id
+        )));
+    }
 
     info!(channel, id = %record.id, parent = ?record.parent, index, "context created");
     Ok(to_result_body(&record))

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -49,6 +49,13 @@ pub async fn list_seeds(
     })
 }
 
+/// Serialises seed rotation process-wide. Two concurrent rotations
+/// would both read active generation N and both write N+1 — corrupting
+/// the generation chain and racing `reencrypt_all` with mismatched
+/// old/new seed pairs.
+static ROTATE_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
 pub async fn rotate_seed(
     keys_ks: &KeyspaceHandle,
     imported_ks: &KeyspaceHandle,
@@ -58,6 +65,9 @@ pub async fn rotate_seed(
     mnemonic: Option<&str>,
     channel: &str,
 ) -> Result<RotateSeedResultBody, AppError> {
+    // Held across read-generation → archive → write-new → re-encrypt.
+    let _rotation_guard = ROTATE_LOCK.lock().await;
+
     let previous_id = get_active_seed_id(keys_ks)
         .await
         .map_err(|e| AppError::Internal(format!("{e}")))?;
@@ -208,6 +218,46 @@ mod tests {
                 _dir: dir,
             }
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_rotations_produce_distinct_generations() {
+        // Without ROTATE_LOCK both rotations read active generation 0
+        // and both write generation 1, corrupting the chain.
+        let h = TestHarness::new().await;
+
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let keys_ks = h.keys_ks.clone();
+            let imported_ks = h.imported_ks.clone();
+            let audit_ks = h.audit_ks.clone();
+            let seed_store = h.seed_store.clone();
+            handles.push(tokio::spawn(async move {
+                rotate_seed(
+                    &keys_ks,
+                    &imported_ks,
+                    &seed_store,
+                    &audit_ks,
+                    "did:key:z6MkTestAdmin",
+                    None,
+                    "test",
+                )
+                .await
+                .expect("rotate")
+            }));
+        }
+        let mut new_ids = Vec::new();
+        for hd in handles {
+            new_ids.push(hd.await.expect("join").new_seed_id);
+        }
+        new_ids.sort_unstable();
+        assert_eq!(
+            new_ids,
+            vec![1, 2],
+            "two concurrent rotations must produce generations 1 and 2"
+        );
+        let active = get_active_seed_id(&h.keys_ks).await.expect("active id");
+        assert_eq!(active, 2);
     }
 
     #[tokio::test]

--- a/vti-common/src/store/counter.rs
+++ b/vti-common/src/store/counter.rs
@@ -1,0 +1,95 @@
+//! Process-wide serialised allocation of little-endian `u32` store
+//! counters.
+//!
+//! The store has no atomic increment primitive, so a bare
+//! read → +1 → write sequence hands the same value to two concurrent
+//! callers. For BIP-32 path and context-index counters that means two
+//! records silently sharing a private-key subtree — the exact bug
+//! `vta-service`'s path allocator was patched for, later found
+//! re-implemented unguarded in the context allocator.
+//!
+//! Every counter in the workspace allocates through [`allocate_u32`],
+//! which serialises behind one process-wide lock. The lock is
+//! app-level (not the `LocalStore` per-keyspace write lock) so it
+//! also covers the vsock backend, whose get/insert pair crosses two
+//! RPCs. Allocation is infrequent and the critical section is two
+//! store ops, so a single global lock is acceptable; per-key sharding
+//! would be a refinement only if this becomes a hot path.
+//!
+//! Counters only ever move forward. A caller that allocates a value
+//! and then fails simply leaves a gap — gaps are safe, reuse is not.
+
+use std::sync::LazyLock;
+
+use tokio::sync::Mutex;
+
+use super::KeyspaceHandle;
+use crate::error::AppError;
+
+static COUNTER_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// Allocate the next value of the `u32` counter stored at
+/// `counter_key`, returning the pre-increment value (a missing key
+/// reads as 0). Serialised process-wide: concurrent callers never
+/// observe the same value.
+pub async fn allocate_u32(ks: &KeyspaceHandle, counter_key: &str) -> Result<u32, AppError> {
+    let _guard = COUNTER_LOCK.lock().await;
+    let current: u32 = match ks.get_raw(counter_key).await? {
+        Some(bytes) => {
+            let arr: [u8; 4] = bytes
+                .try_into()
+                .map_err(|_| AppError::Internal(format!("corrupt counter at {counter_key}")))?;
+            u32::from_le_bytes(arr)
+        }
+        None => 0,
+    };
+    ks.insert_raw(counter_key, (current + 1).to_le_bytes().to_vec())
+        .await?;
+    Ok(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn allocate_u32_is_collision_free_under_concurrency() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store.keyspace("test").expect("keyspace");
+
+        let n = 64usize;
+        let mut handles = Vec::with_capacity(n);
+        for _ in 0..n {
+            let ks = ks.clone();
+            handles.push(tokio::spawn(async move {
+                allocate_u32(&ks, "counter:x").await.expect("alloc")
+            }));
+        }
+        let mut seen = std::collections::HashSet::with_capacity(n);
+        for h in handles {
+            let v = h.await.expect("join");
+            assert!(seen.insert(v), "duplicate counter value {v}");
+        }
+        assert_eq!(seen.len(), n);
+    }
+
+    #[tokio::test]
+    async fn allocate_u32_starts_at_zero_and_is_sequential() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store.keyspace("test").expect("keyspace");
+
+        for expect in 0..3u32 {
+            assert_eq!(allocate_u32(&ks, "counter:y").await.unwrap(), expect);
+        }
+    }
+}

--- a/vti-common/src/store/mod.rs
+++ b/vti-common/src/store/mod.rs
@@ -8,6 +8,8 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tracing::info;
 
+pub mod counter;
+
 #[cfg(feature = "encryption")]
 pub(crate) mod encryption;
 
@@ -160,6 +162,33 @@ impl KeyspaceHandle {
                     return Ok(false);
                 }
                 h.insert(key, value).await?;
+                Ok(true)
+            }
+        }
+    }
+
+    /// Raw-bytes variant of [`KeyspaceHandle::insert_if_absent`] — same
+    /// semantics and the same vsock TOCTOU caveat, for values that are
+    /// stored via `insert_raw`/`get_raw` rather than as serde JSON.
+    pub async fn insert_raw_if_absent(
+        &self,
+        key: impl Into<Vec<u8>>,
+        value: impl Into<Vec<u8>>,
+    ) -> Result<bool, AppError> {
+        match self {
+            KeyspaceHandle::Local(h) => h.insert_raw_if_absent(key, value).await,
+            #[cfg(feature = "vsock-store")]
+            KeyspaceHandle::Vsock(h) => {
+                tracing::warn!(
+                    "KeyspaceHandle::Vsock::insert_raw_if_absent using non-atomic get+insert \
+                     fallback; vsock proto lacks a native insert-if-absent opcode. \
+                     Single-replica TEE deployments are unaffected in practice."
+                );
+                let key = key.into();
+                if h.get_raw(key.clone()).await?.is_some() {
+                    return Ok(false);
+                }
+                h.insert_raw(key, value).await?;
                 Ok(true)
             }
         }
@@ -567,6 +596,23 @@ impl LocalKeyspaceHandle {
     ) -> Result<bool, AppError> {
         let key = key.into();
         let bytes = serde_json::to_vec(value)?;
+        self.insert_bytes_if_absent(key, bytes).await
+    }
+
+    /// Raw-bytes variant of [`LocalKeyspaceHandle::insert_if_absent`] —
+    /// same lock, same exactly-one-winner guarantee.
+    pub async fn insert_raw_if_absent(
+        &self,
+        key: impl Into<Vec<u8>>,
+        value: impl Into<Vec<u8>>,
+    ) -> Result<bool, AppError> {
+        self.insert_bytes_if_absent(key.into(), value.into()).await
+    }
+
+    /// Shared body: check and insert run under the per-keyspace write
+    /// lock (see [`WriteLocks`]), so exactly one of two racing callers
+    /// observes `true`.
+    async fn insert_bytes_if_absent(&self, key: Vec<u8>, bytes: Vec<u8>) -> Result<bool, AppError> {
         let bytes = self.maybe_encrypt(bytes)?;
         let ks = self.keyspace.clone();
         let lock = self.write_lock.clone();


### PR DESCRIPTION
## Summary

Second task from the hardening plan (`tasks/vta-architecture-plan.md`, **P0.4**). **Stacked on #341** — it reuses the `insert_if_absent` primitive and write-lock infrastructure introduced there; GitHub will retarget this to `main` when #341 merges.

Four read-modify-write races of the same family the path allocator was already patched for (`ALLOC_LOCK`):

1. **`allocate_context_index` had no lock** — two concurrent `create_context` calls could receive the same index, i.e. the **same BIP-32 subtree**: identical private keys across trust boundaries. All counters now go through one process-wide locked allocator, `vti_common::store::counter::allocate_u32` (app-level lock so the vsock backend is covered too). `ALLOC_LOCK` retired; the existing paths regression test passes against the shared allocator.
2. **KEK salt overwrite**: two racing first-ever imports could each generate a salt; the loser's overwrite made the winner's just-encrypted secret permanently undecryptable. Claimed via new `KeyspaceHandle::insert_raw_if_absent`; the loser reads the winner's salt back.
3. **`rotate_seed` unsynchronised**: concurrent rotations both read generation N and both wrote N+1, corrupting the chain and racing `reencrypt_all` with mismatched seed pairs. Now behind `ROTATE_LOCK` across read → archive → write → re-encrypt.
4. **`create_context` last-writer-wins**: a lost same-id race silently re-pointed the context's BIP-32 base path. Both layers now claim the record atomically (`store_new_context`); losers get 409, their counter slot stays as a safe gap (counters skip, never reuse).

## Tests
Concurrency regression tests for all four: 64-task collision-freedom for context indices (mirrors the paths test), 16-task salt convergence, generation-chain integrity (concurrent rotations → generations 1 and 2), exactly-one-winner same-id create with winner's-record-intact assertion.

Full gate: workspace tests 40 suites / 0 failed, clippy clean, fmt. No dependency changes (deny unchanged from #341).