### PR TITLE
refactor(vta): hoist the provision-integration context preamble (P2.6)

### DIFF
--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1431,23 +1431,28 @@ pub async fn handle_provision_integration(
 
     let deps = operations::provision_integration::ProvisionIntegrationDeps::from(state.as_ref());
 
-    // Resolve the target context. When the caller sent one, use it
-    // verbatim (integration-class consumer pattern). When omitted, run
-    // the spec's three inference rules — single-context grant, super-
-    // admin + single-context maintainer, else AmbiguousContext.
-    let context = match body.context {
-        Some(c) => c,
-        None => match app_try!(
-            operations::provision_integration::infer_target_context(&auth, &deps.contexts_ks).await
-        ) {
-            Ok(ctx) => ctx,
-            Err(operations::provision_integration::AmbiguousContext {
-                candidates,
-                message,
-            }) => {
-                // Emit the canonical Trust Task error code so clients
-                // can surface candidates structurally. `args` carries
-                // the list in arrival order (sorted by the helper).
+    // Resolve + ensure the target context via the shared preamble (inference
+    // rules — single-context grant, super-admin + single-context maintainer,
+    // else AmbiguousContext — plus `--create-context`, super-admin-gated inside
+    // `create_context`). Only the ambiguous-case rendering is transport-
+    // specific: emit the canonical Trust Task `context_required` problem report
+    // with `args = candidates` (sorted by the helper).
+    let (context, context_created) =
+        match operations::provision_integration::resolve_target_context(
+            &auth,
+            &deps.contexts_ks,
+            body.context,
+            body.create_context,
+        )
+        .await
+        {
+            Ok(v) => v,
+            Err(operations::provision_integration::ResolveContextError::Ambiguous(
+                operations::provision_integration::AmbiguousContext {
+                    candidates,
+                    message,
+                },
+            )) => {
                 let report = ProblemReport {
                     code: vta_sdk::protocols::problem_report_codes::PROVISION_CONTEXT_REQUIRED
                         .to_string(),
@@ -1457,21 +1462,10 @@ pub async fn handle_provision_integration(
                 };
                 return Ok(Some(DIDCommResponse::problem_report(report)));
             }
-        },
-    };
-
-    // `--create-context` from the wire body. Same semantics as the
-    // REST handler — super-admin gate enforced inside
-    // `operations::contexts::create_context`. Idempotent.
-    let context_created = app_try!(
-        operations::provision_integration::ensure_target_context_or_create(
-            &deps.contexts_ks,
-            &auth,
-            &context,
-            body.create_context,
-        )
-        .await
-    );
+            Err(operations::provision_integration::ResolveContextError::Op(e)) => {
+                return Ok(Some(app_err_to_response(e)));
+            }
+        };
     let output = app_try!(
         operations::provision_integration::provision_integration(
             &deps,

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -49,7 +49,10 @@ mod templates;
 mod vta_keys;
 mod webvh;
 
-pub use preconditions::{AmbiguousContext, ensure_target_context_or_create, infer_target_context};
+pub use preconditions::{
+    AmbiguousContext, ResolveContextError, ensure_target_context_or_create, infer_target_context,
+    resolve_target_context,
+};
 
 use std::collections::BTreeMap;
 use std::sync::Arc;

--- a/vta-service/src/operations/provision_integration/preconditions.rs
+++ b/vta-service/src/operations/provision_integration/preconditions.rs
@@ -165,6 +165,57 @@ pub async fn ensure_target_context_or_create(
     Ok(true)
 }
 
+/// Failure modes of [`resolve_target_context`], kept distinct so each transport
+/// renders the ambiguous case in its own idiom.
+#[derive(Debug)]
+pub enum ResolveContextError {
+    /// Inference couldn't pick a single target — carries the candidates so the
+    /// transport can surface them (REST: 400 with candidates inlined; DIDComm:
+    /// `provision/integration:context_required` problem report, `args =
+    /// candidates`).
+    Ambiguous(AmbiguousContext),
+    /// Any other failure — storage error, no-context-at-all `NotFound`, the
+    /// missing-context-without-`--create-context` `NotFound`, or the super-admin
+    /// gate inside `create_context`.
+    Op(AppError),
+}
+
+impl From<AppError> for ResolveContextError {
+    fn from(e: AppError) -> Self {
+        Self::Op(e)
+    }
+}
+
+/// Resolve the provision target context end-to-end: use the caller-supplied
+/// `requested` context verbatim, else infer it ([`infer_target_context`]); then
+/// ensure it exists, creating it inline when `create_context`
+/// ([`ensure_target_context_or_create`]). Returns `(context, context_created)`.
+///
+/// This is the shared preamble for both provision handlers (REST
+/// `routes::bootstrap`, DIDComm `messaging::handlers`) — the context policy
+/// (inference rules + create-or-reject + the super-admin gate concentration)
+/// lives here once. Both transports pass the **already VP-verified** request
+/// separately; only this context step is hoisted (the VP-verify and
+/// summary-mapping steps differ per transport by design).
+pub async fn resolve_target_context(
+    auth: &AuthClaims,
+    contexts_ks: &KeyspaceHandle,
+    requested: Option<String>,
+    create_context: bool,
+) -> Result<(String, bool), ResolveContextError> {
+    let context = match requested {
+        Some(c) => c,
+        // `?` on the outer `Result` maps store-level `AppError` → `Op`; the
+        // inner `map_err` lifts the ambiguous case.
+        None => infer_target_context(auth, contexts_ks)
+            .await?
+            .map_err(ResolveContextError::Ambiguous)?,
+    };
+    let created =
+        ensure_target_context_or_create(contexts_ks, auth, &context, create_context).await?;
+    Ok((context, created))
+}
+
 pub(super) async fn preconditions(
     state: &ProvisionIntegrationDeps,
     auth: &AuthClaims,
@@ -418,6 +469,83 @@ mod tests {
         assert!(
             matches!(err, AppError::NotFound(_)),
             "expected NotFound, got {err:?}"
+        );
+    }
+
+    // ── resolve_target_context (shared REST + DIDComm preamble) ──────────
+
+    /// Caller-supplied context that already exists → returned verbatim,
+    /// `context_created = false`, inference not consulted.
+    #[tokio::test]
+    async fn resolve_uses_requested_existing_context() {
+        let (_dir, _store, ks) = fresh_contexts_ks().await;
+        seed_context(&ks, "ctx_a").await;
+        let a = auth(Role::Admin, vec!["ctx_a"]);
+
+        let (context, created) = resolve_target_context(&a, &ks, Some("ctx_a".into()), false)
+            .await
+            .map_err(|_| ())
+            .expect("resolves");
+        assert_eq!(context, "ctx_a");
+        assert!(!created);
+    }
+
+    /// Requested context that doesn't exist, `create_context = true` →
+    /// created inline, `context_created = true`.
+    #[tokio::test]
+    async fn resolve_creates_requested_context_inline() {
+        let (_dir, _store, ks) = fresh_contexts_ks().await;
+        let a = auth(Role::Admin, vec![]); // super-admin (create_context gate)
+
+        let (context, created) = resolve_target_context(&a, &ks, Some("ctx-new".into()), true)
+            .await
+            .expect("resolves");
+        assert_eq!(context, "ctx-new");
+        assert!(created);
+        assert!(
+            crate::contexts::get_context(&ks, "ctx-new")
+                .await
+                .unwrap()
+                .is_some(),
+            "context must have been created"
+        );
+    }
+
+    /// Omitted context + ambiguous inference → `ResolveContextError::Ambiguous`
+    /// carrying the candidates (the transport renders them).
+    #[tokio::test]
+    async fn resolve_propagates_ambiguous_inference() {
+        let (_dir, _store, ks) = fresh_contexts_ks().await;
+        let a = auth(Role::Admin, vec!["ctx_x", "ctx_y"]);
+
+        let err = resolve_target_context(&a, &ks, None, false)
+            .await
+            .err()
+            .expect("ambiguous");
+        match err {
+            ResolveContextError::Ambiguous(amb) => {
+                assert_eq!(
+                    amb.candidates,
+                    vec!["ctx_x".to_string(), "ctx_y".to_string()]
+                );
+            }
+            ResolveContextError::Op(e) => panic!("expected Ambiguous, got Op({e:?})"),
+        }
+    }
+
+    /// Requested missing context without `--create-context` → `Op(NotFound)`.
+    #[tokio::test]
+    async fn resolve_missing_context_without_create_is_op_not_found() {
+        let (_dir, _store, ks) = fresh_contexts_ks().await;
+        let a = auth(Role::Admin, vec!["ctx_absent"]);
+
+        let err = resolve_target_context(&a, &ks, Some("ctx_absent".into()), false)
+            .await
+            .err()
+            .expect("not found");
+        assert!(
+            matches!(err, ResolveContextError::Op(AppError::NotFound(_))),
+            "expected Op(NotFound)",
         );
     }
 }

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -658,49 +658,38 @@ mod provision {
 
         let deps = crate::operations::provision_integration::ProvisionIntegrationDeps::from(&state);
 
-        // Resolve the target context. When the caller sent one, use it
-        // verbatim; otherwise run the spec's inference rules. On
-        // ambiguity we collapse into Validation here — REST clients
-        // (pnm-cli, scripts) get the message + candidates inline. The
-        // DIDComm path emits the canonical
-        // `provision/integration:context_required` code so structured
-        // clients can branch on it; REST's typed-error vocabulary
-        // wasn't designed for arbitrary new codes, so we stay with the
-        // existing 400 shape.
-        let context = match req.context {
-            Some(c) => c,
-            None => match crate::operations::provision_integration::infer_target_context(
+        // Resolve + ensure the target context via the shared preamble. On
+        // ambiguity we collapse into Validation here — REST clients (pnm-cli,
+        // scripts) get the message + candidates inline. The DIDComm path emits
+        // the canonical `provision/integration:context_required` code so
+        // structured clients can branch on it; REST's typed-error vocabulary
+        // wasn't designed for arbitrary new codes, so we stay with the existing
+        // 400 shape. `--create-context` (super-admin gate inside
+        // `create_context`) is honoured inside the helper.
+        use crate::operations::provision_integration::ResolveContextError;
+        let (context, context_created) =
+            match crate::operations::provision_integration::resolve_target_context(
                 &auth.0,
                 &deps.contexts_ks,
+                req.context,
+                req.create_context,
             )
-            .await?
+            .await
             {
-                Ok(ctx) => ctx,
-                Err(crate::operations::provision_integration::AmbiguousContext {
-                    candidates,
-                    message,
-                }) => {
+                Ok(v) => v,
+                Err(ResolveContextError::Ambiguous(
+                    crate::operations::provision_integration::AmbiguousContext {
+                        candidates,
+                        message,
+                    },
+                )) => {
                     return Err(AppError::Validation(format!(
                         "{message} (candidates: {})",
                         candidates.join(", "),
                     )));
                 }
-            },
-        };
-
-        // `--create-context`: create the target context inline if
-        // it doesn't exist. Hits the super-admin gate inside
-        // `operations::contexts::create_context` — context-admin
-        // callers surface as Forbidden here. Idempotent when the
-        // context already exists.
-        let context_created =
-            crate::operations::provision_integration::ensure_target_context_or_create(
-                &deps.contexts_ks,
-                &auth.0,
-                &context,
-                req.create_context,
-            )
-            .await?;
+                Err(ResolveContextError::Op(e)) => return Err(e),
+            };
         let output = provision_integration_lib(
             &deps,
             &auth.0,


### PR DESCRIPTION
## P2.6 — shared provision-integration context preamble

The REST (`routes::bootstrap`) and DIDComm (`messaging::handlers`) provision handlers each re-implemented the context-resolution preamble — duplicated **policy** logic in the most security-sensitive flow.

### Change
New `operations::provision_integration::resolve_target_context` (+ typed `ResolveContextError::{Ambiguous, Op}`) folds the `infer_target_context` → `AmbiguousContext` → `ensure_target_context_or_create` chain into one tested helper: use the caller-supplied context verbatim, else infer it (the spec's three inference rules), then ensure it exists (creating inline under the super-admin gate when `create_context`). Both handlers call it; only the ambiguous-case **rendering** stays transport-specific (REST: 400 with candidates inlined; DIDComm: `provision/integration:context_required` problem report, `args = candidates`).

### Scope (deliberately context-resolution only)
The plan's ~−150 also assumed unifying VP-verify and the summary mapping, but those differ **by design**:
- VP verify: REST uses typed `.verify()`; DIDComm uses `verify_value` over the raw bytes (to preserve a 0.2 client's camelCase `ask.type` inside the signed VP). Unifying would change REST's wire-body handling + the security-sensitive verify path.
- Summary: REST and the SDK use different per-crate response types.

So those stay per-transport. **Preserved:** relayer ≠ holder onion auth (no sender==holder check). Net LOC ~neutral (handlers −~30, helper +~25, +4 tests) — the win is the single-source, unit-tested context policy.

### Tests
4 new unit tests on `resolve_target_context`: requested-existing (no create), create-inline, ambiguous-propagation, missing-without-create → `Op(NotFound)`.

### Verification
fmt + clippy clean (default & tee); vta-service lib **724** + all **18** integration suites green; vta-enclave checks.