### PR TITLE
fix(vtc-service): audit config mutations with the real admin DID (P1.2)

### DIFF
--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -1237,6 +1237,18 @@ diff-and-confirm flow: the response surfaces every changed field
 with a pre-apply preview; a second call with `confirm=true` applies.
 Per-field audit events emitted on apply.
 
+**Config-mutation audit (P1.2).** Every config-mutation door audits
+to the calling admin's real DID — there is no longer a
+`did:key:vtc-admin` actor sentinel. `PATCH /v1/admin/config` emits
+`ConfigChanged` (with per-key `sensitive` redaction), `PUT
+/v1/community/profile` emits `CommunityProfileUpdated`, and
+`reload`/`restart`/`import` carry the real actor too. Audit is
+**fail-closed**: a mutation that produces a change but cannot be
+recorded (no `AuditWriter` configured) returns `503` rather than
+applying silently, so auditability never depends on which equivalent
+door the admin used. A no-op (nothing changed) emits nothing and does
+not require the writer.
+
 Full config taxonomy (which key reloads, which restarts, which is
 UX-settable, sensitive-flag) lives in `docs/04-reference/vtc-config.md`,
 not in this spec.

--- a/vtc-service/src/routes/admin/config.rs
+++ b/vtc-service/src/routes/admin/config.rs
@@ -9,11 +9,13 @@
 //!   require a daemon restart (M0.8.3), and which were rejected
 //!   (and why).
 //!
-//! Sensitive values are run through
-//! `vti_common::audit::ConfigChange::redact_if` before the
-//! `ConfigChanged` audit event is emitted (audit emission is
-//! deferred until `AuditWriter` lands on `AppState` post-M0.9 —
-//! same pattern as `community/profile`).
+//! Every mutating handler emits an audit event keyed to the calling
+//! admin's real DID (the `AdminAuth` extractor's `did`). Sensitive
+//! values are run through `vti_common::audit::ConfigChange::redact_if`
+//! before the `ConfigChanged` event is persisted. Audit is
+//! fail-closed: a mutation that produces a change but cannot be
+//! recorded (no `AuditWriter` configured) returns 503 rather than
+//! applying silently.
 
 use std::collections::HashMap;
 
@@ -79,14 +81,19 @@ pub async fn get_config(
 
 /// PATCH handler.
 pub async fn patch_config(
-    _admin: AdminAuth,
+    admin: AdminAuth,
     State(state): State<AppState>,
     Json(req): Json<PatchRequest>,
 ) -> Result<(StatusCode, Json<PatchResponse>), AppError> {
     let store = ConfigStore::new(state.config_ks.clone());
+    // Snapshot the current db-layer overrides up front so each applied
+    // key's audit record carries its real `old_value` + source.
+    let current = store.snapshot().await?;
     let mut applied = Vec::new();
     let mut pending_restart = Vec::new();
     let mut rejected = Vec::new();
+    let mut audit_changes: Vec<ConfigChange> = Vec::new();
+    let mut requires_restart = false;
 
     for (key, value) in req.overrides {
         let Some(def) = lookup(&key) else {
@@ -105,6 +112,8 @@ pub async fn patch_config(
             continue;
         }
 
+        let old_value = current.get(&key).cloned();
+
         if let Err(e) = store.put(&key, &value).await {
             rejected.push(RejectedKey {
                 key,
@@ -120,16 +129,47 @@ pub async fn patch_config(
             "admin config PATCH applied"
         );
 
+        let mut change = ConfigChange {
+            key: key.clone(),
+            old_value: old_value.clone(),
+            new_value: value,
+            // The db-overlay is the only PATCH-writable layer, so a
+            // prior db value was `Db`; absence means the resolved
+            // value came from a lower (env/toml/default) layer — we
+            // record `Default` to match the import path's convention.
+            source_before: if old_value.is_some() {
+                ConfigSource::Db
+            } else {
+                ConfigSource::Default
+            },
+        };
+        change.redact_if(|k| matches!(lookup(k), Some(d) if d.sensitive));
+        audit_changes.push(change);
+
         if def.requires_restart {
+            requires_restart = true;
             pending_restart.push(key);
         } else {
             applied.push(key);
         }
     }
 
-    // `ConfigChanged` audit emission lands when AuditWriter is wired
-    // into AppState post-M0.9. The audit event's sensitive-value
-    // redaction will use `ConfigChange::redact_if` from M0.1.5.
+    // Fail-closed: a config mutation that can't be audited is refused
+    // (matches reload/restart/import). No applied changes → nothing to
+    // audit, so a rejects-only or empty PATCH never needs the writer.
+    if !audit_changes.is_empty() {
+        let audit_writer = require_audit_writer(&state)?;
+        audit_writer
+            .write(
+                &admin.0.did,
+                None,
+                AuditEvent::ConfigChanged(ConfigChangedData {
+                    changes: audit_changes,
+                    requires_restart,
+                }),
+            )
+            .await?;
+    }
 
     Ok((
         StatusCode::OK,
@@ -173,7 +213,7 @@ pub struct ReloadResponse {
 /// session-cleanup interval, etc.) will plug into the same diff
 /// loop.
 pub async fn reload_config(
-    _admin: AdminAuth,
+    admin: AdminAuth,
     State(state): State<AppState>,
 ) -> Result<Json<ReloadResponse>, AppError> {
     let audit_writer = require_audit_writer(&state)?;
@@ -217,8 +257,7 @@ pub async fn reload_config(
 
     audit_writer
         .write(
-            "did:key:vtc-admin", // M0.6.2 will swap this for the real admin DID once
-            // the audit-actor plumbing wires `AdminAuth` through.
+            &admin.0.did,
             None,
             AuditEvent::ConfigReloaded(ConfigReloadedData {
                 keys_reloaded: keys_reloaded.clone(),
@@ -261,7 +300,7 @@ pub struct RestartResponse {
 /// log *before* signalling shutdown — so the row survives even if
 /// the drain wedges.
 pub async fn restart_config(
-    _admin: AdminAuth,
+    admin: AdminAuth,
     State(state): State<AppState>,
 ) -> Result<Json<RestartResponse>, AppError> {
     let audit_writer = require_audit_writer(&state)?;
@@ -275,7 +314,7 @@ pub async fn restart_config(
 
     audit_writer
         .write(
-            "did:key:vtc-admin",
+            &admin.0.did,
             None,
             AuditEvent::RestartRequested(RestartRequestedData {
                 drain_timeout_seconds: DEFAULT_DRAIN_TIMEOUT_SECS,
@@ -442,7 +481,7 @@ pub struct ImportResponse {
 }
 
 pub async fn import_config(
-    _admin: AdminAuth,
+    admin: AdminAuth,
     State(state): State<AppState>,
     Query(query): Query<ImportQuery>,
     Json(req): Json<ConfigExport>,
@@ -583,7 +622,7 @@ pub async fn import_config(
     if !audit_changes.is_empty() {
         audit_writer
             .write(
-                "did:key:vtc-admin",
+                &admin.0.did,
                 None,
                 AuditEvent::ConfigChanged(ConfigChangedData {
                     changes: audit_changes,
@@ -595,7 +634,7 @@ pub async fn import_config(
     if !community_profile_applied.is_empty() {
         audit_writer
             .write(
-                "did:key:vtc-admin",
+                &admin.0.did,
                 None,
                 AuditEvent::CommunityProfileUpdated(CommunityProfileUpdatedData {
                     fields_changed: community_profile_applied.clone(),

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -19,6 +19,7 @@ use axum::http::StatusCode;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tracing::info;
+use vti_common::audit::{AuditEvent, CommunityProfileUpdatedData};
 use vti_common::auth::{AdminAuth, AuthClaims};
 use vti_common::error::AppError;
 
@@ -126,8 +127,14 @@ pub struct UpdateProfileResponse {
 }
 
 /// PUT handler. Admin-only. Refuses changes to `community_did`.
+///
+/// Emits a `CommunityProfileUpdated` audit event keyed to the
+/// calling admin's real DID. Audit is fail-closed: a change that
+/// can't be recorded (no `AuditWriter`) returns 503 rather than
+/// persisting silently — matching the `/v1/admin/config` doors so
+/// auditability doesn't depend on which surface the admin used.
 pub async fn put_profile(
-    _admin: AdminAuth,
+    admin: AdminAuth,
     State(state): State<AppState>,
     Json(update): Json<CommunityProfileUpdate>,
 ) -> Result<(StatusCode, Json<UpdateProfileResponse>), AppError> {
@@ -149,6 +156,15 @@ pub async fn put_profile(
         ));
     }
 
+    // Fail-closed: refuse to persist a change we can't audit.
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::ServiceError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: "audit writer not configured".into(),
+        })?;
+
     store_profile(&state.community_ks, &profile).await?;
     info!(
         community_did = %profile.community_did,
@@ -156,10 +172,15 @@ pub async fn put_profile(
         "community profile updated"
     );
 
-    // Audit emission (`CommunityProfileUpdated` per M0.1.5) is wired
-    // in once an `AuditWriter` lands in `AppState` (post-M0.9). The
-    // `fields_changed` list returned here is the same shape the
-    // event will carry.
+    audit_writer
+        .write(
+            &admin.0.did,
+            None,
+            AuditEvent::CommunityProfileUpdated(CommunityProfileUpdatedData {
+                fields_changed: fields_changed.clone(),
+            }),
+        )
+        .await?;
 
     Ok((
         StatusCode::OK,

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -126,7 +126,7 @@ async fn get_requires_authentication() {
 
 #[tokio::test]
 async fn patch_applies_reloadable_key_immediately() {
-    let fix = build().await;
+    let fix = build_with(true, None).await;
     let token = token_for(&fix, "admin").await;
     let req = Request::builder()
         .method("PATCH")
@@ -165,7 +165,7 @@ async fn patch_applies_reloadable_key_immediately() {
 
 #[tokio::test]
 async fn patch_restart_required_key_is_pending() {
-    let fix = build().await;
+    let fix = build_with(true, None).await;
     let token = token_for(&fix, "admin").await;
     let req = Request::builder()
         .method("PATCH")
@@ -237,7 +237,7 @@ async fn patch_invalid_value_rejected_with_reason() {
 
 #[tokio::test]
 async fn patch_mixed_batch_partitions_correctly() {
-    let fix = build().await;
+    let fix = build_with(true, None).await;
     let token = token_for(&fix, "admin").await;
     let body = json!({
         "log.level": "debug",      // applied
@@ -305,6 +305,94 @@ async fn patch_empty_body_returns_empty_response() {
     assert_eq!(body["applied"], json!([]));
     assert_eq!(body["pendingRestart"], json!([]));
     assert_eq!(body["rejected"], json!([]));
+}
+
+#[tokio::test]
+async fn patch_emits_config_changed_audit_with_real_actor() {
+    use vti_common::audit::{AuditEnvelope, AuditEvent};
+
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("PATCH")
+        .uri("/v1/admin/config")
+        .header("Trust-Task", CONFIG_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"log.level":"debug","server.port":9100}"#))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let raw = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(b"2".to_vec())
+        .await
+        .unwrap();
+    let envelopes: Vec<AuditEnvelope> = raw
+        .iter()
+        .map(|(_, v)| serde_json::from_slice(v).unwrap())
+        .collect();
+    let changed: Vec<&AuditEnvelope> = envelopes
+        .iter()
+        .filter(|e| matches!(e.event, AuditEvent::ConfigChanged(_)))
+        .collect();
+    assert_eq!(changed.len(), 1, "exactly one ConfigChanged envelope");
+    let env = changed[0];
+    // Actor is the calling admin's real DID, not the old sentinel.
+    assert_eq!(env.actor_did_plain.as_deref(), Some("did:key:z6MkAdmin"));
+    let AuditEvent::ConfigChanged(data) = &env.event else {
+        unreachable!()
+    };
+    assert!(
+        data.requires_restart,
+        "server.port change flags requires_restart"
+    );
+    let keys: Vec<&str> = data.changes.iter().map(|c| c.key.as_str()).collect();
+    assert!(keys.contains(&"log.level"));
+    assert!(keys.contains(&"server.port"));
+}
+
+#[tokio::test]
+async fn patch_rejects_only_does_not_need_audit_writer() {
+    // A PATCH that applies nothing (only rejects) emits no audit, so
+    // it must not 503 even when no AuditWriter is configured.
+    let fix = build_with(false, None).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("PATCH")
+        .uri("/v1/admin/config")
+        .header("Trust-Task", CONFIG_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"made.up.key":"value"}"#))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["applied"], json!([]));
+    assert_eq!(body["rejected"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn patch_503_when_audit_writer_missing() {
+    // A PATCH that would apply a real change is refused (fail-closed)
+    // when the change can't be audited.
+    let fix = build_with(false, None).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("PATCH")
+        .uri("/v1/admin/config")
+        .header("Trust-Task", CONFIG_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"log.level":"debug"}"#))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
 }
 
 // ──────────────────────── Trust-Task gate ────────────────────────
@@ -727,8 +815,15 @@ async fn import_confirm_applies_profile_and_overrides() {
     let mut saw_config = false;
     for env in &envelopes {
         match &env.event {
-            vti_common::audit::AuditEvent::CommunityProfileUpdated(_) => saw_profile = true,
-            vti_common::audit::AuditEvent::ConfigChanged(_) => saw_config = true,
+            vti_common::audit::AuditEvent::CommunityProfileUpdated(_) => {
+                saw_profile = true;
+                // Actor is the importing admin's real DID, not the sentinel.
+                assert_eq!(env.actor_did_plain.as_deref(), Some("did:key:z6MkAdmin"));
+            }
+            vti_common::audit::AuditEvent::ConfigChanged(_) => {
+                saw_config = true;
+                assert_eq!(env.actor_did_plain.as_deref(), Some("did:key:z6MkAdmin"));
+            }
             _ => {}
         }
     }

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -32,6 +32,17 @@ async fn build() -> Fixture {
     }
 }
 
+/// Fixture with an `AuditWriter` wired — required for any PUT that
+/// actually changes a field (audit is fail-closed).
+async fn build_with_audit() -> Fixture {
+    let vtc = TestVtc::builder().with_audit(true).build().await;
+    Fixture {
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        vtc,
+    }
+}
+
 async fn token_for(fix: &Fixture, role: &str) -> String {
     fix.vtc.token("did:key:z6MkAdmin", role, vec![]).await
 }
@@ -128,7 +139,7 @@ async fn put_requires_admin_role() {
 
 #[tokio::test]
 async fn put_updates_profile_and_lists_changed_fields() {
-    let fix = build().await;
+    let fix = build_with_audit().await;
     seed_profile(&fix).await;
     let token = token_for(&fix, "admin").await;
     let req = Request::builder()
@@ -219,7 +230,7 @@ async fn put_rejects_oversized_extensions() {
 
 #[tokio::test]
 async fn put_does_not_accept_community_did_in_request() {
-    let fix = build().await;
+    let fix = build_with_audit().await;
     seed_profile(&fix).await;
     let token = token_for(&fix, "admin").await;
 
@@ -251,6 +262,88 @@ async fn put_does_not_accept_community_did_in_request() {
     let changed = body["fieldsChanged"].as_array().unwrap();
     assert_eq!(changed.len(), 1);
     assert_eq!(changed[0], "name");
+}
+
+#[tokio::test]
+async fn put_emits_profile_updated_audit_with_real_actor() {
+    use vti_common::audit::{AuditEnvelope, AuditEvent};
+
+    let fix = build_with_audit().await;
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"name":"Renamed","description":"new"}"#))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let raw = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(b"2".to_vec())
+        .await
+        .unwrap();
+    let envelopes: Vec<AuditEnvelope> = raw
+        .iter()
+        .map(|(_, v)| serde_json::from_slice(v).unwrap())
+        .collect();
+    let updated: Vec<&AuditEnvelope> = envelopes
+        .iter()
+        .filter(|e| matches!(e.event, AuditEvent::CommunityProfileUpdated(_)))
+        .collect();
+    assert_eq!(updated.len(), 1, "one CommunityProfileUpdated envelope");
+    let env = updated[0];
+    assert_eq!(env.actor_did_plain.as_deref(), Some("did:key:z6MkAdmin"));
+    let AuditEvent::CommunityProfileUpdated(data) = &env.event else {
+        unreachable!()
+    };
+    assert!(data.fields_changed.contains(&"name".to_string()));
+    assert!(data.fields_changed.contains(&"description".to_string()));
+}
+
+#[tokio::test]
+async fn put_503_when_audit_writer_missing() {
+    // Fail-closed: a profile change that can't be audited is refused.
+    let fix = build().await; // no AuditWriter
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"name":"Renamed"}"#))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn put_idempotent_noop_does_not_need_audit_writer() {
+    // A no-op PUT emits no audit, so it must not 503 without a writer.
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/v1/community/profile")
+        .header("Trust-Task", PROFILE_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"name":"Example Community"}"#)) // already the value
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["fieldsChanged"].as_array().unwrap().is_empty());
 }
 
 // ──────────────────────── Public profile (unauth) ─────────────


### PR DESCRIPTION
## P1.2 — Config-mutation audit + real actor DID

Closes the gap where the three config-mutation doors emitted no audit (or used the literal `did:key:vtc-admin` actor sentinel), so auditability depended on which equivalent door an admin used.

### Changes
- **`PATCH /v1/admin/config`** (`patch_config`) now emits a `ConfigChanged` audit event, snapshotting the db overlay up front so each key carries its real `old_value`/`source_before`, with `ConfigChange::redact_if` masking `sensitive` keys.
- All four `did:key:vtc-admin` sentinels (`reload`/`restart`/`import`×2) replaced with the real `AdminAuth` DID.
- **`PUT /v1/community/profile`** (`put_profile`) now emits `CommunityProfileUpdated`.
- **Fail-closed:** a mutation that produces a change but can't be recorded (no `AuditWriter`) returns 503 — matching the existing reload/restart/import convention. No-op / rejects-only requests emit nothing and don't need the writer.

### Tests
New audit-actor + 503-when-missing coverage for PATCH admin config and PUT profile; strengthened the import audit test to assert the real actor. `rg did:key:vtc-admin` returns nothing in code. Doc: `vtc-mvp.md` §14.6.

Plan: `tasks/vtc-architecture-plan.md` P1.2.