### PR TITLE
fix(vta-service): validate config at boot; require opt-in for plaintext seed fallback (P0.9 part 1)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -86,7 +86,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   silent plaintext fallback unless `secrets.allow_plaintext = true` (footgun:
   one wrong TOML key → master seed on disk in clear). Tests: validate rules
   (the opt-in path is cfg-unreachable in the test harness — dev-dep forces
-  keyring on — documented) — PR: ____
+  keyring on — documented) — PR: #356 (in review)
 - `[ ]` **P0.9b** Split from P0.9 (config-compat risk; needs care):
   `deny_unknown_fields`/unknown-key WARNING pass on `AppConfig` (could reject
   existing configs with legacy/extra keys — softer warning preferred);

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -77,9 +77,22 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   torn fsync favours a recoverable reopen over a brick. Counter allocator
   also now fsyncs (path-counter loss = key reuse). Tests: persist-survives-
   reopen, carve-out-admits-one — PR: #343 (merged)
-- `[ ]` **P0.9** (M) Boot-time `config::validate()`; `deny_unknown_fields`;
-  hard-fail missing identity unless `--allow-degraded`; explicit opt-in for
-  plaintext seed store — PR: ____
+- `[~]` **P0.9a** (S) Boot-time `config::validate()` + plaintext-seed opt-in —
+  branch `fix/p0.9-config-validation` (worktree). `AppConfig::validate()` runs
+  at `server::run` boot: hard-errors on unambiguously-broken values
+  (retention_days=0, present-but-empty public_url/resolver_url), warns (never
+  blocks) on cross-field advisories (rest without public_url) so it can't
+  reject a config that boots fine today. `create_seed_store` now errors on the
+  silent plaintext fallback unless `secrets.allow_plaintext = true` (footgun:
+  one wrong TOML key → master seed on disk in clear). Tests: validate rules
+  (the opt-in path is cfg-unreachable in the test harness — dev-dep forces
+  keyring on — documented) — PR: ____
+- `[ ]` **P0.9b** Split from P0.9 (config-compat risk; needs care):
+  `deny_unknown_fields`/unknown-key WARNING pass on `AppConfig` (could reject
+  existing configs with legacy/extra keys — softer warning preferred);
+  hard-fail at boot on missing identity (`vta_did`/JWT keys) unless a new
+  `--allow-degraded` CLI flag (needs cold-start / TEE-autogen / import-did
+  flow analysis so it doesn't break a legitimate not-yet-configured boot) — PR: ____
 - `[~]` **P0.10** (S) `TimeoutLayer`; attestation routes onto governed branch;
   explicit 100 MB layer + governor on `/backup/blob` — branch
   `fix/p0.10-timeouts-ratelimit`. Global `TimeoutLayer` (120s, →408) as the

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -120,6 +120,15 @@ pub struct SecretsConfig {
     /// (vault-secrets feature).
     #[serde(default)]
     pub vault_skip_verify: bool,
+    /// Opt in to the **plaintext file** seed-store fallback. Off by
+    /// default: when no secure backend (keyring / cloud / Vault /
+    /// config-seed) is compiled-in *and* configured, `create_seed_store`
+    /// errors rather than silently writing the BIP-32 master seed to a
+    /// file in clear. Set `true` only for dev/test where that is
+    /// acceptable. (P0.9 — closes the "one wrong TOML key → master seed
+    /// on disk in cleartext" footgun.)
+    #[serde(default)]
+    pub allow_plaintext: bool,
 }
 
 fn default_keyring_service() -> String {
@@ -175,6 +184,7 @@ impl Default for SecretsConfig {
             vault_approle_secret_id: None,
             vault_approle_mount: default_vault_approle_mount(),
             vault_skip_verify: false,
+            allow_plaintext: false,
         }
     }
 }
@@ -750,10 +760,130 @@ impl AppConfig {
         Ok(())
     }
 
+    /// Validate the loaded runtime config, called at daemon boot
+    /// (`server::run`). Catches misconfigurations that would otherwise
+    /// produce a half-started or misbehaving service — the setup wizard
+    /// validates its *inputs*, but a hand-edited `config.toml` never went
+    /// through that gate.
+    ///
+    /// Conservative by design: it hard-errors only on values that are
+    /// unambiguously broken (a present-but-empty URL, a zero retention
+    /// window the sweeper can't honour) and *warns* — never blocks — on
+    /// cross-field advisories that a working deployment might legitimately
+    /// have, so it can't reject a config that boots fine today.
+    pub fn validate(&self) -> Result<(), AppError> {
+        let mut errors: Vec<String> = Vec::new();
+
+        // A present-but-empty URL is always a mistake (the operator set the
+        // key and left it blank); an *absent* key is fine (the default /
+        // serverless path).
+        if self
+            .public_url
+            .as_deref()
+            .is_some_and(|u| u.trim().is_empty())
+        {
+            errors.push(
+                "public_url is set to an empty string — remove the key for a \
+                 serverless VTA, or give it a value (e.g. https://vta.example.com)"
+                    .into(),
+            );
+        }
+        if self
+            .resolver_url
+            .as_deref()
+            .is_some_and(|u| u.trim().is_empty())
+        {
+            errors.push(
+                "resolver_url is set to an empty string — remove the key to resolve \
+                 DIDs locally, or give it a ws:// or wss:// URL"
+                    .into(),
+            );
+        }
+        // retention_days = 0 would silently disable audit retention; the
+        // sweeper assumes a positive window. (Mirrors the setup-time rule.)
+        if self.audit.retention_days == 0 {
+            errors.push("audit.retention_days must be > 0 (default is 28)".into());
+        }
+
+        if !errors.is_empty() {
+            return Err(AppError::Config(format!(
+                "invalid configuration in {}:\n  - {}",
+                self.config_path.display(),
+                errors.join("\n  - ")
+            )));
+        }
+
+        // Advisory (non-blocking): a REST-advertising VTA with no public_url
+        // publishes a DID document with no reachable REST endpoint. We don't
+        // hard-fail — a dev VTA legitimately runs REST without publishing —
+        // but the operator should see it.
+        if self.services.rest && self.public_url.is_none() {
+            tracing::warn!(
+                "services.rest = true but public_url is unset — the VTA DID document \
+                 will advertise no reachable REST endpoint"
+            );
+        }
+
+        Ok(())
+    }
+
     pub fn save(&self) -> Result<(), AppError> {
         let contents = toml::to_string_pretty(self)
             .map_err(|e| AppError::Config(format!("failed to serialize config: {e}")))?;
         std::fs::write(&self.config_path, contents).map_err(AppError::Io)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod validate_tests {
+    use super::*;
+
+    /// Parse a (possibly empty) TOML snippet into an `AppConfig`. An empty
+    /// document is valid — every field defaults (Options to None, server /
+    /// store / audit to their default fns).
+    fn cfg(toml_str: &str) -> AppConfig {
+        toml::from_str::<AppConfig>(toml_str).expect("parse test config")
+    }
+
+    #[test]
+    fn default_config_validates() {
+        cfg("")
+            .validate()
+            .expect("a fully-defaulted config must validate");
+    }
+
+    #[test]
+    fn zero_retention_days_is_rejected() {
+        let err = cfg("[audit]\nretention_days = 0\n")
+            .validate()
+            .expect_err("retention_days = 0 must be rejected");
+        assert!(format!("{err:?}").contains("retention_days"), "{err:?}");
+    }
+
+    #[test]
+    fn present_but_empty_public_url_is_rejected() {
+        let err = cfg("public_url = \"\"\n")
+            .validate()
+            .expect_err("empty public_url must be rejected");
+        assert!(format!("{err:?}").contains("public_url"), "{err:?}");
+    }
+
+    #[test]
+    fn present_but_empty_resolver_url_is_rejected() {
+        let err = cfg("resolver_url = \"   \"\n")
+            .validate()
+            .expect_err("whitespace-only resolver_url must be rejected");
+        assert!(format!("{err:?}").contains("resolver_url"), "{err:?}");
+    }
+
+    #[test]
+    fn rest_without_public_url_only_warns_does_not_fail() {
+        // services.rest defaults to true and public_url is absent — this is
+        // an advisory (a dev VTA legitimately runs REST without publishing),
+        // so validate must NOT hard-fail.
+        cfg("")
+            .validate()
+            .expect("rest-without-public_url is advisory, not an error");
     }
 }

--- a/vta-service/src/keys/seed_store/mod.rs
+++ b/vta-service/src/keys/seed_store/mod.rs
@@ -121,10 +121,33 @@ pub fn create_seed_store(config: &AppConfig) -> Result<Box<dyn SeedStore>, AppEr
     // only when `keyring` is the selected feature.
     #[allow(unreachable_code)]
     {
+        // No secure backend was compiled-in AND configured. Writing the
+        // BIP-32 master seed to a plaintext file is a real footgun (one
+        // wrong/missing TOML key would silently do it), so require an
+        // explicit opt-in rather than falling through silently (P0.9).
+        if !config.secrets.allow_plaintext {
+            return Err(AppError::Config(
+                "no secure seed-store backend is available (keyring/cloud/Vault/config-seed \
+                 not compiled-in or not configured), and the plaintext file fallback is \
+                 disabled. Configure a secure backend, or set `secrets.allow_plaintext = true` \
+                 to explicitly accept storing the master seed in a cleartext file (dev/test only)."
+                    .into(),
+            ));
+        }
         tracing::warn!(
-            "no secure seed store backend available — falling back to plaintext file storage"
+            "secrets.allow_plaintext = true — storing the BIP-32 master seed in a PLAINTEXT \
+             file. This is NOT secure; use a keyring or cloud/Vault backend in production."
         );
         let store = PlaintextSeedStore::new(&config.store.data_dir);
         Ok(Box::new(store))
     }
 }
+
+// NOTE: the plaintext-fallback opt-in above (`secrets.allow_plaintext`) is
+// not unit-tested. The fallthrough is only reachable when NO secure backend
+// is compiled-in, but the test harness can never produce that build: the
+// dev-dependency self-reference (`vta-service = { features = ["test-support"]
+// }`, no `default-features = false`) re-enables the default `keyring` feature
+// for every test target, so `create_seed_store` always takes the keyring
+// branch in tests. The opt-in guard is a simple `if !allow_plaintext { Err }`
+// on the otherwise-silent production fallthrough.

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -330,6 +330,10 @@ pub async fn run(
     storage_encryption_key: Option<[u8; 32]>,
     tee_context: Option<TeeContext>,
 ) -> Result<(), AppError> {
+    // Fail fast on a broken config rather than booting a half-started
+    // service that passes a port-liveness check but can't function (P0.9).
+    config.validate()?;
+
     // Open the runtime-state keyspace once up front so the boot decisions
     // below can read it (and the migration can seed it from the legacy
     // `[services]` block on first boot post-upgrade). Same encryption policy


### PR DESCRIPTION
## Summary

Plan task **P0.9** (part 1 — see scope note). Worked in an isolated worktree (parallel agent active).

### 1. Boot-time config validation (no half-started service)
A hand-edited `config.toml` never went through the setup wizard's input validation, so a broken runtime config booted a service that passed a port-liveness check but couldn't function. New `AppConfig::validate()`, called at the top of `server::run` (covers both the local `vta` binary and the enclave). **Conservative by design** so it can't reject a config that boots fine today:
- **Hard error** on unambiguously-broken values: `audit.retention_days = 0` (the sweeper needs a positive window); a present-but-empty `public_url`/`resolver_url` (key set, left blank).
- **Warns, never blocks**, on cross-field advisories (`services.rest` with no `public_url`) — a dev VTA legitimately runs REST without publishing.

### 2. Plaintext seed-store requires explicit opt-in (footgun)
`create_seed_store` silently fell through to a **plaintext file** backend when no secure backend was compiled-in and configured — one wrong/missing TOML key would write the **BIP-32 master seed to disk in clear**. It now errors unless `secrets.allow_plaintext = true`. Default builds carry the `keyring` feature and never reach this path, so **production is unaffected**.

## Scope note (split)
`deny_unknown_fields` and the **missing-identity hard-fail (+ a new `--allow-degraded` flag)** are split to **P0.9b**. Both carry real risk: `deny_unknown_fields` could reject existing configs with legacy/extra keys (a softer warning pass is preferable), and the identity hard-fail needs cold-start / TEE-autogen / import-did flow analysis so it doesn't break a legitimately not-yet-configured boot. They deserve their own focused change rather than riding along here.

## Tests
`AppConfig::validate` rules (default-valid; zero-retention rejected; empty `public_url`/`resolver_url` rejected; rest-without-public_url only warns).

**Honest gap**: the plaintext opt-in path is **cfg-unreachable in the test harness** — the dev-dependency self-reference (`vta-service = { features = ["test-support"] }`, no `default-features = false`) re-enables the default `keyring` feature for every test target, so `create_seed_store` always takes the keyring branch in tests. I documented this at the call site rather than ship a gated test that never runs. The guard is a simple `if !allow_plaintext { Err }`; I verified it compiles under `--no-default-features`.

Gate: vta-service 16 suites / 0 failures, clippy clean, fmt.