### PR TITLE
refactor(vta): ServiceLifecycle generic for rest+webauthn enable/update (P2.3 part 1)

### DIFF
--- a/vta-service/src/operations/protocol/enable_rest.rs
+++ b/vta-service/src/operations/protocol/enable_rest.rs
@@ -1,57 +1,41 @@
 //! `enable_rest` operation.
 //!
-//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.4.
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.4. A thin
+//! wrapper over the shared [`service_lifecycle`](super::service_lifecycle)
+//! engine — see [`run_enable`] for the full sequence (super-admin →
+//! PROTOCOL_LOCK → validate URL → preconditions → snapshot → patch → publish →
+//! persist `services.rest = true` → telemetry).
 //!
-//! Sequence (under [`PROTOCOL_LOCK`]):
-//! 1. Verify caller is super-admin.
-//! 2. Validate URL via
-//!    [`vta_sdk::protocol::services::validate_service_url`] (T1.2).
-//! 3. Confirm `services.rest` is currently `false` AND no
-//!    `#vta-rest` entry is in the DID document — refuse with
-//!    [`EnableRestError::ServiceAlreadyEnabled`] otherwise.
-//! 4. Look up the VTA's webvh record + current document.
-//! 5. Persist a [`RestSnapshot::Disabled`] snapshot before the
-//!    runtime mutation, per spec §3.5a (rollback target if the
-//!    operator later runs `services rest rollback`).
-//! 6. Patch the document — insert `#vta-rest` via
-//!    [`with_rest_service`] — and publish via [`update_did_webvh`].
-//! 7. Persist `services.rest = true` to the config file.
-//! 8. Emit [`TelemetryKind::ServicesRestEnable`].
-//!
-//! Brick-prevention is **not** consulted — enabling can only add a
-//! transport service, never remove one, so the §3.2 invariant is
-//! preserved by construction.
+//! Brick-prevention is **not** consulted — enabling can only add a transport
+//! service, never remove one, so the §3.2 invariant is preserved by
+//! construction.
 
 use std::sync::Arc;
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
-use serde_json::Value as JsonValue;
 use thiserror::Error;
 use tokio::sync::RwLock;
-use tracing::info;
 
 use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
-
-use vta_sdk::protocol::services::validate_service_url;
+use vti_common::telemetry::SharedTelemetrySink;
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::document::{
-    DocumentPatchError, current_rest_service, with_rest_service,
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::OpContext;
+use crate::operations::protocol::document::DocumentPatchError;
+use crate::operations::protocol::service_lifecycle::{
+    EnableMutationError, RestService, ServiceLifecycleDeps, ServiceMutationError, run_enable,
 };
-use crate::operations::protocol::snapshot::{self, RestSnapshot, ServiceConfigSnapshot};
-use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 
 #[derive(Debug, Clone)]
 pub struct EnableRestParams {
     /// Public URL the VTA will advertise on its `#vta-rest` service
-    /// entry. Validated by [`validate_service_url`] before any
-    /// runtime mutation occurs.
+    /// entry. Validated by `validate_service_url` before any runtime
+    /// mutation occurs.
     pub url: String,
 }
 
@@ -61,13 +45,12 @@ pub struct EnableRestResult {
     /// The validated URL that was published — canonicalised from
     /// `params.url` by `url::Url`.
     pub url: String,
-    /// The VTA's own DID — subject of the LogEntry this enable
-    /// wrote. Propagated upward so route + DIDComm response
-    /// shapes can emit the "fetch did.jsonl + redeploy" hint to
-    /// operators running serverless deployments.
+    /// The VTA's own DID — subject of the LogEntry this enable wrote.
+    /// Propagated so route + DIDComm response shapes can emit the
+    /// "fetch did.jsonl + redeploy" hint for serverless deployments.
     pub vta_did: String,
-    /// True when `record.server_id == "serverless"` — the new
-    /// LogEntry is local-only.
+    /// True when `record.server_id == "serverless"` — the new LogEntry
+    /// is local-only.
     pub serverless: bool,
 }
 
@@ -118,6 +101,27 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
+impl ServiceMutationError for EnableRestError {
+    fn validation(msg: String) -> Self {
+        Self::Validation(msg)
+    }
+    fn auth(msg: String) -> Self {
+        Self::Auth(msg)
+    }
+    fn storage(msg: String) -> Self {
+        Self::Storage(msg)
+    }
+}
+
+impl EnableMutationError for EnableRestError {
+    fn already_enabled() -> Self {
+        Self::ServiceAlreadyEnabled
+    }
+    fn config_persistence(msg: String) -> Self {
+        Self::ConfigPersistence(msg)
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn enable_rest(
     config: &Arc<RwLock<AppConfig>>,
@@ -138,140 +142,58 @@ pub async fn enable_rest(
     webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<EnableRestResult, EnableRestError> {
-    auth.require_super_admin()
-        .map_err(|e| EnableRestError::Auth(e.to_string()))?;
-
-    let _guard = PROTOCOL_LOCK.lock().await;
-
-    // 1. Validate URL up front. Cheap, runs before any I/O.
-    let validated = validate_service_url(&params.url)
-        .map_err(|e| EnableRestError::Validation(e.to_string()))?;
-    let canonical_url = validated.to_string();
-
-    // 2. Read preconditions: REST must be off, both in config and
-    //    in the on-chain DID document. We check both because the
-    //    sources should agree, and a divergence is itself a bug we
-    //    want to surface (operator can run `services list` to
-    //    inspect).
-    let (vta_did, scid, current_doc) = read_preconditions(config, webvh_ks).await?;
-
-    // 3. Persist snapshot BEFORE the runtime mutation per spec
-    //    §3.5a. Pre-state for an enable is RestSnapshot::Disabled
-    //    so a future rollback re-applies "off."
-    snapshot::write(
-        snapshot_ks,
-        ServiceConfigSnapshot::Rest(RestSnapshot::Disabled),
-    )
-    .await
-    .map_err(|e| EnableRestError::Storage(format!("snapshot write: {e}")))?;
-
-    // 4. Patch the document with the new REST service entry.
-    let patched = with_rest_service(current_doc, &canonical_url)?;
-
-    // 5. Publish via update_did_webvh.
-    let update_result = update_did_webvh(
+    let deps = ServiceLifecycleDeps {
+        config,
         keys_ks,
         imported_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
+        snapshot_ks,
         seed_store,
-        auth,
-        &scid,
-        UpdateDidWebvhOptions {
-            document: Some(patched),
-            ..Default::default()
-        },
         did_resolver,
         didcomm_bridge,
-        Some(vta_did.as_str()),
+        telemetry,
         webvh_auth_locks,
+    };
+    // REST persists "enabled" as runtime state (fjall) + the in-memory flag.
+    // If this fails after publish, the LogEntry advertises REST but config
+    // disagrees — same risk window as before; operator retries.
+    let ok = run_enable::<RestService, EnableRestError>(
+        &deps,
+        auth,
+        &params.url,
+        ctx,
         channel,
+        || async {
+            crate::operations::protocol::runtime_state::set_rest_enabled(service_state_ks, true)
+                .await
+                .map_err(|e| format!("runtime state: {e}"))?;
+            config.write().await.services.rest = true;
+            Ok(())
+        },
     )
     .await?;
 
-    // 6. Persist `services.rest = true`. If this fails, the
-    //    published LogEntry advertises REST but config disagrees —
-    //    same risk window as `disable_didcomm`'s
-    //    `persist_didcomm_disabled`. Operator retries with the
-    //    config in a known state.
-    crate::operations::protocol::runtime_state::set_rest_enabled(service_state_ks, true)
-        .await
-        .map_err(|e| EnableRestError::ConfigPersistence(format!("runtime state: {e}")))?;
-    {
-        let mut cfg = config.write().await;
-        cfg.services.rest = true;
-    }
-
-    // 7. Telemetry. Channel and version-id let an external verifier
-    //    join this event to chain history.
-    let mut event = TelemetryEvent::new(TelemetryKind::ServicesRestEnable)
-        .with_field("channel", JsonValue::from(channel))
-        .with_field(
-            "new_version_id",
-            JsonValue::from(update_result.new_version_id.clone()),
-        )
-        .with_field("url", JsonValue::from(canonical_url.clone()));
-    if let Some(tag) = ctx.telemetry_triggered_by() {
-        event = event.with_field("triggered_by", JsonValue::from(tag));
-    }
-    let _ = telemetry.record(event).await;
-
-    info!(
-        channel,
-        url = %canonical_url,
-        new_version_id = %update_result.new_version_id,
-        vta_did = %vta_did,
-        "REST enabled"
-    );
-
     Ok(EnableRestResult {
-        new_version_id: update_result.new_version_id,
-        url: canonical_url,
-        vta_did,
-        // `update_did_webvh` derives `serverless` from the same
-        // record we loaded in `read_preconditions`; trust its
-        // answer so this op layer stays a single source of truth
-        // (no parallel `server_id == "serverless"` check here).
-        serverless: update_result.serverless,
+        new_version_id: ok.new_version_id,
+        url: ok.canonical_url,
+        vta_did: ok.vta_did,
+        serverless: ok.serverless,
     })
-}
-
-async fn read_preconditions(
-    config: &Arc<RwLock<AppConfig>>,
-    webvh_ks: &KeyspaceHandle,
-) -> Result<(String, String, JsonValue), EnableRestError> {
-    {
-        let cfg = config.read().await;
-        if cfg.services.rest {
-            return Err(EnableRestError::ServiceAlreadyEnabled);
-        }
-    }
-
-    let state = super::preconditions::load_vta_doc_state(config, webvh_ks).await?;
-
-    if current_rest_service(&state.current_doc).is_some() {
-        // Config and on-chain doc disagree (config: rest=false,
-        // doc: rest entry present). Surface as ServiceAlreadyEnabled
-        // — reconciling means the operator should run `services
-        // list`, not retry the enable.
-        return Err(EnableRestError::ServiceAlreadyEnabled);
-    }
-
-    Ok((state.vta_did, state.scid, state.current_doc))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::operations::protocol::snapshot::ServiceKind;
+    use crate::operations::protocol::service_lifecycle::check_enable_preconditions;
+    use crate::operations::protocol::snapshot::{self, ServiceKind};
     use crate::store::Store;
+    use vta_sdk::protocol::services::validate_service_url;
     use vti_common::config::StoreConfig as VtiStoreConfig;
 
-    /// Owns the on-disk fjall store so all keyspaces a test reaches
-    /// for share a single open handle (fjall locks the data dir on
-    /// each open). Caller derives webvh / snapshot / etc. handles
-    /// off `store`.
+    /// Owns the on-disk fjall store so all keyspaces a test reaches for
+    /// share a single open handle (fjall locks the data dir on each open).
     struct TestFixture {
         _dir: tempfile::TempDir,
         config: Arc<RwLock<AppConfig>>,
@@ -292,12 +214,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut cfg = test_app_config(dir.path().into());
         cfg.services.rest = rest_initially;
-        // §3.2 brick-prevention: keep DIDComm on so an enable-rest
-        // test never needs to consider the no-transport edge case.
+        // §3.2 brick-prevention: keep DIDComm on so an enable-rest test
+        // never needs to consider the no-transport edge case.
         cfg.services.didcomm = true;
         cfg.vta_did = Some("did:webvh:scid123:host:vta".into());
         cfg.config_path = dir.path().join("vta.toml");
-        // Persist so `persist_rest_enabled` has a file to write to.
         let initial = toml::to_string_pretty(&cfg).unwrap();
         std::fs::write(&cfg.config_path, initial).unwrap();
 
@@ -313,34 +234,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_preconditions_rejects_when_already_enabled() {
+    async fn preconditions_reject_when_already_enabled() {
         let fx = build_fixture(true);
-        let err = read_preconditions(&fx.config, &fx.webvh_ks())
-            .await
-            .unwrap_err();
+        let err =
+            check_enable_preconditions::<RestService, EnableRestError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
         assert!(matches!(err, EnableRestError::ServiceAlreadyEnabled));
     }
 
     #[tokio::test]
-    async fn read_preconditions_rejects_without_vta_did() {
+    async fn preconditions_reject_without_vta_did() {
         let fx = build_fixture(false);
         fx.config.write().await.vta_did = None;
-        let err = read_preconditions(&fx.config, &fx.webvh_ks())
-            .await
-            .unwrap_err();
+        let err =
+            check_enable_preconditions::<RestService, EnableRestError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
         assert!(matches!(err, EnableRestError::VtaDidNotConfigured));
     }
 
-    /// URL validation runs first, before any storage reads. An
-    /// invalid URL never reaches the snapshot layer.
+    /// URL validation runs first, before any storage reads. An invalid URL
+    /// never reaches the snapshot layer.
     #[tokio::test]
     async fn enable_rest_url_validation_runs_before_persist() {
         let fx = build_fixture(false);
         let snapshot_ks = fx.snapshot_ks();
 
-        // Exercise the validation step alone — `enable_rest` runs it
-        // before any I/O, so an invalid URL must not write a
-        // snapshot.
         let validated = validate_service_url("http://insecure.example.com");
         assert!(validated.is_err(), "http:// must be rejected");
 
@@ -352,10 +272,4 @@ mod tests {
             "validation error must abort before snapshot write",
         );
     }
-
-    // (Removed: `persist_rest_enabled_writes_rest_true_to_config_file`.
-    // The op now writes runtime state to fjall via
-    // `runtime_state::set_rest_enabled`, not to the config file on disk.
-    // The integration tests for the full `enable_rest` op cover that path
-    // end-to-end.)
 }

--- a/vta-service/src/operations/protocol/enable_webauthn.rs
+++ b/vta-service/src/operations/protocol/enable_webauthn.rs
@@ -1,55 +1,39 @@
 //! `enable_webauthn` operation.
 //!
-//! Mirrors [`super::enable_rest`] for the WebAuthn-RP transport.
+//! Mirrors [`super::enable_rest`] for the WebAuthn-RP transport — a thin
+//! wrapper over the shared [`service_lifecycle`](super::service_lifecycle)
+//! engine. See [`run_enable`] for the sequence. The only transport-specific
+//! difference is how "enabled" is persisted: WebAuthn writes the config file
+//! (no runtime-state keyspace), so `_service_state_ks` is unused here.
 //!
-//! Sequence (under [`PROTOCOL_LOCK`]):
-//! 1. Verify caller is super-admin.
-//! 2. Validate URL via
-//!    [`vta_sdk::protocol::services::validate_service_url`].
-//! 3. Confirm `services.webauthn` is currently `false` AND no
-//!    `#vta-webauthn` entry is in the DID document — refuse with
-//!    [`EnableWebauthnError::ServiceAlreadyEnabled`] otherwise.
-//! 4. Look up the VTA's webvh record + current document.
-//! 5. Persist a [`WebauthnSnapshot::Disabled`] snapshot before the
-//!    runtime mutation, per spec §3.5a.
-//! 6. Patch the document — insert `#vta-webauthn` via
-//!    [`with_webauthn_service`] — and publish via
-//!    [`update_did_webvh`].
-//! 7. Persist `services.webauthn = true` to the config file.
-//! 8. Emit [`TelemetryKind::ServicesWebauthnEnable`].
-//!
-//! Brick-prevention is not consulted — enabling can only add a
-//! transport service.
+//! Brick-prevention is not consulted — enabling can only add a transport
+//! service.
 
 use std::sync::Arc;
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
-use serde_json::Value as JsonValue;
 use thiserror::Error;
 use tokio::sync::RwLock;
-use tracing::info;
 
 use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
-
-use vta_sdk::protocol::services::validate_service_url;
+use vti_common::telemetry::SharedTelemetrySink;
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::document::{
-    DocumentPatchError, current_webauthn_service, with_webauthn_service,
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::OpContext;
+use crate::operations::protocol::document::DocumentPatchError;
+use crate::operations::protocol::service_lifecycle::{
+    EnableMutationError, ServiceLifecycleDeps, ServiceMutationError, WebauthnService, run_enable,
 };
-use crate::operations::protocol::snapshot::{self, ServiceConfigSnapshot, WebauthnSnapshot};
-use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 
 #[derive(Debug, Clone)]
 pub struct EnableWebauthnParams {
-    /// Public URL the VTA will advertise on its `#vta-webauthn`
-    /// service entry. Typically the auth-portal URL (e.g.
+    /// Public URL the VTA will advertise on its `#vta-webauthn` service
+    /// entry. Typically the auth-portal URL (e.g.
     /// `https://vta.example.com/auth/portal`).
     pub url: String,
 }
@@ -111,6 +95,27 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
+impl ServiceMutationError for EnableWebauthnError {
+    fn validation(msg: String) -> Self {
+        Self::Validation(msg)
+    }
+    fn auth(msg: String) -> Self {
+        Self::Auth(msg)
+    }
+    fn storage(msg: String) -> Self {
+        Self::Storage(msg)
+    }
+}
+
+impl EnableMutationError for EnableWebauthnError {
+    fn already_enabled() -> Self {
+        Self::ServiceAlreadyEnabled
+    }
+    fn config_persistence(msg: String) -> Self {
+        Self::ConfigPersistence(msg)
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn enable_webauthn(
     config: &Arc<RwLock<AppConfig>>,
@@ -120,12 +125,9 @@ pub async fn enable_webauthn(
     webvh_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
     snapshot_ks: &KeyspaceHandle,
-    // Threaded by every caller (REST + DIDComm dispatch + rollback) for
-    // signature parity with the other protocol-mutation operations.
-    // Not consumed inside this function — webauthn enable/update don't
-    // currently touch the per-kind service-state keyspace; the param
-    // is here so future runtime-state work can read/write it without
-    // churning every call site again.
+    // Threaded by every caller for signature parity with the other protocol-
+    // mutation operations; WebAuthn persists to the config file, not the
+    // per-kind service-state keyspace, so it is unused here.
     _service_state_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
     did_resolver: &DIDCacheClient,
@@ -137,109 +139,45 @@ pub async fn enable_webauthn(
     webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<EnableWebauthnResult, EnableWebauthnError> {
-    auth.require_super_admin()
-        .map_err(|e| EnableWebauthnError::Auth(e.to_string()))?;
-
-    let _guard = PROTOCOL_LOCK.lock().await;
-
-    let validated = validate_service_url(&params.url)
-        .map_err(|e| EnableWebauthnError::Validation(e.to_string()))?;
-    let canonical_url = validated.to_string();
-
-    let (vta_did, scid, current_doc) = read_preconditions(config, webvh_ks).await?;
-
-    snapshot::write(
-        snapshot_ks,
-        ServiceConfigSnapshot::Webauthn(WebauthnSnapshot::Disabled),
-    )
-    .await
-    .map_err(|e| EnableWebauthnError::Storage(format!("snapshot write: {e}")))?;
-
-    let patched = with_webauthn_service(current_doc, &canonical_url)?;
-
-    let update_result = update_did_webvh(
+    let deps = ServiceLifecycleDeps {
+        config,
         keys_ks,
         imported_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
+        snapshot_ks,
         seed_store,
-        auth,
-        &scid,
-        UpdateDidWebvhOptions {
-            document: Some(patched),
-            ..Default::default()
-        },
         did_resolver,
         didcomm_bridge,
-        Some(vta_did.as_str()),
+        telemetry,
         webvh_auth_locks,
+    };
+    // WebAuthn persists "enabled" by writing the config file.
+    let ok = run_enable::<WebauthnService, EnableWebauthnError>(
+        &deps,
+        auth,
+        &params.url,
+        ctx,
         channel,
+        || async {
+            let (contents, path) = {
+                let mut cfg = config.write().await;
+                cfg.services.webauthn = true;
+                let contents = toml::to_string_pretty(&*cfg).map_err(|e| e.to_string())?;
+                let path = cfg.config_path.clone();
+                (contents, path)
+            };
+            std::fs::write(&path, contents).map_err(|e| e.to_string())?;
+            Ok(())
+        },
     )
     .await?;
 
-    persist_webauthn_enabled(config).await?;
-
-    let mut event = TelemetryEvent::new(TelemetryKind::ServicesWebauthnEnable)
-        .with_field("channel", JsonValue::from(channel))
-        .with_field(
-            "new_version_id",
-            JsonValue::from(update_result.new_version_id.clone()),
-        )
-        .with_field("url", JsonValue::from(canonical_url.clone()));
-    if let Some(tag) = ctx.telemetry_triggered_by() {
-        event = event.with_field("triggered_by", JsonValue::from(tag));
-    }
-    let _ = telemetry.record(event).await;
-
-    info!(
-        channel,
-        url = %canonical_url,
-        new_version_id = %update_result.new_version_id,
-        vta_did = %vta_did,
-        "WebAuthn enabled"
-    );
-
     Ok(EnableWebauthnResult {
-        new_version_id: update_result.new_version_id,
-        url: canonical_url,
-        vta_did,
-        serverless: update_result.serverless,
+        new_version_id: ok.new_version_id,
+        url: ok.canonical_url,
+        vta_did: ok.vta_did,
+        serverless: ok.serverless,
     })
-}
-
-async fn read_preconditions(
-    config: &Arc<RwLock<AppConfig>>,
-    webvh_ks: &KeyspaceHandle,
-) -> Result<(String, String, JsonValue), EnableWebauthnError> {
-    {
-        let cfg = config.read().await;
-        if cfg.services.webauthn {
-            return Err(EnableWebauthnError::ServiceAlreadyEnabled);
-        }
-    }
-
-    let state = super::preconditions::load_vta_doc_state(config, webvh_ks).await?;
-
-    if current_webauthn_service(&state.current_doc).is_some() {
-        return Err(EnableWebauthnError::ServiceAlreadyEnabled);
-    }
-
-    Ok((state.vta_did, state.scid, state.current_doc))
-}
-
-async fn persist_webauthn_enabled(
-    config: &Arc<RwLock<AppConfig>>,
-) -> Result<(), EnableWebauthnError> {
-    let (contents, path) = {
-        let mut cfg = config.write().await;
-        cfg.services.webauthn = true;
-        let contents = toml::to_string_pretty(&*cfg)
-            .map_err(|e| EnableWebauthnError::ConfigPersistence(e.to_string()))?;
-        let path = cfg.config_path.clone();
-        (contents, path)
-    };
-    std::fs::write(&path, contents)
-        .map_err(|e| EnableWebauthnError::ConfigPersistence(e.to_string()))?;
-    Ok(())
 }

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -24,6 +24,7 @@ pub mod rollback_didcomm;
 pub mod rollback_rest;
 pub mod rollback_webauthn;
 pub mod runtime_state;
+pub(crate) mod service_lifecycle;
 pub mod snapshot;
 pub mod update_didcomm;
 pub mod update_rest;

--- a/vta-service/src/operations/protocol/service_lifecycle.rs
+++ b/vta-service/src/operations/protocol/service_lifecycle.rs
@@ -1,0 +1,423 @@
+//! Generic enable/update engine for the transport-service families
+//! (`rest`, `webauthn`) — P2.3 part (a).
+//!
+//! `enable_rest` / `enable_webauthn` and `update_rest` / `update_webauthn`
+//! were ~95% identical: they differ only in the config flag they read/flip,
+//! the document patcher + service reader, the snapshot variant, the telemetry
+//! kind, and (enable only) how "enabled" is persisted. This module captures
+//! the shared skeleton once:
+//!
+//! ```text
+//! super-admin → PROTOCOL_LOCK → validate URL → preconditions →
+//! snapshot (pre-state) → patch document → publish (update_did_webvh) →
+//! [persist enabled, enable only] → telemetry → result
+//! ```
+//!
+//! The transport differences live behind [`ServiceLifecycle`] (all-sync hooks,
+//! so the engine futures stay `Send`); the enable-vs-update *shape* is the two
+//! `run_*` engines. The per-op modules keep their public `*Params` / `*Result`
+//! / `*Error` types and become thin wrappers, so every caller (routes, DIDComm
+//! dispatch, rollback) is untouched. Disable/rollback (brick-prevention) and
+//! the DIDComm family are intentionally out of scope here.
+
+use std::sync::Arc;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use serde_json::Value as JsonValue;
+use tracing::info;
+
+use vti_common::seed_store::SeedStore;
+use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
+
+use vta_sdk::protocol::services::validate_service_url;
+
+use crate::auth::AuthClaims;
+use crate::config::AppConfig;
+use crate::didcomm_bridge::DIDCommBridge;
+use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
+use crate::operations::protocol::document::DocumentPatchError;
+use crate::operations::protocol::preconditions::ProtocolPreconditionError;
+use crate::operations::protocol::snapshot::{self, ServiceConfigSnapshot};
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
+use crate::store::KeyspaceHandle;
+use tokio::sync::RwLock;
+
+/// Transport-specific hooks for the shared enable/update engine. One impl per
+/// advertised transport service (`RestService`, `WebauthnService`). All methods
+/// are synchronous so a generic engine over `S: ServiceLifecycle` produces a
+/// `Send` future (the only async step — persisting "enabled" — is passed to
+/// [`run_enable`] as a closure instead).
+pub(crate) trait ServiceLifecycle {
+    /// Human label for log lines (`"REST"`, `"WebAuthn"`).
+    const LABEL: &'static str;
+    /// Telemetry kind emitted on a successful enable.
+    const ENABLE_TELEMETRY: TelemetryKind;
+    /// Telemetry kind emitted on a successful update.
+    const UPDATE_TELEMETRY: TelemetryKind;
+
+    /// Is this service currently flagged on in the live config?
+    fn config_enabled(cfg: &AppConfig) -> bool;
+    /// The URL this service currently advertises in the DID document, if any.
+    fn current_service_url(doc: &JsonValue) -> Option<String>;
+    /// Patch the document to advertise `url` on this service entry (insert on
+    /// enable, replace on update — the patcher is idempotent on shape).
+    fn with_service(doc: JsonValue, url: &str) -> Result<JsonValue, DocumentPatchError>;
+    /// Pre-state snapshot for an enable (rollback target = "off").
+    fn snapshot_disabled() -> ServiceConfigSnapshot;
+    /// Pre-state snapshot for an update (rollback target = the prior URL).
+    fn snapshot_enabled(prior_url: String) -> ServiceConfigSnapshot;
+}
+
+/// Error-construction surface the engine needs. Implemented by each per-op
+/// error enum so the engine builds the *caller's* error type directly — the
+/// public `*Error` enums (matched by routes + DIDComm `ToProblemReport`) are
+/// preserved unchanged. The `From` supertraits reuse the enums' existing
+/// `#[from]` / `From<…>` impls for the `?`-propagated cases.
+pub(crate) trait ServiceMutationError:
+    Sized + From<ProtocolPreconditionError> + From<DocumentPatchError> + From<UpdateDidWebvhError>
+{
+    fn validation(msg: String) -> Self;
+    fn auth(msg: String) -> Self;
+    fn storage(msg: String) -> Self;
+}
+
+/// Enable-specific error constructors.
+pub(crate) trait EnableMutationError: ServiceMutationError {
+    fn already_enabled() -> Self;
+    fn config_persistence(msg: String) -> Self;
+}
+
+/// Update-specific error constructors.
+pub(crate) trait UpdateMutationError: ServiceMutationError {
+    fn not_present() -> Self;
+}
+
+/// Successful enable/update outcome. The per-op wrapper maps this into its
+/// public `*Result` (`prior_url` is `Some` only for updates).
+pub(crate) struct ServiceMutationOk {
+    pub new_version_id: String,
+    pub canonical_url: String,
+    pub vta_did: String,
+    pub serverless: bool,
+    pub prior_url: Option<String>,
+}
+
+/// Keyspaces + shared infra threaded into both engines. Bundling them keeps the
+/// engine signatures (and the wrapper call sites) from sprawling past the
+/// `too_many_arguments` line; the fields mirror the historical positional args.
+pub(crate) struct ServiceLifecycleDeps<'a> {
+    pub config: &'a Arc<RwLock<AppConfig>>,
+    pub keys_ks: &'a KeyspaceHandle,
+    pub imported_ks: &'a KeyspaceHandle,
+    pub contexts_ks: &'a KeyspaceHandle,
+    pub webvh_ks: &'a KeyspaceHandle,
+    pub audit_ks: &'a KeyspaceHandle,
+    pub snapshot_ks: &'a KeyspaceHandle,
+    pub seed_store: &'a dyn SeedStore,
+    pub did_resolver: &'a DIDCacheClient,
+    pub didcomm_bridge: &'a Arc<DIDCommBridge>,
+    pub telemetry: &'a SharedTelemetrySink,
+    pub webvh_auth_locks: &'a crate::operations::did_webvh::WebvhAuthLocks,
+}
+
+/// Publish a patched document via `update_did_webvh` — the common publish step
+/// shared by enable + update.
+async fn publish_patch<E: ServiceMutationError>(
+    deps: &ServiceLifecycleDeps<'_>,
+    auth: &AuthClaims,
+    scid: &str,
+    vta_did: &str,
+    patched: JsonValue,
+    channel: &str,
+) -> Result<crate::operations::did_webvh::UpdateDidWebvhResult, E> {
+    update_did_webvh(
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.contexts_ks,
+        deps.webvh_ks,
+        deps.audit_ks,
+        deps.seed_store,
+        auth,
+        scid,
+        UpdateDidWebvhOptions {
+            document: Some(patched),
+            ..Default::default()
+        },
+        deps.did_resolver,
+        deps.didcomm_bridge,
+        Some(vta_did),
+        deps.webvh_auth_locks,
+        channel,
+    )
+    .await
+    .map_err(E::from)
+}
+
+/// Enable preconditions: the service must be OFF in both the live config and
+/// the on-chain DID document. A divergence surfaces as already-enabled (the
+/// operator reconciles via `services list`). Returns the loaded doc state.
+///
+/// Extracted from [`run_enable`] so it stays unit-testable with just a config +
+/// store fixture (no resolver / seed-store / bridge), preserving the coverage
+/// the per-op `read_preconditions` helpers used to carry.
+pub(crate) async fn check_enable_preconditions<S, E>(
+    config: &Arc<RwLock<AppConfig>>,
+    webvh_ks: &KeyspaceHandle,
+) -> Result<crate::operations::protocol::preconditions::VtaDocState, E>
+where
+    S: ServiceLifecycle,
+    E: EnableMutationError,
+{
+    {
+        let cfg = config.read().await;
+        if S::config_enabled(&cfg) {
+            return Err(E::already_enabled());
+        }
+    }
+    let state =
+        crate::operations::protocol::preconditions::load_vta_doc_state(config, webvh_ks).await?;
+    if S::current_service_url(&state.current_doc).is_some() {
+        return Err(E::already_enabled());
+    }
+    Ok(state)
+}
+
+/// Update preconditions: the service must be ON in both the live config and the
+/// on-chain document. Returns the loaded doc state plus the prior URL (the
+/// rollback target captured for the snapshot).
+pub(crate) async fn check_update_preconditions<S, E>(
+    config: &Arc<RwLock<AppConfig>>,
+    webvh_ks: &KeyspaceHandle,
+) -> Result<
+    (
+        crate::operations::protocol::preconditions::VtaDocState,
+        String,
+    ),
+    E,
+>
+where
+    S: ServiceLifecycle,
+    E: UpdateMutationError,
+{
+    {
+        let cfg = config.read().await;
+        if !S::config_enabled(&cfg) {
+            return Err(E::not_present());
+        }
+    }
+    let state =
+        crate::operations::protocol::preconditions::load_vta_doc_state(config, webvh_ks).await?;
+    let prior_url = S::current_service_url(&state.current_doc).ok_or_else(E::not_present)?;
+    Ok((state, prior_url))
+}
+
+/// Generic `enable_<service>` engine.
+///
+/// `persist_enabled` performs the (async, transport-specific) "flip to enabled"
+/// step after a successful publish — REST writes runtime-state + the in-memory
+/// flag, WebAuthn writes the config file. Passing it as a closure keeps
+/// [`ServiceLifecycle`] all-sync (and the engine future `Send`).
+pub(crate) async fn run_enable<S, E>(
+    deps: &ServiceLifecycleDeps<'_>,
+    auth: &AuthClaims,
+    url: &str,
+    ctx: OpContext,
+    channel: &str,
+    persist_enabled: impl AsyncFnOnce() -> Result<(), String>,
+) -> Result<ServiceMutationOk, E>
+where
+    S: ServiceLifecycle,
+    E: EnableMutationError,
+{
+    auth.require_super_admin()
+        .map_err(|e| E::auth(e.to_string()))?;
+
+    let _guard = PROTOCOL_LOCK.lock().await;
+
+    let canonical_url = validate_service_url(url)
+        .map_err(|e| E::validation(e.to_string()))?
+        .to_string();
+
+    let state = check_enable_preconditions::<S, E>(deps.config, deps.webvh_ks).await?;
+
+    // Snapshot BEFORE the runtime mutation (spec §3.5a): pre-state is "off".
+    snapshot::write(deps.snapshot_ks, S::snapshot_disabled())
+        .await
+        .map_err(|e| E::storage(format!("snapshot write: {e}")))?;
+
+    let patched = S::with_service(state.current_doc, &canonical_url)?;
+    let update_result =
+        publish_patch::<E>(deps, auth, &state.scid, &state.vta_did, patched, channel).await?;
+
+    persist_enabled().await.map_err(E::config_persistence)?;
+
+    emit_telemetry(
+        deps.telemetry,
+        S::ENABLE_TELEMETRY,
+        channel,
+        &update_result.new_version_id,
+        &canonical_url,
+        None,
+        ctx,
+    )
+    .await;
+    info!(
+        channel,
+        url = %canonical_url,
+        new_version_id = %update_result.new_version_id,
+        vta_did = %state.vta_did,
+        "{} enabled",
+        S::LABEL,
+    );
+
+    Ok(ServiceMutationOk {
+        new_version_id: update_result.new_version_id,
+        canonical_url,
+        vta_did: state.vta_did,
+        serverless: update_result.serverless,
+        prior_url: None,
+    })
+}
+
+/// Generic `update_<service>` engine. No config flip — the service stays
+/// enabled; only the advertised URL changes. The prior URL is captured for the
+/// rollback snapshot and surfaced in `prior_url`.
+pub(crate) async fn run_update<S, E>(
+    deps: &ServiceLifecycleDeps<'_>,
+    auth: &AuthClaims,
+    url: &str,
+    ctx: OpContext,
+    channel: &str,
+) -> Result<ServiceMutationOk, E>
+where
+    S: ServiceLifecycle,
+    E: UpdateMutationError,
+{
+    auth.require_super_admin()
+        .map_err(|e| E::auth(e.to_string()))?;
+
+    let _guard = PROTOCOL_LOCK.lock().await;
+
+    let canonical_url = validate_service_url(url)
+        .map_err(|e| E::validation(e.to_string()))?
+        .to_string();
+
+    let (state, prior_url) = check_update_preconditions::<S, E>(deps.config, deps.webvh_ks).await?;
+
+    // Snapshot BEFORE the mutation (spec §3.5a): pre-state is the prior URL.
+    snapshot::write(deps.snapshot_ks, S::snapshot_enabled(prior_url.clone()))
+        .await
+        .map_err(|e| E::storage(format!("snapshot write: {e}")))?;
+
+    let patched = S::with_service(state.current_doc, &canonical_url)?;
+    let update_result =
+        publish_patch::<E>(deps, auth, &state.scid, &state.vta_did, patched, channel).await?;
+
+    emit_telemetry(
+        deps.telemetry,
+        S::UPDATE_TELEMETRY,
+        channel,
+        &update_result.new_version_id,
+        &canonical_url,
+        Some(&prior_url),
+        ctx,
+    )
+    .await;
+    info!(
+        channel,
+        prior_url = %prior_url,
+        url = %canonical_url,
+        new_version_id = %update_result.new_version_id,
+        vta_did = %state.vta_did,
+        "{} URL updated",
+        S::LABEL,
+    );
+
+    Ok(ServiceMutationOk {
+        new_version_id: update_result.new_version_id,
+        canonical_url,
+        vta_did: state.vta_did,
+        serverless: update_result.serverless,
+        prior_url: Some(prior_url),
+    })
+}
+
+/// Shared telemetry emission (channel + version + URL, optional prior URL, plus
+/// the `triggered_by` tag for rollback-dispatched ops).
+async fn emit_telemetry(
+    telemetry: &SharedTelemetrySink,
+    kind: TelemetryKind,
+    channel: &str,
+    new_version_id: &str,
+    url: &str,
+    prior_url: Option<&str>,
+    ctx: OpContext,
+) {
+    let mut event = TelemetryEvent::new(kind)
+        .with_field("channel", JsonValue::from(channel))
+        .with_field("new_version_id", JsonValue::from(new_version_id))
+        .with_field("url", JsonValue::from(url));
+    if let Some(prior) = prior_url {
+        event = event.with_field("prior_url", JsonValue::from(prior));
+    }
+    if let Some(tag) = ctx.telemetry_triggered_by() {
+        event = event.with_field("triggered_by", JsonValue::from(tag));
+    }
+    let _ = telemetry.record(event).await;
+}
+
+/// REST transport (`#vta-rest`).
+pub(crate) struct RestService;
+
+impl ServiceLifecycle for RestService {
+    const LABEL: &'static str = "REST";
+    const ENABLE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesRestEnable;
+    const UPDATE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesRestUpdate;
+
+    fn config_enabled(cfg: &AppConfig) -> bool {
+        cfg.services.rest
+    }
+    fn current_service_url(doc: &JsonValue) -> Option<String> {
+        crate::operations::protocol::document::current_rest_service(doc).map(|s| s.url)
+    }
+    fn with_service(doc: JsonValue, url: &str) -> Result<JsonValue, DocumentPatchError> {
+        crate::operations::protocol::document::with_rest_service(doc, url)
+    }
+    fn snapshot_disabled() -> ServiceConfigSnapshot {
+        ServiceConfigSnapshot::Rest(crate::operations::protocol::snapshot::RestSnapshot::Disabled)
+    }
+    fn snapshot_enabled(prior_url: String) -> ServiceConfigSnapshot {
+        ServiceConfigSnapshot::Rest(
+            crate::operations::protocol::snapshot::RestSnapshot::Enabled { url: prior_url },
+        )
+    }
+}
+
+/// WebAuthn transport (`#vta-webauthn`).
+pub(crate) struct WebauthnService;
+
+impl ServiceLifecycle for WebauthnService {
+    const LABEL: &'static str = "WebAuthn";
+    const ENABLE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesWebauthnEnable;
+    const UPDATE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesWebauthnUpdate;
+
+    fn config_enabled(cfg: &AppConfig) -> bool {
+        cfg.services.webauthn
+    }
+    fn current_service_url(doc: &JsonValue) -> Option<String> {
+        crate::operations::protocol::document::current_webauthn_service(doc).map(|s| s.url)
+    }
+    fn with_service(doc: JsonValue, url: &str) -> Result<JsonValue, DocumentPatchError> {
+        crate::operations::protocol::document::with_webauthn_service(doc, url)
+    }
+    fn snapshot_disabled() -> ServiceConfigSnapshot {
+        ServiceConfigSnapshot::Webauthn(
+            crate::operations::protocol::snapshot::WebauthnSnapshot::Disabled,
+        )
+    }
+    fn snapshot_enabled(prior_url: String) -> ServiceConfigSnapshot {
+        ServiceConfigSnapshot::Webauthn(
+            crate::operations::protocol::snapshot::WebauthnSnapshot::Enabled { url: prior_url },
+        )
+    }
+}

--- a/vta-service/src/operations/protocol/update_rest.rs
+++ b/vta-service/src/operations/protocol/update_rest.rs
@@ -1,50 +1,32 @@
 //! `update_rest` operation.
 //!
-//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.4.
-//!
-//! Sequence (under [`PROTOCOL_LOCK`]):
-//! 1. Verify caller is super-admin.
-//! 2. Validate the new URL via
-//!    [`vta_sdk::protocol::services::validate_service_url`] (T1.2).
-//! 3. Confirm `services.rest` is currently `true` AND a
-//!    `#vta-rest` entry exists in the DID document — refuse with
-//!    [`UpdateRestError::ServiceNotPresent`] otherwise.
-//! 4. Read the prior URL from the on-chain DID document for the
-//!    snapshot.
-//! 5. Persist a [`RestSnapshot::Enabled { url: prior_url }`]
-//!    snapshot before the runtime mutation, per spec §3.5a — a
-//!    future rollback restores the prior URL.
-//! 6. Patch the document — replace the `#vta-rest` entry's URL
-//!    via [`with_rest_service`] — and publish via [`update_did_webvh`].
-//! 7. Emit [`TelemetryKind::ServicesRestUpdate`].
-//!
-//! No `services.rest` config flip — REST stays enabled across an
-//! update; only the URL changes. The brick-prevention invariant is
-//! not consulted (update can't change the on/off state).
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.4. A thin
+//! wrapper over the shared [`service_lifecycle`](super::service_lifecycle)
+//! engine — see [`run_update`] for the sequence (super-admin → PROTOCOL_LOCK →
+//! validate URL → preconditions → snapshot prior URL → patch → publish →
+//! telemetry). No `services.rest` config flip — REST stays enabled across an
+//! update; only the URL changes. Brick-prevention is not consulted (update
+//! can't change the on/off state).
 
 use std::sync::Arc;
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
-use serde_json::Value as JsonValue;
 use thiserror::Error;
 use tokio::sync::RwLock;
-use tracing::info;
 
 use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
-
-use vta_sdk::protocol::services::validate_service_url;
+use vti_common::telemetry::SharedTelemetrySink;
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::document::{
-    DocumentPatchError, current_rest_service, with_rest_service,
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::OpContext;
+use crate::operations::protocol::document::DocumentPatchError;
+use crate::operations::protocol::service_lifecycle::{
+    RestService, ServiceLifecycleDeps, ServiceMutationError, UpdateMutationError, run_update,
 };
-use crate::operations::protocol::snapshot::{self, RestSnapshot, ServiceConfigSnapshot};
-use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 
 #[derive(Debug, Clone)]
@@ -57,12 +39,10 @@ pub struct UpdateRestParams {
 #[derive(Debug, Clone)]
 pub struct UpdateRestResult {
     pub new_version_id: String,
-    /// Pre-update URL — captured from the on-chain DID document
-    /// and surfaced so callers / telemetry can join the
-    /// before-and-after.
+    /// Pre-update URL — captured from the on-chain DID document and
+    /// surfaced so callers / telemetry can join the before-and-after.
     pub prior_url: String,
-    /// The validated new URL that was published — canonicalised
-    /// from `params.url` by `url::Url`.
+    /// The validated new URL that was published.
     pub url: String,
     /// The VTA's own DID. See [`super::enable_rest::EnableRestResult`].
     pub vta_did: String,
@@ -117,6 +97,24 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
+impl ServiceMutationError for UpdateRestError {
+    fn validation(msg: String) -> Self {
+        Self::Validation(msg)
+    }
+    fn auth(msg: String) -> Self {
+        Self::Auth(msg)
+    }
+    fn storage(msg: String) -> Self {
+        Self::Storage(msg)
+    }
+}
+
+impl UpdateMutationError for UpdateRestError {
+    fn not_present() -> Self {
+        Self::ServiceNotPresent
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn update_rest(
     config: &Arc<RwLock<AppConfig>>,
@@ -137,130 +135,44 @@ pub async fn update_rest(
     webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<UpdateRestResult, UpdateRestError> {
-    auth.require_super_admin()
-        .map_err(|e| UpdateRestError::Auth(e.to_string()))?;
-
-    let _guard = PROTOCOL_LOCK.lock().await;
-
-    // 1. Validate the new URL up front. Cheap; runs before I/O.
-    let validated = validate_service_url(&params.url)
-        .map_err(|e| UpdateRestError::Validation(e.to_string()))?;
-    let canonical_url = validated.to_string();
-
-    // 2. Read preconditions: REST must be on, both in config and
-    //    on-chain. Capture the prior URL while we're at it — the
-    //    snapshot needs it.
-    let (vta_did, scid, current_doc, prior_url) = read_preconditions(config, webvh_ks).await?;
-
-    // 3. Persist snapshot BEFORE the runtime mutation per spec
-    //    §3.5a. Pre-state for an update is RestSnapshot::Enabled
-    //    with the prior URL — rollback restores that URL.
-    snapshot::write(
-        snapshot_ks,
-        ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
-            url: prior_url.clone(),
-        }),
-    )
-    .await
-    .map_err(|e| UpdateRestError::Storage(format!("snapshot write: {e}")))?;
-
-    // 4. Patch the document — replace the #vta-rest entry's URL.
-    //    `with_rest_service` overwrites the existing entry's URL
-    //    while preserving everything else byte-for-byte.
-    let patched = with_rest_service(current_doc, &canonical_url)?;
-
-    // 5. Publish via update_did_webvh.
-    let update_result = update_did_webvh(
+    let deps = ServiceLifecycleDeps {
+        config,
         keys_ks,
         imported_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
+        snapshot_ks,
         seed_store,
-        auth,
-        &scid,
-        UpdateDidWebvhOptions {
-            document: Some(patched),
-            ..Default::default()
-        },
         did_resolver,
         didcomm_bridge,
-        Some(vta_did.as_str()),
+        telemetry,
         webvh_auth_locks,
-        channel,
-    )
-    .await?;
-
-    // 6. No config persistence — services.rest stays true. The
-    //    AppConfig has no field for the public REST URL, so the
-    //    DID document is the single source of truth for the URL
-    //    (the SDK's session.rs:1100 already pulls from there).
-    //    Operators who restart the VTA pick the new URL up via
-    //    DID resolution; no config-file write is necessary.
-
-    // 7. Telemetry: prior + new URL together so external verifiers
-    //    can graph URL transitions per VTA.
-    let mut event = TelemetryEvent::new(TelemetryKind::ServicesRestUpdate)
-        .with_field("channel", JsonValue::from(channel))
-        .with_field(
-            "new_version_id",
-            JsonValue::from(update_result.new_version_id.clone()),
-        )
-        .with_field("prior_url", JsonValue::from(prior_url.clone()))
-        .with_field("url", JsonValue::from(canonical_url.clone()));
-    if let Some(tag) = ctx.telemetry_triggered_by() {
-        event = event.with_field("triggered_by", JsonValue::from(tag));
-    }
-    let _ = telemetry.record(event).await;
-
-    info!(
-        channel,
-        prior_url = %prior_url,
-        url = %canonical_url,
-        new_version_id = %update_result.new_version_id,
-        vta_did = %vta_did,
-        "REST URL updated"
-    );
+    };
+    let ok =
+        run_update::<RestService, UpdateRestError>(&deps, auth, &params.url, ctx, channel).await?;
 
     Ok(UpdateRestResult {
-        new_version_id: update_result.new_version_id,
-        prior_url,
-        url: canonical_url,
-        vta_did,
-        serverless: update_result.serverless,
+        new_version_id: ok.new_version_id,
+        // `run_update` always sets `prior_url` to `Some` on success.
+        prior_url: ok.prior_url.unwrap_or_default(),
+        url: ok.canonical_url,
+        vta_did: ok.vta_did,
+        serverless: ok.serverless,
     })
-}
-
-async fn read_preconditions(
-    config: &Arc<RwLock<AppConfig>>,
-    webvh_ks: &KeyspaceHandle,
-) -> Result<(String, String, JsonValue, String), UpdateRestError> {
-    {
-        let cfg = config.read().await;
-        if !cfg.services.rest {
-            return Err(UpdateRestError::ServiceNotPresent);
-        }
-    }
-
-    let state = super::preconditions::load_vta_doc_state(config, webvh_ks).await?;
-
-    let prior_url = current_rest_service(&state.current_doc)
-        .map(|s| s.url)
-        .ok_or(UpdateRestError::ServiceNotPresent)?;
-
-    Ok((state.vta_did, state.scid, state.current_doc, prior_url))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::operations::protocol::snapshot::ServiceKind;
+    use crate::operations::protocol::service_lifecycle::check_update_preconditions;
+    use crate::operations::protocol::snapshot::{
+        self, RestSnapshot, ServiceConfigSnapshot, ServiceKind,
+    };
     use crate::store::Store;
+    use vta_sdk::protocol::services::validate_service_url;
     use vti_common::config::StoreConfig as VtiStoreConfig;
 
-    /// Mirrors `enable_rest::tests::TestFixture` — owns the fjall
-    /// store so a single test can derive multiple keyspaces from
-    /// the same handle (fjall locks the data dir on open).
     struct TestFixture {
         _dir: tempfile::TempDir,
         config: Arc<RwLock<AppConfig>>,
@@ -299,28 +211,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_preconditions_rejects_when_rest_disabled() {
+    async fn preconditions_reject_when_rest_disabled() {
         let fx = build_fixture(false);
-        let err = read_preconditions(&fx.config, &fx.webvh_ks())
-            .await
-            .unwrap_err();
+        let err =
+            check_update_preconditions::<RestService, UpdateRestError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
         assert!(matches!(err, UpdateRestError::ServiceNotPresent));
     }
 
     #[tokio::test]
-    async fn read_preconditions_rejects_without_vta_did() {
+    async fn preconditions_reject_without_vta_did() {
         let fx = build_fixture(true);
         fx.config.write().await.vta_did = None;
-        let err = read_preconditions(&fx.config, &fx.webvh_ks())
-            .await
-            .unwrap_err();
+        let err =
+            check_update_preconditions::<RestService, UpdateRestError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
         assert!(matches!(err, UpdateRestError::VtaDidNotConfigured));
     }
 
-    /// URL validation runs first, before any storage reads or
-    /// snapshot writes — invalid URL means the snapshot keyspace
-    /// stays untouched, leaving any prior snapshot from a
-    /// successful mutation intact.
+    /// URL validation runs first, before any storage reads or snapshot
+    /// writes — invalid URL means the snapshot keyspace stays untouched.
     #[tokio::test]
     async fn invalid_url_aborts_before_snapshot_write() {
         let fx = build_fixture(true);
@@ -338,12 +250,8 @@ mod tests {
         );
     }
 
-    /// Direct exercise of the snapshot semantics: after a
-    /// successful update, the snapshot must record the *prior*
-    /// URL (not the new one). Constructed directly here because
-    /// the full operation requires a webvh store fixture too
-    /// large for a unit test — full path coverage lives in the
-    /// e2e matrix (P6).
+    /// After a successful update, the snapshot records the *prior* URL (the
+    /// rollback target), not the new one.
     #[tokio::test]
     async fn snapshot_records_prior_url_for_rollback() {
         let fx = build_fixture(true);

--- a/vta-service/src/operations/protocol/update_webauthn.rs
+++ b/vta-service/src/operations/protocol/update_webauthn.rs
@@ -1,35 +1,31 @@
 //! `update_webauthn` operation.
 //!
-//! Mirrors [`super::update_rest`]: replaces the URL on an existing
-//! `#vta-webauthn` entry. Refuses with
-//! [`UpdateWebauthnError::ServiceNotPresent`] when WebAuthn is not
-//! currently advertised.
-//!
-//! Snapshots the prior URL so rollback can restore it.
+//! Mirrors [`super::update_rest`] for the WebAuthn-RP transport — a thin
+//! wrapper over the shared [`service_lifecycle`](super::service_lifecycle)
+//! engine. See [`run_update`] for the sequence. Replaces the URL on an existing
+//! `#vta-webauthn` entry; refuses with [`UpdateWebauthnError::ServiceNotPresent`]
+//! when WebAuthn is not currently advertised. Snapshots the prior URL so
+//! rollback can restore it.
 
 use std::sync::Arc;
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
-use serde_json::Value as JsonValue;
 use thiserror::Error;
 use tokio::sync::RwLock;
-use tracing::info;
 
 use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
-
-use vta_sdk::protocol::services::validate_service_url;
+use vti_common::telemetry::SharedTelemetrySink;
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::document::{
-    DocumentPatchError, current_webauthn_service, with_webauthn_service,
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::OpContext;
+use crate::operations::protocol::document::DocumentPatchError;
+use crate::operations::protocol::service_lifecycle::{
+    ServiceLifecycleDeps, ServiceMutationError, UpdateMutationError, WebauthnService, run_update,
 };
-use crate::operations::protocol::snapshot::{self, ServiceConfigSnapshot, WebauthnSnapshot};
-use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 
 #[derive(Debug, Clone)]
@@ -90,6 +86,24 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
+impl ServiceMutationError for UpdateWebauthnError {
+    fn validation(msg: String) -> Self {
+        Self::Validation(msg)
+    }
+    fn auth(msg: String) -> Self {
+        Self::Auth(msg)
+    }
+    fn storage(msg: String) -> Self {
+        Self::Storage(msg)
+    }
+}
+
+impl UpdateMutationError for UpdateWebauthnError {
+    fn not_present() -> Self {
+        Self::ServiceNotPresent
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn update_webauthn(
     config: &Arc<RwLock<AppConfig>>,
@@ -99,9 +113,7 @@ pub async fn update_webauthn(
     webvh_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
     snapshot_ks: &KeyspaceHandle,
-    // Threaded by every caller for signature parity with the other
-    // protocol-mutation operations. Not consumed inside this function;
-    // see `enable_webauthn` for the rationale.
+    // Threaded for signature parity; see `enable_webauthn`.
     _service_state_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
     did_resolver: &DIDCacheClient,
@@ -113,90 +125,28 @@ pub async fn update_webauthn(
     webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<UpdateWebauthnResult, UpdateWebauthnError> {
-    auth.require_super_admin()
-        .map_err(|e| UpdateWebauthnError::Auth(e.to_string()))?;
-
-    let _guard = PROTOCOL_LOCK.lock().await;
-
-    let validated = validate_service_url(&params.url)
-        .map_err(|e| UpdateWebauthnError::Validation(e.to_string()))?;
-    let canonical_url = validated.to_string();
-
-    let (vta_did, scid, current_doc, prior_url) = read_preconditions(config, webvh_ks).await?;
-
-    snapshot::write(
-        snapshot_ks,
-        ServiceConfigSnapshot::Webauthn(WebauthnSnapshot::Enabled { url: prior_url }),
-    )
-    .await
-    .map_err(|e| UpdateWebauthnError::Storage(format!("snapshot write: {e}")))?;
-
-    let patched = with_webauthn_service(current_doc, &canonical_url)?;
-
-    let update_result = update_did_webvh(
+    let deps = ServiceLifecycleDeps {
+        config,
         keys_ks,
         imported_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
+        snapshot_ks,
         seed_store,
-        auth,
-        &scid,
-        UpdateDidWebvhOptions {
-            document: Some(patched),
-            ..Default::default()
-        },
         did_resolver,
         didcomm_bridge,
-        Some(vta_did.as_str()),
+        telemetry,
         webvh_auth_locks,
-        channel,
-    )
-    .await?;
-
-    let mut event = TelemetryEvent::new(TelemetryKind::ServicesWebauthnUpdate)
-        .with_field("channel", JsonValue::from(channel))
-        .with_field(
-            "new_version_id",
-            JsonValue::from(update_result.new_version_id.clone()),
-        )
-        .with_field("url", JsonValue::from(canonical_url.clone()));
-    if let Some(tag) = ctx.telemetry_triggered_by() {
-        event = event.with_field("triggered_by", JsonValue::from(tag));
-    }
-    let _ = telemetry.record(event).await;
-
-    info!(
-        channel,
-        url = %canonical_url,
-        new_version_id = %update_result.new_version_id,
-        vta_did = %vta_did,
-        "WebAuthn updated"
-    );
+    };
+    let ok =
+        run_update::<WebauthnService, UpdateWebauthnError>(&deps, auth, &params.url, ctx, channel)
+            .await?;
 
     Ok(UpdateWebauthnResult {
-        new_version_id: update_result.new_version_id,
-        url: canonical_url,
-        vta_did,
-        serverless: update_result.serverless,
+        new_version_id: ok.new_version_id,
+        url: ok.canonical_url,
+        vta_did: ok.vta_did,
+        serverless: ok.serverless,
     })
-}
-
-async fn read_preconditions(
-    config: &Arc<RwLock<AppConfig>>,
-    webvh_ks: &KeyspaceHandle,
-) -> Result<(String, String, JsonValue, String), UpdateWebauthnError> {
-    {
-        let cfg = config.read().await;
-        if !cfg.services.webauthn {
-            return Err(UpdateWebauthnError::ServiceNotPresent);
-        }
-    }
-
-    let state = super::preconditions::load_vta_doc_state(config, webvh_ks).await?;
-
-    let prior = current_webauthn_service(&state.current_doc)
-        .ok_or(UpdateWebauthnError::ServiceNotPresent)?;
-
-    Ok((state.vta_did, state.scid, state.current_doc, prior.url))
 }


### PR DESCRIPTION
## P2.3 part 1 — `ServiceLifecycle` generic (enable + update)

First slice of P2.3 (the user-approved cut: enable+update, the lowest-risk of the generic since neither consults brick-prevention). Collapses the ~95%-identical `enable_rest`/`enable_webauthn` and `update_rest`/`update_webauthn` ops onto one shared engine.

### New `operations/protocol/service_lifecycle.rs`
- **`ServiceLifecycle` trait** — all-sync transport hooks (config flag, document patcher + service reader, snapshot variants, telemetry kinds, label), with `RestService` / `WebauthnService` impls. Sync hooks keep the generic engine's future `Send`.
- **`run_enable` / `run_update`** — the shared skeleton: super-admin → `PROTOCOL_LOCK` → validate URL → preconditions → **snapshot-before-publish** → patch → `update_did_webvh` → [persist enabled, enable only] → telemetry. The async "persist enabled" step is an `AsyncFnOnce` (REST: runtime-state + in-memory flag; WebAuthn: config file).
- Shared `publish_patch`, `emit_telemetry`, and `check_{enable,update}_preconditions` helpers (preconditions stay unit-testable with just a config + store fixture).
- A `ServiceMutationError` / `EnableMutationError` / `UpdateMutationError` constructor-trait family so the engine builds each op's **existing** `*Error` enum directly — **routes + DIDComm `ToProblemReport` mappings are untouched**.

### Wrappers
`enable_rest` / `enable_webauthn` / `update_rest` / `update_webauthn` are now thin wrappers keeping their public `*Params`/`*Result`/`*Error` types — **zero caller churn** (routes, DIDComm dispatch, rollback all unchanged).

### LOC / scope note
Wrappers −288 LOC (1181→893); engine +417 → **net +129**. The plan's −2.5–3k is unrealistic: in `routes/protocol.rs` `ErrorBody` is already shared and the 87 per-variant arms are irreducible operator-UX content; the genuine reduction is the part-(a) generic, where it's offset by the engine's fixed cost. That cost amortises in **part 2** (disable/rollback reuse `publish_patch`/`emit_telemetry`/`check_*`; + the didcomm `publish_service_patch` helper; + the `ProtocolOpError`/error-mapping trait).

One observability-only behaviour change: webauthn-update telemetry now carries `prior_url` (additive; matches rest-update).

### Verification
fmt + clippy clean (default & tee); vta-service lib **719** (119 protocol-op unit tests, incl. precondition tests migrated onto the generic `check_*_preconditions`) + all **18** integration suites green; vta-enclave checks.