### PR TITLE
fix(vtc-service): apply config_store overrides onto AppConfig at boot (P1.1 part 2a)

### DIFF
--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -1220,6 +1220,17 @@ Three-layer overlay:
 the `config` keyspace. `POST .../reload` re-applies hot-reloadable
 settings; `POST .../restart` initiates graceful shutdown.
 
+**Boot-time application (P1.1).** The db-overlay (`config` keyspace) is
+**canonical**: at startup `config_store::apply_overrides` folds every
+stored override onto the in-memory `AppConfig` (through the same
+`env > db > toml > default` precedence) *before* anything derives from
+it — the server bind `host`/`port` and the `public_url`-derived WebAuthn
+RP + status-list URLs. Without this a `PATCH` to a `requires_restart`
+key would be stored but never applied, even after the restart it asks
+for. (`log.level` is the exception: the tracing subscriber is
+initialised in `main` before this runs, so its subscriber reload is a
+separate follow-up; the in-memory value is still updated.)
+
 **Restart-endpoint supervisor handshake.** The restart endpoint
 refuses to exit unless a supervisor is detected — either
 `VTC_SUPERVISED=1` or the systemd notify socket (`NOTIFY_SOCKET`)

--- a/vtc-service/src/config_store.rs
+++ b/vtc-service/src/config_store.rs
@@ -318,6 +318,65 @@ pub async fn compute_effective_config(
 }
 
 // ---------------------------------------------------------------------------
+// Boot-time override application
+// ---------------------------------------------------------------------------
+
+/// Write the resolved (effective) `value` for `key` back into the
+/// in-memory [`AppConfig`]. The inverse of [`toml_layer_value`] — one
+/// arm per registry key (the step-4 the [`REGISTRY`] doc references).
+///
+/// A type mismatch is skipped rather than panicked: the value was
+/// validated by the PATCH that stored it, so a mismatch here means a
+/// corrupt row, and a corrupt row must not take down boot.
+fn set_app_config_field(cfg: &mut AppConfig, key: &str, value: &Value) {
+    match key {
+        "server.host" => {
+            if let Some(s) = value.as_str() {
+                cfg.server.host = s.to_string();
+            }
+        }
+        "server.port" => match value.as_u64().and_then(|n| u16::try_from(n).ok()) {
+            Some(p) => cfg.server.port = p,
+            None => tracing::warn!(
+                %value,
+                "config override `server.port` is not a valid u16 — ignored"
+            ),
+        },
+        "log.level" => {
+            if let Some(s) = value.as_str() {
+                cfg.log.level = s.to_string();
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Fold the db-overlay (the `config` keyspace) onto the in-memory
+/// [`AppConfig`] at boot, so an operator's runtime PATCHes actually
+/// take effect.
+///
+/// This is the step that makes `config_store` **canonical** (P1.1):
+/// without it a `PATCH /v1/admin/config` against a `requires_restart`
+/// key (the server bind host/port) is stored but never applied — even
+/// after the restart it asks for, because boot read only TOML + env.
+/// Resolves every registry key through the same
+/// `env > db > toml > default` precedence [`compute_effective_config`]
+/// uses, then writes the resolved value back into `cfg`.
+///
+/// **`log.level` caveat:** the tracing subscriber is initialised from
+/// `cfg.log.level` in `main` *before* this runs, so a db-override of
+/// `log.level` updates the in-memory config but not the already-live
+/// filter — wiring the subscriber reload is the same separate follow-up
+/// `reload_config` documents.
+pub async fn apply_overrides(cfg: &mut AppConfig, db: &ConfigStore) -> Result<(), AppError> {
+    let eff = compute_effective_config(cfg, db).await?;
+    for field in eff.fields {
+        set_app_config_field(cfg, &field.key, &field.value);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
 
@@ -509,5 +568,64 @@ mod tests {
         assert!(host.requires_restart);
         let level = eff.fields.iter().find(|f| f.key == "log.level").unwrap();
         assert!(!level.requires_restart);
+    }
+
+    // ── apply_overrides (P1.1: boot folds the db overlay onto AppConfig) ──
+
+    #[tokio::test]
+    async fn apply_overrides_writes_db_layer_into_config() {
+        let (store, _dir) = temp_store();
+        let mut cfg = default_app_config();
+        assert_eq!(cfg.server.host, "0.0.0.0");
+        assert_eq!(cfg.server.port, 8200);
+
+        store.put("server.host", &json!("10.0.0.5")).await.unwrap();
+        store.put("server.port", &json!(9100)).await.unwrap();
+        store.put("log.level", &json!("debug")).await.unwrap();
+
+        apply_overrides(&mut cfg, &store).await.unwrap();
+
+        assert_eq!(cfg.server.host, "10.0.0.5");
+        assert_eq!(cfg.server.port, 9100);
+        assert_eq!(cfg.log.level, "debug");
+    }
+
+    #[tokio::test]
+    async fn apply_overrides_preserves_toml_when_no_db_override() {
+        let (store, _dir) = temp_store();
+        let mut cfg = default_app_config();
+        cfg.server.host = "192.168.1.1".into(); // toml-layer value
+        cfg.server.port = 8443;
+
+        apply_overrides(&mut cfg, &store).await.unwrap();
+
+        assert_eq!(cfg.server.host, "192.168.1.1");
+        assert_eq!(cfg.server.port, 8443);
+    }
+
+    #[tokio::test]
+    async fn apply_overrides_db_beats_toml() {
+        let (store, _dir) = temp_store();
+        let mut cfg = default_app_config();
+        cfg.server.port = 8443; // toml-layer
+        store.put("server.port", &json!(9100)).await.unwrap();
+
+        apply_overrides(&mut cfg, &store).await.unwrap();
+
+        assert_eq!(cfg.server.port, 9100, "db override must win over toml");
+    }
+
+    #[tokio::test]
+    async fn apply_overrides_ignores_out_of_range_port() {
+        // The U64 registry kind accepts any u64, but the field is u16 —
+        // a stored 70000 is a corrupt row and must not be applied.
+        let (store, _dir) = temp_store();
+        let mut cfg = default_app_config();
+        cfg.server.port = 8443;
+        store.put("server.port", &json!(70_000)).await.unwrap();
+
+        apply_overrides(&mut cfg, &store).await.unwrap();
+
+        assert_eq!(cfg.server.port, 8443, "out-of-range port override ignored");
     }
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -198,7 +198,7 @@ impl PasskeyState for AppState {
 }
 
 pub async fn run(
-    config: AppConfig,
+    mut config: AppConfig,
     store: Store,
     secret_store: Box<dyn SecretStore>,
 ) -> Result<(), AppError> {
@@ -207,6 +207,19 @@ pub async fn run(
     let acl_ks = store.keyspace("acl")?;
     let community_ks = store.keyspace("community")?;
     let config_ks = store.keyspace("config")?;
+
+    // P1.1: `config_store` (the db overlay) is canonical for the runtime
+    // config keys — fold any operator PATCHes onto the in-memory config
+    // *before* anything derives from it. The server bind address
+    // (`server.host`/`server.port`) and the `public_url`-derived WebAuthn
+    // RP + status-list URLs are all read from `config` below; without this
+    // a PATCH to a `requires_restart` key is stored but never applied,
+    // even after the restart it asks for.
+    crate::config_store::apply_overrides(
+        &mut config,
+        &crate::config_store::ConfigStore::new(config_ks.clone()),
+    )
+    .await?;
     let passkey_ks = store.keyspace("passkey")?;
     let install_ks = store.keyspace("install")?;
     // `install_store` is built later (after `init_auth` yields the storage


### PR DESCRIPTION
## P1.1 part 2a — close the latent boot gap

The db-overlay (`config` keyspace) is meant to be the **canonical** runtime-config surface (`env > db_overrides > toml > defaults`), but the boot path read only TOML + env. So a `PATCH /v1/admin/config` against a `requires_restart` key (`server.host`/`server.port`) was stored and **never applied — even after the restart it asks for**. The plan flags this as the prerequisite for migrating `public_url` into `config_store`.

### Change
- `config_store::apply_overrides(cfg, db)` — resolves every registry key through the same `env > db > toml > default` precedence `compute_effective_config` uses, then writes the result back into `AppConfig` (`set_app_config_field`, the inverse of `toml_layer_value`).
- `server::run` now takes `mut config` and folds the overlay on **right after the config keyspace opens** — before the bind address and the `public_url`-derived WebAuthn RP + status-list URLs are read.
- A corrupt/out-of-range row (e.g. a `server.port` stored as a valid `u64` that doesn't fit `u16`) is logged and skipped, not fatal.
- `log.level` is applied to the in-memory config, but the live tracing subscriber is initialised in `main` before `run()` — its subscriber-reload remains the separate follow-up `reload_config` already documents.

### Scope
This is **part 2a**: it closes the latent gap and makes `server.host`/`server.port` actually restart-effective. **Part 2b** (migrating `public_url`'s write path off `config.toml` onto the `config_store` overlay — touching the legacy `/v1/config` surface) is now unblocked and follows separately.

### Tests
`apply_overrides` writes db→config, preserves toml when no override, db-beats-toml, and ignores an out-of-range port. Full lib (562) + config/admin integration suites green.

Plan: `tasks/vtc-architecture-plan.md` P1.1.