### PR TITLE
refactor(vta): relocate trust-task dispatch to crate::trust_tasks + typed return (P2.4)

### DIFF
--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -33,6 +33,11 @@ pub mod status;
 pub mod store;
 #[cfg(feature = "tee")]
 pub mod tee;
+/// Transport-neutral Trust-Task dispatch subsystem. Both the REST route
+/// (`routes::trust_tasks`-mounted `dispatch_trust_task`) and the DIDComm
+/// `handle_trust_task` handler dispatch through `dispatch_trust_task_core`
+/// here, so it lives at the crate root rather than under `routes::` (P2.4).
+pub mod trust_tasks;
 pub mod vault;
 #[cfg(feature = "webvh")]
 pub mod webvh_auth;

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -278,10 +278,8 @@ pub async fn handle_trust_task(
     // `permission_denied` *envelope*, not a DIDComm problem-report — a
     // conformant Trust-Task client only understands binding envelopes.
     let response = match auth_from_message(&message, &app_state.acl_ks).await {
-        Ok(auth) => {
-            crate::routes::trust_tasks::dispatch_trust_task_core(&app_state, &auth, &body).await
-        }
-        Err(e) => crate::routes::trust_tasks::reject_trust_task(
+        Ok(auth) => crate::trust_tasks::dispatch_trust_task_core(&app_state, &auth, &body).await,
+        Err(e) => crate::trust_tasks::reject_trust_task(
             &body,
             trust_tasks_rs::RejectReason::PermissionDenied {
                 reason: e.to_string(),
@@ -289,22 +287,17 @@ pub async fn handle_trust_task(
         ),
     };
 
-    let doc = response_into_json(response).await?;
+    // The dispatch core returns a typed `TrustTaskOutcome`; its `body` is
+    // already the serialised framework trust-task document, so we parse it
+    // straight into the DIDComm reply — no round-trip through an
+    // `axum::Response` to re-extract the JSON. The self-describing document
+    // (its own `type` + status `code`) carries the result; the HTTP status the
+    // core attaches is dropped on the DIDComm wire.
+    let doc: serde_json::Value = serde_json::from_slice(&response.body).map_err(handler_err)?;
 
     // The reply is itself a trust-task envelope; the service sets `thid`
     // from the inbound message id for client correlation.
     Ok(Some(DIDCommResponse::new(TRUST_TASK_ENVELOPE_TYPE, doc)))
-}
-
-/// Decompose an axum `Response` (the shared core's return) into its JSON
-/// body. The body is always a serialised framework trust-task document.
-async fn response_into_json(
-    resp: axum::response::Response,
-) -> Result<serde_json::Value, DIDCommServiceError> {
-    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
-        .await
-        .map_err(handler_err)?;
-    serde_json::from_slice(&bytes).map_err(handler_err)
 }
 
 // ---------------------------------------------------------------------------

--- a/vta-service/src/operations/step_up.rs
+++ b/vta-service/src/operations/step_up.rs
@@ -7,7 +7,7 @@
 //! modes) who must approve. It deliberately takes `config` + `acl_ks` rather
 //! than `&AppState`/`&VtaState` so **both** transports resolve the same policy:
 //! the REST `RequireStepUp` extractor + the trust-task `require_step_up`
-//! wrapper (`routes::trust_tasks::step_up`, which turn a [`StepUpDecision`] into
+//! wrapper (`crate::trust_tasks::step_up`, which turn a [`StepUpDecision`] into
 //! a `403`/reject + the approve-request push), and the DIDComm message handlers
 //! (`messaging::handlers`).
 //!
@@ -15,7 +15,7 @@
 //! `operations::step_up_policy` documented — `messaging::handlers` no longer
 //! reaches up into `routes::` to resolve a gate. The route/transport concerns
 //! (Response shaping, challenge minting, approver push, the approve-response
-//! Trust Task handler) stay in `routes::trust_tasks::step_up`.
+//! Trust Task handler) stay in `crate::trust_tasks::step_up`.
 
 use vti_common::acl::get_acl_entry;
 use vti_common::auth::step_up::StepUpMode;

--- a/vta-service/src/operations/step_up_policy.rs
+++ b/vta-service/src/operations/step_up_policy.rs
@@ -2,7 +2,7 @@
 //!
 //! The *gate* resolution algorithm lives alongside this module in
 //! [`crate::operations::step_up`] (the route-layer `RequireStepUp` extractor +
-//! `require_step_up` wrapper in `crate::routes::trust_tasks::step_up` turn its
+//! `require_step_up` wrapper in `crate::trust_tasks::step_up` turn its
 //! decision into a `403`/reject). This module is the *management* half:
 //! validating, canonicalizing, and durably applying a new
 //! [`StepUpPolicy`], so an operator can change the VTA's posture at runtime
@@ -10,7 +10,7 @@
 //!
 //! Two callers share [`set_step_up_policy`]:
 //! - the wire path — the `auth/step-up/policy/0.2` trust-task handler
-//!   (`routes::trust_tasks::step_up_policy`), authorized by a super-admin bearer;
+//!   (`crate::trust_tasks::step_up_policy`), authorized by a super-admin bearer;
 //! - the **break-glass** path — the offline `vta step-up policy` CLI (direct
 //!   config access, no wire auth), which the spec REQUIRES so an over-strict
 //!   policy can be recovered without traversing the step-up gate.

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -9,10 +9,8 @@ use crate::acl::Role;
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::error::AppError;
 use crate::operations;
-use crate::routes::trust_tasks::{
-    AclChangeRoleOp, AclGrantOp, AclRevokeOp, AclSwapKeyOp, RequireStepUp,
-};
 use crate::server::AppState;
+use crate::trust_tasks::{AclChangeRoleOp, AclGrantOp, AclRevokeOp, AclSwapKeyOp, RequireStepUp};
 
 #[derive(Debug, Deserialize)]
 pub struct ListAclQuery {

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -11,8 +11,8 @@ use vta_sdk::protocols::context_management::{
 use crate::auth::{AdminAuth, AuthClaims, SuperAdminAuth};
 use crate::error::AppError;
 use crate::operations;
-use crate::routes::trust_tasks::{ContextDeleteOp, RequireStepUp};
 use crate::server::AppState;
+use crate::trust_tasks::{ContextDeleteOp, RequireStepUp};
 
 #[derive(Debug, Deserialize)]
 pub struct CreateContextRequest {

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -21,7 +21,6 @@ mod passkey_vms;
 #[cfg(feature = "webvh")]
 mod protocol;
 mod step_up;
-pub(crate) mod trust_tasks;
 mod vta;
 
 use std::sync::Arc;
@@ -302,7 +301,10 @@ pub fn router_with_cors(allowed_origins: &[String], trust_xff: bool) -> Router<A
         // Trust-task envelope dispatcher (per
         // docs/05-design-notes/trust-task-uri-registry.md). Phase 2
         // scaffold; handlers register per Phase 3 slice.
-        .route("/api/trust-tasks", post(trust_tasks::dispatch_trust_task))
+        .route(
+            "/api/trust-tasks",
+            post(crate::trust_tasks::dispatch_trust_task),
+        )
         .route(
             "/config",
             get(config::get_config).patch(config::update_config),

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -3,7 +3,7 @@
 //! Mirrors the legacy REST `/acl/*` routes one-for-one. Auth: Admin or
 //! Initiator for list/create/get/delete; Admin-only for update.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
 use vta_sdk::protocols::acl_management::create::CreateAclBody;
@@ -26,7 +26,7 @@ pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
     }
@@ -52,7 +52,7 @@ pub(super) async fn handle_create(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
     }
@@ -103,7 +103,7 @@ pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
     }
@@ -123,7 +123,7 @@ pub(super) async fn handle_update(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -179,7 +179,7 @@ pub(super) async fn handle_delete(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
     }

--- a/vta-service/src/trust_tasks/audit.rs
+++ b/vta-service/src/trust_tasks/audit.rs
@@ -3,7 +3,7 @@
 //! Auth: Admin for list-logs and get-retention; Super-Admin for
 //! update-retention (enforced inside the operation function).
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::protocols::audit_management::list::ListAuditLogsBody;
@@ -20,7 +20,7 @@ pub(super) async fn handle_list_logs(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: ListAuditLogsBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -38,7 +38,7 @@ pub(super) async fn handle_get_retention(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let _req: GetRetentionBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -54,7 +54,7 @@ pub(super) async fn handle_update_retention(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: UpdateRetentionBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/auth.rs
+++ b/vta-service/src/trust_tasks/auth.rs
@@ -6,7 +6,7 @@
 //! `routes::auth` — see the `REST_ROUTED` allowlist in the parity
 //! harness for the full list.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::{Value, json};
 use trust_tasks_rs::{RejectReason, TrustTask};
 use vta_sdk::protocols::auth::{RevokeSessionRequest, RevokeSessionResponse, epoch_to_rfc3339};
@@ -32,7 +32,7 @@ pub(super) async fn handle_revoke_session(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     // 1. Parse the payload.
     let req: RevokeSessionRequest = match serde_json::from_value(doc.payload.clone()) {
         Ok(r) => r,
@@ -128,7 +128,7 @@ pub(super) async fn handle_whoami(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     // Live session state: acr/amr are updated in place by step-up, and
     // created_at is the session's issue time.
     let session = match get_session(&state.sessions_ks, &auth.session_id).await {
@@ -202,7 +202,7 @@ pub(super) async fn handle_sessions_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let all = match list_sessions(&state.sessions_ks).await {
         Ok(s) => s,
         Err(e) => {

--- a/vta-service/src/trust_tasks/backup.rs
+++ b/vta-service/src/trust_tasks/backup.rs
@@ -8,7 +8,7 @@
 //! See `docs/05-design-notes/backup-descriptor-pattern.md` for the
 //! protocol design.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::protocols::backup_management::descriptors::{
@@ -27,7 +27,7 @@ pub(super) async fn handle_initiate_export(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: InitiateExportBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -45,7 +45,7 @@ pub(super) async fn handle_complete_export(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: CompleteExportBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -63,7 +63,7 @@ pub(super) async fn handle_initiate_import(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: InitiateImportBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -82,7 +82,7 @@ pub(super) async fn handle_finalize_import(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: FinalizeImportBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -100,7 +100,7 @@ pub(super) async fn handle_abort(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: AbortBundleBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/config.rs
+++ b/vta-service/src/trust_tasks/config.rs
@@ -3,7 +3,7 @@
 //! Auth: any authenticated caller for `get`; Super Admin for
 //! `update` (enforced inside the operation function).
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::protocols::vta_management::get_config::GetConfigBody;
@@ -20,7 +20,7 @@ pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let _req: GetConfigBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -36,7 +36,7 @@ pub(super) async fn handle_update(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: UpdateConfigBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/contexts.rs
+++ b/vta-service/src/trust_tasks/contexts.rs
@@ -4,7 +4,7 @@
 //! authenticated caller for list/get; admin for update-did;
 //! super-admin for create/update/preview-delete/delete.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::protocols::context_management::create::CreateContextBody;
@@ -25,7 +25,7 @@ pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let _req: ListContextsBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -42,7 +42,7 @@ pub(super) async fn handle_create(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     // Admin role required; `create_context` enforces the finer gate (super-admin
     // for a top-level context, admin-of-parent for a sub-context).
     if let Err(e) = auth.require_admin() {
@@ -73,7 +73,7 @@ pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: GetContextBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -96,7 +96,7 @@ pub(super) async fn handle_update(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -127,7 +127,7 @@ pub(super) async fn handle_update_did(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -154,7 +154,7 @@ pub(super) async fn handle_preview_delete(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     // Admin role; the operation enforces access to the context or an ancestor.
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
@@ -188,7 +188,7 @@ pub(super) async fn handle_delete(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }

--- a/vta-service/src/trust_tasks/credential_exchange.rs
+++ b/vta-service/src/trust_tasks/credential_exchange.rs
@@ -22,7 +22,7 @@
 //! caller's super-admin claims authorize key access and give correct audit
 //! attribution.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::protocols::credential_exchange::{
@@ -70,7 +70,7 @@ pub(super) async fn handle_pending_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -110,7 +110,7 @@ pub(super) async fn handle_pending_approve(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -149,7 +149,7 @@ pub(super) async fn handle_pending_deny(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }

--- a/vta-service/src/trust_tasks/device.rs
+++ b/vta-service/src/trust_tasks/device.rs
@@ -6,7 +6,7 @@
 //! requires the DID to already be in the ACL (provision-integration +
 //! acl/swap-key). See dtgwg `device/*`.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use trust_tasks_rs::specs::device::disable::v0_1 as disable_spec;
@@ -27,7 +27,7 @@ pub(super) async fn handle_register(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let payload: register_spec::Payload = match parse_payload(&doc) {
         Ok(p) => p,
         Err(resp) => return resp,
@@ -62,7 +62,7 @@ pub(super) async fn handle_heartbeat(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let payload: heartbeat_spec::Payload = match parse_payload(&doc) {
         Ok(p) => p,
         Err(resp) => return resp,
@@ -78,7 +78,7 @@ pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let payload: list_spec::Payload = match parse_payload(&doc) {
         Ok(p) => p,
         Err(resp) => return resp,
@@ -94,7 +94,7 @@ pub(super) async fn handle_disable(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let payload: disable_spec::Payload = match parse_payload(&doc) {
         Ok(p) => p,
         Err(resp) => return resp,
@@ -113,7 +113,7 @@ pub(super) async fn handle_set_wake(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let payload: set_wake_spec::Payload = match parse_payload(&doc) {
         Ok(p) => p,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/did_templates.rs
+++ b/vta-service/src/trust_tasks/did_templates.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::did_templates::TemplateVars;
@@ -43,7 +43,7 @@ pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let _: ListDidTemplatesBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -65,7 +65,7 @@ pub(super) async fn handle_create(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: CreateDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -89,7 +89,7 @@ pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: GetDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -112,7 +112,7 @@ pub(super) async fn handle_update(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: UpdateDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -137,7 +137,7 @@ pub(super) async fn handle_delete(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: DeleteDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -168,7 +168,7 @@ pub(super) async fn handle_render(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: RenderDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -197,7 +197,7 @@ pub(super) async fn handle_context_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: ListContextDidTemplatesBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -221,7 +221,7 @@ pub(super) async fn handle_context_create(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: CreateContextDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -248,7 +248,7 @@ pub(super) async fn handle_context_get(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: GetContextDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -273,7 +273,7 @@ pub(super) async fn handle_context_update(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: UpdateContextDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -300,7 +300,7 @@ pub(super) async fn handle_context_delete(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: DeleteContextDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -332,7 +332,7 @@ pub(super) async fn handle_context_render(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: RenderContextDidTemplateBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/discovery.rs
+++ b/vta-service/src/trust_tasks/discovery.rs
@@ -5,7 +5,7 @@
 //! capabilities`. If that grows beyond trivial it should move to
 //! `operations::discovery`.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::protocols::discovery::{
@@ -27,7 +27,7 @@ pub(super) async fn handle_capabilities(
     state: &AppState,
     _auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let _req: CapabilitiesBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/helpers.rs
+++ b/vta-service/src/trust_tasks/helpers.rs
@@ -35,6 +35,33 @@ use crate::error::AppError;
 /// envelope (`"trust-task"`).
 pub(super) const TRANSPORT_TRUST_TASK: &str = "trust-task";
 
+/// The transport-neutral result of dispatching a Trust Task: the framework
+/// HTTP status code plus the serialised result/error document bytes.
+///
+/// Both transports render from this one value — the REST route turns it into
+/// an `axum::Response` via [`IntoResponse`]; the DIDComm `handle_trust_task`
+/// reads [`body`](Self::body) straight as the reply envelope, with no
+/// round-trip through an `axum::Response` to re-extract the JSON. The body
+/// stays raw bytes (not a `serde_json::Value`) so the wire output is
+/// byte-identical to direct document serialisation: serde_json has no
+/// `preserve_order` feature here, so a `Value` round-trip would alphabetise
+/// object keys and change the bytes.
+pub(crate) struct TrustTaskOutcome {
+    pub(crate) status: StatusCode,
+    pub(crate) body: Vec<u8>,
+}
+
+impl IntoResponse for TrustTaskOutcome {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            self.body,
+        )
+            .into_response()
+    }
+}
+
 /// Parse a trust-task document's `payload` field as the typed body
 /// `T`, or return a `MalformedRequest` rejection response.
 ///
@@ -42,7 +69,7 @@ pub(super) const TRANSPORT_TRUST_TASK: &str = "trust-task";
 /// changes is the target type.
 pub(super) fn parse_payload<T: serde::de::DeserializeOwned>(
     doc: &TrustTask<Value>,
-) -> Result<T, Response> {
+) -> Result<T, TrustTaskOutcome> {
     serde_json::from_value::<T>(doc.payload.clone()).map_err(|e| {
         reject_with(
             doc,
@@ -61,7 +88,7 @@ pub(super) fn parse_payload<T: serde::de::DeserializeOwned>(
 /// - `Validation` / `TrustTaskMalformed` → `malformed_request`
 /// - `NotFound` / `Conflict` → `task_failed`
 /// - everything else → `internal_error`
-pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> Response {
+pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> TrustTaskOutcome {
     let message = err.to_string();
     let reason = match err {
         AppError::Authentication(_) | AppError::Unauthorized(_) | AppError::Forbidden(_) => {
@@ -82,7 +109,7 @@ pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> Resp
 /// Build a routed rejection document for the given reason and wrap it
 /// in an HTTP response. The framework computes the status code from
 /// the reject's standard code.
-pub(super) fn reject_with(doc: &TrustTask<Value>, reason: RejectReason) -> Response {
+pub(super) fn reject_with(doc: &TrustTask<Value>, reason: RejectReason) -> TrustTaskOutcome {
     let routed = doc.reject_with(format!("urn:uuid:{}", Uuid::new_v4()), reason);
     error_response(routed)
 }
@@ -92,7 +119,7 @@ pub(super) fn reject_with(doc: &TrustTask<Value>, reason: RejectReason) -> Respo
 pub(super) fn success_response<R: serde::Serialize>(
     doc: &TrustTask<Value>,
     payload: R,
-) -> Response {
+) -> TrustTaskOutcome {
     let response_doc = doc.respond_with(format!("urn:uuid:{}", Uuid::new_v4()), payload);
     let body = match serde_json::to_vec(&response_doc) {
         Ok(b) => b,
@@ -106,12 +133,10 @@ pub(super) fn success_response<R: serde::Serialize>(
             );
         }
     };
-    (
-        StatusCode::OK,
-        [(axum::http::header::CONTENT_TYPE, "application/json")],
+    TrustTaskOutcome {
+        status: StatusCode::OK,
         body,
-    )
-        .into_response()
+    }
 }
 
 /// Build a routed `task_failed` rejection for a URI we know about but
@@ -119,7 +144,7 @@ pub(super) fn success_response<R: serde::Serialize>(
 /// land their match arms before the handler body — each new slice can
 /// stub via this helper, then replace with a real handler.
 #[allow(dead_code)]
-pub(super) fn not_implemented_yet(doc: TrustTask<Value>, reason: &str) -> Response {
+pub(super) fn not_implemented_yet(doc: TrustTask<Value>, reason: &str) -> TrustTaskOutcome {
     let reject = RejectReason::TaskFailed {
         reason: reason.to_string(),
         details: None,
@@ -129,7 +154,7 @@ pub(super) fn not_implemented_yet(doc: TrustTask<Value>, reason: &str) -> Respon
 }
 
 /// Build an `unsupported_type` rejection for an unrecognised type URI.
-pub(super) fn method_not_found(doc: TrustTask<Value>, type_uri: &str) -> Response {
+pub(super) fn method_not_found(doc: TrustTask<Value>, type_uri: &str) -> TrustTaskOutcome {
     let reject = RejectReason::UnsupportedType {
         type_uri: type_uri.to_string(),
     };
@@ -139,23 +164,18 @@ pub(super) fn method_not_found(doc: TrustTask<Value>, type_uri: &str) -> Respons
 
 /// Wrap a routed `ErrorResponse` in an HTTP response with the right
 /// status code per the framework's status table.
-pub(super) fn error_response(err_doc: ErrorResponse) -> Response {
+pub(super) fn error_response(err_doc: ErrorResponse) -> TrustTaskOutcome {
     let status = StatusCode::from_u16(status_for_code(&err_doc.payload.code))
         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
     let body = serde_json::to_vec(&err_doc).unwrap_or_else(|_| Vec::new());
-    (
-        status,
-        [(axum::http::header::CONTENT_TYPE, "application/json")],
-        body,
-    )
-        .into_response()
+    TrustTaskOutcome { status, body }
 }
 
 /// Build a `trust-task-error/0.1` document for a body-parse failure.
 /// Unrouted (no issuer / recipient) — the framework permits this on
 /// malformed-body failures since the producer can correlate on the
 /// response `id`.
-pub(super) fn body_parse_error_response(reason: &str) -> Response {
+pub(super) fn body_parse_error_response(reason: &str) -> TrustTaskOutcome {
     let reject = RejectReason::MalformedRequest {
         reason: format!("body did not parse as a Trust Task document: {reason}"),
     };

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -4,7 +4,7 @@
 //! caller for list/get; admin for create/rename/revoke; write
 //! (Application or higher) for sign.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use base64::Engine as _;
 use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
@@ -28,7 +28,7 @@ pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: ListKeysBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -56,7 +56,7 @@ pub(super) async fn handle_create(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -95,7 +95,7 @@ pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: GetKeyBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -111,7 +111,7 @@ pub(super) async fn handle_rename(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -139,7 +139,7 @@ pub(super) async fn handle_revoke(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -177,7 +177,7 @@ pub(super) async fn handle_sign(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_write() {
         return app_error_to_reject(&doc, e);
     }

--- a/vta-service/src/trust_tasks/management.rs
+++ b/vta-service/src/trust_tasks/management.rs
@@ -5,7 +5,7 @@
 //! Does NOT restart the process; calls `crate::server::trigger_restart`
 //! on the in-process supervisor channel.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::protocols::vta_management::restart::{ReloadServicesBody, RestartResult};
@@ -21,7 +21,7 @@ pub(super) async fn handle_reload_services(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -36,7 +36,7 @@
 //! framework SPEC §8.5) instead of axum's plain-text 400 default.
 
 use axum::extract::State;
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 
@@ -62,10 +62,11 @@ mod passkey_vms;
 #[cfg(feature = "webvh")]
 mod provision_integration;
 mod seeds;
-// `pub(crate)` so the DIDComm message handlers can reach `resolve_step_up`
-// to honour step-up floors on that transport too (P0.13). The step-up engine
-// living under `routes/` is a known layering wrinkle that P2.4 relocates to
-// `operations/`.
+// `pub(crate)` so the REST routes (`routes::acl`, `routes::contexts`) can
+// reach the `RequireStepUp` extractor + op markers. The step-up *engine* lives
+// in `operations::step_up` (P2.4); this module holds only the transport
+// wrappers (the trust-task `require_step_up`/`handle_approve_response` and the
+// REST `RequireStepUp` extractor) over it.
 pub(crate) mod step_up;
 mod step_up_policy;
 pub(crate) use step_up::{
@@ -76,6 +77,11 @@ mod vault;
 mod webvh;
 mod wire_v0_2;
 
+/// The transport-neutral dispatch result — see [`helpers::TrustTaskOutcome`].
+/// Re-exported so both transports (`routes`-mounted REST handler + DIDComm
+/// `messaging::handlers::handle_trust_task`) can name `crate::trust_tasks::
+/// TrustTaskOutcome`.
+pub(crate) use helpers::TrustTaskOutcome;
 use helpers::{body_parse_error_response, method_not_found, reject_with};
 #[cfg(feature = "didcomm")]
 use trust_tasks_rs::RejectReason;
@@ -227,7 +233,7 @@ macro_rules! dispatch_table {
             state: &AppState,
             auth: &AuthClaims,
             doc: TrustTask<Value>,
-        ) -> Response {
+        ) -> TrustTaskOutcome {
             let type_uri = doc.type_uri.to_string();
             match type_uri.as_str() {
                 $(
@@ -272,18 +278,22 @@ pub async fn dispatch_trust_task(
     State(state): State<AppState>,
     body: axum::body::Bytes,
 ) -> Result<Response, AppError> {
-    Ok(dispatch_trust_task_core(&state, &auth, &body).await)
+    Ok(dispatch_trust_task_core(&state, &auth, &body)
+        .await
+        .into_response())
 }
 
 /// Transport-agnostic trust-task dispatch core.
 ///
-/// Parses the envelope bytes and dispatches by `type` URI, returning
-/// the framework result/error document wrapped in a `Response` (the
-/// status code comes from the framework's status table). Shared by:
-/// - the REST route [`dispatch_trust_task`] (returns the `Response` as-is), and
+/// Parses the envelope bytes and dispatches by `type` URI, returning a
+/// typed [`TrustTaskOutcome`] — the framework result/error document bytes
+/// plus the status code from the framework's status table. Shared by:
+/// - the REST route [`dispatch_trust_task`], which renders it via
+///   `IntoResponse`, and
 /// - the DIDComm trust-task handler
-///   (`crate::messaging::handlers::handle_trust_task`), which decomposes
-///   the `Response` body into a DIDComm reply.
+///   (`crate::messaging::handlers::handle_trust_task`), which reads
+///   `outcome.body` straight as the reply envelope — no round-trip through
+///   an `axum::Response` to re-extract the JSON.
 ///
 /// `body` is the full `TrustTask<Value>` envelope JSON — the HTTP POST
 /// body on REST, the DIDComm message body on DIDComm.
@@ -291,7 +301,7 @@ pub(crate) async fn dispatch_trust_task_core(
     state: &AppState,
     auth: &AuthClaims,
     body: &[u8],
-) -> Response {
+) -> TrustTaskOutcome {
     // 1. Parse the envelope.
     let doc: TrustTask<Value> = match serde_json::from_slice(body) {
         Ok(d) => d,
@@ -344,8 +354,8 @@ pub(crate) async fn dispatch_trust_task_core(
         if let Ok(uri_0_1) = spec.uri_0_1.parse() {
             doc.type_uri = uri_0_1;
         }
-        let resp = dispatch_typed(state, auth, doc).await;
-        return wire_v0_2::upconvert_response(resp, spec).await;
+        let outcome = dispatch_typed(state, auth, doc).await;
+        return wire_v0_2::upconvert_response(outcome, spec);
     }
     dispatch_typed(state, auth, doc).await
 }
@@ -360,7 +370,7 @@ pub(crate) async fn dispatch_trust_task_core(
 /// rejects unauthenticated callers before dispatch, so this gap is
 /// DIDComm-only — hence the feature gate.)
 #[cfg(feature = "didcomm")]
-pub(crate) fn reject_trust_task(body: &[u8], reason: RejectReason) -> Response {
+pub(crate) fn reject_trust_task(body: &[u8], reason: RejectReason) -> TrustTaskOutcome {
     match serde_json::from_slice::<TrustTask<Value>>(body) {
         Ok(doc) => reject_with(&doc, reason),
         Err(e) => body_parse_error_response(&e.to_string()),

--- a/vta-service/src/trust_tasks/passkey_vms.rs
+++ b/vta-service/src/trust_tasks/passkey_vms.rs
@@ -17,7 +17,7 @@
 
 #![cfg(all(feature = "webvh", feature = "didcomm"))]
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::{ErrorPayload, StandardCode, TrustTask, TrustTaskCode};
 use vta_sdk::protocols::did_management::passkey_vms::{
@@ -91,7 +91,7 @@ fn slug_from_doc(doc: &TrustTask<Value>) -> String {
 
 /// Render a `PasskeyVmError` as a spec-taxonomy trust-task error response,
 /// namespaced to the task that raised it.
-fn passkey_vm_reject(doc: &TrustTask<Value>, err: PasskeyVmError) -> Response {
+fn passkey_vm_reject(doc: &TrustTask<Value>, err: PasskeyVmError) -> TrustTaskOutcome {
     let slug = slug_from_doc(doc);
     let (code, reason) = passkey_vm_code(&slug, &err);
     let mut payload = ErrorPayload::new(code).with_message(err.to_string());
@@ -107,7 +107,7 @@ pub(super) async fn handle_enroll_challenge(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: EnrollPasskeyChallengeBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -136,7 +136,7 @@ pub(super) async fn handle_enroll_submit(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: EnrollPasskeySubmitBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -182,7 +182,7 @@ pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: ListPasskeyVmsBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -200,7 +200,7 @@ pub(super) async fn handle_revoke(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: RevokePasskeyVmBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/provision_integration.rs
+++ b/vta-service/src/trust_tasks/provision_integration.rs
@@ -18,7 +18,7 @@
 
 #![cfg(feature = "webvh")]
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::provision_integration::http::{
@@ -42,7 +42,7 @@ pub(super) async fn handle_request(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: ProvisionIntegrationRequest = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/seeds.rs
+++ b/vta-service/src/trust_tasks/seeds.rs
@@ -3,7 +3,7 @@
 //! Auth: Admin for list/rotate; Admin for export-mnemonic (one-shot
 //! mnemonic dump under `MnemonicExportGuard`).
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::protocols::key_management::secret::GetKeySecretBody;
@@ -21,7 +21,7 @@ pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -40,7 +40,7 @@ pub(super) async fn handle_rotate(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -71,7 +71,7 @@ pub(super) async fn handle_export_mnemonic(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -44,7 +44,7 @@ use vti_common::store::KeyspaceHandle;
 // turn its `StepUpDecision` into a `403`/reject + approve-request push.
 use crate::operations::step_up::{StepUpDecision, resolve_step_up};
 
-use super::helpers::{reject_with, success_response};
+use super::helpers::{TrustTaskOutcome, reject_with, success_response};
 
 /// Why a step-up gate failed to verify. Maps to the spec's approve-response
 /// error codes in the handler.
@@ -229,7 +229,7 @@ pub(super) async fn handle_approve_response(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     // 1. Parse the typed payload from a version-normalised copy (see above).
     let payload: approve_response::Payload = {
         let mut payload_value = doc.payload.clone();
@@ -766,7 +766,7 @@ pub(super) async fn require_step_up(
     auth: &AuthClaims,
     op_class: &str,
     doc: &TrustTask<Value>,
-) -> Option<Response> {
+) -> Option<TrustTaskOutcome> {
     if auth.acr == STEP_UP_TARGET_ACR {
         return None;
     }

--- a/vta-service/src/trust_tasks/step_up_policy.rs
+++ b/vta-service/src/trust_tasks/step_up_policy.rs
@@ -12,7 +12,7 @@
 //! the authenticated caller; full TT-proof verification lands with the
 //! session-pubkey binding (dispatcher Phase 3), as for every other mutating arm.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde_json::{Value, json};
 
 use trust_tasks_rs::specs::auth::step_up::policy::v0_2 as policy;
@@ -39,7 +39,7 @@ pub(super) async fn handle_set_step_up_policy(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     // Authz: only a super-admin may change the VTA's security posture.
     if !auth.is_super_admin() {
         return reject_with(

--- a/vta-service/src/trust_tasks/vault.rs
+++ b/vta-service/src/trust_tasks/vault.rs
@@ -19,7 +19,7 @@
 //! carry the write capabilities; Application/Reader carry read-only;
 //! Monitor carries none.
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
@@ -347,7 +347,7 @@ fn require_capability(
     doc: &TrustTask<Value>,
     cap: Capability,
     action: &str,
-) -> Result<(), Response> {
+) -> Result<(), TrustTaskOutcome> {
     if role_has_capability(&auth.role, cap) {
         Ok(())
     } else {
@@ -370,7 +370,7 @@ fn enforce_context_scope(
     auth: &AuthClaims,
     context_id: Option<&str>,
     doc: &TrustTask<Value>,
-) -> Result<(), Response> {
+) -> Result<(), TrustTaskOutcome> {
     let Some(ctx) = context_id else {
         return Ok(()); // No context filter — caller's full visibility applies.
     };
@@ -393,7 +393,7 @@ pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(r) = require_capability(auth, &doc, Capability::VaultRead, "read") {
         return r;
     }
@@ -466,7 +466,7 @@ pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(r) = require_capability(auth, &doc, Capability::VaultRead, "read") {
         return r;
     }
@@ -512,7 +512,7 @@ pub(super) async fn handle_upsert(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(r) = require_capability(auth, &doc, Capability::VaultWrite, "write") {
         return r;
     }
@@ -830,7 +830,7 @@ pub(super) async fn handle_delete(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(r) = require_capability(auth, &doc, Capability::VaultWrite, "write") {
         return r;
     }
@@ -922,7 +922,7 @@ pub(super) async fn handle_release(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(r) = require_capability(auth, &doc, Capability::FillRelease, "release") {
         return r;
     }
@@ -1031,7 +1031,7 @@ pub(super) async fn handle_proxy_login(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(r) = require_capability(auth, &doc, Capability::ProxyLogin, "proxy-login") {
         return r;
     }
@@ -1231,7 +1231,7 @@ pub(super) async fn handle_sign_trust_task(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(r) = require_capability(auth, &doc, Capability::SignTrustTask, "sign-trust-task") {
         return r;
     }

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -31,7 +31,7 @@
 
 #![cfg(feature = "webvh")]
 
-use axum::response::Response;
+use super::helpers::TrustTaskOutcome;
 use didwebvh_rs::witness::Witnesses;
 use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
@@ -69,7 +69,7 @@ pub(super) async fn handle_servers_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let _: ListWebvhServersBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -87,7 +87,7 @@ pub(super) async fn handle_servers_add(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -125,7 +125,7 @@ pub(super) async fn handle_servers_update(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -152,7 +152,7 @@ pub(super) async fn handle_servers_remove(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }
@@ -180,7 +180,7 @@ pub(super) async fn handle_dids_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: ListDidsWebvhBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -204,7 +204,7 @@ pub(super) async fn handle_dids_create(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let body: CreateDidWebvhBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -246,7 +246,7 @@ pub(super) async fn handle_dids_get(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: GetDidWebvhBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -272,7 +272,7 @@ pub(super) async fn handle_dids_get_log(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: GetDidWebvhLogBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -296,7 +296,7 @@ pub(super) async fn handle_dids_delete(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: DeleteDidWebvhBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -350,7 +350,7 @@ pub(super) async fn handle_dids_update(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: UpdateDidWithDid = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -400,7 +400,7 @@ pub(super) async fn handle_dids_rotate_keys(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     let req: RotateKeysWithDid = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -448,7 +448,7 @@ pub(super) async fn handle_dids_register_with_server(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-) -> Response {
+) -> TrustTaskOutcome {
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }

--- a/vta-service/src/trust_tasks/wire_v0_2.rs
+++ b/vta-service/src/trust_tasks/wire_v0_2.rs
@@ -32,9 +32,9 @@
 //! payload) — mutating those bytes would void the proof, so they get genuine
 //! version-matched typed handlers instead.
 
-use axum::body::Body;
-use axum::response::Response;
 use serde_json::Value;
+
+use super::TrustTaskOutcome;
 
 /// One spec's 0.1 ⇄ 0.2 mapping. Paths are `.`-separated and relative to the
 /// document `payload`; a `*` segment fans out over every array element or
@@ -245,29 +245,22 @@ pub(super) fn kebabize_paths(payload: &mut Value, paths: &[&str]) {
     apply_paths(payload, paths, kebabize);
 }
 
-/// Maximum response body we'll re-read to up-convert. Trust-Task responses are
-/// small; the workspace-wide 1 MB request cap bounds the inputs that produce
-/// them. Generous headroom over that.
-const MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
-
-/// Up-convert a handler's response: retype `…/0.1#response` → `…/0.2#response`
+/// Up-convert a dispatch outcome: retype `…/0.1#response` → `…/0.2#response`
 /// and rewrite the response payload's enum values to camel. Error/reject
 /// documents (a different `type`) are passed through with only the type
 /// prefix swapped, since their payload carries no spec enums.
-pub(super) async fn upconvert_response(resp: Response, spec: &WireSpecV02) -> Response {
-    let (parts, body) = resp.into_parts();
-    let bytes = match axum::body::to_bytes(body, MAX_RESPONSE_BYTES).await {
-        Ok(b) => b,
-        Err(_) => {
-            // Body couldn't be buffered (shouldn't happen for our in-memory
-            // responses). Nothing left to send — surface an empty body.
-            return Response::from_parts(parts, Body::empty());
-        }
-    };
-    let mut doc: Value = match serde_json::from_slice(&bytes) {
+///
+/// Operates on the typed [`TrustTaskOutcome`] body directly — the status is
+/// preserved untouched and there is no round-trip through an `axum::Response`.
+pub(super) fn upconvert_response(
+    outcome: TrustTaskOutcome,
+    spec: &WireSpecV02,
+) -> TrustTaskOutcome {
+    let TrustTaskOutcome { status, body } = outcome;
+    let mut doc: Value = match serde_json::from_slice(&body) {
         Ok(v) => v,
         // Not JSON (shouldn't happen) — pass the original bytes through.
-        Err(_) => return Response::from_parts(parts, Body::from(bytes)),
+        Err(_) => return TrustTaskOutcome { status, body },
     };
 
     // Retype the response document. A success response echoes the (now 0.1)
@@ -285,8 +278,11 @@ pub(super) async fn upconvert_response(resp: Response, spec: &WireSpecV02) -> Re
         apply_paths(payload, spec.response_paths, camelize);
     }
 
-    let new_bytes = serde_json::to_vec(&doc).unwrap_or_else(|_| bytes.to_vec());
-    Response::from_parts(parts, Body::from(new_bytes))
+    let new_body = serde_json::to_vec(&doc).unwrap_or(body);
+    TrustTaskOutcome {
+        status,
+        body: new_body,
+    }
 }
 
 #[cfg(test)]
@@ -394,18 +390,13 @@ mod tests {
                 "truncated": false
             }
         });
-        let body = serde_json::to_vec(&doc).unwrap();
-        let resp = Response::builder()
-            .status(200)
-            .header("content-type", "application/json")
-            .body(Body::from(body))
-            .unwrap();
+        let outcome = TrustTaskOutcome {
+            status: axum::http::StatusCode::OK,
+            body: serde_json::to_vec(&doc).unwrap(),
+        };
 
-        let out = upconvert_response(resp, spec).await;
-        let bytes = axum::body::to_bytes(out.into_body(), MAX_RESPONSE_BYTES)
-            .await
-            .unwrap();
-        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        let out = upconvert_response(outcome, spec);
+        let v: Value = serde_json::from_slice(&out.body).unwrap();
 
         assert_eq!(
             v["type"],
@@ -432,15 +423,12 @@ mod tests {
             "type": "https://trusttasks.org/spec/trust-task-error/0.1",
             "payload": { "code": "permission_denied", "reason": "nope" }
         });
-        let resp = Response::builder()
-            .status(403)
-            .body(Body::from(serde_json::to_vec(&doc).unwrap()))
-            .unwrap();
-        let out = upconvert_response(resp, spec).await;
-        let bytes = axum::body::to_bytes(out.into_body(), MAX_RESPONSE_BYTES)
-            .await
-            .unwrap();
-        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        let outcome = TrustTaskOutcome {
+            status: axum::http::StatusCode::FORBIDDEN,
+            body: serde_json::to_vec(&doc).unwrap(),
+        };
+        let out = upconvert_response(outcome, spec);
+        let v: Value = serde_json::from_slice(&out.body).unwrap();
         assert_eq!(
             v["type"],
             "https://trusttasks.org/spec/trust-task-error/0.1"
@@ -486,15 +474,12 @@ mod tests {
                 "truncated": false
             }
         });
-        let resp = Response::builder()
-            .status(200)
-            .body(Body::from(serde_json::to_vec(&doc).unwrap()))
-            .unwrap();
-        let out = upconvert_response(resp, spec).await;
-        let bytes = axum::body::to_bytes(out.into_body(), MAX_RESPONSE_BYTES)
-            .await
-            .unwrap();
-        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        let outcome = TrustTaskOutcome {
+            status: axum::http::StatusCode::OK,
+            body: serde_json::to_vec(&doc).unwrap(),
+        };
+        let out = upconvert_response(outcome, spec);
+        let v: Value = serde_json::from_slice(&out.body).unwrap();
         assert_eq!(
             v["type"],
             "https://trusttasks.org/spec/vault/list/0.2#response"


### PR DESCRIPTION
## What

P2.4 final piece — close out "move logic out of routes" for the trust-task dispatcher (plan area **(d)**). Two coordinated changes that serve one goal (a transport-neutral dispatch subsystem):

1. **Relocate** `routes/trust_tasks/` → crate root `trust_tasks/`.
2. **Typed dispatch return** — `TrustTaskOutcome` replaces `axum::Response` through the dispatch core, killing both `axum::Response` round-trips.

## Relocation

`git mv routes/trust_tasks → trust_tasks/`. The subsystem had **zero** internal `crate::routes` references — the slice handlers only reach `operations::` / `server::` / `auth::` + `vta_sdk`, so it was already transport-neutral; declaring it at the crate root makes that structural. `routes::{acl,contexts}` (step-up extractor imports) and `messaging::handlers` now import `crate::trust_tasks::*`.

➡️ **messaging no longer imports `routes::`** — the P2.4 headline accept criterion.

git detected all 22 subsystem files as renames, so the diff is rename + small per-file deltas (the signature/import changes below).

## Typed return

New `TrustTaskOutcome { status: StatusCode, body: Vec<u8> }`. The wire helpers, every slice `handle_*`, `dispatch_typed` / `dispatch_trust_task_core`, `reject_trust_task`, and `wire_v0_2::upconvert_response` return it instead of `axum::Response`:

- **REST** (`dispatch_trust_task`) renders it via `IntoResponse`.
- **DIDComm** (`handle_trust_task`) reads `outcome.body` straight into the reply envelope — `response_into_json` deleted.

This removes **both** `axum::Response` round-trips the plan flagged: messaging's `to_bytes(into_body())` and `wire_v0_2::upconvert_response`'s internal one (which now transforms the body bytes in place, status untouched).

### Why `body: Vec<u8>` and not `serde_json::Value`

`serde_json` has no `preserve_order` feature in this workspace, so round-tripping a response document through `Value` would alphabetise object keys and change the wire bytes. Raw bytes keep the output **byte-identical** to direct document serialisation.

## step_up.rs split

`step_up.rs` mixes transports, so the return types split cleanly:
- Trust-task functions (`handle_approve_response`, `require_step_up`) → `TrustTaskOutcome`.
- REST-only 403 builders (`issue_step_up_challenge`, `step_up_denied_response`) and the `RequireStepUp` axum extractor stay `axum::Response` — they emit the REST `403`-carries-approve-request shape, not a trust-task document.

## Accept criteria (P2.4)

- ✅ messaging no longer imports `routes::`
- ✅ typed return; both transports render from it (no `axum::Response` round-trip to extract JSON)
- ✅ wire behaviour byte-identical (raw-bytes body)

This **closes P2.4** — all four "move logic out of routes" areas are now done (vault #407/#410/#413/#414, step-up #416, backup-blob #417, dispatch this PR).

## Verification

- fmt + clippy (default & `tee`) clean, all targets
- vta-service lib **719** + bin **45** + all integration suites green — including the dispatch-exercising ones: `api_integration` 115, `vault_trust_task` 12, `step_up_approve_response` 5, `step_up_policy` 7, and the authenticate/refresh/whoami/sessions/pending trust-task suites
- vta-enclave checks
- No version bump (relocation + additive type)
