### PR TITLE
fix(vtc-service): make the legacy /v1/config surface non-divergent (P1.1, part 1)

### DIFF
--- a/vtc-service/src/routes/config.rs
+++ b/vtc-service/src/routes/config.rs
@@ -1,3 +1,30 @@
+//! `GET / PATCH /v1/config` — the legacy community-config surface.
+//!
+//! P1.1 makes this a **safe, non-divergent** surface rather than a third
+//! uncoordinated config-write path:
+//!
+//! - **Identity is immutable at runtime.** `vtc_did` / `vta_did` are set at
+//!   `vtc setup`; a PATCH carrying either returns 409 and `config.toml` is left
+//!   untouched. (Previously a PATCH could rewrite them → next-boot auth-dead or
+//!   recovery-authority re-pointed.)
+//! - **`CommunityProfile` is the sole owner of name/description.** A PATCH's
+//!   `vtc_name` / `vtc_description` are applied to the profile, and
+//!   `GET /v1/config` reads them back from the profile — so there is one write
+//!   path per field, not two diverging copies.
+//! - **`public_url` is persisted env-safely + atomically.** It is the
+//!   operational RP origin the WebAuthn handle + status-list URLs derive from at
+//!   boot, so it stays in `config.toml`; the write re-reads the on-disk TOML as
+//!   its base (ephemeral `VTC_*` env overlays never leak in), writes
+//!   tempfile-then-rename, and re-restricts perms. It is boot-stable, so the
+//!   response flags it under `pending_restart`.
+//!
+//! Migrating `public_url` into the `config_store` overlay as a
+//! `requires_restart` key (so it shares the canonical PATCH surface) is the
+//! follow-up increment — it needs the boot path to apply `config_store`
+//! overrides, which it does not yet.
+
+use std::path::Path;
+
 use axum::Json;
 use axum::extract::State;
 use serde::{Deserialize, Serialize};
@@ -5,6 +32,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::auth::{AuthClaims, SuperAdminAuth};
+use crate::community::{CommunityProfileUpdate, load_profile, store_profile};
 use crate::error::AppError;
 use crate::server::AppState;
 
@@ -17,67 +45,205 @@ pub struct ConfigResponse {
     pub public_url: Option<String>,
 }
 
+/// Response for `PATCH /v1/config`: the resolved view plus any boot-stable keys
+/// that were stored but need a restart to take effect.
+#[derive(Debug, Serialize)]
+pub struct UpdateConfigResponse {
+    #[serde(flatten)]
+    pub config: ConfigResponse,
+    pub pending_restart: Vec<String>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct UpdateConfigRequest {
     pub vtc_did: Option<String>,
+    /// Recovery-authority DID. Like `vtc_did`, set at setup and rejected here.
+    pub vta_did: Option<String>,
     pub vtc_name: Option<String>,
     pub vtc_description: Option<String>,
     pub public_url: Option<String>,
 }
 
+/// Resolve the name/description pair: the `CommunityProfile` is authoritative
+/// once it exists; pre-profile (fresh install) we fall back to the TOML values.
+async fn resolved_name_description(
+    state: &AppState,
+) -> Result<(Option<String>, Option<String>), AppError> {
+    if let Some(profile) = load_profile(&state.community_ks).await? {
+        Ok((Some(profile.name), Some(profile.description)))
+    } else {
+        let config = state.config.read().await;
+        Ok((config.vtc_name.clone(), config.vtc_description.clone()))
+    }
+}
+
 pub async fn get_config(
-    _auth: AuthClaims,
+    auth: AuthClaims,
     State(state): State<AppState>,
 ) -> Result<Json<ConfigResponse>, AppError> {
+    let (vtc_name, vtc_description) = resolved_name_description(&state).await?;
     let config = state.config.read().await;
-    info!(caller = %_auth.did, "config retrieved");
+    info!(caller = %auth.did, "config retrieved");
     Ok(Json(ConfigResponse {
         vtc_did: config.vtc_did.clone(),
-        vtc_name: config.vtc_name.clone(),
-        vtc_description: config.vtc_description.clone(),
+        vtc_name,
+        vtc_description,
         public_url: config.public_url.clone(),
     }))
 }
 
 pub async fn update_config(
-    _auth: SuperAdminAuth,
+    auth: SuperAdminAuth,
     State(state): State<AppState>,
     Json(req): Json<UpdateConfigRequest>,
-) -> Result<Json<ConfigResponse>, AppError> {
-    let (response, contents, path) = {
-        let mut config = state.config.write().await;
+) -> Result<Json<UpdateConfigResponse>, AppError> {
+    // Identity is set at `vtc setup` and never rewriteable at runtime — a
+    // mistaken PATCH must not strand the daemon auth-dead or re-point the
+    // recovery authority. `config.toml` is left untouched on this path.
+    if req.vtc_did.is_some() || req.vta_did.is_some() {
+        return Err(AppError::Conflict(
+            "vtc_did / vta_did are set at `vtc setup` and cannot be changed at runtime; \
+             refusing to rewrite community identity"
+                .into(),
+        ));
+    }
 
-        if let Some(vtc_did) = req.vtc_did {
-            config.vtc_did = Some(vtc_did);
-        }
-        if let Some(vtc_name) = req.vtc_name {
-            config.vtc_name = Some(vtc_name);
-        }
-        if let Some(vtc_description) = req.vtc_description {
-            config.vtc_description = Some(vtc_description);
-        }
-        if let Some(public_url) = req.public_url {
-            config.public_url = Some(public_url);
-        }
+    let mut pending_restart = Vec::new();
 
-        let response = ConfigResponse {
-            vtc_did: config.vtc_did.clone(),
-            vtc_name: config.vtc_name.clone(),
-            vtc_description: config.vtc_description.clone(),
-            public_url: config.public_url.clone(),
+    // name/description → the CommunityProfile (sole owner). One write path.
+    if req.vtc_name.is_some() || req.vtc_description.is_some() {
+        let mut profile = load_profile(&state.community_ks).await?.ok_or_else(|| {
+            AppError::Conflict(
+                "community profile not initialised — set name/description at setup or via \
+                 `PUT /v1/community/profile` first"
+                    .into(),
+            )
+        })?;
+        let patch = CommunityProfileUpdate {
+            name: req.vtc_name.clone(),
+            description: req.vtc_description.clone(),
+            ..CommunityProfileUpdate::default()
         };
-        let contents = toml::to_string_pretty(&*config)
-            .map_err(|e| AppError::Config(format!("failed to serialize config: {e}")))?;
-        let path = config.config_path.clone();
+        let changed = patch.apply(&mut profile)?;
+        if !changed.is_empty() {
+            store_profile(&state.community_ks, &profile).await?;
+        }
+    }
 
-        (response, contents, path)
-    }; // write lock released here
+    // public_url → the operational RP origin (WebAuthn + status-list URLs derive
+    // from it at boot). Persist env-safely + atomically; restart required.
+    if let Some(public_url) = req.public_url.clone() {
+        let path = {
+            let mut config = state.config.write().await;
+            config.public_url = Some(public_url.clone());
+            config.config_path.clone()
+        };
+        persist_public_url(&path, Some(&public_url))?;
+        pending_restart.push("public_url".into());
+    }
 
-    std::fs::write(&path, contents).map_err(AppError::Io)?;
-    // Re-harden after every rewrite: config.toml holds the JWT signing key
-    // (and, under the config-secret backend, the key bundle).
-    crate::secure_file::restrict_file_to_owner(&path).map_err(AppError::Io)?;
+    let (vtc_name, vtc_description) = resolved_name_description(&state).await?;
+    let config = state.config.read().await;
+    info!(caller = %auth.0.did, ?pending_restart, "config updated");
+    Ok(Json(UpdateConfigResponse {
+        config: ConfigResponse {
+            vtc_did: config.vtc_did.clone(),
+            vtc_name,
+            vtc_description,
+            public_url: config.public_url.clone(),
+        },
+        pending_restart,
+    }))
+}
 
-    info!(caller = %_auth.0.did, "config updated");
-    Ok(Json(response))
+/// Persist `public_url` into `config.toml` **env-safely** and **atomically**.
+///
+/// Re-reads the on-disk TOML as the base so the ephemeral `VTC_*` env overlays
+/// folded into the in-memory `AppConfig` are never baked into the file (P1.1) —
+/// only the single `public_url` key is touched. Writes tempfile-then-rename for
+/// atomicity and re-restricts the file to its owner (it holds the JWT signing
+/// key, and under the config-secret backend the key bundle).
+fn persist_public_url(path: &Path, public_url: Option<&str>) -> Result<(), AppError> {
+    let existing = std::fs::read_to_string(path).map_err(AppError::Io)?;
+    let mut doc: toml::Table = toml::from_str(&existing)
+        .map_err(|e| AppError::Config(format!("failed to parse {}: {e}", path.display())))?;
+    match public_url {
+        Some(url) => {
+            doc.insert("public_url".into(), toml::Value::String(url.to_string()));
+        }
+        None => {
+            doc.remove("public_url");
+        }
+    }
+    let contents = toml::to_string_pretty(&doc)
+        .map_err(|e| AppError::Config(format!("failed to serialize config: {e}")))?;
+
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("config.toml");
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let tmp = dir.join(format!(".{file_name}.tmp"));
+
+    std::fs::write(&tmp, contents).map_err(AppError::Io)?;
+    // Harden the temp file *before* the rename so the published file is never
+    // briefly world-readable.
+    crate::secure_file::restrict_file_to_owner(&tmp).map_err(AppError::Io)?;
+    std::fs::rename(&tmp, path).map_err(AppError::Io)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn persist_public_url_is_env_safe_and_atomic() {
+        // The on-disk base has no env-sourced values; updating public_url must
+        // leave every other key exactly as written (no env-overlay bake-in).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            "vtc_did = \"did:webvh:vtc.example\"\n\
+             [server]\nhost = \"127.0.0.1\"\nport = 8200\n"
+        )
+        .unwrap();
+        drop(f);
+
+        persist_public_url(&path, Some("https://vtc.example.com")).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        let doc: toml::Table = toml::from_str(&written).unwrap();
+        assert_eq!(
+            doc.get("public_url").and_then(|v| v.as_str()),
+            Some("https://vtc.example.com")
+        );
+        // Untouched keys survive verbatim.
+        assert_eq!(
+            doc.get("vtc_did").and_then(|v| v.as_str()),
+            Some("did:webvh:vtc.example")
+        );
+        let server = doc.get("server").and_then(|v| v.as_table()).unwrap();
+        assert_eq!(
+            server.get("host").and_then(|v| v.as_str()),
+            Some("127.0.0.1")
+        );
+        assert_eq!(server.get("port").and_then(|v| v.as_integer()), Some(8200));
+
+        // No leftover temp file.
+        assert!(!dir.path().join(".config.toml.tmp").exists());
+    }
+
+    #[test]
+    fn persist_public_url_none_removes_the_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "public_url = \"https://old.example\"\n").unwrap();
+        persist_public_url(&path, None).unwrap();
+        let doc: toml::Table = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(doc.get("public_url").is_none());
+    }
 }

--- a/vtc-service/tests/config_legacy.rs
+++ b/vtc-service/tests/config_legacy.rs
@@ -1,0 +1,209 @@
+//! Integration coverage for the legacy `/v1/config` surface (P1.1).
+//!
+//! Exercises the full router stack — Trust-Task header → auth extractor →
+//! handler → community/config keyspaces — through `Router::oneshot`, pinning
+//! the P1.1 invariants: identity is immutable at runtime, `CommunityProfile`
+//! owns name/description, and a boot-stable key reports `pending_restart`.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vtc_service::community::{CommunityProfile, store_profile};
+use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
+
+const CONFIG_TASK: &str = "https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0";
+const ADMIN_DID: &str = "did:key:z6MkAdmin";
+
+struct Fixture {
+    router: axum::Router,
+    state: AppState,
+    vtc: TestVtc,
+}
+
+async fn build() -> Fixture {
+    let vtc = TestVtc::builder().build().await;
+    Fixture {
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        vtc,
+    }
+}
+
+/// Super-admin = admin role + empty `allowed_contexts`.
+async fn super_admin_token(fix: &Fixture) -> String {
+    fix.vtc.token(ADMIN_DID, "admin", vec![]).await
+}
+
+async fn send(
+    fix: &Fixture,
+    method: &str,
+    token: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method(method)
+        .uri("/v1/config")
+        .header("Trust-Task", CONFIG_TASK)
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"));
+    let body = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(req.body(body).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, v)
+}
+
+async fn seed_profile(fix: &Fixture, name: &str) {
+    let p = CommunityProfile::new("did:webvh:vtc.example.com:abc", name);
+    store_profile(&fix.state.community_ks, &p).await.unwrap();
+}
+
+#[tokio::test]
+async fn patch_vtc_did_is_rejected_409() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    // The request body is snake_case (no rename_all on `UpdateConfigRequest`).
+    let (status, body) = send(
+        &fix,
+        "PATCH",
+        &token,
+        Some(json!({ "vtc_did": "did:key:zEvilNewIdentity" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "vtc_did rewrite must be refused: {body}"
+    );
+    // The in-memory identity is unchanged.
+    assert_eq!(
+        fix.state.config.read().await.vtc_did.as_deref(),
+        Some(vtc_service::test_support::TEST_VTC_DID)
+    );
+}
+
+#[tokio::test]
+async fn patch_vta_did_is_rejected_409() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    let (status, body) = send(
+        &fix,
+        "PATCH",
+        &token,
+        Some(json!({ "vta_did": "did:key:zNewRecoveryAuthority" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "vta_did rewrite must be refused: {body}"
+    );
+}
+
+#[tokio::test]
+async fn patch_name_writes_to_profile_and_get_reads_it_back() {
+    let fix = build().await;
+    seed_profile(&fix, "Original").await;
+    let token = super_admin_token(&fix).await;
+
+    let (status, _) = send(
+        &fix,
+        "PATCH",
+        &token,
+        Some(json!({ "vtc_name": "Renamed Community", "vtc_description": "New desc" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // The profile is the authoritative store…
+    let profile = vtc_service::community::load_profile(&fix.state.community_ks)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(profile.name, "Renamed Community");
+    assert_eq!(profile.description, "New desc");
+
+    // …and GET /v1/config reads name/description back from it.
+    let (status, body) = send(&fix, "GET", &token, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["vtc_name"], "Renamed Community");
+    assert_eq!(body["vtc_description"], "New desc");
+}
+
+#[tokio::test]
+async fn patch_name_without_a_profile_is_409() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    let (status, body) = send(
+        &fix,
+        "PATCH",
+        &token,
+        Some(json!({ "vtc_name": "No Profile Yet" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "name change without a profile must 409: {body}"
+    );
+}
+
+#[tokio::test]
+async fn patch_public_url_flags_pending_restart_and_persists_to_toml() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+
+    // Point the in-memory config at a real on-disk config.toml so the
+    // env-safe atomic write has a base to read.
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let cfg_path = cfg_dir.path().join("config.toml");
+    std::fs::write(&cfg_path, "vtc_did = \"did:webvh:vtc.example.com:abc\"\n").unwrap();
+    {
+        let mut c = fix.state.config.write().await;
+        c.config_path = cfg_path.clone();
+    }
+
+    let (status, body) = send(
+        &fix,
+        "PATCH",
+        &token,
+        Some(json!({ "public_url": "https://vtc.example.com" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(
+        body["pending_restart"],
+        json!(["public_url"]),
+        "public_url is boot-stable → pending_restart: {body}"
+    );
+    assert_eq!(body["public_url"], "https://vtc.example.com");
+
+    // Persisted to the on-disk TOML, base preserved.
+    let written = std::fs::read_to_string(&cfg_path).unwrap();
+    let doc: toml::Table = toml::from_str(&written).unwrap();
+    assert_eq!(
+        doc.get("public_url").and_then(|v| v.as_str()),
+        Some("https://vtc.example.com")
+    );
+    assert_eq!(
+        doc.get("vtc_did").and_then(|v| v.as_str()),
+        Some("did:webvh:vtc.example.com:abc")
+    );
+}


### PR DESCRIPTION
## P1.1 — One config-mutation surface; boot-stable derived state made explicit (part 1)

P1.1 is the keystone of Phase 1 ("kill the divergence engines"). Phase 1 is explicitly **small PRs**; this is the first, scoped to the **legacy `/v1/config` surface** — the most dangerous of the three config-write paths.

### Problem
`PATCH /v1/config` was a third, uncoordinated config-write path:
- it could **rewrite `vtc_did`/`vta_did`** → next-boot auth-dead or recovery-authority re-pointed;
- it serialized the **env-overlaid** in-memory struct back to TOML (baking ephemeral `VTC_*` overrides in permanently) via a **non-atomic** `std::fs::write`;
- it kept community **name/description** in `config.toml` in parallel with the `CommunityProfile` row, with nothing syncing them.

### Fix
- **Identity is immutable at runtime.** A PATCH carrying `vtc_did` or `vta_did` → **409**; `config.toml` untouched.
- **`CommunityProfile` is the sole owner of name/description.** `vtc_name`/`vtc_description` in a PATCH apply to the profile; `GET /v1/config` reads them back from the profile — **one write path per field**. (Name change before the profile exists → 409.)
- **`public_url` persisted env-safely + atomically.** It's the operational RP origin the WebAuthn handle + status-list URLs derive from at boot, so it stays in `config.toml`, but the write re-reads the **on-disk TOML as its base** (no `VTC_*` bake-in), touches only that key, writes **tempfile-then-rename**, and re-restricts perms. It's boot-stable → the response reports it under `pending_restart`.

`AppConfig::save()` (dead + buggy — serialized env overlays, non-atomic) is no longer the persistence path here.

### Acceptance criteria (this surface)
- ✅ PATCH with `vtc_did` → 409 and `config.toml` unchanged.
- ✅ `VTC_*` env overrides don't leak into TOML on a PATCH (on-disk base + single-key edit).
- ✅ name set via the profile is what `GET /v1/config` returns.
- ✅ PATCH of a boot-stable key (`public_url`) returns a restart-required indication.
- ✅ one write path per field (name/desc → profile; identity immutable).

### Follow-up (part 2)
Migrate `public_url` into the `config_store` overlay as a `requires_restart` key so it shares the canonical PATCH surface — this needs the **boot path to apply `config_store` overrides** (it doesn't yet; `server.host/port` have the same latent gap). P1.2 (audit the config mutations + real actor DID) builds on this.

### Tests
Unit: env-safe + atomic persist, key removal. Integration (`tests/config_legacy.rs`): `vtc_did`/`vta_did` → 409 (identity unchanged); name → profile + GET reads it back; name without profile → 409; `public_url` → `pending_restart` + on-disk TOML updated with base preserved. `cargo fmt --check` clean, no new clippy warnings on touched files, full lib suite **552**.

> Note: a pre-existing `TimeoutLayer::new` deprecation warning (from the merged P0.10) shows under `cargo clippy --tests`; it's unrelated to this PR and left for a separate cleanup.