### PR TITLE
refactor(vta): WebvhDeps bundle for the WebVH DID-management ops (P2.5 part 4a)

### DIFF
--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -902,21 +902,9 @@ didcomm_handler!(
     did_management::delete::DeleteDidWebvhBody,
     |s, auth, body, did_resolver| {
         let vta_did = s.config.read().await.vta_did.clone();
-        operations::did_webvh::delete_did_webvh(
-            &s.webvh_ks,
-            &s.keys_ks,
-            &s.imported_ks,
-            &s.audit_ks,
-            &*s.seed_store,
-            &auth,
-            &body.did,
-            did_resolver,
-            &s.didcomm_bridge,
-            vta_did.as_deref(),
-            &s.webvh_auth_locks,
-            "didcomm",
-        )
-        .await
+        let deps = operations::did_webvh::WebvhDeps::from_vta_state(s, did_resolver);
+        operations::did_webvh::delete_did_webvh(&deps, &auth, &body.did, vta_did.as_deref(), "didcomm")
+            .await
     }
 );
 
@@ -963,16 +951,10 @@ didcomm_handler!(
     did_management::servers::ListWebvhServerDomainsBody,
     |s, auth, body, did_resolver| {
         let vta_did = s.config.read().await.vta_did.clone();
+        let deps = operations::did_webvh::WebvhDeps::from_vta_state(s, did_resolver);
         operations::did_webvh::list_webvh_server_domains(
-            &s.keys_ks,
-            &s.imported_ks,
-            &s.audit_ks,
-            &s.webvh_ks,
-            &*s.seed_store,
+            &deps,
             &auth,
-            did_resolver,
-            &s.didcomm_bridge,
-            &s.webvh_auth_locks,
             vta_did.as_deref(),
             &body.server_id,
         )
@@ -1022,15 +1004,10 @@ didcomm_handler!(
     did_management::servers::RegisterDidWithServerBody,
     |s, auth, body, did_resolver| {
         let vta_did = s.config.read().await.vta_did.clone();
+        let deps = operations::did_webvh::WebvhDeps::from_vta_state(s, did_resolver);
         let result = operations::did_webvh::register_did_with_server(
-            &s.webvh_ks,
-            &s.keys_ks,
-            &s.imported_ks,
-            &s.audit_ks,
-            &*s.seed_store,
+            &deps,
             &auth,
-            did_resolver,
-            &s.didcomm_bridge,
             operations::did_webvh::RegisterDidWithServerParams {
                 did: body.did,
                 server_id: body.server_id,
@@ -1038,7 +1015,6 @@ didcomm_handler!(
                 domain: body.domain,
             },
             vta_did.as_deref(),
-            &s.webvh_auth_locks,
             "didcomm",
         )
         .await
@@ -1621,21 +1597,14 @@ pub async fn handle_rotate_did_webvh_keys(
     };
 
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_vta_state(&state, did_resolver);
     let result = app_try!(
         operations::did_webvh::rotate_did_webvh_keys(
-            &state.keys_ks,
-            &state.imported_ks,
-            &state.contexts_ks,
-            &state.webvh_ks,
-            &state.audit_ks,
-            &*state.seed_store,
+            &deps,
             &auth,
             &env.scid,
             opts,
-            did_resolver,
-            &state.didcomm_bridge,
             vta_did.as_deref(),
-            &state.webvh_auth_locks,
             "didcomm",
         )
         .await

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -77,6 +77,78 @@ use zeroize::Zeroize;
 
 use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
 
+/// Shared dependency bundle for the WebVH DID-management operations
+/// (`delete_did_webvh`, `rotate_did_webvh_keys`, `register_did_with_server`,
+/// `list_webvh_server_domains`) — P2.5.
+///
+/// These ops each took the same 11–14 positional arguments: the five keyspaces
+/// the WebVH publish path touches (keys / imported / contexts / webvh / audit)
+/// plus `seed_store`, `did_resolver`, `didcomm_bridge`, and the per-server
+/// `auth_locks`. Bundling them into one borrowed struct — built once at the
+/// transport boundary via [`WebvhDeps::from_app_state`] /
+/// [`WebvhDeps::from_vta_state`] (or directly by the offline CLI / tests) and
+/// threaded through unchanged — drops every op to ≤6 args.
+///
+/// All fields are borrows. The per-op identity (`vta_did`, `scid`, the DID
+/// being operated on, the WebVH server target) stays a separate argument — it
+/// varies per call and isn't ambient state. `contexts_ks` is read only by
+/// `rotate_did_webvh_keys`; the other ops ignore it.
+pub struct WebvhDeps<'a> {
+    pub keys_ks: &'a KeyspaceHandle,
+    pub imported_ks: &'a KeyspaceHandle,
+    pub contexts_ks: &'a KeyspaceHandle,
+    pub webvh_ks: &'a KeyspaceHandle,
+    pub audit_ks: &'a KeyspaceHandle,
+    pub seed_store: &'a dyn SeedStore,
+    pub did_resolver: &'a DIDCacheClient,
+    pub didcomm_bridge: &'a Arc<DIDCommBridge>,
+    pub auth_locks: &'a WebvhAuthLocks,
+}
+
+impl<'a> WebvhDeps<'a> {
+    /// Borrow the WebVH op dependencies from an [`AppState`](crate::server::AppState)
+    /// (REST + trust-task transports). `did_resolver` is threaded separately
+    /// because `AppState` holds it as an `Option` — the caller unwraps it
+    /// (surfacing the typed "DID resolver not available" reject) first.
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    pub fn from_app_state(
+        s: &'a crate::server::AppState,
+        did_resolver: &'a DIDCacheClient,
+    ) -> Self {
+        Self {
+            keys_ks: &s.keys_ks,
+            imported_ks: &s.imported_ks,
+            contexts_ks: &s.contexts_ks,
+            webvh_ks: &s.webvh_ks,
+            audit_ks: &s.audit_ks,
+            seed_store: &*s.seed_store,
+            did_resolver,
+            didcomm_bridge: &s.didcomm_bridge,
+            auth_locks: &s.webvh_auth_locks,
+        }
+    }
+
+    /// Borrow the WebVH op dependencies from a
+    /// [`VtaState`](crate::messaging::router::VtaState) (DIDComm transport).
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    pub fn from_vta_state(
+        s: &'a crate::messaging::router::VtaState,
+        did_resolver: &'a DIDCacheClient,
+    ) -> Self {
+        Self {
+            keys_ks: &s.keys_ks,
+            imported_ks: &s.imported_ks,
+            contexts_ks: &s.contexts_ks,
+            webvh_ks: &s.webvh_ks,
+            audit_ks: &s.audit_ks,
+            seed_store: &*s.seed_store,
+            did_resolver,
+            didcomm_bridge: &s.didcomm_bridge,
+            auth_locks: &s.webvh_auth_locks,
+        }
+    }
+}
+
 /// Resolve a DID template by name for use in a create-DID flow.
 ///
 /// Resolution order:
@@ -1038,24 +1110,16 @@ pub async fn create_did_webvh(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn delete_did_webvh(
-    webvh_ks: &KeyspaceHandle,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
+    deps: &WebvhDeps<'_>,
     auth: &AuthClaims,
     did: &str,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
     vta_did: Option<&str>,
-    auth_locks: &WebvhAuthLocks,
     channel: &str,
 ) -> Result<DeleteDidWebvhResultBody, AppError> {
     auth.require_admin()?;
 
-    let record = webvh_store::get_did(webvh_ks, did)
+    let record = webvh_store::get_did(deps.webvh_ks, did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("webvh DID not found: {did}")))?;
     // Mirror the context-scoping that create/get/get_log/list already
@@ -1070,19 +1134,19 @@ pub async fn delete_did_webvh(
     // local cleanup succeed silently. (Spec / audit H4: surface the
     // failure on the result body.)
     let mut daemon_cleanup_error: Option<String> = None;
-    let server = webvh_store::get_server(webvh_ks, &record.server_id).await?;
+    let server = webvh_store::get_server(deps.webvh_ks, &record.server_id).await?;
     if let Some(server) = server {
         match vta_did {
             Some(vta_did_value) => {
                 if let Err(e) = delete_log_on_server(
-                    keys_ks,
-                    imported_ks,
-                    audit_ks,
-                    webvh_ks,
-                    seed_store,
-                    did_resolver,
-                    didcomm_bridge,
-                    auth_locks,
+                    deps.keys_ks,
+                    deps.imported_ks,
+                    deps.audit_ks,
+                    deps.webvh_ks,
+                    deps.seed_store,
+                    deps.did_resolver,
+                    deps.didcomm_bridge,
+                    deps.auth_locks,
                     vta_did_value,
                     &server,
                     &record.mnemonic,
@@ -1116,11 +1180,11 @@ pub async fn delete_did_webvh(
     }
 
     // Remove local DID record and log
-    webvh_store::delete_did(webvh_ks, did).await?;
+    webvh_store::delete_did(deps.webvh_ks, did).await?;
 
     // Clean up associated key records (best-effort)
     for key_id in &[format!("{did}#key-0"), format!("{did}#key-1")] {
-        let _ = keys_ks.remove(keys::store_key(key_id)).await;
+        let _ = deps.keys_ks.remove(keys::store_key(key_id)).await;
     }
     // Clean up pre-rotation key records (M4: bound to the record's
     // declared count so a DID created with a high pre_rotation_count
@@ -1129,10 +1193,10 @@ pub async fn delete_did_webvh(
     for i in 0..pre_rotation_bound {
         let key_id = format!("{did}#pre-rotation-{i}");
         let store_key = keys::store_key(&key_id);
-        if keys_ks.get_raw(store_key.clone()).await?.is_none() {
+        if deps.keys_ks.get_raw(store_key.clone()).await?.is_none() {
             break;
         }
-        let _ = keys_ks.remove(store_key).await;
+        let _ = deps.keys_ks.remove(store_key).await;
     }
 
     info!(channel, did = %did, "webvh DID deleted");

--- a/vta-service/src/operations/did_webvh/register_server.rs
+++ b/vta-service/src/operations/did_webvh/register_server.rs
@@ -19,9 +19,6 @@
 //! - Local `did.jsonl` is the source of truth and is pushed
 //!   verbatim; the host's prior content (if any) is overwritten.
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use chrono::Utc;
 use didwebvh_rs::url::WebVHURL;
 use thiserror::Error;
@@ -29,9 +26,7 @@ use tracing::info;
 
 use crate::audit;
 use crate::auth::AuthClaims;
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
-use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
 use super::{RaceDetected, RecordSnapshot};
@@ -119,19 +114,11 @@ impl From<AppError> for RegisterDidWithServerError {
 /// server and flip the local record's `server_id` so future
 /// `update_did_webvh` calls (and therefore future `services`
 /// mutations) auto-publish there.
-#[allow(clippy::too_many_arguments)]
 pub async fn register_did_with_server(
-    webvh_ks: &KeyspaceHandle,
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    seed_store: &dyn crate::keys::seed_store::SeedStore,
+    deps: &super::WebvhDeps<'_>,
     auth: &AuthClaims,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
     params: RegisterDidWithServerParams,
     vta_did: Option<&str>,
-    auth_locks: &super::WebvhAuthLocks,
     channel: &str,
 ) -> Result<RegisterDidWithServerResult, RegisterDidWithServerError> {
     auth.require_super_admin()
@@ -146,7 +133,7 @@ pub async fn register_did_with_server(
     //    and the second `store_did` clobbers the first. The local
     //    record then points at one of two upstream hosts that each
     //    think they own the DID.
-    let mut record = webvh_store::get_did(webvh_ks, &params.did)
+    let mut record = webvh_store::get_did(deps.webvh_ks, &params.did)
         .await?
         .ok_or_else(|| RegisterDidWithServerError::DidNotFound(params.did.clone()))?;
     let snapshot = RecordSnapshot::capture(&record);
@@ -159,12 +146,12 @@ pub async fn register_did_with_server(
     }
 
     // 2. Look up the target server.
-    let server = webvh_store::get_server(webvh_ks, &params.server_id)
+    let server = webvh_store::get_server(deps.webvh_ks, &params.server_id)
         .await?
         .ok_or_else(|| RegisterDidWithServerError::ServerNotFound(params.server_id.clone()))?;
 
     // 3. Read the local did.jsonl. Source of truth for the push.
-    let did_log = webvh_store::get_did_log(webvh_ks, &params.did)
+    let did_log = webvh_store::get_did_log(deps.webvh_ks, &params.did)
         .await?
         .ok_or_else(|| RegisterDidWithServerError::LogMissing(params.did.clone()))?;
 
@@ -195,14 +182,14 @@ pub async fn register_did_with_server(
         )
     })?;
     let response = super::register_did_atomic_on_server(
-        keys_ks,
-        imported_ks,
-        audit_ks,
-        webvh_ks,
-        seed_store,
-        did_resolver,
-        didcomm_bridge,
-        auth_locks,
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.audit_ks,
+        deps.webvh_ks,
+        deps.seed_store,
+        deps.did_resolver,
+        deps.didcomm_bridge,
+        deps.auth_locks,
         vta_did_value,
         &server,
         &request_path,
@@ -226,7 +213,7 @@ pub async fn register_did_with_server(
     //    this, the loser's `store_did` silently overwrites the
     //    winner's, and the local record points at the wrong upstream
     //    while the host actually owning the slot is left orphaned.
-    let current = webvh_store::get_did(webvh_ks, &params.did)
+    let current = webvh_store::get_did(deps.webvh_ks, &params.did)
         .await?
         .ok_or_else(|| RegisterDidWithServerError::DidNotFound(params.did.clone()))?;
     snapshot
@@ -242,12 +229,12 @@ pub async fn register_did_with_server(
     record.mnemonic = response.mnemonic;
     record.updated_at = Utc::now();
     let log_entry_count = record.log_entry_count;
-    webvh_store::store_did(webvh_ks, &record).await?;
+    webvh_store::store_did(deps.webvh_ks, &record).await?;
 
     // 6. Audit. Best-effort; log+swallow on error.
     let resource = format!("did:webvh:{}", record.scid);
     if let Err(e) = audit::record(
-        audit_ks,
+        deps.audit_ks,
         "did.register_server",
         &auth.did,
         Some(&resource),
@@ -277,8 +264,13 @@ pub async fn register_did_with_server(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+
     use super::*;
-    use crate::store::Store;
+    use crate::didcomm_bridge::DIDCommBridge;
+    use crate::store::{KeyspaceHandle, Store};
     use crate::test_support::test_app_config;
     use vta_sdk::webvh::{WebvhDidRecord, WebvhServerRecord};
     use vti_common::config::StoreConfig as VtiStoreConfig;
@@ -361,6 +353,30 @@ mod tests {
         Arc::new(DIDCommBridge::placeholder())
     }
 
+    /// Build a [`WebvhDeps`] from the loose test parts. The preflight-path
+    /// tests bail before any real key op, so the same `webvh_ks` doubles for
+    /// keys / imported / contexts.
+    fn deps<'a>(
+        webvh_ks: &'a KeyspaceHandle,
+        audit_ks: &'a KeyspaceHandle,
+        seed: &'a dyn crate::keys::seed_store::SeedStore,
+        resolver: &'a DIDCacheClient,
+        bridge: &'a Arc<DIDCommBridge>,
+        locks: &'a super::super::WebvhAuthLocks,
+    ) -> super::super::WebvhDeps<'a> {
+        super::super::WebvhDeps {
+            keys_ks: webvh_ks,
+            imported_ks: webvh_ks,
+            contexts_ks: webvh_ks,
+            webvh_ks,
+            audit_ks,
+            seed_store: seed,
+            did_resolver: resolver,
+            didcomm_bridge: bridge,
+            auth_locks: locks,
+        }
+    }
+
     #[tokio::test]
     async fn rejects_non_super_admin() {
         let (_dir, webvh_ks, audit_ks) = setup().await;
@@ -368,15 +384,10 @@ mod tests {
         let seed = crate::keys::seed_store::PlaintextSeedStore::new(_dir.path());
         let auth_locks = super::super::WebvhAuthLocks::new();
         let bridge = bridge();
+        let deps = deps(&webvh_ks, &audit_ks, &seed, &resolver, &bridge, &auth_locks);
         let err = register_did_with_server(
-            &webvh_ks,
-            &webvh_ks,
-            &webvh_ks,
-            &audit_ks,
-            &seed,
+            &deps,
             &other_user(),
-            &resolver,
-            &bridge,
             RegisterDidWithServerParams {
                 did: "did:webvh:scid:host:vta".into(),
                 server_id: "primary".into(),
@@ -384,7 +395,6 @@ mod tests {
                 domain: None,
             },
             None,
-            &auth_locks,
             "test",
         )
         .await
@@ -399,15 +409,10 @@ mod tests {
         let seed = crate::keys::seed_store::PlaintextSeedStore::new(_dir.path());
         let auth_locks = super::super::WebvhAuthLocks::new();
         let bridge = bridge();
+        let deps = deps(&webvh_ks, &audit_ks, &seed, &resolver, &bridge, &auth_locks);
         let err = register_did_with_server(
-            &webvh_ks,
-            &webvh_ks,
-            &webvh_ks,
-            &audit_ks,
-            &seed,
+            &deps,
             &super_admin(),
-            &resolver,
-            &bridge,
             RegisterDidWithServerParams {
                 did: "did:webvh:nonexistent:host:vta".into(),
                 server_id: "primary".into(),
@@ -415,7 +420,6 @@ mod tests {
                 domain: None,
             },
             None,
-            &auth_locks,
             "test",
         )
         .await
@@ -435,15 +439,10 @@ mod tests {
         let seed = crate::keys::seed_store::PlaintextSeedStore::new(_dir.path());
         let auth_locks = super::super::WebvhAuthLocks::new();
         let bridge = bridge();
+        let deps = deps(&webvh_ks, &audit_ks, &seed, &resolver, &bridge, &auth_locks);
         let err = register_did_with_server(
-            &webvh_ks,
-            &webvh_ks,
-            &webvh_ks,
-            &audit_ks,
-            &seed,
+            &deps,
             &super_admin(),
-            &resolver,
-            &bridge,
             RegisterDidWithServerParams {
                 did: did.into(),
                 server_id: "primary".into(),
@@ -451,7 +450,6 @@ mod tests {
                 domain: None,
             },
             None,
-            &auth_locks,
             "test",
         )
         .await
@@ -477,15 +475,10 @@ mod tests {
         let seed = crate::keys::seed_store::PlaintextSeedStore::new(_dir.path());
         let auth_locks = super::super::WebvhAuthLocks::new();
         let bridge = bridge();
+        let deps = deps(&webvh_ks, &audit_ks, &seed, &resolver, &bridge, &auth_locks);
         let err = register_did_with_server(
-            &webvh_ks,
-            &webvh_ks,
-            &webvh_ks,
-            &audit_ks,
-            &seed,
+            &deps,
             &super_admin(),
-            &resolver,
-            &bridge,
             RegisterDidWithServerParams {
                 did: did.into(),
                 server_id: "missing-host".into(),
@@ -493,7 +486,6 @@ mod tests {
                 domain: None,
             },
             None,
-            &auth_locks,
             "test",
         )
         .await
@@ -517,15 +509,10 @@ mod tests {
         let seed = crate::keys::seed_store::PlaintextSeedStore::new(_dir.path());
         let auth_locks = super::super::WebvhAuthLocks::new();
         let bridge = bridge();
+        let deps = deps(&webvh_ks, &audit_ks, &seed, &resolver, &bridge, &auth_locks);
         let err = register_did_with_server(
-            &webvh_ks,
-            &webvh_ks,
-            &webvh_ks,
-            &audit_ks,
-            &seed,
+            &deps,
             &super_admin(),
-            &resolver,
-            &bridge,
             RegisterDidWithServerParams {
                 did: did.into(),
                 server_id: "primary".into(),
@@ -533,7 +520,6 @@ mod tests {
                 domain: None,
             },
             None,
-            &auth_locks,
             "test",
         )
         .await

--- a/vta-service/src/operations/did_webvh/servers.rs
+++ b/vta-service/src/operations/did_webvh/servers.rs
@@ -76,17 +76,9 @@ pub async fn list_webvh_servers(
 /// hosting server side. For DIDComm-only servers we return an
 /// empty list and a `None` default so the CLI falls back to the
 /// server-side resolution chain rather than blocking the user.
-#[allow(clippy::too_many_arguments)]
 pub async fn list_webvh_server_domains(
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    seed_store: &dyn crate::keys::seed_store::SeedStore,
+    deps: &crate::operations::did_webvh::WebvhDeps<'_>,
     auth: &AuthClaims,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &std::sync::Arc<crate::didcomm_bridge::DIDCommBridge>,
-    auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     vta_did: Option<&str>,
     server_id: &str,
 ) -> Result<vta_sdk::protocols::did_management::servers::ListWebvhServerDomainsResultBody, AppError>
@@ -97,7 +89,7 @@ pub async fn list_webvh_server_domains(
 
     // Any authenticated caller may discover hosting domains —
     // identical scope rule as `list_webvh_servers`.
-    let server = webvh_store::get_server(webvh_ks, server_id)
+    let server = webvh_store::get_server(deps.webvh_ks, server_id)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {server_id}")))?;
 
@@ -109,23 +101,23 @@ pub async fn list_webvh_server_domains(
     })?;
 
     let identity = crate::operations::did_webvh::auth_cache::load_vta_webvh_signing_identity(
-        keys_ks,
-        imported_ks,
-        seed_store,
-        audit_ks,
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.seed_store,
+        deps.audit_ks,
         vta_did_value,
     )
     .await?;
     let auth_ctx = crate::operations::did_webvh::auth_cache::AuthContext {
-        webvh_ks,
+        webvh_ks: deps.webvh_ks,
         identity: &identity,
-        locks: auth_locks,
+        locks: deps.auth_locks,
     };
 
     let transport = crate::operations::did_webvh::WebvhTransport::from_server_authenticated(
         &server,
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         &auth_ctx,
     )
     .await?;

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -1081,20 +1081,24 @@ mod pre_rotation_e2e_tests {
         .await;
         sleep(VERSION_TIME_GAP).await;
 
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = crate::operations::did_webvh::WebvhDeps {
+            keys_ks: &ts.keys_ks,
+            imported_ks: &ts.imported_ks,
+            contexts_ks: &ts.contexts_ks,
+            webvh_ks: &ts.webvh_ks,
+            audit_ks: &ts.audit_ks,
+            seed_store: &seed_store,
+            did_resolver: &resolver,
+            didcomm_bridge: &bridge,
+            auth_locks: &auth_locks,
+        };
         let result = rotate_did_webvh_keys(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             RotateDidWebvhKeysOptions::default(),
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -1524,23 +1528,27 @@ mod pre_rotation_e2e_tests {
 
         // And full rotate-keys still works on a fresh state — the
         // guard didn't accidentally fail-closed in the happy case.
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = crate::operations::did_webvh::WebvhDeps {
+            keys_ks: &ts.keys_ks,
+            imported_ks: &ts.imported_ks,
+            contexts_ks: &ts.contexts_ks,
+            webvh_ks: &ts.webvh_ks,
+            audit_ks: &ts.audit_ks,
+            seed_store: &seed_store,
+            did_resolver: &resolver,
+            didcomm_bridge: &bridge,
+            auth_locks: &auth_locks,
+        };
         let result = rotate_did_webvh_keys(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             RotateDidWebvhKeysOptions {
                 pre_rotation_count: None,
                 label: None,
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await

--- a/vta-service/src/operations/did_webvh/update/rotate.rs
+++ b/vta-service/src/operations/did_webvh/update/rotate.rs
@@ -3,9 +3,6 @@
 //! record's `next_fragment_id` (under a CAS guard), then delegates to
 //! [`super::update_did_webvh`].
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use didwebvh_rs::log_entry::LogEntryMethods;
 use serde_json::Value;
 
@@ -15,34 +12,22 @@ use super::options::{RotateDidWebvhKeysOptions, UpdateDidWebvhOptions, UpdateDid
 use super::orchestrator::update_did_webvh;
 use super::state::{find_record_by_scid, state_from_jsonl};
 use crate::auth::AuthClaims;
-use crate::didcomm_bridge::DIDCommBridge;
-use crate::keys::seed_store::SeedStore;
-use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
 /// Rotate every verificationMethod's keys (preserving role/type but
 /// minting fresh public-key bytes + bumping fragment ids), then drive
 /// the doc-bearing [`update_did_webvh`] path. Auth keys + pre-rotation
 /// rotate as a consequence of the document update.
-#[allow(clippy::too_many_arguments)]
 pub async fn rotate_did_webvh_keys(
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
+    deps: &super::super::WebvhDeps<'_>,
     auth: &AuthClaims,
     scid: &str,
     opts: RotateDidWebvhKeysOptions,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
     vta_did: Option<&str>,
-    auth_locks: &super::super::WebvhAuthLocks,
     channel: &str,
 ) -> Result<UpdateDidWebvhResult, UpdateDidWebvhError> {
     // 1. Load record + log.
-    let mut record = find_record_by_scid(webvh_ks, scid)
+    let mut record = find_record_by_scid(deps.webvh_ks, scid)
         .await?
         .ok_or_else(|| UpdateDidWebvhError::NotFound(format!("SCID {scid} not found")))?;
     auth.require_admin()
@@ -54,7 +39,7 @@ pub async fn rotate_did_webvh_keys(
         ))
     })?;
 
-    let did_log = webvh_store::get_did_log(webvh_ks, &record.did)
+    let did_log = webvh_store::get_did_log(deps.webvh_ks, &record.did)
         .await
         .map_err(|e| UpdateDidWebvhError::Persistence(format!("get_did_log: {e}")))?
         .ok_or_else(|| {
@@ -69,7 +54,7 @@ pub async fn rotate_did_webvh_keys(
     })?;
 
     // 2. Resolve context base path.
-    let context = crate::contexts::get_context(contexts_ks, &record.context_id)
+    let context = crate::contexts::get_context(deps.contexts_ks, &record.context_id)
         .await
         .map_err(|e| UpdateDidWebvhError::Persistence(format!("get_context: {e}")))?
         .ok_or_else(|| {
@@ -93,7 +78,8 @@ pub async fn rotate_did_webvh_keys(
         })?;
 
     let vm_count = vms.len() as u32;
-    let derived_vms = derive_webvh_keys(keys_ks, seed_store, &context.base_path, vm_count).await?;
+    let derived_vms =
+        derive_webvh_keys(deps.keys_ks, deps.seed_store, &context.base_path, vm_count).await?;
     let first_new_fragment_id = record.next_fragment_id;
     // Snapshot the version-vector fields so the next_fragment_id bump
     // (below) can detect a concurrent rotate that would have derived
@@ -152,7 +138,7 @@ pub async fn rotate_did_webvh_keys(
     //    the record between snapshot and now, refuse rather than
     //    blindly clobbering — the in-flight derived keys would
     //    overlap the winner's already-issued fragment ids.
-    let current = webvh_store::get_did(webvh_ks, &record.did)
+    let current = webvh_store::get_did(deps.webvh_ks, &record.did)
         .await
         .map_err(|e| UpdateDidWebvhError::Persistence(format!("get_did (rotate CAS): {e}")))?
         .ok_or_else(|| {
@@ -162,7 +148,7 @@ pub async fn rotate_did_webvh_keys(
         .assert_unchanged(&current)
         .map_err(|race| UpdateDidWebvhError::Conflict(race.to_string()))?;
     record.next_fragment_id += vm_count;
-    webvh_store::store_did(webvh_ks, &record)
+    webvh_store::store_did(deps.webvh_ks, &record)
         .await
         .map_err(|e| UpdateDidWebvhError::Persistence(format!("store_did (frag bump): {e}")))?;
 
@@ -172,12 +158,12 @@ pub async fn rotate_did_webvh_keys(
         .label
         .or_else(|| Some(format!("rotate-keys for {}", record.did)));
     let result = update_did_webvh(
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        seed_store,
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.contexts_ks,
+        deps.webvh_ks,
+        deps.audit_ks,
+        deps.seed_store,
         auth,
         scid,
         UpdateDidWebvhOptions {
@@ -192,10 +178,10 @@ pub async fn rotate_did_webvh_keys(
             // user-edited document flow), so pass None.
             expected_version_id: None,
         },
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         vta_did,
-        auth_locks,
+        deps.auth_locks,
         channel,
     )
     .await?;

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -85,16 +85,10 @@ pub async fn list_server_domains_handler(
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
     let config = state.config.read().await;
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(&state, did_resolver);
     let result = operations::did_webvh::list_webvh_server_domains(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.audit_ks,
-        &state.webvh_ks,
-        &*state.seed_store,
+        &deps,
         &auth,
-        did_resolver,
-        &state.didcomm_bridge,
-        &state.webvh_auth_locks,
         config.vta_did.as_deref(),
         &id,
     )
@@ -239,21 +233,9 @@ pub async fn delete_did_handler(
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
     let vta_did = state.config.read().await.vta_did.clone();
-    operations::did_webvh::delete_did_webvh(
-        &state.webvh_ks,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.audit_ks,
-        &*state.seed_store,
-        &auth.0,
-        &did,
-        did_resolver,
-        &state.didcomm_bridge,
-        vta_did.as_deref(),
-        &state.webvh_auth_locks,
-        "rest",
-    )
-    .await?;
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(&state, did_resolver);
+    operations::did_webvh::delete_did_webvh(&deps, &auth.0, &did, vta_did.as_deref(), "rest")
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -306,20 +288,13 @@ pub async fn rotate_did_keys_handler(
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(&state, did_resolver);
     let result = operations::did_webvh::rotate_did_webvh_keys(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &*state.seed_store,
+        &deps,
         &auth.0,
         &scid,
         body,
-        did_resolver,
-        &state.didcomm_bridge,
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;
@@ -347,15 +322,10 @@ pub async fn register_did_with_server_handler(
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(&state, did_resolver);
     let result = register_did_with_server(
-        &state.webvh_ks,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.audit_ks,
-        &*state.seed_store,
+        &deps,
         &auth.0,
-        did_resolver,
-        &state.didcomm_bridge,
         RegisterDidWithServerParams {
             did: body.did,
             server_id: body.server_id,
@@ -363,7 +333,6 @@ pub async fn register_did_with_server_handler(
             domain: body.domain,
         },
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         "rest",
     )
     .await

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -311,18 +311,12 @@ pub(super) async fn handle_dids_delete(
         }
     };
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
     match operations::did_webvh::delete_did_webvh(
-        &state.webvh_ks,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.audit_ks,
-        &*state.seed_store,
+        &deps,
         auth,
         &req.did,
-        did_resolver,
-        &state.didcomm_bridge,
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         TRANSPORT_TRUST_TASK,
     )
     .await
@@ -419,20 +413,13 @@ pub(super) async fn handle_dids_rotate_keys(
         pre_rotation_count: req.body.pre_rotation_count,
         label: req.body.label,
     };
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
     match operations::did_webvh::rotate_did_webvh_keys(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &*state.seed_store,
+        &deps,
         auth,
         &req.did,
         options,
-        did_resolver,
-        &state.didcomm_bridge,
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         TRANSPORT_TRUST_TASK,
     )
     .await
@@ -466,15 +453,10 @@ pub(super) async fn handle_dids_register_with_server(
         }
     };
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
     match register_did_with_server(
-        &state.webvh_ks,
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.audit_ks,
-        &*state.seed_store,
+        &deps,
         auth,
-        did_resolver,
-        &state.didcomm_bridge,
         RegisterDidWithServerParams {
             did: req.did,
             server_id: req.server_id,
@@ -482,7 +464,6 @@ pub(super) async fn handle_dids_register_with_server(
             domain: req.domain.clone(),
         },
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -276,6 +276,7 @@ pub async fn run_delete_did(
     let store = Store::open(&config.store)?;
     let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
     let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
     let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
     let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
@@ -285,21 +286,19 @@ pub async fn run_delete_did(
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let no_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
-    operations::did_webvh::delete_did_webvh(
-        &webvh_ks,
-        &keys_ks,
-        &imported_ks,
-        &audit_ks,
-        &*seed_store,
-        &auth,
-        &did,
-        &did_resolver,
-        &no_bridge,
-        config.vta_did.as_deref(),
-        &auth_locks,
-        "cli",
-    )
-    .await?;
+    let deps = operations::did_webvh::WebvhDeps {
+        keys_ks: &keys_ks,
+        imported_ks: &imported_ks,
+        contexts_ks: &contexts_ks,
+        webvh_ks: &webvh_ks,
+        audit_ks: &audit_ks,
+        seed_store: &*seed_store,
+        did_resolver: &did_resolver,
+        didcomm_bridge: &no_bridge,
+        auth_locks: &auth_locks,
+    };
+    operations::did_webvh::delete_did_webvh(&deps, &auth, &did, config.vta_did.as_deref(), "cli")
+        .await?;
     store.persist().await?;
 
     eprintln!("WebVH DID deleted: {did}");
@@ -513,6 +512,7 @@ pub async fn run_register_did(
     let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
     let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
     let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
+    let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
     let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
@@ -521,15 +521,20 @@ pub async fn run_register_did(
     let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
 
     let auth = cli_super_admin();
+    let deps = operations::did_webvh::WebvhDeps {
+        keys_ks: &keys_ks,
+        imported_ks: &imported_ks,
+        contexts_ks: &contexts_ks,
+        webvh_ks: &webvh_ks,
+        audit_ks: &audit_ks,
+        seed_store: &*seed_store,
+        did_resolver: &did_resolver,
+        didcomm_bridge: &didcomm_bridge,
+        auth_locks: &auth_locks,
+    };
     let result = operations::did_webvh::register_did_with_server(
-        &webvh_ks,
-        &keys_ks,
-        &imported_ks,
-        &audit_ks,
-        &*seed_store,
+        &deps,
         &auth,
-        &did_resolver,
-        &didcomm_bridge,
         operations::did_webvh::RegisterDidWithServerParams {
             did,
             server_id: server,
@@ -537,7 +542,6 @@ pub async fn run_register_did(
             domain: None,
         },
         config.vta_did.as_deref(),
-        &auth_locks,
         "vta-cli-offline",
     )
     .await?;


### PR DESCRIPTION
## What

Continues the per-family dep-struct sweep (after the protocol ops in #425 / #428) into the WebVH DID-management surface. `delete_did_webvh`, `rotate_did_webvh_keys`, `register_did_with_server`, and `list_webvh_server_domains` each took the same **11–14 positional args** — the five keyspaces the WebVH publish path touches (keys / imported / contexts / webvh / audit) plus `seed_store`, `did_resolver`, `didcomm_bridge`, and the per-server `auth_locks`.

This is **P2.5 part 4a** — after the AppState-split churn analysis (~450–790 access sites, high risk, marginal benefit), part 4 was rescoped to continue the proven per-family pattern instead.

## Changes

- **New `pub operations::did_webvh::WebvhDeps<'a>`** (9 borrowed fields) with `from_app_state` (REST + trust-task) / `from_vta_state` (DIDComm) constructors; the offline CLI and unit tests build it via struct literal. `did_resolver` is threaded separately because `AppState` holds it as an `Option`.
- The per-op identity (`vta_did`, `scid`, the DID, the server target) stays a separate argument — it varies per call. Each op drops to **≤6 args**; all four `#[allow(clippy::too_many_arguments)]` removed.
- Call sites updated: `routes/did_webvh.rs` (4), `messaging/handlers.rs` (4), `trust_tasks/webvh.rs` (3), `webvh_cli.rs` (2, now opening `contexts_ks` for the superset), and the rotate unit tests in `update/mod.rs` (2). `register_server`'s five preflight tests gained a small `deps()` helper.

Scoped to the four same-shaped ops. `create_did_webvh` (distinct subset — no `auth_locks`/`audit_ks`, has `did_templates_ks` + `config`), the three `auth_cache` server helpers, and the `update_did_webvh` orchestrator keep their positional signatures — a follow-up slice (4b).

## Wire behaviour

Byte-identical: the public `*Params`/`*Result`/`*Error` types and all routes/DIDComm/CLI surfaces are unchanged.

## Checks

- `cargo fmt --check` clean
- `cargo clippy --all-targets` (default & tee feature sets) clean
- lib **724** + all 18 integration suites green
- `vta-enclave` checks