### PR TITLE
refactor(vta): extract vault/upsert secret-unsealing to operations (P2.4 part 4)

### DIFF
--- a/vta-service/src/operations/vault/mod.rs
+++ b/vta-service/src/operations/vault/mod.rs
@@ -32,6 +32,8 @@ pub mod proxy_login;
 pub mod release;
 /// `vault/sign-trust-task/0.1` envelope validation + signing.
 pub mod sign_trust_task;
+/// `vault/upsert/0.1` sealed-secret unsealing.
+pub mod upsert;
 
 /// DIDComm `Message.typ` for the proxy-login envelope's cleartext (a
 /// `SessionBlob` per `vault/_shared/0.1/session-blob`). Workspace-namespaced,

--- a/vta-service/src/operations/vault/upsert.rs
+++ b/vta-service/src/operations/vault/upsert.rs
@@ -1,0 +1,59 @@
+//! `vault/upsert/0.1` secret-unsealing — the DIDComm-authcrypt crypto behind
+//! the upsert path (P2.4).
+//!
+//! Moved out of `routes/trust_tasks/vault.rs` so the last bit of secret-bearing
+//! crypto leaves the route layer. The route still owns the envelope-variant
+//! check (it knows the `SealedEnvelope` wire shape) and the entry merge/store;
+//! this unpacks the JWE, cross-checks the authcrypt sender against the
+//! authenticated caller, and deserialises the cleartext as a `VaultSecret`.
+
+use affinidi_tdk::messaging::ATM;
+
+use vti_common::vault::VaultSecret;
+
+/// Why unsealing a `didcomm-authcrypt` sealed secret failed. The route maps
+/// each onto the canonical `vault/upsert:sealed_secret_invalid` reject (sender
+/// mismatch is `permission_denied`).
+pub enum UnsealError {
+    /// The ATM failed to unpack the JWE.
+    UnpackFailed(String),
+    /// The unpacked message carries no `from` (sender).
+    MissingSender,
+    /// The authcrypt sender DID is not the authenticated caller — stops an
+    /// attacker relaying someone else's pre-signed seal through their session.
+    SenderMismatch { sender: String, caller: String },
+    /// The cleartext body is not a `VaultSecret`.
+    CleartextInvalid(String),
+}
+
+/// Unpack a `didcomm-authcrypt` JWE, verify the sender is `caller_did`, and
+/// return the enclosed `VaultSecret`.
+///
+/// The route has already established that the envelope is the
+/// `didcomm-authcrypt` variant and that an ATM is configured.
+pub async fn unseal_secret(
+    atm: &ATM,
+    caller_did: &str,
+    jwe: &str,
+) -> Result<VaultSecret, UnsealError> {
+    let (msg, _metadata) = atm
+        .unpack(jwe)
+        .await
+        .map_err(|e| UnsealError::UnpackFailed(e.to_string()))?;
+
+    // Cross-check: the authcrypt sender's DID must equal the authenticated
+    // caller.
+    let sender = msg
+        .from
+        .as_deref()
+        .map(|s| s.split('#').next().unwrap_or(s).to_string())
+        .ok_or(UnsealError::MissingSender)?;
+    if sender != caller_did {
+        return Err(UnsealError::SenderMismatch {
+            sender,
+            caller: caller_did.to_string(),
+        });
+    }
+
+    serde_json::from_value(msg.body).map_err(|e| UnsealError::CleartextInvalid(e.to_string()))
+}

--- a/vta-service/src/routes/trust_tasks/vault.rs
+++ b/vta-service/src/routes/trust_tasks/vault.rs
@@ -445,105 +445,6 @@ fn require_sign_trust_task(auth: &AuthClaims, doc: &TrustTask<Value>) -> Result<
     }
 }
 
-/// Unseal a `SealedEnvelope` into the cleartext [`VaultSecret`].
-///
-/// M2A supports the `didcomm-authcrypt` variant only. The JWE is unpacked
-/// through the VTA's ATM (same machinery the `/auth/` endpoint uses), the
-/// resulting message's `from` is cross-checked against the authenticated
-/// caller (an attacker can't relay someone else's pre-signed seal through
-/// their own auth context), and the cleartext body is deserialised as
-/// `VaultSecret`.
-///
-/// Returns an `axum::Response` carrying the appropriate Trust Task reject
-/// on failure — `envelope_unsupported` for non-DIDComm variants,
-/// `permission_denied` for sender mismatch, `sealed_secret_invalid` for
-/// every other failure path (parse, unpack, schema mismatch).
-async fn unseal_secret(
-    state: &AppState,
-    auth: &AuthClaims,
-    doc: &TrustTask<Value>,
-    envelope: &SealedEnvelope,
-) -> Result<VaultSecret, Response> {
-    let jwe = match envelope {
-        SealedEnvelope::DidcommAuthcrypt { jwe } => jwe,
-        other => {
-            return Err(reject_with(
-                doc,
-                RejectReason::TaskFailed {
-                    reason: format!(
-                        "vault/upsert:envelope_unsupported — received {kind}; this maintainer accepts only didcomm-authcrypt in M2A",
-                        kind = other.kind_name()
-                    ),
-                    details: Some(serde_json::json!({
-                        "receivedEnvelope": other.kind_name(),
-                        "supportedEnvelopes": ["didcomm-authcrypt"],
-                    })),
-                },
-            ));
-        }
-    };
-
-    let atm = state.atm.as_ref().ok_or_else(|| {
-        reject_with(
-            doc,
-            RejectReason::InternalError {
-                reason: "ATM not configured — server cannot unpack DIDComm envelopes".into(),
-            },
-        )
-    })?;
-
-    let (msg, _metadata) = atm.unpack(jwe).await.map_err(|e| {
-        reject_with(
-            doc,
-            RejectReason::TaskFailed {
-                reason: format!("vault/upsert:sealed_secret_invalid — DIDComm unpack: {e}"),
-                details: Some(serde_json::json!({ "reason": "unpack_failed" })),
-            },
-        )
-    })?;
-
-    // Cross-check: the authcrypt sender's DID must equal the authenticated
-    // caller. Stops an attacker from replaying someone else's pre-signed
-    // seal through their own session.
-    let sender = msg
-        .from
-        .as_deref()
-        .map(|s| s.split('#').next().unwrap_or(s).to_string())
-        .ok_or_else(|| {
-            reject_with(
-                doc,
-                RejectReason::TaskFailed {
-                    reason: "vault/upsert:sealed_secret_invalid — JWE has no sender (from)".into(),
-                    details: Some(serde_json::json!({ "reason": "missing_sender" })),
-                },
-            )
-        })?;
-    if sender != auth.did {
-        return Err(reject_with(
-            doc,
-            RejectReason::PermissionDenied {
-                reason: format!(
-                    "vault/upsert:sealed_secret_invalid — JWE sender {sender} does not match authenticated caller {}",
-                    auth.did
-                ),
-            },
-        ));
-    }
-
-    let secret: VaultSecret = serde_json::from_value(msg.body).map_err(|e| {
-        reject_with(
-            doc,
-            RejectReason::TaskFailed {
-                reason: format!(
-                    "vault/upsert:sealed_secret_invalid — cleartext not a VaultSecret: {e}"
-                ),
-                details: Some(serde_json::json!({ "reason": "cleartext_schema_invalid" })),
-            },
-        )
-    })?;
-    Ok(secret)
-}
-
 /// Reject if the caller's `allowed_contexts` is non-empty AND `context_id`
 /// (if supplied) is not in the allowed list. Empty allowed_contexts means
 /// super-admin scope.
@@ -774,10 +675,89 @@ pub(super) async fn handle_upsert(
     //   - no sealed_secret, existing entry → reuse existing secret.
     //   - no sealed_secret, create → secret_required.
     let secret: VaultSecret = match (&req.sealed_secret, existing.as_ref()) {
-        (Some(env), _) => match unseal_secret(state, auth, &doc, env).await {
-            Ok(s) => s,
-            Err(resp) => return resp,
-        },
+        (Some(env), _) => {
+            // Envelope-variant check stays here (the route owns the
+            // `SealedEnvelope` wire shape); the unpack + sender cross-check +
+            // cleartext deserialise are the operations-layer crypto (P2.4).
+            let jwe = match env {
+                SealedEnvelope::DidcommAuthcrypt { jwe } => jwe,
+                other => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::TaskFailed {
+                            reason: format!(
+                                "vault/upsert:envelope_unsupported — received {kind}; this maintainer accepts only didcomm-authcrypt in M2A",
+                                kind = other.kind_name()
+                            ),
+                            details: Some(serde_json::json!({
+                                "receivedEnvelope": other.kind_name(),
+                                "supportedEnvelopes": ["didcomm-authcrypt"],
+                            })),
+                        },
+                    );
+                }
+            };
+            let atm = match state.atm.as_ref() {
+                Some(atm) => atm,
+                None => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::InternalError {
+                            reason: "ATM not configured — server cannot unpack DIDComm envelopes"
+                                .into(),
+                        },
+                    );
+                }
+            };
+            use crate::operations::vault::upsert::UnsealError;
+            match crate::operations::vault::upsert::unseal_secret(atm, &auth.did, jwe).await {
+                Ok(s) => s,
+                Err(UnsealError::SenderMismatch { sender, caller }) => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::PermissionDenied {
+                            reason: format!(
+                                "vault/upsert:sealed_secret_invalid — JWE sender {sender} does not match authenticated caller {caller}"
+                            ),
+                        },
+                    );
+                }
+                Err(UnsealError::UnpackFailed(e)) => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::TaskFailed {
+                            reason: format!(
+                                "vault/upsert:sealed_secret_invalid — DIDComm unpack: {e}"
+                            ),
+                            details: Some(serde_json::json!({ "reason": "unpack_failed" })),
+                        },
+                    );
+                }
+                Err(UnsealError::MissingSender) => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::TaskFailed {
+                            reason: "vault/upsert:sealed_secret_invalid — JWE has no sender (from)"
+                                .into(),
+                            details: Some(serde_json::json!({ "reason": "missing_sender" })),
+                        },
+                    );
+                }
+                Err(UnsealError::CleartextInvalid(e)) => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::TaskFailed {
+                            reason: format!(
+                                "vault/upsert:sealed_secret_invalid — cleartext not a VaultSecret: {e}"
+                            ),
+                            details: Some(
+                                serde_json::json!({ "reason": "cleartext_schema_invalid" }),
+                            ),
+                        },
+                    );
+                }
+            }
+        }
         (None, Some(e)) => e.secret.clone(),
         (None, None) => {
             return reject_with(


### PR DESCRIPTION
## P2.4(b) part 4 (final vault increment) — vault/upsert unseal → operations

Moves the last secret-bearing crypto out of `routes/trust_tasks/vault.rs`: the DIDComm-authcrypt unseal behind `vault/upsert`. Builds on #407 / #410 / #413.

### Changes
- **`operations::vault::upsert::unseal_secret(atm, caller_did, jwe)`** — unpacks the JWE, cross-checks the authcrypt sender against the authenticated caller (stops an attacker relaying someone else's pre-signed seal through their own session), and deserialises the cleartext as a `VaultSecret`. Returns a typed **`UnsealError`** (`UnpackFailed` / `MissingSender` / `SenderMismatch` / `CleartextInvalid`).
- The route keeps the envelope-variant check (it owns the `SealedEnvelope` wire shape → `envelope_unsupported` reject), the ATM-readiness check, and the entry merge/store, mapping `UnsealError` back to the exact `sealed_secret_invalid` / `permission_denied` codes.

### Vault extraction complete
All secret-handling crypto — release JWE sealing (#407), proxy-login session sealing (#410), sign-trust-task signing (#413), and upsert unsealing (this PR) — now lives in `operations::vault::*`. The vault route handlers are `gate → parse → scope → call → map` adapters.

The residual in `vault.rs` (~1530 LOC) is request/response **wire structs**, capability gates, `enforce_context_scope`, the thin CRUD handlers (list/get/delete), and the upsert entry-merge (request-shaped field mapping, not crypto) — all legitimately route-layer. The plan's rough ≤450 estimate would require relocating the wire-type definitions, a separate concern.

### Verification
P2.0's 12 vault wire tests green **unchanged**; fmt + clippy clean (all-targets); tee compiles; full vta-service suite (965) green.
