### PR TITLE
fix(vtc-service): multi-thread REST runtime + request timeout + offload Argon2id (P0.10)

### DIFF
--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -142,7 +142,7 @@ axum-extra = { workspace = true }
 jsonwebtoken = { workspace = true }
 fjall = { workspace = true }
 toml = { workspace = true }
-tower-http = { workspace = true, features = ["cors", "trace"] }
+tower-http = { workspace = true, features = ["cors", "trace", "timeout"] }
 tower_governor = "0.8"
 mime_guess = { version = "2", optional = true }
 unicode-normalization = { version = "0.1", optional = true }

--- a/vtc-service/src/routes/admin/invites.rs
+++ b/vtc-service/src/routes/admin/invites.rs
@@ -186,7 +186,14 @@ pub async fn create_invite(
 
     let minted = mint_install_token(signer.as_ref(), &vtc_did, &req.did, ttl_seconds)?;
     let claim_code = claim_secret::generate();
-    let claim_code_hash = claim_secret::hash(&claim_code)?;
+    // Argon2id hashing is CPU-bound (~50–200 ms); keep it off the async REST
+    // runtime so a burst of invite mints doesn't stall other requests (P0.10).
+    let claim_code_hash = {
+        let claim_code = claim_code.clone();
+        tokio::task::spawn_blocking(move || claim_secret::hash(&claim_code))
+            .await
+            .map_err(|e| AppError::Internal(format!("claim-secret hash task failed: {e}")))??
+    };
     let expires_at = Utc::now() + ChronoDuration::seconds(ttl_seconds as i64);
     state
         .install_store

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -134,7 +134,18 @@ pub async fn claim_start(
                 message: "claim_secret_required".into(),
             });
         };
-        if !claim_secret::verify(supplied, &stored_hash)? {
+        // Argon2id verification is CPU-bound (~50–200 ms); run it on the
+        // blocking pool so it doesn't stall the async REST runtime — this is
+        // an *unauthenticated* route, so a few concurrent claim-starts must
+        // not wedge every other request (P0.10).
+        let supplied = supplied.to_string();
+        let verified =
+            tokio::task::spawn_blocking(move || claim_secret::verify(&supplied, &stored_hash))
+                .await
+                .map_err(|e| {
+                    AppError::Internal(format!("claim-secret verify task failed: {e}"))
+                })??;
+        if !verified {
             return Err(AppError::ServiceError {
                 status: StatusCode::UNAUTHORIZED,
                 message: "claim_secret_invalid".into(),

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -26,6 +26,7 @@ use crate::store::{KeyspaceHandle, Store};
 use crate::supervisor::{SupervisorKind, detect_supervisor};
 use tokio::sync::{RwLock, watch};
 use tower_http::cors::CorsLayer;
+use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, warn};
 use vti_common::audit::{AuditKeyStore, AuditWriter};
@@ -37,6 +38,12 @@ use webauthn_rs::Webauthn;
 /// canonical "how long is an admin invite redeemable" value. An hour
 /// is the same default `webvh-common`'s passkey routes use.
 const DEFAULT_ENROLLMENT_TTL_SECS: u64 = 60 * 60;
+
+/// Whole-request timeout for the REST surface (P0.10). A wedged handler — a
+/// registry call without its own timeout, a slow downstream — must not hold
+/// its connection (and a runtime worker) open forever. `tower_http`'s
+/// `TimeoutLayer` returns `408 Request Timeout` when exceeded.
+const REST_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[derive(Clone)]
 #[allow(dead_code)]
@@ -961,13 +968,24 @@ fn run_rest_thread(
     routing: crate::config::RoutingConfig,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
-    let rt = tokio::runtime::Builder::new_current_thread()
+    // P0.10: the REST surface must not run CPU-bound work (Argon2id verify on
+    // the unauth claim-start, Rego eval, VC signing) on a single executor — a
+    // few distinct source IPs hitting claim-start would otherwise saturate the
+    // lone thread (the 5 rps governor is per-IP, so it doesn't help). A small
+    // worker pool lets concurrent requests progress while one is mid-Argon2id;
+    // the heavy calls themselves are also moved off-runtime via `spawn_blocking`.
+    let worker_threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(2)
+        .clamp(2, 8);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
         .enable_all()
         .build()
         .expect("failed to build REST runtime");
 
     rt.block_on(async {
-        info!("REST thread started");
+        info!(worker_threads, "REST thread started");
 
         let listener = tokio::net::TcpListener::from_std(std_listener)
             .expect("failed to convert std TcpListener to tokio TcpListener");
@@ -995,20 +1013,24 @@ fn run_rest_thread(
         let website_state = build_website_state(&state.config).await;
 
         let trust_xff = state.config.read().await.server.trust_xff;
+        // `TimeoutLayer` is the outermost layer so the whole-request budget
+        // (P0.10) covers every inner middleware + the handler.
         #[cfg(feature = "website")]
         let app = routes::router_with_xff(&routing, website_state, trust_xff)
             .with_state(state)
             .layer(csrf_layer)
             .layer(host_layer)
             .layer(cors_layer)
-            .layer(TraceLayer::new_for_http());
+            .layer(TraceLayer::new_for_http())
+            .layer(TimeoutLayer::new(REST_REQUEST_TIMEOUT));
         #[cfg(not(feature = "website"))]
         let app = routes::router_with_xff(&routing, trust_xff)
             .with_state(state)
             .layer(csrf_layer)
             .layer(host_layer)
             .layer(cors_layer)
-            .layer(TraceLayer::new_for_http());
+            .layer(TraceLayer::new_for_http())
+            .layer(TimeoutLayer::new(REST_REQUEST_TIMEOUT));
 
         let shutdown_rx = shutdown_rx.clone();
         // `into_make_service_with_connect_info` is required for the
@@ -1419,5 +1441,54 @@ async fn shutdown_signal() {
     tokio::select! {
         () = ctrl_c => info!("received SIGINT"),
         () = terminate => info!("received SIGTERM"),
+    }
+}
+
+#[cfg(test)]
+mod p0_10_timeout_tests {
+    //! P0.10: the REST `TimeoutLayer` bounds each request so a wedged handler
+    //! can't hold a connection (and a worker) forever, and a concurrent fast
+    //! request is unaffected.
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn timeout_layer_408s_a_slow_handler_but_not_a_fast_one() {
+        async fn slow() -> &'static str {
+            tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+            "done"
+        }
+        async fn fast() -> &'static str {
+            "ok"
+        }
+
+        let app = axum::Router::new()
+            .route("/slow", get(slow))
+            .route("/fast", get(fast))
+            .layer(TimeoutLayer::new(std::time::Duration::from_millis(50)));
+
+        let slow_res = app
+            .clone()
+            .oneshot(Request::builder().uri("/slow").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            slow_res.status(),
+            StatusCode::REQUEST_TIMEOUT,
+            "a handler exceeding the budget must 408"
+        );
+
+        let fast_res = app
+            .oneshot(Request::builder().uri("/fast").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            fast_res.status(),
+            StatusCode::OK,
+            "a fast request must be unaffected by the timeout"
+        );
     }
 }


### PR DESCRIPTION
## P0.10 — Single-threaded REST runtime + synchronous Argon2id + no request timeout

### Problem
The REST surface ran on `new_current_thread`, and CPU-bound work ran inline on that one executor: Argon2id verify on the **unauth** `/v1/install/claim/start` (m=19456 KiB, ~50–200 ms), Argon2id hash on invite mint, plus Rego eval / VC signing. A handful of distinct source IPs hitting claim-start saturated the lone thread (the 5 rps governor is per-IP, so it doesn't help). And there was no `TimeoutLayer` anywhere, so one wedged handler (a registry call without its own timeout) held its connection — and a runtime slot — forever.

### Fix
- **Multi-thread REST runtime.** `new_multi_thread` with `worker_threads = clamp(available_parallelism, 2..=8)`, so concurrent requests make progress while one is mid-Argon2id.
- **Request timeout.** `tower_http::timeout::TimeoutLayer` (30 s) as the outermost REST layer (returns `408`); enabled the tower-http `timeout` feature.
- **Offload Argon2id.** Both calls move onto `spawn_blocking`: `claim_secret::verify` in `claim_start` and `claim_secret::hash` in the admin invite-mint route — the hashing never runs on an async runtime thread.

### Acceptance
- ✅ a slow handler doesn't delay a concurrent `/health` past the timeout (TimeoutLayer 408s the slow one; the fast one is unaffected).
- ✅ claim-start verify no longer runs on the async thread.

### Tests
`timeout_layer_408s_a_slow_handler_but_not_a_fast_one` (slow handler → 408, concurrent fast → 200); existing `install_claim` (13) + `install_flow` (1) confirm claim-start verify correctness is unchanged through `spawn_blocking`. `cargo fmt --check` clean, no new clippy warnings, full lib suite **534**.

> Touches `server.rs` (runtime + router layer) — disjoint regions from the unmerged P0.9 (`init_auth`), so a clean 3-way merge.