### PR TITLE
feat(tee): attestation-gated anchor writer + threat-model claim (P0.2c+d)

### DIFF
--- a/docs/02-vta/tee-architecture.md
+++ b/docs/02-vta/tee-architecture.md
@@ -480,6 +480,7 @@ is skipped, and the existing SeedStore/config-based key loading is used.
 | Cold boot attack | Nitro Enclaves use dedicated memory that's hardware-isolated; not accessible to parent; no DMA path |
 | Attacker replays a **stale-but-valid** ciphertext snapshot (rollback) | Confidentiality alone does **not** stop this — KMS faithfully decrypts any ciphertext that was ever validly produced under the key, including a stale one. Mitigated by the **anti-rollback anchor** (P0.2, see below): a MAC'd integrity manifest pins the protected singletons, and an external attestation-gated monotonic counter pins "the latest version." A replayed snapshot has `version < authoritative` ⇒ boot **fails closed**. |
 | Parent rolls back carve-out / ACL to a **consistent** past snapshot (e.g. reopen the single-use Mode-B carve-out, resurrect a revoked admin, force BIP-32 counter reuse) | Detected at boot via the version pin (anti-rollback anchor, P0.2); fail closed. AAD (P0.1) stops *relocation* but not *rollback*; the anchor is what enforces freshness. |
+| **Root-on-parent** rolls back the external counter too (it shares the enclave's instance-role credentials) | The counter table denies `UpdateItem` to the instance role; the only permitted writer (`vta-anchor-writer`) is reachable solely via a credential KMS-sealed under the PCR0/PCR8 attestation conditions, which a compromised parent cannot decrypt or forge (P0.2c). So a root-on-parent attacker can roll the *local* store back but **not** the counter ⇒ boot fails closed. Holds within the operator's AWS-account trust root (IAM/KMS/DynamoDB control-plane intact) — the same root the seed already relies on; cross-account isolation is the deferred Option C (P0.2e). Without the sealed writer credential configured the deployment is P0.2b (instance-role writes) and this row does **not** hold. |
 | Parent denies egress to the anchor | DoS only — the parent can already DoS by not starting the enclave. Enclave fails closed (refuses boot / security-relevant ops). Documented break-glass `tee.kms.allow_unanchored` for incident recovery, off by default. |
 | Mnemonic exfiltration | Never displayed on console. Export requires: super admin auth + time-limited window + env var at boot. One-time use, entropy zeroed after export. |
 | Signing key theft | Key stored in CI/CD or HSM, never on EC2. If stolen: revoke, generate new key, rebuild + re-sign, update PCR8 in KMS policy. |
@@ -520,15 +521,15 @@ nitro-cli build-enclave --docker-uri vta-nitro --output-file vta.eif \
 
 ## Anti-rollback anchor (P0.2)
 
-> **Status:** P0.2a (local MAC'd manifest) and P0.2b (external DynamoDB
-> counter) are **implemented**; P0.2c (the KMS-attestation-gated writer that
-> resists root-on-parent) is still to come. Provision the DynamoDB table +
-> instance-role IAM below to enable the counter (P0.2b); the **PCR-gated writer
-> key + the `vta-anchor-writer` deny** are only needed once P0.2c lands. Until
-> then the counter is written with the **instance role**, so it resists
-> storage/backup rollback but **not** a root-on-parent attacker (who shares
-> those credentials). The local manifest slice (P0.2a) needs **no** external
-> infrastructure. The whole feature is **TEE-only** — non-TEE VTAs are
+> **Status:** P0.2a (local MAC'd manifest), P0.2b (external DynamoDB counter),
+> and P0.2c (the KMS-attestation-gated `vta-anchor-writer` + instance-role deny
+> that resists root-on-parent) are all **implemented**. Provision the DynamoDB
+> table, seal the writer credential, and apply the `vta-anchor-writer` policy +
+> instance-role deny below for full protection. Omitting the writer credential
+> falls back to instance-role writes (P0.2b — resists storage/backup rollback
+> but not root-on-parent); omitting the whole `[tee.kms.anchor]` block is
+> manifest-only (P0.2a). Option C (a cross-account anchor service) remains
+> deferred (P0.2e). The whole feature is **TEE-only** — non-TEE VTAs are
 > unaffected and need none of this.
 
 ### Why it exists
@@ -587,35 +588,43 @@ replicas and torn writes fail safely (compare-and-set linearization point).
 > and `dynamodb:UpdateContinuousBackups` to a break-glass admin role (MFA,
 > separate account), the same posture as `kms:PutKeyPolicy`.
 
-#### 2. KMS key gating the writer credential (P0.2c)
+#### 2. Seal the writer credential under the PCR-gated KMS key (P0.2c)
 
-The `vta-anchor-writer` credential is **KMS-sealed under a PCR-conditioned
-key**, mirroring the seed key (Component 3). Only the genuine enclave image can
-`Decrypt` it; the parent cannot, because it cannot produce a valid attestation
-for the right PCRs. Create a key whose policy releases `Decrypt` *only* under
-attestation:
+The `vta-anchor-writer` credential is **KMS-sealed under the enclave's existing
+seed KMS key** (`tee.kms.key_arn`, Component 3) — that key's policy already
+releases `kms:Decrypt` *only* under the PCR0/PCR8 attestation conditions, so
+only the genuine enclave image can open the ciphertext; the parent cannot,
+because it can't produce a valid attestation. (A separate key with the same
+conditions works too, but reusing the seed key keeps one PCR policy to manage.)
 
-```json
-{
-    "Sid": "AllowEnclaveToUnsealAnchorWriterCredential",
-    "Effect": "Allow",
-    "Principal": { "AWS": "arn:aws:iam::ACCOUNT_ID:role/vta-enclave-role" },
-    "Action": "kms:Decrypt",
-    "Resource": "*",
-    "Condition": {
-        "StringEqualsIgnoreCase": {
-            "kms:RecipientAttestation:PCR0": "<enclave-image-hash>",
-            "kms:RecipientAttestation:PCR8": "<signing-cert-hash>"
-        }
-    }
-}
+Create the IAM user, then seal its access key as JSON under the seed key and
+paste the base64 ciphertext into config:
+
+```bash
+# 1. Create the writer principal and an access key.
+aws iam create-user --user-name vta-anchor-writer
+aws iam create-access-key --user-name vta-anchor-writer   # capture AccessKeyId + SecretAccessKey
+
+# 2. Seal {access_key_id, secret_access_key} under the seed KMS key.
+printf '{"access_key_id":"AKIA…","secret_access_key":"…"}' \
+  | aws kms encrypt --key-id "$SEED_KEY_ARN" --plaintext fileb:///dev/stdin \
+        --query CiphertextBlob --output text   # → base64 ciphertext
 ```
 
-Seal the writer credential under this key once at provisioning time (it is the
-`vta-anchor-writer` access key, or an STS session for that role — P0.2c
-finalizes the exact delivery) and hand the ciphertext to the enclave the same
-way the seed ciphertext is delivered. The parent stores the ciphertext but
-cannot open it.
+```toml
+# 3. Paste the ciphertext into the EIF-baked config.
+[tee.kms.anchor]
+table_name                  = "vta-rollback-anchor"
+writer_credential_ciphertext = "AQIDAH…"   # base64 KMS ciphertext from step 2
+```
+
+At boot the enclave `kms:Decrypt`s this (attestation-gated, same path as the
+seed) and uses the resulting static credentials for the counter's reads and
+writes. The parent stores the ciphertext but can't open it, and the plaintext
+key never leaves the enclave. **A configured-but-unsealable credential is fatal
+at boot** — falling back to the instance role would silently downgrade to
+P0.2b. Rotate by issuing a new access key, re-sealing, and updating config (the
+old key can then be deleted from IAM).
 
 #### 3. IAM — writer principal + instance-role deny
 
@@ -623,18 +632,23 @@ The fence has two halves. First, a dedicated writer principal is the only one
 allowed to mutate the counter:
 
 ```json
-// Policy on the vta-anchor-writer principal (whose credential is KMS-sealed above)
+// Policy on the vta-anchor-writer principal (whose credential is KMS-sealed above).
+// The enclave uses these credentials for the counter's read, init, and bump.
 {
     "Effect": "Allow",
-    "Action": "dynamodb:UpdateItem",
+    "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem"
+    ],
     "Resource": "arn:aws:dynamodb:us-east-1:ACCOUNT_ID:table/vta-rollback-anchor"
 }
 ```
 
 Second — the load-bearing part — the **EC2 instance role explicitly denies**
 counter writes, so a root-on-parent attacker holding those credentials cannot
-bump or roll the counter back. Reads may stay on the instance role (the boot
-check only needs to *read* the authoritative version):
+bump or roll the counter back. The instance-role read allow below is optional
+(the enclave reads with the writer credential too), but harmless to keep:
 
 ```json
 // Statements on the vta-enclave-role (parent instance role)
@@ -679,8 +693,11 @@ allow_unanchored  = false
 # Present this block to enable the external counter (P0.2b); omit it for
 # manifest-only (P0.2a). Region is reused from [tee.kms].region.
 [tee.kms.anchor]
-table_name        = "vta-rollback-anchor"        # DynamoDB single-item table
-# writer_key_arn  = "arn:aws:kms:…:key/anchor-writer-key"   # P0.2c (not yet read)
+table_name                   = "vta-rollback-anchor"   # DynamoDB single-item table
+# P0.2c: base64 KMS ciphertext of the vta-anchor-writer access key (see above).
+# Present → counter written with the attestation-gated writer (resists
+# root-on-parent). Absent → written with the instance role (P0.2b).
+writer_credential_ciphertext = "AQIDAH…"
 ```
 
 ### First boot, recovery, and break-glass

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -22,7 +22,7 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
   only (default/plaintext unaffected) — documented in CHANGELOG. Tests:
   cross-key/cross-keyspace paste rejected (unit + through the real handle),
   wrong-key, legacy-format clear error, passthrough unchanged — PR: #346 (merged)
-- `[~]` **P0.2** (XL) Enclave-side anti-rollback anchor for carve-out sentinel /
+- `[x]` **P0.2** (XL) Enclave-side anti-rollback anchor for carve-out sentinel /
   JWT fingerprint / ACL — deps: P0.1. **Design note MERGED** (PR #365,
   `docs/05-design-notes/tee-anti-rollback-anchor.md`). **§9 open questions
   RESOLVED in review** (branch `docs/p0.2-resolve-open-questions`): (1) substrate
@@ -86,7 +86,29 @@ Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note fi
     (init+bump, M<ext / M>ext detection, allow_unanchored re-anchor, unreachable
     fail-closed-vs-unanchored) + anchored e2e (chokepoints CAS-bump the counter).
     New dep `aws-sdk-dynamodb` (tee feature). fmt + clippy (default & tee) clean;
-    vti-common 239 + e2e, vta-service 745 (tee) green; vta-enclave checks — PR: ____
+    vti-common 239 + e2e, vta-service 745 (tee) green; vta-enclave checks — PR: #383 (merged)
+  - `[x]` **P0.2c+d** (M) Attestation-gated writer + threat-model claim —
+    branch `fix/p0.2c-attested-writer` (worktree). Closes the root-on-parent gap:
+    the counter is now written by the `vta-anchor-writer` principal, reachable
+    only via an AWS credential **KMS-sealed under the PCR-gated seed key** — a
+    compromised parent holds the instance role (IAM-denied on the table) but
+    can't produce the attestation to `kms:Decrypt` the writer credential. New
+    `TeeAnchorConfig.writer_credential_ciphertext` (base64 KMS ciphertext of
+    `{access_key_id, secret_access_key}`); `server::run` unseals it at boot via
+    a new `kms_bootstrap::attested_decrypt` wrapper (reuses the seed's
+    NSM-attested Decrypt path, mandatory PCR enforcement on real hardware) and
+    builds the DynamoDB client with those static creds (`WriterCredentials`,
+    zeroized on drop). **Configured-but-unsealable is fatal** — no silent
+    downgrade to instance-role writes. Absent → P0.2b. P0.2d: threat-model table
+    updated to claim root-on-parent rollback resistance (within the AWS-account
+    trust root; cross-account = deferred P0.2e). Operator runbook updated
+    (seal-the-writer-credential procedure, writer principal needs Get/Put/Update,
+    config). Tests: `WriterCredentials` JSON parse (tolerate-extra/require-both);
+    the KMS+DynamoDB paths need real AWS/NSM (inspection-tested like the rest of
+    the TEE KMS code). fmt + clippy (default & tee) clean; vta-service 747 (tee)
+    green; vta-enclave checks; no version bump (additive) — PR: ____
+  - `[ ]` **P0.2e** (XL, deferred) Option C cross-account anchor service —
+    out of Phase-0 scope; documented as the max-assurance / multi-tenant upgrade.
 - `[x]` **P0.3** (S) `create_key`/`import_key`: existence check + identifier
   validation (closes `#key-0` overwrite) — branch `fix/p0.3-key-overwrite`.
   Scope grew during root-cause analysis: the store's multi-op "atomic"

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -443,17 +443,25 @@ pub struct TeeKmsConfig {
     pub allow_unanchored: bool,
 }
 
-/// External anti-rollback anchor configuration (P0.2b — DynamoDB counter).
+/// External anti-rollback anchor configuration (P0.2b counter + P0.2c writer).
 #[cfg(feature = "tee")]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TeeAnchorConfig {
     /// DynamoDB table holding the single-item monotonic version counter (one
     /// item per VTA DID). The region is reused from [`TeeKmsConfig::region`].
     pub table_name: String,
-    // NOTE: `writer_key_arn` (the KMS-attestation-gated writer credential that
-    // resists root-on-parent) lands in P0.2c. In P0.2b the counter is written
-    // with the instance-role credentials, so it resists storage/backup rollback
-    // but NOT a root-on-parent attacker who shares those credentials.
+    /// KMS-attestation-gated writer credential (P0.2c — root-on-parent
+    /// resistance). Base64 of the `vta-anchor-writer` IAM credentials
+    /// (`{"access_key_id","secret_access_key"}`) sealed under the PCR-gated KMS
+    /// key ([`TeeKmsConfig::key_arn`]): only the genuine enclave image can
+    /// `kms:Decrypt` it, so a root-on-parent attacker — who holds the
+    /// *instance-role* credentials but cannot produce a valid attestation —
+    /// cannot obtain the only principal allowed to write the counter (the
+    /// instance role is explicitly denied on the table; see the operator
+    /// runbook). Unset → P0.2b: the counter is written with the instance role
+    /// (resists storage/backup rollback, **not** root-on-parent).
+    #[serde(default)]
+    pub writer_credential_ciphertext: Option<String>,
 }
 
 // KMS ciphertexts (seed, JWT key, fingerprint) are stored as K/V entries

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -469,14 +469,47 @@ pub async fn run(
         // manifest-only (P0.2a) with a warning.
         let anchor: Option<Arc<dyn vti_common::integrity::AnchorCounter>> =
             match (kms.anchor.as_ref(), config.vta_did.as_ref()) {
-                (Some(anchor_cfg), Some(vta_did)) => Some(Arc::new(
-                    crate::tee::anchor::DynamoAnchorCounter::new(
-                        &kms.region,
-                        anchor_cfg.table_name.clone(),
-                        vta_did.clone(),
-                    )
-                    .await,
-                )),
+                (Some(anchor_cfg), Some(vta_did)) => {
+                    // P0.2c: if a sealed writer credential is configured, unseal
+                    // it through the attestation-gated KMS Decrypt so the counter
+                    // is written with the `vta-anchor-writer` principal (which the
+                    // instance role is IAM-denied) rather than the instance role
+                    // a root-on-parent attacker shares. A configured-but-
+                    // unsealable credential is fatal — falling back to the
+                    // instance role would silently downgrade to P0.2b.
+                    let writer = match anchor_cfg.writer_credential_ciphertext.as_ref() {
+                        Some(b64) => {
+                            let ct = base64::engine::general_purpose::STANDARD
+                                .decode(b64)
+                                .map_err(|e| {
+                                    AppError::Config(format!(
+                                        "tee.kms.anchor.writer_credential_ciphertext is not \
+                                         valid base64: {e}"
+                                    ))
+                                })?;
+                            let pt = crate::tee::kms_bootstrap::attested_decrypt(kms, &ct).await?;
+                            let creds: crate::tee::anchor::WriterCredentials =
+                                serde_json::from_slice(&pt).map_err(|e| {
+                                    AppError::Config(format!(
+                                        "anchor writer credential did not decrypt to \
+                                         {{access_key_id, secret_access_key}}: {e}"
+                                    ))
+                                })?;
+                            info!("anchor writer credential unsealed (attestation-gated, P0.2c)");
+                            Some(creds)
+                        }
+                        None => None,
+                    };
+                    Some(Arc::new(
+                        crate::tee::anchor::DynamoAnchorCounter::new(
+                            &kms.region,
+                            anchor_cfg.table_name.clone(),
+                            vta_did.clone(),
+                            writer,
+                        )
+                        .await,
+                    ))
+                }
                 (Some(_), None) => {
                     warn!(
                         "tee.kms.anchor is configured but vta_did is unset — booting \

--- a/vta-service/src/tee/anchor.rs
+++ b/vta-service/src/tee/anchor.rs
@@ -17,7 +17,10 @@ use std::future::Future;
 use std::pin::Pin;
 
 use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::config::Credentials;
 use aws_sdk_dynamodb::types::AttributeValue;
+use serde::Deserialize;
+use zeroize::ZeroizeOnDrop;
 
 use vti_common::error::AppError;
 use vti_common::integrity::AnchorCounter;
@@ -29,6 +32,15 @@ const UPDATED_AT_ATTR: &str = "updated_at";
 
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+/// The `vta-anchor-writer` IAM credentials, unsealed at boot from the
+/// attestation-gated KMS ciphertext (P0.2c). Zeroized on drop; once the client
+/// is built the AWS SDK holds its own copy.
+#[derive(Deserialize, ZeroizeOnDrop)]
+pub struct WriterCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+}
+
 /// External anchor counter backed by a single DynamoDB item keyed by VTA DID.
 pub struct DynamoAnchorCounter {
     client: Client,
@@ -37,14 +49,33 @@ pub struct DynamoAnchorCounter {
 }
 
 impl DynamoAnchorCounter {
-    /// Build a client for `region` and bind it to `table` + `vta_did` (the
-    /// partition key). Uses the default credential chain — in a Nitro enclave
-    /// that resolves to the instance role via the parent's IMDS proxy.
-    pub async fn new(region: &str, table: String, vta_did: String) -> Self {
-        let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .region(aws_config::Region::new(region.to_string()))
-            .load()
-            .await;
+    /// Build a client for `region` bound to `table` + `vta_did` (the partition
+    /// key).
+    ///
+    /// With `writer` (P0.2c) the client uses the attestation-gated
+    /// `vta-anchor-writer` static credentials — the only principal allowed to
+    /// write the counter (the instance role is IAM-denied), so a root-on-parent
+    /// attacker can't move it. Without `writer` (P0.2b) it uses the default
+    /// credential chain (the instance role via the parent's IMDS proxy), which
+    /// resists storage rollback but not root-on-parent.
+    pub async fn new(
+        region: &str,
+        table: String,
+        vta_did: String,
+        writer: Option<WriterCredentials>,
+    ) -> Self {
+        let mut builder = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new(region.to_string()));
+        if let Some(w) = writer {
+            builder = builder.credentials_provider(Credentials::new(
+                w.access_key_id.clone(),
+                w.secret_access_key.clone(),
+                None,
+                None,
+                "vta-anchor-writer",
+            ));
+        }
+        let sdk_config = builder.load().await;
         Self {
             client: Client::new(&sdk_config),
             table,
@@ -160,4 +191,29 @@ impl AnchorCounter for DynamoAnchorCounter {
 /// RFC-3339 UTC timestamp for the `updated_at` bookkeeping attribute.
 fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The sealed writer credential is the JSON the operator encrypts under the
+    /// PCR-gated KMS key; it must deserialize to the two AWS fields (P0.2c).
+    #[test]
+    fn writer_credentials_parse_from_sealed_json() {
+        let json = br#"{"access_key_id":"AKIAEXAMPLE","secret_access_key":"s3cr3t"}"#;
+        let w: WriterCredentials = serde_json::from_slice(json).expect("parse writer creds");
+        assert_eq!(w.access_key_id, "AKIAEXAMPLE");
+        assert_eq!(w.secret_access_key, "s3cr3t");
+    }
+
+    /// Extra fields (e.g. a future `session_token`) are tolerated; a missing
+    /// required field is a hard parse error surfaced as a config problem.
+    #[test]
+    fn writer_credentials_tolerate_extra_but_require_both() {
+        let extra = br#"{"access_key_id":"A","secret_access_key":"B","note":"x"}"#;
+        assert!(serde_json::from_slice::<WriterCredentials>(extra).is_ok());
+        let missing = br#"{"access_key_id":"A"}"#;
+        assert!(serde_json::from_slice::<WriterCredentials>(missing).is_err());
+    }
 }

--- a/vta-service/src/tee/kms_bootstrap.rs
+++ b/vta-service/src/tee/kms_bootstrap.rs
@@ -448,6 +448,21 @@ fn unwrap_cms_response(
 
 /// Decrypt a KMS data key ciphertext (the `CiphertextBlob` from `GenerateDataKey`).
 ///
+/// Attested KMS `Decrypt` of an arbitrary ciphertext sealed under the bootstrap
+/// KMS key, for callers outside the seed/data-key path (P0.2c: the anchor
+/// writer credential). Same attestation semantics as the data-key decrypt — on
+/// real Nitro hardware the PCR-gated `Recipient` path is mandatory unless
+/// `allow_unattested_fallback` is set — but flattens the typed error class the
+/// bootstrap state machine needs into a plain [`AppError`].
+pub(crate) async fn attested_decrypt(
+    config: &TeeKmsConfig,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, AppError> {
+    kms_decrypt_data_key(config, ciphertext)
+        .await
+        .map_err(|(_, e)| e)
+}
+
 /// On real Nitro hardware (`/dev/nsm` available), uses attestation-based
 /// KMS Decrypt with the `Recipient` parameter. If attestation fails, the
 /// call is **terminal** unless `allow_unattested_fallback` is explicitly


### PR DESCRIPTION
Closes the **root-on-parent** gap left by P0.2b and updates the threat-model claim (P0.2d). With this, the P0.2 anti-rollback anchor is complete (a–d; Option C / P0.2e remains a deferred future item).

## The gap it closes
P0.2b wrote the counter with the enclave's **instance-role** credentials — which a root-on-parent attacker shares, so it could roll the counter back too. P0.2c makes the counter writable only by a dedicated `vta-anchor-writer` principal whose AWS credential is **KMS-sealed under the PCR-gated seed key**: only the genuine enclave image can `kms:Decrypt` it. The compromised parent holds the instance role (IAM-**denied** for writes on the table) but can't produce the attestation to unseal the writer — so it can roll the *local* store back but **not** the counter ⇒ boot fails closed.

## Code
- **config**: `TeeAnchorConfig.writer_credential_ciphertext` — base64 KMS ciphertext of `{access_key_id, secret_access_key}`. Present → P0.2c (attested writer); absent → P0.2b (instance-role writes).
- **kms_bootstrap**: new `pub(crate) attested_decrypt()` over the existing NSM-attested KMS `Decrypt` path (mandatory PCR enforcement on real hardware unless `allow_unattested_fallback`), flattening the typed error class for non-bootstrap callers.
- **anchor**: `WriterCredentials` (`Deserialize` + `ZeroizeOnDrop`); `DynamoAnchorCounter::new` takes `Option<WriterCredentials>` and builds the client with those static creds when present.
- **server::run**: unseal the ciphertext via `attested_decrypt` and build the counter with it. **A configured-but-unsealable credential is fatal** — falling back to the instance role would silently downgrade to P0.2b.

Why a sealed static access key (not STS AssumeRole): STS has no `RecipientAttestation` condition, so KMS-sealing the credential is the only way to gate a DynamoDB writer on attestation. The plaintext key exists only inside the attested enclave, and the instance-role deny makes it the sole path to a counter write.

## P0.2d — threat model
Threat table now claims **root-on-parent rollback resistance**, within the operator's AWS-account trust root (IAM/KMS/DynamoDB control-plane intact — the same root the seed relies on; cross-account isolation is the deferred Option C / P0.2e). Operator runbook updated: seal-the-writer-credential procedure (`aws kms encrypt`), writer principal's Get/Put/Update policy, instance-role deny, config, status banner.

## Tests
`WriterCredentials` JSON parse (tolerate-extra / require-both). The KMS-Decrypt + DynamoDB write paths need real AWS/NSM, so they're inspection-tested like the rest of the TEE KMS code.

## Gate
- `cargo fmt` + `clippy` (default & `tee`) clean.
- `vta-service` **747** (tee) green; `vta-enclave` checks. No version bump (additive).

Plan ref: `tasks/vta-architecture-plan.md` P0.2; design note §4 Option B / §6 (P0.2c+d)