### PR TITLE
fix(vtc-service): make public_url canonical in config_store (P1.1 part 2b)

### DIFF
--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -1231,6 +1231,11 @@ for. (`log.level` is the exception: the tracing subscriber is
 initialised in `main` before this runs, so its subscriber reload is a
 separate follow-up; the in-memory value is still updated.)
 
+`public_url` is itself a `requires_restart` registry key (P1.1 part 2b):
+both `PATCH /v1/admin/config` and the legacy `PATCH /v1/config` write it
+to the db-overlay — there is no `config.toml` round-trip — and boot
+applies it like any other overlay key.
+
 **Restart-endpoint supervisor handshake.** The restart endpoint
 refuses to exit unless a supervisor is detected — either
 `VTC_SUPERVISED=1` or the systemd notify socket (`NOTIFY_SOCKET`)

--- a/vtc-service/src/config_store.rs
+++ b/vtc-service/src/config_store.rs
@@ -129,6 +129,16 @@ pub const REGISTRY: &[ConfigKeyDef] = &[
         requires_restart: false,
         sensitive: false,
     },
+    // The operational RP origin: the WebAuthn relying-party handle +
+    // every VMC's `credentialStatus` status-list URL derive from it at
+    // boot, so a change needs a restart. Canonical in the db-overlay
+    // (P1.1 part 2b) — no longer round-tripped through `config.toml`.
+    ConfigKeyDef {
+        key: "public_url",
+        kind: ConfigKeyKind::String,
+        requires_restart: true,
+        sensitive: false,
+    },
 ];
 
 /// Look up a key's metadata. `None` means the key is not
@@ -254,6 +264,9 @@ fn toml_layer_value(key: &str, cfg: &AppConfig) -> Option<Value> {
                 Some(Value::String(cfg.log.level.clone()))
             }
         }
+        // `public_url` has no compiled-in default — `None` (unset) is the
+        // default, so any configured value is the toml-layer value.
+        "public_url" => cfg.public_url.clone().map(Value::String),
         _ => None,
     }
 }
@@ -267,6 +280,9 @@ fn default_layer_value(key: &str) -> Value {
         "server.host" => Value::String(default_host_value()),
         "server.port" => Value::Number(serde_json::Number::from(default_port_value())),
         "log.level" => Value::String("info".into()),
+        // No compiled-in default: `null` means "unset" (pre-setup
+        // deployment — WebAuthn / status lists deferred).
+        "public_url" => Value::Null,
         _ => Value::Null, // unreachable for registry keys
     }
 }
@@ -283,6 +299,7 @@ fn env_layer_value(key: &str) -> Option<Value> {
             .and_then(|s| s.parse::<u64>().ok())
             .map(|n| Value::Number(serde_json::Number::from(n))),
         "log.level" => std::env::var("VTC_LOG_LEVEL").ok().map(Value::String),
+        "public_url" => std::env::var("VTC_PUBLIC_URL").ok().map(Value::String),
         _ => None,
     }
 }
@@ -346,6 +363,12 @@ fn set_app_config_field(cfg: &mut AppConfig, key: &str, value: &Value) {
             if let Some(s) = value.as_str() {
                 cfg.log.level = s.to_string();
             }
+        }
+        // A string sets it; `null` (the default layer, i.e. unset) leaves
+        // it `None`. A configured value resolves via `toml_layer_value`,
+        // so an absent db override never clears a TOML-set `public_url`.
+        "public_url" => {
+            cfg.public_url = value.as_str().map(str::to_string);
         }
         _ => {}
     }
@@ -627,5 +650,38 @@ mod tests {
         apply_overrides(&mut cfg, &store).await.unwrap();
 
         assert_eq!(cfg.server.port, 8443, "out-of-range port override ignored");
+    }
+
+    #[tokio::test]
+    async fn apply_overrides_public_url_db_beats_toml_and_preserves_toml() {
+        let (store, _dir) = temp_store();
+        let mut cfg = default_app_config();
+        cfg.public_url = Some("https://toml.example".into()); // toml-layer
+
+        // No db override → toml value preserved.
+        apply_overrides(&mut cfg, &store).await.unwrap();
+        assert_eq!(cfg.public_url.as_deref(), Some("https://toml.example"));
+
+        // db override wins.
+        store
+            .put("public_url", &json!("https://db.example"))
+            .await
+            .unwrap();
+        apply_overrides(&mut cfg, &store).await.unwrap();
+        assert_eq!(cfg.public_url.as_deref(), Some("https://db.example"));
+    }
+
+    #[tokio::test]
+    async fn apply_overrides_public_url_unset_stays_none() {
+        let (store, _dir) = temp_store();
+        let mut cfg = default_app_config();
+        assert!(cfg.public_url.is_none());
+        // No db override + no toml value → default layer (null) → stays None,
+        // never spuriously set to an empty string.
+        apply_overrides(&mut cfg, &store).await.unwrap();
+        assert!(
+            cfg.public_url.is_none(),
+            "no override → public_url stays unset"
+        );
     }
 }

--- a/vtc-service/src/routes/config.rs
+++ b/vtc-service/src/routes/config.rs
@@ -11,19 +11,13 @@
 //!   `vtc_name` / `vtc_description` are applied to the profile, and
 //!   `GET /v1/config` reads them back from the profile — so there is one write
 //!   path per field, not two diverging copies.
-//! - **`public_url` is persisted env-safely + atomically.** It is the
-//!   operational RP origin the WebAuthn handle + status-list URLs derive from at
-//!   boot, so it stays in `config.toml`; the write re-reads the on-disk TOML as
-//!   its base (ephemeral `VTC_*` env overlays never leak in), writes
-//!   tempfile-then-rename, and re-restricts perms. It is boot-stable, so the
-//!   response flags it under `pending_restart`.
-//!
-//! Migrating `public_url` into the `config_store` overlay as a
-//! `requires_restart` key (so it shares the canonical PATCH surface) is the
-//! follow-up increment — it needs the boot path to apply `config_store`
-//! overrides, which it does not yet.
-
-use std::path::Path;
+//! - **`public_url` is canonical in the `config_store` overlay** (P1.1 part 2b).
+//!   It is the operational RP origin the WebAuthn handle + status-list URLs
+//!   derive from at boot, so it's `requires_restart`: a PATCH writes it to the
+//!   db-overlay (not `config.toml`) and `config_store::apply_overrides` folds it
+//!   onto `AppConfig` at the next boot. Both this surface and
+//!   `PATCH /v1/admin/config` now write the same place — one canonical store,
+//!   no `config.toml` round-trip. The response flags it under `pending_restart`.
 
 use axum::Json;
 use axum::extract::State;
@@ -33,6 +27,7 @@ use tracing::info;
 
 use crate::auth::{AuthClaims, SuperAdminAuth};
 use crate::community::{CommunityProfileUpdate, load_profile, store_profile};
+use crate::config_store::ConfigStore;
 use crate::error::AppError;
 use crate::server::AppState;
 
@@ -77,18 +72,34 @@ async fn resolved_name_description(
     }
 }
 
+/// Resolve the effective `public_url` — the value in force, or pending after
+/// a restart: `env > db-overlay > in-memory (toml/boot)`. After a PATCH the
+/// db-overlay carries the new value, so GET reflects it even though it is
+/// `requires_restart` and not yet live. Mirrors `config_store`'s precedence.
+async fn resolved_public_url(state: &AppState) -> Result<Option<String>, AppError> {
+    if let Ok(v) = std::env::var("VTC_PUBLIC_URL") {
+        return Ok(Some(v));
+    }
+    let store = ConfigStore::new(state.config_ks.clone());
+    if let Some(v) = store.get("public_url").await? {
+        return Ok(v.as_str().map(str::to_string));
+    }
+    Ok(state.config.read().await.public_url.clone())
+}
+
 pub async fn get_config(
     auth: AuthClaims,
     State(state): State<AppState>,
 ) -> Result<Json<ConfigResponse>, AppError> {
     let (vtc_name, vtc_description) = resolved_name_description(&state).await?;
-    let config = state.config.read().await;
+    let public_url = resolved_public_url(&state).await?;
+    let vtc_did = state.config.read().await.vtc_did.clone();
     info!(caller = %auth.did, "config retrieved");
     Ok(Json(ConfigResponse {
-        vtc_did: config.vtc_did.clone(),
+        vtc_did,
         vtc_name,
         vtc_description,
-        public_url: config.public_url.clone(),
+        public_url,
     }))
 }
 
@@ -130,120 +141,37 @@ pub async fn update_config(
         }
     }
 
-    // public_url → the operational RP origin (WebAuthn + status-list URLs derive
-    // from it at boot). Persist env-safely + atomically; restart required.
+    // public_url → the `config_store` db-overlay (canonical, P1.1 part 2b). It
+    // is the operational RP origin (WebAuthn + status-list URLs derive from it
+    // at boot), so it's `requires_restart`: stored now, folded onto `AppConfig`
+    // at the next boot by `apply_overrides`. We deliberately do NOT touch the
+    // in-memory value — mutating it would diverge the live derived state (the
+    // already-built WebAuthn RP) from the stored config.
     if let Some(public_url) = req.public_url.clone() {
-        let path = {
-            let mut config = state.config.write().await;
-            config.public_url = Some(public_url.clone());
-            config.config_path.clone()
-        };
-        persist_public_url(&path, Some(&public_url))?;
+        let store = ConfigStore::new(state.config_ks.clone());
+        store
+            .put("public_url", &serde_json::Value::String(public_url))
+            .await?;
         pending_restart.push("public_url".into());
     }
 
     let (vtc_name, vtc_description) = resolved_name_description(&state).await?;
-    let config = state.config.read().await;
+    let public_url = resolved_public_url(&state).await?;
+    let vtc_did = state.config.read().await.vtc_did.clone();
     info!(caller = %auth.0.did, ?pending_restart, "config updated");
     Ok(Json(UpdateConfigResponse {
         config: ConfigResponse {
-            vtc_did: config.vtc_did.clone(),
+            vtc_did,
             vtc_name,
             vtc_description,
-            public_url: config.public_url.clone(),
+            public_url,
         },
         pending_restart,
     }))
 }
 
-/// Persist `public_url` into `config.toml` **env-safely** and **atomically**.
-///
-/// Re-reads the on-disk TOML as the base so the ephemeral `VTC_*` env overlays
-/// folded into the in-memory `AppConfig` are never baked into the file (P1.1) —
-/// only the single `public_url` key is touched. Writes tempfile-then-rename for
-/// atomicity and re-restricts the file to its owner (it holds the JWT signing
-/// key, and under the config-secret backend the key bundle).
-fn persist_public_url(path: &Path, public_url: Option<&str>) -> Result<(), AppError> {
-    let existing = std::fs::read_to_string(path).map_err(AppError::Io)?;
-    let mut doc: toml::Table = toml::from_str(&existing)
-        .map_err(|e| AppError::Config(format!("failed to parse {}: {e}", path.display())))?;
-    match public_url {
-        Some(url) => {
-            doc.insert("public_url".into(), toml::Value::String(url.to_string()));
-        }
-        None => {
-            doc.remove("public_url");
-        }
-    }
-    let contents = toml::to_string_pretty(&doc)
-        .map_err(|e| AppError::Config(format!("failed to serialize config: {e}")))?;
-
-    let file_name = path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("config.toml");
-    let dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let tmp = dir.join(format!(".{file_name}.tmp"));
-
-    std::fs::write(&tmp, contents).map_err(AppError::Io)?;
-    // Harden the temp file *before* the rename so the published file is never
-    // briefly world-readable.
-    crate::secure_file::restrict_file_to_owner(&tmp).map_err(AppError::Io)?;
-    std::fs::rename(&tmp, path).map_err(AppError::Io)?;
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::Write;
-
-    #[test]
-    fn persist_public_url_is_env_safe_and_atomic() {
-        // The on-disk base has no env-sourced values; updating public_url must
-        // leave every other key exactly as written (no env-overlay bake-in).
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("config.toml");
-        let mut f = std::fs::File::create(&path).unwrap();
-        writeln!(
-            f,
-            "vtc_did = \"did:webvh:vtc.example\"\n\
-             [server]\nhost = \"127.0.0.1\"\nport = 8200\n"
-        )
-        .unwrap();
-        drop(f);
-
-        persist_public_url(&path, Some("https://vtc.example.com")).unwrap();
-
-        let written = std::fs::read_to_string(&path).unwrap();
-        let doc: toml::Table = toml::from_str(&written).unwrap();
-        assert_eq!(
-            doc.get("public_url").and_then(|v| v.as_str()),
-            Some("https://vtc.example.com")
-        );
-        // Untouched keys survive verbatim.
-        assert_eq!(
-            doc.get("vtc_did").and_then(|v| v.as_str()),
-            Some("did:webvh:vtc.example")
-        );
-        let server = doc.get("server").and_then(|v| v.as_table()).unwrap();
-        assert_eq!(
-            server.get("host").and_then(|v| v.as_str()),
-            Some("127.0.0.1")
-        );
-        assert_eq!(server.get("port").and_then(|v| v.as_integer()), Some(8200));
-
-        // No leftover temp file.
-        assert!(!dir.path().join(".config.toml.tmp").exists());
-    }
-
-    #[test]
-    fn persist_public_url_none_removes_the_key() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("config.toml");
-        std::fs::write(&path, "public_url = \"https://old.example\"\n").unwrap();
-        persist_public_url(&path, None).unwrap();
-        let doc: toml::Table = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert!(doc.get("public_url").is_none());
-    }
-}
+// Behavioural coverage lives in `tests/config_legacy.rs` — the
+// `public_url` write path now stores to the `config_store` db-overlay
+// (canonical, P1.1 part 2b) rather than rewriting `config.toml`, so the
+// round-trip is exercised through the full router stack there. Per-key
+// overlay precedence is unit-tested in `crate::config_store::tests`.

--- a/vtc-service/tests/config_legacy.rs
+++ b/vtc-service/tests/config_legacy.rs
@@ -12,6 +12,7 @@ use serde_json::{Value, json};
 use tower::ServiceExt;
 
 use vtc_service::community::{CommunityProfile, store_profile};
+use vtc_service::config_store::ConfigStore;
 use vtc_service::server::AppState;
 use vtc_service::test_support::TestVtc;
 
@@ -166,19 +167,14 @@ async fn patch_name_without_a_profile_is_409() {
 }
 
 #[tokio::test]
-async fn patch_public_url_flags_pending_restart_and_persists_to_toml() {
+async fn patch_public_url_flags_pending_restart_and_stores_in_config_store() {
     let fix = build().await;
     let token = super_admin_token(&fix).await;
 
-    // Point the in-memory config at a real on-disk config.toml so the
-    // env-safe atomic write has a base to read.
-    let cfg_dir = tempfile::tempdir().unwrap();
-    let cfg_path = cfg_dir.path().join("config.toml");
-    std::fs::write(&cfg_path, "vtc_did = \"did:webvh:vtc.example.com:abc\"\n").unwrap();
-    {
-        let mut c = fix.state.config.write().await;
-        c.config_path = cfg_path.clone();
-    }
+    // The running (in-memory) value before the PATCH — must be untouched, since
+    // public_url is requires_restart (mutating it would diverge the live
+    // WebAuthn RP / status-list URLs from the stored config).
+    let before = fix.state.config.read().await.public_url.clone();
 
     let (status, body) = send(
         &fix,
@@ -195,15 +191,20 @@ async fn patch_public_url_flags_pending_restart_and_persists_to_toml() {
     );
     assert_eq!(body["public_url"], "https://vtc.example.com");
 
-    // Persisted to the on-disk TOML, base preserved.
-    let written = std::fs::read_to_string(&cfg_path).unwrap();
-    let doc: toml::Table = toml::from_str(&written).unwrap();
+    // Canonical store: the db-overlay (`config` keyspace), NOT config.toml.
+    let store = ConfigStore::new(fix.state.config_ks.clone());
     assert_eq!(
-        doc.get("public_url").and_then(|v| v.as_str()),
-        Some("https://vtc.example.com")
+        store.get("public_url").await.unwrap(),
+        Some(json!("https://vtc.example.com")),
+        "public_url must be stored in the config_store overlay"
     );
-    assert_eq!(
-        doc.get("vtc_did").and_then(|v| v.as_str()),
-        Some("did:webvh:vtc.example.com:abc")
-    );
+
+    // Running value untouched (applied only at the next boot).
+    assert_eq!(fix.state.config.read().await.public_url, before);
+
+    // GET reflects the pending value (reads the overlay), with pending_restart
+    // already signalled on the PATCH.
+    let (status, body) = send(&fix, "GET", &token, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["public_url"], "https://vtc.example.com");
 }


### PR DESCRIPTION
## P1.1 part 2b — public_url onto the config_store overlay

`public_url` is the operational RP origin (the WebAuthn handle + every VMC's `credentialStatus` status-list URL derive from it at boot). Part 1 (#396) kept it in `config.toml`, persisted via a bespoke env-safe atomic TOML rewrite — a **second config-write path** divergent from the `config_store` overlay the admin surface uses. Now that boot folds the overlay onto `AppConfig` (#405, part 2a), this migrates `public_url` onto `config_store` so both doors write one canonical store.

### Change
- **Registry:** `public_url` is now a `requires_restart` `String` registry key, with toml/default/env/set arms. Default layer is `null` (= unset), so an absent db override never clears a TOML-configured value and an unset key never becomes an empty string. `PATCH /v1/admin/config` drives it for free.
- **Legacy `PATCH /v1/config`:** writes `public_url` to `config_store` (not `config.toml`) and no longer mutates the in-memory value — mutating it would diverge the live WebAuthn RP from the stored config. `persist_public_url` + its TOML-rewrite helper are removed.
- **GET /v1/config** (and the PATCH response) resolve the *effective* `public_url` (`env > db-overlay > in-memory`), so a PATCH is reflected, with `pending_restart` signalling it takes effect at the next boot.

### Tests
`config_store` apply_overrides for `public_url` (db-beats-toml, toml preserved, unset→None); `config_legacy` PATCH asserts `config_store` persistence + untouched running value + GET reflects it. Full lib (562) + config/admin integration suites green.

Plan: `tasks/vtc-architecture-plan.md` P1.1. **With #405, this completes P1.1 — and Phase 1.**