### PR TITLE
refactor(vta): central keyspace-name registry; fix imported/imported_secrets divergence (P1.3)

### DIFF
--- a/vta-service/src/acl_cli.rs
+++ b/vta-service/src/acl_cli.rs
@@ -16,7 +16,7 @@ pub async fn run_acl_list(
 
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
 
     let mut entries = list_acl_entries(&acl_ks).await?;
 
@@ -54,7 +54,7 @@ pub async fn run_acl_get(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
 
     let entry = get_acl_entry(&acl_ks, &did)
         .await?
@@ -88,7 +88,7 @@ pub async fn run_acl_update(
 
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
 
     let mut entry = get_acl_entry(&acl_ks, &did)
         .await?
@@ -135,7 +135,7 @@ pub async fn run_acl_delete(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
 
     let entry = get_acl_entry(&acl_ks, &did)
         .await?

--- a/vta-service/src/acl_sweeper.rs
+++ b/vta-service/src/acl_sweeper.rs
@@ -119,8 +119,8 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         };
         let store = Store::open(&config).unwrap();
-        let acl_ks = store.keyspace("acl").unwrap();
-        let audit_ks = store.keyspace("audit").unwrap();
+        let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
+        let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
         (store, acl_ks, audit_ks, dir)
     }
 

--- a/vta-service/src/backup_bundle_store.rs
+++ b/vta-service/src/backup_bundle_store.rs
@@ -236,7 +236,9 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let ks = store.keyspace("backup_bundles_test").unwrap();
+        let ks = store
+            .keyspace(crate::keyspaces::BACKUP_BUNDLES_TEST)
+            .unwrap();
         (dir, ks)
     }
 

--- a/vta-service/src/backup_bundle_sweeper.rs
+++ b/vta-service/src/backup_bundle_sweeper.rs
@@ -188,7 +188,9 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let ks = store.keyspace("backup_bundles_sweeper_test").unwrap();
+        let ks = store
+            .keyspace(crate::keyspaces::BACKUP_BUNDLES_SWEEPER_TEST)
+            .unwrap();
         let blob_dir = dir.path().join("backups");
         tokio::fs::create_dir_all(&blob_dir).await.unwrap();
         (dir, ks, blob_dir)

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -78,7 +78,7 @@ pub async fn run_seal(
     // forces the consumer to regenerate their request.
     let config_store = AppConfig::load(config_path)?;
     let persistent_store = Store::open(&config_store.store)?;
-    let nonce_ks = persistent_store.keyspace("sealed_nonces")?;
+    let nonce_ks = persistent_store.keyspace(crate::keyspaces::SEALED_NONCES)?;
     let nonce_store = PersistentNonceStore::new(nonce_ks);
     let bundle = seal_payload(&recipient_pk, bundle_id, producer, &payload, &nonce_store).await?;
     persistent_store.persist().await?;
@@ -793,8 +793,8 @@ pub async fn run_context_create(
 
     let app_config = AppConfig::load(config_path)?;
     let store = Store::open(&app_config.store)?;
-    let contexts_ks = store.keyspace("contexts")?;
-    let acl_ks = store.keyspace("acl")?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
 
     let auth = AuthClaims::unsafe_local_cli_super_admin("context-create");
     let display_name = name.unwrap_or_else(|| id.clone());
@@ -859,7 +859,7 @@ pub async fn run_context_list(
 
     let app_config = AppConfig::load(config_path)?;
     let store = Store::open(&app_config.store)?;
-    let contexts_ks = store.keyspace("contexts")?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
 
     let auth = AuthClaims::unsafe_local_cli_super_admin("context-list");
     let resp = crate::operations::contexts::list_contexts(&contexts_ks, &auth, "vta-contexts-list")
@@ -881,7 +881,7 @@ pub async fn run_context_get(
 
     let app_config = AppConfig::load(config_path)?;
     let store = Store::open(&app_config.store)?;
-    let contexts_ks = store.keyspace("contexts")?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
 
     let auth = AuthClaims::unsafe_local_cli_super_admin("context-get");
     let record =
@@ -907,7 +907,7 @@ pub async fn run_context_update(
 
     let app_config = AppConfig::load(config_path)?;
     let store = Store::open(&app_config.store)?;
-    let contexts_ks = store.keyspace("contexts")?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
 
     let auth = AuthClaims::unsafe_local_cli_super_admin("context-update");
     let params = UpdateContextParams {
@@ -943,14 +943,14 @@ pub async fn run_context_delete(
 
     let app_config = AppConfig::load(config_path)?;
     let store = Store::open(&app_config.store)?;
-    let contexts_ks = store.keyspace("contexts")?;
-    let keys_ks = store.keyspace("keys")?;
-    let acl_ks = store.keyspace("acl")?;
-    let did_templates_ks = store.keyspace("did_templates")?;
-    let audit_ks = store.keyspace("audit")?;
-    let imported_ks = store.keyspace("imported_secrets")?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
+    let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES)?;
+    let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
+    let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
     #[cfg(feature = "webvh")]
-    let webvh_ks = store.keyspace("webvh")?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
 
     let auth = AuthClaims::unsafe_local_cli_super_admin("context-delete");
 
@@ -1162,7 +1162,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("contexts").expect("contexts keyspace");
+        let ks = store
+            .keyspace(crate::keyspaces::CONTEXTS)
+            .expect("contexts keyspace");
         (dir, store, ks)
     }
 

--- a/vta-service/src/contexts/mod.rs
+++ b/vta-service/src/contexts/mod.rs
@@ -133,7 +133,12 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        (store.keyspace("contexts").expect("keyspace"), dir)
+        (
+            store
+                .keyspace(crate::keyspaces::CONTEXTS)
+                .expect("keyspace"),
+            dir,
+        )
     }
 
     /// Regression test for the context-index race: N concurrent

--- a/vta-service/src/did_key.rs
+++ b/vta-service/src/did_key.rs
@@ -22,8 +22,8 @@ pub struct CreateDidKeyArgs {
 pub async fn run_create_did_key(args: CreateDidKeyArgs) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(args.config_path)?;
     let store = Store::open(&config.store)?;
-    let keys_ks = store.keyspace("keys")?;
-    let contexts_ks = store.keyspace("contexts")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
 
     // Load seed from configured backend using the active generation
     let seed_store = create_seed_store(&config)?;
@@ -60,7 +60,7 @@ pub async fn run_create_did_key(args: CreateDidKeyArgs) -> Result<(), Box<dyn st
 
     // Optionally create ACL entry
     if args.admin {
-        let acl_ks = store.keyspace("acl")?;
+        let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
         let entry = AclEntry::new(did.clone(), Role::Admin, "cli:create-did-key")
             .with_label(args.label.clone())
             .with_contexts(vec![args.context.clone()]);

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -28,11 +28,11 @@ pub async fn run_create_did_webvh(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(args.config_path)?;
     let store = Store::open(&config.store)?;
-    let keys_ks = store.keyspace("keys")?;
-    let imported_ks = store.keyspace("imported_secrets")?;
-    let contexts_ks = store.keyspace("contexts")?;
-    let webvh_ks = store.keyspace("webvh")?;
-    let did_templates_ks = store.keyspace("did_templates")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
+    let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES)?;
 
     // Resolve context
     let ctx = match crate::contexts::get_context(&contexts_ks, &args.context).await? {
@@ -220,7 +220,7 @@ pub async fn run_create_did_webvh(
             &keys_ks,
             &imported_ks,
             &Arc::from(seed_store),
-            &store.keyspace("audit")?,
+            &store.keyspace(crate::keyspaces::AUDIT)?,
             &auth,
             &result.signing_key_id,
             "cli",
@@ -239,7 +239,7 @@ pub async fn run_create_did_webvh(
                 &keys_ks,
                 &imported_ks,
                 &Arc::from(create_seed_store(&config)?),
-                &store.keyspace("audit")?,
+                &store.keyspace(crate::keyspaces::AUDIT)?,
                 &auth,
                 &result.ka_key_id,
                 "cli",

--- a/vta-service/src/import_did.rs
+++ b/vta-service/src/import_did.rs
@@ -17,7 +17,7 @@ pub struct ImportDidArgs {
 pub async fn run_import_did(args: ImportDidArgs) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(args.config_path)?;
     let store = Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
 
     // Validate DID format
     if !args.did.starts_with("did:") {

--- a/vta-service/src/keys/imported.rs
+++ b/vta-service/src/keys/imported.rs
@@ -293,7 +293,7 @@ mod tests {
 
         let mut handles = Vec::new();
         for _ in 0..16 {
-            let ks = store.keyspace("keys").unwrap();
+            let ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
             handles.push(tokio::spawn(async move {
                 get_or_create_salt(&ks).await.expect("salt")
             }));
@@ -302,7 +302,7 @@ mod tests {
         for h in handles {
             salts.push(h.await.expect("join"));
         }
-        let persisted = get_salt(&store.keyspace("keys").unwrap())
+        let persisted = get_salt(&store.keyspace(crate::keyspaces::KEYS).unwrap())
             .await
             .unwrap()
             .expect("salt persisted");
@@ -317,8 +317,8 @@ mod tests {
     #[tokio::test]
     async fn test_store_and_load_secret() {
         let (store, _dir) = temp_store();
-        let imported_ks = store.keyspace("imported_secrets").unwrap();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
         let seed = [42u8; 32];
         let secret = b"my-secret-key-bytes-32-chars!!!!";
 
@@ -336,8 +336,8 @@ mod tests {
     #[tokio::test]
     async fn test_wrong_aad_fails() {
         let (store, _dir) = temp_store();
-        let imported_ks = store.keyspace("imported_secrets").unwrap();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
         let seed = [42u8; 32];
         let secret = b"my-secret-key-bytes-32-chars!!!!";
 
@@ -353,8 +353,8 @@ mod tests {
     #[tokio::test]
     async fn test_delete_secret_removes_value() {
         let (store, _dir) = temp_store();
-        let imported_ks = store.keyspace("imported_secrets").unwrap();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
         let seed = [42u8; 32];
 
         store_secret(
@@ -377,8 +377,8 @@ mod tests {
     #[tokio::test]
     async fn test_reencrypt_all() {
         let (store, _dir) = temp_store();
-        let imported_ks = store.keyspace("imported_secrets").unwrap();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
         let old_seed = [42u8; 32];
         let new_seed = [99u8; 32];
         let secret = b"my-secret-key-bytes-32-chars!!!!";

--- a/vta-service/src/keys/mod.rs
+++ b/vta-service/src/keys/mod.rs
@@ -380,7 +380,7 @@ mod tests {
     async fn test_create_store_recover_cycle() {
         let seed = test_seed();
         let (store, _dir) = temp_store();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
         let did = "did:webvh:abc123:example.com:vta";
 
         // === CREATION (first boot — derive_entity_keys + save) ===
@@ -462,7 +462,7 @@ mod tests {
                 data_dir: dir.path().to_path_buf(),
             };
             let store = Store::open(&config).unwrap();
-            let keys_ks = store.keyspace("keys").unwrap();
+            let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
 
             let derived = derive_entity_keys(&seed, "m/44'/0'", "signing", "ka", &keys_ks)
                 .await
@@ -481,7 +481,7 @@ mod tests {
                 data_dir: dir.path().to_path_buf(),
             };
             let store = Store::open(&config).unwrap();
-            let keys_ks = store.keyspace("keys").unwrap();
+            let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
 
             let signing: KeyRecord = keys_ks
                 .get(store_key(&format!("{did}#key-0")))
@@ -518,7 +518,7 @@ mod tests {
     async fn test_path_allocation_produces_unique_keys() {
         let seed = test_seed();
         let (store, _dir) = temp_store();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
 
         let base = "m/44'/0'";
         let mut pub_keys = Vec::new();

--- a/vta-service/src/keys/paths.rs
+++ b/vta-service/src/keys/paths.rs
@@ -45,7 +45,7 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let keys_ks = Arc::new(store.keyspace("keys").expect("keyspace"));
+        let keys_ks = Arc::new(store.keyspace(crate::keyspaces::KEYS).expect("keyspace"));
 
         let base = "m/26'/0'";
         let n = 64usize;

--- a/vta-service/src/keys/seeds.rs
+++ b/vta-service/src/keys/seeds.rs
@@ -563,7 +563,7 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .unwrap();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
         save_seed_record(
             &keys_ks,
             &SeedRecord {

--- a/vta-service/src/keys_cli.rs
+++ b/vta-service/src/keys_cli.rs
@@ -33,7 +33,7 @@ pub async fn run_keys_list(
 
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let keys_ks = store.keyspace("keys")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
 
     let raw = keys_ks.prefix_iter_raw("key:").await?;
 
@@ -73,7 +73,7 @@ pub async fn run_keys_secrets(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let keys_ks = store.keyspace("keys")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
     let seed_store = create_seed_store(&config)?;
 
     // Resolve key IDs: explicit args or all active keys in a context
@@ -169,7 +169,7 @@ pub async fn run_keys_seeds_list(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let keys_ks = store.keyspace("keys")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
 
     let active_id = keys::seeds::get_active_seed_id(&keys_ks).await?;
     let records = keys::seeds::list_seed_records(&keys_ks).await?;
@@ -215,7 +215,7 @@ pub async fn run_rotate_seed(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let keys_ks = store.keyspace("keys")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
     let seed_store = create_seed_store(&config)?;
 
     let current_id = keys::seeds::get_active_seed_id(&keys_ks).await?;

--- a/vta-service/src/keyspaces.rs
+++ b/vta-service/src/keyspaces.rs
@@ -1,0 +1,182 @@
+//! Central registry of the VTA's keyspace names.
+//!
+//! Every `store.keyspace(..)` call in `vta-service` (server, offline CLIs,
+//! backup, tests) names its keyspace through a `const` here rather than a bare
+//! string literal. This is the single source of truth that killed the
+//! `"imported"` / `"imported_secrets"` test-vs-production divergence (a test
+//! opened a *different*, empty keyspace than the one production writes), and
+//! the [`tests::no_bare_keyspace_literals`] guard keeps it that way.
+//!
+//! Keyspace *names* live here; per-keyspace *key formats* (the `key:`, `seed:`,
+//! `path_counter:` … record families inside a keyspace) are a separate concern
+//! and are not yet centralised.
+
+/// Master seed + key records (`key:`, `seed:`, `path_counter:`,
+/// `active_seed_id`, `imported_kek_salt`, …) and the backup import sentinel.
+pub const KEYS: &str = "keys";
+/// Auth sessions + challenges.
+pub const SESSIONS: &str = "sessions";
+/// ACL entries + the seal record + the integrity-anchor root.
+pub const ACL: &str = "acl";
+/// Trust contexts (the BIP-32 key hierarchy roots).
+pub const CONTEXTS: &str = "contexts";
+/// Stored DID templates (global + context-scoped).
+pub const DID_TEMPLATES: &str = "did_templates";
+/// Audit log.
+pub const AUDIT: &str = "audit";
+/// Imported secret material (KEK-wrapped). Named `imported_secrets`, **not**
+/// `imported` — the latter was a long-standing test-only typo that operated on
+/// an empty keyspace disjoint from production. Always reference this const.
+pub const IMPORTED_SECRETS: &str = "imported_secrets";
+/// Ephemeral cache (resolver/auth caches).
+pub const CACHE: &str = "cache";
+/// Holder credential vault (third-party secrets stored on this VTA).
+pub const VAULT: &str = "vault";
+/// Persistent runtime service-enable state (`operations::protocol::runtime_state`).
+pub const SERVICE_STATE: &str = "service_state";
+/// Sealed-bootstrap anti-replay nonce log.
+pub const SEALED_NONCES: &str = "sealed_nonces";
+/// In-flight backup-bundle control-plane records.
+pub const BACKUP_BUNDLES: &str = "backup_bundles";
+/// WebVH DID records + `did.jsonl` state.
+pub const WEBVH: &str = "webvh";
+/// In-flight passkey-as-verificationMethod enrolment state.
+pub const PASSKEY_VMS: &str = "passkey_vms";
+/// Persisted protocol-management drain set.
+pub const DRAINS: &str = "drains";
+/// Per-kind previous-config snapshots for fail-forward rollback.
+/// (Historically `operations::protocol::snapshot::KEYSPACE_NAME`.)
+pub const SNAPSHOT: &str = "service_prev_config";
+/// KMS-protected, unencrypted boot keyspace (TEE integrity manifest, etc.).
+pub const BOOTSTRAP: &str = "bootstrap";
+
+/// Every production keyspace. Partitioned by [`BACKED_UP`] +
+/// [`EXCLUDED_FROM_BACKUP`]; the [`tests::backup_partition_is_total`] guard
+/// asserts the partition stays exhaustive so a newly-added keyspace can't be
+/// silently omitted from the backup decision.
+pub const ALL: &[&str] = &[
+    KEYS,
+    SESSIONS,
+    ACL,
+    CONTEXTS,
+    DID_TEMPLATES,
+    AUDIT,
+    IMPORTED_SECRETS,
+    CACHE,
+    VAULT,
+    SERVICE_STATE,
+    SEALED_NONCES,
+    BACKUP_BUNDLES,
+    WEBVH,
+    PASSKEY_VMS,
+    DRAINS,
+    SNAPSHOT,
+    BOOTSTRAP,
+];
+
+/// Keyspaces whose contents a full `export_backup` captures (as typed
+/// collections — see `operations::backup`).
+pub const BACKED_UP: &[&str] = &[KEYS, ACL, CONTEXTS, AUDIT, IMPORTED_SECRETS, WEBVH];
+
+/// Keyspaces deliberately **not** in a backup.
+///
+/// Most are ephemeral / runtime / re-derivable: [`SESSIONS`], [`CACHE`],
+/// [`SEALED_NONCES`], [`SERVICE_STATE`], [`BACKUP_BUNDLES`], [`PASSKEY_VMS`],
+/// [`DRAINS`], [`SNAPSHOT`], [`BOOTSTRAP`]. [`DID_TEMPLATES`] and [`VAULT`]
+/// hold durable operator/holder state and are **known backup gaps** — a
+/// backup-fidelity follow-up should move them into [`BACKED_UP`], not leave
+/// them silently dropped.
+pub const EXCLUDED_FROM_BACKUP: &[&str] = &[
+    SESSIONS,
+    DID_TEMPLATES,
+    CACHE,
+    VAULT,
+    SERVICE_STATE,
+    SEALED_NONCES,
+    BACKUP_BUNDLES,
+    PASSKEY_VMS,
+    DRAINS,
+    SNAPSHOT,
+    BOOTSTRAP,
+];
+
+/// Test-only keyspaces (descriptor sweeper tests open isolated keyspaces so a
+/// run can't clobber the shared `backup_bundles`).
+#[cfg(test)]
+pub const BACKUP_BUNDLES_TEST: &str = "backup_bundles_test";
+#[cfg(test)]
+pub const BACKUP_BUNDLES_SWEEPER_TEST: &str = "backup_bundles_sweeper_test";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    /// The backup partition must be total and disjoint: every production
+    /// keyspace is either backed up or explicitly excluded. Adding a keyspace
+    /// to [`ALL`] without classifying it fails here — that's the point.
+    #[test]
+    fn backup_partition_is_total() {
+        let all: BTreeSet<&str> = ALL.iter().copied().collect();
+        let backed: BTreeSet<&str> = BACKED_UP.iter().copied().collect();
+        let excluded: BTreeSet<&str> = EXCLUDED_FROM_BACKUP.iter().copied().collect();
+
+        assert_eq!(all.len(), ALL.len(), "ALL has a duplicate");
+        assert!(
+            backed.is_disjoint(&excluded),
+            "a keyspace is both backed up and excluded: {:?}",
+            backed.intersection(&excluded).collect::<Vec<_>>()
+        );
+        let union: BTreeSet<&str> = backed.union(&excluded).copied().collect();
+        assert_eq!(
+            union, all,
+            "backup partition is not exhaustive — every keyspace in ALL must be in \
+             exactly one of BACKED_UP / EXCLUDED_FROM_BACKUP"
+        );
+    }
+
+    /// Guard (the "CI grep"): no bare `.keyspace("literal")` anywhere in the
+    /// crate source except this registry. New code must name keyspaces through
+    /// a `crate::keyspaces::*` const.
+    #[test]
+    fn no_bare_keyspace_literals() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+        visit(&src, &mut |path, content| {
+            if path.file_name().and_then(|n| n.to_str()) == Some("keyspaces.rs") {
+                return;
+            }
+            for (lineno, line) in content.lines().enumerate() {
+                if line.contains(".keyspace(\"") {
+                    offenders.push(format!(
+                        "{}:{}: {}",
+                        path.display(),
+                        lineno + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        });
+        assert!(
+            offenders.is_empty(),
+            "bare keyspace string literal(s) found — use a crate::keyspaces::* const:\n{}",
+            offenders.join("\n")
+        );
+    }
+
+    fn visit(dir: &std::path::Path, f: &mut dyn FnMut(&std::path::Path, &str)) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                visit(&path, f);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs")
+                && let Ok(content) = std::fs::read_to_string(&path)
+            {
+                f(&path, &content);
+            }
+        }
+    }
+}

--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -18,6 +18,7 @@ pub mod did_templates;
 pub mod didcomm_bridge;
 pub mod error;
 pub mod keys;
+pub mod keyspaces;
 #[cfg(feature = "didcomm")]
 pub mod messaging;
 #[cfg(feature = "rest")]

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -2005,7 +2005,7 @@ async fn run_bootstrap_admin(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = store::Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
 
     // Check if already sealed
     if let Some(existing) = seal::get_seal(&acl_ks).await? {
@@ -2317,7 +2317,7 @@ async fn auth_sign_challenge(
     let key_id = format!("{did}#{multibase}");
 
     let store = store::Store::open(&config.store)?;
-    let keys_ks = store.keyspace("keys")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
     let record: KeyRecord = keys_ks
         .get(keys::store_key(&key_id))
         .await?
@@ -2366,8 +2366,8 @@ async fn auth_sign_challenge(
 async fn export_admin(config_path: Option<PathBuf>) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = store::Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
-    let keys_ks = store.keyspace("keys")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
     let seed_store = create_seed_store(&config)?;
 
     let vta_did = config.vta_did.as_deref().unwrap_or("(not set)");

--- a/vta-service/src/messaging/auth.rs
+++ b/vta-service/src/messaging/auth.rs
@@ -73,7 +73,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let acl_ks = store.keyspace("acl").unwrap();
+        let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
         (store, acl_ks, dir)
     }
 

--- a/vta-service/src/messaging/drain_store.rs
+++ b/vta-service/src/messaging/drain_store.rs
@@ -60,7 +60,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let ks = store.keyspace("drains").unwrap();
+        let ks = store.keyspace(crate::keyspaces::DRAINS).unwrap();
         (dir, ks)
     }
 

--- a/vta-service/src/messaging/drain_sweeper.rs
+++ b/vta-service/src/messaging/drain_sweeper.rs
@@ -184,7 +184,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let ks = store.keyspace("drains").unwrap();
+        let ks = store.keyspace(crate::keyspaces::DRAINS).unwrap();
         (dir, ks)
     }
 

--- a/vta-service/src/messaging/registry.rs
+++ b/vta-service/src/messaging/registry.rs
@@ -1090,7 +1090,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let ks = store.keyspace("drains").unwrap();
+        let ks = store.keyspace(crate::keyspaces::DRAINS).unwrap();
         (dir, ks)
     }
 

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -514,9 +514,9 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let acl_ks = store.keyspace("acl").unwrap();
-        let audit_ks = store.keyspace("audit").unwrap();
-        let contexts_ks = store.keyspace("contexts").unwrap();
+        let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
+        let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
+        let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
         (store, acl_ks, audit_ks, contexts_ks, dir)
     }
 

--- a/vta-service/src/operations/backup/descriptors.rs
+++ b/vta-service/src/operations/backup/descriptors.rs
@@ -635,7 +635,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let ks = store.keyspace("backup_bundles").unwrap();
+        let ks = store.keyspace(crate::keyspaces::BACKUP_BUNDLES).unwrap();
         (dir, ks)
     }
 

--- a/vta-service/src/operations/backup/mod.rs
+++ b/vta-service/src/operations/backup/mod.rs
@@ -80,6 +80,12 @@ pub async fn export_backup(
     password: &str,
     include_audit: bool,
 ) -> Result<BackupEnvelope, AppError> {
+    // The keyspaces captured here are exactly `crate::keyspaces::BACKED_UP`
+    // ({keys, acl, contexts, audit, imported_secrets, webvh}). That registry
+    // partitions every keyspace into BACKED_UP vs EXCLUDED_FROM_BACKUP and a
+    // guard test (`keyspaces::tests::backup_partition_is_total`) keeps the
+    // partition total, so a newly-added keyspace can't be silently dropped from
+    // the backup decision. If you add a keyspace to BACKED_UP, wire it in here.
     let keys_ks = ks.keys;
     let acl_ks = ks.acl;
     let contexts_ks = ks.contexts;
@@ -1003,7 +1009,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let webvh_ks = store.keyspace("webvh").unwrap();
+        let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
 
         // Plant a stale auth record (as if a previous VTA installation
         // had cached daemon REST tokens here).

--- a/vta-service/src/operations/contexts.rs
+++ b/vta-service/src/operations/contexts.rs
@@ -506,7 +506,7 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .unwrap();
-        let ks = store.keyspace("contexts").unwrap();
+        let ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
         (dir, store, ks)
     }
 
@@ -660,15 +660,16 @@ mod tests {
         })
         .unwrap();
         let k = |n: &str| store.keyspace(n).unwrap();
+        use crate::keyspaces as ks;
         OwnedKs {
-            keys: k("keys"),
-            acl: k("acl"),
-            contexts: k("contexts"),
-            did_templates: k("did_templates"),
-            audit: k("audit"),
-            imported: k("imported"),
+            keys: k(ks::KEYS),
+            acl: k(ks::ACL),
+            contexts: k(ks::CONTEXTS),
+            did_templates: k(ks::DID_TEMPLATES),
+            audit: k(ks::AUDIT),
+            imported: k(ks::IMPORTED_SECRETS),
             #[cfg(feature = "webvh")]
-            webvh: k("webvh"),
+            webvh: k(ks::WEBVH),
             _dir: dir,
             _store: store,
         }

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -1162,7 +1162,7 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .unwrap();
-        let ks = store.keyspace("vault").unwrap();
+        let ks = store.keyspace(crate::keyspaces::VAULT).unwrap();
         (dir, store, ks)
     }
 
@@ -1861,8 +1861,8 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .unwrap();
-        let vault = store.keyspace("vault").unwrap();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let vault = store.keyspace(crate::keyspaces::VAULT).unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
 
         // The holder subject key is a VTA-derived key (context `acme`).
         let seed = vec![42u8; 64];
@@ -2109,8 +2109,8 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .unwrap();
-        let vault = store.keyspace("vault").unwrap();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let vault = store.keyspace(crate::keyspaces::VAULT).unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
 
         let seed = vec![42u8; 64];
         let seed_store: Arc<dyn SeedStore> =

--- a/vta-service/src/operations/device.rs
+++ b/vta-service/src/operations/device.rs
@@ -533,8 +533,8 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let acl_ks = store.keyspace("acl").unwrap();
-        let audit_ks = store.keyspace("audit").unwrap();
+        let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
+        let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
         (acl_ks, audit_ks, dir)
     }
 

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -1448,7 +1448,7 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let webvh_ks = store.keyspace("webvh").expect("keyspace");
+        let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).expect("keyspace");
 
         let now = Utc::now();
         let did = "did:webvh:QmTest:example.com:abc";

--- a/vta-service/src/operations/did_webvh/register_server.rs
+++ b/vta-service/src/operations/did_webvh/register_server.rs
@@ -289,8 +289,8 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let webvh_ks = store.keyspace("webvh").unwrap();
-        let audit_ks = store.keyspace("audit").unwrap();
+        let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
+        let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
         // Force the test_app_config helper to be exercised so any
         // future field addition surfaces as a test failure.
         let _ = test_app_config(dir.path().into());

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -306,7 +306,7 @@ mod tests {
         };
         std::mem::forget(dir);
         let store = Store::open(&cfg).expect("open store");
-        store.keyspace("keys").expect("keyspace")
+        store.keyspace(crate::keyspaces::KEYS).expect("keyspace")
     }
 
     fn test_pub_multibase() -> String {

--- a/vta-service/src/operations/did_webvh/webvh_keys.rs
+++ b/vta-service/src/operations/did_webvh/webvh_keys.rs
@@ -206,7 +206,7 @@ mod tests {
         // Test fixture only — no production code does this.
         std::mem::forget(dir);
         let store = Store::open(&cfg).expect("open store");
-        store.keyspace("keys").expect("keyspace")
+        store.keyspace(crate::keyspaces::KEYS).expect("keyspace")
     }
 
     fn handle(scid: &str, version_id: &str, role: WebvhKeyRole, hash: &str) -> WebvhKeyHandle {

--- a/vta-service/src/operations/export.rs
+++ b/vta-service/src/operations/export.rs
@@ -303,13 +303,13 @@ mod tests {
         })
         .expect("open store");
         TestEnv {
-            contexts_ks: store.keyspace("contexts").unwrap(),
-            keys_ks: store.keyspace("keys").unwrap(),
-            imported_ks: store.keyspace("imported").unwrap(),
-            audit_ks: store.keyspace("audit").unwrap(),
-            acl_ks: store.keyspace("acl").unwrap(),
+            contexts_ks: store.keyspace(crate::keyspaces::CONTEXTS).unwrap(),
+            keys_ks: store.keyspace(crate::keyspaces::KEYS).unwrap(),
+            imported_ks: store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap(),
+            audit_ks: store.keyspace(crate::keyspaces::AUDIT).unwrap(),
+            acl_ks: store.keyspace(crate::keyspaces::ACL).unwrap(),
             #[cfg(feature = "webvh")]
-            webvh_ks: store.keyspace("webvh").unwrap(),
+            webvh_ks: store.keyspace(crate::keyspaces::WEBVH).unwrap(),
             seed_store: Arc::new(PlaintextSeedStore::new(&data_dir)),
             _dir: dir,
             _store: store,

--- a/vta-service/src/operations/holder_keys.rs
+++ b/vta-service/src/operations/holder_keys.rs
@@ -200,7 +200,7 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .unwrap();
-        let keys_ks = store.keyspace("keys").unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
 
         let seed = vec![42u8; 64];
         let seed_store: Arc<dyn SeedStore> =

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -996,10 +996,10 @@ mod tests {
             };
             let store = Store::open(&store_config).expect("open store");
 
-            let keys_ks = store.keyspace("keys").unwrap();
-            let contexts_ks = store.keyspace("contexts").unwrap();
-            let audit_ks = store.keyspace("audit").unwrap();
-            let imported_ks = store.keyspace("imported_secrets").unwrap();
+            let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
+            let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
+            let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
+            let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
 
             // 32-byte seed; will be expanded to 64 bytes by BIP-32 internally
             let seed_store: Arc<dyn SeedStore> =

--- a/vta-service/src/operations/protocol/disable_rest.rs
+++ b/vta-service/src/operations/protocol/disable_rest.rs
@@ -315,7 +315,7 @@ mod tests {
 
     impl TestFixture {
         fn webvh_ks(&self) -> KeyspaceHandle {
-            self.store.keyspace("webvh").unwrap()
+            self.store.keyspace(crate::keyspaces::WEBVH).unwrap()
         }
     }
 

--- a/vta-service/src/operations/protocol/drain_cancel.rs
+++ b/vta-service/src/operations/protocol/drain_cancel.rs
@@ -101,7 +101,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let drains_ks = store.keyspace("drains").unwrap();
+        let drains_ks = store.keyspace(crate::keyspaces::DRAINS).unwrap();
         let sink: SharedTelemetrySink = Arc::new(RingBufferTelemetry::with_capacity(64));
         let reg = Arc::new(MediatorListenerRegistry::new(Arc::clone(&sink)));
 

--- a/vta-service/src/operations/protocol/enable_rest.rs
+++ b/vta-service/src/operations/protocol/enable_rest.rs
@@ -283,7 +283,7 @@ mod tests {
             self.store.keyspace(snapshot::KEYSPACE_NAME).unwrap()
         }
         fn webvh_ks(&self) -> KeyspaceHandle {
-            self.store.keyspace("webvh").unwrap()
+            self.store.keyspace(crate::keyspaces::WEBVH).unwrap()
         }
     }
 

--- a/vta-service/src/operations/protocol/list.rs
+++ b/vta-service/src/operations/protocol/list.rs
@@ -195,7 +195,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let webvh_ks = store.keyspace("webvh").unwrap();
+        let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
         let context_admin = AuthClaims {
             did: "did:key:z6Mk-context-admin".into(),
             role: Role::Admin,
@@ -232,7 +232,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let webvh_ks = store.keyspace("webvh").unwrap();
+        let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
         let super_admin = AuthClaims::unsafe_local_cli_super_admin("test");
 
         let err = list_services(&config, &webvh_ks, &super_admin)
@@ -265,7 +265,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let webvh_ks = store.keyspace("webvh").unwrap();
+        let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
         let super_admin = AuthClaims::unsafe_local_cli_super_admin("test");
 
         let response = list_services(&config, &webvh_ks, &super_admin)
@@ -323,7 +323,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let webvh_ks = store.keyspace("webvh").unwrap();
+        let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
 
         // Stage a webvh record + log line so list_services can read
         // the on-chain document. Service array deliberately puts

--- a/vta-service/src/operations/protocol/list_drain.rs
+++ b/vta-service/src/operations/protocol/list_drain.rs
@@ -72,7 +72,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let ks = store.keyspace("drains").unwrap();
+        let ks = store.keyspace(crate::keyspaces::DRAINS).unwrap();
         (dir, ks)
     }
 

--- a/vta-service/src/operations/protocol/snapshot.rs
+++ b/vta-service/src/operations/protocol/snapshot.rs
@@ -38,7 +38,7 @@ use vti_common::store::KeyspaceHandle;
 /// [`KeyspaceHandle`] via [`vti_common::store::Store::keyspace`]
 /// once at startup (or in tests) and pass it to [`read`] / [`write`]
 /// / [`clear`].
-pub const KEYSPACE_NAME: &str = "service_prev_config";
+pub const KEYSPACE_NAME: &str = crate::keyspaces::SNAPSHOT;
 
 /// Identifier for which transport kind a snapshot pertains to.
 ///

--- a/vta-service/src/operations/protocol/update_rest.rs
+++ b/vta-service/src/operations/protocol/update_rest.rs
@@ -272,7 +272,7 @@ mod tests {
             self.store.keyspace(snapshot::KEYSPACE_NAME).unwrap()
         }
         fn webvh_ks(&self) -> KeyspaceHandle {
-            self.store.keyspace("webvh").unwrap()
+            self.store.keyspace(crate::keyspaces::WEBVH).unwrap()
         }
     }
 

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -1088,7 +1088,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("webvh").expect("open webvh ks");
+        let ks = store
+            .keyspace(crate::keyspaces::WEBVH)
+            .expect("open webvh ks");
         (dir, store, ks)
     }
 

--- a/vta-service/src/operations/provision_integration/preconditions.rs
+++ b/vta-service/src/operations/provision_integration/preconditions.rs
@@ -304,7 +304,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("contexts").expect("open contexts ks");
+        let ks = store
+            .keyspace(crate::keyspaces::CONTEXTS)
+            .expect("open contexts ks");
         (dir, store, ks)
     }
 

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -204,9 +204,9 @@ mod tests {
             };
             let store = Store::open(&store_config).expect("open store");
 
-            let keys_ks = store.keyspace("keys").unwrap();
-            let imported_ks = store.keyspace("imported_secrets").unwrap();
-            let audit_ks = store.keyspace("audit").unwrap();
+            let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
+            let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+            let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
 
             let initial_seed = vec![0xABu8; 32];
             let seed_store: Arc<dyn SeedStore> =
@@ -251,9 +251,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let keys_ks = store.keyspace("keys").unwrap();
-        let imported_ks = store.keyspace("imported_secrets").unwrap();
-        let audit_ks = store.keyspace("audit").unwrap();
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
+        let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+        let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
 
         // Bootstrap generation 0 as the active seed.
         save_seed_record(

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -472,7 +472,7 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         };
         let store = Store::open(&store_config).expect("open store");
-        let keys_ks = store.keyspace("keys").expect("keyspace");
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).expect("keyspace");
 
         let n_tasks: usize = 16;
         let successes = std::sync::Arc::new(AtomicUsize::new(0));

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -1051,7 +1051,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let acl_ks = store.keyspace("acl").unwrap();
+        let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
         let caller = "did:key:zCaller";
 
         let mk_config = |allow_carveout: bool, enabled: bool| {
@@ -1113,7 +1113,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let acl_ks = store.keyspace("acl").unwrap();
+        let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
         let caller = "did:key:zCaller";
 
         let mut c: crate::config::AppConfig = toml::from_str("").unwrap();
@@ -1173,7 +1173,7 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .unwrap();
-        let ks = store.keyspace("sessions").unwrap();
+        let ks = store.keyspace(crate::keyspaces::SESSIONS).unwrap();
 
         let resp = issue_step_up_challenge(
             &ks,

--- a/vta-service/src/seal.rs
+++ b/vta-service/src/seal.rs
@@ -65,7 +65,7 @@ pub async fn get_seal(acl_ks: &KeyspaceHandle) -> Result<Option<SealRecord>, App
 ///
 /// Call this at the top of any CLI command that modifies state.
 pub async fn require_unsealed(store: &Store) -> Result<(), AppError> {
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
     if let Some(seal) = get_seal(&acl_ks).await? {
         return Err(AppError::Config(format!(
             "VTA is sealed (by {} on {}). \
@@ -120,7 +120,7 @@ pub(crate) async fn read_unseal_state(
     store_config: &StoreConfig,
 ) -> Result<UnsealChallenge, AppError> {
     let store = Store::open(store_config)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
 
     let seal = get_seal(&acl_ks)
         .await?
@@ -156,7 +156,7 @@ pub(crate) async fn read_unseal_state(
 /// blocked on stdin).
 pub(crate) async fn remove_seal_marker(store_config: &StoreConfig) -> Result<bool, AppError> {
     let store = Store::open(store_config)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
     if get_seal(&acl_ks).await?.is_none() {
         return Ok(false);
     }
@@ -349,7 +349,7 @@ mod tests {
             data_dir: data_dir.to_path_buf(),
         };
         let store = Store::open(&config).expect("open store");
-        let acl_ks = store.keyspace("acl").expect("acl keyspace");
+        let acl_ks = store.keyspace(crate::keyspaces::ACL).expect("acl keyspace");
 
         let entry = AclEntry::new(admin_did, Role::Admin, "test")
             .with_label(Some("test-super-admin".into()));
@@ -447,7 +447,7 @@ mod tests {
         };
         {
             let store = Store::open(&config).expect("open");
-            let acl_ks = store.keyspace("acl").expect("acl");
+            let acl_ks = store.keyspace(crate::keyspaces::ACL).expect("acl");
             // Seal directly without seeding a super-admin.
             seal(&acl_ks, "did:key:zPhantom").await.expect("seal");
             store.persist().await.expect("persist");

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -268,23 +268,23 @@ pub async fn build_app_state(
         }
     };
 
-    let keys_ks = apply_encryption(store.keyspace("keys")?);
-    let sessions_ks = apply_encryption(store.keyspace("sessions")?);
-    let acl_ks = apply_encryption(store.keyspace("acl")?);
-    let contexts_ks = apply_encryption(store.keyspace("contexts")?);
-    let did_templates_ks = apply_encryption(store.keyspace("did_templates")?);
-    let audit_ks = apply_encryption(store.keyspace("audit")?);
-    let imported_ks = apply_encryption(store.keyspace("imported_secrets")?);
-    let cache_ks = apply_encryption(store.keyspace("cache")?);
-    let vault_ks = apply_encryption(store.keyspace("vault")?);
+    let keys_ks = apply_encryption(store.keyspace(crate::keyspaces::KEYS)?);
+    let sessions_ks = apply_encryption(store.keyspace(crate::keyspaces::SESSIONS)?);
+    let acl_ks = apply_encryption(store.keyspace(crate::keyspaces::ACL)?);
+    let contexts_ks = apply_encryption(store.keyspace(crate::keyspaces::CONTEXTS)?);
+    let did_templates_ks = apply_encryption(store.keyspace(crate::keyspaces::DID_TEMPLATES)?);
+    let audit_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT)?);
+    let imported_ks = apply_encryption(store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?);
+    let cache_ks = apply_encryption(store.keyspace(crate::keyspaces::CACHE)?);
+    let vault_ks = apply_encryption(store.keyspace(crate::keyspaces::VAULT)?);
     // Persistent runtime state for service enable/disable. Encrypted because
     // a couple of bool records are cheap and the keyspace may grow.
-    let service_state_ks = apply_encryption(store.keyspace("service_state")?);
+    let service_state_ks = apply_encryption(store.keyspace(crate::keyspaces::SERVICE_STATE)?);
     // Sealed-transfer anti-replay store. Bundle_ids are not secret and the
     // row is a one-byte sentinel, so the keyspace is intentionally
     // unencrypted — saves a decrypt hop on every request.
-    let sealed_nonces_ks = apply_encryption(store.keyspace("sealed_nonces")?);
-    let backup_bundles_ks = apply_encryption(store.keyspace("backup_bundles")?);
+    let sealed_nonces_ks = apply_encryption(store.keyspace(crate::keyspaces::SEALED_NONCES)?);
+    let backup_bundles_ks = apply_encryption(store.keyspace(crate::keyspaces::BACKUP_BUNDLES)?);
     // Stage `.vtabak` blobs under `{data_dir}/backups`. Created lazily
     // by the op layer at first `initiate-*` call (so a VTA that never
     // does backups doesn't get an empty directory). See
@@ -292,11 +292,11 @@ pub async fn build_app_state(
     // machine" for the file-system layout.
     let backup_blob_dir = config.store.data_dir.join("backups");
     #[cfg(feature = "webvh")]
-    let webvh_ks = apply_encryption(store.keyspace("webvh")?);
+    let webvh_ks = apply_encryption(store.keyspace(crate::keyspaces::WEBVH)?);
     #[cfg(feature = "webvh")]
-    let passkey_vms_ks = apply_encryption(store.keyspace("passkey_vms")?);
+    let passkey_vms_ks = apply_encryption(store.keyspace(crate::keyspaces::PASSKEY_VMS)?);
     #[cfg(feature = "webvh")]
-    let drains_ks = apply_encryption(store.keyspace("drains")?);
+    let drains_ks = apply_encryption(store.keyspace(crate::keyspaces::DRAINS)?);
     #[cfg(feature = "webvh")]
     let snapshot_ks =
         apply_encryption(store.keyspace(crate::operations::protocol::snapshot::KEYSPACE_NAME)?);
@@ -407,7 +407,7 @@ pub async fn run(
     // still present, the rewrite didn't finish and the state is hybrid.
     {
         let keys_ks_boot = {
-            let ks = store.keyspace("keys")?;
+            let ks = store.keyspace(crate::keyspaces::KEYS)?;
             match storage_encryption_key {
                 Some(key) => ks.with_encryption(key),
                 None => ks,
@@ -432,7 +432,7 @@ pub async fn run(
     // `[services]` block on first boot post-upgrade). Same encryption policy
     // as the rest of the keyspaces.
     let boot_service_state_ks = {
-        let ks = store.keyspace("service_state")?;
+        let ks = store.keyspace(crate::keyspaces::SERVICE_STATE)?;
         match storage_encryption_key {
             Some(key) => ks.with_encryption(key),
             None => ks,
@@ -478,7 +478,7 @@ pub async fn run(
     // continue (a stale/legacy archive is still readable via the load path).
     {
         let keys_ks_boot = {
-            let ks = store.keyspace("keys")?;
+            let ks = store.keyspace(crate::keyspaces::KEYS)?;
             match storage_encryption_key {
                 Some(key) => ks.with_encryption(key),
                 None => ks,
@@ -562,7 +562,7 @@ pub async fn run(
         let outcome = vti_common::integrity::boot_verify_and_install(
             vti_common::integrity::derive_mac_key(&storage_key),
             enc("keys")?,
-            store.keyspace("bootstrap")?, // unencrypted, KMS-protected
+            store.keyspace(crate::keyspaces::BOOTSTRAP)?, // unencrypted, KMS-protected
             enc("acl")?,
             enc("contexts")?,
             anchor,
@@ -627,14 +627,14 @@ pub async fn run(
                 None => ks,
             }
         };
-        let sessions_ks = apply_encryption(store.keyspace("sessions")?);
-        let acl_ks = apply_encryption(store.keyspace("acl")?);
-        let audit_ks = apply_encryption(store.keyspace("audit")?);
-        let vault_ks = apply_encryption(store.keyspace("vault")?);
-        let backup_bundles_ks = apply_encryption(store.keyspace("backup_bundles")?);
+        let sessions_ks = apply_encryption(store.keyspace(crate::keyspaces::SESSIONS)?);
+        let acl_ks = apply_encryption(store.keyspace(crate::keyspaces::ACL)?);
+        let audit_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT)?);
+        let vault_ks = apply_encryption(store.keyspace(crate::keyspaces::VAULT)?);
+        let backup_bundles_ks = apply_encryption(store.keyspace(crate::keyspaces::BACKUP_BUNDLES)?);
         let backup_blob_dir = config.store.data_dir.join("backups");
         #[cfg(feature = "webvh")]
-        let drains_ks = apply_encryption(store.keyspace("drains")?);
+        let drains_ks = apply_encryption(store.keyspace(crate::keyspaces::DRAINS)?);
 
         // Pluggable telemetry sink + multi-mediator listener registry.
         // The registry holds active/drain state and the per-mediator
@@ -1729,7 +1729,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("store open");
-        let keys_ks = store.keyspace("keys").expect("keys keyspace");
+        let keys_ks = store
+            .keyspace(crate::keyspaces::KEYS)
+            .expect("keys keyspace");
         (store, keys_ks, dir)
     }
 

--- a/vta-service/src/services_cli.rs
+++ b/vta-service/src/services_cli.rs
@@ -121,14 +121,14 @@ async fn build_offline_deps(
         )
     })?;
 
-    let keys_ks = store.keyspace("keys")?;
-    let imported_ks = store.keyspace("imported_secrets")?;
-    let contexts_ks = store.keyspace("contexts")?;
-    let audit_ks = store.keyspace("audit")?;
-    let webvh_ks = store.keyspace("webvh")?;
-    let drains_ks = store.keyspace("drains")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
+    let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
+    let drains_ks = store.keyspace(crate::keyspaces::DRAINS)?;
     let snapshot_ks = store.keyspace(snapshot::KEYSPACE_NAME)?;
-    let service_state_ks = store.keyspace("service_state")?;
+    let service_state_ks = store.keyspace(crate::keyspaces::SERVICE_STATE)?;
     // Sync the in-memory config from fjall (authoritative) so the readers
     // throughout the codebase see the current runtime state, not the legacy
     // (possibly stale) [services] block on disk.

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -500,11 +500,11 @@ pub async fn apply_inputs(
     let store = Store::open(&StoreConfig {
         data_dir: inputs.data_dir.clone(),
     })?;
-    let keys_ks = store.keyspace("keys")?;
-    let imported_ks = store.keyspace("imported_secrets")?;
-    let contexts_ks = store.keyspace("contexts")?;
-    let webvh_ks = store.keyspace("webvh")?;
-    let did_templates_ks = store.keyspace("did_templates")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
+    let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES)?;
 
     let mut vta_ctx = create_seed_context(&contexts_ks, "vta", "Verifiable Trust Agent").await?;
     eprintln!("  Created application context: vta");
@@ -1355,7 +1355,7 @@ async fn seed_initial_admin(
     let store = Store::open(&StoreConfig {
         data_dir: data_dir.to_path_buf(),
     })?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
 
     if let Some(existing) = seal::get_seal(&acl_ks).await? {
         return Err(format!(

--- a/vta-service/src/status.rs
+++ b/vta-service/src/status.rs
@@ -205,10 +205,10 @@ pub async fn run_status(config_path: Option<PathBuf>) -> Result<(), Box<dyn std:
     }
 
     // 8. Gather stats from store
-    let contexts_ks = store.keyspace("contexts")?;
-    let keys_ks = store.keyspace("keys")?;
-    let acl_ks = store.keyspace("acl")?;
-    let sessions_ks = store.keyspace("sessions")?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
+    let sessions_ks = store.keyspace(crate::keyspaces::SESSIONS)?;
 
     // --- Contexts ---
     let ctx_records = contexts::list_contexts(&contexts_ks).await?;
@@ -322,7 +322,7 @@ async fn send_trust_ping(
 
     let root = ExtendedSigningKey::from_seed(&seed)?;
 
-    let keys_ks = store.keyspace("keys")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
 
     // Internal storage always uses #key-0 for the signing record, regardless
     // of DID method. The X25519 record at #key-1 only exists for did:webvh

--- a/vta-service/src/tee/admin_bootstrap.rs
+++ b/vta-service/src/tee/admin_bootstrap.rs
@@ -60,9 +60,9 @@ pub async fn maybe_bootstrap_admin(
             ks
         }
     };
-    let keys_ks = apply_enc(store.keyspace("keys")?);
-    let contexts_ks = apply_enc(store.keyspace("contexts")?);
-    let acl_ks = apply_enc(store.keyspace("acl")?);
+    let keys_ks = apply_enc(store.keyspace(crate::keyspaces::KEYS)?);
+    let contexts_ks = apply_enc(store.keyspace(crate::keyspaces::CONTEXTS)?);
+    let acl_ks = apply_enc(store.keyspace(crate::keyspaces::ACL)?);
 
     // One-time migration: if the legacy pre-Phase-3 credential row is still in
     // the store, the old endpoint retrieving it is gone. Move any operator
@@ -76,7 +76,7 @@ pub async fn maybe_bootstrap_admin(
         info!("migrating legacy tee:admin_credential row — carve-out now closed");
         keys_ks.remove(LEGACY_ADMIN_CREDENTIAL_KEY).await?;
         // Old row might also be mirrored in the bootstrap keyspace.
-        if let Ok(bootstrap_ks) = store.keyspace("bootstrap") {
+        if let Ok(bootstrap_ks) = store.keyspace(crate::keyspaces::BOOTSTRAP) {
             let _ = bootstrap_ks.remove(LEGACY_ADMIN_CREDENTIAL_KEY).await;
         }
         keys_ks

--- a/vta-service/src/tee/did_autogen.rs
+++ b/vta-service/src/tee/did_autogen.rs
@@ -56,8 +56,8 @@ pub async fn maybe_generate_vta_did(
             ks
         }
     };
-    let keys_ks = apply_enc(store.keyspace("keys")?);
-    let contexts_ks = apply_enc(store.keyspace("contexts")?);
+    let keys_ks = apply_enc(store.keyspace(crate::keyspaces::KEYS)?);
+    let contexts_ks = apply_enc(store.keyspace(crate::keyspaces::CONTEXTS)?);
 
     // Check if DID already exists in the store (subsequent boot)
     if let Some(did_bytes) = keys_ks.get_raw(VTA_DID_STORE_KEY).await? {
@@ -232,7 +232,7 @@ pub async fn maybe_generate_vta_did(
 
     // Also store in bootstrap keyspace (no encryption) so the parent proxy
     // can read it and write did.jsonl to disk for the operator.
-    let bootstrap_ks = store.keyspace("bootstrap")?;
+    let bootstrap_ks = store.keyspace(crate::keyspaces::BOOTSTRAP)?;
     bootstrap_ks
         .insert_raw("tee:did_log", log_content.as_bytes().to_vec())
         .await?;

--- a/vta-service/src/tee/kms_bootstrap.rs
+++ b/vta-service/src/tee/kms_bootstrap.rs
@@ -84,7 +84,7 @@ pub async fn bootstrap_secrets(
     store: &crate::store::Store,
 ) -> Result<BootstrappedSecrets, AppError> {
     // Bootstrap keyspace — no encryption (data is KMS-protected)
-    let bs_ks = store.keyspace("bootstrap")?;
+    let bs_ks = store.keyspace(crate::keyspaces::BOOTSTRAP)?;
 
     let dk_ct = bs_ks.get_raw(BOOTSTRAP_DK_CT_KEY).await?;
     let seed_ct = bs_ks.get_raw(BOOTSTRAP_SEED_CT_KEY).await?;
@@ -220,7 +220,7 @@ pub async fn re_encrypt_bootstrap_secrets(
     seed: &[u8],
     jwt_key: &[u8; 32],
 ) -> Result<(), AppError> {
-    let bs_ks = store.keyspace("bootstrap")?;
+    let bs_ks = store.keyspace(crate::keyspaces::BOOTSTRAP)?;
 
     // Clear any existing ciphertexts first
     let _ = bs_ks.remove(BOOTSTRAP_DK_CT_KEY).await;

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -85,19 +85,29 @@ pub async fn open_test_store() -> TestStore {
     })
     .expect("open store");
     TestStore {
-        contexts_ks: store.keyspace("contexts").expect("contexts ks"),
-        did_templates_ks: store.keyspace("did_templates").expect("did_templates ks"),
-        keys_ks: store.keyspace("keys").expect("keys ks"),
-        acl_ks: store.keyspace("acl").expect("acl ks"),
-        audit_ks: store.keyspace("audit").expect("audit ks"),
-        imported_ks: store.keyspace("imported").expect("imported ks"),
-        webvh_ks: store.keyspace("webvh").expect("webvh ks"),
-        sealed_nonces_ks: store.keyspace("sealed_nonces").expect("nonces ks"),
-        drains_ks: store.keyspace("drains").expect("drains ks"),
+        contexts_ks: store
+            .keyspace(crate::keyspaces::CONTEXTS)
+            .expect("contexts ks"),
+        did_templates_ks: store
+            .keyspace(crate::keyspaces::DID_TEMPLATES)
+            .expect("did_templates ks"),
+        keys_ks: store.keyspace(crate::keyspaces::KEYS).expect("keys ks"),
+        acl_ks: store.keyspace(crate::keyspaces::ACL).expect("acl ks"),
+        audit_ks: store.keyspace(crate::keyspaces::AUDIT).expect("audit ks"),
+        imported_ks: store
+            .keyspace(crate::keyspaces::IMPORTED_SECRETS)
+            .expect("imported ks"),
+        webvh_ks: store.keyspace(crate::keyspaces::WEBVH).expect("webvh ks"),
+        sealed_nonces_ks: store
+            .keyspace(crate::keyspaces::SEALED_NONCES)
+            .expect("nonces ks"),
+        drains_ks: store.keyspace(crate::keyspaces::DRAINS).expect("drains ks"),
         snapshot_ks: store
             .keyspace(crate::operations::protocol::snapshot::KEYSPACE_NAME)
             .expect("snapshot ks"),
-        service_state_ks: store.keyspace("service_state").expect("service_state ks"),
+        service_state_ks: store
+            .keyspace(crate::keyspaces::SERVICE_STATE)
+            .expect("service_state ks"),
         _dir: dir,
         _store: store,
         data_dir,
@@ -449,10 +459,10 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
     };
     let store = Store::open(&store_config).expect("open store");
 
-    let keys_ks = store.keyspace("keys").unwrap();
-    let sessions_ks = store.keyspace("sessions").unwrap();
-    let acl_ks = store.keyspace("acl").unwrap();
-    let contexts_ks = store.keyspace("contexts").unwrap();
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
+    let sessions_ks = store.keyspace(crate::keyspaces::SESSIONS).unwrap();
+    let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
     // Seed a default `ctx1` context so route tests that reference
     // it in ACL entries or key derivations don't have to set up
     // contexts themselves. The ACL `create`/`update` operations
@@ -478,22 +488,22 @@ pub async fn build_test_app() -> (axum::Router, TestAppContext) {
         .await
         .expect("seed ctx1");
     }
-    let audit_ks = store.keyspace("audit").unwrap();
-    let cache_ks = store.keyspace("cache").unwrap();
-    let vault_ks = store.keyspace("vault").unwrap();
+    let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
+    let cache_ks = store.keyspace(crate::keyspaces::CACHE).unwrap();
+    let vault_ks = store.keyspace(crate::keyspaces::VAULT).unwrap();
     let vault_ks_ctx = vault_ks.clone();
-    let service_state_ks = store.keyspace("service_state").unwrap();
-    let imported_ks = store.keyspace("imported_secrets").unwrap();
-    let sealed_nonces_ks = store.keyspace("sealed_nonces").unwrap();
-    let backup_bundles_ks = store.keyspace("backup_bundles").unwrap();
+    let service_state_ks = store.keyspace(crate::keyspaces::SERVICE_STATE).unwrap();
+    let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+    let sealed_nonces_ks = store.keyspace(crate::keyspaces::SEALED_NONCES).unwrap();
+    let backup_bundles_ks = store.keyspace(crate::keyspaces::BACKUP_BUNDLES).unwrap();
     let backup_blob_dir = dir.path().join("backups");
-    let did_templates_ks = store.keyspace("did_templates").unwrap();
+    let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES).unwrap();
     #[cfg(feature = "webvh")]
-    let webvh_ks = store.keyspace("webvh").unwrap();
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
     #[cfg(feature = "webvh")]
-    let passkey_vms_ks = store.keyspace("passkey_vms").unwrap();
+    let passkey_vms_ks = store.keyspace(crate::keyspaces::PASSKEY_VMS).unwrap();
     #[cfg(feature = "webvh")]
-    let drains_ks = store.keyspace("drains").unwrap();
+    let drains_ks = store.keyspace(crate::keyspaces::DRAINS).unwrap();
     #[cfg(feature = "webvh")]
     let snapshot_ks = store
         .keyspace(crate::operations::protocol::snapshot::KEYSPACE_NAME)

--- a/vta-service/src/vault/bbs.rs
+++ b/vta-service/src/vault/bbs.rs
@@ -535,7 +535,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("vault").expect("vault keyspace");
+        let ks = store
+            .keyspace(crate::keyspaces::VAULT)
+            .expect("vault keyspace");
         (dir, store, ks)
     }
 

--- a/vta-service/src/vault/consent.rs
+++ b/vta-service/src/vault/consent.rs
@@ -534,7 +534,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("vault").expect("vault keyspace");
+        let ks = store
+            .keyspace(crate::keyspaces::VAULT)
+            .expect("vault keyspace");
         (dir, store, ks)
     }
 

--- a/vta-service/src/vault/mint.rs
+++ b/vta-service/src/vault/mint.rs
@@ -375,7 +375,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("vault").expect("vault keyspace");
+        let ks = store
+            .keyspace(crate::keyspaces::VAULT)
+            .expect("vault keyspace");
         (dir, store, ks)
     }
 

--- a/vta-service/src/vault/present.rs
+++ b/vta-service/src/vault/present.rs
@@ -439,7 +439,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("vault").expect("vault keyspace");
+        let ks = store
+            .keyspace(crate::keyspaces::VAULT)
+            .expect("vault keyspace");
         (dir, store, ks)
     }
 

--- a/vta-service/src/vault/query.rs
+++ b/vta-service/src/vault/query.rs
@@ -276,7 +276,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("vault").expect("vault keyspace");
+        let ks = store
+            .keyspace(crate::keyspaces::VAULT)
+            .expect("vault keyspace");
         (dir, store, ks)
     }
 

--- a/vta-service/src/vault/receive.rs
+++ b/vta-service/src/vault/receive.rs
@@ -587,7 +587,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("vault").expect("vault keyspace");
+        let ks = store
+            .keyspace(crate::keyspaces::VAULT)
+            .expect("vault keyspace");
         (dir, store, ks)
     }
 

--- a/vta-service/src/vault/status.rs
+++ b/vta-service/src/vault/status.rs
@@ -641,7 +641,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("vault").expect("vault keyspace");
+        let ks = store
+            .keyspace(crate::keyspaces::VAULT)
+            .expect("vault keyspace");
         (dir, store, ks)
     }
 

--- a/vta-service/src/vault/storage.rs
+++ b/vta-service/src/vault/storage.rs
@@ -116,7 +116,9 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
         })
         .expect("open store");
-        let ks = store.keyspace("vault").expect("vault keyspace");
+        let ks = store
+            .keyspace(crate::keyspaces::VAULT)
+            .expect("vault keyspace");
         let ks = match key {
             Some(k) => ks.with_encryption(k),
             None => ks,
@@ -339,7 +341,9 @@ mod tests {
         // encryption key. `get_raw` only decrypts when its handle carries a
         // key, so this plain handle returns the actual on-disk ciphertext —
         // the genuine "at rest" bytes, not a decrypted view.
-        let plain = store.keyspace("vault").expect("plain vault handle");
+        let plain = store
+            .keyspace(crate::keyspaces::VAULT)
+            .expect("plain vault handle");
         assert!(!plain.is_encrypted());
         let raw = plain
             .get_raw(record_key("cred-secret"))

--- a/vta-service/src/vault_cli.rs
+++ b/vta-service/src/vault_cli.rs
@@ -44,7 +44,7 @@ pub struct VaultSeedArgs {
 pub async fn run_vault_seed(args: VaultSeedArgs) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(args.config_path)?;
     let store = Store::open(&config.store)?;
-    let vault_ks = store.keyspace("vault")?;
+    let vault_ks = store.keyspace(crate::keyspaces::VAULT)?;
 
     let records: Vec<StoredVaultEntry> = match (&args.entries_file, &args.context) {
         (Some(path), _) => load_records_from_file(path)?,
@@ -293,7 +293,7 @@ pub struct VaultWipeArgs {
 pub async fn run_vault_wipe(args: VaultWipeArgs) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(args.config_path)?;
     let store = Store::open(&config.store)?;
-    let vault_ks = store.keyspace("vault")?;
+    let vault_ks = store.keyspace(crate::keyspaces::VAULT)?;
 
     // Enumerate every key under the `vault:` prefix. We use the raw
     // iterator so a deserialise failure on a single row doesn't abort

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -39,7 +39,7 @@ pub async fn run_add_server(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let webvh_ks = store.keyspace("webvh")?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
 
     let auth = cli_super_admin();
@@ -69,7 +69,7 @@ pub async fn run_list_servers(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let webvh_ks = store.keyspace("webvh")?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
 
     let auth = cli_super_admin();
     let result = operations::did_webvh::list_webvh_servers(&webvh_ks, &auth, "cli").await?;
@@ -99,7 +99,7 @@ pub async fn run_update_server(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let webvh_ks = store.keyspace("webvh")?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
 
     let auth = cli_super_admin();
     let result =
@@ -121,7 +121,7 @@ pub async fn run_remove_server(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let webvh_ks = store.keyspace("webvh")?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
 
     let auth = cli_super_admin();
     operations::did_webvh::remove_webvh_server(&webvh_ks, &auth, &id, "cli").await?;
@@ -146,11 +146,11 @@ pub async fn run_create_did(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path.clone())?;
     let store = Store::open(&config.store)?;
-    let keys_ks = store.keyspace("keys")?;
-    let imported_ks = store.keyspace("imported_secrets")?;
-    let contexts_ks = store.keyspace("contexts")?;
-    let webvh_ks = store.keyspace("webvh")?;
-    let did_templates_ks = store.keyspace("did_templates")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
+    let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES)?;
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
         Arc::from(create_seed_store(&config)?);
 
@@ -238,7 +238,7 @@ pub async fn run_list_dids(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let webvh_ks = store.keyspace("webvh")?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
 
     let auth = cli_super_admin();
     let result = operations::did_webvh::list_dids_webvh(
@@ -274,10 +274,10 @@ pub async fn run_delete_did(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let keys_ks = store.keyspace("keys")?;
-    let imported_ks = store.keyspace("imported_secrets")?;
-    let audit_ks = store.keyspace("audit")?;
-    let webvh_ks = store.keyspace("webvh")?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
+    let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
         Arc::from(create_seed_store(&config)?);
 
@@ -315,7 +315,7 @@ pub async fn run_did_log(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let webvh_ks = store.keyspace("webvh")?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
 
     let log = crate::webvh_store::get_did_log(&webvh_ks, &did)
         .await?
@@ -371,11 +371,11 @@ pub async fn run_edit_did(
 
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let webvh_ks = store.keyspace("webvh")?;
-    let keys_ks = store.keyspace("keys")?;
-    let imported_ks = store.keyspace("imported_secrets")?;
-    let contexts_ks = store.keyspace("contexts")?;
-    let audit_ks = store.keyspace("audit")?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
+    let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
@@ -510,10 +510,10 @@ pub async fn run_register_did(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let webvh_ks = store.keyspace("webvh")?;
-    let keys_ks = store.keyspace("keys")?;
-    let imported_ks = store.keyspace("imported_secrets")?;
-    let audit_ks = store.keyspace("audit")?;
+    let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+    let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
+    let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =

--- a/vta-service/src/webvh_store.rs
+++ b/vta-service/src/webvh_store.rs
@@ -175,7 +175,7 @@ mod tests {
             data_dir: dir.path().into(),
         })
         .unwrap();
-        let ks = store.keyspace("webvh").unwrap();
+        let ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
         (dir, ks)
     }
 


### PR DESCRIPTION
## P1.3 — Keyspace-name registry

vta-service named its ~17 keyspaces with bare string literals across ~230 call sites (server, offline CLIs, backup, tests). That already produced a **live test-vs-production divergence**: tests opened keyspace `"imported"` while production writes `"imported_secrets"`, so the test `imported_ks` was an empty keyspace disjoint from what prod populates — masking any bug in that path.

### Change
- **New `crate::keyspaces` module** — one `const` per keyspace, the single source of truth. Every `.keyspace(..)` call (and the `contexts` test helper's `k(..)`) now names its keyspace through a const.
- **`"imported"` → `IMPORTED_SECRETS`** fixed at all three test sites.
- `operations::protocol::snapshot::KEYSPACE_NAME` re-points to `keyspaces::SNAPSHOT`.
- **Backup**: the registry partitions every keyspace into `BACKED_UP` (`{keys, acl, contexts, audit, imported_secrets, webvh}` — exactly what `export_backup` reads) vs `EXCLUDED_FROM_BACKUP` (with `did_templates` + `vault` flagged as **known gaps**, not silent drops). A guard test keeps the partition total, so a new keyspace can't be silently dropped from the backup decision.

### Acceptance
- ✅ **Zero bare keyspace string literals** outside the registry — enforced by the `no_bare_keyspace_literals` guard test (the "CI grep": scans `src/`, asserts no `.keyspace("literal")` outside `keyspaces.rs`).
- ✅ **Backup enumerates keyspaces from the registry** — `backup_partition_is_total` asserts `ALL == BACKED_UP ∪ EXCLUDED_FROM_BACKUP` (disjoint), forcing a backup classification when a keyspace is added.

### Deferred
Typed per-keyspace key-format constructors (`Key::Acl(did)`, `Key::PathCounter(base)`, …) — a separate, much larger surface. The P1.3 acceptance criteria are keyspace-scoped and met here; the key-format registry is a good follow-up.

### Verification
fmt + clippy clean (default & tee); vta-service lib **716** (default) / **749** (tee) + bin **45** + all integration suites green; vta-enclave checks. 66 files (mostly mechanical literal→const).

Phase 1 item P1.3 of the VTA architecture simplification plan.
