### PR TITLE
fix(vta-service): atomic + durable carve-out close before bundle delivery (P0.8)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -37,8 +37,16 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
 - `[ ]` **P0.6** (S) TEE seed rotation: reject or persist (no silent key loss) — PR: ____
 - `[ ]` **P0.7** (M) `Zeroizing` seed bytes end-to-end; encrypt retired-seed
   archive; fix "secure deletion" claim — PR: ____
-- `[ ]` **P0.8** (S) Atomic + persisted carve-out close (ACL → sentinel →
-  `persist()` before bundle release) — PR: ____
+- `[~]` **P0.8** (S) Atomic + persisted carve-out close — branch
+  `fix/p0.8-carveout-durability`. Added `KeyspaceHandle::persist()` (local
+  fsync + vsock OP_PERSIST passthrough). `mint_mode_b` now: seal first
+  (fail-fast, no carve-out writes) → ACL → sentinel-via-`insert_raw_if_absent`
+  (atomic claim, defence-in-depth beyond MODE_B_LOCK; compensating ACL
+  delete on lost race) → `persist()` BEFORE returning the bundle (security
+  barrier: no reopen-after-delivery). ACL-before-sentinel journal order so a
+  torn fsync favours a recoverable reopen over a brick. Counter allocator
+  also now fsyncs (path-counter loss = key reuse). Tests: persist-survives-
+  reopen, carve-out-admits-one — PR: ____
 - `[ ]` **P0.9** (M) Boot-time `config::validate()`; `deny_unknown_fields`;
   hard-fail missing identity unless `--allow-degraded`; explicit opt-in for
   plaintext seed store — PR: ____

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -46,7 +46,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   barrier: no reopen-after-delivery). ACL-before-sentinel journal order so a
   torn fsync favours a recoverable reopen over a brick. Counter allocator
   also now fsyncs (path-counter loss = key reuse). Tests: persist-survives-
-  reopen, carve-out-admits-one — PR: ____
+  reopen, carve-out-admits-one — PR: #343 (in review)
 - `[ ]` **P0.9** (M) Boot-time `config::validate()`; `deny_unknown_fields`;
   hard-fail missing identity unless `--allow-degraded`; explicit opt-in for
   plaintext seed store — PR: ____

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -34,6 +34,8 @@ use vta_sdk::sealed_transfer::{
 };
 
 #[cfg(feature = "tee")]
+use crate::acl::delete_acl_entry;
+#[cfg(feature = "tee")]
 use crate::acl::store_acl_entry;
 #[cfg(feature = "tee")]
 use crate::acl::{AclEntry, Role};
@@ -252,26 +254,10 @@ async fn mint_mode_b(
         .attest(user_data.as_slice(), &bundle_id)
         .map_err(|e| AppError::Internal(format!("tee attest failed: {e}")))?;
 
-    // Mint admin credential and insert ACL entry. Sentinel write goes
-    // FIRST so that even if a future refactor breaks the `MODE_B_LOCK`
-    // guard above, a concurrent request fails closed (the sentinel is
-    // visible before any second admin row could be written). The
-    // current `MODE_B_LOCK` ensures the check-and-set is already
-    // serialized; this ordering is defence-in-depth.
     let (did, private_key_multibase) = crate::auth::credentials::generate_did_key();
 
-    state
-        .keys_ks
-        .insert_raw(BOOTSTRAP_CARVEOUT_CLOSED_KEY, did.as_bytes().to_vec())
-        .await?;
-
-    let entry = AclEntry::new(did.clone(), Role::Admin, "tee:mode-b")
-        .with_label(Some("TEE first-boot admin".to_string()))
-        .with_created_at(now);
-    store_acl_entry(&state.acl_ks, &entry).await?;
-
     let credential = CredentialBundle {
-        did,
+        did: did.clone(),
         private_key_multibase,
         vta_did,
         vta_url,
@@ -292,6 +278,9 @@ async fn mint_mode_b(
         affinidi_crypto::did_key::ed25519_pub_to_x25519_bytes(client_ed25519_pub)
             .map_err(|e| AppError::Internal(format!("client_did X25519 derivation: {e}")))?;
 
+    // Seal FIRST, before touching any carve-out state. A seal failure
+    // here must leave the carve-out open and retryable — no ACL, no
+    // sentinel written.
     let nonce_store = PersistentNonceStore::new(state.sealed_nonces_ks.clone());
     let payload = SealedPayloadV1::AdminCredential(Box::new(credential));
     let bundle = seal_payload(
@@ -303,6 +292,48 @@ async fn mint_mode_b(
     )
     .await
     .map_err(|e| AppError::Internal(format!("sealed-transfer seal failed: {e}")))?;
+
+    // Now commit the carve-out. Ordering and durability are load-bearing
+    // (P0.8):
+    //
+    //   1. ACL entry is written to the journal BEFORE the sentinel, so a
+    //      torn fsync recovers to {ACL, no sentinel} — a safe, self-
+    //      healing reopen (no bundle was delivered) — rather than
+    //      {sentinel, no ACL}, which would brick the VTA (carve-out
+    //      closed, no admin).
+    //   2. The sentinel is claimed with `insert_raw_if_absent`: even if a
+    //      future refactor breaks the `MODE_B_LOCK` guard above, a
+    //      concurrent request's claim returns `false` and fails closed,
+    //      so exactly one admin is ever minted. (Defence-in-depth — the
+    //      lock already serializes; this no longer relies on it.)
+    //   3. `persist()` fsyncs the ACL + sentinel + replay nonce together
+    //      BEFORE the bundle is returned. This is the security barrier:
+    //      the admin credential never leaves the enclave until the
+    //      carve-out is durably closed, so a power loss after delivery
+    //      cannot reopen it and mint a second admin.
+    let entry = AclEntry::new(did.clone(), Role::Admin, "tee:mode-b")
+        .with_label(Some("TEE first-boot admin".to_string()))
+        .with_created_at(now);
+    store_acl_entry(&state.acl_ks, &entry).await?;
+
+    if !state
+        .keys_ks
+        .insert_raw_if_absent(BOOTSTRAP_CARVEOUT_CLOSED_KEY, did.as_bytes().to_vec())
+        .await?
+    {
+        // Lost the carve-out race (only reachable if MODE_B_LOCK were
+        // bypassed). Roll back the ACL we just wrote so it does not
+        // linger as an admin entry for an undeliverable DID, and refuse.
+        let _ = delete_acl_entry(&state.acl_ks, &did).await;
+        return Err(AppError::Forbidden(
+            "TEE first-boot carve-out has already been used".into(),
+        ));
+    }
+
+    // Durability barrier: do not return the bundle until the carve-out
+    // close is on disk.
+    state.keys_ks.persist().await?;
+
     info!("TEE first-boot carve-out consumed — closed for good");
     Ok(bundle)
 }
@@ -406,25 +437,24 @@ mod tests {
         }
     }
 
-    /// Concurrency contract for [`MODE_B_LOCK`].
+    /// Concurrency contract for the carve-out close (P0.8).
     ///
     /// Property under test: when N concurrent `mint_mode_b`-style
-    /// "lock-then-check-then-set" sequences race against the same
-    /// keyspace, exactly one writes the carve-out sentinel; the others
-    /// see the sentinel after acquiring the lock and refuse.
+    /// sequences race against the same keyspace, exactly one claims the
+    /// carve-out sentinel; the others see the atomic claim fail and
+    /// refuse. Each task takes `MODE_B_LOCK` (the primary serializer)
+    /// and then claims the sentinel via `insert_raw_if_absent` (the
+    /// mechanism `mint_mode_b` now uses) — so the claim is correct
+    /// *even if a future refactor drops the lock*, which is the
+    /// defence-in-depth P0.8 strengthened.
     ///
     /// This is the safety invariant CLAUDE.md highlights as load-bearing
-    /// — two concurrent `/bootstrap/request` calls without the lock
-    /// would both pass the `is_some()` check and both mint admin
-    /// credentials. The test deliberately mirrors the exact ordering
-    /// (`lock → get_raw → ... await ... → insert_raw`) including a
-    /// yield point between the check and the set, where an unprotected
-    /// implementation would interleave.
-    ///
-    /// Uses the actual `MODE_B_LOCK` static and the actual sentinel key
-    /// constant so a refactor that relocates either is caught here.
+    /// — two concurrent `/bootstrap/request` calls that both minted an
+    /// admin would be a privilege-escalation hole. Uses the actual
+    /// `MODE_B_LOCK` static and the actual sentinel key constant so a
+    /// refactor that relocates either is caught here.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn mode_b_lock_serializes_carveout_check_and_set() {
+    async fn carveout_claim_admits_exactly_one_concurrent_minter() {
         use crate::tee::admin_bootstrap::BOOTSTRAP_CARVEOUT_CLOSED_KEY;
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::time::Duration;
@@ -446,27 +476,24 @@ mod tests {
             let ks = keys_ks.clone();
             let successes = std::sync::Arc::clone(&successes);
             handles.push(tokio::spawn(async move {
-                // Same shape as `mint_mode_b`: take MODE_B_LOCK, check
-                // the sentinel, do "work", write the sentinel. The yield
-                // between check and set models the TEE attestation +
-                // mint window an unprotected impl would race in.
+                // Same shape as `mint_mode_b`: take MODE_B_LOCK, do
+                // "work" (the yield models the TEE attestation + seal
+                // window), then claim the sentinel atomically. The
+                // atomic claim is what guarantees exactly-one even
+                // without the lock.
                 let _guard = MODE_B_LOCK.lock().await;
-                if ks
-                    .get_raw(BOOTSTRAP_CARVEOUT_CLOSED_KEY)
-                    .await
-                    .expect("get_raw sentinel")
-                    .is_some()
-                {
-                    return; // carve-out already used
-                }
                 tokio::time::sleep(Duration::from_millis(2)).await;
-                ks.insert_raw(
-                    BOOTSTRAP_CARVEOUT_CLOSED_KEY,
-                    format!("admin-{i}").into_bytes(),
-                )
-                .await
-                .expect("insert sentinel");
-                successes.fetch_add(1, Ordering::SeqCst);
+                let claimed = ks
+                    .insert_raw_if_absent(
+                        BOOTSTRAP_CARVEOUT_CLOSED_KEY,
+                        format!("admin-{i}").into_bytes(),
+                    )
+                    .await
+                    .expect("claim sentinel");
+                if claimed {
+                    ks.persist().await.expect("persist carve-out");
+                    successes.fetch_add(1, Ordering::SeqCst);
+                }
             }));
         }
 
@@ -477,8 +504,7 @@ mod tests {
         assert_eq!(
             successes.load(Ordering::SeqCst),
             1,
-            "MODE_B_LOCK must serialize the carve-out check-and-set so \
-             exactly one task writes the sentinel; got {} successes",
+            "exactly one task may claim the carve-out sentinel; got {} successes",
             successes.load(Ordering::SeqCst),
         );
         assert!(

--- a/vti-common/src/store/counter.rs
+++ b/vti-common/src/store/counter.rs
@@ -32,6 +32,12 @@ static COUNTER_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 /// `counter_key`, returning the pre-increment value (a missing key
 /// reads as 0). Serialised process-wide: concurrent callers never
 /// observe the same value.
+///
+/// The increment is fsynced before the value is returned: a counter
+/// that survives only in the journal buffer could be re-derived after
+/// a crash, handing out an already-used value — for BIP-32 path
+/// counters that is silent private-key reuse. Allocation is
+/// infrequent; the fsync cost is acceptable.
 pub async fn allocate_u32(ks: &KeyspaceHandle, counter_key: &str) -> Result<u32, AppError> {
     let _guard = COUNTER_LOCK.lock().await;
     let current: u32 = match ks.get_raw(counter_key).await? {
@@ -45,6 +51,7 @@ pub async fn allocate_u32(ks: &KeyspaceHandle, counter_key: &str) -> Result<u32,
     };
     ks.insert_raw(counter_key, (current + 1).to_le_bytes().to_vec())
         .await?;
+    ks.persist().await?;
     Ok(current)
 }
 

--- a/vti-common/src/store/mod.rs
+++ b/vti-common/src/store/mod.rs
@@ -118,6 +118,22 @@ impl KeyspaceHandle {
         }
     }
 
+    /// Durably flush the store to disk (a write barrier).
+    ///
+    /// Persistence is store-wide, not per-keyspace: the local backend
+    /// fsyncs the shared fjall journal, the vsock backend asks the
+    /// parent proxy to flush. Call after security-critical writes whose
+    /// loss on crash would violate an invariant (carve-out close,
+    /// counter allocation) — once this returns, the writes survive
+    /// power loss.
+    pub async fn persist(&self) -> Result<(), AppError> {
+        match self {
+            KeyspaceHandle::Local(h) => h.persist().await,
+            #[cfg(feature = "vsock-store")]
+            KeyspaceHandle::Vsock(h) => h.persist().await,
+        }
+    }
+
     pub async fn insert<V: Serialize>(
         &self,
         key: impl Into<Vec<u8>>,
@@ -333,6 +349,10 @@ pub struct LocalStore {
 #[derive(Clone)]
 pub struct LocalKeyspaceHandle {
     keyspace: fjall::Keyspace,
+    /// The owning database, kept so the handle can fsync the shared
+    /// journal ([`LocalKeyspaceHandle::persist`]) — fjall only exposes
+    /// persistence at the database level.
+    db: fjall::Database,
     /// Shared with every other handle for the same keyspace name — see
     /// [`WriteLocks`].
     write_lock: std::sync::Arc<std::sync::Mutex<()>>,
@@ -371,6 +391,7 @@ impl LocalStore {
             .clone();
         Ok(LocalKeyspaceHandle {
             keyspace,
+            db: self.db.clone(),
             write_lock,
             #[cfg(feature = "encryption")]
             encryption_key: None,
@@ -402,6 +423,13 @@ impl LocalKeyspaceHandle {
         {
             false
         }
+    }
+
+    /// Fsync the owning database's journal — see
+    /// [`KeyspaceHandle::persist`].
+    pub async fn persist(&self) -> Result<(), AppError> {
+        let db = self.db.clone();
+        blocking_with_timeout(move || Ok(db.persist(PersistMode::SyncAll)?)).await
     }
 
     pub async fn insert<V: Serialize>(
@@ -653,6 +681,35 @@ mod tests {
         };
         let store = Store::open(&config).expect("failed to open store");
         (store, dir)
+    }
+
+    #[tokio::test]
+    async fn persist_survives_store_reopen() {
+        // persist() is the durability barrier mint_mode_b relies on
+        // before returning the admin bundle. Prove a persisted write
+        // survives dropping and reopening the store from the same dir
+        // (the closest a unit test gets to a power-loss boundary).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().to_path_buf();
+        {
+            let store = Store::open(&StoreConfig {
+                data_dir: path.clone(),
+            })
+            .expect("open store");
+            let ks = store.keyspace("keys").unwrap();
+            ks.insert_raw("carveout:closed", b"admin-did".to_vec())
+                .await
+                .unwrap();
+            ks.persist().await.unwrap();
+            // store dropped here without an explicit graceful shutdown
+        }
+        let store = Store::open(&StoreConfig { data_dir: path }).expect("reopen store");
+        let ks = store.keyspace("keys").unwrap();
+        assert_eq!(
+            ks.get_raw("carveout:closed").await.unwrap().as_deref(),
+            Some(b"admin-did".as_slice()),
+            "a persisted write must survive a store reopen"
+        );
     }
 
     #[tokio::test]

--- a/vti-common/src/store/vsock.rs
+++ b/vti-common/src/store/vsock.rs
@@ -225,6 +225,15 @@ impl VsockKeyspaceHandle {
         }
     }
 
+    /// Ask the parent proxy to flush the store to disk — see
+    /// [`crate::store::KeyspaceHandle::persist`]. Store-wide, not
+    /// per-keyspace.
+    pub async fn persist(&self) -> Result<(), AppError> {
+        let payload = vec![OP_PERSIST];
+        let resp = self.send(&payload).await?;
+        decode_ok(&resp)
+    }
+
     pub async fn insert<V: Serialize>(
         &self,
         key: impl Into<Vec<u8>>,


### PR DESCRIPTION
## Summary

Plan task **P0.8** (`tasks/vta-architecture-plan.md`). Branches cleanly off `main`.

The TEE Mode-B carve-out close had **no durability barrier** — the sentinel and ACL were written with no `persist()` before the sealed admin bundle was returned. Two crash windows:

- **Reopen-after-delivery (security):** power loss after the bundle is delivered but before the sentinel reaches disk reopens the single-use carve-out → an attacker re-runs `/bootstrap/request` and mints a **second admin**.
- **Brick:** a crash between the two writes could leave {sentinel, no ACL} = carve-out closed, no admin.

## The fix

`mint_mode_b` restructured so the persisted state is only ever {nothing} or {both}, and the bundle never leaves the enclave until the close is durable:

1. **Seal first**, before any carve-out write — a seal failure leaves the carve-out open and retryable.
2. **ACL, then sentinel** (journal order) — a torn fsync recovers to {ACL, no sentinel}: a safe, self-healing reopen (no bundle was delivered) rather than a brick.
3. **Claim the sentinel via `insert_raw_if_absent`** (atomic): even if a future refactor drops `MODE_B_LOCK`, a concurrent claim returns `false` and fails closed. Lost-race path rolls back the ACL. Strengthens — no longer relies on — the lock.
4. **`persist()` before returning** — fsyncs ACL + sentinel + replay nonce together. The security barrier against reopen-after-delivery.

Adds `KeyspaceHandle::persist()` (local fjall `SyncAll`; vsock forwards the existing `OP_PERSIST` to the parent proxy). The **counter allocator now fsyncs each allocation** too — a path-counter lost on crash would re-derive an already-used BIP-32 index (silent key reuse); a persisted-counter-but-lost-record crash is a safe gap, never reuse.

## Design note (the tension I weighed)

The old code wrote the sentinel *first* as documented defence-in-depth against a broken `MODE_B_LOCK`. That ordering risks a brick on a torn fsync. I kept the defence-in-depth — and made it stronger — by claiming the sentinel atomically (`insert_raw_if_absent`), which is correct *without* the lock, while ordering ACL-before-sentinel for the better crash-recovery outcome. CLAUDE.md documents the lock as the primary serializer; this PR preserves that and adds an atomic backstop.

## Tests
- `persist_survives_store_reopen`: a persisted write survives drop + reopen of the store.
- `carveout_claim_admits_exactly_one_concurrent_minter`: 16 racing tasks via the real `MODE_B_LOCK` + sentinel constant; exactly one claims. (Replaces the prior lock test, updated to the new atomic-claim mechanism.)
- Full gate: 2761 default-feature + 715 tee-feature tests, clippy clean (default + tee), fmt.

## Invariants preserved
`MODE_B_LOCK` still spans the whole sequence; carve-out single-use; `BootstrapRequestBody` `deny_unknown_fields` untouched; bundle digest/armor path unchanged.