### PR TITLE
refactor(vta): one token-mint path + single DI-proof verifier (P1.4)

### DIFF
--- a/vta-service/src/auth/di_proof.rs
+++ b/vta-service/src/auth/di_proof.rs
@@ -1,0 +1,80 @@
+//! Single `eddsa-jcs-2022` Data-Integrity proof verifier for Trust Task
+//! documents (P1.4).
+//!
+//! Two `/auth/*` paths need to verify a holder's DI proof on a Trust Task and
+//! recover the cryptographically-proven signer DID: the canonical REST
+//! authenticate path (`routes/auth.rs::verify_authenticate_proof`, signer
+//! unknown a priori) and the did-signed step-up gate
+//! (`routes/trust_tasks/step_up.rs::verify_did_signed_gate`, signer checked
+//! against the document issuer). They had drifted into two copies of the same
+//! extract → round-trip → verify-proofless-doc logic; this is the one
+//! implementation both delegate to.
+//!
+//! `did:key` resolution is local (no network I/O) — the mobile holder key is
+//! always a `did:key`, matching the engine's signing side.
+
+use affinidi_data_integrity::{DataIntegrityProof, DidKeyResolver, VerifyOptions};
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+
+/// Why a Trust Task DI-proof verification failed. Callers map these onto their
+/// own transport error types (`AppError::Authentication`, `GateError`, …).
+#[derive(Debug)]
+pub enum DiProofError {
+    /// The document carries no `proof`.
+    NoProof,
+    /// The `proof` block is not a Data-Integrity proof.
+    NotDataIntegrity,
+    /// The proof's `verificationMethod` carries no DID.
+    NoDid,
+    /// The signature failed to verify (carries the underlying reason).
+    VerifyFailed(String),
+}
+
+impl std::fmt::Display for DiProofError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoProof => write!(f, "document has no proof"),
+            Self::NotDataIntegrity => write!(f, "proof is not a Data Integrity proof"),
+            Self::NoDid => write!(f, "proof verificationMethod carries no DID"),
+            Self::VerifyFailed(e) => write!(f, "proof verification failed: {e}"),
+        }
+    }
+}
+
+/// Verify the `eddsa-jcs-2022` Data-Integrity proof on `doc` and return the
+/// proven signer DID — the base DID (before `#`) of the proof's
+/// `verificationMethod`.
+///
+/// The signature is verified over the document with its `proof` block removed
+/// (`eddsa-jcs-2022` canonicalises the proofless document via JCS). The
+/// returned DID is *proven*, not merely claimed; binding it to an expected
+/// identity (session DID, document issuer) is the caller's job.
+pub async fn verify_trust_task_proof(doc: &TrustTask<Value>) -> Result<String, DiProofError> {
+    let proof = doc.proof.as_ref().ok_or(DiProofError::NoProof)?;
+
+    // The framework `Proof` round-trips into a `DataIntegrityProof` (same shape;
+    // the mobile engine builds it the same way).
+    let di: DataIntegrityProof = serde_json::to_value(proof)
+        .ok()
+        .and_then(|v| serde_json::from_value(v).ok())
+        .ok_or(DiProofError::NotDataIntegrity)?;
+
+    let signer_did = di
+        .verification_method
+        .split('#')
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    if signer_did.is_empty() {
+        return Err(DiProofError::NoDid);
+    }
+
+    let mut unsigned = doc.clone();
+    unsigned.proof = None;
+    di.verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+        .await
+        .map_err(|e| DiProofError::VerifyFailed(e.to_string()))?;
+
+    Ok(signer_did)
+}

--- a/vta-service/src/auth/mod.rs
+++ b/vta-service/src/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod backend;
 pub mod credentials;
+pub mod di_proof;
 
 pub use backend::VtaAuthBackend;
 pub use vti_common::auth::extractor::{

--- a/vta-service/src/routes/auth.rs
+++ b/vta-service/src/routes/auth.rs
@@ -1,4 +1,3 @@
-use affinidi_data_integrity::{DataIntegrityProof, DidKeyResolver, VerifyOptions};
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
@@ -10,15 +9,12 @@ use trust_tasks_rs::specs::auth::authenticate::v0_1 as authenticate;
 use trust_tasks_rs::specs::auth::refresh::v0_1 as refresh;
 use uuid::Uuid;
 
-use vta_sdk::protocols::auth::{
-    AuthenticateResponse, ChallengeRequest, Session as WireSession, TokenBundle, epoch_to_rfc3339,
-};
+use vta_sdk::protocols::auth::{AuthenticateResponse, ChallengeRequest};
 
-use crate::acl::{Role, check_acl, check_acl_full};
+use crate::acl::{Role, check_acl};
 use crate::audit::audit;
 use crate::auth::session::{
-    Session, SessionState, delete_session, get_session, list_sessions, now_epoch,
-    store_refresh_index, store_session, update_session,
+    Session, SessionState, delete_session, get_session, list_sessions, now_epoch, store_session,
 };
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::error::AppError;
@@ -285,35 +281,9 @@ async fn try_authenticate_trust_task(
 /// downstream by the canonical handler (`signer_did == session.did`).
 /// `did:key` resolution is local (no I/O), matching the mobile holder key.
 async fn verify_authenticate_proof(doc: &TrustTask<Value>) -> Result<String, AppError> {
-    let proof = doc
-        .proof
-        .as_ref()
-        .ok_or_else(|| AppError::Authentication("authenticate document has no proof".into()))?;
-
-    let di: DataIntegrityProof = serde_json::to_value(proof)
-        .ok()
-        .and_then(|v| serde_json::from_value(v).ok())
-        .ok_or_else(|| AppError::Authentication("proof is not a Data Integrity proof".into()))?;
-
-    let signer_did = di
-        .verification_method
-        .split('#')
-        .next()
-        .unwrap_or_default()
-        .to_string();
-    if signer_did.is_empty() {
-        return Err(AppError::Authentication(
-            "proof verificationMethod carries no DID".into(),
-        ));
-    }
-
-    let mut unsigned = doc.clone();
-    unsigned.proof = None;
-    di.verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+    crate::auth::di_proof::verify_trust_task_proof(doc)
         .await
-        .map_err(|e| AppError::Authentication(format!("proof verification failed: {e}")))?;
-
-    Ok(signer_did)
+        .map_err(|e| AppError::Authentication(e.to_string()))
 }
 
 // ---------- POST /auth/refresh ----------
@@ -646,17 +616,13 @@ pub async fn passkey_login_finish(
         ));
     }
 
-    let jwt_keys = state
-        .jwt_keys
-        .as_ref()
-        .ok_or_else(|| AppError::Authentication("JWT keys not configured".into()))?;
     let did_resolver = state
         .did_resolver
         .clone()
         .ok_or_else(|| AppError::Authentication("DID resolver not configured".into()))?;
 
     // 1. Look up pending session.
-    let mut session = get_session(&state.sessions_ks, &req.session_id)
+    let session = get_session(&state.sessions_ks, &req.session_id)
         .await?
         .ok_or_else(|| AppError::Authentication("session not found".into()))?;
     if session.state != SessionState::ChallengeSent {
@@ -666,15 +632,9 @@ pub async fn passkey_login_finish(
         ));
     }
 
-    // 2. Challenge TTL.
-    let (challenge_ttl, access_expiry, refresh_expiry) = {
-        let config = state.config.read().await;
-        (
-            config.auth.challenge_ttl,
-            config.auth.access_token_expiry,
-            config.auth.refresh_token_expiry,
-        )
-    };
+    // 2. Challenge TTL — gate early so we don't burn a crypto verify on an
+    //    expired challenge. (The canonical handler re-checks it too.)
+    let challenge_ttl = state.config.read().await.auth.challenge_ttl;
     if now_epoch().saturating_sub(session.created_at) > challenge_ttl {
         warn!(session_id = %req.session_id, "passkey login rejected: challenge expired");
         return Err(AppError::Authentication("challenge expired".into()));
@@ -725,42 +685,30 @@ pub async fn passkey_login_finish(
             .await
             .map_err(|e| AppError::Authentication(format!("assertion verification failed: {e}")))?;
 
-    // 6. ACL lookup for role + contexts.
-    let (role, allowed_contexts) = check_acl_full(&state.acl_ks, &session.did).await?;
-
-    // 7. Mint tokens — same shape as the legacy authenticate() flow.
-    #[cfg(feature = "tee")]
-    let tee_attested = session.tee_attested;
-    #[cfg(not(feature = "tee"))]
-    let tee_attested = false;
-    // Passkey-login is the second factor (DID-key challenged first via
-    // the challenge endpoint, then a WebAuthn assertion proves
-    // possession of a passkey VM). amr captures both, acr promotes to
-    // aal2.
-    let claims = jwt_keys
-        .new_claims(
-            session.did.clone(),
-            session.session_id.clone(),
-            role.to_string(),
-            allowed_contexts,
-            access_expiry,
-            tee_attested,
-        )
-        .with_aal(vec!["did".to_string(), "passkey".to_string()], "aal2");
-    let access_expires_at = claims.exp;
-    let access_token = jwt_keys.encode(&claims)?;
-    let refresh_token = Uuid::new_v4().to_string();
-    let refresh_expires_at = now_epoch() + refresh_expiry;
-
-    // Persist AAL on the session row so a subsequent /auth/refresh
-    // re-mints at aal2 (rather than silently dropping back to aal1).
-    session.state = SessionState::Authenticated;
-    session.refresh_token = Some(refresh_token.clone());
-    session.refresh_expires_at = Some(refresh_expires_at);
-    session.amr = claims.amr.clone();
-    session.acr = claims.acr.clone();
-    update_session(&state.sessions_ks, &session).await?;
-    store_refresh_index(&state.sessions_ks, &refresh_token, &session.session_id).await?;
+    // 6. Mint tokens through the single canonical authenticate path
+    //    (`handle_authenticate_with_aal`) rather than re-deriving the
+    //    session/JWT/refresh-token logic here (P1.4). Passkey-login is the
+    //    second factor — the DID-key was challenged first via the challenge
+    //    endpoint, then this WebAuthn assertion proved possession of a passkey
+    //    VM — so we issue `amr=["did","passkey"], acr="aal2"`. The challenge was
+    //    already verified cryptographically above (step 5), so we pass the
+    //    session's own challenge for the handler's constant-time match. Routing
+    //    through the handler also applies the acr-correct (shortened) aal2
+    //    access-token TTL, which the bespoke mint here did not.
+    let backend = crate::auth::VtaAuthBackend::from_state(&state).await?;
+    let resp = vti_common::auth::handlers::handle_authenticate_with_aal(
+        &backend,
+        vti_common::auth::AuthenticateInput {
+            session_id: session.session_id.clone(),
+            challenge: session.challenge.clone(),
+            signer_did: session.did.clone(),
+            created_time: None,
+            session_pubkey_b58btc: None,
+        },
+        vec!["did".to_string(), "passkey".to_string()],
+        "aal2".to_string(),
+    )
+    .await?;
 
     info!(did = %session.did, session_id = %session.session_id, "passkey login successful");
     audit!(
@@ -770,23 +718,5 @@ pub async fn passkey_login_finish(
         outcome = "success"
     );
 
-    let issued_at_epoch = now_epoch();
-    Ok(Json(AuthenticateResponse {
-        session: WireSession {
-            id: session.session_id.clone(),
-            subject: session.did.clone(),
-            issued_at: epoch_to_rfc3339(issued_at_epoch),
-            expires_at: epoch_to_rfc3339(access_expires_at),
-            amr: claims.amr.clone(),
-            acr: claims.acr.clone(),
-        },
-        tokens: TokenBundle {
-            access_token,
-            refresh_token: Some(refresh_token),
-            token_type: "Bearer".to_string(),
-            expires_in: access_expires_at.saturating_sub(issued_at_epoch),
-            refresh_expires_in: Some(refresh_expires_at.saturating_sub(issued_at_epoch)),
-            scope: Vec::new(),
-        },
-    }))
+    Ok(Json(resp))
 }

--- a/vta-service/src/routes/trust_tasks/step_up.rs
+++ b/vta-service/src/routes/trust_tasks/step_up.rs
@@ -15,7 +15,6 @@
 //! pending step-up, dispatches on `evidence.kind`, and elevates the session
 //! lands alongside it.
 
-use affinidi_data_integrity::{DataIntegrityProof, DidKeyResolver, VerifyOptions};
 use axum::extract::FromRequestParts;
 use axum::http::StatusCode;
 use axum::http::request::Parts;
@@ -78,31 +77,30 @@ pub(super) async fn verify_did_signed_gate(
     doc: &TrustTask<Value>,
     expected_signer: &str,
 ) -> Result<(), GateError> {
-    let proof = doc.proof.as_ref().ok_or(GateError::NoGate)?;
+    use crate::auth::di_proof::DiProofError;
 
-    // The framework `Proof` round-trips into a `DataIntegrityProof` (same shape;
-    // the mobile engine builds it the same way).
-    let di: DataIntegrityProof = serde_json::to_value(proof)
-        .ok()
-        .and_then(|v| serde_json::from_value(v).ok())
-        .ok_or_else(|| GateError::ProofInvalid("not a Data Integrity proof".to_string()))?;
+    // Verify the eddsa-jcs-2022 proof via the single shared verifier (P1.4),
+    // which returns the cryptographically-proven signer DID.
+    let signer_did = crate::auth::di_proof::verify_trust_task_proof(doc)
+        .await
+        .map_err(|e| match e {
+            DiProofError::NoProof => GateError::NoGate,
+            DiProofError::NotDataIntegrity => {
+                GateError::ProofInvalid("not a Data Integrity proof".to_string())
+            }
+            DiProofError::NoDid | DiProofError::VerifyFailed(_) => {
+                GateError::ProofInvalid(e.to_string())
+            }
+        })?;
 
-    // Bind identity: the signing key's DID must be the signer (the document
-    // `issuer`). The resolver confirms the signature is by this
-    // verificationMethod; this check ties that VM to the issuer so a valid proof
-    // by some *other* DID can't stand in for the approver.
-    let vm_did = di.verification_method.split('#').next().unwrap_or_default();
-    if vm_did != expected_signer {
+    // Bind identity: the proven signer must be the expected signer (the document
+    // `issuer`), so a valid proof by some *other* DID can't stand in for the
+    // approver.
+    if signer_did != expected_signer {
         return Err(GateError::SubjectMismatch);
     }
 
-    // Verify over the document with the proof removed (eddsa-jcs-2022
-    // canonicalizes the proofless document; the signature lives on `di`).
-    let mut unsigned = doc.clone();
-    unsigned.proof = None;
-    di.verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
-        .await
-        .map_err(|e| GateError::ProofInvalid(e.to_string()))
+    Ok(())
 }
 
 /// A `task_failed` reject carrying a spec error code (e.g.
@@ -1030,6 +1028,7 @@ impl<O: StepUpOp> FromRequestParts<AppState> for RequireStepUp<O> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use affinidi_data_integrity::DataIntegrityProof;
     use affinidi_data_integrity::crypto_suites::CryptoSuite;
     use affinidi_data_integrity::prepare_sign_input;
     use ed25519_dalek::{Signer, SigningKey};


### PR DESCRIPTION
## P1.4 — One mint path; one DI-proof verifier

Collapses the last two Phase-1 auth divergence engines.

### 1. One token-mint path
`POST /auth/passkey-login/finish` re-derived the session-transition / JWT / refresh-token minting (~60 LOC) instead of using the canonical `vti_common::auth::handlers` path. It now calls **`handle_authenticate_with_aal`** with `amr=["did","passkey"], acr="aal2"` — the WebAuthn assertion is the proven second factor; the session's own challenge (already verified in step 5) is passed for the handler's constant-time match.

**This also fixes a latent bug**: the bespoke mint used the full access-token TTL, whereas the canonical path applies the acr-correct **shortened aal2 TTL** (M2 from the May 2026 review). Token/refresh semantics are now covered by the existing vti-common handler tests.

### 2. One DI-proof verifier
The `eddsa-jcs-2022` Data-Integrity proof verifier existed twice — `verify_authenticate_proof` (auth.rs, signer unknown a priori) and `verify_did_signed_gate` (step_up.rs, signer checked against the document issuer). New **`crate::auth::di_proof::verify_trust_task_proof`** is the single implementation (extract proof → `DataIntegrityProof` → verify proofless doc → return the proven signer DID); both sites delegate and map the typed `DiProofError` onto their own transport errors (`AppError` / `GateError`).

### Location note
Hosted in **vta-service** (`crate::auth`) rather than vti-common: the foundation crate doesn't depend on `affinidi-data-integrity` or `trust_tasks_rs`, both call sites are in vta-service, and adding two heavy deps to the leaf crate for a verifier only vta-service uses isn't warranted. Easy to hoist later if a third consumer (e.g. vtc-service) appears.

### Coverage
The shared verifier's happy-path + subject-mismatch + proof-invalid cases run through the existing **step_up** tests, and signer-extraction through the **authenticate-trust-task** tests — both now delegate to `di_proof` (the acceptance: "both former call sites delegating"). fmt + clippy clean (default & tee, all-targets); vta-service lib **716** (default) / **749** (tee) + all integration suites green; vta-enclave checks.

Completes **Phase 1** of the VTA architecture simplification plan (P1.1–P1.4), closing Checkpoint 1.
