### PR TITLE
refactor(vtc-service): RegistryRecord::for_job dedups syncer record-shape (P2.7)

### DIFF
--- a/vtc-service/src/registry/model.rs
+++ b/vtc-service/src/registry/model.rs
@@ -72,6 +72,31 @@ impl RegistryRecord {
             last_synced_at: Utc::now(),
         }
     }
+
+    /// The registry record a successfully-dispatched [`SyncJob`] should
+    /// publish + mirror, or `None` for [`SyncJobKind::DeleteMember`]
+    /// (which *removes* the record rather than writing one).
+    ///
+    /// Centralises the `fresh_active` / `departed` construction — and the
+    /// `disposition == "historical"` → `active_to` branch — that the
+    /// dispatcher (`run_call`) and the local-mirror update
+    /// (`update_mirror`) both needed (P2.7), so the two can't drift on
+    /// the disposition rule.
+    pub fn for_job(job: &SyncJob) -> Option<RegistryRecord> {
+        match job.kind {
+            SyncJobKind::PublishMember | SyncJobKind::UpdateMember => {
+                Some(Self::fresh_active(&job.member_did))
+            }
+            SyncJobKind::MarkDeparted => {
+                let now = Utc::now();
+                // Historical fills the active window's end; Tombstone
+                // leaves `active_to` open (`None`).
+                let active_to = (job.disposition.as_deref() == Some("historical")).then_some(now);
+                Some(Self::departed(&job.member_did, now, active_to))
+            }
+            SyncJobKind::DeleteMember => None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -336,5 +361,44 @@ mod tests {
             v.get("activeTo").is_none(),
             "activeTo should be omitted, got {v}"
         );
+    }
+
+    // ── RegistryRecord::for_job (P2.7) ──
+
+    #[test]
+    fn for_job_publish_and_update_yield_fresh_active() {
+        for kind in [SyncJobKind::PublishMember, SyncJobKind::UpdateMember] {
+            let job = SyncJob::fresh(kind, "did:key:zA");
+            let rec = RegistryRecord::for_job(&job).expect("publish/update yields a record");
+            assert_eq!(rec.status, RegistryStatus::Active);
+            assert_eq!(rec.member_did, "did:key:zA");
+            assert!(rec.active_to.is_none(), "{kind:?} active_to must be open");
+        }
+    }
+
+    #[test]
+    fn for_job_mark_departed_historical_fills_active_to() {
+        let mut job = SyncJob::fresh(SyncJobKind::MarkDeparted, "did:key:zA");
+        job.disposition = Some("historical".into());
+        let rec = RegistryRecord::for_job(&job).expect("departed yields a record");
+        assert_eq!(rec.status, RegistryStatus::Departed);
+        assert!(rec.active_to.is_some(), "historical fills active_to");
+    }
+
+    #[test]
+    fn for_job_mark_departed_tombstone_leaves_active_to_open() {
+        let mut job = SyncJob::fresh(SyncJobKind::MarkDeparted, "did:key:zA");
+        job.disposition = Some("tombstone".into());
+        let rec = RegistryRecord::for_job(&job).unwrap();
+        assert_eq!(rec.status, RegistryStatus::Departed);
+        assert!(rec.active_to.is_none(), "tombstone leaves active_to None");
+    }
+
+    #[test]
+    fn for_job_delete_member_yields_none() {
+        // DeleteMember removes the registry record, so there is nothing to
+        // publish / mirror — the syncer takes the delete path instead.
+        let job = SyncJob::fresh(SyncJobKind::DeleteMember, "did:key:zA");
+        assert!(RegistryRecord::for_job(&job).is_none());
     }
 }

--- a/vtc-service/src/registry/syncer.rs
+++ b/vtc-service/src/registry/syncer.rs
@@ -408,46 +408,25 @@ impl MembershipSyncer {
     }
 
     async fn run_call(&self, job: &SyncJob) -> Result<(), RegistryError> {
-        match job.kind {
-            SyncJobKind::PublishMember | SyncJobKind::UpdateMember => {
-                let record = RegistryRecord::fresh_active(&job.member_did);
-                self.client.publish_member(&record).await
-            }
-            SyncJobKind::MarkDeparted => {
-                let now = chrono::Utc::now();
-                let active_to = if job.disposition.as_deref() == Some("historical") {
-                    Some(now)
-                } else {
-                    None
-                };
-                let record = RegistryRecord::departed(&job.member_did, now, active_to);
-                self.client.publish_member(&record).await
-            }
-            SyncJobKind::DeleteMember => self.client.delete_member(&job.member_did).await,
+        // `for_job` yields the record to publish for every kind except
+        // DeleteMember, which removes the member from the registry instead.
+        match RegistryRecord::for_job(job) {
+            Some(record) => self.client.publish_member(&record).await,
+            None => self.client.delete_member(&job.member_did).await,
         }
     }
 
     async fn update_mirror(&self, job: &SyncJob) {
-        match job.kind {
-            SyncJobKind::PublishMember | SyncJobKind::UpdateMember => {
-                let record = RegistryRecord::fresh_active(&job.member_did);
+        // Mirror the same disposition the registry call applied (P2.7): a
+        // record to store for publish/update/departed, or a delete for
+        // DeleteMember.
+        match RegistryRecord::for_job(job) {
+            Some(record) => {
                 if let Err(e) = store_record(&self.registry_records_ks, &record).await {
                     warn!(error = %e, did = %job.member_did, "failed to update registry_records mirror");
                 }
             }
-            SyncJobKind::MarkDeparted => {
-                let now = chrono::Utc::now();
-                let active_to = if job.disposition.as_deref() == Some("historical") {
-                    Some(now)
-                } else {
-                    None
-                };
-                let record = RegistryRecord::departed(&job.member_did, now, active_to);
-                if let Err(e) = store_record(&self.registry_records_ks, &record).await {
-                    warn!(error = %e, did = %job.member_did, "failed to update registry_records mirror");
-                }
-            }
-            SyncJobKind::DeleteMember => {
+            None => {
                 if let Err(e) =
                     super::storage::delete_record(&self.registry_records_ks, &job.member_did).await
                 {


### PR DESCRIPTION
## P2.7 — one record-shape source for the syncer

`run_call` (the registry dispatch) and `update_mirror` (the local `registry_records` mirror) each independently built the `RegistryRecord` per job kind — `fresh_active` for publish/update, `departed` for `MarkDeparted` with the same `disposition == "historical" → active_to` branch. A drift hazard: a change to the disposition rule had to be made in two places.

### Change
Extract `RegistryRecord::for_job(&SyncJob) -> Option<RegistryRecord>` (`None` for `DeleteMember`, which *removes* the record rather than writing one). `run_call` and `update_mirror` now both match on it — publish/store the `Some(record)`, or take the delete path on `None` — so the record shape can't diverge between the registry and its local mirror.

### Tests
`for_job` unit tests (publish/update → Active; MarkDeparted historical fills `active_to`, tombstone leaves it open; DeleteMember → None). The syncer behaviour suites (happy-path, transient/permanent failure, delete-drops-mirror) are unchanged and still exercise both paths through `for_job`. Full lib (569) green.

Plan: `tasks/vtc-architecture-plan.md` P2.7.