### PR TITLE
fix(vtc-service): encrypt install/audit_key/passkey keyspaces at rest (P0.7)

### DIFF
--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -73,6 +73,10 @@ vti-common = { path = "../vti-common", version = "0.10", features = [
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.
   "setup",
+  # `encryption` enables `KeyspaceHandle::with_encryption` /
+  # `migrate_to_encrypted` for at-rest encryption of the secret-bearing
+  # keyspaces (install, audit_key, passkey) — P0.7.
+  "encryption",
 ] }
 vta-sdk = { path = "../vta-sdk", version = "0.11", features = [
   "didcomm",

--- a/vtc-service/src/install/state_machine.rs
+++ b/vtc-service/src/install/state_machine.rs
@@ -600,4 +600,122 @@ mod tests {
             _ => panic!("expected Issued"),
         }
     }
+
+    fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
+    }
+
+    /// P0.7 accept criterion: the on-disk bytes for an issued install
+    /// token do not contain the (base64) ephemeral signing key — i.e. the
+    /// `install` keyspace is encrypted at rest. We prove it by writing the
+    /// *same* token to a bare and an encrypted store and showing the
+    /// plaintext fragment present in the former is absent in the latter.
+    #[tokio::test]
+    async fn issued_token_is_encrypted_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).unwrap();
+        let exp = Utc::now() + Duration::seconds(600);
+        let admin = "did:key:zTestAdmin".to_string();
+
+        // Bare write — confirms the secret is plaintext-visible without
+        // encryption (the pre-P0.7 state we're fixing).
+        let plain_jti = Uuid::new_v4();
+        let plain_ks = store.keyspace("install-plain").unwrap();
+        InstallTokenStore::new(plain_ks.clone())
+            .record_issued(
+                &plain_jti,
+                [0xAB; 32],
+                [0xCD; 32],
+                exp,
+                None,
+                Some(admin.clone()),
+            )
+            .await
+            .unwrap();
+        let plaintext = plain_ks
+            .get_raw(token_key(&plain_jti))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            contains(&plaintext, admin.as_bytes()),
+            "sanity: admin DID is plaintext-visible in an unencrypted store"
+        );
+
+        // Encrypted write — the same secret must not be on disk in clear.
+        let key = [0x77; 32];
+        let enc_jti = Uuid::new_v4();
+        let enc_store =
+            InstallTokenStore::new(store.keyspace("install").unwrap().with_encryption(key));
+        enc_store
+            .record_issued(
+                &enc_jti,
+                [0xAB; 32],
+                [0xCD; 32],
+                exp,
+                None,
+                Some(admin.clone()),
+            )
+            .await
+            .unwrap();
+
+        let on_disk = store
+            .keyspace("install")
+            .unwrap()
+            .get_raw(token_key(&enc_jti))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(on_disk.starts_with(b"VAE1"), "value must be encrypted");
+        assert!(
+            !contains(&on_disk, admin.as_bytes()),
+            "admin DID must not appear in ciphertext"
+        );
+        assert!(
+            !contains(&on_disk, &plaintext),
+            "the plaintext token blob must not appear verbatim on disk"
+        );
+
+        // And the encrypted store reads the token back intact.
+        assert!(enc_store.get_token(&enc_jti).await.unwrap().is_some());
+    }
+
+    /// P0.7: a boot over a pre-encryption store still reads existing rows.
+    /// A token written in plaintext is migrated in place and an encrypted
+    /// store then reads it back.
+    #[tokio::test]
+    async fn legacy_plaintext_token_survives_migration() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = Store::open(&cfg).unwrap();
+        let exp = Utc::now() + Duration::seconds(600);
+
+        // Legacy plaintext write.
+        let jti = Uuid::new_v4();
+        InstallTokenStore::new(store.keyspace("install").unwrap())
+            .record_issued(&jti, [0xAB; 32], [0xCD; 32], exp, None, None)
+            .await
+            .unwrap();
+
+        // Boot-time migration (mirrors what `server::run` does).
+        let key = [0x99; 32];
+        let migrated = store
+            .keyspace("install")
+            .unwrap()
+            .migrate_to_encrypted(key)
+            .await
+            .unwrap();
+        assert_eq!(migrated, 1);
+
+        // The encrypted store reads the pre-existing token.
+        let enc_store =
+            InstallTokenStore::new(store.keyspace("install").unwrap().with_encryption(key));
+        let outcome = enc_store.start_claim(&jti).await.unwrap();
+        assert_eq!(*outcome.ephemeral_signing_key, [0xCD; 32]);
+    }
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -10,6 +10,8 @@ use affinidi_tdk::secrets_resolver::{SecretsResolver, ThreadedSecretsResolver, s
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use hkdf::Hkdf;
+use sha2::Sha256;
 
 use crate::auth::AuthState;
 use crate::auth::jwt::JwtKeys;
@@ -202,7 +204,8 @@ pub async fn run(
     let config_ks = store.keyspace("config")?;
     let passkey_ks = store.keyspace("passkey")?;
     let install_ks = store.keyspace("install")?;
-    let install_store = InstallTokenStore::new(install_ks.clone());
+    // `install_store` is built later (after `init_auth` yields the storage
+    // key) so it wraps the encrypted `install` handle — see P0.7 below.
     let members_ks = store.keyspace("members")?;
     let join_requests_ks = store.keyspace("join_requests")?;
     let policies_ks = store.keyspace("policies")?;
@@ -320,6 +323,7 @@ pub async fn run(
         install_signer,
         audit_writer,
         credential_signer,
+        storage_key,
     ) = init_auth(
         &config,
         &*secret_store,
@@ -327,6 +331,35 @@ pub async fn run(
         audit_key_ks.clone(),
     )
     .await;
+
+    // P0.7: `install` (ephemeral install-token signing key) and `passkey`
+    // (WebAuthn state) also hold secrets in the clear. `init_auth` already
+    // migrated + wrapped `audit_key`; do the same for these two here, where
+    // the derived storage key is in scope. Migration is idempotent and
+    // crash-safe; a failure aborts boot rather than serving a store with a
+    // half-encrypted secret keyspace. `install_store` is (re)built on the
+    // wrapped handle so issued tokens are encrypted on disk.
+    let (install_ks, passkey_ks, audit_key_ks) = match storage_key {
+        Some(key) => {
+            let n_install = install_ks.migrate_to_encrypted(key).await?;
+            let n_passkey = passkey_ks.migrate_to_encrypted(key).await?;
+            if n_install > 0 || n_passkey > 0 {
+                info!(
+                    "encrypted {n_install} legacy install + {n_passkey} legacy passkey row(s) at rest"
+                );
+            }
+            // `audit_key`'s on-disk rows were already migrated inside
+            // `init_auth`; wrap the `AppState`-bound handle too so the
+            // field is consistent with what the `AuditKeyStore` uses.
+            (
+                install_ks.with_encryption(key),
+                passkey_ks.with_encryption(key),
+                audit_key_ks.with_encryption(key),
+            )
+        }
+        None => (install_ks, passkey_ks, audit_key_ks),
+    };
+    let install_store = InstallTokenStore::new(install_ks.clone());
 
     // Build WebAuthn relying party handle from `public_url`. Optional —
     // a serverless / pre-setup deployment has no public URL yet and
@@ -1056,12 +1089,18 @@ async fn init_auth(
     Option<Arc<InstallTokenSigner>>,
     Option<AuditWriter>,
     Option<Arc<crate::credentials::LocalSigner>>,
+    // P0.7: at-rest storage-encryption key (HKDF of the bundle Ed25519
+    // seed). `None` only when no key material is configured yet (pre-setup)
+    // or derivation fails — the caller then leaves keyspaces unencrypted.
+    // The `audit_key` keyspace is already migrated + wrapped with this key
+    // before return; the caller re-wraps `install` + `passkey`.
+    Option<[u8; 32]>,
 ) {
     let vtc_did = match &config.vtc_did {
         Some(did) => did.clone(),
         None => {
             warn!("vtc_did not configured — auth endpoints will not work (run setup first)");
-            return (None, None, None, None, None, None, None);
+            return (None, None, None, None, None, None, None, None);
         }
     };
 
@@ -1074,11 +1113,11 @@ async fn init_auth(
         Ok(Some(s)) => s,
         Ok(None) => {
             warn!("no key material found — auth endpoints will not work (run setup first)");
-            return (None, None, None, None, None, None, None);
+            return (None, None, None, None, None, None, None, None);
         }
         Err(e) => {
             warn!("failed to load key material: {e} — auth endpoints will not work");
-            return (None, None, None, None, None, None, None);
+            return (None, None, None, None, None, None, None, None);
         }
     };
 
@@ -1086,9 +1125,18 @@ async fn init_auth(
         Ok(pair) => pair,
         Err(msg) => {
             warn!("{msg}");
-            return (None, None, None, None, None, None, None);
+            return (None, None, None, None, None, None, None, None);
         }
     };
+
+    // P0.7: derive the at-rest storage-encryption key from the same 32-byte
+    // Ed25519 seed (HKDF-SHA256, info `vtc-storage-key/v1`). Domain-separated
+    // from the install-token (`vtc-install-jwt-key/v2`) and audit
+    // (`vtc-audit-key/v2`) derivations by its info string, so the same IKM
+    // yields three independent keys. `None` only on the (practically
+    // impossible) HKDF-expand failure, in which case keyspaces stay
+    // plaintext rather than the daemon refusing to boot.
+    let storage_key: Option<[u8; 32]> = derive_storage_key(&*ed25519_bytes);
 
     // M2.9 credential signer — wraps the same 32-byte Ed25519
     // seed in a [`LocalSigner`] handle so VMC / VEC / status-list
@@ -1111,6 +1159,31 @@ async fn init_auth(
             warn!("failed to derive install token signer: {e} — install routes disabled");
             None
         }
+    };
+
+    // P0.7: the `audit_key` keyspace holds the HMAC audit key in the clear.
+    // Migrate any pre-encryption plaintext row in place, then wrap the
+    // handle so the key is encrypted at rest going forward. A migration
+    // failure leaves the keyspace bare (still readable) and is logged — we
+    // only build the encrypted handle once the legacy rows are converted,
+    // so an encrypted read can never hit a stale plaintext row.
+    let audit_key_ks = match storage_key {
+        Some(key) => match audit_key_ks.migrate_to_encrypted(key).await {
+            Ok(n) => {
+                if n > 0 {
+                    info!("encrypted {n} legacy audit_key row(s) at rest");
+                }
+                audit_key_ks.with_encryption(key)
+            }
+            Err(e) => {
+                warn!(
+                    "audit_key encryption-at-rest migration failed: {e} — \
+                     keyspace left unencrypted"
+                );
+                audit_key_ks
+            }
+        },
+        None => audit_key_ks,
     };
 
     // Derive the HMAC audit key from the same 32 bytes. The
@@ -1140,6 +1213,7 @@ async fn init_auth(
                 install_signer,
                 audit_writer,
                 credential_signer,
+                storage_key,
             );
         }
     };
@@ -1173,6 +1247,7 @@ async fn init_auth(
                     install_signer,
                     audit_writer,
                     credential_signer,
+                    storage_key,
                 );
             }
         },
@@ -1188,6 +1263,7 @@ async fn init_auth(
                 install_signer,
                 audit_writer,
                 credential_signer,
+                storage_key,
             );
         }
     };
@@ -1242,7 +1318,27 @@ async fn init_auth(
         install_signer,
         audit_writer,
         credential_signer,
+        storage_key,
     )
+}
+
+/// Derive the at-rest storage-encryption key (P0.7).
+///
+/// `HKDF-SHA256(IKM = bundle Ed25519 seed, info = b"vtc-storage-key/v1")`.
+/// The info string domain-separates this key from the install-token signer
+/// (`vtc-install-jwt-key/v2`) and audit HMAC key (`vtc-audit-key/v2`) that
+/// share the same IKM. Returns `None` only if HKDF expand fails (it cannot
+/// for a 32-byte output), in which case the caller leaves keyspaces
+/// unencrypted rather than refusing to boot.
+fn derive_storage_key(ed25519_seed: &[u8]) -> Option<[u8; 32]> {
+    let mut key = [0u8; 32];
+    match Hkdf::<Sha256>::new(None, ed25519_seed).expand(b"vtc-storage-key/v1", &mut key) {
+        Ok(()) => Some(key),
+        Err(e) => {
+            warn!("failed to derive storage-encryption key: {e} — keyspaces left unencrypted");
+            None
+        }
+    }
 }
 
 /// Decode a base64url-no-pad JWT signing key and construct `JwtKeys`.

--- a/vti-common/src/store/encryption.rs
+++ b/vti-common/src/store/encryption.rs
@@ -85,6 +85,16 @@ pub fn encrypt_value(
     Ok(output)
 }
 
+/// True if `data` is in the v1 AAD-authenticated on-disk format (i.e. it
+/// carries the [`MAGIC`] prefix). Used by the boot migration
+/// ([`super::KeyspaceHandle::migrate_to_encrypted`]) to tell an
+/// already-encrypted row apart from a legacy plaintext one without
+/// attempting (and failing) a decrypt. This is a *format* check only — it
+/// does not authenticate the value.
+pub(crate) fn is_v1_encrypted(data: &[u8]) -> bool {
+    data.len() >= MAGIC.len() && &data[..MAGIC.len()] == MAGIC
+}
+
 /// Decrypt an AAD-authenticated value, verifying it against its
 /// `(keyspace, key)` location. Input: `MAGIC ‖ nonce ‖ ct+tag`.
 fn decrypt_value(

--- a/vti-common/src/store/mod.rs
+++ b/vti-common/src/store/mod.rs
@@ -118,6 +118,52 @@ impl KeyspaceHandle {
         }
     }
 
+    /// Re-encrypt every legacy plaintext row in this keyspace under `key`,
+    /// in place, so a store first written before encryption-at-rest was
+    /// enabled can be read by an encrypted handle.
+    ///
+    /// Must be called on a **bare** handle (no encryption configured): it
+    /// reads raw bytes *without* decrypting, then writes each plaintext
+    /// row back through an encrypted handle. Returns the number of rows
+    /// newly encrypted.
+    ///
+    /// **Idempotent and crash-safe.** Rows already in the v1 encrypted
+    /// format ([`encryption::is_v1_encrypted`]) are skipped, so an
+    /// interrupted run leaves a mix of encrypted + plaintext rows that a
+    /// re-run completes. The format magic (`VAE1`) is what distinguishes
+    /// the two; no value this is used for (serde-JSON state, raw key
+    /// bytes) begins with those four bytes, so detection is unambiguous.
+    ///
+    /// This deliberately does **not** add a lenient read-fallback to the
+    /// decrypt path — that would reintroduce the cut-and-paste downgrade
+    /// hole [`encryption`] documents. The store stays strictly
+    /// fail-closed; migration is a one-shot forward conversion.
+    #[cfg(feature = "encryption")]
+    pub async fn migrate_to_encrypted(&self, key: [u8; 32]) -> Result<usize, AppError> {
+        if self.is_encrypted() {
+            return Err(AppError::Internal(
+                "migrate_to_encrypted must be called on a bare (unencrypted) keyspace handle"
+                    .into(),
+            ));
+        }
+        // Bare read: returns raw on-disk bytes with no decryption, so
+        // both legacy plaintext rows and any already-encrypted rows from
+        // a prior partial run come back verbatim.
+        let rows = self.prefix_iter_raw(Vec::<u8>::new()).await?;
+        let encrypted = self.clone().with_encryption(key);
+        let mut migrated = 0usize;
+        for (k, v) in rows {
+            if encryption::is_v1_encrypted(&v) {
+                continue;
+            }
+            // insert_raw on the encrypted handle re-encrypts the value
+            // bound to its (keyspace, key) AAD location.
+            encrypted.insert_raw(k, v).await?;
+            migrated += 1;
+        }
+        Ok(migrated)
+    }
+
     /// Durably flush the store to disk (a write barrier).
     ///
     /// Persistence is store-wide, not per-keyspace: the local backend
@@ -958,5 +1004,101 @@ mod tests {
         // But reading with the correct encryption key should work
         let decrypted = ks_enc.get_raw("test").await.unwrap().unwrap();
         assert_eq!(decrypted, b"plaintext secret");
+    }
+
+    /// P0.7: a keyspace first written in plaintext (pre-encryption-at-rest)
+    /// can be migrated in place so an encrypted handle reads it, and the
+    /// migrated rows are genuinely ciphertext on disk.
+    #[cfg(feature = "encryption")]
+    #[tokio::test]
+    async fn migrate_to_encrypted_converts_legacy_plaintext() {
+        let (store, _dir) = temp_store();
+        let key = [0x33; 32];
+
+        // Seed legacy plaintext rows via a bare handle.
+        let bare = store.keyspace("install").unwrap();
+        bare.insert_raw("token:a", b"ephemeral-key-bytes".to_vec())
+            .await
+            .unwrap();
+        bare.insert("token:b", &"json-state".to_string())
+            .await
+            .unwrap();
+
+        // Migrate.
+        let migrated = bare.migrate_to_encrypted(key).await.unwrap();
+        assert_eq!(migrated, 2, "both legacy rows must be encrypted");
+
+        // On disk (bare read) the rows are now ciphertext, not the
+        // original plaintext.
+        let on_disk = bare.get_raw("token:a").await.unwrap().unwrap();
+        assert_ne!(on_disk, b"ephemeral-key-bytes");
+        assert!(
+            on_disk.starts_with(b"VAE1"),
+            "migrated row must carry the v1 encryption magic"
+        );
+
+        // An encrypted handle reads the original values back.
+        let enc = store.keyspace("install").unwrap().with_encryption(key);
+        assert_eq!(
+            enc.get_raw("token:a").await.unwrap().unwrap(),
+            b"ephemeral-key-bytes"
+        );
+        let b: String = enc.get("token:b").await.unwrap().unwrap();
+        assert_eq!(b, "json-state");
+    }
+
+    /// Re-running the migration is a no-op: already-encrypted rows are
+    /// detected by their format magic and skipped, so an interrupted run
+    /// is completed (not double-encrypted) by a re-run.
+    #[cfg(feature = "encryption")]
+    #[tokio::test]
+    async fn migrate_to_encrypted_is_idempotent_and_crash_safe() {
+        let (store, _dir) = temp_store();
+        let key = [0x44; 32];
+
+        let bare = store.keyspace("passkey").unwrap();
+        bare.insert_raw("row:1", b"plaintext-one".to_vec())
+            .await
+            .unwrap();
+
+        // First pass encrypts the one legacy row.
+        assert_eq!(bare.migrate_to_encrypted(key).await.unwrap(), 1);
+
+        // A new legacy row lands (simulating a crash mid-migration that
+        // left one row plaintext) alongside the already-encrypted one.
+        bare.insert_raw("row:2", b"plaintext-two".to_vec())
+            .await
+            .unwrap();
+
+        // Second pass skips the encrypted row and only converts the new
+        // one — never double-encrypting.
+        assert_eq!(bare.migrate_to_encrypted(key).await.unwrap(), 1);
+
+        // Third pass is a pure no-op.
+        assert_eq!(bare.migrate_to_encrypted(key).await.unwrap(), 0);
+
+        let enc = store.keyspace("passkey").unwrap().with_encryption(key);
+        assert_eq!(
+            enc.get_raw("row:1").await.unwrap().unwrap(),
+            b"plaintext-one"
+        );
+        assert_eq!(
+            enc.get_raw("row:2").await.unwrap().unwrap(),
+            b"plaintext-two"
+        );
+    }
+
+    /// Calling the migration on an already-encrypted handle is a usage
+    /// error — it would try to decrypt legacy plaintext and fail. Guard
+    /// against it explicitly rather than corrupting data.
+    #[cfg(feature = "encryption")]
+    #[tokio::test]
+    async fn migrate_to_encrypted_rejects_encrypted_handle() {
+        let (store, _dir) = temp_store();
+        let enc = store
+            .keyspace("install")
+            .unwrap()
+            .with_encryption([0x55; 32]);
+        assert!(enc.migrate_to_encrypted([0x55; 32]).await.is_err());
     }
 }


### PR DESCRIPTION
## P0.7 — encryption-at-rest for VTC secret-bearing keyspaces

Part of the VTC architecture-review P0 security cluster.

### Problem
`vtc-service` opened every keyspace bare, leaving three secret-bearing keyspaces in plaintext fjall:
- `install` — the install-token ephemeral Ed25519 private key
- `audit_key` — the HMAC audit key
- `passkey` — WebAuthn passkey state

`vti_common::store::KeyspaceHandle::with_encryption` already exists and the VTA uses it; this wires it into the VTC. The signing bundle correctly lives in the seed-store backend (not a keyspace), so it is left alone.

### Approach
- **Key derivation** (`init_auth`): `HKDF-SHA256(IKM = bundle Ed25519 seed, info = b"vtc-storage-key/v1")`, domain-separated by its info string from the existing install-token (`vtc-install-jwt-key/v2`) and audit (`vtc-audit-key/v2`) derivations that share the same IKM. `init_auth` migrates + wraps `audit_key` and returns the key; `run` re-wraps `install` (rebuilding `install_store`) and `passkey` before building `AppState`.
- **Back-compat** (the key design decision): `decrypt_value` is strictly fail-closed — non-`VAE1` data is a hard error. A lenient plaintext read-fallback was rejected because it reintroduces the cut-and-paste downgrade hole the encryption module documents, and that module is shared with the TEE-running VTA. Instead, a new `KeyspaceHandle::migrate_to_encrypted` does a one-shot, **idempotent, crash-safe** forward conversion: it re-encrypts legacy plaintext rows in place and skips already-encrypted ones by their format magic. Boot runs it for the three keyspaces before wrapping, so an upgrade over a pre-encryption store keeps reading existing rows while new writes land encrypted.

### Accept criteria (both covered by tests)
- ✅ On-disk bytes for an issued install token do not contain the (base64) ephemeral key.
- ✅ A boot over a pre-encryption store still reads existing rows.

### Tests
- `vti-common`: `migrate_to_encrypted` converts legacy plaintext / is idempotent + crash-safe / rejects an already-encrypted handle.
- `vtc-service`: `issued_token_is_encrypted_on_disk`, `legacy_plaintext_token_survives_migration`.

### CI
- `cargo fmt --check` ✅
- `cargo clippy -p vtc-service --all-targets` ✅ (clean)
- `cargo test -p vtc-service` ✅ (only the 6 known environmental failures under `VTC_SKIP_ADMIN_UI_BUILD=1`: 4 `admin_ui::tests` + 2 `routing_modes::path_mode_admin_*`)
- `cargo test -p vti-common --features encryption` ✅
- `cargo deny check` — not run locally (cargo-deny not installed); no new external crates, `Cargo.lock` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)