### PR TITLE
fix(vta-service): DIDComm swap_acl honours step-up floors (P0.13a)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -124,8 +124,22 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   locks the invariant (passes on default + bbs feature) — PR: #349 (in review)
 - `[ ]` **P0.12** (M) Deferred-presentation sweeper + reachable
   approve/deny/list surface — PR: ____
-- `[ ]` **P0.13** (S) Decide + enforce/document cross-transport step-up policy
-  (DIDComm `swap_acl`; ignored vault `step_up_proof`) — PR: ____
+- **P0.13** — DECISION (operator): ENFORCE on both transports (not document).
+- `[~]` **P0.13a** (M) DIDComm `swap_acl` honours step-up floors — branch
+  `fix/p0.13a-didcomm-stepup` (worktree). Refactored `resolve_step_up` to take
+  `config` + `acl_ks` (not `&AppState`) so the DIDComm handler (`VtaState`)
+  can call it; made it + `StepUpDecision` + the `step_up` module `pub(crate)`
+  (the routes→messaging reach is a known wrinkle P2.4 relocates).
+  `handle_swap_acl` now resolves the `acl/swap-key` floor (non-escalating);
+  when a floor genuinely requires AAL2 the DIDComm caller (always AAL1,
+  unelevatable in-band) is rejected with a `forbidden`/StepUpRequired problem
+  report directing to REST. Added `StepUpRequired` → `forbidden` arm to
+  `app_err_to_response`. Test: `resolve_step_up` swap-key floor/carve-out/
+  disabled matrix — PR: ____
+- `[ ]` **P0.13b** (M) Vault step-up enforcement — wire `require_step_up` into
+  the vault TT handlers (release/upsert/sign-trust-task) using new `vault/*`
+  op-classes; remove the dormant `step_up_proof` field. (Operator chose
+  "enforce now".) — PR: ____
 - `[~]` **P0.14** (S) Tolerant list iteration (skip+log poisoned rows); backup
   export fails loudly — branch `fix/p0.14-tolerant-list-iteration`.
   list_acl_entries / list_contexts / list_keys skip+warn (one corrupt row

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -59,7 +59,11 @@ fn app_err_to_response(e: AppError) -> DIDCommResponse {
         // privilege-laundering rejection. Emit a workspace-specific
         // `e.p.msg.forbidden` code; SDK clients that don't know it
         // fall back to `DidcommRemote { code, comment }` cleanly.
-        AppError::Forbidden(msg) => ProblemReport {
+        // Step-up-required is a policy refusal (the op needs an AAL2 session
+        // the caller doesn't have). Surface it as `forbidden` rather than
+        // `internal-error` — DIDComm sender-auth can't be elevated to AAL2,
+        // so the comment directs the caller to the REST step-up path.
+        AppError::Forbidden(msg) | AppError::StepUpRequired(msg) => ProblemReport {
             code: vta_sdk::protocols::problem_report_codes::FORBIDDEN.to_string(),
             comment: msg.clone(),
             args: Vec::new(),
@@ -585,6 +589,34 @@ pub async fn handle_swap_acl(
             serde_json::from_value(message.body).map_err(handler_err)?;
         (body.presentation, None)
     };
+
+    // Honour any operator-configured step-up floor for `acl/swap-key` on the
+    // DIDComm transport too (P0.13). Previously only the REST route gated on
+    // step-up, so a `swap-key` floor was silently bypassed over DIDComm.
+    // swap-key is structurally non-escalating (self-service rotation of the
+    // caller's own entry), so a floor with `allow_aal1_if_non_escalating`
+    // still admits it. DIDComm sender-auth is AAL1 and cannot be elevated to
+    // AAL2 in-band, so a floor that genuinely requires step-up is
+    // unsatisfiable here — reject with guidance to use the REST path.
+    if !matches!(
+        crate::routes::trust_tasks::step_up::resolve_step_up(
+            &state.config,
+            &state.acl_ks,
+            crate::routes::trust_tasks::step_up::op::ACL_SWAP_KEY,
+            &auth.did,
+            true, // swap-key is non-escalating
+        )
+        .await,
+        crate::routes::trust_tasks::step_up::StepUpDecision::Allow
+    ) {
+        return Ok(Some(app_err_to_response(AppError::StepUpRequired(
+            "acl/swap-key requires a stepped-up (AAL2) session under this VTA's step-up \
+             policy. DIDComm sender-authentication is AAL1 and cannot be elevated in-band; \
+             perform this self-service rotation over the authenticated REST session, which \
+             can complete step-up."
+                .to_string(),
+        ))));
+    }
 
     let did_resolver = state
         .did_resolver

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -60,7 +60,11 @@ mod passkey_vms;
 #[cfg(feature = "webvh")]
 mod provision_integration;
 mod seeds;
-mod step_up;
+// `pub(crate)` so the DIDComm message handlers can reach `resolve_step_up`
+// to honour step-up floors on that transport too (P0.13). The step-up engine
+// living under `routes/` is a known layering wrinkle that P2.4 relocates to
+// `operations/`.
+pub(crate) mod step_up;
 mod step_up_policy;
 pub(crate) use step_up::{
     AclChangeRoleOp, AclGrantOp, AclRevokeOp, AclSwapKeyOp, ContextDeleteOp, RequireStepUp,

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -619,7 +619,7 @@ fn step_up_denied_response() -> Response {
 /// Step-up enforcement decision resolved from the policy floor for an
 /// operation-class, plus (for `delegated` modes) the caller's configured
 /// approver.
-enum StepUpDecision {
+pub(crate) enum StepUpDecision {
     /// Not gated — proceed at AAL1 (disabled policy, `none` floor, or the
     /// non-escalation carve-out applied).
     Allow,
@@ -641,14 +641,19 @@ enum StepUpDecision {
 /// `is_non_escalating` is the structural carve-out signal (true only for
 /// self-service ops like `acl/swap-key`); it lets a floor with
 /// `allow_aal1_if_non_escalating` admit the op at AAL1.
-async fn resolve_step_up(
-    state: &AppState,
+///
+/// Takes `config` + `acl_ks` directly (rather than `&AppState`) so the DIDComm
+/// message handlers — which hold a `VtaState`, not an `AppState` — can resolve
+/// the same policy. `pub(crate)` for that reason (P0.13).
+pub(crate) async fn resolve_step_up(
+    config: &tokio::sync::RwLock<crate::config::AppConfig>,
+    acl_ks: &KeyspaceHandle,
     op_class: &str,
     caller_did: &str,
     is_non_escalating: bool,
 ) -> StepUpDecision {
     let (floor_mode, allow_carveout) = {
-        let cfg = state.config.read().await;
+        let cfg = config.read().await;
         match cfg.auth.step_up.floor_record(op_class) {
             None => return StepUpDecision::Allow,
             Some(f) => (f.mode, f.allow_aal1_if_non_escalating),
@@ -659,10 +664,7 @@ async fn resolve_step_up(
     // (`stepUp.require`), additive-only: the effective mode is the strictest of
     // the two. The caller's entry is also where a `delegated` approver lives, so
     // fetch it once.
-    let entry = get_acl_entry(&state.acl_ks, caller_did)
-        .await
-        .ok()
-        .flatten();
+    let entry = get_acl_entry(acl_ks, caller_did).await.ok().flatten();
     let override_mode = entry
         .as_ref()
         .and_then(|e| e.step_up_require)
@@ -852,23 +854,24 @@ pub(super) async fn require_step_up(
     // Trust-task gated ops (grant, change-role, revoke, context-delete,
     // key-revoke) are all escalating — they never qualify for the
     // non-escalation carve-out.
-    let (recipient, approver_any) = match resolve_step_up(state, op_class, &auth.did, false).await {
-        StepUpDecision::Allow => return None,
-        StepUpDecision::Require { recipient } => (recipient, false),
-        StepUpDecision::RequireAny => (String::new(), true),
-        StepUpDecision::Deny => {
-            return Some(reject_with(
-                doc,
-                RejectReason::TaskFailed {
-                    reason: "auth:step_up_required".to_string(),
-                    details: Some(json!({
-                        "requiredAcr": STEP_UP_TARGET_ACR,
-                        "reason": "no step-up approver is configured for this subject",
-                    })),
-                },
-            ));
-        }
-    };
+    let (recipient, approver_any) =
+        match resolve_step_up(&state.config, &state.acl_ks, op_class, &auth.did, false).await {
+            StepUpDecision::Allow => return None,
+            StepUpDecision::Require { recipient } => (recipient, false),
+            StepUpDecision::RequireAny => (String::new(), true),
+            StepUpDecision::Deny => {
+                return Some(reject_with(
+                    doc,
+                    RejectReason::TaskFailed {
+                        reason: "auth:step_up_required".to_string(),
+                        details: Some(json!({
+                            "requiredAcr": STEP_UP_TARGET_ACR,
+                            "reason": "no step-up approver is configured for this subject",
+                        })),
+                    },
+                ));
+            }
+        };
     let vta_did = state
         .config
         .read()
@@ -984,13 +987,20 @@ impl<O: StepUpOp> FromRequestParts<AppState> for RequireStepUp<O> {
         // Resolve the floor for this route's operation-class, honoring the
         // non-escalation carve-out (`O::IS_NON_ESCALATING`) and, for delegated
         // modes, routing to the caller's configured approver.
-        let (recipient, approver_any) =
-            match resolve_step_up(state, O::OP_CLASS, &claims.did, O::IS_NON_ESCALATING).await {
-                StepUpDecision::Allow => return Ok(RequireStepUp(std::marker::PhantomData)),
-                StepUpDecision::Require { recipient } => (recipient, false),
-                StepUpDecision::RequireAny => (String::new(), true),
-                StepUpDecision::Deny => return Err(step_up_denied_response()),
-            };
+        let (recipient, approver_any) = match resolve_step_up(
+            &state.config,
+            &state.acl_ks,
+            O::OP_CLASS,
+            &claims.did,
+            O::IS_NON_ESCALATING,
+        )
+        .await
+        {
+            StepUpDecision::Allow => return Ok(RequireStepUp(std::marker::PhantomData)),
+            StepUpDecision::Require { recipient } => (recipient, false),
+            StepUpDecision::RequireAny => (String::new(), true),
+            StepUpDecision::Deny => return Err(step_up_denied_response()),
+        };
         let vta_did = state
             .config
             .read()
@@ -1020,6 +1030,68 @@ mod tests {
     use http_body_util::BodyExt;
     use multibase::Base;
     use serde_json::json;
+
+    /// The step-up decision the DIDComm `handle_swap_acl` gate now branches on
+    /// (P0.13). swap-key is non-escalating, so a floor only gates it when the
+    /// operator declines the carve-out; a disabled policy never gates.
+    #[tokio::test]
+    async fn resolve_step_up_swap_key_honours_floor_and_carveout() {
+        use vti_common::auth::step_up::{StepUpFloor, StepUpPolicy};
+        use vti_common::config::StoreConfig;
+        use vti_common::store::Store;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        let acl_ks = store.keyspace("acl").unwrap();
+        let caller = "did:key:zCaller";
+
+        let mk_config = |allow_carveout: bool, enabled: bool| {
+            let mut c: crate::config::AppConfig = toml::from_str("").unwrap();
+            c.auth.step_up = StepUpPolicy {
+                enabled,
+                floors: vec![StepUpFloor {
+                    operation: op::ACL_SWAP_KEY.to_string(),
+                    mode: StepUpMode::SelfApprove,
+                    allow_aal1_if_non_escalating: allow_carveout,
+                }],
+            };
+            tokio::sync::RwLock::new(c)
+        };
+
+        // Floor requires step-up, no carve-out → swap-key is gated (the new
+        // DIDComm behaviour: this caller, always AAL1, gets rejected).
+        let cfg = mk_config(false, true);
+        assert!(
+            !matches!(
+                resolve_step_up(&cfg, &acl_ks, op::ACL_SWAP_KEY, caller, true).await,
+                StepUpDecision::Allow
+            ),
+            "a swap-key floor without the carve-out must gate even a non-escalating request"
+        );
+
+        // Same floor WITH the carve-out → admitted at AAL1 (DIDComm proceeds).
+        let cfg = mk_config(true, true);
+        assert!(
+            matches!(
+                resolve_step_up(&cfg, &acl_ks, op::ACL_SWAP_KEY, caller, true).await,
+                StepUpDecision::Allow
+            ),
+            "the non-escalation carve-out must admit swap-key at AAL1"
+        );
+
+        // Policy disabled (the shipping default) → never gated.
+        let cfg = mk_config(false, false);
+        assert!(
+            matches!(
+                resolve_step_up(&cfg, &acl_ks, op::ACL_SWAP_KEY, caller, true).await,
+                StepUpDecision::Allow
+            ),
+            "a disabled policy gates nothing"
+        );
+    }
 
     #[test]
     fn approver_mediator_routes_did_key_to_configured_mediator() {


### PR DESCRIPTION
## Summary

Plan task **P0.13**, part a (operator decision: **enforce** step-up on both transports, not document the asymmetry). Worked in an isolated worktree.

The REST `acl/swap-key` route gates on `RequireStepUp<AclSwapKeyOp>`, but the **DIDComm handler had no equivalent** — so an operator who configured a step-up floor for `acl/swap-key` had it **silently bypassed over DIDComm**.

## Change
- **`resolve_step_up` refactored** to take `(config, acl_ks)` instead of `&AppState`, so the DIDComm message handlers (which hold a `VtaState`, not an `AppState`) can resolve the same policy. It, `StepUpDecision`, and the `step_up` module are now `pub(crate)`. *(The step-up engine living under `routes/` and reached from `messaging/` is a known layering wrinkle that P2.4 relocates to `operations/`; comment notes it.)*
- **`handle_swap_acl`** now resolves the `acl/swap-key` floor. swap-key is structurally **non-escalating** (self-service rotation), so a floor with `allow_aal1_if_non_escalating` still admits it. DIDComm sender-auth is **AAL1 and cannot be elevated to AAL2 in-band**, so a floor that genuinely requires step-up is unsatisfiable there — the caller is rejected with a `forbidden`/`StepUpRequired` problem report directing them to the REST session (which can complete step-up).
- Added a `StepUpRequired → forbidden` arm to `app_err_to_response` so it surfaces as `e.p.msg.forbidden`, not `internal-error`.

## Behaviour / compatibility
The shipping default is **step-up disabled** (gates nothing), so this is **inert** until an operator enables a swap-key floor. Existing DIDComm rotation is unaffected unless the operator explicitly requires step-up for `acl/swap-key` *without* the carve-out — exactly the policy they'd be asking for.

## Tests
`resolve_step_up` swap-key matrix: floor-without-carve-out gates (the new DIDComm rejection path); floor-with-carve-out admits at AAL1; disabled policy never gates. The existing REST step-up suite (api_integration) still passes through the refactored signature. Gate: vta-service 16 suites / 0 failures, clippy clean (default + tee), fmt.

## Follow-up
**P0.13b** (the other half of the operator's 'enforce now' decision): wire `require_step_up` into the vault TT handlers (release/upsert/sign-trust-task) via new `vault/*` op-classes and remove the dormant `step_up_proof` field. Tracked in the todo; separate PR.