### PR TITLE
fix(vtc-service): bind recognise to holder proof-of-possession (P0.2 part 2)

### DIFF
--- a/vtc-service/src/recognition/challenge.rs
+++ b/vtc-service/src/recognition/challenge.rs
@@ -1,0 +1,170 @@
+//! Single-use recognise challenge — the freshness / replay / audience anchor
+//! for the two-step cross-community `POST /v1/auth/recognise` flow.
+//!
+//! Unlike [`crate::credentials::present_challenge`] (keyed by the DIDComm
+//! thread id of an in-flight `credential-exchange/query`), the recognise flow
+//! has no thread: the caller fetches a nonce from
+//! `POST /v1/auth/recognise/challenge`, the foreign-credential holder signs a
+//! W3C VP over `{nonce, domain = this VTC's DID, [VEC, VMC]}`, and the
+//! `recognise` handler [`consume`]s the challenge by the nonce embedded in that
+//! VP. The **nonce itself is the key**.
+//!
+//! - **single-use** — the record is removed on consume, so a replayed VP (same
+//!   nonce) finds no challenge and is refused;
+//! - **TTL-bounded** — a stale nonce (aged out) is refused;
+//! - **audience-bound** — the stored `aud` is the VTC DID the holder's VP
+//!   `domain` must name, so a VP captured by a different VTC can't be replayed
+//!   here.
+//!
+//! Stored in the `join_requests` keyspace under a disjoint
+//! `recognise-challenge:` prefix — never collides with `present-challenge:`,
+//! `join_requests:`, or `credx-pending:`.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// Primary-key prefix. Disjoint from `present-challenge:`, `join_requests:`,
+/// and `credx-pending:`.
+const PREFIX: &str = "recognise-challenge:";
+
+/// Default lifetime of a recognise challenge. Short — the holder fetches a
+/// nonce and presents in one round-trip.
+pub const DEFAULT_CHALLENGE_TTL: Duration = Duration::minutes(5);
+
+fn key(nonce: &str) -> Vec<u8> {
+    format!("{PREFIX}{nonce}").into_bytes()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RecogniseChallenge {
+    /// The verifier identity (this VTC's DID) the holder's VP `domain` must
+    /// name. Recovered on [`consume`] and fed to the VP verifier as the
+    /// expected audience.
+    aud: String,
+    expires_at: DateTime<Utc>,
+}
+
+/// The audience binding recovered by [`consume`] — the verifier identity the
+/// holder's VP `domain` must name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsumedChallenge {
+    /// The VTC DID the holder bound as the presentation `domain`.
+    pub aud: String,
+}
+
+/// Issue a single-use recognise challenge bound to `aud` (this VTC's DID).
+/// Returns the freshly-generated nonce for the caller to sign into its VP.
+pub async fn issue(
+    ks: &KeyspaceHandle,
+    aud: &str,
+    ttl: Duration,
+    now: DateTime<Utc>,
+) -> Result<String, AppError> {
+    let nonce = Uuid::new_v4().to_string();
+    let rec = RecogniseChallenge {
+        aud: aud.to_string(),
+        expires_at: now + ttl,
+    };
+    ks.insert(key(&nonce), &rec).await?;
+    Ok(nonce)
+}
+
+/// Consume the challenge identified by `nonce`. **Single-use**: the record is
+/// removed before the expiry check, so a replayed presentation finds no
+/// challenge. Errors if absent (unknown / already-consumed) or expired.
+pub async fn consume(
+    ks: &KeyspaceHandle,
+    nonce: &str,
+    now: DateTime<Utc>,
+) -> Result<ConsumedChallenge, AppError> {
+    let rec: RecogniseChallenge = ks.get(key(nonce)).await?.ok_or_else(|| {
+        AppError::Validation(
+            "no recognise challenge for this nonce (unknown or already consumed)".into(),
+        )
+    })?;
+    // Remove first — single-use, even on the expired path.
+    ks.remove(key(nonce)).await?;
+    if now >= rec.expires_at {
+        return Err(AppError::Validation(
+            "recognise challenge expired (fetch a fresh one)".into(),
+        ));
+    }
+    Ok(ConsumedChallenge { aud: rec.aud })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn fresh_ks() -> (tempfile::TempDir, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("join_requests").unwrap();
+        (dir, ks)
+    }
+
+    #[tokio::test]
+    async fn issue_then_consume_round_trips() {
+        let (_dir, ks) = fresh_ks();
+        let now = Utc::now();
+        let nonce = issue(&ks, "did:web:vtc.example", DEFAULT_CHALLENGE_TTL, now)
+            .await
+            .unwrap();
+
+        let consumed = consume(&ks, &nonce, now).await.unwrap();
+        assert_eq!(consumed.aud, "did:web:vtc.example");
+    }
+
+    #[tokio::test]
+    async fn consume_is_single_use() {
+        let (_dir, ks) = fresh_ks();
+        let now = Utc::now();
+        let nonce = issue(&ks, "did:web:vtc.example", DEFAULT_CHALLENGE_TTL, now)
+            .await
+            .unwrap();
+
+        consume(&ks, &nonce, now).await.expect("first consume");
+        // A replay with the same nonce finds no challenge.
+        let err = consume(&ks, &nonce, now).await.unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("already consumed")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_rejects_an_expired_challenge() {
+        let (_dir, ks) = fresh_ks();
+        let issued_at = Utc::now() - Duration::minutes(10);
+        let nonce = issue(&ks, "did:web:vtc.example", DEFAULT_CHALLENGE_TTL, issued_at)
+            .await
+            .unwrap();
+
+        let err = consume(&ks, &nonce, Utc::now()).await.unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("expired")),
+            "{err:?}"
+        );
+        // Even expired, it was consumed (single-use cleanup).
+        let again = consume(&ks, &nonce, Utc::now()).await.unwrap_err();
+        assert!(matches!(&again, AppError::Validation(m) if m.contains("already consumed")));
+    }
+
+    #[tokio::test]
+    async fn consume_rejects_an_unknown_nonce() {
+        let (_dir, ks) = fresh_ks();
+        let err = consume(&ks, "never-issued", Utc::now()).await.unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("unknown")),
+            "{err:?}"
+        );
+    }
+}

--- a/vtc-service/src/recognition/mod.rs
+++ b/vtc-service/src/recognition/mod.rs
@@ -49,6 +49,7 @@
 //! (min of three TTLs) and refresh paths are rare relative to
 //! "regular member" sessions.
 
+pub mod challenge;
 pub mod verify;
 
 pub use verify::{

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -898,6 +898,12 @@ fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
     // source IP.
     let auth_recognise = TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/recognise/1.0")
         .expect("static Trust-Task URL");
+    // Step 1 of the recognise flow — issues the single-use challenge nonce the
+    // holder binds into the VP presented to `/auth/recognise`. Same unauth
+    // chain (governor + body cap) as the other challenge endpoints.
+    let auth_recognise_challenge =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/recognise/challenge/1.0")
+            .expect("static Trust-Task URL");
 
     // L2: rate-limiter key extractor honours `trust_xff`. The
     // governor is applied in the routing chain below via a
@@ -962,6 +968,11 @@ fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
             "/install/claim/finish",
             post(install::claim_finish),
             install_claim_finish,
+        )
+        .route_with_task(
+            "/auth/recognise/challenge",
+            post(recognise::recognise_challenge),
+            auth_recognise_challenge,
         )
         .route_with_task(
             "/auth/recognise",

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -2,11 +2,34 @@
 //!
 //! Phase 3 M3.10. Spec §8.4.
 //!
-//! The route accepts a foreign community's (`VEC`, `VMC`) pair,
-//! runs the M3.9 verifier, evaluates `cross_community_roles.rego`
-//! to map the foreign role onto a local role, and mints a session
-//! JWT with TTL clamped to
+//! The caller presents a foreign community's (`VEC`, `VMC`) pair **inside a
+//! holder-signed W3C Verifiable Presentation**, the route runs the M3.9
+//! verifier, evaluates `cross_community_roles.rego` to map the foreign role
+//! onto a local role, and mints a session JWT with TTL clamped to
 //! `min(jwt_default, vec.validUntil - now, vmc.validUntil - now)`.
+//!
+//! ## Holder proof-of-possession (P0.2 part 2)
+//!
+//! A VEC + VMC are bearer artifacts: anyone who captures the pair (a relayed
+//! join, an audit log, a compromised member device) holds everything the old
+//! `{vec, vmc}` body needed. Minting a session straight off them made the pair
+//! a **replayable impersonation token** for the subject — no proof the caller
+//! controls the subject's key, no replay nonce, no audience binding.
+//!
+//! The flow is now two-step and proof-of-possession bound:
+//! 1. `POST /v1/auth/recognise/challenge` issues a single-use, TTL'd `nonce`
+//!    bound to this VTC's DID (see [`crate::recognition::challenge`]).
+//! 2. `POST /v1/auth/recognise` carries a **VP** whose holder
+//!    `eddsa-jcs-2022` proof (`proofPurpose: authentication`) commits to that
+//!    `nonce` (freshness/replay) + this VTC's DID as `domain` (audience), and
+//!    embeds the VEC + VMC. The handler consumes the challenge, verifies the
+//!    holder proof (proves possession of the subject key) plus each embedded
+//!    credential's issuer proof, and refuses unless the **VP holder is the
+//!    credential subject**. Only then does it run the recognition gate + mint.
+//!
+//! A captured VEC + VMC is now inert: the attacker can't produce the holder
+//! signature over a fresh challenge, and a replayed VP finds its single-use
+//! nonce already consumed.
 //!
 //! ## No refresh path
 //!
@@ -31,6 +54,7 @@ use uuid::Uuid;
 use vti_common::audit::{AuditEvent, CrossCommunitySessionMintedData};
 
 use crate::auth::session::{Session, SessionState, now_epoch, store_session};
+use crate::credentials::exchange::verify_vp_token;
 use crate::error::AppError;
 use crate::policy::{
     PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy, get_active_policy_id,
@@ -38,18 +62,32 @@ use crate::policy::{
 };
 use crate::recognition::{
     DidResolverKeyResolver, ForeignIssuerKeyResolver, HttpStatusListFetcher, RecognitionError,
-    VerifiedForeignCredential, verify_foreign_vec,
+    VerifiedForeignCredential, challenge, verify_foreign_vec,
 };
 use crate::server::AppState;
 use affinidi_vc::VerifiableCredential;
 
-/// Request body for `POST /v1/auth/recognise`. The caller
-/// supplies the foreign VEC + VMC verbatim — the route
-/// resolves the issuer's key + status list itself.
+/// Request body for `POST /v1/auth/recognise`. The caller supplies a
+/// holder-signed W3C Verifiable Presentation that embeds the foreign VEC and
+/// VMC in `verifiableCredential` and binds the challenge `nonce` (top-level)
+/// plus this VTC's DID as the `domain`. The route verifies the holder proof,
+/// the embedded issuer proofs, the status list, and the registry recognition
+/// itself.
 #[derive(Debug, Deserialize)]
 pub struct RecogniseRequest {
-    pub vec: VerifiableCredential,
-    pub vmc: VerifiableCredential,
+    /// A W3C Data-Integrity VP, holder-signed with
+    /// `proofPurpose: authentication`.
+    pub presentation: JsonValue,
+}
+
+/// Response body for `POST /v1/auth/recognise/challenge`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecogniseChallengeResponse {
+    /// Single-use nonce the holder must bind into the VP's top-level `nonce`.
+    pub nonce: String,
+    /// Unix-epoch seconds at which the challenge expires.
+    pub expires_at: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -74,31 +112,110 @@ pub struct RecogniseData {
     pub mapped_role: String,
 }
 
+/// `POST /v1/auth/recognise/challenge` — issue a single-use, TTL'd nonce the
+/// holder binds into their recognise VP. Bound to this VTC's DID as the
+/// audience, so the resulting VP can't be replayed against a different VTC.
+pub async fn recognise_challenge(
+    State(state): State<AppState>,
+) -> Result<Json<RecogniseChallengeResponse>, AppError> {
+    let vtc_did = vtc_did(&state).await?;
+    let now = Utc::now();
+    let nonce = challenge::issue(
+        &state.join_requests_ks,
+        &vtc_did,
+        challenge::DEFAULT_CHALLENGE_TTL,
+        now,
+    )
+    .await?;
+    let expires_at = (now + challenge::DEFAULT_CHALLENGE_TTL).timestamp() as u64;
+    Ok(Json(RecogniseChallengeResponse { nonce, expires_at }))
+}
+
 pub async fn recognise(
     State(state): State<AppState>,
     Json(req): Json<RecogniseRequest>,
 ) -> Result<Json<RecogniseResponse>, AppError> {
-    // Pre-flight: the route depends on three pieces of optional
-    // state. Refuse cleanly when any is missing rather than
-    // 500ing inside the handler.
-    let registry = state.registry_client.as_ref().cloned().ok_or_else(|| {
-        AppError::Validation("trust-registry client not configured on this VTC".into())
-    })?;
+    // Pre-flight: the route depends on optional state. Refuse cleanly when a
+    // piece is missing rather than 500ing mid-handler. The `resolver` is
+    // needed immediately (VP holder + issuer proof verification); the
+    // `registry_client` is acquired later, just before the recognition gate
+    // that needs it, so the cheap caller-input + holder-binding checks
+    // fail-fast first. `jwt_keys` is re-checked inside
+    // `mint_recognised_session`, checked here only to surface a config issue
+    // before any real verification runs.
     let resolver = state
         .did_resolver
         .as_ref()
         .cloned()
         .ok_or_else(|| AppError::Internal("DID resolver not configured".into()))?;
-    // JWT-keys availability is re-checked inside
-    // `mint_recognised_session` — but bail early when the
-    // verifier hasn't been wired either, so the response is
-    // shaped by config issues rather than running a real
-    // verification first.
     state
         .jwt_keys
         .as_ref()
         .ok_or_else(|| AppError::Authentication("JWT keys not configured".into()))?;
 
+    let now = Utc::now();
+
+    // 1. Consume the challenge the holder bound into the VP. The nonce is read
+    //    from the *unverified* VP purely to look it up; the holder signature
+    //    over that same nonce is verified in step 2. Single-use + TTL: a
+    //    replayed VP finds its nonce already consumed; a stale nonce is gone.
+    let nonce = req
+        .presentation
+        .get("nonce")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| {
+            AppError::Validation("presentation carries no top-level `nonce` to consume".into())
+        })?
+        .to_string();
+    let consumed = challenge::consume(&state.join_requests_ks, &nonce, now).await?;
+
+    // 2. Verify the holder proof (proof-of-possession of the subject key) and
+    //    bind freshness (`nonce`) + audience (`domain == consumed.aud`, this
+    //    VTC's DID). `verify_vp_token` also verifies each embedded credential's
+    //    issuer `eddsa-jcs-2022` proof + temporal validity. `did:key` holders
+    //    and issuers resolve locally.
+    //
+    //    `verify_vp_token` reads a DCQL `vp_token` (a map keyed by query id) or
+    //    a bare SD-JWT-VC string; recognise carries a single W3C DI VP, so wrap
+    //    it in a one-entry map before handing it over.
+    let vp_token = serde_json::json!({ "recognise": req.presentation });
+    let verified_vp = verify_vp_token(
+        &vp_token,
+        &consumed.aud,
+        &nonce,
+        state.did_resolver.as_ref(),
+        now,
+    )
+    .await?;
+    let holder_did = verified_vp.holder;
+
+    // 3. Pull the raw VEC + VMC back out of the (now holder-bound) VP so the
+    //    recognition gate can run its status-list / registry / role checks.
+    let (vec, vmc) = extract_vec_vmc(&req.presentation)?;
+
+    // 4. Holder-binding (the headline of P0.2 part 2). The proven VP holder
+    //    MUST be the credential subject — otherwise a captured VEC + VMC,
+    //    re-wrapped in a VP signed by the *attacker's own* holder key, would
+    //    still verify in step 2 and mint a session to the victim subject.
+    //    Cheap (no network) and fail-fast, so it gates before the recognition
+    //    HTTP calls. `verify_foreign_vec` independently binds
+    //    `vmc.subject == vec.subject` (part 1), making this transitive to the
+    //    returned `verified.subject_did`.
+    let vec_subject = vc_subject_id(&vec)
+        .ok_or_else(|| AppError::Validation("foreign VEC has no credentialSubject.id".into()))?;
+    if holder_did != vec_subject {
+        let err = RecognitionError::Malformed(format!(
+            "VP holder `{holder_did}` is not the credential subject `{vec_subject}`"
+        ));
+        emit_denied_audit(&state, &holder_did, None, "holder-binding", None, &err).await;
+        return Err(AppError::Forbidden(
+            "presentation holder is not the foreign credential subject".into(),
+        ));
+    }
+
+    let registry = state.registry_client.as_ref().cloned().ok_or_else(|| {
+        AppError::Validation("trust-registry client not configured on this VTC".into())
+    })?;
     let key_resolver: Arc<dyn ForeignIssuerKeyResolver> =
         Arc::new(DidResolverKeyResolver::new(resolver));
     // Verify the foreign status list's own issuer signature (bound to the
@@ -109,36 +226,102 @@ pub async fn recognise(
         key_resolver.clone(),
     );
 
-    let actor_did_for_audit = req.vec.credential_subject_id_for_audit();
-
-    // Run the M3.9 verifier. Failures are mapped to `denied`
-    // audit envelopes + a 403 response.
+    // 5. Run the M3.9 recognition gate. Failures are mapped to `denied` audit
+    //    envelopes (actor = the cryptographically-proven VP holder) + a 403.
     let verified = match verify_foreign_vec(
-        &req.vec,
-        &req.vmc,
+        &vec,
+        &vmc,
         key_resolver.as_ref(),
         &status_fetcher,
         Arc::clone(&registry),
-        Utc::now(),
+        now,
     )
     .await
     {
         Ok(v) => v,
         Err(e) => {
-            emit_denied_audit(
-                &state,
-                &actor_did_for_audit,
-                None,
-                e.reason_code(),
-                None,
-                &e,
-            )
-            .await;
+            emit_denied_audit(&state, &holder_did, None, e.reason_code(), None, &e).await;
             return Err(map_recognition_error(e));
         }
     };
 
     mint_recognised_session(&state, verified).await
+}
+
+/// This VTC's own DID — the audience a recognise challenge is bound to and the
+/// `domain` the holder's VP must name.
+async fn vtc_did(state: &AppState) -> Result<String, AppError> {
+    state
+        .config
+        .read()
+        .await
+        .vtc_did
+        .clone()
+        .ok_or_else(|| AppError::Validation("VTC DID not configured".into()))
+}
+
+/// Pull the foreign VEC + VMC out of a VP's `verifiableCredential`, classifying
+/// by `type`. Both must be present exactly once. Accepts either a single object
+/// or an array (the W3C VP shape).
+fn extract_vec_vmc(
+    presentation: &JsonValue,
+) -> Result<(VerifiableCredential, VerifiableCredential), AppError> {
+    let raw = presentation
+        .get("verifiableCredential")
+        .ok_or_else(|| AppError::Validation("presentation has no `verifiableCredential`".into()))?;
+    let entries: Vec<&JsonValue> = match raw {
+        JsonValue::Array(items) => items.iter().collect(),
+        other => vec![other],
+    };
+
+    let mut vec_cred: Option<VerifiableCredential> = None;
+    let mut vmc_cred: Option<VerifiableCredential> = None;
+    for entry in entries {
+        let cred: VerifiableCredential = serde_json::from_value(entry.clone()).map_err(|e| {
+            AppError::Validation(format!("embedded credential is not a valid VC: {e}"))
+        })?;
+        // Route the credential to its slot by type. Other credential types are
+        // ignored — the recognition gate only acts on the VEC + VMC pair.
+        let (slot, label) = if cred
+            .types
+            .iter()
+            .any(|t| t == "VerifiableEndorsementCredential")
+        {
+            (&mut vec_cred, "VerifiableEndorsementCredential")
+        } else if cred
+            .types
+            .iter()
+            .any(|t| t == "VerifiableMembershipCredential")
+        {
+            (&mut vmc_cred, "VerifiableMembershipCredential")
+        } else {
+            continue;
+        };
+        if slot.replace(cred).is_some() {
+            return Err(AppError::Validation(format!(
+                "presentation carries more than one {label}"
+            )));
+        }
+    }
+
+    let vec = vec_cred.ok_or_else(|| {
+        AppError::Validation("presentation has no VerifiableEndorsementCredential".into())
+    })?;
+    let vmc = vmc_cred.ok_or_else(|| {
+        AppError::Validation("presentation has no VerifiableMembershipCredential".into())
+    })?;
+    Ok((vec, vmc))
+}
+
+/// Read a credential's `credentialSubject.id`. `None` if absent or
+/// id-less (a VEC the recognition gate would reject anyway).
+fn vc_subject_id(vc: &VerifiableCredential) -> Option<String> {
+    use affinidi_vc::SubjectValue;
+    let subj = match &vc.credential_subject {
+        SubjectValue::Single(m) => Some(m),
+        SubjectValue::Multiple(v) => v.first(),
+    }?;
+    subj.get("id").and_then(|v| v.as_str()).map(str::to_string)
 }
 
 /// Post-verification half of the recognise flow — exposed at
@@ -388,25 +571,5 @@ async fn emit_denied_audit(
         .await
     {
         warn!(error = %e, "failed to emit CrossCommunitySessionMinted (denied) envelope");
-    }
-}
-
-// Helper trait — extracts the subject DID from the VEC even
-// when verification hasn't run yet, so audit envelopes for the
-// `denied` arm can still name an actor when possible.
-trait CredentialSubjectIdAccessor {
-    fn credential_subject_id_for_audit(&self) -> String;
-}
-
-impl CredentialSubjectIdAccessor for VerifiableCredential {
-    fn credential_subject_id_for_audit(&self) -> String {
-        use affinidi_vc::SubjectValue;
-        let subj_map = match &self.credential_subject {
-            SubjectValue::Single(m) => Some(m.clone()),
-            SubjectValue::Multiple(v) => v.first().cloned(),
-        };
-        subj_map
-            .and_then(|m| m.get("id").and_then(|v| v.as_str()).map(str::to_string))
-            .unwrap_or_else(|| "<unknown-subject>".into())
     }
 }

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -272,3 +272,261 @@ async fn missing_active_policy_surfaces_as_internal_error() {
     // caller-fixable input.
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
+
+/// Route-level coverage for the P0.2-part-2 holder-binding rewrite: the
+/// `/v1/auth/recognise` route now demands a holder-signed VP (challenge nonce +
+/// audience bound) embedding the VEC + VMC, and refuses unless the VP holder is
+/// the credential subject. These drive the real HTTP stack via `oneshot` and a
+/// holder-signed `eddsa-jcs-2022` VP, exercising everything up to (but not
+/// through) the registry-gated `verify_foreign_vec` — `TestVtc` wires no
+/// registry client, so a VP that clears the holder-binding gate fails next at
+/// the registry pre-flight, which is exactly how we assert the gate let it pass.
+mod holder_binding {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use ed25519_dalek::SigningKey;
+    use http_body_util::BodyExt;
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use vtc_service::test_support::TestVtc;
+
+    const VTC_DID: &str = "did:key:z6MkTestVTC";
+    const RECOGNISE_TASK: &str = "https://trusttasks.org/openvtc/vtc/auth/recognise/1.0";
+    const CHALLENGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/auth/recognise/challenge/1.0";
+
+    async fn test_vtc() -> TestVtc {
+        // `with_did_resolver` so the route's VP holder/issuer `did:key`
+        // resolution is wired; `vtc_did` sets the audience the holder binds.
+        TestVtc::builder()
+            .vtc_did(VTC_DID)
+            .with_did_resolver(true)
+            .build()
+            .await
+    }
+
+    fn did_for(seed: u8) -> String {
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(
+            &SigningKey::from_bytes(&[seed; 32])
+                .verifying_key()
+                .to_bytes(),
+        )
+    }
+
+    fn secret_for(seed: u8) -> affinidi_secrets_resolver::secrets::Secret {
+        let did = did_for(seed);
+        let vm = format!("{did}#{}", did.strip_prefix("did:key:").unwrap());
+        affinidi_secrets_resolver::secrets::Secret::generate_ed25519(Some(&vm), Some(&[seed; 32]))
+    }
+
+    async fn sign_vc(issuer_seed: u8, vc_type: &str, subject_did: &str) -> Value {
+        use affinidi_data_integrity::{
+            DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite,
+        };
+        let issuer_did = did_for(issuer_seed);
+        let mut vc = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", vc_type],
+            "issuer": issuer_did,
+            "validFrom": "2020-01-01T00:00:00Z",
+            "validUntil": "2999-01-01T00:00:00Z",
+            "credentialSubject": {
+                "id": subject_did,
+                "endorsement": { "role": "moderator", "communityDid": issuer_did },
+            },
+        });
+        let proof = DataIntegrityProof::sign(
+            &vc,
+            &secret_for(issuer_seed),
+            SignOptions::new()
+                .with_proof_purpose("assertionMethod")
+                .with_cryptosuite(CryptoSuite::EddsaJcs2022),
+        )
+        .await
+        .unwrap();
+        vc["proof"] = serde_json::to_value(&proof).unwrap();
+        vc
+    }
+
+    /// Build a holder-signed DI VP embedding a foreign VEC + VMC (both issued by
+    /// `issuer_seed`, subject `subject_seed`), holder-signed by `holder_seed`
+    /// with `proofPurpose: authentication` over `nonce` + `domain = VTC_DID`.
+    /// Returns the VP object. When `holder_seed == subject_seed` the holder is
+    /// the credential subject (the legitimate case).
+    async fn build_vp(issuer_seed: u8, holder_seed: u8, subject_seed: u8, nonce: &str) -> Value {
+        use affinidi_data_integrity::{
+            DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite,
+        };
+        let subject_did = did_for(subject_seed);
+        let holder_did = did_for(holder_seed);
+        let vec = sign_vc(issuer_seed, "VerifiableEndorsementCredential", &subject_did).await;
+        let vmc = sign_vc(issuer_seed, "VerifiableMembershipCredential", &subject_did).await;
+        let mut vp = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiablePresentation"],
+            "holder": holder_did,
+            "verifiableCredential": [vec, vmc],
+            "nonce": nonce,
+            "domain": VTC_DID,
+        });
+        let proof = DataIntegrityProof::sign(
+            &vp,
+            &secret_for(holder_seed),
+            SignOptions::new()
+                .with_proof_purpose("authentication")
+                .with_cryptosuite(CryptoSuite::EddsaJcs2022),
+        )
+        .await
+        .unwrap();
+        vp["proof"] = serde_json::to_value(&proof).unwrap();
+        vp
+    }
+
+    async fn post_recognise(router: &axum::Router, vp: &Value) -> (StatusCode, String) {
+        let body = json!({ "presentation": vp });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/auth/recognise")
+            .header("Trust-Task", RECOGNISE_TASK)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = router.clone().oneshot(req).await.expect("request");
+        let status = resp.status();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        (status, String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    /// Fetch a fresh challenge nonce through the real `/challenge` endpoint.
+    async fn fetch_nonce(router: &axum::Router) -> String {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/auth/recognise/challenge")
+            .header("Trust-Task", CHALLENGE_TASK)
+            .body(Body::empty())
+            .unwrap();
+        let resp = router
+            .clone()
+            .oneshot(req)
+            .await
+            .expect("challenge request");
+        assert_eq!(resp.status(), StatusCode::OK, "challenge endpoint must 200");
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        v["nonce"].as_str().expect("nonce in response").to_string()
+    }
+
+    #[tokio::test]
+    async fn challenge_endpoint_issues_a_nonce() {
+        let vtc = test_vtc().await;
+        let nonce = fetch_nonce(&vtc.router).await;
+        assert!(!nonce.is_empty(), "challenge must return a non-empty nonce");
+    }
+
+    #[tokio::test]
+    async fn presentation_without_a_nonce_is_rejected() {
+        let vtc = test_vtc().await;
+        // Build a VP then strip its nonce — the handler can't even look up a
+        // challenge, so it refuses before any verification.
+        let mut vp = build_vp(9, 5, 5, "irrelevant").await;
+        vp.as_object_mut().unwrap().remove("nonce");
+        let (status, body) = post_recognise(&vtc.router, &vp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+        assert!(body.contains("nonce"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn presentation_with_an_unissued_nonce_is_rejected() {
+        let vtc = test_vtc().await;
+        // A VP carrying a nonce we never issued: the challenge consume finds
+        // nothing. This is the captured-credential replay an attacker would try
+        // without first fetching a live challenge.
+        let vp = build_vp(9, 5, 5, "never-issued-by-this-vtc").await;
+        let (status, body) = post_recognise(&vtc.router, &vp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+        assert!(
+            body.contains("unknown or already consumed"),
+            "expected challenge-miss, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn holder_that_is_not_the_subject_is_rejected() {
+        // The headline. Attacker (holder seed 7) captured a victim's (subject
+        // seed 5) VEC + VMC and re-wraps them in a VP signed with the
+        // attacker's own holder key over a freshly-fetched challenge. The
+        // holder proof verifies — but the holder is not the credential subject,
+        // so the route must refuse before minting.
+        let vtc = test_vtc().await;
+        let nonce = fetch_nonce(&vtc.router).await;
+        let vp = build_vp(9, 7, 5, &nonce).await;
+        let (status, body) = post_recognise(&vtc.router, &vp).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+        assert!(
+            body.contains("holder") && body.contains("subject"),
+            "expected holder-binding refusal, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn matching_holder_clears_the_binding_gate() {
+        // The legitimate case: holder == subject (seed 5). The holder-binding
+        // gate must let it through — it then fails at the registry pre-flight
+        // (TestVtc wires no registry client), proving the request got *past*
+        // the binding gate rather than being wrongly 403'd.
+        let vtc = test_vtc().await;
+        let nonce = fetch_nonce(&vtc.router).await;
+        let vp = build_vp(9, 5, 5, &nonce).await;
+        let (status, body) = post_recognise(&vtc.router, &vp).await;
+        assert_ne!(
+            status,
+            StatusCode::FORBIDDEN,
+            "a matching holder must not be refused by the binding gate: {body}"
+        );
+        assert!(
+            body.contains("trust-registry client not configured"),
+            "expected to reach the registry gate, got {status}: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_consumed_challenge_cannot_be_replayed() {
+        // Single-use: present the same (attacker) VP twice on one nonce. The
+        // first consumes the challenge (and is refused at the holder-binding
+        // gate); the replay finds the nonce already consumed.
+        let vtc = test_vtc().await;
+        let nonce = fetch_nonce(&vtc.router).await;
+        let vp = build_vp(9, 7, 5, &nonce).await;
+
+        let (first, _) = post_recognise(&vtc.router, &vp).await;
+        assert_eq!(
+            first,
+            StatusCode::FORBIDDEN,
+            "first present: holder-binding"
+        );
+
+        let (second, body) = post_recognise(&vtc.router, &vp).await;
+        assert_eq!(second, StatusCode::BAD_REQUEST, "{body}");
+        assert!(
+            body.contains("unknown or already consumed"),
+            "replay must hit the single-use challenge guard: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_tampered_holder_proof_is_rejected() {
+        // Mutate a credential claim after the VP was signed: the embedded VC is
+        // covered by the holder's VP proof, so the holder-proof verification
+        // fails — no presentation with any altered byte survives.
+        let vtc = test_vtc().await;
+        let nonce = fetch_nonce(&vtc.router).await;
+        let mut vp = build_vp(9, 5, 5, &nonce).await;
+        vp["verifiableCredential"][0]["credentialSubject"]["endorsement"]["role"] = json!("admin");
+        let (status, body) = post_recognise(&vtc.router, &vp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+        assert!(
+            body.contains("verify"),
+            "expected proof-failure, got: {body}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`POST /v1/auth/recognise` accepted a raw `{vec, vmc}` pair and minted a cross-community session to `vec.subject` with **no proof the caller controlled the subject key, no replay nonce, and no audience binding**. A VEC + VMC are bearer artifacts (a relayed join, an audit log, a compromised member device hold them), so the pair was a **replayable impersonation token** for the subject — anyone who captured one could mint a session as that subject, against this VTC or any other.

This is **P0.2 part 2** of the VTC architecture review. Part 1 (#351) bound `vmc.subject == vec.subject`; this part adds the holder proof-of-possession.

## Fix — two-step, proof-of-possession bound

1. **New `POST /v1/auth/recognise/challenge`** issues a single-use, TTL'd nonce bound to this VTC's DID. Stored in the `join_requests` keyspace under a `recognise-challenge:` prefix (disjoint from `present-challenge:`), keyed by the nonce itself (`recognition::challenge`, mirroring `credentials::present_challenge`).
2. **`POST /v1/auth/recognise`** now takes a holder-signed W3C Data-Integrity VP embedding the VEC + VMC. The handler:
   - consumes the challenge (single-use + TTL — a replayed VP finds its nonce gone);
   - verifies the holder `eddsa-jcs-2022` proof (`proofPurpose: authentication`) committing to the nonce (freshness) + this VTC's DID as `domain` (audience), plus each embedded issuer proof, via `verify_vp_token`;
   - **refuses unless the proven holder is the credential subject** — fail-fast, before the registry-gated recognition checks;
   - then runs the existing M3.9 recognition gate + mint (`mint_recognised_session` unchanged).

The denied-audit actor is now the cryptographically-proven holder, not the unverified VEC subject (closes the pre-verification audit gap).

A captured VEC + VMC is now inert: the attacker can't produce the holder signature over a fresh challenge, and a replayed VP finds its nonce consumed.

> **Wire-shape change is safe:** the only caller of this route is `tests/recognise.rs`. The pre-flight dependency checks were reordered (registry acquired just before the gate that needs it) so the cheap caller-input + holder-binding checks fail-fast first.

## Tests
- 4 challenge-store unit tests (round-trip, single-use, expiry, unknown nonce).
- 7 route tests over the real HTTP stack with holder-signed VP fixtures: challenge issuance, missing / unissued / replayed nonce, **holder ≠ subject rejection**, matching holder clears the gate, tampered proof.
- Existing `mint_recognised_session` tests unchanged.

## Verification
`cargo fmt --check`, `cargo clippy --all-targets` (clean), `cargo test -p vtc-service` (496 lib + 15 recognise pass; the 4 `admin_ui` failures are the known `VTC_SKIP_ADMIN_UI_BUILD` env artifact), `cargo deny check` all green.