### PR TITLE
fix(vtc-service): route promote-to-admin through the role-change ceremony (P0.14)

### DIFF
--- a/vtc-service/src/routes/members/promote.rs
+++ b/vtc-service/src/routes/members/promote.rs
@@ -26,7 +26,7 @@ use vti_common::auth::passkey::store::{
 };
 
 use crate::acl::admin::{AdminEntry, get_admin_entry, store_admin_entry};
-use crate::acl::{VtcRole, get_acl_entry, store_acl_entry};
+use crate::acl::{VtcRole, get_acl_entry};
 use crate::auth::AdminAuth;
 use crate::error::AppError;
 use crate::members::get_member;
@@ -161,13 +161,13 @@ pub async fn promote_finish(
 
     let cred_id_hex = hex::encode(<_ as AsRef<[u8]>>::as_ref(uv_result.cred_id()));
 
-    // 2. Critical section: re-check + apply role change.
+    // 2. Critical section: re-check, then run the role-change ceremony.
     let _guard = PROMOTE_LOCK.lock().await;
 
-    let mut target_acl = get_acl_entry(&state.acl_ks, &target_did)
+    let target_acl = get_acl_entry(&state.acl_ks, &target_did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
-    let _target_member = get_member(&state.members_ks, &target_did)
+    get_member(&state.members_ks, &target_did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
 
@@ -177,9 +177,24 @@ pub async fn promote_finish(
         )));
     }
 
-    let previous_role = target_acl.role.clone();
-    target_acl.role = VtcRole::Admin;
-    store_acl_entry(&state.acl_ks, &target_acl).await?;
+    // P0.14: route the actual promotion through the role-change ceremony so the
+    // operator's `role_change.rego` — plus the host no-last-admin / step-up
+    // invariants in the Remint executor — governs the community's
+    // highest-privilege grant, instead of a bare ACL write that bypassed
+    // policy entirely. The UV ceremony above is the verified step-up, so we
+    // pass `step_up = true`: the default policy's "admin with a verified
+    // step-up" branch allows, while a tightened policy (quorum/tenure) denies
+    // → 403 even after a valid UV. Remint re-mints the role VEC at `admin` and
+    // delivers it to the member's wallet.
+    let granted = crate::routes::members::update::role_change_via_pipeline(
+        &state,
+        &auth.0.did,
+        &target_did,
+        &target_acl.role.to_string(),
+        "admin",
+        true,
+    )
+    .await?;
 
     // Create the admin sister record so the new admin can enrol a
     // device via the existing passkey flow. Empty passkey list
@@ -205,7 +220,7 @@ pub async fn promote_finish(
             &auth.0.did,
             Some(&target_did),
             AuditEvent::AdminPromoted(AdminPromotedData {
-                previous_role: previous_role.to_string(),
+                previous_role: granted.previous_role,
                 authorising_credential_id: cred_id_hex,
             }),
         )

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -114,6 +114,9 @@ pub async fn update_member(
             &did,
             &acl.role.to_string(),
             &new_role.to_string(),
+            // PATCH carries no reauth — the step-up path is the
+            // promote-to-admin endpoint, which passes `true`.
+            false,
         )
         .await?;
         audit_writer
@@ -153,27 +156,40 @@ pub async fn update_member(
     Ok(Json(MemberResponse::from_pair_for_route(acl, member)))
 }
 
-struct RoleChangeResult {
-    previous_role: String,
-    new_role: String,
+#[derive(Debug)]
+pub(crate) struct RoleChangeResult {
+    pub(crate) previous_role: String,
+    pub(crate) new_role: String,
 }
 
-/// Run a (non-admin) role change through the decision pipeline:
-/// assemble Facts → decide the active `roleChange` policy → apply via
-/// the Remint executor. A policy `deny` → 403; a `refer` (admin
-/// promotion needing step-up — not reachable here since admin is
-/// refused upstream, but an operator policy could still refer) →
+/// Run a role change through the decision pipeline: assemble Facts →
+/// decide the active `roleChange` policy → apply via the Remint executor.
+/// A policy `deny` → 403; a `refer` (admin promotion needing step-up) →
 /// `StepUpRequired`.
-async fn role_change_via_pipeline(
+///
+/// `step_up` reports whether a verified reauth accompanies this change.
+/// PATCH passes `false` (and refuses `admin` upstream); the
+/// promote-to-admin endpoint passes `true` after its UV ceremony so the
+/// policy's "admin with step-up" branch can allow. Shared by both so the
+/// operator's `role_change.rego` governs *every* role transition,
+/// including the highest-privilege admin grant (P0.14).
+pub(crate) async fn role_change_via_pipeline(
     state: &AppState,
     actor_did: &str,
     subject_did: &str,
     current_role: &str,
     target_role: &str,
+    step_up: bool,
 ) -> Result<RoleChangeResult, AppError> {
-    let facts =
-        assemble_role_change_facts(state, actor_did, subject_did, current_role, target_role)
-            .await?;
+    let facts = assemble_role_change_facts(
+        state,
+        actor_did,
+        subject_did,
+        current_role,
+        target_role,
+        step_up,
+    )
+    .await?;
     let verified = VerifiedFacts::assemble(facts)?;
     let policy = load_active_compiled(
         &state.active_policies_ks,
@@ -240,15 +256,16 @@ async fn role_change_via_pipeline(
 }
 
 /// Assemble purpose-`role-change` [`Facts`]: the actor's role, the
-/// subject's current member facts, and the requested `target_role`
-/// (with `step_up: false` — PATCH carries no reauth; the step-up path
-/// is the promote-to-admin endpoint).
+/// subject's current member facts, and the requested `target_role`.
+/// `step_up` flows into `evidence.request.step_up` so the policy's
+/// "admin with a verified step-up" branch can fire on the promote path.
 async fn assemble_role_change_facts(
     state: &AppState,
     actor_did: &str,
     subject_did: &str,
     current_role: &str,
     target_role: &str,
+    step_up: bool,
 ) -> Result<Facts, AppError> {
     let actor_role = get_acl_entry(&state.acl_ks, actor_did)
         .await?
@@ -280,7 +297,7 @@ async fn assemble_role_change_facts(
         evidence: Evidence {
             invitation: None,
             presentation: None,
-            request: Some(json!({ "target_role": target_role, "step_up": false })),
+            request: Some(json!({ "target_role": target_role, "step_up": step_up })),
         },
         state: FactsState {
             subject_member: Some(MemberState {
@@ -324,5 +341,135 @@ impl MemberResponse {
             personhood: member.personhood,
             personhood_asserted_at: member.personhood_asserted_at,
         }
+    }
+}
+
+#[cfg(test)]
+mod p0_14_role_change_policy_tests {
+    //! P0.14: admin promotion must flow through `role_change_via_pipeline`
+    //! (called by `promote_finish` with `step_up = true`), so the operator's
+    //! `role_change.rego` governs the grant. These exercise the shared
+    //! pipeline directly — the full UV ceremony is covered separately.
+    use super::*;
+    use affinidi_status_list::StatusPurpose;
+
+    use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
+    use crate::members::{Member, store_member};
+    use crate::policy::{Policy, PolicyPurpose, set_active_policy_id, store_policy};
+    use crate::test_support::TestVtc;
+
+    const RP: &str = "https://vtc.example.com";
+    const ADMIN: &str = "did:key:zPromoter";
+    const SUBJECT: &str = "did:key:zCandidate";
+
+    async fn build() -> TestVtc {
+        let vtc = TestVtc::builder()
+            .with_signers(true)
+            .with_public_url(RP)
+            .build()
+            .await;
+        crate::policy::default::install_defaults(
+            &vtc.state.policies_ks,
+            &vtc.state.active_policies_ks,
+        )
+        .await
+        .expect("install default policies");
+        for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+            crate::status_list::ensure_initial(
+                &vtc.state.status_lists_ks,
+                purpose,
+                format!("{RP}/v1/status-lists/{purpose}"),
+            )
+            .await
+            .expect("ensure status list");
+        }
+        seed(&vtc, ADMIN, VtcRole::Admin).await;
+        seed(&vtc, SUBJECT, VtcRole::Member).await;
+        vtc
+    }
+
+    async fn seed(vtc: &TestVtc, did: &str, role: VtcRole) {
+        store_acl_entry(
+            &vtc.state.acl_ks,
+            &VtcAclEntry {
+                did: did.into(),
+                role,
+                label: None,
+                allowed_contexts: vec![],
+                created_at: crate::auth::session::now_epoch(),
+                created_by: "did:key:vtc-install".into(),
+                expires_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        store_member(&vtc.state.members_ks, &Member::fresh(did))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn admin_promotion_with_step_up_is_allowed_by_default_policy() {
+        let vtc = build().await;
+        let granted = role_change_via_pipeline(
+            &vtc.state, ADMIN, SUBJECT, "member", "admin", /* step_up */ true,
+        )
+        .await
+        .expect("default policy allows admin promotion with a verified step-up");
+        assert_eq!(granted.new_role, "admin");
+        assert_eq!(granted.previous_role, "member");
+        // The Remint executor wrote the new role.
+        let acl = get_acl_entry(&vtc.state.acl_ks, SUBJECT)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(acl.role, VtcRole::Admin);
+    }
+
+    #[tokio::test]
+    async fn admin_promotion_is_403_when_policy_denies_even_with_step_up() {
+        let vtc = build().await;
+        // Activate a role_change policy that refuses every promotion.
+        let src = "package vtc.role_change\nimport rego.v1\n\
+                   default decision := {\"effect\": \"deny\", \"with\": {\"code\": \"frozen\"}}\n";
+        let id = uuid::Uuid::new_v4();
+        let sha: [u8; 32] = {
+            use sha2::{Digest, Sha256};
+            Sha256::digest(src.as_bytes()).into()
+        };
+        store_policy(
+            &vtc.state.policies_ks,
+            &Policy {
+                id,
+                purpose: PolicyPurpose::RoleChange,
+                rego_source: src.into(),
+                sha256: sha,
+                activated_at: Some(Utc::now()),
+                author_did: "did:key:test".into(),
+                created_at: Utc::now(),
+                version: 1,
+            },
+        )
+        .await
+        .unwrap();
+        set_active_policy_id(&vtc.state.active_policies_ks, PolicyPurpose::RoleChange, id)
+            .await
+            .unwrap();
+
+        let err = role_change_via_pipeline(
+            &vtc.state, ADMIN, SUBJECT, "member", "admin", /* step_up */ true,
+        )
+        .await
+        .expect_err("a deny policy must block the promotion even after a valid UV");
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "deny → 403 Forbidden; got {err:?}"
+        );
+        // The ACL was left untouched.
+        let acl = get_acl_entry(&vtc.state.acl_ks, SUBJECT)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(acl.role, VtcRole::Member, "denied promotion must not write");
     }
 }


### PR DESCRIPTION
## P0.14 — Promote-to-admin bypasses the role-change policy entirely

### Problem
`PATCH /v1/members/{did}` refuses `role=admin` specifically so the role-change policy's step-up branch is reached on the dedicated promote endpoint — but `promote_finish` (`routes/members/promote.rs`) ran **no policy at all**: passkey UV ceremony, then a direct `target_acl.role = VtcRole::Admin` write. The operator-authored `vtc.role_change` policy — the documented governance surface for the community's single most privileged grant — was never consulted on the actual admin-promotion path. An operator who tightens `role_change.rego` (quorum/tenure) was silently ignored.

### Fix
Share the role-change pipeline between PATCH and promote:
- `role_change_via_pipeline` / `assemble_role_change_facts` (in `update.rs`) gain a `step_up` parameter and are exposed `pub(crate)`. PATCH passes `false` (and still refuses admin upstream); the promote endpoint passes `true` — its UV ceremony is the verified step-up.
- `promote_finish` now calls `role_change_via_pipeline(..., target="admin", step_up=true)` after a successful UV, instead of writing the ACL directly. Under the default `role_change.rego`, the "admin with a verified step-up" branch allows; a tightened policy that denies yields **403 even after a valid UV**. The `Remint` executor applies the grant (re-mints the role VEC, enforces no-last-admin via `LAST_ADMIN_LOCK`, delivers the VEC). The `AdminEntry` sister record + `AdminPromoted` audit are unchanged.

### Acceptance
- ✅ a `role_change.rego` returning `deny` for an admin promotion causes `promote_finish` to 403 even after a valid UV.

### Tests
Two lib unit tests drive the shared pipeline directly (the full UV ceremony is covered separately, per the existing test split): admin promotion with `step_up=true` is allowed under the default policy (ACL becomes admin); the same is `Forbidden` (→403) under a deny policy, leaving the ACL untouched. `cargo fmt --check` clean, no new clippy warnings, `members_crud` 13 pass, full lib suite **535**.

Note: routing through `Remint` means `promote_finish` now re-mints the member's role VEC at `admin` (additive, consistent with all other role changes) and requires the credential signer — already required by every other ceremony path on a configured VTC.