### PR TITLE
refactor(vta): extract vault/sign-trust-task signing to operations (P2.4 part 3)

### DIFF
--- a/vta-service/src/operations/vault/mod.rs
+++ b/vta-service/src/operations/vault/mod.rs
@@ -30,6 +30,8 @@ use vta_sdk::did_key::decode_private_key_multibase;
 pub mod proxy_login;
 /// `vault/release/0.1` sealing logic.
 pub mod release;
+/// `vault/sign-trust-task/0.1` envelope validation + signing.
+pub mod sign_trust_task;
 
 /// DIDComm `Message.typ` for the proxy-login envelope's cleartext (a
 /// `SessionBlob` per `vault/_shared/0.1/session-blob`). Workspace-namespaced,

--- a/vta-service/src/operations/vault/sign_trust_task.rs
+++ b/vta-service/src/operations/vault/sign_trust_task.rs
@@ -1,0 +1,167 @@
+//! `vault/sign-trust-task/0.1` business logic — attach an `eddsa-jcs-2022`
+//! Data-Integrity proof to a Trust Task envelope, signing as the principal DID
+//! of a `did-self-issued` / `didcomm-peer` vault entry (P2.4).
+//!
+//! Moved out of `routes/trust_tasks/vault.rs` so the route handler is a thin
+//! adapter: it keeps the capability/context/step-up gates + the audit log +
+//! the wire response, and maps the typed [`SignTrustTaskError`] back to the
+//! canonical spec reject codes. The signable-kind check, envelope structural
+//! validation, and the signing live here.
+
+use serde_json::Value;
+
+use vti_common::vault::VaultSecret;
+
+use crate::error::AppError;
+use crate::keys::seed_store::SeedStore;
+use crate::store::KeyspaceHandle;
+
+/// A signed envelope + the principal DID it was signed as (for the route's
+/// audit log).
+pub struct SignedEnvelope {
+    pub signed: Value,
+    pub principal_did: String,
+}
+
+/// Why signing failed. The route maps each onto the canonical
+/// `vault/sign-trust-task/0.1` reject reason (conformance-ordered:
+/// `not_signable` → `envelope_invalid` → `envelope_already_proofed` →
+/// `envelope_issuer_mismatch` → `envelope_expired`).
+pub enum SignTrustTaskError {
+    /// Entry kind carries no DID-based signing identity.
+    NotSignable { kind: &'static str },
+    /// `unsignedEnvelope` is not a JSON object.
+    EnvelopeNotObject,
+    /// A required envelope field is missing.
+    EnvelopeMissingField { field: &'static str },
+    /// `issuer` is present but not a string.
+    IssuerNotString,
+    /// The envelope already carries a `proof`.
+    AlreadyProofed,
+    /// `envelope.issuer` != the entry's principal DID.
+    IssuerMismatch {
+        envelope_issuer: String,
+        expected: String,
+    },
+    /// `expiresAt` is present but not an RFC-3339 timestamp.
+    ExpiresAtNotRfc3339 { value: String },
+    /// `expiresAt` is in the past.
+    Expired { value: String },
+    /// Internal failure (key load, sign, serialise).
+    App(AppError),
+}
+
+impl From<AppError> for SignTrustTaskError {
+    fn from(e: AppError) -> Self {
+        SignTrustTaskError::App(e)
+    }
+}
+
+/// Validate `unsigned_envelope` against `secret`'s principal identity and
+/// attach an `eddsa-jcs-2022` proof signed as that principal.
+///
+/// The caller has already gated capability + context scope + step-up.
+pub async fn sign_envelope(
+    keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    secret: &VaultSecret,
+    unsigned_envelope: &Value,
+) -> Result<SignedEnvelope, SignTrustTaskError> {
+    // Only DID-anchored kinds carry a principal identity to sign as.
+    let (principal_did, signing_key_id) = match secret {
+        VaultSecret::DidSelfIssued {
+            did,
+            signing_key_id,
+            ..
+        }
+        | VaultSecret::DidcommPeer {
+            peer_did: did,
+            signing_key_id,
+            ..
+        } => (did.clone(), signing_key_id.clone()),
+        other => {
+            return Err(SignTrustTaskError::NotSignable {
+                kind: super::secret_kind_label(other.kind()),
+            });
+        }
+    };
+
+    // Structural validation. Per spec: id, type, issuer, recipient, issuedAt,
+    // payload all required; proof must be absent.
+    let envelope_obj = unsigned_envelope
+        .as_object()
+        .ok_or(SignTrustTaskError::EnvelopeNotObject)?;
+    for field in ["id", "type", "issuer", "recipient", "issuedAt", "payload"] {
+        if !envelope_obj.contains_key(field) {
+            return Err(SignTrustTaskError::EnvelopeMissingField { field });
+        }
+    }
+    if envelope_obj.contains_key("proof") {
+        return Err(SignTrustTaskError::AlreadyProofed);
+    }
+
+    // Strict issuer match: refuse to silently rewrite the consumer's issuer.
+    let envelope_issuer = envelope_obj
+        .get("issuer")
+        .and_then(|v| v.as_str())
+        .ok_or(SignTrustTaskError::IssuerNotString)?;
+    if envelope_issuer != principal_did {
+        return Err(SignTrustTaskError::IssuerMismatch {
+            envelope_issuer: envelope_issuer.to_string(),
+            expected: principal_did,
+        });
+    }
+
+    // expiresAt (if present) must be a future RFC-3339 timestamp.
+    if let Some(exp_v) = envelope_obj.get("expiresAt") {
+        let exp_str = exp_v.as_str().unwrap_or_default();
+        match chrono::DateTime::parse_from_rfc3339(exp_str) {
+            Ok(exp) if exp < chrono::Utc::now() => {
+                return Err(SignTrustTaskError::Expired {
+                    value: exp_str.to_string(),
+                });
+            }
+            Ok(_) => {}
+            Err(_) => {
+                return Err(SignTrustTaskError::ExpiresAtNotRfc3339 {
+                    value: exp_str.to_string(),
+                });
+            }
+        }
+    }
+
+    // Load the signing key as an affinidi Secret and sign. The proof's
+    // verificationMethod kid IS the entry's signing_key_id — the maintainer
+    // trusts the stored reference (validated at upsert time).
+    let secret_key = super::load_signing_secret_by_id(
+        keys_ks,
+        imported_ks,
+        seed_store,
+        audit_ks,
+        &signing_key_id,
+    )
+    .await?;
+    let proof = affinidi_data_integrity::DataIntegrityProof::sign(
+        unsigned_envelope,
+        &secret_key,
+        affinidi_data_integrity::SignOptions::new(),
+    )
+    .await
+    .map_err(|e| AppError::Internal(format!("DataIntegrityProof sign failed: {e}")))?;
+    let proof_value = serde_json::to_value(&proof)
+        .map_err(|e| AppError::Internal(format!("serialize proof: {e}")))?;
+
+    // Attach the proof, preserving every other field byte-for-byte.
+    let mut signed = unsigned_envelope.clone();
+    signed
+        .as_object_mut()
+        .expect("envelope is an object — checked above")
+        .insert("proof".to_string(), proof_value);
+
+    Ok(SignedEnvelope {
+        signed,
+        principal_did,
+    })
+}

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -1378,44 +1378,33 @@ pub(super) async fn handle_sign_trust_task(
         return reject;
     }
 
-    // Only signable kinds (DID-anchored secrets) carry a principal
-    // identity the maintainer can sign as. Password / OAuth / passkey
-    // / bearer / ssh / custom kinds have no DID — reject loudly so the
-    // consumer can fall back to a different flow (proxy-login for
-    // session creds, release for browser autofill).
-    let (principal_did, signing_key_id) = match &stored.secret {
-        VaultSecret::DidSelfIssued {
-            did,
-            signing_key_id,
-            ..
-        }
-        | VaultSecret::DidcommPeer {
-            peer_did: did,
-            signing_key_id,
-            ..
-        } => (did.clone(), signing_key_id.clone()),
-        other => {
+    // Validate the envelope against the entry's principal identity and sign
+    // (operations layer; P2.4). The typed `SignTrustTaskError` maps back to the
+    // canonical spec reject codes.
+    use crate::operations::vault::sign_trust_task::SignTrustTaskError;
+    let signed = match crate::operations::vault::sign_trust_task::sign_envelope(
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.audit_ks,
+        &*state.seed_store,
+        &stored.secret,
+        &req.unsigned_envelope,
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(SignTrustTaskError::NotSignable { kind }) => {
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
                     reason: format!(
-                        "vault/sign-trust-task:not_signable — entry kind '{}' has no DID-based signing identity",
-                        crate::operations::vault::secret_kind_label(other.kind()),
+                        "vault/sign-trust-task:not_signable — entry kind '{kind}' has no DID-based signing identity"
                     ),
-                    details: Some(serde_json::json!({
-                        "secretKind": crate::operations::vault::secret_kind_label(other.kind()),
-                    })),
+                    details: Some(serde_json::json!({ "secretKind": kind })),
                 },
             );
         }
-    };
-
-    // Structural validation of the supplied envelope. Per spec: id,
-    // type, issuer, recipient, issuedAt, payload all required; proof
-    // must be absent.
-    let envelope_obj = match req.unsigned_envelope.as_object() {
-        Some(o) => o,
-        None => {
+        Err(SignTrustTaskError::EnvelopeNotObject) => {
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
@@ -1424,9 +1413,7 @@ pub(super) async fn handle_sign_trust_task(
                 },
             );
         }
-    };
-    for field in ["id", "type", "issuer", "recipient", "issuedAt", "payload"] {
-        if !envelope_obj.contains_key(field) {
+        Err(SignTrustTaskError::EnvelopeMissingField { field }) => {
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
@@ -1437,24 +1424,7 @@ pub(super) async fn handle_sign_trust_task(
                 },
             );
         }
-    }
-    if envelope_obj.contains_key("proof") {
-        return reject_with(
-            &doc,
-            RejectReason::TaskFailed {
-                reason: "vault/sign-trust-task:envelope_already_proofed — strip the existing proof and resubmit".into(),
-                details: None,
-            },
-        );
-    }
-
-    // Strict issuer match: the maintainer refuses to silently rewrite
-    // the consumer's issuer. Mismatch is loud so consumer bugs surface
-    // explicitly rather than as cryptic verification failures at the
-    // recipient.
-    let envelope_issuer = match envelope_obj.get("issuer").and_then(|v| v.as_str()) {
-        Some(s) => s,
-        None => {
+        Err(SignTrustTaskError::IssuerNotString) => {
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
@@ -1464,129 +1434,77 @@ pub(super) async fn handle_sign_trust_task(
                 },
             );
         }
-    };
-    if envelope_issuer != principal_did {
-        return reject_with(
-            &doc,
-            RejectReason::TaskFailed {
-                reason: "vault/sign-trust-task:envelope_issuer_mismatch — envelope.issuer must equal the entry's principalDid".into(),
-                details: Some(serde_json::json!({
-                    "envelopeIssuer": envelope_issuer,
-                    "expectedIssuer": principal_did,
-                })),
-            },
-        );
-    }
-
-    // expiresAt (if present) must not be in the past.
-    if let Some(exp_v) = envelope_obj.get("expiresAt") {
-        let exp_str = exp_v.as_str().unwrap_or_default();
-        match chrono::DateTime::parse_from_rfc3339(exp_str) {
-            Ok(exp) if exp < chrono::Utc::now() => {
-                return reject_with(
-                    &doc,
-                    RejectReason::TaskFailed {
-                        reason: "vault/sign-trust-task:envelope_expired — envelope.expiresAt is in the past".into(),
-                        details: Some(serde_json::json!({ "expiresAt": exp_str })),
-                    },
-                );
-            }
-            Ok(_) => {} // future-dated, fine
-            Err(_) => {
-                return reject_with(
-                    &doc,
-                    RejectReason::TaskFailed {
-                        reason: "vault/sign-trust-task:envelope_invalid — expiresAt must be an RFC 3339 timestamp".into(),
-                        details: Some(serde_json::json!({ "expiresAt": exp_str })),
-                    },
-                );
-            }
-        }
-    }
-
-    // Load the signing key as an affinidi Secret (the shape
-    // DataIntegrityProof::sign consumes). The kid the proof's
-    // verificationMethod field carries IS the entry's signing_key_id —
-    // the maintainer trusts the stored entry's reference because the
-    // upsert path validated it at the time the entry was written.
-    let secret = match crate::operations::vault::load_signing_secret_by_id(
-        &state.keys_ks,
-        &state.imported_ks,
-        &*state.seed_store,
-        &state.audit_ks,
-        &signing_key_id,
-    )
-    .await
-    {
-        Ok(s) => s,
-        Err(e) => return app_error_to_reject(&doc, e),
-    };
-
-    // Sign. `DataIntegrityProof::sign` takes the document WITHOUT a
-    // `proof` field — we already validated none is present. The
-    // resulting `proof` object carries cryptosuite, verificationMethod
-    // (`<principalDid>#<signingKeyId>`), proofPurpose=assertionMethod,
-    // created, and proofValue.
-    let proof = match affinidi_data_integrity::DataIntegrityProof::sign(
-        &req.unsigned_envelope,
-        &secret,
-        affinidi_data_integrity::SignOptions::new(),
-    )
-    .await
-    {
-        Ok(p) => p,
-        Err(e) => {
-            return app_error_to_reject(
+        Err(SignTrustTaskError::AlreadyProofed) => {
+            return reject_with(
                 &doc,
-                AppError::Internal(format!("DataIntegrityProof sign failed: {e}")),
+                RejectReason::TaskFailed {
+                    reason: "vault/sign-trust-task:envelope_already_proofed — strip the existing proof and resubmit".into(),
+                    details: None,
+                },
             );
         }
-    };
-    let proof_value = match serde_json::to_value(&proof) {
-        Ok(v) => v,
-        Err(e) => {
-            return app_error_to_reject(&doc, AppError::Internal(format!("serialize proof: {e}")));
+        Err(SignTrustTaskError::IssuerMismatch {
+            envelope_issuer,
+            expected,
+        }) => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: "vault/sign-trust-task:envelope_issuer_mismatch — envelope.issuer must equal the entry's principalDid".into(),
+                    details: Some(serde_json::json!({
+                        "envelopeIssuer": envelope_issuer,
+                        "expectedIssuer": expected,
+                    })),
+                },
+            );
         }
+        Err(SignTrustTaskError::ExpiresAtNotRfc3339 { value }) => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: "vault/sign-trust-task:envelope_invalid — expiresAt must be an RFC 3339 timestamp".into(),
+                    details: Some(serde_json::json!({ "expiresAt": value })),
+                },
+            );
+        }
+        Err(SignTrustTaskError::Expired { value }) => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason:
+                        "vault/sign-trust-task:envelope_expired — envelope.expiresAt is in the past"
+                            .into(),
+                    details: Some(serde_json::json!({ "expiresAt": value })),
+                },
+            );
+        }
+        Err(SignTrustTaskError::App(e)) => return app_error_to_reject(&doc, e),
     };
 
-    // Attach proof to the envelope. Mutate the parsed JSON in place so
-    // every other field — including any consumer-supplied `ext` — is
-    // preserved byte-for-byte.
-    let mut signed = req.unsigned_envelope.clone();
-    signed
-        .as_object_mut()
-        .expect("envelope is an object — checked above")
-        .insert("proof".to_string(), proof_value);
-
-    // Audit log — `{who, when, entryId, envelope: {id, type, recipient}, outcome}`.
-    // Per the spec, payload is OMITTED (it may carry sensitive RP-side
-    // task content).
-    let envelope_id = envelope_obj
-        .get("id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let envelope_type = envelope_obj
-        .get("type")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let envelope_recipient = envelope_obj
-        .get("recipient")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    // Audit log — `{who, when, entryId, envelope: {id, type, recipient}}`.
+    // Per the spec, payload is OMITTED (it may carry sensitive RP-side content).
+    let str_field = |k: &str| {
+        signed
+            .signed
+            .get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
     tracing::info!(
         actor = %auth.did,
         entry_id = %req.entry_id,
-        envelope_id,
-        envelope_type,
-        envelope_recipient,
-        principal_did = %principal_did,
+        envelope_id = %str_field("id"),
+        envelope_type = %str_field("type"),
+        envelope_recipient = %str_field("recipient"),
+        principal_did = %signed.principal_did,
         "vault/sign-trust-task: signed"
     );
 
     success_response(
         &doc,
         VaultSignTrustTaskResponseBody {
-            signed_envelope: signed,
+            signed_envelope: signed.signed,
         },
     )
 }


### PR DESCRIPTION
## P2.4(b) part 3 — vault/sign-trust-task → operations

Builds on #407 (release) + #410 (proxy-login). Moves the sign-trust-task business logic — the signable-kind check, envelope structural validation, and the `eddsa-jcs-2022` signing — out of `routes/trust_tasks/vault.rs` into `operations::vault::sign_trust_task`. The route handler keeps the capability/context/step-up gates, the audit log, and the wire response, mapping the typed `SignTrustTaskError` back to the canonical spec reject codes.

### Changes
- **`operations::vault::sign_trust_task::sign_envelope`** — validates the envelope against the entry's principal identity (DID-anchored kinds only), loads the signing `Secret`, signs, and attaches the proof byte-preservingly. Returns `SignedEnvelope { signed, principal_did }`; failures surface as a typed **`SignTrustTaskError`** (`NotSignable` / `EnvelopeNotObject` / `EnvelopeMissingField` / `IssuerNotString` / `AlreadyProofed` / `IssuerMismatch` / `ExpiresAtNotRfc3339` / `Expired` / `App`), conformance-ordered.
- **`handle_sign_trust_task`** reduced from ~260 to ~75 lines — the error→reject mapping preserves the exact spec reason strings + detail payloads. `vault.rs` **1638 → 1556**.

### Verification
P2.0's 12 vault wire tests green **unchanged**; fmt + clippy clean (all-targets); full vta-service suite (965) green.

Remaining P2.4(b): **part 4 upsert unseal** toward the ≤450-LOC route-file target.
