### PR TITLE
fix(vtc-service): vtc status trust-ping reads JSON key bundle, not raw 64 bytes (P0.19)

### DIFF
--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -22,7 +22,6 @@ use crate::install::{InstallTokenSigner, InstallTokenStore};
 use crate::keys::seed_store::SecretStore;
 use crate::messaging;
 use crate::routes;
-use crate::setup::VtcKeyBundle;
 use crate::store::{KeyspaceHandle, Store};
 use crate::supervisor::{SupervisorKind, detect_supervisor};
 use tokio::sync::{RwLock, watch};
@@ -32,7 +31,6 @@ use tracing::{debug, error, info, warn};
 use vti_common::audit::{AuditKeyStore, AuditWriter};
 use vti_common::auth::passkey::{PasskeyState, build_webauthn};
 use webauthn_rs::Webauthn;
-use zeroize::Zeroizing;
 
 /// Default enrolment-invite TTL surfaced by `PasskeyState::enrollment_ttl`.
 /// Admin-invite enrolment lands in M0.6; until then this constant is the
@@ -1121,13 +1119,14 @@ async fn init_auth(
         }
     };
 
-    let (ed25519_bytes, x25519_bytes) = match decode_secret_store_value(&vtc_did, &stored) {
-        Ok(pair) => pair,
-        Err(msg) => {
-            warn!("{msg}");
-            return (None, None, None, None, None, None, None, None);
-        }
-    };
+    let (ed25519_bytes, x25519_bytes) =
+        match crate::setup::bundle::decode_secret_store_value(&vtc_did, &stored) {
+            Ok(pair) => pair,
+            Err(msg) => {
+                warn!("{msg}");
+                return (None, None, None, None, None, None, None, None);
+            }
+        };
 
     // P0.7: derive the at-rest storage-encryption key from the same 32-byte
     // Ed25519 seed (HKDF-SHA256, info `vtc-storage-key/v1`). Domain-separated
@@ -1421,50 +1420,4 @@ async fn shutdown_signal() {
         () = ctrl_c => info!("received SIGINT"),
         () = terminate => info!("received SIGTERM"),
     }
-}
-
-/// Pull the Ed25519 + X25519 private bytes out of whatever the
-/// secret store handed us.
-///
-/// Accepts two on-disk shapes:
-/// - **New** — a serialized [`VtcKeyBundle`] (JSON). Production
-///   shape after `vtc setup`. Decoded via
-///   [`VtcKeyBundle::from_secret_store_bytes`].
-/// - **Legacy** — 64 raw bytes `[Ed25519:32 || X25519:32]`. Used
-///   by integration-test fixtures and the not-yet-replaced
-///   bootstrap CLI path. Synthesizes an in-memory bundle so
-///   downstream code stays identical.
-///
-/// Returns `(ed25519_priv, x25519_priv)` on success; `Err(msg)`
-/// otherwise. Both halves come back inside `Zeroizing` so a
-/// best-effort scrub fires on drop.
-fn decode_secret_store_value(
-    vtc_did: &str,
-    stored: &[u8],
-) -> Result<(Zeroizing<[u8; 32]>, Zeroizing<[u8; 32]>), String> {
-    if stored.len() == 64 {
-        // Legacy raw-bytes shape — used by every integration-test
-        // fixture today. Promote into a bundle-shaped pair via a
-        // direct copy.
-        let mut ed = Zeroizing::new([0u8; 32]);
-        let mut x = Zeroizing::new([0u8; 32]);
-        ed.copy_from_slice(&stored[..32]);
-        x.copy_from_slice(&stored[32..]);
-        return Ok((ed, x));
-    }
-    let bundle = VtcKeyBundle::from_secret_store_bytes(stored)
-        .map_err(|e| format!("secret store payload not a VtcKeyBundle: {e}"))?;
-    if bundle.integration_did != vtc_did {
-        return Err(format!(
-            "VtcKeyBundle DID '{}' does not match config.vtc_did '{}' — refusing to init auth",
-            bundle.integration_did, vtc_did
-        ));
-    }
-    let ed = bundle
-        .ed25519_private_bytes()
-        .map_err(|e| format!("bundle Ed25519 decode: {e}"))?;
-    let x = bundle
-        .x25519_private_bytes()
-        .map_err(|e| format!("bundle X25519 decode: {e}"))?;
-    Ok((ed, x))
 }

--- a/vtc-service/src/setup/bundle.rs
+++ b/vtc-service/src/setup/bundle.rs
@@ -247,6 +247,54 @@ pub fn bundle_from_inline_secret(secret: &str) -> Result<VtcKeyBundle, AppError>
     VtcKeyBundle::from_secret_store_bytes(&bytes)
 }
 
+/// Decode whatever the secret store handed back into the VTC's
+/// `(ed25519, x25519)` private-scalar pair.
+///
+/// Accepts both on-disk shapes, so every consumer (auth bootstrap in
+/// `server.rs`, the `vtc status` trust-ping) reads keys the same way:
+///
+/// - **JSON `VtcKeyBundle`** — what `vtc setup` has written since the
+///   VTA-driven-keys rework, i.e. every real deployment. The bundle's
+///   `integration_did` is checked against `vtc_did` so a mismatched bundle
+///   can't silently sign for the wrong DID.
+/// - **Legacy 64 raw bytes** (`ed‖x`) — used by the integration-test
+///   fixtures; split directly.
+///
+/// Returning the pair in [`Zeroizing`] buffers keeps the live scalars off
+/// the heap-without-wipe path. The error is a display `String` because both
+/// call sites only surface it (a warning log / a `Box<dyn Error>` bubble),
+/// never match on it.
+pub fn decode_secret_store_value(
+    vtc_did: &str,
+    stored: &[u8],
+) -> Result<(Zeroizing<[u8; 32]>, Zeroizing<[u8; 32]>), String> {
+    if stored.len() == 64 {
+        // Legacy raw-bytes shape — used by every integration-test
+        // fixture today. Promote into a bundle-shaped pair via a
+        // direct copy.
+        let mut ed = Zeroizing::new([0u8; 32]);
+        let mut x = Zeroizing::new([0u8; 32]);
+        ed.copy_from_slice(&stored[..32]);
+        x.copy_from_slice(&stored[32..]);
+        return Ok((ed, x));
+    }
+    let bundle = VtcKeyBundle::from_secret_store_bytes(stored)
+        .map_err(|e| format!("secret store payload not a VtcKeyBundle: {e}"))?;
+    if bundle.integration_did != vtc_did {
+        return Err(format!(
+            "VtcKeyBundle DID '{}' does not match config.vtc_did '{}' — refusing to init auth",
+            bundle.integration_did, vtc_did
+        ));
+    }
+    let ed = bundle
+        .ed25519_private_bytes()
+        .map_err(|e| format!("bundle Ed25519 decode: {e}"))?;
+    let x = bundle
+        .x25519_private_bytes()
+        .map_err(|e| format!("bundle X25519 decode: {e}"))?;
+    Ok((ed, x))
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -314,5 +362,43 @@ mod tests {
         b.ed25519_private_multibase = encode_private_multibase(&raw, X25519_PRIV_CODEC);
         let err = b.ed25519_private_bytes().unwrap_err();
         assert!(format!("{err}").contains("wrong multicodec prefix"));
+    }
+
+    /// P0.19: the JSON `VtcKeyBundle` shape every real deployment writes
+    /// decodes into the right scalar pair. This is the shape the `vtc
+    /// status` trust-ping used to reject with a "not 64 bytes" error.
+    #[test]
+    fn decode_secret_store_value_accepts_json_bundle() {
+        let b = fixture(); // did:webvh:vtc.example.com:abc, ed=0x11.., x=0x22..
+        let bytes = b.to_secret_store_bytes().unwrap();
+        let (ed, x) =
+            decode_secret_store_value("did:webvh:vtc.example.com:abc", &bytes).expect("decodes");
+        assert_eq!(&*ed, &[0x11; 32]);
+        assert_eq!(&*x, &[0x22; 32]);
+    }
+
+    /// The legacy 64-raw-byte shape (test/CI fixtures) still splits
+    /// cleanly — the DID is irrelevant for this path.
+    #[test]
+    fn decode_secret_store_value_accepts_legacy_64_bytes() {
+        let mut raw = Vec::with_capacity(64);
+        raw.extend_from_slice(&[0xAA; 32]);
+        raw.extend_from_slice(&[0xBB; 32]);
+        let (ed, x) = decode_secret_store_value("did:any", &raw).expect("64-byte split");
+        assert_eq!(&*ed, &[0xAA; 32]);
+        assert_eq!(&*x, &[0xBB; 32]);
+    }
+
+    /// A bundle whose DID doesn't match the configured `vtc_did` is
+    /// refused — it must not silently sign for the wrong identity.
+    #[test]
+    fn decode_secret_store_value_rejects_did_mismatch() {
+        let b = fixture();
+        let bytes = b.to_secret_store_bytes().unwrap();
+        let err = decode_secret_store_value("did:webvh:someone.else", &bytes).unwrap_err();
+        assert!(
+            err.contains("does not match"),
+            "expected DID-mismatch error, got: {err}"
+        );
     }
 }

--- a/vtc-service/src/status.rs
+++ b/vtc-service/src/status.rs
@@ -266,20 +266,21 @@ async fn send_trust_ping(
         .await?
         .ok_or("no key material available")?;
 
-    if key_material.len() != 64 {
-        return Err(format!("key material is {} bytes, expected 64", key_material.len()).into());
-    }
-
-    let ed25519_bytes: &[u8; 32] = key_material[..32].try_into().unwrap();
-    let x25519_bytes: &[u8; 32] = key_material[32..].try_into().unwrap();
+    // Accept both on-disk shapes: the JSON `VtcKeyBundle` every real
+    // deployment writes since the VTA-driven-keys rework, and the legacy
+    // 64-raw-byte fixture shape. The old `len() == 64` guard here rejected
+    // the bundle shape, so the trust-ping failed on every production VTC
+    // with a baffling byte-count error (P0.19).
+    let (ed25519_bytes, x25519_bytes) =
+        crate::setup::bundle::decode_secret_store_value(vtc_did, &key_material)?;
 
     let tdk = TDKSharedState::new(TDKConfig::builder().build()?).await?;
 
-    let mut signing_secret = Secret::generate_ed25519(None, Some(ed25519_bytes));
+    let mut signing_secret = Secret::generate_ed25519(None, Some(&ed25519_bytes));
     signing_secret.id = format!("{vtc_did}#key-0");
     tdk.secrets_resolver().insert(signing_secret).await;
 
-    let mut ka_secret = Secret::generate_x25519(None, Some(x25519_bytes))?;
+    let mut ka_secret = Secret::generate_x25519(None, Some(&x25519_bytes))?;
     ka_secret.id = format!("{vtc_did}#key-1");
     tdk.secrets_resolver().insert(ka_secret).await;
 


### PR DESCRIPTION
## P0.19 — `vtc status` trust-ping broken for every production deployment (S)

**Problem:** `send_trust_ping` (`status.rs`) rejected key material whose length ≠ 64 bytes and split it as `[Ed25519:32 ‖ X25519:32]`. Since the VTA-driven-keys rework the wizard stores the JSON `VtcKeyBundle` shape, so on **every real deployment** the `vtc status` mediator ping failed with a baffling `key material is N bytes, expected 64` error — only legacy/test fixtures (raw 64 bytes) passed.

**Change:** `server.rs::decode_secret_store_value` already handled both on-disk shapes (JSON bundle, with a DID-match check, plus the legacy 64-byte split). This PR:
- Moves that helper to its natural home next to `VtcKeyBundle` in `setup::bundle` and makes it `pub`.
- Points both consumers at it: the auth-bootstrap path (`server.rs`) and the trust-ping (`status.rs`).
- Deletes the manual `len() == 64` guard + split in `status.rs`.

`setup::bundle` is unconditionally compiled (only `wizard` is gated on the `setup` feature), so this is safe across all feature combos — verified with `--no-default-features --features keyring`.

## Tests
- `setup::bundle::tests::decode_secret_store_value_accepts_json_bundle` — the production JSON shape decodes to the right scalar pair (the shape the trust-ping used to reject).
- `setup::bundle::tests::decode_secret_store_value_accepts_legacy_64_bytes` — the legacy fixture shape still splits cleanly.
- `setup::bundle::tests::decode_secret_store_value_rejects_did_mismatch` — a bundle whose DID ≠ configured `vtc_did` is refused.

Full `setup::` suite (18) green; `cargo clippy` clean; default + non-default feature builds compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)