### PR TITLE
refactor(vtc-service): one dtg::into_typed for the JSON→VC step (P2.8)

### DIFF
--- a/vtc-service/src/credentials/custom_endorsement.rs
+++ b/vtc-service/src/credentials/custom_endorsement.rs
@@ -147,11 +147,7 @@ pub async fn build_custom_endorsement(
         params.validity,
     )
     .await?;
-    serde_json::from_value(doc).map_err(|e| {
-        AppError::Internal(format!(
-            "DTG custom endorsement -> VerifiableCredential: {e}"
-        ))
-    })
+    super::dtg::into_typed(doc, "custom endorsement")
 }
 
 #[cfg(test)]

--- a/vtc-service/src/credentials/dtg.rs
+++ b/vtc-service/src/credentials/dtg.rs
@@ -25,6 +25,7 @@
 //! Issuance signs through the VTC's local issuer key ([`LocalSigner`]); the key
 //! is never exported. `issuer = signer.issuer_did()` for every credential.
 
+use affinidi_vc::VerifiableCredential;
 use chrono::{DateTime, Duration, Utc};
 use dtg_credentials::DTGCredential;
 use serde_json::Value;
@@ -35,6 +36,16 @@ use crate::acl::VtcRole;
 use super::signer::LocalSigner;
 use super::vec::COMMUNITY_ROLE_ENDORSEMENT_TYPE;
 use super::vmc::CredentialStatusRef;
+
+/// Parse a signed catalog credential (the JSON any `issue_*` returns) into the
+/// typed [`VerifiableCredential`] the credential builders hand back. Centralises
+/// the `serde_json::from_value` + `AppError::Internal` mapping the `build_vmc` /
+/// `build_role_vec` / `build_custom_endorsement` builders each repeated (P2.8);
+/// `kind` (e.g. `"VMC"`, `"role VEC"`) is woven into the error for diagnosis.
+pub fn into_typed(doc: Value, kind: &str) -> Result<VerifiableCredential, AppError> {
+    serde_json::from_value(doc)
+        .map_err(|e| AppError::Internal(format!("DTG {kind} -> VerifiableCredential: {e}")))
+}
 
 /// `[validFrom, validUntil]` for a credential minted `now` with `validity`.
 fn window(validity: Duration) -> (DateTime<Utc>, DateTime<Utc>) {
@@ -182,6 +193,23 @@ mod tests {
         proof
             .verify_with_public_key(&unsigned, signer.public_bytes(), VerifyOptions::new())
             .map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn into_typed_maps_malformed_json_to_kind_tagged_internal() {
+        // A non-VC JSON shape fails the typed parse with an Internal error
+        // that names the credential kind for diagnosis. (The success path is
+        // covered by the build_vmc / build_role_vec / build_custom_endorsement
+        // suites, which all route through `into_typed`.)
+        let err = into_typed(serde_json::json!({ "not": "a credential" }), "VMC")
+            .expect_err("a non-VC object must not parse as a VerifiableCredential");
+        match err {
+            AppError::Internal(msg) => {
+                assert!(msg.contains("VMC"), "error must name the kind: {msg}");
+                assert!(msg.contains("VerifiableCredential"), "{msg}");
+            }
+            other => panic!("expected Internal, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/vtc-service/src/credentials/vec.rs
+++ b/vtc-service/src/credentials/vec.rs
@@ -95,8 +95,7 @@ pub async fn build_role_vec(
         params.validity,
     )
     .await?;
-    serde_json::from_value(doc)
-        .map_err(|e| AppError::Internal(format!("DTG VEC -> VerifiableCredential: {e}")))
+    super::dtg::into_typed(doc, "role VEC")
 }
 
 #[cfg(test)]

--- a/vtc-service/src/credentials/vmc.rs
+++ b/vtc-service/src/credentials/vmc.rs
@@ -163,8 +163,7 @@ pub async fn build_vmc(
         params.personhood,
     )
     .await?;
-    serde_json::from_value(doc)
-        .map_err(|e| AppError::Internal(format!("DTG VMC -> VerifiableCredential: {e}")))
+    super::dtg::into_typed(doc, "VMC")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## P2.8 — collapse the DTG credential builders

`build_vmc`, `build_role_vec`, and `build_custom_endorsement` each ended with the same `serde_json::from_value::<VerifiableCredential>` + `AppError::Internal("DTG X -> VerifiableCredential")` mapping after their `dtg::issue_*` call. Collapse that onto one **`dtg::into_typed(doc, kind)`** helper; the three builders now end in a single call (`issue_* → into_typed`).

`invitation::issue_invitation` is intentionally left alone — it returns the signed VIC as JSON (status-list allocate + schema-validate flow), not a typed VC, so it shares no conversion tail.

### Tests
`into_typed` error-path unit test (malformed JSON → kind-tagged `Internal`); the existing builder suites (unchanged, per the task's acceptance) cover the success path through it. Full lib (565) green.

Plan: `tasks/vtc-architecture-plan.md` P2.8.