### PR TITLE
fix(vta-service): sweep deferred-presentation records (P0.12a)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -130,7 +130,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   sweep loop (threaded `vault_ks` through `run_storage_thread`), runs each
   `session_cleanup_interval` alongside the acl/audit/backup sweepers. Fixes the
   unbounded `pending-present:` growth (one record per untrusted-verifier query).
-  Test: sweep reclaims terminal+stale, keeps live, idempotent — PR: ____
+  Test: sweep reclaims terminal+stale, keeps live, idempotent — PR: #363 (in review)
 - `[ ]` **P0.12b** (M) Reachable approve/deny/list wire surface — expose the
   zero-caller `approve_pending_presentation`/`deny_pending_presentation`/
   `pending::list` over a TT slice (defer→list→approve→re-present end-to-end),

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -40,7 +40,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   seed rotation; create_context claims its record atomically at both
   layers; concurrency regression tests for all four —
   PR: #342 (merged)
-- `[~]` **P0.5** (L) Backup/restore: export counters, full `AclEntry`
+- `[x]` **P0.5** (L) Backup/restore: export counters, full `AclEntry`
   round-trip, import-in-progress sentinel — branch `fix/p0.5-backup-fidelity`
   (worktree). vta-sdk `BackupPayload` gains `path_counters`,
   `subcontext_counters`, `acl_entries_full` (raw `AclEntry` JSON — vta-sdk
@@ -51,7 +51,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   to lossy + warn). Crash-safety: `IMPORT_IN_PROGRESS_KEY` written+fsynced
   before the clear, removed+fsynced after; `server::run` refuses boot on a
   half-imported store. Tests: counter-no-reuse (exported + recomputed),
-  full-ACL-fields (expiry+step-up survive), sentinel lifecycle — PR: #358 (in review)
+  full-ACL-fields (expiry+step-up survive), sentinel lifecycle — PR: #358 (merged)
 - `[x]` **P0.6** (S) TEE seed rotation: reject or persist (no silent key loss) —
   branch `fix/p0.6-tee-seed-rotation`. Chose REJECT (the plan's safe minimum;
   in-place re-encryption is a follow-up). New `SeedStore::set_persists_across_restart()`
@@ -62,7 +62,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   refusal+no-mutation (tee), trait flag, existing non-TEE rotation unaffected
   — PR: #344 (merged). Follow-up: in-place re-encryption so TEE rotation
   works rather than refuses (needs runtime KMS access on KmsTeeSeedStore).
-- `[~]` **P0.7a** (S) `Zeroizing` seed bytes + honest "secure deletion" —
+- `[x]` **P0.7a** (S) `Zeroizing` seed bytes + honest "secure deletion" —
   branch `fix/p0.7-seed-zeroize` (isolated worktree). `load_seed_bytes`
   returns `Zeroizing<Vec<u8>>` (the 40-caller key-derivation path — all use
   `&seed`, so transparent via Deref); the low-level `rotate_seed`'s old/new
@@ -70,7 +70,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   derivation.rs) wrapped too. `delete_secret` dropped its ineffective
   zero-overwrite (LSM keeps old SSTables; value is ciphertext anyway) with an
   honest comment. Trait-level `SeedStore::get` Zeroizing deferred (crosses
-  vtc + 8 backends) — PR: #353 (in review)
+  vtc + 8 backends) — PR: #353 (merged)
 - `[ ]` **P0.7b** (L) Encrypt the retired-seed archive independently of the
   keyspace-encryption flag. Split from P0.7: needs a rotation-re-encryption
   (or successor-chain) design + a migration for existing plaintext archives —
@@ -87,7 +87,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   torn fsync favours a recoverable reopen over a brick. Counter allocator
   also now fsyncs (path-counter loss = key reuse). Tests: persist-survives-
   reopen, carve-out-admits-one — PR: #343 (merged)
-- `[~]` **P0.9a** (S) Boot-time `config::validate()` + plaintext-seed opt-in —
+- `[x]` **P0.9a** (S) Boot-time `config::validate()` + plaintext-seed opt-in —
   branch `fix/p0.9-config-validation` (worktree). `AppConfig::validate()` runs
   at `server::run` boot: hard-errors on unambiguously-broken values
   (retention_days=0, present-but-empty public_url/resolver_url), warns (never
@@ -96,14 +96,14 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   silent plaintext fallback unless `secrets.allow_plaintext = true` (footgun:
   one wrong TOML key → master seed on disk in clear). Tests: validate rules
   (the opt-in path is cfg-unreachable in the test harness — dev-dep forces
-  keyring on — documented) — PR: #356 (in review)
+  keyring on — documented) — PR: #356 (merged)
 - `[ ]` **P0.9b** Split from P0.9 (config-compat risk; needs care):
   `deny_unknown_fields`/unknown-key WARNING pass on `AppConfig` (could reject
   existing configs with legacy/extra keys — softer warning preferred);
   hard-fail at boot on missing identity (`vta_did`/JWT keys) unless a new
   `--allow-degraded` CLI flag (needs cold-start / TEE-autogen / import-did
   flow analysis so it doesn't break a legitimate not-yet-configured boot) — PR: ____
-- `[~]` **P0.10** (S) `TimeoutLayer`; attestation routes onto governed branch;
+- `[x]` **P0.10** (S) `TimeoutLayer`; attestation routes onto governed branch;
   explicit 100 MB layer + governor on `/backup/blob` — branch
   `fix/p0.10-timeouts-ratelimit`. Global `TimeoutLayer` (120s, →408) as the
   hang backstop; moved the 4 unauth attestation routes (status, report
@@ -113,19 +113,31 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   Factored `apply_unauth_governor()` (DRYs the trust_xff if/else, reused by
   both branches). Tests: blob+attestation 429 floods, 408 slow-handler,
   existing /auth/challenge 429 still green. tower-http `timeout` feature
-  added — PR: #352 (in review)
-- `[~]` **P0.11** (S) BBS matchable ⇒ presentable — branch
+  added — PR: #352 (merged)
+- `[x]` **P0.11** (S) BBS matchable ⇒ presentable — branch
   `fix/p0.11-bbs-presentable`. Chose UNMATCH: `dcql_format` returns `None`
   for `Bbs2023` (was `Some("ldp_vc")` → matched-then-failed the whole
   vp_token in present_single's catch-all). Wiring `present_bbs` needs
   issuer BBS G2 pubkey resolution that present_single lacks + BBS is
   audit-gated (#294), so full BBS DCQL presentation is a follow-up tied to
   that audit. Guard test `formats_admitted_for_dcql_are_all_presentable`
-  locks the invariant (passes on default + bbs feature) — PR: #349 (in review)
-- `[ ]` **P0.12** (M) Deferred-presentation sweeper + reachable
-  approve/deny/list surface — PR: ____
+  locks the invariant (passes on default + bbs feature) — PR: #349 (merged)
+- `[~]` **P0.12a** (S) Deferred-presentation sweeper — branch
+  `fix/p0.12a-pending-present-sweeper` (worktree). Added `pending::sweep`
+  (reclaims terminal `Approved`/`Denied` + stale `expires_at<=now` records;
+  also reclaims undecodable garbage rows; tolerant — one bad/stuck row never
+  aborts the pass) + `pending::remove`. Wired into the existing storage-thread
+  sweep loop (threaded `vault_ks` through `run_storage_thread`), runs each
+  `session_cleanup_interval` alongside the acl/audit/backup sweepers. Fixes the
+  unbounded `pending-present:` growth (one record per untrusted-verifier query).
+  Test: sweep reclaims terminal+stale, keeps live, idempotent — PR: ____
+- `[ ]` **P0.12b** (M) Reachable approve/deny/list wire surface — expose the
+  zero-caller `approve_pending_presentation`/`deny_pending_presentation`/
+  `pending::list` over a TT slice (defer→list→approve→re-present end-to-end),
+  delete-on-terminal in approve/deny. Plan sequenced this AFTER the sweeper
+  (P0.12a). — PR: ____
 - **P0.13** — DECISION (operator): ENFORCE on both transports (not document).
-- `[~]` **P0.13a** (M) DIDComm `swap_acl` honours step-up floors — branch
+- `[x]` **P0.13a** (M) DIDComm `swap_acl` honours step-up floors — branch
   `fix/p0.13a-didcomm-stepup` (worktree). Refactored `resolve_step_up` to take
   `config` + `acl_ks` (not `&AppState`) so the DIDComm handler (`VtaState`)
   can call it; made it + `StepUpDecision` + the `step_up` module `pub(crate)`
@@ -136,7 +148,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   report directing to REST. Added `StepUpRequired` → `forbidden` arm to
   `app_err_to_response`. Test: `resolve_step_up` swap-key floor/carve-out/
   disabled matrix — PR: ____
-- `[~]` **P0.13b** (M) Vault step-up enforcement — branch
+- `[x]` **P0.13b** (M) Vault step-up enforcement — branch
   `fix/p0.13b-vault-stepup` (worktree). Added `vault/release`,
   `vault/proxy-login`, `vault/sign-trust-task` op-classes (vti-common
   op_class + ALL + step_up `op` re-export). The three vault TT handlers
@@ -146,14 +158,14 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   the session-ACR gate, policy-driven — inert under the shipping default).
   Note: the actual op was proxy-login, not upsert (upsert has no step_up_proof
   / discloses nothing). Tests: op-class recognition; resolve gates a
-  configured vault floor only — PR: #362 (in review)
-- `[~]` **P0.14** (S) Tolerant list iteration (skip+log poisoned rows); backup
+  configured vault floor only — PR: #362 (merged)
+- `[x]` **P0.14** (S) Tolerant list iteration (skip+log poisoned rows); backup
   export fails loudly — branch `fix/p0.14-tolerant-list-iteration`.
   list_acl_entries / list_contexts / list_keys skip+warn (one corrupt row
   no longer aborts the whole listing); backup export (seed/key/context/ACL
   collections) now errors loudly on a corrupt row (incomplete backup is
   worse than none). ACL field-fidelity stays for P0.5. Tests: ACL list
-  skips garbage row, export aborts on corrupt key row — PR: #347 (in review)
+  skips garbage row, export aborts on corrupt key row — PR: #347 (merged)
 
 **Checkpoint 0:** `[ ]` all P0 merged or deferred-with-issue; CI green;
 tee-architecture.md updated.

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -913,6 +913,52 @@ pub mod pending {
         }
         Ok(out)
     }
+
+    /// Delete a pending-presentation record by id. Idempotent — removing an
+    /// absent id is a no-op.
+    pub async fn remove(vault: &KeyspaceHandle, id: &str) -> Result<(), AppError> {
+        vault.remove(key(id)).await
+    }
+
+    /// Reclaim pending-presentation records that can no longer be acted on, so
+    /// the namespace doesn't grow unbounded at DIDComm message rate (P0.12).
+    /// A record is reclaimed when it is **terminal** (`Approved`/`Denied`) or
+    /// **stale** (`expires_at <= now` — its verifier nonce is no longer fresh,
+    /// so approval would refuse anyway). Undecodable rows are garbage that can
+    /// never be acted on, so they're reclaimed too (logged). Returns the count
+    /// removed.
+    ///
+    /// Tolerant by design (mirrors the steady-state list paths): one bad or
+    /// stuck row never aborts the whole pass — a delete that errors is left for
+    /// the next pass rather than failing the sweep.
+    pub async fn sweep(vault: &KeyspaceHandle, now: DateTime<Utc>) -> Result<usize, AppError> {
+        let raw = vault.prefix_iter_raw(PREFIX.as_bytes().to_vec()).await?;
+        let mut removed = 0usize;
+        for (k, v) in raw {
+            let reclaim = match serde_json::from_slice::<PendingPresentation>(&v) {
+                Ok(rec) => rec.status != PendingStatus::Pending || rec.expires_at <= now,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "pending-present sweeper: reclaiming an undecodable record"
+                    );
+                    true
+                }
+            };
+            if reclaim {
+                match vault.remove(k).await {
+                    Ok(()) => removed += 1,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "pending-present sweeper: delete failed; retry next pass"
+                        );
+                    }
+                }
+            }
+        }
+        Ok(removed)
+    }
 }
 
 /// Record a deferred presentation for later out-of-band approval. Called by the
@@ -2349,6 +2395,54 @@ mod tests {
                 .await
                 .unwrap_err();
         assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn sweep_reclaims_terminal_and_stale_records_keeps_live() {
+        let (_dir, vault, _keys_ks, _seed_store, _subject) = holder_fixture().await;
+        let query = membership_query();
+        let verifier = "did:web:stranger.example";
+        let requested = || {
+            vec![RequestedCredential {
+                credential_query_id: "membership".into(),
+                credential_id: "urn:cred:1".into(),
+                claims: vec!["givenName".into()],
+            }]
+        };
+        let now = Utc::now();
+
+        // (1) Live pending (future expiry) — must survive the sweep.
+        defer_presentation(&vault, "live", verifier, requested(), &query, now)
+            .await
+            .expect("defer live");
+        // (2) Terminal (denied) — must be reclaimed.
+        defer_presentation(&vault, "terminal", verifier, requested(), &query, now)
+            .await
+            .expect("defer terminal");
+        deny_pending_presentation(&vault, "terminal")
+            .await
+            .expect("deny");
+        // (3) Stale pending (recorded 48h ago → past the 24h window) — reclaimed.
+        defer_presentation(
+            &vault,
+            "stale",
+            verifier,
+            requested(),
+            &query,
+            now - chrono::Duration::hours(48),
+        )
+        .await
+        .expect("defer stale");
+
+        let removed = pending::sweep(&vault, now).await.expect("sweep");
+        assert_eq!(removed, 2, "terminal + stale records reclaimed");
+
+        let remaining = pending::list(&vault).await.expect("list");
+        assert_eq!(remaining.len(), 1, "only the live pending record survives");
+        assert_eq!(remaining[0].id, "live");
+
+        // Idempotent: a second sweep with nothing terminal/stale removes nothing.
+        assert_eq!(pending::sweep(&vault, now).await.expect("sweep2"), 0);
     }
 
     #[tokio::test]

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -567,6 +567,7 @@ pub async fn run(
         let storage_sessions_ks = sessions_ks.clone();
         let storage_audit_ks = audit_ks.clone();
         let storage_acl_ks = acl_ks.clone();
+        let storage_vault_ks = vault_ks.clone();
         let storage_backup_bundles_ks = backup_bundles_ks.clone();
         let storage_backup_blob_dir = backup_blob_dir.clone();
         let storage_audit_config = config.audit.clone();
@@ -868,6 +869,7 @@ pub async fn run(
                     storage_sessions_ks,
                     storage_audit_ks,
                     storage_acl_ks,
+                    storage_vault_ks,
                     storage_backup_bundles_ks,
                     storage_backup_blob_dir,
                     storage_audit_config,
@@ -964,6 +966,7 @@ fn run_storage_thread(
     sessions_ks: KeyspaceHandle,
     audit_ks: KeyspaceHandle,
     acl_ks: KeyspaceHandle,
+    vault_ks: KeyspaceHandle,
     backup_bundles_ks_storage: KeyspaceHandle,
     backup_blob_dir_storage: std::path::PathBuf,
     audit_config: crate::config::AuditConfig,
@@ -1019,6 +1022,23 @@ fn run_storage_thread(
                         .await
                         {
                             warn!("backup bundle sweeper error: {e}");
+                        }
+                        // Reclaim deferred-presentation records that are
+                        // terminal or stale (P0.12). Without this the
+                        // `pending-present:` namespace grows unbounded at
+                        // DIDComm message rate — every untrusted-verifier
+                        // query writes one.
+                        match crate::operations::credential_exchange::pending::sweep(
+                            &vault_ks,
+                            chrono::Utc::now(),
+                        )
+                        .await
+                        {
+                            Ok(n) if n > 0 => {
+                                info!(reclaimed = n, "pending-present sweeper")
+                            }
+                            Ok(_) => {}
+                            Err(e) => warn!("pending-present sweeper error: {e}"),
                         }
                     }
                     _ = shutdown_rx.changed() => {


### PR DESCRIPTION
## Summary

Plan task **P0.12**, part a (the sweeper — the plan sequences it before the wire surface). Worked in an isolated worktree.

Every untrusted-verifier query the holder defers writes a `pending-present:` record (24h TTL) into the vault keyspace, but there was **no sweeper** — the TTL was only checked at approve time, and approve/deny leave the record behind as `Approved`/`Denied`. So the namespace grew **unbounded at DIDComm message rate**: a remote verifier could inflate the store just by sending queries.

## Change
- **`pending::sweep`** reclaims records that can no longer be acted on:
  - **terminal** (`Approved`/`Denied`), and
  - **stale** (`expires_at <= now` — the verifier's nonce is no longer fresh, so approval would refuse anyway).
  - Undecodable garbage rows are reclaimed too (logged).
  - **Tolerant** (mirrors the steady-state list paths + P0.14): one bad or stuck row never aborts the pass — a delete that errors is retried next pass.
- **`pending::remove`** helper added.
- **Wired into the existing storage-thread sweep loop** (threaded `vault_ks` through `run_storage_thread`): runs each `session_cleanup_interval` alongside the session/audit/acl/backup-bundle sweepers — no new task or timer.

## Scope
This is the **sweeper half** of the deferred-presentation lifecycle. The follow-up (**P0.12b**) makes the currently-dormant `approve_pending_presentation` / `deny_pending_presentation` / `pending::list` surface reachable on the wire (defer → list → approve → re-present) and adds delete-on-terminal — at which point the sweeper still backstops abandoned (never-approved) deferrals.

## Tests
`sweep` reclaims terminal + stale records, keeps the live pending one, and is idempotent. Gate: vta-service **16 suites / 0 failures**, clippy clean (default + tee), fmt.