### PR TITLE
feat(test-support): MockVta ACL-authorize seam for URL-direct provisioning (#429)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9880,7 +9880,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -774,6 +774,27 @@ pub async fn seed_webvh_server(webvh_ks: &KeyspaceHandle, id: &str, server_did: 
         .expect("seed webvh server");
 }
 
+/// Authorize `did` in the ACL so a URL-direct provision / authenticated call is
+/// accepted instead of bouncing off the challenge gate with
+/// `403 forbidden: DID not in ACL`. An empty `contexts` vec is super-admin.
+///
+/// Goes through the canonical [`store_acl_entry`](crate::acl::store_acl_entry)
+/// so the internal `acl:{did}` key convention and `AclEntry` shape stay
+/// encapsulated — callers don't touch the raw [`KeyspaceHandle`]. Counterpart
+/// to [`seed_webvh_server`]; reach it ergonomically via
+/// [`MockVta::authorize_did`] / [`MockVta::grant_super_admin`].
+pub async fn seed_acl_entry(
+    acl_ks: &KeyspaceHandle,
+    did: &str,
+    role: crate::acl::Role,
+    contexts: Vec<String>,
+) {
+    let entry = crate::acl::AclEntry::new(did, role, "test-support").with_contexts(contexts);
+    crate::acl::store_acl_entry(acl_ks, &entry)
+        .await
+        .expect("seed acl entry");
+}
+
 /// A **mock VTA** bound to an ephemeral local port — a real, listening HTTP
 /// server a test harness can drive over the wire, with no setup ceremony.
 ///
@@ -875,6 +896,23 @@ impl MockVta {
     #[cfg(feature = "webvh")]
     pub async fn seed_webvh_server(&self, id: &str, server_did: &str) {
         seed_webvh_server(&self.ctx.webvh_ks, id, server_did).await;
+    }
+
+    /// Authorize `did` in the ACL with `role` + `contexts` so a URL-direct
+    /// provision / authenticated call against this mock is accepted (rather than
+    /// 403ing at the challenge gate). An empty `contexts` vec is super-admin.
+    /// Thin wrapper over [`seed_acl_entry`] against this mock's ACL keyspace;
+    /// counterpart to [`seed_webvh_server`](Self::seed_webvh_server).
+    pub async fn authorize_did(&self, did: &str, role: crate::acl::Role, contexts: Vec<String>) {
+        seed_acl_entry(&self.ctx.acl_ks, did, role, contexts).await;
+    }
+
+    /// Convenience: authorize `did` as a super-admin (admin role, no context
+    /// scope) — the common case for driving a URL-direct provision. Shorthand
+    /// for [`authorize_did`](Self::authorize_did)`(did, Role::Admin, vec![])`.
+    pub async fn grant_super_admin(&self, did: &str) {
+        self.authorize_did(did, crate::acl::Role::Admin, Vec::new())
+            .await;
     }
 
     /// Stop the server and wait for it to wind down gracefully.

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -133,19 +133,13 @@ async fn url_direct_admin_rotation_round_trips_against_rest_only_mock() {
     use vta_sdk::provision_client::ProvisionAsk;
     use vta_sdk::provision_client::provision_admin_rotated_via_rest;
     use vta_sdk::provision_client::setup_key::EphemeralSetupKey;
-    use vti_common::acl::{AclEntry, Role};
 
     let mock = MockVta::start_provisionable().await;
 
-    // Cold-start: grant the setup did:key super-admin directly in the ACL so
-    // the relayer is authorized and the holder VP passes the provision gate.
+    // Cold-start: authorize the setup did:key as super-admin so the relayer is
+    // authorized and the holder VP passes the provision gate.
     let setup = EphemeralSetupKey::generate().expect("generate setup key");
-    let entry = AclEntry::new(&setup.did, Role::Admin, "test").with_contexts(vec![]);
-    mock.ctx
-        .acl_ks
-        .insert(format!("acl:{}", setup.did), &entry)
-        .await
-        .expect("seed super-admin acl");
+    mock.grant_super_admin(&setup.did).await;
 
     let reply = provision_admin_rotated_via_rest(
         mock.base_url(),


### PR DESCRIPTION
Closes #429.

## Problem

Driving a URL-direct provision (or any authenticated call) against a `MockVta` requires the setup `did:key` to be in the ACL first — otherwise the challenge gate 403s with `forbidden: DID not in ACL`. The only way to do that from a downstream test was to reach into the raw keyspace and hand-write the internal key convention:

```rust
let entry = AclEntry::new(&setup.did, Role::Admin, "test").with_contexts(vec![]);
mock.ctx.acl_ks.insert(format!("acl:{}", setup.did), &entry).await...  // leaks acl:{did} + raw KeyspaceHandle
```

That leaks internals, is duplicated by every consumer (vta-service's own e2e + the OpenVTC harness), and has no signpost — the happy path just 403s.

## Change

An ergonomic seam mirroring `seed_webvh_server`:

- **`test_support::seed_acl_entry(acl_ks, did, role, contexts)`** — goes through the canonical `acl::store_acl_entry`, so the `acl:{did}` key convention and `AclEntry` shape stay encapsulated. Callers never touch the raw `KeyspaceHandle`.
- **`MockVta::authorize_did(did, role, contexts)`** + convenience **`MockVta::grant_super_admin(did)`** (empty contexts == super-admin).

`vta-service`'s own `url_direct_admin_rotation_round_trips_against_rest_only_mock` drops the raw snippet for one readable `mock.grant_super_admin(&setup.did).await` — and still round-trips green, so the seam is exercised end to end.

## Version

`vta-service 0.9.2 → 0.9.3` (additive test-support API; the `"0.9"` pin is unchanged, so no dependent churn).

## Verification

- `vta-service` `mock_vta` suite: 5/5 green (incl. the refactored round-trip through `grant_super_admin`).
- `cargo clippy -p vta-service --features test-support --lib --tests` clean for the changed code (two pre-existing `.err().expect()` warnings in `preconditions.rs`, untouched). `cargo fmt` applied; DCO-signed.