### PR TITLE
fix(vtc-service): close ACL + session privilege/scoping gaps (P0.20)

### DIFF
--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -9,7 +9,7 @@ use crate::acl::{
     VtcAclEntry, VtcRole, delete_acl_entry, get_acl_entry, is_acl_entry_visible, list_acl_entries,
     store_acl_entry, validate_acl_modification, validate_vtc_role_assignment,
 };
-use crate::auth::{AdminAuth, ManageAuth, session::now_epoch};
+use crate::auth::{AdminAuth, AuthClaims, ManageAuth, session::now_epoch};
 use crate::error::AppError;
 use crate::server::AppState;
 
@@ -177,6 +177,22 @@ pub async fn update_acl(
         )));
     }
 
+    // Visibility (overlapping contexts) is enough to *see* an admin entry but
+    // not to downgrade it: a context-admin of `ctx-a` must not be able to
+    // demote a peer admin scoped to `[ctx-a, ctx-b]`, and can never touch a
+    // super-admin. Only a super-admin, or an admin covering *every* context
+    // the target holds, may modify an existing Admin entry.
+    if entry.role == VtcRole::Admin && !caller_covers_admin_target(&auth.0, &entry) {
+        return Err(AppError::Forbidden(
+            "cannot modify an admin entry scoped outside your contexts".into(),
+        ));
+    }
+
+    // Snapshot the pre-change authorization so we can detect a privilege
+    // reduction after the patch is applied.
+    let prev_role = entry.role.clone();
+    let prev_contexts = entry.allowed_contexts.clone();
+
     if let Some(role) = req.role {
         validate_vtc_role_assignment(&auth.0, &role)?;
         entry.role = role;
@@ -192,6 +208,22 @@ pub async fn update_acl(
 
     store_acl_entry(&acl, &entry).await?;
 
+    // The `AuthClaims` extractor reads role/contexts straight from the
+    // still-valid JWT (only `/auth/refresh` re-checks the ACL), so a demoted
+    // admin would otherwise keep admin authority for the full access-token TTL.
+    // Revoke the subject's live sessions on any privilege reduction so the
+    // stale bearer is rejected on its next request.
+    if is_privilege_reduction(
+        &prev_role,
+        &prev_contexts,
+        &entry.role,
+        &entry.allowed_contexts,
+    ) {
+        let sessions = state.sessions_ks.clone();
+        let revoked = super::auth::revoke_sessions_for_did(&sessions, &did).await?;
+        info!(did = %did, revoked, "subject sessions revoked after ACL privilege reduction");
+    }
+
     info!(did = %did, "ACL entry updated");
     Ok(Json(AclEntryResponse::from(entry)))
 }
@@ -199,7 +231,11 @@ pub async fn update_acl(
 // ---------- DELETE /acl/{did} ----------
 
 pub async fn delete_acl(
-    auth: ManageAuth,
+    // Deletion is strictly more destructive than the `PATCH` edit, yet the
+    // previous `ManageAuth` gate let an Initiator delete entries while `PATCH`
+    // required Admin. Gate both on Admin so an Initiator can't delete admin
+    // entries it happens to see.
+    auth: AdminAuth,
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<StatusCode, AppError> {
@@ -222,6 +258,16 @@ pub async fn delete_acl(
         )));
     }
 
+    // Same target-role guard as `update_acl`: overlapping contexts make an
+    // admin entry *visible* but not *deletable* by a context-admin scoped
+    // outside its full context set, and a super-admin can only be deleted by
+    // another super-admin.
+    if entry.role == VtcRole::Admin && !caller_covers_admin_target(&auth.0, &entry) {
+        return Err(AppError::Forbidden(
+            "cannot delete an admin entry scoped outside your contexts".into(),
+        ));
+    }
+
     delete_acl_entry(&acl, &did).await?;
 
     info!(caller = %auth.0.did, did = %did, "ACL entry deleted");
@@ -236,7 +282,7 @@ pub async fn delete_acl(
 /// degrades to `Role::Reader` (lowest privilege; only the contexts
 /// match), which is fine because these helpers ignore the role
 /// field entirely.
-fn as_vti_acl_entry(e: &VtcAclEntry) -> vti_common::acl::AclEntry {
+pub(crate) fn as_vti_acl_entry(e: &VtcAclEntry) -> vti_common::acl::AclEntry {
     let role = match e.role {
         VtcRole::Admin => vti_common::acl::Role::Admin,
         _ => vti_common::acl::Role::Reader,
@@ -246,6 +292,51 @@ fn as_vti_acl_entry(e: &VtcAclEntry) -> vti_common::acl::AclEntry {
         .with_contexts(e.allowed_contexts.clone())
         .with_created_at(e.created_at)
         .with_expires_at(e.expires_at)
+}
+
+/// May `caller` delete or downgrade `target`, which is an **Admin** entry?
+///
+/// Mirrors [`vti_common::acl::delegated_any_approver_covers`]: a super-admin
+/// covers any target; a context-admin covers only a context-scoped target
+/// **all** of whose contexts fall within the caller's authority. A target with
+/// no `allowed_contexts` is itself a super-admin and can only be acted on by a
+/// super-admin (the empty-context branch below is `false` for a non-super
+/// caller, so it is refused).
+fn caller_covers_admin_target(caller: &AuthClaims, target: &VtcAclEntry) -> bool {
+    if caller.is_super_admin() {
+        return true;
+    }
+    !target.allowed_contexts.is_empty()
+        && target
+            .allowed_contexts
+            .iter()
+            .all(|ctx| caller.has_context_access(ctx))
+}
+
+/// Did an ACL update reduce the subject's authorization?
+///
+/// A reduction is either losing the `Admin` role, or narrowing the context
+/// scope — going from unrestricted (empty `allowed_contexts`, i.e. super-admin)
+/// to restricted, or dropping any previously-held context. Widening scope or a
+/// lateral role change is not a reduction. Used to decide whether the subject's
+/// live sessions must be revoked so the still-valid JWT can't outlive the
+/// downgrade.
+fn is_privilege_reduction(
+    prev_role: &VtcRole,
+    prev_contexts: &[String],
+    new_role: &VtcRole,
+    new_contexts: &[String],
+) -> bool {
+    let lost_admin = *prev_role == VtcRole::Admin && *new_role != VtcRole::Admin;
+    let narrowed = if prev_contexts.is_empty() {
+        // Previously unrestricted (super-admin scope); any restriction narrows.
+        !new_contexts.is_empty()
+    } else {
+        // Previously restricted; dropping any held context narrows. (A move to
+        // empty/unrestricted is a *widening*, handled by the `false` here.)
+        !new_contexts.is_empty() && prev_contexts.iter().any(|c| !new_contexts.contains(c))
+    };
+    lost_admin || narrowed
 }
 
 #[cfg(test)]
@@ -258,6 +349,119 @@ mod tests {
     //! compatibility with the CLI clients that consume these types.
     use super::*;
     use serde_json::json;
+
+    // ── P0.20: admin-target covering guard ─────────────────────────
+
+    fn claims(super_admin: bool, contexts: &[&str]) -> AuthClaims {
+        AuthClaims {
+            role: vti_common::acl::Role::Admin,
+            allowed_contexts: if super_admin {
+                vec![]
+            } else {
+                contexts.iter().map(|c| c.to_string()).collect()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn admin_entry(contexts: &[&str]) -> VtcAclEntry {
+        VtcAclEntry {
+            did: "did:key:zTarget".into(),
+            role: VtcRole::Admin,
+            label: None,
+            allowed_contexts: contexts.iter().map(|c| c.to_string()).collect(),
+            created_at: 0,
+            created_by: "did:key:zCreator".into(),
+            expires_at: None,
+        }
+    }
+
+    #[test]
+    fn super_admin_covers_any_admin_target() {
+        let sa = claims(true, &[]);
+        assert!(caller_covers_admin_target(
+            &sa,
+            &admin_entry(&["ctx-a", "ctx-b"])
+        ));
+        assert!(caller_covers_admin_target(&sa, &admin_entry(&[]))); // super-admin target
+    }
+
+    #[test]
+    fn context_admin_covers_only_targets_fully_within_its_scope() {
+        let ca = claims(false, &["ctx-a"]);
+        // Target scoped exactly to ctx-a → covered.
+        assert!(caller_covers_admin_target(&ca, &admin_entry(&["ctx-a"])));
+        // Accept-criterion: ctx-a admin can't act on an admin scoped to
+        // [ctx-a, ctx-b] — ctx-b is outside its authority.
+        assert!(!caller_covers_admin_target(
+            &ca,
+            &admin_entry(&["ctx-a", "ctx-b"])
+        ));
+        // A context-admin can never act on a super-admin (empty-context) target.
+        assert!(!caller_covers_admin_target(&ca, &admin_entry(&[])));
+    }
+
+    // ── P0.20: privilege-reduction detection ───────────────────────
+
+    #[test]
+    fn losing_admin_role_is_a_reduction() {
+        assert!(is_privilege_reduction(
+            &VtcRole::Admin,
+            &["ctx-a".into()],
+            &VtcRole::Member,
+            &["ctx-a".into()],
+        ));
+    }
+
+    #[test]
+    fn narrowing_contexts_is_a_reduction() {
+        // Drop a held context.
+        assert!(is_privilege_reduction(
+            &VtcRole::Admin,
+            &["ctx-a".into(), "ctx-b".into()],
+            &VtcRole::Admin,
+            &["ctx-a".into()],
+        ));
+        // Unrestricted → restricted.
+        assert!(is_privilege_reduction(
+            &VtcRole::Admin,
+            &[],
+            &VtcRole::Admin,
+            &["ctx-a".into()],
+        ));
+        // Swap a context (lose ctx-a, gain ctx-b).
+        assert!(is_privilege_reduction(
+            &VtcRole::Admin,
+            &["ctx-a".into()],
+            &VtcRole::Admin,
+            &["ctx-b".into()],
+        ));
+    }
+
+    #[test]
+    fn widening_or_lateral_change_is_not_a_reduction() {
+        // Add a context.
+        assert!(!is_privilege_reduction(
+            &VtcRole::Admin,
+            &["ctx-a".into()],
+            &VtcRole::Admin,
+            &["ctx-a".into(), "ctx-b".into()],
+        ));
+        // Restricted → unrestricted (promotion to super-admin scope).
+        assert!(!is_privilege_reduction(
+            &VtcRole::Admin,
+            &["ctx-a".into()],
+            &VtcRole::Admin,
+            &[],
+        ));
+        // No change (e.g. a label-only edit).
+        assert!(!is_privilege_reduction(
+            &VtcRole::Member,
+            &["ctx-a".into()],
+            &VtcRole::Member,
+            &["ctx-a".into()],
+        ));
+    }
 
     // ── CreateAclRequest ────────────────────────────────────────────
 

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -10,15 +10,17 @@ use vta_sdk::protocols::auth::{
     epoch_to_rfc3339,
 };
 
-use crate::acl::{Role, resolve_auth_role};
+use crate::acl::{Role, get_acl_entry, is_acl_entry_visible, list_acl_entries, resolve_auth_role};
 use crate::auth::session::{
     Session, SessionState, delete_session, get_session, list_sessions, now_epoch,
     store_refresh_index, store_session,
 };
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::error::AppError;
+use crate::routes::acl::as_vti_acl_entry;
 use crate::server::AppState;
 use tracing::{info, warn};
+use vti_common::store::KeyspaceHandle;
 
 // ---------- POST /auth/challenge ----------
 
@@ -841,13 +843,33 @@ pub async fn sign_out(
 }
 
 pub async fn session_list(
-    _auth: ManageAuth,
+    auth: ManageAuth,
     State(state): State<AppState>,
 ) -> Result<Json<Vec<SessionSummary>>, AppError> {
     let sessions = state.sessions_ks.clone();
     let all = list_sessions(&sessions).await?;
-    let summaries: Vec<SessionSummary> = all.into_iter().map(SessionSummary::from).collect();
-    info!(caller = %_auth.0.did, count = summaries.len(), "sessions listed");
+
+    // A super-admin sees the whole roster; a context-admin must only see
+    // sessions whose subject DID is an ACL entry visible to them (overlapping
+    // contexts). Build the visible-DID set once from the ACL rather than doing
+    // a per-session lookup. A session whose subject has no ACL entry (e.g. the
+    // entry was deleted out from under it) is visible only to a super-admin.
+    let summaries: Vec<SessionSummary> = if auth.0.is_super_admin() {
+        all.into_iter().map(SessionSummary::from).collect()
+    } else {
+        let acl = state.acl_ks.clone();
+        let visible: std::collections::HashSet<String> = list_acl_entries(&acl)
+            .await?
+            .into_iter()
+            .filter(|e| is_acl_entry_visible(&auth.0, &as_vti_acl_entry(e)))
+            .map(|e| e.did)
+            .collect();
+        all.into_iter()
+            .filter(|s| visible.contains(&s.did))
+            .map(SessionSummary::from)
+            .collect()
+    };
+    info!(caller = %auth.0.did, count = summaries.len(), "sessions listed");
     Ok(Json(summaries))
 }
 
@@ -888,21 +910,51 @@ pub struct RevokeByDidResponse {
 }
 
 pub async fn revoke_sessions_by_did(
-    _auth: AdminAuth,
+    auth: AdminAuth,
     State(state): State<AppState>,
     Query(query): Query<RevokeByDidQuery>,
 ) -> Result<Json<RevokeByDidResponse>, AppError> {
-    let sessions = state.sessions_ks.clone();
-    let all = list_sessions(&sessions).await?;
-    let mut revoked = 0u64;
-
-    for session in all {
-        if session.did == query.did {
-            delete_session(&sessions, &session.session_id).await?;
-            revoked += 1;
+    // Context-scope: a context-admin may only revoke sessions for a DID whose
+    // ACL entry is visible to them (overlapping contexts). Without this any
+    // context-admin could revoke a super-admin's or any member's sessions
+    // community-wide. Super-admins are unrestricted (and may mop up orphan
+    // sessions for a DID with no ACL row).
+    if !auth.0.is_super_admin() {
+        let acl = state.acl_ks.clone();
+        let visible = get_acl_entry(&acl, &query.did)
+            .await?
+            .as_ref()
+            .is_some_and(|e| is_acl_entry_visible(&auth.0, &as_vti_acl_entry(e)));
+        if !visible {
+            return Err(AppError::Forbidden(
+                "cannot revoke sessions for a DID outside your contexts".into(),
+            ));
         }
     }
 
-    info!(caller = %_auth.0.did, target_did = %query.did, revoked, "sessions revoked by DID");
+    let sessions = state.sessions_ks.clone();
+    let revoked = revoke_sessions_for_did(&sessions, &query.did).await?;
+
+    info!(caller = %auth.0.did, target_did = %query.did, revoked, "sessions revoked by DID");
     Ok(Json(RevokeByDidResponse { revoked }))
+}
+
+/// Delete every session whose subject is `did`; returns the count revoked.
+///
+/// Shared by [`revoke_sessions_by_did`] and the ACL-downgrade path in
+/// [`crate::routes::acl::update_acl`], which revokes a demoted admin's live
+/// sessions so the still-valid JWT can't outlive the downgrade.
+pub(crate) async fn revoke_sessions_for_did(
+    sessions: &KeyspaceHandle,
+    did: &str,
+) -> Result<u64, AppError> {
+    let all = list_sessions(sessions).await?;
+    let mut revoked = 0u64;
+    for session in all {
+        if session.did == did {
+            delete_session(sessions, &session.session_id).await?;
+            revoked += 1;
+        }
+    }
+    Ok(revoked)
 }


### PR DESCRIPTION
## P0.20 — Privilege/scoping gaps in ACL + session management

Closes a cluster of three related privilege-escalation gaps in the VTC's ACL and session-management surfaces.

### (a) `delete_acl` under-gated + no target-role check
`DELETE /v1/acl/{did}` was gated on `ManageAuth` (Admin **or** Initiator) while the strictly-less-destructive `PATCH` required `AdminAuth`. Neither inspected the *target* entry's existing role, so a context-admin of `ctx-a` could delete/downgrade a peer admin scoped to `[ctx-a, ctx-b]` merely because the contexts overlapped (overlap is enough to *see* an entry via `is_acl_entry_visible`).

- Re-gate `delete_acl` on **`AdminAuth`**.
- Add `caller_covers_admin_target()` — acting on an `Admin` target requires super-admin, or an admin covering **every** context the target holds (mirrors `vti_common::acl::delegated_any_approver_covers`). A super-admin (empty-context) target can only be acted on by another super-admin.
- Apply the same guard to `update_acl`.

### (b) Session ops not context-scoped
`revoke_sessions_by_did` and `session_list` had no context scoping — any context-admin could revoke any member's (or a super-admin's) sessions community-wide, and `session_list` returned the full roster + session metadata.

- `session_list` now filters to sessions whose subject DID maps to an ACL entry visible to the caller; super-admins see all.
- `revoke_sessions_by_did` returns `Forbidden` for a DID outside the caller's visible contexts; super-admins stay unrestricted (and can mop up orphan sessions).

### (c) Demoted admin keeps authority for the access-token TTL
`update_acl` rewrote the ACL row but didn't revoke the subject's live sessions, and the `AuthClaims` extractor reads role/contexts from the still-valid JWT (only refresh re-checks the ACL). A demoted admin kept admin authority for the full access-token TTL.

- `update_acl` now revokes the subject's sessions on any privilege reduction (`is_privilege_reduction()` — lost `Admin` role or narrowed context scope), so the stale bearer is rejected on its next request.
- Session-revoke loop extracted to a shared `revoke_sessions_for_did`.

### Acceptance criteria
- ✅ context-admin of `ctx-a` can't delete an admin scoped to `[ctx-a, ctx-b]`
- ✅ `session_list` for a context-admin omits out-of-context sessions
- ✅ a demoted admin's old bearer is rejected on the next request

### Tests
Adds unit tests for `caller_covers_admin_target` and `is_privilege_reduction` covering each accept criterion. `cargo fmt --check` clean, no new clippy warnings on touched files. **Full vtc-service suite: 531 passed, 0 failed.**