### PR TITLE
feat(tee): local MAC'd integrity manifest + boot-verify (P0.2a)

### DIFF
--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -34,11 +34,35 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   is EIF-baked/measured); (5) Option C cross-account = **future P0.2e**. Same PR
   adds the operator setup runbook (DynamoDB table + KMS PCR-gated writer key +
   IAM writer-principal/instance-role-deny + config) and the threat-model rollback
-  rows to `docs/02-vta/tee-architecture.md`. TEE-only feature. **Next: P0.2a**
-  (local MAC'd manifest + boot-verify, no external dependency). Phases:
+  rows to `docs/02-vta/tee-architecture.md`. TEE-only feature. Phases:
   P0.2a (manifest) → P0.2b (counter) → P0.2c (attestation-gated writer) →
   P0.2d (threat-model claim) ; P0.2e (Option C) deferred — design PR: #365
-  (merged); §9-resolution + setup-docs PR: ____ ; impl PR: ____
+  (merged); §9-resolution + setup-docs PR: #377 (merged).
+  - `[x]` **P0.2a** (M) Local MAC'd integrity manifest + boot-verify (Layer 0) —
+    branch `fix/p0.2a-integrity-manifest` (worktree). New
+    `vti_common::integrity`: a 121-byte MAC'd manifest pinning the four covered
+    singletons (carve-out sentinel, ACL root, JWT-fingerprint, path/context
+    counters) under `HMAC-SHA256(HKDF(storage_key), …)`, stored in the
+    `bootstrap` keyspace. Boot (`server::run`, gated on a KMS storage key →
+    TEE-only) verifies the MAC + recomputes-and-compares the live state, failing
+    **closed** on a deleted row / inconsistent snapshot / forged manifest;
+    first-boot/missing baseline gated behind new
+    `tee.kms.allow_anchor_init` (mirrors `allow_fingerprint_init`). Kept in
+    step at runtime by re-sealing at **chokepoints** rather than ~29 call sites:
+    `store_acl_entry`/`delete_acl_entry`/`update_acl_entry_versioned` +
+    `counter::allocate_u32` (all in vti-common) cover every ACL + counter
+    mutation; `mint_mode_b` (carve-out close) and `apply_import` (backup
+    restore) reseal explicitly. A process-global `OnceLock` sealer (set only at
+    TEE boot) makes `reseal_if_active` a true no-op outside a TEE — zero
+    behaviour change for the local VTA. Reads decrypt via encrypted handles, so
+    the manifest hashes *plaintext* content (nonce-independent). Drift-guard test
+    pins the duplicated key strings to the vta-service constants. Does NOT catch
+    a fully-consistent rollback — that's the external counter (P0.2b). Tests:
+    manifest byte/MAC round-trip + tamper, baseline-refused-without-flag,
+    baseline→verify, deletion/forgery detected, e2e (install → chokepoint reseal
+    → reverify → out-of-band tamper → fail-closed → recover). fmt + clippy
+    (default & tee) clean; vti-common 234 + e2e, vta-service 714 (default) / 745
+    (tee) green; vta-enclave checks; no version bump (additive) — PR: ____
 - `[x]` **P0.3** (S) `create_key`/`import_key`: existence check + identifier
   validation (closes `#key-0` overwrite) — branch `fix/p0.3-key-overwrite`.
   Scope grew during root-cause analysis: the store's multi-op "atomic"

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -409,6 +409,21 @@ pub struct TeeKmsConfig {
     /// and intend to reset the VTA to a fresh first-boot state.
     #[serde(default)]
     pub allow_kms_reinit: bool,
+    /// Allow establishing the TEE integrity-manifest baseline when none is
+    /// stored (P0.2a anti-rollback anchor).
+    ///
+    /// **Default: false.** The integrity manifest is the MAC'd snapshot of the
+    /// rollback-protected singletons (carve-out sentinel, ACL root, JWT
+    /// fingerprint, key counters). A missing manifest on a configured VTA is
+    /// indistinguishable from a parent-deleted one, so the enclave refuses to
+    /// boot rather than silently baseline whatever (possibly rolled-back) state
+    /// the parent presents.
+    ///
+    /// Operators on first boot, or migrating from a pre-manifest VTA: set
+    /// `true`, boot once to establish the baseline, then set back to `false`.
+    /// Mirrors [`Self::allow_fingerprint_init`].
+    #[serde(default)]
+    pub allow_anchor_init: bool,
 }
 
 // KMS ciphertexts (seed, JWT key, fingerprint) are stored as K/V entries

--- a/vta-service/src/operations/backup/mod.rs
+++ b/vta-service/src/operations/backup/mod.rs
@@ -780,6 +780,13 @@ pub async fn apply_import(
     keys_ks.remove(IMPORT_IN_PROGRESS_KEY).await?;
     keys_ks.persist().await?;
 
+    // Restore rewrote the covered singletons (ACL, counters, …) via raw inserts
+    // that bypass the integrity chokepoints, so re-seal the TEE manifest to the
+    // freshly-restored state — otherwise the next boot would fail closed against
+    // the pre-restore manifest. The restore is super-admin-authorized, so the
+    // restored state is the new legitimate baseline (P0.2a). No-op outside a TEE.
+    vti_common::integrity::reseal_if_active().await?;
+
     info!(
         keys = payload.key_records.len(),
         acls = payload.acl_entries.len(),

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -261,6 +261,7 @@ mod tests {
             &SeedRecord {
                 id: 0,
                 seed_hex: None,
+                seed_enc: None,
                 created_at: chrono::Utc::now(),
                 retired_at: None,
             },

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -334,6 +334,12 @@ async fn mint_mode_b(
     // close is on disk.
     state.keys_ks.persist().await?;
 
+    // Re-seal the TEE integrity manifest now that the carve-out is closed, so a
+    // subsequent boot detects any parent attempt to reopen it (P0.2a). The
+    // carve-out sentinel write above is a direct `insert_raw_if_absent`, not an
+    // ACL/counter chokepoint, so it needs its own reseal. No-op outside a TEE.
+    vti_common::integrity::reseal_if_active().await?;
+
     info!("TEE first-boot carve-out consumed — closed for good");
     Ok(bundle)
 }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -451,6 +451,32 @@ pub async fn run(
         }
     }
 
+    // TEE anti-rollback anchor — Layer 0 (P0.2a). Verify the MAC'd integrity
+    // manifest against the live store and install the runtime sealer, so a
+    // covered singleton deleted or replayed to an inconsistent snapshot while
+    // the enclave was down is caught here and the VTA fails closed. Gated on a
+    // KMS storage key (i.e. a real TEE); a `None` key is the non-TEE path and
+    // has no untrusted-parent threat. Unlike the reconcile above this is
+    // security-critical, so a failure aborts the boot.
+    #[cfg(feature = "tee")]
+    if let Some(storage_key) = storage_encryption_key
+        && let Some(kms) = config.tee.kms.as_ref()
+    {
+        let enc = |name: &str| -> Result<KeyspaceHandle, AppError> {
+            Ok(store.keyspace(name)?.with_encryption(storage_key))
+        };
+        let outcome = vti_common::integrity::boot_verify_and_install(
+            vti_common::integrity::derive_mac_key(&storage_key),
+            enc("keys")?,
+            store.keyspace("bootstrap")?, // unencrypted, KMS-protected
+            enc("acl")?,
+            enc("contexts")?,
+            kms.allow_anchor_init,
+        )
+        .await?;
+        info!(?outcome, "TEE integrity manifest checked");
+    }
+
     // Determine which services will actually start (feature flag AND
     // persisted runtime state, the latter set by `pnm services {kind}
     // {enable,disable}`).

--- a/vta-service/src/tee/kms_bootstrap.rs
+++ b/vta-service/src/tee/kms_bootstrap.rs
@@ -1278,6 +1278,25 @@ pub(crate) fn classify_kms_error_typed<E: std::error::Error>(
 mod tests {
     use super::*;
 
+    /// Drift guard (P0.2a): the integrity manifest in `vti-common` reads the
+    /// carve-out sentinel and JWT-fingerprint rows by hard-coded key string
+    /// (it can't import these `vta-service` constants). If either key string
+    /// is ever changed here, the manifest would silently stop covering it —
+    /// this test fails the moment they diverge.
+    #[test]
+    fn integrity_manifest_key_strings_match() {
+        assert_eq!(
+            BOOTSTRAP_JWT_FINGERPRINT_KEY,
+            vti_common::integrity::JWT_FINGERPRINT_KEY,
+            "JWT fingerprint key drifted from vti_common::integrity"
+        );
+        assert_eq!(
+            crate::tee::admin_bootstrap::BOOTSTRAP_CARVEOUT_CLOSED_KEY,
+            vti_common::integrity::CARVEOUT_KEY,
+            "carve-out sentinel key drifted from vti_common::integrity"
+        );
+    }
+
     /// Build a synthetic CMS EnvelopedData that mimics what KMS returns
     /// with CiphertextForRecipient. This allows us to test the full
     /// decrypt_cms_envelope round-trip without needing real KMS or NSM.

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -461,7 +461,10 @@ pub async fn get_acl_entry(acl: &KeyspaceHandle, did: &str) -> Result<Option<Acl
 /// paths (admin import, initial seed, sweeper) where there's no
 /// concurrent-edit risk.
 pub async fn store_acl_entry(acl: &KeyspaceHandle, entry: &AclEntry) -> Result<(), AppError> {
-    acl.insert(acl_key(&entry.did), entry).await
+    acl.insert(acl_key(&entry.did), entry).await?;
+    // Re-seal the TEE integrity manifest so this ACL change is reflected in the
+    // sealed snapshot (P0.2a). No-op unless running in a TEE.
+    crate::integrity::reseal_if_active().await
 }
 
 /// Optimistic-concurrency-checked write.
@@ -495,12 +498,16 @@ pub async fn update_acl_entry_versioned(
     }
     new_entry.version = expected_version + 1;
     acl.insert(key, &new_entry).await?;
+    crate::integrity::reseal_if_active().await?; // P0.2a
     Ok(new_entry.version)
 }
 
 /// Delete an ACL entry by DID.
 pub async fn delete_acl_entry(acl: &KeyspaceHandle, did: &str) -> Result<(), AppError> {
-    acl.remove(acl_key(did)).await
+    acl.remove(acl_key(did)).await?;
+    // Re-seal so the deletion is reflected in the manifest (P0.2a). No-op
+    // outside a TEE.
+    crate::integrity::reseal_if_active().await
 }
 
 /// List all ACL entries.

--- a/vti-common/src/integrity/mod.rs
+++ b/vti-common/src/integrity/mod.rs
@@ -1,0 +1,616 @@
+//! TEE integrity manifest (P0.2a — Layer 0 of the anti-rollback anchor).
+//!
+//! In the Nitro-Enclave deployment the parent EC2 host owns the on-disk fjall
+//! database and can delete or replay whole ciphertexts. KMS attestation gives
+//! confidentiality and P0.1 AAD gives location-integrity, but neither gives
+//! **freshness**: a covered row deleted, or the store replayed to an
+//! inconsistent past snapshot, is not detected. This module pins the
+//! security-critical singletons into a single MAC'd record so deletion and
+//! inconsistent tamper are caught at boot.
+//!
+//! Layer 0 alone does **not** catch a fully-consistent rollback (manifest and
+//! all covered rows restored together to a genuine past epoch) — that needs the
+//! external monotonic counter (P0.2b). See
+//! `docs/05-design-notes/tee-anti-rollback-anchor.md`.
+//!
+//! ## Activation
+//!
+//! The manifest is **TEE-only**. It is activated solely by [`install_sealer`],
+//! which the boot path calls only when a storage-encryption key is present
+//! (i.e. in a TEE). Outside a TEE the global sealer is never set, so
+//! [`reseal_if_active`] — invoked from the covered mutation chokepoints
+//! ([`crate::acl::store_acl_entry`] et al.) — is a cheap no-op. No feature flag
+//! is needed; the module compiles everywhere and simply lies dormant.
+//!
+//! ## Covered singletons (design §5.1)
+//!
+//! | Singleton | Location | Rollback it blocks |
+//! |---|---|---|
+//! | Carve-out sentinel | `keys` ▸ [`CARVEOUT_KEY`] | reopen single-use Mode-B carve-out → fresh admin |
+//! | JWT fingerprint | `bootstrap` ▸ [`JWT_FINGERPRINT_KEY`] | delete → silent JWT re-baseline |
+//! | ACL keyspace root | `acl` ▸ `acl:*` | replay → resurrect a revoked admin |
+//! | Path/context counters | `keys` ▸ `path_counter:*`, `contexts` ▸ `ctx_counter*` | rollback → BIP-32 key reuse |
+
+use std::sync::OnceLock;
+
+use hkdf::Hkdf;
+use hmac::digest::KeyInit;
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+use tracing::warn;
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Carve-out sentinel key (lives in the `keys` keyspace). Must match
+/// `vta_service::tee::admin_bootstrap::BOOTSTRAP_CARVEOUT_CLOSED_KEY`; a
+/// drift-guard test in vta-service asserts the two stay equal.
+pub const CARVEOUT_KEY: &str = "tee:bootstrap-carveout-closed";
+/// JWT-fingerprint key (lives in the `bootstrap` keyspace). Must match
+/// `vta_service::tee::kms_bootstrap::BOOTSTRAP_JWT_FINGERPRINT_KEY`.
+pub const JWT_FINGERPRINT_KEY: &str = "bootstrap:jwt_fingerprint";
+/// Manifest record key (lives in the `bootstrap` keyspace).
+pub const MANIFEST_KEY: &str = "tee:integrity-manifest";
+
+const ACL_PREFIX: &str = "acl:";
+const PATH_COUNTER_PREFIX: &str = "path_counter:";
+const CTX_COUNTER_PREFIX: &str = "ctx_counter";
+
+/// HKDF `info` separating the manifest MAC key from the storage-encryption key
+/// it is derived from.
+const MAC_KEY_INFO: &[u8] = b"vti-integrity-manifest-mac/v1";
+/// Domain tag prefixing the MAC input so a manifest blob can't be reinterpreted
+/// in another context.
+const MAC_DOMAIN: &[u8] = b"vti-integrity-manifest/v1";
+
+/// Serialized manifest length: version(8) + carveout(1) + jwt_fp(16) +
+/// acl_root(32) + counters(32) + mac(32).
+const MANIFEST_LEN: usize = 8 + 1 + 16 + 32 + 32 + 32;
+
+/// The hashed snapshot of the four covered singletons.
+#[derive(Clone, PartialEq, Eq, Debug)]
+struct CoveredState {
+    carveout_present: bool,
+    jwt_fp: [u8; 16],
+    acl_root: [u8; 32],
+    counters: [u8; 32],
+}
+
+impl CoveredState {
+    /// Canonical MAC input: domain tag ‖ version ‖ fixed-width fields.
+    fn mac_input(&self, version: u64) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(MAC_DOMAIN.len() + 8 + 1 + 16 + 32 + 32);
+        buf.extend_from_slice(MAC_DOMAIN);
+        buf.extend_from_slice(&version.to_le_bytes());
+        buf.push(self.carveout_present as u8);
+        buf.extend_from_slice(&self.jwt_fp);
+        buf.extend_from_slice(&self.acl_root);
+        buf.extend_from_slice(&self.counters);
+        buf
+    }
+}
+
+/// A loaded-or-recomputed manifest. The `mac` authenticates `version` + state.
+struct Manifest {
+    version: u64,
+    state: CoveredState,
+    mac: [u8; 32],
+}
+
+impl Manifest {
+    /// Build a manifest for `state` at `version`, computing its MAC.
+    fn sealed(mac_key: &[u8; 32], version: u64, state: CoveredState) -> Self {
+        let mac = mac_over(mac_key, &state.mac_input(version));
+        Self {
+            version,
+            state,
+            mac,
+        }
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(MANIFEST_LEN);
+        buf.extend_from_slice(&self.version.to_le_bytes());
+        buf.push(self.state.carveout_present as u8);
+        buf.extend_from_slice(&self.state.jwt_fp);
+        buf.extend_from_slice(&self.state.acl_root);
+        buf.extend_from_slice(&self.state.counters);
+        buf.extend_from_slice(&self.mac);
+        buf
+    }
+
+    fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() != MANIFEST_LEN {
+            return None;
+        }
+        let version = u64::from_le_bytes(b[0..8].try_into().ok()?);
+        let carveout_present = match b[8] {
+            0 => false,
+            1 => true,
+            _ => return None,
+        };
+        let jwt_fp: [u8; 16] = b[9..25].try_into().ok()?;
+        let acl_root: [u8; 32] = b[25..57].try_into().ok()?;
+        let counters: [u8; 32] = b[57..89].try_into().ok()?;
+        let mac: [u8; 32] = b[89..121].try_into().ok()?;
+        Some(Self {
+            version,
+            state: CoveredState {
+                carveout_present,
+                jwt_fp,
+                acl_root,
+                counters,
+            },
+            mac,
+        })
+    }
+
+    /// Constant-time MAC check against `mac_key`.
+    fn mac_valid(&self, mac_key: &[u8; 32]) -> bool {
+        let mut h = HmacSha256::new_from_slice(mac_key).expect("hmac accepts 32-byte key");
+        h.update(&self.state.mac_input(self.version));
+        h.verify_slice(&self.mac).is_ok()
+    }
+}
+
+fn mac_over(mac_key: &[u8; 32], input: &[u8]) -> [u8; 32] {
+    let mut h = HmacSha256::new_from_slice(mac_key).expect("hmac accepts 32-byte key");
+    h.update(input);
+    h.finalize().into_bytes().into()
+}
+
+/// Derive the manifest MAC key from the TEE storage-encryption key. Domain-
+/// separated so it never coincides with the key's encryption use.
+pub fn derive_mac_key(storage_key: &[u8; 32]) -> [u8; 32] {
+    let hk = Hkdf::<Sha256>::new(None, storage_key);
+    let mut out = [0u8; 32];
+    hk.expand(MAC_KEY_INFO, &mut out)
+        .expect("32-byte HKDF output is valid");
+    out
+}
+
+/// Hash a set of key/value rows canonically (sorted by key, length-prefixed),
+/// so the digest is independent of iteration order.
+fn hash_rows(mut rows: Vec<(Vec<u8>, Vec<u8>)>) -> [u8; 32] {
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = Sha256::new();
+    for (k, v) in rows {
+        hasher.update((k.len() as u32).to_le_bytes());
+        hasher.update(&k);
+        hasher.update((v.len() as u32).to_le_bytes());
+        hasher.update(&v);
+    }
+    hasher.finalize().into()
+}
+
+/// The installed sealer. Holds the MAC key and clones of every keyspace the
+/// covered singletons live in. Set once at TEE boot via [`install_sealer`].
+struct ManifestSealer {
+    mac_key: [u8; 32],
+    /// carve-out sentinel + `path_counter:*`
+    keys_ks: KeyspaceHandle,
+    /// JWT fingerprint + the manifest record itself
+    bootstrap_ks: KeyspaceHandle,
+    /// `acl:*`
+    acl_ks: KeyspaceHandle,
+    /// `ctx_counter*`
+    contexts_ks: KeyspaceHandle,
+}
+
+impl ManifestSealer {
+    async fn compute_state(&self) -> Result<CoveredState, AppError> {
+        let carveout_present = self.keys_ks.get_raw(CARVEOUT_KEY).await?.is_some();
+
+        let jwt_fp = match self.bootstrap_ks.get_raw(JWT_FINGERPRINT_KEY).await? {
+            Some(bytes) => {
+                let digest = Sha256::digest(&bytes);
+                let mut fp = [0u8; 16];
+                fp.copy_from_slice(&digest[..16]);
+                fp
+            }
+            None => [0u8; 16],
+        };
+
+        let acl_root = hash_rows(self.acl_ks.prefix_iter_raw(ACL_PREFIX).await?);
+
+        // Counters span two keyspaces; tag each row's key with a keyspace
+        // discriminant so a `path_counter:x` can never collide with a
+        // hypothetical `ctx_counter:x` in the combined digest.
+        let mut counter_rows: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for (k, v) in self.keys_ks.prefix_iter_raw(PATH_COUNTER_PREFIX).await? {
+            let mut tagged = b"k:".to_vec();
+            tagged.extend_from_slice(&k);
+            counter_rows.push((tagged, v));
+        }
+        for (k, v) in self.contexts_ks.prefix_iter_raw(CTX_COUNTER_PREFIX).await? {
+            let mut tagged = b"c:".to_vec();
+            tagged.extend_from_slice(&k);
+            counter_rows.push((tagged, v));
+        }
+        let counters = hash_rows(counter_rows);
+
+        Ok(CoveredState {
+            carveout_present,
+            jwt_fp,
+            acl_root,
+            counters,
+        })
+    }
+
+    async fn load_manifest(&self) -> Result<Option<Manifest>, AppError> {
+        Ok(self
+            .bootstrap_ks
+            .get_raw(MANIFEST_KEY)
+            .await?
+            .and_then(|b| Manifest::from_bytes(&b)))
+    }
+
+    async fn write_manifest(&self, m: &Manifest) -> Result<(), AppError> {
+        self.bootstrap_ks
+            .insert_raw(MANIFEST_KEY, m.to_bytes())
+            .await?;
+        self.bootstrap_ks.persist().await?;
+        Ok(())
+    }
+
+    /// Boot check core (no global side effect, so it is unit-testable). See
+    /// [`boot_verify_and_install`] for semantics.
+    async fn verify_or_baseline(&self, allow_anchor_init: bool) -> Result<BootOutcome, AppError> {
+        let current = self.compute_state().await?;
+        match self.load_manifest().await? {
+            None => {
+                if !allow_anchor_init {
+                    return Err(AppError::Internal(
+                        "TEE integrity manifest is missing and allow_anchor_init is false — \
+                         refusing to start. A missing manifest on a configured VTA is \
+                         indistinguishable from a parent-deleted one; set \
+                         tee.kms.allow_anchor_init = true for ONE boot to establish the \
+                         baseline, then set it back to false."
+                            .into(),
+                    ));
+                }
+                self.write_manifest(&Manifest::sealed(&self.mac_key, 0, current))
+                    .await?;
+                warn!(
+                    "TEE integrity manifest established (version 0) under allow_anchor_init — \
+                     set tee.kms.allow_anchor_init = false now that the baseline exists"
+                );
+                Ok(BootOutcome::Baselined)
+            }
+            Some(stored) => {
+                if !stored.mac_valid(&self.mac_key) {
+                    return Err(AppError::Internal(
+                        "TEE integrity manifest MAC verification failed — the manifest was \
+                         tampered with or the storage key changed. Refusing to start (P0.2). \
+                         Restore a consistent backup or investigate parent-host compromise."
+                            .into(),
+                    ));
+                }
+                if stored.state != current {
+                    return Err(AppError::Internal(format!(
+                        "TEE integrity manifest mismatch — the on-disk state does not match the \
+                         last sealed manifest (a covered singleton was deleted or the store was \
+                         replayed to an inconsistent snapshot). Refusing to start (P0.2). [{}]",
+                        describe_mismatch(&stored.state, &current),
+                    )));
+                }
+                Ok(BootOutcome::Verified)
+            }
+        }
+    }
+}
+
+/// Process-global sealer + a lock serializing reseals so concurrent mutations
+/// can't lose a manifest update or skip a version.
+static SEALER: OnceLock<ManifestSealer> = OnceLock::new();
+static RESEAL_LOCK: Mutex<()> = Mutex::const_new(());
+
+/// Re-seal the manifest after a covered-singleton mutation. **No-op unless a
+/// sealer is installed** (i.e. always, outside a TEE). Recomputes the covered
+/// state from the live store, bumps the version, re-MACs, and persists.
+///
+/// Called from the covered mutation chokepoints. The cost (a few prefix scans +
+/// one HMAC) is paid only in TEE and only on tightening ops, which are
+/// infrequent.
+pub async fn reseal_if_active() -> Result<(), AppError> {
+    let Some(sealer) = SEALER.get() else {
+        return Ok(());
+    };
+    let _guard = RESEAL_LOCK.lock().await;
+    let next_version = sealer
+        .load_manifest()
+        .await?
+        .map(|m| m.version + 1)
+        .unwrap_or(0);
+    let state = sealer.compute_state().await?;
+    let manifest = Manifest::sealed(&sealer.mac_key, next_version, state);
+    sealer.write_manifest(&manifest).await
+}
+
+/// Outcome of the boot check, for logging.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BootOutcome {
+    /// A valid manifest matched the live store.
+    Verified,
+    /// No manifest existed; a baseline was established (first boot /
+    /// `allow_anchor_init`).
+    Baselined,
+}
+
+/// Verify the integrity manifest against the live store and install the sealer
+/// for runtime reseals. Call exactly once at TEE boot, before serving.
+///
+/// - **No manifest present:** with `allow_anchor_init` true, establish a
+///   version-0 baseline over the current state (first boot / migration);
+///   otherwise **fail closed** — a silent baseline would accept whatever
+///   (possibly rolled-back) state the parent presents.
+/// - **Manifest present:** verify its MAC, then recompute the covered state and
+///   compare. A MAC failure (forged/tampered manifest) or a state mismatch
+///   (a covered row deleted, or an inconsistent snapshot) **fails closed**.
+///
+/// On success the sealer is installed so subsequent covered mutations reseal.
+pub async fn boot_verify_and_install(
+    mac_key: [u8; 32],
+    keys_ks: KeyspaceHandle,
+    bootstrap_ks: KeyspaceHandle,
+    acl_ks: KeyspaceHandle,
+    contexts_ks: KeyspaceHandle,
+    allow_anchor_init: bool,
+) -> Result<BootOutcome, AppError> {
+    let sealer = ManifestSealer {
+        mac_key,
+        keys_ks,
+        bootstrap_ks,
+        acl_ks,
+        contexts_ks,
+    };
+    let outcome = sealer.verify_or_baseline(allow_anchor_init).await?;
+    // Install for runtime reseals (only fails if called twice — boot calls once).
+    let _ = SEALER.set(sealer);
+    Ok(outcome)
+}
+
+/// Human-readable diff of which covered component(s) diverged, for the
+/// fail-closed boot error. Never includes secret material — only which field.
+fn describe_mismatch(stored: &CoveredState, current: &CoveredState) -> String {
+    let mut parts = Vec::new();
+    if stored.carveout_present != current.carveout_present {
+        parts.push(format!(
+            "carve-out sentinel (sealed present={}, now present={})",
+            stored.carveout_present, current.carveout_present
+        ));
+    }
+    if stored.jwt_fp != current.jwt_fp {
+        parts.push("JWT fingerprint".into());
+    }
+    if stored.acl_root != current.acl_root {
+        parts.push("ACL root".into());
+    }
+    if stored.counters != current.counters {
+        parts.push("path/context counters".into());
+    }
+    if parts.is_empty() {
+        "no field differs (internal error)".into()
+    } else {
+        parts.join("; ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+
+    struct Ks {
+        keys: KeyspaceHandle,
+        bootstrap: KeyspaceHandle,
+        acl: KeyspaceHandle,
+        contexts: KeyspaceHandle,
+        _dir: tempfile::TempDir,
+    }
+
+    fn open() -> Ks {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        Ks {
+            keys: store.keyspace("keys").unwrap(),
+            bootstrap: store.keyspace("bootstrap").unwrap(),
+            acl: store.keyspace("acl").unwrap(),
+            contexts: store.keyspace("contexts").unwrap(),
+            _dir: dir,
+        }
+    }
+
+    fn sealer(ks: &Ks, mac_key: [u8; 32]) -> ManifestSealer {
+        ManifestSealer {
+            mac_key,
+            keys_ks: ks.keys.clone(),
+            bootstrap_ks: ks.bootstrap.clone(),
+            acl_ks: ks.acl.clone(),
+            contexts_ks: ks.contexts.clone(),
+        }
+    }
+
+    #[test]
+    fn manifest_bytes_round_trip() {
+        let mac_key = [3u8; 32];
+        let state = CoveredState {
+            carveout_present: true,
+            jwt_fp: [7u8; 16],
+            acl_root: [9u8; 32],
+            counters: [11u8; 32],
+        };
+        let m = Manifest::sealed(&mac_key, 5, state.clone());
+        let bytes = m.to_bytes();
+        assert_eq!(bytes.len(), MANIFEST_LEN);
+        let back = Manifest::from_bytes(&bytes).expect("round trip");
+        assert_eq!(back.version, 5);
+        assert_eq!(back.state, state);
+        assert!(back.mac_valid(&mac_key));
+        // Wrong key fails the MAC.
+        assert!(!back.mac_valid(&[4u8; 32]));
+    }
+
+    #[test]
+    fn tampering_any_field_breaks_the_mac() {
+        let mac_key = [1u8; 32];
+        let state = CoveredState {
+            carveout_present: true,
+            jwt_fp: [0u8; 16],
+            acl_root: [0u8; 32],
+            counters: [0u8; 32],
+        };
+        let m = Manifest::sealed(&mac_key, 1, state);
+        let mut bytes = m.to_bytes();
+        bytes[8] ^= 1; // flip carveout_present
+        let tampered = Manifest::from_bytes(&bytes).expect("decodes");
+        assert!(!tampered.mac_valid(&mac_key));
+    }
+
+    // NOTE: these tests drive the global-free `verify_or_baseline` (and direct
+    // sealer methods) rather than `boot_verify_and_install`, so they never set
+    // the process-global SEALER — keeping `reseal_if_active_is_noop` valid
+    // regardless of test order.
+
+    #[tokio::test]
+    async fn baseline_refused_without_allow_anchor_init() {
+        let ks = open();
+        let err = sealer(&ks, [2u8; 32])
+            .verify_or_baseline(false)
+            .await
+            .expect_err("missing manifest + flag false must fail closed");
+        assert!(format!("{err:?}").contains("allow_anchor_init"), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn baseline_then_verify_roundtrips() {
+        let ks = open();
+        let mac_key = [5u8; 32];
+        // Seed some covered state across keyspaces.
+        ks.keys
+            .insert_raw(CARVEOUT_KEY, b"closed".to_vec())
+            .await
+            .unwrap();
+        crate::store::counter::allocate_u32(&ks.keys, "path_counter:m/26'/0'")
+            .await
+            .unwrap();
+        crate::store::counter::allocate_u32(&ks.contexts, "ctx_counter")
+            .await
+            .unwrap();
+        let s = sealer(&ks, mac_key);
+
+        // First boot establishes the baseline.
+        assert_eq!(
+            s.verify_or_baseline(true).await.unwrap(),
+            BootOutcome::Baselined
+        );
+        // A second boot against the unchanged store verifies cleanly.
+        assert_eq!(
+            s.verify_or_baseline(false).await.unwrap(),
+            BootOutcome::Verified
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_a_covered_row_is_detected_at_boot() {
+        let ks = open();
+        let mac_key = [6u8; 32];
+        let s = sealer(&ks, mac_key);
+
+        // Baseline with the carve-out sentinel present.
+        ks.keys
+            .insert_raw(CARVEOUT_KEY, b"closed".to_vec())
+            .await
+            .unwrap();
+        s.verify_or_baseline(true).await.unwrap();
+
+        // Parent deletes the sentinel (reopen the carve-out) while down.
+        ks.keys.remove(CARVEOUT_KEY).await.unwrap();
+
+        let err = s
+            .verify_or_baseline(false)
+            .await
+            .expect_err("deletion must be detected");
+        assert!(format!("{err:?}").contains("carve-out"), "{err:?}");
+        assert!(format!("{err:?}").contains("mismatch"), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn forged_manifest_fails_mac_at_boot() {
+        let ks = open();
+        let mac_key = [8u8; 32];
+        let s = sealer(&ks, mac_key);
+        s.verify_or_baseline(true).await.unwrap();
+
+        // Parent overwrites the manifest with a self-consistent one under a
+        // DIFFERENT key (it can't forge our MAC key).
+        let forged = Manifest::sealed(
+            &[0xFFu8; 32],
+            99,
+            CoveredState {
+                carveout_present: false,
+                jwt_fp: [0u8; 16],
+                acl_root: [0u8; 32],
+                counters: [0u8; 32],
+            },
+        );
+        ks.bootstrap
+            .insert_raw(MANIFEST_KEY, forged.to_bytes())
+            .await
+            .unwrap();
+
+        let err = s
+            .verify_or_baseline(false)
+            .await
+            .expect_err("forged manifest must fail the MAC");
+        assert!(
+            format!("{err:?}").contains("MAC verification failed"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn acl_change_reflected_after_reseal() {
+        // A legitimate ACL change followed by a reseal must verify on the next
+        // boot (i.e. reseal keeps the manifest in step with covered mutations).
+        let ks = open();
+        let mac_key = [10u8; 32];
+        let s = sealer(&ks, mac_key);
+        s.verify_or_baseline(true).await.unwrap();
+
+        // Legitimate ACL write + reseal (simulating the chokepoint).
+        ks.acl
+            .insert_raw("acl:did:key:zAlice", b"{}".to_vec())
+            .await
+            .unwrap();
+        let next = s
+            .load_manifest()
+            .await
+            .unwrap()
+            .map(|m| m.version + 1)
+            .unwrap();
+        let state = s.compute_state().await.unwrap();
+        s.write_manifest(&Manifest::sealed(&mac_key, next, state))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.verify_or_baseline(false).await.unwrap(),
+            BootOutcome::Verified,
+            "post-reseal state must verify"
+        );
+    }
+
+    #[tokio::test]
+    async fn reseal_if_active_is_noop_without_installed_sealer() {
+        // No sealer installed (non-TEE) → reseal is a cheap no-op, never errors.
+        reseal_if_active().await.expect("no-op when not installed");
+    }
+}

--- a/vti-common/src/lib.rs
+++ b/vti-common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod context_path;
 pub mod error;
 pub mod idempotency;
 pub mod identifier;
+pub mod integrity;
 pub mod pagination;
 pub mod seed_store;
 #[cfg(feature = "setup")]

--- a/vti-common/src/store/counter.rs
+++ b/vti-common/src/store/counter.rs
@@ -52,6 +52,10 @@ pub async fn allocate_u32(ks: &KeyspaceHandle, counter_key: &str) -> Result<u32,
     ks.insert_raw(counter_key, (current + 1).to_le_bytes().to_vec())
         .await?;
     ks.persist().await?;
+    // Re-seal the TEE integrity manifest so the counter bump is reflected in the
+    // sealed snapshot — a rolled-back counter forces BIP-32 key reuse (P0.2a).
+    // No-op unless running in a TEE.
+    crate::integrity::reseal_if_active().await?;
     Ok(current)
 }
 

--- a/vti-common/tests/integrity_e2e.rs
+++ b/vti-common/tests/integrity_e2e.rs
@@ -1,0 +1,101 @@
+//! End-to-end test for the TEE integrity manifest (P0.2a).
+//!
+//! Unit tests in `integrity::tests` exercise the global-free `verify_or_baseline`
+//! path. This file drives the **real** public API — `boot_verify_and_install`
+//! (which installs the process-global sealer) and the covered-mutation
+//! chokepoints (`store_acl_entry`, `counter::allocate_u32`) that call
+//! `reseal_if_active`. It must live in its own integration-test binary because
+//! it permanently installs the process-global sealer; co-locating it with the
+//! unit tests would pollute their shared process.
+//!
+//! Flow: baseline → mutate through a chokepoint (auto-reseals) → re-verify
+//! (clean) → tamper out-of-band (bypassing the chokepoint) → re-verify (fails
+//! closed).
+
+use vti_common::acl::{AclEntry, Role, delete_acl_entry, store_acl_entry};
+use vti_common::config::StoreConfig;
+use vti_common::integrity::{BootOutcome, boot_verify_and_install, derive_mac_key};
+use vti_common::store::{KeyspaceHandle, Store, counter};
+
+struct Env {
+    keys: KeyspaceHandle,
+    bootstrap: KeyspaceHandle,
+    acl: KeyspaceHandle,
+    contexts: KeyspaceHandle,
+    mac_key: [u8; 32],
+    _dir: tempfile::TempDir,
+}
+
+fn open() -> Env {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .unwrap();
+    Env {
+        keys: store.keyspace("keys").unwrap(),
+        bootstrap: store.keyspace("bootstrap").unwrap(),
+        acl: store.keyspace("acl").unwrap(),
+        contexts: store.keyspace("contexts").unwrap(),
+        mac_key: derive_mac_key(&[0x5Au8; 32]),
+        _dir: dir,
+    }
+}
+
+async fn boot(env: &Env, allow_init: bool) -> Result<BootOutcome, vti_common::error::AppError> {
+    boot_verify_and_install(
+        env.mac_key,
+        env.keys.clone(),
+        env.bootstrap.clone(),
+        env.acl.clone(),
+        env.contexts.clone(),
+        allow_init,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn install_chokepoint_reseal_then_reverify_then_tamper() {
+    let env = open();
+
+    // Seed some pre-existing covered state, then baseline on first boot.
+    env.keys
+        .insert_raw("tee:bootstrap-carveout-closed", b"closed".to_vec())
+        .await
+        .unwrap();
+    counter::allocate_u32(&env.keys, "path_counter:m/26'/0'")
+        .await
+        .unwrap();
+    assert_eq!(boot(&env, true).await.unwrap(), BootOutcome::Baselined);
+
+    // The sealer is now installed (this process). A legitimate ACL grant flows
+    // through the chokepoint, which auto-reseals the manifest...
+    let alice = AclEntry::new("did:key:zAlice", Role::Admin, "test");
+    store_acl_entry(&env.acl, &alice).await.unwrap();
+    // ...and a counter allocation likewise.
+    counter::allocate_u32(&env.contexts, "ctx_counter")
+        .await
+        .unwrap();
+
+    // A re-boot against the (chokepoint-resealed) state verifies cleanly: the
+    // manifest tracked the mutations, so no false-positive fail-closed.
+    assert_eq!(boot(&env, false).await.unwrap(), BootOutcome::Verified);
+
+    // Now the parent tampers OUT OF BAND — deletes the ACL row directly,
+    // bypassing the chokepoint (simulating an offline store edit). The next
+    // boot must fail closed.
+    env.acl.remove("acl:did:key:zAlice").await.unwrap();
+    let err = boot(&env, false)
+        .await
+        .expect_err("out-of-band ACL deletion must be detected at boot");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("mismatch"), "{msg}");
+    assert!(msg.contains("ACL root"), "{msg}");
+
+    // Re-sealing through the chokepoint (a legitimate revoke would do this)
+    // re-establishes consistency, and the next boot is clean again.
+    delete_acl_entry(&env.acl, "did:key:zMissing")
+        .await
+        .unwrap(); // any chokepoint write reseals
+    assert_eq!(boot(&env, false).await.unwrap(), BootOutcome::Verified);
+}


### PR DESCRIPTION
**Layer 0** of the enclave anti-rollback anchor (design note `docs/05-design-notes/tee-anti-rollback-anchor.md`; §9 decisions in #377). TEE-only.

## Why
In the Nitro model the untrusted parent owns the on-disk fjall DB. KMS gives confidentiality and P0.1 AAD gives location-integrity, but **neither gives freshness** — a covered row deleted, or the store replayed to an inconsistent past snapshot, is undetected. This pins the security-critical singletons into a MAC'd manifest and **fails closed** at boot when the live store diverges.

> Layer 0 does **not** catch a fully-consistent rollback (manifest + all covered rows restored together) — that needs the external monotonic counter (P0.2b). This slice catches **deletion and inconsistent tamper**, and ships value on its own.

## What

**`vti_common::integrity`** (new):
- A 121-byte manifest `{ version, carveout_present, jwt_fp, acl_root, counters, mac }` over the four covered singletons (carve-out sentinel, ACL root, JWT fingerprint, path/context counters — design §5.1). `mac = HMAC-SHA256(HKDF(storage_key), canonical fields)`, stored in the `bootstrap` keyspace. Reads go through encrypted handles, so the manifest hashes **plaintext** content (nonce-independent).
- `boot_verify_and_install`: verify MAC + recompute-and-compare; fail closed on MAC failure (forged) or state mismatch (deleted row / inconsistent snapshot). A missing manifest is **refused** unless `tee.kms.allow_anchor_init` is set for a one-shot baseline (mirrors `allow_fingerprint_init`) — a silent baseline would accept a rolled-back store.
- A process-global `OnceLock` sealer, set **only at TEE boot**, consulted by `reseal_if_active`. Outside a TEE it's never installed → the chokepoints are a true **no-op** (zero behaviour change for the local VTA, no feature flag).

**Runtime sync via chokepoints, not ~29 call sites:** the ACL helpers (`store_acl_entry`/`delete_acl_entry`/`update_acl_entry_versioned`) and `counter::allocate_u32` — all in vti-common — reseal after every covered mutation; `mint_mode_b` (carve-out close) and backup `apply_import` (raw-insert restore) reseal explicitly.

**vta-service wiring:** `server::run` runs the boot check when a KMS storage key is present (TEE-only); new `tee.kms.allow_anchor_init` config; a **drift-guard test** pins the duplicated key strings to the vta-service constants. Also fixes a pre-existing P0.7b tee-only test literal missing `seed_enc` (P0.7b CI ran tee *clippy* but not tee *tests*).

## Tests
manifest byte/MAC round-trip + tamper; baseline-refused-without-flag; baseline→verify; deletion + forgery detected at boot; **end-to-end** install → chokepoint reseal → reverify → out-of-band tamper → fail-closed → recover.

## Gate
- `cargo fmt` + `clippy` (default & `tee`) clean.
- `vti-common` 234 + e2e, `vta-service` **714** (default) / **745** (tee) green; `vta-enclave` checks.
- No version bump (additive).

Plan ref: `tasks/vta-architecture-plan.md` P0.2; design note §5/§7 (P0.2a)