### PR TITLE
fix(vtc-service): verify install claim secret before the ceremony lock (P0.21)

### DIFF
--- a/vtc-service/src/install/state_machine.rs
+++ b/vtc-service/src/install/state_machine.rs
@@ -143,9 +143,11 @@ pub struct StartClaimOutcome {
     pub ephemeral_signing_key: Zeroizing<[u8; 32]>,
     pub cnonce: [u8; 32],
     /// Stored Argon2id PHC hash of the out-of-band claim code.
-    /// `None` for legacy / no-secret rows; the route handler
-    /// MUST verify the operator-supplied code against this when
-    /// present, before issuing the WebAuthn challenge.
+    /// `None` for legacy / no-secret rows. Informational only: the
+    /// route handler verifies the operator-supplied code via
+    /// [`InstallTokenStore::peek_secret_hash`] **before** calling
+    /// `start_claim`, so a wrong code can't stamp the ceremony lock
+    /// (P0.21). Retained here for diagnostics and store-level tests.
     pub claim_secret_hash: Option<String>,
 }
 
@@ -367,6 +369,26 @@ impl InstallTokenStore {
         self.ks.get(token_key(jti)).await
     }
 
+    /// Peek the stored Argon2id claim-secret hash for an `Issued`
+    /// token **without** taking the ceremony lock or stamping
+    /// `claimed_at`.
+    ///
+    /// Returns `Some(hash)` only for an `Issued` row that carries a
+    /// hash; `None` for a missing / consumed / no-secret row. The
+    /// `claim/start` route verifies the operator-supplied code
+    /// against this **before** calling [`Self::start_claim`], so a
+    /// wrong code can never stamp the 300 s ceremony lock and grief
+    /// the legitimate operator (P0.21). The authoritative not-found /
+    /// consumed / expired / concurrency checks stay in `start_claim`.
+    pub async fn peek_secret_hash(&self, jti: &Uuid) -> Result<Option<String>, AppError> {
+        match self.get_token(jti).await? {
+            Some(InstallTokenState::Issued {
+                claim_secret_hash, ..
+            }) => Ok(claim_secret_hash),
+            _ => Ok(None),
+        }
+    }
+
     /// Delete a token's state row. Used by the invite revoke
     /// surface after a [`Self::get_token`] check has confirmed
     /// the row is not `Consumed`. Returns `true` if a row was
@@ -550,6 +572,60 @@ mod tests {
         let jti = issue(&store, 600).await;
         let outcome = store.start_claim(&jti).await.unwrap();
         assert!(outcome.claim_secret_hash.is_none());
+    }
+
+    // ---- P0.21: peek the claim-secret hash without locking ----
+
+    #[tokio::test]
+    async fn peek_secret_hash_does_not_set_claim_lock() {
+        // The whole point of P0.21: reading the stored hash to verify the
+        // operator's code must NOT stamp `claimed_at`, so a wrong code
+        // followed immediately by the correct one isn't locked out.
+        let (store, _dir) = temp_store();
+        let hash = "$argon2id$stub".to_string();
+        let jti = issue_with_hash(&store, 600, Some(hash.clone())).await;
+
+        assert_eq!(
+            store.peek_secret_hash(&jti).await.unwrap().as_deref(),
+            Some(hash.as_str())
+        );
+
+        // The ceremony lock must still be unset after a peek.
+        match store.get_token(&jti).await.unwrap().unwrap() {
+            InstallTokenState::Issued { claimed_at, .. } => {
+                assert!(claimed_at.is_none(), "peek must not set the ceremony lock");
+            }
+            _ => panic!("expected Issued"),
+        }
+
+        // And a subsequent real start still succeeds (lock was never taken),
+        // even after an arbitrary number of prior peeks.
+        let _ = store.peek_secret_hash(&jti).await.unwrap();
+        store.start_claim(&jti).await.expect("start after peek");
+    }
+
+    #[tokio::test]
+    async fn peek_secret_hash_none_for_no_secret_consumed_and_missing() {
+        let (store, _dir) = temp_store();
+
+        // Issued without a secret → None (nothing to verify).
+        let no_secret = issue(&store, 600).await;
+        assert!(store.peek_secret_hash(&no_secret).await.unwrap().is_none());
+
+        // Missing row → None (start_claim is authoritative for not-found).
+        assert!(
+            store
+                .peek_secret_hash(&Uuid::new_v4())
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Consumed row → None (no secret check on a spent token).
+        let consumed = issue_with_hash(&store, 600, Some("$argon2id$stub".into())).await;
+        store.start_claim(&consumed).await.unwrap();
+        store.finish_claim(&consumed).await.unwrap();
+        assert!(store.peek_secret_hash(&consumed).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -116,30 +116,36 @@ pub async fn claim_start(
     let claims = parse_install_token(signer, &req.install_token)?;
     let jti = parse_jti(&claims.jti)?;
 
-    // Take the ceremony lock. `start_claim` validates `Issued`, not
-    // expired; on success the `claimed_at` window is set to "now"
-    // so a second concurrent start sees the lock.
-    let outcome = store.start_claim(&jti).await?;
-
-    // Per-invite claim secret: if the persisted row carries an
-    // Argon2id hash, the operator must supply the matching plaintext
-    // here. Discriminated 401 codes let the browser surface the right
-    // hint (missing code vs wrong code). Tokens without a hash skip
-    // this check — covers legacy rows and tests.
-    if let Some(stored_hash) = outcome.claim_secret_hash.as_deref() {
+    // Per-invite claim secret, verified BEFORE the ceremony lock (P0.21).
+    // `start_claim` stamps `claimed_at`, a 300 s concurrency lock; if we
+    // verified the secret *after* it, anyone holding only the install URL
+    // could grief the legitimate operator by POSTing a wrong code every 5
+    // minutes — each attempt would re-arm the lock, then get rejected. So
+    // we peek the stored hash (no mutation) and verify first; only a
+    // correct (or absent) secret reaches `start_claim`. Discriminated 401
+    // codes let the browser surface the right hint (missing vs wrong code).
+    // Rows without a hash skip this — covers legacy rows and tests. The
+    // authoritative not-found / consumed / expired / concurrency checks
+    // stay in `start_claim` below.
+    if let Some(stored_hash) = store.peek_secret_hash(&jti).await? {
         let Some(supplied) = req.claim_secret.as_deref() else {
             return Err(AppError::ServiceError {
                 status: StatusCode::UNAUTHORIZED,
                 message: "claim_secret_required".into(),
             });
         };
-        if !claim_secret::verify(supplied, stored_hash)? {
+        if !claim_secret::verify(supplied, &stored_hash)? {
             return Err(AppError::ServiceError {
                 status: StatusCode::UNAUTHORIZED,
                 message: "claim_secret_invalid".into(),
             });
         }
     }
+
+    // Take the ceremony lock. `start_claim` validates `Issued`, not
+    // expired; on success the `claimed_at` window is set to "now"
+    // so a second concurrent start sees the lock.
+    store.start_claim(&jti).await?;
 
     let user_uuid = jti;
     // Show the operator their admin DID in the authenticator's UI —


### PR DESCRIPTION
## P0.21 — `claim/start` takes the 5-minute ceremony lock before verifying the claim secret

### Problem
`claim_start` (`routes/install.rs`) called `start_claim` — which sets `claimed_at` and locks out concurrent claims for 300 s (`install/state_machine.rs`) — **before** verifying the out-of-band claim secret.

The claim secret exists so "a leaked install URL is not enough." But an attacker holding only the URL could grief the legitimate operator: POST `claim/start` with a wrong code, which **re-arms the 5-minute lock and then gets rejected**. Repeated every 5 minutes, this holds the real operator off indefinitely. The 5 rps governor doesn't help — one request per window is enough.

### Fix
Verify the claim secret **before** acquiring the ceremony lock.

- New `InstallTokenStore::peek_secret_hash(jti)` reads the stored Argon2id hash for an `Issued` row **without** taking the lock or mutating `claimed_at`. Returns `None` for missing / consumed / no-secret rows.
- `claim_start` verifies the operator-supplied code against the peeked hash first (same discriminated `claim_secret_required` / `claim_secret_invalid` 401s). Only a correct (or absent) secret reaches `start_claim`, so a failed attempt **never** stamps the ceremony lock.
- `start_claim` stays authoritative for not-found / consumed / expired / concurrency.
- Removed the now-redundant post-lock verification and its use of `StartClaimOutcome.claim_secret_hash`; that field's doc is updated to note verification now happens before the lock (it's retained for diagnostics + store tests).

### Acceptance criterion
✅ `claim/start` with the wrong code followed immediately by the correct code succeeds (no lockout) — the wrong-code path returns before `start_claim`, and `start_claim` is the only writer of `claimed_at`. Proven at the store level: `peek_secret_hash` does not set the ceremony lock, and a real `start_claim` still succeeds after any number of peeks.

### Tests
- `peek_secret_hash_does_not_set_claim_lock` — peek leaves `claimed_at` unset; a subsequent `start_claim` succeeds.
- `peek_secret_hash_none_for_no_secret_consumed_and_missing` — None for the rows that need no secret check.

`cargo fmt --check` clean, no new clippy warnings on touched files. **Full vtc-service lib suite: 533 passed.**