### PR TITLE
fix(vta-service): enforce step-up on vault release/proxy-login/sign-trust-task (P0.13b)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -146,7 +146,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   the session-ACR gate, policy-driven — inert under the shipping default).
   Note: the actual op was proxy-login, not upsert (upsert has no step_up_proof
   / discloses nothing). Tests: op-class recognition; resolve gates a
-  configured vault floor only — PR: ____
+  configured vault floor only — PR: #362 (in review)
 - `[~]` **P0.14** (S) Tolerant list iteration (skip+log poisoned rows); backup
   export fails loudly — branch `fix/p0.14-tolerant-list-iteration`.
   list_acl_entries / list_contexts / list_keys skip+warn (one corrupt row

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -136,10 +136,17 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   report directing to REST. Added `StepUpRequired` → `forbidden` arm to
   `app_err_to_response`. Test: `resolve_step_up` swap-key floor/carve-out/
   disabled matrix — PR: ____
-- `[ ]` **P0.13b** (M) Vault step-up enforcement — wire `require_step_up` into
-  the vault TT handlers (release/upsert/sign-trust-task) using new `vault/*`
-  op-classes; remove the dormant `step_up_proof` field. (Operator chose
-  "enforce now".) — PR: ____
+- `[~]` **P0.13b** (M) Vault step-up enforcement — branch
+  `fix/p0.13b-vault-stepup` (worktree). Added `vault/release`,
+  `vault/proxy-login`, `vault/sign-trust-task` op-classes (vti-common
+  op_class + ALL + step_up `op` re-export). The three vault TT handlers
+  (release/proxy-login/sign-trust-task) now call
+  `require_step_up(state, auth, op::VAULT_*)` after the role + context-scope
+  checks; the dormant `step_up_proof` body fields are removed (enforcement is
+  the session-ACR gate, policy-driven — inert under the shipping default).
+  Note: the actual op was proxy-login, not upsert (upsert has no step_up_proof
+  / discloses nothing). Tests: op-class recognition; resolve gates a
+  configured vault floor only — PR: ____
 - `[~]` **P0.14** (S) Tolerant list iteration (skip+log poisoned rows); backup
   export fails loudly — branch `fix/p0.14-tolerant-list-iteration`.
   list_acl_entries / list_contexts / list_keys skip+warn (one corrupt row

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -922,6 +922,7 @@ pub(super) async fn require_step_up(
 pub mod op {
     pub use vti_common::auth::step_up::op_class::{
         ACL_CHANGE_ROLE, ACL_GRANT, ACL_REVOKE, ACL_SWAP_KEY, CONTEXT_DELETE, KEY_REVOKE,
+        VAULT_PROXY_LOGIN, VAULT_RELEASE, VAULT_SIGN_TRUST_TASK,
     };
 }
 
@@ -1090,6 +1091,52 @@ mod tests {
                 StepUpDecision::Allow
             ),
             "a disabled policy gates nothing"
+        );
+    }
+
+    /// P0.13b: a `vault/release` floor gates the op (vault ops are escalating —
+    /// `require_step_up` passes `is_non_escalating = false`, so no carve-out),
+    /// while an unconfigured vault op is untouched.
+    #[tokio::test]
+    async fn resolve_step_up_gates_configured_vault_op_only() {
+        use vti_common::auth::step_up::{StepUpFloor, StepUpPolicy};
+        use vti_common::config::StoreConfig;
+        use vti_common::store::Store;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        let acl_ks = store.keyspace("acl").unwrap();
+        let caller = "did:key:zCaller";
+
+        let mut c: crate::config::AppConfig = toml::from_str("").unwrap();
+        c.auth.step_up = StepUpPolicy {
+            enabled: true,
+            floors: vec![StepUpFloor {
+                operation: op::VAULT_RELEASE.to_string(),
+                mode: StepUpMode::SelfApprove,
+                allow_aal1_if_non_escalating: false,
+            }],
+        };
+        let cfg = tokio::sync::RwLock::new(c);
+
+        // The configured op is gated (the new vault enforcement).
+        assert!(
+            !matches!(
+                resolve_step_up(&cfg, &acl_ks, op::VAULT_RELEASE, caller, false).await,
+                StepUpDecision::Allow
+            ),
+            "a vault/release floor must gate the op"
+        );
+        // A different vault op with no floor is not gated.
+        assert!(
+            matches!(
+                resolve_step_up(&cfg, &acl_ks, op::VAULT_PROXY_LOGIN, caller, false).await,
+                StepUpDecision::Allow
+            ),
+            "an op with no configured floor must not be gated"
         );
     }
 

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -244,9 +244,10 @@ struct VaultReleaseBody {
     #[serde(default)]
     #[allow(dead_code)]
     consumer_context: Option<Value>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    step_up_proof: Option<Value>,
+    // (`step_up_proof` removed in P0.13: step-up is now enforced via the
+    // session ACR gate `require_step_up(op::VAULT_RELEASE)`, not a dormant
+    // body field. An incoming `stepUpProof` is harmlessly ignored — these
+    // bodies don't `deny_unknown_fields`.)
     #[serde(default)]
     ttl_seconds_hint: Option<u32>,
 }
@@ -312,13 +313,10 @@ struct VaultProxyLoginBody {
     #[serde(default)]
     #[allow(dead_code)]
     consumer_context: Option<Value>,
-    /// Step-up proof token (vta-approval JWS) — accepted for forward
-    /// compatibility; the M2B.2b SIOP driver doesn't require step-up
-    /// (the wallet already authenticated this caller). Sensitive sites
-    /// gain step-up enforcement via M3 policy + step-up wiring.
-    #[serde(default)]
-    #[allow(dead_code)]
-    step_up_proof: Option<Value>,
+    // (`step_up_proof` removed in P0.13: step-up is now the
+    // `require_step_up(op::VAULT_PROXY_LOGIN)` session-ACR gate above, which
+    // an operator opts into via a `vault/proxy-login` policy floor — replacing
+    // the dormant "forward-compatibility" body field this comment described.)
     /// Caller-supplied nonce — embedded verbatim as the SIOP id_token's
     /// `nonce` claim for the `did-self-issued` driver. Drivers without
     /// a nonce concept (Password POST, OAuth refresh — M2B.5+) ignore.
@@ -1069,6 +1067,16 @@ pub(super) async fn handle_release(
         return r;
     }
 
+    // Step-up gate (P0.13): honour an operator-configured `vault/release`
+    // floor before disclosing a stored secret. Placed after the role + scope
+    // checks so a caller lacking permission gets that error first, not a
+    // step-up prompt. Inert under the shipping default (step-up disabled).
+    if let Some(reject) =
+        super::step_up::require_step_up(state, auth, super::step_up::op::VAULT_RELEASE, &doc).await
+    {
+        return reject;
+    }
+
     // ATM is required for outbound authcrypt. Pre-flight check before
     // we build the message so the error is clearly "infrastructure not
     // configured" rather than a packing failure mid-flow.
@@ -1256,6 +1264,15 @@ pub(super) async fn handle_proxy_login(
 
     if let Err(r) = enforce_context_scope(auth, Some(&stored.entry.context_id), &doc) {
         return r;
+    }
+
+    // Step-up gate (P0.13): honour a `vault/proxy-login` floor before
+    // minting a session credential for the site. Inert by default.
+    if let Some(reject) =
+        super::step_up::require_step_up(state, auth, super::step_up::op::VAULT_PROXY_LOGIN, &doc)
+            .await
+    {
+        return reject;
     }
 
     // ATM + vta_did are needed for the shared authcrypt tail
@@ -1511,9 +1528,8 @@ struct VaultSignTrustTaskBody {
     #[serde(default)]
     #[allow(dead_code)]
     consumer_context: Option<Value>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    step_up_proof: Option<Value>,
+    // (`step_up_proof` removed in P0.13: enforced via the
+    // `require_step_up(op::VAULT_SIGN_TRUST_TASK)` session-ACR gate above.)
 }
 
 /// Response body for `vault/sign-trust-task/0.1`. Same `unsigned_envelope`
@@ -1574,6 +1590,19 @@ pub(super) async fn handle_sign_trust_task(
 
     if let Err(r) = enforce_context_scope(auth, Some(&stored.entry.context_id), &doc) {
         return r;
+    }
+
+    // Step-up gate (P0.13): honour a `vault/sign-trust-task` floor before
+    // signing as the entry's principal DID. Inert by default.
+    if let Some(reject) = super::step_up::require_step_up(
+        state,
+        auth,
+        super::step_up::op::VAULT_SIGN_TRUST_TASK,
+        &doc,
+    )
+    .await
+    {
+        return reject;
     }
 
     // Only signable kinds (DID-anchored secrets) carry a principal

--- a/vti-common/src/auth/step_up.rs
+++ b/vti-common/src/auth/step_up.rs
@@ -75,6 +75,14 @@ pub mod op_class {
     pub const ACL_SWAP_KEY: &str = "acl/swap-key";
     pub const CONTEXT_DELETE: &str = "context/delete";
     pub const KEY_REVOKE: &str = "key/revoke";
+    /// Disclose a stored vault secret to the caller (`vault/release/0.1`).
+    pub const VAULT_RELEASE: &str = "vault/release";
+    /// Mint a proxy-login session credential for a vault site
+    /// (`vault/proxy-login/0.1`).
+    pub const VAULT_PROXY_LOGIN: &str = "vault/proxy-login";
+    /// Sign a Trust Task envelope as a vault entry's principal DID
+    /// (`vault/sign-trust-task/0.1`).
+    pub const VAULT_SIGN_TRUST_TASK: &str = "vault/sign-trust-task";
 
     /// Every recognized operation-class (excludes the `*` catch-all).
     pub const ALL: &[&str] = &[
@@ -84,6 +92,9 @@ pub mod op_class {
         ACL_SWAP_KEY,
         CONTEXT_DELETE,
         KEY_REVOKE,
+        VAULT_RELEASE,
+        VAULT_PROXY_LOGIN,
+        VAULT_SIGN_TRUST_TASK,
     ];
 
     /// Whether `operation` is a floor target the maintainer recognizes: a known
@@ -292,6 +303,24 @@ mod tests {
     use super::*;
     use crate::config::StoreConfig;
     use crate::store::Store;
+
+    #[test]
+    fn vault_op_classes_are_recognized_floor_targets() {
+        // P0.13: vault ops must be settable as policy floors so step-up can be
+        // enforced on them; an unrecognized op-class is rejected at policy-set
+        // time as `unknownOperation`.
+        for op in [
+            op_class::VAULT_RELEASE,
+            op_class::VAULT_PROXY_LOGIN,
+            op_class::VAULT_SIGN_TRUST_TASK,
+        ] {
+            assert!(
+                op_class::is_recognized(op),
+                "{op} must be a valid floor target"
+            );
+            assert!(op_class::ALL.contains(&op), "{op} must be in ALL");
+        }
+    }
 
     async fn ks() -> KeyspaceHandle {
         let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

Plan task **P0.13**, part b (operator decision: **enforce now**). Worked in an isolated worktree. Completes the vault half of the cross-transport step-up enforcement (part a, #360, did `swap_acl` over DIDComm).

The vault Trust-Task handlers accepted a `step_up_proof` field and **ignored it**, so an operator could not actually gate the sensitive vault ops — disclosing a stored secret, minting a proxy-login session, or signing as an entry's principal DID — behind step-up.

## Change
- **New op-classes** (vti-common `op_class` + `ALL`, re-exported via the step_up `op` module): `vault/release`, `vault/proxy-login`, `vault/sign-trust-task`. Adding them to `ALL` makes them valid policy floor targets (a floor for an unrecognized op is rejected as `unknownOperation`).
- **`handle_release`, `handle_proxy_login`, `handle_sign_trust_task`** now call `require_step_up(state, auth, op::VAULT_*)` **after** the role + context-scope checks (so a caller lacking permission gets that error first, not a step-up prompt) and **before** the secret is disclosed / used.
- **Removed the three dormant `step_up_proof` body fields**: enforcement is the **session-ACR gate** (`require_step_up` reads `auth.acr`), not a body proof. The bodies don't `deny_unknown_fields`, so an incoming `stepUpProof` is harmlessly ignored — **no wire break**.

## Behaviour / compatibility
Policy-driven and **inert by default**: step-up ships disabled, so nothing is gated until an operator sets a `vault/*` floor.

## Scope note
The reviewed third op turned out to be **proxy-login**, not `upsert` — `upsert` stores the *caller's own* secret and discloses nothing, so it carries no `step_up_proof` and isn't gated. The three gated ops are exactly the three that had the dormant field.

## Tests
- The new op-classes are recognized floor targets (in `ALL`).
- `resolve_step_up` gates a configured `vault/release` floor while leaving an unconfigured vault op untouched.
- Gate: vti-common + vta-service **19 suites / 0 failures**, clippy clean (default + tee), fmt.