### PR TITLE
refactor(vta): extract vault/release logic to operations (P2.4 part 1)

### DIFF
--- a/vta-service/src/operations/vault/mod.rs
+++ b/vta-service/src/operations/vault/mod.rs
@@ -11,17 +11,51 @@
 //! land in M2B.5 — they'll grow this module rather than the handler's
 //! file so the auth-elevated paths stay scoped here.
 
+use affinidi_messaging_didcomm::Message;
 use affinidi_secrets_resolver::secrets::Secret;
+use affinidi_tdk::messaging::ATM;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ed25519_dalek::{Signer, SigningKey};
 use serde_json::json;
+use uuid::Uuid;
 
 use crate::error::AppError;
 use crate::keys::seed_store::SeedStore;
 use crate::operations::internal_authority::InternalAuthority;
 use crate::store::KeyspaceHandle;
 use vta_sdk::did_key::decode_private_key_multibase;
+
+/// `vault/release/0.1` sealing logic.
+pub mod release;
+
+/// DIDComm `Message.typ` for the release envelope's cleartext. Workspace-
+/// namespaced (not a Trust Task URI) — purely transport metadata inside the
+/// JWE; the consumer parses the JWE body as `VaultSecret` directly per the
+/// `vault/release/0.1` spec.
+pub const RELEASE_INNER_MSG_TYPE: &str = "https://openvtc.org/vault/release/secret-envelope/1.0";
+
+/// Authcrypt `body` from the VTA (`vta_did`) to `holder_did`, returning the
+/// JWE. Shared by the release + proxy-login flows — both seal a cleartext body
+/// (a `VaultSecret` / a `SessionBlob`) to the calling holder, signed and
+/// encrypted as the VTA. `inner_type` is the inner DIDComm `Message.typ`.
+pub async fn authcrypt_to_holder(
+    atm: &ATM,
+    vta_did: &str,
+    holder_did: &str,
+    inner_type: &str,
+    body: serde_json::Value,
+) -> Result<String, AppError> {
+    let msg = Message::build(Uuid::new_v4().to_string(), inner_type.to_string(), body)
+        .from(vta_did.to_string())
+        .to(holder_did.to_string())
+        .finalize();
+    let (jwe, _metadata) = atm
+        .pack_encrypted(&msg, holder_did, Some(vta_did), Some(vta_did))
+        .await
+        .map_err(|e| AppError::Internal(format!("pack_encrypted failed: {e}")))?;
+    Ok(jwe)
+}
 
 /// HTTP-POST driver for vault/proxy-login/0.1 against
 /// `VaultSecret::Password` entries with a populated `loginConfig`.

--- a/vta-service/src/operations/vault/release.rs
+++ b/vta-service/src/operations/vault/release.rs
@@ -1,0 +1,84 @@
+//! `vault/release/0.1` business logic — seal a stored secret to the holder
+//! over DIDComm authcrypt (P2.4).
+//!
+//! Moved out of `routes/trust_tasks/vault.rs` so the route handler is a thin
+//! adapter (gate → parse → load → context-scope → step-up → call this → map
+//! to the wire response). The capability/context/step-up gates and the
+//! `atm`/`vta_did` readiness checks stay in the route; everything below is the
+//! operations work.
+
+use affinidi_tdk::messaging::ATM;
+
+use vti_common::vault::{SecretKind, StoredVaultEntry, put_stored_vault_entry};
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+/// M2A.3 release TTL ceiling (seconds). A higher client hint silently caps
+/// rather than rejecting.
+pub const TTL_CEILING_SECS: u32 = 60;
+
+/// The sealed secret + the metadata the route needs to build the
+/// `vault/release/0.1#response`.
+pub struct ReleasedSecret {
+    /// DIDComm-authcrypt JWE carrying the `VaultSecret` cleartext.
+    pub jwe: String,
+    /// Echoed back so the consumer knows how to parse the unsealed body.
+    pub secret_kind: SecretKind,
+    /// Effective TTL after capping the caller's hint.
+    pub ttl_seconds: u32,
+}
+
+/// Seal `stored`'s secret to `holder_did` (authcrypt, signed as `vta_did`) and
+/// bump `lastUsedAt` (best-effort, server-managed metadata — **not** a version
+/// bump, so a concurrent upsert with a stale `expectedVersion` still
+/// validates).
+///
+/// The caller has already gated capability + context scope + step-up and
+/// resolved `atm` / `vta_did`.
+pub async fn release_secret(
+    atm: &ATM,
+    vault_ks: &KeyspaceHandle,
+    vta_did: &str,
+    holder_did: &str,
+    mut stored: StoredVaultEntry,
+    ttl_hint: Option<u32>,
+) -> Result<ReleasedSecret, AppError> {
+    let ttl_seconds = ttl_hint
+        .map(|t| t.min(TTL_CEILING_SECS))
+        .unwrap_or(TTL_CEILING_SECS);
+
+    // Per the canonical sealed-envelope schema, the cleartext inside the JWE is
+    // the `VaultSecret` JSON directly.
+    let secret_body = serde_json::to_value(&stored.secret).map_err(|e| {
+        AppError::Internal(format!("vault/release: failed to serialise secret: {e}"))
+    })?;
+
+    let jwe = super::authcrypt_to_holder(
+        atm,
+        vta_did,
+        holder_did,
+        super::RELEASE_INNER_MSG_TYPE,
+        secret_body,
+    )
+    .await?;
+
+    let secret_kind = stored.entry.secret_kind;
+
+    // Persist failure isn't fatal — the secret has been sealed and is on its
+    // way; log so an operator can see lastUsedAt drift if it ever happens.
+    stored.entry.last_used_at = Some(chrono::Utc::now().to_rfc3339());
+    if let Err(e) = put_stored_vault_entry(vault_ks, &stored).await {
+        tracing::warn!(
+            entry_id = %stored.entry.id,
+            error = %e,
+            "vault/release: lastUsedAt update failed; secret release proceeded"
+        );
+    }
+
+    Ok(ReleasedSecret {
+        jwe,
+        secret_kind,
+        ttl_seconds,
+    })
+}

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -273,13 +273,6 @@ enum SealedEnvelopeWire {
     DidcommAuthcrypt { jwe: String },
 }
 
-/// DIDComm `Message.typ` for the release envelope's cleartext. Workspace-
-/// namespaced (not a Trust Task URI) — this is purely transport metadata
-/// inside the JWE; the outer Trust Task envelope carries the
-/// `vault/release/0.1#response` type and the consumer parses the JWE
-/// body as `VaultSecret` directly per the spec.
-const RELEASE_INNER_MSG_TYPE: &str = "https://openvtc.org/vault/release/secret-envelope/1.0";
-
 /// DIDComm `Message.typ` for the proxy-login envelope's cleartext.
 /// Counterpart of [`RELEASE_INNER_MSG_TYPE`] for the SessionBlob the
 /// wallet receives. Same workspace namespace; the JWE body is a
@@ -1049,7 +1042,7 @@ pub(super) async fn handle_release(
         Err(resp) => return resp,
     };
 
-    let mut stored = match get_stored_vault_entry(&state.vault_ks, &req.entry_id).await {
+    let stored = match get_stored_vault_entry(&state.vault_ks, &req.entry_id).await {
         Ok(Some(e)) => e,
         Ok(None) => {
             return reject_with(
@@ -1077,9 +1070,8 @@ pub(super) async fn handle_release(
         return reject;
     }
 
-    // ATM is required for outbound authcrypt. Pre-flight check before
-    // we build the message so the error is clearly "infrastructure not
-    // configured" rather than a packing failure mid-flow.
+    // ATM + vta_did readiness — checked here so the error is clearly
+    // "infrastructure not configured" rather than a packing failure mid-flow.
     let atm = match state.atm.as_ref() {
         Some(atm) => atm,
         None => {
@@ -1091,97 +1083,40 @@ pub(super) async fn handle_release(
             );
         }
     };
-
-    let vta_did = {
-        let config = state.config.read().await;
-        match config.vta_did.clone() {
-            Some(d) => d,
-            None => {
-                return reject_with(
-                    &doc,
-                    RejectReason::InternalError {
-                        reason: "vta_did not configured — server cannot identify itself as signer"
-                            .into(),
-                    },
-                );
-            }
-        }
-    };
-
-    // Cap TTL. Client hint is honoured up to the M2A.3 ceiling (60s);
-    // a higher hint silently caps rather than rejecting.
-    const TTL_CEILING: u32 = 60;
-    let ttl_seconds = req
-        .ttl_seconds_hint
-        .map(|t| t.min(TTL_CEILING))
-        .unwrap_or(TTL_CEILING);
-
-    // Serialise the VaultSecret as the cleartext body of the inner
-    // DIDComm message. Per the canonical sealed-envelope schema, the
-    // cleartext inside the JWE is the VaultSecret JSON directly.
-    let secret_body = match serde_json::to_value(&stored.secret) {
-        Ok(v) => v,
-        Err(e) => {
+    let vta_did = match state.config.read().await.vta_did.clone() {
+        Some(d) => d,
+        None => {
             return reject_with(
                 &doc,
                 RejectReason::InternalError {
-                    reason: format!("vault/release: failed to serialise secret: {e}"),
+                    reason: "vta_did not configured — server cannot identify itself as signer"
+                        .into(),
                 },
             );
         }
     };
 
-    let msg = Message::build(
-        Uuid::new_v4().to_string(),
-        RELEASE_INNER_MSG_TYPE.to_string(),
-        secret_body,
+    // Seal the secret to the holder (operations layer; P2.4).
+    match crate::operations::vault::release::release_secret(
+        atm,
+        &state.vault_ks,
+        &vta_did,
+        &auth.did,
+        stored,
+        req.ttl_seconds_hint,
     )
-    .from(vta_did.clone())
-    .to(auth.did.clone())
-    .finalize();
-
-    let (jwe, _metadata) = match atm
-        .pack_encrypted(&msg, &auth.did, Some(&vta_did), Some(&vta_did))
-        .await
+    .await
     {
-        Ok(packed) => packed,
-        Err(e) => {
-            return reject_with(
-                &doc,
-                RejectReason::InternalError {
-                    reason: format!("vault/release: pack_encrypted failed: {e}"),
-                },
-            );
-        }
-    };
-
-    // Update lastUsedAt on the stored entry. Server-managed metadata —
-    // NOT a version bump (that's reserved for user-visible mutations
-    // gated by optimistic concurrency). A concurrent upsert with a
-    // stale expectedVersion still validates against the version this
-    // release didn't touch.
-    let now = chrono::Utc::now().to_rfc3339();
-    stored.entry.last_used_at = Some(now);
-    if let Err(e) = put_stored_vault_entry(&state.vault_ks, &stored).await {
-        // Persist failure isn't fatal — the secret has been sealed and
-        // is on its way. Log via the audit reject path so an operator
-        // can see lastUsedAt drift if it ever happens.
-        tracing::warn!(
-            entry_id = %stored.entry.id,
-            error = %e,
-            "vault/release: lastUsedAt update failed; secret release proceeded"
-        );
+        Ok(out) => success_response(
+            &doc,
+            VaultReleaseResponseBody {
+                sealed_secret: SealedEnvelopeWire::DidcommAuthcrypt { jwe: out.jwe },
+                secret_kind: out.secret_kind,
+                ttl_seconds: out.ttl_seconds,
+            },
+        ),
+        Err(e) => app_error_to_reject(&doc, e),
     }
-
-    let secret_kind = stored.entry.secret_kind;
-    success_response(
-        &doc,
-        VaultReleaseResponseBody {
-            sealed_secret: SealedEnvelopeWire::DidcommAuthcrypt { jwe },
-            secret_kind,
-            ttl_seconds,
-        },
-    )
 }
 
 /// Per-driver TTL ceilings. SIOP is capped by the underlying id_token's


### PR DESCRIPTION
## P2.4(b) part 1 — vault/release → operations

First increment of moving the password-vault handlers' business logic out of `routes/trust_tasks/vault.rs` (~2k LOC) into the `operations/` layer, so the route handlers become thin `gate → parse → load → scope → step-up → call → map` adapters. The **P2.0 wire tests (#403)** are the behaviour-preserving safety net.

This part extracts `vault/release` and the **shared authcrypt tail** that proxy-login will reuse:

- **`operations::vault::authcrypt_to_holder`** — builds + packs a DIDComm authcrypt envelope from the VTA to the calling holder (the tail shared by release + proxy-login). `RELEASE_INNER_MSG_TYPE` moves here too.
- **`operations::vault::release::release_secret`** — seals a stored `VaultSecret` to the holder and bumps `lastUsedAt` (best-effort, not a version bump), returning the JWE + `secret_kind` + capped TTL.
- **`handle_release`** reduced from ~175 to ~45 lines: gate, parse, load (not-found reject), `enforce_context_scope`, step-up gate, atm/vta_did readiness, then call `release_secret` and map Ok→success / Err→reject. **Behaviour unchanged.**

### Incremental plan
Same per-step discipline as P0.2a/b/c. Follow-ups land the file toward the ≤450-LOC acceptance target:
- part 2 — proxy-login drivers (SIOP + password-POST) + session-blob builders (the bulk, reuses `authcrypt_to_holder`),
- part 3 — sign-trust-task signing,
- part 4 — upsert unseal.

`vault.rs` 2096 → 2031 here.

### Verification
P2.0's 12 vault wire tests green **unchanged**; fmt + clippy clean (all-targets); full vta-service suite (965) green.
