### PR TITLE
refactor(sdk): expose pure context-path/identifier validators (#392)

### DIFF
--- a/vta-sdk/src/context_path.rs
+++ b/vta-sdk/src/context_path.rs
@@ -1,0 +1,213 @@
+//! Hierarchical trust-context paths — the security foundation for
+//! folder/sub-folder contexts.
+//!
+//! A context identifier **is** its materialized path: slash-separated segments,
+//! e.g. `acme/eng/team-a`. The server's authorization gate decides "admin of a
+//! parent → access to descendants" with [`is_ancestor_or_self`] — a **pure,
+//! store-free** segment comparison over data already in the verified JWT.
+//!
+//! ## Why this lives in the SDK
+//! Path construction (`child_path`) and validation (`validate_context_path`)
+//! are the canonical rules for what a context path may contain. A **client**
+//! that derives a sub-context id (e.g. a community's `<top>/<slug>`) must apply
+//! the *same* rules so it only ever sends paths the VTA will accept. Keeping
+//! them here lets clients share the one source of truth instead of mirroring it
+//! and drifting on security-relevant logic. The server re-exports these through
+//! `vti_common::context_path`.
+//!
+//! ## The one footgun, handled
+//! A raw `str::starts_with` is **wrong**: `acme` would "contain" `acme-evil`.
+//! Ancestry here is **segment-aware**, and `/` is the *only* separator — it
+//! cannot appear inside a segment (each segment is a
+//! [`validate_identifier`](crate::identifier::validate_identifier) value), so
+//! there is no `..` / slash-injection / empty-segment aliasing.
+
+use crate::identifier::{ValidationError, validate_identifier};
+
+/// Maximum nesting depth (number of path segments). Bounds derivation depth and
+/// keeps ancestry checks cheap; deep trees are an anti-pattern, not a need.
+pub const MAX_CONTEXT_DEPTH: usize = 8;
+
+/// The path separator. A context identifier is segments joined by this; it never
+/// appears inside a segment.
+pub const SEPARATOR: char = '/';
+
+/// Validate a context path: non-empty, ≤ [`MAX_CONTEXT_DEPTH`] segments, every
+/// segment a valid identifier, and no empty / leading / trailing / doubled
+/// separators.
+pub fn validate_context_path(value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() {
+        return Err(ValidationError("context path must not be empty".into()));
+    }
+    if value.starts_with(SEPARATOR) || value.ends_with(SEPARATOR) {
+        return Err(ValidationError(format!(
+            "context path must not start or end with '{SEPARATOR}'"
+        )));
+    }
+
+    let segments: Vec<&str> = value.split(SEPARATOR).collect();
+    if segments.len() > MAX_CONTEXT_DEPTH {
+        return Err(ValidationError(format!(
+            "context path is {} levels deep; maximum is {MAX_CONTEXT_DEPTH}",
+            segments.len()
+        )));
+    }
+    for segment in &segments {
+        // An empty segment means a leading/trailing/doubled separator — `split`
+        // yields `""` for each. (The leading/trailing case is caught above; this
+        // catches `a//b`.)
+        if segment.is_empty() {
+            return Err(ValidationError(
+                "context path must not contain an empty segment ('//')".into(),
+            ));
+        }
+        validate_identifier("context path segment", segment)?;
+    }
+    Ok(())
+}
+
+/// Split a path into its segments. The path is assumed
+/// [validated](validate_context_path); for an arbitrary string this still
+/// returns the slash-split parts.
+fn segments(path: &str) -> impl Iterator<Item = &str> {
+    path.split(SEPARATOR)
+}
+
+/// Whether `ancestor` is `descendant` itself or an ancestor of it — the test the
+/// ACL gate uses for "admin of a parent context covers the subtree".
+///
+/// **Segment-aware:** `descendant`'s segments must *begin with* `ancestor`'s
+/// segments, segment-for-segment. So `acme` is an ancestor of `acme/eng` but
+/// **not** of `acme-evil`, and `acme/eng` is not an ancestor of `acme/engineering`.
+///
+/// Inputs are compared as-is; callers gate creation through
+/// [`validate_context_path`], so malformed paths simply fail to match.
+pub fn is_ancestor_or_self(ancestor: &str, descendant: &str) -> bool {
+    // Empty strings never participate (an empty `allowed_contexts` entry must
+    // not grant access; super-admin is handled separately by the gate).
+    if ancestor.is_empty() || descendant.is_empty() {
+        return false;
+    }
+    let mut anc = segments(ancestor);
+    let mut desc = segments(descendant);
+    loop {
+        match anc.next() {
+            // Ancestor exhausted: descendant began with all of it → ancestor-or-self.
+            None => return true,
+            Some(a) => match desc.next() {
+                // Descendant ran out first, or a segment differs → not an ancestor.
+                None => return false,
+                Some(d) if a != d => return false,
+                Some(_) => continue,
+            },
+        }
+    }
+}
+
+/// The parent path (one segment shorter), or `None` for a top-level (single
+/// segment) path.
+pub fn parent_path(path: &str) -> Option<&str> {
+    path.rsplit_once(SEPARATOR).map(|(parent, _)| parent)
+}
+
+/// The depth (segment count) of a path. A top-level context is depth 1.
+pub fn depth(path: &str) -> usize {
+    if path.is_empty() {
+        return 0;
+    }
+    path.split(SEPARATOR).count()
+}
+
+/// Build a child path under `parent` by appending a single `segment`. The
+/// `segment` must be one valid identifier — it cannot itself contain a separator
+/// (else it would silently add *several* levels) — and the resulting path must
+/// validate (depth included).
+pub fn child_path(parent: &str, segment: &str) -> Result<String, ValidationError> {
+    // Reject a `segment` that is empty or contains the separator: `child_path`
+    // adds exactly one level.
+    validate_identifier("context path segment", segment)?;
+    let candidate = format!("{parent}{SEPARATOR}{segment}");
+    validate_context_path(&candidate)?;
+    Ok(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_good_paths() {
+        for p in ["acme", "acme/eng", "acme/eng/team-a", "a.b_c/d-e", "x/y/z"] {
+            assert!(validate_context_path(p).is_ok(), "{p} should be valid");
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_paths() {
+        assert!(validate_context_path("").is_err()); // empty
+        assert!(validate_context_path("/acme").is_err()); // leading separator
+        assert!(validate_context_path("acme/").is_err()); // trailing separator
+        assert!(validate_context_path("acme//eng").is_err()); // doubled separator
+        assert!(validate_context_path("acme/ev il").is_err()); // space in a segment
+        // `..` is a *legal* segment name (only alnum/`.`/`_`/`-`), but it can't
+        // escape anything: `/` is the sole separator and can't appear in a
+        // segment, so `..` is just a literal child named "..". The dangerous
+        // forms (slash / empty-segment injection) above are all rejected.
+        assert!(validate_context_path("acme/..").is_ok());
+    }
+
+    #[test]
+    fn enforces_max_depth() {
+        let deep = (0..=MAX_CONTEXT_DEPTH)
+            .map(|i| format!("s{i}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        assert!(
+            validate_context_path(&deep).is_err(),
+            "{deep} exceeds max depth"
+        );
+        let ok = (0..MAX_CONTEXT_DEPTH)
+            .map(|i| format!("s{i}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        assert!(validate_context_path(&ok).is_ok());
+    }
+
+    #[test]
+    fn ancestry_is_segment_aware_not_string_prefix() {
+        // Self.
+        assert!(is_ancestor_or_self("acme", "acme"));
+        assert!(is_ancestor_or_self("acme/eng", "acme/eng"));
+        // True ancestry.
+        assert!(is_ancestor_or_self("acme", "acme/eng"));
+        assert!(is_ancestor_or_self("acme", "acme/eng/team-a"));
+        assert!(is_ancestor_or_self("acme/eng", "acme/eng/team-a"));
+        // The prefix-confusion attack: string-prefix but NOT a segment ancestor.
+        assert!(!is_ancestor_or_self("acme", "acme-evil"));
+        assert!(!is_ancestor_or_self("acme/eng", "acme/engineering"));
+        assert!(!is_ancestor_or_self("ac", "acme"));
+        // Descendant is shorter / a sibling.
+        assert!(!is_ancestor_or_self("acme/eng", "acme"));
+        assert!(!is_ancestor_or_self("acme/eng", "acme/ops"));
+        // Empty never matches.
+        assert!(!is_ancestor_or_self("", "acme"));
+        assert!(!is_ancestor_or_self("acme", ""));
+    }
+
+    #[test]
+    fn parent_and_depth() {
+        assert_eq!(parent_path("acme"), None);
+        assert_eq!(parent_path("acme/eng"), Some("acme"));
+        assert_eq!(parent_path("acme/eng/team-a"), Some("acme/eng"));
+        assert_eq!(depth("acme"), 1);
+        assert_eq!(depth("acme/eng/team-a"), 3);
+        assert_eq!(depth(""), 0);
+    }
+
+    #[test]
+    fn child_path_builds_and_validates() {
+        assert_eq!(child_path("acme", "eng").unwrap(), "acme/eng");
+        assert!(child_path("acme", "ev/il").is_err()); // separator in the new segment
+        assert!(child_path("acme", "").is_err()); // empty segment
+    }
+}

--- a/vta-sdk/src/identifier.rs
+++ b/vta-sdk/src/identifier.rs
@@ -1,0 +1,139 @@
+//! Pure validators for caller-supplied identifiers that compose into
+//! store-keyspace keys.
+//!
+//! Several VTA route handlers build keys by formatting caller-supplied
+//! strings directly into templates like `tpl:ctx:{context_id}:{name}`
+//! or `ctx:{id}`. A caller that supplies a string containing the
+//! separator character `:` could collide with or inject into adjacent
+//! namespaces. This module enforces the invariant at the boundary.
+//!
+//! The accepted character class is deliberately narrow:
+//! `[A-Za-z0-9._-]` with a length cap of 64 bytes. If you think you
+//! need `:` or `/` in an identifier, you probably want the identifier
+//! split into two fields instead — collisions are not worth the
+//! convenience.
+//!
+//! ## Why this lives in the SDK
+//! These rules are the canonical, security-relevant gate for what a
+//! context segment may contain. A **client** that constructs context
+//! paths must apply the *same* rules so it only ever sends paths the
+//! VTA will accept. Keeping the validator here (rather than in the
+//! server-only `vti-common`) lets clients share the one source of
+//! truth instead of mirroring it and risking drift. The server
+//! re-exports these through `vti_common::identifier`, mapping the
+//! [`ValidationError`] to its own `AppError` for ergonomics.
+
+/// Maximum length of a validated identifier in bytes. 64 is generous
+/// for slugs, context IDs, template names; anything longer is almost
+/// certainly a mistake or an injection attempt.
+pub const MAX_IDENTIFIER_LEN: usize = 64;
+
+/// A pure validation failure, dependency-light so clients can consume
+/// it without pulling in any server infrastructure.
+///
+/// The server wraps this into its own `AppError::Validation` (the
+/// `Display` string is preserved verbatim), so error messages are
+/// identical regardless of which side ran the validator.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("{0}")]
+pub struct ValidationError(pub String);
+
+/// Validate a caller-supplied identifier (context ID, template name,
+/// slug). Accepts ASCII alphanumerics plus `.`, `_`, `-`. Rejects
+/// empty strings, anything over [`MAX_IDENTIFIER_LEN`] bytes, and any
+/// character outside the allowed class — including the separator
+/// characters (`:`, `/`, whitespace) that would let a caller collide
+/// with or traverse into adjacent store-keyspace prefixes.
+///
+/// `label` names the field being validated so the resulting
+/// [`ValidationError`] message is self-describing.
+pub fn validate_identifier(label: &str, value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() {
+        return Err(ValidationError(format!("{label} must not be empty")));
+    }
+    if value.len() > MAX_IDENTIFIER_LEN {
+        return Err(ValidationError(format!(
+            "{label} is {} bytes; maximum is {MAX_IDENTIFIER_LEN}",
+            value.len()
+        )));
+    }
+    for (i, ch) in value.chars().enumerate() {
+        let ok = ch.is_ascii_alphanumeric() || ch == '.' || ch == '_' || ch == '-';
+        if !ok {
+            return Err(ValidationError(format!(
+                "{label} contains an invalid character {ch:?} at position {i}; \
+                 allowed: A-Z, a-z, 0-9, '.', '_', '-'"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_common_identifier_shapes() {
+        for ok in [
+            "myapp",
+            "My-App_1",
+            "context.v2",
+            "a",
+            "0",
+            "didcomm-mediator",
+            "_private",
+            "CamelCase",
+        ] {
+            validate_identifier("id", ok).unwrap_or_else(|e| panic!("{ok:?} rejected: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn rejects_empty() {
+        let err = validate_identifier("id", "").expect_err("empty must be rejected");
+        assert_eq!(err.0, "id must not be empty");
+    }
+
+    #[test]
+    fn rejects_separator_injection() {
+        // These are the concrete attack shapes: a caller who can inject
+        // `:` can collide with or escape adjacent store namespaces.
+        for bad in [
+            "global:evil",     // collides with tpl:global: prefix
+            "../../etc",       // path traversal shape
+            "a:b:c",           // keyspace separator
+            "my/ctx",          // path separator
+            "with space",      // whitespace
+            "tab\there",       // control chars
+            "with\nnewline",   // newline injection
+            "null\0byte",      // null byte
+            "unicode:§§",      // non-ASCII
+            "quote\"injected", // quote shape
+        ] {
+            validate_identifier("id", bad).expect_err(&format!("{bad:?} must be rejected"));
+        }
+    }
+
+    #[test]
+    fn rejects_too_long() {
+        let long = "a".repeat(MAX_IDENTIFIER_LEN + 1);
+        validate_identifier("id", &long).expect_err("overlong must be rejected");
+    }
+
+    #[test]
+    fn accepts_exactly_at_limit() {
+        let edge = "a".repeat(MAX_IDENTIFIER_LEN);
+        validate_identifier("id", &edge).expect("exactly-at-limit must pass");
+    }
+
+    #[test]
+    fn error_message_names_the_field() {
+        let err = validate_identifier("context_id", "bad:id").expect_err("rejected");
+        assert!(
+            err.0.contains("context_id"),
+            "error must name the field it is validating — got {}",
+            err.0
+        );
+    }
+}

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -79,6 +79,10 @@
 
 pub mod error;
 pub mod hex;
+// Pure, dependency-light validators shared with clients so they apply the
+// VTA's canonical context-path / identifier rules without mirroring them.
+pub mod context_path;
+pub mod identifier;
 
 #[cfg(feature = "attest-verify")]
 pub mod attestation;

--- a/vti-common/src/context_path.rs
+++ b/vti-common/src/context_path.rs
@@ -1,17 +1,21 @@
-//! Hierarchical trust-context paths — the security foundation for
+//! Server-side re-export of the canonical context-path validators.
+//!
+//! Hierarchical trust-context paths are the security foundation for
 //! folder/sub-folder contexts (`docs/05-design-notes/hierarchical-contexts.md`).
-//!
 //! A context identifier **is** its materialized path: slash-separated segments,
-//! e.g. `acme/eng/team-a`. The authorization gate
-//! ([`crate::auth`]'s `has_context_access`) decides "admin of a parent → access
-//! to descendants" with [`is_ancestor_or_self`] — a **pure, store-free**
-//! segment comparison over data already in the verified JWT.
+//! e.g. `acme/eng/team-a`. The authorization gate ([`crate::auth`]'s
+//! `has_context_access`) decides "admin of a parent → access to descendants"
+//! with [`is_ancestor_or_self`] — a **pure, store-free** segment comparison
+//! over data already in the verified JWT.
 //!
-//! ## Why this is store-free (and why that matters)
-//! Resolving ancestry without a store walk keeps the security gate pure: no
-//! fail-open on a store error, no DoS surface, no parent-pointer **cycles**, no
-//! TOCTOU. The cost — re-parenting rewrites a subtree's paths — is deferred
-//! (moves are disallowed initially).
+//! ## Why this lives in the SDK now
+//! The pure construction/validation rules moved down into
+//! [`vta_sdk::context_path`] so **clients** can derive sub-context ids under
+//! the *same* rules the VTA enforces, without depending on this server-only
+//! crate (see issue #392). This module re-exports the pure helpers verbatim and
+//! wraps the two fallible constructors so they keep returning [`AppError`] for
+//! the server's `?`-ergonomics; the [`ValidationError`](vta_sdk::identifier::ValidationError)
+//! message is preserved verbatim.
 //!
 //! ## The one footgun, handled
 //! A raw `str::starts_with` is **wrong**: `acme` would "contain" `acme-evil`.
@@ -21,115 +25,32 @@
 //! there is no `..` / slash-injection / empty-segment aliasing.
 
 use crate::error::AppError;
-use crate::identifier::validate_identifier;
 
-/// Maximum nesting depth (number of path segments). Bounds derivation depth and
-/// keeps ancestry checks cheap; deep trees are an anti-pattern, not a need.
-pub const MAX_CONTEXT_DEPTH: usize = 8;
-
-/// The path separator. A context identifier is segments joined by this; it never
-/// appears inside a segment.
-pub const SEPARATOR: char = '/';
+// Pure helpers re-exported unchanged — clients make no authz decisions, but the
+// server's ACL gate and callers consume these by their existing paths.
+pub use vta_sdk::context_path::{
+    MAX_CONTEXT_DEPTH, SEPARATOR, depth, is_ancestor_or_self, parent_path,
+};
 
 /// Validate a context path: non-empty, ≤ [`MAX_CONTEXT_DEPTH`] segments, every
 /// segment a valid identifier, and no empty / leading / trailing / doubled
 /// separators.
+///
+/// Thin wrapper over [`vta_sdk::context_path::validate_context_path`] mapping
+/// the SDK error onto [`AppError::Validation`] (message preserved verbatim).
 pub fn validate_context_path(value: &str) -> Result<(), AppError> {
-    if value.is_empty() {
-        return Err(AppError::Validation(
-            "context path must not be empty".into(),
-        ));
-    }
-    if value.starts_with(SEPARATOR) || value.ends_with(SEPARATOR) {
-        return Err(AppError::Validation(format!(
-            "context path must not start or end with '{SEPARATOR}'"
-        )));
-    }
-
-    let segments: Vec<&str> = value.split(SEPARATOR).collect();
-    if segments.len() > MAX_CONTEXT_DEPTH {
-        return Err(AppError::Validation(format!(
-            "context path is {} levels deep; maximum is {MAX_CONTEXT_DEPTH}",
-            segments.len()
-        )));
-    }
-    for segment in &segments {
-        // An empty segment means a leading/trailing/doubled separator — `split`
-        // yields `""` for each. (The leading/trailing case is caught above; this
-        // catches `a//b`.)
-        if segment.is_empty() {
-            return Err(AppError::Validation(
-                "context path must not contain an empty segment ('//')".into(),
-            ));
-        }
-        validate_identifier("context path segment", segment)?;
-    }
-    Ok(())
-}
-
-/// Split a path into its segments. The path is assumed
-/// [validated](validate_context_path); for an arbitrary string this still
-/// returns the slash-split parts.
-fn segments(path: &str) -> impl Iterator<Item = &str> {
-    path.split(SEPARATOR)
-}
-
-/// Whether `ancestor` is `descendant` itself or an ancestor of it — the test the
-/// ACL gate uses for "admin of a parent context covers the subtree".
-///
-/// **Segment-aware:** `descendant`'s segments must *begin with* `ancestor`'s
-/// segments, segment-for-segment. So `acme` is an ancestor of `acme/eng` but
-/// **not** of `acme-evil`, and `acme/eng` is not an ancestor of `acme/engineering`.
-///
-/// Inputs are compared as-is; callers gate creation through
-/// [`validate_context_path`], so malformed paths simply fail to match.
-pub fn is_ancestor_or_self(ancestor: &str, descendant: &str) -> bool {
-    // Empty strings never participate (an empty `allowed_contexts` entry must
-    // not grant access; super-admin is handled separately by the gate).
-    if ancestor.is_empty() || descendant.is_empty() {
-        return false;
-    }
-    let mut anc = segments(ancestor);
-    let mut desc = segments(descendant);
-    loop {
-        match anc.next() {
-            // Ancestor exhausted: descendant began with all of it → ancestor-or-self.
-            None => return true,
-            Some(a) => match desc.next() {
-                // Descendant ran out first, or a segment differs → not an ancestor.
-                None => return false,
-                Some(d) if a != d => return false,
-                Some(_) => continue,
-            },
-        }
-    }
-}
-
-/// The parent path (one segment shorter), or `None` for a top-level (single
-/// segment) path.
-pub fn parent_path(path: &str) -> Option<&str> {
-    path.rsplit_once(SEPARATOR).map(|(parent, _)| parent)
-}
-
-/// The depth (segment count) of a path. A top-level context is depth 1.
-pub fn depth(path: &str) -> usize {
-    if path.is_empty() {
-        return 0;
-    }
-    path.split(SEPARATOR).count()
+    vta_sdk::context_path::validate_context_path(value).map_err(|e| AppError::Validation(e.0))
 }
 
 /// Build a child path under `parent` by appending a single `segment`. The
 /// `segment` must be one valid identifier — it cannot itself contain a separator
 /// (else it would silently add *several* levels) — and the resulting path must
 /// validate (depth included).
+///
+/// Thin wrapper over [`vta_sdk::context_path::child_path`] mapping the SDK error
+/// onto [`AppError::Validation`] (message preserved verbatim).
 pub fn child_path(parent: &str, segment: &str) -> Result<String, AppError> {
-    // Reject a `segment` that is empty or contains the separator: `child_path`
-    // adds exactly one level.
-    validate_identifier("context path segment", segment)?;
-    let candidate = format!("{parent}{SEPARATOR}{segment}");
-    validate_context_path(&candidate)?;
-    Ok(candidate)
+    vta_sdk::context_path::child_path(parent, segment).map_err(|e| AppError::Validation(e.0))
 }
 
 #[cfg(test)]

--- a/vti-common/src/identifier.rs
+++ b/vti-common/src/identifier.rs
@@ -1,57 +1,27 @@
-//! Validators for caller-supplied identifiers that compose into
-//! store-keyspace keys.
+//! Server-side re-export of the canonical identifier validator.
 //!
-//! Several route handlers build keys by formatting caller-supplied
-//! strings directly into templates like `tpl:ctx:{context_id}:{name}`
-//! or `ctx:{id}`. A caller that supplies a string containing the
-//! separator character `:` could collide with or inject into adjacent
-//! namespaces. Today the routes that accept these identifiers require
-//! super-admin, so exposure is limited, but this module enforces the
-//! invariant at the boundary so future lower-privilege surfaces
-//! can't inherit the footgun.
+//! The pure rules now live in [`vta_sdk::identifier`] so **clients** can apply
+//! the same security-relevant gate without depending on this server-only crate
+//! (see issue #392). This module is a thin wrapper that maps the SDK's
+//! dependency-light [`ValidationError`](vta_sdk::identifier::ValidationError)
+//! onto the server's [`AppError`] for `?`-ergonomics at the route handlers.
 //!
-//! The accepted character class is deliberately narrow:
-//! `[A-Za-z0-9._-]` with a length cap of 64 bytes. If you think you
-//! need `:` or `/` in an identifier, you probably want the identifier
-//! split into two fields instead — collisions are not worth the
-//! convenience.
+//! See [`vta_sdk::identifier`] for the rationale behind the narrow
+//! `[A-Za-z0-9._-]` character class and 64-byte cap.
 
 use crate::error::AppError;
 
-/// Maximum length of a validated identifier in bytes. 64 is generous
-/// for slugs, context IDs, template names; anything longer is almost
-/// certainly a mistake or an injection attempt.
-pub const MAX_IDENTIFIER_LEN: usize = 64;
+pub use vta_sdk::identifier::MAX_IDENTIFIER_LEN;
 
-/// Validate a caller-supplied identifier (context ID, template name,
-/// slug). Accepts ASCII alphanumerics plus `.`, `_`, `-`. Rejects
-/// empty strings, anything over [`MAX_IDENTIFIER_LEN`] bytes, and any
-/// character outside the allowed class — including the separator
-/// characters (`:`, `/`, whitespace) that would let a caller collide
-/// with or traverse into adjacent store-keyspace prefixes.
+/// Validate a caller-supplied identifier (context ID, template name, slug).
 ///
-/// `label` names the field being validated so the resulting
-/// `AppError::Validation` message is self-describing.
+/// Thin wrapper over [`vta_sdk::identifier::validate_identifier`] that converts
+/// the SDK [`ValidationError`](vta_sdk::identifier::ValidationError) into an
+/// [`AppError::Validation`]; the message is preserved verbatim. See the SDK
+/// function for the accepted character class and the injection shapes it
+/// rejects.
 pub fn validate_identifier(label: &str, value: &str) -> Result<(), AppError> {
-    if value.is_empty() {
-        return Err(AppError::Validation(format!("{label} must not be empty")));
-    }
-    if value.len() > MAX_IDENTIFIER_LEN {
-        return Err(AppError::Validation(format!(
-            "{label} is {} bytes; maximum is {MAX_IDENTIFIER_LEN}",
-            value.len()
-        )));
-    }
-    for (i, ch) in value.chars().enumerate() {
-        let ok = ch.is_ascii_alphanumeric() || ch == '.' || ch == '_' || ch == '-';
-        if !ok {
-            return Err(AppError::Validation(format!(
-                "{label} contains an invalid character {ch:?} at position {i}; \
-                 allowed: A-Z, a-z, 0-9, '.', '_', '-'"
-            )));
-        }
-    }
-    Ok(())
+    vta_sdk::identifier::validate_identifier(label, value).map_err(|e| AppError::Validation(e.0))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #392.

## What

Move the **pure** context-path and identifier validators down from the server-only `vti-common` into `vta-sdk`, so clients can apply the VTA's canonical, security-relevant rules without depending on server infrastructure (`axum`, `fjall`, `jsonwebtoken`, …) or coupling to `AppError`. This eliminates the drift hazard where a client (e.g. the OpenVTC CLI) mirrors `validate_identifier` / `validate_context_path` byte-for-byte.

## Changes

- **`vta_sdk::identifier`** — `validate_identifier`, `MAX_IDENTIFIER_LEN`, and a small dependency-light `ValidationError` (`#[error("{0}")]`). No `AppError` in the SDK.
- **`vta_sdk::context_path`** — `validate_context_path`, `child_path`, `is_ancestor_or_self`, `parent_path`, `depth`, `MAX_CONTEXT_DEPTH`, `SEPARATOR`. Docs, comments, and unit tests carried over verbatim.
- **`vti_common::{identifier,context_path}`** become thin wrappers: pure helpers re-exported verbatim; the two fallible constructors map `ValidationError` → `AppError::Validation` with the **message preserved byte-for-byte**, so every server call site and error string is unchanged.

`is_ancestor_or_self` moved too — it's a pure segment comparison with no authz semantics on its own; the ACL *decision* stays server-side in `vti_common::auth`.

## Why additive / non-breaking

`vti-common` already depends on `vta-sdk`, so the move is acyclic. New SDK modules use only `std` + `thiserror` (no new deps, no feature gates). Server behavior is unchanged: all existing call sites compile untouched.

## Verification

- `cargo clippy --workspace --lib --bins` — clean.
- Tests green: `vta-sdk` + `vti-common` libs (241), `vta-service` contexts/keys/did_templates (93, incl. separator-injection rejection through the wrapper), `vtc-service` acl (45).
- `cargo fmt` applied; commit DCO-signed.

## Downstream

Once released, OpenVTC bumps `vta-sdk`, deletes its `openvtc-core/src/config/context_path.rs` mirror, and re-exports `vta_sdk::context_path` / `vta_sdk::identifier` instead.

## Note (unrelated, pre-existing)

`vta-sdk/tests/protocol_debug_redaction.rs:169` does not compile on current `main` — `SeedRecordBackup` gained a `seed_enc` field but that test's constructor wasn't updated. Untouched by this PR; flagging for a separate fix.