### PR TITLE
fix(vta-service): make the deferred-presentation approve/deny/list surface reachable (P0.12b)

### DIFF
--- a/vta-sdk/src/protocols/credential_exchange.rs
+++ b/vta-sdk/src/protocols/credential_exchange.rs
@@ -27,6 +27,7 @@
 
 use affinidi_openid4vci::{CredentialOffer, CredentialRequest, CredentialResponse};
 use affinidi_openid4vp::DcqlQuery;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -42,6 +43,24 @@ pub const ISSUE: &str = "https://trusttasks.org/spec/credential-exchange/issue/1
 pub const QUERY: &str = "https://trusttasks.org/spec/credential-exchange/query/1.0";
 /// holder → verifier: a presentation.
 pub const PRESENT: &str = "https://trusttasks.org/spec/credential-exchange/present/1.0";
+
+// ── Deferred-presentation approval surface (holder operator → own VTA) ──
+//
+// When a verifier the holder hasn't pre-trusted sends a `query/1.0`, the VTA
+// **defers** it: it persists a pending record and tells the verifier "consent
+// required" (see `vta-service`'s `handle_credential_query`). These three tasks
+// are the holder operator's out-of-band surface over that backlog — list the
+// deferrals, then approve (re-present, producing the `vp_token`) or deny. All
+// three are **super-admin only**: the credentials presented are the VTA's own.
+
+/// holder operator → own VTA: list deferred presentations awaiting a decision.
+pub const PENDING_LIST: &str = "https://trusttasks.org/spec/credential-exchange/pending-list/1.0";
+/// holder operator → own VTA: approve a deferral and re-present (returns the
+/// `vp_token` in a [`PresentBody`]).
+pub const PENDING_APPROVE: &str =
+    "https://trusttasks.org/spec/credential-exchange/pending-approve/1.0";
+/// holder operator → own VTA: deny a deferral (no presentation is made).
+pub const PENDING_DENY: &str = "https://trusttasks.org/spec/credential-exchange/pending-deny/1.0";
 
 /// `offer/1.0` — issuer → holder. An OID4VCI credential offer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -87,6 +106,71 @@ pub struct QueryBody {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PresentBody {
     pub vp_token: Value,
+}
+
+/// `pending-list/1.0` request — empty. The caller's super-admin authentication
+/// scopes the result to this VTA's own deferred presentations.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PendingListBody {}
+
+/// One deferred presentation awaiting the holder's decision — the
+/// approver-facing view. The internal record additionally stores the full DCQL
+/// query for a byte-faithful re-present; that is **not** exposed here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingPresentationSummary {
+    /// Approval handle (the verifier's DIDComm thread id).
+    pub id: String,
+    /// The verifier that asked. The approved presentation binds to this audience.
+    pub verifier_did: String,
+    /// Every held credential the query would disclose — what the approver authorizes.
+    pub requested: Vec<RequestedCredentialSummary>,
+    /// The verifier's stated purpose (purpose binding), shown to the approver.
+    pub purpose: String,
+    /// When the deferral was recorded.
+    pub created_at: DateTime<Utc>,
+    /// After this the deferral is stale and approval refuses (the verifier's
+    /// nonce is no longer fresh).
+    pub expires_at: DateTime<Utc>,
+}
+
+/// One held credential a deferred query asked for.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestedCredentialSummary {
+    /// The DCQL `credential_query_id` this credential satisfied.
+    pub credential_query_id: String,
+    /// The held credential that would satisfy it.
+    pub credential_id: String,
+    /// The claims the query asks to disclose.
+    pub claims: Vec<String>,
+}
+
+/// `pending-list/1.0` response — the actionable deferrals (`Pending`, not yet
+/// expired). Terminal and stale records are omitted (they can't be acted on).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PendingListResponse {
+    pub pending: Vec<PendingPresentationSummary>,
+}
+
+/// `pending-approve/1.0` request — the deferral id to approve and re-present.
+/// The response is a [`PresentBody`] carrying the freshly-minted `vp_token`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingApproveBody {
+    pub id: String,
+}
+
+/// `pending-deny/1.0` request — the deferral id to refuse.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingDenyBody {
+    pub id: String,
+}
+
+/// `pending-deny/1.0` response — the refused id and its terminal status
+/// (`"denied"`). The record is removed (delete-on-terminal), so a follow-up
+/// list won't show it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingDenyResponse {
+    pub id: String,
+    pub status: String,
 }
 
 #[cfg(test)]
@@ -144,7 +228,16 @@ mod tests {
 
     #[test]
     fn uris_are_versioned_and_distinct() {
-        let all = [OFFER, REQUEST, ISSUE, QUERY, PRESENT];
+        let all = [
+            OFFER,
+            REQUEST,
+            ISSUE,
+            QUERY,
+            PRESENT,
+            PENDING_LIST,
+            PENDING_APPROVE,
+            PENDING_DENY,
+        ];
         for u in all {
             assert!(u.starts_with("https://trusttasks.org/spec/credential-exchange/"));
             assert!(u.ends_with("/1.0"));

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -990,10 +990,11 @@ pub async fn defer_presentation(
 
 /// Approve a deferred presentation: mint the query-scoped consent the holder is
 /// authorizing and **re-present**. ACL-gated via `auth` (the same holder-key
-/// gate as [`present_query`]). Marks the record `Approved` and returns the
-/// `vp_token`.
+/// gate as [`present_query`]). On success the record is **deleted**
+/// (delete-on-terminal, P0.12b) — the `vp_token` has been produced and there is
+/// nothing left to act on, so no `Approved` tombstone is left for the sweeper.
 ///
-/// Refuses a record that isn't `Pending` (already approved / denied) or whose
+/// Refuses a record that is absent (already approved/denied → deleted) or whose
 /// deferral window has lapsed (`expires_at` past — the verifier's nonce is stale).
 #[allow(clippy::too_many_arguments)]
 pub async fn approve_pending_presentation(
@@ -1005,10 +1006,12 @@ pub async fn approve_pending_presentation(
     status_resolver: Option<&dyn crate::vault::status::StatusListResolver>,
     now: DateTime<Utc>,
 ) -> Result<PresentBody, AppError> {
-    let mut record = pending::get(vault, id)
+    let record = pending::get(vault, id)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("no pending presentation `{id}`")))?;
 
+    // With delete-on-terminal a non-`Pending` record cannot persist, but guard
+    // anyway: a legacy `Approved`/`Denied` row predating P0.12b is not actionable.
     if record.status != pending::PendingStatus::Pending {
         return Err(AppError::Validation(format!(
             "pending presentation `{id}` is {:?}, not awaiting approval",
@@ -1043,13 +1046,15 @@ pub async fn approve_pending_presentation(
     )
     .await?;
 
-    record.status = pending::PendingStatus::Approved;
-    pending::put(vault, &record).await?;
+    // Delete-on-terminal (P0.12b): the presentation is delivered, so drop the
+    // record now rather than leaving an `Approved` tombstone for the sweeper.
+    pending::remove(vault, id).await?;
     Ok(present)
 }
 
-/// Deny a deferred presentation — the holder refuses disclosure. Records the
-/// refusal (no presentation is made) and returns the updated record.
+/// Deny a deferred presentation — the holder refuses disclosure. No presentation
+/// is made; the record is **deleted** (delete-on-terminal, P0.12b) and the
+/// removed record (status `Denied`) is returned for the caller's response.
 pub async fn deny_pending_presentation(
     vault: &KeyspaceHandle,
     id: &str,
@@ -1063,8 +1068,10 @@ pub async fn deny_pending_presentation(
             record.status
         )));
     }
+    // Delete-on-terminal: nothing is left to act on after a denial, so remove
+    // the record rather than leaving a `Denied` tombstone for the sweeper.
+    pending::remove(vault, id).await?;
     record.status = pending::PendingStatus::Denied;
-    pending::put(vault, &record).await?;
     Ok(record)
 }
 
@@ -2287,7 +2294,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn defer_then_approve_presents_and_marks_approved() {
+    async fn defer_then_approve_presents_and_deletes_on_terminal() {
         use crate::acl::Role;
 
         let (_dir, vault, keys_ks, seed_store, _subject) = holder_fixture().await;
@@ -2349,20 +2356,21 @@ mod tests {
         assert_eq!(parsed.disclosures.len(), 1);
         assert!(parsed.kb_jwt.is_some(), "holder kb-jwt must be present");
 
-        // The record is now Approved, and a second approval refuses.
-        assert_eq!(
-            pending::get(&vault, "req-1").await.unwrap().unwrap().status,
-            pending::PendingStatus::Approved
+        // Delete-on-terminal: the record is gone, and a second approval finds
+        // nothing to approve.
+        assert!(
+            pending::get(&vault, "req-1").await.unwrap().is_none(),
+            "approved record is deleted, not left as an Approved tombstone"
         );
         let twice =
             approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-1", None, now)
                 .await
                 .unwrap_err();
-        assert!(matches!(twice, AppError::Validation(_)), "{twice:?}");
+        assert!(matches!(twice, AppError::NotFound(_)), "{twice:?}");
     }
 
     #[tokio::test]
-    async fn deny_marks_denied_and_blocks_approval() {
+    async fn deny_deletes_on_terminal_and_blocks_approval() {
         use crate::acl::Role;
 
         let (_dir, vault, keys_ks, seed_store, _subject) = holder_fixture().await;
@@ -2379,12 +2387,17 @@ mod tests {
             .await
             .expect("defer");
 
+        // The returned record reflects the terminal status, but the row is gone.
         let denied = deny_pending_presentation(&vault, "req-2")
             .await
             .expect("deny");
         assert_eq!(denied.status, pending::PendingStatus::Denied);
+        assert!(
+            pending::get(&vault, "req-2").await.unwrap().is_none(),
+            "denied record is deleted, not left as a Denied tombstone"
+        );
 
-        // A denied record cannot then be approved.
+        // A denied (now-deleted) record cannot then be approved.
         let auth = AuthClaims {
             role: Role::Admin,
             allowed_contexts: Vec::new(),
@@ -2394,7 +2407,7 @@ mod tests {
             approve_pending_presentation(&vault, &keys_ks, &seed_store, &auth, "req-2", None, now)
                 .await
                 .unwrap_err();
-        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        assert!(matches!(err, AppError::NotFound(_)), "{err:?}");
     }
 
     #[tokio::test]
@@ -2415,13 +2428,25 @@ mod tests {
         defer_presentation(&vault, "live", verifier, requested(), &query, now)
             .await
             .expect("defer live");
-        // (2) Terminal (denied) — must be reclaimed.
-        defer_presentation(&vault, "terminal", verifier, requested(), &query, now)
-            .await
-            .expect("defer terminal");
-        deny_pending_presentation(&vault, "terminal")
-            .await
-            .expect("deny");
+        // (2) Terminal (denied) — must be reclaimed. Approve/deny now
+        //     delete-on-terminal (P0.12b), so a terminal row only survives as a
+        //     legacy/stuck record; seed one directly to exercise the sweeper's
+        //     terminal-reclaim backstop.
+        pending::put(
+            &vault,
+            &pending::PendingPresentation {
+                id: "terminal".into(),
+                verifier_did: verifier.into(),
+                requested: requested(),
+                purpose: query.purpose.clone(),
+                query: query.clone(),
+                status: pending::PendingStatus::Denied,
+                created_at: now,
+                expires_at: now + chrono::Duration::hours(24),
+            },
+        )
+        .await
+        .expect("seed terminal");
         // (3) Stale pending (recorded 48h ago → past the 24h window) — reclaimed.
         defer_presentation(
             &vault,

--- a/vta-service/src/routes/trust_tasks/credential_exchange.rs
+++ b/vta-service/src/routes/trust_tasks/credential_exchange.rs
@@ -1,0 +1,183 @@
+// Handlers share the `Result<_, Response>` shape via `parse_payload`; the
+// Response is owned and emitted on the same stack frame (see `vault.rs`).
+#![allow(clippy::result_large_err)]
+
+//! Credential-exchange slice — the holder operator's deferred-presentation
+//! approval surface.
+//!
+//! When a verifier the holder hasn't pre-trusted sends a
+//! `credential-exchange/query/1.0`, the VTA **defers** it: it persists a
+//! `pending-present:` record and replies "consent required" (see
+//! `crate::messaging::handlers::handle_credential_query`). These three tasks are
+//! the holder operator's out-of-band surface over that backlog:
+//!
+//! - `pending-list/1.0` — list the actionable deferrals.
+//! - `pending-approve/1.0` — approve one and **re-present** (returns the `vp_token`).
+//! - `pending-deny/1.0` — deny one (no presentation is made).
+//!
+//! All three are **super-admin only**: the credentials presented are the VTA's
+//! own, so authorization mirrors the autonomous wire flow's "own authority"
+//! (`handle_credential_query`). The approve op's re-present resolves the holder
+//! key through the same `auth`-gated path as a trusted-verifier present, so the
+//! caller's super-admin claims authorize key access and give correct audit
+//! attribution.
+
+use axum::response::Response;
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+use vta_sdk::protocols::credential_exchange::{
+    PENDING_APPROVE, PENDING_DENY, PENDING_LIST, PendingApproveBody, PendingDenyBody,
+    PendingDenyResponse, PendingListResponse, PendingPresentationSummary,
+    RequestedCredentialSummary,
+};
+
+use crate::audit::audit;
+use crate::auth::AuthClaims;
+use crate::operations::credential_exchange::{
+    RequestedCredential, approve_pending_presentation, deny_pending_presentation, pending,
+};
+use crate::server::AppState;
+
+use super::helpers::{app_error_to_reject, parse_payload, success_response};
+
+/// URIs handled by this slice. Aggregated by the dispatcher's parity harness.
+#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
+pub(super) const DISPATCHED_URIS: &[&str] = &[PENDING_LIST, PENDING_APPROVE, PENDING_DENY];
+
+/// Project an internal pending record into the approver-facing wire summary.
+/// Drops the full DCQL `query` (an internal re-present detail).
+fn summarize(record: pending::PendingPresentation) -> PendingPresentationSummary {
+    PendingPresentationSummary {
+        id: record.id,
+        verifier_did: record.verifier_did,
+        requested: record
+            .requested
+            .into_iter()
+            .map(summarize_requested)
+            .collect(),
+        purpose: record.purpose,
+        created_at: record.created_at,
+        expires_at: record.expires_at,
+    }
+}
+
+fn summarize_requested(r: RequestedCredential) -> RequestedCredentialSummary {
+    RequestedCredentialSummary {
+        credential_query_id: r.credential_query_id,
+        credential_id: r.credential_id,
+        claims: r.claims,
+    }
+}
+
+/// `credential-exchange/pending-list/1.0` — list the actionable deferred
+/// presentations (status `Pending`, not yet expired). Super-admin only.
+pub(super) async fn handle_pending_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    if let Err(e) = auth.require_super_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+
+    let records = match pending::list(&state.vault_ks).await {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // Only surface what the holder can still act on — terminal records are
+    // deleted (delete-on-terminal), and approval refuses an expired deferral.
+    let now = chrono::Utc::now();
+    let pending_out: Vec<PendingPresentationSummary> = records
+        .into_iter()
+        .filter(|r| r.status == pending::PendingStatus::Pending && r.expires_at > now)
+        .map(summarize)
+        .collect();
+
+    audit!(
+        "credential-exchange.pending-list",
+        actor = &auth.did,
+        resource = "pending-present",
+        outcome = "success"
+    );
+    success_response(
+        &doc,
+        PendingListResponse {
+            pending: pending_out,
+        },
+    )
+}
+
+/// `credential-exchange/pending-approve/1.0` — approve a deferral and
+/// re-present, returning the freshly-minted `vp_token`. Super-admin only.
+/// Deletes the record on success (delete-on-terminal).
+pub(super) async fn handle_pending_approve(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    if let Err(e) = auth.require_super_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let body: PendingApproveBody = match parse_payload(&doc) {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+
+    let present = match approve_pending_presentation(
+        &state.vault_ks,
+        &state.keys_ks,
+        &state.seed_store,
+        auth,
+        &body.id,
+        state.status_list_resolver.as_deref(),
+        chrono::Utc::now(),
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    audit!(
+        "credential-exchange.pending-approve",
+        actor = &auth.did,
+        resource = &body.id,
+        outcome = "success"
+    );
+    success_response(&doc, present)
+}
+
+/// `credential-exchange/pending-deny/1.0` — deny a deferral (no presentation).
+/// Super-admin only. Deletes the record (delete-on-terminal).
+pub(super) async fn handle_pending_deny(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> Response {
+    if let Err(e) = auth.require_super_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let body: PendingDenyBody = match parse_payload(&doc) {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+
+    if let Err(e) = deny_pending_presentation(&state.vault_ks, &body.id).await {
+        return app_error_to_reject(&doc, e);
+    }
+
+    audit!(
+        "credential-exchange.pending-deny",
+        actor = &auth.did,
+        resource = &body.id,
+        outcome = "success"
+    );
+    success_response(
+        &doc,
+        PendingDenyResponse {
+            id: body.id,
+            status: "denied".to_string(),
+        },
+    )
+}

--- a/vta-service/src/routes/trust_tasks/mod.rs
+++ b/vta-service/src/routes/trust_tasks/mod.rs
@@ -49,6 +49,7 @@ mod auth;
 mod backup;
 mod config;
 mod contexts;
+mod credential_exchange;
 mod device;
 mod did_templates;
 mod discovery;
@@ -204,6 +205,7 @@ fn aggregate_dispatched_uris() -> Vec<&'static str> {
     v.extend(backup::DISPATCHED_URIS);
     v.extend(config::DISPATCHED_URIS);
     v.extend(contexts::DISPATCHED_URIS);
+    v.extend(credential_exchange::DISPATCHED_URIS);
     v.extend(device::DISPATCHED_URIS);
     v.extend(did_templates::DISPATCHED_URIS);
     v.extend(discovery::DISPATCHED_URIS);
@@ -445,6 +447,23 @@ async fn dispatch_typed(state: &AppState, auth: &AuthClaims, doc: TrustTask<Valu
         // ─── Discovery ───────────────────────────────────────────────
         vta_sdk::trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0 => {
             discovery::handle_capabilities(state, auth, doc).await
+        }
+        // ─── Credential-exchange: deferred-presentation approval ─────
+        //
+        // The holder operator's out-of-band surface over deferred
+        // presentations (the `credential-exchange/*` family keeps its
+        // URIs in `vta_sdk::protocols::credential_exchange`, not the
+        // central `trust_tasks` registry — so these are matched on that
+        // module's consts and sit outside the `ALL_URIS` parity harness,
+        // like the existing `query`/`present` message types).
+        vta_sdk::protocols::credential_exchange::PENDING_LIST => {
+            credential_exchange::handle_pending_list(state, auth, doc).await
+        }
+        vta_sdk::protocols::credential_exchange::PENDING_APPROVE => {
+            credential_exchange::handle_pending_approve(state, auth, doc).await
+        }
+        vta_sdk::protocols::credential_exchange::PENDING_DENY => {
+            credential_exchange::handle_pending_deny(state, auth, doc).await
         }
         // ─── Vault slice (public 0.1 spec) ──────────────────────────
         vta_sdk::trust_tasks::TASK_VAULT_LIST_0_1 => vault::handle_list(state, auth, doc).await,

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -415,6 +415,7 @@ pub struct TestAppContext {
     pub sessions_ks: KeyspaceHandle,
     pub acl_ks: KeyspaceHandle,
     pub keys_ks: KeyspaceHandle,
+    pub vault_ks: KeyspaceHandle,
     pub backup_bundles_ks: KeyspaceHandle,
     pub backup_blob_dir: std::path::PathBuf,
     pub config: Arc<RwLock<AppConfig>>,
@@ -478,6 +479,7 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
     let audit_ks = store.keyspace("audit").unwrap();
     let cache_ks = store.keyspace("cache").unwrap();
     let vault_ks = store.keyspace("vault").unwrap();
+    let vault_ks_ctx = vault_ks.clone();
     let service_state_ks = store.keyspace("service_state").unwrap();
     let imported_ks = store.keyspace("imported_secrets").unwrap();
     let sealed_nonces_ks = store.keyspace("sealed_nonces").unwrap();
@@ -603,6 +605,7 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
         sessions_ks,
         acl_ks,
         keys_ks,
+        vault_ks: vault_ks_ctx,
         backup_bundles_ks,
         backup_blob_dir,
         config,

--- a/vta-service/tests/pending_presentation_trust_task.rs
+++ b/vta-service/tests/pending_presentation_trust_task.rs
@@ -1,0 +1,286 @@
+//! Integration tests for the deferred-presentation approval surface over the
+//! trust-task dispatcher (`credential-exchange/pending-{list,approve,deny}/1.0`).
+//!
+//! These exercise the **wire plumbing**: dispatch, the super-admin gate, and
+//! the list/deny/approve handlers end to end through the real router. A
+//! `pending-present:` record is seeded directly (the defer half is already
+//! wired in `messaging::handlers::handle_credential_query`); the full
+//! re-present with a real held credential is covered at the operations layer
+//! (`operations::credential_exchange::defer_then_approve_presents_*`, where the
+//! holder fixture lives).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vta_service::operations::credential_exchange::pending;
+use vta_service::test_support::{TestAppContext, build_test_app};
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+
+/// Seed an ACL entry + an authenticated session and mint a matching bearer
+/// token. `contexts` empty ⇒ super-admin; non-empty ⇒ context-scoped admin.
+async fn seed_admin_and_token(
+    ctx: &TestAppContext,
+    did: &str,
+    session_id: &str,
+    contexts: Vec<String>,
+) -> String {
+    let entry = vti_common::acl::AclEntry::new(did, vti_common::acl::Role::Admin, "test")
+        .with_contexts(contexts.clone())
+        .with_created_at(1);
+    vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
+        .await
+        .expect("seed admin ACL");
+
+    let session = Session {
+        session_id: session_id.into(),
+        did: did.into(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".into()],
+        acr: String::new(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+
+    let claims = ctx.jwt_keys.new_claims(
+        did.into(),
+        session_id.into(),
+        "admin".into(),
+        contexts,
+        900,
+        false,
+    );
+    ctx.jwt_keys.encode(&claims).unwrap()
+}
+
+/// A `Pending`, far-from-expiry deferral record, built by deserialization so
+/// the test needs no direct `DcqlQuery` dependency.
+fn seed_record_json(id: &str) -> Value {
+    json!({
+        "id": id,
+        "verifier_did": "did:web:stranger.example",
+        "requested": [{
+            "credential_query_id": "membership",
+            "credential_id": "urn:cred:1",
+            "claims": ["givenName"]
+        }],
+        "purpose": "join the Acme community",
+        "query": {
+            "dcql_query": {
+                "credentials": [{
+                    "id": "membership",
+                    "format": "dc+sd-jwt",
+                    "meta": { "vct_values": ["https://openvtc.org/credentials/MembershipCredential"] }
+                }]
+            },
+            "nonce": "n-1",
+            "purpose": "join the Acme community"
+        },
+        "status": "pending",
+        "created_at": "2026-06-12T00:00:00Z",
+        "expires_at": "2126-06-12T00:00:00Z"
+    })
+}
+
+async fn put_pending(ctx: &TestAppContext, id: &str) {
+    let record: pending::PendingPresentation =
+        serde_json::from_value(seed_record_json(id)).expect("deserialize pending record");
+    pending::put(&ctx.vault_ks, &record)
+        .await
+        .expect("seed pending record");
+}
+
+fn tt(id: &str, type_uri: &str, issuer: &str, payload: Value) -> Value {
+    json!({
+        "id": id,
+        "type": type_uri,
+        "issuer": issuer,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": payload,
+    })
+}
+
+async fn post_tt(router: &axum::Router, token: Option<&str>, doc: &Value) -> (StatusCode, Value) {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("content-type", "application/json");
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    let req = builder
+        .body(Body::from(serde_json::to_vec(doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, v)
+}
+
+#[tokio::test]
+async fn list_then_deny_over_the_wire_deletes_the_record() {
+    let (router, ctx) = build_test_app().await;
+    let did = "did:key:z6MkPendingAdmin";
+    let token = seed_admin_and_token(&ctx, did, "sess-pending-1", vec![]).await;
+    put_pending(&ctx, "req-wire-1").await;
+
+    // List: the seeded deferral shows up with its approver-facing fields.
+    let (status, v) = post_tt(
+        &router,
+        Some(&token),
+        &tt(
+            "urn:uuid:pend-list-1",
+            "https://trusttasks.org/spec/credential-exchange/pending-list/1.0",
+            did,
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "list must succeed: {v}");
+    let items = v["payload"]["pending"].as_array().expect("pending array");
+    assert_eq!(items.len(), 1, "{v}");
+    assert_eq!(items[0]["id"], "req-wire-1", "{v}");
+    assert_eq!(items[0]["verifier_did"], "did:web:stranger.example", "{v}");
+    assert_eq!(items[0]["requested"][0]["claims"][0], "givenName", "{v}");
+    // The internal full query is NOT leaked in the summary.
+    assert!(
+        items[0].get("query").is_none(),
+        "summary omits the query: {v}"
+    );
+
+    // Deny: succeeds and removes the record (delete-on-terminal).
+    let (status, v) = post_tt(
+        &router,
+        Some(&token),
+        &tt(
+            "urn:uuid:pend-deny-1",
+            "https://trusttasks.org/spec/credential-exchange/pending-deny/1.0",
+            did,
+            json!({ "id": "req-wire-1" }),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "deny must succeed: {v}");
+    assert_eq!(v["payload"]["status"], "denied", "{v}");
+    assert!(
+        pending::get(&ctx.vault_ks, "req-wire-1")
+            .await
+            .unwrap()
+            .is_none(),
+        "denied record is deleted"
+    );
+
+    // A follow-up list is now empty.
+    let (status, v) = post_tt(
+        &router,
+        Some(&token),
+        &tt(
+            "urn:uuid:pend-list-2",
+            "https://trusttasks.org/spec/credential-exchange/pending-list/1.0",
+            did,
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(v["payload"]["pending"].as_array().unwrap().len(), 0, "{v}");
+}
+
+#[tokio::test]
+async fn pending_surface_requires_super_admin() {
+    let (router, ctx) = build_test_app().await;
+    let did = "did:key:z6MkContextAdmin";
+    // Context-scoped admin (non-empty contexts) ⇒ NOT super-admin.
+    let token = seed_admin_and_token(&ctx, did, "sess-pending-2", vec!["ctx1".into()]).await;
+    put_pending(&ctx, "req-wire-2").await;
+
+    for (op, payload) in [
+        ("pending-list", json!({})),
+        ("pending-approve", json!({ "id": "req-wire-2" })),
+        ("pending-deny", json!({ "id": "req-wire-2" })),
+    ] {
+        let (status, v) = post_tt(
+            &router,
+            Some(&token),
+            &tt(
+                &format!("urn:uuid:pend-gate-{op}"),
+                &format!("https://trusttasks.org/spec/credential-exchange/{op}/1.0"),
+                did,
+                payload,
+            ),
+        )
+        .await;
+        assert_ne!(
+            status,
+            StatusCode::OK,
+            "{op} must reject a non-super-admin: {v}"
+        );
+    }
+
+    // The record is untouched by the rejected calls.
+    assert!(
+        pending::get(&ctx.vault_ks, "req-wire-2")
+            .await
+            .unwrap()
+            .is_some(),
+        "a rejected deny must not delete the record"
+    );
+}
+
+#[tokio::test]
+async fn approve_without_a_held_credential_fails_but_dispatches() {
+    let (router, ctx) = build_test_app().await;
+    let did = "did:key:z6MkPendingAdmin3";
+    let token = seed_admin_and_token(&ctx, did, "sess-pending-3", vec![]).await;
+    // A deferral whose query matches no held credential (empty vault).
+    put_pending(&ctx, "req-wire-3").await;
+
+    let (status, v) = post_tt(
+        &router,
+        Some(&token),
+        &tt(
+            "urn:uuid:pend-approve-1",
+            "https://trusttasks.org/spec/credential-exchange/pending-approve/1.0",
+            did,
+            json!({ "id": "req-wire-3" }),
+        ),
+    )
+    .await;
+    // The approve handler ran (super-admin gate passed, op invoked) and the op
+    // refused because nothing in the vault satisfies the deferred query.
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "approve with no held credential must fail: {v}"
+    );
+}
+
+#[tokio::test]
+async fn pending_surface_requires_a_bearer_token() {
+    let (router, _ctx) = build_test_app().await;
+    let (status, _v) = post_tt(
+        &router,
+        None,
+        &tt(
+            "urn:uuid:pend-anon",
+            "https://trusttasks.org/spec/credential-exchange/pending-list/1.0",
+            "did:key:z6MkAnon",
+            json!({}),
+        ),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "the dispatcher is authed — no bearer, no access"
+    );
+}


### PR DESCRIPTION
## What

P0.12b. Makes the previously **zero-caller** deferred-presentation surface
(`approve_pending_presentation` / `deny_pending_presentation` / `pending::list`)
reachable on the wire as a Trust-Task slice, completing the flow
**defer → list → approve → re-present** (or deny). Also adds **delete-on-terminal**
to approve/deny.

## Background / root cause

When a verifier the holder hasn't pre-trusted sends a `credential-exchange/query`,
the VTA **defers** it: `handle_credential_query` persists a `pending-present:`
record and replies "consent required (pending `<id>`)". The defer half was wired,
but the holder operator's surface to *act* on those deferrals was dormant —
`approve`/`deny`/`list` had no callers and no wire route, so a deferred
presentation could never actually be approved. P0.12a (#363) added a sweeper to
bound the unbounded growth; this PR makes the surface reachable so deferrals can
be resolved.

## Changes

- **New `credential-exchange` TT slice** (`routes/trust_tasks/credential_exchange.rs`):
  `pending-list` / `pending-approve` / `pending-deny`, wired into
  `dispatch_typed`. Reachable over **both** REST (`POST /api/trust-tasks`) and
  DIDComm (the dispatcher core is shared) — no REST-only special-casing.
- **Super-admin gate.** The presented credentials are the VTA's own, so the gate
  mirrors the autonomous query path's "own authority". Approve passes the
  operator's claims to `approve_pending_presentation`; `resolve_holder_keys`
  resolves the holder key from the credential's subject and gates on
  context/super-admin — so this is correct *and* gives proper audit attribution.
- **delete-on-terminal** in `approve`/`deny`: the record is removed the instant
  it's resolved instead of left as an `Approved`/`Denied` tombstone. The
  sweeper's terminal branch stays as a backstop; its main job is now reclaiming
  *abandoned* (stale, never-actioned) deferrals.
- **SDK wire types** (`vta_sdk::protocols::credential_exchange`): three URIs +
  `PendingListResponse` / `PendingPresentationSummary` / `PendingApproveBody` /
  `PendingDenyBody` / `PendingDenyResponse`. They live alongside `query`/`present`
  (the credential-exchange family is intentionally outside the central
  `trust_tasks::ALL_URIS` registry, whose namespace allowlist excludes
  `credential-exchange`), so they sit outside the `ALL_URIS` parity harness like
  the existing message types. The list summary deliberately omits the internal
  full DCQL `query`.

## Tests

- **Ops layer** (where `holder_fixture` lives) is the true defer→list→approve→
  **re-present** end-to-end with a real held credential (`vp_token` + holder
  `kb-jwt`); updated for delete-on-terminal (approved/denied record is now
  deleted, re-approve → `NotFound`). The sweep test seeds a terminal row directly
  (deny no longer leaves one).
- **New wire integration tests** (`tests/pending_presentation_trust_task.rs`):
  dispatch + super-admin gate + list (summary fields, query not leaked) + deny
  (record deleted) + approve plumbing + unauth path. `TestAppContext` gains
  `vault_ks` so the test can seed a deferral.

The real re-present is covered at the ops layer; the wire tests cover the
dispatch/gate/list/deny/approve-plumbing. CLI (`pnm`) commands for this surface
are a natural follow-up — not in this PR.

## CI

`cargo fmt` clean; `cargo clippy` clean on **default** and **`--features tee`**
(0 warnings); full `vta-sdk` + `vta-service` suites green (703 lib + 111
integration + the rest, 0 failures). No new dependencies; no version bump
(Phase-0 fix PRs batch version bumps into a separate release PR, per #360–#363).

🤖 Generated with [Claude Code](https://claude.com/claude-code)