### PR TITLE
fix(vtc-service): fail closed when a secret backend is configured but not compiled (P0.8)

### DIFF
--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -423,7 +423,14 @@ pub struct ServerConfig {
     pub trust_xff: bool,
 }
 
+// `deny_unknown_fields` so a typo'd backend selector (`aws_secretname`,
+// `gcp_secrets_name`, …) is a loud parse error rather than a silently-dropped
+// key that lets the factory fall through to the keyring/plaintext default
+// (P0.8). Safe here — `SecretsConfig` carries no serde aliases; the
+// alias-bearing fields live on the parent `AppConfig`, which is intentionally
+// left lenient until the alias audit in the plan.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SecretsConfig {
     /// Hex-encoded VTC key material (config-secret feature)
     pub secret: Option<String>,
@@ -854,6 +861,38 @@ mod tests {
         // doesn't collide with a VTA running on the same host.
         let empty: AppConfig = toml::from_str("").unwrap();
         assert_eq!(empty.secrets.keyring_service, "vtc");
+    }
+
+    #[test]
+    fn secrets_unknown_key_is_a_named_parse_error() {
+        // P0.8: a typo'd backend selector must be a loud parse error, not a
+        // silently-dropped key that lets the factory fall through to the
+        // default backend with an empty store.
+        let toml_src = r#"
+            [secrets]
+            aws_secretname = "prod/vtc"
+        "#;
+        let err = toml::from_str::<AppConfig>(toml_src)
+            .expect_err("unknown [secrets] key must not parse");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("aws_secretname"),
+            "error must name the offending key: {msg}"
+        );
+    }
+
+    #[test]
+    fn secrets_known_keys_still_parse() {
+        // deny_unknown_fields must not reject the legitimate fields.
+        let toml_src = r#"
+            [secrets]
+            keyring_service = "vtc-test"
+            aws_secret_name = "prod/vtc"
+            aws_region = "us-east-1"
+        "#;
+        let config: AppConfig = toml::from_str(toml_src).expect("known keys parse");
+        assert_eq!(config.secrets.keyring_service, "vtc-test");
+        assert_eq!(config.secrets.aws_secret_name.as_deref(), Some("prod/vtc"));
     }
 
     #[test]

--- a/vtc-service/src/keys/seed_store/mod.rs
+++ b/vtc-service/src/keys/seed_store/mod.rs
@@ -40,6 +40,12 @@ pub use vti_common::seed_store::SeedStore as SecretStore;
 /// 6. Plaintext file (always available — NOT secure)
 #[allow(unused_variables)]
 pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, AppError> {
+    // For every cloud/config backend, a set selector field on a binary that
+    // wasn't compiled with the matching feature is a hard error — never a
+    // silent fall-through to the keyring/plaintext default. Pre-P0.8 the arm
+    // was simply `#[cfg]`'d away, so a production config pointing at AWS on a
+    // keyring-only binary booted with an empty store and a mere `warn!`
+    // (every auth/issue/install call then 503s). Fail closed instead.
     #[cfg(feature = "aws-secrets")]
     if config.secrets.aws_secret_name.is_some() {
         let store = AwsSecretStore::new(
@@ -47,6 +53,14 @@ pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, A
             config.secrets.aws_region.clone(),
         );
         return Ok(Box::new(store));
+    }
+    #[cfg(not(feature = "aws-secrets"))]
+    if config.secrets.aws_secret_name.is_some() {
+        return Err(AppError::Config(
+            "secrets.aws_secret_name is set but this binary was built without the \
+             'aws-secrets' feature"
+                .into(),
+        ));
     }
 
     #[cfg(feature = "gcp-secrets")]
@@ -58,6 +72,14 @@ pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, A
         })?;
         let store = GcpSecretStore::new(project, config.secrets.gcp_secret_name.clone().unwrap());
         return Ok(Box::new(store));
+    }
+    #[cfg(not(feature = "gcp-secrets"))]
+    if config.secrets.gcp_secret_name.is_some() {
+        return Err(AppError::Config(
+            "secrets.gcp_secret_name is set but this binary was built without the \
+             'gcp-secrets' feature"
+                .into(),
+        ));
     }
 
     #[cfg(feature = "azure-secrets")]
@@ -71,11 +93,27 @@ pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, A
         let store = AzureSecretStore::new(vault_url, secret_name);
         return Ok(Box::new(store));
     }
+    #[cfg(not(feature = "azure-secrets"))]
+    if config.secrets.azure_vault_url.is_some() {
+        return Err(AppError::Config(
+            "secrets.azure_vault_url is set but this binary was built without the \
+             'azure-secrets' feature"
+                .into(),
+        ));
+    }
 
     #[cfg(feature = "config-secret")]
     if config.secrets.secret.is_some() {
         let store = ConfigSecretStore::new(config.secrets.secret.clone().unwrap());
         return Ok(Box::new(store));
+    }
+    #[cfg(not(feature = "config-secret"))]
+    if config.secrets.secret.is_some() {
+        return Err(AppError::Config(
+            "secrets.secret is set but this binary was built without the \
+             'config-secret' feature"
+                .into(),
+        ));
     }
 
     #[cfg(feature = "keyring")]
@@ -91,5 +129,71 @@ pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, A
         );
         let store = PlaintextSecretStore::new(&config.store.data_dir);
         Ok(Box::new(store))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_config() -> AppConfig {
+        // Every `AppConfig` field is optional or has a serde default, so an
+        // empty document yields an all-default config we can poke at.
+        toml::from_str("").expect("empty config parses")
+    }
+
+    // The default test build compiles only `keyring` (see Cargo.toml
+    // `default`), so the cloud/config backends are all "not compiled" here —
+    // exactly the set-but-uncompiled case P0.8 must fail closed on.
+
+    // `Box<dyn SecretStore>` is not `Debug`, so `expect_err` won't compile;
+    // pattern-match the result instead.
+    fn assert_config_err_mentions(config: &AppConfig, needle: &str) {
+        match create_secret_store(config) {
+            Err(AppError::Config(msg)) => {
+                assert!(
+                    msg.contains(needle),
+                    "error should mention {needle:?}: {msg}"
+                )
+            }
+            Err(other) => panic!("expected Config error, got {other:?}"),
+            Ok(_) => panic!("expected a Config error, got a store (did the feature leak on?)"),
+        }
+    }
+
+    #[test]
+    fn aws_set_without_feature_is_config_error() {
+        let mut config = base_config();
+        config.secrets.aws_secret_name = Some("prod/vtc-secret".into());
+        assert_config_err_mentions(&config, "aws-secrets");
+    }
+
+    #[test]
+    fn gcp_set_without_feature_is_config_error() {
+        let mut config = base_config();
+        config.secrets.gcp_secret_name = Some("vtc-secret".into());
+        assert_config_err_mentions(&config, "gcp-secrets");
+    }
+
+    #[test]
+    fn azure_set_without_feature_is_config_error() {
+        let mut config = base_config();
+        config.secrets.azure_vault_url = Some("https://v.vault.azure.net".into());
+        assert_config_err_mentions(&config, "azure-secrets");
+    }
+
+    #[test]
+    fn config_secret_set_without_feature_is_config_error() {
+        let mut config = base_config();
+        config.secrets.secret = Some("ab".repeat(32));
+        assert_config_err_mentions(&config, "config-secret");
+    }
+
+    #[test]
+    fn no_backend_set_falls_through_to_the_default() {
+        // No selector field set → the compiled default (keyring) is chosen,
+        // not an error. Guards must only fire when a backend is *requested*.
+        let config = base_config();
+        assert!(create_secret_store(&config).is_ok());
     }
 }


### PR DESCRIPTION
## P0.8 — Secret-store factory silently falls back when the backend isn't compiled; typo'd keys ignored

### Problem
Each backend arm in `create_secret_store` (`keys/seed_store/mod.rs`) was `#[cfg(feature)]`-gated with **no `else`**. A config that set `secrets.aws_secret_name` on a binary built without `aws-secrets` compiled that arm away and silently selected the keyring (or plaintext) → empty store → boot proceeded with `"no key material found"` as a mere `warn!`, while monitoring saw a healthy listener and every auth/issue/install call 503'd. `SecretsConfig` had no `deny_unknown_fields`, so `aws_secretname` (typo) was silently dropped → identical fallback.

### Fix
- **Hard-fail on set-but-uncompiled backend.** Added `#[cfg(not(feature))]` arms returning `AppError::Config` for every backend selector — `aws_secret_name` / `gcp_secret_name` / `azure_vault_url` / `secret`. A requested-but-unavailable backend is now a boot error, never a downgrade to the default store.
- **`deny_unknown_fields` on `SecretsConfig`.** A typo'd key under `[secrets]` is now a named parse error. Safe here — `SecretsConfig` has no serde aliases (the alias-bearing fields are on the parent `AppConfig`, intentionally left lenient until the plan's alias audit).

### Acceptance
- ✅ per-backend: field set + feature off → `Err(Config)` naming the feature.
- ✅ unknown key under `[secrets]` → parse error naming the key.

### Tests
5 factory tests (each backend → fail closed; no backend → falls through to default) + 2 config tests (unknown key rejected by name; known keys still parse). The default build compiles only `keyring`, so the cloud/config backends are genuinely "not compiled" under test. `cargo fmt --check` clean, no new clippy warnings, full lib suite **540 passed**.