### PR TITLE
fix(vtc-service): non-admin VtcRole no longer 500s /auth/challenge with a serde leak (P0.16)

### DIFF
--- a/vtc-service/src/acl/mod.rs
+++ b/vtc-service/src/acl/mod.rs
@@ -6,8 +6,8 @@ pub mod storage;
 pub use entry::VtcAclEntry;
 pub use role::VtcRole;
 pub use storage::{
-    delete_acl_entry, get_acl_entry, list_acl_entries, list_acl_entries_paginated, store_acl_entry,
-    validate_vtc_role_assignment,
+    delete_acl_entry, get_acl_entry, list_acl_entries, list_acl_entries_paginated,
+    map_vtc_role_to_auth_role, resolve_auth_role, store_acl_entry, validate_vtc_role_assignment,
 };
 pub use vti_common::acl::{
     Role, check_acl, check_acl_full, is_acl_entry_visible, validate_acl_modification,

--- a/vtc-service/src/acl/storage.rs
+++ b/vtc-service/src/acl/storage.rs
@@ -25,8 +25,10 @@
 //! full keyspace (audit, emergency-bootstrap cleanup) working
 //! without rewriting them.
 
+use vti_common::acl::Role;
 use vti_common::audit::AuditKey;
 use vti_common::auth::extractor::AuthClaims;
+use vti_common::auth::session::now_epoch;
 use vti_common::error::AppError;
 use vti_common::pagination::{Cursor, Paginated, paginate};
 use vti_common::store::KeyspaceHandle;
@@ -36,6 +38,49 @@ use super::entry::{VtcAclEntry, decode, iter};
 
 fn acl_key(did: &str) -> String {
     format!("acl:{did}")
+}
+
+/// Map a stored [`VtcRole`] to the `vti_common::acl::Role` the JWT/session
+/// layer understands.
+///
+/// Phase 1's auth/session/passkey stack is keyed to the VTA role taxonomy;
+/// only `Admin` has a session-layer equivalent. The other VTC roles
+/// (`Moderator`/`Issuer`/`Member`/`Custom`) are valid ACL records but carry
+/// no JWT-session semantics yet (Phase 2 makes `AuthClaims` VtcRole-aware),
+/// so they're refused with a clean `Forbidden`. Fails closed — no privilege
+/// is granted, and the message carries neither serde internals nor the role
+/// name (this is consumed on the unauthenticated `/auth/challenge` path).
+pub fn map_vtc_role_to_auth_role(role: &VtcRole) -> Result<Role, AppError> {
+    match role {
+        VtcRole::Admin => Ok(Role::Admin),
+        VtcRole::Moderator | VtcRole::Issuer | VtcRole::Member | VtcRole::Custom(_) => Err(
+            AppError::Forbidden("DID is not permitted to authenticate on this VTC".into()),
+        ),
+    }
+}
+
+/// VTC analogue of `vti_common::acl::check_acl_full`: resolve a DID's auth
+/// role + allowed contexts from the VTC ACL, decoding the row as a
+/// [`VtcAclEntry`] and mapping `VtcRole → Role`.
+///
+/// **Use this — not `vti_common::acl::check_acl[_full]` — for every
+/// auth-time ACL gate on the VTC store.** The vti-common helpers decode the
+/// row into the VTA `Role` taxonomy and hard-error
+/// (`AppError::Serialization` → HTTP 500 leaking the serde text) on any
+/// VTC-only role string. This decoder never 500s on a VTC role; it returns a
+/// clean `Forbidden` for absent / expired / non-admin rows. P0.16.
+pub async fn resolve_auth_role(
+    acl_ks: &KeyspaceHandle,
+    did: &str,
+) -> Result<(Role, Vec<String>), AppError> {
+    let entry = get_acl_entry(acl_ks, did)
+        .await?
+        .ok_or_else(|| AppError::Forbidden(format!("DID not in ACL: {did}")))?;
+    if entry.is_expired(now_epoch()) {
+        return Err(AppError::Forbidden(format!("ACL entry expired: {did}")));
+    }
+    let role = map_vtc_role_to_auth_role(&entry.role)?;
+    Ok((role, entry.allowed_contexts))
 }
 
 /// Retrieve an ACL entry by DID. `Ok(None)` if absent.
@@ -268,5 +313,90 @@ mod tests {
         assert_eq!(page3.items.len(), 1);
         assert_eq!(page3.items[0].did, "did:key:zE");
         assert!(page3.next_cursor.is_none());
+    }
+
+    // ---- P0.16: VtcRole → auth Role resolution ----
+
+    #[test]
+    fn admin_maps_to_admin_role() {
+        assert_eq!(
+            map_vtc_role_to_auth_role(&VtcRole::Admin).unwrap(),
+            Role::Admin
+        );
+    }
+
+    #[test]
+    fn non_admin_roles_are_cleanly_forbidden() {
+        use axum::response::IntoResponse;
+        for role in [
+            VtcRole::Moderator,
+            VtcRole::Issuer,
+            VtcRole::Member,
+            VtcRole::custom("editor").unwrap(),
+        ] {
+            let err = map_vtc_role_to_auth_role(&role)
+                .expect_err("non-admin role must not map to an auth role");
+            // 403, not 500 — the whole point of P0.16.
+            assert_eq!(
+                err.into_response().status(),
+                axum::http::StatusCode::FORBIDDEN,
+                "{role} must yield 403"
+            );
+        }
+    }
+
+    #[test]
+    fn forbidden_message_carries_no_serde_internals_or_role_name() {
+        let AppError::Forbidden(msg) = map_vtc_role_to_auth_role(&VtcRole::Moderator).unwrap_err()
+        else {
+            panic!("expected Forbidden");
+        };
+        assert!(!msg.contains("variant"), "must not leak serde text: {msg}");
+        assert!(
+            !msg.contains("moderator"),
+            "must not enumerate the role to an unauth caller: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_auth_role_admits_admin_with_contexts() {
+        let (ks, _dir) = temp_ks().await;
+        let mut e = entry("did:key:zAdmin", VtcRole::Admin);
+        e.allowed_contexts = vec!["ctx-a".into()];
+        store_acl_entry(&ks, &e).await.unwrap();
+
+        let (role, contexts) = resolve_auth_role(&ks, "did:key:zAdmin").await.unwrap();
+        assert_eq!(role, Role::Admin);
+        assert_eq!(contexts, vec!["ctx-a".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn resolve_auth_role_forbids_non_admin_absent_and_expired() {
+        let (ks, _dir) = temp_ks().await;
+
+        // Non-admin VTC role → clean Forbidden (would 500 via the VTA
+        // decoder pre-P0.16).
+        store_acl_entry(&ks, &entry("did:key:zMod", VtcRole::Moderator))
+            .await
+            .unwrap();
+        assert!(matches!(
+            resolve_auth_role(&ks, "did:key:zMod").await,
+            Err(AppError::Forbidden(_))
+        ));
+
+        // Absent DID → Forbidden.
+        assert!(matches!(
+            resolve_auth_role(&ks, "did:key:zNobody").await,
+            Err(AppError::Forbidden(_))
+        ));
+
+        // Expired admin row → Forbidden (expiry honoured).
+        let mut expired = entry("did:key:zStale", VtcRole::Admin);
+        expired.expires_at = Some(1); // long past
+        store_acl_entry(&ks, &expired).await.unwrap();
+        assert!(matches!(
+            resolve_auth_role(&ks, "did:key:zStale").await,
+            Err(AppError::Forbidden(_))
+        ));
     }
 }

--- a/vtc-service/src/auth/backend.rs
+++ b/vtc-service/src/auth/backend.rs
@@ -11,12 +11,13 @@
 //!   default → accept-any).
 //! - JWT audience `"VTC"` (set by the `JwtKeys` instance held
 //!   on `AppState`).
-//! - Role type is `VtcRole` (re-exported as `crate::acl::Role`).
-//!
-//! Role enum and ACL helper signatures are otherwise identical
-//! to VTA's — both consume `vti_common::acl::check_acl_full`,
-//! which the canonical handler invokes uniformly through
-//! [`AuthBackend::check_acl`].
+//! - The session/JWT layer is keyed to the VTA `vti_common::acl::Role`
+//!   taxonomy (`crate::acl::Role`), but VTC stores `VtcAclEntry` rows
+//!   whose `role` is a [`VtcRole`]. [`AuthBackend::check_acl`] therefore
+//!   decodes the row with the VTC decoder and maps `VtcRole → Role`
+//!   itself — it must **not** route through `vti_common::acl::check_acl*`,
+//!   which deserializes into the VTA `Role` and hard-errors on any
+//!   VTC-only role string (see [`VtcAuthBackend::check_acl`], P0.16).
 
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -25,7 +26,7 @@ use vti_common::auth::backend::{AuthBackend, AuthError, RoleResolution};
 use vti_common::auth::handlers::KeyspaceSessionStore;
 use vti_common::auth::jwt::JwtKeys;
 
-use crate::acl::Role;
+use crate::acl::{Role, resolve_auth_role};
 use crate::error::AppError;
 use crate::server::AppState;
 
@@ -106,8 +107,13 @@ impl AuthBackend for VtcAuthBackend {
     }
 
     async fn check_acl(&self, did: &str) -> Result<RoleResolution<Self::Role>, Self::Error> {
-        let (role, allowed_contexts) =
-            vti_common::acl::check_acl_full(&self.state.acl_ks, did).await?;
+        // VTC-aware resolver: decodes the `acl:<did>` row as a `VtcAclEntry`
+        // and maps `VtcRole → Role`. Must NOT route through
+        // `vti_common::acl::check_acl_full`, which decodes into the VTA
+        // `Role` taxonomy and hard-errors (`AppError::Serialization` → HTTP
+        // 500 leaking serde text to the unauthenticated `/auth/challenge`
+        // caller) on any VTC-only role string. P0.16.
+        let (role, allowed_contexts) = resolve_auth_role(&self.state.acl_ks, did).await?;
         Ok(RoleResolution::with_contexts(role, allowed_contexts))
     }
 

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -10,7 +10,7 @@ use vta_sdk::protocols::auth::{
     epoch_to_rfc3339,
 };
 
-use crate::acl::{Role, check_acl_full};
+use crate::acl::{Role, resolve_auth_role};
 use crate::auth::session::{
     Session, SessionState, delete_session, get_session, list_sessions, now_epoch,
     store_refresh_index, store_session,
@@ -511,7 +511,9 @@ pub async fn passkey_login_finish(
 
     // Check ACL — the DID must still be authorised; revocation
     // since enrolment is a real path (operator demoted, etc.).
-    let (role, allowed_contexts) = check_acl_full(&state.acl_ks, &user.did).await?;
+    // Uses the VTC-aware resolver so a demoted-to-VtcRole row yields a
+    // clean 403, not a 500 in the VTA-taxonomy deserializer (P0.16).
+    let (role, allowed_contexts) = resolve_auth_role(&state.acl_ks, &user.did).await?;
 
     // Mint access + refresh tokens (mirrors `authenticate_and_mint`
     // for parity with the DIDComm login path).

--- a/vtc-service/tests/auth_acl_roles.rs
+++ b/vtc-service/tests/auth_acl_roles.rs
@@ -1,0 +1,121 @@
+//! P0.16 — a non-admin `VtcRole` ACL row must not 500 the unauthenticated
+//! `POST /v1/auth/challenge` or leak serde internals.
+//!
+//! Before the fix, `check_acl` routed through `vti_common::acl::check_acl_full`,
+//! which deserializes the `acl:<did>` row into the VTA `Role` taxonomy and
+//! hard-errors on a VTC-only role string (`moderator`/`issuer`/`member`/
+//! `custom:*`) → `AppError::Serialization` → HTTP 500 whose body carried the
+//! serde text to an unauthenticated caller. The fix decodes the row with the
+//! VTC decoder and maps `VtcRole → Role`, returning a clean 403 for
+//! non-admin roles while the admin row still authenticates.
+
+use reqwest::StatusCode;
+use serde_json::{Value, json};
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::test_support::MockVtc;
+
+fn entry(did: &str, role: VtcRole) -> VtcAclEntry {
+    VtcAclEntry {
+        did: did.into(),
+        role,
+        label: None,
+        allowed_contexts: vec![],
+        created_at: 1,
+        created_by: "did:key:vtc-install".into(),
+        expires_at: None,
+    }
+}
+
+/// The canonical `/v1/auth/challenge` route is Trust-Task-gated (only the
+/// `/wallet/auth/challenge` alias is exempt), so the flat-JSON client must
+/// send the challenge task header.
+const CHALLENGE_TASK: &str = "https://trusttasks.org/spec/auth/challenge/0.1";
+
+async fn challenge(base_url: &str, did: &str) -> (StatusCode, String) {
+    let resp = reqwest::Client::new()
+        .post(format!("{base_url}/v1/auth/challenge"))
+        .header("Trust-Task", CHALLENGE_TASK)
+        .json(&json!({ "did": did }))
+        .send()
+        .await
+        .expect("POST /v1/auth/challenge");
+    let status = resp.status();
+    let body = resp.text().await.expect("read body");
+    (status, body)
+}
+
+#[tokio::test]
+async fn moderator_row_yields_clean_403_not_500_serde_leak() {
+    let mock = MockVtc::start().await;
+    let did = "did:key:z6MkModerator";
+    store_acl_entry(&mock.vtc.state.acl_ks, &entry(did, VtcRole::Moderator))
+        .await
+        .expect("seed moderator acl row");
+
+    let (status, body) = challenge(mock.base_url(), did).await;
+
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "moderator must get a clean 403, not a 500: {body}"
+    );
+    // The pre-fix bug leaked the serde error text. Make sure none of it
+    // (nor the role name) appears in the response to an unauth caller.
+    assert!(
+        !body.contains("unknown variant") && !body.contains("moderator"),
+        "challenge 403 body must not leak serde internals or the role: {body}"
+    );
+
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn every_non_admin_vtc_role_is_cleanly_forbidden() {
+    let mock = MockVtc::start().await;
+    let cases = [
+        ("did:key:z6MkIssuer", VtcRole::Issuer),
+        ("did:key:z6MkMember", VtcRole::Member),
+        ("did:key:z6MkCustom", VtcRole::custom("editor").unwrap()),
+    ];
+    for (did, role) in cases {
+        store_acl_entry(&mock.vtc.state.acl_ks, &entry(did, role.clone()))
+            .await
+            .expect("seed acl row");
+        let (status, body) = challenge(mock.base_url(), did).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "{role} must yield 403, got {status}: {body}"
+        );
+        assert!(
+            !body.contains("unknown variant"),
+            "{role} 403 body must not leak serde internals: {body}"
+        );
+    }
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn admin_row_still_authenticates() {
+    let mock = MockVtc::start().await;
+    let did = "did:key:z6MkAdminRow";
+    store_acl_entry(&mock.vtc.state.acl_ks, &entry(did, VtcRole::Admin))
+        .await
+        .expect("seed admin acl row");
+
+    let (status, body) = challenge(mock.base_url(), did).await;
+
+    assert_eq!(status, StatusCode::OK, "admin must authenticate: {body}");
+    let parsed: Value = serde_json::from_str(&body).expect("challenge json");
+    assert!(
+        parsed["challenge"].as_str().is_some_and(|c| !c.is_empty()),
+        "expected a challenge in the response: {body}"
+    );
+    assert!(
+        parsed["sessionId"].as_str().is_some(),
+        "expected a sessionId in the response: {body}"
+    );
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
## P0.16 — non-admin `VtcRole` ACL row 500s the unauth `/auth/challenge` and leaks serde internals

Part of the VTC architecture-review P0 security cluster.

### Problem
`VtcAuthBackend::check_acl` resolved roles through `vti_common::acl::check_acl_full`, which deserializes the `acl:<did>` row into the **VTA** `Role` taxonomy (`admin`/`initiator`/`application`/`reader`/`monitor`). VTC writes `VtcAclEntry` rows whose role serializes as `moderator`/`issuer`/`member`/`custom:<name>`, and `POST /v1/acl` permits creating them.

When such a DID hits the **unauthenticated** `POST /v1/auth/challenge`, the foreign deserializer fails with `unknown variant 'moderator'` → `AppError::Serialization` → **HTTP 500 whose body leaks the serde text** to an unauthenticated caller, and every non-admin VtcRole silently can't authenticate. Fails closed (no escalation) but is a reachable correctness + info-leak bug.

The passkey-login finish handler (`routes/auth.rs`) had the identical bug on the same root cause.

### Fix
A VTC-aware resolver in `crate::acl` (used by both auth-time ACL gates):
- `map_vtc_role_to_auth_role(VtcRole) -> Role` — `Admin → Role::Admin`; the other VTC roles have no JWT-session equivalent in Phase 1 (the session/passkey stack is keyed to the VTA taxonomy — VtcRole-aware auth is Phase 2) and are refused with a clean `Forbidden`. The message carries **neither serde internals nor the role name** (it's consumed on the unauth challenge path, so no role enumeration).
- `resolve_auth_role(acl_ks, did)` — the VTC analogue of `check_acl_full`: decodes `VtcAclEntry`, honours the row's expiry, maps the role. Never 500s on a VTC-only role; returns clean `Forbidden` for absent / expired / non-admin rows.

`check_acl` and `passkey_login_finish` now route through it instead of the VTA-taxonomy helper.

### Accept criteria (covered by tests)
- ✅ Creating a `moderator` ACL entry then calling `/auth/challenge` for that DID → clean **403** (no serde text / role name in body).
- ✅ An admin row still authenticates (200 with challenge + sessionId).

### Tests
- `acl::storage` unit tests: role mapping (admin→Admin; non-admin→403, no serde/role leak) + `resolve_auth_role` (admin w/ contexts; non-admin/absent/expired → Forbidden).
- `tests/auth_acl_roles.rs`: end-to-end over real HTTP via `MockVtc` — moderator/issuer/member/custom → 403 (no serde leak); admin → 200.

### CI
- `cargo fmt --check` ✅
- `cargo clippy -p vtc-service --all-targets` ✅ (clean)
- `cargo test -p vtc-service` ✅ — 513 lib + all integration green; only the 6 known environmental failures under `VTC_SKIP_ADMIN_UI_BUILD=1` (4 `admin_ui::tests` + 2 `routing_modes::path_mode_admin_*`).
- `cargo deny check` — not run locally (cargo-deny not installed); no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)