### PR TITLE
refactor(vta): CreateDidWebvhDeps bundle for create_did_webvh (P2.5 part 4c-bis)

### DIFF
--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -171,21 +171,18 @@ pub async fn run_create_did_webvh(
         is_vta_identity: false,
     };
 
-    let result = operations::did_webvh::create_did_webvh(
-        &keys_ks,
-        &imported_ks,
-        &contexts_ks,
-        &webvh_ks,
-        &did_templates_ks,
-        &*seed_store,
-        &config,
-        &auth,
-        params,
-        &did_resolver,
-        &no_bridge,
-        "cli",
-    )
-    .await?;
+    let deps = operations::did_webvh::CreateDidWebvhDeps {
+        keys_ks: &keys_ks,
+        imported_ks: &imported_ks,
+        contexts_ks: &contexts_ks,
+        webvh_ks: &webvh_ks,
+        did_templates_ks: &did_templates_ks,
+        seed_store: &*seed_store,
+        config: &config,
+        did_resolver: &did_resolver,
+        didcomm_bridge: &no_bridge,
+    };
+    let result = operations::did_webvh::create_did_webvh(&deps, &auth, params, "cli").await?;
 
     let final_did = &result.did;
     eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -837,21 +837,9 @@ didcomm_handler!(
     did_management::create::CreateDidWebvhBody,
     |s, auth, body, did_resolver| {
         let config = s.config.read().await;
-        operations::did_webvh::create_did_webvh(
-            &s.keys_ks,
-            &s.imported_ks,
-            &s.contexts_ks,
-            &s.webvh_ks,
-            &s.did_templates_ks,
-            &*s.seed_store,
-            &config,
-            &auth,
-            body.into(),
-            did_resolver,
-            &s.didcomm_bridge,
-            "didcomm",
-        )
-        .await
+        let deps =
+            operations::did_webvh::CreateDidWebvhDeps::from_vta_state(s, &config, did_resolver);
+        operations::did_webvh::create_did_webvh(&deps, &auth, body.into(), "didcomm").await
     }
 );
 

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -149,6 +149,73 @@ impl<'a> WebvhDeps<'a> {
     }
 }
 
+/// Dependency bundle for [`create_did_webvh`] — P2.5.
+///
+/// Create has a *different* shape from [`WebvhDeps`]: it mints + stores a new
+/// DID locally (no remote publish at create time, so no `auth_locks` / `audit_ks`
+/// / `vta_did`), but it renders a DID template (`did_templates_ks`) and reads
+/// operator config (`config`). Distinct struct rather than a strained reuse.
+///
+/// `config` is a borrowed `&AppConfig` snapshot — REST/DIDComm callers pass the
+/// guard from `state.config.read().await`, so the constructors take it as an
+/// explicit argument (it can't be produced synchronously from `&state`).
+pub struct CreateDidWebvhDeps<'a> {
+    pub keys_ks: &'a KeyspaceHandle,
+    pub imported_ks: &'a KeyspaceHandle,
+    pub contexts_ks: &'a KeyspaceHandle,
+    pub webvh_ks: &'a KeyspaceHandle,
+    pub did_templates_ks: &'a KeyspaceHandle,
+    pub seed_store: &'a dyn SeedStore,
+    pub config: &'a AppConfig,
+    pub did_resolver: &'a DIDCacheClient,
+    pub didcomm_bridge: &'a Arc<DIDCommBridge>,
+}
+
+impl<'a> CreateDidWebvhDeps<'a> {
+    /// Borrow create-deps from an [`AppState`](crate::server::AppState) (REST +
+    /// trust-task). `config` (the read-guard snapshot) and the unwrapped
+    /// `did_resolver` are threaded separately.
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    pub fn from_app_state(
+        s: &'a crate::server::AppState,
+        config: &'a AppConfig,
+        did_resolver: &'a DIDCacheClient,
+    ) -> Self {
+        Self {
+            keys_ks: &s.keys_ks,
+            imported_ks: &s.imported_ks,
+            contexts_ks: &s.contexts_ks,
+            webvh_ks: &s.webvh_ks,
+            did_templates_ks: &s.did_templates_ks,
+            seed_store: &*s.seed_store,
+            config,
+            did_resolver,
+            didcomm_bridge: &s.didcomm_bridge,
+        }
+    }
+
+    /// Borrow create-deps from a
+    /// [`VtaState`](crate::messaging::router::VtaState) (DIDComm transport).
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    pub fn from_vta_state(
+        s: &'a crate::messaging::router::VtaState,
+        config: &'a AppConfig,
+        did_resolver: &'a DIDCacheClient,
+    ) -> Self {
+        Self {
+            keys_ks: &s.keys_ks,
+            imported_ks: &s.imported_ks,
+            contexts_ks: &s.contexts_ks,
+            webvh_ks: &s.webvh_ks,
+            did_templates_ks: &s.did_templates_ks,
+            seed_store: &*s.seed_store,
+            config,
+            did_resolver,
+            didcomm_bridge: &s.didcomm_bridge,
+        }
+    }
+}
+
 /// Resolve a DID template by name for use in a create-DID flow.
 ///
 /// Resolution order:
@@ -391,21 +458,27 @@ fn document_has_didcomm_service(doc: &serde_json::Value) -> bool {
         })
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn create_did_webvh(
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    did_templates_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
-    config: &AppConfig,
+    deps: &CreateDidWebvhDeps<'_>,
     auth: &AuthClaims,
     mut params: CreateDidWebvhParams,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
     channel: &str,
 ) -> Result<CreateDidWebvhResultBody, AppError> {
+    // Re-bind the bundled deps to the historical local names so the (large)
+    // body below is unchanged. All fields are `Copy` references, so this
+    // copies the borrows out of `*deps` rather than moving the struct.
+    let CreateDidWebvhDeps {
+        keys_ks,
+        imported_ks,
+        contexts_ks,
+        webvh_ks,
+        did_templates_ks,
+        seed_store,
+        config,
+        did_resolver,
+        didcomm_bridge,
+    } = *deps;
+
     auth.require_admin()?;
     auth.require_context(&params.context_id)?;
 

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -589,7 +589,9 @@ mod pre_rotation_e2e_tests {
     use crate::config::AppConfig;
     use crate::didcomm_bridge::DIDCommBridge;
     use crate::keys::seed_store::PlaintextSeedStore;
-    use crate::operations::did_webvh::{CreateDidWebvhParams, create_did_webvh};
+    use crate::operations::did_webvh::{
+        CreateDidWebvhDeps, CreateDidWebvhParams, create_did_webvh,
+    };
     use crate::test_support::{TestStore, open_test_store, test_app_config};
 
     fn admin_auth() -> AuthClaims {
@@ -653,14 +655,19 @@ mod pre_rotation_e2e_tests {
         context_id: &str,
         pre_rotation_count: u32,
     ) -> (String, String) {
-        let result = create_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.did_templates_ks,
+        let deps = CreateDidWebvhDeps {
+            keys_ks: &ts.keys_ks,
+            imported_ks: &ts.imported_ks,
+            contexts_ks: &ts.contexts_ks,
+            webvh_ks: &ts.webvh_ks,
+            did_templates_ks: &ts.did_templates_ks,
             seed_store,
-            cfg,
+            config: cfg,
+            did_resolver: resolver,
+            didcomm_bridge: bridge,
+        };
+        let result = create_did_webvh(
+            &deps,
             auth,
             CreateDidWebvhParams {
                 context_id: context_id.into(),
@@ -683,8 +690,6 @@ mod pre_rotation_e2e_tests {
                 template_vars: Default::default(),
                 is_vta_identity: false,
             },
-            resolver,
-            bridge,
             "test",
         )
         .await

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -411,14 +411,26 @@ pub async fn provision_integration(
         let template_vars_hashmap: std::collections::HashMap<String, Value> =
             template_vars.clone().into_iter().collect();
 
+        let config = state.config.read().await;
+        let did_resolver = state
+            .did_resolver
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("DID resolver not initialized".into()))?;
+        // `state` is a `ProvisionIntegrationDeps`, not an `AppState`, so build
+        // the create-deps by hand (it carries all nine fields).
+        let create_deps = super::did_webvh::CreateDidWebvhDeps {
+            keys_ks: &state.keys_ks,
+            imported_ks: &state.imported_ks,
+            contexts_ks: &state.contexts_ks,
+            webvh_ks: &state.webvh_ks,
+            did_templates_ks: &state.did_templates_ks,
+            seed_store: &*state.seed_store,
+            config: &config,
+            did_resolver,
+            didcomm_bridge: &state.didcomm_bridge,
+        };
         let create_result = super::did_webvh::create_did_webvh(
-            &state.keys_ks,
-            &state.imported_ks,
-            &state.contexts_ks,
-            &state.webvh_ks,
-            &state.did_templates_ks,
-            &*state.seed_store,
-            &*state.config.read().await,
+            &create_deps,
             auth,
             super::did_webvh::CreateDidWebvhParams {
                 context_id: context.clone(),
@@ -450,11 +462,6 @@ pub async fn provision_integration(
                 // never the VTA's own identity.
                 is_vta_identity: false,
             },
-            state
-                .did_resolver
-                .as_ref()
-                .ok_or_else(|| AppError::Internal("DID resolver not initialized".into()))?,
-            &state.didcomm_bridge,
             "provision-integration",
         )
         .await?;

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -140,21 +140,9 @@ pub async fn create_did_handler(
         .did_resolver
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
-    let result = operations::did_webvh::create_did_webvh(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.did_templates_ks,
-        &*state.seed_store,
-        &config,
-        &auth.0,
-        params,
-        did_resolver,
-        &state.didcomm_bridge,
-        "rest",
-    )
-    .await?;
+    let deps =
+        operations::did_webvh::CreateDidWebvhDeps::from_app_state(&state, &config, did_resolver);
+    let result = operations::did_webvh::create_did_webvh(&deps, &auth.0, params, "rest").await?;
     Ok((StatusCode::CREATED, Json(result)))
 }
 

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1297,7 +1297,7 @@ async fn create_simple_webvh_did(
         is_vta_identity,
     };
 
-    let result = operations::did_webvh::create_did_webvh(
+    let deps = operations::did_webvh::CreateDidWebvhDeps {
         keys_ks,
         imported_ks,
         contexts_ks,
@@ -1305,14 +1305,12 @@ async fn create_simple_webvh_did(
         did_templates_ks,
         seed_store,
         config,
-        &auth,
-        params,
-        &did_resolver,
-        &no_bridge,
-        "setup",
-    )
-    .await
-    .map_err(|e| format!("{e}"))?;
+        did_resolver: &did_resolver,
+        didcomm_bridge: &no_bridge,
+    };
+    let result = operations::did_webvh::create_did_webvh(&deps, &auth, params, "setup")
+        .await
+        .map_err(|e| format!("{e}"))?;
 
     let final_did = result.did.clone();
     eprintln!("  Created DID: {final_did}");

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -220,22 +220,9 @@ pub(super) async fn handle_dids_create(
         }
     };
     let params = body.into();
-    match operations::did_webvh::create_did_webvh(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.did_templates_ks,
-        &*state.seed_store,
-        &config,
-        auth,
-        params,
-        did_resolver,
-        &state.didcomm_bridge,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
+    let deps =
+        operations::did_webvh::CreateDidWebvhDeps::from_app_state(state, &config, did_resolver);
+    match operations::did_webvh::create_did_webvh(&deps, auth, params, TRANSPORT_TRUST_TASK).await {
         Ok(body) => success_response(&doc, body),
         Err(e) => app_error_to_reject(&doc, e),
     }

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -190,21 +190,18 @@ pub async fn run_create_did(
 
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let no_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
-    let result = operations::did_webvh::create_did_webvh(
-        &keys_ks,
-        &imported_ks,
-        &contexts_ks,
-        &webvh_ks,
-        &did_templates_ks,
-        &*seed_store,
-        &config,
-        &auth,
-        params,
-        &did_resolver,
-        &no_bridge,
-        "cli",
-    )
-    .await?;
+    let deps = operations::did_webvh::CreateDidWebvhDeps {
+        keys_ks: &keys_ks,
+        imported_ks: &imported_ks,
+        contexts_ks: &contexts_ks,
+        webvh_ks: &webvh_ks,
+        did_templates_ks: &did_templates_ks,
+        seed_store: &*seed_store,
+        config: &config,
+        did_resolver: &did_resolver,
+        didcomm_bridge: &no_bridge,
+    };
+    let result = operations::did_webvh::create_did_webvh(&deps, &auth, params, "cli").await?;
     store.persist().await?;
 
     eprintln!("\x1b[1;32mCreated DID:\x1b[0m {}", result.did);


### PR DESCRIPTION
## What

`create_did_webvh` took **12 positional args**. Its shape differs from `WebvhDeps` (#432): it mints + stores a DID *locally* (no remote publish at create time → no `auth_locks` / `audit_ks` / `vta_did`) but renders a DID template (`did_templates_ks`) and reads operator `config`. So it gets its own **`CreateDidWebvhDeps`** (9 fields) rather than a strained `WebvhDeps` reuse.

This is **P2.5 part 4c-bis** — now unblocked by #431/#433 (MockVta create-did-webvh round-trip).

## Changes

- `create_did_webvh(deps, auth, params, channel)` = **4 args**; the `#[allow(clippy::too_many_arguments)]` removed.
- **The ~785-line body is unchanged** — the fn destructures `*deps` back into the historical local names at the top. All fields are `Copy` references, so this copies the borrows out (rather than moving the non-`Copy` struct out of a shared borrow). Zero body churn → zero risk of a missed rename.
- `from_app_state` / `from_vta_state` constructors take `config` (the `state.config.read().await` guard snapshot) + the unwrapped `did_resolver` explicitly, since neither can be produced synchronously from `&state`.
- Call sites (8): `routes/did_webvh.rs`, `trust_tasks/webvh.rs`, `messaging/handlers.rs` use the constructors; the three scratch builders (`webvh_cli`, `setup/from_toml`, the runtime `vta create-did-webvh`) + `provision_integration` (whose `state` is a `ProvisionIntegrationDeps`, not `AppState`) + the `update/mod` rotate-test helper build the struct literally.

## Safety net

Exercised end-to-end by #433's **new MockVta `create_did_webvh` round-trip test** — the work that prompted deferring this slice now validates it.

## Wire behaviour

Byte-identical.

## Checks

- `cargo fmt --check` clean
- `cargo clippy --all-targets` (default & tee) clean
- lib **724** + all 18 integration suites green (incl. the MockVta round-trip)
- `vta-enclave` checks