### PR TITLE
refactor(vta): reuse WebvhDeps for the auth_cache server-publish helpers (P2.5 part 4c)

### DIFF
--- a/vta-service/src/operations/did_webvh/auth_cache.rs
+++ b/vta-service/src/operations/did_webvh/auth_cache.rs
@@ -212,34 +212,31 @@ async fn persist_tokens(
 /// For DIDComm transports, no auth handshake is performed (DIDComm
 /// authcrypt handles the equivalent at the envelope layer) — the
 /// helper falls through to the plain `publish_did` path.
-#[allow(clippy::too_many_arguments)]
 pub async fn publish_log_to_server(
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
-    didcomm_bridge: &Arc<crate::didcomm_bridge::DIDCommBridge>,
-    auth_locks: &WebvhAuthLocks,
+    deps: &super::WebvhDeps<'_>,
     vta_did: &str,
     server: &WebvhServerRecord,
     mnemonic: &str,
     log_content: &str,
     domain: Option<&str>,
 ) -> Result<(), AppError> {
-    let identity =
-        load_vta_webvh_signing_identity(keys_ks, imported_ks, seed_store, audit_ks, vta_did)
-            .await?;
+    let identity = load_vta_webvh_signing_identity(
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.seed_store,
+        deps.audit_ks,
+        vta_did,
+    )
+    .await?;
     let auth_ctx = AuthContext {
-        webvh_ks,
+        webvh_ks: deps.webvh_ks,
         identity: &identity,
-        locks: auth_locks,
+        locks: deps.auth_locks,
     };
     let mut transport = super::WebvhTransport::from_server_authenticated(
         server,
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         &auth_ctx,
     )
     .await?;
@@ -250,33 +247,30 @@ pub async fn publish_log_to_server(
 
 /// Authenticate and delete a DID log on the hosting server. Same
 /// encapsulation as [`publish_log_to_server`].
-#[allow(clippy::too_many_arguments)]
 pub async fn delete_log_on_server(
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
-    didcomm_bridge: &Arc<crate::didcomm_bridge::DIDCommBridge>,
-    auth_locks: &WebvhAuthLocks,
+    deps: &super::WebvhDeps<'_>,
     vta_did: &str,
     server: &WebvhServerRecord,
     mnemonic: &str,
     domain: Option<&str>,
 ) -> Result<(), AppError> {
-    let identity =
-        load_vta_webvh_signing_identity(keys_ks, imported_ks, seed_store, audit_ks, vta_did)
-            .await?;
+    let identity = load_vta_webvh_signing_identity(
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.seed_store,
+        deps.audit_ks,
+        vta_did,
+    )
+    .await?;
     let auth_ctx = AuthContext {
-        webvh_ks,
+        webvh_ks: deps.webvh_ks,
         identity: &identity,
-        locks: auth_locks,
+        locks: deps.auth_locks,
     };
     let mut transport = super::WebvhTransport::from_server_authenticated(
         server,
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         &auth_ctx,
     )
     .await?;
@@ -287,16 +281,8 @@ pub async fn delete_log_on_server(
 
 /// Authenticate and atomically claim + publish a DID slot on the
 /// hosting server. Same encapsulation as [`publish_log_to_server`].
-#[allow(clippy::too_many_arguments)]
 pub async fn register_did_atomic_on_server(
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    did_resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
-    didcomm_bridge: &Arc<crate::didcomm_bridge::DIDCommBridge>,
-    auth_locks: &WebvhAuthLocks,
+    deps: &super::WebvhDeps<'_>,
     vta_did: &str,
     server: &WebvhServerRecord,
     path: &str,
@@ -304,18 +290,23 @@ pub async fn register_did_atomic_on_server(
     force: bool,
     domain: Option<&str>,
 ) -> Result<crate::webvh_client::RequestUriResponse, AppError> {
-    let identity =
-        load_vta_webvh_signing_identity(keys_ks, imported_ks, seed_store, audit_ks, vta_did)
-            .await?;
+    let identity = load_vta_webvh_signing_identity(
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.seed_store,
+        deps.audit_ks,
+        vta_did,
+    )
+    .await?;
     let auth_ctx = AuthContext {
-        webvh_ks,
+        webvh_ks: deps.webvh_ks,
         identity: &identity,
-        locks: auth_locks,
+        locks: deps.auth_locks,
     };
     let mut transport = super::WebvhTransport::from_server_authenticated(
         server,
-        did_resolver,
-        didcomm_bridge,
+        deps.did_resolver,
+        deps.didcomm_bridge,
         &auth_ctx,
     )
     .await?;

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -1138,21 +1138,8 @@ pub async fn delete_did_webvh(
     if let Some(server) = server {
         match vta_did {
             Some(vta_did_value) => {
-                if let Err(e) = delete_log_on_server(
-                    deps.keys_ks,
-                    deps.imported_ks,
-                    deps.audit_ks,
-                    deps.webvh_ks,
-                    deps.seed_store,
-                    deps.did_resolver,
-                    deps.didcomm_bridge,
-                    deps.auth_locks,
-                    vta_did_value,
-                    &server,
-                    &record.mnemonic,
-                    None,
-                )
-                .await
+                if let Err(e) =
+                    delete_log_on_server(deps, vta_did_value, &server, &record.mnemonic, None).await
                 {
                     tracing::warn!(
                         did = %did,

--- a/vta-service/src/operations/did_webvh/register_server.rs
+++ b/vta-service/src/operations/did_webvh/register_server.rs
@@ -182,14 +182,7 @@ pub async fn register_did_with_server(
         )
     })?;
     let response = super::register_did_atomic_on_server(
-        deps.keys_ks,
-        deps.imported_ks,
-        deps.audit_ks,
-        deps.webvh_ks,
-        deps.seed_store,
-        deps.did_resolver,
-        deps.didcomm_bridge,
-        deps.auth_locks,
+        deps,
         vta_did_value,
         &server,
         &request_path,

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -401,15 +401,19 @@ pub async fn update_did_webvh(
                     .to_string(),
             )
         })?;
-        super::super::publish_log_to_server(
+        let deps = super::super::WebvhDeps {
             keys_ks,
             imported_ks,
-            audit_ks,
+            contexts_ks,
             webvh_ks,
+            audit_ks,
             seed_store,
             did_resolver,
             didcomm_bridge,
             auth_locks,
+        };
+        super::super::publish_log_to_server(
+            &deps,
             vta_did,
             &server,
             &record.mnemonic,


### PR DESCRIPTION
## What

The three `auth_cache` helpers that authenticate to a webvh hosting server and publish / delete / atomically-claim a DID slot — `publish_log_to_server` (13 args), `delete_log_on_server` (12), `register_did_atomic_on_server` (14) — shared an identical 9-arg prefix that is *exactly* the ambient deps the part-4a (`#432`) `WebvhDeps` models (they ignore `contexts_ks`). **Reused it as-is.**

This is **P2.5 part 4c**.

## Changes

- Each helper now takes `&WebvhDeps` plus its per-call tail (`vta_did`, the `server` target, op-specific args). `register_did_atomic_on_server` → 7 args; the other two → ≤6. All three `#[allow(clippy::too_many_arguments)]` removed.
- **Synergy with part 4a:** two of the three call sites — `delete_log_on_server` inside `delete_did_webvh` and `register_did_atomic_on_server` inside `register_did_with_server` — already held a `WebvhDeps`, so they now pass it **straight through** (collapsing two ~12-arg invocations to one). The third (`publish_log_to_server` in the `update_did_webvh` orchestrator) builds a `WebvhDeps` from its locals; the orchestrator's own conversion is a later slice.

## Scope

Scoped to the auth_cache helpers — the cleanest, most synergistic remaining did_webvh cluster (3 internal call sites, zero new structs). Deferred:
- `create_did_webvh` (distinct shape: +`did_templates_ks`/`config`, −`auth_locks`) → its own `CreateDidWebvhDeps`.
- `update_did_webvh` (**25 call sites** — the core publish fn) → its own focused PR.

## Wire behaviour

Byte-identical — internal helper signatures only; no public API change.

## Checks

- `cargo fmt --check` clean
- `cargo clippy --all-targets` (default & tee) clean
- lib **724** + all 18 integration suites green
- `vta-enclave` checks