### PR TITLE
fix(vta-service): stop folding the service URL into the webvh DID name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,7 +2340,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.11.2",
+ "vta-sdk 0.11.3",
 ]
 
 [[package]]
@@ -3120,7 +3120,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.11.2",
+ "vta-sdk 0.11.3",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.11.2",
+ "vta-sdk 0.11.3",
 ]
 
 [[package]]
@@ -9722,7 +9722,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.11.2",
+ "vta-sdk 0.11.3",
  "x25519-dalek",
 ]
 
@@ -9761,7 +9761,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.11.2",
+ "vta-sdk 0.11.3",
 ]
 
 [[package]]
@@ -9796,7 +9796,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9845,7 +9845,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -9923,7 +9923,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.11.2",
+ "vta-sdk 0.11.3",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -10005,7 +10005,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.11.2",
+ "vta-sdk 0.11.3",
  "vtc-service",
  "vti-common",
  "webauthn-rs",
@@ -10050,7 +10050,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.11.2",
+ "vta-sdk 0.11.3",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10077,7 +10077,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.11.2",
+ "vta-sdk 0.11.3",
  "vta-service",
  "vti-common",
 ]

--- a/docs/02-vta/provision-integration.md
+++ b/docs/02-vta/provision-integration.md
@@ -459,6 +459,22 @@ optionally `--var WEBVH_PATH=<path>`) to have the VTA publish the
 new integration's log directly to that server instead of
 self-hosting.
 
+`WEBVH_PATH` is the **only** input to the DID's path — the integration's
+service `URL` (its DIDComm endpoint) never influences the DID name. The
+value resolves as:
+
+- **omitted** → the hosting server auto-assigns a random path. This is
+  the default; re-running provisioning mints a fresh name each time
+  rather than colliding on a deterministic one.
+- **a label** (e.g. `--var WEBVH_PATH=acme`) → `did:webvh:<scid>:<host>:acme`.
+- **`.well-known`** (the root DID, served at `/.well-known/did.jsonl`) →
+  rejected on a shared hosting server, because a domain's root slot can
+  belong to only one tenant. Root DIDs are available only in **serverless**
+  mode (omit `WEBVH_SERVER` and self-host at the bare `URL`).
+
+An already-taken explicit path returns a clean `409 Conflict` ("path
+already taken"), not a server error.
+
 On a multi-tenant hosting server, add `--var WEBVH_DOMAIN=<name>` to
 pin which tenant domain the DID is allocated under (the
 `did:webvh:<scid>:<host>` host slot). Omit it to let the server run

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/did_management/create.rs
+++ b/vta-sdk/src/protocols/did_management/create.rs
@@ -19,10 +19,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// `AutoAssign` is the default because that is the long-standing
 /// "no path given → the server assigns one" contract: the setup wizard's
-/// "leave blank → server-assigned" prompt, and the SDK's
-/// `webvh_path_from_url` deriving *no path* from empty / `.well-known` /
-/// bare-origin URLs. An absent path has never meant the `.well-known`
-/// root on a hosting server — that is the serverless case.
+/// "leave blank → server-assigned" prompt maps a blank path here. An
+/// absent path has never meant the `.well-known` root on a hosting
+/// server — that is the serverless case (selected by the absence of a
+/// `server_id`, where the DID location comes from the `URL` itself).
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(tag = "mode", content = "path", rename_all = "snake_case")]
 pub enum WebvhPathMode {
@@ -77,7 +77,6 @@ impl From<String> for WebvhPathMode {
         match path.trim() {
             // Empty / whitespace-only is auto-assign, not an explicit
             // empty path — an explicit "" would be rejected by the host.
-            // Mirrors `webvh_path_from_url`'s empty → no-path derivation.
             "" => WebvhPathMode::AutoAssign,
             ".well-known" => WebvhPathMode::WellKnown,
             trimmed => WebvhPathMode::Explicit(trimmed.to_string()),

--- a/vta-sdk/src/provision_client/runner.rs
+++ b/vta-sdk/src/provision_client/runner.rs
@@ -324,29 +324,13 @@ pub async fn run_connection_test(
 /// are 2+ (interactive consumers should drive `run_connection_test` +
 /// `run_provision_flight` directly to surface a picker).
 ///
-/// The consumer's DID path is conventionally folded into the template `URL`
-/// var (`https://host.example.com/webvh`). In serverless mode the VTA reads
-/// the path straight from `URL`; in server-managed mode it reads `WEBVH_PATH`
-/// and ignores `URL`. So when this auto-selects a server, it must lift the path
-/// out of `URL` into `WEBVH_PATH` — otherwise the path is silently dropped and
-/// the hosting server rejects the empty path
-/// (`e.p.did.path-invalid`). [`webvh_path_from_url`] does that derivation.
-///
-/// Empty path / bare origin / `.well-known` → `None` (no `WEBVH_PATH`, let the
-/// server assign); `/webvh` → `webvh`; `/dids/daemon` → `dids/daemon`.
-pub(crate) fn webvh_path_from_url(url: &str) -> Option<String> {
-    let after_scheme = url.split_once("://").map_or(url, |(_, rest)| rest);
-    let path = after_scheme.split_once('/').map_or("", |(_, p)| p);
-    // Drop any query / fragment, then strip surrounding slashes.
-    let path = path.split(['?', '#']).next().unwrap_or("");
-    let trimmed = path.trim_matches('/');
-    if trimmed.is_empty() || trimmed == ".well-known" {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
+/// The DID path is governed solely by `WEBVH_PATH`; the service `URL` (the
+/// integration's DIDComm endpoint) never influences the DID name. When this
+/// auto-selects a server it does **not** derive a path from `URL` — absent
+/// `WEBVH_PATH` means the hosting server auto-assigns a random path. A
+/// consumer that wants an explicit path sets `WEBVH_PATH` in the ask's
+/// `integration_template_vars` directly (preserved by `inject_webvh_vars`),
+/// or drives the lower-level `run_provision_flight`.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_provision(
     intent: VtaIntent,
@@ -417,18 +401,14 @@ pub async fn run_provision(
                         return Err(ProvisionError::WorkflowFailed(msg));
                     }
                 };
-                // Server-managed mode ignores `URL` and reads the path from
-                // `WEBVH_PATH`. When we auto-selected a server, lift the path
-                // out of the ask's `URL` var so the consumer's "path folded
-                // into URL" contract still works (else it's silently dropped →
-                // hosting server rejects the empty path). No-op for serverless
-                // (webvh_server_id == None), which uses `URL` directly.
-                let webvh_path = webvh_server_id.as_ref().and_then(|_| {
-                    ask.integration_template_vars
-                        .get("URL")
-                        .and_then(|v| v.as_str())
-                        .and_then(webvh_path_from_url)
-                });
+                // The DID path is governed solely by `WEBVH_PATH`; the
+                // service `URL` must never leak into the DID name, so we no
+                // longer derive a path from it. Absent `WEBVH_PATH` → the
+                // hosting server auto-assigns. An explicit path already in
+                // the ask's `integration_template_vars` is preserved by
+                // `inject_webvh_vars` (it only inserts when `Some`), so
+                // passing `None` here doesn't clobber it.
+                let webvh_path: Option<String> = None;
                 let mediator_did_clone = mediator_did.clone();
                 let rest_url_clone = rest_url.clone();
                 let _ = events.send(VtaEvent::PreflightDone {
@@ -558,44 +538,5 @@ mod tests {
     fn select_returns_neither_when_no_transport_advertised() {
         let r = resolved(None, None);
         assert_eq!(select_initial_transport(&r), InitialChoice::Neither);
-    }
-
-    #[test]
-    fn webvh_path_from_url_bare_origin_is_none() {
-        assert_eq!(webvh_path_from_url("https://host.example.com"), None);
-        assert_eq!(webvh_path_from_url("https://host.example.com/"), None);
-    }
-
-    #[test]
-    fn webvh_path_from_url_well_known_is_none() {
-        // `.well-known` is the webvh log marker, not a DID path.
-        assert_eq!(
-            webvh_path_from_url("https://host.example.com/.well-known"),
-            None
-        );
-    }
-
-    #[test]
-    fn webvh_path_from_url_single_segment() {
-        assert_eq!(
-            webvh_path_from_url("https://host.example.com/webvh"),
-            Some("webvh".to_string())
-        );
-    }
-
-    #[test]
-    fn webvh_path_from_url_multi_segment() {
-        assert_eq!(
-            webvh_path_from_url("https://host.example.com/dids/daemon"),
-            Some("dids/daemon".to_string())
-        );
-    }
-
-    #[test]
-    fn webvh_path_from_url_strips_query_and_fragment() {
-        assert_eq!(
-            webvh_path_from_url("https://host.example.com/dids/daemon?ts=1#x"),
-            Some("dids/daemon".to_string())
-        );
     }
 }

--- a/vta-sdk/src/provision_client/runner_didcomm.rs
+++ b/vta-sdk/src/provision_client/runner_didcomm.rs
@@ -536,15 +536,15 @@ pub async fn run_provision_flight(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provision_client::runner::webvh_path_from_url;
     use serde_json::json;
 
-    /// Regression for `e.p.did.path-invalid` (server-managed, single
-    /// auto-selected server): the path folded into `URL` must reach the
-    /// VTA as `WEBVH_PATH`. Mirrors the derive→inject chain that
-    /// `run_provision`'s `PreflightDone` handler runs before the flight.
+    /// Server-managed, no explicit path (what `run_provision`'s
+    /// `PreflightDone` handler now does — it passes `None` and never
+    /// derives a path from `URL`): `WEBVH_SERVER` is set but `WEBVH_PATH`
+    /// stays unset, so the hosting server auto-assigns a random path. The
+    /// service `URL` must not leak into the DID name.
     #[test]
-    fn server_managed_url_path_is_injected_as_webvh_path() {
+    fn server_managed_no_path_leaves_webvh_path_unset() {
         let mut ask = ProvisionAsk::for_template(
             "did-host-http-didcomm",
             [(
@@ -556,21 +556,38 @@ mod tests {
             "ctx",
         );
 
-        // What the PreflightDone handler does: derive path from URL when a
-        // server was auto-selected, then inject it for the flight.
-        let server_id = Some("srv-1".to_string());
-        let derived = server_id
-            .as_ref()
-            .and_then(|_| ask.integration_template_vars.get("URL"))
-            .and_then(|v| v.as_str())
-            .and_then(webvh_path_from_url);
-        assert_eq!(derived.as_deref(), Some("dids/daemon"));
+        inject_webvh_vars(&mut ask, Some("srv-1"), None);
 
-        inject_webvh_vars(&mut ask, server_id.as_deref(), derived.as_deref());
+        assert!(
+            !ask.integration_template_vars.contains_key("WEBVH_PATH"),
+            "URL path must not be folded into WEBVH_PATH"
+        );
+        assert_eq!(
+            ask.integration_template_vars.get("WEBVH_SERVER"),
+            Some(&json!("srv-1"))
+        );
+    }
+
+    /// An explicit operator-chosen path is forwarded verbatim as
+    /// `WEBVH_PATH` (server-managed `Custom`).
+    #[test]
+    fn server_managed_explicit_path_is_injected() {
+        let mut ask = ProvisionAsk::for_template(
+            "did-host-http-didcomm",
+            [(
+                "URL".to_string(),
+                json!("https://host.example.com/dids/daemon"),
+            )]
+            .into_iter()
+            .collect(),
+            "ctx",
+        );
+
+        inject_webvh_vars(&mut ask, Some("srv-1"), Some("acme"));
 
         assert_eq!(
             ask.integration_template_vars.get("WEBVH_PATH"),
-            Some(&json!("dids/daemon"))
+            Some(&json!("acme"))
         );
         assert_eq!(
             ask.integration_template_vars.get("WEBVH_SERVER"),

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -295,23 +295,20 @@ pub async fn provision_integration(
 
     let webvh_server_id = webvh::resolve_webvh_server(&template_vars, &state.webvh_ks).await?;
 
-    // Optional `WEBVH_PATH` template var: when the webvh server should
-    // allocate a specific path (rather than letting the server pick),
-    // the operator sets it in `mediator_template_vars`. Removed from the
-    // map so the template renderer doesn't also see it — it is transport
-    // metadata, not document content.
-    let mut webvh_path = webvh::take_webvh_path(&mut template_vars)?;
-
-    // Defense-in-depth: in server-managed mode (`WEBVH_SERVER` set) the
-    // hosting server reads `WEBVH_PATH` and ignores `URL`. A consumer that
-    // folded the DID path into `URL` but didn't set `WEBVH_PATH` would hand
-    // the server an empty path → `e.p.did.path-invalid`. When that happens,
-    // derive the path from the `URL` var so the integration still lands.
-    // Only applies when a server is selected and no explicit path was given;
-    // serverless mode reads the path from `URL` directly and is untouched.
-    if webvh_server_id.is_some() && webvh_path.is_none() {
-        webvh_path = webvh::webvh_path_from_url_var(&template_vars);
-    }
+    // Optional `WEBVH_PATH` template var: the *only* input to the DID's
+    // path. The service `URL` never influences the DID name — that
+    // derivation leaked the REST route (`…/mediator/v1`) into the
+    // identifier and, being deterministic, collided on every re-run.
+    // Removed from the map so the template renderer doesn't also see it —
+    // it is transport metadata, not document content.
+    //
+    // The value maps onto the total `WebvhPathMode` below: absent / empty
+    // → `AutoAssign` (the hosting server mints a random path),
+    // `.well-known` → `WellKnown` (root), any other label → `Explicit`.
+    // The mapping is mode-independent: serverless mode never reads
+    // `WEBVH_PATH` at all (the DID location comes straight from `URL`), so
+    // this only governs server-managed publication.
+    let webvh_path = webvh::take_webvh_path(&mut template_vars)?;
 
     // Optional `WEBVH_DOMAIN` template var: when the webvh hosting server
     // is multi-tenant, this pins which tenant domain the DID is allocated
@@ -383,6 +380,13 @@ pub async fn provision_integration(
         // - WEBVH_SERVER unset → serverless mode; we need a `url`. This is
         //   the only path where an absent URL is a hard error; surface it
         //   with guidance naming the `WEBVH_SERVER` alternative.
+
+        // Resolve the path request into the explicit, total path mode, and
+        // reject an explicit root request on a shared server before any
+        // state is written (see `reject_root_on_shared_server`).
+        let path_mode = vta_sdk::protocols::did_management::create::WebvhPathMode::from(webvh_path);
+        webvh::reject_root_on_shared_server(&path_mode, webvh_server_id.is_some())?;
+
         let (params_server_id, params_url) = match &webvh_server_id {
             Some(id) => (Some(id.clone()), None),
             None => {
@@ -417,12 +421,10 @@ pub async fn provision_integration(
                 context_id: context.clone(),
                 server_id: params_server_id,
                 url: params_url,
-                // `webvh_path` is `None` when the operator gave no path
-                // (or only `.well-known`/bare URL): server-managed mode
-                // then auto-assigns. An explicit label maps to `Explicit`.
-                path_mode: vta_sdk::protocols::did_management::create::WebvhPathMode::from(
-                    webvh_path,
-                ),
+                // Absent `WEBVH_PATH` → `AutoAssign` (server mints a
+                // random path); `.well-known` → `WellKnown` (root, already
+                // rejected above on shared servers); a label → `Explicit`.
+                path_mode,
                 // Explicit tenant domain when the caller set
                 // `WEBVH_DOMAIN` (multi-tenant hosting server); `None`
                 // lets the remote resolve to its caller-default / system

--- a/vta-service/src/operations/provision_integration/webvh.rs
+++ b/vta-service/src/operations/provision_integration/webvh.rs
@@ -92,31 +92,34 @@ pub(super) fn take_webvh_path(
     Ok(Some(trimmed.to_string()))
 }
 
-/// Defense-in-depth fallback: derive a `WEBVH_PATH` from the `URL`
-/// template var when the operator folded the DID path into the URL but
-/// did not set `WEBVH_PATH` explicitly.
+/// Reject an explicit root (`.well-known`) DID request on a shared
+/// (server-managed) hosting server.
 ///
-/// Server-managed mode reads `WEBVH_PATH` and ignores `URL`, so a
-/// consumer that only set `URL` (`https://host.example.com/dids/daemon`)
-/// would otherwise hand the hosting server an empty path and get
-/// `e.p.did.path-invalid`. This reads `URL` (without removing it) and
-/// returns the path component for the caller to use as a fallback.
-///
-/// Read-only and conservative: bare origins, empty paths and
-/// `.well-known` (the webvh log marker, never a DID path) → `None`,
-/// letting the server run its own allocation. Mirrors the SDK-side
-/// `runner::webvh_path_from_url` so both layers agree on the derivation.
-pub(super) fn webvh_path_from_url_var(template_vars: &BTreeMap<String, Value>) -> Option<String> {
-    let url = template_vars.get("URL").and_then(|v| v.as_str())?;
-    let after_scheme = url.split_once("://").map_or(url, |(_, rest)| rest);
-    let path = after_scheme.split_once('/').map_or("", |(_, p)| p);
-    let path = path.split(['?', '#']).next().unwrap_or("");
-    let trimmed = path.trim_matches('/');
-    if trimmed.is_empty() || trimmed == ".well-known" {
-        None
-    } else {
-        Some(trimmed.to_string())
+/// A domain's `/.well-known/did.jsonl` slot can belong to only one
+/// tenant, so on a shared hosting server an explicit root request must
+/// fail loud — before any state is written — rather than collide on the
+/// remote. Serverless mode owns the whole domain and serves root from the
+/// bare `URL`, so it passes here (and never consults the path mode
+/// anyway). The check is unconditional: it rejects root on a shared
+/// server even when the slot happens to be free, because the rule is a
+/// policy, not a runtime occupancy test — hence `Validation` (400), not
+/// `Conflict` (409).
+pub(super) fn reject_root_on_shared_server(
+    path_mode: &vta_sdk::protocols::did_management::create::WebvhPathMode,
+    server_managed: bool,
+) -> Result<(), AppError> {
+    use vta_sdk::protocols::did_management::create::WebvhPathMode;
+    if server_managed && matches!(path_mode, WebvhPathMode::WellKnown) {
+        return Err(AppError::Validation(
+            "WEBVH_PATH '.well-known' (root DID) is not available on a shared webvh \
+             hosting server — a domain's root slot can belong to only one tenant. Omit \
+             WEBVH_PATH for a server-assigned path, or set an explicit label. Root DIDs \
+             are only available in serverless mode (omit WEBVH_SERVER and self-host at \
+             the URL)."
+                .into(),
+        ));
     }
+    Ok(())
 }
 
 /// Remove and return the optional `WEBVH_DOMAIN` template var.
@@ -215,45 +218,41 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn webvh_path_from_url_var_absent_is_none() {
-        let v = vars(&[]);
-        assert_eq!(webvh_path_from_url_var(&v), None);
-    }
+    mod reject_root {
+        use super::super::reject_root_on_shared_server;
+        use crate::error::AppError;
+        use vta_sdk::protocols::did_management::create::WebvhPathMode;
 
-    #[test]
-    fn webvh_path_from_url_var_bare_origin_is_none() {
-        let v = vars(&[("URL", json!("https://host.example.com"))]);
-        assert_eq!(webvh_path_from_url_var(&v), None);
-        let v = vars(&[("URL", json!("https://host.example.com/"))]);
-        assert_eq!(webvh_path_from_url_var(&v), None);
-    }
+        #[test]
+        fn root_on_shared_server_is_rejected() {
+            let err = reject_root_on_shared_server(&WebvhPathMode::WellKnown, true)
+                .expect_err("root on a shared server must be rejected");
+            assert!(
+                matches!(err, AppError::Validation(_)),
+                "must be a 400 validation error, got: {err:?}"
+            );
+            assert!(
+                err.to_string().contains(".well-known"),
+                "error should name the offending value: {err}"
+            );
+        }
 
-    #[test]
-    fn webvh_path_from_url_var_well_known_is_none() {
-        // `.well-known` is the webvh log marker, never a DID path.
-        let v = vars(&[("URL", json!("https://host.example.com/.well-known"))]);
-        assert_eq!(webvh_path_from_url_var(&v), None);
-    }
+        #[test]
+        fn root_in_serverless_mode_is_allowed() {
+            // `server_managed = false` — serverless owns the whole domain.
+            assert!(reject_root_on_shared_server(&WebvhPathMode::WellKnown, false).is_ok());
+        }
 
-    #[test]
-    fn webvh_path_from_url_var_single_segment() {
-        let v = vars(&[("URL", json!("https://host.example.com/webvh"))]);
-        assert_eq!(webvh_path_from_url_var(&v), Some("webvh".to_string()));
-    }
+        #[test]
+        fn explicit_path_on_shared_server_is_allowed() {
+            assert!(
+                reject_root_on_shared_server(&WebvhPathMode::Explicit("acme".into()), true).is_ok()
+            );
+        }
 
-    #[test]
-    fn webvh_path_from_url_var_multi_segment() {
-        let v = vars(&[("URL", json!("https://host.example.com/dids/daemon"))]);
-        assert_eq!(webvh_path_from_url_var(&v), Some("dids/daemon".to_string()));
-    }
-
-    #[test]
-    fn webvh_path_from_url_var_strips_query_and_fragment() {
-        let v = vars(&[(
-            "URL",
-            json!("https://host.example.com/dids/daemon?x=1#frag"),
-        )]);
-        assert_eq!(webvh_path_from_url_var(&v), Some("dids/daemon".to_string()));
+        #[test]
+        fn auto_assign_on_shared_server_is_allowed() {
+            assert!(reject_root_on_shared_server(&WebvhPathMode::AutoAssign, true).is_ok());
+        }
     }
 }

--- a/vta-service/src/webvh_client.rs
+++ b/vta-service/src/webvh_client.rs
@@ -391,6 +391,10 @@ impl WebvhClient {
             return Err(match status {
                 reqwest::StatusCode::UNAUTHORIZED => AppError::Unauthorized(msg),
                 reqwest::StatusCode::FORBIDDEN => AppError::Forbidden(msg),
+                // A taken path (e.g. `POST /api/dids` on an already-reserved
+                // slot) is a clean conflict, not a malformed request — keep
+                // it a 409 to the caller rather than collapsing to a 400.
+                reqwest::StatusCode::CONFLICT => AppError::Conflict(msg),
                 s if s.is_client_error() => AppError::Validation(msg),
                 _ => AppError::Internal(msg),
             });

--- a/vta-service/src/webvh_didcomm.rs
+++ b/vta-service/src/webvh_didcomm.rs
@@ -118,9 +118,23 @@ fn parse_check_name_response(body: serde_json::Value) -> Result<RequestUriRespon
             .get("available")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        // `available == false` ⇒ the path is already taken: a clean,
+        // client-facing conflict (409), not a server fault. (Before the
+        // path-resolution fix, a deterministic URL-derived name collided
+        // here on every re-run and surfaced — wrongly — as a 500.)
+        // `available == true` but un-reserved is a genuine remote anomaly —
+        // we asked for `reserve=true`, the slot was free, yet nothing was
+        // granted — so that stays a 500.
+        if !available {
+            return Err(AppError::Conflict(
+                "webvh path already taken on the hosting server — choose a different \
+                 WEBVH_PATH, or omit it for a server-assigned path"
+                    .to_string(),
+            ));
+        }
         return Err(AppError::Internal(format!(
-            "remote refused reservation (available={available}); \
-             check-name with reserve=true expected to succeed"
+            "remote refused reservation despite the path being available \
+             (available={available}); check-name with reserve=true expected to succeed"
         )));
     }
     // Prefer the spec `record`; fall back to the flat legacy body.
@@ -426,16 +440,39 @@ mod tests {
         assert_eq!(resp.did_url, "https://did.example.com/alice/did.jsonl");
     }
 
-    /// A response with `reserved: false` is the host declining the
-    /// reservation (an explicit taken path); surface the `available` flag
-    /// in the error rather than silently fabricating a mnemonic.
+    /// `reserved: false` + `available: false` means the path is already
+    /// taken — a clean client-facing conflict (409), not a server fault.
+    /// (This is the case that, with a deterministic URL-derived name, used
+    /// to surface — wrongly — as a 500 on every re-run.)
     #[test]
-    fn not_reserved_is_an_error_carrying_availability() {
+    fn not_reserved_and_unavailable_is_a_conflict() {
         let body = json!({ "available": false, "reserved": false });
         let err = parse_check_name_response(body).expect_err("must error");
         assert!(
-            err.to_string().contains("available=false"),
-            "error should surface availability: {err}"
+            matches!(err, crate::error::AppError::Conflict(_)),
+            "taken path must be a 409 conflict, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("taken"),
+            "conflict should explain the path is taken: {err}"
+        );
+    }
+
+    /// `reserved: false` but `available: true` is a genuine remote anomaly
+    /// — we asked for `reserve=true`, the slot was free, yet nothing was
+    /// granted. That stays a 500 so it isn't mistaken for a normal
+    /// already-taken conflict.
+    #[test]
+    fn not_reserved_but_available_is_an_internal_anomaly() {
+        let body = json!({ "available": true, "reserved": false });
+        let err = parse_check_name_response(body).expect_err("must error");
+        assert!(
+            matches!(err, crate::error::AppError::Internal(_)),
+            "free-but-ungranted slot must be a 500 anomaly, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("available=true"),
+            "anomaly should surface availability: {err}"
         );
     }
 


### PR DESCRIPTION
## Problem

Provisioning a server-managed integration (a `WEBVH_SERVER` is selected) with a **blank `WEBVH_PATH`** derived the DID's path from the `URL` template var — which is the integration's **DIDComm service endpoint** (`https://<host>/mediator/v1`), not a desired DID name. The REST route leaked into the identifier (`did:webvh:<scid>:<host>:mediator`), and because the derivation was deterministic, every re-run reserved the same name and the second attempt failed:

```
provision-integration call failed: server error (500): internal error:
remote refused reservation (available=false); check-name with reserve=true expected to succeed
```

## Audit findings (diagnosis corrected)

The spec's structural claims held, but two assumptions were wrong:

1. **No probe+commit race.** `build_check_name_body` already sends `reserve: true` — a single atomic check-and-reserve. The 500 came from `parse_check_name_response` mapping a *refused* reservation to `AppError::Internal` (500) instead of a conflict.
2. **The three-variant enum already exists.** `WebvhPathMode { Explicit, AutoAssign, WellKnown }` is a 1:1 match for Custom/Random/Root and is already plumbed through `CreateDidWebvhParams`, with `AutoAssign → None → server-side random mint`. Reused it rather than adding a parallel type.

Decision (with @glenngore): resolve a blank path by reusing `WebvhPathMode` — absent → `AutoAssign` (random), `.well-known` → root, label → explicit. Mode-independent (serverless reads the path from `URL` directly and never consults `WEBVH_PATH`). Keeps the mediator wizard's blank→omit contract working, so no wizard change.

## Changes

**vta-service** (`0.9.0` → `0.9.1`)
- Delete the `URL → WEBVH_PATH` derivation fold + `webvh_path_from_url_var`. `WEBVH_PATH` is now the sole path input.
- `reject_root_on_shared_server`: an explicit `.well-known` (root) request on a shared hosting server returns a typed **400**, never a silent collision.
- Map a taken path to **`Conflict`/409** (not `Internal`/500) on both the DIDComm and REST `request_uri` paths.

**vta-sdk** (`0.11.2` → `0.11.3`)
- Delete the `URL → WEBVH_PATH` fold in `run_provision` + the `webvh_path_from_url` helper, so consumers can't re-introduce the leak.

**docs** — document the `WEBVH_PATH` resolution semantics.

Patch bumps keep the `"0.11"` / `"0.9"` internal pins satisfied (no cascade). **The mediator-setup wizard in `../affinidi-tdk-rs` was not touched** — it's already correct.

## Acceptance criteria

- [x] Server-managed, no `WEBVH_PATH` → random path; DID contains no segment of the service URL.
- [x] Re-running with no path supplied succeeds (no deterministic collision).
- [x] `Custom` path already taken → clean **409 / taken**, not 500.
- [x] `Root` against a shared server → clear typed error (400).
- [x] Serverless, no path → `did:webvh:<scid>:<domain>` at `/.well-known` (unchanged).
- [x] No code path reads the DID name from the `URL` var.

## Tests

`cargo fmt --check`, `cargo clippy` clean; full workspace compiles. **vta-sdk 118 passed, vta-service 703 passed** (+4 new `reject_root` tests, rewrote the SDK fold tests and the `not_reserved` error-mapping tests).