### PR TITLE
feat(sdk,pnm): client-side PCR pinning for bootstrap connect (P3.4)

### DIFF
--- a/docs/02-vta/tee-architecture.md
+++ b/docs/02-vta/tee-architecture.md
@@ -316,6 +316,22 @@ statement — all data operations require attestation:
 or config change baked into the EIF). After each build, update the KMS key policy
 with the new PCR0 value from `nitro-cli build-enclave` output.
 
+**Client-side PCR pinning (P3.4).** The KMS key policy pins the image *server-side*
+(KMS won't release secrets to the wrong PCR0/PCR8). Operators can additionally pin
+it *client-side* at first-boot bootstrap:
+
+```bash
+pnm bootstrap connect --vta-url https://vta.example.com \
+    --expect-pcr0 <hash> --expect-pcr8 <hash>
+```
+
+The attestation is always cryptographically verified; `--expect-pcr0/--expect-pcr8`
+add defense-in-depth — a genuine-but-*wrong* enclave build produces a valid quote
+with a different PCR0, and the pin makes `pnm` refuse to install the admin
+credential (typed `PcrMismatch`). Use the **same** `nitro-cli build-enclave` hashes
+you put in the KMS policy; when PCR0 rotates on a rebuild, update both. Omit the
+flags to accept any genuine Nitro enclave (the pre-P3.4 behaviour).
+
 ### Component 4: Config Changes
 
 ```toml

--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -160,7 +160,10 @@ pub async fn run_open(
             }
             println!();
             println!("To install this credential, use the online bootstrap flow:");
-            println!("  pnm bootstrap connect --vta-url <url> [--expect-digest <sha256>]");
+            println!(
+                "  pnm bootstrap connect --vta-url <url> [--expect-digest <sha256>] \
+                 [--expect-pcr0 <hex>] [--expect-pcr8 <hex>]"
+            );
         }
         SealedPayloadV1::ContextProvision(p) => {
             println!("Payload: ContextProvision");
@@ -255,20 +258,25 @@ struct BootstrapResponseWire {
     digest: String,
 }
 
-/// `pnm bootstrap connect --vta-url <URL> [--expect-digest <HEX>]`
+/// `pnm bootstrap connect --vta-url <URL> [--expect-digest <HEX>]
+///   [--expect-pcr0 <HEX>] [--expect-pcr8 <HEX>]`
 ///
 /// Online TEE first-boot bootstrap. Generates an ephemeral Ed25519 keypair,
 /// POSTs the `did:key` as `client_did` to `/bootstrap/request`, verifies
-/// the attestation quote, installs the minted admin credential, and
+/// the attestation quote (optionally pinning the enclave PCR0/PCR8 — P3.4),
+/// installs the minted admin credential, and
 /// registers the VTA under a slug in `pnm` config. Only the first successful
 /// call against a fresh TEE VTA succeeds — the carve-out closes on success.
 ///
 /// For non-TEE VTAs use `pnm setup` (temp did:key + admin grant via
 /// `vta acl create` + auto-rotate on first authenticated connect).
+#[allow(clippy::too_many_arguments)]
 pub async fn run_connect(
     vta_url: String,
     expect_digest: Option<String>,
     no_verify_digest: bool,
+    expect_pcr0: Option<String>,
+    expect_pcr8: Option<String>,
     vta_slug: Option<String>,
     pnm_config: &mut crate::config::PnmConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -333,13 +341,34 @@ pub async fn run_connect(
     // so we pass the raw Ed25519 pubkey we generated (the same bytes the
     // server decoded from `client_did`) rather than any X25519 derivative.
     let attest = verify_nitro_assertion(&opened.producer, &ed_pub, &nonce)?;
+    // Client-side PCR pinning (P3.4): refuse a genuine-but-WRONG enclave image
+    // / signing cert. No-op unless the operator passed --expect-pcr0/8.
+    attest
+        .check_pcrs(expect_pcr0.as_deref(), expect_pcr8.as_deref())
+        .map_err(|e| {
+            format!(
+                "{e}. The attestation is cryptographically valid but the enclave does not \
+                 match the pinned measurement — refusing to bootstrap. Confirm the expected \
+                 PCR against the deployed EIF / KMS key policy."
+            )
+        })?;
     println!("TEE attestation verified.");
     println!("  Enclave module: {}", attest.module_id);
     if !attest.pcr0_hex.is_empty() {
-        println!("  PCR0:           {}", attest.pcr0_hex);
+        let pinned = if expect_pcr0.is_some() {
+            " (pinned ✓)"
+        } else {
+            ""
+        };
+        println!("  PCR0:           {}{pinned}", attest.pcr0_hex);
     }
     if !attest.pcr8_hex.is_empty() {
-        println!("  PCR8:           {}", attest.pcr8_hex);
+        let pinned = if expect_pcr8.is_some() {
+            " (pinned ✓)"
+        } else {
+            ""
+        };
+        println!("  PCR8:           {}{pinned}", attest.pcr8_hex);
     }
 
     let credential = match opened.payload {

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -284,6 +284,16 @@ pub(crate) enum BootstrapCommands {
         /// Required when `--expect-digest` is not provided; there is no silent TOFU.
         #[arg(long)]
         no_verify_digest: bool,
+        /// Pin the enclave image measurement (PCR0, hex). When set, refuse to
+        /// bootstrap unless the attested PCR0 matches — defense-in-depth so a
+        /// genuine-but-wrong enclave build can't complete the handshake. Match
+        /// the value baked into the KMS key policy (see the TEE runbook).
+        #[arg(long)]
+        expect_pcr0: Option<String>,
+        /// Pin the EIF signing-certificate measurement (PCR8, hex). As
+        /// `--expect-pcr0`, but for the signing cert.
+        #[arg(long)]
+        expect_pcr8: Option<String>,
         /// Slug to register this VTA under in pnm config (default: tail of the
         /// VTA DID).
         #[arg(long)]

--- a/pnm-cli/src/commands/bootstrap.rs
+++ b/pnm-cli/src/commands/bootstrap.rs
@@ -42,12 +42,16 @@ pub(crate) async fn run_offline(
             vta_url,
             expect_digest,
             no_verify_digest,
+            expect_pcr0,
+            expect_pcr8,
             slug,
         } => Some(
             bootstrap::run_connect(
                 vta_url.clone(),
                 expect_digest.clone(),
                 *no_verify_digest,
+                expect_pcr0.clone(),
+                expect_pcr8.clone(),
                 slug.clone(),
                 pnm_config,
             )

--- a/tasks/vta-architecture-todo.md
+++ b/tasks/vta-architecture-todo.md
@@ -349,7 +349,19 @@ CLAUDE.md hot-spots section updated.
   P1.3 — PR: ____
 - `[ ]` **P3.3** (M) Vetted CMS/DER crate + real-KMS golden vector; bounded KMS
   retry at boot — PR: ____
-- `[ ]` **P3.4** (S) `--expect-pcr0/8` pinning in `pnm bootstrap connect` — PR: ____
+- `[x]` **P3.4** (S) `--expect-pcr0/8` pinning in `pnm bootstrap connect` —
+  branch `fix/p3.4-pcr-pinning` (worktree). `verify_nitro_assertion` extracted
+  PCR0/8 but never checked them — any genuine Nitro enclave passed, only the
+  KMS key policy pinned the image. Added `VerifiedAttestation::check_pcrs`
+  (case/0x/whitespace-tolerant) + typed `PcrMismatch { which, expected, actual }`
+  in `vta-sdk::attestation`; new `pnm bootstrap connect --expect-pcr0/--expect-pcr8`
+  thread through to it and **refuse to install the admin credential** on
+  mismatch (genuine-but-wrong build → valid quote, different PCR0). Non-breaking
+  (method on the returned `VerifiedAttestation`, opt-in; `None` = pre-P3.4
+  accept-any). Docs: client-pin block in `tee-architecture.md` next to the KMS
+  PCR0-rotation note (use the same `nitro-cli build-enclave` hashes). Tests:
+  check_pcrs none/match (case+0x)/pcr0-mismatch/pcr8-mismatch/absent-pcr.
+  fmt + clippy clean; vta-sdk 168, pnm-cli 39 green — PR: ____
 - `[ ]` **P3.5** (S) `cargo hack --each-feature` CI + REST-only test job — PR: ____
 - `[ ]` **P3.6** (M) Pure `BootDecision` resolver in kms_bootstrap with full
   truth-table tests — PR: ____

--- a/vta-sdk/src/attestation.rs
+++ b/vta-sdk/src/attestation.rs
@@ -50,6 +50,19 @@ pub enum AttestationVerifyError {
     BadProducerDid(String),
 }
 
+/// An attested enclave measurement did not match the operator-pinned value
+/// (P3.4). The attestation itself is cryptographically valid — this is the
+/// defense-in-depth check that the *right* enclave image / signing cert is
+/// running, which otherwise only the KMS key policy pins.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("PCR{which} mismatch: enclave reported {actual}, operator expected {expected}")]
+pub struct PcrMismatch {
+    /// Which PCR diverged (0 = image, 8 = signing cert).
+    pub which: u8,
+    pub expected: String,
+    pub actual: String,
+}
+
 use crate::hex::lower as hex_lower;
 
 fn is_nitro_format(format: &str) -> bool {
@@ -135,6 +148,59 @@ pub fn verify_nitro_quote(
         pcr0_hex,
         pcr8_hex,
     })
+}
+
+/// Normalize a hex PCR string for comparison: strip an optional `0x`/`0X`
+/// prefix and any whitespace, lowercase the rest.
+fn normalize_pcr_hex(s: &str) -> String {
+    let s = s.trim();
+    let s = s
+        .strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(s);
+    s.chars()
+        .filter(|c| !c.is_whitespace())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+impl VerifiedAttestation {
+    /// Pin the verified enclave's measurements to operator-supplied expected
+    /// values (P3.4 — client-side PCR pinning). A `None` expectation is not
+    /// checked; comparison is case-insensitive and tolerates a `0x` prefix /
+    /// whitespace. Returns [`PcrMismatch`] on the first divergence.
+    ///
+    /// The cryptographic attestation only proves the quote came from *a*
+    /// genuine Nitro enclave — a different (wrong) VTA build still produces a
+    /// valid quote, just with a different PCR0. Pinning lets the operator
+    /// refuse to bootstrap against anything but the exact expected image
+    /// (PCR0) and signing cert (PCR8), the same values the KMS key policy pins
+    /// server-side.
+    pub fn check_pcrs(
+        &self,
+        expect_pcr0: Option<&str>,
+        expect_pcr8: Option<&str>,
+    ) -> Result<(), PcrMismatch> {
+        check_pcr(0, expect_pcr0, &self.pcr0_hex)?;
+        check_pcr(8, expect_pcr8, &self.pcr8_hex)?;
+        Ok(())
+    }
+}
+
+fn check_pcr(which: u8, expected: Option<&str>, actual: &str) -> Result<(), PcrMismatch> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let expected = normalize_pcr_hex(expected);
+    let actual = normalize_pcr_hex(actual);
+    if expected != actual {
+        return Err(PcrMismatch {
+            which,
+            expected,
+            actual,
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -296,5 +362,55 @@ mod tests {
         // trips through the public API. A later CI job with real
         // fixtures will exercise the full path.
         let _ = AttestationVerifyError::BadProducerDid("smoke".into());
+    }
+
+    fn attest(pcr0: &str, pcr8: &str) -> VerifiedAttestation {
+        VerifiedAttestation {
+            module_id: "i-abc".into(),
+            pcr0_hex: pcr0.into(),
+            pcr8_hex: pcr8.into(),
+        }
+    }
+
+    #[test]
+    fn check_pcrs_none_is_noop() {
+        // No pins → accept any genuine attestation (pre-P3.4 behaviour).
+        assert!(attest("aaaa", "bbbb").check_pcrs(None, None).is_ok());
+    }
+
+    #[test]
+    fn check_pcrs_matching_passes_case_and_prefix_insensitive() {
+        let a = attest("ABCD1234", " effff ");
+        // Case-insensitive, tolerates 0x prefix and surrounding whitespace.
+        assert!(a.check_pcrs(Some("0xabcd1234"), Some("EFFFF")).is_ok());
+        assert!(a.check_pcrs(Some("abcd1234"), None).is_ok());
+    }
+
+    #[test]
+    fn check_pcrs_pcr0_mismatch_is_typed() {
+        let err = attest("aaaa", "bbbb")
+            .check_pcrs(Some("dead"), None)
+            .expect_err("wrong PCR0 must be rejected");
+        assert_eq!(err.which, 0);
+        assert_eq!(err.expected, "dead");
+        assert_eq!(err.actual, "aaaa");
+    }
+
+    #[test]
+    fn check_pcrs_pcr8_mismatch_is_typed() {
+        let err = attest("aaaa", "bbbb")
+            .check_pcrs(Some("aaaa"), Some("cafe"))
+            .expect_err("wrong PCR8 must be rejected");
+        assert_eq!(err.which, 8);
+    }
+
+    #[test]
+    fn check_pcrs_expecting_an_absent_pcr_fails() {
+        // Operator pins PCR0 but the quote carried none (empty) → mismatch.
+        let err = attest("", "bbbb")
+            .check_pcrs(Some("abcd"), None)
+            .expect_err("pinning an absent PCR must fail closed");
+        assert_eq!(err.which, 0);
+        assert_eq!(err.actual, "");
     }
 }


### PR DESCRIPTION
`verify_nitro_assertion` extracted PCR0/PCR8 from the attestation but **never checked them** — any genuine Nitro enclave passed, so only the *server-side* KMS key policy pinned the image. A genuine-but-**wrong** enclave build produces a valid quote with a different PCR0, and nothing on the client refused it.

## What
- **`vta-sdk::attestation`**: `VerifiedAttestation::check_pcrs(expect_pcr0, expect_pcr8)` compares the attested measurements to operator-supplied values (case-insensitive; tolerates `0x` prefix / whitespace) and returns a typed `PcrMismatch { which, expected, actual }`. A `None` expectation isn't checked → **opt-in and non-breaking** (a method on the already-returned `VerifiedAttestation`, not a signature change; the one real caller and all tests are untouched).
- **`pnm bootstrap connect`**: new `--expect-pcr0` / `--expect-pcr8` flags thread through to `check_pcrs`; on mismatch the command **refuses to install the minted admin credential** with a clear message. Omitting the flags keeps the pre-P3.4 accept-any-genuine-enclave behaviour.
- **docs**: client-pin block in `tee-architecture.md` next to the KMS PCR0-rotation note — use the same `nitro-cli build-enclave` hashes for both, and update both when PCR0 rotates on a rebuild.

## Tests
`check_pcrs`: none-is-noop, matching (case + `0x` + whitespace), PCR0-mismatch and PCR8-mismatch are typed, pinning an *absent* PCR fails closed.

## Gate
- `cargo fmt` + `clippy` clean.
- `vta-sdk` **168**, `pnm-cli` **39** green.

Plan ref: `tasks/vta-architecture-plan.md` P3.4