### PR TITLE
feat(sdk): add VtaClient::connect_auto for dual-transport auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.11.1",
 ]
 
 [[package]]
@@ -2340,7 +2340,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.11.2",
 ]
 
 [[package]]
@@ -3120,7 +3120,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.11.2",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.11.2",
 ]
 
 [[package]]
@@ -9722,7 +9722,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.11.2",
  "x25519-dalek",
 ]
 
@@ -9761,12 +9761,42 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.11.2",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a9942f0711f78e450428696b510985affbf6e2c3ccee51b115955aea8435f7"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.11.2"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9811,36 +9841,6 @@ dependencies = [
  "wiremock",
  "x25519-dalek",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a9942f0711f78e450428696b510985affbf6e2c3ccee51b115955aea8435f7"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "getrandom 0.4.2",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -9923,7 +9923,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.11.2",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -10005,7 +10005,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.11.2",
  "vtc-service",
  "vti-common",
  "webauthn-rs",
@@ -10050,7 +10050,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.11.2",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10077,7 +10077,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.11.2",
  "vta-service",
  "vti-common",
 ]

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.1"
+version = "0.11.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/auto_connect.rs
+++ b/vta-sdk/src/client/auto_connect.rs
@@ -1,0 +1,116 @@
+//! Transport-agnostic authenticated connect.
+//!
+//! [`VtaClient::connect_auto`] selects DIDComm vs REST from the supplied
+//! credentials and encapsulates the handshake plus the REST-fallback
+//! computation. Consumers used to re-implement this branch by hand — the
+//! transport choice, the `rest_fallback` derivation, and the empty-URL
+//! rule are SDK-level knowledge, so they live here where they can't drift
+//! between call sites.
+
+use crate::client::VtaClient;
+use crate::error::VtaError;
+use crate::session::TokenResult;
+
+/// Inputs for [`VtaClient::connect_auto`].
+///
+/// `mediator_did.is_some()` selects DIDComm; otherwise a REST
+/// challenge-response handshake is used.
+#[derive(Debug, Clone)]
+pub struct AutoConnect<'a> {
+    /// VTA REST base URL. May be empty on the DIDComm path (fully-DIDComm
+    /// VTAs publishing no `#vta-rest` service); when non-empty it is passed
+    /// through as the DIDComm client's REST fallback. **Required (non-empty)
+    /// on the REST path** — an empty `vta_url` with no mediator is an error.
+    pub vta_url: &'a str,
+    /// The VTA's DID.
+    pub vta_did: &'a str,
+    /// The caller's credential DID (the proven signer).
+    pub credential_did: &'a str,
+    /// The caller's Ed25519 private key, multibase-encoded.
+    pub private_key_multibase: &'a str,
+    /// `Some(mediator)` => connect over DIDComm via this mediator;
+    /// `None` => authenticate over REST challenge-response.
+    pub mediator_did: Option<&'a str>,
+}
+
+/// Result of [`VtaClient::connect_auto`].
+///
+/// Carries the authenticated client plus, on the REST path, the issued
+/// token so callers that cache it (e.g. in an OS keyring) still can.
+/// `rest_token` is `None` on the DIDComm path — there the session itself is
+/// the authenticator and there is no bearer token to cache.
+///
+/// On the DIDComm path the inner `client` owns a live, auto-reconnecting
+/// mediator session: callers **must** call [`VtaClient::shutdown`] when
+/// done (or drive the whole interaction through
+/// [`VtaClient::with_didcomm`]). See [`VtaClient::connect_didcomm`].
+pub struct ConnectedVta {
+    /// The authenticated client.
+    pub client: VtaClient,
+    /// The issued REST token, or `None` on the DIDComm path.
+    pub rest_token: Option<TokenResult>,
+}
+
+impl VtaClient {
+    /// Connect to a VTA, selecting the transport from `input`.
+    ///
+    /// - **DIDComm** (`mediator_did = Some`): derives
+    ///   `rest_fallback = (!vta_url.is_empty()).then(|| vta_url)` and calls
+    ///   [`connect_didcomm`](Self::connect_didcomm). An empty `vta_url` is
+    ///   valid (fully-DIDComm VTAs). `rest_token` is `None`.
+    /// - **REST** (`mediator_did = None`): errors with
+    ///   [`VtaError::Validation`] if `vta_url` is empty, otherwise runs the
+    ///   challenge-response handshake, builds a [`VtaClient::new`] client,
+    ///   sets its bearer token, and returns the token in `rest_token` so the
+    ///   caller can cache it.
+    ///
+    /// Token caching and auth-retry policy stay caller-side — they are
+    /// application-specific.
+    #[cfg(feature = "session")]
+    pub async fn connect_auto(input: AutoConnect<'_>) -> Result<ConnectedVta, VtaError> {
+        match input.mediator_did {
+            // DIDComm transport. Empty `vta_url` is valid — it just means no
+            // REST fallback for unauthenticated ops like `health()`.
+            Some(mediator) => {
+                let rest_fallback = (!input.vta_url.is_empty()).then(|| input.vta_url.to_string());
+                let client = VtaClient::connect_didcomm(
+                    input.credential_did,
+                    input.private_key_multibase,
+                    input.vta_did,
+                    mediator,
+                    rest_fallback,
+                )
+                .await?;
+                Ok(ConnectedVta {
+                    client,
+                    rest_token: None,
+                })
+            }
+            // REST transport. A non-empty URL is mandatory — without a
+            // mediator there is nothing else to reach the VTA on.
+            None => {
+                if input.vta_url.is_empty() {
+                    return Err(VtaError::Validation(
+                        "REST transport requires a non-empty vta_url (no mediator_did was supplied)"
+                            .into(),
+                    ));
+                }
+                let token = crate::session::challenge_response(
+                    input.vta_url,
+                    input.credential_did,
+                    input.private_key_multibase,
+                    input.vta_did,
+                )
+                .await
+                .map_err(|e| VtaError::Auth(e.to_string()))?;
+
+                let client = VtaClient::new(input.vta_url);
+                client.set_token_async(token.access_token.clone()).await;
+                Ok(ConnectedVta {
+                    client,
+                    rest_token: Some(token),
+                })
+            }
+        }
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -98,6 +98,8 @@ pub use types::*;
 // ── Per-domain impl blocks ─────────────────────────────────────────
 
 mod acl;
+#[cfg(feature = "session")]
+mod auto_connect;
 mod backup;
 mod backup_descriptors;
 mod bootstrap;
@@ -110,6 +112,11 @@ mod webvh;
 
 #[cfg(feature = "client")]
 mod audit;
+
+#[cfg(feature = "session")]
+pub use crate::session::TokenResult;
+#[cfg(feature = "session")]
+pub use auto_connect::{AutoConnect, ConnectedVta};
 
 /// Percent-encode characters that are unsafe inside a URL path segment.
 ///

--- a/vta-sdk/src/prelude.rs
+++ b/vta-sdk/src/prelude.rs
@@ -31,6 +31,10 @@ pub use crate::client::{
     UpdateAclRequest, UpdateConfigRequest, UpdateContextDidRequest, VtaClient, WrappingKeyResponse,
 };
 
+// Transport-agnostic connect (feature-gated)
+#[cfg(feature = "session")]
+pub use crate::client::{AutoConnect, ConnectedVta, TokenResult};
+
 // DID key utilities
 pub use crate::did_key::{decode_private_key_multibase, ed25519_multibase_pubkey};
 

--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -679,3 +679,71 @@ async fn connect_errors_when_no_session() {
         err.to_string().contains("auth login") || err.to_string().contains("Not authenticated")
     );
 }
+
+// ── VtaClient::connect_auto ─────────────────────────────────────────
+//
+// The DIDComm arm needs a live mediator round-trip, so only the REST
+// arm and the transport-selection guards are exercised here. The
+// `rest_fallback = (!vta_url.is_empty()).then(...)` derivation on the
+// DIDComm arm is unit-trivial and shared with `connect_didcomm`.
+
+#[tokio::test]
+async fn connect_auto_rest_authenticates_and_returns_token() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    let future = now_secs() + 3600;
+    mount_authenticate(&server, future).await;
+    // An authenticated call must carry the token established at connect.
+    Mock::given(method("GET"))
+        .and(path("/config"))
+        .and(wiremock::matchers::header(
+            "authorization",
+            "Bearer access-jwt",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "vta_did": null, "vta_name": null, "public_url": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+
+    let connected = vta_sdk::client::VtaClient::connect_auto(vta_sdk::client::AutoConnect {
+        vta_url: &server.uri(),
+        vta_did: &vta_did,
+        credential_did: &did,
+        private_key_multibase: &pk,
+        mediator_did: None,
+    })
+    .await
+    .expect("REST connect_auto");
+
+    // REST path surfaces the issued token so callers can cache it.
+    let token = connected.rest_token.expect("rest path returns a token");
+    assert_eq!(token.access_token, "access-jwt");
+    // ...and the same token is attached to the client.
+    connected.client.get_config().await.unwrap();
+}
+
+#[tokio::test]
+async fn connect_auto_rest_requires_non_empty_url() {
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+
+    let result = vta_sdk::client::VtaClient::connect_auto(vta_sdk::client::AutoConnect {
+        vta_url: "",
+        vta_did: &vta_did,
+        credential_did: &did,
+        private_key_multibase: &pk,
+        mediator_did: None,
+    })
+    .await;
+
+    match result {
+        Err(vta_sdk::error::VtaError::Validation(_)) => {}
+        Ok(_) => panic!("empty url on the REST path must error"),
+        Err(other) => panic!("expected Validation error, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Adds a transport-agnostic authenticated-connect helper to `vta-sdk` —
`VtaClient::connect_auto(AutoConnect { .. }) -> ConnectedVta` — that
selects DIDComm vs REST from the credentials and encapsulates the
handshake plus the REST-fallback computation. Today consumers
re-implement that branch by hand (duplicated in two places in the
`openvtc` repo), letting the empty-URL guard / `rest_fallback` rule
drift between call sites. That branch is SDK-level knowledge, so it
now lives in the SDK.

Closes #366.

## Behavior

- **DIDComm** (`mediator_did = Some`): `rest_fallback = (!vta_url.is_empty()).then(...)`,
  then `connect_didcomm(...)`; `rest_token = None`. Empty `vta_url` is
  valid (fully-DIDComm VTAs publishing no `#vta-rest` service).
- **REST** (`mediator_did = None`): empty `vta_url` → `VtaError::Validation`;
  otherwise `session::challenge_response(...)` → `VtaClient::new` +
  token set, returning the issued token in `rest_token` so callers that
  cache it (e.g. OS keyring) still can.

## Changes

- `vta-sdk/src/client/auto_connect.rs` (new) — `AutoConnect<'a>`,
  `ConnectedVta`, and `VtaClient::connect_auto`, feature-gated on `session`.
- `vta-sdk/src/client/mod.rs`, `vta-sdk/src/prelude.rs` — re-export
  `AutoConnect`, `ConnectedVta`, `TokenResult`.
- `vta-sdk/tests/session_store.rs` — REST happy-path + empty-URL guard tests.
- `vta-sdk/Cargo.toml` — `0.11.1 → 0.11.2`. Purely additive, so existing
  `"0.11"` dependent pins stay valid (no dependent churn).

## Scope

SDK side only. The consumer-side deletions in the `openvtc` repo
(`did-git-sign`, `openvtc-core`; tracked as R22) land separately once
this is released.

## Verification

- `cargo fmt` + `cargo clippy` clean.
- New `connect_auto` tests pass. (The 2 failing `ensure_authenticated_*rotation*`
  tests are pre-existing on `main` — unrelated to this change.)
- `cargo check --workspace` (excluding `vta-enclave`) compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)