### PR TITLE
fix(vtc-service): stop relationships_by_did scan leaking colon-prefix-colliding DIDs (P0.11)

### DIFF
--- a/vtc-service/src/relationships/storage.rs
+++ b/vtc-service/src/relationships/storage.rs
@@ -176,7 +176,19 @@ pub async fn list_for_did(
             continue;
         };
         if let Some(raw) = primary.get_raw(primary_key(id)).await? {
-            hydrated.push((idx_key, raw));
+            // P0.11: the prefix `relationships_by_did:<did>:` also matches a
+            // *longer* DID that has `<did>` as a colon-delimited prefix —
+            // `did:webvh:scid:host` vs `did:webvh:scid:host:acme` — because
+            // `did:webvh` DIDs legitimately contain colons. Such a hydrated
+            // row belongs to a different DID, so post-filter on the actual
+            // edge endpoints before including it. Undecodable rows are skipped
+            // (orphan-tolerant, same as a missing primary row).
+            match decode(&raw) {
+                Ok(rel) if rel.issuer_did == did || rel.subject_did == did => {
+                    hydrated.push((idx_key, raw));
+                }
+                _ => {}
+            }
         }
     }
 
@@ -318,6 +330,39 @@ mod tests {
         assert_eq!(got.map(|r| r.id), Some(rel.id));
         let miss = find_by_hash(&primary, "feedface").await.unwrap();
         assert!(miss.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_does_not_leak_colon_prefix_colliding_did() {
+        // P0.11: `did:webvh` DIDs contain colons, so the index scan for
+        // `did:webvh:s:h` would otherwise also match the keys of
+        // `did:webvh:s:h:x` (whose index keys share the scanned prefix),
+        // leaking another member's relationship rows.
+        let (primary, index, audit, _dir) = temp_kss().await;
+        let short = fresh("did:webvh:s:h", "did:key:zPeer");
+        let long = fresh("did:webvh:s:h:x", "did:key:zPeer2");
+        store_relationship(&primary, &index, &short).await.unwrap();
+        store_relationship(&primary, &index, &long).await.unwrap();
+
+        // Querying the shorter DID must return only its own edge.
+        let page = list_for_did(&primary, &index, &audit, "did:webvh:s:h", None, 10)
+            .await
+            .unwrap();
+        let ids: Vec<_> = page.items.iter().map(|r| r.id).collect();
+        assert_eq!(ids, vec![short.id], "must return only the exact DID's edge");
+        assert!(
+            !ids.contains(&long.id),
+            "colon-extended DID's edge must not leak"
+        );
+
+        // …and the longer DID still finds its own edge.
+        let page_long = list_for_did(&primary, &index, &audit, "did:webvh:s:h:x", None, 10)
+            .await
+            .unwrap();
+        assert_eq!(
+            page_long.items.iter().map(|r| r.id).collect::<Vec<_>>(),
+            vec![long.id]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## P0.11 — `relationships_by_did` index scan leaks other DIDs' rows (colon-prefix collision)

### Problem
The secondary index key is `relationships_by_did:<did>:<uuid>`, and `list_for_did` scans the prefix `relationships_by_did:<did>:`. `did:webvh` DIDs legitimately contain colons: for `did:webvh:scid:host` vs `did:webvh:scid:host:acme`, the scan prefix `…host:` also matches the **second** DID's keys, and `list_for_did` never post-filtered on the actual edge endpoints → it returned another member's relationship rows (cross-member information exposure).

### Fix
Minimal, no key-format change (so no migration): after hydrating each index entry to its primary row, post-filter on `rel.issuer_did == did || rel.subject_did == did` before including it. Undecodable rows are skipped, matching the existing orphan-tolerant walk.

### Acceptance
- ✅ store edges for `did:webvh:s:h` and `did:webvh:s:h:x`; `list_for_did("did:webvh:s:h")` returns only the first DID's edges (and the longer DID still finds its own).

### Tests
New regression test `list_does_not_leak_colon_prefix_colliding_did`. `cargo fmt --check` clean, no new clippy warnings, full lib suite **534 passed**.