### PR TITLE
refactor(vtc-service): keyspace-name registry + offline-CLI durability (P2.5)

### DIFF
--- a/vtc-service/src/acl_cli.rs
+++ b/vtc-service/src/acl_cli.rs
@@ -11,6 +11,7 @@
 //! For online ACL management against a running VTC, use the admin UI
 //! (ACL plugin) or the REST `/v1/acl` surface.
 
+use crate::store::keyspaces;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -34,7 +35,7 @@ fn now_epoch() -> u64 {
 pub async fn run_acl_list(config_path: Option<PathBuf>) -> CliResult {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(keyspaces::ACL)?;
 
     let mut entries = list_acl_entries(&acl_ks).await?;
     if entries.is_empty() {
@@ -94,7 +95,7 @@ pub async fn run_acl_add(args: AclAddArgs) -> CliResult {
 
     let config = AppConfig::load(args.config_path)?;
     let store = Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(keyspaces::ACL)?;
 
     let now = now_epoch();
     let existing = get_acl_entry(&acl_ks, &args.did).await?;
@@ -128,7 +129,7 @@ pub async fn run_acl_add(args: AclAddArgs) -> CliResult {
 pub async fn run_acl_remove(config_path: Option<PathBuf>, did: String) -> CliResult {
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(keyspaces::ACL)?;
 
     if get_acl_entry(&acl_ks, &did).await?.is_none() {
         println!("No ACL entry for {did} — nothing to remove.");

--- a/vtc-service/src/did_key.rs
+++ b/vtc-service/src/did_key.rs
@@ -1,3 +1,4 @@
+use crate::store::keyspaces;
 use std::path::PathBuf;
 
 use base64::Engine;
@@ -22,7 +23,7 @@ pub async fn run_create_did_key(args: CreateDidKeyArgs) -> Result<(), Box<dyn st
 
     // Optionally create ACL entry
     if args.admin {
-        let acl_ks = store.keyspace("acl")?;
+        let acl_ks = store.keyspace(keyspaces::ACL)?;
         let entry = VtcAclEntry {
             did: did.clone(),
             role: VtcRole::Admin,

--- a/vtc-service/src/emergency.rs
+++ b/vtc-service/src/emergency.rs
@@ -35,6 +35,7 @@
 //! - The `VtcKeyBundle` — the VTC's DID + integration keys stay
 //!   put, only the admin ACL state resets.
 
+use crate::store::keyspaces;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -245,9 +246,9 @@ pub async fn run_emergency_bootstrap_with_store(
         )
         .await?;
 
-    let acl_ks = store.keyspace("acl")?;
-    let passkey_ks = store.keyspace("passkey")?;
-    let install_ks = store.keyspace("install")?;
+    let acl_ks = store.keyspace(keyspaces::ACL)?;
+    let passkey_ks = store.keyspace(keyspaces::PASSKEY)?;
+    let install_ks = store.keyspace(keyspaces::INSTALL)?;
     let install_store = InstallTokenStore::new(install_ks);
 
     // --- destructive cleanup ----------------------------------------
@@ -355,6 +356,12 @@ pub async fn run_emergency_bootstrap_with_store(
              fresh-install state?"
         );
     }
+
+    // Flush the destructive cleanup + the freshly-minted install-token row to
+    // disk before handing the URL back — without this a crash could leave the
+    // old admins half-deleted or the new token row non-durable, handing the
+    // operator a dead recovery URL (P2.5).
+    store.persist().await?;
 
     Ok(EmergencyBootstrapOutcome {
         install_url,

--- a/vtc-service/src/main.rs
+++ b/vtc-service/src/main.rs
@@ -1,6 +1,7 @@
 // Module tree is declared in lib.rs (so integration tests under
 // `tests/` can pull the same modules the binary uses). Re-import the
 // pieces this binary needs at the top level.
+use vtc_service::store::keyspaces;
 use vtc_service::{acl_cli, config, did_key, keys, server, status, store};
 #[cfg(feature = "setup")]
 use vtc_service::{emergency, setup};
@@ -372,9 +373,9 @@ async fn run_invite_cli(
     // be stopped — fjall does not allow concurrent processes on
     // the same data dir.
     let store = VtiStore::open(&config.store)?;
-    let install_ks = store.keyspace("install")?;
+    let install_ks = store.keyspace(keyspaces::INSTALL)?;
     let install_store = InstallTokenStore::new(install_ks);
-    let acl_ks = store.keyspace("acl")?;
+    let acl_ks = store.keyspace(keyspaces::ACL)?;
 
     // Ensure the ACL entry exists with Admin role. The post-login
     // flow gates on `check_acl(acl_ks, &user.did)`, so a DID
@@ -410,6 +411,12 @@ async fn run_invite_cli(
             Some(admin_did.clone()),
         )
         .await?;
+
+    // Flush the ACL entry + install-token row to disk before handing out the
+    // URL — without this the token row may not survive a crash between mint and
+    // the operator's first claim, leaving them with a dead URL (P2.5). Matches
+    // the `acl_cli` / `did_key` offline write paths.
+    store.persist().await?;
 
     let install_url = format!(
         "{}/admin/install?token={}",

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -1,3 +1,4 @@
+use crate::store::keyspaces;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -203,10 +204,10 @@ pub async fn run(
     secret_store: Box<dyn SecretStore>,
 ) -> Result<(), AppError> {
     // Open cached keyspace handles
-    let sessions_ks = store.keyspace("sessions")?;
-    let acl_ks = store.keyspace("acl")?;
-    let community_ks = store.keyspace("community")?;
-    let config_ks = store.keyspace("config")?;
+    let sessions_ks = store.keyspace(keyspaces::SESSIONS)?;
+    let acl_ks = store.keyspace(keyspaces::ACL)?;
+    let community_ks = store.keyspace(keyspaces::COMMUNITY)?;
+    let config_ks = store.keyspace(keyspaces::CONFIG)?;
 
     // P1.1: `config_store` (the db overlay) is canonical for the runtime
     // config keys — fold any operator PATCHes onto the in-memory config
@@ -220,29 +221,29 @@ pub async fn run(
         &crate::config_store::ConfigStore::new(config_ks.clone()),
     )
     .await?;
-    let passkey_ks = store.keyspace("passkey")?;
-    let install_ks = store.keyspace("install")?;
+    let passkey_ks = store.keyspace(keyspaces::PASSKEY)?;
+    let install_ks = store.keyspace(keyspaces::INSTALL)?;
     // `install_store` is built later (after `init_auth` yields the storage
     // key) so it wraps the encrypted `install` handle — see P0.7 below.
-    let members_ks = store.keyspace("members")?;
-    let join_requests_ks = store.keyspace("join_requests")?;
-    let policies_ks = store.keyspace("policies")?;
-    let active_policies_ks = store.keyspace("active_policies")?;
-    let status_lists_ks = store.keyspace("status_lists")?;
-    let registry_records_ks = store.keyspace("registry_records")?;
-    let sync_queue_ks = store.keyspace("sync_queue")?;
-    let sync_cursor_ks = store.keyspace("sync_cursor")?;
-    let relationships_ks = store.keyspace("relationships")?;
-    let relationships_by_did_ks = store.keyspace("relationships_by_did")?;
-    let endorsement_types_ks = store.keyspace("endorsement_types")?;
-    let schemas_ks = store.keyspace("schemas")?;
+    let members_ks = store.keyspace(keyspaces::MEMBERS)?;
+    let join_requests_ks = store.keyspace(keyspaces::JOIN_REQUESTS)?;
+    let policies_ks = store.keyspace(keyspaces::POLICIES)?;
+    let active_policies_ks = store.keyspace(keyspaces::ACTIVE_POLICIES)?;
+    let status_lists_ks = store.keyspace(keyspaces::STATUS_LISTS)?;
+    let registry_records_ks = store.keyspace(keyspaces::REGISTRY_RECORDS)?;
+    let sync_queue_ks = store.keyspace(keyspaces::SYNC_QUEUE)?;
+    let sync_cursor_ks = store.keyspace(keyspaces::SYNC_CURSOR)?;
+    let relationships_ks = store.keyspace(keyspaces::RELATIONSHIPS)?;
+    let relationships_by_did_ks = store.keyspace(keyspaces::RELATIONSHIPS_BY_DID)?;
+    let endorsement_types_ks = store.keyspace(keyspaces::ENDORSEMENT_TYPES)?;
+    let schemas_ks = store.keyspace(keyspaces::SCHEMAS)?;
     // Seed the schema store with the built-in catalog Issues types (idempotent;
     // never overwrites operator edits) so the registry reflects what the VTC
     // mints out of the box.
     crate::schemas::seed_default_issues(&schemas_ks).await?;
-    let endorsements_ks = store.keyspace("endorsements")?;
-    let audit_ks = store.keyspace("audit")?;
-    let audit_key_ks = store.keyspace("audit_key")?;
+    let endorsements_ks = store.keyspace(keyspaces::ENDORSEMENTS)?;
+    let audit_ks = store.keyspace(keyspaces::AUDIT)?;
+    let audit_key_ks = store.keyspace(keyspaces::AUDIT_KEY)?;
 
     // M2.5: install the workspace-shipped default policies for any
     // PolicyPurpose that lacks an active row. Idempotent — operator

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -28,6 +28,7 @@
 //! Refuses to re-run on an already-set-up daemon (config or seed
 //! present).
 
+use crate::store::keyspaces;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -1348,16 +1349,11 @@ fn open_keyspaces(config: &AppConfig) -> Result<(), AppError> {
     let store = Store::open(&StoreConfig {
         data_dir: config.store.data_dir.clone(),
     })?;
-    for ks in [
-        "sessions",
-        "acl",
-        "community",
-        "config",
-        "passkey",
-        "install",
-        "audit",
-        "audit_key",
-    ] {
+    // Pre-create *every* keyspace the daemon opens at boot, not a subset
+    // (this used to open 8 of 21), so the first `vtc start` doesn't pay the
+    // partition-creation cost. Iterating `keyspaces::ALL` keeps it in lockstep
+    // with `server::run`.
+    for ks in keyspaces::ALL {
         let _ = store.keyspace(ks)?;
     }
     Ok(())
@@ -1385,7 +1381,7 @@ async fn mint_initial_install_token(
     let store = Store::open(&StoreConfig {
         data_dir: config.store.data_dir.clone(),
     })?;
-    let install_ks = store.keyspace("install")?;
+    let install_ks = store.keyspace(keyspaces::INSTALL)?;
     let install_store = InstallTokenStore::new(install_ks);
     let exp = Utc::now() + ChronoDuration::seconds(INSTALL_TOKEN_DEFAULT_TTL_SECS as i64);
     install_store

--- a/vtc-service/src/status.rs
+++ b/vtc-service/src/status.rs
@@ -1,3 +1,4 @@
+use crate::store::keyspaces;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -198,8 +199,8 @@ pub async fn run_status(config_path: Option<PathBuf>) -> Result<(), Box<dyn std:
     }
 
     // 8. Gather stats from store
-    let acl_ks = store.keyspace("acl")?;
-    let sessions_ks = store.keyspace("sessions")?;
+    let acl_ks = store.keyspace(keyspaces::ACL)?;
+    let sessions_ks = store.keyspace(keyspaces::SESSIONS)?;
 
     // --- ACL ---
     let acl_entries = acl::list_acl_entries(&acl_ks).await?;

--- a/vtc-service/src/store/keyspaces.rs
+++ b/vtc-service/src/store/keyspaces.rs
@@ -1,0 +1,84 @@
+//! Canonical keyspace names (P2.5).
+//!
+//! Every keyspace the daemon opens is named exactly once here so the
+//! literals can't drift across `server.rs`, the offline CLIs, and the
+//! setup wizard's pre-create pass. [`ALL`] is the full set — the
+//! wizard's `open_keyspaces` iterates it so it can no longer silently
+//! pre-create a *subset* (it used to open 8 of 21), and a test pins
+//! `ALL.len()` to the `AppState` keyspace-field count so a keyspace
+//! can't be added to one without the other.
+//!
+//! Names are the stable on-disk fjall partition identifiers — changing
+//! one orphans existing data, so treat them as a wire contract.
+
+pub const SESSIONS: &str = "sessions";
+pub const ACL: &str = "acl";
+pub const COMMUNITY: &str = "community";
+pub const CONFIG: &str = "config";
+pub const PASSKEY: &str = "passkey";
+pub const INSTALL: &str = "install";
+pub const MEMBERS: &str = "members";
+pub const JOIN_REQUESTS: &str = "join_requests";
+pub const POLICIES: &str = "policies";
+pub const ACTIVE_POLICIES: &str = "active_policies";
+pub const STATUS_LISTS: &str = "status_lists";
+pub const REGISTRY_RECORDS: &str = "registry_records";
+pub const SYNC_QUEUE: &str = "sync_queue";
+pub const SYNC_CURSOR: &str = "sync_cursor";
+pub const RELATIONSHIPS: &str = "relationships";
+pub const RELATIONSHIPS_BY_DID: &str = "relationships_by_did";
+pub const ENDORSEMENT_TYPES: &str = "endorsement_types";
+pub const SCHEMAS: &str = "schemas";
+pub const ENDORSEMENTS: &str = "endorsements";
+pub const AUDIT: &str = "audit";
+pub const AUDIT_KEY: &str = "audit_key";
+
+/// Every keyspace the daemon opens, in `AppState` field order. The
+/// setup wizard pre-creates exactly this set; `server::run` opens
+/// exactly this set.
+pub const ALL: &[&str] = &[
+    SESSIONS,
+    ACL,
+    COMMUNITY,
+    CONFIG,
+    PASSKEY,
+    INSTALL,
+    MEMBERS,
+    JOIN_REQUESTS,
+    POLICIES,
+    ACTIVE_POLICIES,
+    STATUS_LISTS,
+    REGISTRY_RECORDS,
+    SYNC_QUEUE,
+    SYNC_CURSOR,
+    RELATIONSHIPS,
+    RELATIONSHIPS_BY_DID,
+    ENDORSEMENT_TYPES,
+    SCHEMAS,
+    ENDORSEMENTS,
+    AUDIT,
+    AUDIT_KEY,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `ALL` must stay in sync with the `AppState` keyspace fields.
+    /// `server::run` opens 21 keyspaces into 21 `*_ks` fields — if a
+    /// keyspace is added to one without the other, this trips.
+    #[test]
+    fn all_matches_app_state_keyspace_count() {
+        assert_eq!(ALL.len(), 21, "ALL must list every AppState keyspace");
+    }
+
+    /// No accidental duplicate in `ALL` (a copy-paste slip would make
+    /// the wizard pre-create one keyspace twice and skip another).
+    #[test]
+    fn all_has_no_duplicates() {
+        let mut seen = std::collections::HashSet::new();
+        for name in ALL {
+            assert!(seen.insert(*name), "duplicate keyspace name in ALL: {name}");
+        }
+    }
+}

--- a/vtc-service/src/store/mod.rs
+++ b/vtc-service/src/store/mod.rs
@@ -1,1 +1,3 @@
 pub use vti_common::store::*;
+
+pub mod keyspaces;


### PR DESCRIPTION
## P2.5 — keyspace-name registry + offline-CLI durability

### Problem
Keyspace-name string literals were re-typed across `server.rs`, the offline CLIs (`main.rs` invite, `emergency.rs`, `acl_cli.rs`, `did_key.rs`, `status.rs`) and the setup wizard. The drift had already bitten: the wizard's `open_keyspaces` pre-create pass opened **8 of the daemon's 21** keyspaces and nobody noticed. Separately, `run_invite_cli` (`vtc admin invite`) and `run_emergency_bootstrap` wrote an Admin ACL entry + install-token row and exited **without `store.persist()`** — so the operator could be handed a URL whose token row isn't durable across a crash.

### Change
- New `store::keyspaces` module: one `const` per keyspace + `ALL` (the full set). `server.rs`, the CLIs and the wizard consume the consts.
- `open_keyspaces` now iterates `keyspaces::ALL` — it can't silently pre-create a subset again.
- **Durability:** both offline write paths now `store.persist().await?` before returning / printing the URL (matching `acl_cli`/`did_key`).

### Tests
`ALL.len()` pinned to the `AppState` keyspace-field count (21) so a keyspace can't be added to one without the other, plus a no-duplicates check. Full lib (564) + emergency-bootstrap integration green. Test/test-support code keeps its literals (per the task's "excl. tests" acceptance); production code is now the constants module only.

Plan: `tasks/vtc-architecture-plan.md` P2.5. Mirrors the VTA's merged equivalent (#398).