### PR TITLE
fix(vtc-service): spawn the retention sweeper + GC expired exchange / sync rows (P0.6)

### DIFF
--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -40,6 +40,12 @@ pub struct AppConfig {
     /// flips a previously-asserted member's flag to `false`.
     #[serde(default)]
     pub renewal: RenewalConfig,
+    /// Retention sweeper settings (§5.5). Controls the window after which
+    /// terminal join requests (and expired credential-exchange / Failed
+    /// sync-job rows) are purged, plus the sweep cadence. Defaults to a
+    /// 30-day window swept hourly.
+    #[serde(default)]
+    pub join_requests: crate::join::retention::JoinRequestsConfig,
     /// Public community website settings (Phase 5 M5.4). When
     /// `root_dir` is unset the website handler 503s — the
     /// feature is opt-in by operator configuration, even though

--- a/vtc-service/src/credentials/exchange.rs
+++ b/vtc-service/src/credentials/exchange.rs
@@ -1195,6 +1195,31 @@ pub async fn make_offer(
     Ok((credential_offer(issuer_id, config_ids, code.clone()), code))
 }
 
+/// GC every pending-issuance row whose `expires_at` has passed. [`redeem`]
+/// rejects an expired offer, but an offer the holder never redeems would
+/// otherwise sit in the keyspace forever (each carrying a minted credential).
+/// Returns the count purged. Called by the daemon's retention sweeper.
+pub async fn sweep_expired_pending(
+    ks: &KeyspaceHandle,
+    now: DateTime<Utc>,
+) -> Result<usize, AppError> {
+    let now_ts = now.timestamp();
+    let mut purged = 0usize;
+    for (k, raw) in ks
+        .prefix_iter_raw(PENDING_PREFIX.as_bytes().to_vec())
+        .await?
+    {
+        // Unparseable rows are left alone — best-effort GC, not validation.
+        if let Ok(rec) = serde_json::from_slice::<PendingIssuance>(&raw)
+            && now_ts >= rec.expires_at
+        {
+            ks.remove(k).await?;
+            purged += 1;
+        }
+    }
+    Ok(purged)
+}
+
 /// Redeem a credential request against a persisted pending offer.
 ///
 /// Looks the pending issuance up by the request's proof `nonce` (the
@@ -1502,6 +1527,47 @@ mod tests {
         // Single-use: the offer is consumed.
         let again = redeem(&ks, &req, now).await.unwrap_err();
         assert!(matches!(again, AppError::NotFound(_)), "{again:?}");
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_pending_removes_only_expired() {
+        let (_d, _s, ks) = fresh_ks();
+        let holder = Holder::new(40);
+        let now = Utc::now();
+        // Expired offer: made an hour ago with the 30-min TTL.
+        make_offer(
+            &ks,
+            ISSUER,
+            vec!["MembershipCredential".into()],
+            a_credential(),
+            &holder.did,
+            DEFAULT_OFFER_TTL,
+            now - Duration::hours(1),
+        )
+        .await
+        .expect("expired offer");
+        // Fresh offer: made now → survives.
+        make_offer(
+            &ks,
+            ISSUER,
+            vec!["MembershipCredential".into()],
+            a_credential(),
+            &holder.did,
+            DEFAULT_OFFER_TTL,
+            now,
+        )
+        .await
+        .expect("fresh offer");
+
+        let purged = sweep_expired_pending(&ks, now).await.unwrap();
+        assert_eq!(purged, 1, "only the expired offer should be purged");
+
+        let remaining = ks
+            .prefix_iter_raw(b"credx-pending:".to_vec())
+            .await
+            .unwrap()
+            .len();
+        assert_eq!(remaining, 1, "the fresh offer survives");
     }
 
     #[tokio::test]

--- a/vtc-service/src/credentials/present_challenge.rs
+++ b/vtc-service/src/credentials/present_challenge.rs
@@ -94,6 +94,26 @@ pub async fn consume(
     })
 }
 
+/// GC every present-challenge row whose `expires_at` has passed. The
+/// happy-path [`consume`] already removes a row single-use, but a challenge
+/// that is *never* answered (a `query` sent to a holder who walks away) would
+/// otherwise linger in the keyspace past its TTL forever. Returns the count
+/// purged. Called by the daemon's retention sweeper.
+pub async fn sweep_expired(ks: &KeyspaceHandle, now: DateTime<Utc>) -> Result<usize, AppError> {
+    let mut purged = 0usize;
+    for (k, raw) in ks.prefix_iter_raw(PREFIX.as_bytes().to_vec()).await? {
+        // A row we can't parse is left alone — don't delete data we don't
+        // understand; this is best-effort GC, not validation.
+        if let Ok(rec) = serde_json::from_slice::<PresentChallenge>(&raw)
+            && now >= rec.expires_at
+        {
+            ks.remove(k).await?;
+            purged += 1;
+        }
+    }
+    Ok(purged)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,5 +204,33 @@ mod tests {
             matches!(&err, AppError::Validation(m) if m.contains("unknown")),
             "{err:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_removes_only_expired() {
+        let (_dir, ks) = fresh_ks();
+        let now = Utc::now();
+        // Stale: issued 10 min ago with the 5-min TTL → expired.
+        issue(
+            &ks,
+            "stale",
+            "did:web:v",
+            DEFAULT_CHALLENGE_TTL,
+            now - Duration::minutes(10),
+        )
+        .await
+        .unwrap();
+        // Fresh: issued now → survives.
+        issue(&ks, "fresh", "did:web:v", DEFAULT_CHALLENGE_TTL, now)
+            .await
+            .unwrap();
+
+        let purged = sweep_expired(&ks, now).await.unwrap();
+        assert_eq!(purged, 1, "only the expired challenge should be purged");
+
+        // The fresh row is still consumable; the stale one is gone.
+        assert!(consume(&ks, "fresh", now).await.is_ok());
+        let err = consume(&ks, "stale", now).await.unwrap_err();
+        assert!(matches!(&err, AppError::Validation(m) if m.contains("unknown")));
     }
 }

--- a/vtc-service/src/join/retention.rs
+++ b/vtc-service/src/join/retention.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use chrono::{Duration as ChronoDuration, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use tracing::{debug, info, warn};
@@ -55,8 +55,17 @@ pub struct RetentionSweeper;
 impl RetentionSweeper {
     /// Spawn the sweeper. Returns immediately; the task runs
     /// until the daemon's shutdown watcher fires.
+    ///
+    /// Sweeps four kinds of stale row each tick:
+    /// - `Rejected` / `Withdrawn` join requests past the retention window
+    ///   (PII in the submitted VP — the headline);
+    /// - expired `present-challenge:` + `credx-pending:` rows (TTLs are
+    ///   otherwise enforced only on the read path) — both in `join_requests_ks`;
+    /// - `Failed` registry sync jobs past the retention window
+    ///   (`sync_queue_ks`).
     pub fn spawn(
-        ks: KeyspaceHandle,
+        join_requests_ks: KeyspaceHandle,
+        sync_queue_ks: KeyspaceHandle,
         config: JoinRequestsConfig,
         mut shutdown_rx: watch::Receiver<bool>,
     ) -> tokio::task::JoinHandle<()> {
@@ -65,22 +74,36 @@ impl RetentionSweeper {
             info!(
                 retention_days = config.retention_days,
                 interval_secs = interval.as_secs(),
-                "join-request retention sweeper started"
+                "retention sweeper started"
             );
             // Sweep once on startup so a freshly-restarted daemon
             // catches up on rows that aged out while it was down.
-            if let Err(e) = sweep_once(&ks, config.retention_days).await {
-                warn!(error = %e, "initial join-request sweep failed");
+            if let Err(e) = sweep_all(
+                &join_requests_ks,
+                &sync_queue_ks,
+                config.retention_days,
+                Utc::now(),
+            )
+            .await
+            {
+                warn!(error = %e, "initial retention sweep failed");
             }
             loop {
                 tokio::select! {
                     _ = shutdown_rx.changed() => {
-                        info!("join-request retention sweeper shutting down");
+                        info!("retention sweeper shutting down");
                         return;
                     }
                     _ = tokio::time::sleep(interval) => {
-                        if let Err(e) = sweep_once(&ks, config.retention_days).await {
-                            warn!(error = %e, "join-request sweep failed");
+                        if let Err(e) = sweep_all(
+                            &join_requests_ks,
+                            &sync_queue_ks,
+                            config.retention_days,
+                            Utc::now(),
+                        )
+                        .await
+                        {
+                            warn!(error = %e, "retention sweep failed");
                         }
                     }
                 }
@@ -89,11 +112,43 @@ impl RetentionSweeper {
     }
 }
 
+/// One full retention pass across all four stale-row kinds. Each sub-sweep is
+/// independent; an error in one is propagated but the others on the same tick
+/// have already run (sweeps are ordered, not transactional). `present-challenge:`
+/// and `credx-pending:` share `join_requests_ks` with the join rows.
+async fn sweep_all(
+    join_requests_ks: &KeyspaceHandle,
+    sync_queue_ks: &KeyspaceHandle,
+    retention_days: u32,
+    now: DateTime<Utc>,
+) -> Result<(), AppError> {
+    sweep_once(join_requests_ks, retention_days, now).await?;
+    let challenges =
+        crate::credentials::present_challenge::sweep_expired(join_requests_ks, now).await?;
+    let offers = crate::credentials::exchange::sweep_expired_pending(join_requests_ks, now).await?;
+    let failed_jobs =
+        crate::registry::storage::sweep_failed_sync_jobs(sync_queue_ks, retention_days, now)
+            .await?;
+    if challenges + offers + failed_jobs > 0 {
+        info!(
+            expired_challenges = challenges,
+            expired_offers = offers,
+            failed_sync_jobs = failed_jobs,
+            "retention sweep purged auxiliary stale rows"
+        );
+    }
+    Ok(())
+}
+
 /// One pass: scan every row, delete those whose status is
 /// `Rejected` / `Withdrawn` AND `submitted_at` is older than the
 /// retention window.
-async fn sweep_once(ks: &KeyspaceHandle, retention_days: u32) -> Result<(), AppError> {
-    let cutoff = Utc::now() - ChronoDuration::days(retention_days as i64);
+async fn sweep_once(
+    ks: &KeyspaceHandle,
+    retention_days: u32,
+    now: DateTime<Utc>,
+) -> Result<(), AppError> {
+    let cutoff = now - ChronoDuration::days(retention_days as i64);
     let rows = list_join_requests(ks).await?;
     let mut purged = 0usize;
     for row in rows {
@@ -157,7 +212,7 @@ mod tests {
             store_join_request(&ks, r).await.unwrap();
         }
 
-        sweep_once(&ks, 30).await.unwrap();
+        sweep_once(&ks, 30, Utc::now()).await.unwrap();
 
         let remaining = list_join_requests(&ks).await.unwrap();
         let dids: Vec<_> = remaining.iter().map(|r| r.id).collect();
@@ -177,7 +232,7 @@ mod tests {
         let (ks, _dir) = temp_ks().await;
         let old = at(Utc::now() - ChronoDuration::days(45), JoinStatus::Withdrawn);
         store_join_request(&ks, &old).await.unwrap();
-        sweep_once(&ks, 30).await.unwrap();
+        sweep_once(&ks, 30, Utc::now()).await.unwrap();
         assert!(
             list_join_requests(&ks).await.unwrap().is_empty(),
             "old Withdrawn rows must be purged"
@@ -189,7 +244,106 @@ mod tests {
         let (ks, _dir) = temp_ks().await;
         let approved = at(Utc::now() - ChronoDuration::days(365), JoinStatus::Approved);
         store_join_request(&ks, &approved).await.unwrap();
-        sweep_once(&ks, 30).await.unwrap();
+        sweep_once(&ks, 30, Utc::now()).await.unwrap();
         assert_eq!(list_join_requests(&ks).await.unwrap().len(), 1);
+    }
+
+    /// `sweep_all` orchestrates all four kinds: a stale row of each is purged
+    /// and a not-yet-expired row of each survives.
+    #[tokio::test]
+    async fn sweep_all_purges_every_stale_kind_and_keeps_fresh() {
+        use crate::credentials::{exchange, present_challenge};
+        use crate::registry::model::{SyncJob, SyncJobKind, SyncJobState};
+        use crate::registry::storage::{list_sync_jobs, store_sync_job};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let join_ks = store.keyspace("join_requests").unwrap();
+        let sync_ks = store.keyspace("sync_queue").unwrap();
+        let now = Utc::now();
+
+        // --- stale rows (all must be purged) ---
+        store_join_request(
+            &join_ks,
+            &at(now - ChronoDuration::days(31), JoinStatus::Rejected),
+        )
+        .await
+        .unwrap();
+        present_challenge::issue(
+            &join_ks,
+            "stale-thread",
+            "did:web:v",
+            present_challenge::DEFAULT_CHALLENGE_TTL,
+            now - ChronoDuration::minutes(10),
+        )
+        .await
+        .unwrap();
+        exchange::make_offer(
+            &join_ks,
+            "https://issuer.example",
+            vec!["VMC".into()],
+            serde_json::json!({ "vc": 1 }),
+            "did:key:zHolder",
+            exchange::DEFAULT_OFFER_TTL,
+            now - ChronoDuration::hours(1),
+        )
+        .await
+        .unwrap();
+        let mut failed = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zMember");
+        failed.state = SyncJobState::Failed;
+        failed.last_attempted_at = Some(now - ChronoDuration::days(40));
+        store_sync_job(&sync_ks, &failed).await.unwrap();
+
+        // --- fresh rows (all must survive) ---
+        let fresh_join = at(now, JoinStatus::Rejected);
+        store_join_request(&join_ks, &fresh_join).await.unwrap();
+        present_challenge::issue(
+            &join_ks,
+            "fresh-thread",
+            "did:web:v",
+            present_challenge::DEFAULT_CHALLENGE_TTL,
+            now,
+        )
+        .await
+        .unwrap();
+
+        sweep_all(&join_ks, &sync_ks, 30, now).await.unwrap();
+
+        // Stale join purged, fresh join survives.
+        let join_ids: Vec<_> = list_join_requests(&join_ks)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| r.id)
+            .collect();
+        assert_eq!(
+            join_ids,
+            vec![fresh_join.id],
+            "only the fresh Rejected row survives"
+        );
+        // Fresh challenge still consumable; stale one gone.
+        assert!(
+            present_challenge::consume(&join_ks, "fresh-thread", now)
+                .await
+                .is_ok()
+        );
+        assert!(
+            present_challenge::consume(&join_ks, "stale-thread", now)
+                .await
+                .is_err()
+        );
+        // Expired credx-pending offer purged.
+        assert!(
+            join_ks
+                .prefix_iter_raw(b"credx-pending:".to_vec())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        // Old Failed sync job reaped.
+        assert!(list_sync_jobs(&sync_ks).await.unwrap().is_empty());
     }
 }

--- a/vtc-service/src/registry/model.rs
+++ b/vtc-service/src/registry/model.rs
@@ -141,8 +141,10 @@ pub const MAX_BACKOFF_SECONDS: i64 = 3600;
 /// `member_did` is stored in plaintext because the registry
 /// HTTP / DIDComm call needs the unhashed DID. The hashed
 /// form lives only on the audit envelope's actor field (per
-/// §11.1). Rows are deleted on `Complete` and age out via
-/// the retention sweeper on `Failed`.
+/// §11.1). Rows are deleted on `Complete`; `Failed` rows age
+/// out after the retention window via the daemon's retention
+/// sweeper ([`super::storage::sweep_failed_sync_jobs`], spawned
+/// from `server::run`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncJob {

--- a/vtc-service/src/registry/storage.rs
+++ b/vtc-service/src/registry/storage.rs
@@ -6,12 +6,12 @@
 //! - `sync_cursor` (singleton, key `cursor`) — audit-log
 //!   tail position.
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use uuid::Uuid;
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
-use super::model::{RegistryRecord, SyncJob};
+use super::model::{RegistryRecord, SyncJob, SyncJobState};
 
 /// Prefix every registry-record row sits under.
 pub const REGISTRY_RECORDS_PREFIX: &[u8] = b"registry_records:";
@@ -116,6 +116,31 @@ pub async fn list_sync_jobs(ks: &KeyspaceHandle) -> Result<Vec<SyncJob>, AppErro
         }
     }
     Ok(out)
+}
+
+/// Reap `Failed` sync jobs older than `retention_days`. A job flips to `Failed`
+/// only after exhausting its retry budget (`DEFAULT_MAX_ATTEMPTS`) and has
+/// surfaced in `/health/diagnostics` for operator intervention; past the
+/// retention window it is terminal clutter holding a plaintext `member_did`.
+/// Age is measured from `last_attempted_at` (when it gave up), falling back to
+/// `created_at`. Active / in-flight / retrying jobs are never touched. Returns
+/// the count purged.
+pub async fn sweep_failed_sync_jobs(
+    ks: &KeyspaceHandle,
+    retention_days: u32,
+    now: DateTime<Utc>,
+) -> Result<usize, AppError> {
+    let cutoff = now - ChronoDuration::days(retention_days as i64);
+    let mut purged = 0usize;
+    for job in list_sync_jobs(ks).await? {
+        if job.state == SyncJobState::Failed
+            && job.last_attempted_at.unwrap_or(job.created_at) < cutoff
+        {
+            delete_sync_job(ks, job.id).await?;
+            purged += 1;
+        }
+    }
+    Ok(purged)
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +269,51 @@ mod tests {
         for j in all {
             assert_eq!(j.state, SyncJobState::Pending);
         }
+    }
+
+    #[tokio::test]
+    async fn sweep_failed_sync_jobs_reaps_only_old_failed() {
+        let (_r, queue, _c, _dir) = temp_keyspaces().await;
+        let now = Utc::now();
+
+        // Old Failed (40 days since last attempt) → reaped.
+        let mut old_failed = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zOld");
+        old_failed.state = SyncJobState::Failed;
+        old_failed.last_attempted_at = Some(now - ChronoDuration::days(40));
+        // Recent Failed (3 days) → within the 30-day window, survives.
+        let mut recent_failed = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zRecent");
+        recent_failed.state = SyncJobState::Failed;
+        recent_failed.last_attempted_at = Some(now - ChronoDuration::days(3));
+        // Old Pending → never reaped (only Failed jobs age out).
+        let mut old_pending = SyncJob::fresh(SyncJobKind::PublishMember, "did:key:zPending");
+        old_pending.created_at = now - ChronoDuration::days(99);
+        old_pending.last_attempted_at = Some(now - ChronoDuration::days(99));
+
+        for j in [&old_failed, &recent_failed, &old_pending] {
+            store_sync_job(&queue, j).await.unwrap();
+        }
+
+        let purged = sweep_failed_sync_jobs(&queue, 30, now).await.unwrap();
+        assert_eq!(purged, 1);
+
+        let remaining: Vec<String> = list_sync_jobs(&queue)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|j| j.member_did)
+            .collect();
+        assert!(
+            !remaining.contains(&"did:key:zOld".to_string()),
+            "old Failed reaped"
+        );
+        assert!(
+            remaining.contains(&"did:key:zRecent".to_string()),
+            "recent Failed survives"
+        );
+        assert!(
+            remaining.contains(&"did:key:zPending".to_string()),
+            "Pending never reaped"
+        );
     }
 
     #[tokio::test]

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -568,6 +568,18 @@ pub async fn run(
         });
     }
 
+    // P0.6: spawn the retention sweeper. It was defined but never spawned, so
+    // terminal join requests (PII in the submitted VP), expired
+    // present-challenge / credx-pending rows, and `Failed` registry sync jobs
+    // accumulated forever. Unconditional — unlike the registry syncer, it has
+    // no external dependency. Runs on its own task until shutdown.
+    crate::join::retention::RetentionSweeper::spawn(
+        state.join_requests_ks.clone(),
+        state.sync_queue_ks.clone(),
+        boot_cfg.join_requests.clone(),
+        shutdown_rx.clone(),
+    );
+
     // M0.10: consume + audit any pending emergency-bootstrap marker
     // left behind by `vtc admin emergency-bootstrap`. The marker is
     // **one-shot**: `take_pending_emergency` deletes it as part of

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -42,6 +42,7 @@ fn cfg_with(routing: RoutingConfig, cors: CorsConfig) -> AppConfig {
         cors,
         registry: Default::default(),
         renewal: Default::default(),
+        join_requests: Default::default(),
         website: Default::default(),
         admin_ui: Default::default(),
         config_path: std::path::PathBuf::new(),


### PR DESCRIPTION
## Problem

`RetentionSweeper` — documented as "the sole control on inadvertent PII retention" — was defined and re-exported but **never spawned** in `server.rs`. So `Rejected` / `Withdrawn` join requests, each holding the full submitted VP (PII, up to 256 KiB), were **retained forever** and `join_requests:` grew unbounded. Three sibling leaks share the class:

- `present-challenge:` and `credx-pending:` rows enforce their TTL **only on the read path** — an abandoned challenge or unredeemed offer lingers forever;
- `Failed` registry sync jobs were never reaped, despite a `model.rs` comment claiming a sweeper that didn't exist.

This is **P0.6** of the VTC architecture review.

## Fix

- **Spawn `RetentionSweeper`** in `server.rs`, unconditionally (no external dependency, unlike the registry syncer), wired from a new operator-tunable config block `AppConfig.join_requests` (default **30-day** window, swept **hourly**).
- **Extend the sweep** to four kinds each tick (`sweep_all`):
  - `Rejected` / `Withdrawn` join requests past the retention window (existing);
  - expired `present-challenge:` rows — `present_challenge::sweep_expired`;
  - expired `credx-pending:` offers — `exchange::sweep_expired_pending` (both share `join_requests_ks`);
  - `Failed` sync jobs past the retention window — `registry::storage::sweep_failed_sync_jobs` (`sync_queue_ks`).
- Each sub-sweep leaves **unparseable rows alone** (best-effort GC, not validation) and never touches non-terminal / in-flight rows. The `sweep_once` join sweep now takes an explicit `now` for testability. Fixed the (now-accurate) `model.rs` comment to name the actual sweeper.

## Tests

- Per-kind coverage in each module: an expired row is purged, a not-yet-expired row of the same kind survives, and wrong-state rows are never touched (`present_challenge`, `exchange`, `registry::storage`).
- A `sweep_all` orchestration test stages a stale **and** fresh row of all four kinds in one pass and asserts exactly the stale ones are purged.
- Existing join-sweep tests adopt the new `sweep_once(.., now)` signature.

## Verification
`cargo fmt --check`, `cargo clippy --all-targets` (clean), `cargo test -p vtc-service` (506 lib pass incl. 7 new; the only failures are the 6 known `VTC_SKIP_ADMIN_UI_BUILD` admin-SPA artifacts — 4 `admin_ui` + 2 `routing_modes`), `cargo deny check` ok. No new dependencies.