### PR TITLE
refactor(vta): reuse WebvhDeps for the passkey-VM enrollment ops (P2.5 part 4b)

### DIFF
--- a/vta-service/src/operations/passkey_vms/mod.rs
+++ b/vta-service/src/operations/passkey_vms/mod.rs
@@ -37,9 +37,6 @@
 //! routes use `AdminAuth`; this module asserts the per-DID context
 //! gate.
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use base64::Engine;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -56,8 +53,6 @@ use vta_sdk::protocols::did_management::passkey_vms::{
 use vti_common::auth::passkey::build_webauthn;
 
 use crate::auth::AuthClaims;
-use crate::didcomm_bridge::DIDCommBridge;
-use crate::keys::seed_store::SeedStore;
 use crate::operations::did_webvh::{UpdateDidWebvhOptions, update_did_webvh};
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
@@ -163,7 +158,6 @@ fn fragment_for_credential(credential_id: &[u8]) -> String {
 
 /// Mint a WebAuthn registration challenge tied to `did`. Caller
 /// must have `admin` role on the DID's context.
-#[allow(clippy::too_many_arguments)]
 pub async fn start_enrollment(
     webvh_ks: &KeyspaceHandle,
     passkey_vms_ks: &KeyspaceHandle,
@@ -229,21 +223,12 @@ pub async fn start_enrollment(
 
 /// Verify the WebAuthn ceremony, build the passkey VM, append it
 /// to the DID document, and publish via WebVH.
-#[allow(clippy::too_many_arguments)]
 pub async fn finish_enrollment(
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
+    deps: &crate::operations::did_webvh::WebvhDeps<'_>,
     passkey_vms_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
     auth: &AuthClaims,
     body: EnrollPasskeySubmitBody,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
     vta_did: Option<&str>,
-    auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     config: &crate::config::AppConfig,
     channel: &str,
 ) -> Result<EnrollPasskeySubmitResponse, PasskeyVmError> {
@@ -252,7 +237,7 @@ pub async fn finish_enrollment(
     let webauthn = build_webauthn(public_url)
         .map_err(|e| PasskeyVmError::NotAvailable(format!("webauthn builder: {e}")))?;
 
-    let record = webvh_store::get_did(webvh_ks, &body.did)
+    let record = webvh_store::get_did(deps.webvh_ks, &body.did)
         .await
         .map_err(|e| PasskeyVmError::Persistence(format!("get_did: {e}")))?
         .ok_or(PasskeyVmError::DidNotFound)?;
@@ -312,7 +297,7 @@ pub async fn finish_enrollment(
 
     // 5. Read current document, append the VM, reference it from
     //    `authentication`.
-    let did_log = webvh_store::get_did_log(webvh_ks, &record.did)
+    let did_log = webvh_store::get_did_log(deps.webvh_ks, &record.did)
         .await
         .map_err(|e| PasskeyVmError::Persistence(format!("get_did_log: {e}")))?
         .ok_or(PasskeyVmError::DidNotFound)?;
@@ -331,19 +316,19 @@ pub async fn finish_enrollment(
         expected_version_id: None,
     };
     let result = update_did_webvh(
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        seed_store,
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.contexts_ks,
+        deps.webvh_ks,
+        deps.audit_ks,
+        deps.seed_store,
         auth,
         &record.scid,
         opts,
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         vta_did,
-        auth_locks,
+        deps.auth_locks,
         channel,
     )
     .await?;
@@ -433,24 +418,15 @@ pub async fn list_passkeys(
 // revoke_passkey
 // ---------------------------------------------------------------------------
 
-#[allow(clippy::too_many_arguments)]
 pub async fn revoke_passkey(
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
+    deps: &crate::operations::did_webvh::WebvhDeps<'_>,
     auth: &AuthClaims,
     did: &str,
     fragment: &str,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
     vta_did: Option<&str>,
-    auth_locks: &crate::operations::did_webvh::WebvhAuthLocks,
     channel: &str,
 ) -> Result<(), PasskeyVmError> {
-    let record = webvh_store::get_did(webvh_ks, did)
+    let record = webvh_store::get_did(deps.webvh_ks, did)
         .await
         .map_err(|e| PasskeyVmError::Persistence(format!("get_did: {e}")))?
         .ok_or(PasskeyVmError::DidNotFound)?;
@@ -464,7 +440,7 @@ pub async fn revoke_passkey(
     }
     let vm_id = format!("{did}#{fragment}");
 
-    let did_log = webvh_store::get_did_log(webvh_ks, did)
+    let did_log = webvh_store::get_did_log(deps.webvh_ks, did)
         .await
         .map_err(|e| PasskeyVmError::Persistence(format!("get_did_log: {e}")))?
         .ok_or(PasskeyVmError::DidNotFound)?;
@@ -481,19 +457,19 @@ pub async fn revoke_passkey(
         expected_version_id: None,
     };
     update_did_webvh(
-        keys_ks,
-        imported_ks,
-        contexts_ks,
-        webvh_ks,
-        audit_ks,
-        seed_store,
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.contexts_ks,
+        deps.webvh_ks,
+        deps.audit_ks,
+        deps.seed_store,
         auth,
         &record.scid,
         opts,
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         vta_did,
-        auth_locks,
+        deps.auth_locks,
         channel,
     )
     .await?;

--- a/vta-service/src/routes/passkey_vms.rs
+++ b/vta-service/src/routes/passkey_vms.rs
@@ -85,20 +85,13 @@ pub async fn enroll_submit_handler(
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
     let vta_did = state.config.read().await.vta_did.clone();
     let config = state.config.read().await.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(&state, did_resolver);
     let result = operations::passkey_vms::finish_enrollment(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
+        &deps,
         &state.passkey_vms_ks,
-        &*state.seed_store,
         &auth.0,
         body,
-        did_resolver,
-        &state.didcomm_bridge,
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         &config,
         "rest",
     )
@@ -126,20 +119,13 @@ pub async fn revoke_passkey_handler(
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(&state, did_resolver);
     operations::passkey_vms::revoke_passkey(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &*state.seed_store,
+        &deps,
         &auth.0,
         &q.did,
         &fragment,
-        did_resolver,
-        &state.didcomm_bridge,
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;

--- a/vta-service/src/trust_tasks/passkey_vms.rs
+++ b/vta-service/src/trust_tasks/passkey_vms.rs
@@ -152,20 +152,13 @@ pub(super) async fn handle_enroll_submit(
     };
     let vta_did = state.config.read().await.vta_did.clone();
     let config = state.config.read().await.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
     match operations::passkey_vms::finish_enrollment(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
+        &deps,
         &state.passkey_vms_ks,
-        &*state.seed_store,
         auth,
         req,
-        did_resolver,
-        &state.didcomm_bridge,
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         &config,
         TRANSPORT_TRUST_TASK,
     )
@@ -215,20 +208,13 @@ pub(super) async fn handle_revoke(
         }
     };
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
     match operations::passkey_vms::revoke_passkey(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &*state.seed_store,
+        &deps,
         auth,
         &req.did,
         &req.fragment,
-        did_resolver,
-        &state.didcomm_bridge,
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         TRANSPORT_TRUST_TASK,
     )
     .await


### PR DESCRIPTION
## What

`finish_enrollment` (**15 args** — the single worst remaining offender) and `revoke_passkey` (**14**) both drive the WebVH publish path (read doc → append / remove the passkey VM → `update_did_webvh`), so they carry the exact same ambient deps the part-4a (`#432`) `WebvhDeps` already models: the five keyspaces + `seed_store` + `did_resolver` + `didcomm_bridge` + `auth_locks`.

This is **P2.5 part 4b**.

## Changes

- Both ops now take `&operations::did_webvh::WebvhDeps` (**reused as-is, no new struct**) plus their per-op tail:
  - `finish_enrollment` → `(deps, passkey_vms_ks, auth, body, vta_did, config, channel)` = 7 args
  - `revoke_passkey` → `(deps, auth, did, fragment, vta_did, channel)` = 6 args
  - `passkey_vms_ks` + `config` stay separate (passkey-specific, not webvh-publish deps).
- Both `#[allow(clippy::too_many_arguments)]` removed, plus a now-dead one on the 6-arg `start_enrollment`.
- Call sites updated: `routes/passkey_vms.rs` (2), `trust_tasks/passkey_vms.rs` (2), each building `WebvhDeps::from_app_state` once. No DIDComm handler — passkey enrollment is REST + trust-task only.

## Why this slice (not create_did_webvh)

Chosen over the `create_did_webvh` / `auth_cache` slice to avoid overlapping the in-flight MockVta create-did-webvh work (#431), which exercises that exact publish path. Passkey only *calls* `update_did_webvh` (signature untouched), so it's independent — that slice is deferred to part 4c, after #431 lands.

## Wire behaviour

Byte-identical: the public `*Body`/`*Response`/`*Error` types and all REST/trust-task surfaces are unchanged.

## Checks

- `cargo fmt --check` clean
- `cargo clippy --all-targets` (default & tee feature sets) clean
- lib **724** + all 18 integration suites green
- `vta-enclave` checks