### PR TITLE
fix(vtc-service): serialize admit under LAST_ADMIN_LOCK to close duplicate-credential TOCTOU (P0.15)

### DIFF
--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -56,10 +56,12 @@ use crate::members::{Disposition, Member, delete_member, get_member, store_membe
 use crate::server::AppState;
 use crate::status_list;
 
-/// Process-wide mutex serialising every member departure so the
-/// "would this leave zero admins?" check + ACL delete is one atomic
-/// critical section — concurrent removals can't both pass the check
-/// and both delete. (fjall isn't multi-process safe regardless, so a
+/// Process-wide mutex serialising member-state mutations — admit,
+/// depart, and role-change — so each check-then-write is one atomic
+/// critical section. Departures can't both pass the "would this leave
+/// zero admins?" check and both delete; admits can't both pass the
+/// "no existing ACL row" check and both mint a VMC + burn a status-list
+/// slot (P0.15). (fjall isn't multi-process safe regardless, so a
 /// process-wide lock is the right grain.)
 static LAST_ADMIN_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
@@ -174,12 +176,21 @@ fn parse_role(role: &str) -> Result<VtcRole, AppError> {
 /// then issues credentials and stamps their ids back onto the member.
 /// A failure partway leaves the safer state (auth path works; metadata
 /// reconcilable by the next admin action).
+///
+/// The existence check + writes run under [`LAST_ADMIN_LOCK`], matching
+/// `depart`/`remint` — without it two concurrent admits for the same DID
+/// (two approved `Pending`s, or a submit auto-admit racing an approve)
+/// both observe "no ACL row" and both proceed, minting two VMCs and
+/// burning two status-list slots (P0.15). With the lock, the loser sees
+/// the row the winner wrote and gets a `Conflict`.
 async fn admit(
     state: &AppState,
     subject_did: &str,
     role: VtcRole,
     actor_did: &str,
 ) -> Result<AdmitOutcome, AppError> {
+    let _guard = LAST_ADMIN_LOCK.lock().await;
+
     if get_acl_entry(&state.acl_ks, subject_did).await?.is_some() {
         return Err(AppError::Conflict(format!(
             "{subject_did} already has an ACL row; refusing to admit a duplicate membership"

--- a/vtc-service/tests/ceremony_execute.rs
+++ b/vtc-service/tests/ceremony_execute.rs
@@ -123,6 +123,61 @@ async fn admit_duplicate_acl_is_conflict() {
     );
 }
 
+/// P0.15: two concurrent admits for the same DID must resolve to exactly
+/// one membership — one wins (Admitted), the other loses (Conflict). Before
+/// the serializing lock, both could pass the bare `get_acl_entry().is_some()`
+/// guard and proceed, minting two VMCs and burning two status-list slots.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_admits_for_one_did_yield_one_membership() {
+    let (state, _dir) = build_state().await;
+    let subject = "did:key:zRacer";
+
+    let make_plan = || EffectPlan::Admit {
+        subject: subject.into(),
+        role: "member".into(),
+        obligations: vec![],
+    };
+
+    let (s1, s2) = (state.clone(), state.clone());
+    let h1 = tokio::spawn(async move { execute::apply(&s1, make_plan(), ACTOR_DID).await });
+    // Re-declare the plan builder for the second task (closure isn't `Copy`).
+    let make_plan2 = || EffectPlan::Admit {
+        subject: subject.into(),
+        role: "member".into(),
+        obligations: vec![],
+    };
+    let h2 = tokio::spawn(async move { execute::apply(&s2, make_plan2(), ACTOR_DID).await });
+
+    let r1 = h1.await.expect("task 1 panicked");
+    let r2 = h2.await.expect("task 2 panicked");
+
+    let wins = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
+    let conflicts = [&r1, &r2]
+        .iter()
+        .filter(|r| matches!(r, Err(vti_common::error::AppError::Conflict(_))))
+        .count();
+    assert_eq!(
+        wins, 1,
+        "exactly one admit must win; got r1={r1:?} r2={r2:?}"
+    );
+    assert_eq!(
+        conflicts, 1,
+        "the loser must get Conflict; got r1={r1:?} r2={r2:?}"
+    );
+
+    // The winner's slot is the one recorded on the single member row — proving
+    // exactly one slot was burned (not two).
+    let winner = [r1, r2].into_iter().find_map(Result::ok).expect("a winner");
+    let EffectOutcome::Admitted(creds) = winner else {
+        panic!("winner must be Admitted");
+    };
+    let member = get_member(&state.members_ks, subject)
+        .await
+        .unwrap()
+        .expect("one member row");
+    assert_eq!(member.status_list_index, Some(creds.status_list_index));
+}
+
 /// A `NoStateChange` plan (deny / refer / request_more) writes nothing.
 #[tokio::test]
 async fn no_state_change_is_a_noop() {


### PR DESCRIPTION
## P0.15 — `admit` lacks the serializing lock the other effect arms use: duplicate-credential TOCTOU

### Problem
`depart` and `remint` run their check-then-write under `LAST_ADMIN_LOCK`, but `admit` (`ceremony/execute.rs`) did a bare `get_acl_entry(...).is_some()` guard then wrote ACL / Member / VMC / status-list slot with **no lock**. Two concurrent admits for the same subject DID (two `Pending`s approved in parallel, or a submit auto-admit racing an approve) both observe "no ACL row," both proceed → **two VMCs minted, two status-list slots burned, audit double-counts**.

### Fix
Take `LAST_ADMIN_LOCK` across the existence check + writes in `admit`, matching `depart`/`remint`. Lock ordering is unchanged (`LAST_ADMIN_LOCK` outer, status-list lock inner — identical to depart's revocation flip), so no deadlock. The loser now sees the winner's ACL row and gets a `Conflict`. The lock's doc is generalised to cover admit/depart/role-change.

### Acceptance
- ✅ two simultaneous admits for one DID → exactly one VMC and one slot; the loser gets `Conflict`.

### Tests
New `concurrent_admits_for_one_did_yield_one_membership` (multi-thread runtime, two spawned `apply(Admit)` tasks): asserts exactly one Admitted + one Conflict, and a single member row carrying the winner's slot. Without the lock both tasks would win. `cargo fmt --check` clean, no new clippy warnings on the touched files; the 8 `ceremony_execute` integration tests pass.