### PR TITLE
fix(vta-service): refuse seed rotation when the backend can't persist it (P0.6)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -34,7 +34,15 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   PR: #342 (stacked on #341)
 - `[ ]` **P0.5** (L) Backup/restore: export counters (no BIP-32 path reuse),
   full `AclEntry` round-trip, import-in-progress sentinel — PR: ____
-- `[ ]` **P0.6** (S) TEE seed rotation: reject or persist (no silent key loss) — PR: ____
+- `[~]` **P0.6** (S) TEE seed rotation: reject or persist (no silent key loss) —
+  branch `fix/p0.6-tee-seed-rotation`. Chose REJECT (the plan's safe minimum;
+  in-place re-encryption is a follow-up). New `SeedStore::set_persists_across_restart()`
+  (default true; `KmsTeeSeedStore` → false, fixed its misleading set() comment).
+  Guard at the low-level `seeds::rotate_seed` chokepoint (catches offline CLI
+  too) + a typed `AppError::Conflict` with operator guidance at
+  `operations::seeds::rotate_seed` (runtime REST/DIDComm/TT path). Tests:
+  refusal+no-mutation (tee), trait flag, existing non-TEE rotation unaffected
+  — PR: ____
 - `[ ]` **P0.7** (M) `Zeroizing` seed bytes end-to-end; encrypt retired-seed
   archive; fix "secure deletion" claim — PR: ____
 - `[~]` **P0.8** (S) Atomic + persisted carve-out close — branch

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -42,7 +42,8 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   too) + a typed `AppError::Conflict` with operator guidance at
   `operations::seeds::rotate_seed` (runtime REST/DIDComm/TT path). Tests:
   refusal+no-mutation (tee), trait flag, existing non-TEE rotation unaffected
-  — PR: ____
+  — PR: #344 (in review). Follow-up: in-place re-encryption so TEE rotation
+  works rather than refuses (needs runtime KMS access on KmsTeeSeedStore).
 - `[ ]` **P0.7** (M) `Zeroizing` seed bytes end-to-end; encrypt retired-seed
   archive; fix "secure deletion" claim — PR: ____
 - `[~]` **P0.8** (S) Atomic + persisted carve-out close — branch

--- a/vta-service/src/keys/seed_store/kms_tee.rs
+++ b/vta-service/src/keys/seed_store/kms_tee.rs
@@ -45,11 +45,15 @@ impl SeedStore for KmsTeeSeedStore {
     fn set(&self, seed: &[u8]) -> BoxFuture<'_, Result<(), AppError>> {
         let seed = seed.to_vec();
         Box::pin(async move {
-            // Update in-memory seed. The new ciphertext will be persisted
-            // to the bootstrap keyspace on the next restart via KMS bootstrap.
+            // Updates the in-memory seed ONLY. This is NOT durable: nothing
+            // re-encrypts the new seed into the bootstrap keyspace, so on the
+            // next enclave boot KMS bootstrap restores the *original* seed and
+            // this value is lost. `set_persists_across_restart()` returns
+            // `false` so the rotation path refuses before ever reaching here;
+            // any other caller must treat the write as ephemeral.
             tracing::warn!(
-                "seed updated in memory — restart the enclave to re-encrypt \
-                 and persist the new seed via KMS bootstrap"
+                "KmsTeeSeedStore::set updates the in-memory seed only — it is \
+                 NOT persisted and will be lost on the next enclave boot"
             );
             let mut guard = self
                 .seed
@@ -58,5 +62,29 @@ impl SeedStore for KmsTeeSeedStore {
             *guard = Some(seed);
             Ok(())
         })
+    }
+
+    fn set_persists_across_restart(&self) -> bool {
+        // The seed is held only in enclave memory; rotating it would be
+        // silently undone on the next boot (KMS restores the original
+        // bootstrap seed). Until in-place re-encryption is wired up, the
+        // rotation path must refuse — see `operations::seeds::rotate_seed`.
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_does_not_persist_across_restart() {
+        let store =
+            KmsTeeSeedStore::new(vec![0u8; 32], "arn:aws:kms:test".into(), "us-east-1".into());
+        assert!(
+            !store.set_persists_across_restart(),
+            "the TEE KMS seed store must report that set() is not restart-durable \
+             so the rotation path refuses"
+        );
     }
 }

--- a/vta-service/src/keys/seeds.rs
+++ b/vta-service/src/keys/seeds.rs
@@ -121,6 +121,21 @@ pub async fn rotate_seed(
     seed_store: &dyn SeedStore,
     mnemonic: Option<&str>,
 ) -> Result<u32, Box<dyn std::error::Error>> {
+    // Authoritative guard: a backend whose `set` does not survive a
+    // restart (the TEE KMS store) would have its rotated seed silently
+    // discarded on the next boot, making every post-rotation key
+    // unrecoverable. Refuse before mutating any state. The runtime
+    // entry point (`operations::seeds::rotate_seed`) checks this too
+    // and returns a typed, operator-friendly error first.
+    if !seed_store.set_persists_across_restart() {
+        return Err(
+            "seed rotation is not supported by the active seed store: a \
+                    rotated seed would not survive a restart, so every key minted \
+                    after rotation would become unrecoverable"
+                .into(),
+        );
+    }
+
     let old_id = get_active_seed_id(keys_ks).await?;
 
     // Load current seed bytes for archival

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -68,6 +68,22 @@ pub async fn rotate_seed(
     // Held across read-generation → archive → write-new → re-encrypt.
     let _rotation_guard = ROTATE_LOCK.lock().await;
 
+    // Refuse rotation on a seed store whose `set` does not survive a
+    // restart (the TEE KMS store). Rotating would bump `active_seed_id`
+    // to a generation whose bytes live only in enclave memory; the next
+    // boot would restore the original seed and every key minted after
+    // rotation would be permanently unrecoverable. Typed Conflict so the
+    // CLI can render operator guidance rather than a generic 500.
+    if !seed_store.set_persists_across_restart() {
+        return Err(AppError::Conflict(
+            "seed rotation is unavailable on this VTA: the active seed store does \
+             not persist a rotated seed across a restart, so every key minted after \
+             rotation would become unrecoverable on the next boot. TEE/KMS \
+             deployments re-seed via a fresh enclave bootstrap, not in-place rotation."
+                .into(),
+        ));
+    }
+
     let previous_id = get_active_seed_id(keys_ks)
         .await
         .map_err(|e| AppError::Internal(format!("{e}")))?;
@@ -218,6 +234,68 @@ mod tests {
                 _dir: dir,
             }
         }
+    }
+
+    /// P0.6: rotation must refuse on a seed store whose `set` does not
+    /// survive a restart (the TEE KMS store), and must mutate nothing —
+    /// otherwise a TEE operator who runs `keys rotate-seed` silently
+    /// loses every key minted afterwards on the next enclave boot.
+    #[cfg(feature = "tee")]
+    #[tokio::test]
+    async fn rotate_seed_refused_on_non_durable_store_and_leaves_state_intact() {
+        use crate::keys::seed_store::KmsTeeSeedStore;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let keys_ks = store.keyspace("keys").unwrap();
+        let imported_ks = store.keyspace("imported_secrets").unwrap();
+        let audit_ks = store.keyspace("audit").unwrap();
+
+        // Bootstrap generation 0 as the active seed.
+        save_seed_record(
+            &keys_ks,
+            &SeedRecord {
+                id: 0,
+                seed_hex: None,
+                created_at: chrono::Utc::now(),
+                retired_at: None,
+            },
+        )
+        .await
+        .expect("save gen-0 record");
+
+        let seed_store: Arc<dyn SeedStore> = Arc::new(KmsTeeSeedStore::new(
+            vec![0xABu8; 32],
+            "arn:aws:kms:test".into(),
+            "us-east-1".into(),
+        ));
+
+        let err = rotate_seed(
+            &keys_ks,
+            &imported_ks,
+            &seed_store,
+            &audit_ks,
+            "did:key:z6MkTestAdmin",
+            None,
+            "test",
+        )
+        .await
+        .expect_err("TEE rotation must be refused");
+        assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+
+        // Nothing mutated: active id unchanged, gen-0 still active (not
+        // archived/retired), no gen-1 record created.
+        assert_eq!(get_active_seed_id(&keys_ks).await.unwrap(), 0);
+        let gen0 = get_seed_record(&keys_ks, 0).await.unwrap().unwrap();
+        assert!(gen0.retired_at.is_none(), "gen-0 must not be retired");
+        assert!(gen0.seed_hex.is_none(), "gen-0 must stay active");
+        assert!(
+            get_seed_record(&keys_ks, 1).await.unwrap().is_none(),
+            "no gen-1 record may be created by a refused rotation"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/vti-common/src/seed_store.rs
+++ b/vti-common/src/seed_store.rs
@@ -30,4 +30,23 @@ pub trait SeedStore: Send + Sync {
     fn delete(&self) -> BoxFuture<'_, Result<(), AppError>> {
         Box::pin(async { Ok(()) })
     }
+
+    /// Whether a successful [`set`](SeedStore::set) durably survives a
+    /// process / host restart.
+    ///
+    /// `true` for backends that write the secret to durable storage
+    /// (OS keyring, cloud secret managers, plaintext file). `false`
+    /// for backends whose `set` only updates in-memory state and rely
+    /// on a separate persistence step that does not happen
+    /// automatically — notably the TEE KMS store, where a rotated seed
+    /// lives only in enclave memory and the next boot restores the
+    /// *original* KMS-bootstrapped seed instead.
+    ///
+    /// Seed rotation must refuse when this is `false`: rotating would
+    /// bump `active_seed_id` to a generation whose bytes vanish on
+    /// restart, silently making every key minted after the rotation
+    /// unrecoverable.
+    fn set_persists_across_restart(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
## Summary

Plan task **P0.6** (`tasks/vta-architecture-plan.md`). Branches off `main`.

`POST /keys/seeds/rotate` was not gated in TEE builds, but `KmsTeeSeedStore::set` only updates the **in-memory** seed — nothing re-encrypts it into the bootstrap keyspace. A TEE operator who rotated would, on the next enclave boot, have KMS restore the **original** seed while `active_seed_id` pointed at a generation whose bytes existed only in now-gone memory. **Every key minted after the rotation becomes permanently unrecoverable** — silent, surfacing only after a restart. (The backend's own comment claimed the new seed would persist on next boot; it's false, and corrected here.)

## Fix

The plan's safe minimum — **reject**; in-place re-encryption is a documented follow-up. Add `SeedStore::set_persists_across_restart()` (default `true`), overridden to `false` in `KmsTeeSeedStore`. Rotation refuses when `false`:

- **Low-level `keys::seeds::rotate_seed`** guards at the top, before mutating any state — the authoritative chokepoint that also covers the offline `vta keys rotate-seed` CLI and any future caller.
- **`operations::seeds::rotate_seed`** (runtime REST / DIDComm / Trust-Task path) checks first and returns a typed **`AppError::Conflict` (409)** with operator guidance, per the operator-error-suggests-fix principle, rather than a generic 500.

All durable backends (keyring, AWS/GCP/Azure, Vault, plaintext) keep the default `true` and are unaffected; `config-seed` already errors in `set()`.

## Tests
- TEE rotation refused with `Conflict` **and no state mutated** (`active_seed_id` unchanged, gen-0 not archived, no gen-1 record created).
- `KmsTeeSeedStore::set_persists_across_restart()` is `false`.
- Existing non-TEE rotation + concurrent-rotation tests still pass (default-`true`), proving non-TEE is unaffected.
- Gate: workspace 81 suites / 0 failures, 717 tee-lib tests / 0 failures, clippy clean (default + tee), fmt.

## Follow-up (out of scope)
Wiring in-place re-encryption (`re_encrypt_bootstrap_secrets` on the rotation path so TEE rotation *works* rather than refuses) needs runtime KMS access on `KmsTeeSeedStore` and is a larger change — tracked under the same plan item.

## Invariants preserved
`ROTATE_LOCK` serialization (P0.4) intact; archive-old-before-write-new ordering unchanged; the guard runs before any mutation so a refused rotation is a true no-op.