### PR TITLE
fix(vtc-service): move unauthenticated join-request POSTs onto the governed branch (P0.5)

### DIFF
--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -243,6 +243,13 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
     // collapses to `join-requests/submit/1.0` until TrustTaskRouter
     // gains per-method selectors (same workaround community/profile,
     // admin/config, members/{did} use).
+    // The unauthenticated `/join-requests` POST submit, `/accept`, and
+    // `/status` move to `build_unauth_routes` (P0.5) so the governor + 64 KiB
+    // cap apply; their Trust Tasks are declared there. The admin GET list keeps
+    // the `/join-requests` mount here under the *same* `join-requests/submit/1.0`
+    // task it has always required (axum merges this GET with the governed POST;
+    // the task descriptor collapse to `submit/1.0` for the list is unchanged —
+    // a per-method `list/1.0` split is future work, tracked separately).
     let join_submit = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0")
         .expect("static Trust-Task URL");
     let join_show = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/show/1.0")
@@ -252,13 +259,9 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             .expect("static Trust-Task URL");
     let join_reject = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0")
         .expect("static Trust-Task URL");
-    let join_accept = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0")
-        .expect("static Trust-Task URL");
     let join_manifest =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/manifest/1.0")
             .expect("static Trust-Task URL");
-    let join_status = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/status/1.0")
-        .expect("static Trust-Task URL");
     // Policies (Phase 2 M2.3). Three distinct Trust Tasks for the
     // three POST endpoints — upload, activate, test — so SIEM
     // filters + soft-gate consumers can target each precisely.
@@ -665,14 +668,13 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             post(members::promote::promote_finish),
             members_promote,
         )
-        // Join requests (Phase 1 M1.7–M1.10).
+        // Join requests (Phase 1 M1.7–M1.10). The unauth POST submit /
+        // accept / status live on the governed branch (`build_unauth_routes`,
+        // P0.5); the admin GET list keeps this `/join-requests` mount (axum
+        // merges this GET with the governed-branch POST submit).
         .route_with_task(
             "/join-requests",
-            // Submit (unauth) + admin list share the mount; the
-            // submit Trust Task `join-requests/submit/1.0` covers
-            // both methods here. Per-method selectors land
-            // alongside the same router work admin/config awaits.
-            post(join_requests::submit::submit).get(join_requests::read::list_join_requests),
+            get(join_requests::read::list_join_requests),
             join_submit,
         )
         .route_with_task(
@@ -690,14 +692,6 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             post(join_requests::decide::reject),
             join_reject,
         )
-        // Accept (unauth — the reciprocal VC + holder binding are the
-        // auth, like submit): the member counter-signs the issued VMC to
-        // close the bidirectional edge.
-        .route_with_task(
-            "/join-requests/{id}/accept",
-            post(join_requests::accept::accept),
-            join_accept,
-        )
         // Manifest (unauth public discovery): the community's join
         // evidence requirements. Static `manifest` segment takes
         // precedence over the `{id}` show route.
@@ -705,13 +699,6 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
             "/join-requests/manifest",
             get(join_requests::manifest::manifest),
             join_manifest,
-        )
-        // Status (unauth — holder binding in the body): the applicant
-        // polls their own request's lifecycle.
-        .route_with_task(
-            "/join-requests/{id}/status",
-            post(join_requests::status::status),
-            join_status,
         )
         // Credential-exchange query send (admin): prepare a DCQL query + issue a
         // single-use presentation challenge for a holder. Plain admin route (no
@@ -904,6 +891,18 @@ fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
     let auth_recognise_challenge =
         TrustTask::new("https://trusttasks.org/openvtc/vtc/auth/recognise/challenge/1.0")
             .expect("static Trust-Task URL");
+    // P0.5 — the unauthenticated join-request POSTs (submit / accept / status)
+    // do the same attacker-driven crypto as recognise (Ed25519 holder-binding
+    // verify, reciprocal-VC counter-sign verify, Rego eval) but were left on
+    // the 1 MiB / no-limiter main chain. Move them here so the governor + 64
+    // KiB cap apply. The admin GET list + show + approve / reject and the
+    // public GET manifest stay on the `api` chain.
+    let join_submit = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0")
+        .expect("static Trust-Task URL");
+    let join_accept = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/accept/1.0")
+        .expect("static Trust-Task URL");
+    let join_status = TrustTask::new("https://trusttasks.org/openvtc/vtc/join-requests/status/1.0")
+        .expect("static Trust-Task URL");
 
     // L2: rate-limiter key extractor honours `trust_xff`. The
     // governor is applied in the routing chain below via a
@@ -978,6 +977,25 @@ fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
             "/auth/recognise",
             post(recognise::recognise),
             auth_recognise,
+        )
+        // Join-request POSTs (P0.5). Submit shares the `/join-requests` mount
+        // with the admin GET list on the `api` chain — axum merges the GET +
+        // POST method routers; the unauth POST lands here (governed), the admin
+        // GET stays there (JWT-gated).
+        .route_with_task(
+            "/join-requests",
+            post(join_requests::submit::submit),
+            join_submit,
+        )
+        .route_with_task(
+            "/join-requests/{id}/accept",
+            post(join_requests::accept::accept),
+            join_accept,
+        )
+        .route_with_task(
+            "/join-requests/{id}/status",
+            post(join_requests::status::status),
+            join_status,
         )
         .into_router()
         .layer(DefaultBodyLimit::max(UNAUTH_BODY_SIZE));

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1692,3 +1692,93 @@ decision := {"effect": "request_more", "with": {
     assert_eq!(body["needs"][0], "agreed:code-of-conduct");
     assert_eq!(body["presentationDefinition"]["id"], "pd-coc");
 }
+
+// ---------------------------------------------------------------------------
+// P0.5 — the unauthenticated join-request POSTs (submit / accept / status)
+// must sit on the governed branch (5 rps + burst 10 per source IP), like the
+// recognise route — they run attacker-driven crypto + Rego eval and were
+// previously on the ungoverned 1 MiB main chain. The governor is the
+// outermost layer, so a flood trips 429 before the handler runs; the admin
+// GET list stays on the JWT-gated `api` chain (no governor).
+// ---------------------------------------------------------------------------
+
+/// Fire rapid requests at `uri` and report whether any returned 429 — proof
+/// the endpoint sits behind the unauth governor. The governor (burst 10) trips
+/// well within 40 sequential in-memory requests.
+async fn floods_to_429(router: &axum::Router, method: &str, uri: &str, task: &str) -> bool {
+    for _ in 0..40 {
+        let (status, _) = send(router, method, uri, task, None, Some(json!({}))).await;
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            return true;
+        }
+    }
+    false
+}
+
+#[tokio::test]
+async fn submit_post_is_rate_limited() {
+    let fix = build_fixture().await;
+    assert!(
+        floods_to_429(&fix.router, "POST", "/v1/join-requests", SUBMIT_TASK).await,
+        "POST /v1/join-requests must be on the governed branch (no 429 in 40 requests)"
+    );
+}
+
+#[tokio::test]
+async fn accept_post_is_rate_limited() {
+    let fix = build_fixture().await;
+    assert!(
+        floods_to_429(
+            &fix.router,
+            "POST",
+            "/v1/join-requests/00000000-0000-0000-0000-000000000000/accept",
+            ACCEPT_TASK,
+        )
+        .await,
+        "POST /v1/join-requests/{{id}}/accept must be on the governed branch"
+    );
+}
+
+#[tokio::test]
+async fn status_post_is_rate_limited() {
+    let fix = build_fixture().await;
+    assert!(
+        floods_to_429(
+            &fix.router,
+            "POST",
+            "/v1/join-requests/00000000-0000-0000-0000-000000000000/status",
+            STATUS_TASK,
+        )
+        .await,
+        "POST /v1/join-requests/{{id}}/status must be on the governed branch"
+    );
+}
+
+/// The admin GET list stays on the `api` chain (JWT-gated, no governor): 40
+/// rapid unauthenticated GETs stay `401` and never trip `429`. This is the
+/// other half of the split — the POST moved, the GET did not.
+#[tokio::test]
+async fn admin_list_get_is_not_rate_limited() {
+    let fix = build_fixture().await;
+    for _ in 0..40 {
+        let (status, _) = send(
+            &fix.router,
+            "GET",
+            "/v1/join-requests",
+            SUBMIT_TASK,
+            None,
+            None,
+        )
+        .await;
+        assert_ne!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "the admin GET list must stay off the governor (got 429)"
+        );
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "unauthenticated GET list should be 401, got {status}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`recognise` was deliberately moved onto the **governed** unauth branch (64 KiB body cap + 5 rps / burst-10 per-IP `tower-governor`) because it runs attacker-driven crypto. Three sibling endpoints doing the same class of work were left on the main `api` chain (**1 MiB cap, no limiter**), all with **no auth extractor** — the holder binding / reciprocal-VC signature in the body is the auth:

- `POST /v1/join-requests` — `submit` (Ed25519 holder-binding verify + Rego eval)
- `POST /v1/join-requests/{id}/accept` — `accept` (reciprocal-VC counter-sign verify)
- `POST /v1/join-requests/{id}/status` — `status` (holder-binding verify)

At 16× the body size with no per-IP throttle, they were a CPU-amplification / DoS surface.

This is **P0.5** of the VTC architecture review.

## Fix

Move the three POST registrations into `build_unauth_routes` (governor + 64 KiB cap), and **split** the shared `/join-requests` mount:

- the admin **GET list** stays on the JWT-gated `api` chain — axum merges that GET with the governed POST submit on the same path;
- the GET list keeps its existing `join-requests/submit/1.0` Trust-Task requirement, so **no wire change** for admin clients (the per-method `list/1.0` split stays future work);
- admin GET show / approve / reject and the public GET manifest are unchanged.

## Tests

- Each of the three POSTs trips **429 under a 40-request flood** from one IP (the governor is the outermost layer, so it fires before the handler) — proves they're on the governed branch.
- The admin GET list stays **401** and never 429 — proves it stayed on `api` (the other half of the split).
- All existing join-request coverage unchanged.

## Verification
`cargo fmt --check`, `cargo clippy --all-targets` (clean), `cargo test -p vtc-service` (every binary green except the known `VTC_SKIP_ADMIN_UI_BUILD` admin-SPA artifacts: the 4 `admin_ui` lib tests + 2 `routing_modes` `/admin`-SPA tests, both confirmed pre-existing by stashing this change), `cargo deny check` ok. No new dependencies.