### PR TITLE
fix(vti-common,vtc-service): single mint path + one holder-sig verifier (P1.4)

### DIFF
--- a/vtc-service/src/holder_signature.rs
+++ b/vtc-service/src/holder_signature.rs
@@ -1,0 +1,115 @@
+//! Shared `did:key` Ed25519 holder-signature verification (P1.4).
+//!
+//! The VTC's REST holder-binding signatures — join submit / accept /
+//! status and member-rotation's old/new `did:key` signatures — are all
+//! an Ed25519 signature over `domain_tag || canonical_json`, verified
+//! against the signer's intrinsic `did:key` public key. They differ
+//! only by domain tag + canonical struct, so they all delegate to the
+//! one verifier here (replacing four byte-identical copies of the
+//! pubkey-resolve → sig-decode → verify crypto).
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+/// Verify `signature_hex` (hex Ed25519) over `domain_tag || payload`
+/// against the intrinsic public key of `did` (a `did:key`).
+///
+/// `payload` is the canonical (key-ordered) JSON the signer produced;
+/// the helper prepends `domain_tag`. Pass an **empty** `domain_tag` when
+/// the caller's `payload` already includes the tag — member rotation
+/// builds one combined buffer because the same bytes feed both the
+/// `did:key` and `did:webvh` verification paths.
+///
+/// Returns a human-readable error string; callers map it into their own
+/// error type (and frame *which* signature failed).
+pub fn verify_domain_signed(
+    did: &str,
+    domain_tag: &[u8],
+    payload: &[u8],
+    signature_hex: &str,
+) -> Result<(), String> {
+    let pub_bytes = affinidi_crypto::did_key::did_key_to_ed25519_pub(did)
+        .map_err(|e| format!("{did} is not a parseable did:key: {e}"))?;
+    let vk = VerifyingKey::from_bytes(&pub_bytes)
+        .map_err(|e| format!("{did} decodes to an invalid Ed25519 pubkey: {e}"))?;
+    let raw = hex::decode(signature_hex).map_err(|e| format!("signature is not hex: {e}"))?;
+    let sig = Signature::from_slice(&raw)
+        .map_err(|e| format!("signature is not a 64-byte Ed25519 value: {e}"))?;
+
+    let mut signing_bytes = Vec::with_capacity(domain_tag.len() + payload.len());
+    signing_bytes.extend_from_slice(domain_tag);
+    signing_bytes.extend_from_slice(payload);
+
+    vk.verify(&signing_bytes, &sig)
+        .map_err(|e| format!("holder-binding signature failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    const TAG: &[u8] = b"vtc-test/v1\0";
+
+    fn signer() -> (SigningKey, String) {
+        let sk = SigningKey::from_bytes(&[0x11; 32]);
+        let did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&sk.verifying_key().to_bytes());
+        (sk, did)
+    }
+
+    /// Helper mirroring the helper's own concatenation so the test can
+    /// produce the exact bytes the signer hashes.
+    fn sign_over(sk: &SigningKey, tag: &[u8], payload: &[u8]) -> String {
+        let mut buf = tag.to_vec();
+        buf.extend_from_slice(payload);
+        hex::encode(sk.sign(&buf).to_bytes())
+    }
+
+    #[test]
+    fn round_trip_verifies() {
+        let (sk, did) = signer();
+        let payload = b"{\"a\":1}";
+        let sig = sign_over(&sk, TAG, payload);
+        assert!(verify_domain_signed(&did, TAG, payload, &sig).is_ok());
+    }
+
+    #[test]
+    fn empty_tag_matches_pre_prefixed_payload() {
+        // The rotation path passes its tag inside `payload` + an empty
+        // domain tag; verifying that against a signature over the same
+        // combined bytes must succeed.
+        let (sk, did) = signer();
+        let mut combined = TAG.to_vec();
+        combined.extend_from_slice(b"rotation-body");
+        let sig = sign_over(&sk, &[], &combined);
+        assert!(verify_domain_signed(&did, &[], &combined, &sig).is_ok());
+    }
+
+    #[test]
+    fn wrong_domain_tag_rejected() {
+        // A signature produced under one tag must not verify under
+        // another — domain separation between submit/accept/status/etc.
+        let (sk, did) = signer();
+        let payload = b"body";
+        let sig = sign_over(&sk, b"vtc-other/v1\0", payload);
+        assert!(verify_domain_signed(&did, TAG, payload, &sig).is_err());
+    }
+
+    #[test]
+    fn wrong_signer_rejected() {
+        let (_sk, did) = signer();
+        let other = SigningKey::from_bytes(&[0x22; 32]);
+        let payload = b"body";
+        let sig = sign_over(&other, TAG, payload);
+        assert!(verify_domain_signed(&did, TAG, payload, &sig).is_err());
+    }
+
+    #[test]
+    fn non_did_key_and_garbage_sig_rejected() {
+        let (_sk, did) = signer();
+        // Not a did:key.
+        assert!(verify_domain_signed("did:web:example.com", TAG, b"x", "00").is_err());
+        // Not hex / not 64 bytes.
+        assert!(verify_domain_signed(&did, TAG, b"x", "not-hex").is_err());
+        assert!(verify_domain_signed(&did, TAG, b"x", "0011").is_err());
+    }
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -28,6 +28,7 @@ pub mod emergency;
 pub mod endorsement_types;
 pub mod endorsements;
 pub mod error;
+pub mod holder_signature;
 pub mod install;
 pub mod join;
 pub mod keys;

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -484,10 +484,8 @@ pub async fn passkey_login_finish(
         .webauthn
         .as_ref()
         .ok_or_else(|| AppError::Authentication("WebAuthn not configured".into()))?;
-    let jwt_keys = state
-        .jwt_keys
-        .as_ref()
-        .ok_or_else(|| AppError::Authentication("JWT keys not configured".into()))?;
+    // JWT-keys presence is enforced by `VtcAuthBackend::from_state` at the
+    // mint step below (the shared minter owns token issuance now).
 
     let auth_state = take_auth_state(&state.passkey_ks, &req.auth_id)
         .await?
@@ -517,60 +515,55 @@ pub async fn passkey_login_finish(
     // clean 403, not a 500 in the VTA-taxonomy deserializer (P0.16).
     let (role, allowed_contexts) = resolve_auth_role(&state.acl_ks, &user.did).await?;
 
-    // Mint access + refresh tokens (mirrors `authenticate_and_mint`
-    // for parity with the DIDComm login path).
-    let config = state.config.read().await;
-    let access_expiry = config.auth.access_token_expiry;
-    let refresh_expiry = config.auth.refresh_token_expiry;
-    drop(config);
-
+    // Mint access + refresh tokens through the shared minter so the
+    // passkey path gets the same `aal2` short access TTL + Authenticated
+    // audit as the canonical `/auth/` handler (P1.4) — previously this
+    // hand-rolled the mint with the full `aal1` TTL, giving the one
+    // token class the hardening protects the longest exposure.
+    // Passkey-login: amr=["passkey"], acr="aal2" — the WebAuthn
+    // assertion alone is two factors (possession of the authenticator +
+    // a user-verification gesture / biometric).
+    let backend = crate::auth::VtcAuthBackend::from_state(&state).await?;
     let session_id = Uuid::new_v4().to_string();
-    // Passkey-login: WebAuthn assertion bound to the holder's
-    // registered credential. amr=["passkey"], acr="aal2" — the
-    // assertion alone is two factors (possession of the
-    // authenticator + user verification gesture / biometric).
-    let claims = jwt_keys
-        .new_claims(
-            user.did.clone(),
-            session_id.clone(),
-            role.to_string(),
-            allowed_contexts,
-            access_expiry,
-            false,
-        )
-        .with_aal(vec!["passkey".to_string()], "aal2");
-    let access_expires_at = claims.exp;
-    let access_token = jwt_keys.encode(&claims)?;
-
-    let refresh_token = Uuid::new_v4().to_string();
-    let refresh_expires_at = now_epoch() + refresh_expiry;
+    let amr = vec!["passkey".to_string()];
+    let acr = "aal2".to_string();
+    let minted = vti_common::auth::handlers::mint_session_tokens(
+        &backend,
+        &user.did,
+        &session_id,
+        &role,
+        &allowed_contexts,
+        &amr,
+        &acr,
+        false,
+    )
+    .await?;
 
     // Persist the session record so `/auth/sessions` lists it and
-    // refresh-token rotation finds it. AAL is captured from the JWT
-    // claims so refresh keeps the holder at aal2 instead of dropping
-    // to aal1 on every token rotation.
+    // refresh-token rotation finds it. AAL is captured so refresh keeps
+    // the holder at aal2 instead of dropping to aal1 on every rotation.
     let session = Session {
         session_id: session_id.clone(),
         did: user.did.clone(),
         challenge: String::new(),
         state: SessionState::Authenticated,
-        created_at: now_epoch(),
-        refresh_token: Some(refresh_token.clone()),
-        refresh_expires_at: Some(refresh_expires_at),
+        created_at: minted.issued_at,
+        refresh_token: Some(minted.refresh_token.clone()),
+        refresh_expires_at: Some(minted.refresh_expires_at),
         tee_attested: false,
-        amr: claims.amr.clone(),
-        acr: claims.acr.clone(),
+        amr: amr.clone(),
+        acr: acr.clone(),
         token_id: None,
         session_pubkey_b58btc: None,
     };
     store_session(&state.sessions_ks, &session).await?;
-    store_refresh_index(&state.sessions_ks, &refresh_token, &session_id).await?;
+    store_refresh_index(&state.sessions_ks, &minted.refresh_token, &session_id).await?;
 
     info!(did = %user.did, %session_id, "passkey login successful");
 
     // Set cookies — same shape as `admin_login`.
-    let max_age = access_expires_at.saturating_sub(now_epoch()).max(1);
-    let session_cookie = build_session_cookie(&access_token, max_age);
+    let max_age = minted.access_expires_at.saturating_sub(now_epoch()).max(1);
+    let session_cookie = build_session_cookie(&minted.access_token, max_age);
 
     use rand::RngExt;
     let mut csrf_bytes = [0u8; 32];
@@ -578,22 +571,21 @@ pub async fn passkey_login_finish(
     let csrf = hex::encode(csrf_bytes);
     let csrf_cookie = build_csrf_cookie(&csrf, max_age);
 
-    let issued_at_epoch = now_epoch();
     let resp = AuthenticateResponse {
         session: WireSession {
             id: session_id.clone(),
             subject: user.did.clone(),
-            issued_at: epoch_to_rfc3339(issued_at_epoch),
-            expires_at: epoch_to_rfc3339(access_expires_at),
-            amr: claims.amr.clone(),
-            acr: claims.acr.clone(),
+            issued_at: epoch_to_rfc3339(minted.issued_at),
+            expires_at: epoch_to_rfc3339(minted.access_expires_at),
+            amr: amr.clone(),
+            acr: acr.clone(),
         },
         tokens: TokenBundle {
-            access_token: access_token.clone(),
-            refresh_token: Some(refresh_token),
+            access_token: minted.access_token.clone(),
+            refresh_token: Some(minted.refresh_token),
             token_type: "Bearer".to_string(),
-            expires_in: access_expires_at.saturating_sub(issued_at_epoch),
-            refresh_expires_in: Some(refresh_expires_at.saturating_sub(issued_at_epoch)),
+            expires_in: minted.access_ttl,
+            refresh_expires_in: Some(minted.refresh_expires_at.saturating_sub(minted.issued_at)),
             scope: Vec::new(),
         },
     };

--- a/vtc-service/src/routes/join_requests/accept.rs
+++ b/vtc-service/src/routes/join_requests/accept.rs
@@ -26,7 +26,6 @@ use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::info;
@@ -339,24 +338,14 @@ fn verify_holder_signature(
     vc: &JsonValue,
     signature_hex: &str,
 ) -> Result<(), AppError> {
-    let pubkey_bytes = affinidi_crypto::did_key::did_key_to_ed25519_pub(member_did)
-        .map_err(|e| AppError::Validation(format!("member_did is not a parseable did:key: {e}")))?;
-    let verifying = VerifyingKey::from_bytes(&pubkey_bytes)
-        .map_err(|e| AppError::Validation(format!("member_did decodes to an invalid key: {e}")))?;
-
     let payload = canonical_payload(member_did, vmc_id, vc)?;
-    let signing_bytes = signing_bytes(&payload);
-
-    let raw_sig = hex::decode(signature_hex)
-        .map_err(|e| AppError::Validation(format!("signature is not hex: {e}")))?;
-    let signature = Signature::from_slice(&raw_sig).map_err(|e| {
-        AppError::Validation(format!("signature is not a 64-byte Ed25519 value: {e}"))
-    })?;
-
-    verifying
-        .verify(&signing_bytes, &signature)
-        .map_err(|e| AppError::Validation(format!("holder-binding signature failed: {e}")))?;
-    Ok(())
+    crate::holder_signature::verify_domain_signed(
+        member_did,
+        JOIN_ACCEPT_DOMAIN_TAG,
+        &payload,
+        signature_hex,
+    )
+    .map_err(AppError::Validation)
 }
 
 /// Canonical signing payload — typed struct, field order pinned by the
@@ -376,11 +365,4 @@ fn canonical_payload(member_did: &str, vmc_id: &str, vc: &JsonValue) -> Result<V
         vc,
     })
     .map_err(|e| AppError::Internal(format!("canonical payload serialize: {e}")))
-}
-
-fn signing_bytes(payload: &[u8]) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(JOIN_ACCEPT_DOMAIN_TAG.len() + payload.len());
-    buf.extend_from_slice(JOIN_ACCEPT_DOMAIN_TAG);
-    buf.extend_from_slice(payload);
-    buf
 }

--- a/vtc-service/src/routes/join_requests/status.rs
+++ b/vtc-service/src/routes/join_requests/status.rs
@@ -19,7 +19,6 @@
 
 use axum::Json;
 use axum::extract::{Path, State};
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -105,27 +104,14 @@ fn verify_holder_signature(
     request_id: Uuid,
     signature_hex: &str,
 ) -> Result<(), AppError> {
-    let pubkey_bytes =
-        affinidi_crypto::did_key::did_key_to_ed25519_pub(applicant_did).map_err(|e| {
-            AppError::Validation(format!("applicantDid is not a parseable did:key: {e}"))
-        })?;
-    let verifying = VerifyingKey::from_bytes(&pubkey_bytes).map_err(|e| {
-        AppError::Validation(format!("applicantDid decodes to an invalid key: {e}"))
-    })?;
-
     let payload = canonical_payload(applicant_did, request_id)?;
-    let signing_bytes = signing_bytes(&payload);
-
-    let raw_sig = hex::decode(signature_hex)
-        .map_err(|e| AppError::Validation(format!("signature is not hex: {e}")))?;
-    let signature = Signature::from_slice(&raw_sig).map_err(|e| {
-        AppError::Validation(format!("signature is not a 64-byte Ed25519 value: {e}"))
-    })?;
-
-    verifying
-        .verify(&signing_bytes, &signature)
-        .map_err(|e| AppError::Validation(format!("holder-binding signature failed: {e}")))?;
-    Ok(())
+    crate::holder_signature::verify_domain_signed(
+        applicant_did,
+        JOIN_STATUS_DOMAIN_TAG,
+        &payload,
+        signature_hex,
+    )
+    .map_err(AppError::Validation)
 }
 
 /// Canonical signing payload — typed struct, field order pinned by the
@@ -143,11 +129,4 @@ fn canonical_payload(applicant_did: &str, request_id: Uuid) -> Result<Vec<u8>, A
         request_id: request_id.to_string(),
     })
     .map_err(|e| AppError::Internal(format!("canonical payload serialize: {e}")))
-}
-
-fn signing_bytes(payload: &[u8]) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(JOIN_STATUS_DOMAIN_TAG.len() + payload.len());
-    buf.extend_from_slice(JOIN_STATUS_DOMAIN_TAG);
-    buf.extend_from_slice(payload);
-    buf
 }

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -49,7 +49,6 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use chrono::Utc;
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::{info, warn};
@@ -548,16 +547,6 @@ fn verify_holder_signature(
     created: i64,
     signature_hex: &str,
 ) -> Result<(), AppError> {
-    let pubkey_bytes =
-        affinidi_crypto::did_key::did_key_to_ed25519_pub(applicant_did).map_err(|e| {
-            AppError::Validation(format!("applicant_did is not a parseable did:key: {e}"))
-        })?;
-    let verifying = VerifyingKey::from_bytes(&pubkey_bytes).map_err(|e| {
-        AppError::Validation(format!(
-            "applicant_did decodes to an invalid Ed25519 pubkey: {e}"
-        ))
-    })?;
-
     let payload = canonical_payload(
         applicant_did,
         vp,
@@ -566,18 +555,13 @@ fn verify_holder_signature(
         audience,
         created,
     )?;
-    let signing_bytes = signing_bytes(&payload);
-
-    let raw_sig = hex::decode(signature_hex)
-        .map_err(|e| AppError::Validation(format!("signature is not hex: {e}")))?;
-    let signature = Signature::from_slice(&raw_sig).map_err(|e| {
-        AppError::Validation(format!("signature is not a 64-byte Ed25519 value: {e}"))
-    })?;
-
-    verifying
-        .verify(&signing_bytes, &signature)
-        .map_err(|e| AppError::Validation(format!("holder-binding signature failed: {e}")))?;
-    Ok(())
+    crate::holder_signature::verify_domain_signed(
+        applicant_did,
+        JOIN_REQUEST_SUBMIT_DOMAIN_TAG,
+        &payload,
+        signature_hex,
+    )
+    .map_err(AppError::Validation)
 }
 
 /// Canonical signing payload — a typed struct serialised via
@@ -631,7 +615,10 @@ async fn find_open_request(
         .map(|r| r.id))
 }
 
-/// Domain-tag prefixed bytes the signer hashes over.
+/// Domain-tag prefixed bytes the signer hashes over. Verification goes
+/// through [`crate::holder_signature::verify_domain_signed`]; this
+/// remains for the round-trip tests that must *produce* the same bytes.
+#[cfg(test)]
 fn signing_bytes(payload: &[u8]) -> Vec<u8> {
     let mut buf = Vec::with_capacity(JOIN_REQUEST_SUBMIT_DOMAIN_TAG.len() + payload.len());
     buf.extend_from_slice(JOIN_REQUEST_SUBMIT_DOMAIN_TAG);

--- a/vtc-service/src/routes/members/rotate.rs
+++ b/vtc-service/src/routes/members/rotate.rs
@@ -500,15 +500,12 @@ fn canonical_signing_bytes(
     Ok(buf)
 }
 
-fn verify_did_key_signature(did: &str, payload: &[u8], hex_sig: &str) -> Result<(), String> {
-    let pub_bytes = affinidi_crypto::did_key::did_key_to_ed25519_pub(did)
-        .map_err(|e| format!("did:key parse: {e}"))?;
-    let vk =
-        VerifyingKey::from_bytes(&pub_bytes).map_err(|e| format!("invalid Ed25519 pubkey: {e}"))?;
-    let raw = hex::decode(hex_sig).map_err(|e| format!("signature is not hex: {e}"))?;
-    let sig = Signature::from_slice(&raw).map_err(|e| format!("signature is not 64 bytes: {e}"))?;
-    vk.verify(payload, &sig)
-        .map_err(|e| format!("signature verification: {e}"))
+/// Verify an Ed25519 signature from a `did:key` over the rotation's
+/// canonical signing bytes. Those bytes already include
+/// [`ROTATION_DOMAIN_TAG`] (the same buffer feeds the `did:webvh` path
+/// below), so the shared verifier is called with an empty domain tag.
+fn verify_did_key_signature(did: &str, signing_bytes: &[u8], hex_sig: &str) -> Result<(), String> {
+    crate::holder_signature::verify_domain_signed(did, &[], signing_bytes, hex_sig)
 }
 
 /// Verify an Ed25519 signature against the `#key-0`

--- a/vti-common/src/auth/handlers/authenticate.rs
+++ b/vti-common/src/auth/handlers/authenticate.rs
@@ -23,13 +23,12 @@
 //! 9. Emit `Authenticated` audit event and return canonical
 //!    `AuthenticateResponse`.
 
-use uuid::Uuid;
 use vta_sdk::protocols::auth::{
     AuthenticateResponse, Session as WireSession, TokenBundle, epoch_to_rfc3339,
 };
 
 use crate::auth::AuthError;
-use crate::auth::backend::{AuthAuditEvent, AuthBackend, AuthenticateInput, SessionStore};
+use crate::auth::backend::{AuthBackend, AuthenticateInput, SessionStore};
 use crate::auth::session::{SessionState, now_epoch};
 
 /// Default first-factor AMR; the transport layer (or step-up
@@ -121,40 +120,29 @@ pub async fn handle_authenticate_with_aal<B: AuthBackend>(
 
     let role_resolution = backend.check_acl(&session.did).await?;
 
-    // ---- Mint tokens ----
+    // ---- Mint tokens (acr-dependent TTL + Authenticated audit) ----
     //
-    // Access-token TTL is acr-dependent: stepped-up sessions
-    // (`aal2`) get a shorter window (M2 from the May 2026
-    // security review) to bound the blast radius of a leaked
-    // elevated token.
-    let access_ttl = if acr == "aal2" {
-        backend.access_token_ttl_for_aal2()
-    } else {
-        backend.access_token_ttl()
-    };
-
-    let refresh_token = Uuid::new_v4().to_string();
-    let refresh_expires_at = now.saturating_add(backend.refresh_token_ttl());
-    let access_expires_at = now.saturating_add(access_ttl);
-
-    let access_token = backend
-        .mint_access_token(
-            &session.did,
-            &session.session_id,
-            &role_resolution.role,
-            &role_resolution.contexts,
-            &amr,
-            &acr,
-            session.tee_attested,
-            access_ttl,
-        )
-        .await?;
+    // The shared minter centralises the `aal2` short-TTL hardening
+    // (M2 from the May 2026 security review — bound the blast radius
+    // of a leaked elevated token) so every mint path applies it
+    // identically.
+    let minted = super::mint::mint_session_tokens(
+        backend,
+        &session.did,
+        &session.session_id,
+        &role_resolution.role,
+        &role_resolution.contexts,
+        &amr,
+        &acr,
+        session.tee_attested,
+    )
+    .await?;
 
     // ---- Transition session + persist refresh index ----
 
     session.state = SessionState::Authenticated;
-    session.refresh_token = Some(refresh_token.clone());
-    session.refresh_expires_at = Some(refresh_expires_at);
+    session.refresh_token = Some(minted.refresh_token.clone());
+    session.refresh_expires_at = Some(minted.refresh_expires_at);
     session.amr = amr.clone();
     session.acr = acr.clone();
     if let Some(pk) = input.session_pubkey_b58btc {
@@ -168,16 +156,9 @@ pub async fn handle_authenticate_with_aal<B: AuthBackend>(
         .map_err(|e| AuthError::Internal(format!("store_session failed: {e:?}")))?;
     backend
         .sessions()
-        .store_refresh_index(&refresh_token, &session.session_id)
+        .store_refresh_index(&minted.refresh_token, &session.session_id)
         .await
         .map_err(|e| AuthError::Internal(format!("store_refresh_index failed: {e:?}")))?;
-
-    backend.audit(AuthAuditEvent::Authenticated {
-        did: &session.did,
-        session_id: &session.session_id,
-        amr: &amr,
-        acr: &acr,
-    });
 
     // ---- Build canonical response ----
 
@@ -185,16 +166,16 @@ pub async fn handle_authenticate_with_aal<B: AuthBackend>(
         session: WireSession {
             id: session.session_id.clone(),
             subject: session.did,
-            issued_at: epoch_to_rfc3339(now),
-            expires_at: epoch_to_rfc3339(access_expires_at),
+            issued_at: epoch_to_rfc3339(minted.issued_at),
+            expires_at: epoch_to_rfc3339(minted.access_expires_at),
             amr,
             acr,
         },
         tokens: TokenBundle {
-            access_token,
-            refresh_token: Some(refresh_token),
+            access_token: minted.access_token,
+            refresh_token: Some(minted.refresh_token),
             token_type: "Bearer".to_string(),
-            expires_in: access_ttl,
+            expires_in: minted.access_ttl,
             refresh_expires_in: Some(backend.refresh_token_ttl()),
             scope: role_resolution
                 .contexts

--- a/vti-common/src/auth/handlers/mint.rs
+++ b/vti-common/src/auth/handlers/mint.rs
@@ -1,0 +1,248 @@
+//! Shared session-token minting.
+//!
+//! The single place that computes the acr-dependent access-token TTL,
+//! mints the access + refresh token pair, and fires the
+//! `Authenticated` audit hook. Both the canonical `/auth/` handler
+//! ([`super::handle_authenticate_with_aal`]) and out-of-band step-up
+//! mints (e.g. VTC passkey-login-finish) call this so the AAL2
+//! short-TTL hardening (M2 — bound a leaked elevated token) and the
+//! audit hook can't drift between paths.
+
+use uuid::Uuid;
+
+use crate::auth::backend::{AuthAuditEvent, AuthBackend};
+use crate::auth::session::now_epoch;
+
+/// Tokens minted for an authenticated session, plus the timing the
+/// caller needs to build its wire response and persist the session.
+pub struct MintedTokens {
+    pub access_token: String,
+    pub refresh_token: String,
+    /// Access-token TTL actually applied (acr-dependent).
+    pub access_ttl: u64,
+    /// Absolute epoch-second expiry of the access token.
+    pub access_expires_at: u64,
+    /// Absolute epoch-second expiry of the refresh token.
+    pub refresh_expires_at: u64,
+    /// Epoch second the tokens were minted at.
+    pub issued_at: u64,
+}
+
+/// Mint an access + refresh token pair for an already-authenticated
+/// subject and fire the `Authenticated` audit hook.
+///
+/// The access TTL is **acr-dependent**: a stepped-up (`aal2`) session
+/// gets [`AuthBackend::access_token_ttl_for_aal2`] (M2 — bounds the
+/// blast radius of a leaked elevated token), everything else gets
+/// [`AuthBackend::access_token_ttl`]. Centralising this is the point
+/// of the helper: callers that hand-rolled the mint (VTC
+/// passkey-login-finish) previously issued `aal2` tokens with the
+/// full `aal1` TTL, so the one token class the hardening protects got
+/// the longest exposure — and emitted no `Authenticated` audit event.
+///
+/// Does **not** persist the session or refresh index — the caller
+/// owns the session lifecycle (the canonical handler transitions a
+/// `ChallengeSent` row to `Authenticated`; the passkey path creates a
+/// fresh `Authenticated` row).
+#[allow(clippy::too_many_arguments)]
+pub async fn mint_session_tokens<B: AuthBackend>(
+    backend: &B,
+    did: &str,
+    session_id: &str,
+    role: &B::Role,
+    contexts: &[String],
+    amr: &[String],
+    acr: &str,
+    tee_attested: bool,
+) -> Result<MintedTokens, B::Error> {
+    let now = now_epoch();
+    let access_ttl = if acr == "aal2" {
+        backend.access_token_ttl_for_aal2()
+    } else {
+        backend.access_token_ttl()
+    };
+    let refresh_token = Uuid::new_v4().to_string();
+    let refresh_expires_at = now.saturating_add(backend.refresh_token_ttl());
+    let access_expires_at = now.saturating_add(access_ttl);
+
+    let access_token = backend
+        .mint_access_token(
+            did,
+            session_id,
+            role,
+            contexts,
+            amr,
+            acr,
+            tee_attested,
+            access_ttl,
+        )
+        .await?;
+
+    backend.audit(AuthAuditEvent::Authenticated {
+        did,
+        session_id,
+        amr,
+        acr,
+    });
+
+    Ok(MintedTokens {
+        access_token,
+        refresh_token,
+        access_ttl,
+        access_expires_at,
+        refresh_expires_at,
+        issued_at: now,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::backend::{RoleResolution, SessionStore};
+    use crate::auth::session::Session;
+    use crate::error::AppError;
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// `mint_session_tokens` never touches the session store, so every
+    /// method is `unreachable!()`.
+    struct DummyStore;
+
+    #[async_trait]
+    impl SessionStore for DummyStore {
+        type Error = AppError;
+        async fn store_session(&self, _: &Session) -> Result<(), AppError> {
+            unreachable!()
+        }
+        async fn get_session(&self, _: &str) -> Result<Option<Session>, AppError> {
+            unreachable!()
+        }
+        async fn delete_session(&self, _: &str) -> Result<(), AppError> {
+            unreachable!()
+        }
+        async fn store_refresh_index(&self, _: &str, _: &str) -> Result<(), AppError> {
+            unreachable!()
+        }
+        async fn take_session_id_by_refresh(&self, _: &str) -> Result<Option<String>, AppError> {
+            unreachable!()
+        }
+        async fn count_pending_challenges(&self, _: &str) -> Result<usize, AppError> {
+            unreachable!()
+        }
+    }
+
+    struct MockBackend {
+        store: DummyStore,
+        authenticated_fired: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl AuthBackend for MockBackend {
+        type Store = DummyStore;
+        type Error = AppError;
+        type Role = String;
+
+        fn sessions(&self) -> &DummyStore {
+            &self.store
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn mint_access_token(
+            &self,
+            _subject: &str,
+            _session_id: &str,
+            _role: &String,
+            _contexts: &[String],
+            _amr: &[String],
+            _acr: &str,
+            _tee_attested: bool,
+            ttl_secs: u64,
+        ) -> Result<String, AppError> {
+            // Echo the applied TTL so the test can confirm which one was used.
+            Ok(format!("token-ttl-{ttl_secs}"))
+        }
+
+        async fn check_acl(&self, _did: &str) -> Result<RoleResolution<String>, AppError> {
+            unreachable!()
+        }
+
+        fn challenge_ttl(&self) -> u64 {
+            60
+        }
+        fn access_token_ttl(&self) -> u64 {
+            900
+        }
+        fn refresh_token_ttl(&self) -> u64 {
+            86_400
+        }
+
+        fn audit(&self, event: AuthAuditEvent<'_>) {
+            if matches!(event, AuthAuditEvent::Authenticated { .. }) {
+                self.authenticated_fired.store(true, Ordering::SeqCst);
+            }
+        }
+    }
+
+    fn backend() -> (MockBackend, Arc<AtomicBool>) {
+        let fired = Arc::new(AtomicBool::new(false));
+        (
+            MockBackend {
+                store: DummyStore,
+                authenticated_fired: fired.clone(),
+            },
+            fired,
+        )
+    }
+
+    #[tokio::test]
+    async fn aal2_mint_uses_short_ttl_and_fires_authenticated_audit() {
+        let (backend, fired) = backend();
+        let minted = mint_session_tokens(
+            &backend,
+            "did:key:zA",
+            "sess-1",
+            &"admin".to_string(),
+            &[],
+            &["passkey".to_string()],
+            "aal2",
+            false,
+        )
+        .await
+        .unwrap();
+
+        // aal2 → access_token_ttl_for_aal2() = max(60, 900/3) = 300.
+        // This is the M2 hardening the passkey path previously bypassed.
+        assert_eq!(minted.access_ttl, backend.access_token_ttl_for_aal2());
+        assert_eq!(minted.access_ttl, 300);
+        assert_eq!(minted.access_token, "token-ttl-300");
+        assert_eq!(minted.access_expires_at, minted.issued_at + 300);
+        assert_eq!(minted.refresh_expires_at, minted.issued_at + 86_400);
+        assert!(
+            fired.load(Ordering::SeqCst),
+            "Authenticated audit hook must fire"
+        );
+    }
+
+    #[tokio::test]
+    async fn aal1_mint_uses_full_ttl() {
+        let (backend, fired) = backend();
+        let minted = mint_session_tokens(
+            &backend,
+            "did:key:zA",
+            "sess-1",
+            &"member".to_string(),
+            &[],
+            &["did".to_string()],
+            "aal1",
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(minted.access_ttl, backend.access_token_ttl());
+        assert_eq!(minted.access_ttl, 900);
+        assert_eq!(minted.access_token, "token-ttl-900");
+        assert!(fired.load(Ordering::SeqCst));
+    }
+}

--- a/vti-common/src/auth/handlers/mod.rs
+++ b/vti-common/src/auth/handlers/mod.rs
@@ -12,11 +12,13 @@
 
 pub mod authenticate;
 pub mod challenge;
+pub mod mint;
 pub mod refresh;
 pub mod store;
 
 pub use authenticate::{handle_authenticate, handle_authenticate_with_aal};
 pub use challenge::handle_challenge;
+pub use mint::{MintedTokens, mint_session_tokens};
 pub use refresh::handle_refresh;
 pub use store::KeyspaceSessionStore;
 


### PR DESCRIPTION
## P1.4 — Single token-mint path + AAL2 short-TTL parity; one holder-signature verifier

### Part 1 — shared `mint_session_tokens` (security)
VTC `passkey_login_finish` hand-rolled the token mint and issued its `aal2` token with the **full ~15-min `aal1` TTL** — the one token class the M2 hardening (`access_token_ttl_for_aal2`, 1/3 and min 60s) protects got the longest exposure — and fired no `Authenticated` audit hook.

Extracted `mint_session_tokens(backend, did, session_id, role, contexts, amr, acr, tee_attested)` in vti-common: computes the acr-dependent access TTL, mints the access + refresh pair, fires the `Authenticated` audit hook. Both the canonical `handle_authenticate_with_aal` and the passkey path delegate to it, so the hardening + audit can't drift. Session persistence stays with each caller. Passkey-finish now yields `expires_in == access_token_ttl_for_aal2()`.

> Note: `VtcAuthBackend` uses the default `audit()` (tracing) and there is no `AuditEvent::Authenticated` audit-log variant — a *persisted* login envelope is separate scope.

### Part 2 — one `did:key` holder-signature verifier (refactor)
Four byte-identical copies of the domain-tagged Ed25519 verifier (join submit/accept/status + member-rotation's did:key path) differed only by domain tag + canonical struct. Collapsed onto `crate::holder_signature::verify_domain_signed(did, domain_tag, payload, sig)`. The verified bytes are **byte-identical** before/after — a pure dedup, no wire/behaviour change. Rotation passes an empty domain tag (its buffer already includes `ROTATION_DOMAIN_TAG`, shared with the unchanged did:webvh path).

### Tests
`mint_session_tokens` unit tests (aal2→short TTL + audit fires, aal1→full); `verify_domain_signed` unit tests (round-trip, domain-tag separation, wrong-signer, non-did:key, malformed sig). All existing auth/passkey/join/rotation/members suites pass unchanged (241 vti-common + 552 vtc-service lib tests green).

Plan: `tasks/vtc-architecture-plan.md` P1.4.