### PR TITLE
fix(vtc-service): bound Rego evaluation time + input size, fail closed (P0.18)

### DIFF
--- a/vtc-service/src/ceremony/evaluate.rs
+++ b/vtc-service/src/ceremony/evaluate.rs
@@ -43,7 +43,22 @@ use crate::policy::engine::{self, CompiledPolicy};
 pub fn evaluate(verified: &VerifiedFacts, policy: &CompiledPolicy) -> Result<Verdict, AppError> {
     let input = verified.to_input()?;
     let query = verified.purpose().decision_query();
-    let results = engine::evaluate(policy, &query, input)?;
+    let results = match engine::evaluate(policy, &query, input) {
+        Ok(results) => results,
+        // Resource-bound abort (time budget or input-size cap, P0.18). The
+        // join decision runs on the unauthenticated submit route, so a
+        // pathological policy / adversarial input must fail **closed** —
+        // deny — not surface a 500 or hang the handler.
+        Err(e @ AppError::ResourceExhausted(_)) => {
+            tracing::warn!(
+                purpose = verified.purpose().as_str(),
+                error = %e,
+                "ceremony policy evaluation hit a resource bound — failing closed (deny)",
+            );
+            return Ok(Verdict::default_deny());
+        }
+        Err(e) => return Err(e),
+    };
 
     match decision_value(&results) {
         Some(decision) => Verdict::from_decision(decision),
@@ -205,5 +220,36 @@ default decision := {"effect": "allow", "with": {"fields": ["did"]}}
         let policy = compile(DIRECTORY, Uuid::new_v4()).unwrap();
         let verdict = evaluate(&join_facts(true), &policy).expect("evaluate");
         assert_eq!(verdict, Verdict::default_deny());
+    }
+
+    /// Fail-closed (P0.18): a join policy whose `decision` rule does
+    /// pathological work trips the evaluator's resource budget. On the
+    /// unauthenticated submit path this must degrade to a **deny**, not a
+    /// 500 or a hang.
+    #[test]
+    fn resource_bound_abort_fails_closed_to_deny() {
+        // The expensive comprehension runs whenever `decision` is
+        // evaluated, so the timer trips before any allow can be returned.
+        const RUNAWAY_JOIN: &str = r#"
+package vtc.join
+
+import rego.v1
+
+xs := numbers.range(1, 10000)
+
+default decision := {"effect": "deny", "with": {"code": "default"}}
+
+decision := {"effect": "allow", "with": {"role": "member"}} if {
+    count([1 | some i in xs; some j in xs; i == j]) >= 0
+}
+"#;
+        let policy = compile(RUNAWAY_JOIN, Uuid::new_v4()).unwrap();
+        let verdict = evaluate(&join_facts(true), &policy)
+            .expect("resource-bound abort must not surface as an error");
+        assert_eq!(
+            verdict,
+            Verdict::default_deny(),
+            "a policy that exhausts its budget must fail closed (deny)"
+        );
     }
 }

--- a/vtc-service/src/policy/engine.rs
+++ b/vtc-service/src/policy/engine.rs
@@ -25,12 +25,42 @@
 //! reallocated.
 
 use std::fmt;
+use std::num::NonZeroU32;
+use std::time::Duration;
 
+use regorus::utils::limits::{ExecutionTimerConfig, LimitError};
 use regorus::{Engine, Value as RegoValue};
 use serde_json::Value as JsonValue;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 use vti_common::error::AppError;
+
+/// Wall-clock ceiling for a single policy evaluation.
+///
+/// The join-decision policy is evaluated on the **unauthenticated** submit
+/// route against attacker-influenced facts (the VP + claim graph flow into
+/// `input`). Without a bound, a pathological operator-uploaded policy or an
+/// adversarial input shape burns CPU per request unbounded. regorus's
+/// cooperative timer interrupts evaluation once elapsed work exceeds this —
+/// real policies evaluate in microseconds, so the headroom is ~1000×, while
+/// a runaway aborts fast enough that the 5 rps/IP governor keeps total cost
+/// bounded.
+const POLICY_EVAL_TIME_LIMIT: Duration = Duration::from_millis(250);
+
+/// How many evaluation "work units" the timer accumulates between wall-clock
+/// checks. Larger = lower per-unit overhead, smaller = tighter abort latency.
+/// 1000 keeps the monotonic-clock reads cheap while still aborting a tight
+/// loop within a few milliseconds of the ceiling.
+const POLICY_EVAL_CHECK_INTERVAL: u32 = 1000;
+
+/// Maximum serialized size of the `input` document handed to a policy.
+///
+/// Caps the attacker-influenced join input *before* evaluation so a large
+/// (but under the 1 MB global body cap) VP / claim graph can't be amplified
+/// into an expensive evaluation. 256 KiB is far above any legitimate join
+/// input. Evaluation fails closed (default-deny on the join path) when
+/// exceeded.
+const MAX_POLICY_INPUT_BYTES: usize = 256 * 1024;
 
 /// Module path used for the single Rego source in every compiled
 /// policy. Surfaces in regorus's compile-error messages as
@@ -107,18 +137,62 @@ pub fn compile(rego_source: &str, id: Uuid) -> Result<CompiledPolicy, AppError> 
 /// Returns [`AppError::Internal`] on evaluation failure. Policies that
 /// parse cleanly but reference undefined rules surface here, not at
 /// [`compile`] time — Rego is permissive about forward references.
+///
+/// ## Resource bounds (P0.18)
+///
+/// This is the unauthenticated DoS surface: the join-decision policy runs
+/// here against attacker-influenced `input`. Two guards keep a pathological
+/// policy or adversarial input from burning CPU unbounded:
+///
+/// - **Input-size cap.** The serialized `input` is rejected up front if it
+///   exceeds [`MAX_POLICY_INPUT_BYTES`].
+/// - **Evaluation time budget.** A regorus [`ExecutionTimerConfig`] interrupts
+///   evaluation once it exceeds [`POLICY_EVAL_TIME_LIMIT`].
+///
+/// Both bounds surface as [`AppError::ResourceExhausted`] — distinct from the
+/// `Internal` policy-bug error so callers on the join path can fail closed
+/// (default-deny) rather than 500. A `tokio::time::timeout` would *not* work
+/// here: regorus evaluation is synchronous and CPU-bound, so a timeout future
+/// can't pre-empt it — it would leak a wedged worker thread. The cooperative
+/// in-engine timer actually stops the work.
 pub fn evaluate(
     compiled: &CompiledPolicy,
     query: &str,
     input: JsonValue,
 ) -> Result<JsonValue, AppError> {
+    // Cap the attacker-influenced input before it reaches the interpreter.
+    let input_bytes = serde_json::to_vec(&input)?;
+    if input_bytes.len() > MAX_POLICY_INPUT_BYTES {
+        return Err(AppError::ResourceExhausted(format!(
+            "policy input ({} bytes) exceeds the {MAX_POLICY_INPUT_BYTES}-byte cap",
+            input_bytes.len()
+        )));
+    }
+
     let mut engine = compiled.engine.clone();
+    // Bound applies to this evaluation's clone; set after cloning so it holds
+    // regardless of whether the compiled engine carried a config.
+    engine.set_execution_timer_config(ExecutionTimerConfig {
+        limit: POLICY_EVAL_TIME_LIMIT,
+        check_interval: NonZeroU32::new(POLICY_EVAL_CHECK_INTERVAL)
+            .expect("POLICY_EVAL_CHECK_INTERVAL is non-zero"),
+    });
     engine.set_input(RegoValue::from(input));
+
     let results = engine.eval_query(query.to_string(), false).map_err(|e| {
-        AppError::Internal(format!(
-            "rego evaluation failed for policy {}: {e}",
-            compiled.id
-        ))
+        // A time/instruction-budget abort is a resource bound, not a policy
+        // bug — surface it as ResourceExhausted so the join path denies.
+        if e.downcast_ref::<LimitError>().is_some() {
+            AppError::ResourceExhausted(format!(
+                "policy {} evaluation exceeded its resource budget",
+                compiled.id
+            ))
+        } else {
+            AppError::Internal(format!(
+                "rego evaluation failed for policy {}: {e}",
+                compiled.id
+            ))
+        }
     })?;
     serde_json::to_value(results).map_err(AppError::from)
 }
@@ -263,6 +337,56 @@ allow if {
         // property isn't trivially satisfied by a constant hasher.
         let c = compile(DENY_POLICY, Uuid::new_v4()).unwrap();
         assert_ne!(a.source_sha256(), c.source_sha256());
+    }
+
+    /// Input-size cap (P0.18): an `input` whose serialized form exceeds
+    /// [`MAX_POLICY_INPUT_BYTES`] is rejected before evaluation with
+    /// `ResourceExhausted`, never handed to the interpreter.
+    #[test]
+    fn evaluate_rejects_oversized_input() {
+        let compiled = compile(ALLOW_POLICY, test_id()).unwrap();
+        let blob = "x".repeat(MAX_POLICY_INPUT_BYTES + 1);
+        let err = evaluate(&compiled, "data.vtc.test.allow", json!({ "blob": blob }))
+            .expect_err("oversized input must be rejected");
+        assert!(
+            matches!(err, AppError::ResourceExhausted(_)),
+            "expected ResourceExhausted, got {err:?}"
+        );
+
+        // A just-under-cap input still evaluates normally — the cap is a
+        // ceiling, not a blanket rejection of large-ish inputs.
+        let ok = evaluate(&compiled, "data.vtc.test.allow", json!({ "role": "admin" }))
+            .expect("normal input must still evaluate");
+        assert_eq!(pluck_expression_value(&ok), &json!(true));
+    }
+
+    /// Time budget (P0.18): a policy that does pathological work is
+    /// interrupted by the execution timer and surfaces as
+    /// `ResourceExhausted` (the join path turns that into a deny) rather
+    /// than hanging the evaluation unbounded.
+    #[test]
+    fn evaluate_aborts_runaway_policy() {
+        // A doubly-nested comprehension over a 10k range is ~100M
+        // iterations — orders of magnitude past the 250ms ceiling, so the
+        // cooperative timer trips long before it could complete.
+        const RUNAWAY: &str = "\
+package vtc.test
+
+import rego.v1
+
+xs := numbers.range(1, 10000)
+
+allow if {
+    count([1 | some i in xs; some j in xs; i == j]) >= 0
+}
+";
+        let compiled = compile(RUNAWAY, test_id()).unwrap();
+        let err = evaluate(&compiled, "data.vtc.test.allow", json!({}))
+            .expect_err("runaway policy must abort");
+        assert!(
+            matches!(err, AppError::ResourceExhausted(_)),
+            "expected ResourceExhausted, got {err:?}"
+        );
     }
 
     /// Extract `result[0].expressions[0].value` from regorus's

--- a/vti-common/src/error.rs
+++ b/vti-common/src/error.rs
@@ -98,6 +98,16 @@ pub enum AppError {
     #[error("invalid pagination cursor")]
     InvalidCursor,
 
+    /// A bounded computation aborted because it hit a resource ceiling
+    /// (time/instruction budget or an input-size cap) before completing.
+    /// Used by the Rego policy evaluator to refuse pathological policies
+    /// or adversarial inputs on the unauthenticated join path rather than
+    /// burning CPU unbounded. Rendered as **503 Service Unavailable** — the
+    /// evaluation did not complete, and the message is generic so an
+    /// attacker can't probe the exact limits.
+    #[error("resource limit exceeded: {0}")]
+    ResourceExhausted(String),
+
     /// Catch-all for service-specific errors (e.g., KeyDerivation, BadGateway, TeeAttestation).
     /// Services create helper functions to construct these with appropriate status codes.
     #[error("{message}")]
@@ -184,6 +194,7 @@ impl IntoResponse for AppError {
             AppError::TrustTaskMalformed(_) => StatusCode::BAD_REQUEST,
             AppError::IdempotencyKeyConflict => StatusCode::UNPROCESSABLE_ENTITY,
             AppError::InvalidCursor => StatusCode::BAD_REQUEST,
+            AppError::ResourceExhausted(_) => StatusCode::SERVICE_UNAVAILABLE,
             AppError::ServiceError { status, .. } => *status,
             AppError::Vsock { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         };


### PR DESCRIPTION
## P0.18 — Rego evaluation has no timeout/instruction budget: DoS on the unauth join path (M)

**Problem:** `policy/engine.rs::evaluate` cloned the engine, set input, and called `eval_query` with **no** time/instruction bound and **no** input-size cap. The join decision policy is evaluated on the **unauthenticated** submit route against attacker-influenced facts (the VP + claim graph flow into `input`). A pathological operator-uploaded policy or an adversarial input shape burns CPU per request unbounded; the `tower-governor` 5 rps/IP cap limits rate but each request stays expensive.

**Change:**
- **Input-size cap** — the serialized `input` is rejected at 256 KiB before it reaches the interpreter (`MAX_POLICY_INPUT_BYTES`). Far above any legitimate join input, well under the 1 MB global body cap.
- **Evaluation time budget** — each eval runs under regorus's cooperative `ExecutionTimerConfig` (250 ms ceiling). Real policies evaluate in microseconds, so the headroom is ~1000×.
  - A `tokio::time::timeout` (the plan's fallback suggestion) would **not** work here: regorus evaluation is synchronous and CPU-bound, so a timeout future can't pre-empt it — it would leak a wedged worker thread. The in-engine cooperative timer actually stops the work.
- **Fail closed** — both bounds surface as a new typed `AppError::ResourceExhausted` (503), distinct from the `Internal` policy-bug error. The ceremony `evaluate` stage (the unauthenticated join decision) maps it to `Verdict::default_deny()`, so a runaway policy/input **denies** rather than 500-ing or hanging the handler. The timer abort is detected by downcasting regorus's error to `LimitError` — reliable, no string matching.

## Tests
- `policy::engine::tests::evaluate_rejects_oversized_input` — oversized input → `ResourceExhausted`; a normal input still evaluates.
- `policy::engine::tests::evaluate_aborts_runaway_policy` — a ~100M-iteration policy aborts with `ResourceExhausted` instead of hanging.
- `ceremony::evaluate::tests::resource_bound_abort_fails_closed_to_deny` — a runaway join policy degrades to a deny verdict on the unauth path.

Full `policy::` + `ceremony::` suites (93 tests) green; `cargo clippy` clean; `cargo check --workspace` green (the additive `AppError` variant breaks no exhaustive match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)