### PR TITLE
fix(vtc-service): serialize the status-list read-modify-write (P0.1)

### DIFF
--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -231,6 +231,13 @@ async fn issue_member_credentials(
         )
     })?;
 
+    // Hold the status-list write lock across the whole allocate → build →
+    // store sequence (P0.1). The raw guard (not `with_locked`) is needed
+    // because the VMC/VEC build sits between the allocate and the store —
+    // see the doc comment above: the row is persisted only after both VCs
+    // build, so a build failure doesn't burn the slot. The guard keeps a
+    // concurrent writer from clobbering this allocation in that window.
+    let _sl_guard = status_list::lock().await;
     let mut row = status_list::get_state(&state.status_lists_ks, StatusPurpose::Revocation)
         .await?
         .ok_or_else(|| {
@@ -464,18 +471,13 @@ async fn depart(
 /// audit — the caller emits the `StatusListFlipped` event from the
 /// returned [`DepartOutcome`].
 async fn flip_revocation(state: &AppState, slot: u32) -> Result<(), AppError> {
-    let mut row = status_list::get_state(&state.status_lists_ks, StatusPurpose::Revocation)
-        .await?
-        .ok_or_else(|| {
-            AppError::Internal(
-                "revocation status list not provisioned — set `public_url` + restart".into(),
-            )
-        })?;
-    status_list::flip(&mut row, slot, true)
-        .map_err(|e| AppError::Internal(format!("flip revocation slot {slot}: {e}")))?;
-    status_list::store_state(&state.status_lists_ks, &row).await?;
-    status_list::maybe_emit_occupancy_warning(&row);
-    Ok(())
+    // Locked RMW: the flip must not be clobbered by a concurrent
+    // allocate/flip on the same row (P0.1).
+    status_list::with_locked(&state.status_lists_ks, StatusPurpose::Revocation, |row| {
+        status_list::flip(row, slot, true)
+            .map_err(|e| AppError::Internal(format!("flip revocation slot {slot}: {e}")))
+    })
+    .await
 }
 
 /// Pull the top-level `id` field off a signed VC. The upstream

--- a/vtc-service/src/credentials/invitation.rs
+++ b/vtc-service/src/credentials/invitation.rs
@@ -40,6 +40,12 @@ pub async fn issue_invitation(
     subject_did: &str,
     validity: Duration,
 ) -> Result<Value, AppError> {
+    // Hold the status-list write lock across allocate → build → store
+    // (P0.1). The raw guard (not `with_locked`) is needed because the VIC
+    // build sits between the allocate and the store so a build failure
+    // doesn't burn the slot (see below) — the guard keeps a concurrent
+    // writer from clobbering this allocation in that window.
+    let _sl_guard = status_list::lock().await;
     let mut row = status_list::get_state(status_lists_ks, StatusPurpose::Revocation)
         .await?
         .ok_or_else(|| {

--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -131,20 +131,22 @@ pub async fn issue(
         )));
     }
 
-    // 5. Allocate status-list slot.
-    let mut sl_state = status_list::get_state(
+    // 5. Allocate status-list slot — locked RMW so a concurrent
+    //    allocate/flip can't clobber this allocation (P0.1).
+    let (slot, list_credential_id) = status_list::with_locked(
         &state.status_lists_ks,
         affinidi_status_list::StatusPurpose::Revocation,
+        |row| {
+            let slot = status_list::allocate(row).ok_or_else(|| {
+                AppError::Internal(
+                    "revocation status list is full — cannot allocate slot for endorsement".into(),
+                )
+            })?;
+            Ok((slot, row.list_credential_id.clone()))
+        },
     )
-    .await?
-    .ok_or_else(|| AppError::Internal("revocation status list not initialised".into()))?;
-    let slot = status_list::allocate(&mut sl_state).ok_or_else(|| {
-        AppError::Internal(
-            "revocation status list is full — cannot allocate slot for endorsement".into(),
-        )
-    })?;
-    status_list::store_state(&state.status_lists_ks, &sl_state).await?;
-    let status_ref = CredentialStatusRef::revocation(sl_state.list_credential_id.clone(), slot);
+    .await?;
+    let status_ref = CredentialStatusRef::revocation(list_credential_id, slot);
 
     // 6. Build + sign the VEC.
     let id = Uuid::new_v4();
@@ -345,20 +347,20 @@ pub async fn revoke(
         return Ok((StatusCode::OK, Json(RevokeResponse { id: id.to_string() })));
     }
 
-    // Flip the status-list bit.
-    let mut sl_state = status_list::get_state(
+    // Flip the status-list bit — locked RMW so a concurrent allocate/flip
+    // can't clobber this revocation (P0.1). (Wrapping the subsequent
+    // `mark_revoked` in the same critical section for crash-atomicity is
+    // the separate P3.9 hygiene item.)
+    let slot_idx = row.status_list_index;
+    status_list::with_locked(
         &state.status_lists_ks,
         affinidi_status_list::StatusPurpose::Revocation,
+        move |sl| {
+            status_list::flip(sl, slot_idx, true)
+                .map_err(|e| AppError::Internal(format!("flip status-list bit {slot_idx}: {e}")))
+        },
     )
-    .await?
-    .ok_or_else(|| AppError::Internal("revocation status list not initialised".into()))?;
-    status_list::flip(&mut sl_state, row.status_list_index, true).map_err(|e| {
-        AppError::Internal(format!(
-            "flip status-list bit {}: {e}",
-            row.status_list_index
-        ))
-    })?;
-    status_list::store_state(&state.status_lists_ks, &sl_state).await?;
+    .await?;
 
     // Mark the row revoked.
     let updated = mark_revoked(&state.endorsements_ks, id)

--- a/vtc-service/src/routes/members/personhood.rs
+++ b/vtc-service/src/routes/members/personhood.rs
@@ -282,8 +282,11 @@ pub async fn assert(
         ));
     }
 
-    // 7. Allocate/reuse status-list slot + mint a fresh VMC.
-    let mut sl_state = status_list::get_state(
+    // 7. Allocate/reuse status-list slot + mint a fresh VMC. The
+    //    `list_credential_id` read here is immutable; the allocation goes
+    //    through `with_locked` (P0.1) which re-reads the row under the
+    //    lock so it can't be lost to a concurrent writer.
+    let sl_state = status_list::get_state(
         &state.status_lists_ks,
         affinidi_status_list::StatusPurpose::Revocation,
     )
@@ -292,11 +295,18 @@ pub async fn assert(
     let slot = match member.status_list_index {
         Some(s) => s,
         None => {
-            let s = status_list::allocate(&mut sl_state).ok_or_else(|| {
-                AppError::Internal("revocation status list is full — cannot allocate slot".into())
-            })?;
-            status_list::store_state(&state.status_lists_ks, &sl_state).await?;
-            s
+            status_list::with_locked(
+                &state.status_lists_ks,
+                affinidi_status_list::StatusPurpose::Revocation,
+                |row| {
+                    status_list::allocate(row).ok_or_else(|| {
+                        AppError::Internal(
+                            "revocation status list is full — cannot allocate slot".into(),
+                        )
+                    })
+                },
+            )
+            .await?
         }
     };
     let status_ref = CredentialStatusRef::revocation(sl_state.list_credential_id.clone(), slot);

--- a/vtc-service/src/routes/members/renew.rs
+++ b/vtc-service/src/routes/members/renew.rs
@@ -113,16 +113,19 @@ pub async fn renew(
     // reseed.
     let slot = match member.status_list_index {
         Some(s) => s,
+        // Locked RMW (P0.1) — and `with_locked` re-reads the row inside
+        // the lock, so the allocation can't be lost to (or built on a
+        // stale copy clobbered by) a concurrent writer.
         None => {
-            let mut row = status_list_state.clone();
-            let s = status_list::allocate(&mut row).ok_or_else(|| {
-                AppError::Internal(format!(
-                    "revocation status list exhausted (capacity = {})",
-                    row.capacity
-                ))
-            })?;
-            status_list::store_state(&state.status_lists_ks, &row).await?;
-            s
+            status_list::with_locked(&state.status_lists_ks, StatusPurpose::Revocation, |row| {
+                status_list::allocate(row).ok_or_else(|| {
+                    AppError::Internal(format!(
+                        "revocation status list exhausted (capacity = {})",
+                        row.capacity
+                    ))
+                })
+            })
+            .await?
         }
     };
 

--- a/vtc-service/src/status_list/mod.rs
+++ b/vtc-service/src/status_list/mod.rs
@@ -48,7 +48,8 @@ pub mod storage;
 pub use allocator::{add_initial_decoys, allocate, flip, occupancy};
 pub use credential::{BITSTRING_STATUS_LIST_VC_TYPE, build_status_list_credential};
 pub use storage::{
-    STATUS_LIST_PREFIX, StatusListState, ensure_initial, get_state, list_states, store_state,
+    STATUS_LIST_PREFIX, StatusListState, ensure_initial, get_state, list_states, lock, store_state,
+    with_locked,
 };
 
 pub use affinidi_status_list::{

--- a/vtc-service/src/status_list/storage.rs
+++ b/vtc-service/src/status_list/storage.rs
@@ -6,8 +6,11 @@
 //! `assigned` mask that drives the allocator's
 //! never-reuse-a-flipped-slot invariant.
 
+use std::sync::LazyLock;
+
 use affinidi_status_list::{DEFAULT_BITSTRING_SIZE, StatusPurpose};
 use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, MutexGuard};
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
@@ -149,6 +152,69 @@ pub async fn ensure_initial(
     super::allocator::add_initial_decoys(&mut state, decoy_count);
     store_state(ks, &state).await?;
     Ok(state)
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency control for the read-modify-write of a status-list row.
+// ---------------------------------------------------------------------------
+
+/// Process-wide lock serializing every status-list row mutation.
+///
+/// A mutation is `get_state` → mutate in memory (`allocate` / `flip`) →
+/// `store_state`, and `store_state` overwrites the whole row. Without a
+/// lock, two concurrent mutations on the same purpose both read the row
+/// before either stores, so the second store clobbers the first —
+/// silently dropping a revocation flip (a credential the operator
+/// believes revoked then resolves *valid*) or aliasing two members onto
+/// one slot (the correlation harm the `assigned` mask exists to prevent).
+///
+/// One process-wide lock (not per-purpose) is the right grain, mirroring
+/// `ceremony::execute::LAST_ADMIN_LOCK`: status-list writes are
+/// infrequent admin operations, and the public serve route reads
+/// `get_state` directly and never takes the lock — so read throughput is
+/// unaffected and cross-purpose contention is negligible.
+static STATUS_LIST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// Acquire the status-list write lock. Hold the returned guard across the
+/// entire `get_state` → mutate → `store_state` sequence.
+///
+/// Most callers want [`with_locked`]. Reach for the raw guard only when
+/// async work must sit between the allocate and the store while still
+/// excluding other writers — e.g. the admit path builds the VMC/VEC
+/// between allocating a slot and persisting it, so a build failure
+/// doesn't burn the slot.
+///
+/// Not re-entrant: never call [`with_locked`] (or `lock` again) while
+/// already holding the guard — it would deadlock.
+pub async fn lock() -> MutexGuard<'static, ()> {
+    STATUS_LIST_LOCK.lock().await
+}
+
+/// Run a status-list row mutation atomically under [`lock`]: load the
+/// row, apply the in-memory mutation `f` (`allocate` / `flip`), persist
+/// it, and emit the occupancy warning — with no interleaving writer.
+/// `f`'s return value is propagated to the caller (e.g. the allocated
+/// slot index).
+///
+/// Returns `AppError::Internal` if the row hasn't been initialised
+/// (`ensure_initial` runs at boot for each purpose once `public_url` is
+/// configured).
+pub async fn with_locked<F, T>(
+    ks: &KeyspaceHandle,
+    purpose: StatusPurpose,
+    f: F,
+) -> Result<T, AppError>
+where
+    F: FnOnce(&mut StatusListState) -> Result<T, AppError>,
+{
+    let _guard = lock().await;
+    let mut state = get_state(ks, purpose)
+        .await?
+        .ok_or_else(|| AppError::Internal(format!("status list for {purpose} not initialised")))?;
+    let out = f(&mut state)?;
+    store_state(ks, &state).await?;
+    super::maybe_emit_occupancy_warning(&state);
+    Ok(out)
 }
 
 // ---------------------------------------------------------------------------
@@ -409,5 +475,122 @@ mod tests {
             reloaded.bits[byte] & (1 << bit) != 0,
             "revocation bit was cleared during reallocation drain"
         );
+    }
+
+    /// Small-capacity state persisted to `ks`, ready for the concurrency
+    /// tests (the production 131_072-bit default makes `allocate`'s
+    /// available-slot scan needlessly heavy per call).
+    async fn seed_small_list(ks: &KeyspaceHandle, capacity: usize) -> StatusListState {
+        let mut state = StatusListState::new(
+            StatusPurpose::Revocation,
+            "https://vtc.example.com/v1/status-lists/revocation".into(),
+        );
+        state.capacity = capacity;
+        state.bits = vec![0u8; capacity.div_ceil(8)];
+        state.assigned = vec![false; capacity];
+        store_state(ks, &state).await.unwrap();
+        state
+    }
+
+    /// Regression for the P0.1 status-list race: N concurrent `allocate`
+    /// calls through [`with_locked`] over the same keyspace must each get
+    /// a *distinct* slot and persist *all* N — none clobbered.
+    ///
+    /// Without the lock, the `get_state` → `allocate` → `store_state` RMW
+    /// races: concurrent writers read the same row and the last
+    /// `store_state` overwrites the others, so fewer than N slots persist
+    /// (and `allocate` can hand the same index to two members — the
+    /// correlation harm the `assigned` mask exists to prevent). Removing
+    /// the `lock().await` inside `with_locked` makes this test fail.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_allocate_under_lock_loses_no_slots() {
+        use crate::status_list::allocator::allocate;
+
+        let (ks, _dir) = temp_ks().await;
+        seed_small_list(&ks, 64).await;
+
+        const N: u32 = 16;
+        let mut handles = Vec::with_capacity(N as usize);
+        for _ in 0..N {
+            let ks = ks.clone();
+            handles.push(tokio::spawn(async move {
+                with_locked(&ks, StatusPurpose::Revocation, |row| {
+                    allocate(row).ok_or_else(|| AppError::Internal("status list full".into()))
+                })
+                .await
+            }));
+        }
+
+        let mut slots = std::collections::HashSet::new();
+        for h in handles {
+            slots.insert(h.await.unwrap().unwrap());
+        }
+        assert_eq!(
+            slots.len(),
+            N as usize,
+            "concurrent allocations collided or were lost (got {} distinct slots)",
+            slots.len()
+        );
+
+        let final_state = get_state(&ks, StatusPurpose::Revocation)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            final_state.count_assigned(),
+            N as usize,
+            "persisted assigned-count dropped allocations to a racing writer"
+        );
+    }
+
+    /// Regression for the P0.1 status-list race: a revocation `flip`
+    /// running concurrently with an `allocate` (a join admit / endorsement
+    /// issue) must keep the revocation bit — the allocate's whole-row
+    /// `store_state` must not clobber it. Both [`with_locked`] mutations
+    /// apply; order is irrelevant.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn revoke_under_lock_survives_concurrent_allocate() {
+        use crate::status_list::allocator::{allocate, flip};
+
+        let (ks, _dir) = temp_ks().await;
+        let mut state = seed_small_list(&ks, 64).await;
+        // Pre-allocate the slot we'll revoke, persist it.
+        let victim = allocate(&mut state).expect("pre-allocate victim");
+        store_state(&ks, &state).await.unwrap();
+
+        let ks_revoke = ks.clone();
+        let ks_alloc = ks.clone();
+        let revoke = tokio::spawn(async move {
+            with_locked(&ks_revoke, StatusPurpose::Revocation, move |row| {
+                flip(row, victim, true).map_err(|e| AppError::Internal(e.to_string()))
+            })
+            .await
+        });
+        let alloc = tokio::spawn(async move {
+            with_locked(&ks_alloc, StatusPurpose::Revocation, |row| {
+                allocate(row).ok_or_else(|| AppError::Internal("status list full".into()))
+            })
+            .await
+        });
+        revoke.await.unwrap().unwrap();
+        let new_slot = alloc.await.unwrap().unwrap();
+
+        let final_state = get_state(&ks, StatusPurpose::Revocation)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            final_state.is_set(victim as usize),
+            "revocation bit was lost to a racing allocate"
+        );
+        assert!(
+            final_state.assigned[victim as usize],
+            "assigned mark on the revoked slot was lost"
+        );
+        assert!(
+            final_state.assigned[new_slot as usize],
+            "the concurrent allocation was lost"
+        );
+        assert_ne!(new_slot, victim, "allocate handed back the revoked slot");
     }
 }


### PR DESCRIPTION
## Problem

Every status-list mutation is a read-modify-write: `get_state` → mutate in memory (`allocate` / `flip`) → `store_state`, and `store_state` overwrites the whole row. With no lock, two concurrent mutations on the same purpose both read the row before either stores, so the second store **clobbers the first**:

- a dropped **revocation flip** → a credential the operator believes revoked resolves *valid*; or
- two members **aliased onto one slot** → the exact correlation harm the `assigned` mask exists to prevent.

This is **P0.1** of the VTC architecture review.

## Fix

A process-wide `STATUS_LIST_LOCK` (`tokio::Mutex`) serializing every status-list row mutation, in `status_list/storage.rs`:

- **`with_locked(ks, purpose, f)`** — load → apply the in-memory mutation → persist → occupancy warning, all under the lock. Used by the 5 simple allocate-then-store sites (endorsements ×2, personhood, renew, depart's `flip_revocation`).
- **raw `lock()` guard** — for the two paths where async work sits *between* allocate and store, so the row is persisted only after the build succeeds (a build failure doesn't burn the slot):
  - admit (`ceremony::execute::issue_member_credentials`) — builds the VMC + VEC between allocate and store;
  - `invitation::issue_invitation` — builds the VIC between allocate and store.

One process-wide lock (not per-purpose) mirrors the existing `LAST_ADMIN_LOCK`: status-list writes are infrequent admin operations, and the public serve route reads `get_state` directly (never takes the lock), so read throughput is unaffected. The lock is documented as non-re-entrant; the two raw-`lock()` sites do not call `with_locked` while holding the guard (verified — they only build/validate/store).

## Tests
New concurrency coverage in `status_list::storage::tests`: `concurrent_allocate_under_lock_loses_no_slots`, `revoke_under_lock_survives_concurrent_allocate`, `revoked_index_survives_restart_and_is_not_reallocated`, plus the existing allocator/round-trip suite.

## Verification
Rebased onto current `main` (clean). `cargo fmt --check`, `cargo clippy --all-targets` (clean), `cargo test -p vtc-service --lib` (498 pass; the 4 `admin_ui` failures are the known `VTC_SKIP_ADMIN_UI_BUILD` env artifact), `cargo deny check` all green.