### PR TITLE
fix(vtc-service): don't surface unverified VC claims as valid facts on the submit path (P0.12)

### DIFF
--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -370,11 +370,20 @@ async fn assemble_join_facts(
     })
 }
 
-/// Project the VP into the verified [`Presentation`] the policy reads.
-/// Holder-binding is already checked (`verified: true`). Credentials
-/// surface with `issuer_trusted: false` / `status: valid` — issuer
-/// trust (TRQP) and status-list resolution are follow-ups; the
-/// structured shape is what matters for the decision contract.
+/// Project the VP into the [`Presentation`] the policy reads.
+///
+/// `verified: true` reflects the **presentation-level** holder-binding the
+/// route already checked (`verify_holder_signature` over the canonical
+/// payload) — the applicant proved control of `applicant_did`. It does **not**
+/// mean the *embedded VCs* were verified: this raw-VP path performs no
+/// per-credential proof / issuer / status resolution (that is the
+/// `vp_token` / credential-exchange `present` path). So each projected
+/// credential is fail-safe — `issuer_trusted: false`, `holder_bound: false`,
+/// `status: unknown` (not `valid` — its status list was never read), and
+/// **`claims: null`** so a policy that branches on credential claims cannot be
+/// fooled into auto-admitting on a forged VC presented under a verified
+/// holder-binding (P0.12). The raw claims are still surfaced for the admin
+/// show / approve UI via the request row's separate `vp_claims` projection.
 fn presentation_from_vp(applicant_did: &str, vp: &JsonValue) -> Presentation {
     let holder = vp
         .get("holder")
@@ -427,16 +436,17 @@ fn credential_from_vc(vc: &JsonValue) -> Option<Credential> {
         credential_type,
         issuer,
         issuer_trusted: false,
-        status: CredentialStatus::Valid,
-        // This raw-VC path does not verify a *per-credential* holder-key binding
-        // (no `kb-jwt` / holder proof / pseudonym check like the vp_token path) —
-        // so we don't claim one. Fail-safe: a policy requiring holder binding will
-        // (correctly) not be satisfied by these.
+        // The raw-VP submit path verifies NOTHING about the embedded VC — not
+        // its issuer proof, not its holder-key binding (no `kb-jwt` / holder
+        // proof / pseudonym check like the vp_token path), and not its
+        // status-list state. So every trust signal is fail-safe: `unknown`
+        // status (the list was never read — not `valid`), `issuer_trusted` /
+        // `holder_bound` false, and **null claims** so a claims-reading policy
+        // cannot auto-admit on attacker-supplied claim values (P0.12). A policy
+        // that needs the claims must run the verifying `present` path.
+        status: CredentialStatus::Unknown,
         holder_bound: false,
-        claims: obj
-            .get("credentialSubject")
-            .cloned()
-            .unwrap_or(JsonValue::Null),
+        claims: JsonValue::Null,
         valid_until: None,
     })
 }
@@ -587,5 +597,66 @@ mod tests {
         )
         .expect_err("non-did:key must fail");
         assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    // ── P0.12: embedded VCs on the raw-VP submit path are fail-safe ──
+
+    #[test]
+    fn presentation_from_vp_does_not_present_unverified_vc_claims() {
+        // A forged VC with attacker-chosen claims, presented under a
+        // (separately-verified) holder binding. The raw-VP path verifies none
+        // of the embedded VC, so its claims/status/trust signals must be
+        // fail-safe — otherwise a policy reading `credentials[].claims` would
+        // auto-admit on forged content.
+        let applicant = "did:key:zApplicant";
+        let vp = serde_json::json!({
+            "type": "VerifiablePresentation",
+            "holder": applicant,
+            "verifiableCredential": [
+                {
+                    "issuer": "did:key:zForgedIssuer",
+                    "type": ["VerifiableCredential", "EmailCredential"],
+                    "credentialSubject": { "email": "ceo@acme.com" }
+                }
+            ]
+        });
+
+        let p = presentation_from_vp(applicant, &vp);
+
+        // Presentation-level holder-binding is the route's verdict; the policy
+        // gate (assemble) still passes so a legitimate submit lands pending.
+        assert!(p.verified, "holder-binding is verified at the route");
+        assert_eq!(p.holder, applicant);
+        assert_eq!(p.credentials.len(), 1);
+
+        let c = &p.credentials[0];
+        // Structural metadata is fine to surface…
+        assert_eq!(c.credential_type, "EmailCredential");
+        assert_eq!(c.issuer, "did:key:zForgedIssuer");
+        // …but every trust signal must be fail-safe.
+        assert!(!c.issuer_trusted, "issuer not vetted on the raw path");
+        assert!(!c.holder_bound, "no per-credential holder proof checked");
+        assert_eq!(
+            c.status,
+            CredentialStatus::Unknown,
+            "status list was never read — must not claim `valid`"
+        );
+        assert_eq!(
+            c.claims,
+            JsonValue::Null,
+            "unverified VC claims must NOT be surfaced to the policy"
+        );
+    }
+
+    #[test]
+    fn presentation_from_vp_with_no_embedded_vcs_is_holder_binding_only() {
+        // The common case: a bare holder-binding VP (no credentials). The
+        // presentation is verified (so the submit lands pending) and carries
+        // no credentials for a policy to (mis)trust.
+        let applicant = "did:key:zApplicant";
+        let vp = serde_json::json!({ "type": "VerifiablePresentation", "holder": applicant });
+        let p = presentation_from_vp(applicant, &vp);
+        assert!(p.verified);
+        assert!(p.credentials.is_empty());
     }
 }


### PR DESCRIPTION
## P0.12 — `Presentation.verified = true` stamped over cryptographically-unverified VCs on the submit path

### Problem
On the REST/DIDComm join-submit path only the **outer** holder-binding signature is checked; the VP's embedded VCs were projected straight from attacker-controlled JSON into ceremony `Credential`s with `status: valid` and verbatim `claims`, under `Presentation { verified: true }`. `facts.rs` documents a `Credential` as "already verified", so any operator policy branching on `evidence.presentation.credentials[].claims` (e.g. "allow if email ends `@acme.com`") would auto-admit on a **fully forged VC**. The shipped `join.rego` requires `issuer_trusted` (hardcoded false here) so the *default* can't auto-admit, but a claims-reading custom policy was exploitable — and the verifying `present`/`vp_token` path made the inconsistency invisible (identical-looking facts, opposite guarantees).

### Fix
`presentation_from_vp` keeps `verified: true` **only** for the presentation-level holder-binding the route genuinely verified (`verify_holder_signature`). The embedded VCs are now fail-safe, since this path resolves no per-credential proof / issuer / status:
- `status: unknown` (the status list was never read — not `valid`),
- `issuer_trusted` / `holder_bound` already `false`,
- **`claims: null`** — unverified claims are not surfaced to the policy.

A policy that needs the claims must run the verifying `present` path. The raw claims remain available for the admin show / approve UI via the request row's separate `vp_claims` projection (unaffected).

### Why not flip `verified` to false
The `VerifiedFacts::assemble` gate turns `presentation.verified == false` into a hard reject, which would break the documented flow where a VC-bearing submit lands **pending** for manual approval (integration test `rest_submit_under_default_join_policy_lands_pending_with_vp_claims`). Nulling the unverified claims achieves the plan's stated goal — *"never present unverified VC claims under verified: true"* — without rejecting the legitimate holder-binding submit.

### Acceptance
- ✅ submitting a VP whose embedded VC is unverified yields facts that do **not** present its claims as trusted/valid (claims `null`, status `unknown`, `issuer_trusted`/`holder_bound` false) — a claims-reading policy is fail-safe.

### Tests
`presentation_from_vp` unit tests: a forged embedded VC → null claims / unknown status / untrusted flags (structural type+issuer still surfaced); a bare holder-binding VP stays verified with no credentials. `cargo fmt --check` clean, no new clippy warnings, full lib suite **535**, join_requests integration **41** (incl. the pending-with-VC test).