### PR TITLE
fix(vtc-service): validate policy package matches declared purpose (P1.5)

### DIFF
--- a/vtc-service/src/policy/engine.rs
+++ b/vtc-service/src/policy/engine.rs
@@ -35,6 +35,8 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 use vti_common::error::AppError;
 
+use super::model::PolicyPurpose;
+
 /// Wall-clock ceiling for a single policy evaluation.
 ///
 /// The join-decision policy is evaluated on the **unauthenticated** submit
@@ -195,6 +197,64 @@ pub fn evaluate(
         }
     })?;
     serde_json::to_value(results).map_err(AppError::from)
+}
+
+/// Reject an uploaded/activated policy whose Rego package doesn't match
+/// its declared `purpose`.
+///
+/// For the four ceremony purposes the decision pipeline probes a fixed
+/// package (`data.<pkg>.decision`); a module compiled into the *wrong*
+/// package — or one that defines neither a four-valued `decision`
+/// verdict nor a boolean `allow` — evaluates to `undefined` at decision
+/// time, which the host reads as a silent default-deny for that whole
+/// ceremony. The operator sees a clean upload + activate and a
+/// community that quietly denies everything. Catch it by probing the
+/// expected package against a trivial input.
+///
+/// Purposes with no single pinned decision package
+/// ([`PolicyPurpose::expected_package`] → `None`: registry, personhood,
+/// …) are not package-validated here.
+pub fn validate_purpose_package(
+    compiled: &CompiledPolicy,
+    purpose: PolicyPurpose,
+) -> Result<(), AppError> {
+    let Some(pkg) = purpose.expected_package() else {
+        return Ok(());
+    };
+    if yields_decision_or_allow(compiled, pkg) {
+        return Ok(());
+    }
+    Err(AppError::Validation(format!(
+        "policy declares purpose `{p}` but yields no decision in package `{pkg}` for a \
+         trivial input — it must define a `decision` rule (or a boolean `allow`) under \
+         `package {pkg}`. A module in the wrong package compiles cleanly but silently \
+         denies every `{p}` request.",
+        p = purpose.as_str(),
+    )))
+}
+
+/// True when the policy yields either a four-valued `decision` verdict
+/// (the pipeline shape) or a boolean `allow` (legacy / default-deny) in
+/// `pkg` for an empty input. An undefined rule (wrong package, or no
+/// default) yields neither.
+fn yields_decision_or_allow(compiled: &CompiledPolicy, pkg: &str) -> bool {
+    let empty = JsonValue::Object(serde_json::Map::new());
+    if let Ok(r) = evaluate(compiled, &format!("data.{pkg}.decision"), empty.clone())
+        && r.pointer("/result/0/expressions/0/value")
+            .and_then(|v| v.get("effect"))
+            .and_then(JsonValue::as_str)
+            .is_some()
+    {
+        return true;
+    }
+    if let Ok(r) = evaluate(compiled, &format!("data.{pkg}.allow"), empty)
+        && r.pointer("/result/0/expressions/0/value")
+            .and_then(JsonValue::as_bool)
+            .is_some()
+    {
+        return true;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -396,5 +456,55 @@ allow if {
         results
             .pointer("/result/0/expressions/0/value")
             .expect("regorus QueryResults must carry result[0].expressions[0].value")
+    }
+
+    // ---- validate_purpose_package (P1.5) ----
+
+    #[test]
+    fn validate_purpose_package_accepts_boolean_allow_in_right_package() {
+        let src = "package vtc.join\nimport rego.v1\ndefault allow := false\n";
+        let c = compile(src, test_id()).unwrap();
+        assert!(validate_purpose_package(&c, PolicyPurpose::Join).is_ok());
+    }
+
+    #[test]
+    fn validate_purpose_package_accepts_decision_rule_in_right_package() {
+        let src = "package vtc.directory\nimport rego.v1\n\
+                   default decision := {\"effect\": \"deny\"}\n";
+        let c = compile(src, test_id()).unwrap();
+        assert!(validate_purpose_package(&c, PolicyPurpose::Directory).is_ok());
+    }
+
+    #[test]
+    fn validate_purpose_package_rejects_wrong_package() {
+        // A join policy compiled into vtc.removal yields nothing at
+        // data.vtc.join.{decision,allow} → silent default-deny footgun.
+        let src = "package vtc.removal\nimport rego.v1\ndefault allow := false\n";
+        let c = compile(src, test_id()).unwrap();
+        let err = validate_purpose_package(&c, PolicyPurpose::Join).unwrap_err();
+        match err {
+            AppError::Validation(msg) => assert!(
+                msg.contains("vtc.join"),
+                "error must name the expected package: {msg}"
+            ),
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_purpose_package_rejects_missing_default_rule() {
+        // Right package but no `default` — undefined for empty input,
+        // which is the same silent-deny shape we reject.
+        let src = "package vtc.join\nimport rego.v1\nallow if input.role == \"admin\"\n";
+        let c = compile(src, test_id()).unwrap();
+        assert!(validate_purpose_package(&c, PolicyPurpose::Join).is_err());
+    }
+
+    #[test]
+    fn validate_purpose_package_skips_unpinned_purposes() {
+        // Registry has no expected_package → never package-validated.
+        let src = "package whatever\nimport rego.v1\ndefault publish_on_join := true\n";
+        let c = compile(src, test_id()).unwrap();
+        assert!(validate_purpose_package(&c, PolicyPurpose::Registry).is_ok());
     }
 }

--- a/vtc-service/src/policy/mod.rs
+++ b/vtc-service/src/policy/mod.rs
@@ -44,7 +44,7 @@ pub mod extract;
 pub mod model;
 pub mod storage;
 
-pub use engine::{CompiledPolicy, compile, evaluate};
+pub use engine::{CompiledPolicy, compile, evaluate, validate_purpose_package};
 pub use model::{POLICY_SOURCE_MAX_BYTES, Policy, PolicyPurpose};
 pub use storage::{
     clear_active_policy_id, delete_policy, get_active_policy_id, get_policy, list_policies,

--- a/vtc-service/src/policy/model.rs
+++ b/vtc-service/src/policy/model.rs
@@ -156,6 +156,28 @@ impl PolicyPurpose {
             PolicyPurpose::RoleChange => "roleChange",
         }
     }
+
+    /// The Rego package an uploaded policy for this purpose must live
+    /// in, for the four ceremony purposes the decision pipeline probes
+    /// by a fixed package (`data.<pkg>.decision`). A module compiled
+    /// into the *wrong* package compiles cleanly but evaluates to
+    /// `undefined` at decision time, which the host reads as a silent
+    /// default-deny for that whole ceremony — so the package is part of
+    /// the upload contract, validated by
+    /// [`crate::policy::validate_purpose_package`].
+    ///
+    /// `None` for purposes without a single pinned decision package
+    /// (registry, personhood, role-definitions, …) — those are not
+    /// package-validated at upload.
+    pub fn expected_package(self) -> Option<&'static str> {
+        match self {
+            PolicyPurpose::Join => Some("vtc.join"),
+            PolicyPurpose::Removal => Some("vtc.removal"),
+            PolicyPurpose::RoleChange => Some("vtc.role_change"),
+            PolicyPurpose::Directory => Some("vtc.directory"),
+            _ => None,
+        }
+    }
 }
 
 /// `[u8; 32]` ↔ 64-char lowercase-hex string serde adapter. Used by

--- a/vtc-service/src/routes/policies/admin.rs
+++ b/vtc-service/src/routes/policies/admin.rs
@@ -44,7 +44,7 @@ use crate::auth::AdminAuth;
 use crate::policy::POLICY_SOURCE_MAX_BYTES;
 use crate::policy::{
     PolicyPurpose, compile, evaluate, get_active_policy_id, get_policy, max_version_for,
-    new_policy, set_active_policy_id, store_policy,
+    new_policy, set_active_policy_id, store_policy, validate_purpose_package,
 };
 use crate::server::AppState;
 
@@ -145,6 +145,10 @@ pub async fn upload(
     // `Policy { id, .. }` after compile rather than mint twice.
     let id = Uuid::new_v4();
     let compiled = compile(&body.rego_source, id)?;
+    // Reject a module compiled into the wrong package for its declared
+    // purpose — it would compile + activate cleanly, then evaluate to
+    // `undefined` (silent host default-deny) for that whole ceremony.
+    validate_purpose_package(&compiled, body.purpose)?;
     let sha256 = *compiled.source_sha256();
     let version = max_version_for(&state.policies_ks, body.purpose).await? + 1;
 
@@ -211,6 +215,11 @@ pub async fn activate(
     let mut policy = get_policy(&state.policies_ks, id)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("policy not found: {id}")))?;
+
+    // Re-probe before flipping it live: a policy uploaded before the
+    // package gate (or via a path that bypassed `upload`) must not be
+    // activated into a silent default-deny for its ceremony.
+    validate_purpose_package(&compile(&policy.rego_source, policy.id)?, policy.purpose)?;
 
     let previous = get_active_policy_id(&state.active_policies_ks, policy.purpose).await?;
 

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -36,8 +36,12 @@ const SHOW_TASK: &str = UPLOAD_TASK;
 
 const ADMIN_DID: &str = "did:key:zPolicyAdmin";
 
+// Test fixtures must live in the package their declared purpose expects
+// (P1.5: a join policy in `vtc.test` is now rejected at upload as a
+// silent-deny footgun). These exercise generic upload/activate/list
+// mechanics, so they just need a valid `allow` rule in the right package.
 const JOIN_ALLOW_POLICY: &str = "\
-package vtc.test
+package vtc.join
 
 import rego.v1
 
@@ -46,8 +50,16 @@ default allow := false
 allow if input.role == \"admin\"
 ";
 
-const ALT_POLICY: &str = "\
-package vtc.test
+const JOIN_ALT_POLICY: &str = "\
+package vtc.join
+
+import rego.v1
+
+default allow := true
+";
+
+const REMOVAL_POLICY: &str = "\
+package vtc.removal
 
 import rego.v1
 
@@ -203,6 +215,32 @@ async fn upload_bad_rego_returns_400() {
     );
 }
 
+/// P1.5: a policy whose Rego package doesn't match its declared
+/// purpose is rejected at upload — it would compile + activate cleanly
+/// then evaluate to `undefined` (silent host default-deny) for the
+/// whole ceremony.
+#[tokio::test]
+async fn upload_rejects_purpose_package_mismatch() {
+    let fix = build_fixture().await;
+    // purpose=join, but the module lives in vtc.removal.
+    let mismatched = "package vtc.removal\nimport rego.v1\ndefault allow := false\n";
+    let req = auth_request(
+        "POST",
+        "/v1/policies",
+        UPLOAD_TASK,
+        &fix.admin_token,
+        json!({ "purpose": "join", "regoSource": mismatched }),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_json(resp.into_body()).await;
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("vtc.join"),
+        "error must name the expected package: {body}"
+    );
+}
+
 /// Acceptance bullet 2: activate-after-upload swaps the active
 /// pointer and stamps `activated_at` on the row.
 #[tokio::test]
@@ -272,7 +310,7 @@ async fn activate_replaces_predecessor() {
     let fix = build_fixture().await;
     let first = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
     let first_id: Uuid = first["id"].as_str().unwrap().parse().unwrap();
-    let second = upload_policy(&fix, "join", ALT_POLICY).await;
+    let second = upload_policy(&fix, "join", JOIN_ALT_POLICY).await;
     let second_id: Uuid = second["id"].as_str().unwrap().parse().unwrap();
     assert_eq!(second["version"], 2, "second upload bumps version");
 
@@ -330,7 +368,7 @@ async fn test_does_not_mutate_state() {
         TEST_TASK,
         &fix.admin_token,
         json!({
-            "query": "data.vtc.test.allow",
+            "query": "data.vtc.join.allow",
             "input": { "role": "admin" }
         }),
     );
@@ -466,7 +504,7 @@ fn auth_get(uri: &str, task: &str, token: &str) -> Request<Body> {
 async fn list_returns_all_policies() {
     let fix = build_fixture().await;
     let a = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
-    let _b = upload_policy(&fix, "removal", ALT_POLICY).await;
+    let _b = upload_policy(&fix, "removal", REMOVAL_POLICY).await;
     let a_id = a["id"].as_str().unwrap();
 
     // Activate one of them so the isActive flag has signal.
@@ -503,7 +541,7 @@ async fn list_returns_all_policies() {
 async fn list_filters_by_purpose() {
     let fix = build_fixture().await;
     upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
-    upload_policy(&fix, "removal", ALT_POLICY).await;
+    upload_policy(&fix, "removal", REMOVAL_POLICY).await;
 
     let resp = fix
         .router
@@ -529,7 +567,7 @@ async fn list_filters_by_purpose() {
 async fn list_filters_by_status() {
     let fix = build_fixture().await;
     let join = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
-    let removal = upload_policy(&fix, "removal", ALT_POLICY).await;
+    let removal = upload_policy(&fix, "removal", REMOVAL_POLICY).await;
     let join_id = join["id"].as_str().unwrap();
     let _removal_id = removal["id"].as_str().unwrap();
 
@@ -589,7 +627,7 @@ async fn list_filters_by_status() {
 async fn list_active_by_purpose_is_exact_under_limit_one() {
     let fix = build_fixture().await;
     let join = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
-    let removal = upload_policy(&fix, "removal", ALT_POLICY).await;
+    let removal = upload_policy(&fix, "removal", REMOVAL_POLICY).await;
     let join_id = join["id"].as_str().unwrap();
     let removal_id = removal["id"].as_str().unwrap();
 


### PR DESCRIPTION
## P1.5 — Policy upload validates package/purpose match

### Problem
`POST /v1/policies` compiled + stored a policy under the operator-declared `purpose` but never checked the module's Rego **package** matched the purpose's expected package. A mismatch (e.g. a `purpose: join` policy whose source is `package vtc.removal`) compiled + activated cleanly, then evaluated to `undefined` at decision time — which the host reads as a **silent default-deny** for that entire ceremony. The operator saw a clean upload + activate and a community that quietly denied everything.

### Fix
- `PolicyPurpose::expected_package()` — the four ceremony purposes map to a fixed package (`vtc.join` / `vtc.removal` / `vtc.role_change` / `vtc.directory`); other purposes return `None` (not package-validated).
- `policy::validate_purpose_package()` — probes `data.<pkg>.{decision,allow}` against a trivial input and rejects (naming the expected package) when the module yields neither a four-valued `decision` verdict nor a boolean `allow`.
- Wired into **`upload`** (primary gate) and **`activate`** (defense-in-depth for rows that bypassed upload).

### Tests
`validate_purpose_package` unit tests (right package, decision rule, wrong package, missing-default, unpinned-purpose skip); an integration test asserting a purpose/package mismatch → 400 naming `vtc.join`. Migrated the existing policy fixtures off the generic `vtc.test` package onto the package their purpose expects. Full lib (552) + integration suites green.

Plan: `tasks/vtc-architecture-plan.md` P1.5. **This completes Phase 1.**