### PR TITLE
refactor(vta): ServiceOpDeps bundle for rest+webauthn protocol ops (P2.5 part 2)

### DIFF
--- a/vta-service/src/messaging/handlers_protocol.rs
+++ b/vta-service/src/messaging/handlers_protocol.rs
@@ -29,7 +29,6 @@ use vta_sdk::protocols::protocol_management;
 use super::router::VtaState;
 use crate::messaging::auth::auth_from_message;
 use crate::messaging::handshake::AlwaysOkProver;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommParams, DisableTransport, disable_didcomm,
 };
@@ -43,6 +42,7 @@ use crate::operations::protocol::update_didcomm::{
     MigrateAuditKind, UpdateDidcommParams, update_didcomm,
 };
 use crate::operations::protocol::update_rest::{UpdateRestParams, update_rest};
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 
 type HandlerResult = Result<Option<DIDCommResponse>, DIDCommServiceError>;
 
@@ -532,26 +532,16 @@ pub async fn handle_enable_rest(
 
     let url = body_str_field(&message, "url")?;
 
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| handler_err("did_resolver unavailable"))?;
+    let deps = ServiceOpDeps::from_vta_state(&state, did_resolver);
     let result = enable_rest(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        state
-            .did_resolver
-            .as_ref()
-            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
-        &state.didcomm_bridge,
-        &state.telemetry,
+        &deps,
         &auth,
         EnableRestParams { url },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "didcomm",
     )
     .await;
@@ -580,26 +570,16 @@ pub async fn handle_update_rest(
 
     let url = body_str_field(&message, "url")?;
 
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| handler_err("did_resolver unavailable"))?;
+    let deps = ServiceOpDeps::from_vta_state(&state, did_resolver);
     let result = update_rest(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        state
-            .did_resolver
-            .as_ref()
-            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
-        &state.didcomm_bridge,
-        &state.telemetry,
+        &deps,
         &auth,
         UpdateRestParams { url },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "didcomm",
     )
     .await;
@@ -627,26 +607,16 @@ pub async fn handle_disable_rest(
 ) -> HandlerResult {
     let auth = protocol_auth!(state, message);
 
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| handler_err("did_resolver unavailable"))?;
+    let deps = ServiceOpDeps::from_vta_state(&state, did_resolver);
     let result = disable_rest(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        state
-            .did_resolver
-            .as_ref()
-            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
-        &state.didcomm_bridge,
-        &state.telemetry,
+        &deps,
         &auth,
         DisableRestParams,
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "didcomm",
     )
     .await;
@@ -675,28 +645,12 @@ pub async fn handle_rollback_rest(
 ) -> HandlerResult {
     let auth = protocol_auth!(state, message);
 
-    let result = rollback_rest(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        state
-            .did_resolver
-            .as_ref()
-            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
-        &state.didcomm_bridge,
-        &state.telemetry,
-        &auth,
-        RollbackRestParams,
-        &state.webvh_auth_locks,
-        "didcomm",
-    )
-    .await;
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| handler_err("did_resolver unavailable"))?;
+    let deps = ServiceOpDeps::from_vta_state(&state, did_resolver);
+    let result = rollback_rest(&deps, &auth, RollbackRestParams, "didcomm").await;
 
     match result {
         Ok(r) => response(

--- a/vta-service/src/operations/protocol/disable_rest.rs
+++ b/vta-service/src/operations/protocol/disable_rest.rs
@@ -16,32 +16,23 @@
 //! process-level binding), so the local CLI can still reach the VTA; only the
 //! *advertisement* is removed.
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use serde_json::Value as JsonValue;
 use thiserror::Error;
-use tokio::sync::RwLock;
 use tracing::info;
 
 use vta_sdk::error::VtaError;
 
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
+use vti_common::telemetry::{TelemetryEvent, TelemetryKind};
 
 use crate::auth::AuthClaims;
-use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::UpdateDidWebvhError;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::document::DocumentPatchError;
 use crate::operations::protocol::service_lifecycle::{
-    DisableMutationError, RestService, ServiceLifecycle, ServiceLifecycleDeps,
-    check_disable_preconditions, publish_patch,
+    DisableMutationError, RestService, ServiceLifecycle, check_disable_preconditions, publish_patch,
 };
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 use crate::operations::protocol::{PROTOCOL_LOCK, snapshot};
-use crate::store::KeyspaceHandle;
 
 #[derive(Debug, Clone, Default)]
 pub struct DisableRestParams;
@@ -128,24 +119,11 @@ impl DisableMutationError for DisableRestError {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn disable_rest(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     _params: DisableRestParams,
     ctx: OpContext,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<DisableRestResult, DisableRestError> {
     auth.require_super_admin()
@@ -153,28 +131,14 @@ pub async fn disable_rest(
 
     let _guard = PROTOCOL_LOCK.lock().await;
 
-    let deps = ServiceLifecycleDeps {
-        config,
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        snapshot_ks,
-        seed_store,
-        did_resolver,
-        didcomm_bridge,
-        telemetry,
-        webvh_auth_locks,
-    };
-
     // Brick-prevention (§3.2) + preconditions, capturing the prior URL.
     let (state, prior_url) =
-        check_disable_preconditions::<RestService, DisableRestError>(config, webvh_ks).await?;
+        check_disable_preconditions::<RestService, DisableRestError>(deps.config, deps.webvh_ks)
+            .await?;
 
     // Snapshot BEFORE the mutation (spec §3.5a): pre-state is the prior URL.
     snapshot::write(
-        snapshot_ks,
+        deps.snapshot_ks,
         RestService::snapshot_enabled(prior_url.clone()),
     )
     .await
@@ -182,7 +146,7 @@ pub async fn disable_rest(
 
     let patched = RestService::without_service(state.current_doc);
     let update_result = publish_patch::<DisableRestError>(
-        &deps,
+        deps,
         auth,
         &state.scid,
         &state.vta_did,
@@ -194,11 +158,11 @@ pub async fn disable_rest(
     // Persist services.rest = false to fjall (authoritative runtime state) +
     // mirror into the in-memory config. Same post-publish risk window as the
     // other ops if this fails — operator retries.
-    crate::operations::protocol::runtime_state::set_rest_enabled(service_state_ks, false)
+    crate::operations::protocol::runtime_state::set_rest_enabled(deps.service_state_ks, false)
         .await
         .map_err(|e| DisableRestError::Storage(format!("runtime state: {e}")))?;
     {
-        let mut cfg = config.write().await;
+        let mut cfg = deps.config.write().await;
         cfg.services.rest = false;
     }
 
@@ -212,7 +176,7 @@ pub async fn disable_rest(
     if let Some(tag) = ctx.telemetry_triggered_by() {
         event = event.with_field("triggered_by", JsonValue::from(tag));
     }
-    let _ = telemetry.record(event).await;
+    let _ = deps.telemetry.record(event).await;
 
     info!(
         channel,
@@ -232,12 +196,17 @@ pub async fn disable_rest(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
     use super::*;
+    use crate::config::AppConfig;
     use crate::operations::protocol::invariant::{
         CurrentServices, ProposedOp, would_violate_last_service,
     };
     use crate::operations::protocol::snapshot::ServiceKind;
-    use crate::store::Store;
+    use crate::store::{KeyspaceHandle, Store};
     use vti_common::config::StoreConfig as VtiStoreConfig;
 
     /// Mirrors the test fixture in enable_rest / update_rest — owns the fjall

--- a/vta-service/src/operations/protocol/disable_webauthn.rs
+++ b/vta-service/src/operations/protocol/disable_webauthn.rs
@@ -16,7 +16,6 @@
 
 use std::sync::Arc;
 
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -24,23 +23,19 @@ use tracing::{info, warn};
 
 use vta_sdk::error::VtaError;
 
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
+use vti_common::telemetry::{TelemetryEvent, TelemetryKind};
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::UpdateDidWebvhError;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::document::DocumentPatchError;
 use crate::operations::protocol::passkey_vm_cleanup::{self, CleanupSummary};
 use crate::operations::protocol::service_lifecycle::{
-    DisableMutationError, ServiceLifecycle, ServiceLifecycleDeps, WebauthnService,
-    check_disable_preconditions, publish_patch,
+    DisableMutationError, ServiceLifecycle, WebauthnService, check_disable_preconditions,
+    publish_patch,
 };
-use crate::operations::protocol::{PROTOCOL_LOCK, snapshot};
-use crate::store::KeyspaceHandle;
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK, ServiceOpDeps, snapshot};
 
 #[derive(Debug, Clone, Default)]
 pub struct DisableWebauthnParams {}
@@ -120,24 +115,11 @@ impl DisableMutationError for DisableWebauthnError {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn disable_webauthn(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    _service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     _params: DisableWebauthnParams,
     ctx: OpContext,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<DisableWebauthnResult, DisableWebauthnError> {
     auth.require_super_admin()
@@ -145,30 +127,17 @@ pub async fn disable_webauthn(
 
     let _guard = PROTOCOL_LOCK.lock().await;
 
-    let deps = ServiceLifecycleDeps {
-        config,
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        snapshot_ks,
-        seed_store,
-        did_resolver,
-        didcomm_bridge,
-        telemetry,
-        webvh_auth_locks,
-    };
-
     // Brick-prevention (§3.2) + preconditions, capturing the prior URL.
-    let (state, prior_url) =
-        check_disable_preconditions::<WebauthnService, DisableWebauthnError>(config, webvh_ks)
-            .await?;
+    let (state, prior_url) = check_disable_preconditions::<WebauthnService, DisableWebauthnError>(
+        deps.config,
+        deps.webvh_ks,
+    )
+    .await?;
 
     // Snapshot BEFORE the mutation (spec §3.5a): re-enables WebAuthn at the
     // prior URL on rollback.
     snapshot::write(
-        snapshot_ks,
+        deps.snapshot_ks,
         WebauthnService::snapshot_enabled(prior_url.clone()),
     )
     .await
@@ -179,17 +148,17 @@ pub async fn disable_webauthn(
     // "remove this surface AND its dependent state"; partial success beats
     // abort-and-leave-the-service-on).
     let cleanup = passkey_vm_cleanup::strip_all_passkey_vms(
-        config,
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        seed_store,
-        did_resolver,
-        didcomm_bridge,
+        deps.config,
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.contexts_ks,
+        deps.webvh_ks,
+        deps.audit_ks,
+        deps.seed_store,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         auth,
-        webvh_auth_locks,
+        deps.webvh_auth_locks,
         channel,
     )
     .await?;
@@ -204,7 +173,7 @@ pub async fn disable_webauthn(
 
     let patched = WebauthnService::without_service(state.current_doc);
     let update_result = publish_patch::<DisableWebauthnError>(
-        &deps,
+        deps,
         auth,
         &state.scid,
         &state.vta_did,
@@ -213,7 +182,7 @@ pub async fn disable_webauthn(
     )
     .await?;
 
-    persist_webauthn_disabled(config).await?;
+    persist_webauthn_disabled(deps.config).await?;
 
     let mut event = TelemetryEvent::new(TelemetryKind::ServicesWebauthnDisable)
         .with_field("channel", JsonValue::from(channel))
@@ -230,7 +199,7 @@ pub async fn disable_webauthn(
     if let Some(tag) = ctx.telemetry_triggered_by() {
         event = event.with_field("triggered_by", JsonValue::from(tag));
     }
-    let _ = telemetry.record(event).await;
+    let _ = deps.telemetry.record(event).await;
 
     info!(
         channel,

--- a/vta-service/src/operations/protocol/enable_rest.rs
+++ b/vta-service/src/operations/protocol/enable_rest.rs
@@ -10,26 +10,16 @@
 //! service, never remove one, so the §3.2 invariant is preserved by
 //! construction.
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use thiserror::Error;
-use tokio::sync::RwLock;
-
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::SharedTelemetrySink;
 
 use crate::auth::AuthClaims;
-use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::UpdateDidWebvhError;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::document::DocumentPatchError;
 use crate::operations::protocol::service_lifecycle::{
-    EnableMutationError, RestService, ServiceLifecycleDeps, ServiceMutationError, run_enable,
+    EnableMutationError, RestService, ServiceMutationError, run_enable,
 };
-use crate::store::KeyspaceHandle;
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 
 #[derive(Debug, Clone)]
 pub struct EnableRestParams {
@@ -122,54 +112,30 @@ impl EnableMutationError for EnableRestError {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn enable_rest(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     params: EnableRestParams,
     ctx: OpContext,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<EnableRestResult, EnableRestError> {
-    let deps = ServiceLifecycleDeps {
-        config,
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        snapshot_ks,
-        seed_store,
-        did_resolver,
-        didcomm_bridge,
-        telemetry,
-        webvh_auth_locks,
-    };
     // REST persists "enabled" as runtime state (fjall) + the in-memory flag.
     // If this fails after publish, the LogEntry advertises REST but config
     // disagrees — same risk window as before; operator retries.
     let ok = run_enable::<RestService, EnableRestError>(
-        &deps,
+        deps,
         auth,
         &params.url,
         ctx,
         channel,
         || async {
-            crate::operations::protocol::runtime_state::set_rest_enabled(service_state_ks, true)
-                .await
-                .map_err(|e| format!("runtime state: {e}"))?;
-            config.write().await.services.rest = true;
+            crate::operations::protocol::runtime_state::set_rest_enabled(
+                deps.service_state_ks,
+                true,
+            )
+            .await
+            .map_err(|e| format!("runtime state: {e}"))?;
+            deps.config.write().await.services.rest = true;
             Ok(())
         },
     )
@@ -185,10 +151,15 @@ pub async fn enable_rest(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
     use super::*;
+    use crate::config::AppConfig;
     use crate::operations::protocol::service_lifecycle::check_enable_preconditions;
     use crate::operations::protocol::snapshot::{self, ServiceKind};
-    use crate::store::Store;
+    use crate::store::{KeyspaceHandle, Store};
     use vta_sdk::protocol::services::validate_service_url;
     use vti_common::config::StoreConfig as VtiStoreConfig;
 

--- a/vta-service/src/operations/protocol/enable_webauthn.rs
+++ b/vta-service/src/operations/protocol/enable_webauthn.rs
@@ -9,26 +9,16 @@
 //! Brick-prevention is not consulted — enabling can only add a transport
 //! service.
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use thiserror::Error;
-use tokio::sync::RwLock;
-
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::SharedTelemetrySink;
 
 use crate::auth::AuthClaims;
-use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::UpdateDidWebvhError;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::document::DocumentPatchError;
 use crate::operations::protocol::service_lifecycle::{
-    EnableMutationError, ServiceLifecycleDeps, ServiceMutationError, WebauthnService, run_enable,
+    EnableMutationError, ServiceMutationError, WebauthnService, run_enable,
 };
-use crate::store::KeyspaceHandle;
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 
 #[derive(Debug, Clone)]
 pub struct EnableWebauthnParams {
@@ -116,53 +106,24 @@ impl EnableMutationError for EnableWebauthnError {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn enable_webauthn(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    // Threaded by every caller for signature parity with the other protocol-
-    // mutation operations; WebAuthn persists to the config file, not the
-    // per-kind service-state keyspace, so it is unused here.
-    _service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     params: EnableWebauthnParams,
     ctx: OpContext,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<EnableWebauthnResult, EnableWebauthnError> {
-    let deps = ServiceLifecycleDeps {
-        config,
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        snapshot_ks,
-        seed_store,
-        did_resolver,
-        didcomm_bridge,
-        telemetry,
-        webvh_auth_locks,
-    };
-    // WebAuthn persists "enabled" by writing the config file.
+    // WebAuthn persists "enabled" by writing the config file (not the per-kind
+    // service-state keyspace), so `deps.service_state_ks` is unused here.
     let ok = run_enable::<WebauthnService, EnableWebauthnError>(
-        &deps,
+        deps,
         auth,
         &params.url,
         ctx,
         channel,
         || async {
             let (contents, path) = {
-                let mut cfg = config.write().await;
+                let mut cfg = deps.config.write().await;
                 cfg.services.webauthn = true;
                 let contents = toml::to_string_pretty(&*cfg).map_err(|e| e.to_string())?;
                 let path = cfg.config_path.clone();

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -132,6 +132,93 @@ impl OpContext {
     }
 }
 
+/// Ambient dependencies shared by every REST/WebAuthn service-management
+/// operation (`enable` / `update` / `disable` / `rollback`).
+///
+/// Before P2.5 each of these eight ops took the same ~14 positional arguments
+/// (config + keyspaces + seed-store + resolver + bridge + telemetry +
+/// auth-locks), tripping `clippy::too_many_arguments`. Bundling them into one
+/// borrowed struct — built once at the transport boundary via
+/// [`ServiceOpDeps::from_app_state`] / [`ServiceOpDeps::from_vta_state`] (or
+/// directly by the offline CLI) and threaded through unchanged — drops every op
+/// to ≤5 args and lets the rollback dispatcher hand its forward op the deps
+/// verbatim instead of re-listing every keyspace.
+///
+/// All fields are borrows: the struct is cheap to build per request and never
+/// outlives the state it borrows from. The internal lifecycle engine
+/// ([`service_lifecycle`]) reads the subset it needs; `service_state_ks` is
+/// consumed only by the REST enable/disable runtime-state persist step (the
+/// engine itself never touches it).
+pub struct ServiceOpDeps<'a> {
+    pub config: &'a std::sync::Arc<tokio::sync::RwLock<crate::config::AppConfig>>,
+    pub keys_ks: &'a crate::store::KeyspaceHandle,
+    pub imported_ks: &'a crate::store::KeyspaceHandle,
+    pub contexts_ks: &'a crate::store::KeyspaceHandle,
+    pub webvh_ks: &'a crate::store::KeyspaceHandle,
+    pub audit_ks: &'a crate::store::KeyspaceHandle,
+    pub snapshot_ks: &'a crate::store::KeyspaceHandle,
+    pub service_state_ks: &'a crate::store::KeyspaceHandle,
+    pub seed_store: &'a dyn vti_common::seed_store::SeedStore,
+    pub did_resolver: &'a affinidi_did_resolver_cache_sdk::DIDCacheClient,
+    pub didcomm_bridge: &'a std::sync::Arc<crate::didcomm_bridge::DIDCommBridge>,
+    pub telemetry: &'a vti_common::telemetry::SharedTelemetrySink,
+    pub webvh_auth_locks: &'a crate::operations::did_webvh::WebvhAuthLocks,
+}
+
+impl<'a> ServiceOpDeps<'a> {
+    /// Borrow the service-op dependencies from an [`AppState`](crate::server::AppState)
+    /// (REST transport).
+    ///
+    /// `did_resolver` is threaded separately because `AppState` holds it as an
+    /// `Option` — the caller unwraps it (surfacing the typed
+    /// `DidResolverUnavailable` reject) before building the deps.
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    pub fn from_app_state(
+        s: &'a crate::server::AppState,
+        did_resolver: &'a affinidi_did_resolver_cache_sdk::DIDCacheClient,
+    ) -> Self {
+        Self {
+            config: &s.config,
+            keys_ks: &s.keys_ks,
+            imported_ks: &s.imported_ks,
+            contexts_ks: &s.contexts_ks,
+            webvh_ks: &s.webvh_ks,
+            audit_ks: &s.audit_ks,
+            snapshot_ks: &s.snapshot_ks,
+            service_state_ks: &s.service_state_ks,
+            seed_store: &*s.seed_store,
+            did_resolver,
+            didcomm_bridge: &s.didcomm_bridge,
+            telemetry: &s.telemetry,
+            webvh_auth_locks: &s.webvh_auth_locks,
+        }
+    }
+
+    /// Borrow the service-op dependencies from a
+    /// [`VtaState`](crate::messaging::router::VtaState) (DIDComm transport).
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    pub fn from_vta_state(
+        s: &'a crate::messaging::router::VtaState,
+        did_resolver: &'a affinidi_did_resolver_cache_sdk::DIDCacheClient,
+    ) -> Self {
+        Self {
+            config: &s.config,
+            keys_ks: &s.keys_ks,
+            imported_ks: &s.imported_ks,
+            contexts_ks: &s.contexts_ks,
+            webvh_ks: &s.webvh_ks,
+            audit_ks: &s.audit_ks,
+            snapshot_ks: &s.snapshot_ks,
+            service_state_ks: &s.service_state_ks,
+            seed_store: &*s.seed_store,
+            did_resolver,
+            didcomm_bridge: &s.didcomm_bridge,
+            telemetry: &s.telemetry,
+            webvh_auth_locks: &s.webvh_auth_locks,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::PROTOCOL_LOCK;

--- a/vta-service/src/operations/protocol/rollback_rest.rs
+++ b/vta-service/src/operations/protocol/rollback_rest.rs
@@ -35,20 +35,14 @@
 
 use std::sync::Arc;
 
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::info;
 
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::SharedTelemetrySink;
-
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::UpdateDidWebvhError;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::disable_rest::{
     DisableRestError, DisableRestParams, disable_rest,
 };
@@ -58,6 +52,7 @@ use crate::operations::protocol::snapshot::{
     self, RestSnapshot, ServiceConfigSnapshot, ServiceKind,
 };
 use crate::operations::protocol::update_rest::{UpdateRestError, UpdateRestParams, update_rest};
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 use crate::store::KeyspaceHandle;
 
 #[derive(Debug, Clone, Default)]
@@ -157,23 +152,10 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn rollback_rest(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     _params: RollbackRestParams,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<RollbackRestResult, RollbackRestError> {
     auth.require_super_admin()
@@ -182,7 +164,7 @@ pub async fn rollback_rest(
     // 1. Read the snapshot. None → NoPriorMutation. Note: we do
     //    NOT take PROTOCOL_LOCK here because the dispatched
     //    forward op takes it; holding it twice would deadlock.
-    let snap = snapshot::read(snapshot_ks, ServiceKind::Rest)
+    let snap = snapshot::read(deps.snapshot_ks, ServiceKind::Rest)
         .await
         .map_err(|e| RollbackRestError::Storage(format!("snapshot read: {e}")))?
         .ok_or(RollbackRestError::NoPriorMutation)?;
@@ -204,7 +186,7 @@ pub async fn rollback_rest(
     //    what the snapshot will be compared against), and config
     //    is asserted to match by the existing precondition checks
     //    in the forward ops.
-    let current_url = read_current_rest_url(config, webvh_ks).await?;
+    let current_url = read_current_rest_url(deps.config, deps.webvh_ks).await?;
 
     // 3. Dispatch table (see module doc).
     info!(
@@ -216,26 +198,8 @@ pub async fn rollback_rest(
     match (rest_snap, current_url.as_deref()) {
         // Snapshot says off, currently on → disable.
         (RestSnapshot::Disabled, Some(_)) => {
-            let result = disable_rest(
-                config,
-                keys_ks,
-                imported_ks,
-                contexts_ks,
-                webvh_ks,
-                audit_ks,
-                snapshot_ks,
-                service_state_ks,
-                seed_store,
-                did_resolver,
-                didcomm_bridge,
-                telemetry,
-                auth,
-                DisableRestParams,
-                OpContext::Rollback,
-                webvh_auth_locks,
-                channel,
-            )
-            .await?;
+            let result =
+                disable_rest(deps, auth, DisableRestParams, OpContext::Rollback, channel).await?;
             Ok(RollbackRestResult {
                 new_version_id: Some(result.new_version_id),
                 kind: RollbackKind::Disabled,
@@ -247,22 +211,10 @@ pub async fn rollback_rest(
         // Snapshot says on with URL X, currently off → enable.
         (RestSnapshot::Enabled { url }, None) => {
             let result = enable_rest(
-                config,
-                keys_ks,
-                imported_ks,
-                contexts_ks,
-                webvh_ks,
-                audit_ks,
-                snapshot_ks,
-                service_state_ks,
-                seed_store,
-                did_resolver,
-                didcomm_bridge,
-                telemetry,
+                deps,
                 auth,
                 EnableRestParams { url: url.clone() },
                 OpContext::Rollback,
-                webvh_auth_locks,
                 channel,
             )
             .await?;
@@ -278,22 +230,10 @@ pub async fn rollback_rest(
         // X != Y → update.
         (RestSnapshot::Enabled { url }, Some(current)) if url != current => {
             let result = update_rest(
-                config,
-                keys_ks,
-                imported_ks,
-                contexts_ks,
-                webvh_ks,
-                audit_ks,
-                snapshot_ks,
-                service_state_ks,
-                seed_store,
-                did_resolver,
-                didcomm_bridge,
-                telemetry,
+                deps,
                 auth,
                 UpdateRestParams { url: url.clone() },
                 OpContext::Rollback,
-                webvh_auth_locks,
                 channel,
             )
             .await?;

--- a/vta-service/src/operations/protocol/rollback_webauthn.rs
+++ b/vta-service/src/operations/protocol/rollback_webauthn.rs
@@ -11,20 +11,14 @@
 
 use std::sync::Arc;
 
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::info;
 
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::SharedTelemetrySink;
-
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::UpdateDidWebvhError;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::disable_webauthn::{
     DisableWebauthnError, DisableWebauthnParams, disable_webauthn,
 };
@@ -38,6 +32,7 @@ use crate::operations::protocol::snapshot::{
 use crate::operations::protocol::update_webauthn::{
     UpdateWebauthnError, UpdateWebauthnParams, update_webauthn,
 };
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 use crate::store::KeyspaceHandle;
 
 #[derive(Debug, Clone, Default)]
@@ -113,29 +108,16 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn rollback_webauthn(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     _params: RollbackWebauthnParams,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<RollbackWebauthnResult, RollbackWebauthnError> {
     auth.require_super_admin()
         .map_err(|e| RollbackWebauthnError::Auth(e.to_string()))?;
 
-    let snap = snapshot::read(snapshot_ks, ServiceKind::Webauthn)
+    let snap = snapshot::read(deps.snapshot_ks, ServiceKind::Webauthn)
         .await
         .map_err(|e| RollbackWebauthnError::Storage(format!("snapshot read: {e}")))?
         .ok_or(RollbackWebauthnError::NoPriorMutation)?;
@@ -148,7 +130,7 @@ pub async fn rollback_webauthn(
         }
     };
 
-    let current_url = read_current_webauthn_url(config, webvh_ks).await?;
+    let current_url = read_current_webauthn_url(deps.config, deps.webvh_ks).await?;
 
     info!(
         channel,
@@ -160,22 +142,10 @@ pub async fn rollback_webauthn(
     match (webauthn_snap, current_url.as_deref()) {
         (WebauthnSnapshot::Disabled, Some(_)) => {
             let result = disable_webauthn(
-                config,
-                keys_ks,
-                imported_ks,
-                contexts_ks,
-                webvh_ks,
-                audit_ks,
-                snapshot_ks,
-                service_state_ks,
-                seed_store,
-                did_resolver,
-                didcomm_bridge,
-                telemetry,
+                deps,
                 auth,
                 DisableWebauthnParams::default(),
                 OpContext::Rollback,
-                webvh_auth_locks,
                 channel,
             )
             .await?;
@@ -188,22 +158,10 @@ pub async fn rollback_webauthn(
         }
         (WebauthnSnapshot::Enabled { url }, None) => {
             let result = enable_webauthn(
-                config,
-                keys_ks,
-                imported_ks,
-                contexts_ks,
-                webvh_ks,
-                audit_ks,
-                snapshot_ks,
-                service_state_ks,
-                seed_store,
-                did_resolver,
-                didcomm_bridge,
-                telemetry,
+                deps,
                 auth,
                 EnableWebauthnParams { url: url.clone() },
                 OpContext::Rollback,
-                webvh_auth_locks,
                 channel,
             )
             .await?;
@@ -216,22 +174,10 @@ pub async fn rollback_webauthn(
         }
         (WebauthnSnapshot::Enabled { url }, Some(current)) if url != current => {
             let result = update_webauthn(
-                config,
-                keys_ks,
-                imported_ks,
-                contexts_ks,
-                webvh_ks,
-                audit_ks,
-                snapshot_ks,
-                service_state_ks,
-                seed_store,
-                did_resolver,
-                didcomm_bridge,
-                telemetry,
+                deps,
                 auth,
                 UpdateWebauthnParams { url: url.clone() },
                 OpContext::Rollback,
-                webvh_auth_locks,
                 channel,
             )
             .await?;

--- a/vta-service/src/operations/protocol/service_lifecycle.rs
+++ b/vta-service/src/operations/protocol/service_lifecycle.rs
@@ -28,18 +28,15 @@
 
 use std::sync::Arc;
 
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use serde_json::Value as JsonValue;
 use tracing::info;
 
-use vti_common::seed_store::SeedStore;
 use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
 
 use vta_sdk::protocol::services::validate_service_url;
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
 use crate::operations::protocol::document::DocumentPatchError;
 use crate::operations::protocol::invariant::{
@@ -132,30 +129,18 @@ pub(crate) struct ServiceMutationOk {
     pub prior_url: Option<String>,
 }
 
-/// Keyspaces + shared infra threaded into both engines. Bundling them keeps the
-/// engine signatures (and the wrapper call sites) from sprawling past the
-/// `too_many_arguments` line; the fields mirror the historical positional args.
-pub(crate) struct ServiceLifecycleDeps<'a> {
-    pub config: &'a Arc<RwLock<AppConfig>>,
-    pub keys_ks: &'a KeyspaceHandle,
-    pub imported_ks: &'a KeyspaceHandle,
-    pub contexts_ks: &'a KeyspaceHandle,
-    pub webvh_ks: &'a KeyspaceHandle,
-    pub audit_ks: &'a KeyspaceHandle,
-    pub snapshot_ks: &'a KeyspaceHandle,
-    pub seed_store: &'a dyn SeedStore,
-    pub did_resolver: &'a DIDCacheClient,
-    pub didcomm_bridge: &'a Arc<DIDCommBridge>,
-    pub telemetry: &'a SharedTelemetrySink,
-    pub webvh_auth_locks: &'a crate::operations::did_webvh::WebvhAuthLocks,
-}
+/// The shared dependency bundle both engines read is
+/// [`super::ServiceOpDeps`] — the same struct the public ops receive at their
+/// boundary (P2.5). The engine reads only the subset it needs (every field
+/// except `service_state_ks`, which is the REST persist step's concern).
+pub(crate) use super::ServiceOpDeps;
 
 /// Publish a patched document via `update_did_webvh` — the common publish step
 /// shared by enable / update / disable. Bound only on `From<UpdateDidWebvhError>`
 /// (the single error it propagates) so disable errors — which carry no
 /// `validation` constructor — can use it too.
 pub(crate) async fn publish_patch<E: From<UpdateDidWebvhError>>(
-    deps: &ServiceLifecycleDeps<'_>,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     scid: &str,
     vta_did: &str,
@@ -295,7 +280,7 @@ where
 /// flag, WebAuthn writes the config file. Passing it as a closure keeps
 /// [`ServiceLifecycle`] all-sync (and the engine future `Send`).
 pub(crate) async fn run_enable<S, E>(
-    deps: &ServiceLifecycleDeps<'_>,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     url: &str,
     ctx: OpContext,
@@ -360,7 +345,7 @@ where
 /// enabled; only the advertised URL changes. The prior URL is captured for the
 /// rollback snapshot and surfaced in `prior_url`.
 pub(crate) async fn run_update<S, E>(
-    deps: &ServiceLifecycleDeps<'_>,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     url: &str,
     ctx: OpContext,

--- a/vta-service/src/operations/protocol/update_rest.rs
+++ b/vta-service/src/operations/protocol/update_rest.rs
@@ -8,26 +8,16 @@
 //! update; only the URL changes. Brick-prevention is not consulted (update
 //! can't change the on/off state).
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use thiserror::Error;
-use tokio::sync::RwLock;
-
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::SharedTelemetrySink;
 
 use crate::auth::AuthClaims;
-use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::UpdateDidWebvhError;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::document::DocumentPatchError;
 use crate::operations::protocol::service_lifecycle::{
-    RestService, ServiceLifecycleDeps, ServiceMutationError, UpdateMutationError, run_update,
+    RestService, ServiceMutationError, UpdateMutationError, run_update,
 };
-use crate::store::KeyspaceHandle;
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 
 #[derive(Debug, Clone)]
 pub struct UpdateRestParams {
@@ -115,42 +105,15 @@ impl UpdateMutationError for UpdateRestError {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn update_rest(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    _service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     params: UpdateRestParams,
     ctx: OpContext,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<UpdateRestResult, UpdateRestError> {
-    let deps = ServiceLifecycleDeps {
-        config,
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        snapshot_ks,
-        seed_store,
-        did_resolver,
-        didcomm_bridge,
-        telemetry,
-        webvh_auth_locks,
-    };
     let ok =
-        run_update::<RestService, UpdateRestError>(&deps, auth, &params.url, ctx, channel).await?;
+        run_update::<RestService, UpdateRestError>(deps, auth, &params.url, ctx, channel).await?;
 
     Ok(UpdateRestResult {
         new_version_id: ok.new_version_id,
@@ -164,12 +127,17 @@ pub async fn update_rest(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
     use super::*;
+    use crate::config::AppConfig;
     use crate::operations::protocol::service_lifecycle::check_update_preconditions;
     use crate::operations::protocol::snapshot::{
         self, RestSnapshot, ServiceConfigSnapshot, ServiceKind,
     };
-    use crate::store::Store;
+    use crate::store::{KeyspaceHandle, Store};
     use vta_sdk::protocol::services::validate_service_url;
     use vti_common::config::StoreConfig as VtiStoreConfig;
 

--- a/vta-service/src/operations/protocol/update_webauthn.rs
+++ b/vta-service/src/operations/protocol/update_webauthn.rs
@@ -7,26 +7,16 @@
 //! when WebAuthn is not currently advertised. Snapshots the prior URL so
 //! rollback can restore it.
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use thiserror::Error;
-use tokio::sync::RwLock;
-
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::SharedTelemetrySink;
 
 use crate::auth::AuthClaims;
-use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::operations::did_webvh::UpdateDidWebvhError;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::document::DocumentPatchError;
 use crate::operations::protocol::service_lifecycle::{
-    ServiceLifecycleDeps, ServiceMutationError, UpdateMutationError, WebauthnService, run_update,
+    ServiceMutationError, UpdateMutationError, WebauthnService, run_update,
 };
-use crate::store::KeyspaceHandle;
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 
 #[derive(Debug, Clone)]
 pub struct UpdateWebauthnParams {
@@ -104,43 +94,15 @@ impl UpdateMutationError for UpdateWebauthnError {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn update_webauthn(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    // Threaded for signature parity; see `enable_webauthn`.
-    _service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     params: UpdateWebauthnParams,
     ctx: OpContext,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<UpdateWebauthnResult, UpdateWebauthnError> {
-    let deps = ServiceLifecycleDeps {
-        config,
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        snapshot_ks,
-        seed_store,
-        did_resolver,
-        didcomm_bridge,
-        telemetry,
-        webvh_auth_locks,
-    };
     let ok =
-        run_update::<WebauthnService, UpdateWebauthnError>(&deps, auth, &params.url, ctx, channel)
+        run_update::<WebauthnService, UpdateWebauthnError>(deps, auth, &params.url, ctx, channel)
             .await?;
 
     Ok(UpdateWebauthnResult {

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -17,7 +17,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::auth::SuperAdminAuth;
 use crate::messaging::handshake::{AlwaysOkProver, HandshakeError, HandshakeStage};
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::disable_didcomm::DisableTransport as DidcommTransport;
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommError, DisableDidcommParams, DisableTransport, disable_didcomm,
@@ -53,6 +52,7 @@ use crate::operations::protocol::update_rest::{UpdateRestError, UpdateRestParams
 use crate::operations::protocol::update_webauthn::{
     UpdateWebauthnError, UpdateWebauthnParams, update_webauthn,
 };
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 use crate::server::AppState;
 use vta_sdk::protocol::DidcommStatusResponse;
 
@@ -1400,23 +1400,12 @@ pub async fn enable_rest_handler(
         .ok_or(RestServiceHttpError::DidResolverUnavailable)?
         .clone();
 
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
     let result = enable_rest(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &state.didcomm_bridge,
-        &state.telemetry,
+        &deps,
         &auth.0,
         EnableRestParams { url: req.url },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;
@@ -1444,23 +1433,12 @@ pub async fn update_rest_handler(
         .ok_or(RestServiceHttpError::DidResolverUnavailable)?
         .clone();
 
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
     let result = update_rest(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &state.didcomm_bridge,
-        &state.telemetry,
+        &deps,
         &auth.0,
         UpdateRestParams { url: req.url },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;
@@ -1488,26 +1466,8 @@ pub async fn disable_rest_handler(
         .ok_or(RestServiceHttpError::DidResolverUnavailable)?
         .clone();
 
-    let result = disable_rest(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &state.didcomm_bridge,
-        &state.telemetry,
-        &auth.0,
-        DisableRestParams,
-        OpContext::Direct,
-        &state.webvh_auth_locks,
-        "rest",
-    )
-    .await?;
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
+    let result = disable_rest(&deps, &auth.0, DisableRestParams, OpContext::Direct, "rest").await?;
 
     Ok(Json(vta_sdk::protocol::services::ServiceMutationResponse {
         log_entry_version_id: result.new_version_id,
@@ -1758,25 +1718,8 @@ pub async fn rollback_rest_handler(
         .ok_or(RollbackRestHttpError::DidResolverUnavailable)?
         .clone();
 
-    let result = rollback_rest(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &state.didcomm_bridge,
-        &state.telemetry,
-        &auth.0,
-        RollbackRestParams,
-        &state.webvh_auth_locks,
-        "rest",
-    )
-    .await?;
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
+    let result = rollback_rest(&deps, &auth.0, RollbackRestParams, "rest").await?;
 
     Ok(Json(RollbackResponse {
         log_entry_version_id: result.new_version_id.unwrap_or_default(),
@@ -2196,23 +2139,12 @@ pub async fn enable_webauthn_handler(
         .as_ref()
         .ok_or(WebauthnServiceHttpError::DidResolverUnavailable)?
         .clone();
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
     let result = enable_webauthn(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &state.didcomm_bridge,
-        &state.telemetry,
+        &deps,
         &auth.0,
         EnableWebauthnParams { url: req.url },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;
@@ -2236,23 +2168,12 @@ pub async fn update_webauthn_handler(
         .as_ref()
         .ok_or(WebauthnServiceHttpError::DidResolverUnavailable)?
         .clone();
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
     let result = update_webauthn(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &state.didcomm_bridge,
-        &state.telemetry,
+        &deps,
         &auth.0,
         UpdateWebauthnParams { url: req.url },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;
@@ -2278,23 +2199,12 @@ pub async fn disable_webauthn_handler(
         .as_ref()
         .ok_or(WebauthnServiceHttpError::DidResolverUnavailable)?
         .clone();
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
     let result = disable_webauthn(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &state.didcomm_bridge,
-        &state.telemetry,
+        &deps,
         &auth.0,
         DisableWebauthnParams::default(),
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;
@@ -2318,25 +2228,8 @@ pub async fn rollback_webauthn_handler(
         .as_ref()
         .ok_or(WebauthnServiceHttpError::DidResolverUnavailable)?
         .clone();
-    let result = rollback_webauthn(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &state.didcomm_bridge,
-        &state.telemetry,
-        &auth.0,
-        RollbackWebauthnParams,
-        &state.webvh_auth_locks,
-        "rest",
-    )
-    .await?;
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
+    let result = rollback_webauthn(&deps, &auth.0, RollbackWebauthnParams, "rest").await?;
     let kind_str = match result.kind {
         WebauthnRollbackKind::Disabled => "disabled",
         WebauthnRollbackKind::Enabled => "enabled",

--- a/vta-service/src/services_cli.rs
+++ b/vta-service/src/services_cli.rs
@@ -49,6 +49,7 @@ use crate::messaging::drain_sweeper::{DrainSweeper, teardown_channel};
 use crate::messaging::handshake::AlwaysOkProver;
 use crate::messaging::registry::MediatorListenerRegistry;
 use crate::operations::protocol::OpContext;
+use crate::operations::protocol::ServiceOpDeps;
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommParams, DisableTransport, disable_didcomm,
 };
@@ -95,6 +96,30 @@ struct OfflineDeps {
     /// possible here because the fjall store requires exclusive
     /// access. A throwaway map suffices.
     webvh_auth_locks: crate::operations::did_webvh::WebvhAuthLocks,
+}
+
+impl OfflineDeps {
+    /// Borrow the REST/WebAuthn service-op dependency bundle. The offline CLI
+    /// owns its `did_resolver` (always present, unlike `AppState`'s `Option`),
+    /// so this is infallible — the same shape `ServiceOpDeps::from_app_state`
+    /// produces for the online path.
+    fn service_op_deps(&self) -> ServiceOpDeps<'_> {
+        ServiceOpDeps {
+            config: &self.config,
+            keys_ks: &self.keys_ks,
+            imported_ks: &self.imported_ks,
+            contexts_ks: &self.contexts_ks,
+            webvh_ks: &self.webvh_ks,
+            audit_ks: &self.audit_ks,
+            snapshot_ks: &self.snapshot_ks,
+            service_state_ks: &self.service_state_ks,
+            seed_store: &self.seed_store,
+            did_resolver: &self.did_resolver,
+            didcomm_bridge: &self.didcomm_bridge,
+            telemetry: &self.telemetry,
+            webvh_auth_locks: &self.webvh_auth_locks,
+        }
+    }
 }
 
 /// Open the local VTA state for offline service-management.
@@ -256,23 +281,12 @@ pub async fn run_services_list(config_path: Option<PathBuf>) -> CliResult {
 
 pub async fn run_services_rest_enable(config_path: Option<PathBuf>, url: String) -> CliResult {
     let d = build_offline_deps(config_path).await?;
+    let deps = d.service_op_deps();
     let result = enable_rest(
-        &d.config,
-        &d.keys_ks,
-        &d.imported_ks,
-        &d.contexts_ks,
-        &d.webvh_ks,
-        &d.audit_ks,
-        &d.snapshot_ks,
-        &d.service_state_ks,
-        &d.seed_store,
-        &d.did_resolver,
-        &d.didcomm_bridge,
-        &d.telemetry,
+        &deps,
         &d.auth,
         EnableRestParams { url },
         OpContext::Direct,
-        &d.webvh_auth_locks,
         "vta-cli-offline",
     )
     .await
@@ -286,23 +300,12 @@ pub async fn run_services_rest_enable(config_path: Option<PathBuf>, url: String)
 
 pub async fn run_services_rest_update(config_path: Option<PathBuf>, url: String) -> CliResult {
     let d = build_offline_deps(config_path).await?;
+    let deps = d.service_op_deps();
     let result = update_rest(
-        &d.config,
-        &d.keys_ks,
-        &d.imported_ks,
-        &d.contexts_ks,
-        &d.webvh_ks,
-        &d.audit_ks,
-        &d.snapshot_ks,
-        &d.service_state_ks,
-        &d.seed_store,
-        &d.did_resolver,
-        &d.didcomm_bridge,
-        &d.telemetry,
+        &deps,
         &d.auth,
         UpdateRestParams { url },
         OpContext::Direct,
-        &d.webvh_auth_locks,
         "vta-cli-offline",
     )
     .await
@@ -317,23 +320,12 @@ pub async fn run_services_rest_update(config_path: Option<PathBuf>, url: String)
 
 pub async fn run_services_rest_disable(config_path: Option<PathBuf>) -> CliResult {
     let d = build_offline_deps(config_path).await?;
+    let deps = d.service_op_deps();
     let result = disable_rest(
-        &d.config,
-        &d.keys_ks,
-        &d.imported_ks,
-        &d.contexts_ks,
-        &d.webvh_ks,
-        &d.audit_ks,
-        &d.snapshot_ks,
-        &d.service_state_ks,
-        &d.seed_store,
-        &d.did_resolver,
-        &d.didcomm_bridge,
-        &d.telemetry,
+        &deps,
         &d.auth,
         DisableRestParams,
         OpContext::Direct,
-        &d.webvh_auth_locks,
         "vta-cli-offline",
     )
     .await
@@ -347,26 +339,10 @@ pub async fn run_services_rest_disable(config_path: Option<PathBuf>) -> CliResul
 
 pub async fn run_services_rest_rollback(config_path: Option<PathBuf>) -> CliResult {
     let d = build_offline_deps(config_path).await?;
-    let result = rollback_rest(
-        &d.config,
-        &d.keys_ks,
-        &d.imported_ks,
-        &d.contexts_ks,
-        &d.webvh_ks,
-        &d.audit_ks,
-        &d.snapshot_ks,
-        &d.service_state_ks,
-        &d.seed_store,
-        &d.did_resolver,
-        &d.didcomm_bridge,
-        &d.telemetry,
-        &d.auth,
-        RollbackRestParams,
-        &d.webvh_auth_locks,
-        "vta-cli-offline",
-    )
-    .await
-    .map_err(report_op_error)?;
+    let deps = d.service_op_deps();
+    let result = rollback_rest(&deps, &d.auth, RollbackRestParams, "vta-cli-offline")
+        .await
+        .map_err(report_op_error)?;
     if matches!(
         result.kind,
         crate::operations::protocol::rollback_rest::RollbackKind::NoOp


### PR DESCRIPTION
## What

The eight REST/WebAuthn service-management ops (`enable`/`update`/`disable`/`rollback` × `rest`/`webauthn`) each took the same ~14 positional args — `config` + 8 keyspaces + `seed_store` + `did_resolver` + `didcomm_bridge` + `telemetry` + `webvh_auth_locks` — tripping `clippy::too_many_arguments` (`update_rest` topped out at 25 args). This bundles the ambient deps into one borrowed `operations::protocol::ServiceOpDeps`, built once at the transport boundary and threaded through unchanged.

This is **P2.5 part 2** — the proven `ProvisionIntegrationDeps` pattern applied to the worst-offending op family.

## Changes

- **New `pub struct ServiceOpDeps<'a>`** (in `protocol/mod.rs`) with `from_app_state` (REST) / `from_vta_state` (DIDComm) constructors, plus an offline-CLI `OfflineDeps::service_op_deps` builder. `did_resolver` is passed in unwrapped because `AppState` holds it as `Option` — the caller keeps surfacing the typed `DidResolverUnavailable` reject.
- The internal engine's `ServiceLifecycleDeps` is **subsumed** — now `pub(crate) use super::ServiceOpDeps`. The engine reads every field except `service_state_ks` (the REST persist step's concern).
- All eight ops drop to **≤5 args** `(deps, auth, params, ctx, channel)`; the rollback dispatchers hand their forward op the deps verbatim instead of re-listing every keyspace. **All 8 `#[allow(clippy::too_many_arguments)]` removed.**
- Call sites updated: `routes/protocol.rs` (8), `messaging/handlers_protocol.rs` (4 REST), `services_cli.rs` (4 REST).

The four DIDComm-family ops (extra `registry`/`sweeper`/`drains_ks`/`prover`) keep their positional signatures — a follow-up part, as their dep shape differs.

## Wire behaviour

Byte-identical: the public `*Params`/`*Result`/`*Error` types and all routes/DIDComm response shapes are unchanged. The P2.0/P2.3 op + router safety nets pass unmodified.

## Net

**−419 LOC** (266 insertions, 685 deletions across 13 files).

## Checks

- `cargo fmt --check` clean
- `cargo clippy --all-targets` (default & tee feature sets) clean
- lib **724** + all 18 integration suites (api_integration 115, security 34, vault_trust_task 12, step-up, …) green
- `vta-enclave` checks