### PR TITLE
fix(vtc-service): 0600 perms on secret-bearing files (P0.17)

### DIFF
--- a/vtc-service/src/keys/seed_store/plaintext.rs
+++ b/vtc-service/src/keys/seed_store/plaintext.rs
@@ -66,7 +66,38 @@ impl super::SecretStore for PlaintextSecretStore {
             std::fs::write(&self.path, hex_val).map_err(|e| {
                 AppError::SecretStore(format!("failed to write plaintext secret file: {e}"))
             })?;
+            // The file holds raw key material — owner-only, matching the
+            // workspace 0600 discipline for secret-bearing files.
+            crate::secure_file::restrict_file_to_owner(&self.path).map_err(|e| {
+                AppError::SecretStore(format!(
+                    "failed to harden plaintext secret file permissions: {e}"
+                ))
+            })?;
             Ok(())
         })
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::keys::seed_store::SecretStore;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[tokio::test]
+    async fn set_produces_mode_0600() {
+        let tmp = std::env::temp_dir().join(format!("vtc-plaintext-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let store = PlaintextSecretStore::new(&tmp);
+
+        store.set(b"super-secret-key-material").await.unwrap();
+
+        let mode = std::fs::metadata(&store.path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "secret.plaintext must be 0600, got {mode:o}"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -40,6 +40,7 @@ pub mod relationships;
 pub mod routes;
 pub mod routing;
 pub mod schemas;
+pub mod secure_file;
 pub mod server;
 pub mod setup;
 pub mod status;

--- a/vtc-service/src/routes/config.rs
+++ b/vtc-service/src/routes/config.rs
@@ -74,6 +74,9 @@ pub async fn update_config(
     }; // write lock released here
 
     std::fs::write(&path, contents).map_err(AppError::Io)?;
+    // Re-harden after every rewrite: config.toml holds the JWT signing key
+    // (and, under the config-secret backend, the key bundle).
+    crate::secure_file::restrict_file_to_owner(&path).map_err(AppError::Io)?;
 
     info!(caller = %_auth.0.did, "config updated");
     Ok(Json(response))

--- a/vtc-service/src/secure_file.rs
+++ b/vtc-service/src/secure_file.rs
@@ -1,0 +1,116 @@
+//! Owner-only permission hardening for secret-bearing files written by the
+//! VTC service (`config.toml` — carries `auth.jwt_signing_key` and, under the
+//! config-secret backend, the hex `VtcKeyBundle`; `secret.plaintext` — the
+//! dev secret store).
+//!
+//! This mirrors the workspace discipline used for PNM bootstrap secrets
+//! (`vta-cli-common::secure_file::restrict_file_to_owner`,
+//! `vta-sdk::provision_client::setup_key`). `vtc-service` can't depend on
+//! `vta-cli-common` (wrong direction in the crate graph — the CLIs depend on
+//! the services, not the reverse), so the small helper is reproduced here.
+//!
+//! # Unix
+//! `chmod 0600` — owner read/write only.
+//!
+//! # Windows
+//! `icacls <path> /inheritance:r /grant:r <user>:(F)` — strip inherited ACEs
+//! and replace the DACL with a single full-control grant to the current user.
+//!
+//! Defence-in-depth: the file content is the secret, but file-mode hardening
+//! keeps it off a co-tenant's `cat`.
+
+use std::path::Path;
+
+/// Restrict `path` (a file) so only the owner can read / write.
+///
+/// Unix → `0600`. Windows → user-only DACL via `icacls`. Other platforms are
+/// a no-op. Best-effort: callers should treat an error as a hardening failure,
+/// not a write failure (the bytes are already on disk by the time this runs).
+pub fn restrict_file_to_owner(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = std::fs::metadata(path)?.permissions();
+        perm.set_mode(0o600);
+        std::fs::set_permissions(path, perm)?;
+    }
+    #[cfg(windows)]
+    {
+        apply_windows_user_only_dacl(path)?;
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn apply_windows_user_only_dacl(path: &Path) -> std::io::Result<()> {
+    use std::process::Command;
+
+    // `USERNAME` is present on every modern Windows shell. A missing value
+    // means an unusual execution context (service / scheduled task without a
+    // user) — surface it rather than silently leaving the file wide open.
+    let user = std::env::var("USERNAME").map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "USERNAME env var not set — cannot apply Windows user-only DACL",
+        )
+    })?;
+    let user_trimmed = user.trim();
+    if user_trimmed.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "USERNAME is empty — cannot apply Windows user-only DACL",
+        ));
+    }
+
+    let path_str = path.to_str().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path is not valid UTF-8 — cannot pass to icacls",
+        )
+    })?;
+
+    let output = Command::new("icacls")
+        .arg(path_str)
+        .arg("/inheritance:r")
+        .arg("/grant:r")
+        .arg(format!("{user_trimmed}:(F)"))
+        .output()?;
+
+    if !output.status.success() {
+        return Err(std::io::Error::other(format!(
+            "icacls failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn restrict_file_sets_0600_on_unix() {
+        let tmp = std::env::temp_dir().join(format!("vtc-secure-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let f = tmp.join("secret.bin");
+        std::fs::write(&f, b"sensitive").unwrap();
+
+        // Start permissive so the change is observable.
+        let mut perm = std::fs::metadata(&f).unwrap().permissions();
+        perm.set_mode(0o644);
+        std::fs::set_permissions(&f, perm).unwrap();
+
+        restrict_file_to_owner(&f).expect("restrict_file_to_owner succeeds");
+
+        let mode = std::fs::metadata(&f).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -1333,6 +1333,14 @@ fn write_config_toml(path: &std::path::Path, config: &AppConfig) -> Result<(), A
             format!("write config {}: {e}", path.display()),
         ))
     })?;
+    // config.toml carries `auth.jwt_signing_key` and, under the config-secret
+    // backend, the hex `VtcKeyBundle` — owner-only, never world-readable.
+    crate::secure_file::restrict_file_to_owner(path).map_err(|e| {
+        AppError::Io(std::io::Error::new(
+            e.kind(),
+            format!("harden config perms {}: {e}", path.display()),
+        ))
+    })?;
     Ok(())
 }
 
@@ -1553,5 +1561,40 @@ mod tests {
         assert!(msg.contains("--name \"VTC\""));
         assert!(msg.contains("--admin-did did:key:zAbc"));
         assert!(msg.contains("--admin-expires 1h"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_config_toml_produces_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = std::env::temp_dir().join(format!("vtc-cfg-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let cfg_path = tmp.join("config.toml");
+
+        let config = build_app_config(
+            cfg_path.clone(),
+            "did:webvh:scid:vtc.example.com".into(),
+            "did:webvh:scid:vta.example.com".into(),
+            "https://vtc.example.com".into(),
+            tmp.join("data"),
+            secrets_choice_to_config(SecretsBackendChoice::Keyring {
+                service: "vtc".into(),
+            }),
+            None,
+        )
+        .unwrap();
+
+        write_config_toml(&cfg_path, &config).unwrap();
+
+        // The serialized config carries `auth.jwt_signing_key` — must not be
+        // world-readable.
+        let mode = std::fs::metadata(&cfg_path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "config.toml must be 0600, got {mode:o}"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }


### PR DESCRIPTION
## P0.17 — Secret-bearing files written world-readable (S)

**Problem:** every `config.toml` carries `auth.jwt_signing_key` (the Ed25519 JWT signing seed) and, under the config-secret backend, the hex-encoded `VtcKeyBundle` with both private keys. `secret.plaintext` holds raw key material. All three were written via `std::fs::write` under the default umask (0644), leaving key material world-readable — diverging from the workspace 0600 + Windows-ACL discipline already used for PNM bootstrap secrets.

**Change:**
- New `vtc-service::secure_file::restrict_file_to_owner` — Unix `chmod 0600`, Windows user-only DACL via `icacls`, no-op elsewhere. Mirrors `vta-cli-common::secure_file` (vtc-service can't depend on vta-cli-common — wrong direction in the crate graph, so the small helper is reproduced).
- Applied after every write at the three call sites:
  - `setup/wizard.rs::write_config_toml`
  - `routes/config.rs` `/v1/config` save path (re-hardens on every rewrite)
  - `keys/seed_store/plaintext.rs::PlaintextSecretStore::set`

**Note:** the helper `chmod`s after the write (rather than `OpenOptions::mode` on create), because the `/v1/config` rewrite path operates on a pre-existing file where create-mode wouldn't re-tighten perms. This leaves a brief creation window at 0644 before the chmod — the same trade-off the existing `vta-sdk`/`vta-cli-common` helpers accept.

## Tests
- `setup::wizard::tests::write_config_toml_produces_mode_0600`
- `keys::seed_store::plaintext::tests::set_produces_mode_0600`
- `secure_file::tests::restrict_file_sets_0600_on_unix`

`cargo clippy -p vtc-service` clean; `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)