### PR TITLE
fix(sdk): DI-signed REST auth for the provision-client (+ release bump)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2365,7 +2365,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.11.3",
+ "vta-sdk 0.12.0",
 ]
 
 [[package]]
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -3145,7 +3145,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.11.3",
+ "vta-sdk 0.12.0",
 ]
 
 [[package]]
@@ -6505,7 +6505,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6527,7 +6527,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.11.3",
+ "vta-sdk 0.12.0",
 ]
 
 [[package]]
@@ -9739,7 +9739,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9757,13 +9757,13 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.11.3",
+ "vta-sdk 0.12.0",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "vta-enclave"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9778,7 +9778,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9796,7 +9796,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.11.3",
+ "vta-sdk 0.12.0",
 ]
 
 [[package]]
@@ -9831,7 +9831,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9880,7 +9880,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -9960,7 +9960,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.11.3",
+ "vta-sdk 0.12.0",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -9973,7 +9973,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10042,7 +10042,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "vta-sdk 0.11.3",
+ "vta-sdk 0.12.0",
  "vtc-service",
  "vti-common",
  "webauthn-rs",
@@ -10054,7 +10054,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -10087,7 +10087,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.11.3",
+ "vta-sdk 0.12.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10114,7 +10114,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.11.3",
+ "vta-sdk 0.12.0",
  "vta-service",
  "vti-common",
 ]

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.12", features = ["session"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.12", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.12", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.11", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.12", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 # `vta-enclave` is a Linux-only Nitro Enclave binary (vsock-store depends
 # on `tokio-vsock`). Publishing to crates.io would surface "fails on

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.1"
+version = "0.6.2"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -61,7 +61,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.12", features = ["session"] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.3"
+version = "0.12.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -99,6 +99,7 @@ provision-client = [
   "provision-integration",
   "session",
   "dep:tracing",
+  "dep:trust-tasks-rs",
 ]
 # Expose in-memory test fixtures for downstream integration tests.
 # Currently gates: `SessionBackend` mocks (always); `provision_client::test_helpers`
@@ -146,6 +147,11 @@ affinidi-crypto = { workspace = true, optional = true }
 affinidi-vc = { workspace = true, optional = true }
 affinidi-data-integrity = { workspace = true, optional = true }
 affinidi-secrets-resolver = { workspace = true, optional = true }
+# Trust Task document/proof types for the DI-signed REST auth path
+# (`provision_client::auth_rest`). Optional + gated on `provision-client` so the
+# published artifact stays slim for non-provisioning consumers; also present as
+# a dev-dependency for the always-on conformance tests below.
+trust-tasks-rs = { workspace = true, optional = true }
 ciborium = { version = "0.2", optional = true }
 # Used only by sealed-transfer to feed an OS-backed CSPRNG into hpke's
 # rand_core 0.9 trait surface (rand 0.10 + rand_core 0.10 are incompatible).

--- a/vta-sdk/src/provision_client/auth_rest.rs
+++ b/vta-sdk/src/provision_client/auth_rest.rs
@@ -1,0 +1,167 @@
+//! DI-signed (`eddsa-jcs-2022`) REST authentication for the provision-client.
+//!
+//! The provision REST legs previously authenticated via
+//! [`crate::session::challenge_response`], which packs a **DIDComm** envelope
+//! the VTA unpacks with its ATM. A REST-only VTA (no mediator / ATM) rejects
+//! that with `ATM not configured`, so provisioning over plain REST against
+//! such a VTA was impossible — see issue #406's MockVta e2e.
+//!
+//! This module implements the *canonical* REST auth the VTA tries first
+//! (`vta-service/src/routes/auth.rs::try_authenticate_trust_task`): a plain
+//! `auth/authenticate/0.1` Trust Task whose holder `eddsa-jcs-2022`
+//! Data-Integrity proof **is** the authentication — no DIDComm packing, no
+//! mediator. It mirrors `vta-mobile-core::build_authenticate`, but signs
+//! in-process with the holder key (which the provision-client owns) via the
+//! same [`DataIntegrityProof::sign`] primitive the VP signer uses
+//! ([`crate::provision_integration::request`]).
+//!
+//! It works against *any* VTA — REST-only or DIDComm-enabled — because the
+//! server attempts the DI path before the DIDComm-envelope path.
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+use affinidi_secrets_resolver::secrets::Secret;
+use chrono::Utc;
+use serde_json::{Value, json};
+use trust_tasks_rs::{Proof, TrustTask};
+
+use crate::did_key::decode_private_key_multibase;
+use crate::protocols::auth::{AuthenticateResponse, ChallengeRequest, ChallengeResponse};
+use crate::session::TokenResult;
+use crate::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1;
+
+/// The `did:key:zXxx#zXxx` verification-method id the Data-Integrity resolver
+/// recognises for a `did:key` holder.
+fn did_key_to_vm(did: &str) -> Option<String> {
+    let mb = did.strip_prefix("did:key:")?;
+    Some(format!("{did}#{mb}"))
+}
+
+/// Authenticate over plain REST using a DI-signed `auth/authenticate/0.1`
+/// Trust Task, returning the same [`TokenResult`] as
+/// [`crate::session::challenge_response`].
+///
+/// `client_did` must be a `did:key` whose private seed is
+/// `private_key_multibase` (the holder/setup key); `vta_did` is the VTA the
+/// document is addressed to. No DIDComm / mediator is involved.
+pub(crate) async fn challenge_response_di(
+    base_url: &str,
+    client_did: &str,
+    private_key_multibase: &str,
+    vta_did: &str,
+) -> Result<TokenResult, Box<dyn std::error::Error>> {
+    let http = reqwest::Client::new();
+
+    // Step 1 — request a challenge. Flat `{ subject }` request → canonical
+    // `{ challenge, sessionId, expiresAt }` response.
+    let challenge_url = format!("{base_url}/auth/challenge");
+    let challenge_resp = http
+        .post(&challenge_url)
+        .json(&ChallengeRequest {
+            did: client_did.to_string(),
+        })
+        .send()
+        .await
+        .map_err(|e| format!("could not connect to VTA at {challenge_url}: {e}"))?;
+    if !challenge_resp.status().is_success() {
+        let status = challenge_resp.status();
+        let body = challenge_resp.text().await.unwrap_or_default();
+        return Err(format!("challenge request failed ({status}): {body}").into());
+    }
+    let challenge: ChallengeResponse = challenge_resp.json().await.map_err(|e| {
+        format!("unexpected challenge response from VTA at {challenge_url} (is this a VTA?): {e}")
+    })?;
+
+    // Step 2 — build the `auth/authenticate/0.1` Trust Task. The payload is a
+    // `Value` matching the spec `authenticate::Payload` shape
+    // (`{ challenge, sessionId }`); the server deserializes it into the typed
+    // payload after verifying the proof.
+    let type_uri = TASK_AUTH_AUTHENTICATE_0_1
+        .parse()
+        .map_err(|e| format!("authenticate type URI parse: {e}"))?;
+    let mut doc: TrustTask<Value> = TrustTask::new(
+        format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        type_uri,
+        json!({
+            "challenge": challenge.challenge,
+            "sessionId": challenge.session_id,
+        }),
+    );
+    doc.issuer = Some(client_did.to_string());
+    doc.recipient = Some(vta_did.to_string());
+    doc.issued_at = Some(Utc::now());
+
+    // Step 3 — attach the holder's `eddsa-jcs-2022` Data-Integrity proof. Build
+    // a `Secret` whose id is the `did:key:zXxx#zXxx` verification method, sign
+    // the proof-less document (JCS is presence-sensitive — the server verifies
+    // against the same shape with `proof` stripped), then graft the proof on.
+    let vm_id = did_key_to_vm(client_did).ok_or_else(|| {
+        format!("the DI-signed auth path requires a did:key holder; got {client_did}")
+    })?;
+    let seed = decode_private_key_multibase(private_key_multibase)?;
+    let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed));
+    signer.id = vm_id.clone();
+
+    let sign_options = SignOptions::new()
+        .with_proof_purpose("assertionMethod")
+        .with_created(Utc::now());
+
+    let mut signing_doc =
+        serde_json::to_value(&doc).map_err(|e| format!("serialize authenticate document: {e}"))?;
+    if let Some(obj) = signing_doc.as_object_mut() {
+        obj.remove("proof");
+    }
+    let di_proof = DataIntegrityProof::sign(&signing_doc, &signer, sign_options)
+        .await
+        .map_err(|e| format!("sign authenticate Trust Task: {e}"))?;
+    let proof_json =
+        serde_json::to_value(&di_proof).map_err(|e| format!("serialize proof: {e}"))?;
+    doc.proof =
+        Some(serde_json::from_value::<Proof>(proof_json).map_err(|e| format!("proof shape: {e}"))?);
+
+    // Step 4 — POST the signed document. A Trust Task request yields a TT
+    // `#response` document whose payload is the `{ session, tokens }`
+    // `AuthenticateResponse`.
+    let auth_url = format!("{base_url}/auth/");
+    let body =
+        serde_json::to_string(&doc).map_err(|e| format!("serialize signed document: {e}"))?;
+    let auth_resp = http
+        .post(&auth_url)
+        .header("content-type", "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("could not connect to VTA at {auth_url}: {e}"))?;
+    let status = auth_resp.status();
+    if !status.is_success() {
+        let body = auth_resp.text().await.unwrap_or_default();
+        return Err(format!("authentication failed ({status}): {body}").into());
+    }
+    let auth_text = auth_resp
+        .text()
+        .await
+        .map_err(|e| format!("failed to read auth response from VTA: {e}"))?;
+    // A Trust-Task request yields a TT `#response` document whose payload is the
+    // `{ session, tokens }` body; some clients/mocks return that body flat.
+    // Accept either: try flat first, then unwrap the Trust-Task envelope.
+    let auth_data: AuthenticateResponse = match serde_json::from_str(&auth_text) {
+        Ok(flat) => flat,
+        Err(_) => {
+            let response_doc: TrustTask<Value> = serde_json::from_str(&auth_text).map_err(|e| {
+                format!("unexpected auth response from VTA at {auth_url} (is this a VTA?): {e}")
+            })?;
+            serde_json::from_value(response_doc.payload)
+                .map_err(|e| format!("auth response payload is not an AuthenticateResponse: {e}"))?
+        }
+    };
+    let access_expires_at = auth_data.access_expires_at_epoch().ok_or_else(|| {
+        format!(
+            "VTA returned unparseable session.issuedAt: '{}'",
+            auth_data.session.issued_at
+        )
+    })?;
+
+    Ok(TokenResult {
+        access_token: auth_data.tokens.access_token,
+        access_expires_at,
+    })
+}

--- a/vta-sdk/src/provision_client/mod.rs
+++ b/vta-sdk/src/provision_client/mod.rs
@@ -43,6 +43,7 @@
 //! end-to-end flow.
 
 pub mod ask;
+pub(crate) mod auth_rest;
 pub mod diagnostics;
 pub mod driver;
 pub mod error;

--- a/vta-sdk/src/provision_client/runner_rest.rs
+++ b/vta-sdk/src/provision_client/runner_rest.rs
@@ -10,7 +10,6 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::client::VtaClient;
 use crate::did_key::decode_private_key_multibase;
 use crate::provision_integration::http::ProvisionIntegrationRequest;
-use crate::session;
 
 use super::ask::ProvisionAsk;
 use super::diagnostics::{DiagCheck, DiagStatus};
@@ -21,8 +20,8 @@ use super::result::{admin_rotation_response_to_reply, decode_nonce_b64url, respo
 /// Run the REST leg of the AdminOnly auth check.
 ///
 /// AdminOnly's proof-of-ACL today is "the auth handshake completes" —
-/// for REST that's a successful round-trip through
-/// [`session::challenge_response`]. The returned access token is
+/// for REST that's a successful round-trip through the DI-signed
+/// [`super::auth_rest::challenge_response_di`]. The returned access token is
 /// discarded; the integration's downstream code re-authenticates at
 /// runtime via the same flow.
 ///
@@ -39,7 +38,9 @@ pub(crate) async fn run_rest_attempt_admin_only(
 ) -> AttemptOutcome {
     let _ = tx.send(VtaEvent::CheckStart(DiagCheck::AuthenticateREST));
 
-    match session::challenge_response(rest_url, &setup_did, &setup_privkey_mb, vta_did).await {
+    match super::auth_rest::challenge_response_di(rest_url, &setup_did, &setup_privkey_mb, vta_did)
+        .await
+    {
         Ok(_auth) => {
             let _ = tx.send(VtaEvent::CheckDone(
                 DiagCheck::AuthenticateREST,
@@ -89,7 +90,7 @@ pub(crate) async fn run_rest_attempt_admin_only(
 /// Run the REST FullSetup flow: authenticate, then POST a VP-framed
 /// provision-integration request and open the returned sealed bundle.
 ///
-/// Pre-auth boundary: failures inside [`session::challenge_response`] or
+/// Pre-auth boundary: failures inside [`super::auth_rest::challenge_response_di`] or
 /// [`VtaClient`] construction → [`AttemptOutcome::PreAuthFailure`]. Once
 /// auth completes, any error from the provision RPC, VP signing, nonce
 /// decode, or sealed-bundle opening is [`AttemptOutcome::PostAuthFailure`]
@@ -105,37 +106,43 @@ pub(crate) async fn run_rest_attempt_full_setup(
 ) -> AttemptOutcome {
     let _ = tx.send(VtaEvent::CheckStart(DiagCheck::AuthenticateREST));
 
-    let token_result =
-        match session::challenge_response(rest_url, &setup_did, &setup_privkey_mb, vta_did).await {
-            Ok(r) => {
-                let _ = tx.send(VtaEvent::CheckDone(
-                    DiagCheck::AuthenticateREST,
-                    DiagStatus::Ok(format!("REST auth as {setup_did}")),
-                ));
-                r
-            }
-            Err(e) => {
-                let msg = e.to_string();
-                let _ = tx.send(VtaEvent::CheckDone(
-                    DiagCheck::AuthenticateREST,
-                    DiagStatus::Failed(msg.clone()),
-                ));
-                let _ = tx.send(VtaEvent::CheckDone(
-                    DiagCheck::ListWebvhServers,
-                    DiagStatus::Skipped("REST auth did not complete".into()),
-                ));
-                let _ = tx.send(VtaEvent::CheckDone(
-                    DiagCheck::ProvisionIntegration,
-                    DiagStatus::Skipped("REST auth did not complete".into()),
-                ));
-                return AttemptOutcome::PreAuthFailure(format!(
-                    "Could not complete REST authentication against the VTA. \
+    let token_result = match super::auth_rest::challenge_response_di(
+        rest_url,
+        &setup_did,
+        &setup_privkey_mb,
+        vta_did,
+    )
+    .await
+    {
+        Ok(r) => {
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::AuthenticateREST,
+                DiagStatus::Ok(format!("REST auth as {setup_did}")),
+            ));
+            r
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::AuthenticateREST,
+                DiagStatus::Failed(msg.clone()),
+            ));
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ListWebvhServers,
+                DiagStatus::Skipped("REST auth did not complete".into()),
+            ));
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ProvisionIntegration,
+                DiagStatus::Skipped("REST auth did not complete".into()),
+            ));
+            return AttemptOutcome::PreAuthFailure(format!(
+                "Could not complete REST authentication against the VTA. \
                      Confirm the `pnm acl create` command ran successfully for \
                      this setup DID and that the VTA's REST endpoint is reachable. \
                      ({msg})"
-                ));
-            }
-        };
+            ));
+        }
+    };
 
     let client = VtaClient::new(rest_url);
     client.set_token_async(token_result.access_token).await;
@@ -250,37 +257,43 @@ pub(crate) async fn run_rest_attempt_admin_rotated(
 ) -> AttemptOutcome {
     let _ = tx.send(VtaEvent::CheckStart(DiagCheck::AuthenticateREST));
 
-    let token_result =
-        match session::challenge_response(rest_url, &setup_did, &setup_privkey_mb, vta_did).await {
-            Ok(r) => {
-                let _ = tx.send(VtaEvent::CheckDone(
-                    DiagCheck::AuthenticateREST,
-                    DiagStatus::Ok(format!("REST auth as {setup_did}")),
-                ));
-                r
-            }
-            Err(e) => {
-                let msg = e.to_string();
-                let _ = tx.send(VtaEvent::CheckDone(
-                    DiagCheck::AuthenticateREST,
-                    DiagStatus::Failed(msg.clone()),
-                ));
-                let _ = tx.send(VtaEvent::CheckDone(
-                    DiagCheck::ListWebvhServers,
-                    DiagStatus::Skipped("REST auth did not complete".into()),
-                ));
-                let _ = tx.send(VtaEvent::CheckDone(
-                    DiagCheck::ProvisionIntegration,
-                    DiagStatus::Skipped("REST auth did not complete".into()),
-                ));
-                return AttemptOutcome::PreAuthFailure(format!(
-                    "Could not complete REST authentication against the VTA. \
+    let token_result = match super::auth_rest::challenge_response_di(
+        rest_url,
+        &setup_did,
+        &setup_privkey_mb,
+        vta_did,
+    )
+    .await
+    {
+        Ok(r) => {
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::AuthenticateREST,
+                DiagStatus::Ok(format!("REST auth as {setup_did}")),
+            ));
+            r
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::AuthenticateREST,
+                DiagStatus::Failed(msg.clone()),
+            ));
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ListWebvhServers,
+                DiagStatus::Skipped("REST auth did not complete".into()),
+            ));
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ProvisionIntegration,
+                DiagStatus::Skipped("REST auth did not complete".into()),
+            ));
+            return AttemptOutcome::PreAuthFailure(format!(
+                "Could not complete REST authentication against the VTA. \
                      Confirm the `pnm acl create` command ran successfully for \
                      this setup DID and that the VTA's REST endpoint is reachable. \
                      ({msg})"
-                ));
-            }
-        };
+            ));
+        }
+    };
 
     let client = VtaClient::new(rest_url);
     client.set_token_async(token_result.access_token).await;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -75,7 +75,7 @@ required-features = ["cli-synthesis"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.10", features = ["encryption", "passkey"] }
-vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["didcomm", "sealed-transfer", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.12", features = ["didcomm", "sealed-transfer", "provision-integration"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -230,10 +230,11 @@ http-body-util = "0.1"
 # without each having to copy ~140 LoC of AppState-wiring boilerplate.
 # Production builds remain unaffected — this is dev-deps only.
 vta-service = { path = ".", features = ["test-support"] }
-# Test-only: the SDK REST `VtaClient` the `MockVta` e2e tests drive (issue
-# #406) to hit `GET /webvh/servers`. The `client` feature is kept out of the
-# production `vta-sdk` dep above so the server build stays lean.
-vta-sdk = { path = "../vta-sdk", version = "0.11", features = ["client"] }
+# Test-only: the SDK REST `VtaClient` + provision-client (the URL-direct
+# `provision_admin_rotated_via_rest` + DI-signed REST auth) the `MockVta`
+# bootstrap→provision e2e tests drive (issues #406, DI-auth follow-up). Kept out
+# of the production `vta-sdk` dep above so the server build stays lean.
+vta-sdk = { path = "../vta-sdk", version = "0.12", features = ["provision-client"] }
 # Mock HTTP server for the did-hosting-daemon REST auth flow tests. Each
 # test spins up a real local server bound to a random port, validates
 # the JWS-signed request bodies the daemon would see, and serves

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -120,3 +120,56 @@ async fn seeded_webvh_server_is_listed_over_http() {
 
     mock.shutdown().await;
 }
+
+/// Full URL-direct provision against a **REST-only** MockVta, end to end:
+/// `provision_admin_rotated_via_rest` authenticates via the DI-signed
+/// `auth/authenticate/0.1` Trust Task (no DIDComm / ATM — the mock has none),
+/// the VTA mints a fresh admin DID + issues the authorization VC + seals the
+/// rotation bundle, and the client opens it. This is the round-trip that
+/// failed with "ATM not configured" before the DI-signed REST auth path
+/// existed; it ties together the #406 seams + the DI-auth fix.
+#[tokio::test]
+async fn url_direct_admin_rotation_round_trips_against_rest_only_mock() {
+    use vta_sdk::provision_client::ProvisionAsk;
+    use vta_sdk::provision_client::provision_admin_rotated_via_rest;
+    use vta_sdk::provision_client::setup_key::EphemeralSetupKey;
+    use vti_common::acl::{AclEntry, Role};
+
+    let mock = MockVta::start_provisionable().await;
+
+    // Cold-start: grant the setup did:key super-admin directly in the ACL so
+    // the relayer is authorized and the holder VP passes the provision gate.
+    let setup = EphemeralSetupKey::generate().expect("generate setup key");
+    let entry = AclEntry::new(&setup.did, Role::Admin, "test").with_contexts(vec![]);
+    mock.ctx
+        .acl_ks
+        .insert(format!("acl:{}", setup.did), &entry)
+        .await
+        .expect("seed super-admin acl");
+
+    let reply = provision_admin_rotated_via_rest(
+        mock.base_url(),
+        mock.vta_did(),
+        setup.did.clone(),
+        setup.private_key_multibase().to_string(),
+        ProvisionAsk::vta_admin_rotated("ctx1"),
+    )
+    .await
+    .expect("URL-direct admin rotation should round-trip against the REST-only mock");
+
+    assert!(
+        reply.admin_did.starts_with("did:key:"),
+        "rotated admin must be a did:key, got {}",
+        reply.admin_did
+    );
+    assert_ne!(
+        reply.admin_did, setup.did,
+        "rotation must mint a fresh admin DID, not echo the setup DID"
+    );
+    assert!(
+        !reply.admin_private_key_mb.is_empty(),
+        "rotated admin must carry its private key"
+    );
+
+    mock.shutdown().await;
+}

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -78,7 +78,7 @@ vti-common = { path = "../vti-common", version = "0.10", features = [
   # keyspaces (install, audit_key, passkey) — P0.7.
   "encryption",
 ] }
-vta-sdk = { path = "../vta-sdk", version = "0.11", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.12", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -43,7 +43,7 @@ setup = ["dep:dialoguer"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.11", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.12", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }


### PR DESCRIPTION
## What

The provision-client's REST legs authenticated via `session::challenge_response`, which packs a **DIDComm** envelope the VTA unpacks with its ATM. A REST-only VTA (no mediator / ATM) rejects that with `ATM not configured` — the gap flagged in #426 that blocked the full MockVta bootstrap→provision e2e.

This implements the **canonical REST auth** the server already tries first (`routes/auth.rs::try_authenticate_trust_task`): a plain `auth/authenticate/0.1` Trust Task whose holder `eddsa-jcs-2022` Data-Integrity proof *is* the authentication — no DIDComm packing, no mediator. It mirrors `vta-mobile-core::build_authenticate`, signing in-process with the holder key the provision-client already owns, via the same `DataIntegrityProof::sign` primitive the VP signer uses.

## Changes

- **`provision_client::auth_rest::challenge_response_di`** (`pub(crate)`) — challenge → DI-signed authenticate TT → token. All three REST attempt fns (`run_rest_attempt_{admin_only,full_setup,admin_rotated}`) route through it. Works against **any** VTA — REST-only or DIDComm-enabled — because the server attempts the DI path before the DIDComm-envelope path.
- `trust-tasks-rs` promoted to an **optional** dep gated on `provision-client` (kept out of the slim default artifact, per the existing dev-only intent).
- Response parsing accepts a flat `{session,tokens}` **or** a TT `#response` envelope, so existing wiremocks and the real server both work.

## Tests

- **`vta-service`**: `url_direct_admin_rotation_round_trips_against_rest_only_mock` — a full URL-direct admin rotation against a **REST-only** MockVta, end to end (auth → VC issue → seal → open). This is the exact round-trip that died on "ATM not configured" in #426.
- **`vta-sdk`**: wiremock round-trip through `provision_admin_rotated_via_rest`.

## Release bump (folded in)

Folds in the unreleased public-API additions from #424 (`context_path`/`identifier` modules) and #426 (`provision_admin_rotated_via_rest`):

- **vta-sdk 0.11.3 → 0.12.0** (minor — new public modules/fns); all 9 internal `vta-sdk = "0.11"` pins → `"0.12"`.
- Dependents **patched** to pick up the new SDK (major.minor pins unchanged, no cascade): vti-common 0.10.1, vta-service 0.9.2, vta-cli-common / vtc-service / pnm-cli / cnm-cli 0.9.1, vta-mobile-core 0.6.2, vta-enclave 0.7.2, didcomm-test 0.6.2.

## Verification

- `cargo check --workspace --lib --bins` clean (resolves with the new versions).
- `cargo clippy --workspace --lib --bins` clean (one pre-existing `vtc-service` `tower_http` deprecation).
- Green: vta-sdk lib (336) + provision_client_e2e (5), vta-service mock_vta (5). `cargo fmt` applied; DCO-signed.