### PR TITLE
refactor(vta): update_did_webvh takes &WebvhDeps (P2.5 part 4c-ter)

### DIFF
--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1529,21 +1529,14 @@ pub async fn handle_update_did_webvh(
     };
 
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_vta_state(&state, did_resolver);
     let result = app_try!(
         operations::did_webvh::update_did_webvh(
-            &state.keys_ks,
-            &state.imported_ks,
-            &state.contexts_ks,
-            &state.webvh_ks,
-            &state.audit_ks,
-            &*state.seed_store,
+            &deps,
             &auth,
             &env.scid,
             opts,
-            did_resolver,
-            &state.didcomm_bridge,
             vta_did.as_deref(),
-            &state.webvh_auth_locks,
             "didcomm",
         )
         .await

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -608,6 +608,28 @@ mod pre_rotation_e2e_tests {
         Arc::new(DIDCommBridge::placeholder())
     }
 
+    /// Build a [`WebvhDeps`](crate::operations::did_webvh::WebvhDeps) from the
+    /// loose test fixtures so the `update_did_webvh` calls below stay compact.
+    fn webvh_deps<'a>(
+        ts: &'a TestStore,
+        seed_store: &'a dyn crate::keys::seed_store::SeedStore,
+        resolver: &'a DIDCacheClient,
+        bridge: &'a Arc<DIDCommBridge>,
+        locks: &'a crate::operations::did_webvh::WebvhAuthLocks,
+    ) -> crate::operations::did_webvh::WebvhDeps<'a> {
+        crate::operations::did_webvh::WebvhDeps {
+            keys_ks: &ts.keys_ks,
+            imported_ks: &ts.imported_ks,
+            contexts_ks: &ts.contexts_ks,
+            webvh_ks: &ts.webvh_ks,
+            audit_ks: &ts.audit_ks,
+            seed_store,
+            did_resolver: resolver,
+            didcomm_bridge: bridge,
+            auth_locks: locks,
+        }
+    }
+
     fn ts_app_config(ts: &TestStore) -> AppConfig {
         test_app_config(ts.data_dir.clone())
     }
@@ -736,6 +758,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -751,22 +775,14 @@ mod pre_rotation_e2e_tests {
         sleep(VERSION_TIME_GAP).await;
 
         let result = update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
                 document: Some(doc_patch(&did, "v2")),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -791,6 +807,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -806,22 +824,14 @@ mod pre_rotation_e2e_tests {
         sleep(VERSION_TIME_GAP).await;
 
         let result = update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
                 document: Some(doc_patch(&did, "v2")),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -848,6 +858,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -863,22 +875,14 @@ mod pre_rotation_e2e_tests {
         sleep(VERSION_TIME_GAP).await;
 
         update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
                 document: Some(doc_patch(&did, "v2")),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -886,22 +890,14 @@ mod pre_rotation_e2e_tests {
         sleep(VERSION_TIME_GAP).await;
 
         let result2 = update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
                 document: Some(doc_patch(&did, "v3")),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -922,6 +918,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -937,22 +935,14 @@ mod pre_rotation_e2e_tests {
         sleep(VERSION_TIME_GAP).await;
 
         update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
                 document: Some(doc_patch(&did, "v2")),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -960,22 +950,14 @@ mod pre_rotation_e2e_tests {
         sleep(VERSION_TIME_GAP).await;
 
         update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
                 document: Some(doc_patch(&did, "v3")),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -996,6 +978,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -1012,12 +996,7 @@ mod pre_rotation_e2e_tests {
 
         // Update 1: turn off pre-rotation.
         let r1 = update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -1025,10 +1004,7 @@ mod pre_rotation_e2e_tests {
                 pre_rotation_count: Some(0),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -1038,22 +1014,14 @@ mod pre_rotation_e2e_tests {
 
         // Update 2: ordinary non-pre-rotation update.
         let r2 = update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
                 document: Some(doc_patch(&did, "v3")),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -1072,6 +1040,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -1086,18 +1056,6 @@ mod pre_rotation_e2e_tests {
         .await;
         sleep(VERSION_TIME_GAP).await;
 
-        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
-        let deps = crate::operations::did_webvh::WebvhDeps {
-            keys_ks: &ts.keys_ks,
-            imported_ks: &ts.imported_ks,
-            contexts_ks: &ts.contexts_ks,
-            webvh_ks: &ts.webvh_ks,
-            audit_ks: &ts.audit_ks,
-            seed_store: &seed_store,
-            did_resolver: &resolver,
-            didcomm_bridge: &bridge,
-            auth_locks: &auth_locks,
-        };
         let result = rotate_did_webvh_keys(
             &deps,
             &auth,
@@ -1134,6 +1092,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -1184,22 +1144,14 @@ mod pre_rotation_e2e_tests {
         // The update should succeed via the legacy fallback in
         // `load_pre_rotation_signing_key`.
         let result = update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
                 document: Some(doc_patch(&did, "v2")),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -1226,6 +1178,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -1258,22 +1212,14 @@ mod pre_rotation_e2e_tests {
         // Concurrent update by "operator B" — bumps the chain to `2-…`.
         sleep(VERSION_TIME_GAP).await;
         update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
                 document: Some(doc_patch(&did, "by-b")),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -1282,12 +1228,7 @@ mod pre_rotation_e2e_tests {
         // Operator A tries to save with the stale `1-…` precondition.
         sleep(VERSION_TIME_GAP).await;
         let err = update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -1295,10 +1236,7 @@ mod pre_rotation_e2e_tests {
                 expected_version_id: Some(genesis_version_id.clone()),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await
@@ -1350,7 +1288,6 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
-
         let (did, scid) = create_did(
             &ts,
             &seed_store,
@@ -1469,6 +1406,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -1533,18 +1472,6 @@ mod pre_rotation_e2e_tests {
 
         // And full rotate-keys still works on a fresh state — the
         // guard didn't accidentally fail-closed in the happy case.
-        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
-        let deps = crate::operations::did_webvh::WebvhDeps {
-            keys_ks: &ts.keys_ks,
-            imported_ks: &ts.imported_ks,
-            contexts_ks: &ts.contexts_ks,
-            webvh_ks: &ts.webvh_ks,
-            audit_ks: &ts.audit_ks,
-            seed_store: &seed_store,
-            did_resolver: &resolver,
-            didcomm_bridge: &bridge,
-            auth_locks: &auth_locks,
-        };
         let result = rotate_did_webvh_keys(
             &deps,
             &auth,
@@ -1572,6 +1499,8 @@ mod pre_rotation_e2e_tests {
         let auth = admin_auth();
         let resolver = build_resolver().await;
         let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
 
         let (did, scid) = create_did(
             &ts,
@@ -1601,12 +1530,7 @@ mod pre_rotation_e2e_tests {
 
         sleep(VERSION_TIME_GAP).await;
         let result = update_did_webvh(
-            &ts.keys_ks,
-            &ts.imported_ks,
-            &ts.contexts_ks,
-            &ts.webvh_ks,
-            &ts.audit_ks,
-            &seed_store,
+            &deps,
             &auth,
             &scid,
             UpdateDidWebvhOptions {
@@ -1614,10 +1538,7 @@ mod pre_rotation_e2e_tests {
                 expected_version_id: Some(current_version_id),
                 ..Default::default()
             },
-            &resolver,
-            &bridge,
             None,
-            &crate::operations::did_webvh::WebvhAuthLocks::new(),
             "test",
         )
         .await

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -5,9 +5,6 @@
 //! signing key (pre-rotation aware) → call `didwebvh_rs::update_did`
 //! → CAS check → persist log + handles → publish to host → audit.
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_tdk::secrets_resolver::secrets::Secret;
 use chrono::Utc;
 use didwebvh_rs::log_entry::LogEntryMethods;
@@ -24,11 +21,8 @@ use super::state::{find_record_by_scid, state_from_jsonl, state_to_jsonl};
 use super::validate::{validate_document_for_update, validate_watchers, validate_witnesses};
 use crate::audit;
 use crate::auth::AuthClaims;
-use crate::didcomm_bridge::DIDCommBridge;
-use crate::keys::seed_store::SeedStore;
 use crate::operations::did_webvh::concurrency::RecordSnapshot;
 use crate::operations::did_webvh::webvh_keys::{self, WebvhKeyHandle, WebvhKeyRole};
-use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 
 /// Drive a webvh DID update end-to-end. See module docs.
@@ -42,23 +36,27 @@ use crate::webvh_store;
 ///   with `Publish("…")` rather than silently 401.
 /// - `auth_locks` — per-server async mutex for serialising
 ///   auth-cache reads. Lives on `AppState`.
-#[allow(clippy::too_many_arguments)]
 pub async fn update_did_webvh(
-    keys_ks: &KeyspaceHandle,
-    imported_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    webvh_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    seed_store: &dyn SeedStore,
+    deps: &super::super::WebvhDeps<'_>,
     auth: &AuthClaims,
     scid: &str,
     opts: UpdateDidWebvhOptions,
-    did_resolver: &DIDCacheClient,
-    didcomm_bridge: &Arc<DIDCommBridge>,
     vta_did: Option<&str>,
-    auth_locks: &super::super::WebvhAuthLocks,
     channel: &str,
 ) -> Result<UpdateDidWebvhResult, UpdateDidWebvhError> {
+    // Re-bind the bundled deps to the historical local names so the (large) body
+    // below is unchanged. All fields are `Copy` references — this copies the
+    // borrows out of `*deps`; `deps` itself stays usable (the publish step below
+    // forwards it to `publish_log_to_server`).
+    let super::super::WebvhDeps {
+        keys_ks,
+        contexts_ks,
+        webvh_ks,
+        audit_ks,
+        seed_store,
+        did_resolver,
+        ..
+    } = *deps;
     // 1. Resolve SCID → record. Snapshot the version-vector fields
     //    immediately. The snapshot is consulted just before the
     //    final store (step 11) to catch any concurrent record
@@ -401,19 +399,8 @@ pub async fn update_did_webvh(
                     .to_string(),
             )
         })?;
-        let deps = super::super::WebvhDeps {
-            keys_ks,
-            imported_ks,
-            contexts_ks,
-            webvh_ks,
-            audit_ks,
-            seed_store,
-            did_resolver,
-            didcomm_bridge,
-            auth_locks,
-        };
         super::super::publish_log_to_server(
-            &deps,
+            deps,
             vta_did,
             &server,
             &record.mnemonic,

--- a/vta-service/src/operations/did_webvh/update/rotate.rs
+++ b/vta-service/src/operations/did_webvh/update/rotate.rs
@@ -158,12 +158,7 @@ pub async fn rotate_did_webvh_keys(
         .label
         .or_else(|| Some(format!("rotate-keys for {}", record.did)));
     let result = update_did_webvh(
-        deps.keys_ks,
-        deps.imported_ks,
-        deps.contexts_ks,
-        deps.webvh_ks,
-        deps.audit_ks,
-        deps.seed_store,
+        deps,
         auth,
         scid,
         UpdateDidWebvhOptions {
@@ -178,10 +173,7 @@ pub async fn rotate_did_webvh_keys(
             // user-edited document flow), so pass None.
             expected_version_id: None,
         },
-        deps.did_resolver,
-        deps.didcomm_bridge,
         vta_did,
-        deps.auth_locks,
         channel,
     )
     .await?;

--- a/vta-service/src/operations/passkey_vms/mod.rs
+++ b/vta-service/src/operations/passkey_vms/mod.rs
@@ -315,23 +315,7 @@ pub async fn finish_enrollment(
         label: Some(format!("enroll passkey VM {fragment}")),
         expected_version_id: None,
     };
-    let result = update_did_webvh(
-        deps.keys_ks,
-        deps.imported_ks,
-        deps.contexts_ks,
-        deps.webvh_ks,
-        deps.audit_ks,
-        deps.seed_store,
-        auth,
-        &record.scid,
-        opts,
-        deps.did_resolver,
-        deps.didcomm_bridge,
-        vta_did,
-        deps.auth_locks,
-        channel,
-    )
-    .await?;
+    let result = update_did_webvh(deps, auth, &record.scid, opts, vta_did, channel).await?;
 
     Ok(EnrollPasskeySubmitResponse {
         verification_method: vm,
@@ -456,23 +440,7 @@ pub async fn revoke_passkey(
         label: Some(format!("revoke passkey VM {fragment}")),
         expected_version_id: None,
     };
-    update_did_webvh(
-        deps.keys_ks,
-        deps.imported_ks,
-        deps.contexts_ks,
-        deps.webvh_ks,
-        deps.audit_ks,
-        deps.seed_store,
-        auth,
-        &record.scid,
-        opts,
-        deps.did_resolver,
-        deps.didcomm_bridge,
-        vta_did,
-        deps.auth_locks,
-        channel,
-    )
-    .await?;
+    update_did_webvh(deps, auth, &record.scid, opts, vta_did, channel).await?;
     Ok(())
 }
 

--- a/vta-service/src/operations/protocol/disable_didcomm.rs
+++ b/vta-service/src/operations/protocol/disable_didcomm.rs
@@ -181,22 +181,14 @@ pub async fn disable_didcomm(
 
     // Publish via update_did_webvh.
     let update_result = update_did_webvh(
-        deps.keys_ks,
-        deps.imported_ks,
-        deps.contexts_ks,
-        deps.webvh_ks,
-        deps.audit_ks,
-        deps.seed_store,
+        &deps.webvh(),
         auth,
         &scid,
         UpdateDidWebvhOptions {
             document: Some(patched),
             ..Default::default()
         },
-        deps.did_resolver,
-        deps.didcomm_bridge,
         Some(vta_did.as_str()),
-        deps.webvh_auth_locks,
         channel,
     )
     .await?;

--- a/vta-service/src/operations/protocol/enable_didcomm.rs
+++ b/vta-service/src/operations/protocol/enable_didcomm.rs
@@ -173,22 +173,14 @@ pub async fn enable_didcomm(
     // LogEntry append. Rotates control keys; preserves
     // verificationMethod.
     let update_result = update_did_webvh(
-        deps.keys_ks,
-        deps.imported_ks,
-        deps.contexts_ks,
-        deps.webvh_ks,
-        deps.audit_ks,
-        deps.seed_store,
+        &deps.webvh(),
         auth,
         &scid,
         UpdateDidWebvhOptions {
             document: Some(patched),
             ..Default::default()
         },
-        deps.did_resolver,
-        deps.didcomm_bridge,
         Some(vta_did.as_str()),
-        deps.webvh_auth_locks,
         channel,
     )
     .await?;

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -237,6 +237,24 @@ impl<'a> ServiceOpDeps<'a> {
             sweeper: &s.drain_sweeper,
         }
     }
+
+    /// Borrow the [`WebvhDeps`](crate::operations::did_webvh::WebvhDeps) subset —
+    /// the keyspaces + seed-store + resolver + bridge + auth-locks the WebVH
+    /// publish path (`update_did_webvh`) needs. Lets the protocol ops hand their
+    /// `update_did_webvh` call a `WebvhDeps` without re-listing every field.
+    pub fn webvh(&self) -> crate::operations::did_webvh::WebvhDeps<'a> {
+        crate::operations::did_webvh::WebvhDeps {
+            keys_ks: self.keys_ks,
+            imported_ks: self.imported_ks,
+            contexts_ks: self.contexts_ks,
+            webvh_ks: self.webvh_ks,
+            audit_ks: self.audit_ks,
+            seed_store: self.seed_store,
+            did_resolver: self.did_resolver,
+            didcomm_bridge: self.didcomm_bridge,
+            auth_locks: self.webvh_auth_locks,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/vta-service/src/operations/protocol/passkey_vm_cleanup.rs
+++ b/vta-service/src/operations/protocol/passkey_vm_cleanup.rs
@@ -123,23 +123,26 @@ pub async fn strip_all_passkey_vms(
             let cfg = config.read().await;
             cfg.vta_did.clone()
         };
-        let result = update_did_webvh(
+        let deps = crate::operations::did_webvh::WebvhDeps {
             keys_ks,
             imported_ks,
             contexts_ks,
             webvh_ks,
             audit_ks,
             seed_store,
+            did_resolver,
+            didcomm_bridge,
+            auth_locks: webvh_auth_locks,
+        };
+        let result = update_did_webvh(
+            &deps,
             auth,
             scid,
             UpdateDidWebvhOptions {
                 document: Some(patched_doc),
                 ..Default::default()
             },
-            did_resolver,
-            didcomm_bridge,
             vta_did.as_deref(),
-            webvh_auth_locks,
             channel,
         )
         .await;

--- a/vta-service/src/operations/protocol/service_lifecycle.rs
+++ b/vta-service/src/operations/protocol/service_lifecycle.rs
@@ -148,22 +148,14 @@ pub(crate) async fn publish_patch<E: From<UpdateDidWebvhError>>(
     channel: &str,
 ) -> Result<crate::operations::did_webvh::UpdateDidWebvhResult, E> {
     update_did_webvh(
-        deps.keys_ks,
-        deps.imported_ks,
-        deps.contexts_ks,
-        deps.webvh_ks,
-        deps.audit_ks,
-        deps.seed_store,
+        &deps.webvh(),
         auth,
         scid,
         UpdateDidWebvhOptions {
             document: Some(patched),
             ..Default::default()
         },
-        deps.did_resolver,
-        deps.didcomm_bridge,
         Some(vta_did),
-        deps.webvh_auth_locks,
         channel,
     )
     .await

--- a/vta-service/src/operations/protocol/update_didcomm.rs
+++ b/vta-service/src/operations/protocol/update_didcomm.rs
@@ -233,22 +233,14 @@ pub async fn update_didcomm(
 
     // Publish new LogEntry.
     let update_result = update_did_webvh(
-        deps.keys_ks,
-        deps.imported_ks,
-        deps.contexts_ks,
-        deps.webvh_ks,
-        deps.audit_ks,
-        deps.seed_store,
+        &deps.webvh(),
         auth,
         &scid,
         UpdateDidWebvhOptions {
             document: Some(patched),
             ..Default::default()
         },
-        deps.did_resolver,
-        deps.didcomm_bridge,
         Some(vta_did.as_str()),
-        deps.webvh_auth_locks,
         channel,
     )
     .await?;

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -242,20 +242,13 @@ pub async fn update_did_handler(
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(&state, did_resolver);
     let result = operations::did_webvh::update_did_webvh(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &*state.seed_store,
+        &deps,
         &auth.0,
         &scid,
         body,
-        did_resolver,
-        &state.didcomm_bridge,
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         "rest",
     )
     .await?;

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -351,20 +351,13 @@ pub(super) async fn handle_dids_update(
         }
     };
     let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
     match operations::did_webvh::update_did_webvh(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.contexts_ks,
-        &state.webvh_ks,
-        &state.audit_ks,
-        &*state.seed_store,
+        &deps,
         auth,
         &did,
         options,
-        did_resolver,
-        &state.didcomm_bridge,
         vta_did.as_deref(),
-        &state.webvh_auth_locks,
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -466,20 +466,23 @@ pub async fn run_edit_did(
     let auth = cli_super_admin();
     let vta_did = config.vta_did.clone();
     let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+    let deps = crate::operations::did_webvh::WebvhDeps {
+        keys_ks: &keys_ks,
+        imported_ks: &imported_ks,
+        contexts_ks: &contexts_ks,
+        webvh_ks: &webvh_ks,
+        audit_ks: &audit_ks,
+        seed_store: &*seed_store,
+        did_resolver: &did_resolver,
+        didcomm_bridge: &didcomm_bridge,
+        auth_locks: &auth_locks,
+    };
     let result = crate::operations::did_webvh::update_did_webvh(
-        &keys_ks,
-        &imported_ks,
-        &contexts_ks,
-        &webvh_ks,
-        &audit_ks,
-        &*seed_store,
+        &deps,
         &auth,
         &scid,
         opts,
-        &did_resolver,
-        &didcomm_bridge,
         vta_did.as_deref(),
-        &auth_locks,
         "vta-cli-offline",
     )
     .await?;


### PR DESCRIPTION
## What

Converts the core WebVH publish fn — `update_did_webvh` — from **14 positional args** to `(deps: &WebvhDeps, auth, scid, opts, vta_did, channel)` = **6**. This is the highest-leverage piece of the did_webvh family: the op families that already hold a `WebvhDeps`/`ServiceOpDeps` now hand it straight through instead of re-listing every keyspace.

This is **P2.5 part 4c-ter** — and it **closes the did_webvh family**.

## Changes

- **The ~300-line orchestrator body is unchanged** — it destructures `*deps` back into the six locals it still uses (`..` for the three the publish step now reads off `deps` directly). The `#[allow(clippy::too_many_arguments)]` is removed.
- **New `ServiceOpDeps::webvh()`** returns the `WebvhDeps` subset, so the four protocol callers (`publish_patch`, `enable`/`disable`/`update_didcomm`) pass `&deps.webvh()`.
- **Pass-through wins:** `rotate_did_webvh_keys`, passkey `finish_enrollment` / `revoke_passkey`, and the orchestrator's own internal `publish_log_to_server` call all forward their existing `WebvhDeps` verbatim — their old call sites unpacked it field-by-field.
- **26 call sites total:** routes / trust_tasks / messaging via the state constructors; `webvh_cli` + `passkey_vm_cleanup` build a `WebvhDeps` literal; the 12 `update/mod.rs` unit-test calls go through a new `webvh_deps()` test helper.

## Wire behaviour

Byte-identical — the orchestrator's behaviour, error mapping, and CAS / pre-rotation signing logic are untouched (the destructure trick guarantees zero body churn).

## Net

**−161 LOC** (the biggest reduction in the series — the test calls collapse and three op families become pass-through).

## Checks

- `cargo fmt --check` clean
- `cargo clippy --all-targets` (default & tee) clean
- lib **724** + all 18 integration suites green
- `vta-enclave` checks

## Family complete

Every op in the did_webvh family — create / update / rotate / delete / register / list / the auth_cache server helpers — now takes a deps bundle (`#432` 4a, `#435` 4c, `#438` 4c-bis, this).