### PR TITLE
fix(vta-service): zeroize master-seed bytes; drop ineffective secret-delete overwrite (P0.7 part 1)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -60,7 +60,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   derivation.rs) wrapped too. `delete_secret` dropped its ineffective
   zero-overwrite (LSM keeps old SSTables; value is ciphertext anyway) with an
   honest comment. Trait-level `SeedStore::get` Zeroizing deferred (crosses
-  vtc + 8 backends) — PR: ____
+  vtc + 8 backends) — PR: #353 (in review)
 - `[ ]` **P0.7b** (L) Encrypt the retired-seed archive independently of the
   keyspace-encryption flag. Split from P0.7: needs a rotation-re-encryption
   (or successor-chain) design + a migration for existing plaintext archives —

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -52,8 +52,21 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   refusal+no-mutation (tee), trait flag, existing non-TEE rotation unaffected
   — PR: #344 (merged). Follow-up: in-place re-encryption so TEE rotation
   works rather than refuses (needs runtime KMS access on KmsTeeSeedStore).
-- `[ ]` **P0.7** (M) `Zeroizing` seed bytes end-to-end; encrypt retired-seed
-  archive; fix "secure deletion" claim — PR: ____
+- `[~]` **P0.7a** (S) `Zeroizing` seed bytes + honest "secure deletion" —
+  branch `fix/p0.7-seed-zeroize` (isolated worktree). `load_seed_bytes`
+  returns `Zeroizing<Vec<u8>>` (the 40-caller key-derivation path — all use
+  `&seed`, so transparent via Deref); the low-level `rotate_seed`'s old/new
+  master seeds and the two direct `seed_store.get()` callers (status.rs,
+  derivation.rs) wrapped too. `delete_secret` dropped its ineffective
+  zero-overwrite (LSM keeps old SSTables; value is ciphertext anyway) with an
+  honest comment. Trait-level `SeedStore::get` Zeroizing deferred (crosses
+  vtc + 8 backends) — PR: ____
+- `[ ]` **P0.7b** (L) Encrypt the retired-seed archive independently of the
+  keyspace-encryption flag. Split from P0.7: needs a rotation-re-encryption
+  (or successor-chain) design + a migration for existing plaintext archives —
+  the KEK derives from the *rotating* master seed, so it's not a casual reuse
+  of the imported-secrets pattern. Plaintext master seeds on disk only when:
+  non-TEE + no `storage_encryption_key` + has rotated — PR: ____
 - `[x]` **P0.8** (S) Atomic + persisted carve-out close — branch
   `fix/p0.8-carveout-durability`. Added `KeyspaceHandle::persist()` (local
   fsync + vsock OP_PERSIST passthrough). `mint_mode_b` now: seal first

--- a/vta-service/src/keys/derivation.rs
+++ b/vta-service/src/keys/derivation.rs
@@ -121,6 +121,8 @@ pub async fn load_or_generate_seed(
 
     if let Some(existing) = seed_store.get().await? {
         debug!("master seed loaded from store");
+        // Master seed in plaintext — wipe on drop (P0.7).
+        let existing = zeroize::Zeroizing::new(existing);
         return ExtendedSigningKey::from_seed(&existing).map_err(|e| {
             key_derivation_error(format!(
                 "Couldn't create bip32 root signing key! Reason: {e}"
@@ -128,11 +130,11 @@ pub async fn load_or_generate_seed(
         });
     }
 
-    let mut seed = [0u8; 32];
-    rand::rng().fill_bytes(&mut seed);
-    seed_store.set(&seed).await?;
+    let mut seed = zeroize::Zeroizing::new([0u8; 32]);
+    rand::rng().fill_bytes(&mut *seed);
+    seed_store.set(&*seed).await?;
     info!("new random master seed generated and stored");
-    ExtendedSigningKey::from_seed(&seed).map_err(|e| {
+    ExtendedSigningKey::from_seed(&*seed).map_err(|e| {
         key_derivation_error(format!(
             "Couldn't create bip32 root signing key! Reason: {e}"
         ))

--- a/vta-service/src/keys/imported.rs
+++ b/vta-service/src/keys/imported.rs
@@ -159,14 +159,19 @@ pub async fn load_secret(
     Ok(std::mem::take(&mut plaintext))
 }
 
-/// Securely delete an imported secret (overwrite then remove).
+/// Delete an imported secret.
+///
+/// Note on erasure: the store is an LSM tree (fjall), so a `remove` writes a
+/// tombstone and the original value's bytes persist in immutable SSTables /
+/// the journal until compaction — an in-place "overwrite with zeros" before
+/// removing does NOT erase them (it just appends another version) and was
+/// removed as ineffective theater (P0.7). This is acceptable because the
+/// stored value is *ciphertext* (AES-256-GCM under the seed-derived KEK), not
+/// plaintext: a forensic read of un-compacted SSTables yields encrypted bytes,
+/// not the secret. True at-rest erasure of the keyspace is the storage layer's
+/// job (compaction / encrypted volume), not this function's.
 pub async fn delete_secret(imported_ks: &KeyspaceHandle, key_id: &str) -> Result<(), AppError> {
     let store_key = format!("{SECRET_PREFIX}{key_id}");
-    // Overwrite with zeros before deletion
-    if let Some(blob) = imported_ks.get_raw(store_key.clone()).await? {
-        let zeros = vec![0u8; blob.len()];
-        imported_ks.insert_raw(store_key.clone(), zeros).await?;
-    }
     imported_ks.remove(store_key).await?;
     Ok(())
 }
@@ -346,7 +351,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_secure_delete() {
+    async fn test_delete_secret_removes_value() {
         let (store, _dir) = temp_store();
         let imported_ks = store.keyspace("imported_secrets").unwrap();
         let keys_ks = store.keyspace("keys").unwrap();

--- a/vta-service/src/keys/seeds.rs
+++ b/vta-service/src/keys/seeds.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::info;
+use zeroize::Zeroizing;
 
 use crate::keys::seed_store::SeedStore;
 use crate::store::KeyspaceHandle;
@@ -88,25 +89,32 @@ pub async fn list_seed_records(
 /// - If the seed record exists with `seed_hex: Some(hex)` → retired, decode hex.
 /// - If the seed record exists with `seed_hex: None` → active, load from external store.
 /// - If no seed record exists → pre-rotation state, load from external store.
+///
+/// Returns the BIP-32 master seed wrapped in [`Zeroizing`] so the bytes are
+/// wiped from memory when the caller drops them (P0.7). The seed is the root
+/// of every derived key; the codebase already zeroizes *derived* secrets, and
+/// this closes the gap for the root itself. Callers use it via `&seed`
+/// (deref-coerces to `&[u8]`), so no call site needs to change.
 pub async fn load_seed_bytes(
     keys_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
     seed_id: Option<u32>,
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+) -> Result<Zeroizing<Vec<u8>>, Box<dyn std::error::Error>> {
     let effective_id = seed_id.unwrap_or(0);
 
     if let Some(record) = get_seed_record(keys_ks, effective_id).await?
         && let Some(ref hex_str) = record.seed_hex
     {
         // Retired seed — archived in fjall
-        return Ok(hex::decode(hex_str)?);
+        return Ok(Zeroizing::new(hex::decode(hex_str)?));
     }
     // Active seed or pre-rotation: load from external store
-    seed_store
+    let bytes = seed_store
         .get()
         .await
         .map_err(|e| format!("{e}"))?
-        .ok_or_else(|| "no seed found in external store".into())
+        .ok_or("no seed found in external store")?;
+    Ok(Zeroizing::new(bytes))
 }
 
 /// Rotate to a new seed generation.
@@ -138,12 +146,15 @@ pub async fn rotate_seed(
 
     let old_id = get_active_seed_id(keys_ks).await?;
 
-    // Load current seed bytes for archival
-    let old_seed = seed_store
-        .get()
-        .await
-        .map_err(|e| format!("{e}"))?
-        .ok_or("no active seed found — cannot rotate")?;
+    // Load current seed bytes for archival. Zeroized on drop — this is the
+    // outgoing master seed in plaintext (P0.7).
+    let old_seed = Zeroizing::new(
+        seed_store
+            .get()
+            .await
+            .map_err(|e| format!("{e}"))?
+            .ok_or("no active seed found — cannot rotate")?,
+    );
 
     // Archive the old seed into fjall
     let mut old_record = get_seed_record(keys_ks, old_id)
@@ -154,20 +165,20 @@ pub async fn rotate_seed(
             created_at: Utc::now(),
             retired_at: None,
         });
-    old_record.seed_hex = Some(hex::encode(&old_seed));
+    old_record.seed_hex = Some(hex::encode(old_seed.as_slice()));
     old_record.retired_at = Some(Utc::now());
     save_seed_record(keys_ks, &old_record).await?;
     info!(seed_id = old_id, "archived retired seed");
 
-    // Generate or derive the new seed
-    let new_seed: Vec<u8> = if let Some(phrase) = mnemonic {
+    // Generate or derive the new seed (zeroized on drop, P0.7).
+    let new_seed: Zeroizing<Vec<u8>> = if let Some(phrase) = mnemonic {
         let m =
             bip39::Mnemonic::parse(phrase).map_err(|e| format!("invalid BIP-39 mnemonic: {e}"))?;
-        m.to_seed("").to_vec()
+        Zeroizing::new(m.to_seed("").to_vec())
     } else {
-        let mut buf = [0u8; 32];
-        rand::Rng::fill_bytes(&mut rand::rng(), &mut buf);
-        buf.to_vec()
+        let mut buf = Zeroizing::new([0u8; 32]);
+        rand::Rng::fill_bytes(&mut rand::rng(), &mut *buf);
+        Zeroizing::new(buf.to_vec())
     };
 
     // Store new seed in external backend

--- a/vta-service/src/status.rs
+++ b/vta-service/src/status.rs
@@ -317,7 +317,8 @@ async fn send_trust_ping(
     mediator_did: &str,
 ) -> Result<u128, Box<dyn std::error::Error>> {
     let seed_store = create_seed_store(config)?;
-    let seed = seed_store.get().await?.ok_or("no master seed available")?;
+    // Master seed in plaintext — wipe on drop (P0.7).
+    let seed = zeroize::Zeroizing::new(seed_store.get().await?.ok_or("no master seed available")?);
 
     let root = ExtendedSigningKey::from_seed(&seed)?;
 


### PR DESCRIPTION
## Summary

Plan task **P0.7** (part 1 — see scope note). Worked in an isolated git worktree (parallel agent active on the repo).

The codebase diligently zeroizes *derived* secrets but left the **BIP-32 master seed** — the root of every key — sitting in freed memory.

- `load_seed_bytes` now returns `Zeroizing<Vec<u8>>`, wiping the seed on drop. All ~40 callers use it via `&seed` (deref-coerces to `&[u8]`), so the change is **transparent** — zero call-site edits.
- The low-level `rotate_seed`'s old + new master seeds, and the two direct `seed_store.get()` callers (`status.rs`, `keys/derivation.rs`), are wrapped in `Zeroizing` too — the remaining places a plaintext master seed is held in memory.
- `delete_secret` claimed "secure delete" via an overwrite-with-zeros before remove. On an LSM tree (fjall) that **erases nothing** — it appends another version; the original bytes persist in immutable SSTables until compaction. Dropped the theater (pure write churn) and documented honestly: the stored value is *ciphertext*, so a forensic read yields encrypted bytes, and true at-rest erasure is the storage layer's job. Renamed `test_secure_delete` → `test_delete_secret_removes_value`.

## Scope notes (deliberately split)
- **Trait-level `SeedStore::get` → `Zeroizing`** (so backends wipe intermediates like the keyring hex `String`, and vtc-service benefits) is **deferred** — it crosses vtc-service + 8 backend impls. The contained change here captures the dominant win (the returned seed allocation is wiped on drop).
- **Encrypting the retired-seed *archive*** (stored as plaintext hex; exposed only when non-TEE + no `storage_encryption_key` + the VTA has rotated) is split to **P0.7b**. The KEK derives from the *rotating* master seed, so it needs a rotation-re-encryption (or successor-chain) design **plus a migration** for existing plaintext archives — an L-sized task, not a casual reuse of the imported-secrets pattern. Tracked in the todo.

## Tests / gate
No behavioural change to assert beyond what existing rotation/derivation/delete tests already cover (the `Zeroizing` type is compiler-enforced; the value round-trip is exercised by the seed-rotation and key-derivation suites). No `.clone()` escapes were introduced. Gate: vta-service 16 suites / 0 failures, clippy clean, fmt, `--features tee` check clean.