### PR TITLE
fix(vta-service): request timeout + governed unauth attestation & blob branches (P0.10)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -67,8 +67,17 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
 - `[ ]` **P0.9** (M) Boot-time `config::validate()`; `deny_unknown_fields`;
   hard-fail missing identity unless `--allow-degraded`; explicit opt-in for
   plaintext seed store — PR: ____
-- `[ ]` **P0.10** (S) `TimeoutLayer`; attestation routes onto governed branch;
-  explicit 100 MB layer + governor on `/backup/blob` — PR: ____
+- `[~]` **P0.10** (S) `TimeoutLayer`; attestation routes onto governed branch;
+  explicit 100 MB layer + governor on `/backup/blob` — branch
+  `fix/p0.10-timeouts-ratelimit`. Global `TimeoutLayer` (120s, →408) as the
+  hang backstop; moved the 4 unauth attestation routes (status, report
+  GET+POST, did-log) onto the rate-limited+body-capped unauth branch
+  (mnemonic stays authed); blob branch now has an explicit
+  `DefaultBodyLimit::max(100MB)` (was `disable()`) + the governor.
+  Factored `apply_unauth_governor()` (DRYs the trust_xff if/else, reused by
+  both branches). Tests: blob+attestation 429 floods, 408 slow-handler,
+  existing /auth/challenge 429 still green. tower-http `timeout` feature
+  added — PR: ____
 - `[~]` **P0.11** (S) BBS matchable ⇒ presentable — branch
   `fix/p0.11-bbs-presentable`. Chose UNMATCH: `dcql_format` returns `None`
   for `Bbs2023` (was `Some("ldp_vc")` → matched-then-failed the whole

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -77,7 +77,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   Factored `apply_unauth_governor()` (DRYs the trust_xff if/else, reused by
   both branches). Tests: blob+attestation 429 floods, 408 slow-handler,
   existing /auth/challenge 429 still green. tower-http `timeout` feature
-  added — PR: ____
+  added — PR: #352 (in review)
 - `[~]` **P0.11** (S) BBS matchable ⇒ presentable — branch
   `fix/p0.11-bbs-presentable`. Chose UNMATCH: `dcql_format` returns `None`
   for `Bbs2023` (was `Some("ldp_vc")` → matched-then-failed the whole

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -137,7 +137,7 @@ axum-extra = { workspace = true }
 jsonwebtoken = { workspace = true }
 fjall = { workspace = true }
 toml = { workspace = true }
-tower-http = { workspace = true, features = ["trace", "limit", "cors"] }
+tower-http = { workspace = true, features = ["trace", "limit", "cors", "timeout"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -232,6 +232,12 @@ vta-service = { path = ".", features = ["test-support"] }
 # binary required. Loopback HTTP is accepted by `WebvhClient::new`'s
 # HTTPS policy, so no insecure-test knob is needed.
 wiremock = "0.6"
+# Drives the focused request-timeout regression test (a standalone
+# router with a short TimeoutLayer + a sleepy handler → 408). The
+# production router uses the same layer at REQUEST_TIMEOUT; testing the
+# wiring with a short duration keeps the test deterministic.
+tower-http = { workspace = true, features = ["timeout"] }
+tower = { version = "0.5", features = ["util"] }
 
 [lints]
 workspace = true

--- a/vta-service/src/routes/backup_blob.rs
+++ b/vta-service/src/routes/backup_blob.rs
@@ -349,9 +349,14 @@ async fn set_file_mode_600(path: &std::path::Path) -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
     //! Integration tests for the blob endpoints. Exercise the full
-    //! router (`build_test_app`) so the body-cap layer disable, the
-    //! token header extraction, and the state-machine guards all
-    //! land at the same level the real service runs.
+    //! router (`build_test_app`) so the body-cap layer, the token header
+    //! extraction, and the state-machine guards all land at the same level
+    //! the real service runs.
+    //!
+    //! Every request carries an `x-forwarded-for` header: the blob branch
+    //! is rate-limited (P0.10) and `tower::oneshot` carries no socket peer
+    //! IP, so the governor's key extractor needs an explicit client IP
+    //! (production requests always have a peer address or a proxy XFF).
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
@@ -445,6 +450,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("GET")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, &token)
             .body(Body::empty())
             .unwrap();
@@ -473,6 +479,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("GET")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, &token)
             .body(Body::empty())
             .unwrap();
@@ -483,6 +490,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("GET")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, &token)
             .body(Body::empty())
             .unwrap();
@@ -498,6 +506,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("GET")
+            .header("x-forwarded-for", "192.0.2.1")
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -511,6 +520,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("GET")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, "bogus-token")
             .body(Body::empty())
             .unwrap();
@@ -524,6 +534,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{}", Uuid::new_v4()))
             .method("GET")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, "any-token")
             .body(Body::empty())
             .unwrap();
@@ -540,6 +551,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("GET")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, &token)
             .body(Body::empty())
             .unwrap();
@@ -553,6 +565,7 @@ mod tests {
         let req = Request::builder()
             .uri("/backup/blob/not-a-uuid")
             .method("GET")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, "x")
             .body(Body::empty())
             .unwrap();
@@ -569,6 +582,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("POST")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, &token)
             .body(Body::from(bytes.clone()))
             .unwrap();
@@ -596,6 +610,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("POST")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, &token)
             .body(Body::from(b"short".to_vec()))
             .unwrap();
@@ -615,6 +630,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("POST")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, &token)
             .body(Body::from(tampered))
             .unwrap();
@@ -632,6 +648,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("POST")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, &token)
             .body(Body::from(bytes.clone()))
             .unwrap();
@@ -642,6 +659,7 @@ mod tests {
         let req = Request::builder()
             .uri(format!("/backup/blob/{bundle_id}"))
             .method("POST")
+            .header("x-forwarded-for", "192.0.2.1")
             .header(TOKEN_HEADER, &token)
             .body(Body::from(bytes))
             .unwrap();

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod trust_tasks;
 mod vta;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Router;
 use axum::extract::DefaultBodyLimit;
@@ -33,6 +34,7 @@ use axum::routing::{delete, get, post, put};
 use tower_governor::GovernorLayer;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::timeout::TimeoutLayer;
 
 use crate::server::AppState;
 
@@ -70,6 +72,51 @@ pub(super) const BACKUP_BLOB_BODY_SIZE: usize = 100 * 1024 * 1024;
 /// them protects VTA CPU regardless of any reverse proxy upstream.
 const UNAUTH_RPS: u64 = 5;
 const UNAUTH_BURST: u32 = 10;
+
+/// Global per-request timeout. The REST surface runs on a current-thread
+/// runtime, so a handler that stalls on network I/O (a dead mediator, a
+/// slow remote DID host) would otherwise hold its connection — and a
+/// caller's patience — indefinitely. Generous on purpose: longer than any
+/// legitimate single request (local-fast backups, self-limiting mediator
+/// handshakes, a 100 MB blob transfer at modest bandwidth) but bounded, so
+/// "indefinite" becomes "120 s then 408". Not a substitute for the
+/// handshake/op-specific timeouts, which stay; this is the backstop.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Apply the unauthenticated-endpoint rate limiter to `router`.
+///
+/// Split out so the two key extractors — which instantiate
+/// `GovernorConfig` at distinct generic types — are confined here and the
+/// returned `Router<AppState>` is uniform (type-erased by axum). Used for
+/// both the unauth branch and the token-gated backup-blob branch, which is
+/// otherwise an unthrottled large-body write surface.
+///
+/// `trust_xff`: `false` keys on the socket peer (`PeerIpKeyExtractor`,
+/// spoof-safe for direct binding); `true` honours `X-Forwarded-For`
+/// (`SmartIpKeyExtractor`, only safe behind a header-sanitising proxy).
+fn apply_unauth_governor(router: Router<AppState>, trust_xff: bool) -> Router<AppState> {
+    if trust_xff {
+        let cfg = Arc::new(
+            GovernorConfigBuilder::default()
+                .per_second(UNAUTH_RPS)
+                .burst_size(UNAUTH_BURST)
+                .key_extractor(tower_governor::key_extractor::SmartIpKeyExtractor)
+                .finish()
+                .expect("governor config values are static and non-zero"),
+        );
+        router.layer(GovernorLayer::new(cfg))
+    } else {
+        let cfg = Arc::new(
+            GovernorConfigBuilder::default()
+                .per_second(UNAUTH_RPS)
+                .burst_size(UNAUTH_BURST)
+                .key_extractor(tower_governor::key_extractor::PeerIpKeyExtractor)
+                .finish()
+                .expect("governor config values are static and non-zero"),
+        );
+        router.layer(GovernorLayer::new(cfg))
+    }
+}
 
 /// Health-check route — served without the request/response trace layer.
 /// Minimal response only; detailed info requires authentication.
@@ -187,12 +234,21 @@ pub fn router_with_cors(allowed_origins: &[String], trust_xff: bool) -> Router<A
         // Auth flow entry points
         .route("/auth/challenge", post(auth::challenge))
         .route("/auth/", post(auth::authenticate))
-        .route("/auth/refresh", post(auth::refresh))
-        // Tighter body cap on unauth endpoints — see UNAUTH_BODY_SIZE.
-        // Layered on this sub-router (not the global one) so authenticated
-        // endpoints keep the regular MAX_BODY_SIZE budget needed for backup
-        // import etc.
-        .layer(DefaultBodyLimit::max(UNAUTH_BODY_SIZE));
+        .route("/auth/refresh", post(auth::refresh));
+    // Public, unauthenticated TEE attestation endpoints. These take no
+    // auth extractor and run crypto on caller input (report generation),
+    // so they MUST sit on the rate-limited + body-capped unauth branch —
+    // not the main router, where they previously bypassed both. The
+    // super-admin `/attestation/mnemonic` routes stay on the authed
+    // router (JWT is their gate).
+    #[cfg(feature = "tee")]
+    let unauth = unauth
+        .route("/attestation/status", get(attestation::status))
+        .route(
+            "/attestation/report",
+            get(attestation::cached_report).post(attestation::generate_report),
+        )
+        .route("/attestation/did-log", get(attestation::did_log));
     #[cfg(feature = "webvh")]
     let unauth = unauth
         // Public did.jsonl retrieval — matches webvh's world-readable
@@ -200,31 +256,15 @@ pub fn router_with_cors(allowed_origins: &[String], trust_xff: bool) -> Router<A
         // limited via the same governor layer as the other unauth
         // endpoints.
         .route("/did/{did}/log", get(did_webvh::get_did_log_public_handler));
-    // Apply the rate-limit layer in a branch so the two key
-    // extractors' distinct generic types don't pollute the
-    // `unauth` shape. The layered router is type-erased on the
-    // axum side once we hand it off.
-    let unauth = if trust_xff {
-        let cfg = Arc::new(
-            GovernorConfigBuilder::default()
-                .per_second(UNAUTH_RPS)
-                .burst_size(UNAUTH_BURST)
-                .key_extractor(tower_governor::key_extractor::SmartIpKeyExtractor)
-                .finish()
-                .expect("governor config values are static and non-zero"),
-        );
-        unauth.layer(GovernorLayer::new(cfg))
-    } else {
-        let cfg = Arc::new(
-            GovernorConfigBuilder::default()
-                .per_second(UNAUTH_RPS)
-                .burst_size(UNAUTH_BURST)
-                .key_extractor(tower_governor::key_extractor::PeerIpKeyExtractor)
-                .finish()
-                .expect("governor config values are static and non-zero"),
-        );
-        unauth.layer(GovernorLayer::new(cfg))
-    };
+    // Tighter body cap on unauth endpoints — see UNAUTH_BODY_SIZE.
+    // Applied after ALL unauth routes (including the cfg-gated ones) are
+    // registered so every POST on this branch (auth, attestation report)
+    // gets the 64 KB ceiling, not just the base set. Layered here (not
+    // globally) so authenticated endpoints keep MAX_BODY_SIZE for backup
+    // import etc.
+    let unauth = unauth.layer(DefaultBodyLimit::max(UNAUTH_BODY_SIZE));
+    // Rate-limit every unauth endpoint (see `apply_unauth_governor`).
+    let unauth = apply_unauth_governor(unauth, trust_xff);
 
     // Auth portal — same-origin popup target for cross-origin WebAuthn
     // flows. Sits on its own router branch so:
@@ -359,21 +399,16 @@ pub fn router_with_cors(allowed_origins: &[String], trust_xff: bool) -> Router<A
                 .delete(cache::delete_cached),
         );
 
-    // TEE attestation routes (feature-gated)
+    // TEE attestation routes (feature-gated). The unauthenticated ones
+    // (`status`, `report`, `did-log`) live on the rate-limited `unauth`
+    // branch above; only the super-admin-gated mnemonic export stays on
+    // the authed router (JWT is its gate, so it's intentionally off the
+    // rate limiter like every other authed route).
     #[cfg(feature = "tee")]
-    let router = router
-        .route("/attestation/status", get(attestation::status))
-        .route(
-            "/attestation/report",
-            get(attestation::cached_report).post(attestation::generate_report),
-        )
-        // Mnemonic export (super admin only, time-limited)
-        .route(
-            "/attestation/mnemonic",
-            get(attestation::mnemonic_status).post(attestation::mnemonic_export),
-        )
-        // Auto-generated DID log (unauthenticated — public data)
-        .route("/attestation/did-log", get(attestation::did_log));
+    let router = router.route(
+        "/attestation/mnemonic",
+        get(attestation::mnemonic_status).post(attestation::mnemonic_export),
+    );
     // `GET /attestation/admin-credential` retired in Phase 3 —
     // sealed-bootstrap Mode B replaces it via `POST /bootstrap/request`.
 
@@ -501,20 +536,24 @@ pub fn router_with_cors(allowed_origins: &[String], trust_xff: bool) -> Router<A
     // in `docs/05-design-notes/backup-descriptor-pattern.md`
     // §"Auth model".
     //
-    // Body limit is disabled at the router level so the global
-    // `MAX_BODY_SIZE` (1 MB) doesn't constrain backups, which
-    // legitimately need 10s of MB. The handler enforces a
-    // `BACKUP_BLOB_BODY_SIZE` (100 MB) ceiling itself via
-    // `axum::body::to_bytes` so we still reject pathological
-    // uploads; doing it inside the handler keeps the limit
-    // visible in one place (not split between two layers with
-    // ambiguous override semantics).
+    // Body limit: an explicit `BACKUP_BLOB_BODY_SIZE` (100 MB) layer —
+    // NOT `disable()`. The global `MAX_BODY_SIZE` (1 MB) is too small for
+    // backups (10s of MB), but `disable()` meant any future handler added
+    // to this branch silently inherited an *unlimited* body. The layer is
+    // a branch backstop at the same value the handler already enforces via
+    // `axum::body::to_bytes` (both at `BACKUP_BLOB_BODY_SIZE`, so they
+    // agree — no ambiguous override).
+    //
+    // Rate-limited like the unauth branch: the token gate is real, but
+    // without throttling an attacker replaying/guessing bundle_ids gets
+    // free 100 MB disk-write attempts and free SHA-256 over 100 MB bodies.
     let backup_blob_router = Router::new()
         .route(
             "/backup/blob/{bundle_id}",
             get(backup_blob::get_blob).post(backup_blob::post_blob),
         )
-        .layer(DefaultBodyLimit::disable());
+        .layer(DefaultBodyLimit::max(BACKUP_BLOB_BODY_SIZE));
+    let backup_blob_router = apply_unauth_governor(backup_blob_router, trust_xff);
     let router = router.merge(backup_blob_router);
 
     // Authenticated health details and capabilities
@@ -522,12 +561,23 @@ pub fn router_with_cors(allowed_origins: &[String], trust_xff: bool) -> Router<A
         .route("/health/details", get(health::health_details))
         .route("/capabilities", get(capabilities::capabilities));
 
-    // Apply global request body size limit to protect enclave memory
-    let router = router.layer(DefaultBodyLimit::max(MAX_BODY_SIZE));
+    // Apply global request body size limit to protect enclave memory,
+    // plus the global request timeout backstop (no handler may hold a
+    // connection indefinitely). The blob branch's own 100 MB body limit,
+    // applied inner to this 1 MB global one, still wins for that branch
+    // (the inner layer sets the limit extension last).
+    let router =
+        router
+            .layer(DefaultBodyLimit::max(MAX_BODY_SIZE))
+            .layer(TimeoutLayer::with_status_code(
+                axum::http::StatusCode::REQUEST_TIMEOUT,
+                REQUEST_TIMEOUT,
+            ));
 
     // Apply CORS conditionally — empty origin list = no layer at all
     // (preserves the legacy no-cross-origin behaviour for production
-    // deployments that don't need browser-side fetch).
+    // deployments that don't need browser-side fetch). CORS stays
+    // outermost so preflight handling and headers wrap the timeout.
     match build_cors_layer(allowed_origins) {
         Some(cors) => router.layer(cors),
         None => router,

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -3459,6 +3459,101 @@ async fn unauth_endpoint_rate_limit_returns_429_after_burst() {
     );
 }
 
+/// P0.10: the token-gated backup-blob branch must also be rate-limited.
+/// Without a token the handler rejects the request, but the governor sits
+/// *outside* the handler, so a flood trips 429 before the handler ever
+/// runs — proving the branch carries the limiter (it previously did not).
+#[tokio::test]
+async fn backup_blob_branch_is_rate_limited() {
+    let (app, _ctx) = TestApp::new().await;
+    let mut saw_429 = false;
+    for _ in 0..20 {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/backup/blob/some-bundle-id")
+            .header("x-forwarded-for", "192.0.2.7")
+            .body(Body::empty())
+            .unwrap();
+        let (status, _) = app.request(req).await;
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            saw_429 = true;
+            break;
+        }
+    }
+    assert!(
+        saw_429,
+        "expected a 429 within 20 GET /backup/blob calls; the backup-blob \
+         branch is missing its GovernorLayer"
+    );
+}
+
+/// P0.10: the unauthenticated TEE attestation endpoints (`status`,
+/// `report`, `did-log`) were on the main router, bypassing the rate
+/// limiter. They now live on the governed `unauth` branch. Flooding
+/// `GET /attestation/status` must trip 429 — the governor runs before the
+/// handler, so this holds even though the test app has no real TEE state
+/// (the handler would otherwise error). Only the super-admin
+/// `/attestation/mnemonic` routes stay off the limiter (JWT-gated).
+#[cfg(feature = "tee")]
+#[tokio::test]
+async fn unauth_attestation_status_is_rate_limited() {
+    let (app, _ctx) = TestApp::new().await;
+    let mut saw_429 = false;
+    for _ in 0..20 {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/attestation/status")
+            .header("x-forwarded-for", "192.0.2.9")
+            .body(Body::empty())
+            .unwrap();
+        let (status, _) = app.request(req).await;
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            saw_429 = true;
+            break;
+        }
+    }
+    assert!(
+        saw_429,
+        "expected a 429 within 20 GET /attestation/status calls; the unauth \
+         attestation routes are not on the governed branch"
+    );
+}
+
+/// P0.10: a handler that stalls must not hold its connection forever. The
+/// production router wraps every route in a `TimeoutLayer` at
+/// `REQUEST_TIMEOUT`; this drives the same layer (at a short, deterministic
+/// duration) over a deliberately-slow handler and asserts it returns
+/// `408 Request Timeout` rather than hanging.
+#[tokio::test]
+async fn request_timeout_layer_returns_408_for_slow_handler() {
+    use std::time::Duration;
+    use tower::ServiceExt;
+    use tower_http::timeout::TimeoutLayer;
+
+    let app: axum::Router = axum::Router::new()
+        .route(
+            "/slow",
+            axum::routing::get(|| async {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                "should never arrive"
+            }),
+        )
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            Duration::from_millis(50),
+        ));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/slow").body(Body::empty()).unwrap())
+        .await
+        .expect("layer must produce a response, not hang");
+    assert_eq!(
+        resp.status(),
+        StatusCode::REQUEST_TIMEOUT,
+        "a handler slower than the timeout must yield 408, not block the connection"
+    );
+}
+
 /// `MAX_BODY_SIZE` (1 MB) is enforced via axum's `DefaultBodyLimit::max`
 /// across every authenticated mutation endpoint. A 1.5 MB body must
 /// be rejected with 413 — this is the protection against memory


### PR DESCRIPTION
## Summary

Plan task **P0.10** — three router-hardening gaps from the review.

### 1. No request timeout
The REST surface runs on a current-thread runtime, so a handler stalled on network I/O (dead mediator, slow DID host) held its connection **indefinitely**. Adds a global `TimeoutLayer` at `REQUEST_TIMEOUT` (**120 s → 408**) as the backstop — generous enough for any legitimate single request (local-fast backups, self-limiting handshakes, a 100 MB blob transfer at modest bandwidth), bounded so "indefinite" becomes "120 s then 408". Not a replacement for the op-specific handshake timeouts, which stay.

### 2. Unauthenticated attestation routes bypassed the rate limiter
`GET /attestation/status`, `GET+POST /attestation/report`, and `GET /attestation/did-log` take **no auth extractor** (report even runs crypto on caller input) yet were on the **main** router, outside the governor + body cap — breaking the "branch ⇒ posture" invariant. They now live on the unauth branch (rate-limited + 64 KB cap). The super-admin `/attestation/mnemonic` routes stay on the authed router (JWT is their gate).

### 3. `/backup/blob` — disabled body limit + no rate limit
`DefaultBodyLimit::disable()` meant any future handler on that branch silently inherited an **unlimited** body; replaced with an explicit 100 MB layer (same value the handler's `to_bytes` already enforces, so they agree — no ambiguity). Added the governor: the `X-Backup-Token` gate is real, but without throttling an attacker replaying bundle_ids gets free 100 MB disk-write + SHA-256 attempts.

Factored `apply_unauth_governor()` to DRY the `trust_xff` key-extractor if/else, now reused by both the unauth and blob branches.

## Tests
- 429 floods on `/backup/blob` and (tee) `/attestation/status`.
- A 408 slow-handler timeout test (focused mini-router at a short duration; production uses the same layer at `REQUEST_TIMEOUT`).
- The existing `/auth/challenge` 429 test still passes — proving the `apply_unauth_governor` refactor preserved behaviour.
- The blob **unit** tests now stamp `x-forwarded-for`: their branch is now governed and `tower::oneshot` carries no peer IP (production always has one via `ConnectInfo`/proxy). This is a test-harness artifact, not a production behaviour change.

Gate: workspace 82 suites / 0 failures, tee api_integration green, clippy clean (default + tee), fmt. Adds the tower-http `timeout` feature; no `Cargo.lock` change.

## Invariants preserved
Router branch ⇒ posture (now *strengthened* — the unauth attestation routes join the governed branch); JWT routes stay off the limiter; `/auth/portal` off both; CORS stays outermost; `/acl/swap` ordering; the blob branch's 100 MB cap still wins over the global 1 MB (inner layer).