### PR TITLE
refactor(vta): share the disable skeleton via ServiceLifecycle helpers (P2.3 part 2)

### DIFF
--- a/vta-service/src/operations/protocol/disable_rest.rs
+++ b/vta-service/src/operations/protocol/disable_rest.rs
@@ -1,32 +1,20 @@
 //! `disable_rest` operation.
 //!
-//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.2,
-//! §3.4.
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.2, §3.4.
+//! Shares the disable skeleton (brick-prevention → preconditions → snapshot →
+//! patch-remove → publish) with [`super::disable_webauthn`] via the
+//! [`service_lifecycle`](super::service_lifecycle) helpers; the REST-specific
+//! persist (runtime-state + in-memory flag) and telemetry stay here.
 //!
 //! Sequence (under [`PROTOCOL_LOCK`]):
-//! 1. Verify caller is super-admin.
-//! 2. Confirm `services.rest` is currently `true` AND a `#vta-rest`
-//!    entry exists in the DID document — refuse with
-//!    [`DisableRestError::ServiceNotPresent`] otherwise.
-//! 3. Brick-prevention via
-//!    [`would_violate_last_service`] — refuse with
-//!    [`DisableRestError::LastServiceRefused`] when DIDComm is
-//!    also disabled (VTA would have no advertised transport).
-//! 4. Read the prior URL from the on-chain DID document for the
-//!    snapshot.
-//! 5. Persist a [`RestSnapshot::Enabled { url: prior_url }`]
-//!    snapshot before the runtime mutation, per spec §3.5a — a
-//!    future rollback re-enables REST at the same URL.
-//! 6. Patch the document — remove the `#vta-rest` entry via
-//!    [`without_rest_service`] — and publish via
-//!    [`update_did_webvh`].
-//! 7. Persist `services.rest = false` to the config file.
-//! 8. Emit [`TelemetryKind::ServicesRestDisable`].
+//! 1. super-admin → 2. brick-prevention (refuse if it would leave no advertised
+//!    transport) → 3. snapshot `RestSnapshot::Enabled { prior_url }` (rollback
+//!    target) → 4. remove `#vta-rest` + publish → 5. persist `services.rest =
+//!    false` → 6. telemetry.
 //!
-//! REST has no drain semantics — there's nothing to keep listening
-//! for after the URL is unadvertised. The Axum process stays running
-//! (it's a process-level binding), so the local CLI can still reach
-//! the VTA; only the *advertisement* is removed.
+//! REST has no drain semantics — the Axum process stays running (it's a
+//! process-level binding), so the local CLI can still reach the VTA; only the
+//! *advertisement* is removed.
 
 use std::sync::Arc;
 
@@ -45,17 +33,14 @@ use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::document::{
-    DocumentPatchError, current_rest_service, without_rest_service,
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::OpContext;
+use crate::operations::protocol::document::DocumentPatchError;
+use crate::operations::protocol::service_lifecycle::{
+    DisableMutationError, RestService, ServiceLifecycle, ServiceLifecycleDeps,
+    check_disable_preconditions, publish_patch,
 };
-use crate::operations::protocol::invariant::{
-    CurrentServices, ProposedOp, would_violate_last_service,
-};
-use crate::operations::protocol::snapshot::{
-    self, RestSnapshot, ServiceConfigSnapshot, ServiceKind,
-};
-use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
+use crate::operations::protocol::{PROTOCOL_LOCK, snapshot};
 use crate::store::KeyspaceHandle;
 
 #[derive(Debug, Clone, Default)]
@@ -64,8 +49,8 @@ pub struct DisableRestParams;
 #[derive(Debug, Clone)]
 pub struct DisableRestResult {
     pub new_version_id: String,
-    /// Pre-disable URL — recorded so callers / telemetry / audit
-    /// can graph what was just unadvertised.
+    /// Pre-disable URL — recorded so callers / telemetry / audit can graph
+    /// what was just unadvertised.
     pub prior_url: String,
     /// The VTA's own DID. See [`super::enable_rest::EnableRestResult`].
     pub vta_did: String,
@@ -124,17 +109,22 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
-/// Map [`VtaError::LastServiceRefused`] (from the invariant
-/// helper) onto our typed variant. Other [`VtaError`] shapes
-/// shouldn't surface here — the helper is total over its inputs —
-/// but if one ever does we route it through `Storage` so it isn't
-/// silently swallowed.
+/// Map [`VtaError::LastServiceRefused`] (from the invariant helper) onto our
+/// typed variant. Other [`VtaError`] shapes shouldn't surface here — the helper
+/// is total over its inputs — but if one ever does we route it through
+/// `Storage` so it isn't silently swallowed.
 impl From<VtaError> for DisableRestError {
     fn from(value: VtaError) -> Self {
         match value {
             VtaError::LastServiceRefused => Self::LastServiceRefused,
             other => Self::Storage(other.to_string()),
         }
+    }
+}
+
+impl DisableMutationError for DisableRestError {
+    fn not_present() -> Self {
+        Self::ServiceNotPresent
     }
 }
 
@@ -163,69 +153,47 @@ pub async fn disable_rest(
 
     let _guard = PROTOCOL_LOCK.lock().await;
 
-    // 1. Brick-prevention runs FIRST — fail-fast on the cheap
-    //    config-only check before any I/O. Mirrors disable_didcomm's
-    //    order, where the §3.2 invariant is checked before reading
-    //    the webvh log. The prior_url for the snapshot is captured
-    //    later, after the brick check has already passed.
-    let (didcomm_enabled, webauthn_enabled) = {
-        let cfg = config.read().await;
-        if !cfg.services.rest {
-            return Err(DisableRestError::ServiceNotPresent);
-        }
-        (cfg.services.didcomm, cfg.services.webauthn)
-    };
-    would_violate_last_service(
-        &CurrentServices::new(true, didcomm_enabled, webauthn_enabled),
-        ProposedOp::disable(ServiceKind::Rest),
-    )?;
-
-    // 2. Read on-chain state: VTA DID record + DID log. Validates
-    //    services.rest == true (already done above) AND captures
-    //    the prior URL for the snapshot.
-    let (vta_did, scid, current_doc, prior_url, _) = read_preconditions(config, webvh_ks).await?;
-
-    // 3. Persist snapshot BEFORE the runtime mutation per spec
-    //    §3.5a. Pre-state is RestSnapshot::Enabled with the prior
-    //    URL — rollback re-enables REST at that URL.
-    snapshot::write(
-        snapshot_ks,
-        ServiceConfigSnapshot::Rest(RestSnapshot::Enabled {
-            url: prior_url.clone(),
-        }),
-    )
-    .await
-    .map_err(|e| DisableRestError::Storage(format!("snapshot write: {e}")))?;
-
-    // 4. Patch the document — remove the #vta-rest entry.
-    let patched = without_rest_service(current_doc);
-
-    // 5. Publish via update_did_webvh.
-    let update_result = update_did_webvh(
+    let deps = ServiceLifecycleDeps {
+        config,
         keys_ks,
         imported_ks,
         contexts_ks,
         webvh_ks,
         audit_ks,
+        snapshot_ks,
         seed_store,
-        auth,
-        &scid,
-        UpdateDidWebvhOptions {
-            document: Some(patched),
-            ..Default::default()
-        },
         did_resolver,
         didcomm_bridge,
-        Some(vta_did.as_str()),
+        telemetry,
         webvh_auth_locks,
+    };
+
+    // Brick-prevention (§3.2) + preconditions, capturing the prior URL.
+    let (state, prior_url) =
+        check_disable_preconditions::<RestService, DisableRestError>(config, webvh_ks).await?;
+
+    // Snapshot BEFORE the mutation (spec §3.5a): pre-state is the prior URL.
+    snapshot::write(
+        snapshot_ks,
+        RestService::snapshot_enabled(prior_url.clone()),
+    )
+    .await
+    .map_err(|e| DisableRestError::Storage(format!("snapshot write: {e}")))?;
+
+    let patched = RestService::without_service(state.current_doc);
+    let update_result = publish_patch::<DisableRestError>(
+        &deps,
+        auth,
+        &state.scid,
+        &state.vta_did,
+        patched,
         channel,
     )
     .await?;
 
-    // 6. Persist services.rest = false to fjall (authoritative runtime state)
-    //    + mirror into the in-memory config so existing readers see it. Same
-    //    risk window as the other ops if this fails after publish — operator
-    //    retries.
+    // Persist services.rest = false to fjall (authoritative runtime state) +
+    // mirror into the in-memory config. Same post-publish risk window as the
+    // other ops if this fails — operator retries.
     crate::operations::protocol::runtime_state::set_rest_enabled(service_state_ks, false)
         .await
         .map_err(|e| DisableRestError::Storage(format!("runtime state: {e}")))?;
@@ -234,8 +202,6 @@ pub async fn disable_rest(
         cfg.services.rest = false;
     }
 
-    // 7. Telemetry. Prior URL is included so an external verifier
-    //    knows what URL just stopped being advertised.
     let mut event = TelemetryEvent::new(TelemetryKind::ServicesRestDisable)
         .with_field("channel", JsonValue::from(channel))
         .with_field(
@@ -252,61 +218,30 @@ pub async fn disable_rest(
         channel,
         prior_url = %prior_url,
         new_version_id = %update_result.new_version_id,
-        vta_did = %vta_did,
+        vta_did = %state.vta_did,
         "REST disabled"
     );
 
     Ok(DisableRestResult {
         new_version_id: update_result.new_version_id,
         prior_url,
-        vta_did,
+        vta_did: state.vta_did,
         serverless: update_result.serverless,
     })
-}
-
-async fn read_preconditions(
-    config: &Arc<RwLock<AppConfig>>,
-    webvh_ks: &KeyspaceHandle,
-) -> Result<(String, String, JsonValue, String, bool), DisableRestError> {
-    // Op-specific config check first — this is what `services.rest`
-    // gates. Capture `didcomm_enabled` while we hold the read-lock
-    // so the caller knows whether disabling REST would brick the
-    // VTA (no protocol surface).
-    let didcomm_enabled = {
-        let cfg = config.read().await;
-        if !cfg.services.rest {
-            return Err(DisableRestError::ServiceNotPresent);
-        }
-        cfg.services.didcomm
-    };
-
-    // Common load: `vta_did`, `scid`, `did_log`, `current_doc` —
-    // shared with every other protocol op via
-    // `super::preconditions::load_vta_doc_state`.
-    let state = super::preconditions::load_vta_doc_state(config, webvh_ks).await?;
-
-    let prior_url = current_rest_service(&state.current_doc)
-        .map(|s| s.url)
-        .ok_or(DisableRestError::ServiceNotPresent)?;
-
-    Ok((
-        state.vta_did,
-        state.scid,
-        state.current_doc,
-        prior_url,
-        didcomm_enabled,
-    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::operations::protocol::invariant::{
+        CurrentServices, ProposedOp, would_violate_last_service,
+    };
+    use crate::operations::protocol::snapshot::ServiceKind;
     use crate::store::Store;
     use vti_common::config::StoreConfig as VtiStoreConfig;
 
-    /// Mirrors the test fixture in enable_rest / update_rest —
-    /// owns the fjall store so a single test can derive multiple
-    /// keyspaces from the same handle.
+    /// Mirrors the test fixture in enable_rest / update_rest — owns the fjall
+    /// store so a single test can derive multiple keyspaces from one handle.
     struct TestFixture {
         _dir: tempfile::TempDir,
         config: Arc<RwLock<AppConfig>>,
@@ -342,27 +277,47 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_preconditions_rejects_when_rest_disabled() {
+    async fn preconditions_reject_when_rest_disabled() {
         let fx = build_fixture(false, true);
-        let err = read_preconditions(&fx.config, &fx.webvh_ks())
-            .await
-            .unwrap_err();
+        let err = check_disable_preconditions::<RestService, DisableRestError>(
+            &fx.config,
+            &fx.webvh_ks(),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, DisableRestError::ServiceNotPresent));
     }
 
+    /// Brick-prevention runs before the doc load: "REST on, DIDComm off"
+    /// surfaces as `LastServiceRefused` (not a missing-vta_did storage error).
     #[tokio::test]
-    async fn read_preconditions_rejects_without_vta_did() {
+    async fn preconditions_reject_when_would_brick() {
+        let fx = build_fixture(true, false);
+        let err = check_disable_preconditions::<RestService, DisableRestError>(
+            &fx.config,
+            &fx.webvh_ks(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, DisableRestError::LastServiceRefused));
+    }
+
+    #[tokio::test]
+    async fn preconditions_reject_without_vta_did() {
         let fx = build_fixture(true, true);
         fx.config.write().await.vta_did = None;
-        let err = read_preconditions(&fx.config, &fx.webvh_ks())
-            .await
-            .unwrap_err();
+        let err = check_disable_preconditions::<RestService, DisableRestError>(
+            &fx.config,
+            &fx.webvh_ks(),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, DisableRestError::VtaDidNotConfigured));
     }
 
-    /// The brick-prevention helper is wired correctly: invoking it
-    /// from a "REST on, DIDComm off" state with a disable-rest op
-    /// must surface as `LastServiceRefused`.
+    /// The brick-prevention helper is wired correctly: invoking it from a
+    /// "REST on, DIDComm off" state with a disable-rest op must surface as
+    /// `LastServiceRefused`.
     #[test]
     fn brick_prevention_rejects_disable_rest_when_didcomm_off() {
         let result = would_violate_last_service(
@@ -373,8 +328,7 @@ mod tests {
         assert!(matches!(err, DisableRestError::LastServiceRefused));
     }
 
-    /// Conversely, brick-prevention accepts disabling REST when
-    /// DIDComm is on (S3 → S2).
+    /// Conversely, brick-prevention accepts disabling REST when DIDComm is on.
     #[test]
     fn brick_prevention_allows_disable_rest_when_didcomm_on() {
         let result = would_violate_last_service(
@@ -384,8 +338,8 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    /// Disabling REST is also allowed when WebAuthn alone is on
-    /// — WebAuthn counts as a transport for invariant purposes.
+    /// Disabling REST is also allowed when WebAuthn alone is on — WebAuthn
+    /// counts as a transport for invariant purposes.
     #[test]
     fn brick_prevention_allows_disable_rest_when_webauthn_on() {
         let result = would_violate_last_service(
@@ -395,16 +349,9 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    // (Removed: `persist_rest_disabled_flips_config_to_false`. The op now
-    // writes runtime state to fjall via `runtime_state::set_rest_enabled`,
-    // not to the config file on disk. The integration tests for the full
-    // `disable_rest` op cover that path end-to-end.)
-
     /// Confirms the typed `From<VtaError>` path: the helper's
-    /// `LastServiceRefused` round-trips into our error variant
-    /// correctly, and any other VtaError shape lands in `Storage`
-    /// (defensive — the helper is total today, but the impl
-    /// shouldn't drop unknown variants).
+    /// `LastServiceRefused` round-trips into our error variant, and any other
+    /// VtaError shape lands in `Storage` (defensive).
     #[test]
     fn vta_error_to_disable_rest_error_mapping_is_typed() {
         let mapped = DisableRestError::from(VtaError::LastServiceRefused);

--- a/vta-service/src/operations/protocol/disable_webauthn.rs
+++ b/vta-service/src/operations/protocol/disable_webauthn.rs
@@ -1,28 +1,18 @@
 //! `disable_webauthn` operation.
 //!
-//! Mirrors [`super::disable_rest`] for the WebAuthn-RP transport, plus
-//! one additional concern: per the operator's chosen hard-disable
-//! semantics, this op also strips passkey VMs from every DID the VTA
-//! controls (a passkey VM is useless when its RP is no longer
-//! advertised).
+//! Mirrors [`super::disable_rest`] for the WebAuthn-RP transport — sharing the
+//! disable skeleton (brick-prevention → preconditions → snapshot → patch-remove
+//! → publish) via the [`service_lifecycle`](super::service_lifecycle) helpers —
+//! plus one WebAuthn-only concern: per the operator's chosen hard-disable
+//! semantics, this op also strips passkey VMs from every DID the VTA controls
+//! (a passkey VM is useless when its RP is no longer advertised).
 //!
 //! Sequence (under [`PROTOCOL_LOCK`]):
-//! 1. Verify caller is super-admin.
-//! 2. Brick-prevention check (REST or DIDComm or no-other-on-WebAuthn).
-//! 3. Confirm `services.webauthn = true` and `#vta-webauthn` is
-//!    advertised; load the prior URL for the snapshot.
-//! 4. Persist a [`WebauthnSnapshot::Enabled { url: prior_url }`]
-//!    snapshot before the mutation, per spec §3.5a.
-//! 5. **Strip passkey VMs** from every DID via
-//!    [`super::passkey_vm_cleanup::strip_all_passkey_vms`]. Per-DID
-//!    failures are non-fatal — they're returned in the result so
-//!    the operator can investigate, and the disable still proceeds
-//!    (an operator who disables but leaves orphan VMs can fix
-//!    individual DIDs later).
-//! 6. Patch the VTA's DID document removing `#vta-webauthn` and
-//!    publish via [`update_did_webvh`].
-//! 7. Persist `services.webauthn = false`.
-//! 8. Emit [`TelemetryKind::ServicesWebauthnDisable`].
+//! 1. super-admin → 2. brick-prevention + preconditions (capture prior URL) →
+//!    3. snapshot `WebauthnSnapshot::Enabled { prior_url }` → 4. **strip passkey
+//!    VMs** (per-DID failures non-fatal, surfaced in the result) → 5. remove
+//!    `#vta-webauthn` + publish → 6. persist `services.webauthn = false` →
+//!    7. telemetry.
 
 use std::sync::Arc;
 
@@ -32,27 +22,24 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
+use vta_sdk::error::VtaError;
+
 use vti_common::seed_store::SeedStore;
 use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
-
-use vta_sdk::error::VtaError;
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
-use crate::operations::protocol::document::{
-    DocumentPatchError, current_webauthn_service, without_webauthn_service,
-};
-use crate::operations::protocol::invariant::{
-    CurrentServices, ProposedOp, would_violate_last_service,
-};
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::OpContext;
+use crate::operations::protocol::document::DocumentPatchError;
 use crate::operations::protocol::passkey_vm_cleanup::{self, CleanupSummary};
-use crate::operations::protocol::snapshot::{
-    self, ServiceConfigSnapshot, ServiceKind, WebauthnSnapshot,
+use crate::operations::protocol::service_lifecycle::{
+    DisableMutationError, ServiceLifecycle, ServiceLifecycleDeps, WebauthnService,
+    check_disable_preconditions, publish_patch,
 };
-use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
+use crate::operations::protocol::{PROTOCOL_LOCK, snapshot};
 use crate::store::KeyspaceHandle;
 
 #[derive(Debug, Clone, Default)]
@@ -63,9 +50,9 @@ pub struct DisableWebauthnResult {
     pub new_version_id: String,
     pub vta_did: String,
     pub serverless: bool,
-    /// Summary of the passkey-VM cleanup sweep. `succeeded` /
-    /// `failed` counts plus per-DID outcomes so the CLI can show
-    /// the operator which DIDs (if any) still need attention.
+    /// Summary of the passkey-VM cleanup sweep. `succeeded` / `failed` counts
+    /// plus per-DID outcomes so the CLI can show the operator which DIDs (if
+    /// any) still need attention.
     pub cleanup: CleanupSummary,
 }
 
@@ -127,6 +114,12 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
+impl DisableMutationError for DisableWebauthnError {
+    fn not_present() -> Self {
+        Self::ServiceNotPresent
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn disable_webauthn(
     config: &Arc<RwLock<AppConfig>>,
@@ -152,39 +145,39 @@ pub async fn disable_webauthn(
 
     let _guard = PROTOCOL_LOCK.lock().await;
 
-    // 1. Brick-prevention check up front — cheap, no I/O.
-    let (rest_enabled, didcomm_enabled) = {
-        let cfg = config.read().await;
-        if !cfg.services.webauthn {
-            return Err(DisableWebauthnError::ServiceNotPresent);
-        }
-        (cfg.services.rest, cfg.services.didcomm)
+    let deps = ServiceLifecycleDeps {
+        config,
+        keys_ks,
+        imported_ks,
+        contexts_ks,
+        webvh_ks,
+        audit_ks,
+        snapshot_ks,
+        seed_store,
+        did_resolver,
+        didcomm_bridge,
+        telemetry,
+        webvh_auth_locks,
     };
-    would_violate_last_service(
-        &CurrentServices::new(rest_enabled, didcomm_enabled, true),
-        ProposedOp::disable(ServiceKind::Webauthn),
-    )?;
 
-    // 2. Read preconditions: capture the prior URL for the snapshot.
-    let (vta_did, scid, current_doc, prior_url) = read_preconditions(config, webvh_ks).await?;
+    // Brick-prevention (§3.2) + preconditions, capturing the prior URL.
+    let (state, prior_url) =
+        check_disable_preconditions::<WebauthnService, DisableWebauthnError>(config, webvh_ks)
+            .await?;
 
-    // 3. Persist snapshot BEFORE the runtime mutation per spec §3.5a.
-    //    Pre-state is WebauthnSnapshot::Enabled with the prior URL so
-    //    a rollback re-enables WebAuthn at that URL.
+    // Snapshot BEFORE the mutation (spec §3.5a): re-enables WebAuthn at the
+    // prior URL on rollback.
     snapshot::write(
         snapshot_ks,
-        ServiceConfigSnapshot::Webauthn(WebauthnSnapshot::Enabled {
-            url: prior_url.clone(),
-        }),
+        WebauthnService::snapshot_enabled(prior_url.clone()),
     )
     .await
     .map_err(|e| DisableWebauthnError::Storage(format!("snapshot write: {e}")))?;
 
-    // 4. Hard-disable: strip passkey VMs from every DID. Per-DID
-    //    failures are non-fatal — we collect them in the summary.
-    //    Best-effort by design (operator's intent on disable is
-    //    "remove this surface AND its dependent state"; partial
-    //    success is better than abort-and-leave-the-service-on).
+    // Hard-disable: strip passkey VMs from every DID. Per-DID failures are
+    // non-fatal — collected in the summary (operator's intent on disable is
+    // "remove this surface AND its dependent state"; partial success beats
+    // abort-and-leave-the-service-on).
     let cleanup = passkey_vm_cleanup::strip_all_passkey_vms(
         config,
         keys_ks,
@@ -209,34 +202,19 @@ pub async fn disable_webauthn(
         );
     }
 
-    // 5. Remove the WebAuthn service entry and publish.
-    let patched = without_webauthn_service(current_doc);
-
-    let update_result = update_did_webvh(
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        seed_store,
+    let patched = WebauthnService::without_service(state.current_doc);
+    let update_result = publish_patch::<DisableWebauthnError>(
+        &deps,
         auth,
-        &scid,
-        UpdateDidWebvhOptions {
-            document: Some(patched),
-            ..Default::default()
-        },
-        did_resolver,
-        didcomm_bridge,
-        Some(vta_did.as_str()),
-        webvh_auth_locks,
+        &state.scid,
+        &state.vta_did,
+        patched,
         channel,
     )
     .await?;
 
-    // 6. Persist services.webauthn = false.
     persist_webauthn_disabled(config).await?;
 
-    // 7. Telemetry.
     let mut event = TelemetryEvent::new(TelemetryKind::ServicesWebauthnDisable)
         .with_field("channel", JsonValue::from(channel))
         .with_field(
@@ -257,7 +235,7 @@ pub async fn disable_webauthn(
     info!(
         channel,
         new_version_id = %update_result.new_version_id,
-        vta_did = %vta_did,
+        vta_did = %state.vta_did,
         passkey_vm_cleanup_succeeded = cleanup.succeeded,
         passkey_vm_cleanup_failed = cleanup.failed,
         "WebAuthn disabled"
@@ -265,20 +243,10 @@ pub async fn disable_webauthn(
 
     Ok(DisableWebauthnResult {
         new_version_id: update_result.new_version_id,
-        vta_did,
+        vta_did: state.vta_did,
         serverless: update_result.serverless,
         cleanup,
     })
-}
-
-async fn read_preconditions(
-    config: &Arc<RwLock<AppConfig>>,
-    webvh_ks: &KeyspaceHandle,
-) -> Result<(String, String, JsonValue, String), DisableWebauthnError> {
-    let state = super::preconditions::load_vta_doc_state(config, webvh_ks).await?;
-    let svc = current_webauthn_service(&state.current_doc)
-        .ok_or(DisableWebauthnError::ServiceNotPresent)?;
-    Ok((state.vta_did, state.scid, state.current_doc, svc.url))
 }
 
 async fn persist_webauthn_disabled(

--- a/vta-service/src/operations/protocol/service_lifecycle.rs
+++ b/vta-service/src/operations/protocol/service_lifecycle.rs
@@ -17,8 +17,14 @@
 //! so the engine futures stay `Send`); the enable-vs-update *shape* is the two
 //! `run_*` engines. The per-op modules keep their public `*Params` / `*Result`
 //! / `*Error` types and become thin wrappers, so every caller (routes, DIDComm
-//! dispatch, rollback) is untouched. Disable/rollback (brick-prevention) and
-//! the DIDComm family are intentionally out of scope here.
+//! dispatch, rollback) is untouched.
+//!
+//! `disable_{rest,webauthn}` reuse the lower-level pieces — `publish_patch`,
+//! `check_disable_preconditions` (brick-prevention + preconditions), and the
+//! `without_service` / `snapshot_enabled` hooks — rather than a full
+//! `run_disable` engine, because disable diverges per transport (WebAuthn also
+//! strips passkey VMs and returns a cleanup summary). Rollback (a dispatcher
+//! over the forward ops) and the DIDComm family stay out of scope.
 
 use std::sync::Arc;
 
@@ -36,11 +42,15 @@ use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
 use crate::operations::protocol::document::DocumentPatchError;
+use crate::operations::protocol::invariant::{
+    CurrentServices, ProposedOp, would_violate_last_service,
+};
 use crate::operations::protocol::preconditions::ProtocolPreconditionError;
-use crate::operations::protocol::snapshot::{self, ServiceConfigSnapshot};
+use crate::operations::protocol::snapshot::{self, ServiceConfigSnapshot, ServiceKind};
 use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
 use crate::store::KeyspaceHandle;
 use tokio::sync::RwLock;
+use vta_sdk::error::VtaError;
 
 /// Transport-specific hooks for the shared enable/update engine. One impl per
 /// advertised transport service (`RestService`, `WebauthnService`). All methods
@@ -50,6 +60,9 @@ use tokio::sync::RwLock;
 pub(crate) trait ServiceLifecycle {
     /// Human label for log lines (`"REST"`, `"WebAuthn"`).
     const LABEL: &'static str;
+    /// This service's [`ServiceKind`] — used by the brick-prevention check on
+    /// the disable path.
+    const KIND: ServiceKind;
     /// Telemetry kind emitted on a successful enable.
     const ENABLE_TELEMETRY: TelemetryKind;
     /// Telemetry kind emitted on a successful update.
@@ -62,9 +75,12 @@ pub(crate) trait ServiceLifecycle {
     /// Patch the document to advertise `url` on this service entry (insert on
     /// enable, replace on update — the patcher is idempotent on shape).
     fn with_service(doc: JsonValue, url: &str) -> Result<JsonValue, DocumentPatchError>;
+    /// Patch the document to remove this service entry (the disable path —
+    /// infallible: removing an absent entry is a no-op).
+    fn without_service(doc: JsonValue) -> JsonValue;
     /// Pre-state snapshot for an enable (rollback target = "off").
     fn snapshot_disabled() -> ServiceConfigSnapshot;
-    /// Pre-state snapshot for an update (rollback target = the prior URL).
+    /// Pre-state snapshot for an update/disable (rollback target = prior URL).
     fn snapshot_enabled(prior_url: String) -> ServiceConfigSnapshot;
 }
 
@@ -89,6 +105,20 @@ pub(crate) trait EnableMutationError: ServiceMutationError {
 
 /// Update-specific error constructors.
 pub(crate) trait UpdateMutationError: ServiceMutationError {
+    fn not_present() -> Self;
+}
+
+/// Disable-specific error surface. Independent of [`ServiceMutationError`]
+/// because disable takes no URL (so has no `validation` constructor); it adds
+/// `From<VtaError>` for the brick-prevention check's `LastServiceRefused`.
+pub(crate) trait DisableMutationError:
+    Sized
+    + From<ProtocolPreconditionError>
+    + From<DocumentPatchError>
+    + From<UpdateDidWebvhError>
+    + From<VtaError>
+{
+    /// The service is not currently advertised — nothing to disable.
     fn not_present() -> Self;
 }
 
@@ -121,8 +151,10 @@ pub(crate) struct ServiceLifecycleDeps<'a> {
 }
 
 /// Publish a patched document via `update_did_webvh` — the common publish step
-/// shared by enable + update.
-async fn publish_patch<E: ServiceMutationError>(
+/// shared by enable / update / disable. Bound only on `From<UpdateDidWebvhError>`
+/// (the single error it propagates) so disable errors — which carry no
+/// `validation` constructor — can use it too.
+pub(crate) async fn publish_patch<E: From<UpdateDidWebvhError>>(
     deps: &ServiceLifecycleDeps<'_>,
     auth: &AuthClaims,
     scid: &str,
@@ -205,6 +237,51 @@ where
             return Err(E::not_present());
         }
     }
+    let state =
+        crate::operations::protocol::preconditions::load_vta_doc_state(config, webvh_ks).await?;
+    let prior_url = S::current_service_url(&state.current_doc).ok_or_else(E::not_present)?;
+    Ok((state, prior_url))
+}
+
+/// Disable preconditions: the service must be ON, disabling it must not leave
+/// the VTA with no advertised transport (brick-prevention, spec §3.2 — checked
+/// before any I/O), and it must be present on-chain. Returns the loaded doc
+/// state plus the prior URL (the rollback target for the snapshot).
+///
+/// The caller takes `PROTOCOL_LOCK` first (mirrors the historical order: lock →
+/// brick-check → load), then runs its op-specific steps (webauthn's passkey-VM
+/// cleanup, persist, telemetry) around [`publish_patch`].
+pub(crate) async fn check_disable_preconditions<S, E>(
+    config: &Arc<RwLock<AppConfig>>,
+    webvh_ks: &KeyspaceHandle,
+) -> Result<
+    (
+        crate::operations::protocol::preconditions::VtaDocState,
+        String,
+    ),
+    E,
+>
+where
+    S: ServiceLifecycle,
+    E: DisableMutationError,
+{
+    // Brick-prevention runs FIRST — cheap config-only check before any I/O.
+    let (rest, didcomm, webauthn) = {
+        let cfg = config.read().await;
+        if !S::config_enabled(&cfg) {
+            return Err(E::not_present());
+        }
+        (
+            cfg.services.rest,
+            cfg.services.didcomm,
+            cfg.services.webauthn,
+        )
+    };
+    would_violate_last_service(
+        &CurrentServices::new(rest, didcomm, webauthn),
+        ProposedOp::disable(S::KIND),
+    )?;
+
     let state =
         crate::operations::protocol::preconditions::load_vta_doc_state(config, webvh_ks).await?;
     let prior_url = S::current_service_url(&state.current_doc).ok_or_else(E::not_present)?;
@@ -371,6 +448,7 @@ pub(crate) struct RestService;
 
 impl ServiceLifecycle for RestService {
     const LABEL: &'static str = "REST";
+    const KIND: ServiceKind = ServiceKind::Rest;
     const ENABLE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesRestEnable;
     const UPDATE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesRestUpdate;
 
@@ -382,6 +460,9 @@ impl ServiceLifecycle for RestService {
     }
     fn with_service(doc: JsonValue, url: &str) -> Result<JsonValue, DocumentPatchError> {
         crate::operations::protocol::document::with_rest_service(doc, url)
+    }
+    fn without_service(doc: JsonValue) -> JsonValue {
+        crate::operations::protocol::document::without_rest_service(doc)
     }
     fn snapshot_disabled() -> ServiceConfigSnapshot {
         ServiceConfigSnapshot::Rest(crate::operations::protocol::snapshot::RestSnapshot::Disabled)
@@ -398,6 +479,7 @@ pub(crate) struct WebauthnService;
 
 impl ServiceLifecycle for WebauthnService {
     const LABEL: &'static str = "WebAuthn";
+    const KIND: ServiceKind = ServiceKind::Webauthn;
     const ENABLE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesWebauthnEnable;
     const UPDATE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesWebauthnUpdate;
 
@@ -409,6 +491,9 @@ impl ServiceLifecycle for WebauthnService {
     }
     fn with_service(doc: JsonValue, url: &str) -> Result<JsonValue, DocumentPatchError> {
         crate::operations::protocol::document::with_webauthn_service(doc, url)
+    }
+    fn without_service(doc: JsonValue) -> JsonValue {
+        crate::operations::protocol::document::without_webauthn_service(doc)
     }
     fn snapshot_disabled() -> ServiceConfigSnapshot {
         ServiceConfigSnapshot::Webauthn(


### PR DESCRIPTION
## P2.3 part 2 — disable light-touch dedup

Follows #419. `disable_rest` / `disable_webauthn` now reuse the part-1 engine's lower-level helpers instead of duplicating the brick-prevention → preconditions → publish skeleton.

A full `run_disable` engine was **deliberately avoided**: disable diverges per transport — `disable_webauthn` also strips passkey VMs and returns a `cleanup` summary, so forcing both into one engine would be contorted. Rollback (a dispatcher over the forward ops, not the patch/publish skeleton) stays out of scope.

### `service_lifecycle.rs` additions
- **`check_disable_preconditions<S, E>`** — brick-prevention (§3.2, before any I/O) + preconditions, capturing the prior URL. Unit-testable with just a config + store fixture.
- **`DisableMutationError`** trait — independent of `ServiceMutationError` (disable takes no URL → no `validation` ctor; adds `From<VtaError>` for the brick-check's `LastServiceRefused`).
- **`KIND` + `without_service`** hooks on `ServiceLifecycle`.
- `publish_patch`'s bound relaxed to `From<UpdateDidWebvhError>` so disable errors can use it.

The WebAuthn-only passkey-VM cleanup and each op's persist / telemetry / result stay explicit (zero caller churn — public `*Params`/`*Result`/`*Error` unchanged).

### LOC / scope
Disable files −94; engine +75 → net −19. The value is the single-source disable skeleton (brick-prevention + preconditions + publish in one place across both transports). Per the part-1 finding, the error-mapping consolidation (c/d) is ~net-zero LOC (shared `ErrorBody`; 87 irreducible per-variant arms) and rollback is a dispatcher — both deferred as low-value.

### Verification
fmt + clippy clean (default & tee); vta-service lib **720** (120 protocol-op unit tests, incl. new disable precondition + brick-prevention coverage) + all **18** integration suites green; vta-enclave checks.