### PR TITLE
fix(vta-service): unknown-key warning + missing-identity hard-fail (P0.9b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7755,6 +7755,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_jcs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9902,6 +9912,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.13.4",
  "serde",
+ "serde_ignored",
  "serde_json",
  "sha2 0.11.0",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ tokio = { version = "1", features = [
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
+# Surfaces unknown/typo'd keys during deserialization without rejecting them
+# (config.rs unknown-key warning pass).
+serde_ignored = "0.1"
 
 # Error handling
 thiserror = "2"

--- a/docs/02-vta/non-interactive-setup.md
+++ b/docs/02-vta/non-interactive-setup.md
@@ -146,7 +146,7 @@ proceed with a clear error if the feature isn't compiled in.
 
 | `kind` | Fields | Use when |
 |---|---|---|
-| `"skip"` | — | No VTA DID. REST works; DIDComm/VC issuance doesn't. |
+| `"skip"` | — | No VTA DID — the VTA has no signing identity. **The daemon refuses to boot in this state** (see note below). |
 | `"existing"` | `did` | You already have a VTA DID. |
 | `"create_webvh"` | `url`, `portable` (default `true`), `pre_rotation_count` (default `1`) | Mint a new did:webvh in "simple mode". |
 
@@ -154,6 +154,16 @@ proceed with a clear error if the feature isn't compiled in.
 `<data_dir>/did-logs/<label>-did.jsonl` for re-publishing or audit.
 Operators who need advanced DID options (template-from-file, pre-signed
 log import, user-specified key IDs) should use interactive setup.
+
+> **Booting without an identity.** A VTA whose `vta_did` (or JWT signing
+> key) is unset has no usable signing identity: every authenticated
+> endpoint answers `401` even though the port is open. To stop that from
+> looking healthy to a liveness probe, `vta` **refuses to start** in this
+> state and exits non-zero with a message naming the missing piece. If you
+> deliberately want to boot a not-yet-provisioned instance — e.g. to
+> inspect it or finish provisioning out-of-band — pass `vta --allow-degraded`,
+> which restores the old serve-anyway behaviour. TEE/enclave deployments are
+> unaffected: their identity is auto-generated during enclave boot.
 
 ## Mnemonic policy
 

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -97,12 +97,36 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   one wrong TOML key → master seed on disk in clear). Tests: validate rules
   (the opt-in path is cfg-unreachable in the test harness — dev-dep forces
   keyring on — documented) — PR: #356 (merged)
-- `[ ]` **P0.9b** Split from P0.9 (config-compat risk; needs care):
-  `deny_unknown_fields`/unknown-key WARNING pass on `AppConfig` (could reject
-  existing configs with legacy/extra keys — softer warning preferred);
-  hard-fail at boot on missing identity (`vta_did`/JWT keys) unless a new
-  `--allow-degraded` CLI flag (needs cold-start / TEE-autogen / import-did
-  flow analysis so it doesn't break a legitimate not-yet-configured boot) — PR: ____
+- `[x]` **P0.9b** (M) Unknown-key WARNING pass + missing-identity hard-fail —
+  branch `fix/p0.9b-config-identity` (worktree). Two config-compat-sensitive
+  halves of P0.9, deliberately *soft* where rejection would risk existing
+  deployments:
+  - **Unknown-key warning** (not `deny_unknown_fields`): `AppConfig::load`
+    deserializes through `serde_ignored` and records every unmapped dotted
+    path into a `#[serde(skip)] unknown_keys` field; `validate()` emits one
+    `warn!` per key (named, with a typo/renamed/wrong-section hint). Warning
+    lives in `validate()` (not `load()`) because `load()` runs before the
+    tracing subscriber is installed. We *warn, never reject* — a legacy/extra
+    key must not block a config that boots fine today. Aliases
+    (`community_name`) and known nested keys are not flagged.
+  - **Missing-identity hard-fail**: `server::run` gains an `allow_degraded`
+    param; after `init_auth`, `jwt_keys.is_none()` (covers absent `vta_did`,
+    absent JWT signing key, *or* unloadable key material) now refuses to boot
+    with a fix-suggesting message (`missing_identity_message` names the
+    specific gap + points at the escape hatch) rather than serving a VTA that
+    401s every authed request but passes a liveness probe. New top-level
+    `vta --allow-degraded` flag preserves the old degraded boot. **TEE/enclave
+    passes `allow_degraded = true`** — its identity is established earlier in
+    enclave boot by KMS autogen + admin-bootstrap, and a degraded first boot
+    is an existing documented state there; the hard-fail guards the local
+    `vta` daemon, which owns the CLI opt-out. import-did / cold-start flows run
+    `vta setup` first (identity present), so they're unaffected.
+  Tests: load collects nested+top-level typos and still validates; aliases not
+  flagged; `missing_identity_message` arm-by-arm (vta_did / jwt key / key
+  material). Smoke-tested end-to-end: no-identity boot exits non-zero with the
+  message; `--allow-degraded` binds the listener. New dep `serde_ignored`. fmt
+  + clippy (default & tee) clean; lib suite 709 green; no-default / rest-only
+  combos compile — PR: ____
 - `[x]` **P0.10** (S) `TimeoutLayer`; attestation routes onto governed branch;
   explicit 100 MB layer + governor on `/backup/blob` — branch
   `fix/p0.10-timeouts-ratelimit`. Global `TimeoutLayer` (120s, →408) as the

--- a/vta-enclave/src/main.rs
+++ b/vta-enclave/src/main.rs
@@ -241,12 +241,20 @@ async fn main() {
     };
 
     // ── Start the server ──
+    // `allow_degraded = true`: in a TEE the signing identity is established
+    // earlier in this boot by KMS autogen (`maybe_generate_vta_did`) +
+    // admin-bootstrap, and a degraded first boot is an existing, documented
+    // state (see the TEE-required warning in `server::run`). The
+    // missing-identity hard-fail (P0.9b) is a guard for the local `vta`
+    // daemon, which exposes the `--allow-degraded` opt-out on its CLI; the
+    // enclave has no such CLI surface.
     if let Err(e) = vta_service::server::run(
         config,
         store,
         seed_store,
         storage_encryption_key,
         tee_context,
+        true,
     )
     .await
     {

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -140,6 +140,7 @@ toml = { workspace = true }
 tower-http = { workspace = true, features = ["trace", "limit", "cors", "timeout"] }
 tokio = { workspace = true }
 serde = { workspace = true }
+serde_ignored = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 # Used by the password-POST proxy-login driver to form-encode credentials

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -53,6 +53,16 @@ pub struct AppConfig {
     pub tee: TeeConfig,
     #[serde(skip)]
     pub config_path: PathBuf,
+    /// Dotted paths of keys present in the parsed `config.toml` that no
+    /// field of `AppConfig` claims — typos, removed/renamed settings, or
+    /// keys meant for a different section. Collected by `load()` (via
+    /// `serde_ignored`) and surfaced as advisory warnings in `validate()`.
+    /// `#[serde(skip)]` so it never round-trips through the file itself.
+    /// We *warn* rather than reject (no `deny_unknown_fields`): an existing
+    /// deployment may legitimately carry a legacy/extra key, and a config
+    /// that boots fine today must keep booting (P0.9b).
+    #[serde(skip)]
+    pub unknown_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -461,10 +471,20 @@ impl AppConfig {
         }
 
         let contents = std::fs::read_to_string(&path).map_err(AppError::Io)?;
-        let mut config = toml::from_str::<AppConfig>(&contents)
+
+        // Deserialize through `serde_ignored` so we can *record* every key the
+        // schema doesn't recognise (typo'd / legacy / mis-sectioned) instead of
+        // silently dropping it. We don't reject — `validate()` warns. (P0.9b)
+        let de = toml::Deserializer::parse(&contents)
             .map_err(|e| AppError::Config(format!("failed to parse {}: {e}", path.display())))?;
+        let mut unknown_keys: Vec<String> = Vec::new();
+        let mut config: AppConfig = serde_ignored::deserialize(de, |key_path| {
+            unknown_keys.push(key_path.to_string());
+        })
+        .map_err(|e| AppError::Config(format!("failed to parse {}: {e}", path.display())))?;
 
         config.config_path = path.clone();
+        config.unknown_keys = unknown_keys;
 
         // =====================================================================
         // SECURITY: When KMS bootstrap is configured (TEE mode), the config
@@ -772,6 +792,20 @@ impl AppConfig {
     /// cross-field advisories that a working deployment might legitimately
     /// have, so it can't reject a config that boots fine today.
     pub fn validate(&self) -> Result<(), AppError> {
+        // Advisory (non-blocking): keys the schema doesn't recognise. Emitted
+        // here rather than in `load()` because `load()` runs before the tracing
+        // subscriber is installed, so a warn there would be dropped. A typo'd
+        // key means the operator's intended setting silently took its default —
+        // worth flagging, but never a reason to refuse a config that otherwise
+        // boots (P0.9b — softer than `deny_unknown_fields`).
+        for key in &self.unknown_keys {
+            tracing::warn!(
+                "unknown configuration key `{key}` in {} — ignored. Check for a typo, \
+                 a removed/renamed setting, or a key placed in the wrong [section].",
+                self.config_path.display()
+            );
+        }
+
         let mut errors: Vec<String> = Vec::new();
 
         // A present-but-empty URL is always a mistake (the operator set the
@@ -885,5 +919,61 @@ mod validate_tests {
         cfg("")
             .validate()
             .expect("rest-without-public_url is advisory, not an error");
+    }
+
+    /// Write `contents` to a `config.toml` in a fresh tempdir and run it
+    /// through the real `AppConfig::load` path (the only path that populates
+    /// `unknown_keys` — `toml::from_str` doesn't). Returns the loaded config;
+    /// the `TempDir` is returned too so the file outlives the call.
+    fn load(contents: &str) -> (AppConfig, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, contents).expect("write config");
+        let config = AppConfig::load(Some(path)).expect("load config");
+        (config, dir)
+    }
+
+    #[test]
+    fn unknown_keys_are_collected_not_rejected() {
+        // A typo'd top-level key and a typo inside a nested table. `load`
+        // must succeed (no rejection) and record both as dotted paths.
+        let (config, _dir) = load(
+            "vta_naem = \"oops\"\n\
+             [secrets]\nkyring_service = \"vta-2\"\n",
+        );
+        assert!(
+            config.unknown_keys.iter().any(|k| k == "vta_naem"),
+            "top-level typo should be flagged: {:?}",
+            config.unknown_keys
+        );
+        assert!(
+            config
+                .unknown_keys
+                .iter()
+                .any(|k| k == "secrets.kyring_service"),
+            "nested typo should be flagged with a dotted path: {:?}",
+            config.unknown_keys
+        );
+        // Advisory only — a config with unknown keys still validates.
+        config
+            .validate()
+            .expect("unknown keys are advisory, not a hard error");
+    }
+
+    #[test]
+    fn known_keys_and_aliases_are_not_flagged() {
+        // `community_name` is a serde alias for `vta_name`; a real nested
+        // key must not be reported. Nothing should land in `unknown_keys`.
+        let (config, _dir) = load(
+            "community_name = \"acme\"\n\
+             [server]\nport = 9000\n",
+        );
+        assert!(
+            config.unknown_keys.is_empty(),
+            "known keys + aliases must not be flagged: {:?}",
+            config.unknown_keys
+        );
+        assert_eq!(config.vta_name.as_deref(), Some("acme"));
+        assert_eq!(config.server.port, 9000);
     }
 }

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -41,6 +41,14 @@ struct Cli {
     #[arg(short, long, global = true)]
     config: Option<PathBuf>,
 
+    /// Boot the daemon even when the VTA has no usable signing identity
+    /// (missing `vta_did` or JWT signing key). Without this flag the daemon
+    /// refuses to start rather than come up in a state where every
+    /// authenticated endpoint returns 401 (P0.9b). Use only to inspect or
+    /// finish provisioning a half-set-up instance. Ignored by subcommands.
+    #[arg(long)]
+    allow_degraded: bool,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -1848,8 +1856,12 @@ async fn main() {
                 Arc::from(create_seed_store(&config).expect("failed to create seed store"));
 
             if let Err(e) = server::run(
-                config, store, seed_store, None, // no storage encryption (non-TEE mode)
+                config,
+                store,
+                seed_store,
+                None, // no storage encryption (non-TEE mode)
                 None, // no TEE context (use vta-enclave for TEE mode)
+                cli.allow_degraded,
             )
             .await
             {

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -355,6 +355,7 @@ pub async fn run(
     seed_store: Arc<dyn SeedStore>,
     storage_encryption_key: Option<[u8; 32]>,
     tee_context: Option<TeeContext>,
+    allow_degraded: bool,
 ) -> Result<(), AppError> {
     // Fail fast on a broken config rather than booting a half-started
     // service that passes a port-liveness check but can't function (P0.9).
@@ -508,6 +509,21 @@ pub async fn run(
 
         // Initialize auth infrastructure
         let auth = init_auth(&config, &*seed_store, &keys_ks).await;
+
+        // Fail-closed on missing identity (P0.9b). `init_auth` yields
+        // `jwt_keys: Some` only when the VTA has a complete, usable signing
+        // identity: a configured `vta_did`, its key records + seed present, and
+        // a decodable JWT signing key. With any of those missing the VTA still
+        // *boots* but every authenticated endpoint returns 401 — a service that
+        // looks "up" to a liveness probe while being inert. Refuse to start
+        // unless the operator explicitly opted into a degraded boot (e.g. to
+        // inspect or finish provisioning a half-set-up instance). TEE
+        // front-ends pass `allow_degraded = true`: their identity is
+        // established by KMS autogen / admin-bootstrap earlier in enclave boot,
+        // and a degraded first boot there is an existing, documented state.
+        if auth.jwt_keys.is_none() && !allow_degraded {
+            return Err(AppError::Config(missing_identity_message(&config)));
+        }
 
         // Pluggable telemetry sink + multi-mediator listener registry.
         // The registry holds active/drain state and the per-mediator
@@ -1204,6 +1220,36 @@ impl AuthInit {
     }
 }
 
+/// Build the operator-facing boot-refusal message for the missing-identity
+/// gate (P0.9b). Names the specific gap so the fix is obvious, and always
+/// points at the `--allow-degraded` escape hatch (mirrors CLAUDE.md's
+/// "operator errors should suggest the fix").
+fn missing_identity_message(config: &AppConfig) -> String {
+    let cause = if config.vta_did.is_none() {
+        "vta_did is not configured — this VTA has no identity. Run `vta setup` \
+         to provision one"
+            .to_string()
+    } else if config.auth.jwt_signing_key.is_none() {
+        "auth.jwt_signing_key is not configured — the VTA can't issue access \
+         tokens. Run `vta setup`, or restore the key to config.toml"
+            .to_string()
+    } else {
+        format!(
+            "vta_did is set ({}) but its signing identity could not be loaded — \
+             the VTA key records may be missing from the store or the seed \
+             backend may be unreachable. Check the store data_dir and the \
+             secrets backend",
+            config.vta_did.as_deref().unwrap_or_default()
+        )
+    };
+    format!(
+        "refusing to start: {cause}. A VTA without a usable signing identity \
+         boots but answers every authenticated request with 401. To start \
+         anyway (e.g. to inspect or finish provisioning a half-set-up \
+         instance), pass `--allow-degraded`."
+    )
+}
+
 async fn init_auth(
     config: &AppConfig,
     seed_store: &dyn SeedStore,
@@ -1701,5 +1747,42 @@ mod tests {
             matches!(result, Err(AppError::NotFound(_))),
             "expected NotFound for did:webvh missing #key-1, got {result:?}"
         );
+    }
+
+    /// Build an `AppConfig` from a TOML snippet for the message tests.
+    fn cfg(toml_str: &str) -> AppConfig {
+        toml::from_str::<AppConfig>(toml_str).expect("parse test config")
+    }
+
+    /// P0.9b: the missing-identity refusal names the *specific* gap and always
+    /// points at the `--allow-degraded` escape hatch.
+    #[test]
+    fn missing_identity_message_names_absent_vta_did() {
+        let msg = missing_identity_message(&cfg(""));
+        assert!(msg.contains("vta_did is not configured"), "{msg}");
+        assert!(msg.contains("vta setup"), "{msg}");
+        assert!(msg.contains("--allow-degraded"), "{msg}");
+    }
+
+    #[test]
+    fn missing_identity_message_names_absent_jwt_key() {
+        // vta_did present, JWT signing key absent → the message must point at
+        // the JWT key, not the DID.
+        let msg = missing_identity_message(&cfg("vta_did = \"did:key:z6MkTest\"\n"));
+        assert!(msg.contains("auth.jwt_signing_key"), "{msg}");
+        assert!(!msg.contains("vta_did is not configured"), "{msg}");
+        assert!(msg.contains("--allow-degraded"), "{msg}");
+    }
+
+    #[test]
+    fn missing_identity_message_falls_back_to_key_material() {
+        // Both identity fields present but key material unloadable (the real
+        // gate reaches this arm when `init_auth` can't derive/find the keys).
+        let msg = missing_identity_message(&cfg(
+            "vta_did = \"did:key:z6MkTest\"\n[auth]\njwt_signing_key = \"AAAA\"\n",
+        ));
+        assert!(msg.contains("could not be loaded"), "{msg}");
+        assert!(msg.contains("did:key:z6MkTest"), "{msg}");
+        assert!(msg.contains("--allow-degraded"), "{msg}");
     }
 }

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -672,6 +672,7 @@ pub async fn apply_inputs(inputs: WizardInputs) -> Result<(), Box<dyn std::error
         tee: Default::default(),
         resolver_url: inputs.resolver_url.clone(),
         config_path: inputs.config_path.clone(),
+        unknown_keys: Vec::new(),
     };
     config.save()?;
 
@@ -1022,6 +1023,7 @@ fn scratch_config_for_seed_store(
         tee: Default::default(),
         resolver_url: None,
         config_path,
+        unknown_keys: Vec::new(),
     }
 }
 

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -718,6 +718,7 @@ pub async fn run_setup_wizard(
             tee: Default::default(),
             resolver_url: None,
             config_path: config_path.clone(),
+            unknown_keys: Vec::new(),
         })
         .map_err(|e| format!("{e}"))?;
         seed_store.set(&seed).await.map_err(|e| format!("{e}"))?;
@@ -764,6 +765,7 @@ pub async fn run_setup_wizard(
         tee: Default::default(),
         resolver_url: None,
         config_path: config_path.clone(),
+        unknown_keys: Vec::new(),
     };
     let wizard_seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
         Arc::from(create_seed_store(&wizard_config).map_err(|e| format!("{e}"))?);
@@ -862,6 +864,7 @@ pub async fn run_setup_wizard(
         tee: Default::default(),
         resolver_url,
         config_path: config_path.clone(),
+        unknown_keys: Vec::new(),
     };
     config.save()?;
 

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -126,6 +126,7 @@ pub fn test_app_config(data_dir: PathBuf) -> AppConfig {
         #[cfg(feature = "tee")]
         tee: Default::default(),
         config_path: PathBuf::new(),
+        unknown_keys: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## What

The two config-compat-sensitive halves of **P0.9**, deliberately *soft* where a hard rejection would risk breaking existing deployments.

### 1. Unknown-key warning pass (not `deny_unknown_fields`)
`AppConfig::load` now deserializes through `serde_ignored`, recording every key the schema doesn't claim into a `#[serde(skip)] unknown_keys` field; `validate()` emits one `warn!` per key (named, with a typo / renamed / wrong-section hint).

- The warning lives in `validate()` rather than `load()` because `load()` runs **before** the tracing subscriber is installed — a `warn!` there would be silently dropped.
- **Warn, never reject.** A legacy/extra key must not block a config that boots fine today. Serde aliases (`community_name`) and known nested keys are not flagged.

### 2. Missing-identity hard-fail + `--allow-degraded`
`server::run` gains an `allow_degraded` param. After `init_auth`, `jwt_keys.is_none()` — which covers an absent `vta_did`, an absent JWT signing key, **or** unloadable key material — now refuses to boot with a fix-suggesting message (`missing_identity_message` names the specific gap and points at the escape hatch) rather than serving a VTA that `401`s every authenticated request but still passes a port-liveness probe.

- New top-level `vta --allow-degraded` flag preserves the old degraded boot.
- **TEE/enclave passes `allow_degraded = true`**: its identity is established earlier in enclave boot by KMS autogen + admin-bootstrap, and a degraded first boot is an existing, documented state there. The hard-fail guards the local `vta` daemon, which owns the CLI opt-out.
- `import-did` / cold-start flows run `vta setup` first (identity present), so they're unaffected.

## Tests
- Unit: `load` collects nested + top-level typos and still validates; aliases not flagged; `missing_identity_message` tested arm-by-arm (vta_did / jwt key / key material).
- **Smoke-tested end-to-end**: no-identity boot exits non-zero with the named message + `--allow-degraded` hint; `--allow-degraded` binds the listener; the unknown-key warning fires in both runs.

## Gate
- New dep `serde_ignored`.
- `cargo fmt` + `clippy` (default & `tee`) clean.
- `vta-service` lib suite 709 passed; `--no-default-features` and rest-only combos compile.

Plan ref: `tasks/vta-architecture-plan.md` P0.9 (part 2)