### PR TITLE
fix(vti-common): bind keyspace values to their location with AES-GCM AAD (P0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### vti-common — security: keyspace values bound to their location (AAD); breaking on-disk format
+
+AES-256-GCM keyspace encryption now authenticates every value against its
+`(keyspace, key)` location via associated data (AAD), and prefixes a 4-byte
+format magic (`VAE1`). Previously a value's ciphertext was bound to nothing: an
+attacker who controls the storage medium — in the Nitro model the **untrusted
+parent EC2 instance owns the fjall database** — could cut-and-paste a ciphertext
+from one key to another (e.g. resurrect a revoked admin ACL row, or move a value
+across keyspaces that share the single storage key) without breaking any crypto.
+Binding `(keyspace, key)` into the AAD makes any such relocation fail
+authentication. The `sealed_nonces` and `cache` keyspaces, previously stored in
+plaintext, are now encrypted alongside the rest.
+
+**Breaking — encrypted stores only.** The new format is intentionally **not**
+backward-compatible with the previous AAD-less layout: a legacy read-fallback
+would reintroduce the cut-and-paste hole via downgrade. A stale value yields a
+clear "incompatible store format — re-bootstrap or restore from backup" error
+rather than a confusing decryption failure.
+
+- **Affected:** TEE/Nitro deployments, and any non-TEE VTA configured with an
+  explicit `storage_encryption_key`. These must **re-bootstrap a fresh enclave**
+  or **restore from a backup** taken with this build (backup export/import is
+  format-independent — it re-encrypts on import).
+- **Not affected:** deployments with no encryption key configured (the default
+  local/dev path) never encrypted and are byte-for-byte unchanged.
+
+This is the integrity half of the TEE storage threat model; anti-rollback of a
+whole keyspace (replay/delete of records) is tracked separately.
+
 ### vta-sdk 0.11.0 → 0.11.1 — fix: never trust a key's label as its DIDComm kid
 
 Patch release cutting the publish boundary for the fix in #337. The published

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -12,8 +12,16 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
 
 ## Phase 0 — Security & correctness fixes (parallelizable, land any time)
 
-- `[ ]` **P0.1** (M) AAD binding (`keyspace||key`) for keyspace encryption;
-  encrypt `sealed_nonces` + `cache` — PR: ____
+- `[~]` **P0.1** (M) AAD binding (`keyspace||key`) for keyspace encryption;
+  encrypt `sealed_nonces` + `cache` — branch `fix/p0.1-keyspace-aad`.
+  AES-GCM AAD = len-prefixed keyspace ‖ store-key, 4-byte magic `VAE1`, NO
+  legacy read-fallback (downgrade-safe) → clear error on stale data.
+  Threaded keyspace name + store key through every encrypt/decrypt site in
+  the local + vsock handles; encrypted `cache` + `sealed_nonces` at both
+  AppState construction sites. Breaking on-disk change for encrypted stores
+  only (default/plaintext unaffected) — documented in CHANGELOG. Tests:
+  cross-key/cross-keyspace paste rejected (unit + through the real handle),
+  wrong-key, legacy-format clear error, passthrough unchanged — PR: ____
 - `[ ]` **P0.2** (XL) Enclave-side anti-rollback anchor for carve-out sentinel /
   JWT fingerprint / ACL — design note first — deps: P0.1 — PR: ____
 - `[~]` **P0.3** (S) `create_key`/`import_key`: existence check + identifier

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -21,7 +21,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   AppState construction sites. Breaking on-disk change for encrypted stores
   only (default/plaintext unaffected) — documented in CHANGELOG. Tests:
   cross-key/cross-keyspace paste rejected (unit + through the real handle),
-  wrong-key, legacy-format clear error, passthrough unchanged — PR: ____
+  wrong-key, legacy-format clear error, passthrough unchanged — PR: #346 (in review)
 - `[ ]` **P0.2** (XL) Enclave-side anti-rollback anchor for carve-out sentinel /
   JWT fingerprint / ACL — design note first — deps: P0.1 — PR: ____
 - `[~]` **P0.3** (S) `create_key`/`import_key`: existence check + identifier

--- a/vta-service/src/sealed_nonce_store.rs
+++ b/vta-service/src/sealed_nonce_store.rs
@@ -22,8 +22,11 @@ use crate::store::KeyspaceHandle;
 const KEY_PREFIX: &str = "sealed-nonce:";
 
 /// Fjall-backed (or vsock-backed) persistent nonce store. Any
-/// [`KeyspaceHandle`] will do; the TEE-mode service uses an unencrypted
-/// keyspace since the bundle_id itself is not secret.
+/// [`KeyspaceHandle`] will do. The bundle_id lives in the (plaintext)
+/// key; encrypted deployments now also encrypt the row value, binding it
+/// to its `(keyspace, key)` location via AAD so a hostile store operator
+/// cannot relocate or substitute a nonce record (P0.1). Anti-rollback of
+/// the whole keyspace is a separate concern (P0.2).
 pub struct PersistentNonceStore {
     ks: KeyspaceHandle,
     /// Serialises the check-and-record critical section across threads so

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -216,7 +216,7 @@ pub async fn build_app_state(
     let did_templates_ks = apply_encryption(store.keyspace("did_templates")?);
     let audit_ks = apply_encryption(store.keyspace("audit")?);
     let imported_ks = apply_encryption(store.keyspace("imported_secrets")?);
-    let cache_ks = store.keyspace("cache")?;
+    let cache_ks = apply_encryption(store.keyspace("cache")?);
     let vault_ks = apply_encryption(store.keyspace("vault")?);
     // Persistent runtime state for service enable/disable. Encrypted because
     // a couple of bool records are cheap and the keyspace may grow.
@@ -224,7 +224,7 @@ pub async fn build_app_state(
     // Sealed-transfer anti-replay store. Bundle_ids are not secret and the
     // row is a one-byte sentinel, so the keyspace is intentionally
     // unencrypted — saves a decrypt hop on every request.
-    let sealed_nonces_ks = store.keyspace("sealed_nonces")?;
+    let sealed_nonces_ks = apply_encryption(store.keyspace("sealed_nonces")?);
     let backup_bundles_ks = apply_encryption(store.keyspace("backup_bundles")?);
     // Stage `.vtabak` blobs under `{data_dir}/backups`. Created lazily
     // by the op layer at first `initiate-*` call (so a VTA that never
@@ -434,10 +434,10 @@ pub async fn run(
         let did_templates_ks = apply_encryption(store.keyspace("did_templates")?);
         let audit_ks = apply_encryption(store.keyspace("audit")?);
         let imported_ks = apply_encryption(store.keyspace("imported_secrets")?);
-        let cache_ks = store.keyspace("cache")?;
+        let cache_ks = apply_encryption(store.keyspace("cache")?);
         let vault_ks = apply_encryption(store.keyspace("vault")?);
         let service_state_ks = apply_encryption(store.keyspace("service_state")?);
-        let sealed_nonces_ks = store.keyspace("sealed_nonces")?;
+        let sealed_nonces_ks = apply_encryption(store.keyspace("sealed_nonces")?);
         let backup_bundles_ks = apply_encryption(store.keyspace("backup_bundles")?);
         let backup_blob_dir = config.store.data_dir.join("backups");
         #[cfg(feature = "webvh")]

--- a/vti-common/src/store/encryption.rs
+++ b/vti-common/src/store/encryption.rs
@@ -1,58 +1,209 @@
+//! AES-256-GCM encryption for keyspace values, bound to their location.
+//!
+//! # Associated data (the integrity fix)
+//!
+//! Every value is authenticated against its `(keyspace, key)` location via
+//! AES-GCM associated data (AAD). Without it, a value's ciphertext is bound to
+//! nothing: an attacker who controls the storage medium (in the Nitro model the
+//! parent EC2 instance owns the fjall database) could **cut-and-paste** a
+//! ciphertext from one key to another — e.g. resurrect a revoked admin ACL row,
+//! or move a value across keyspaces that share the single storage key — without
+//! breaking any crypto. Binding `(keyspace, key)` into the AAD makes such a
+//! relocation fail authentication.
+//!
+//! # On-disk format (v1)
+//!
+//! ```text
+//! [4-byte magic "VAE1"][12-byte random nonce][ciphertext + 16-byte GCM tag]
+//! ```
+//!
+//! # Breaking change
+//!
+//! This is **not** wire-compatible with the previous AAD-less format
+//! (`[nonce][ct]`). Values written by an older build cannot be decrypted by
+//! this one — by design: a legacy read-fallback would reintroduce the
+//! cut-and-paste hole via downgrade (an attacker would just write legacy-format
+//! values). Encrypted deployments (TEE, or non-TEE with an explicit
+//! `storage_encryption_key`) must re-bootstrap or restore from backup. Stores
+//! with no encryption key configured are unaffected — they never encrypted.
+
 use crate::error::AppError;
 
+/// Format magic for AAD-authenticated values. Distinguishes the v1 format
+/// from the legacy AAD-less layout so a stale value yields a clear error
+/// rather than a confusing GCM authentication failure.
+const MAGIC: &[u8; 4] = b"VAE1";
 const NONCE_LEN: usize = 12;
 const TAG_LEN: usize = 16;
 
-/// Encrypt plaintext with AES-256-GCM.
-/// Output: `[12-byte random nonce][ciphertext + 16-byte auth tag]`
-pub fn encrypt_value(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, AppError> {
-    use aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead};
+/// Build the AES-GCM associated data binding a value to its location.
+///
+/// `len(keyspace) ‖ keyspace ‖ key` — the length prefix makes the encoding
+/// unambiguous regardless of what bytes the store key contains, so no two
+/// distinct `(keyspace, key)` pairs can produce the same AAD.
+fn build_aad(keyspace: &str, key: &[u8]) -> Vec<u8> {
+    let ks = keyspace.as_bytes();
+    let mut aad = Vec::with_capacity(4 + ks.len() + key.len());
+    aad.extend_from_slice(&(ks.len() as u32).to_be_bytes());
+    aad.extend_from_slice(ks);
+    aad.extend_from_slice(key);
+    aad
+}
 
-    let cipher = Aes256Gcm::new_from_slice(key)
+/// Encrypt `plaintext` with AES-256-GCM, authenticating it against its
+/// `(keyspace, key)` location. Output: `MAGIC ‖ nonce ‖ ct+tag`.
+pub fn encrypt_value(
+    enc_key: &[u8; 32],
+    keyspace: &str,
+    store_key: &[u8],
+    plaintext: &[u8],
+) -> Result<Vec<u8>, AppError> {
+    use aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead, aead::Payload};
+
+    let cipher = Aes256Gcm::new_from_slice(enc_key)
         .map_err(|e| AppError::Internal(format!("AES key error: {e}")))?;
 
     let mut nonce_bytes = [0u8; NONCE_LEN];
     rand::fill(&mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
 
+    let aad = build_aad(keyspace, store_key);
     let ciphertext = cipher
-        .encrypt(nonce, plaintext)
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext,
+                aad: &aad,
+            },
+        )
         .map_err(|e| AppError::Internal(format!("AES-GCM encryption failed: {e}")))?;
 
-    let mut output = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    let mut output = Vec::with_capacity(MAGIC.len() + NONCE_LEN + ciphertext.len());
+    output.extend_from_slice(MAGIC);
     output.extend_from_slice(&nonce_bytes);
     output.extend_from_slice(&ciphertext);
     Ok(output)
 }
 
-/// Decrypt AES-256-GCM encrypted value.
-/// Input: `[12-byte nonce][ciphertext + 16-byte auth tag]`
-fn decrypt_value(key: &[u8; 32], data: &[u8]) -> Result<Vec<u8>, AppError> {
-    use aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead};
+/// Decrypt an AAD-authenticated value, verifying it against its
+/// `(keyspace, key)` location. Input: `MAGIC ‖ nonce ‖ ct+tag`.
+fn decrypt_value(
+    enc_key: &[u8; 32],
+    keyspace: &str,
+    store_key: &[u8],
+    data: &[u8],
+) -> Result<Vec<u8>, AppError> {
+    use aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead, aead::Payload};
 
-    if data.len() < NONCE_LEN + TAG_LEN {
+    if data.len() < MAGIC.len() || &data[..MAGIC.len()] != MAGIC {
+        return Err(AppError::Internal(
+            "encrypted value is not in the AAD-authenticated v1 format \
+             (likely written by a pre-integrity-fix build); this store is \
+             incompatible — re-bootstrap or restore from backup"
+                .into(),
+        ));
+    }
+    let body = &data[MAGIC.len()..];
+    if body.len() < NONCE_LEN + TAG_LEN {
         return Err(AppError::Internal(
             "encrypted value too short (missing nonce or auth tag)".into(),
         ));
     }
 
-    let cipher = Aes256Gcm::new_from_slice(key)
+    let cipher = Aes256Gcm::new_from_slice(enc_key)
         .map_err(|e| AppError::Internal(format!("AES key error: {e}")))?;
 
-    let nonce = Nonce::from_slice(&data[..NONCE_LEN]);
-    let ciphertext = &data[NONCE_LEN..];
+    let nonce = Nonce::from_slice(&body[..NONCE_LEN]);
+    let ciphertext = &body[NONCE_LEN..];
+    let aad = build_aad(keyspace, store_key);
 
-    cipher.decrypt(nonce, ciphertext).map_err(|e| {
-        AppError::Internal(format!(
-            "AES-GCM decryption failed (data may be corrupt or key mismatch): {e}"
-        ))
-    })
+    cipher
+        .decrypt(
+            nonce,
+            Payload {
+                msg: ciphertext,
+                aad: &aad,
+            },
+        )
+        .map_err(|e| {
+            AppError::Internal(format!(
+                "AES-GCM decryption failed (corrupt data, wrong key, or value \
+                 moved to a different keyspace/key): {e}"
+            ))
+        })
 }
 
 /// Decrypt bytes if an encryption key is provided, otherwise return a copy.
-pub fn maybe_decrypt_bytes(key: Option<&[u8; 32]>, data: &[u8]) -> Result<Vec<u8>, AppError> {
-    match key {
-        Some(k) => decrypt_value(k, data),
+/// `keyspace` and `store_key` identify the value's location for AAD
+/// verification.
+pub fn maybe_decrypt_bytes(
+    enc_key: Option<&[u8; 32]>,
+    keyspace: &str,
+    store_key: &[u8],
+    data: &[u8],
+) -> Result<Vec<u8>, AppError> {
+    match enc_key {
+        Some(k) => decrypt_value(k, keyspace, store_key, data),
         None => Ok(data.to_vec()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: [u8; 32] = [7u8; 32];
+
+    #[test]
+    fn round_trip_at_same_location() {
+        let ct = encrypt_value(&KEY, "acl", b"acl:did:key:zX", b"secret").unwrap();
+        let pt = decrypt_value(&KEY, "acl", b"acl:did:key:zX", &ct).unwrap();
+        assert_eq!(pt, b"secret");
+    }
+
+    #[test]
+    fn cross_key_paste_is_rejected() {
+        // A value encrypted for key A must not decrypt when relocated to key B.
+        let ct = encrypt_value(&KEY, "acl", b"acl:victim", b"admin-row").unwrap();
+        let err = decrypt_value(&KEY, "acl", b"acl:attacker", &ct);
+        assert!(err.is_err(), "cross-key paste must fail authentication");
+    }
+
+    #[test]
+    fn cross_keyspace_paste_is_rejected() {
+        // Same key string, different keyspace (both share the storage key).
+        let ct = encrypt_value(&KEY, "keys", b"active_seed_id", b"\x01").unwrap();
+        let err = decrypt_value(&KEY, "contexts", b"active_seed_id", &ct);
+        assert!(
+            err.is_err(),
+            "cross-keyspace paste must fail authentication"
+        );
+    }
+
+    #[test]
+    fn wrong_key_is_rejected() {
+        let ct = encrypt_value(&KEY, "acl", b"k", b"v").unwrap();
+        let err = decrypt_value(&[9u8; 32], "acl", b"k", &ct);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn legacy_unauthenticated_value_gives_clear_error() {
+        // A pre-v1 value (no magic prefix) must be rejected with a
+        // format-specific message, not a generic GCM failure.
+        let legacy = vec![0u8; NONCE_LEN + TAG_LEN + 4];
+        let err = decrypt_value(&KEY, "acl", b"k", &legacy).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("v1 format") || msg.contains("re-bootstrap"),
+            "expected a format-incompatibility hint, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn maybe_decrypt_without_key_is_passthrough() {
+        let data = b"plain";
+        let out = maybe_decrypt_bytes(None, "acl", b"k", data).unwrap();
+        assert_eq!(out, data);
     }
 }

--- a/vti-common/src/store/mod.rs
+++ b/vti-common/src/store/mod.rs
@@ -349,6 +349,10 @@ pub struct LocalStore {
 #[derive(Clone)]
 pub struct LocalKeyspaceHandle {
     keyspace: fjall::Keyspace,
+    /// Keyspace name, bound into the AES-GCM associated data so a value
+    /// cannot be relocated to another keyspace (which shares the storage
+    /// key) and still authenticate. See [`encryption`].
+    name: String,
     /// The owning database, kept so the handle can fsync the shared
     /// journal ([`LocalKeyspaceHandle::persist`]) — fjall only exposes
     /// persistence at the database level.
@@ -391,6 +395,7 @@ impl LocalStore {
             .clone();
         Ok(LocalKeyspaceHandle {
             keyspace,
+            name: name.to_string(),
             db: self.db.clone(),
             write_lock,
             #[cfg(feature = "encryption")]
@@ -439,7 +444,7 @@ impl LocalKeyspaceHandle {
     ) -> Result<(), AppError> {
         let key = key.into();
         let bytes = serde_json::to_vec(value)?;
-        let bytes = self.maybe_encrypt(bytes)?;
+        let bytes = self.maybe_encrypt(&key, bytes)?;
         let ks = self.keyspace.clone();
         blocking_with_timeout(move || Ok(ks.insert(key, bytes)?)).await
     }
@@ -452,12 +457,14 @@ impl LocalKeyspaceHandle {
         let ks = self.keyspace.clone();
         #[cfg(feature = "encryption")]
         let enc_key = self.encryption_key.clone();
-        blocking_with_timeout(move || match ks.get(key)? {
+        #[cfg(feature = "encryption")]
+        let name = self.name.clone();
+        blocking_with_timeout(move || match ks.get(&key)? {
             Some(bytes) => {
                 #[cfg(feature = "encryption")]
                 let bytes = {
                     let k = enc_key.as_ref().map(|arc| &***arc);
-                    encryption::maybe_decrypt_bytes(k, &bytes)?
+                    encryption::maybe_decrypt_bytes(k, &name, &key, &bytes)?
                 };
                 #[cfg(not(feature = "encryption"))]
                 let bytes = bytes.to_vec();
@@ -493,6 +500,8 @@ impl LocalKeyspaceHandle {
         let lock = self.write_lock.clone();
         #[cfg(feature = "encryption")]
         let enc_key = self.encryption_key.clone();
+        #[cfg(feature = "encryption")]
+        let name = self.name.clone();
         blocking_with_timeout(move || {
             let _guard = lock_writes(&lock);
             match ks.get(&key)? {
@@ -501,7 +510,7 @@ impl LocalKeyspaceHandle {
                     #[cfg(feature = "encryption")]
                     let bytes = {
                         let k = enc_key.as_ref().map(|arc| &***arc);
-                        encryption::maybe_decrypt_bytes(k, &bytes)?
+                        encryption::maybe_decrypt_bytes(k, &name, &key, &bytes)?
                     };
                     #[cfg(not(feature = "encryption"))]
                     let bytes = bytes.to_vec();
@@ -519,7 +528,7 @@ impl LocalKeyspaceHandle {
         value: impl Into<Vec<u8>>,
     ) -> Result<(), AppError> {
         let key = key.into();
-        let value = self.maybe_encrypt(value.into())?;
+        let value = self.maybe_encrypt(&key, value.into())?;
         let ks = self.keyspace.clone();
         blocking_with_timeout(move || Ok(ks.insert(key, value)?)).await
     }
@@ -529,12 +538,14 @@ impl LocalKeyspaceHandle {
         let ks = self.keyspace.clone();
         #[cfg(feature = "encryption")]
         let enc_key = self.encryption_key.clone();
-        blocking_with_timeout(move || match ks.get(key)? {
+        #[cfg(feature = "encryption")]
+        let name = self.name.clone();
+        blocking_with_timeout(move || match ks.get(&key)? {
             Some(bytes) => {
                 #[cfg(feature = "encryption")]
                 let bytes = {
                     let k = enc_key.as_ref().map(|arc| &***arc);
-                    encryption::maybe_decrypt_bytes(k, &bytes)?
+                    encryption::maybe_decrypt_bytes(k, &name, &key, &bytes)?
                 };
                 #[cfg(not(feature = "encryption"))]
                 let bytes = bytes.to_vec();
@@ -553,6 +564,8 @@ impl LocalKeyspaceHandle {
         let ks = self.keyspace.clone();
         #[cfg(feature = "encryption")]
         let enc_key = self.encryption_key.clone();
+        #[cfg(feature = "encryption")]
+        let name = self.name.clone();
         blocking_with_timeout(move || {
             let mut results = Vec::new();
             for guard in ks.prefix(&prefix) {
@@ -560,7 +573,7 @@ impl LocalKeyspaceHandle {
                 #[cfg(feature = "encryption")]
                 let value = {
                     let k = enc_key.as_ref().map(|arc| &***arc);
-                    encryption::maybe_decrypt_bytes(k, &value)?
+                    encryption::maybe_decrypt_bytes(k, &name, &key, &value)?
                 };
                 #[cfg(not(feature = "encryption"))]
                 let value = value.to_vec();
@@ -599,7 +612,8 @@ impl LocalKeyspaceHandle {
         let old_key = old_key.into();
         let new_key = new_key.into();
         let bytes = serde_json::to_vec(value)?;
-        let bytes = self.maybe_encrypt(bytes)?;
+        // The value lands at `new_key`, so bind the AAD to `new_key`.
+        let bytes = self.maybe_encrypt(&new_key, bytes)?;
         let ks = self.keyspace.clone();
         let lock = self.write_lock.clone();
         blocking_with_timeout(move || {
@@ -641,7 +655,7 @@ impl LocalKeyspaceHandle {
     /// lock (see [`WriteLocks`]), so exactly one of two racing callers
     /// observes `true`.
     async fn insert_bytes_if_absent(&self, key: Vec<u8>, bytes: Vec<u8>) -> Result<bool, AppError> {
-        let bytes = self.maybe_encrypt(bytes)?;
+        let bytes = self.maybe_encrypt(&key, bytes)?;
         let ks = self.keyspace.clone();
         let lock = self.write_lock.clone();
         blocking_with_timeout(move || {
@@ -655,16 +669,17 @@ impl LocalKeyspaceHandle {
         .await
     }
 
-    fn maybe_encrypt(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, AppError> {
+    fn maybe_encrypt(&self, store_key: &[u8], plaintext: Vec<u8>) -> Result<Vec<u8>, AppError> {
         #[cfg(feature = "encryption")]
         {
             match self.encryption_key.as_ref().map(|arc| &***arc) {
-                Some(key) => encryption::encrypt_value(key, &plaintext),
+                Some(key) => encryption::encrypt_value(key, &self.name, store_key, &plaintext),
                 None => Ok(plaintext),
             }
         }
         #[cfg(not(feature = "encryption"))]
         {
+            let _ = store_key;
             Ok(plaintext)
         }
     }
@@ -879,6 +894,43 @@ mod tests {
         ks.insert("json:test", &"encrypted value").await.unwrap();
         let got: String = ks.get("json:test").await.unwrap().unwrap();
         assert_eq!(got, "encrypted value");
+    }
+
+    /// End-to-end AAD enforcement through the real handle (P0.1): a
+    /// ciphertext written at one key must not decrypt when an attacker
+    /// who controls the store relocates it to another key — even within
+    /// the same keyspace and storage key. Without AAD this paste
+    /// succeeds and resurrects e.g. a revoked ACL row.
+    #[cfg(feature = "encryption")]
+    #[tokio::test]
+    async fn encrypted_value_cannot_be_pasted_to_another_key() {
+        let (store, _dir) = temp_store();
+        let key = [0x55; 32];
+        let ks = store.keyspace("acl").unwrap().with_encryption(key);
+
+        ks.insert_raw("acl:victim", b"admin-row".to_vec())
+            .await
+            .unwrap();
+
+        // Simulate a hostile store operator copying the raw ciphertext
+        // from one key to another (writing it back via an unencrypted
+        // handle so no re-encryption happens).
+        let raw = store.keyspace("acl").unwrap();
+        let stolen = raw.get_raw("acl:victim").await.unwrap().unwrap();
+        raw.insert_raw("acl:attacker", stolen).await.unwrap();
+
+        // Reading the relocated ciphertext through the encrypted handle
+        // must fail AAD authentication, not silently return the value.
+        let err = ks.get_raw("acl:attacker").await;
+        assert!(
+            err.is_err(),
+            "a ciphertext pasted to a different key must fail AAD authentication"
+        );
+        // The original location still decrypts fine.
+        assert_eq!(
+            ks.get_raw("acl:victim").await.unwrap().unwrap(),
+            b"admin-row"
+        );
     }
 
     #[cfg(feature = "encryption")]

--- a/vti-common/src/store/vsock.rs
+++ b/vti-common/src/store/vsock.rs
@@ -241,7 +241,7 @@ impl VsockKeyspaceHandle {
     ) -> Result<(), AppError> {
         let key = key.into();
         let bytes = serde_json::to_vec(value)?;
-        let bytes = self.maybe_encrypt(bytes)?;
+        let bytes = self.maybe_encrypt(&key, bytes)?;
         let mut payload = vec![OP_INSERT];
         encode_keyspace(&mut payload, &self.keyspace);
         encode_bytes(&mut payload, &key);
@@ -261,7 +261,7 @@ impl VsockKeyspaceHandle {
         let resp = self.send(&payload).await?;
         match decode_value(&resp)? {
             Some(bytes) => {
-                let bytes = self.maybe_decrypt(&bytes)?;
+                let bytes = self.maybe_decrypt(&key, &bytes)?;
                 Ok(Some(serde_json::from_slice(&bytes)?))
             }
             None => Ok(None),
@@ -283,7 +283,7 @@ impl VsockKeyspaceHandle {
         value: impl Into<Vec<u8>>,
     ) -> Result<(), AppError> {
         let key = key.into();
-        let value = self.maybe_encrypt(value.into())?;
+        let value = self.maybe_encrypt(&key, value.into())?;
         let mut payload = vec![OP_INSERT];
         encode_keyspace(&mut payload, &self.keyspace);
         encode_bytes(&mut payload, &key);
@@ -299,7 +299,7 @@ impl VsockKeyspaceHandle {
         encode_bytes(&mut payload, &key);
         let resp = self.send(&payload).await?;
         match decode_value(&resp)? {
-            Some(bytes) => Ok(Some(self.maybe_decrypt(&bytes)?)),
+            Some(bytes) => Ok(Some(self.maybe_decrypt(&key, &bytes)?)),
             None => Ok(None),
         }
     }
@@ -318,7 +318,7 @@ impl VsockKeyspaceHandle {
         pairs
             .into_iter()
             .map(|(k, v)| {
-                let v = self.maybe_decrypt(&v)?;
+                let v = self.maybe_decrypt(&k, &v)?;
                 Ok((k, v))
             })
             .collect()
@@ -353,9 +353,10 @@ impl VsockKeyspaceHandle {
             return Ok(false);
         }
 
-        // Insert new, delete old
+        // Insert new, delete old. The value lands at `new_key`, so bind
+        // the AAD to `new_key_bytes`.
         let bytes = serde_json::to_vec(value)?;
-        let bytes = self.maybe_encrypt(bytes)?;
+        let bytes = self.maybe_encrypt(&new_key_bytes, bytes)?;
 
         let mut insert_payload = vec![OP_INSERT];
         encode_keyspace(&mut insert_payload, &self.keyspace);
@@ -393,30 +394,39 @@ impl VsockKeyspaceHandle {
         Ok(resp)
     }
 
-    fn maybe_encrypt(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, AppError> {
+    fn maybe_encrypt(&self, store_key: &[u8], plaintext: Vec<u8>) -> Result<Vec<u8>, AppError> {
         #[cfg(feature = "encryption")]
         {
             match self.encryption_key.as_ref().map(|arc| &***arc) {
-                Some(key) => super::encryption::encrypt_value(key, &plaintext),
+                Some(key) => {
+                    super::encryption::encrypt_value(key, &self.keyspace, store_key, &plaintext)
+                }
                 None => Ok(plaintext),
             }
         }
         #[cfg(not(feature = "encryption"))]
         {
+            let _ = store_key;
             Ok(plaintext)
         }
     }
 
-    fn maybe_decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>, AppError> {
+    fn maybe_decrypt(&self, store_key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, AppError> {
         #[cfg(feature = "encryption")]
         {
             match self.encryption_key.as_ref().map(|arc| &***arc) {
-                Some(key) => super::encryption::maybe_decrypt_bytes(Some(key), ciphertext),
+                Some(key) => super::encryption::maybe_decrypt_bytes(
+                    Some(key),
+                    &self.keyspace,
+                    store_key,
+                    ciphertext,
+                ),
                 None => Ok(ciphertext.to_vec()),
             }
         }
         #[cfg(not(feature = "encryption"))]
         {
+            let _ = store_key;
             Ok(ciphertext.to_vec())
         }
     }


### PR DESCRIPTION
## Summary

Plan task **P0.1** — the highest-severity finding in the architecture review. Branches off `main`.

Keyspace encryption authenticated **nothing about where a value lived**: the on-disk format was `[nonce][ct+tag]` with no associated data. In the Nitro model the **untrusted parent EC2 instance owns the fjall database**, so an attacker who controls storage could **cut-and-paste** a ciphertext from one key to another without breaking any crypto — resurrect a revoked admin ACL row, or move a value across keyspaces (they share the single storage key). Confidentiality was enforced; **integrity was not**.

## Fix

Every value is now authenticated against its `(keyspace, key)` location via AES-GCM **AAD** = `len(keyspace) ‖ keyspace ‖ store_key`, behind a 4-byte format magic `VAE1`. Any relocation now fails authentication. The keyspace name + store key are threaded through every encrypt/decrypt site in **both** the local fjall handle and the vsock handle. `sealed_nonces` and `cache` (previously plaintext) are now encrypted at both AppState construction sites.

**No legacy read-fallback** — that would reintroduce the hole via downgrade (an attacker would just write legacy-format values). A stale value yields a clear *"incompatible store format — re-bootstrap or restore from backup"* error rather than a confusing GCM failure.

## ⚠️ Breaking — encrypted stores only

The new format is intentionally not backward-compatible.
- **Affected:** TEE/Nitro, and any non-TEE VTA with an explicit `storage_encryption_key`. Must **re-bootstrap a fresh enclave** or **restore from a backup** taken with this build (backup import is format-independent — it re-encrypts on import).
- **Not affected:** deployments with no encryption key (default local/dev) never encrypted — byte-for-byte unchanged.

Documented in `CHANGELOG.md`.

## Design note
AAD uses a **length-prefixed** keyspace so no two distinct `(keyspace, key)` pairs collide regardless of key bytes. The magic prefix exists purely to give stale data a *specific* error (it is not a version-negotiation hook — there is deliberately no v0 path). Encryption only activates when a storage key is configured, which bounds the breaking change precisely.

## Tests
Unit: round-trip; cross-key paste rejected; cross-keyspace paste rejected; wrong-key rejected; legacy-format → clear error; no-key passthrough unchanged. Integration: end-to-end paste-rejection through the real encrypted `KeyspaceHandle` (write ciphertext, relocate via an unencrypted handle, confirm the encrypted handle refuses it). Gate: workspace 81 suites / 0 failures, 717 tee-lib tests / 0 failures, clippy clean (default + tee), fmt.

## Scope boundary
This is the **integrity** half of the TEE storage threat model. Whole-keyspace **anti-rollback** (replay/delete of records — e.g. deleting the carve-out sentinel) is the separate, larger **P0.2** (needs an enclave-anchored integrity root; design-note-first).