### PR TITLE
refactor(vta): extend ServiceOpDeps to the DIDComm protocol ops (P2.5 part 3)

### DIFF
--- a/vta-service/src/messaging/handlers_protocol.rs
+++ b/vta-service/src/messaging/handlers_protocol.rs
@@ -296,25 +296,13 @@ pub async fn handle_disable_didcomm(
 
     let body: DisableDidcommBody = serde_json::from_value(message.body).map_err(handler_err)?;
 
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| handler_err("did_resolver unavailable"))?;
+    let deps = ServiceOpDeps::from_vta_state(&state, did_resolver);
     let result = disable_didcomm(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.drains_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        state
-            .did_resolver
-            .as_ref()
-            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
-        &state.didcomm_bridge,
-        &state.mediator_registry,
-        &state.drain_sweeper,
-        &state.telemetry,
+        &deps,
         &auth,
         DisableDidcommParams {
             drain_ttl: Duration::from_secs(body.drain_ttl_secs),
@@ -323,7 +311,6 @@ pub async fn handle_disable_didcomm(
             transport: DisableTransport::Didcomm,
         },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "didcomm",
     )
     .await;
@@ -379,25 +366,13 @@ pub async fn handle_update_didcomm(
         MigrateAuditKind::Forward
     };
 
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| handler_err("did_resolver unavailable"))?;
+    let deps = ServiceOpDeps::from_vta_state(&state, did_resolver);
     let result = update_didcomm(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.drains_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        state
-            .did_resolver
-            .as_ref()
-            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
-        &state.didcomm_bridge,
-        &state.mediator_registry,
-        &state.drain_sweeper,
-        &state.telemetry,
+        &deps,
         &prover,
         &auth,
         UpdateDidcommParams {
@@ -409,7 +384,6 @@ pub async fn handle_update_didcomm(
             transport: crate::operations::protocol::disable_didcomm::DisableTransport::Didcomm,
         },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "didcomm",
     )
     .await;
@@ -699,25 +673,13 @@ pub async fn handle_rollback_didcomm(
             None => &always_ok,
         };
 
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| handler_err("did_resolver unavailable"))?;
+    let deps = ServiceOpDeps::from_vta_state(&state, did_resolver);
     let result = rollback_didcomm(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.drains_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        state
-            .did_resolver
-            .as_ref()
-            .ok_or_else(|| handler_err("did_resolver unavailable"))?,
-        &state.didcomm_bridge,
-        &state.mediator_registry,
-        &state.drain_sweeper,
-        &state.telemetry,
+        &deps,
         prover_ref,
         &auth,
         RollbackDidcommParams {
@@ -727,7 +689,6 @@ pub async fn handle_rollback_didcomm(
             // the dispatch ends up in disable_didcomm.
             transport: DisableTransport::Didcomm,
         },
-        &state.webvh_auth_locks,
         "didcomm",
     )
     .await;

--- a/vta-service/src/operations/protocol/disable_didcomm.rs
+++ b/vta-service/src/operations/protocol/disable_didcomm.rs
@@ -33,18 +33,15 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::info;
 
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
+use vti_common::telemetry::{TelemetryEvent, TelemetryKind};
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::messaging::drain_sweeper::DrainSweeper;
-use crate::messaging::registry::{MediatorListenerRegistry, RegistryError};
+use crate::messaging::registry::RegistryError;
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
 use crate::operations::protocol::document::{DocumentPatchError, without_didcomm_service};
-use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK, ServiceOpDeps};
 use crate::store::KeyspaceHandle;
 
 /// Spec minimum drain TTL when called over DIDComm transport: 1
@@ -147,27 +144,11 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn disable_didcomm(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    drains_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    registry: &MediatorListenerRegistry,
-    sweeper: &DrainSweeper,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
     params: DisableDidcommParams,
     ctx: OpContext,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<DisableDidcommResult, DisableDidcommError> {
     auth.require_super_admin()
@@ -177,7 +158,7 @@ pub async fn disable_didcomm(
 
     // Pre-flight checks (atomic; nothing mutated until past here).
     let (vta_did, scid, current_doc, prior_mediator) =
-        read_preconditions(config, webvh_ks, &params).await?;
+        read_preconditions(deps.config, deps.webvh_ks, &params).await?;
 
     // Persist snapshot BEFORE the runtime mutation per spec §3.5a.
     // Pre-state is DidcommSnapshot::Enabled with the prior mediator
@@ -186,7 +167,7 @@ pub async fn disable_didcomm(
     // service entry doesn't carry routing-keys today.
     use crate::operations::protocol::snapshot::{self, DidcommSnapshot, ServiceConfigSnapshot};
     snapshot::write(
-        snapshot_ks,
+        deps.snapshot_ks,
         ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Enabled {
             mediator_did: prior_mediator.clone(),
             routing_keys: vec![],
@@ -200,22 +181,22 @@ pub async fn disable_didcomm(
 
     // Publish via update_did_webvh.
     let update_result = update_did_webvh(
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        seed_store,
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.contexts_ks,
+        deps.webvh_ks,
+        deps.audit_ks,
+        deps.seed_store,
         auth,
         &scid,
         UpdateDidWebvhOptions {
             document: Some(patched),
             ..Default::default()
         },
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         Some(vta_did.as_str()),
-        webvh_auth_locks,
+        deps.webvh_auth_locks,
         channel,
     )
     .await?;
@@ -223,11 +204,11 @@ pub async fn disable_didcomm(
     // Persist: `services.didcomm = false` to fjall (authoritative runtime
     // state) + mirror into the in-memory config. `messaging` stays intact so
     // the drained listener can still reach the mediator until its TTL expires.
-    crate::operations::protocol::runtime_state::set_didcomm_enabled(service_state_ks, false)
+    crate::operations::protocol::runtime_state::set_didcomm_enabled(deps.service_state_ks, false)
         .await
         .map_err(|e| DisableDidcommError::ConfigPersistence(format!("runtime state: {e}")))?;
     {
-        let mut cfg = config.write().await;
+        let mut cfg = deps.config.write().await;
         cfg.services.didcomm = false;
     }
 
@@ -239,13 +220,13 @@ pub async fn disable_didcomm(
         // sweeper fires; with TTL=0 we don't go through the
         // sweeper, so deactivate is the only signal — the
         // listener is removed on next service restart.
-        registry.record_deactivate().await;
+        deps.registry.record_deactivate().await;
         None
     } else {
         // First, dethrone the active mediator in registry state so
         // the subsequent drain insert isn't refused with
         // `ActiveMediatorMustBeReplaced`.
-        registry.record_deactivate().await;
+        deps.registry.record_deactivate().await;
         let deadline = Utc::now()
             + chrono::Duration::from_std(params.drain_ttl).map_err(|e| {
                 DisableDidcommError::ConfigPersistence(format!("drain TTL out of range: {e}"))
@@ -254,14 +235,14 @@ pub async fn disable_didcomm(
         // entry. Re-resolving the prior mediator here is bounded
         // and avoids carrying the endpoint through several layers
         // of state.
-        let endpoint = best_effort_endpoint(did_resolver, &prior_mediator).await;
-        registry
-            .record_drain_persisted(drains_ks, &prior_mediator, endpoint, deadline)
+        let endpoint = best_effort_endpoint(deps.did_resolver, &prior_mediator).await;
+        deps.registry
+            .record_drain_persisted(deps.drains_ks, &prior_mediator, endpoint, deadline)
             .await?;
         // Arm the sweeper so the TTL actually fires. Without this
         // call the drain entry sits in fjall + registry forever
         // (it would be replayed on next boot but never expire).
-        sweeper.arm(&prior_mediator, deadline).await;
+        deps.sweeper.arm(&prior_mediator, deadline).await;
         Some(deadline)
     };
 
@@ -285,7 +266,7 @@ pub async fn disable_didcomm(
     if let Some(tag) = ctx.telemetry_triggered_by() {
         event = event.with_field("triggered_by", JsonValue::from(tag));
     }
-    let _ = telemetry.record(event).await;
+    let _ = deps.telemetry.record(event).await;
 
     info!(
         channel,
@@ -367,9 +348,15 @@ async fn best_effort_endpoint(resolver: &DIDCacheClient, mediator_did: &str) -> 
 
 #[cfg(test)]
 mod tests {
+    use vti_common::seed_store::SeedStore;
+    use vti_common::telemetry::SharedTelemetrySink;
+
     use super::*;
     use crate::config::AppConfig;
+    use crate::didcomm_bridge::DIDCommBridge;
     use crate::keys::seed_store::PlaintextSeedStore;
+    use crate::messaging::drain_sweeper::DrainSweeper;
+    use crate::messaging::registry::MediatorListenerRegistry;
     use crate::operations::protocol::snapshot;
     use crate::store::Store;
     use crate::test_support::test_app_config;
@@ -444,6 +431,84 @@ mod tests {
         }
     }
 
+    /// Owns every keyspace + shared infra and hands out a borrowed
+    /// [`ServiceOpDeps`] (P2.5). All the refusal-path tests below bail before
+    /// touching the registry/sweeper, so a fresh bundle per test is enough.
+    struct TestEnv {
+        _dirs: Vec<tempfile::TempDir>,
+        keys_ks: KeyspaceHandle,
+        imported_ks: KeyspaceHandle,
+        contexts_ks: KeyspaceHandle,
+        webvh_ks: KeyspaceHandle,
+        audit_ks: KeyspaceHandle,
+        snapshot_ks: KeyspaceHandle,
+        service_state_ks: KeyspaceHandle,
+        drains_ks: KeyspaceHandle,
+        config: Arc<RwLock<AppConfig>>,
+        seed: Arc<dyn SeedStore>,
+        resolver: DIDCacheClient,
+        bridge: Arc<DIDCommBridge>,
+        sink: SharedTelemetrySink,
+        registry: Arc<MediatorListenerRegistry>,
+        sweeper: Arc<DrainSweeper>,
+        locks: crate::operations::did_webvh::WebvhAuthLocks,
+    }
+
+    impl TestEnv {
+        async fn new(seed_dir: &std::path::Path, config: Arc<RwLock<AppConfig>>) -> Self {
+            let (bridge, registry, sink) = registry();
+            let (d1, keys_ks) = empty_keyspace("keys").await;
+            let (d2, imported_ks) = empty_keyspace("imported_secrets").await;
+            let (d3, contexts_ks) = empty_keyspace("contexts").await;
+            let (d4, webvh_ks) = empty_keyspace("webvh").await;
+            let (d5, audit_ks) = empty_keyspace("audit").await;
+            let (d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
+            let (d7, service_state_ks) = empty_keyspace("service_state").await;
+            let (d8, drains_ks) = empty_keyspace("drains").await;
+            let sweeper = sweeper_for(Arc::clone(&registry), drains_ks.clone());
+            Self {
+                _dirs: vec![d1, d2, d3, d4, d5, d6, d7, d8],
+                keys_ks,
+                imported_ks,
+                contexts_ks,
+                webvh_ks,
+                audit_ks,
+                snapshot_ks,
+                service_state_ks,
+                drains_ks,
+                config,
+                seed: dummy_seed(seed_dir),
+                resolver: resolver().await,
+                bridge,
+                sink,
+                registry,
+                sweeper,
+                locks: crate::operations::did_webvh::WebvhAuthLocks::new(),
+            }
+        }
+
+        fn deps(&self) -> ServiceOpDeps<'_> {
+            ServiceOpDeps {
+                config: &self.config,
+                keys_ks: &self.keys_ks,
+                imported_ks: &self.imported_ks,
+                contexts_ks: &self.contexts_ks,
+                webvh_ks: &self.webvh_ks,
+                audit_ks: &self.audit_ks,
+                snapshot_ks: &self.snapshot_ks,
+                service_state_ks: &self.service_state_ks,
+                drains_ks: &self.drains_ks,
+                seed_store: &*self.seed,
+                did_resolver: &self.resolver,
+                didcomm_bridge: &self.bridge,
+                telemetry: &self.sink,
+                webvh_auth_locks: &self.locks,
+                registry: &self.registry,
+                sweeper: &self.sweeper,
+            }
+        }
+    }
+
     #[tokio::test]
     async fn refuses_when_not_currently_enabled() {
         let dir = tempfile::tempdir().unwrap();
@@ -452,38 +517,13 @@ mod tests {
             /* didcomm = */ false,
             /* rest = */ true,
         );
-        let (bridge, reg, sink) = registry();
-        let (_d1, keys_ks) = empty_keyspace("keys").await;
-        let (_dimp, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_d2, contexts_ks) = empty_keyspace("contexts").await;
-        let (_d3, webvh_ks) = empty_keyspace("webvh").await;
-        let (_d4, audit_ks) = empty_keyspace("audit").await;
-        let (_d5, drains_ks) = empty_keyspace("drains").await;
-        let (_d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = resolver().await;
-        let seed = dummy_seed(dir.path());
+        let env = TestEnv::new(dir.path(), config).await;
 
         let err = disable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &drains_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &reg,
-            &sweeper_for(Arc::clone(&reg), drains_ks.clone()),
-            &sink,
+            &env.deps(),
             &super_admin(),
             rest_params(Duration::from_secs(3600)),
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -501,38 +541,13 @@ mod tests {
             /* didcomm = */ true,
             /* rest = */ false,
         );
-        let (bridge, reg, sink) = registry();
-        let (_d1, keys_ks) = empty_keyspace("keys").await;
-        let (_dimp, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_d2, contexts_ks) = empty_keyspace("contexts").await;
-        let (_d3, webvh_ks) = empty_keyspace("webvh").await;
-        let (_d4, audit_ks) = empty_keyspace("audit").await;
-        let (_d5, drains_ks) = empty_keyspace("drains").await;
-        let (_d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = resolver().await;
-        let seed = dummy_seed(dir.path());
+        let env = TestEnv::new(dir.path(), config).await;
 
         let err = disable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &drains_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &reg,
-            &sweeper_for(Arc::clone(&reg), drains_ks.clone()),
-            &sink,
+            &env.deps(),
             &super_admin(),
             rest_params(Duration::from_secs(3600)),
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -546,39 +561,14 @@ mod tests {
         // DIDComm transport.
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path(), true, true);
-        let (bridge, reg, sink) = registry();
-        let (_d1, keys_ks) = empty_keyspace("keys").await;
-        let (_dimp, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_d2, contexts_ks) = empty_keyspace("contexts").await;
-        let (_d3, webvh_ks) = empty_keyspace("webvh").await;
-        let (_d4, audit_ks) = empty_keyspace("audit").await;
-        let (_d5, drains_ks) = empty_keyspace("drains").await;
-        let (_d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = resolver().await;
-        let seed = dummy_seed(dir.path());
+        let env = TestEnv::new(dir.path(), config).await;
 
         // 30 minutes < 1h minimum.
         let err = disable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &drains_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &reg,
-            &sweeper_for(Arc::clone(&reg), drains_ks.clone()),
-            &sink,
+            &env.deps(),
             &super_admin(),
             didcomm_params(Duration::from_secs(1800)),
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -600,39 +590,14 @@ mod tests {
     async fn refuses_drain_ttl_above_max() {
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path(), true, true);
-        let (bridge, reg, sink) = registry();
-        let (_d1, keys_ks) = empty_keyspace("keys").await;
-        let (_dimp, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_d2, contexts_ks) = empty_keyspace("contexts").await;
-        let (_d3, webvh_ks) = empty_keyspace("webvh").await;
-        let (_d4, audit_ks) = empty_keyspace("audit").await;
-        let (_d5, drains_ks) = empty_keyspace("drains").await;
-        let (_d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = resolver().await;
-        let seed = dummy_seed(dir.path());
+        let env = TestEnv::new(dir.path(), config).await;
 
         // 31 days > 30-day MAX_DRAIN_TTL.
         let err = disable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &drains_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &reg,
-            &sweeper_for(Arc::clone(&reg), drains_ks.clone()),
-            &sink,
+            &env.deps(),
             &super_admin(),
             rest_params(Duration::from_secs(31 * 86_400)),
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -651,41 +616,16 @@ mod tests {
         // 0s is permitted over REST transport.
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path(), true, true);
-        let (bridge, reg, sink) = registry();
-        let (_d1, keys_ks) = empty_keyspace("keys").await;
-        let (_dimp, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_d2, contexts_ks) = empty_keyspace("contexts").await;
-        let (_d3, webvh_ks) = empty_keyspace("webvh").await;
-        let (_d4, audit_ks) = empty_keyspace("audit").await;
-        let (_d5, drains_ks) = empty_keyspace("drains").await;
-        let (_d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = resolver().await;
-        let seed = dummy_seed(dir.path());
+        let env = TestEnv::new(dir.path(), config).await;
 
         // 0s over REST passes the TTL guard; the next refusal
         // will be VtaDidRecordMissing (because no webvh setup in
         // the fixture). That confirms TTL=0 is not the blocker.
         let err = disable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &drains_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &reg,
-            &sweeper_for(Arc::clone(&reg), drains_ks.clone()),
-            &sink,
+            &env.deps(),
             &super_admin(),
             rest_params(Duration::from_secs(0)),
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -700,38 +640,13 @@ mod tests {
     async fn allows_1h_drain_over_didcomm() {
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path(), true, true);
-        let (bridge, reg, sink) = registry();
-        let (_d1, keys_ks) = empty_keyspace("keys").await;
-        let (_dimp, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_d2, contexts_ks) = empty_keyspace("contexts").await;
-        let (_d3, webvh_ks) = empty_keyspace("webvh").await;
-        let (_d4, audit_ks) = empty_keyspace("audit").await;
-        let (_d5, drains_ks) = empty_keyspace("drains").await;
-        let (_d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = resolver().await;
-        let seed = dummy_seed(dir.path());
+        let env = TestEnv::new(dir.path(), config).await;
 
         let err = disable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &drains_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &reg,
-            &sweeper_for(Arc::clone(&reg), drains_ks.clone()),
-            &sink,
+            &env.deps(),
             &super_admin(),
             didcomm_params(Duration::from_secs(3600)),
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await

--- a/vta-service/src/operations/protocol/enable_didcomm.rs
+++ b/vta-service/src/operations/protocol/enable_didcomm.rs
@@ -27,27 +27,24 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::info;
 
 use vti_common::config::MessagingConfig;
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
+use vti_common::telemetry::{TelemetryEvent, TelemetryKind};
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::messaging::handshake::{
     HandshakeError, HandshakeOptions, ListenerProver, mediator_handshake,
 };
-use crate::messaging::registry::{MediatorBinding, MediatorListenerRegistry, RegistryError};
+use crate::messaging::registry::{MediatorBinding, RegistryError};
 use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, update_did_webvh};
 use crate::operations::protocol::document::{DocumentPatchError, with_didcomm_service};
-use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK, ServiceOpDeps};
 use crate::store::KeyspaceHandle;
 
 /// Caller-supplied parameters.
@@ -121,26 +118,12 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn enable_didcomm(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    registry: &MediatorListenerRegistry,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     prover: &(dyn ListenerProver + Send + Sync),
     auth: &AuthClaims,
     params: EnableDidcommParams,
     ctx: OpContext,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<EnableDidcommResult, EnableDidcommError> {
     auth.require_super_admin()
@@ -150,15 +133,15 @@ pub async fn enable_didcomm(
 
     // Pre-flight: must currently be disabled, VTA DID must exist,
     // current DID document must be loadable.
-    let (vta_did, scid, current_doc) = read_preconditions(config, webvh_ks).await?;
+    let (vta_did, scid, current_doc) = read_preconditions(deps.config, deps.webvh_ks).await?;
 
     // Step 1–5: handshake (with --force gating step 2–5). On failure
     // this returns before any LogEntry is published — atomicity
     // guarantee.
     let resolved = mediator_handshake(
-        did_resolver,
+        deps.did_resolver,
         prover,
-        telemetry,
+        deps.telemetry,
         &params.mediator_did,
         &vta_did,
         HandshakeOptions {
@@ -175,7 +158,7 @@ pub async fn enable_didcomm(
     // mutation never started; no snapshot needed).
     use crate::operations::protocol::snapshot::{self, DidcommSnapshot, ServiceConfigSnapshot};
     snapshot::write(
-        snapshot_ks,
+        deps.snapshot_ks,
         ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Disabled),
     )
     .await
@@ -190,22 +173,22 @@ pub async fn enable_didcomm(
     // LogEntry append. Rotates control keys; preserves
     // verificationMethod.
     let update_result = update_did_webvh(
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        seed_store,
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.contexts_ks,
+        deps.webvh_ks,
+        deps.audit_ks,
+        deps.seed_store,
         auth,
         &scid,
         UpdateDidWebvhOptions {
             document: Some(patched),
             ..Default::default()
         },
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         Some(vta_did.as_str()),
-        webvh_auth_locks,
+        deps.webvh_auth_locks,
         channel,
     )
     .await?;
@@ -216,16 +199,16 @@ pub async fn enable_didcomm(
     //   * `messaging.mediator_did` / `mediator_url` to disk — that's operator
     //     config (the endpoint to register with), not runtime state, so it
     //     belongs in config.toml.
-    crate::operations::protocol::runtime_state::set_didcomm_enabled(service_state_ks, true)
+    crate::operations::protocol::runtime_state::set_didcomm_enabled(deps.service_state_ks, true)
         .await
         .map_err(|e| EnableDidcommError::ConfigPersistence(format!("runtime state: {e}")))?;
-    persist_didcomm_enabled(config, &resolved.mediator_did, &resolved.endpoint).await?;
+    persist_didcomm_enabled(deps.config, &resolved.mediator_did, &resolved.endpoint).await?;
 
     // Register the mediator as active. The caller (the route layer)
     // is responsible for opening the upstream listener if it isn't
     // already; the registry's `record_activate` updates state +
     // emits the `ServicesDidcommUpdate` telemetry event.
-    registry
+    deps.registry
         .record_activate(MediatorBinding {
             mediator_did: resolved.mediator_did.clone(),
             endpoint: resolved.endpoint.clone(),
@@ -243,7 +226,7 @@ pub async fn enable_didcomm(
     if let Some(tag) = ctx.telemetry_triggered_by() {
         event = event.with_field("triggered_by", JsonValue::from(tag));
     }
-    let _ = telemetry.record(event).await;
+    let _ = deps.telemetry.record(event).await;
 
     info!(
         channel,
@@ -300,10 +283,17 @@ async fn persist_didcomm_enabled(
 
 #[cfg(test)]
 mod tests {
+    use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+    use vti_common::seed_store::SeedStore;
+    use vti_common::telemetry::SharedTelemetrySink;
+
     use super::*;
     use crate::config::AppConfig;
+    use crate::didcomm_bridge::DIDCommBridge;
     use crate::keys::seed_store::PlaintextSeedStore;
+    use crate::messaging::drain_sweeper::DrainSweeper;
     use crate::messaging::handshake::{AlwaysOkProver, FailingProver, HandshakeStage};
+    use crate::messaging::registry::MediatorListenerRegistry;
     use crate::operations::protocol::snapshot;
     use crate::store::Store;
     use crate::test_support::test_app_config;
@@ -350,41 +340,105 @@ mod tests {
         Arc::new(PlaintextSeedStore::new(dir))
     }
 
+    /// Owns every keyspace (each from its own fjall store, as the refusal-path
+    /// tests need) plus the shared infra, and hands out a borrowed
+    /// [`ServiceOpDeps`]. Consolidates the previously-inline per-test setup so
+    /// the op can be called with the P2.5 dep bundle.
+    struct TestEnv {
+        _dirs: Vec<tempfile::TempDir>,
+        keys_ks: KeyspaceHandle,
+        imported_ks: KeyspaceHandle,
+        contexts_ks: KeyspaceHandle,
+        webvh_ks: KeyspaceHandle,
+        audit_ks: KeyspaceHandle,
+        snapshot_ks: KeyspaceHandle,
+        service_state_ks: KeyspaceHandle,
+        drains_ks: KeyspaceHandle,
+        config: Arc<RwLock<AppConfig>>,
+        seed: Arc<dyn SeedStore>,
+        resolver: DIDCacheClient,
+        bridge: Arc<DIDCommBridge>,
+        sink: SharedTelemetrySink,
+        registry: Arc<MediatorListenerRegistry>,
+        sweeper: Arc<DrainSweeper>,
+        locks: crate::operations::did_webvh::WebvhAuthLocks,
+    }
+
+    impl TestEnv {
+        async fn new(seed_dir: &std::path::Path, config: Arc<RwLock<AppConfig>>) -> Self {
+            let (bridge, registry, sink) = mocks();
+            let (d1, keys_ks) = empty_keyspace("keys").await;
+            let (d2, imported_ks) = empty_keyspace("imported_secrets").await;
+            let (d3, contexts_ks) = empty_keyspace("contexts").await;
+            let (d4, webvh_ks) = empty_keyspace("webvh").await;
+            let (d5, audit_ks) = empty_keyspace("audit").await;
+            let (d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
+            let (d7, service_state_ks) = empty_keyspace("service_state").await;
+            let (d8, drains_ks) = empty_keyspace("drains").await;
+            let (tx, _rx) = crate::messaging::drain_sweeper::teardown_channel(8);
+            let sweeper = Arc::new(DrainSweeper::new(
+                Arc::clone(&registry),
+                drains_ks.clone(),
+                tx,
+            ));
+            let resolver = DIDCacheClient::new(
+                affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
+            )
+            .await
+            .unwrap();
+            Self {
+                _dirs: vec![d1, d2, d3, d4, d5, d6, d7, d8],
+                keys_ks,
+                imported_ks,
+                contexts_ks,
+                webvh_ks,
+                audit_ks,
+                snapshot_ks,
+                service_state_ks,
+                drains_ks,
+                config,
+                seed: dummy_seed_store(seed_dir),
+                resolver,
+                bridge,
+                sink,
+                registry,
+                sweeper,
+                locks: crate::operations::did_webvh::WebvhAuthLocks::new(),
+            }
+        }
+
+        fn deps(&self) -> ServiceOpDeps<'_> {
+            ServiceOpDeps {
+                config: &self.config,
+                keys_ks: &self.keys_ks,
+                imported_ks: &self.imported_ks,
+                contexts_ks: &self.contexts_ks,
+                webvh_ks: &self.webvh_ks,
+                audit_ks: &self.audit_ks,
+                snapshot_ks: &self.snapshot_ks,
+                service_state_ks: &self.service_state_ks,
+                drains_ks: &self.drains_ks,
+                seed_store: &*self.seed,
+                did_resolver: &self.resolver,
+                didcomm_bridge: &self.bridge,
+                telemetry: &self.sink,
+                webvh_auth_locks: &self.locks,
+                registry: &self.registry,
+                sweeper: &self.sweeper,
+            }
+        }
+    }
+
     #[tokio::test]
     async fn refuses_when_didcomm_already_enabled() {
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path());
         config.write().await.services.didcomm = true;
-        let (bridge, registry, sink) = mocks();
-        let (_kd, keys_ks) = empty_keyspace("keys").await;
-        let (_imp_d, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_cd, contexts_ks) = empty_keyspace("contexts").await;
-        let (_wd, webvh_ks) = empty_keyspace("webvh").await;
-        let (_ad, audit_ks) = empty_keyspace("audit").await;
-        let (_sd, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state2, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = DIDCacheClient::new(
-            affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
-        )
-        .await
-        .unwrap();
+        let env = TestEnv::new(dir.path(), config).await;
         let prover = AlwaysOkProver;
-        let seed = dummy_seed_store(dir.path());
 
         let result = enable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &registry,
-            &sink,
+            &env.deps(),
             &prover,
             &super_admin(),
             EnableDidcommParams {
@@ -393,7 +447,6 @@ mod tests {
                 handshake_timeout: Duration::from_secs(1),
             },
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await;
@@ -409,36 +462,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path());
         config.write().await.vta_did = None;
-        let (bridge, registry, sink) = mocks();
-        let (_kd, keys_ks) = empty_keyspace("keys").await;
-        let (_imp_d, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_cd, contexts_ks) = empty_keyspace("contexts").await;
-        let (_wd, webvh_ks) = empty_keyspace("webvh").await;
-        let (_ad, audit_ks) = empty_keyspace("audit").await;
-        let (_sd, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state2, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = DIDCacheClient::new(
-            affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
-        )
-        .await
-        .unwrap();
+        let env = TestEnv::new(dir.path(), config).await;
         let prover = AlwaysOkProver;
-        let seed = dummy_seed_store(dir.path());
 
         let result = enable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &registry,
-            &sink,
+            &env.deps(),
             &prover,
             &super_admin(),
             EnableDidcommParams {
@@ -447,7 +475,6 @@ mod tests {
                 handshake_timeout: Duration::from_secs(1),
             },
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await;
@@ -463,36 +490,11 @@ mod tests {
         // Configured VTA DID, but webvh_ks is empty — corrupted state.
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path());
-        let (bridge, registry, sink) = mocks();
-        let (_kd, keys_ks) = empty_keyspace("keys").await;
-        let (_imp_d, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_cd, contexts_ks) = empty_keyspace("contexts").await;
-        let (_wd, webvh_ks) = empty_keyspace("webvh").await;
-        let (_ad, audit_ks) = empty_keyspace("audit").await;
-        let (_sd, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state2, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = DIDCacheClient::new(
-            affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
-        )
-        .await
-        .unwrap();
+        let env = TestEnv::new(dir.path(), config).await;
         let prover = AlwaysOkProver;
-        let seed = dummy_seed_store(dir.path());
 
         let result = enable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &registry,
-            &sink,
+            &env.deps(),
             &prover,
             &super_admin(),
             EnableDidcommParams {
@@ -501,7 +503,6 @@ mod tests {
                 handshake_timeout: Duration::from_secs(1),
             },
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await;
@@ -524,39 +525,14 @@ mod tests {
         // leaves config and registry untouched.
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path());
-        let (bridge, registry, sink) = mocks();
-        let (_kd, keys_ks) = empty_keyspace("keys").await;
-        let (_imp_d, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_cd, contexts_ks) = empty_keyspace("contexts").await;
-        let (_wd, webvh_ks) = empty_keyspace("webvh").await;
-        let (_ad, audit_ks) = empty_keyspace("audit").await;
-        let (_sd, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state2, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = DIDCacheClient::new(
-            affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
-        )
-        .await
-        .unwrap();
+        let env = TestEnv::new(dir.path(), config.clone()).await;
         let prover = FailingProver {
             stage: HandshakeStage::TrustPing,
             cause: "synthetic".into(),
         };
-        let seed = dummy_seed_store(dir.path());
 
         let _ = enable_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &registry,
-            &sink,
+            &env.deps(),
             &prover,
             &super_admin(),
             EnableDidcommParams {
@@ -565,7 +541,6 @@ mod tests {
                 handshake_timeout: Duration::from_secs(1),
             },
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await;
@@ -575,7 +550,7 @@ mod tests {
         assert!(!cfg.services.didcomm);
         assert!(cfg.messaging.is_none());
         // Registry untouched.
-        assert!(registry.active_listener_id().await.is_none());
+        assert!(env.registry.active_listener_id().await.is_none());
     }
 
     // The success path lands in the integration test (P3.5) — it

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -132,23 +132,27 @@ impl OpContext {
     }
 }
 
-/// Ambient dependencies shared by every REST/WebAuthn service-management
-/// operation (`enable` / `update` / `disable` / `rollback`).
+/// Ambient dependencies shared by every service-management operation
+/// (`enable` / `update` / `disable` / `rollback`, across REST, WebAuthn, and
+/// DIDComm).
 ///
-/// Before P2.5 each of these eight ops took the same ~14 positional arguments
-/// (config + keyspaces + seed-store + resolver + bridge + telemetry +
-/// auth-locks), tripping `clippy::too_many_arguments`. Bundling them into one
-/// borrowed struct — built once at the transport boundary via
-/// [`ServiceOpDeps::from_app_state`] / [`ServiceOpDeps::from_vta_state`] (or
+/// Before P2.5 each op took the same long run of positional arguments (config,
+/// keyspaces, seed-store, resolver, bridge, telemetry, auth-locks, and — for the
+/// DIDComm family — the mediator registry, drain sweeper, and drain keyspace),
+/// tripping `clippy::too_many_arguments` (the worst topped out at 25 args).
+/// Bundling them into one borrowed struct — built once at the transport boundary
+/// via [`ServiceOpDeps::from_app_state`] / [`ServiceOpDeps::from_vta_state`] (or
 /// directly by the offline CLI) and threaded through unchanged — drops every op
-/// to ≤5 args and lets the rollback dispatcher hand its forward op the deps
+/// to ≤6 args and lets the rollback dispatcher hand its forward op the deps
 /// verbatim instead of re-listing every keyspace.
 ///
 /// All fields are borrows: the struct is cheap to build per request and never
-/// outlives the state it borrows from. The internal lifecycle engine
-/// ([`service_lifecycle`]) reads the subset it needs; `service_state_ks` is
-/// consumed only by the REST enable/disable runtime-state persist step (the
-/// engine itself never touches it).
+/// outlives the state it borrows from. Each op reads the subset it needs — the
+/// REST/WebAuthn ops ignore `drains_ks` / `registry` / `sweeper`; the lifecycle
+/// engine ([`service_lifecycle`]) additionally ignores `service_state_ks` (the
+/// REST persist step's concern). The per-call mediator handshake `prover` is
+/// **not** here — it's constructed per invocation (transient vs live), so the
+/// DIDComm ops still take it as a separate argument.
 pub struct ServiceOpDeps<'a> {
     pub config: &'a std::sync::Arc<tokio::sync::RwLock<crate::config::AppConfig>>,
     pub keys_ks: &'a crate::store::KeyspaceHandle,
@@ -158,11 +162,21 @@ pub struct ServiceOpDeps<'a> {
     pub audit_ks: &'a crate::store::KeyspaceHandle,
     pub snapshot_ks: &'a crate::store::KeyspaceHandle,
     pub service_state_ks: &'a crate::store::KeyspaceHandle,
+    /// Persisted drain set — read only by the DIDComm family (mediator
+    /// changes go through a drain window; REST/WebAuthn have no drain
+    /// semantics).
+    pub drains_ks: &'a crate::store::KeyspaceHandle,
     pub seed_store: &'a dyn vti_common::seed_store::SeedStore,
     pub did_resolver: &'a affinidi_did_resolver_cache_sdk::DIDCacheClient,
     pub didcomm_bridge: &'a std::sync::Arc<crate::didcomm_bridge::DIDCommBridge>,
     pub telemetry: &'a vti_common::telemetry::SharedTelemetrySink,
     pub webvh_auth_locks: &'a crate::operations::did_webvh::WebvhAuthLocks,
+    /// Active + draining mediator listener registry — DIDComm family only.
+    #[cfg(feature = "webvh")]
+    pub registry: &'a crate::messaging::registry::MediatorListenerRegistry,
+    /// Per-mediator drain-TTL sweeper — DIDComm family only.
+    #[cfg(feature = "webvh")]
+    pub sweeper: &'a crate::messaging::drain_sweeper::DrainSweeper,
 }
 
 impl<'a> ServiceOpDeps<'a> {
@@ -186,11 +200,14 @@ impl<'a> ServiceOpDeps<'a> {
             audit_ks: &s.audit_ks,
             snapshot_ks: &s.snapshot_ks,
             service_state_ks: &s.service_state_ks,
+            drains_ks: &s.drains_ks,
             seed_store: &*s.seed_store,
             did_resolver,
             didcomm_bridge: &s.didcomm_bridge,
             telemetry: &s.telemetry,
             webvh_auth_locks: &s.webvh_auth_locks,
+            registry: &s.mediator_registry,
+            sweeper: &s.drain_sweeper,
         }
     }
 
@@ -210,11 +227,14 @@ impl<'a> ServiceOpDeps<'a> {
             audit_ks: &s.audit_ks,
             snapshot_ks: &s.snapshot_ks,
             service_state_ks: &s.service_state_ks,
+            drains_ks: &s.drains_ks,
             seed_store: &*s.seed_store,
             did_resolver,
             didcomm_bridge: &s.didcomm_bridge,
             telemetry: &s.telemetry,
             webvh_auth_locks: &s.webvh_auth_locks,
+            registry: &s.mediator_registry,
+            sweeper: &s.drain_sweeper,
         }
     }
 }

--- a/vta-service/src/operations/protocol/rollback_didcomm.rs
+++ b/vta-service/src/operations/protocol/rollback_didcomm.rs
@@ -35,23 +35,15 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::info;
 
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::SharedTelemetrySink;
-
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::messaging::drain_sweeper::DrainSweeper;
 use crate::messaging::handshake::{HandshakeError, ListenerProver};
-use crate::messaging::registry::MediatorListenerRegistry;
 use crate::operations::did_webvh::UpdateDidWebvhError;
-use crate::operations::protocol::OpContext;
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommError, DisableDidcommParams, DisableTransport, disable_didcomm,
 };
@@ -65,6 +57,7 @@ use crate::operations::protocol::snapshot::{
 use crate::operations::protocol::update_didcomm::{
     MigrateAuditKind, UpdateDidcommError, UpdateDidcommParams, update_didcomm,
 };
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
 use crate::store::KeyspaceHandle;
 
 /// Handshake timeout when re-promoting a prior mediator. Matches
@@ -179,27 +172,11 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn rollback_didcomm(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    drains_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    registry: &MediatorListenerRegistry,
-    sweeper: &DrainSweeper,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     prover: &(dyn ListenerProver + Send + Sync),
     auth: &AuthClaims,
     params: RollbackDidcommParams,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<RollbackDidcommResult, RollbackDidcommError> {
     auth.require_super_admin()
@@ -208,7 +185,7 @@ pub async fn rollback_didcomm(
     // PROTOCOL_LOCK is taken by the dispatched forward op —
     // holding it twice would deadlock. The snapshot read is
     // atomic via fjall.
-    let snap = snapshot::read(snapshot_ks, ServiceKind::Didcomm)
+    let snap = snapshot::read(deps.snapshot_ks, ServiceKind::Didcomm)
         .await
         .map_err(|e| RollbackDidcommError::Storage(format!("snapshot read: {e}")))?
         .ok_or(RollbackDidcommError::NoPriorMutation)?;
@@ -221,7 +198,7 @@ pub async fn rollback_didcomm(
         }
     };
 
-    let current_mediator = read_current_didcomm_mediator(config, webvh_ks).await?;
+    let current_mediator = read_current_didcomm_mediator(deps.config, deps.webvh_ks).await?;
 
     info!(
         channel,
@@ -234,28 +211,13 @@ pub async fn rollback_didcomm(
         // Snapshot says off, currently on → disable.
         (DidcommSnapshot::Disabled, Some(prior)) => {
             let result = disable_didcomm(
-                config,
-                keys_ks,
-                imported_ks,
-                contexts_ks,
-                webvh_ks,
-                audit_ks,
-                drains_ks,
-                snapshot_ks,
-                service_state_ks,
-                seed_store,
-                did_resolver,
-                didcomm_bridge,
-                registry,
-                sweeper,
-                telemetry,
+                deps,
                 auth,
                 DisableDidcommParams {
                     drain_ttl: params.drain_ttl,
                     transport: params.transport,
                 },
                 OpContext::Rollback,
-                webvh_auth_locks,
                 channel,
             )
             .await?;
@@ -279,19 +241,7 @@ pub async fn rollback_didcomm(
             None,
         ) => {
             let result = enable_didcomm(
-                config,
-                keys_ks,
-                imported_ks,
-                contexts_ks,
-                webvh_ks,
-                audit_ks,
-                snapshot_ks,
-                service_state_ks,
-                seed_store,
-                did_resolver,
-                didcomm_bridge,
-                registry,
-                telemetry,
+                deps,
                 prover,
                 auth,
                 EnableDidcommParams {
@@ -300,7 +250,6 @@ pub async fn rollback_didcomm(
                     handshake_timeout: DEFAULT_ROLLBACK_HANDSHAKE_TIMEOUT,
                 },
                 OpContext::Rollback,
-                webvh_auth_locks,
                 channel,
             )
             .await?;
@@ -324,21 +273,7 @@ pub async fn rollback_didcomm(
             Some(current),
         ) if mediator_did != current => {
             let result = update_didcomm(
-                config,
-                keys_ks,
-                imported_ks,
-                contexts_ks,
-                webvh_ks,
-                audit_ks,
-                drains_ks,
-                snapshot_ks,
-                service_state_ks,
-                seed_store,
-                did_resolver,
-                didcomm_bridge,
-                registry,
-                sweeper,
-                telemetry,
+                deps,
                 prover,
                 auth,
                 UpdateDidcommParams {
@@ -350,7 +285,6 @@ pub async fn rollback_didcomm(
                     transport: params.transport,
                 },
                 OpContext::Rollback,
-                webvh_auth_locks,
                 channel,
             )
             .await?;

--- a/vta-service/src/operations/protocol/update_didcomm.rs
+++ b/vta-service/src/operations/protocol/update_didcomm.rs
@@ -32,14 +32,11 @@ use tokio::sync::RwLock;
 use tracing::info;
 
 use vti_common::config::MessagingConfig;
-use vti_common::seed_store::SeedStore;
-use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
+use vti_common::telemetry::{TelemetryEvent, TelemetryKind};
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::messaging::drain_sweeper::DrainSweeper;
 use crate::messaging::handshake::{
     HandshakeError, HandshakeOptions, ListenerProver, mediator_handshake,
 };
@@ -48,7 +45,7 @@ use crate::operations::did_webvh::{UpdateDidWebvhError, UpdateDidWebvhOptions, u
 use crate::operations::protocol::document::{
     DocumentPatchError, current_didcomm_service, with_didcomm_service,
 };
-use crate::operations::protocol::{OpContext, PROTOCOL_LOCK};
+use crate::operations::protocol::{OpContext, PROTOCOL_LOCK, ServiceOpDeps};
 use crate::store::KeyspaceHandle;
 
 /// Distinguish a forward migrate from a rollback in telemetry. The
@@ -163,28 +160,12 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn update_didcomm(
-    config: &Arc<RwLock<AppConfig>>,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    drains_ks: &KeyspaceHandle,
-    snapshot_ks: &KeyspaceHandle,
-    _service_state_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
-    registry: &MediatorListenerRegistry,
-    sweeper: &DrainSweeper,
-    telemetry: &SharedTelemetrySink,
+    deps: &ServiceOpDeps<'_>,
     prover: &(dyn ListenerProver + Send + Sync),
     auth: &AuthClaims,
     params: UpdateDidcommParams,
     ctx: OpContext,
-    webvh_auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<UpdateDidcommResult, UpdateDidcommError> {
     auth.require_super_admin()
@@ -208,7 +189,7 @@ pub async fn update_didcomm(
     //    active and not be in drain. Read-only — purely captures
     //    the prior state we'll snapshot.
     let (vta_did, scid, current_doc, prior_mediator) =
-        read_preconditions(config, registry, webvh_ks, &params).await?;
+        read_preconditions(deps.config, deps.registry, deps.webvh_ks, &params).await?;
 
     // 2. Persist snapshot BEFORE any side-effecting I/O per spec
     //    §3.5a. Mirrors `update_rest`'s ordering. The handshake
@@ -221,7 +202,7 @@ pub async fn update_didcomm(
     //    today (tracked: list.rs's matching gap).
     use crate::operations::protocol::snapshot::{self, DidcommSnapshot, ServiceConfigSnapshot};
     snapshot::write(
-        snapshot_ks,
+        deps.snapshot_ks,
         ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Enabled {
             mediator_did: prior_mediator.clone(),
             routing_keys: vec![],
@@ -234,9 +215,9 @@ pub async fn update_didcomm(
     //    — the spec's atomicity guarantee. Snapshot already on disk
     //    is harmless; a subsequent successful update overwrites it.
     let resolved = mediator_handshake(
-        did_resolver,
+        deps.did_resolver,
         prover,
-        telemetry,
+        deps.telemetry,
         &params.new_mediator_did,
         &vta_did,
         HandshakeOptions {
@@ -252,33 +233,33 @@ pub async fn update_didcomm(
 
     // Publish new LogEntry.
     let update_result = update_did_webvh(
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        seed_store,
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.contexts_ks,
+        deps.webvh_ks,
+        deps.audit_ks,
+        deps.seed_store,
         auth,
         &scid,
         UpdateDidWebvhOptions {
             document: Some(patched),
             ..Default::default()
         },
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         Some(vta_did.as_str()),
-        webvh_auth_locks,
+        deps.webvh_auth_locks,
         channel,
     )
     .await?;
 
     // Persist config: messaging.mediator_did = new.
-    persist_new_mediator(config, &resolved.mediator_did, &resolved.endpoint).await?;
+    persist_new_mediator(deps.config, &resolved.mediator_did, &resolved.endpoint).await?;
 
     // Promote new mediator; place prior in drain. The
     // record_activate call evicts any drain entry for the new
     // mediator (rollback semantics).
-    registry
+    deps.registry
         .record_activate(MediatorBinding {
             mediator_did: resolved.mediator_did.clone(),
             endpoint: resolved.endpoint.clone(),
@@ -289,12 +270,12 @@ pub async fn update_didcomm(
         + chrono::Duration::from_std(params.drain_ttl).map_err(|e| {
             UpdateDidcommError::ConfigPersistence(format!("drain TTL out of range: {e}"))
         })?;
-    let prior_endpoint = best_effort_endpoint(did_resolver, &prior_mediator).await;
-    registry
-        .record_drain_persisted(drains_ks, &prior_mediator, prior_endpoint, deadline)
+    let prior_endpoint = best_effort_endpoint(deps.did_resolver, &prior_mediator).await;
+    deps.registry
+        .record_drain_persisted(deps.drains_ks, &prior_mediator, prior_endpoint, deadline)
         .await?;
     // Arm the sweeper so the drain TTL actually fires.
-    sweeper.arm(&prior_mediator, deadline).await;
+    deps.sweeper.arm(&prior_mediator, deadline).await;
 
     let mut event = TelemetryEvent::new(TelemetryKind::ServicesDidcommUpdate)
         .with_mediator(&resolved.mediator_did)
@@ -311,7 +292,7 @@ pub async fn update_didcomm(
     if let Some(tag) = ctx.telemetry_triggered_by() {
         event = event.with_field("triggered_by", JsonValue::from(tag));
     }
-    let _ = telemetry.record(event).await;
+    let _ = deps.telemetry.record(event).await;
 
     info!(
         channel,
@@ -404,9 +385,14 @@ async fn best_effort_endpoint(resolver: &DIDCacheClient, mediator_did: &str) -> 
 
 #[cfg(test)]
 mod tests {
+    use vti_common::seed_store::SeedStore;
+    use vti_common::telemetry::SharedTelemetrySink;
+
     use super::*;
     use crate::config::AppConfig;
+    use crate::didcomm_bridge::DIDCommBridge;
     use crate::keys::seed_store::PlaintextSeedStore;
+    use crate::messaging::drain_sweeper::DrainSweeper;
     use crate::messaging::handshake::AlwaysOkProver;
     use crate::operations::protocol::snapshot;
     use crate::store::Store;
@@ -468,6 +454,84 @@ mod tests {
         .unwrap()
     }
 
+    /// Owns every keyspace + shared infra and hands out a borrowed
+    /// [`ServiceOpDeps`] (P2.5). `registry` / `drains_ks` stay public so a
+    /// test can pre-seed drain state before the op runs.
+    struct TestEnv {
+        _dirs: Vec<tempfile::TempDir>,
+        keys_ks: KeyspaceHandle,
+        imported_ks: KeyspaceHandle,
+        contexts_ks: KeyspaceHandle,
+        webvh_ks: KeyspaceHandle,
+        audit_ks: KeyspaceHandle,
+        snapshot_ks: KeyspaceHandle,
+        service_state_ks: KeyspaceHandle,
+        drains_ks: KeyspaceHandle,
+        config: Arc<RwLock<AppConfig>>,
+        seed: Arc<dyn SeedStore>,
+        resolver: DIDCacheClient,
+        bridge: Arc<DIDCommBridge>,
+        sink: SharedTelemetrySink,
+        registry: Arc<MediatorListenerRegistry>,
+        sweeper: Arc<DrainSweeper>,
+        locks: crate::operations::did_webvh::WebvhAuthLocks,
+    }
+
+    impl TestEnv {
+        async fn new(seed_dir: &std::path::Path, config: Arc<RwLock<AppConfig>>) -> Self {
+            let (bridge, registry, sink) = registry();
+            let (d1, keys_ks) = empty_keyspace("keys").await;
+            let (d2, imported_ks) = empty_keyspace("imported_secrets").await;
+            let (d3, contexts_ks) = empty_keyspace("contexts").await;
+            let (d4, webvh_ks) = empty_keyspace("webvh").await;
+            let (d5, audit_ks) = empty_keyspace("audit").await;
+            let (d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
+            let (d7, service_state_ks) = empty_keyspace("service_state").await;
+            let (d8, drains_ks) = empty_keyspace("drains").await;
+            let sweeper = sweeper_for(Arc::clone(&registry), drains_ks.clone());
+            Self {
+                _dirs: vec![d1, d2, d3, d4, d5, d6, d7, d8],
+                keys_ks,
+                imported_ks,
+                contexts_ks,
+                webvh_ks,
+                audit_ks,
+                snapshot_ks,
+                service_state_ks,
+                drains_ks,
+                config,
+                seed: dummy_seed(seed_dir),
+                resolver: resolver().await,
+                bridge,
+                sink,
+                registry,
+                sweeper,
+                locks: crate::operations::did_webvh::WebvhAuthLocks::new(),
+            }
+        }
+
+        fn deps(&self) -> ServiceOpDeps<'_> {
+            ServiceOpDeps {
+                config: &self.config,
+                keys_ks: &self.keys_ks,
+                imported_ks: &self.imported_ks,
+                contexts_ks: &self.contexts_ks,
+                webvh_ks: &self.webvh_ks,
+                audit_ks: &self.audit_ks,
+                snapshot_ks: &self.snapshot_ks,
+                service_state_ks: &self.service_state_ks,
+                drains_ks: &self.drains_ks,
+                seed_store: &*self.seed,
+                did_resolver: &self.resolver,
+                didcomm_bridge: &self.bridge,
+                telemetry: &self.sink,
+                webvh_auth_locks: &self.locks,
+                registry: &self.registry,
+                sweeper: &self.sweeper,
+            }
+        }
+    }
+
     fn forward_params(new_mediator: &str) -> UpdateDidcommParams {
         UpdateDidcommParams {
             new_mediator_did: new_mediator.into(),
@@ -483,40 +547,15 @@ mod tests {
     async fn refuses_when_didcomm_not_enabled() {
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path(), /* didcomm = */ false);
-        let (bridge, reg, sink) = registry();
-        let (_d1, keys_ks) = empty_keyspace("keys").await;
-        let (_dimp, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_d2, contexts_ks) = empty_keyspace("contexts").await;
-        let (_d3, webvh_ks) = empty_keyspace("webvh").await;
-        let (_d4, audit_ks) = empty_keyspace("audit").await;
-        let (_d5, drains_ks) = empty_keyspace("drains").await;
-        let (_d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = resolver().await;
+        let env = TestEnv::new(dir.path(), config).await;
         let prover = AlwaysOkProver;
-        let seed = dummy_seed(dir.path());
 
         let err = update_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &drains_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &reg,
-            &sweeper_for(Arc::clone(&reg), drains_ks.clone()),
-            &sink,
+            &env.deps(),
             &prover,
             &super_admin(),
             forward_params("did:m:B"),
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -529,40 +568,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path(), true);
         config.write().await.vta_did = None;
-        let (bridge, reg, sink) = registry();
-        let (_d1, keys_ks) = empty_keyspace("keys").await;
-        let (_dimp, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_d2, contexts_ks) = empty_keyspace("contexts").await;
-        let (_d3, webvh_ks) = empty_keyspace("webvh").await;
-        let (_d4, audit_ks) = empty_keyspace("audit").await;
-        let (_d5, drains_ks) = empty_keyspace("drains").await;
-        let (_d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = resolver().await;
+        let env = TestEnv::new(dir.path(), config).await;
         let prover = AlwaysOkProver;
-        let seed = dummy_seed(dir.path());
 
         let err = update_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &drains_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &reg,
-            &sweeper_for(Arc::clone(&reg), drains_ks.clone()),
-            &sink,
+            &env.deps(),
             &prover,
             &super_admin(),
             forward_params("did:m:B"),
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -577,60 +591,38 @@ mod tests {
         // operator at `drain cancel` or `rollback`.
         let dir = tempfile::tempdir().unwrap();
         let config = fresh_config(dir.path(), true);
-        let (bridge, reg, sink) = registry();
-        let (_d1, keys_ks) = empty_keyspace("keys").await;
-        let (_dimp, imported_ks) = empty_keyspace("imported_secrets").await;
-        let (_d2, contexts_ks) = empty_keyspace("contexts").await;
-        let (_d3, webvh_ks) = empty_keyspace("webvh").await;
-        let (_d4, audit_ks) = empty_keyspace("audit").await;
-        let (_d5, drains_ks) = empty_keyspace("drains").await;
-        let (_d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
-        let (_d_svc_state, service_state_ks) = empty_keyspace("service_state").await;
-        let resolver = resolver().await;
+        let env = TestEnv::new(dir.path(), config).await;
         let prover = AlwaysOkProver;
-        let seed = dummy_seed(dir.path());
 
         // Pre-populate registry with mediator B in drain.
-        reg.record_activate(MediatorBinding {
-            mediator_did: "did:m:A".into(),
-            endpoint: "wss://A".into(),
-        })
-        .await;
-        reg.record_activate(MediatorBinding {
-            mediator_did: "did:m:placeholder".into(),
-            endpoint: "wss://placeholder".into(),
-        })
-        .await;
-        reg.record_drain_persisted(
-            &drains_ks,
-            "did:m:B",
-            "wss://B".into(),
-            Utc::now() + chrono::Duration::seconds(3600),
-        )
-        .await
-        .unwrap();
+        env.registry
+            .record_activate(MediatorBinding {
+                mediator_did: "did:m:A".into(),
+                endpoint: "wss://A".into(),
+            })
+            .await;
+        env.registry
+            .record_activate(MediatorBinding {
+                mediator_did: "did:m:placeholder".into(),
+                endpoint: "wss://placeholder".into(),
+            })
+            .await;
+        env.registry
+            .record_drain_persisted(
+                &env.drains_ks,
+                "did:m:B",
+                "wss://B".into(),
+                Utc::now() + chrono::Duration::seconds(3600),
+            )
+            .await
+            .unwrap();
 
         let err = update_didcomm(
-            &config,
-            &keys_ks,
-            &imported_ks,
-            &contexts_ks,
-            &webvh_ks,
-            &audit_ks,
-            &drains_ks,
-            &snapshot_ks,
-            &service_state_ks,
-            &*seed,
-            &resolver,
-            &bridge,
-            &reg,
-            &sweeper_for(Arc::clone(&reg), drains_ks.clone()),
-            &sink,
+            &env.deps(),
             &prover,
             &super_admin(),
             forward_params("did:m:B"),
             OpContext::Direct,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -114,7 +114,6 @@ pub async fn enable_didcomm_handler(
         });
     }
 
-    let bridge = Arc::clone(&state.didcomm_bridge);
     let did_resolver = state
         .did_resolver
         .as_ref()
@@ -144,20 +143,9 @@ pub async fn enable_didcomm_handler(
 
     let prover = AlwaysOkProver;
 
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
     let result = match enable_didcomm(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &bridge,
-        &state.mediator_registry,
-        &state.telemetry,
+        &deps,
         &prover,
         &auth.0,
         EnableDidcommParams {
@@ -166,7 +154,6 @@ pub async fn enable_didcomm_handler(
             handshake_timeout: timeout,
         },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "rest",
     )
     .await
@@ -498,36 +485,21 @@ pub async fn disable_didcomm_handler(
     State(state): State<AppState>,
     Json(req): Json<DisableDidcommRequest>,
 ) -> Result<Json<DisableDidcommResponse>, DisableDidcommHttpError> {
-    let bridge = Arc::clone(&state.didcomm_bridge);
     let did_resolver = state
         .did_resolver
         .as_ref()
         .ok_or(DisableDidcommHttpError::DidResolverUnavailable)?
         .clone();
 
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
     let result = disable_didcomm(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.drains_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &bridge,
-        &state.mediator_registry,
-        &state.drain_sweeper,
-        &state.telemetry,
+        &deps,
         &auth.0,
         DisableDidcommParams {
             drain_ttl: Duration::from_secs(req.drain_ttl_secs),
             transport: DisableTransport::Rest,
         },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;
@@ -811,22 +783,9 @@ pub async fn update_didcomm_handler(
             None => &always_ok,
         };
 
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
     let result = update_didcomm(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.drains_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &bridge,
-        &state.mediator_registry,
-        &state.drain_sweeper,
-        &state.telemetry,
+        &deps,
         prover_ref,
         &auth.0,
         UpdateDidcommParams {
@@ -838,7 +797,6 @@ pub async fn update_didcomm_handler(
             transport: crate::operations::protocol::disable_didcomm::DisableTransport::Rest,
         },
         OpContext::Direct,
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;
@@ -1767,29 +1725,15 @@ pub async fn rollback_didcomm_handler(
 
     let drain_ttl = Duration::from_secs(req.drain_ttl_secs.unwrap_or(86_400));
 
+    let deps = ServiceOpDeps::from_app_state(&state, &did_resolver);
     let result = rollback_didcomm(
-        &state.config,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &state.drains_ks,
-        &state.snapshot_ks,
-        &state.service_state_ks,
-        &*state.seed_store,
-        &did_resolver,
-        &bridge,
-        &state.mediator_registry,
-        &state.drain_sweeper,
-        &state.telemetry,
+        &deps,
         prover_ref,
         &auth.0,
         RollbackDidcommParams {
             drain_ttl,
             transport: DidcommTransport::Rest,
         },
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;

--- a/vta-service/src/services_cli.rs
+++ b/vta-service/src/services_cli.rs
@@ -99,10 +99,10 @@ struct OfflineDeps {
 }
 
 impl OfflineDeps {
-    /// Borrow the REST/WebAuthn service-op dependency bundle. The offline CLI
-    /// owns its `did_resolver` (always present, unlike `AppState`'s `Option`),
-    /// so this is infallible — the same shape `ServiceOpDeps::from_app_state`
-    /// produces for the online path.
+    /// Borrow the full service-op dependency bundle. The offline CLI owns its
+    /// `did_resolver` (always present, unlike `AppState`'s `Option`), so this is
+    /// infallible — the same shape `ServiceOpDeps::from_app_state` produces for
+    /// the online path (REST/WebAuthn + DIDComm).
     fn service_op_deps(&self) -> ServiceOpDeps<'_> {
         ServiceOpDeps {
             config: &self.config,
@@ -113,11 +113,14 @@ impl OfflineDeps {
             audit_ks: &self.audit_ks,
             snapshot_ks: &self.snapshot_ks,
             service_state_ks: &self.service_state_ks,
+            drains_ks: &self.drains_ks,
             seed_store: &self.seed_store,
             did_resolver: &self.did_resolver,
             didcomm_bridge: &self.didcomm_bridge,
             telemetry: &self.telemetry,
             webvh_auth_locks: &self.webvh_auth_locks,
+            registry: &self.registry,
+            sweeper: &self.sweeper,
         }
     }
 }
@@ -369,20 +372,9 @@ pub async fn run_services_didcomm_enable(
     let d = build_offline_deps(config_path).await?;
     let prover = AlwaysOkProver;
     let timeout = std::time::Duration::from_secs(handshake_timeout_secs.unwrap_or(10));
+    let deps = d.service_op_deps();
     let result = enable_didcomm(
-        &d.config,
-        &d.keys_ks,
-        &d.imported_ks,
-        &d.contexts_ks,
-        &d.webvh_ks,
-        &d.audit_ks,
-        &d.snapshot_ks,
-        &d.service_state_ks,
-        &d.seed_store,
-        &d.did_resolver,
-        &d.didcomm_bridge,
-        &d.registry,
-        &d.telemetry,
+        &deps,
         &prover,
         &d.auth,
         EnableDidcommParams {
@@ -391,7 +383,6 @@ pub async fn run_services_didcomm_enable(
             handshake_timeout: timeout,
         },
         OpContext::Direct,
-        &d.webvh_auth_locks,
         "vta-cli-offline",
     )
     .await
@@ -415,22 +406,9 @@ pub async fn run_services_didcomm_update(
 ) -> CliResult {
     let d = build_offline_deps(config_path).await?;
     let prover = AlwaysOkProver;
+    let deps = d.service_op_deps();
     let result = update_didcomm(
-        &d.config,
-        &d.keys_ks,
-        &d.imported_ks,
-        &d.contexts_ks,
-        &d.webvh_ks,
-        &d.audit_ks,
-        &d.drains_ks,
-        &d.snapshot_ks,
-        &d.service_state_ks,
-        &d.seed_store,
-        &d.did_resolver,
-        &d.didcomm_bridge,
-        &d.registry,
-        &d.sweeper,
-        &d.telemetry,
+        &deps,
         &prover,
         &d.auth,
         UpdateDidcommParams {
@@ -442,7 +420,6 @@ pub async fn run_services_didcomm_update(
             transport: crate::operations::protocol::disable_didcomm::DisableTransport::Rest,
         },
         OpContext::Direct,
-        &d.webvh_auth_locks,
         "vta-cli-offline",
     )
     .await
@@ -461,22 +438,9 @@ pub async fn run_services_didcomm_disable(
     drain_ttl_secs: u64,
 ) -> CliResult {
     let d = build_offline_deps(config_path).await?;
+    let deps = d.service_op_deps();
     let result = disable_didcomm(
-        &d.config,
-        &d.keys_ks,
-        &d.imported_ks,
-        &d.contexts_ks,
-        &d.webvh_ks,
-        &d.audit_ks,
-        &d.drains_ks,
-        &d.snapshot_ks,
-        &d.service_state_ks,
-        &d.seed_store,
-        &d.did_resolver,
-        &d.didcomm_bridge,
-        &d.registry,
-        &d.sweeper,
-        &d.telemetry,
+        &deps,
         &d.auth,
         DisableDidcommParams {
             drain_ttl: std::time::Duration::from_secs(drain_ttl_secs),
@@ -486,7 +450,6 @@ pub async fn run_services_didcomm_disable(
             transport: DisableTransport::Rest,
         },
         OpContext::Direct,
-        &d.webvh_auth_locks,
         "vta-cli-offline",
     )
     .await
@@ -514,29 +477,15 @@ pub async fn run_services_didcomm_rollback(
     // `AlwaysOkProver`. A subsequent `pnm services didcomm update`
     // against a running VTA exercises the live prover.
     let prover = AlwaysOkProver;
+    let deps = d.service_op_deps();
     let result = rollback_didcomm(
-        &d.config,
-        &d.keys_ks,
-        &d.imported_ks,
-        &d.contexts_ks,
-        &d.webvh_ks,
-        &d.audit_ks,
-        &d.drains_ks,
-        &d.snapshot_ks,
-        &d.service_state_ks,
-        &d.seed_store,
-        &d.did_resolver,
-        &d.didcomm_bridge,
-        &d.registry,
-        &d.sweeper,
-        &d.telemetry,
+        &deps,
         &prover,
         &d.auth,
         RollbackDidcommParams {
             drain_ttl: std::time::Duration::from_secs(drain_ttl_secs.unwrap_or(86_400)),
             transport: DisableTransport::Rest,
         },
-        &d.webvh_auth_locks,
         "vta-cli-offline",
     )
     .await


### PR DESCRIPTION
## What

Completes the protocol-op dep-struct sweep started in #425 (P2.5 part 2). The four DIDComm-family ops (`enable`/`update`/`disable`/`rollback_didcomm`) were the last `clippy::too_many_arguments` holdouts in the service-management surface — **21–25 positional args each** — carrying the same ambient deps as the REST/WebAuthn ops plus the mediator registry, drain sweeper, and drain keyspace.

After this, **all 12 service-management ops** (across REST, WebAuthn, and DIDComm) take the single `ServiceOpDeps` bundle.

## Changes

- **`ServiceOpDeps` grows three fields**: `drains_ks` (ungated) and `#[cfg(webvh)]` `registry` / `sweeper`. The `from_app_state` / `from_vta_state` constructors and the offline `OfflineDeps::service_op_deps` builder all populate them; REST/WebAuthn ops ignore the new fields.
- **`prover` stays a separate argument** — it's constructed per invocation (transient vs live `ListenerProver`), not ambient state. So `enable`/`update`/`rollback` take `(deps, prover, auth, params[, ctx], channel)` and `disable` takes `(deps, auth, params, ctx, channel)` — all **≤6 args**. All four `#[allow(clippy::too_many_arguments)]` removed.
- `rollback_didcomm` now hands its dispatched forward op (`enable`/`update`/`disable`) the deps verbatim instead of re-listing every keyspace.
- Call sites updated: `routes/protocol.rs` (4), `messaging/handlers_protocol.rs` (3), `services_cli.rs` (4). The enable route's now-redundant `bridge` clone is dropped (update/rollback keep theirs for `build_live_prover`).
- Unit tests for enable/update/disable gained a `TestEnv` owner (mirrors the rest/webauthn `TestFixture`) that holds every keyspace + infra and hands out a borrowed `ServiceOpDeps`, collapsing the ~18-line-per-call positional setup. `rollback_didcomm`'s tests only exercise snapshot/error paths and are untouched.

## Wire behaviour

Byte-identical: the public `*Params`/`*Result`/`*Error` types and all routes/DIDComm response shapes are unchanged. The P2.0/P2.3 op + router safety nets pass unmodified.

## Net

**−310 LOC** (459 insertions, 769 deletions across 8 files).

## Checks

- `cargo fmt --check` clean
- `cargo clippy --all-targets` (default & tee feature sets) clean
- lib **724** + all 18 integration suites (api_integration 115, security 34, vault_trust_task 12, step-up, …) green
- `vta-enclave` checks