### PR TITLE
fix(vtc-service): bind join-submit signature to audience + freshness, dedup open requests (P0.13)

### DIFF
--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -16,6 +16,8 @@
 //!   "vp":               { … opaque JSON … },
 //!   "registryConsent":  ? bool,
 //!   "extensions":       ? object,
+//!   "audience":         "<this VTC's did>",
+//!   "created":          <unix-seconds>,
 //!   "signature":        "<hex Ed25519 signature>"
 //! }
 //! ```
@@ -28,12 +30,20 @@
 //!   "vp":               vp,
 //!   "registryConsent":  registry_consent (default false),
 //!   "extensions":       extensions (default null),
+//!   "audience":         audience,
+//!   "created":          created,
 //! })
 //! ```
 //!
 //! `canonical_json` is just `serde_json::to_vec` on a
 //! key-ordered object — sufficient because both sides agree on
 //! the field ordering via the typed struct.
+//!
+//! `audience` (must equal this VTC's `vtc_did`) and `created` (within a
+//! short freshness window) are bound into the signature so a captured body
+//! can't be replayed against another community or after the window (P0.13).
+//! On the DIDComm path the authcrypt envelope authenticates + addresses the
+//! sender, so it carries no separate signature/audience/created.
 
 use axum::Json;
 use axum::extract::State;
@@ -54,12 +64,19 @@ use crate::ceremony::{
     Presentation, Purpose, State as FactsState, Subject, Verdict, VerifiedFacts,
 };
 use crate::community::load_profile;
-use crate::join::{JoinRequest, JoinStatus, JoinTransport, store_join_request};
+use crate::join::{JoinRequest, JoinStatus, JoinTransport, list_join_requests, store_join_request};
 use crate::members::list_members;
 use crate::policy::{PolicyPurpose, extract::extract_vp_claims, load_active_compiled};
 use crate::server::AppState;
 
 pub const JOIN_REQUEST_SUBMIT_DOMAIN_TAG: &[u8] = b"vtc-join-request/v1\0";
+
+/// How old a join-submit holder signature's `created` may be (seconds).
+/// Bounds replay of a captured body to this window; the per-applicant
+/// open-request dedup closes the in-window concurrent-replay gap (P0.13).
+const JOIN_SUBMIT_FRESHNESS_SECS: i64 = 300;
+/// Tolerated clock skew for a `created` slightly in the future.
+const JOIN_SUBMIT_FUTURE_SKEW_SECS: i64 = 60;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -70,8 +87,26 @@ pub struct SubmitRequestBody {
     pub registry_consent: bool,
     #[serde(default)]
     pub extensions: JsonValue,
-    /// Hex-encoded Ed25519 signature.
+    /// The VTC this submission is addressed to — must equal this VTC's
+    /// `vtc_did`. Bound into the holder signature so a body captured for one
+    /// community can't be replayed against another (P0.13).
+    pub audience: String,
+    /// Unix-seconds the applicant signed at. Must be within
+    /// [`JOIN_SUBMIT_FRESHNESS_SECS`] of now (small future skew allowed). Bound
+    /// into the signature so a stale captured body is rejected (P0.13).
+    pub created: i64,
+    /// Hex-encoded Ed25519 signature over the canonical payload (which now
+    /// includes `audience` + `created`).
     pub signature: String,
+}
+
+/// The REST holder-binding inputs threaded into [`submit_inner`]. `None` on the
+/// DIDComm path, where the authcrypt envelope authenticates the sender (and is
+/// addressed to this VTC), so no separate signed audience/freshness is needed.
+pub struct HolderBinding<'a> {
+    pub signature_hex: &'a str,
+    pub audience: &'a str,
+    pub created: i64,
 }
 
 #[derive(Debug, Serialize)]
@@ -107,7 +142,11 @@ pub async fn submit(
         req.vp,
         req.registry_consent,
         req.extensions,
-        Some(&req.signature),
+        Some(HolderBinding {
+            signature_hex: &req.signature,
+            audience: &req.audience,
+            created: req.created,
+        }),
         JoinTransport::Rest,
     )
     .await?;
@@ -158,25 +197,71 @@ pub async fn submit_inner(
     vp: JsonValue,
     registry_consent: bool,
     extensions: JsonValue,
-    signature_hex: Option<&str>,
+    binding: Option<HolderBinding<'_>>,
     transport: JoinTransport,
 ) -> Result<JoinSubmitOutcome, AppError> {
-    // 1. Holder binding (REST only).
-    if let Some(hex_sig) = signature_hex {
-        verify_holder_signature(&applicant_did, &vp, registry_consent, &extensions, hex_sig)?;
+    // 1. Holder binding (REST only): audience + freshness + signature. The
+    // DIDComm path (`binding == None`) is authenticated + addressed by the
+    // authcrypt envelope, so it skips this.
+    if let Some(b) = binding.as_ref() {
+        // Audience: the signed payload must name THIS VTC, so a body captured
+        // for another community can't be replayed here (P0.13).
+        let vtc_did = state
+            .config
+            .read()
+            .await
+            .vtc_did
+            .clone()
+            .ok_or_else(|| AppError::Internal("vtc_did not configured".into()))?;
+        if b.audience != vtc_did {
+            return Err(AppError::Validation(format!(
+                "join-request audience ({}) does not match this VTC ({vtc_did})",
+                b.audience
+            )));
+        }
+        // Freshness: a stale captured body is rejected; small future skew ok.
+        let now = crate::auth::session::now_epoch() as i64;
+        if b.created < now - JOIN_SUBMIT_FRESHNESS_SECS
+            || b.created > now + JOIN_SUBMIT_FUTURE_SKEW_SECS
+        {
+            return Err(AppError::Validation(
+                "join-request `created` is outside the freshness window — re-sign and resubmit"
+                    .into(),
+            ));
+        }
+        verify_holder_signature(
+            &applicant_did,
+            &vp,
+            registry_consent,
+            &extensions,
+            b.audience,
+            b.created,
+            b.signature_hex,
+        )?;
     }
 
-    // 2. The lossy `vp_claims` projection is still stored on the row
+    // 2. Dedup: at most one open (Pending/Deferred) request per applicant
+    // (P0.13). Blocks replay of a captured body while a request is open and
+    // caps unbounded accumulation. An already-admitted applicant is caught
+    // later by the admit duplicate-ACL guard.
+    if let Some(existing) = find_open_request(&state.join_requests_ks, &applicant_did).await? {
+        return Err(AppError::Conflict(format!(
+            "an open join request already exists for {applicant_did} (id {existing}); \
+             withdraw or await its decision before resubmitting"
+        )));
+    }
+
+    // 3. The lossy `vp_claims` projection is still stored on the row
     // for the admin show + the approve path; the decision pipeline
     // reads structured Facts instead (assembled below).
     let vp_claims = extract_vp_claims(&vp);
 
-    // 3. Decide: assemble verified Facts (the route-layer holder-binding
+    // 4. Decide: assemble verified Facts (the route-layer holder-binding
     // makes this presentation `verified`) and run the active join policy.
     let presentation = presentation_from_vp(&applicant_did, &vp);
     let verdict = decide_join(state, &applicant_did, presentation).await?;
 
-    // 4. Realize the verdict (store + audit + auto-admit on allow).
+    // 5. Realize the verdict (store + audit + auto-admit on allow).
     realize_join_verdict(
         state,
         &applicant_did,
@@ -443,11 +528,14 @@ fn credential_from_vc(vc: &JsonValue) -> Option<Credential> {
 
 /// Verify the Ed25519 signature over the canonical signing
 /// payload (see module docs).
+#[allow(clippy::too_many_arguments)]
 fn verify_holder_signature(
     applicant_did: &str,
     vp: &JsonValue,
     registry_consent: bool,
     extensions: &JsonValue,
+    audience: &str,
+    created: i64,
     signature_hex: &str,
 ) -> Result<(), AppError> {
     let pubkey_bytes =
@@ -460,7 +548,14 @@ fn verify_holder_signature(
         ))
     })?;
 
-    let payload = canonical_payload(applicant_did, vp, registry_consent, extensions)?;
+    let payload = canonical_payload(
+        applicant_did,
+        vp,
+        registry_consent,
+        extensions,
+        audience,
+        created,
+    )?;
     let signing_bytes = signing_bytes(&payload);
 
     let raw_sig = hex::decode(signature_hex)
@@ -486,6 +581,9 @@ struct CanonicalPayload<'a> {
     vp: &'a JsonValue,
     registry_consent: bool,
     extensions: &'a JsonValue,
+    /// P0.13 audience + freshness binding.
+    audience: &'a str,
+    created: i64,
 }
 
 fn canonical_payload(
@@ -493,14 +591,34 @@ fn canonical_payload(
     vp: &JsonValue,
     registry_consent: bool,
     extensions: &JsonValue,
+    audience: &str,
+    created: i64,
 ) -> Result<Vec<u8>, AppError> {
     serde_json::to_vec(&CanonicalPayload {
         applicant_did,
         vp,
         registry_consent,
         extensions,
+        audience,
+        created,
     })
     .map_err(|e| AppError::Internal(format!("canonical payload serialize: {e}")))
+}
+
+/// Find an applicant's open (Pending/Deferred) join request, if any. Used to
+/// dedup / cap open requests per applicant (P0.13).
+async fn find_open_request(
+    ks: &vti_common::store::KeyspaceHandle,
+    applicant_did: &str,
+) -> Result<Option<Uuid>, AppError> {
+    let all = list_join_requests(ks).await?;
+    Ok(all
+        .into_iter()
+        .find(|r| {
+            r.applicant_did == applicant_did
+                && matches!(r.status, JoinStatus::Pending | JoinStatus::Deferred)
+        })
+        .map(|r| r.id))
 }
 
 /// Domain-tag prefixed bytes the signer hashes over.
@@ -527,15 +645,19 @@ mod tests {
         (sk, did)
     }
 
+    const AUD: &str = "did:key:zThisVtc";
+    const CREATED: i64 = 1_900_000_000;
+
     #[test]
     fn sign_then_verify_round_trip() {
         let (sk, did) = pair();
         let vp = serde_json::json!({"vp":"placeholder"});
-        let payload = canonical_payload(&did, &vp, false, &JsonValue::Null).unwrap();
+        let payload = canonical_payload(&did, &vp, false, &JsonValue::Null, AUD, CREATED).unwrap();
         let sig = sk.sign(&signing_bytes(&payload));
         let sig_hex = hex::encode(sig.to_bytes());
 
-        verify_holder_signature(&did, &vp, false, &JsonValue::Null, &sig_hex).unwrap();
+        verify_holder_signature(&did, &vp, false, &JsonValue::Null, AUD, CREATED, &sig_hex)
+            .unwrap();
     }
 
     #[test]
@@ -543,12 +665,14 @@ mod tests {
         let (_a_sk, a_did) = pair();
         let other = SigningKey::from_bytes(&[0xCD; 32]);
         let vp = serde_json::json!({});
-        let payload = canonical_payload(&a_did, &vp, false, &JsonValue::Null).unwrap();
+        let payload =
+            canonical_payload(&a_did, &vp, false, &JsonValue::Null, AUD, CREATED).unwrap();
         let sig = other.sign(&signing_bytes(&payload));
         let sig_hex = hex::encode(sig.to_bytes());
 
-        let err = verify_holder_signature(&a_did, &vp, false, &JsonValue::Null, &sig_hex)
-            .expect_err("wrong signer must fail");
+        let err =
+            verify_holder_signature(&a_did, &vp, false, &JsonValue::Null, AUD, CREATED, &sig_hex)
+                .expect_err("wrong signer must fail");
         assert!(matches!(err, AppError::Validation(_)));
     }
 
@@ -556,23 +680,61 @@ mod tests {
     fn verify_rejects_tampered_payload() {
         let (sk, did) = pair();
         let vp = serde_json::json!({"vp":"original"});
-        let payload = canonical_payload(&did, &vp, false, &JsonValue::Null).unwrap();
+        let payload = canonical_payload(&did, &vp, false, &JsonValue::Null, AUD, CREATED).unwrap();
         let sig = sk.sign(&signing_bytes(&payload));
         let sig_hex = hex::encode(sig.to_bytes());
 
         // Same signature, different VP body.
         let tampered = serde_json::json!({"vp":"changed"});
-        let err = verify_holder_signature(&did, &tampered, false, &JsonValue::Null, &sig_hex)
-            .expect_err("tampered VP must fail");
+        let err = verify_holder_signature(
+            &did,
+            &tampered,
+            false,
+            &JsonValue::Null,
+            AUD,
+            CREATED,
+            &sig_hex,
+        )
+        .expect_err("tampered VP must fail");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn verify_rejects_tampered_audience() {
+        // P0.13: the audience is part of the signed payload, so re-pointing it
+        // (cross-community replay) breaks the signature.
+        let (sk, did) = pair();
+        let vp = serde_json::json!({"vp":"x"});
+        let payload = canonical_payload(&did, &vp, false, &JsonValue::Null, AUD, CREATED).unwrap();
+        let sig = sk.sign(&signing_bytes(&payload));
+        let sig_hex = hex::encode(sig.to_bytes());
+
+        let err = verify_holder_signature(
+            &did,
+            &vp,
+            false,
+            &JsonValue::Null,
+            "did:key:zOtherVtc",
+            CREATED,
+            &sig_hex,
+        )
+        .expect_err("re-pointed audience must fail the signature");
         assert!(matches!(err, AppError::Validation(_)));
     }
 
     #[test]
     fn verify_rejects_garbage_signature() {
         let (_sk, did) = pair();
-        let err =
-            verify_holder_signature(&did, &JsonValue::Null, false, &JsonValue::Null, "not-hex")
-                .expect_err("garbage sig must fail");
+        let err = verify_holder_signature(
+            &did,
+            &JsonValue::Null,
+            false,
+            &JsonValue::Null,
+            AUD,
+            CREATED,
+            "not-hex",
+        )
+        .expect_err("garbage sig must fail");
         assert!(matches!(err, AppError::Validation(_)));
     }
 
@@ -583,6 +745,8 @@ mod tests {
             &JsonValue::Null,
             false,
             &JsonValue::Null,
+            AUD,
+            CREATED,
             "00",
         )
         .expect_err("non-did:key must fail");

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -168,13 +168,17 @@ async fn build_fixture() -> Fixture {
 }
 
 /// Build a canonical-signing-payload signature for the holder-
-/// binding check. Mirrors the verifier's payload construction.
+/// binding check. Mirrors the verifier's payload construction
+/// (P0.13: now includes `audience` + `created`).
+#[allow(clippy::too_many_arguments)]
 fn sign_holder_payload(
     sk: &SigningKey,
     applicant_did: &str,
     vp: &Value,
     registry_consent: bool,
     extensions: &Value,
+    audience: &str,
+    created: i64,
 ) -> String {
     #[derive(serde::Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -183,18 +187,45 @@ fn sign_holder_payload(
         vp: &'a Value,
         registry_consent: bool,
         extensions: &'a Value,
+        audience: &'a str,
+        created: i64,
     }
     let payload = serde_json::to_vec(&Payload {
         applicant_did,
         vp,
         registry_consent,
         extensions,
+        audience,
+        created,
     })
     .unwrap();
     let mut signing = Vec::with_capacity(JOIN_REQUEST_SUBMIT_DOMAIN_TAG.len() + payload.len());
     signing.extend_from_slice(JOIN_REQUEST_SUBMIT_DOMAIN_TAG);
     signing.extend_from_slice(&payload);
     hex::encode(sk.sign(&signing).to_bytes())
+}
+
+/// Build a complete, signed REST join-submit body for the common case
+/// (`registryConsent = false`, no extensions), addressed to this test VTC
+/// (`TEST_VTC_DID`) with a fresh `created`. (P0.13)
+fn signed_submit_body(sk: &SigningKey, applicant_did: &str, vp: &Value) -> Value {
+    let created = vtc_service::auth::session::now_epoch() as i64;
+    let signature = sign_holder_payload(
+        sk,
+        applicant_did,
+        vp,
+        false,
+        &Value::Null,
+        vtc_service::test_support::TEST_VTC_DID,
+        created,
+    );
+    json!({
+        "applicantDid": applicant_did,
+        "vp": vp,
+        "audience": vtc_service::test_support::TEST_VTC_DID,
+        "created": created,
+        "signature": signature,
+    })
 }
 
 fn applicant_pair() -> (SigningKey, String) {
@@ -250,7 +281,7 @@ async fn rest_submit_happy_path_persists_pending() {
     let fix = build_fixture().await;
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
-    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
 
     let (status, body) = send(
         &fix.router,
@@ -258,11 +289,7 @@ async fn rest_submit_happy_path_persists_pending() {
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": signature,
-        })),
+        Some(submit_body),
     )
     .await;
     assert_eq!(status, StatusCode::CREATED, "got {body}");
@@ -276,7 +303,16 @@ async fn rest_submit_rejects_wrong_signer() {
     let (_a_sk, applicant_did) = applicant_pair();
     let other = SigningKey::from_bytes(&[0xEE; 32]);
     let vp = json!({});
-    let bad_sig = sign_holder_payload(&other, &applicant_did, &vp, false, &Value::Null);
+    let created = vtc_service::auth::session::now_epoch() as i64;
+    let bad_sig = sign_holder_payload(
+        &other,
+        &applicant_did,
+        &vp,
+        false,
+        &Value::Null,
+        vtc_service::test_support::TEST_VTC_DID,
+        created,
+    );
 
     let (status, body) = send(
         &fix.router,
@@ -287,6 +323,8 @@ async fn rest_submit_rejects_wrong_signer() {
         Some(json!({
             "applicantDid": applicant_did,
             "vp": vp,
+            "audience": vtc_service::test_support::TEST_VTC_DID,
+            "created": created,
             "signature": bad_sig,
         })),
     )
@@ -306,11 +344,126 @@ async fn rest_submit_rejects_non_did_key_applicant() {
         Some(json!({
             "applicantDid": "did:web:not-supported.example.com",
             "vp": {},
+            "audience": vtc_service::test_support::TEST_VTC_DID,
+            "created": vtc_service::auth::session::now_epoch(),
             "signature": "00",
         })),
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// P0.13 — replay / freshness / audience binding + per-applicant dedup.
+
+#[tokio::test]
+async fn rest_submit_dedups_an_open_request_for_the_same_applicant() {
+    // A captured body replayed while a request is still open is refused, and a
+    // second concurrent submit can't accumulate a second open row.
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(signed_submit_body(&sk, &applicant_did, &vp)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "got {body}");
+    assert_eq!(body["status"], "pending");
+
+    // Replay / duplicate → 409 (the first request is still open).
+    let (status2, body2) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(signed_submit_body(&sk, &applicant_did, &vp)),
+    )
+    .await;
+    assert_eq!(
+        status2,
+        StatusCode::CONFLICT,
+        "a second open request for one applicant must 409: {body2}"
+    );
+}
+
+#[tokio::test]
+async fn rest_submit_rejects_a_foreign_audience() {
+    // A body signed + addressed to a different community cannot be replayed
+    // against this VTC.
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({});
+    let created = vtc_service::auth::session::now_epoch() as i64;
+    let foreign = "did:webvh:other.example.com:xyz";
+    let sig = sign_holder_payload(
+        &sk,
+        &applicant_did,
+        &vp,
+        false,
+        &Value::Null,
+        foreign,
+        created,
+    );
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "audience": foreign,
+            "created": created,
+            "signature": sig,
+        })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a submission addressed to another community must be rejected: {body}"
+    );
+}
+
+#[tokio::test]
+async fn rest_submit_rejects_a_stale_created() {
+    // A captured body replayed long after signing is outside the freshness
+    // window and is rejected.
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({});
+    let stale = vtc_service::auth::session::now_epoch() as i64 - 10_000;
+    let aud = vtc_service::test_support::TEST_VTC_DID;
+    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null, aud, stale);
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(json!({
+            "applicantDid": applicant_did,
+            "vp": vp,
+            "audience": aud,
+            "created": stale,
+            "signature": sig,
+        })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a stale `created` must be rejected: {body}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -320,18 +473,14 @@ async fn rest_submit_rejects_non_did_key_applicant() {
 async fn submit_pending(fix: &Fixture) -> Uuid {
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({"a":"b"});
-    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
     let (_, body) = send(
         &fix.router,
         "POST",
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": sig,
-        })),
+        Some(submit_body),
     )
     .await;
     Uuid::parse_str(body["requestId"].as_str().unwrap()).unwrap()
@@ -384,18 +533,14 @@ async fn approve_writes_acl_and_member_atomically() {
     let fix = build_fixture().await;
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({});
-    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
     let (_, body) = send(
         &fix.router,
         "POST",
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": sig,
-        })),
+        Some(submit_body),
     )
     .await;
     let id = body["requestId"].as_str().unwrap();
@@ -469,18 +614,14 @@ async fn approve_409_when_duplicate_acl_exists() {
     let fix = build_fixture().await;
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({});
-    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
     let (_, body) = send(
         &fix.router,
         "POST",
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": sig,
-        })),
+        Some(submit_body),
     )
     .await;
     let id = body["requestId"].as_str().unwrap();
@@ -519,18 +660,14 @@ async fn reject_leaves_no_acl_or_member_rows() {
     let fix = build_fixture().await;
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({});
-    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
     let (_, body) = send(
         &fix.router,
         "POST",
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": sig,
-        })),
+        Some(submit_body),
     )
     .await;
     let id = body["requestId"].as_str().unwrap();
@@ -582,18 +719,14 @@ async fn approve_409_when_request_already_decided() {
     let fix = build_fixture().await;
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({});
-    let sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
     let (_, body) = send(
         &fix.router,
         "POST",
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": sig,
-        })),
+        Some(submit_body),
     )
     .await;
     let id = body["requestId"].as_str().unwrap();
@@ -697,7 +830,7 @@ async fn rest_submit_under_allow_policy_auto_admits() {
 
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
-    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
 
     let (status, body) = send(
         &fix.router,
@@ -705,11 +838,7 @@ async fn rest_submit_under_allow_policy_auto_admits() {
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": signature,
-        })),
+        Some(submit_body),
     )
     .await;
     assert_eq!(status, StatusCode::CREATED, "got {body}");
@@ -754,7 +883,7 @@ async fn rest_submit_under_default_join_policy_lands_pending_with_vp_claims() {
             }
         ]
     });
-    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
 
     let (status, body) = send(
         &fix.router,
@@ -762,11 +891,7 @@ async fn rest_submit_under_default_join_policy_lands_pending_with_vp_claims() {
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": signature,
-        })),
+        Some(submit_body),
     )
     .await;
     assert_eq!(status, StatusCode::CREATED, "got {body}");
@@ -809,7 +934,7 @@ async fn rest_submit_under_deny_all_policy_persists_rejected_with_decision() {
 
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
-    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
 
     let (status, body) = send(
         &fix.router,
@@ -817,11 +942,7 @@ async fn rest_submit_under_deny_all_policy_persists_rejected_with_decision() {
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": signature,
-        })),
+        Some(submit_body),
     )
     .await;
     // Submission still 201 — the row persists either way; the
@@ -859,18 +980,14 @@ async fn policy_rejected_row_cannot_be_approved() {
 
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
-    let signature = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
     let (status, body) = send(
         &fix.router,
         "POST",
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({
-            "applicantDid": applicant_did,
-            "vp": vp,
-            "signature": signature,
-        })),
+        Some(submit_body),
     )
     .await;
     assert_eq!(status, StatusCode::CREATED, "got {body}");
@@ -1288,14 +1405,14 @@ async fn admin_query_send_requires_admin() {
 async fn admit_member(fix: &Fixture) -> (SigningKey, String, Uuid, String) {
     let (sk, member_did) = applicant_pair();
     let vp = json!({});
-    let sig = sign_holder_payload(&sk, &member_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &member_did, &vp);
     let (_, body) = send(
         &fix.router,
         "POST",
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({ "applicantDid": member_did, "vp": vp, "signature": sig })),
+        Some(submit_body),
     )
     .await;
     let id = Uuid::parse_str(body["requestId"].as_str().unwrap()).unwrap();
@@ -1669,14 +1786,14 @@ decision := {"effect": "request_more", "with": {
 
     let (sk, applicant_did) = applicant_pair();
     let vp = json!({});
-    let submit_sig = sign_holder_payload(&sk, &applicant_did, &vp, false, &Value::Null);
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
     let (_, body) = send(
         &fix.router,
         "POST",
         "/v1/join-requests",
         SUBMIT_TASK,
         None,
-        Some(json!({ "applicantDid": applicant_did, "vp": vp, "signature": submit_sig })),
+        Some(submit_body),
     )
     .await;
     assert_eq!(


### PR DESCRIPTION
## P0.13 — Join-submit holder signature has no freshness/nonce/audience binding (replayable)

### Problem
The REST join-submit holder signature covered only `domain_tag || canonical_json({applicantDid, vp, registryConsent, extensions})` — **no nonce, no timestamp, no target community**. A captured submit body was replayable indefinitely, and replayable against a *different* community (no audience binding). There was also no dedup against an existing open request, so an applicant could accumulate — or an attacker replay into — many open rows (each ≤256 KiB; compounds the P0.6 growth concern). The verifying `present`/vp_token path binds a single-use nonce + audience; the legacy submit path didn't.

### Fix (the plan's "at minimum" option)
- **Audience + freshness binding.** `audience` (must equal this VTC's `vtc_did`) and `created` (Unix-seconds, within a **300 s** window + 60 s future skew) are now part of the canonical signing payload and the REST `SubmitRequestBody`. A body addressed to another community → **400**; a stale `created` → **400**.
- **Per-applicant dedup.** At most one open (`Pending`/`Deferred`) request per applicant — a second submit while one is open → **409**. This closes the in-window concurrent-replay gap and caps unbounded row growth. An already-admitted applicant is still caught by the admit duplicate-ACL guard (P0.15).

The **DIDComm path is unchanged**: its authcrypt envelope authenticates + addresses the sender, so it carries no separate signed audience/freshness (`binding == None`) — it just gains the same dedup. **No SDK change** — the SDK only defines the DIDComm body (which has no signature).

### Acceptance
- ✅ replaying a captured submit body is rejected (dedup 409 / stale-created 400).
- ✅ submitting against a different community DID is rejected (400).
- ✅ a second submit for the same applicant yields one row or a 409.

### Tests
New: `rest_submit_dedups_an_open_request_for_the_same_applicant` (409), `rest_submit_rejects_a_foreign_audience` (400), `rest_submit_rejects_a_stale_created` (400), plus a unit test that re-pointing the audience breaks the signature. The existing `join_requests` suite was updated for the new wire shape via a `signed_submit_body` helper (**44 pass**). `cargo fmt --check` clean, no new clippy warnings, full lib suite **534**, members_crud **7**, ceremony_execute **13**.

> ⚠️ **Wire change**: the REST `POST /v1/join-requests` body now requires `audience` + `created`, signed. External REST clients must update. (DIDComm clients unaffected.)
>
> Touches `submit.rs` — disjoint regions from the unmerged P0.12 (`presentation_from_vp`/`credential_from_vc`), so a clean 3-way merge.