### PR TITLE
docs(vtc): reflect P0.2/P0.3/P0.7 hardening in recognition + MVP docs (Checkpoint 0)

### DIFF
--- a/docs/03-vtc/trust-registry.md
+++ b/docs/03-vtc/trust-registry.md
@@ -110,10 +110,17 @@ batched purges that haven't yet flushed).
 
 ## Cross-community recognition
 
-A peer community's member presents their VMC to our VTC and asks
-for a session. Our VTC verifies the foreign credential, checks the
-peer registry, runs our `cross_community_roles.rego` to map their
-role to ours, and (on success) mints a session.
+A peer community's member asks our VTC for a session by **presenting**
+their `(VEC, VMC)` pair inside a holder-signed Verifiable Presentation.
+A VEC + VMC are bearer artifacts: anyone who captures the pair (a relayed
+join, an audit log, a compromised member device) would otherwise hold a
+replayable impersonation token for that subject. So recognition is a
+**two-step, proof-of-possession-bound** flow (P0.2, PRs #351 + #354) —
+the caller first fetches a single-use challenge, then presents the
+credentials inside a VP whose holder proof commits to that challenge.
+Our VTC verifies the holder + issuer proofs, checks the peer registry,
+runs `cross_community_roles.rego` to map their role to ours, and (on
+success) mints a session.
 
 ```mermaid
 sequenceDiagram
@@ -122,36 +129,59 @@ sequenceDiagram
     participant FOREIGN as Their VTC
     participant TR as Trust Registry
 
-    M->>US: POST /v1/auth/recognise<br/>(foreign VMC envelope)
-    US->>US: Verify VMC signature<br/>against foreign issuer's resolved DID
-    US->>FOREIGN: GET /v1/status-lists/revocation
-    FOREIGN-->>US: Status list
-    US->>US: Check bit at credentialStatus.statusListIndex
-    alt slot revoked
-        US-->>M: 403 ForeignCredentialRevoked
-    else slot clear
-        US->>TR: GET /registry/v2/membership/<foreign-issuer>
-        TR-->>US: Active / not-active
-        alt foreign issuer not in registry
-            US-->>M: 403 IssuerNotRecognised
-        else recognised
-            US->>US: Evaluate cross_community_roles.rego
-            US->>US: Mint session<br/>TTL = min(JWT-default, VMC.validUntil)
-            US-->>M: { access_token, refresh_token }
+    M->>US: POST /v1/auth/recognise/challenge
+    US-->>M: { nonce, expires_at }<br/>(single-use, TTL'd, bound to our DID)
+    M->>US: POST /v1/auth/recognise<br/>(VP: holder proof over nonce + our DID;<br/>embeds VEC + VMC)
+    US->>US: Consume nonce (single-use)
+    US->>US: Verify holder proof + each embedded issuer proof
+    US->>US: Require VP holder == VEC subject == VMC subject
+    alt holder proof / subject mismatch
+        US-->>M: 401 / 403
+    else proofs valid
+        US->>FOREIGN: GET /v1/status-lists/revocation
+        FOREIGN-->>US: Status list
+        US->>US: Check bit at credentialStatus.statusListIndex
+        alt slot revoked
+            US-->>M: 403 ForeignCredentialRevoked
+        else slot clear
+            US->>TR: GET /registry/v2/membership/<foreign-issuer>
+            TR-->>US: Active / not-active
+            alt foreign issuer not in registry
+                US-->>M: 403 IssuerNotRecognised
+            else recognised
+                US->>US: Evaluate cross_community_roles.rego
+                US->>US: Mint session<br/>TTL = min(JWT-default, VEC.validUntil, VMC.validUntil)
+                US-->>M: { access_token, refresh_token }
+            end
         end
     end
 ```
 
 **Session-mint hardening invariants** (every one is load-bearing):
 
-- Foreign VMC must pass **live** status-list revocation check.
+- **Holder proof-of-possession.** The VP's `eddsa-jcs-2022` holder proof
+  (`proofPurpose: authentication`) must verify and commit to the
+  single-use challenge `nonce` (freshness/replay) plus this VTC's DID as
+  `domain` (audience). A captured VEC + VMC is inert without the
+  subject's private key, and a replayed VP finds its nonce already
+  consumed.
+- **Subject binding.** The verified VP holder DID must equal the VEC
+  `credentialSubject.id`, and the VMC subject must equal the VEC subject.
+  The VMC only attests "live, non-revoked member"; without the
+  `vmc.subject == vec.subject` check, member A's role VEC paired with any
+  *other* current member B's VMC (same issuer) would pass the gate.
+- Foreign VEC + VMC must pass a **live** status-list revocation check.
 - Foreign issuer must be in the trust-registry recognition graph
   **at mint time**.
 - Minted session TTL = `min(JWT-audience-default,
   foreign-VEC.validUntil, foreign-VMC.validUntil)`.
-- **No caching** — every mint re-runs policy + status-list + registry
-  checks. A peer community removed mid-session doesn't retain
-  access on refresh.
+- **No caching, no refresh** — every mint re-runs holder/issuer proof +
+  policy + status-list + registry checks. Cross-community sessions
+  (`xc-`-prefixed) never refresh; a peer community removed mid-session
+  loses access when the clamped TTL elapses.
+- **Untrusted denied-path audit actor.** On a rejected recognise the
+  audit envelope's actor is the cryptographically-proven VP holder (the
+  signer), never an unverified DID lifted from the credential body.
 
 ## Configuration
 

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -599,6 +599,23 @@ claim maps to a local ACL role. Default deny-all.
 
 **Session-mint hardening.**
 
+- **Holder proof-of-possession (P0.2, PR #354).** Recognition is a
+  two-step flow: `POST /v1/auth/recognise/challenge` issues a single-use,
+  TTL'd `nonce` bound to this VTC's DID, then `POST /v1/auth/recognise`
+  carries the `(VEC, VMC)` pair **inside a holder-signed VP** whose
+  `eddsa-jcs-2022` proof (`proofPurpose: authentication`) commits to that
+  nonce (freshness/replay) and our DID as `domain` (audience). The mint
+  verifies the holder proof plus each embedded issuer proof and refuses
+  unless the **verified VP holder == VEC subject**. A bare `{vec, vmc}`
+  body is no longer accepted — a captured pair is inert without the
+  subject's key, and a replayed VP finds its nonce consumed.
+- **Subject binding (P0.2, PR #351).** The VMC subject must equal the VEC
+  subject. The VMC's only job is the "live, non-revoked member" gate;
+  without this check, member A's role VEC + any other current member B's
+  VMC (same issuer) would pass.
+- **Denied-path audit actor (P0.2).** A rejected recognise records the
+  cryptographically-proven VP holder as actor, never an unverified DID
+  read from the credential body.
 - The foreign VEC must pass StatusList revocation check at
   session-mint time (the issuer's status list URL is resolved live).
 - The foreign issuer must be present in the trust-registry's
@@ -832,11 +849,19 @@ Trust Task ID.
 - Challenge-response with JWT audience `"VTC"` — cross-audience
   tokens rejected.
 - Sessions issued from REST (Bearer) or DIDComm (authcrypt sender).
+- **DIDComm sender is the authenticated key, not the plaintext `from`
+  (P0.3, PR #350).** The router requires authcrypt (`require_authenticated`,
+  no anonymous sender) and every handler derives the sender DID from
+  `meta.encrypted_from_kid` (the key that actually encrypted the message),
+  rejecting any message whose plaintext `from` ≠ the authcrypt key DID.
+  This closes the "self-remove as the victim" and impersonation classes
+  on join-submit / accept / self-remove / status.
 - **Step-up reauth** required for: passkey enrolment / revocation,
   admin promotion, emergency operations. Implemented as a fresh
   WebAuthn user-verification ceremony embedded in the request.
-- Cross-community sessions (§8.4): TTL clamped to inputs, recognition
-  re-evaluated on every refresh.
+- Cross-community sessions (§8.4): TTL clamped to inputs; recognition is
+  re-evaluated on every **mint** — these sessions do **not** refresh
+  (see §8.4).
 
 ## 10. Member lifecycle
 
@@ -1151,6 +1176,18 @@ Bilateral counter-signing is v2.
 Public website lives on filesystem at `website.root_dir`, not in
 fjall (§3-K).
 
+**Encryption at rest (P0.7, PR #364).** The keyspaces holding secret or
+forgery-sensitive material — `install` (the install-token ephemeral
+Ed25519 private key), `audit_key` (the HMAC actor-hash key), and
+`passkey` (WebAuthn state) — are opened with `with_encryption`. The
+storage key is HKDF-derived from the bundle Ed25519 seed (info
+`vtc-storage-key/v1`) in `init_auth`. Back-compat for pre-encryption
+deployments is a one-shot, idempotent, crash-safe
+`KeyspaceHandle::migrate_to_encrypted` pass at boot — **not** a
+try-decrypt-else-plaintext read fallback, which would reintroduce the
+cut-and-paste downgrade hole in the VTA-shared encryption module. The
+signing bundle itself lives in the seed-store backend, not a keyspace.
+
 ## 14. Operational
 
 ### 14.1 Backup / restore
@@ -1297,6 +1334,23 @@ the route handler then enforces the operator-configured
 `website.max_bundle_size_mb` (default 50) and
 `max_file_size_mb` (default 10) at runtime. All other routes
 inherit 1 MB.
+
+### 14.5 Phase 0 security hardening (status)
+
+The Phase 0 review (`tasks/vtc-architecture-plan.md`) tracked a set of
+security/correctness fixes landed independently of the phase sequence.
+The three with cross-cutting wire/storage implications are recorded at
+their canonical sections; this index keeps them findable:
+
+| Item | What it hardened | Section | PRs |
+|---|---|---|---|
+| **P0.2** | Cross-community `recognise`: holder proof-of-possession + challenge nonce + audience binding, `vmc.subject == vec.subject`, untrusted denied-path audit actor | §8.4 | #351, #354 |
+| **P0.3** | DIDComm handlers authenticate the sender via `encrypted_from_kid` (authcrypt key), reject plaintext-`from` impersonation + anoncrypt | §9.7 | #350 |
+| **P0.7** | Encryption at rest for `install` / `audit_key` / `passkey`; HKDF storage key, migrate-not-fallback back-compat | §13 | #364 |
+
+Note: the workspace VTA backlog has its own, unrelated **P0.2**
+(enclave anti-rollback anchor) — the IDs collide across the two service
+backlogs; the entries above are the VTC plan's.
 
 ## 15. CLI
 


### PR DESCRIPTION
## Checkpoint 0 — doc updates

Brings the cross-community recognition docs and the MVP design note in line with the **already-merged** Phase 0 hardening (P0.2 #351 + #354, P0.3 #350, P0.7 #364). The docs still described the pre-hardening bearer `recognise` flow and hadn't recorded the sender-auth / at-rest changes.

> Note: the plan refers to `docs/03-vtc/cross-community.md`, but that file was renamed to **`docs/03-vtc/trust-registry.md`** (the "Phase 3 recognition + trust-registry sync" doc). Updates landed there.

### `docs/03-vtc/trust-registry.md`
- Rewrote **Cross-community recognition** for the two-step, proof-of-possession-bound flow (P0.2):
  - `POST /v1/auth/recognise/challenge` → single-use, TTL'd nonce bound to our DID.
  - `POST /v1/auth/recognise` carries a holder-signed VP (proof over nonce + our DID as `domain`) embedding the VEC + VMC.
  - Require **VP holder == VEC subject == VMC subject** before the recognition gate + mint.
  - Updated the sequence diagram and hardening invariants (holder PoP, subject binding, no-cache/no-refresh, untrusted denied-path audit actor).

### `docs/05-design-notes/vtc-mvp.md`
- **§8.4** — added the holder-PoP, `vmc.subject == vec.subject`, and denied-path-audit-actor invariants (P0.2).
- **§9.7** — documented that the DIDComm sender is the authcrypt key (`encrypted_from_kid`), not the plaintext `from` (P0.3); fixed the stale "recognition re-evaluated on every refresh" line — cross-community sessions **do not** refresh.
- **§13** — encryption-at-rest note for `install` / `audit_key` / `passkey` (HKDF storage key, migrate-not-fallback) (P0.7).
- **§14.5** — new index table recording P0.2/P0.3/P0.7 status, with a note on the VTA/VTC **P0.2** ID collision (the VTA backlog's P0.2 is the unrelated enclave anti-rollback anchor).

Docs-only; no code change. All claims verified against the current `routes/recognise.rs`, `messaging.rs`, and the P0.7 storage path.

### Checkpoint 0 status
This covers the **doc-update** portion. The other gate — "all P0 merged or deferred-with-issue" — is **not** yet met: several VTC P0 items remain open in `tasks/vtc-architecture-todo.md` (P0.1, P0.5, P0.6, P0.8–P0.15). Note the todo's `[ ]` boxes for P0.2/P0.3 are stale — that work is merged (#350/#351/#354); they should be ticked.