### PR TITLE
fix: tolerate corrupt rows in list paths; fail loudly in backup export (P0.14)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -12,7 +12,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
 
 ## Phase 0 — Security & correctness fixes (parallelizable, land any time)
 
-- `[~]` **P0.1** (M) AAD binding (`keyspace||key`) for keyspace encryption;
+- `[x]` **P0.1** (M) AAD binding (`keyspace||key`) for keyspace encryption;
   encrypt `sealed_nonces` + `cache` — branch `fix/p0.1-keyspace-aad`.
   AES-GCM AAD = len-prefixed keyspace ‖ store-key, 4-byte magic `VAE1`, NO
   legacy read-fallback (downgrade-safe) → clear error on stale data.
@@ -21,17 +21,17 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   AppState construction sites. Breaking on-disk change for encrypted stores
   only (default/plaintext unaffected) — documented in CHANGELOG. Tests:
   cross-key/cross-keyspace paste rejected (unit + through the real handle),
-  wrong-key, legacy-format clear error, passthrough unchanged — PR: #346 (in review)
+  wrong-key, legacy-format clear error, passthrough unchanged — PR: #346 (merged)
 - `[ ]` **P0.2** (XL) Enclave-side anti-rollback anchor for carve-out sentinel /
   JWT fingerprint / ACL — design note first — deps: P0.1 — PR: ____
-- `[~]` **P0.3** (S) `create_key`/`import_key`: existence check + identifier
+- `[x]` **P0.3** (S) `create_key`/`import_key`: existence check + identifier
   validation (closes `#key-0` overwrite) — branch `fix/p0.3-key-overwrite`.
   Scope grew during root-cause analysis: the store's multi-op "atomic"
   closures (take_raw/swap) were NOT actually atomic — added a shared
   per-keyspace write lock in LocalStore + `insert_if_absent` primitive +
   concurrency regression tests; also validated `rename_key`'s new id
-  (wire-facing bypass) — PR: #341 (in review)
-- `[~]` **P0.4** (S) Shared locked counter allocator; fix
+  (wire-facing bypass) — PR: #341 (merged)
+- `[x]` **P0.4** (S) Shared locked counter allocator; fix
   `allocate_context_index` race (same-subtree key derivation) —
   implemented on branch `fix/p0.4-counter-races`. Delivered:
   `vti-common/src/store/counter.rs` (app-level lock so the vsock backend
@@ -39,10 +39,10 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   `insert_raw_if_absent` closes the KEK salt race; ROTATE_LOCK serialises
   seed rotation; create_context claims its record atomically at both
   layers; concurrency regression tests for all four —
-  PR: #342 (stacked on #341)
+  PR: #342 (merged)
 - `[ ]` **P0.5** (L) Backup/restore: export counters (no BIP-32 path reuse),
   full `AclEntry` round-trip, import-in-progress sentinel — PR: ____
-- `[~]` **P0.6** (S) TEE seed rotation: reject or persist (no silent key loss) —
+- `[x]` **P0.6** (S) TEE seed rotation: reject or persist (no silent key loss) —
   branch `fix/p0.6-tee-seed-rotation`. Chose REJECT (the plan's safe minimum;
   in-place re-encryption is a follow-up). New `SeedStore::set_persists_across_restart()`
   (default true; `KmsTeeSeedStore` → false, fixed its misleading set() comment).
@@ -50,11 +50,11 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   too) + a typed `AppError::Conflict` with operator guidance at
   `operations::seeds::rotate_seed` (runtime REST/DIDComm/TT path). Tests:
   refusal+no-mutation (tee), trait flag, existing non-TEE rotation unaffected
-  — PR: #344 (in review). Follow-up: in-place re-encryption so TEE rotation
+  — PR: #344 (merged). Follow-up: in-place re-encryption so TEE rotation
   works rather than refuses (needs runtime KMS access on KmsTeeSeedStore).
 - `[ ]` **P0.7** (M) `Zeroizing` seed bytes end-to-end; encrypt retired-seed
   archive; fix "secure deletion" claim — PR: ____
-- `[~]` **P0.8** (S) Atomic + persisted carve-out close — branch
+- `[x]` **P0.8** (S) Atomic + persisted carve-out close — branch
   `fix/p0.8-carveout-durability`. Added `KeyspaceHandle::persist()` (local
   fsync + vsock OP_PERSIST passthrough). `mint_mode_b` now: seal first
   (fail-fast, no carve-out writes) → ACL → sentinel-via-`insert_raw_if_absent`
@@ -63,7 +63,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   barrier: no reopen-after-delivery). ACL-before-sentinel journal order so a
   torn fsync favours a recoverable reopen over a brick. Counter allocator
   also now fsyncs (path-counter loss = key reuse). Tests: persist-survives-
-  reopen, carve-out-admits-one — PR: #343 (in review)
+  reopen, carve-out-admits-one — PR: #343 (merged)
 - `[ ]` **P0.9** (M) Boot-time `config::validate()`; `deny_unknown_fields`;
   hard-fail missing identity unless `--allow-degraded`; explicit opt-in for
   plaintext seed store — PR: ____
@@ -81,7 +81,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   no longer aborts the whole listing); backup export (seed/key/context/ACL
   collections) now errors loudly on a corrupt row (incomplete backup is
   worse than none). ACL field-fidelity stays for P0.5. Tests: ACL list
-  skips garbage row, export aborts on corrupt key row — PR: ____
+  skips garbage row, export aborts on corrupt key row — PR: #347 (in review)
 
 **Checkpoint 0:** `[ ]` all P0 merged or deferred-with-issue; CI green;
 tee-architecture.md updated.

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -75,8 +75,13 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   approve/deny/list surface — PR: ____
 - `[ ]` **P0.13** (S) Decide + enforce/document cross-transport step-up policy
   (DIDComm `swap_acl`; ignored vault `step_up_proof`) — PR: ____
-- `[ ]` **P0.14** (S) Tolerant list iteration (skip+log poisoned rows); backup
-  export fails loudly — PR: ____
+- `[~]` **P0.14** (S) Tolerant list iteration (skip+log poisoned rows); backup
+  export fails loudly — branch `fix/p0.14-tolerant-list-iteration`.
+  list_acl_entries / list_contexts / list_keys skip+warn (one corrupt row
+  no longer aborts the whole listing); backup export (seed/key/context/ACL
+  collections) now errors loudly on a corrupt row (incomplete backup is
+  worse than none). ACL field-fidelity stays for P0.5. Tests: ACL list
+  skips garbage row, export aborts on corrupt key row — PR: ____
 
 **Checkpoint 0:** `[ ]` all P0 merged or deferred-with-issue; CI green;
 tee-architecture.md updated.

--- a/vta-service/src/contexts/mod.rs
+++ b/vta-service/src/contexts/mod.rs
@@ -36,12 +36,29 @@ pub async fn delete_context(ks: &KeyspaceHandle, id: &str) -> Result<(), AppErro
 }
 
 /// List all context records.
+///
+/// A row that fails to deserialize is skipped with a warning rather than
+/// aborting the whole listing — one corrupt context must not break
+/// context management for every other context.
 pub async fn list_contexts(ks: &KeyspaceHandle) -> Result<Vec<ContextRecord>, AppError> {
     let raw = ks.prefix_iter_raw("ctx:").await?;
     let mut records = Vec::with_capacity(raw.len());
-    for (_key, value) in raw {
-        let record: ContextRecord = serde_json::from_slice(&value)?;
-        records.push(record);
+    let mut skipped = 0usize;
+    for (key, value) in raw {
+        match serde_json::from_slice::<ContextRecord>(&value) {
+            Ok(record) => records.push(record),
+            Err(e) => {
+                skipped += 1;
+                tracing::warn!(
+                    key = %String::from_utf8_lossy(&key),
+                    error = %e,
+                    "skipping undeserializable context row in list_contexts"
+                );
+            }
+        }
+    }
+    if skipped > 0 {
+        tracing::warn!(skipped, "list_contexts skipped corrupt rows");
     }
     Ok(records)
 }

--- a/vta-service/src/operations/backup/mod.rs
+++ b/vta-service/src/operations/backup/mod.rs
@@ -106,19 +106,32 @@ pub async fn export_backup(
         .await
         .map_err(|e| AppError::Internal(format!("get active seed id: {e}")))?;
 
+    // A backup must be COMPLETE: unlike the steady-state list paths (which
+    // skip a corrupt row so one bad entry can't break management), export
+    // FAILS LOUDLY on any row it cannot deserialize. Silently omitting a
+    // key or ACL row from a backup loses key material or an admin grant —
+    // far worse than refusing to take the backup.
+    fn corrupt_row(kind: &str, key: &[u8], e: impl std::fmt::Display) -> AppError {
+        AppError::Internal(format!(
+            "backup aborted: {kind} row '{}' is corrupt and would be silently \
+             omitted from the backup: {e}",
+            String::from_utf8_lossy(key)
+        ))
+    }
+
     // 2. Collect seed records (retired seeds)
     let seed_records: Vec<SeedRecordBackup> = {
         let raw = keys_ks.prefix_iter_raw("seed:").await?;
-        let mut records = Vec::new();
-        for (_, value) in raw {
-            if let Ok(sr) = serde_json::from_slice::<SeedRecord>(&value) {
-                records.push(SeedRecordBackup {
-                    id: sr.id,
-                    seed_hex: sr.seed_hex,
-                    created_at: sr.created_at,
-                    retired_at: sr.retired_at,
-                });
-            }
+        let mut records = Vec::with_capacity(raw.len());
+        for (key, value) in raw {
+            let sr: SeedRecord =
+                serde_json::from_slice(&value).map_err(|e| corrupt_row("seed", &key, e))?;
+            records.push(SeedRecordBackup {
+                id: sr.id,
+                seed_hex: sr.seed_hex,
+                created_at: sr.created_at,
+                retired_at: sr.retired_at,
+            });
         }
         records
     };
@@ -126,17 +139,21 @@ pub async fn export_backup(
     // 3. Collect key records
     let key_records: Vec<vta_sdk::keys::KeyRecord> = {
         let raw = keys_ks.prefix_iter_raw("key:").await?;
-        raw.into_iter()
-            .filter_map(|(_, v)| serde_json::from_slice(&v).ok())
-            .collect()
+        let mut out = Vec::with_capacity(raw.len());
+        for (key, value) in raw {
+            out.push(serde_json::from_slice(&value).map_err(|e| corrupt_row("key", &key, e))?);
+        }
+        out
     };
 
     // 4. Collect context records + counter
     let context_records: Vec<vta_sdk::contexts::ContextRecord> = {
         let raw = contexts_ks.prefix_iter_raw("ctx:").await?;
-        raw.into_iter()
-            .filter_map(|(_, v)| serde_json::from_slice(&v).ok())
-            .collect()
+        let mut out = Vec::with_capacity(raw.len());
+        for (key, value) in raw {
+            out.push(serde_json::from_slice(&value).map_err(|e| corrupt_row("context", &key, e))?);
+        }
+        out
     };
     let context_counter: u32 = contexts_ks
         .get_raw("ctx_counter")
@@ -144,30 +161,32 @@ pub async fn export_backup(
         .and_then(|b| b.try_into().ok().map(u32::from_le_bytes))
         .unwrap_or(0);
 
-    // 5. Collect ACL entries
+    // 5. Collect ACL entries. (Field-level fidelity of AclEntryBackup is a
+    // separate concern — P0.5; here we only ensure a corrupt row aborts the
+    // backup rather than being silently dropped.)
     let acl_entries: Vec<AclEntryBackup> = {
         let raw = acl_ks.prefix_iter_raw("acl:").await?;
-        raw.into_iter()
-            .filter_map(|(_, v)| {
-                serde_json::from_slice::<serde_json::Value>(&v)
-                    .ok()
-                    .map(|val| AclEntryBackup {
-                        did: val["did"].as_str().unwrap_or_default().to_string(),
-                        role: val["role"].as_str().unwrap_or("Viewer").to_string(),
-                        label: val["label"].as_str().map(String::from),
-                        allowed_contexts: val["allowed_contexts"]
-                            .as_array()
-                            .map(|a| {
-                                a.iter()
-                                    .filter_map(|v| v.as_str().map(String::from))
-                                    .collect()
-                            })
-                            .unwrap_or_default(),
-                        created_at: val["created_at"].as_u64().unwrap_or(0),
-                        created_by: val["created_by"].as_str().unwrap_or_default().to_string(),
+        let mut out = Vec::with_capacity(raw.len());
+        for (key, v) in raw {
+            let val: serde_json::Value =
+                serde_json::from_slice(&v).map_err(|e| corrupt_row("ACL", &key, e))?;
+            out.push(AclEntryBackup {
+                did: val["did"].as_str().unwrap_or_default().to_string(),
+                role: val["role"].as_str().unwrap_or("Viewer").to_string(),
+                label: val["label"].as_str().map(String::from),
+                allowed_contexts: val["allowed_contexts"]
+                    .as_array()
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
                     })
-            })
-            .collect()
+                    .unwrap_or_default(),
+                created_at: val["created_at"].as_u64().unwrap_or(0),
+                created_by: val["created_by"].as_str().unwrap_or_default().to_string(),
+            });
+        }
+        out
     };
 
     // 6. Collect seal record
@@ -850,6 +869,44 @@ mod tests {
         assert!(
             remaining.is_none(),
             "server-auth: prefix must be cleared on import; otherwise stale tokens leak across installations"
+        );
+    }
+
+    /// A backup must be complete: a corrupt `key:` row must ABORT the
+    /// export rather than be silently omitted (which would drop key
+    /// material from the backup). This is the deliberate opposite of the
+    /// steady-state list paths, which skip corrupt rows.
+    #[tokio::test]
+    async fn export_aborts_on_corrupt_key_row() {
+        let ts = crate::test_support::open_test_store().await;
+        let seed_store = crate::test_support::TestSeedStore(vec![42u8; 32]);
+        let config = crate::test_support::test_app_config(ts.data_dir.clone());
+        let auth = crate::test_support::super_admin_claims();
+
+        // Plant a garbage row under the `key:` prefix that export scans.
+        ts.keys_ks
+            .insert_raw("key:corrupt", b"{not a key record".to_vec())
+            .await
+            .unwrap();
+
+        let ks = super::super::Keyspaces {
+            keys: &ts.keys_ks,
+            acl: &ts.acl_ks,
+            contexts: &ts.contexts_ks,
+            did_templates: &ts.did_templates_ks,
+            audit: &ts.audit_ks,
+            imported: &ts.imported_ks,
+            #[cfg(feature = "webvh")]
+            webvh: &ts.webvh_ks,
+        };
+
+        let err = export_backup(&ks, &seed_store, &config, &auth, "a-strong-password", false)
+            .await
+            .expect_err("export must abort on a corrupt key row");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("corrupt") && msg.contains("key"),
+            "error must name the corrupt-row cause, got: {msg}"
         );
     }
 

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -403,8 +403,22 @@ pub async fn list_keys(
     let raw = keys_ks.prefix_iter_raw("key:").await?;
 
     let mut records: Vec<KeyRecord> = Vec::with_capacity(raw.len());
-    for (_key, value) in raw {
-        let record: KeyRecord = serde_json::from_slice(&value)?;
+    let mut skipped = 0usize;
+    for (key, value) in raw {
+        // Skip (don't abort on) a corrupt row: one undeserializable key
+        // record must not break key listing for every other key.
+        let record: KeyRecord = match serde_json::from_slice(&value) {
+            Ok(r) => r,
+            Err(e) => {
+                skipped += 1;
+                tracing::warn!(
+                    key = %String::from_utf8_lossy(&key),
+                    error = %e,
+                    "skipping undeserializable key row in list_keys"
+                );
+                continue;
+            }
+        };
         if let Some(ref status) = params.status
             && record.status != *status
         {
@@ -422,6 +436,9 @@ pub async fn list_keys(
             }
         }
         records.push(record);
+    }
+    if skipped > 0 {
+        tracing::warn!(channel, skipped, "list_keys skipped corrupt rows");
     }
 
     let total = records.len() as u64;

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -504,12 +504,32 @@ pub async fn delete_acl_entry(acl: &KeyspaceHandle, did: &str) -> Result<(), App
 }
 
 /// List all ACL entries.
+///
+/// A row that fails to deserialize is **skipped with a warning**, not
+/// propagated: one corrupt entry must not take down ACL management or
+/// the auth paths that enumerate entries (a `?` here would abort the
+/// whole listing). Backup export deliberately takes the opposite stance
+/// and fails loudly — an incomplete *backup* is worse than a degraded
+/// *list*.
 pub async fn list_acl_entries(acl: &KeyspaceHandle) -> Result<Vec<AclEntry>, AppError> {
     let raw = acl.prefix_iter_raw("acl:").await?;
     let mut entries = Vec::with_capacity(raw.len());
-    for (_key, value) in raw {
-        let entry: AclEntry = serde_json::from_slice(&value)?;
-        entries.push(entry);
+    let mut skipped = 0usize;
+    for (key, value) in raw {
+        match serde_json::from_slice::<AclEntry>(&value) {
+            Ok(entry) => entries.push(entry),
+            Err(e) => {
+                skipped += 1;
+                tracing::warn!(
+                    key = %String::from_utf8_lossy(&key),
+                    error = %e,
+                    "skipping undeserializable ACL row in list_acl_entries"
+                );
+            }
+        }
+    }
+    if skipped > 0 {
+        tracing::warn!(skipped, "list_acl_entries skipped corrupt rows");
     }
     Ok(entries)
 }
@@ -740,6 +760,32 @@ mod tests {
 
     fn sample_entry(did: &str, role: Role) -> AclEntry {
         AclEntry::new(did, role, "did:key:zSetup").with_label(Some(format!("test-{did}")))
+    }
+
+    #[tokio::test]
+    async fn list_acl_entries_skips_corrupt_rows() {
+        // A single undeserializable row must not abort the whole listing —
+        // otherwise one corrupt entry bricks ACL management and the auth
+        // paths that enumerate entries.
+        let (store, _dir) = temp_store();
+        let ks = store.keyspace("acl").unwrap();
+
+        store_acl_entry(&ks, &sample_entry("did:key:zAlice", Role::Admin))
+            .await
+            .unwrap();
+        // Inject garbage under the acl: prefix.
+        ks.insert_raw("acl:did:key:zCorrupt", b"{not valid json".to_vec())
+            .await
+            .unwrap();
+        store_acl_entry(&ks, &sample_entry("did:key:zBob", Role::Reader))
+            .await
+            .unwrap();
+
+        let entries = list_acl_entries(&ks).await.expect("listing must not abort");
+        let dids: Vec<&str> = entries.iter().map(|e| e.did.as_str()).collect();
+        assert!(dids.contains(&"did:key:zAlice"));
+        assert!(dids.contains(&"did:key:zBob"));
+        assert_eq!(entries.len(), 2, "the corrupt row is skipped, not surfaced");
     }
 
     fn scoped_entry(did: &str, role: Role, contexts: &[&str]) -> AclEntry {


### PR DESCRIPTION
## Summary

Plan task **P0.14** (`tasks/vta-architecture-plan.md`). Two opposite-but-correct policies for a corrupt stored row:

### List paths — skip + warn (don't abort)
`list_acl_entries`, `list_contexts`, and `list_keys` each did `serde_json::from_slice(..)?` inside the loop, so **one** undeserializable row aborted the entire listing — taking down ACL / context / key management, and (for ACL) the auth paths that enumerate entries. They now skip the bad row with a `warn!` (logging the row key + a skipped count) and return the good rows.

### Backup export — fail loudly (don't drop)
Export did the opposite wrong thing: `filter_map(..ok())` **silently dropped** unparseable rows, so a corrupt key or ACL row would vanish from the backup — losing key material or an admin grant without a trace. The seed / key / context / ACL collections now **abort** the export with a row-naming error. *An incomplete backup is worse than a failed one.*

The split is deliberate: a degraded live *list* keeps the VTA manageable; an incomplete *backup* is a silent data-loss trap.

## Scope
ACL backup *field-level* fidelity (the `AclEntryBackup` shape drops expiry/step-up/capabilities) is a **separate** task — **P0.5**. This PR only changes the corrupt-row *handling*, not the field set.

## Tests
- `list_acl_entries_skips_corrupt_rows`: injects a garbage `acl:` row, asserts both good entries are returned and the bad one is skipped.
- `export_aborts_on_corrupt_key_row`: plants a garbage `key:` row, asserts `export_backup` errors with a corrupt-row message.
- Gate: workspace 81 suites / 0 failures, clippy clean, fmt.

No tee-gated code touched; default workspace coverage is complete for this change.