### PR TITLE
feat(tee): external DynamoDB anti-rollback counter + CAS protocol (P0.2b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,6 +1148,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-dynamodb"
+version = "1.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715fd8729709daa491b2d4aeed33e576d76031c164ad34b65062ea585d97ad5e"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-kms"
 version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9877,6 +9902,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-lc-rs",
+ "aws-sdk-dynamodb",
  "aws-sdk-kms",
  "aws-sdk-secretsmanager",
  "axum",

--- a/docs/02-vta/tee-architecture.md
+++ b/docs/02-vta/tee-architecture.md
@@ -520,11 +520,15 @@ nitro-cli build-enclave --docker-uri vta-nitro --output-file vta.eif \
 
 ## Anti-rollback anchor (P0.2)
 
-> **Status:** design-approved (see
-> `docs/05-design-notes/tee-anti-rollback-anchor.md`), implementation in
-> progress (P0.2a–c). Provision the infrastructure below when deploying the
-> counter slice (P0.2b/c). The local manifest slice (P0.2a) needs **no**
-> external infrastructure. The whole feature is **TEE-only** — non-TEE VTAs are
+> **Status:** P0.2a (local MAC'd manifest) and P0.2b (external DynamoDB
+> counter) are **implemented**; P0.2c (the KMS-attestation-gated writer that
+> resists root-on-parent) is still to come. Provision the DynamoDB table +
+> instance-role IAM below to enable the counter (P0.2b); the **PCR-gated writer
+> key + the `vta-anchor-writer` deny** are only needed once P0.2c lands. Until
+> then the counter is written with the **instance role**, so it resists
+> storage/backup rollback but **not** a root-on-parent attacker (who shares
+> those credentials). The local manifest slice (P0.2a) needs **no** external
+> infrastructure. The whole feature is **TEE-only** — non-TEE VTAs are
 > unaffected and need none of this.
 
 ### Why it exists
@@ -664,13 +668,19 @@ Additions to `[tee.kms]`, all `Option`/defaulted so existing TEE and non-TEE
 configs are unaffected:
 
 ```toml
+[tee.kms]
+# One-shot baselines (mirror allow_fingerprint_init): establish the manifest
+# AND initialize the external counter on first boot / migration, then set false.
+allow_anchor_init = false
+# BREAK-GLASS: boot manifest-only when the counter is unreachable, or re-anchor
+# the counter to the local manifest when they diverge (incident recovery only).
+allow_unanchored  = false
+
+# Present this block to enable the external counter (P0.2b); omit it for
+# manifest-only (P0.2a). Region is reused from [tee.kms].region.
 [tee.kms.anchor]
 table_name        = "vta-rollback-anchor"        # DynamoDB single-item table
-writer_key_arn    = "arn:aws:kms:us-east-1:123456789012:key/anchor-writer-key"
-allow_anchor_init = false   # one-shot first-boot baseline (establish version 0); see below
-
-[tee.kms]
-allow_unanchored  = false   # BREAK-GLASS: boot without the anchor (incident recovery only)
+# writer_key_arn  = "arn:aws:kms:…:key/anchor-writer-key"   # P0.2c (not yet read)
 ```
 
 ### First boot, recovery, and break-glass

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -62,7 +62,31 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
     baseline→verify, deletion/forgery detected, e2e (install → chokepoint reseal
     → reverify → out-of-band tamper → fail-closed → recover). fmt + clippy
     (default & tee) clean; vti-common 234 + e2e, vta-service 714 (default) / 745
-    (tee) green; vta-enclave checks; no version bump (additive) — PR: ____
+    (tee) green; vta-enclave checks; no version bump (additive) — PR: #380 (merged)
+  - `[x]` **P0.2b** (M) External DynamoDB counter + CAS commit protocol —
+    branch `fix/p0.2b-external-counter` (worktree). Pins the manifest version to
+    an AWS-managed linearizable counter the parent can proxy but not forge,
+    upgrading detection from deletion/inconsistency (P0.2a) to **consistent
+    storage rollback**. New `vti_common::integrity::AnchorCounter` trait
+    (read/init/CAS-set) keeps the AWS SDK out of the foundation crate; concrete
+    `DynamoAnchorCounter` (vta-service, conditional `UpdateItem` CAS) injected at
+    boot. Boot version-compare (M<ext → local rolled back; M>ext → counter
+    rolled back / torn; M==ext → proceed) on top of the P0.2a MAC+recompute.
+    Reseal is **external-first** (§5.4): CAS-bump the counter *before* the local
+    manifest write, so a crash leaves M<ext (fail-closed safe direction). Bumps
+    on **every** covered mutation (operator decision) — each one is a synchronous
+    DynamoDB round-trip that fails closed if unreachable. `allow_unanchored`
+    break-glass: boot manifest-only when the counter is unreachable, or
+    re-anchor it to the MAC-trusted local manifest on divergence; `allow_anchor_init`
+    also initializes the counter (first boot / migration from a manifest-only
+    P0.2a VTA). Config: `[tee.kms.anchor] table_name`, `[tee.kms] allow_unanchored`.
+    Operator runbook + status updated (`docs/02-vta/tee-architecture.md`).
+    **Scope: instance-role creds → resists storage/backup rollback, NOT
+    root-on-parent (P0.2c).** Tests: anchor protocol via in-memory CAS mock
+    (init+bump, M<ext / M>ext detection, allow_unanchored re-anchor, unreachable
+    fail-closed-vs-unanchored) + anchored e2e (chokepoints CAS-bump the counter).
+    New dep `aws-sdk-dynamodb` (tee feature). fmt + clippy (default & tee) clean;
+    vti-common 239 + e2e, vta-service 745 (tee) green; vta-enclave checks — PR: ____
 - `[x]` **P0.3** (S) `create_key`/`import_key`: existence check + identifier
   validation (closes `#key-0` overwrite) — branch `fix/p0.3-key-overwrite`.
   Scope grew during root-cause analysis: the store's multi-op "atomic"

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -44,6 +44,7 @@ tee = [
   "webvh",
   "dep:libc",
   "dep:aws-sdk-kms",
+  "dep:aws-sdk-dynamodb",
   "dep:aws-config",
   "dep:aws-lc-rs",
   "dep:didwebvh-rs",
@@ -209,6 +210,9 @@ aes-gcm = { workspace = true }
 argon2 = "0.5"
 hmac = "0.13"
 aws-sdk-kms = { version = "1", optional = true }
+# Single-item monotonic counter for the P0.2b anti-rollback anchor (CAS via
+# conditional UpdateItem). Same release train as aws-sdk-kms / aws-config.
+aws-sdk-dynamodb = { version = "1", optional = true }
 # RSA-OAEP for KMS CiphertextForRecipient unwrap. aws-lc-rs is AWS's own
 # BoringSSL-based crypto lib; constant-time operations, already transitive
 # via aws-sdk-* so no new build-time cost. Replaces the RustCrypto `rsa`

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -424,6 +424,36 @@ pub struct TeeKmsConfig {
     /// Mirrors [`Self::allow_fingerprint_init`].
     #[serde(default)]
     pub allow_anchor_init: bool,
+    /// External anti-rollback counter (P0.2b). When set, the integrity manifest
+    /// version is pinned to a DynamoDB single-item counter the parent can't roll
+    /// back, upgrading detection from "deletion / inconsistent tamper" (P0.2a)
+    /// to "consistent storage rollback". Absent → manifest-only (P0.2a).
+    #[serde(default)]
+    pub anchor: Option<TeeAnchorConfig>,
+    /// Break-glass: boot even when the external anchor counter can't be reached
+    /// or disagrees with the local manifest (P0.2b).
+    ///
+    /// **Default: false.** If the parent denies egress to the counter the
+    /// enclave fails closed (a DoS, not an integrity breach). Setting this true
+    /// lets it boot manifest-only when the counter is unreachable, or re-anchor
+    /// the counter to the MAC-trusted local manifest when they diverge — for
+    /// incident recovery only. Safe to expose as config because TEE config is
+    /// baked into the measured EIF, so the parent can't flip it at runtime.
+    #[serde(default)]
+    pub allow_unanchored: bool,
+}
+
+/// External anti-rollback anchor configuration (P0.2b — DynamoDB counter).
+#[cfg(feature = "tee")]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TeeAnchorConfig {
+    /// DynamoDB table holding the single-item monotonic version counter (one
+    /// item per VTA DID). The region is reused from [`TeeKmsConfig::region`].
+    pub table_name: String,
+    // NOTE: `writer_key_arn` (the KMS-attestation-gated writer credential that
+    // resists root-on-parent) lands in P0.2c. In P0.2b the counter is written
+    // with the instance-role credentials, so it resists storage/backup rollback
+    // but NOT a root-on-parent attacker who shares those credentials.
 }
 
 // KMS ciphertexts (seed, JWT key, fingerprint) are stored as K/V entries

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -451,13 +451,12 @@ pub async fn run(
         }
     }
 
-    // TEE anti-rollback anchor — Layer 0 (P0.2a). Verify the MAC'd integrity
-    // manifest against the live store and install the runtime sealer, so a
-    // covered singleton deleted or replayed to an inconsistent snapshot while
-    // the enclave was down is caught here and the VTA fails closed. Gated on a
-    // KMS storage key (i.e. a real TEE); a `None` key is the non-TEE path and
-    // has no untrusted-parent threat. Unlike the reconcile above this is
-    // security-critical, so a failure aborts the boot.
+    // TEE anti-rollback anchor (P0.2). Verify the MAC'd integrity manifest
+    // (Layer 0, P0.2a) plus the external monotonic counter (P0.2b) against the
+    // live store, install the runtime sealer, and fail closed on a covered
+    // singleton deleted / replayed / rolled back. Gated on a KMS storage key
+    // (i.e. a real TEE); a `None` key is the non-TEE path with no
+    // untrusted-parent threat. Security-critical, so a failure aborts the boot.
     #[cfg(feature = "tee")]
     if let Some(storage_key) = storage_encryption_key
         && let Some(kms) = config.tee.kms.as_ref()
@@ -465,16 +464,40 @@ pub async fn run(
         let enc = |name: &str| -> Result<KeyspaceHandle, AppError> {
             Ok(store.keyspace(name)?.with_encryption(storage_key))
         };
+        // Build the external counter when configured. It is keyed by the VTA
+        // DID; without an identity there is nothing to key on, so fall back to
+        // manifest-only (P0.2a) with a warning.
+        let anchor: Option<Arc<dyn vti_common::integrity::AnchorCounter>> =
+            match (kms.anchor.as_ref(), config.vta_did.as_ref()) {
+                (Some(anchor_cfg), Some(vta_did)) => Some(Arc::new(
+                    crate::tee::anchor::DynamoAnchorCounter::new(
+                        &kms.region,
+                        anchor_cfg.table_name.clone(),
+                        vta_did.clone(),
+                    )
+                    .await,
+                )),
+                (Some(_), None) => {
+                    warn!(
+                        "tee.kms.anchor is configured but vta_did is unset — booting \
+                         manifest-only (P0.2a); the external rollback counter is disabled"
+                    );
+                    None
+                }
+                (None, _) => None,
+            };
         let outcome = vti_common::integrity::boot_verify_and_install(
             vti_common::integrity::derive_mac_key(&storage_key),
             enc("keys")?,
             store.keyspace("bootstrap")?, // unencrypted, KMS-protected
             enc("acl")?,
             enc("contexts")?,
+            anchor,
             kms.allow_anchor_init,
+            kms.allow_unanchored,
         )
         .await?;
-        info!(?outcome, "TEE integrity manifest checked");
+        info!(?outcome, "TEE anti-rollback anchor checked");
     }
 
     // Determine which services will actually start (feature flag AND

--- a/vta-service/src/tee/anchor.rs
+++ b/vta-service/src/tee/anchor.rs
@@ -1,0 +1,163 @@
+//! DynamoDB-backed external anti-rollback counter (P0.2b).
+//!
+//! Implements [`vti_common::integrity::AnchorCounter`] over a single-item
+//! DynamoDB table — one item per VTA DID holding a monotonic `version`. The
+//! atomic compare-and-set is a conditional `UpdateItem`
+//! (`ConditionExpression: version = :expected`), which is the §5.4
+//! linearization point: a concurrent replica or a torn write fails the
+//! condition rather than silently clobbering the counter.
+//!
+//! The parent EC2 host proxies the (TLS-protected) bytes but can neither read
+//! nor forge the responses. **P0.2b scope:** the counter is written with the
+//! enclave's *instance-role* credentials, which a root-on-parent attacker
+//! shares — so this resists storage/backup rollback but not a compromised
+//! parent OS. The KMS-attestation-gated writer that closes that gap is P0.2c.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::types::AttributeValue;
+
+use vti_common::error::AppError;
+use vti_common::integrity::AnchorCounter;
+
+const PARTITION_KEY: &str = "vta_did";
+const VERSION_ATTR: &str = "version";
+const DIGEST_ATTR: &str = "digest";
+const UPDATED_AT_ATTR: &str = "updated_at";
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// External anchor counter backed by a single DynamoDB item keyed by VTA DID.
+pub struct DynamoAnchorCounter {
+    client: Client,
+    table: String,
+    vta_did: String,
+}
+
+impl DynamoAnchorCounter {
+    /// Build a client for `region` and bind it to `table` + `vta_did` (the
+    /// partition key). Uses the default credential chain — in a Nitro enclave
+    /// that resolves to the instance role via the parent's IMDS proxy.
+    pub async fn new(region: &str, table: String, vta_did: String) -> Self {
+        let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new(region.to_string()))
+            .load()
+            .await;
+        Self {
+            client: Client::new(&sdk_config),
+            table,
+            vta_did,
+        }
+    }
+
+    fn pk(&self) -> AttributeValue {
+        AttributeValue::S(self.vta_did.clone())
+    }
+}
+
+/// Parse a DynamoDB numeric attribute into a `u64`.
+fn parse_version(av: &AttributeValue) -> Result<u64, AppError> {
+    match av {
+        AttributeValue::N(n) => n
+            .parse::<u64>()
+            .map_err(|e| AppError::Internal(format!("anchor: non-numeric version '{n}': {e}"))),
+        _ => Err(AppError::Internal(
+            "anchor: version attribute is not a number".into(),
+        )),
+    }
+}
+
+impl AnchorCounter for DynamoAnchorCounter {
+    fn read(&self) -> BoxFuture<'_, Result<Option<u64>, AppError>> {
+        Box::pin(async move {
+            let resp = self
+                .client
+                .get_item()
+                .table_name(&self.table)
+                .key(PARTITION_KEY, self.pk())
+                .consistent_read(true) // must observe the latest committed bump
+                .send()
+                .await
+                .map_err(|e| {
+                    AppError::Internal(format!(
+                        "anchor get_item failed: {}",
+                        e.into_service_error()
+                    ))
+                })?;
+            match resp.item().and_then(|i| i.get(VERSION_ATTR)) {
+                Some(av) => Ok(Some(parse_version(av)?)),
+                None => Ok(None),
+            }
+        })
+    }
+
+    fn init(&self, version: u64, digest: [u8; 32]) -> BoxFuture<'_, Result<(), AppError>> {
+        Box::pin(async move {
+            self.client
+                .put_item()
+                .table_name(&self.table)
+                .item(PARTITION_KEY, self.pk())
+                .item(VERSION_ATTR, AttributeValue::N(version.to_string()))
+                .item(DIGEST_ATTR, AttributeValue::S(hex::encode(digest)))
+                .item(UPDATED_AT_ATTR, AttributeValue::S(now_rfc3339()))
+                // Create-if-absent: never overwrite an existing counter.
+                .condition_expression(format!("attribute_not_exists({PARTITION_KEY})"))
+                .send()
+                .await
+                .map_err(|e| {
+                    let svc = e.into_service_error();
+                    if svc.is_conditional_check_failed_exception() {
+                        AppError::Conflict("anchor counter already initialized".into())
+                    } else {
+                        AppError::Internal(format!("anchor put_item failed: {svc}"))
+                    }
+                })?;
+            Ok(())
+        })
+    }
+
+    fn set(
+        &self,
+        expected: u64,
+        new: u64,
+        digest: [u8; 32],
+    ) -> BoxFuture<'_, Result<(), AppError>> {
+        Box::pin(async move {
+            self.client
+                .update_item()
+                .table_name(&self.table)
+                .key(PARTITION_KEY, self.pk())
+                .update_expression(format!(
+                    "SET {VERSION_ATTR} = :new, {DIGEST_ATTR} = :d, {UPDATED_AT_ATTR} = :t"
+                ))
+                // The compare-and-set: only bump if the stored version is what
+                // the caller observed (§5.4 linearization point).
+                .condition_expression(format!("{VERSION_ATTR} = :expected"))
+                .expression_attribute_values(":new", AttributeValue::N(new.to_string()))
+                .expression_attribute_values(":expected", AttributeValue::N(expected.to_string()))
+                .expression_attribute_values(":d", AttributeValue::S(hex::encode(digest)))
+                .expression_attribute_values(":t", AttributeValue::S(now_rfc3339()))
+                .send()
+                .await
+                .map_err(|e| {
+                    let svc = e.into_service_error();
+                    if svc.is_conditional_check_failed_exception() {
+                        AppError::Conflict(format!(
+                            "anchor CAS failed: counter is not at expected v{expected} \
+                             (concurrent writer or rollback)"
+                        ))
+                    } else {
+                        AppError::Internal(format!("anchor update_item failed: {svc}"))
+                    }
+                })?;
+            Ok(())
+        })
+    }
+}
+
+/// RFC-3339 UTC timestamp for the `updated_at` bookkeeping attribute.
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}

--- a/vta-service/src/tee/mod.rs
+++ b/vta-service/src/tee/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin_bootstrap;
+pub mod anchor;
 mod detect;
 pub mod did_autogen;
 pub mod kms_bootstrap;

--- a/vti-common/src/integrity/mod.rs
+++ b/vti-common/src/integrity/mod.rs
@@ -31,7 +31,9 @@
 //! | ACL keyspace root | `acl` ▸ `acl:*` | replay → resurrect a revoked admin |
 //! | Path/context counters | `keys` ▸ `path_counter:*`, `contexts` ▸ `ctx_counter*` | rollback → BIP-32 key reuse |
 
-use std::sync::OnceLock;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
 
 use hkdf::Hkdf;
 use hmac::digest::KeyInit;
@@ -44,6 +46,31 @@ use crate::error::AppError;
 use crate::store::KeyspaceHandle;
 
 type HmacSha256 = Hmac<Sha256>;
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// The external monotonic anchor (P0.2b). An AWS-managed linearizable store
+/// (DynamoDB) holding one version counter per VTA DID, which the parent can
+/// proxy but not forge. The concrete implementation lives in the service crate
+/// (it needs the AWS SDK, which must not leak into this foundation crate); this
+/// trait is what the integrity layer depends on, and what the unit tests mock.
+///
+/// All three methods are single-item operations keyed by the VTA DID. `set`
+/// MUST be an atomic compare-and-set (DynamoDB `ConditionExpression
+/// version = :expected`) — that conditional is the §5.4 linearization point.
+pub trait AnchorCounter: Send + Sync {
+    /// Read the authoritative version, or `None` if the counter has never been
+    /// initialized (first boot / migration from a manifest-only P0.2a VTA).
+    fn read(&self) -> BoxFuture<'_, Result<Option<u64>, AppError>>;
+
+    /// Create the counter at `version` if it does not yet exist
+    /// (`attribute_not_exists` guard). Errors if it already exists.
+    fn init(&self, version: u64, digest: [u8; 32]) -> BoxFuture<'_, Result<(), AppError>>;
+
+    /// Atomic compare-and-set: move the counter from `expected` to `new`,
+    /// failing (`AppError::Conflict`) if the stored value is not `expected`.
+    fn set(&self, expected: u64, new: u64, digest: [u8; 32])
+    -> BoxFuture<'_, Result<(), AppError>>;
+}
 
 /// Carve-out sentinel key (lives in the `keys` keyspace). Must match
 /// `vta_service::tee::admin_bootstrap::BOOTSTRAP_CARVEOUT_CLOSED_KEY`; a
@@ -198,6 +225,10 @@ struct ManifestSealer {
     acl_ks: KeyspaceHandle,
     /// `ctx_counter*`
     contexts_ks: KeyspaceHandle,
+    /// External monotonic counter (P0.2b). `None` = manifest-only mode: either
+    /// no anchor is configured, or boot fell back to unanchored after the
+    /// counter was unreachable (`allow_unanchored`).
+    anchor: Option<Arc<dyn AnchorCounter>>,
 }
 
 impl ManifestSealer {
@@ -256,11 +287,36 @@ impl ManifestSealer {
         Ok(())
     }
 
-    /// Boot check core (no global side effect, so it is unit-testable). See
-    /// [`boot_verify_and_install`] for semantics.
-    async fn verify_or_baseline(&self, allow_anchor_init: bool) -> Result<BootOutcome, AppError> {
+    /// Recompute the covered state, advance the version, and persist —
+    /// external-first (§5.4). No global side effect, so it is unit-testable.
+    async fn reseal(&self) -> Result<(), AppError> {
+        let cur_version = self.load_manifest().await?.map(|m| m.version);
+        let next_version = cur_version.map(|v| v + 1).unwrap_or(0);
+        let state = self.compute_state().await?;
+        let manifest = Manifest::sealed(&self.mac_key, next_version, state);
+
+        // Advance the counter before committing the local manifest, so a crash
+        // leaves manifest_version < counter (fail-closed safe direction).
+        if let Some(anchor) = &self.anchor {
+            match cur_version {
+                Some(expected) => anchor.set(expected, next_version, manifest.mac).await?,
+                None => anchor.init(next_version, manifest.mac).await?,
+            }
+        }
+        self.write_manifest(&manifest).await
+    }
+
+    /// Boot check core (no global side effect, so it is unit-testable). Returns
+    /// the outcome and whether the installed sealer should drop the anchor
+    /// (unanchored fallback). See [`boot_verify_and_install`] for semantics.
+    async fn verify_or_baseline(
+        &self,
+        allow_anchor_init: bool,
+        allow_unanchored: bool,
+    ) -> Result<(BootOutcome, bool), AppError> {
+        // ── Layer 0: the local MAC'd manifest (P0.2a) ───────────────────────
         let current = self.compute_state().await?;
-        match self.load_manifest().await? {
+        let (manifest, baselined) = match self.load_manifest().await? {
             None => {
                 if !allow_anchor_init {
                     return Err(AppError::Internal(
@@ -272,13 +328,13 @@ impl ManifestSealer {
                             .into(),
                     ));
                 }
-                self.write_manifest(&Manifest::sealed(&self.mac_key, 0, current))
-                    .await?;
+                let m = Manifest::sealed(&self.mac_key, 0, current);
+                self.write_manifest(&m).await?;
                 warn!(
                     "TEE integrity manifest established (version 0) under allow_anchor_init — \
                      set tee.kms.allow_anchor_init = false now that the baseline exists"
                 );
-                Ok(BootOutcome::Baselined)
+                (m, true)
             }
             Some(stored) => {
                 if !stored.mac_valid(&self.mac_key) {
@@ -297,7 +353,81 @@ impl ManifestSealer {
                         describe_mismatch(&stored.state, &current),
                     )));
                 }
-                Ok(BootOutcome::Verified)
+                (stored, false)
+            }
+        };
+
+        // ── Layer 1: the external monotonic counter (P0.2b) ─────────────────
+        let Some(anchor) = &self.anchor else {
+            // No external counter configured → manifest-only (P0.2a behaviour).
+            return Ok((BootOutcome::manifest(baselined), false));
+        };
+        let m_version = manifest.version;
+        let digest = manifest.mac;
+
+        match anchor.read().await {
+            // Parent denies egress / transient AWS failure: we cannot verify
+            // freshness. Fail closed unless the operator opted into a
+            // (loudly-warned) unanchored boot — which then runs manifest-only.
+            Err(e) => {
+                if !allow_unanchored {
+                    return Err(AppError::Internal(format!(
+                        "external anchor counter is unreachable ({e}) — cannot verify rollback \
+                         freshness, refusing to start (P0.2b). This is a denial-of-service, not \
+                         an integrity breach; set tee.kms.allow_unanchored = true to boot \
+                         manifest-only for incident recovery."
+                    )));
+                }
+                warn!(
+                    error = %e,
+                    "external anchor counter unreachable — booting UNANCHORED (manifest-only, \
+                     P0.2a level) under allow_unanchored. Rollback protection is degraded until \
+                     the counter is reachable again."
+                );
+                Ok((BootOutcome::Unanchored, true))
+            }
+            // Counter absent: first boot, or migration from a manifest-only
+            // P0.2a VTA. Establish it under the same one-shot init flag.
+            Ok(None) => {
+                if !allow_anchor_init {
+                    return Err(AppError::Internal(
+                        "external anchor counter does not exist and allow_anchor_init is false — \
+                         refusing to start. Set tee.kms.allow_anchor_init = true for ONE boot to \
+                         initialize it (first boot, or migration from a manifest-only VTA)."
+                            .into(),
+                    ));
+                }
+                anchor.init(m_version, digest).await?;
+                warn!(version = m_version, "external anchor counter initialized");
+                Ok((BootOutcome::manifest(baselined), false))
+            }
+            Ok(Some(n_ext)) if n_ext == m_version => Ok((BootOutcome::manifest(baselined), false)),
+            // Version mismatch — a rollback (of the local store or the counter)
+            // or a torn commit. Fail closed; allow_unanchored re-anchors the
+            // counter to the MAC-trusted local manifest for recovery.
+            Ok(Some(n_ext)) => {
+                if !allow_unanchored {
+                    let cause = if m_version < n_ext {
+                        "the local store was rolled back to an older epoch"
+                    } else {
+                        "the external counter was rolled back, or a tightening op was torn \
+                         mid-commit"
+                    };
+                    return Err(AppError::Internal(format!(
+                        "external anchor version mismatch: manifest=v{m_version}, counter=v{n_ext} \
+                         — {cause}. Refusing to start (P0.2b). Restore a consistent backup whose \
+                         manifest matches the counter, or set tee.kms.allow_unanchored = true to \
+                         re-anchor the counter to the local manifest."
+                    )));
+                }
+                anchor.set(n_ext, m_version, digest).await?;
+                warn!(
+                    from = n_ext,
+                    to = m_version,
+                    "external anchor counter RE-ANCHORED to the local manifest under \
+                     allow_unanchored — set it back to false now that they agree"
+                );
+                Ok((BootOutcome::ReAnchored, false))
             }
         }
     }
@@ -310,34 +440,47 @@ static RESEAL_LOCK: Mutex<()> = Mutex::const_new(());
 
 /// Re-seal the manifest after a covered-singleton mutation. **No-op unless a
 /// sealer is installed** (i.e. always, outside a TEE). Recomputes the covered
-/// state from the live store, bumps the version, re-MACs, and persists.
+/// state, bumps the version, and persists — **external-first** (§5.4): the
+/// counter is advanced via CAS *before* the local manifest is written, so a
+/// crash leaves `manifest_version < counter` (the fail-closed safe direction),
+/// never a silently-rolled-back-but-self-consistent local state.
 ///
-/// Called from the covered mutation chokepoints. The cost (a few prefix scans +
-/// one HMAC) is paid only in TEE and only on tightening ops, which are
-/// infrequent.
+/// Called from the covered mutation chokepoints. With an external anchor this
+/// does a synchronous DynamoDB CAS per covered mutation; a CAS conflict or an
+/// unreachable counter fails the mutation (fail closed), which is the intended
+/// coupling.
 pub async fn reseal_if_active() -> Result<(), AppError> {
     let Some(sealer) = SEALER.get() else {
         return Ok(());
     };
     let _guard = RESEAL_LOCK.lock().await;
-    let next_version = sealer
-        .load_manifest()
-        .await?
-        .map(|m| m.version + 1)
-        .unwrap_or(0);
-    let state = sealer.compute_state().await?;
-    let manifest = Manifest::sealed(&sealer.mac_key, next_version, state);
-    sealer.write_manifest(&manifest).await
+    sealer.reseal().await
 }
 
 /// Outcome of the boot check, for logging.
 #[derive(Debug, PartialEq, Eq)]
 pub enum BootOutcome {
-    /// A valid manifest matched the live store.
+    /// A valid manifest matched the live store (and the counter, if any).
     Verified,
     /// No manifest existed; a baseline was established (first boot /
     /// `allow_anchor_init`).
     Baselined,
+    /// The external counter was re-anchored to the local manifest under
+    /// `allow_unanchored` (recovery from a divergence).
+    ReAnchored,
+    /// The external counter was unreachable; booted manifest-only under
+    /// `allow_unanchored` (degraded — no rollback freshness this session).
+    Unanchored,
+}
+
+impl BootOutcome {
+    fn manifest(baselined: bool) -> Self {
+        if baselined {
+            Self::Baselined
+        } else {
+            Self::Verified
+        }
+    }
 }
 
 /// Verify the integrity manifest against the live store and install the sealer
@@ -352,22 +495,33 @@ pub enum BootOutcome {
 ///   (a covered row deleted, or an inconsistent snapshot) **fails closed**.
 ///
 /// On success the sealer is installed so subsequent covered mutations reseal.
+#[allow(clippy::too_many_arguments)]
 pub async fn boot_verify_and_install(
     mac_key: [u8; 32],
     keys_ks: KeyspaceHandle,
     bootstrap_ks: KeyspaceHandle,
     acl_ks: KeyspaceHandle,
     contexts_ks: KeyspaceHandle,
+    anchor: Option<Arc<dyn AnchorCounter>>,
     allow_anchor_init: bool,
+    allow_unanchored: bool,
 ) -> Result<BootOutcome, AppError> {
-    let sealer = ManifestSealer {
+    let mut sealer = ManifestSealer {
         mac_key,
         keys_ks,
         bootstrap_ks,
         acl_ks,
         contexts_ks,
+        anchor,
     };
-    let outcome = sealer.verify_or_baseline(allow_anchor_init).await?;
+    let (outcome, drop_anchor) = sealer
+        .verify_or_baseline(allow_anchor_init, allow_unanchored)
+        .await?;
+    // Unanchored fallback: install without the anchor so this session's reseals
+    // stay manifest-only (they can't reach the counter anyway).
+    if drop_anchor {
+        sealer.anchor = None;
+    }
     // Install for runtime reseals (only fails if called twice — boot calls once).
     let _ = SEALER.set(sealer);
     Ok(outcome)
@@ -429,13 +583,111 @@ mod tests {
     }
 
     fn sealer(ks: &Ks, mac_key: [u8; 32]) -> ManifestSealer {
+        sealer_with(ks, mac_key, None)
+    }
+
+    fn sealer_with(
+        ks: &Ks,
+        mac_key: [u8; 32],
+        anchor: Option<Arc<dyn AnchorCounter>>,
+    ) -> ManifestSealer {
         ManifestSealer {
             mac_key,
             keys_ks: ks.keys.clone(),
             bootstrap_ks: ks.bootstrap.clone(),
             acl_ks: ks.acl.clone(),
             contexts_ks: ks.contexts.clone(),
+            anchor,
         }
+    }
+
+    /// In-memory `AnchorCounter` with real compare-and-set semantics; can also
+    /// simulate an unreachable counter (parent egress denied). All logic runs
+    /// synchronously under a std Mutex, returning a ready future.
+    struct MockCounter {
+        version: std::sync::Mutex<Option<u64>>,
+        unreachable: bool,
+    }
+    impl MockCounter {
+        fn empty() -> Arc<Self> {
+            Arc::new(Self {
+                version: std::sync::Mutex::new(None),
+                unreachable: false,
+            })
+        }
+        fn at(v: u64) -> Arc<Self> {
+            Arc::new(Self {
+                version: std::sync::Mutex::new(Some(v)),
+                unreachable: false,
+            })
+        }
+        fn unreachable() -> Arc<Self> {
+            Arc::new(Self {
+                version: std::sync::Mutex::new(None),
+                unreachable: true,
+            })
+        }
+        fn current(&self) -> Option<u64> {
+            *self.version.lock().unwrap()
+        }
+    }
+    impl AnchorCounter for MockCounter {
+        fn read(&self) -> BoxFuture<'_, Result<Option<u64>, AppError>> {
+            let r = if self.unreachable {
+                Err(AppError::Internal("egress denied".into()))
+            } else {
+                Ok(*self.version.lock().unwrap())
+            };
+            Box::pin(async move { r })
+        }
+        fn init(&self, version: u64, _digest: [u8; 32]) -> BoxFuture<'_, Result<(), AppError>> {
+            let r = if self.unreachable {
+                Err(AppError::Internal("egress denied".into()))
+            } else {
+                let mut g = self.version.lock().unwrap();
+                if g.is_some() {
+                    Err(AppError::Conflict("counter already exists".into()))
+                } else {
+                    *g = Some(version);
+                    Ok(())
+                }
+            };
+            Box::pin(async move { r })
+        }
+        fn set(
+            &self,
+            expected: u64,
+            new: u64,
+            _digest: [u8; 32],
+        ) -> BoxFuture<'_, Result<(), AppError>> {
+            let r = if self.unreachable {
+                Err(AppError::Internal("egress denied".into()))
+            } else {
+                let mut g = self.version.lock().unwrap();
+                if *g == Some(expected) {
+                    *g = Some(new);
+                    Ok(())
+                } else {
+                    Err(AppError::Conflict(format!(
+                        "CAS failed: expected {expected}, found {:?}",
+                        *g
+                    )))
+                }
+            };
+            Box::pin(async move { r })
+        }
+    }
+
+    /// Run the boot check and return just the outcome (dropping the
+    /// drop-anchor bool the installer uses).
+    async fn vob(
+        s: &ManifestSealer,
+        allow_init: bool,
+        allow_unanchored: bool,
+    ) -> Result<BootOutcome, AppError> {
+        s.verify_or_baseline(allow_init, allow_unanchored)
+            .await
+            .map(|(o, _)| o)
     }
 
     #[test]
@@ -482,8 +734,7 @@ mod tests {
     #[tokio::test]
     async fn baseline_refused_without_allow_anchor_init() {
         let ks = open();
-        let err = sealer(&ks, [2u8; 32])
-            .verify_or_baseline(false)
+        let err = vob(&sealer(&ks, [2u8; 32]), false, false)
             .await
             .expect_err("missing manifest + flag false must fail closed");
         assert!(format!("{err:?}").contains("allow_anchor_init"), "{err:?}");
@@ -507,15 +758,9 @@ mod tests {
         let s = sealer(&ks, mac_key);
 
         // First boot establishes the baseline.
-        assert_eq!(
-            s.verify_or_baseline(true).await.unwrap(),
-            BootOutcome::Baselined
-        );
+        assert_eq!(vob(&s, true, false).await.unwrap(), BootOutcome::Baselined);
         // A second boot against the unchanged store verifies cleanly.
-        assert_eq!(
-            s.verify_or_baseline(false).await.unwrap(),
-            BootOutcome::Verified
-        );
+        assert_eq!(vob(&s, false, false).await.unwrap(), BootOutcome::Verified);
     }
 
     #[tokio::test]
@@ -529,13 +774,12 @@ mod tests {
             .insert_raw(CARVEOUT_KEY, b"closed".to_vec())
             .await
             .unwrap();
-        s.verify_or_baseline(true).await.unwrap();
+        vob(&s, true, false).await.unwrap();
 
         // Parent deletes the sentinel (reopen the carve-out) while down.
         ks.keys.remove(CARVEOUT_KEY).await.unwrap();
 
-        let err = s
-            .verify_or_baseline(false)
+        let err = vob(&s, false, false)
             .await
             .expect_err("deletion must be detected");
         assert!(format!("{err:?}").contains("carve-out"), "{err:?}");
@@ -547,7 +791,7 @@ mod tests {
         let ks = open();
         let mac_key = [8u8; 32];
         let s = sealer(&ks, mac_key);
-        s.verify_or_baseline(true).await.unwrap();
+        vob(&s, true, false).await.unwrap();
 
         // Parent overwrites the manifest with a self-consistent one under a
         // DIFFERENT key (it can't forge our MAC key).
@@ -566,8 +810,7 @@ mod tests {
             .await
             .unwrap();
 
-        let err = s
-            .verify_or_baseline(false)
+        let err = vob(&s, false, false)
             .await
             .expect_err("forged manifest must fail the MAC");
         assert!(
@@ -583,7 +826,7 @@ mod tests {
         let ks = open();
         let mac_key = [10u8; 32];
         let s = sealer(&ks, mac_key);
-        s.verify_or_baseline(true).await.unwrap();
+        vob(&s, true, false).await.unwrap();
 
         // Legitimate ACL write + reseal (simulating the chokepoint).
         ks.acl
@@ -602,7 +845,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            s.verify_or_baseline(false).await.unwrap(),
+            vob(&s, false, false).await.unwrap(),
             BootOutcome::Verified,
             "post-reseal state must verify"
         );
@@ -612,5 +855,109 @@ mod tests {
     async fn reseal_if_active_is_noop_without_installed_sealer() {
         // No sealer installed (non-TEE) → reseal is a cheap no-op, never errors.
         reseal_if_active().await.expect("no-op when not installed");
+    }
+
+    // ── External anchor (P0.2b) ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn first_boot_initializes_counter_and_reseal_advances_it() {
+        let ks = open();
+        let counter = MockCounter::empty();
+        let s = sealer_with(&ks, [1u8; 32], Some(counter.clone()));
+
+        // First boot baselines the manifest (v0) and initializes the counter.
+        assert_eq!(vob(&s, true, false).await.unwrap(), BootOutcome::Baselined);
+        assert_eq!(counter.current(), Some(0));
+
+        // A covered mutation + reseal advances BOTH (external-first CAS).
+        ks.acl
+            .insert_raw("acl:did:key:zA", b"{}".to_vec())
+            .await
+            .unwrap();
+        s.reseal().await.unwrap();
+        assert_eq!(
+            counter.current(),
+            Some(1),
+            "reseal must CAS-bump the counter"
+        );
+
+        // And the next boot verifies (manifest v1 == counter v1).
+        assert_eq!(vob(&s, false, false).await.unwrap(), BootOutcome::Verified);
+    }
+
+    #[tokio::test]
+    async fn local_rollback_behind_counter_is_detected() {
+        // Manifest is rolled back (v0) while the counter stayed ahead (v1) —
+        // exactly the storage-rollback the external anchor exists to catch.
+        let ks = open();
+        let mac_key = [2u8; 32];
+        // Baseline manifest at v0.
+        sealer(&ks, mac_key).reseal().await.unwrap(); // writes manifest v0 (no anchor)
+        let counter = MockCounter::at(1); // counter ahead
+        let s = sealer_with(&ks, mac_key, Some(counter));
+
+        let err = vob(&s, false, false)
+            .await
+            .expect_err("manifest v0 < counter v1 must fail closed");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("mismatch"), "{msg}");
+        assert!(msg.contains("rolled back"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn counter_rollback_ahead_of_manifest_is_detected() {
+        // Manifest is ahead (v2) of the counter (v0) — a rolled-back counter or
+        // a torn commit. Fail closed.
+        let ks = open();
+        let mac_key = [3u8; 32];
+        let plain = sealer(&ks, mac_key);
+        plain.reseal().await.unwrap(); // v0
+        plain.reseal().await.unwrap(); // v1
+        plain.reseal().await.unwrap(); // v2
+        let counter = MockCounter::at(0);
+        let s = sealer_with(&ks, mac_key, Some(counter));
+
+        let err = vob(&s, false, false)
+            .await
+            .expect_err("manifest v2 > counter v0 must fail closed");
+        assert!(format!("{err:?}").contains("mismatch"), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn allow_unanchored_reanchors_counter_to_manifest() {
+        let ks = open();
+        let mac_key = [4u8; 32];
+        let plain = sealer(&ks, mac_key);
+        plain.reseal().await.unwrap(); // manifest v0
+        plain.reseal().await.unwrap(); // manifest v1
+        let counter = MockCounter::at(5); // diverged ahead
+        let s = sealer_with(&ks, mac_key, Some(counter.clone()));
+
+        // Without the flag → fail closed.
+        assert!(vob(&s, false, false).await.is_err());
+        // With allow_unanchored → re-anchor the counter to the local manifest.
+        assert_eq!(vob(&s, false, true).await.unwrap(), BootOutcome::ReAnchored);
+        assert_eq!(
+            counter.current(),
+            Some(1),
+            "counter re-anchored to manifest v1"
+        );
+    }
+
+    #[tokio::test]
+    async fn unreachable_counter_fails_closed_unless_allowed() {
+        let ks = open();
+        let mac_key = [7u8; 32];
+        sealer(&ks, mac_key).reseal().await.unwrap(); // manifest v0
+        let counter = MockCounter::unreachable();
+        let s = sealer_with(&ks, mac_key, Some(counter));
+
+        // Egress denied + no flag → fail closed.
+        let err = vob(&s, false, false)
+            .await
+            .expect_err("unreachable counter must fail closed");
+        assert!(format!("{err:?}").contains("unreachable"), "{err:?}");
+        // With allow_unanchored → boot manifest-only (degraded).
+        assert_eq!(vob(&s, false, true).await.unwrap(), BootOutcome::Unanchored);
     }
 }

--- a/vti-common/tests/integrity_e2e.rs
+++ b/vti-common/tests/integrity_e2e.rs
@@ -1,21 +1,74 @@
-//! End-to-end test for the TEE integrity manifest (P0.2a).
+//! End-to-end test for the TEE anti-rollback anchor (P0.2a manifest + P0.2b
+//! external counter).
 //!
 //! Unit tests in `integrity::tests` exercise the global-free `verify_or_baseline`
-//! path. This file drives the **real** public API — `boot_verify_and_install`
-//! (which installs the process-global sealer) and the covered-mutation
-//! chokepoints (`store_acl_entry`, `counter::allocate_u32`) that call
-//! `reseal_if_active`. It must live in its own integration-test binary because
-//! it permanently installs the process-global sealer; co-locating it with the
-//! unit tests would pollute their shared process.
+//! / `reseal` paths. This file drives the **real** public API —
+//! `boot_verify_and_install` (which installs the process-global sealer) and the
+//! covered-mutation chokepoints (`store_acl_entry`, `counter::allocate_u32`)
+//! that call `reseal_if_active`. It must live in its own integration-test binary
+//! because it permanently installs the process-global sealer; co-locating it
+//! with the unit tests would pollute their shared process.
 //!
-//! Flow: baseline → mutate through a chokepoint (auto-reseals) → re-verify
-//! (clean) → tamper out-of-band (bypassing the chokepoint) → re-verify (fails
-//! closed).
+//! Flow: baseline (init counter) → mutate through a chokepoint (auto-reseals +
+//! CAS-bumps the counter) → re-verify (clean) → tamper out-of-band (bypassing
+//! the chokepoint) → re-verify (fails closed) → recover.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 
 use vti_common::acl::{AclEntry, Role, delete_acl_entry, store_acl_entry};
 use vti_common::config::StoreConfig;
-use vti_common::integrity::{BootOutcome, boot_verify_and_install, derive_mac_key};
+use vti_common::error::AppError;
+use vti_common::integrity::{AnchorCounter, BootOutcome, boot_verify_and_install, derive_mac_key};
 use vti_common::store::{KeyspaceHandle, Store, counter};
+
+/// In-memory anchor counter with real CAS semantics (mirrors the unit-test
+/// mock; integration tests can't import the unit-test module).
+struct MockCounter(Mutex<Option<u64>>);
+impl MockCounter {
+    fn new() -> Arc<Self> {
+        Arc::new(Self(Mutex::new(None)))
+    }
+    fn current(&self) -> Option<u64> {
+        *self.0.lock().unwrap()
+    }
+}
+impl AnchorCounter for MockCounter {
+    fn read(&self) -> Pin<Box<dyn Future<Output = Result<Option<u64>, AppError>> + Send + '_>> {
+        let v = *self.0.lock().unwrap();
+        Box::pin(async move { Ok(v) })
+    }
+    fn init(
+        &self,
+        version: u64,
+        _digest: [u8; 32],
+    ) -> Pin<Box<dyn Future<Output = Result<(), AppError>> + Send + '_>> {
+        let mut g = self.0.lock().unwrap();
+        let r = if g.is_some() {
+            Err(AppError::Conflict("exists".into()))
+        } else {
+            *g = Some(version);
+            Ok(())
+        };
+        Box::pin(async move { r })
+    }
+    fn set(
+        &self,
+        expected: u64,
+        new: u64,
+        _digest: [u8; 32],
+    ) -> Pin<Box<dyn Future<Output = Result<(), AppError>> + Send + '_>> {
+        let mut g = self.0.lock().unwrap();
+        let r = if *g == Some(expected) {
+            *g = Some(new);
+            Ok(())
+        } else {
+            Err(AppError::Conflict("CAS".into()))
+        };
+        Box::pin(async move { r })
+    }
+}
 
 struct Env {
     keys: KeyspaceHandle,
@@ -23,6 +76,7 @@ struct Env {
     acl: KeyspaceHandle,
     contexts: KeyspaceHandle,
     mac_key: [u8; 32],
+    counter: Arc<MockCounter>,
     _dir: tempfile::TempDir,
 }
 
@@ -38,27 +92,30 @@ fn open() -> Env {
         acl: store.keyspace("acl").unwrap(),
         contexts: store.keyspace("contexts").unwrap(),
         mac_key: derive_mac_key(&[0x5Au8; 32]),
+        counter: MockCounter::new(),
         _dir: dir,
     }
 }
 
-async fn boot(env: &Env, allow_init: bool) -> Result<BootOutcome, vti_common::error::AppError> {
+async fn boot(env: &Env, allow_init: bool) -> Result<BootOutcome, AppError> {
     boot_verify_and_install(
         env.mac_key,
         env.keys.clone(),
         env.bootstrap.clone(),
         env.acl.clone(),
         env.contexts.clone(),
+        Some(env.counter.clone()),
         allow_init,
+        false,
     )
     .await
 }
 
 #[tokio::test]
-async fn install_chokepoint_reseal_then_reverify_then_tamper() {
+async fn anchor_end_to_end_through_chokepoints() {
     let env = open();
 
-    // Seed some pre-existing covered state, then baseline on first boot.
+    // Seed pre-existing covered state, then baseline + init the counter.
     env.keys
         .insert_raw("tee:bootstrap-carveout-closed", b"closed".to_vec())
         .await
@@ -67,23 +124,27 @@ async fn install_chokepoint_reseal_then_reverify_then_tamper() {
         .await
         .unwrap();
     assert_eq!(boot(&env, true).await.unwrap(), BootOutcome::Baselined);
+    assert_eq!(env.counter.current(), Some(0), "counter initialized at v0");
 
-    // The sealer is now installed (this process). A legitimate ACL grant flows
-    // through the chokepoint, which auto-reseals the manifest...
+    // The sealer is now installed (this process). Covered mutations flow through
+    // the chokepoints, which reseal AND CAS-bump the counter (external-first).
     let alice = AclEntry::new("did:key:zAlice", Role::Admin, "test");
-    store_acl_entry(&env.acl, &alice).await.unwrap();
-    // ...and a counter allocation likewise.
+    store_acl_entry(&env.acl, &alice).await.unwrap(); // → v1
     counter::allocate_u32(&env.contexts, "ctx_counter")
         .await
-        .unwrap();
+        .unwrap(); // → v2
+    assert_eq!(
+        env.counter.current(),
+        Some(2),
+        "each covered mutation advanced the external counter"
+    );
 
-    // A re-boot against the (chokepoint-resealed) state verifies cleanly: the
-    // manifest tracked the mutations, so no false-positive fail-closed.
+    // Re-boot against the resealed state: manifest v2 == counter v2 → clean.
     assert_eq!(boot(&env, false).await.unwrap(), BootOutcome::Verified);
 
-    // Now the parent tampers OUT OF BAND — deletes the ACL row directly,
-    // bypassing the chokepoint (simulating an offline store edit). The next
-    // boot must fail closed.
+    // Out-of-band tamper: delete the ACL row directly (bypassing the
+    // chokepoint, so neither the manifest nor the counter moved). Caught by the
+    // Layer-0 recompute (ACL root) before the version check is even reached.
     env.acl.remove("acl:did:key:zAlice").await.unwrap();
     let err = boot(&env, false)
         .await
@@ -92,10 +153,10 @@ async fn install_chokepoint_reseal_then_reverify_then_tamper() {
     assert!(msg.contains("mismatch"), "{msg}");
     assert!(msg.contains("ACL root"), "{msg}");
 
-    // Re-sealing through the chokepoint (a legitimate revoke would do this)
-    // re-establishes consistency, and the next boot is clean again.
+    // Recover: a chokepoint write reseals + bumps, restoring consistency.
     delete_acl_entry(&env.acl, "did:key:zMissing")
         .await
-        .unwrap(); // any chokepoint write reseals
+        .unwrap(); // → v3
+    assert_eq!(env.counter.current(), Some(3));
     assert_eq!(boot(&env, false).await.unwrap(), BootOutcome::Verified);
 }


### PR DESCRIPTION
Adds the external monotonic counter that gives the P0.2a integrity manifest its anti-rollback teeth. A **consistent storage rollback** (manifest + all covered rows restored together to a past epoch) now leaves the local manifest version behind a counter the parent can't roll back → fail closed. TEE-only.

## vti-common (protocol, AWS-free)
- New **`AnchorCounter`** trait (`read` / `init` / CAS-`set`). The AWS SDK is a service concern and must not leak into the foundation crate, so the integrity layer depends only on this trait; unit tests mock it.
- The sealer holds `Option<Arc<dyn AnchorCounter>>`. **reseal is external-first** (§5.4): CAS-bump the counter *before* committing the local manifest, so a crash leaves `manifest_version < counter` — the fail-closed safe direction, never a silently-rolled-back-but-consistent state.
- **Boot version-compare** on top of the MAC + recompute: `manifest < counter` → local store rolled back; `manifest > counter` → counter rolled back / torn commit; equal → proceed. `allow_anchor_init` also initializes the counter (first boot / migration from a manifest-only P0.2a VTA); **`allow_unanchored`** is the break-glass — boot manifest-only when the counter is unreachable, or re-anchor it to the MAC-trusted local manifest on divergence.

## vta-service
- **`DynamoAnchorCounter`** over a single-item table keyed by VTA DID: CAS = conditional `UpdateItem` (`version = :expected`), init = create-if-absent `PutItem`, read = strongly-consistent `GetItem`. `ConditionalCheckFailed` → `AppError::Conflict`.
- Config: `[tee.kms.anchor] { table_name }` enables the counter (omit → manifest-only); `[tee.kms] allow_unanchored`. Region reused from `[tee.kms].region`. `server::run` builds the counter when configured + a VTA DID is set, and threads it + `allow_unanchored` into the boot check.
- New dep `aws-sdk-dynamodb` (tee feature).

Per the operator decision, the counter bumps on **every** covered mutation — each ACL change / key-counter allocation / carve-out close does a synchronous DynamoDB round-trip and fails closed if unreachable.

## Scope
> P0.2b writes the counter with the enclave's **instance-role** credentials, which a root-on-parent attacker shares — so this resists **storage/backup rollback** but **not** a compromised parent OS. The KMS-attestation-gated writer that closes that gap is **P0.2c**; docs do not yet claim parent-compromise resistance.

## Tests
Anchor protocol via an in-memory CAS mock (first-boot init + reseal bump, `manifest<counter` and `manifest>counter` detection, `allow_unanchored` re-anchor, unreachable fail-closed vs unanchored) + an **anchored end-to-end** test driving the real chokepoints (each covered mutation CAS-bumps the counter).

## Gate
- `cargo fmt` + `clippy` (default & `tee`) clean.
- `vti-common` **239** + e2e, `vta-service` **745** (tee) green; `vta-enclave` checks.

Plan ref: `tasks/vta-architecture-plan.md` P0.2; design note §4 Option A / §5.3–5.5 / §5.7 (P0.2b)