### PR TITLE
fix(vta-service): soft restart no longer panics installing Prometheus recorder

### DIFF
--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -399,6 +399,18 @@ pub async fn run(
         None
     };
 
+    // Install the Prometheus recorder once per process (persists across
+    // soft restarts, same as the TCP listener above). The global recorder
+    // can only be set once — installing it inside the restart loop panics
+    // the REST thread on the second iteration with FailedToSetGlobalRecorder.
+    // The handle is cloned into each iteration's AppState below.
+    #[cfg(feature = "rest")]
+    let metrics_handle = if rest_enabled {
+        Some(crate::metrics::install())
+    } else {
+        None
+    };
+
     // ── Restart loop ──────────────────────────────────────────────
     // Each iteration starts all service threads, waits for shutdown
     // or restart signal, tears everything down, then either exits
@@ -633,7 +645,7 @@ pub async fn run(
             tee: tee_context.clone(),
             restart_tx: restart_tx.clone(),
             #[cfg(feature = "rest")]
-            metrics_handle: None, // Set in REST thread after install
+            metrics_handle: metrics_handle.clone(), // installed once, before the loop
         };
 
         // Spawn REST thread (conditional)
@@ -1004,7 +1016,7 @@ fn run_storage_thread(
 #[cfg(feature = "rest")]
 fn run_rest_thread(
     std_listener: std::net::TcpListener,
-    mut state: AppState,
+    state: AppState,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -1015,9 +1027,9 @@ fn run_rest_thread(
     rt.block_on(async {
         info!("REST thread started");
 
-        // Install Prometheus metrics recorder (once per process)
-        let metrics_handle = crate::metrics::install();
-        state.metrics_handle = Some(metrics_handle);
+        // The Prometheus recorder is installed once per process (before the
+        // restart loop in `run`); `state.metrics_handle` already carries the
+        // handle. Installing here would panic on every soft restart.
 
         let listener = tokio::net::TcpListener::from_std(std_listener)
             .expect("failed to convert std TcpListener to tokio TcpListener");


### PR DESCRIPTION
## Problem

Issuing a `/vta/restart` (soft restart) crashes the VTA instead of restarting it:

```
thread 'vta-rest' panicked at vta-service/src/metrics.rs:25:10:
failed to install Prometheus recorder: FailedToSetGlobalRecorder(SetRecorderError { .. })
...
ERROR vta: server error: internal error: one or more threads panicked
```

## Root cause

`server::run()` has a soft-restart loop (`server.rs:406`). Each iteration re-spawns the `vta-rest` thread, and that thread called `crate::metrics::install()` → `install_recorder()`, which sets the **process-global** `metrics` recorder.

The global recorder can only be installed once per process. On the second loop iteration (the first `/vta/restart`), `install_recorder()` returns `FailedToSetGlobalRecorder` and the `.expect("failed to install Prometheus recorder")` in `metrics.rs:25` panics the REST thread. `run()` detects the panicked thread and exits with *"one or more threads panicked"* — a crash where a restart was expected. The call-site comment even claimed "once per process", but the code placed it once per loop *iteration*.

## Fix

Hoist the recorder install out of the restart loop, mirroring the pattern already used directly above it for the TCP listener (*"Bind TCP listener once (persists across soft restarts)"*):

- Install the recorder once, before the loop, into `metrics_handle: Option<PrometheusHandle>` (only when `rest_enabled`).
- Clone that handle into each iteration's `AppState` (`PrometheusHandle` is `Clone` — it wraps an internal `Arc`), so `/metrics` rendering via `routes/vta.rs` is unaffected.
- `run_rest_thread` no longer installs and no longer needs `mut state`.

Root-cause fix, not a workaround: the install genuinely should happen exactly once for the process lifetime, and now it does.

## Verification

- `cargo check -p vta-service` — clean
- `cargo clippy -p vta-service` — no warnings
- `cargo fmt` — applied

### Testing note

The existing `restart_requires_super_admin` test only exercises the auth gate via the router harness — it never drives the real `run()` restart loop (which boots threads on a live TCP port), so it couldn't have caught this. A true regression test would require a full double-boot on a real port; a unit test calling `install()` twice would poison the process-global recorder for every other test in the binary. The fix is structural — `install()` can no longer be reached twice — which is the guard here.