### PR TITLE
test(vtc-service): TestVtc/MockVtc harness + migrate 26 fixtures [P0.1]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10006,6 +10006,7 @@ dependencies = [
  "url",
  "uuid",
  "vta-sdk 0.11.1",
+ "vtc-service",
  "vti-common",
  "webauthn-rs",
  "webauthn-rs-proto",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -12,6 +12,12 @@ repository.workspace = true
 
 [features]
 default = ["setup", "keyring", "website", "admin-ui"]
+# Test-harness surface: the `test_support` module (in-process `TestVtc`
+# builder, `MockVtc` listening server, JWT/session minting). Enabled by
+# the crate's own integration tests via a `[dev-dependencies]` self-dep,
+# and by downstream multi-service harnesses (`vti-harness`). Kept out of
+# production builds — it pulls in `tempfile` and exposes seeding helpers.
+test-support = ["dep:tempfile"]
 setup = ["dep:dialoguer", "dep:didwebvh-rs", "dep:url"]
 # BBS+ (`bbs-2023`) verifier support — lets the join verifier accept
 # selectively-disclosed bbs-2023 presentations. Pulls in the BLS12-381 curve
@@ -200,8 +206,16 @@ async-trait = "0.1"
 # did:key → Ed25519 public-key conversion for the join-request
 # holder-binding signature verifier (M1.8.1).
 affinidi-crypto = { workspace = true }
+# Optional — only compiled under the `test-support` feature, which the
+# `test_support` module (and downstream harnesses) need for tempdir-
+# backed stores. Also a `[dev-dependencies]` entry for the crate's own
+# `cargo test` (no feature flag) — both must stay in sync.
+tempfile = { version = "3", optional = true }
 
 [dev-dependencies]
+# Self-dep with `test-support` enabled so integration tests under
+# `tests/` can import `vtc_service::test_support` (`TestVtc`, `MockVtc`).
+vtc-service = { path = ".", features = ["test-support"] }
 tempfile = "3"
 # Integration tests under `tests/` exercise the route stack via
 # `Router::oneshot` — same pattern as `vta-service/tests/api_integration.rs`.

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -48,3 +48,9 @@ pub mod store;
 pub mod supervisor;
 pub mod webauthn;
 pub mod website;
+
+// `test_support` is gated internally on `any(test, feature = "test-support")`.
+// A `#[cfg(...)]` here would hide the module from the crate's own `cargo
+// test` builds (which don't pass `--features test-support`); the module
+// header handles the gating itself.
+pub mod test_support;

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -75,6 +75,7 @@ pub struct TestVtcBuilder {
     with_signers: bool,
     with_did_resolver: bool,
     credential_signer: Option<Arc<LocalSigner>>,
+    install_signer: Option<Arc<InstallTokenSigner>>,
     public_url: Option<String>,
     supervisor: Option<SupervisorKind>,
 }
@@ -87,6 +88,7 @@ impl Default for TestVtcBuilder {
             with_signers: false,
             with_did_resolver: false,
             credential_signer: None,
+            install_signer: None,
             public_url: None,
             supervisor: None,
         }
@@ -122,6 +124,15 @@ impl TestVtcBuilder {
     /// credentials against it. Does not affect the install signer.
     pub fn with_credential_signer(mut self, signer: Arc<LocalSigner>) -> Self {
         self.credential_signer = Some(signer);
+        self
+    }
+
+    /// Inject a specific [`InstallTokenSigner`] — overriding the one
+    /// [`with_signers`](Self::with_signers) would derive. Use when a test
+    /// mints install tokens with a signer it holds and the route must
+    /// verify them with the same key.
+    pub fn with_install_signer(mut self, signer: Arc<InstallTokenSigner>) -> Self {
+        self.install_signer = Some(signer);
         self
     }
 
@@ -223,7 +234,7 @@ impl TestVtcBuilder {
             None
         };
 
-        let (mut credential_signer, install_signer) = if self.with_signers {
+        let (mut credential_signer, mut install_signer) = if self.with_signers {
             let signer = Arc::new(LocalSigner::from_ed25519_seed(
                 self.vtc_did.clone(),
                 &SIGNER_SEED,
@@ -236,10 +247,14 @@ impl TestVtcBuilder {
         } else {
             (None, None)
         };
-        // An explicitly-injected signer overrides the derived one (used
-        // by tests that verify issued credentials against a held signer).
+        // Explicitly-injected signers override the derived ones (used by
+        // tests that verify issued credentials / install tokens against a
+        // signer they hold).
         if let Some(sig) = self.credential_signer.clone() {
             credential_signer = Some(sig);
+        }
+        if let Some(sig) = self.install_signer.clone() {
+            install_signer = Some(sig);
         }
 
         let webauthn = match &self.public_url {

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -73,6 +73,7 @@ pub struct TestVtcBuilder {
     vtc_did: String,
     with_audit: bool,
     with_signers: bool,
+    with_did_resolver: bool,
     public_url: Option<String>,
     supervisor: Option<SupervisorKind>,
 }
@@ -83,6 +84,7 @@ impl Default for TestVtcBuilder {
             vtc_did: TEST_VTC_DID.to_string(),
             with_audit: false,
             with_signers: false,
+            with_did_resolver: false,
             public_url: None,
             supervisor: None,
         }
@@ -116,6 +118,14 @@ impl TestVtcBuilder {
     /// (passkey/install routes need it).
     pub fn with_public_url(mut self, url: impl Into<String>) -> Self {
         self.public_url = Some(url.into());
+        self
+    }
+
+    /// Attach a local `DIDCacheClient` resolver (the SIOP wallet-login
+    /// and cross-community recognition paths resolve presented DIDs
+    /// through it).
+    pub fn with_did_resolver(mut self, on: bool) -> Self {
+        self.with_did_resolver = on;
         self
     }
 
@@ -224,6 +234,15 @@ impl TestVtcBuilder {
             None => None,
         };
 
+        let did_resolver = if self.with_did_resolver {
+            use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+            DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+                .await
+                .ok()
+        } else {
+            None
+        };
+
         let install_store = InstallTokenStore::new(install_ks.clone());
 
         let state = AppState {
@@ -251,7 +270,7 @@ impl TestVtcBuilder {
             registry_client: None,
             registry_health: crate::registry::RegistryHealth::new(),
             config: Arc::new(RwLock::new(config)),
-            did_resolver: None,
+            did_resolver,
             secrets_resolver: None,
             jwt_keys: Some(jwt_keys.clone()),
             atm: None,

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -318,6 +318,13 @@ impl TestVtc {
         TestVtcBuilder::default()
     }
 
+    /// The on-disk data directory backing the store (for tests that read
+    /// or write files the daemon persists there, e.g. the `did.jsonl`
+    /// publication path).
+    pub fn data_dir(&self) -> &std::path::Path {
+        self._dir.path()
+    }
+
     /// Mint a bearer token for `did` with `role`, creating the backing
     /// `Authenticated` session row so the `AuthClaims` extractor (which
     /// re-checks session state on every request) accepts it.

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -1,0 +1,441 @@
+//! Shared test-harness helpers for `vtc-service` — a tempdir-backed
+//! [`AppState`], the full `routes::router()`, JWT/session minting, and a
+//! [`MockVtc`] listening server a harness can drive over the wire.
+//!
+//! This is the VTC counterpart to `vta_service::test_support`. Pre-
+//! consolidation every integration-test file under `tests/` hand-rolled
+//! the same ~140-line fixture (open ~21 keyspaces → build `AppState` →
+//! `routes::router().with_state(...)`). The [`TestVtc`] builder collapses
+//! that to a few lines at the call site and is the single place a new
+//! `AppState` field has to be wired for tests.
+//!
+//! Gated behind the `test-support` feature *and* `cfg(test)` for the
+//! lib's own unit tests. Downstream integration tests (under `tests/`)
+//! enable the feature via a `[dev-dependencies]` entry on `vtc-service`.
+//!
+//! Kept in the production crate (not a sibling `vtc-test-support`) for the
+//! same reason as the VTA: every helper closes over crate-private types
+//! (`AppState`, `KeyspaceHandle`, `InstallTokenStore`, `LocalSigner`). A
+//! sibling crate would force all of them `pub` on the main API surface.
+
+#![cfg(any(test, feature = "test-support"))]
+
+use std::sync::Arc;
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use tokio::sync::{RwLock, watch};
+
+use crate::config::AppConfig;
+use crate::credentials::LocalSigner;
+use crate::install::{InstallTokenSigner, InstallTokenStore};
+use crate::server::AppState;
+use crate::store::Store;
+use crate::supervisor::SupervisorKind;
+use vti_common::audit::{AuditKeyStore, AuditWriter};
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::config::StoreConfig;
+
+/// The default `vtc_did` used by [`TestVtc`] — a sentinel that satisfies
+/// the routes which only compare it as a string. Matches the value the
+/// pre-consolidation fixtures hard-coded.
+pub const TEST_VTC_DID: &str = "did:webvh:vtc.example.com:abc";
+
+/// Deterministic 32-byte JWT signing seed. Stable across runs so tests
+/// can pre-mint tokens without round-tripping the auth ceremony.
+const JWT_SEED: [u8; 32] = [0x42u8; 32];
+
+/// Deterministic 32-byte Ed25519 seed used to synthesise the credential /
+/// install signers when a test opts in. Not the JWT seed — these sign
+/// VMC/VEC/install material, JWT seed signs access tokens.
+const SIGNER_SEED: [u8; 32] = [0xC5u8; 32];
+
+/// Pin jsonwebtoken's default `CryptoProvider` to `aws_lc` once per
+/// process. The workspace compiles `jsonwebtoken` with only the
+/// `aws_lc_rs` backend; when `cargo test` unifies features across crates
+/// the auto-select panics unless one provider is installed explicitly.
+/// Idempotent — safe to call from every test file.
+pub fn init_jwt_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    });
+}
+
+/// Builder for a tempdir-backed in-process VTC under test.
+///
+/// Defaults give the minimal daemon the route tests assumed before this
+/// module existed: `vtc_did` set, JWT keys present, no audit writer, no
+/// credential/install signer, no `public_url` (so passkey/install routes
+/// 503 — opt in via [`with_public_url`](Self::with_public_url)).
+pub struct TestVtcBuilder {
+    vtc_did: String,
+    with_audit: bool,
+    with_signers: bool,
+    public_url: Option<String>,
+    supervisor: Option<SupervisorKind>,
+}
+
+impl Default for TestVtcBuilder {
+    fn default() -> Self {
+        TestVtcBuilder {
+            vtc_did: TEST_VTC_DID.to_string(),
+            with_audit: false,
+            with_signers: false,
+            public_url: None,
+            supervisor: None,
+        }
+    }
+}
+
+impl TestVtcBuilder {
+    /// Override the configured `vtc_did`.
+    pub fn vtc_did(mut self, did: impl Into<String>) -> Self {
+        self.vtc_did = did.into();
+        self
+    }
+
+    /// Wire an [`AuditWriter`] so audit-emitting routes don't 503.
+    pub fn with_audit(mut self, on: bool) -> Self {
+        self.with_audit = on;
+        self
+    }
+
+    /// Seed a [`LocalSigner`] (credential issuance) and an
+    /// [`InstallTokenSigner`] (install ceremony) from a deterministic
+    /// Ed25519 seed, so VMC/VEC/status-list and install routes work.
+    /// This is the in-process equivalent of having bootstrapped the
+    /// VTC's signing bundle from a VTA.
+    pub fn with_signers(mut self, on: bool) -> Self {
+        self.with_signers = on;
+        self
+    }
+
+    /// Set `public_url`, which builds the WebAuthn relying-party handle
+    /// (passkey/install routes need it).
+    pub fn with_public_url(mut self, url: impl Into<String>) -> Self {
+        self.public_url = Some(url.into());
+        self
+    }
+
+    /// Inject a cached supervisor probe result (the diagnostics /
+    /// restart routes read it).
+    pub fn supervisor(mut self, kind: Option<SupervisorKind>) -> Self {
+        self.supervisor = kind;
+        self
+    }
+
+    /// Build the tempdir-backed [`TestVtc`].
+    pub async fn build(self) -> TestVtc {
+        init_jwt_provider();
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+
+        // Open every keyspace the daemon's `AppState` carries. Keep this
+        // list in lockstep with `server::run`'s keyspace block; a missing
+        // keyspace fails fast at `build()` (the `.expect` below), and the
+        // `AppState { .. }` literal further down won't compile if a field
+        // is dropped.
+        let sessions_ks = store.keyspace("sessions").expect("sessions ks");
+        let acl_ks = store.keyspace("acl").expect("acl ks");
+        let community_ks = store.keyspace("community").expect("community ks");
+        let config_ks = store.keyspace("config").expect("config ks");
+        let passkey_ks = store.keyspace("passkey").expect("passkey ks");
+        let install_ks = store.keyspace("install").expect("install ks");
+        let members_ks = store.keyspace("members").expect("members ks");
+        let join_requests_ks = store.keyspace("join_requests").expect("join_requests ks");
+        let policies_ks = store.keyspace("policies").expect("policies ks");
+        let active_policies_ks = store
+            .keyspace("active_policies")
+            .expect("active_policies ks");
+        let status_lists_ks = store.keyspace("status_lists").expect("status_lists ks");
+        let registry_records_ks = store
+            .keyspace("registry_records")
+            .expect("registry_records ks");
+        let sync_queue_ks = store.keyspace("sync_queue").expect("sync_queue ks");
+        let sync_cursor_ks = store.keyspace("sync_cursor").expect("sync_cursor ks");
+        let relationships_ks = store.keyspace("relationships").expect("relationships ks");
+        let relationships_by_did_ks = store
+            .keyspace("relationships_by_did")
+            .expect("relationships_by_did ks");
+        let endorsement_types_ks = store
+            .keyspace("endorsement_types")
+            .expect("endorsement_types ks");
+        let schemas_ks = store.keyspace("schemas").expect("schemas ks");
+        let endorsements_ks = store.keyspace("endorsements").expect("endorsements ks");
+        let audit_ks = store.keyspace("audit").expect("audit ks");
+        let audit_key_ks = store.keyspace("audit_key").expect("audit_key ks");
+
+        let jwt_keys =
+            Arc::new(JwtKeys::from_ed25519_bytes(&JWT_SEED, "VTC").expect("build VTC JWT keys"));
+
+        let mut config: AppConfig = toml::from_str(&format!(
+            r#"
+            vtc_did = "{}"
+            [store]
+            data_dir = "{}"
+            [auth]
+            jwt_signing_key = "{}"
+            "#,
+            self.vtc_did,
+            dir.path().display(),
+            BASE64.encode(JWT_SEED),
+        ))
+        .expect("parse test config");
+        if let Some(url) = &self.public_url {
+            config.public_url = Some(url.clone());
+        }
+
+        let audit_writer = if self.with_audit {
+            let key_store = AuditKeyStore::new(audit_key_ks.clone());
+            key_store
+                .ensure_initial(&[0xAB; 64])
+                .await
+                .expect("init audit key");
+            Some(AuditWriter::new(audit_ks.clone(), key_store))
+        } else {
+            None
+        };
+
+        let (credential_signer, install_signer) = if self.with_signers {
+            let signer = Arc::new(LocalSigner::from_ed25519_seed(
+                self.vtc_did.clone(),
+                &SIGNER_SEED,
+            ));
+            let install = Arc::new(
+                InstallTokenSigner::from_master_seed(&SIGNER_SEED)
+                    .expect("derive install token signer"),
+            );
+            (Some(signer), Some(install))
+        } else {
+            (None, None)
+        };
+
+        let webauthn = match &self.public_url {
+            Some(url) => match vti_common::auth::passkey::build_webauthn(url) {
+                Ok(w) => Some(Arc::new(w)),
+                Err(e) => panic!("build_webauthn({url}): {e}"),
+            },
+            None => None,
+        };
+
+        let install_store = InstallTokenStore::new(install_ks.clone());
+
+        let state = AppState {
+            sessions_ks,
+            acl_ks,
+            community_ks,
+            config_ks,
+            passkey_ks,
+            install_ks,
+            members_ks,
+            join_requests_ks,
+            policies_ks,
+            active_policies_ks,
+            status_lists_ks,
+            registry_records_ks,
+            sync_queue_ks,
+            sync_cursor_ks,
+            relationships_ks,
+            relationships_by_did_ks,
+            endorsement_types_ks,
+            schemas_ks,
+            endorsements_ks,
+            audit_ks,
+            audit_key_ks,
+            registry_client: None,
+            registry_health: crate::registry::RegistryHealth::new(),
+            config: Arc::new(RwLock::new(config)),
+            did_resolver: None,
+            secrets_resolver: None,
+            jwt_keys: Some(jwt_keys.clone()),
+            atm: None,
+            webauthn,
+            public_url: self.public_url,
+            install_signer,
+            credential_signer,
+            install_store,
+            audit_writer,
+            shutdown_tx: watch::channel(false).0,
+            supervisor: self.supervisor,
+        };
+
+        let router = crate::routes::router().with_state(state.clone());
+
+        TestVtc {
+            router,
+            state,
+            jwt_keys,
+            _dir: dir,
+        }
+    }
+}
+
+/// A tempdir-backed VTC under test: the `routes::router()` (ready for
+/// `tower::ServiceExt::oneshot`), the live [`AppState`] (so tests can
+/// seed/inspect keyspaces directly), and the JWT keys (so tests can mint
+/// their own tokens). Owns the temp data dir — keep it alive for the
+/// duration of the test.
+pub struct TestVtc {
+    /// The assembled router. `tower::ServiceExt::oneshot` it directly, or
+    /// rebuild a routing-config variant with `routes::router_with(...)
+    /// .with_state(tv.state.clone())`.
+    pub router: axum::Router,
+    /// The live application state shared with `router`.
+    pub state: AppState,
+    /// JWT signing keys (audience `"VTC"`) for minting test tokens.
+    pub jwt_keys: Arc<JwtKeys>,
+    _dir: tempfile::TempDir,
+}
+
+impl TestVtc {
+    /// Start building a customised VTC.
+    pub fn builder() -> TestVtcBuilder {
+        TestVtcBuilder::default()
+    }
+
+    /// Mint a bearer token for `did` with `role`, creating the backing
+    /// `Authenticated` session row so the `AuthClaims` extractor (which
+    /// re-checks session state on every request) accepts it.
+    pub async fn token(&self, did: &str, role: &str, contexts: Vec<String>) -> String {
+        use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+        let session_id = format!("sess-{}", uuid::Uuid::new_v4());
+        let session = Session {
+            session_id: session_id.clone(),
+            did: did.to_string(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now_epoch(),
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+            amr: Vec::new(),
+            acr: String::new(),
+            token_id: None,
+            session_pubkey_b58btc: None,
+        };
+        store_session(&self.state.sessions_ks, &session)
+            .await
+            .expect("store test session");
+        let claims = self.jwt_keys.new_claims(
+            did.to_string(),
+            session_id,
+            role.to_string(),
+            contexts,
+            900,
+            false,
+        );
+        self.jwt_keys.encode(&claims).expect("encode test token")
+    }
+
+    /// Convenience: an admin token for the canonical test admin DID.
+    pub async fn admin_token(&self) -> String {
+        self.token("did:key:z6MkAdmin", "admin", Vec::new()).await
+    }
+}
+
+/// Build a default tempdir-backed VTC under test (no audit, no signers,
+/// no `public_url`). Equivalent to `TestVtc::builder().build()`.
+pub async fn build_test_vtc() -> TestVtc {
+    TestVtc::builder().build().await
+}
+
+/// A **mock VTC** bound to an ephemeral local port — a real, listening
+/// HTTP server a harness can drive over the wire, with no setup ceremony.
+///
+/// Wraps a [`TestVtc`] (with signers + a `public_url` so credential and
+/// install routes work) and serves its `routes::router()` on
+/// `127.0.0.1:<random-port>`. The server runs in a background task and
+/// shuts down when the `MockVtc` is dropped (or via
+/// [`shutdown`](Self::shutdown)).
+///
+/// ```no_run
+/// # async fn demo() {
+/// use vtc_service::test_support::MockVtc;
+/// let mock = MockVtc::start().await;
+/// let base = mock.base_url();              // e.g. http://127.0.0.1:54321
+/// // … point a client at `base`, or seed rows via `mock.vtc.state` …
+/// mock.shutdown().await;
+/// # }
+/// ```
+pub struct MockVtc {
+    base_url: String,
+    /// The bootstrapped VTC under test (state, keyspaces, JWT keys) so a
+    /// harness can seed ACL/member/session rows before driving the API.
+    /// Owns the temp data dir — kept alive for the `MockVtc`'s lifetime.
+    pub vtc: TestVtc,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl MockVtc {
+    /// Start a mock VTC on a random loopback port and return once it is
+    /// bound and serving.
+    pub async fn start() -> MockVtc {
+        let vtc = TestVtc::builder()
+            .with_audit(true)
+            .with_signers(true)
+            .with_public_url("http://vtc.test")
+            .build()
+            .await;
+        let router = vtc.router.clone();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral loopback port");
+        let addr = listener.local_addr().expect("resolve local addr");
+        let base_url = format!("http://{addr}");
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            // `ConnectInfo<SocketAddr>` is required — the unauth routes
+            // carry the per-source-IP rate limiter, same as production.
+            let _ = axum::serve(
+                listener,
+                router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+        });
+
+        MockVtc {
+            base_url,
+            vtc,
+            shutdown: Some(tx),
+            handle: Some(handle),
+        }
+    }
+
+    /// The base URL to point a client at (e.g. `http://127.0.0.1:54321`).
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Stop the server and wait for it to wind down gracefully.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for MockVtc {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -74,6 +74,7 @@ pub struct TestVtcBuilder {
     with_audit: bool,
     with_signers: bool,
     with_did_resolver: bool,
+    credential_signer: Option<Arc<LocalSigner>>,
     public_url: Option<String>,
     supervisor: Option<SupervisorKind>,
 }
@@ -85,6 +86,7 @@ impl Default for TestVtcBuilder {
             with_audit: false,
             with_signers: false,
             with_did_resolver: false,
+            credential_signer: None,
             public_url: None,
             supervisor: None,
         }
@@ -111,6 +113,15 @@ impl TestVtcBuilder {
     /// VTC's signing bundle from a VTA.
     pub fn with_signers(mut self, on: bool) -> Self {
         self.with_signers = on;
+        self
+    }
+
+    /// Inject a specific [`LocalSigner`] as the credential signer —
+    /// overriding the one [`with_signers`](Self::with_signers) would
+    /// derive. Use when a test holds the signer and verifies issued
+    /// credentials against it. Does not affect the install signer.
+    pub fn with_credential_signer(mut self, signer: Arc<LocalSigner>) -> Self {
+        self.credential_signer = Some(signer);
         self
     }
 
@@ -212,7 +223,7 @@ impl TestVtcBuilder {
             None
         };
 
-        let (credential_signer, install_signer) = if self.with_signers {
+        let (mut credential_signer, install_signer) = if self.with_signers {
             let signer = Arc::new(LocalSigner::from_ed25519_seed(
                 self.vtc_did.clone(),
                 &SIGNER_SEED,
@@ -225,6 +236,11 @@ impl TestVtcBuilder {
         } else {
             (None, None)
         };
+        // An explicitly-injected signer overrides the derived one (used
+        // by tests that verify issued credentials against a held signer).
+        if let Some(sig) = self.credential_signer.clone() {
+            credential_signer = Some(sig);
+        }
 
         let webauthn = match &self.public_url {
             Some(url) => match vti_common::auth::passkey::build_webauthn(url) {

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -21,20 +21,15 @@ use axum::http::{Request, StatusCode};
 use chrono::{Duration as ChronoDuration, Utc};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 use uuid::Uuid;
 use vti_common::acl::{Role, list_acl_entries};
-use vti_common::audit::{AuditEvent, AuditKeyStore, AuditWriter};
-use vti_common::auth::passkey::build_webauthn;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
+use vti_common::audit::AuditEvent;
 
 use vtc_service::acl::admin::get_admin_entry;
-use vtc_service::config::AppConfig;
 use vtc_service::install::{InstallTokenSigner, InstallTokenStore, mint_install_token};
-use vtc_service::routes;
 use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 use common::webauthn_harness::SoftEd25519Authenticator;
 
@@ -43,63 +38,18 @@ const START_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/start
 const FINISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0";
 const BOOTSTRAP_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     state: AppState,
     router: axum::Router,
     install_signer: Arc<InstallTokenSigner>,
     install_store: InstallTokenStore,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
+    // The same install signer is injected into the AppState so tokens
+    // minted by the fixture verify on the claim/finish route.
     let install_signer = if with_install_signer {
         Some(Arc::new(
             InstallTokenSigner::from_master_seed(&[0xAB; 64]).unwrap(),
@@ -108,63 +58,27 @@ async fn build_fixture(with_install_signer: bool, with_audit: bool) -> Fixture {
         None
     };
 
-    let audit_writer = if with_audit {
-        let key_store = AuditKeyStore::new(audit_key_ks.clone());
-        key_store.ensure_initial(&[0xAB; 64]).await.unwrap();
-        Some(AuditWriter::new(audit_ks.clone(), key_store))
-    } else {
-        None
-    };
+    let mut builder = TestVtc::builder()
+        .with_audit(with_audit)
+        .with_public_url(RP_ORIGIN);
+    if let Some(sig) = &install_signer {
+        builder = builder.with_install_signer(sig.clone());
+    }
+    let vtc = builder.build().await;
 
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        audit_ks: audit_ks.clone(),
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: None,
-        atm: None,
-        webauthn,
-        public_url: Some(RP_ORIGIN.to_string()),
-        install_signer: install_signer.clone(),
-        install_store: install_store.clone(),
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state.clone());
+    let state = vtc.state.clone();
+    let router = vtc.router.clone();
+    let install_store = vtc.state.install_store.clone();
 
     Fixture {
         state,
         router,
+        // Signer-absent path keeps a throwaway in the fixture for minting.
         install_signer: install_signer.unwrap_or_else(|| {
             Arc::new(InstallTokenSigner::from_master_seed(&[0xCD; 64]).unwrap())
         }),
         install_store,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -4,39 +4,25 @@
 //! extractor → handler → three-layer effective view → db-overlay
 //! persistence — via `Router::oneshot`.
 
-use std::sync::Arc;
-
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::auth::jwt::JwtKeys;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
-use vtc_service::config::AppConfig;
-use vtc_service::routes;
 use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 const CONFIG_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/config/manage/1.0";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
+/// Thin wrapper over [`TestVtc`] preserving this suite's original
+/// fixture API (`fix.router`, `fix.state`). The keyspace + `AppState`
+/// wiring now lives in `vtc_service::test_support`.
 struct Fixture {
     router: axum::Router,
-    jwt_keys: Arc<JwtKeys>,
     state: AppState,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    vtc: TestVtc,
 }
 
 async fn build() -> Fixture {
@@ -47,138 +33,20 @@ async fn build_with(
     with_audit: bool,
     supervisor: Option<vtc_service::supervisor::SupervisorKind>,
 ) -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let audit_writer = if with_audit {
-        let key_store = vti_common::audit::AuditKeyStore::new(audit_key_ks.clone());
-        key_store.ensure_initial(&[0xAB; 64]).await.unwrap();
-        Some(vti_common::audit::AuditWriter::new(
-            audit_ks.clone(),
-            key_store,
-        ))
-    } else {
-        None
-    };
-
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys.clone()),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
-        audit_ks,
-        audit_key_ks,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor,
-    };
-
-    let router = routes::router().with_state(state.clone());
+    let vtc = TestVtc::builder()
+        .with_audit(with_audit)
+        .supervisor(supervisor)
+        .build()
+        .await;
     Fixture {
-        router,
-        jwt_keys,
-        state,
-        _dir: dir,
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        vtc,
     }
 }
 
 async fn token_for(fix: &Fixture, role: &str) -> String {
-    use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
-    let session_id = format!("sess-{}", uuid::Uuid::new_v4());
-    let session = Session {
-        session_id: session_id.clone(),
-        did: "did:key:z6MkAdmin".into(),
-        challenge: "test".into(),
-        state: SessionState::Authenticated,
-        created_at: now_epoch(),
-        refresh_token: None,
-        refresh_expires_at: None,
-        tee_attested: false,
-        amr: Vec::new(),
-        acr: String::new(),
-        token_id: None,
-        session_pubkey_b58btc: None,
-    };
-    store_session(&fix.state.sessions_ks, &session)
-        .await
-        .unwrap();
-    let claims = fix.jwt_keys.new_claims(
-        "did:key:z6MkAdmin".to_string(),
-        session_id,
-        role.to_string(),
-        vec![],
-        900,
-        false,
-    );
-    fix.jwt_keys.encode(&claims).expect("encode")
+    fix.vtc.token("did:key:z6MkAdmin", role, vec![]).await
 }
 
 async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -14,27 +14,22 @@ use axum::http::{Request, StatusCode};
 use chrono::Utc;
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 use uuid::Uuid;
 use vti_common::acl::{AclEntry, Role, store_acl_entry};
-use vti_common::audit::{AuditEnvelope, AuditEvent, AuditKeyStore, AuditWriter};
+use vti_common::audit::{AuditEnvelope, AuditEvent};
 use vti_common::auth::jwt::JwtKeys;
 use vti_common::auth::passkey::{
     build_webauthn,
     store::{PasskeyUser, store_credential_mapping, store_passkey_user},
 };
 use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 use webauthn_rs::Webauthn;
 use webauthn_rs::prelude::{CreationChallengeResponse, RequestChallengeResponse};
 
 use vtc_service::acl::admin::{AdminEntry, RegisteredPasskey, get_admin_entry, store_admin_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::install::{InstallTokenSigner, InstallTokenStore};
-use vtc_service::routes;
 use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 use common::webauthn_harness::SoftEd25519Authenticator;
 
@@ -42,14 +37,6 @@ const RP_ORIGIN: &str = "https://vtc.example.com";
 const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0";
 const REGISTER_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0";
 const REVOKE_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0";
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
 
 struct Fixture {
     state: AppState,
@@ -59,55 +46,29 @@ struct Fixture {
     /// Soft authenticator pre-loaded with the bootstrap passkey,
     /// ready to drive UV and additional-device ceremonies.
     authenticator: SoftEd25519Authenticator,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 /// Build a fixture where:
-/// - WebAuthn + install signer + audit writer are all configured.
+/// - WebAuthn (via public_url) + audit writer are configured.
 /// - One admin is pre-bootstrapped: PasskeyUser, AdminEntry, ACL
 ///   entry, credential mapping all match a single soft-authenticator
 ///   credential whose Ed25519 key we know.
-/// - JWT keys are wired so we can mint admin session tokens for
-///   the bootstrapped DID.
+/// - JWT keys are wired so we can mint admin session tokens for the
+///   bootstrapped DID.
 async fn build_fixture(with_audit: bool) -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
+    let vtc = TestVtc::builder()
+        .with_audit(with_audit)
+        .with_public_url(RP_ORIGIN)
+        .build()
+        .await;
 
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
-
+    // Run a real WebAuthn registration ceremony against the same RP as
+    // the AppState's webauthn so the persisted PasskeyUser has a real
+    // `Passkey` that subsequent UV-assertion flows can exercise. Mirrors
+    // the post-bootstrap state M0.6.2 leaves the system in.
     let webauthn: Webauthn = build_webauthn(RP_ORIGIN).expect("webauthn builder");
-
-    // Run a real WebAuthn registration ceremony so the persisted
-    // PasskeyUser has a real `Passkey` (matching credential bytes)
-    // that subsequent UV-assertion flows can exercise. Mirrors the
-    // post-bootstrap state M0.6.2 leaves the system in.
     let mut authenticator = SoftEd25519Authenticator::new();
     let user_uuid = Uuid::new_v4();
     let (ccr, reg_state) = vtc_service::webauthn::start_passkey_registration(
@@ -129,15 +90,17 @@ async fn build_fixture(with_audit: bool) -> Fixture {
     let bootstrap_cred_id_hex =
         hex::encode(<_ as AsRef<[u8]>>::as_ref(bootstrap_passkey.cred_id()));
 
-    // Persist the post-bootstrap fixture state.
+    // Persist the post-bootstrap fixture state into the daemon keyspaces.
     let pk_user = PasskeyUser {
         user_uuid,
         did: admin_did.clone(),
         display_name: admin_did.clone(),
         credentials: vec![bootstrap_passkey],
     };
-    store_passkey_user(&passkey_ks, &pk_user).await.unwrap();
-    store_credential_mapping(&passkey_ks, &bootstrap_cred_id_hex, user_uuid)
+    store_passkey_user(&vtc.state.passkey_ks, &pk_user)
+        .await
+        .unwrap();
+    store_credential_mapping(&vtc.state.passkey_ks, &bootstrap_cred_id_hex, user_uuid)
         .await
         .unwrap();
     let admin_entry = AdminEntry {
@@ -152,71 +115,18 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         extensions: Value::Null,
         created_at: Utc::now(),
     };
-    store_admin_entry(&passkey_ks, &admin_entry).await.unwrap();
+    store_admin_entry(&vtc.state.passkey_ks, &admin_entry)
+        .await
+        .unwrap();
     let acl_entry = AclEntry::new(admin_did.clone(), Role::Admin, "did:key:vtc-install")
         .with_label(Some("install bootstrap".into()));
-    store_acl_entry(&acl_ks, &acl_entry).await.unwrap();
+    store_acl_entry(&vtc.state.acl_ks, &acl_entry)
+        .await
+        .unwrap();
 
-    let audit_writer = if with_audit {
-        let key_store = AuditKeyStore::new(audit_key_ks.clone());
-        key_store.ensure_initial(&[0xAB; 64]).await.unwrap();
-        Some(AuditWriter::new(audit_ks.clone(), key_store))
-    } else {
-        None
-    };
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        audit_ks: audit_ks.clone(),
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys.clone()),
-        atm: None,
-        webauthn: Some(Arc::new(webauthn)),
-        public_url: Some(RP_ORIGIN.to_string()),
-        install_signer: Some(Arc::new(
-            InstallTokenSigner::from_master_seed(&[0xAB; 64]).unwrap(),
-        )),
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state.clone());
+    let state = vtc.state.clone();
+    let router = vtc.router.clone();
+    let jwt_keys = vtc.jwt_keys.clone();
 
     Fixture {
         state,
@@ -224,7 +134,7 @@ async fn build_fixture(with_audit: bool) -> Fixture {
         jwt_keys,
         admin_did,
         authenticator,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -11,120 +11,19 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use http_body_util::BodyExt;
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 
 use vti_common::auth::jwt::JwtKeys;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
-use vtc_service::config::AppConfig;
-use vtc_service::routes;
-use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
-/// Pin jsonwebtoken's default `CryptoProvider` to `aws_lc` once per
-/// process. The workspace compiles `jsonwebtoken` with only the
-/// `aws_lc_rs` backend feature (the `rust_crypto` bundle pulls in
-/// `rsa`, exposed to RUSTSEC-2023-0071); installing the provider
-/// explicitly is also defensive against feature-graph surprises
-/// from sibling crates under `cargo test --workspace`.
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
-async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, tempfile::TempDir) {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:key:z6MkTestVTC"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys.clone()),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
-        audit_ks,
-        audit_key_ks,
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
-    (router, jwt_keys, dir)
+async fn build_test_router() -> (axum::Router, Arc<JwtKeys>, TestVtc) {
+    let vtc = TestVtc::builder()
+        .vtc_did("did:key:z6MkTestVTC")
+        .build()
+        .await;
+    (vtc.router.clone(), vtc.jwt_keys.clone(), vtc)
 }
 
 async fn request(router: &axum::Router, req: Request<Body>) -> (StatusCode, String) {

--- a/vtc-service/tests/ceremony_execute.rs
+++ b/vtc-service/tests/ceremony_execute.rs
@@ -14,20 +14,14 @@
 //! It calls `apply` directly against a built `AppState` rather than
 //! over HTTP — the executor is below the route layer.
 
-use std::sync::Arc;
-
 use affinidi_status_list::StatusPurpose;
-use tokio::sync::RwLock;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
 use vtc_service::ceremony::EffectPlan;
 use vtc_service::ceremony::execute::{self, EffectOutcome};
-use vtc_service::config::AppConfig;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::{Disposition, get_member};
 use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const ACTOR_DID: &str = "did:key:zActor";
@@ -35,102 +29,23 @@ const ACTOR_DID: &str = "did:key:zActor";
 /// Build an `AppState` with a credential signer + provisioned status
 /// lists — the minimum the `Admit` arm needs. JWT / webauthn / audit
 /// are left `None`; the executor doesn't touch them.
-async fn build_state() -> (AppState, tempfile::TempDir) {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
+async fn build_state() -> (AppState, TestVtc) {
+    let vtc = TestVtc::builder()
+        .with_signers(true)
+        .with_public_url(RP_ORIGIN)
+        .build()
+        .await;
 
     // The admit path allocates a revocation slot when issuing the VMC.
     for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
         let url = format!("{RP_ORIGIN}/v1/status-lists/{purpose}");
-        vtc_service::status_list::ensure_initial(&status_lists_ks, purpose, url)
+        vtc_service::status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
             .await
             .expect("ensure_initial status list");
     }
 
-    let credential_signer = Some(Arc::new(
-        vtc_service::credentials::LocalSigner::from_ed25519_seed(
-            "did:webvh:vtc.example.com:abc".into(),
-            &[0xCC; 32],
-        ),
-    ));
-
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        public_url = "{RP_ORIGIN}"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks,
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks,
-        registry_records_ks,
-        sync_queue_ks,
-        sync_cursor_ks,
-        relationships_ks,
-        relationships_by_did_ks,
-        endorsement_types_ks,
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks,
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer,
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: None,
-        atm: None,
-        webauthn: None,
-        public_url: Some(RP_ORIGIN.to_string()),
-        install_signer: None,
-        install_store,
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    (state, dir)
+    let state = vtc.state.clone();
+    (state, vtc)
 }
 
 /// `Admit` at a non-`member` role writes the ACL row at that role,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -4,166 +4,36 @@
 //! extractor → handler → community keyspace — through
 //! `Router::oneshot`.
 
-use std::sync::Arc;
-
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::auth::jwt::JwtKeys;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::community::{CommunityProfile, store_profile};
-use vtc_service::config::AppConfig;
-use vtc_service::routes;
 use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 const PROFILE_TASK: &str = "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
-    jwt_keys: Arc<JwtKeys>,
     state: AppState,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    vtc: TestVtc,
 }
 
 async fn build() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys.clone()),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
-        audit_ks,
-        audit_key_ks,
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state.clone());
+    let vtc = TestVtc::builder().build().await;
     Fixture {
-        router,
-        jwt_keys,
-        state,
-        _dir: dir,
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        vtc,
     }
 }
 
 async fn token_for(fix: &Fixture, role: &str) -> String {
-    use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
-
-    let session_id = format!("sess-{}", uuid::Uuid::new_v4());
-    let session = Session {
-        session_id: session_id.clone(),
-        did: "did:key:z6MkAdmin".into(),
-        challenge: "test".into(),
-        state: SessionState::Authenticated,
-        created_at: now_epoch(),
-        refresh_token: None,
-        refresh_expires_at: None,
-        tee_attested: false,
-        amr: Vec::new(),
-        acr: String::new(),
-        token_id: None,
-        session_pubkey_b58btc: None,
-    };
-    store_session(&fix.state.sessions_ks, &session)
-        .await
-        .unwrap();
-
-    let claims = fix.jwt_keys.new_claims(
-        "did:key:z6MkAdmin".to_string(),
-        session_id,
-        role.to_string(),
-        vec![],
-        900,
-        false,
-    );
-    fix.jwt_keys.encode(&claims).expect("encode")
+    fix.vtc.token("did:key:z6MkAdmin", role, vec![]).await
 }
 
 async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {

--- a/vtc-service/tests/cookie_session.rs
+++ b/vtc-service/tests/cookie_session.rs
@@ -19,124 +19,35 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use http_body_util::BodyExt;
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 
 use vti_common::auth::extractor::ADMIN_SESSION_COOKIE;
 use vti_common::auth::jwt::JwtKeys;
 use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::routes;
 use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 const ADMIN_DID: &str = "did:key:z6MkAdminCookie";
 const ACL_TRUST_TASK: &str = "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0";
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
 
 struct Fixture {
     router: axum::Router,
     state: AppState,
     jwt_keys: Arc<JwtKeys>,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    // Held only for Drop (this suite mints tokens via `jwt_keys` directly).
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:key:z6MkTestVTC"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks: acl_ks.clone(),
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys.clone()),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
-        audit_ks,
-        audit_key_ks,
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
+    let vtc = TestVtc::builder()
+        .vtc_did("did:key:z6MkTestVTC")
+        .build()
+        .await;
+    let state = vtc.state.clone();
 
     // Insert admin ACL entry so the protected route doesn't 403.
     store_acl_entry(
@@ -154,12 +65,11 @@ async fn build_fixture() -> Fixture {
     .await
     .expect("acl insert");
 
-    let router = routes::router().with_state(state.clone());
     Fixture {
-        router,
+        router: vtc.router.clone(),
         state,
-        jwt_keys,
-        _dir: dir,
+        jwt_keys: vtc.jwt_keys.clone(),
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -6,164 +6,36 @@
 //!
 //! Phase 3 M3.8.
 
-use std::sync::Arc;
-
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::auth::jwt::JwtKeys;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
-use vtc_service::config::AppConfig;
-use vtc_service::registry::{RegistryHealth, SyncJob, SyncJobKind, SyncJobState, store_sync_job};
-use vtc_service::routes;
+use vtc_service::registry::{SyncJob, SyncJobKind, SyncJobState, store_sync_job};
 use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 const DIAGNOSTICS_TASK: &str = "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
-    jwt_keys: Arc<JwtKeys>,
     state: AppState,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    vtc: TestVtc,
 }
 
 async fn build() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks,
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks,
-        registry_records_ks,
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks,
-        relationships_ks,
-        relationships_by_did_ks,
-        endorsement_types_ks,
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks,
-        registry_client: None,
-        registry_health: RegistryHealth::new(),
-        credential_signer: None,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys.clone()),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
-        audit_ks,
-        audit_key_ks,
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state.clone());
+    let vtc = TestVtc::builder().build().await;
     Fixture {
-        router,
-        jwt_keys,
-        state,
-        _dir: dir,
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        vtc,
     }
 }
 
 async fn token_for(fix: &Fixture, role: &str) -> String {
-    use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
-    let session_id = format!("sess-{}", uuid::Uuid::new_v4());
-    let session = Session {
-        session_id: session_id.clone(),
-        did: "did:key:z6MkAdmin".into(),
-        challenge: "test".into(),
-        state: SessionState::Authenticated,
-        created_at: now_epoch(),
-        refresh_token: None,
-        refresh_expires_at: None,
-        tee_attested: false,
-        amr: Vec::new(),
-        acr: String::new(),
-        token_id: None,
-        session_pubkey_b58btc: None,
-    };
-    store_session(&fix.state.sessions_ks, &session)
-        .await
-        .unwrap();
-    let claims = fix.jwt_keys.new_claims(
-        "did:key:z6MkAdmin".to_string(),
-        session_id,
-        role.to_string(),
-        vec![],
-        900,
-        false,
-    );
-    fix.jwt_keys.encode(&claims).expect("encode")
+    fix.vtc.token("did:key:z6MkAdmin", role, vec![]).await
 }
 
 async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -12,21 +12,12 @@
 
 mod common;
 
-use std::sync::Arc;
-
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
-use tempfile::TempDir;
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
-use vtc_service::config::AppConfig;
-use vtc_service::install::InstallTokenStore;
-use vtc_service::routes;
-use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 // A real `did:webvh` is `did:webvh:<scid>:<host>[:<path>]` — the SCID is
 // the FIRST label after the method, the host second (see the did:webvh
@@ -44,93 +35,17 @@ const VTC_LOG_LABEL: &str = "vtc.example.com";
 struct Fixture {
     router: axum::Router,
     data_dir: std::path::PathBuf,
-    _dir: TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture(vtc_did: &str) -> Fixture {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "{vtc_did}"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: None,
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store,
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
-
+    let vtc = TestVtc::builder().vtc_did(vtc_did).build().await;
+    let data_dir = vtc.data_dir().to_path_buf();
     Fixture {
-        router,
-        data_dir: dir.path().to_path_buf(),
-        _dir: dir,
+        router: vtc.router.clone(),
+        data_dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/directory.rs
+++ b/vtc-service/tests/directory.rs
@@ -19,34 +19,19 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::Value;
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::audit::{AuditKeyStore, AuditWriter};
 use vti_common::auth::jwt::JwtKeys;
-use vti_common::auth::passkey::build_webauthn;
 use vti_common::auth::session::{Session, SessionState, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::{KeyspaceHandle, Store};
+use vti_common::store::KeyspaceHandle;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::{Member, store_member};
 use vtc_service::policy::default::install_defaults;
-use vtc_service::routes;
-use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const DIRECTORY_TASK: &str = "https://trusttasks.org/openvtc/vtc/directory/query/1.0";
 const ADMIN_DID: &str = "did:key:zAdmin1";
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
 
 struct Fixture {
     router: axum::Router,
@@ -55,57 +40,26 @@ struct Fixture {
     acl_ks: KeyspaceHandle,
     members_ks: KeyspaceHandle,
     admin_token: String,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_public_url(RP_ORIGIN)
+        .build()
+        .await;
 
     // The directory route reads the active `directory` policy, so the
     // bundled defaults must be installed (server boot does this).
-    install_defaults(&policies_ks, &active_policies_ks)
+    install_defaults(&vtc.state.policies_ks, &vtc.state.active_policies_ks)
         .await
         .expect("install default policies");
 
-    let install_store = InstallTokenStore::new(install_ks.clone());
-    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
-
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
-
     // Admin viewer: community-admin ACL row + an authenticated session.
     store_acl_entry(
-        &acl_ks,
+        &vtc.state.acl_ks,
         &VtcAclEntry {
             did: ADMIN_DID.into(),
             role: VtcRole::Admin,
@@ -119,58 +73,13 @@ async fn build_fixture() -> Fixture {
     .await
     .unwrap();
 
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        public_url = "{RP_ORIGIN}"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
+    let admin_token = mint_token(&vtc.jwt_keys, &vtc.state.sessions_ks, ADMIN_DID).await;
 
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks: acl_ks.clone(),
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks,
-        registry_records_ks,
-        sync_queue_ks,
-        sync_cursor_ks,
-        relationships_ks,
-        relationships_by_did_ks,
-        endorsement_types_ks,
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks,
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys.clone()),
-        atm: None,
-        webauthn,
-        public_url: Some(RP_ORIGIN.to_string()),
-        install_signer: None,
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
-    let admin_token = mint_token(&jwt_keys, &sessions_ks, ADMIN_DID).await;
+    let jwt_keys = vtc.jwt_keys.clone();
+    let sessions_ks = vtc.state.sessions_ks.clone();
+    let acl_ks = vtc.state.acl_ks.clone();
+    let members_ks = vtc.state.members_ks.clone();
+    let router = vtc.router.clone();
 
     Fixture {
         router,
@@ -179,7 +88,7 @@ async fn build_fixture() -> Fixture {
         acl_ks,
         members_ks,
         admin_token,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -14,30 +14,19 @@ use std::sync::Arc;
 use affinidi_status_list::StatusPurpose;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 use uuid::Uuid;
-use vti_common::audit::{AuditEnvelope, AuditEvent, AuditKeyStore, AuditWriter};
+use vti_common::audit::{AuditEnvelope, AuditEvent};
 use vti_common::auth::jwt::JwtKeys;
 use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::credentials::LocalSigner;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::{Member, store_member};
-use vtc_service::registry::RegistryHealth;
-use vtc_service::routes;
-use vtc_service::server::AppState;
 use vtc_service::status_list;
+use vtc_service::test_support::TestVtc;
 
-const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const REGISTER_TASK: &str = "https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0";
 const DELETE_TYPE_TASK: &str = "https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0";
@@ -48,14 +37,6 @@ const ISSUER_DID: &str = "did:key:zEndIssuer";
 const MEMBER_DID: &str = "did:key:zEndMember";
 const SUBJECT_DID: &str = "did:key:zEndSubject";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
     admin_token: String,
@@ -63,55 +44,30 @@ struct Fixture {
     member_token: String,
     audit_ks: vti_common::store::KeyspaceHandle,
     endorsements_ks: vti_common::store::KeyspaceHandle,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().unwrap();
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_signers(true)
+        .with_public_url(PUBLIC_URL)
+        .build()
+        .await;
+
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
     .unwrap();
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
-        .await
-        .unwrap();
     for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
         let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
-        status_list::ensure_initial(&status_lists_ks, purpose, url)
+        status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
             .await
             .unwrap();
     }
-
-    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
 
     let now = now_epoch();
     for (did, role) in [
@@ -121,7 +77,7 @@ async fn build() -> Fixture {
         (SUBJECT_DID, VtcRole::Member),
     ] {
         store_acl_entry(
-            &acl_ks,
+            &vtc.state.acl_ks,
             &VtcAclEntry {
                 did: did.into(),
                 role,
@@ -134,7 +90,7 @@ async fn build() -> Fixture {
         )
         .await
         .unwrap();
-        store_member(&members_ks, &Member::fresh(did))
+        store_member(&vtc.state.members_ks, &Member::fresh(did))
             .await
             .unwrap();
     }
@@ -169,66 +125,35 @@ async fn build() -> Fixture {
         let claims = jwt_keys.new_claims(did.into(), session_id, role.into(), vec![], 3600, true);
         jwt_keys.encode(&claims).unwrap()
     }
-    let admin_token = mint(&sessions_ks, &jwt_keys, ADMIN_DID, "admin", now).await;
-    let issuer_token = mint(&sessions_ks, &jwt_keys, ISSUER_DID, "reader", now).await;
-    let member_token = mint(&sessions_ks, &jwt_keys, MEMBER_DID, "reader", now).await;
+    let admin_token = mint(
+        &vtc.state.sessions_ks,
+        &vtc.jwt_keys,
+        ADMIN_DID,
+        "admin",
+        now,
+    )
+    .await;
+    let issuer_token = mint(
+        &vtc.state.sessions_ks,
+        &vtc.jwt_keys,
+        ISSUER_DID,
+        "reader",
+        now,
+    )
+    .await;
+    let member_token = mint(
+        &vtc.state.sessions_ks,
+        &vtc.jwt_keys,
+        MEMBER_DID,
+        "reader",
+        now,
+    )
+    .await;
 
-    let install_store = InstallTokenStore::new(install_ks.clone());
+    let audit_ks = vtc.state.audit_ks.clone();
+    let endorsements_ks = vtc.state.endorsements_ks.clone();
+    let router = vtc.router.clone();
 
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "{VTC_DID}"
-        public_url = "{PUBLIC_URL}"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .unwrap();
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks,
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks,
-        registry_records_ks,
-        sync_queue_ks,
-        sync_cursor_ks,
-        relationships_ks,
-        relationships_by_did_ks,
-        endorsement_types_ks,
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: RegistryHealth::new(),
-        audit_ks: audit_ks.clone(),
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: Some(PUBLIC_URL.into()),
-        install_signer: None,
-        credential_signer: Some(signer),
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
     Fixture {
         router,
         admin_token,
@@ -236,7 +161,7 @@ async fn build() -> Fixture {
         member_token,
         audit_ks,
         endorsements_ks,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -14,18 +14,12 @@ use axum::http::{Request, StatusCode};
 use chrono::{Duration as ChronoDuration, Utc};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 use uuid::Uuid;
-use vti_common::auth::passkey::build_webauthn;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 use webauthn_rs::prelude::CreationChallengeResponse;
 
-use vtc_service::config::AppConfig;
 use vtc_service::install::{InstallTokenSigner, InstallTokenStore, mint_install_token};
-use vtc_service::routes;
-use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 use common::webauthn_harness::SoftEd25519Authenticator;
 
@@ -33,66 +27,19 @@ const RP_ORIGIN: &str = "https://vtc.example.com";
 const START_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0";
 const FINISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
     install_signer: Arc<InstallTokenSigner>,
     install_store: InstallTokenStore,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let webauthn = public_url.map(|u| Arc::new(build_webauthn(u).expect("build webauthn")));
+    // 64 bytes of test entropy mirror what production loads from the secret
+    // store (32 Ed25519 + 32 X25519); HKDF only cares about length. The
+    // same signer is injected into the AppState so tokens minted here verify.
     let install_signer = if with_install_signer {
-        // 64 bytes of test entropy mirror what production loads from
-        // the secret store (32 Ed25519 + 32 X25519); HKDF only cares
-        // about length.
         Some(Arc::new(
             InstallTokenSigner::from_master_seed(&[0xAB; 64]).unwrap(),
         ))
@@ -100,54 +47,26 @@ async fn build_fixture(public_url: Option<&str>, with_install_signer: bool) -> F
         None
     };
 
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: None,
-        atm: None,
-        webauthn,
-        public_url: public_url.map(|s| s.to_string()),
-        install_signer: install_signer.clone(),
-        install_store: install_store.clone(),
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
+    let mut builder = TestVtc::builder();
+    if let Some(u) = public_url {
+        builder = builder.with_public_url(u);
+    }
+    if let Some(sig) = &install_signer {
+        builder = builder.with_install_signer(sig.clone());
+    }
+    let vtc = builder.build().await;
 
-    let router = routes::router().with_state(state);
+    let install_store = vtc.state.install_store.clone();
 
     Fixture {
-        router,
-        install_signer: install_signer.clone().unwrap_or_else(|| {
+        router: vtc.router.clone(),
+        // When the AppState signer is absent (testing the 503 path), the
+        // fixture still needs *a* signer to mint tokens with — a throwaway.
+        install_signer: install_signer.unwrap_or_else(|| {
             Arc::new(InstallTokenSigner::from_master_seed(&[0xCD; 64]).unwrap())
         }),
         install_store,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -26,21 +26,16 @@ use axum::http::{Request, StatusCode};
 use chrono::{Duration as ChronoDuration, Utc};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 use uuid::Uuid;
 use vti_common::acl::Role;
-use vti_common::audit::{AuditEnvelope, AuditEvent, AuditKeyStore, AuditWriter};
+use vti_common::audit::{AuditEnvelope, AuditEvent};
 use vti_common::auth::jwt::JwtKeys;
-use vti_common::auth::passkey::build_webauthn;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 use webauthn_rs::prelude::{CreationChallengeResponse, RequestChallengeResponse};
 
-use vtc_service::config::AppConfig;
 use vtc_service::install::{InstallTokenSigner, InstallTokenStore, mint_install_token};
-use vtc_service::routes;
 use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 use common::webauthn_harness::SoftEd25519Authenticator;
 
@@ -58,118 +53,33 @@ const COMMUNITY_PROFILE_TASK: &str =
 const ADMIN_CONFIG_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/config/manage/1.0";
 const RESTART_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/config/restart/1.0";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     state: AppState,
     router: axum::Router,
     install_signer: Arc<InstallTokenSigner>,
     install_store: InstallTokenStore,
     jwt_keys: Arc<JwtKeys>,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
-/// Step 1: `vtc setup` shortcut. Stands up an AppState with
-/// everything `run()` would wire (WebAuthn, install signer, audit
-/// writer, JWT keys). No actual VTA contact — provisioning against
-/// a fake VTA is acceptable per the plan's M0.12.1 acceptance.
+/// Step 1: `vtc setup` shortcut. Stands up an AppState with everything
+/// `run()` would wire (WebAuthn via public_url, install signer, audit
+/// writer, JWT keys). No actual VTA contact. The builder leaves
+/// `supervisor: None` so step 9 asserts `/restart` returns 412.
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
     let install_signer = Arc::new(InstallTokenSigner::from_master_seed(&[0xAB; 64]).unwrap());
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_public_url(RP_ORIGIN)
+        .with_install_signer(install_signer.clone())
+        .build()
+        .await;
 
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 64]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        audit_ks: audit_ks.clone(),
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys.clone()),
-        atm: None,
-        webauthn,
-        public_url: Some(RP_ORIGIN.to_string()),
-        install_signer: Some(install_signer.clone()),
-        install_store: install_store.clone(),
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        // No supervisor — step 9 asserts `/restart` returns 412.
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state.clone());
+    let state = vtc.state.clone();
+    let router = vtc.router.clone();
+    let install_store = vtc.state.install_store.clone();
+    let jwt_keys = vtc.jwt_keys.clone();
 
     Fixture {
         state,
@@ -177,7 +87,7 @@ async fn build_fixture() -> Fixture {
         install_signer,
         install_store,
         jwt_keys,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -15,22 +15,15 @@ use axum::http::{Request, StatusCode};
 use ed25519_dalek::{Signer, SigningKey};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 use uuid::Uuid;
-use vti_common::audit::{AuditKeyStore, AuditWriter};
-use vti_common::auth::jwt::JwtKeys;
-use vti_common::auth::passkey::build_webauthn;
 use vti_common::auth::session::{Session, SessionState, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::{KeyspaceHandle, Store};
+use vti_common::store::KeyspaceHandle;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::get_member;
-use vtc_service::routes;
 use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 /// Mirror of the constant in `vtc_service::routes::join_requests::submit`
 /// — the route module is `pub(crate)` so we can't import it from a
@@ -61,14 +54,6 @@ const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/
 
 const ADMIN_DID: &str = "did:key:zAdmin1";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
     state: AppState,
@@ -77,80 +62,50 @@ struct Fixture {
     members_ks: KeyspaceHandle,
     #[allow(dead_code)]
     join_requests_ks: KeyspaceHandle,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
+    // M2.12 credential signer — deterministic seed so the tests can
+    // reconstruct it and verify issued VMC/VEC proofs against it.
+    let credential_signer = Arc::new(vtc_service::credentials::LocalSigner::from_ed25519_seed(
+        "did:webvh:vtc.example.com:abc".into(),
+        &[0xCC; 32],
+    ));
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_public_url(RP_ORIGIN)
+        .with_credential_signer(credential_signer)
+        .build()
+        .await;
 
     // Install workspace-shipped default policies the same way
-    // `server::run` does at boot (M2.5). The submit handler
-    // (M2.6) evaluates `join.rego` against every submission,
-    // so an empty active-policy set would fail closed.
-    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
-        .await
-        .expect("install default policies");
+    // `server::run` does at boot (M2.5). The submit handler evaluates
+    // `join.rego` against every submission, so an empty active-policy set
+    // would fail closed.
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
+    .expect("install default policies");
 
-    // M2.10 + M2.12: seed both status lists so the approve
-    // handler can allocate a slot when issuing the VMC.
+    // M2.10 + M2.12: seed both status lists so the approve handler can
+    // allocate a slot when issuing the VMC.
     for purpose in [
         affinidi_status_list::StatusPurpose::Revocation,
         affinidi_status_list::StatusPurpose::Suspension,
     ] {
         let url = format!("{RP_ORIGIN}/v1/status-lists/{purpose}");
-        vtc_service::status_list::ensure_initial(&status_lists_ks, purpose, url)
+        vtc_service::status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
             .await
             .expect("ensure_initial status list");
     }
 
-    // M2.12 credential signer — deterministic seed for stable
-    // test fixtures.
-    let credential_signer = Some(Arc::new(
-        vtc_service::credentials::LocalSigner::from_ed25519_seed(
-            "did:webvh:vtc.example.com:abc".into(),
-            &[0xCC; 32],
-        ),
-    ));
-
-    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
-
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
-
     let now = vtc_service::auth::session::now_epoch();
     store_acl_entry(
-        &acl_ks,
+        &vtc.state.acl_ks,
         &VtcAclEntry {
             did: ADMIN_DID.into(),
             role: VtcRole::Admin,
@@ -166,7 +121,7 @@ async fn build_fixture() -> Fixture {
 
     let session_id = "test-admin-session";
     store_session(
-        &sessions_ks,
+        &vtc.state.sessions_ks,
         &Session {
             session_id: session_id.into(),
             did: ADMIN_DID.into(),
@@ -185,7 +140,7 @@ async fn build_fixture() -> Fixture {
     .await
     .unwrap();
 
-    let admin_claims = jwt_keys.new_claims(
+    let admin_claims = vtc.jwt_keys.new_claims(
         ADMIN_DID.into(),
         session_id.into(),
         "admin".into(),
@@ -193,59 +148,13 @@ async fn build_fixture() -> Fixture {
         3600,
         true,
     );
-    let admin_token = jwt_keys.encode(&admin_claims).unwrap();
+    let admin_token = vtc.jwt_keys.encode(&admin_claims).unwrap();
 
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        public_url = "{RP_ORIGIN}"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks: acl_ks.clone(),
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer,
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn,
-        public_url: Some(RP_ORIGIN.to_string()),
-        install_signer: None,
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state.clone());
+    let state = vtc.state.clone();
+    let acl_ks = vtc.state.acl_ks.clone();
+    let members_ks = vtc.state.members_ks.clone();
+    let join_requests_ks = vtc.state.join_requests_ks.clone();
+    let router = vtc.router.clone();
 
     Fixture {
         router,
@@ -254,7 +163,7 @@ async fn build_fixture() -> Fixture {
         acl_ks,
         members_ks,
         join_requests_ks,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -7,27 +7,17 @@
 
 mod common;
 
-use std::sync::Arc;
-
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::audit::{AuditKeyStore, AuditWriter};
-use vti_common::auth::jwt::JwtKeys;
-use vti_common::auth::passkey::build_webauthn;
 use vti_common::auth::session::{Session, SessionState, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::{KeyspaceHandle, Store};
+use vti_common::store::KeyspaceHandle;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::{Member, store_member};
-use vtc_service::routes;
-use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/list/1.0";
@@ -36,14 +26,6 @@ const PROMOTE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/promote-t
 
 const ADMIN_DID: &str = "did:key:zAdmin1";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
     admin_token: String,
@@ -51,66 +33,32 @@ struct Fixture {
     members_ks: KeyspaceHandle,
     #[allow(dead_code)]
     join_requests_ks: KeyspaceHandle,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
+    // Role changes run through the role-change ceremony, which needs the
+    // active decision policy + a credential signer to re-mint the role VEC
+    // (with_signers) and webauthn for the promote UV ceremony (public_url).
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_signers(true)
+        .with_public_url(RP_ORIGIN)
+        .build()
+        .await;
 
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
+    .expect("install default policies");
 
-    // Role changes (PATCH /v1/members/{did}) run through the
-    // role-change ceremony, which needs the active decision policy + a
-    // credential signer to re-mint the role VEC.
-    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
-        .await
-        .expect("install default policies");
-    let credential_signer = Some(Arc::new(
-        vtc_service::credentials::LocalSigner::from_ed25519_seed(
-            "did:webvh:vtc.example.com:abc".into(),
-            &[0xCC; 32],
-        ),
-    ));
-
-    let install_store = InstallTokenStore::new(install_ks.clone());
-    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
-
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
-
-    // Seed an admin ACL row + Member row so the existing fixture
-    // helpers can mint a session token for the admin DID.
+    // Seed an admin ACL row so the admin DID resolves to a community admin.
     let now = vtc_service::auth::session::now_epoch();
     store_acl_entry(
-        &acl_ks,
+        &vtc.state.acl_ks,
         &VtcAclEntry {
             did: ADMIN_DID.into(),
             role: VtcRole::Admin,
@@ -124,20 +72,10 @@ async fn build_fixture() -> Fixture {
     .await
     .unwrap();
 
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        public_url = "{RP_ORIGIN}"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
     // Mint a session row that matches the JWT we hand back. The
-    // AuthClaims extractor requires both a valid JWT AND a
-    // matching `session_id` row in the sessions keyspace.
+    // AuthClaims extractor requires both a valid JWT AND a matching
+    // `session_id` row in the sessions keyspace. The claim is
+    // tee-attested with a 1h TTL (the promote ceremony reads these).
     let session_id = "test-admin-session";
     let session = Session {
         session_id: session_id.into(),
@@ -153,9 +91,11 @@ async fn build_fixture() -> Fixture {
         token_id: None,
         session_pubkey_b58btc: None,
     };
-    store_session(&sessions_ks, &session).await.unwrap();
+    store_session(&vtc.state.sessions_ks, &session)
+        .await
+        .unwrap();
 
-    let admin_claims = jwt_keys.new_claims(
+    let admin_claims = vtc.jwt_keys.new_claims(
         ADMIN_DID.into(),
         session_id.into(),
         "admin".into(),
@@ -163,48 +103,12 @@ async fn build_fixture() -> Fixture {
         3600,
         true,
     );
-    let admin_token = jwt_keys.encode(&admin_claims).unwrap();
+    let admin_token = vtc.jwt_keys.encode(&admin_claims).unwrap();
 
-    let state = AppState {
-        sessions_ks,
-        acl_ks: acl_ks.clone(),
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer,
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn,
-        public_url: Some(RP_ORIGIN.to_string()),
-        install_signer: None,
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
+    let acl_ks = vtc.state.acl_ks.clone();
+    let members_ks = vtc.state.members_ks.clone();
+    let join_requests_ks = vtc.state.join_requests_ks.clone();
+    let router = vtc.router.clone();
 
     Fixture {
         router,
@@ -212,7 +116,7 @@ async fn build_fixture() -> Fixture {
         acl_ks,
         members_ks,
         join_requests_ks,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/personhood.rs
+++ b/vtc-service/tests/personhood.rs
@@ -19,48 +19,26 @@
 //! (see `recognition::verify::tests`) — the integration
 //! coverage here pins the failure-mode + audit surfaces.
 
-use std::sync::Arc;
-
 use affinidi_status_list::StatusPurpose;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::audit::{AuditEnvelope, AuditEvent, AuditKeyStore, AuditWriter};
-use vti_common::auth::jwt::JwtKeys;
+use vti_common::audit::{AuditEnvelope, AuditEvent};
 use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::credentials::LocalSigner;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::{Member, get_member, store_member};
-use vtc_service::registry::RegistryHealth;
-use vtc_service::routes;
-use vtc_service::server::AppState;
 use vtc_service::status_list;
+use vtc_service::test_support::TestVtc;
 
-const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const CHALLENGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0";
 const ASSERT_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0";
 const MEMBER_DID: &str = "did:key:zPerson1";
 const OTHER_MEMBER_DID: &str = "did:key:zPerson2";
 const ADMIN_DID: &str = "did:key:zPersonAdmin";
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
 
 struct Fixture {
     router: axum::Router,
@@ -69,57 +47,31 @@ struct Fixture {
     admin_token: String,
     members_ks: vti_common::store::KeyspaceHandle,
     audit_ks: vti_common::store::KeyspaceHandle,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_signers(true)
+        .with_public_url(PUBLIC_URL)
+        .build()
+        .await;
 
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
-        .await
-        .expect("install default policies");
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
+    .expect("install default policies");
 
     for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
         let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
-        status_list::ensure_initial(&status_lists_ks, purpose, url)
+        status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
             .await
             .unwrap();
     }
-
-    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
-
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
 
     // Seed ACL + Member rows for member, other-member, admin.
     let now = now_epoch();
@@ -129,7 +81,7 @@ async fn build_fixture() -> Fixture {
         (ADMIN_DID, VtcRole::Admin),
     ] {
         store_acl_entry(
-            &acl_ks,
+            &vtc.state.acl_ks,
             &VtcAclEntry {
                 did: did.into(),
                 role,
@@ -142,43 +94,17 @@ async fn build_fixture() -> Fixture {
         )
         .await
         .unwrap();
-        store_member(&members_ks, &Member::fresh(did))
+        store_member(&vtc.state.members_ks, &Member::fresh(did))
             .await
             .unwrap();
     }
 
-    let make_token = |did: &str, role: &str| -> String {
-        let session_id = format!("sess-{}", uuid::Uuid::new_v4());
-        let session = Session {
-            session_id: session_id.clone(),
-            did: did.into(),
-            challenge: "test".into(),
-            state: SessionState::Authenticated,
-            created_at: now,
-            refresh_token: None,
-            refresh_expires_at: None,
-            tee_attested: false,
-            amr: Vec::new(),
-            acr: String::new(),
-            token_id: None,
-            session_pubkey_b58btc: None,
-        };
-        let sessions = sessions_ks.clone();
-        let claims = jwt_keys.new_claims(did.into(), session_id, role.into(), vec![], 3600, true);
-        let token = jwt_keys.encode(&claims).unwrap();
-        // store_session is async; wrap synchronously by leaking
-        // a tokio handle.
-        tokio::runtime::Handle::current().block_on(async move {
-            store_session(&sessions, &session).await.unwrap();
-        });
-        token
-    };
-    // Hack: build_fixture is async, but the closure can't be —
-    // call store_session inline instead.
+    // Mint tokens with fixed session ids so the AuthClaims extractor's
+    // session-state lookup succeeds (tee-attested, 1h TTL).
     let member_token = {
         let session_id = "sess-member";
         store_session(
-            &sessions_ks,
+            &vtc.state.sessions_ks,
             &Session {
                 session_id: session_id.into(),
                 did: MEMBER_DID.into(),
@@ -196,7 +122,7 @@ async fn build_fixture() -> Fixture {
         )
         .await
         .unwrap();
-        let claims = jwt_keys.new_claims(
+        let claims = vtc.jwt_keys.new_claims(
             MEMBER_DID.into(),
             session_id.into(),
             "reader".into(),
@@ -204,12 +130,12 @@ async fn build_fixture() -> Fixture {
             3600,
             true,
         );
-        jwt_keys.encode(&claims).unwrap()
+        vtc.jwt_keys.encode(&claims).unwrap()
     };
     let other_member_token = {
         let session_id = "sess-other";
         store_session(
-            &sessions_ks,
+            &vtc.state.sessions_ks,
             &Session {
                 session_id: session_id.into(),
                 did: OTHER_MEMBER_DID.into(),
@@ -227,7 +153,7 @@ async fn build_fixture() -> Fixture {
         )
         .await
         .unwrap();
-        let claims = jwt_keys.new_claims(
+        let claims = vtc.jwt_keys.new_claims(
             OTHER_MEMBER_DID.into(),
             session_id.into(),
             "reader".into(),
@@ -235,12 +161,12 @@ async fn build_fixture() -> Fixture {
             3600,
             true,
         );
-        jwt_keys.encode(&claims).unwrap()
+        vtc.jwt_keys.encode(&claims).unwrap()
     };
     let admin_token = {
         let session_id = "sess-admin";
         store_session(
-            &sessions_ks,
+            &vtc.state.sessions_ks,
             &Session {
                 session_id: session_id.into(),
                 did: ADMIN_DID.into(),
@@ -258,7 +184,7 @@ async fn build_fixture() -> Fixture {
         )
         .await
         .unwrap();
-        let claims = jwt_keys.new_claims(
+        let claims = vtc.jwt_keys.new_claims(
             ADMIN_DID.into(),
             session_id.into(),
             "admin".into(),
@@ -266,66 +192,13 @@ async fn build_fixture() -> Fixture {
             3600,
             true,
         );
-        jwt_keys.encode(&claims).unwrap()
-    };
-    let _ = make_token; // silence unused
-
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "{VTC_DID}"
-        public_url = "{PUBLIC_URL}"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks,
-        registry_records_ks,
-        sync_queue_ks,
-        sync_cursor_ks,
-        relationships_ks,
-        relationships_by_did_ks,
-        endorsement_types_ks,
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks,
-        registry_client: None,
-        registry_health: RegistryHealth::new(),
-        audit_ks: audit_ks.clone(),
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: Some(PUBLIC_URL.into()),
-        install_signer: None,
-        credential_signer: Some(signer),
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
+        vtc.jwt_keys.encode(&claims).unwrap()
     };
 
-    let router = routes::router().with_state(state);
+    let members_ks = vtc.state.members_ks.clone();
+    let audit_ks = vtc.state.audit_ks.clone();
+    let router = vtc.router.clone();
+
     Fixture {
         router,
         member_token,
@@ -333,7 +206,7 @@ async fn build_fixture() -> Fixture {
         admin_token,
         members_ks,
         audit_ks,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -11,27 +11,17 @@
 
 mod common;
 
-use std::sync::Arc;
-
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 use uuid::Uuid;
-use vti_common::audit::{AuditKeyStore, AuditWriter};
-use vti_common::auth::jwt::JwtKeys;
-use vti_common::auth::session::{Session, SessionState, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::{KeyspaceHandle, Store};
+use vti_common::store::KeyspaceHandle;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::policy::{PolicyPurpose, get_active_policy_id, get_policy};
-use vtc_service::routes;
-use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 const UPLOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
 const ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
@@ -64,64 +54,22 @@ import rego.v1
 default allow := true
 ";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
     admin_token: String,
     policies_ks: KeyspaceHandle,
     active_policies_ks: KeyspaceHandle,
     audit_ks: KeyspaceHandle,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
+    let vtc = TestVtc::builder().with_audit(true).build().await;
 
     let now = vtc_service::auth::session::now_epoch();
     store_acl_entry(
-        &acl_ks,
+        &vtc.state.acl_ks,
         &VtcAclEntry {
             did: ADMIN_DID.into(),
             role: VtcRole::Admin,
@@ -135,83 +83,12 @@ async fn build_fixture() -> Fixture {
     .await
     .unwrap();
 
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
+    let admin_token = vtc.token(ADMIN_DID, "admin", vec![]).await;
 
-    let session_id = "test-policy-admin-session";
-    let session = Session {
-        session_id: session_id.into(),
-        did: ADMIN_DID.into(),
-        challenge: "test".into(),
-        state: SessionState::Authenticated,
-        created_at: now,
-        refresh_token: None,
-        refresh_expires_at: None,
-        tee_attested: false,
-        amr: Vec::new(),
-        acr: String::new(),
-        token_id: None,
-        session_pubkey_b58btc: None,
-    };
-    store_session(&sessions_ks, &session).await.unwrap();
-
-    let admin_claims = jwt_keys.new_claims(
-        ADMIN_DID.into(),
-        session_id.into(),
-        "admin".into(),
-        vec![],
-        3600,
-        true,
-    );
-    let admin_token = jwt_keys.encode(&admin_claims).unwrap();
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks,
-        join_requests_ks,
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        audit_ks: audit_ks.clone(),
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
+    let policies_ks = vtc.state.policies_ks.clone();
+    let active_policies_ks = vtc.state.active_policies_ks.clone();
+    let audit_ks = vtc.state.audit_ks.clone();
+    let router = vtc.router.clone();
 
     Fixture {
         router,
@@ -219,7 +96,7 @@ async fn build_fixture() -> Fixture {
         policies_ks,
         active_policies_ks,
         audit_ks,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -13,124 +13,28 @@
 //!
 //! Phase 3 M3.10.
 
-use std::sync::Arc;
-
 use axum::Json;
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use chrono::{Duration, Utc};
 use http_body_util::BodyExt;
-use tokio::sync::RwLock;
-use vti_common::auth::jwt::JwtKeys;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
-use vtc_service::config::AppConfig;
 use vtc_service::policy::{Policy, PolicyPurpose, set_active_policy_id, store_policy};
 use vtc_service::recognition::VerifiedForeignCredential;
-use vtc_service::registry::RegistryHealth;
 use vtc_service::routes::recognise::{RecogniseResponse, mint_recognised_session};
 use vtc_service::server::AppState;
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
+use vtc_service::test_support::TestVtc;
 
 struct Fixture {
     state: AppState,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + backs `state`; must outlive it.
+    _vtc: TestVtc,
 }
 
 async fn build() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        access_token_expiry = 900
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks,
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks,
-        registry_records_ks,
-        sync_queue_ks,
-        sync_cursor_ks,
-        relationships_ks,
-        relationships_by_did_ks,
-        endorsement_types_ks,
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks,
-        registry_client: None,
-        registry_health: RegistryHealth::new(),
-        credential_signer: None,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
-        audit_ks,
-        audit_key_ks,
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    Fixture { state, _dir: dir }
+    let vtc = TestVtc::builder().build().await;
+    Fixture {
+        state: vtc.state.clone(),
+        _vtc: vtc,
+    }
 }
 
 async fn install_cross_community_policy(state: &AppState, source: &str) {

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -18,31 +18,20 @@ use std::sync::Arc;
 use affinidi_status_list::StatusPurpose;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 use uuid::Uuid;
-use vti_common::audit::{AuditEnvelope, AuditEvent, AuditKeyStore, AuditWriter};
+use vti_common::audit::{AuditEnvelope, AuditEvent};
 use vti_common::auth::jwt::JwtKeys;
 use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, delete_acl_entry, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::credentials::LocalSigner;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::{Member, delete_member, store_member};
-use vtc_service::registry::RegistryHealth;
 use vtc_service::relationships::{Relationship, store_relationship};
-use vtc_service::routes;
-use vtc_service::server::AppState;
 use vtc_service::status_list;
+use vtc_service::test_support::TestVtc;
 
-const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const PUBLISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/relationships/publish/1.0";
 const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/relationships/list/1.0";
@@ -51,14 +40,6 @@ const ISSUER_DID: &str = "did:key:zVrcIssuer";
 const SUBJECT_DID: &str = "did:key:zVrcSubject";
 const STRANGER_DID: &str = "did:key:zStranger";
 const ADMIN_DID: &str = "did:key:zVrcAdmin";
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
 
 struct Fixture {
     router: axum::Router,
@@ -70,57 +51,31 @@ struct Fixture {
     acl_ks: vti_common::store::KeyspaceHandle,
     members_ks: vti_common::store::KeyspaceHandle,
     audit_ks: vti_common::store::KeyspaceHandle,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_signers(true)
+        .with_public_url(PUBLIC_URL)
+        .build()
+        .await;
 
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
-        .await
-        .expect("install default policies");
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
+    .expect("install default policies");
 
     for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
         let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
-        status_list::ensure_initial(&status_lists_ks, purpose, url)
+        status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
             .await
             .unwrap();
     }
-
-    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
-
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
 
     // Seed ACL + Member rows for issuer, subject, admin.
     let now = now_epoch();
@@ -130,7 +85,7 @@ async fn build_fixture() -> Fixture {
         (ADMIN_DID, VtcRole::Admin),
     ] {
         store_acl_entry(
-            &acl_ks,
+            &vtc.state.acl_ks,
             &VtcAclEntry {
                 did: did.into(),
                 role,
@@ -143,7 +98,7 @@ async fn build_fixture() -> Fixture {
         )
         .await
         .unwrap();
-        store_member(&members_ks, &Member::fresh(did))
+        store_member(&vtc.state.members_ks, &Member::fresh(did))
             .await
             .unwrap();
     }
@@ -179,66 +134,38 @@ async fn build_fixture() -> Fixture {
         jwt_keys.encode(&claims).unwrap()
     }
 
-    let issuer_token = mint(&sessions_ks, &jwt_keys, ISSUER_DID, "reader", now).await;
-    let subject_token = mint(&sessions_ks, &jwt_keys, SUBJECT_DID, "reader", now).await;
-    let admin_token = mint(&sessions_ks, &jwt_keys, ADMIN_DID, "admin", now).await;
+    let issuer_token = mint(
+        &vtc.state.sessions_ks,
+        &vtc.jwt_keys,
+        ISSUER_DID,
+        "reader",
+        now,
+    )
+    .await;
+    let subject_token = mint(
+        &vtc.state.sessions_ks,
+        &vtc.jwt_keys,
+        SUBJECT_DID,
+        "reader",
+        now,
+    )
+    .await;
+    let admin_token = mint(
+        &vtc.state.sessions_ks,
+        &vtc.jwt_keys,
+        ADMIN_DID,
+        "admin",
+        now,
+    )
+    .await;
 
-    let install_store = InstallTokenStore::new(install_ks.clone());
+    let relationships_ks = vtc.state.relationships_ks.clone();
+    let relationships_by_did_ks = vtc.state.relationships_by_did_ks.clone();
+    let acl_ks = vtc.state.acl_ks.clone();
+    let members_ks = vtc.state.members_ks.clone();
+    let audit_ks = vtc.state.audit_ks.clone();
+    let router = vtc.router.clone();
 
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "{VTC_DID}"
-        public_url = "{PUBLIC_URL}"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks: acl_ks.clone(),
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks,
-        registry_records_ks,
-        sync_queue_ks,
-        sync_cursor_ks,
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: RegistryHealth::new(),
-        audit_ks: audit_ks.clone(),
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: Some(PUBLIC_URL.into()),
-        install_signer: None,
-        credential_signer: Some(signer),
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
     Fixture {
         router,
         issuer_token,
@@ -249,7 +176,7 @@ async fn build_fixture() -> Fixture {
         acl_ks,
         members_ks,
         audit_ks,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -13,21 +13,14 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::audit::{AuditKeyStore, AuditWriter};
 use vti_common::auth::jwt::JwtKeys;
-use vti_common::auth::passkey::build_webauthn;
 use vti_common::auth::session::{Session, SessionState, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::{KeyspaceHandle, Store};
+use vti_common::store::KeyspaceHandle;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::{Member, get_member, store_member};
-use vtc_service::routes;
-use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const SELF_REMOVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0";
@@ -37,14 +30,6 @@ const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/
 
 const ADMIN_DID: &str = "did:key:zAdmin1";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
     admin_token: String,
@@ -53,73 +38,42 @@ struct Fixture {
     sessions_ks: KeyspaceHandle,
     status_lists_ks: KeyspaceHandle,
     jwt_keys: Arc<JwtKeys>,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_public_url(RP_ORIGIN)
+        .build()
+        .await;
 
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
+    // Install workspace default policies the same way `server::run` does
+    // at boot (M2.5). The admin-remove handler consults `removal.rego`;
+    // an empty policy set would fail closed.
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
+    .expect("install default policies");
 
-    // Install workspace default policies the same way `server::run`
-    // does at boot (M2.5). The admin-remove handler (M2.7)
-    // consults `removal.rego.allow` and the disposition resolver
-    // reads `removal.rego.min_disposition`; an empty policy set
-    // would fail closed.
-    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
-        .await
-        .expect("install default policies");
-
-    // M2.14: seed the revocation status list so the flip-on-
-    // removal path has somewhere to land. Suspension seeded
-    // for parity even though removal only touches revocation.
+    // M2.14: seed the revocation status list so the flip-on-removal path
+    // has somewhere to land. Suspension seeded for parity.
     for purpose in [
         affinidi_status_list::StatusPurpose::Revocation,
         affinidi_status_list::StatusPurpose::Suspension,
     ] {
         let url = format!("{RP_ORIGIN}/v1/status-lists/{purpose}");
-        vtc_service::status_list::ensure_initial(&status_lists_ks, purpose, url)
+        vtc_service::status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
             .await
             .expect("ensure_initial status list");
     }
 
-    let webauthn = Some(Arc::new(build_webauthn(RP_ORIGIN).expect("build webauthn")));
-
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
-
     let now = vtc_service::auth::session::now_epoch();
     store_acl_entry(
-        &acl_ks,
+        &vtc.state.acl_ks,
         &VtcAclEntry {
             did: ADMIN_DID.into(),
             role: VtcRole::Admin,
@@ -132,13 +86,13 @@ async fn build_fixture() -> Fixture {
     )
     .await
     .unwrap();
-    store_member(&members_ks, &Member::fresh(ADMIN_DID))
+    store_member(&vtc.state.members_ks, &Member::fresh(ADMIN_DID))
         .await
         .unwrap();
 
     let session_id = "test-admin-session";
     store_session(
-        &sessions_ks,
+        &vtc.state.sessions_ks,
         &Session {
             session_id: session_id.into(),
             did: ADMIN_DID.into(),
@@ -157,7 +111,7 @@ async fn build_fixture() -> Fixture {
     .await
     .unwrap();
 
-    let admin_claims = jwt_keys.new_claims(
+    let admin_claims = vtc.jwt_keys.new_claims(
         ADMIN_DID.into(),
         session_id.into(),
         "admin".into(),
@@ -165,59 +119,14 @@ async fn build_fixture() -> Fixture {
         3600,
         true,
     );
-    let admin_token = jwt_keys.encode(&admin_claims).unwrap();
+    let admin_token = vtc.jwt_keys.encode(&admin_claims).unwrap();
 
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:webvh:vtc.example.com:abc"
-        public_url = "{RP_ORIGIN}"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks: acl_ks.clone(),
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys.clone()),
-        atm: None,
-        webauthn,
-        public_url: Some(RP_ORIGIN.to_string()),
-        install_signer: None,
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
+    let acl_ks = vtc.state.acl_ks.clone();
+    let members_ks = vtc.state.members_ks.clone();
+    let sessions_ks = vtc.state.sessions_ks.clone();
+    let status_lists_ks = vtc.state.status_lists_ks.clone();
+    let jwt_keys = vtc.jwt_keys.clone();
+    let router = vtc.router.clone();
 
     Fixture {
         router,
@@ -227,7 +136,7 @@ async fn build_fixture() -> Fixture {
         sessions_ks,
         status_lists_ks,
         jwt_keys,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -18,35 +18,19 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::Value;
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::audit::{AuditKeyStore, AuditWriter};
-use vti_common::auth::jwt::JwtKeys;
 use vti_common::auth::session::{Session, SessionState, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
-use vtc_service::config::AppConfig;
 use vtc_service::credentials::LocalSigner;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::{Member, get_member, store_member};
-use vtc_service::routes;
-use vtc_service::server::AppState;
 use vtc_service::status_list;
+use vtc_service::test_support::TestVtc;
 
 const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const RENEW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/renew/1.0";
 const MEMBER_DID: &str = "did:key:zRenewMember";
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
 
 struct Fixture {
     router: axum::Router,
@@ -57,63 +41,39 @@ struct Fixture {
     policies_ks: vti_common::store::KeyspaceHandle,
     active_policies_ks: vti_common::store::KeyspaceHandle,
     audit_ks: vti_common::store::KeyspaceHandle,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
+    // The fixture verifies re-issued VMC/VEC against this signer, so the
+    // AppState must issue with this exact instance.
+    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_public_url(PUBLIC_URL)
+        .with_credential_signer(signer.clone())
+        .build()
+        .await;
 
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
-        .await
-        .expect("install default policies");
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
+    .expect("install default policies");
 
     for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
         let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
-        status_list::ensure_initial(&status_lists_ks, purpose, url)
+        status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
             .await
             .unwrap();
     }
 
-    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
-
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
-
     // Seed a Member ACL row + Member metadata row.
     let now = vtc_service::auth::session::now_epoch();
     store_acl_entry(
-        &acl_ks,
+        &vtc.state.acl_ks,
         &VtcAclEntry {
             did: MEMBER_DID.into(),
             role: VtcRole::Member,
@@ -126,13 +86,13 @@ async fn build_fixture() -> Fixture {
     )
     .await
     .unwrap();
-    store_member(&members_ks, &Member::fresh(MEMBER_DID))
+    store_member(&vtc.state.members_ks, &Member::fresh(MEMBER_DID))
         .await
         .unwrap();
 
     let session_id = "test-member-session";
     store_session(
-        &sessions_ks,
+        &vtc.state.sessions_ks,
         &Session {
             session_id: session_id.into(),
             did: MEMBER_DID.into(),
@@ -151,7 +111,7 @@ async fn build_fixture() -> Fixture {
     .await
     .unwrap();
 
-    let member_claims = jwt_keys.new_claims(
+    let member_claims = vtc.jwt_keys.new_claims(
         MEMBER_DID.into(),
         session_id.into(),
         "reader".into(),
@@ -159,59 +119,14 @@ async fn build_fixture() -> Fixture {
         3600,
         true,
     );
-    let member_token = jwt_keys.encode(&member_claims).unwrap();
+    let member_token = vtc.jwt_keys.encode(&member_claims).unwrap();
 
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "{VTC_DID}"
-        public_url = "{PUBLIC_URL}"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: Some(PUBLIC_URL.into()),
-        install_signer: None,
-        credential_signer: Some(signer.clone()),
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state.clone());
+    let members_ks = vtc.state.members_ks.clone();
+    let status_lists_ks = vtc.state.status_lists_ks.clone();
+    let policies_ks = vtc.state.policies_ks.clone();
+    let active_policies_ks = vtc.state.active_policies_ks.clone();
+    let audit_ks = vtc.state.audit_ks.clone();
+    let router = vtc.router.clone();
 
     Fixture {
         router,
@@ -219,10 +134,10 @@ async fn build_fixture() -> Fixture {
         signer,
         members_ks,
         status_lists_ks,
-        policies_ks: state.policies_ks,
-        active_policies_ks: state.active_policies_ks,
-        audit_ks: state.audit_ks,
-        _dir: dir,
+        policies_ks,
+        active_policies_ks,
+        audit_ks,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -12,39 +12,23 @@ use ed25519_dalek::{Signer, SigningKey};
 use http_body_util::BodyExt;
 use serde::Serialize;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::audit::{AuditKeyStore, AuditWriter};
-use vti_common::auth::jwt::JwtKeys;
 use vti_common::auth::session::{Session, SessionState, list_sessions, store_session};
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
-use vtc_service::config::AppConfig;
 use vtc_service::credentials::LocalSigner;
-use vtc_service::install::InstallTokenStore;
 use vtc_service::members::{Member, get_member, store_member};
-use vtc_service::routes;
 // `ROTATION_DOMAIN_TAG` from the rotate module is `pub(crate)`;
 // duplicate the literal here so the integration test doesn't
 // have to peek through the route layer's private modules.
 const ROTATION_DOMAIN_TAG: &[u8] = b"vtc-did-rotation/v1\0";
-use vtc_service::server::AppState;
 use vtc_service::status_list;
+use vtc_service::test_support::TestVtc;
 
 const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const CHALLENGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0";
 const ROTATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/rotate/1.0";
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
 
 struct Fixture {
     router: axum::Router,
@@ -55,67 +39,44 @@ struct Fixture {
     acl_ks: vti_common::store::KeyspaceHandle,
     sessions_ks: vti_common::store::KeyspaceHandle,
     signer: Arc<LocalSigner>,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture() -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
+    // The fixture verifies re-issued VMC/VEC against this signer, so the
+    // AppState must issue with this exact instance.
+    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_public_url(PUBLIC_URL)
+        .with_credential_signer(signer.clone())
+        .build()
+        .await;
 
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
-
-    vtc_service::policy::default::install_defaults(&policies_ks, &active_policies_ks)
-        .await
-        .unwrap();
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
+    .unwrap();
     for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
         let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
-        status_list::ensure_initial(&status_lists_ks, purpose, url)
+        status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
             .await
             .unwrap();
     }
     // Pre-allocate a slot for the member so rotation can
     // reuse it during credential re-issuance.
-    let mut state_row = status_list::get_state(&status_lists_ks, StatusPurpose::Revocation)
-        .await
-        .unwrap()
-        .unwrap();
+    let mut state_row =
+        status_list::get_state(&vtc.state.status_lists_ks, StatusPurpose::Revocation)
+            .await
+            .unwrap()
+            .unwrap();
     let slot = status_list::allocate(&mut state_row).unwrap();
-    status_list::store_state(&status_lists_ks, &state_row)
+    status_list::store_state(&vtc.state.status_lists_ks, &state_row)
         .await
         .unwrap();
-
-    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
-
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
 
     // Build a member with a deterministic Ed25519 key + matching did:key.
     let member_signing = SigningKey::from_bytes(&[0xAA; 32]);
@@ -124,7 +85,7 @@ async fn build_fixture() -> Fixture {
 
     let now = vtc_service::auth::session::now_epoch();
     store_acl_entry(
-        &acl_ks,
+        &vtc.state.acl_ks,
         &VtcAclEntry {
             did: member_did.clone(),
             role: VtcRole::Member,
@@ -139,11 +100,11 @@ async fn build_fixture() -> Fixture {
     .unwrap();
     let mut m = Member::fresh(&member_did);
     m.status_list_index = Some(slot);
-    store_member(&members_ks, &m).await.unwrap();
+    store_member(&vtc.state.members_ks, &m).await.unwrap();
 
     let session_id = "test-rot-session";
     store_session(
-        &sessions_ks,
+        &vtc.state.sessions_ks,
         &Session {
             session_id: session_id.into(),
             did: member_did.clone(),
@@ -162,7 +123,7 @@ async fn build_fixture() -> Fixture {
     .await
     .unwrap();
 
-    let member_claims = jwt_keys.new_claims(
+    let member_claims = vtc.jwt_keys.new_claims(
         member_did.clone(),
         session_id.into(),
         "reader".into(),
@@ -170,59 +131,12 @@ async fn build_fixture() -> Fixture {
         3600,
         true,
     );
-    let member_token = jwt_keys.encode(&member_claims).unwrap();
+    let member_token = vtc.jwt_keys.encode(&member_claims).unwrap();
 
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "{VTC_DID}"
-        public_url = "{PUBLIC_URL}"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks: acl_ks.clone(),
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks: members_ks.clone(),
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: Some(PUBLIC_URL.into()),
-        install_signer: None,
-        credential_signer: Some(signer.clone()),
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
+    let members_ks = vtc.state.members_ks.clone();
+    let acl_ks = vtc.state.acl_ks.clone();
+    let sessions_ks = vtc.state.sessions_ks.clone();
+    let router = vtc.router.clone();
 
     Fixture {
         router,
@@ -233,7 +147,7 @@ async fn build_fixture() -> Fixture {
         acl_ks,
         sessions_ks,
         signer,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -9,30 +9,15 @@
 //! 2. **CORS layer** wired into `routes::router()` returns the
 //!    expected headers on preflight + actual cross-origin requests.
 
-use std::sync::Arc;
-
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use http_body_util::BodyExt;
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::auth::jwt::JwtKeys;
 use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::config::{AppConfig, CorsConfig, MountConfig, RoutingConfig};
 use vtc_service::routes;
-use vtc_service::server::AppState;
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
+use vtc_service::test_support::TestVtc;
 
 // ═══════════════════════════════════════════════════════════════════
 // Config validation
@@ -226,84 +211,15 @@ fn accepts_https_and_http_origins() {
 // CORS layer wiring
 // ═══════════════════════════════════════════════════════════════════
 
-async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, tempfile::TempDir) {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
-
-    let mut config = cfg_with(RoutingConfig::default(), cors.clone());
-    config.auth.jwt_signing_key = Some(BASE64.encode(jwt_seed));
-    config.store.data_dir = dir.path().to_path_buf();
-
-    let state = AppState {
-        sessions_ks: sessions_ks.clone(),
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks: install_ks.clone(),
-        members_ks: members_ks.clone(),
-        join_requests_ks: join_requests_ks.clone(),
-        policies_ks: policies_ks.clone(),
-        active_policies_ks: active_policies_ks.clone(),
-        status_lists_ks: status_lists_ks.clone(),
-        registry_records_ks: registry_records_ks.clone(),
-        sync_queue_ks: sync_queue_ks.clone(),
-        sync_cursor_ks: sync_cursor_ks.clone(),
-        relationships_ks: relationships_ks.clone(),
-        relationships_by_did_ks: relationships_by_did_ks.clone(),
-        endorsement_types_ks: endorsement_types_ks.clone(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: endorsements_ks.clone(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
+async fn build_router_with_cors(cors: CorsConfig) -> (axum::Router, TestVtc) {
+    // CORS is applied as an explicit layer below, independent of the
+    // state's own config — so a default `TestVtc` state is sufficient.
+    let vtc = TestVtc::builder().build().await;
     let cors_layer = vtc_service_test_cors_layer(&cors);
-    let router = routes::router().with_state(state).layer(cors_layer);
-    (router, dir)
+    let router = routes::router()
+        .with_state(vtc.state.clone())
+        .layer(cors_layer);
+    (router, vtc)
 }
 
 /// Mirror of `server::build_cors_layer` for use in this integration

--- a/vtc-service/tests/routing_modes.rs
+++ b/vtc-service/tests/routing_modes.rs
@@ -24,102 +24,21 @@ use tower::ServiceExt;
 use vtc_service::config::{MountConfig, RoutingConfig};
 use vtc_service::routes;
 use vtc_service::routing::host_dispatch::{HostMap, enforce};
+use vtc_service::test_support::TestVtc;
 
-/// Build a router using only the placeholder + health surfaces;
-/// the API sub-router needs full `AppState` but route-priority
-/// tests only need to see whether prefixes dispatch correctly.
-/// We rely on `routes::router_with()` plus a default state where
-/// every keyspace is open against a tempdir.
-async fn build_router(routing: &RoutingConfig) -> (Router, tempfile::TempDir) {
-    use std::sync::Arc;
-    use tokio::sync::RwLock;
-
-    use base64::Engine;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
-    use vtc_service::config::AppConfig;
-    use vtc_service::server::AppState;
-    use vti_common::auth::jwt::JwtKeys;
-    use vti_common::config::StoreConfig;
-    use vti_common::store::Store;
-
-    init_jwt_provider();
-
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let install_ks = store.keyspace("install").unwrap();
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "did:key:z6MkTestVTC"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        BASE64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks: store.keyspace("sessions").unwrap(),
-        acl_ks: store.keyspace("acl").unwrap(),
-        community_ks: store.keyspace("community").unwrap(),
-        config_ks: store.keyspace("config").unwrap(),
-        passkey_ks: store.keyspace("passkey").unwrap(),
-        install_ks: install_ks.clone(),
-        members_ks: store.keyspace("members").unwrap(),
-        join_requests_ks: store.keyspace("join_requests").unwrap(),
-        policies_ks: store.keyspace("policies").unwrap(),
-        active_policies_ks: store.keyspace("active_policies").unwrap(),
-        status_lists_ks: store.keyspace("status_lists").unwrap(),
-        registry_records_ks: store.keyspace("registry_records").unwrap(),
-        sync_queue_ks: store.keyspace("sync_queue").unwrap(),
-        sync_cursor_ks: store.keyspace("sync_cursor").unwrap(),
-        relationships_ks: store.keyspace("relationships").unwrap(),
-        relationships_by_did_ks: store.keyspace("relationships_by_did").unwrap(),
-        endorsement_types_ks: store.keyspace("endorsement_types").unwrap(),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: store.keyspace("endorsements").unwrap(),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
-        audit_ks: store.keyspace("audit").unwrap(),
-        audit_key_ks: store.keyspace("audit_key").unwrap(),
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
+/// Build a router using the requested routing config over a default
+/// `TestVtc` state. Route-priority tests only need to see whether
+/// prefixes dispatch correctly.
+async fn build_router(routing: &RoutingConfig) -> (Router, TestVtc) {
+    let vtc = TestVtc::builder()
+        .vtc_did("did:key:z6MkTestVTC")
+        .build()
+        .await;
     #[cfg(feature = "website")]
-    let router = routes::router_with(routing, None).with_state(state);
+    let router = routes::router_with(routing, None).with_state(vtc.state.clone());
     #[cfg(not(feature = "website"))]
-    let router = routes::router_with(routing).with_state(state);
-    (router, dir)
-}
-
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
+    let router = routes::router_with(routing).with_state(vtc.state.clone());
+    (router, vtc)
 }
 
 async fn request(router: &Router, req: Request<Body>) -> (StatusCode, Vec<u8>) {

--- a/vtc-service/tests/status_lists.rs
+++ b/vtc-service/tests/status_lists.rs
@@ -17,139 +17,46 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::Value;
-use tokio::sync::RwLock;
 use tower::ServiceExt;
-use vti_common::audit::{AuditKeyStore, AuditWriter};
-use vti_common::auth::jwt::JwtKeys;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
-use vtc_service::config::AppConfig;
 use vtc_service::credentials::LocalSigner;
-use vtc_service::install::InstallTokenStore;
-use vtc_service::routes;
-use vtc_service::server::AppState;
 use vtc_service::status_list;
+use vtc_service::test_support::TestVtc;
 
 const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 const PUBLIC_URL: &str = "https://vtc.example.com";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
     signer: Arc<LocalSigner>,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture(with_signer: bool) -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let community_ks = store.keyspace("community").unwrap();
-    let config_ks = store.keyspace("config").unwrap();
-    let passkey_ks = store.keyspace("passkey").unwrap();
-    let install_ks = store.keyspace("install").unwrap();
-    let members_ks = store.keyspace("members").unwrap();
-    let join_requests_ks = store.keyspace("join_requests").unwrap();
-    let policies_ks = store.keyspace("policies").unwrap();
-    let active_policies_ks = store.keyspace("active_policies").unwrap();
-    let status_lists_ks = store.keyspace("status_lists").unwrap();
-    let registry_records_ks = store.keyspace("registry_records").unwrap();
-    let sync_queue_ks = store.keyspace("sync_queue").unwrap();
-    let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
-    let relationships_ks = store.keyspace("relationships").unwrap();
-    let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
-    let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
-    let endorsements_ks = store.keyspace("endorsements").unwrap();
-    let audit_ks = store.keyspace("audit").unwrap();
-    let audit_key_ks = store.keyspace("audit_key").unwrap();
-    let install_store = InstallTokenStore::new(install_ks.clone());
+    // The signer is held by the fixture and used to verify the served VC,
+    // so it must be the exact instance the AppState issues with.
+    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
+    let mut builder = TestVtc::builder()
+        .with_audit(true)
+        .with_public_url(PUBLIC_URL);
+    if with_signer {
+        builder = builder.with_credential_signer(signer.clone());
+    }
+    let vtc = builder.build().await;
 
     // Seed both status lists like `server::run` does at boot.
-    let signer = Arc::new(LocalSigner::from_ed25519_seed(VTC_DID.into(), &[0xCC; 32]));
     for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
         let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
-        status_list::ensure_initial(&status_lists_ks, purpose, url)
+        status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
             .await
             .unwrap();
     }
 
-    let key_store = AuditKeyStore::new(audit_key_ks.clone());
-    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
-    let audit_writer = Some(AuditWriter::new(audit_ks.clone(), key_store));
-
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").unwrap());
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "{VTC_DID}"
-        public_url = "{PUBLIC_URL}"
-        [store]
-        data_dir = "{}"
-        "#,
-        dir.path().display(),
-    ))
-    .expect("parse config");
-
-    let state = AppState {
-        sessions_ks,
-        acl_ks,
-        community_ks,
-        config_ks,
-        passkey_ks,
-        install_ks,
-        members_ks,
-        join_requests_ks,
-        policies_ks,
-        active_policies_ks,
-        status_lists_ks,
-        registry_records_ks,
-        sync_queue_ks,
-        sync_cursor_ks,
-        relationships_ks,
-        relationships_by_did_ks,
-        endorsement_types_ks,
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks,
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        audit_ks,
-        audit_key_ks,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: None,
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: Some(PUBLIC_URL.into()),
-        install_signer: None,
-        credential_signer: with_signer.then(|| signer.clone()),
-        install_store,
-        audit_writer,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
-
-    let router = routes::router().with_state(state);
-
     Fixture {
-        router,
+        router: vtc.router.clone(),
         signer,
-        _dir: dir,
+        _vtc: vtc,
     }
 }
 

--- a/vtc-service/tests/test_support_smoke.rs
+++ b/vtc-service/tests/test_support_smoke.rs
@@ -1,0 +1,84 @@
+//! Smoke coverage for `vtc_service::test_support` itself — the harness
+//! the rest of the integration suite (and downstream `vti-harness`)
+//! builds on. Pins the `TestVtc` builder, token minting, and the
+//! `MockVtc` listening server.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use vtc_service::test_support::{MockVtc, TestVtc, build_test_vtc};
+
+/// `build_test_vtc()` yields a router whose `/health` endpoint answers —
+/// the cheapest proof the `AppState` is wired and the router assembles.
+#[tokio::test]
+async fn build_test_vtc_serves_health() {
+    let tv = build_test_vtc().await;
+    let resp = tv
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+/// A minted admin token authenticates against an admin-gated route (here
+/// the session row + JWT are both produced by `TestVtc::token`).
+#[tokio::test]
+async fn minted_admin_token_is_accepted() {
+    let tv = TestVtc::builder().build().await;
+    let token = tv.admin_token().await;
+
+    // `GET /v1/admin/config` is AdminAuth-gated; with a valid admin token
+    // it must not 401/403. (200 or any non-auth status is fine here — we
+    // only assert the auth gate let us through.)
+    let resp = tv
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/admin/config")
+                .header(
+                    "trust-task",
+                    "https://trusttasks.org/openvtc/vtc/admin/config/manage/1.0",
+                )
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+/// Opting into signers makes the credential + install signers present, so
+/// the routes that 503 without them are unblocked.
+#[tokio::test]
+async fn with_signers_populates_credential_and_install_signers() {
+    let tv = TestVtc::builder()
+        .with_signers(true)
+        .with_public_url("http://vtc.test")
+        .build()
+        .await;
+    assert!(tv.state.credential_signer.is_some());
+    assert!(tv.state.install_signer.is_some());
+    assert!(tv.state.webauthn.is_some());
+}
+
+/// `MockVtc` binds a real loopback port and serves `/health` over HTTP.
+#[tokio::test]
+async fn mock_vtc_serves_over_http() {
+    let mock = MockVtc::start().await;
+    let url = format!("{}/health", mock.base_url());
+    let resp = reqwest::get(&url).await.expect("GET /health");
+    assert_eq!(resp.status(), StatusCode::OK);
+    mock.shutdown().await;
+}

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -14,8 +14,6 @@
 
 mod common;
 
-use std::sync::Arc;
-
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use base64::Engine;
@@ -23,115 +21,37 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
 use ed25519_dalek::{Signer, SigningKey};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
 use tower::ServiceExt;
 
-use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
-use vti_common::auth::jwt::JwtKeys;
 use vti_common::auth::session::now_epoch;
-use vti_common::config::StoreConfig;
-use vti_common::store::Store;
 
 use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
-use vtc_service::config::AppConfig;
-use vtc_service::routes;
-use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
 
 /// The RP (this VTC's) DID — only ever string-compared as the id_token
 /// `aud`, so it need not be resolvable.
 const VTC_DID: &str = "did:webvh:scidvtc:vtc.example.com";
 const AUTH_TYPE: &str = "https://trusttasks.org/spec/auth/authenticate/0.1";
 
-fn init_jwt_provider() {
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    });
-}
-
 struct Fixture {
     router: axum::Router,
-    _dir: tempfile::TempDir,
+    // Owns the temp data dir + serves `router`'s state; must outlive them.
+    _vtc: TestVtc,
 }
 
 async fn build_fixture(holder_did: &str) -> Fixture {
-    init_jwt_provider();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let store = Store::open(&StoreConfig {
-        data_dir: dir.path().to_path_buf(),
-    })
-    .expect("open store");
-
-    macro_rules! ks {
-        ($n:literal) => {
-            store.keyspace($n).unwrap()
-        };
-    }
-    let install_ks = ks!("install");
-    let jwt_seed = [0x42u8; 32];
-    let jwt_keys = Arc::new(JwtKeys::from_ed25519_bytes(&jwt_seed, "VTC").expect("jwt keys"));
-
-    let config: AppConfig = toml::from_str(&format!(
-        r#"
-        vtc_did = "{VTC_DID}"
-        [store]
-        data_dir = "{}"
-        [auth]
-        jwt_signing_key = "{}"
-        "#,
-        dir.path().display(),
-        B64.encode(jwt_seed),
-    ))
-    .expect("parse config");
-
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
-        .await
-        .expect("did resolver");
-
-    let state = AppState {
-        sessions_ks: ks!("sessions"),
-        acl_ks: ks!("acl"),
-        community_ks: ks!("community"),
-        config_ks: ks!("config"),
-        passkey_ks: ks!("passkey"),
-        install_ks: install_ks.clone(),
-        members_ks: ks!("members"),
-        join_requests_ks: ks!("join_requests"),
-        policies_ks: ks!("policies"),
-        active_policies_ks: ks!("active_policies"),
-        status_lists_ks: ks!("status_lists"),
-        registry_records_ks: ks!("registry_records"),
-        sync_queue_ks: ks!("sync_queue"),
-        sync_cursor_ks: ks!("sync_cursor"),
-        relationships_ks: ks!("relationships"),
-        relationships_by_did_ks: ks!("relationships_by_did"),
-        endorsement_types_ks: ks!("endorsement_types"),
-        schemas_ks: store.keyspace("schemas").unwrap(),
-        endorsements_ks: ks!("endorsements"),
-        registry_client: None,
-        registry_health: vtc_service::registry::RegistryHealth::new(),
-        credential_signer: None,
-        config: Arc::new(RwLock::new(config)),
-        did_resolver: Some(did_resolver),
-        secrets_resolver: None,
-        jwt_keys: Some(jwt_keys),
-        atm: None,
-        webauthn: None,
-        public_url: None,
-        install_signer: None,
-        install_store: vtc_service::install::InstallTokenStore::new(install_ks),
-        audit_ks: ks!("audit"),
-        audit_key_ks: ks!("audit_key"),
-        audit_writer: None,
-        shutdown_tx: tokio::sync::watch::channel(false).0,
-        supervisor: None,
-    };
+    // The SIOP wallet-login path resolves the presented holder DID through
+    // a live `DIDCacheClient`.
+    let vtc = TestVtc::builder()
+        .vtc_did(VTC_DID)
+        .with_did_resolver(true)
+        .build()
+        .await;
 
     // The holder must be an ACL admin: challenge issuance and the
     // authenticate step both gate on the ACL.
     store_acl_entry(
-        &state.acl_ks,
+        &vtc.state.acl_ks,
         &VtcAclEntry {
             did: holder_did.into(),
             role: VtcRole::Admin,
@@ -145,8 +65,10 @@ async fn build_fixture(holder_did: &str) -> Fixture {
     .await
     .expect("acl insert");
 
-    let router = routes::router().with_state(state);
-    Fixture { router, _dir: dir }
+    Fixture {
+        router: vtc.router.clone(),
+        _vtc: vtc,
+    }
 }
 
 /// A fresh Ed25519 holder identity as a `did:key`, plus its


### PR DESCRIPTION
## What

Implements **P0.1** of `tasks/test-harness-plan.md`: a `vtc_service::test_support`
harness (VTC counterpart to `vta_service::test_support`), and migrates 26 of 28
integration-test fixtures onto it.

Before this, every `vtc-service/tests/*.rs` hand-rolled the same ~140-line fixture
(open ~21 keyspaces → build `AppState` → `routes::router().with_state(...)`). A new
`AppState` field meant a 28-file sweep. Now it's a one-file change (the builder).

## The harness

New `test-support` feature exposes:

- **`TestVtc` / `TestVtcBuilder`** — a tempdir-backed in-process VTC. Opt into the
  axes the fixtures actually vary:
  `with_audit`, `with_signers`, `with_public_url` (WebAuthn), `with_did_resolver`,
  `with_credential_signer` / `with_install_signer` (inject a specific signer so
  tests can verify issued credentials / install tokens against a held key),
  `vtc_did`, `supervisor`; plus `data_dir()` and `token()/admin_token()`.
- **`MockVtc`** — a real listening server on an ephemeral loopback port (mirrors
  `MockVta`), for over-the-wire harness tests.

Each builder axis was added in response to a real fixture need and validated
against it — never speculatively.

## Migration

26 of 28 fixtures migrated; every suite passes; `clippy --tests --features
test-support -D warnings` clean throughout. Net **~−1,800 LOC** of duplicated
wiring removed. Coverage spans every shape: all-defaults, custom `vtc_did`,
post-build seeding (ACL/member/status-list/default-policy), custom
token/cookie/mint helpers, tuple-returning fixtures, signer-verifying fixtures,
the soft-WebAuthn registration ceremony (`admin_passkeys`), and the 1,785-LOC
`join_requests` (37 tests).

**Two fixtures intentionally left inline** (documented in their commits):
- `passkey_state` — a sync fixture testing `AppState`'s trait impl directly; the
  async builder would force converting every test to async for no gain.
- `emergency_bootstrap` — a store-level recovery test with a bespoke in-memory
  secret store + mock prover + bundle-derived keys; legitimately builds its own
  `Store`+`AppState`.

## Notes

- `MockVtc`'s smoke test binds a real loopback port — passes locally/CI, skipped
  under sandboxed command runners.
- This is the foundation the rest of `tasks/test-harness-plan.md` builds on
  (the `vti-harness` multi-service fabric and DIDComm loopback).