### PR TITLE
feat(test-support): MockVtc DIDComm join-requests harness + worked round-trip (#436)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9973,7 +9973,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9981,6 +9981,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
+ "affinidi-messaging-test-mediator",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,6 +18,17 @@ default = ["setup", "keyring", "website", "admin-ui"]
 # and by downstream multi-service harnesses (`vti-harness`). Kept out of
 # production builds — it pulls in `tempfile` and exposes seeding helpers.
 test-support = ["dep:tempfile"]
+# In-process DIDComm join-requests harness for `MockVtc` (#436). Spins up an
+# embedded `affinidi-messaging-test-mediator`, stands up a VTC DIDComm responder
+# bound to the REAL `submit`/`manifest`/`status` handlers, and exercises the
+# credential-delivery push so an issued VMC lands back over DIDComm. Pulls the
+# test mediator + the SDK's `vp` helper (for the worked manifest -> VP leg).
+# Implies `test-support`. Test-only — never in a production build.
+didcomm-harness = [
+  "test-support",
+  "dep:affinidi-messaging-test-mediator",
+  "vta-sdk/vp",
+]
 setup = ["dep:dialoguer", "dep:didwebvh-rs", "dep:url"]
 # BBS+ (`bbs-2023`) verifier support — lets the join verifier accept
 # selectively-disclosed bbs-2023 presentations. Pulls in the BLS12-381 curve
@@ -134,6 +145,10 @@ subtle = { workspace = true }
 # accepts `Message` / `UnpackMetadata` by value but doesn't
 # re-export them.
 affinidi-messaging-didcomm = "0.15"
+# Embedded in-process test mediator for the `didcomm-harness` feature
+# (`MockVtc::start_didcomm`, #436). Optional + feature-gated so it never
+# enters a production build; same crate the e2e suite uses.
+affinidi-messaging-test-mediator = { version = "0.2", optional = true }
 tokio-util = { workspace = true, features = ["rt"] }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 base64 = { workspace = true }
@@ -219,7 +234,7 @@ tempfile = { version = "3", optional = true }
 [dev-dependencies]
 # Self-dep with `test-support` enabled so integration tests under
 # `tests/` can import `vtc_service::test_support` (`TestVtc`, `MockVtc`).
-vtc-service = { path = ".", features = ["test-support"] }
+vtc-service = { path = ".", features = ["test-support", "didcomm-harness"] }
 tempfile = "3"
 # Integration tests under `tests/` exercise the route stack via
 # `Router::oneshot` — same pattern as `vta-service/tests/api_integration.rs`.

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -78,6 +78,12 @@ pub struct TestVtcBuilder {
     install_signer: Option<Arc<InstallTokenSigner>>,
     public_url: Option<String>,
     supervisor: Option<SupervisorKind>,
+    /// Messaging (ATM) handle wired into `AppState.atm` — lets the DIDComm
+    /// credential-delivery push send over a (test) mediator.
+    atm: Option<affinidi_tdk::messaging::ATM>,
+    /// Mediator DID for `AppState.config.messaging` — paired with `atm` so the
+    /// delivery path knows which mediator to forward issued credentials through.
+    messaging_mediator: Option<String>,
 }
 
 impl Default for TestVtcBuilder {
@@ -91,6 +97,8 @@ impl Default for TestVtcBuilder {
             install_signer: None,
             public_url: None,
             supervisor: None,
+            atm: None,
+            messaging_mediator: None,
         }
     }
 }
@@ -158,6 +166,22 @@ impl TestVtcBuilder {
         self
     }
 
+    /// Wire a messaging (ATM) handle into `AppState.atm`, so the DIDComm
+    /// handlers and the credential-delivery push (`push_to_holder`) can send
+    /// over a mediator. Pair with [`messaging_mediator`](Self::messaging_mediator).
+    pub fn with_atm(mut self, atm: affinidi_tdk::messaging::ATM) -> Self {
+        self.atm = Some(atm);
+        self
+    }
+
+    /// Set the mediator DID in `AppState.config.messaging`, so credential
+    /// delivery knows which mediator the VTC forwards issued credentials
+    /// through. Pair with [`with_atm`](Self::with_atm).
+    pub fn messaging_mediator(mut self, mediator_did: impl Into<String>) -> Self {
+        self.messaging_mediator = Some(mediator_did.into());
+        self
+    }
+
     /// Build the tempdir-backed [`TestVtc`].
     pub async fn build(self) -> TestVtc {
         init_jwt_provider();
@@ -221,6 +245,13 @@ impl TestVtcBuilder {
         .expect("parse test config");
         if let Some(url) = &self.public_url {
             config.public_url = Some(url.clone());
+        }
+        if let Some(mediator_did) = &self.messaging_mediator {
+            config.messaging = Some(vti_common::config::MessagingConfig {
+                mediator_url: String::new(),
+                mediator_did: mediator_did.clone(),
+                mediator_host: None,
+            });
         }
 
         let audit_writer = if self.with_audit {
@@ -304,7 +335,7 @@ impl TestVtcBuilder {
             did_resolver,
             secrets_resolver: None,
             jwt_keys: Some(jwt_keys.clone()),
-            atm: None,
+            atm: self.atm,
             webauthn,
             public_url: self.public_url,
             install_signer,
@@ -493,6 +524,488 @@ impl Drop for MockVtc {
         }
         if let Some(handle) = self.handle.take() {
             handle.abort();
+        }
+    }
+}
+
+#[cfg(feature = "didcomm-harness")]
+pub use didcomm_harness::{MockVtcDidcomm, TestJoinClient};
+
+/// In-process DIDComm join-requests harness (#436).
+///
+/// [`MockVtcDidcomm`] stands up an embedded `affinidi-messaging-test-mediator`,
+/// a VTC DIDComm responder bound to the **real** join-requests handlers, and a
+/// ready-connected [`TestJoinClient`] applicant — all sharing the one mediator,
+/// the way OpenVTC's e2e drives a community join. A test can then run a genuine
+/// `submit → receipt → manifest → status → (admin approve) → VMC-over-DIDComm`
+/// round-trip, exercising `submit_inner` / `manifest_inner` / `status_inner` and
+/// the credential-delivery push rather than canned responses.
+#[cfg(feature = "didcomm-harness")]
+mod didcomm_harness {
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use affinidi_messaging_test_mediator::{TestMediator, TestMediatorHandle};
+    use affinidi_tdk::common::TDKSharedState;
+    use affinidi_tdk::common::config::TDKConfig;
+    use affinidi_tdk::didcomm::Message;
+    use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
+    use affinidi_tdk::messaging::ATM;
+    use affinidi_tdk::messaging::config::ATMConfig;
+    use affinidi_tdk::messaging::profiles::ATMProfile;
+    use affinidi_tdk::secrets_resolver::SecretsResolver;
+    use affinidi_tdk::secrets_resolver::secrets::Secret;
+    use serde_json::{Value, json};
+    use tokio::sync::{Mutex, oneshot};
+    use uuid::Uuid;
+    use vta_sdk::protocols::join_requests::{
+        JOIN_REQUEST_MANIFEST_RESPONSE_TYPE, JOIN_REQUEST_MANIFEST_TYPE,
+        JOIN_REQUEST_STATUS_RESPONSE_TYPE, JOIN_REQUEST_STATUS_TYPE,
+        JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, JOIN_REQUEST_SUBMIT_TYPE, JoinRequestStatusBody,
+        JoinRequestSubmitBody, JoinRequestSubmitReceiptBody,
+    };
+
+    use crate::join::JoinTransport;
+    use crate::routes::join_requests::manifest::manifest_inner;
+    use crate::routes::join_requests::status::status_inner;
+    use crate::routes::join_requests::submit::submit_inner;
+    use crate::server::AppState;
+
+    use super::TestVtc;
+
+    /// Two DIDComm verification methods: an Ed25519 authentication key and an
+    /// X25519 key-agreement key — the shape an authcrypt counterparty needs.
+    fn peer_key_roles() -> Vec<(PeerKeyRole, KeyType)> {
+        vec![
+            (PeerKeyRole::Verification, KeyType::Ed25519),
+            (PeerKeyRole::Encryption, KeyType::X25519),
+        ]
+    }
+
+    /// Build an ATM whose secrets resolver holds `secrets` (a `did:peer`'s keys).
+    async fn build_atm(secrets: &[Secret]) -> ATM {
+        let tdk = TDKSharedState::new(TDKConfig::builder().build().expect("TDK config"))
+            .await
+            .expect("TDK shared state");
+        for s in secrets {
+            tdk.secrets_resolver().insert(s.clone()).await;
+        }
+        ATM::new(
+            ATMConfig::builder().build().expect("ATM config"),
+            Arc::new(tdk),
+        )
+        .await
+        .expect("ATM init")
+    }
+
+    const POLL: Duration = Duration::from_millis(300);
+
+    /// A message the client received but hasn't yet matched to a request.
+    struct Received {
+        thid: Option<String>,
+        typ: String,
+        body: Value,
+    }
+
+    /// A DIDComm join applicant connected to the harness mediator.
+    ///
+    /// Sends authcrypt requests to the VTC and awaits the threaded reply;
+    /// unsolicited inbound (e.g. a pushed credential) is buffered and drained via
+    /// [`next_pushed`](Self::next_pushed).
+    pub struct TestJoinClient {
+        atm: ATM,
+        profile: Arc<ATMProfile>,
+        did: String,
+        mediator_did: String,
+        /// A standalone holder signing key for building demo `vp_token`s via
+        /// `vta_sdk::vp` — its `id` is a `did:key`.
+        holder_secret: Secret,
+        inbox: Mutex<VecDeque<Received>>,
+    }
+
+    impl TestJoinClient {
+        async fn connect(
+            transport_secrets: &[Secret],
+            did: String,
+            mediator_did: String,
+            holder_secret: Secret,
+        ) -> Self {
+            let atm = build_atm(transport_secrets).await;
+            let profile = Arc::new(
+                ATMProfile::new(&atm, None, did.clone(), Some(mediator_did.clone()))
+                    .await
+                    .expect("applicant ATM profile"),
+            );
+            atm.profile_enable_websocket(&profile)
+                .await
+                .expect("applicant websocket");
+            TestJoinClient {
+                atm,
+                profile,
+                did,
+                mediator_did,
+                holder_secret,
+                inbox: Mutex::new(VecDeque::new()),
+            }
+        }
+
+        /// The applicant's DIDComm (`did:peer`) identity — the authcrypt sender
+        /// the VTC sees as the join applicant.
+        pub fn did(&self) -> &str {
+            &self.did
+        }
+
+        /// A holder signing key (`did:key`) for assembling a `vp_token` from a
+        /// manifest's DCQL via `vta_sdk::vp::build_vp_token`.
+        pub fn holder_secret(&self) -> &Secret {
+            &self.holder_secret
+        }
+
+        /// Send `body` as a `typ` DIDComm message to `vtc_did` (authcrypt,
+        /// forwarded via the mediator) and return the threaded reply body.
+        /// Panics on timeout — this is a test harness.
+        pub async fn request(&self, vtc_did: &str, typ: &str, body: Value) -> Value {
+            let req_id = Uuid::new_v4().to_string();
+            let msg = Message::build(req_id.clone(), typ.to_string(), body)
+                .from(self.did.clone())
+                .to(vtc_did.to_string())
+                .finalize();
+            self.send(&msg, vtc_did).await;
+            self.recv_matching(
+                |r| r.thid.as_deref() == Some(req_id.as_str()),
+                Duration::from_secs(15),
+            )
+            .await
+            .unwrap_or_else(|| panic!("no reply to `{typ}` within timeout"))
+            .body
+        }
+
+        /// Await the next unsolicited inbound message (no thread correlation),
+        /// e.g. a pushed `credential-exchange/issue`. `None` on timeout.
+        pub async fn next_pushed(&self, timeout: Duration) -> Option<(String, Value)> {
+            self.recv_matching(|r| r.thid.is_none(), timeout)
+                .await
+                .map(|r| (r.typ, r.body))
+        }
+
+        async fn send(&self, msg: &Message, to: &str) {
+            let (jwe, _) = self
+                .atm
+                .pack_encrypted(msg, to, Some(&self.did), Some(&self.did))
+                .await
+                .expect("pack_encrypted");
+            self.atm
+                .forward_and_send_message(
+                    &self.profile,
+                    false,
+                    &jwe,
+                    Some(&msg.id),
+                    &self.mediator_did,
+                    to,
+                    None,
+                    None,
+                    false,
+                )
+                .await
+                .expect("forward_and_send_message");
+        }
+
+        /// Return the first message (buffered or freshly received) matching
+        /// `pred`, buffering non-matches; `None` once `timeout` elapses.
+        async fn recv_matching<F: Fn(&Received) -> bool>(
+            &self,
+            pred: F,
+            timeout: Duration,
+        ) -> Option<Received> {
+            if let Some(found) = self.take_buffered(&pred).await {
+                return Some(found);
+            }
+            let start = tokio::time::Instant::now();
+            while start.elapsed() < timeout {
+                let next = self
+                    .atm
+                    .message_pickup()
+                    .live_stream_next(&self.profile, Some(POLL), true)
+                    .await;
+                if let Ok(Some((msg, _meta))) = next {
+                    if msg.typ.contains("problem-report") {
+                        // Surface the problem rather than silently buffering it.
+                        panic!("applicant received problem-report: {}", msg.body);
+                    }
+                    let r = Received {
+                        thid: msg.thid.clone(),
+                        typ: msg.typ.clone(),
+                        body: msg.body.clone(),
+                    };
+                    if pred(&r) {
+                        return Some(r);
+                    }
+                    self.inbox.lock().await.push_back(r);
+                }
+            }
+            None
+        }
+
+        async fn take_buffered<F: Fn(&Received) -> bool>(&self, pred: &F) -> Option<Received> {
+            let mut inbox = self.inbox.lock().await;
+            let pos = inbox.iter().position(pred)?;
+            inbox.remove(pos)
+        }
+    }
+
+    /// A mock VTC serving the join-requests protocol over DIDComm, plus a
+    /// connected applicant client. See module docs.
+    pub struct MockVtcDidcomm {
+        mediator: TestMediatorHandle,
+        vtc_did: String,
+        /// The VTC under test (state + router): seed policies / status-lists /
+        /// Accepts criteria and drive admin actions (e.g. approve) over REST.
+        pub vtc: TestVtc,
+        /// The connected applicant.
+        pub client: TestJoinClient,
+        shutdown_tx: Option<oneshot::Sender<()>>,
+        loop_handle: Option<tokio::task::JoinHandle<()>>,
+    }
+
+    impl MockVtcDidcomm {
+        /// Spin up the mediator, the DIDComm-listening VTC (signers + audit +
+        /// messaging wired), and a connected applicant. Returns once everything
+        /// is bound and the dispatch loop is running.
+        pub async fn start() -> MockVtcDidcomm {
+            // Transport identities. The applicant's is generated up front so it
+            // can be registered LOCAL on the mediator (needed to open inbound).
+            let (vtc_did, vtc_secrets) =
+                DID::generate_did_peer(peer_key_roles(), None).expect("VTC did:peer");
+            let (applicant_did, applicant_secrets) =
+                DID::generate_did_peer(peer_key_roles(), None).expect("applicant did:peer");
+
+            let mediator = TestMediator::builder()
+                .local_did(vtc_did.clone())
+                .local_did(applicant_did.clone())
+                .spawn()
+                .await
+                .expect("spawn test mediator");
+            let mediator_did = mediator.did().to_string();
+
+            // VTC messaging side: an ATM holding the VTC transport keys, a
+            // profile + inbound websocket on the shared mediator.
+            let vtc_atm = build_atm(&vtc_secrets).await;
+            let vtc_profile = Arc::new(
+                ATMProfile::new(&vtc_atm, None, vtc_did.clone(), Some(mediator_did.clone()))
+                    .await
+                    .expect("VTC ATM profile"),
+            );
+            vtc_atm
+                .profile_enable_websocket(&vtc_profile)
+                .await
+                .expect("VTC websocket");
+
+            // VTC state: the transport did:peer is also the configured `vtc_did`
+            // (so credential delivery packs from a resolvable sender), with the
+            // ATM + mediator wired so `push_to_holder` can forward issued VMCs.
+            let vtc = TestVtc::builder()
+                .vtc_did(vtc_did.clone())
+                .with_audit(true)
+                .with_signers(true)
+                .with_public_url("https://vtc.test")
+                .messaging_mediator(mediator_did.clone())
+                .with_atm(vtc_atm.clone())
+                .build()
+                .await;
+
+            // A standalone did:key holder key for the applicant's VP demos.
+            let holder_secret = generate_holder_secret();
+            let client = TestJoinClient::connect(
+                &applicant_secrets,
+                applicant_did,
+                mediator_did.clone(),
+                holder_secret,
+            )
+            .await;
+
+            let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+            let state = vtc.state.clone();
+            let loop_did = vtc_did.clone();
+            let loop_handle = tokio::spawn(async move {
+                run_vtc_join_loop(
+                    vtc_atm,
+                    vtc_profile,
+                    mediator_did,
+                    loop_did,
+                    state,
+                    shutdown_rx,
+                )
+                .await;
+            });
+
+            MockVtcDidcomm {
+                mediator,
+                vtc_did,
+                vtc,
+                client,
+                shutdown_tx: Some(shutdown_tx),
+                loop_handle: Some(loop_handle),
+            }
+        }
+
+        /// The VTC's DIDComm identity — address join messages here.
+        pub fn vtc_did(&self) -> &str {
+            &self.vtc_did
+        }
+
+        /// The shared mediator's DID.
+        pub fn mediator_did(&self) -> &str {
+            self.mediator.did()
+        }
+
+        /// Stop the dispatch loop + mediator and wait for a clean wind-down.
+        pub async fn shutdown(mut self) {
+            if let Some(tx) = self.shutdown_tx.take() {
+                let _ = tx.send(());
+            }
+            if let Some(handle) = self.loop_handle.take() {
+                let _ = handle.await;
+            }
+            self.mediator.shutdown();
+            let _ = self.mediator.join().await;
+        }
+    }
+
+    /// A `did:key` Ed25519 signing `Secret` (id = `did:key:z..#z..`) for the
+    /// applicant to sign demo presentations with.
+    fn generate_holder_secret() -> Secret {
+        let mut secret = Secret::generate_ed25519(None, None);
+        let pub_mb = secret
+            .get_public_keymultibase()
+            .expect("holder pubkey multibase");
+        secret.id = format!("did:key:{pub_mb}#{pub_mb}");
+        secret
+    }
+
+    /// The VTC dispatch loop: receive → call the real handler → reply, until
+    /// shutdown. Mirrors the e2e responder's two-hop reply path (authcrypt the
+    /// inner reply to the applicant, forward through the mediator).
+    async fn run_vtc_join_loop(
+        atm: ATM,
+        profile: Arc<ATMProfile>,
+        mediator_did: String,
+        vtc_did: String,
+        state: AppState,
+        mut shutdown_rx: oneshot::Receiver<()>,
+    ) {
+        loop {
+            if shutdown_rx.try_recv().is_ok() {
+                break;
+            }
+            let next = atm
+                .message_pickup()
+                .live_stream_next(&profile, Some(POLL), true)
+                .await;
+            let Ok(Some((msg, _meta))) = next else {
+                continue;
+            };
+            if msg.typ.contains("problem-report")
+                || msg.typ == "https://didcomm.org/routing/2.0/forward"
+            {
+                continue;
+            }
+            let Some(sender) = msg.from.clone() else {
+                continue;
+            };
+
+            let (reply_type, reply_body) = match dispatch_join(&state, &sender, &msg).await {
+                Ok(Some(reply)) => reply,
+                Ok(None) => continue,
+                Err((code, comment)) => (
+                    "https://didcomm.org/report-problem/2.0/problem-report".to_string(),
+                    json!({ "code": code, "comment": comment }),
+                ),
+            };
+
+            let reply_id = Uuid::new_v4().to_string();
+            let reply_msg = Message::build(reply_id.clone(), reply_type, reply_body)
+                .from(vtc_did.clone())
+                .to(sender.clone())
+                .thid(msg.id.clone())
+                .finalize();
+            let Ok((inner_jwe, _)) = atm
+                .pack_encrypted(&reply_msg, &sender, Some(&vtc_did), Some(&vtc_did))
+                .await
+            else {
+                continue;
+            };
+            let _ = atm
+                .forward_and_send_message(
+                    &profile,
+                    false,
+                    &inner_jwe,
+                    Some(&reply_id),
+                    &mediator_did,
+                    &sender,
+                    None,
+                    None,
+                    false,
+                )
+                .await;
+        }
+        atm.graceful_shutdown().await;
+    }
+
+    /// Map an inbound join message to a `(reply_type, reply_body)` by calling the
+    /// real handler. `Ok(None)` = no reply for this type; `Err` = problem report.
+    async fn dispatch_join(
+        state: &AppState,
+        sender: &str,
+        msg: &Message,
+    ) -> Result<Option<(String, Value)>, (String, String)> {
+        let problem =
+            |e: vti_common::error::AppError| ("e.p.msg.internal-error".to_string(), e.to_string());
+        let bad = |e: serde_json::Error| ("e.p.msg.bad-request".to_string(), e.to_string());
+
+        match msg.typ.as_str() {
+            JOIN_REQUEST_SUBMIT_TYPE => {
+                let body: JoinRequestSubmitBody =
+                    serde_json::from_value(msg.body.clone()).map_err(bad)?;
+                let outcome = submit_inner(
+                    state,
+                    sender.to_string(),
+                    body.vp,
+                    body.registry_consent,
+                    body.extensions,
+                    None,
+                    JoinTransport::DIDComm,
+                )
+                .await
+                .map_err(problem)?;
+                let receipt = JoinRequestSubmitReceiptBody {
+                    request_id: outcome.request.id,
+                    status: outcome.request.status.to_string(),
+                };
+                Ok(Some((
+                    JOIN_REQUEST_SUBMIT_RECEIPT_TYPE.to_string(),
+                    serde_json::to_value(receipt).expect("serialise receipt"),
+                )))
+            }
+            JOIN_REQUEST_MANIFEST_TYPE => {
+                let manifest = manifest_inner(state).await.map_err(problem)?;
+                Ok(Some((
+                    JOIN_REQUEST_MANIFEST_RESPONSE_TYPE.to_string(),
+                    serde_json::to_value(manifest).expect("serialise manifest"),
+                )))
+            }
+            JOIN_REQUEST_STATUS_TYPE => {
+                let body: JoinRequestStatusBody =
+                    serde_json::from_value(msg.body.clone()).map_err(bad)?;
+                let resp = status_inner(state, body.request_id, sender.to_string(), None)
+                    .await
+                    .map_err(problem)?;
+                Ok(Some((
+                    JOIN_REQUEST_STATUS_RESPONSE_TYPE.to_string(),
+                    serde_json::to_value(resp).expect("serialise status"),
+                )))
+            }
+            _ => Ok(None),
         }
     }
 }

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -1,0 +1,273 @@
+//! Worked example for the DIDComm join-requests harness (#436).
+//!
+//! Drives a genuine community-join round-trip against a **real** `vtc-service`
+//! over DIDComm — not canned responses — using [`MockVtcDidcomm`]: an embedded
+//! test mediator carrying both a `did:peer` applicant and the VTC, with the
+//! VTC's DIDComm responder bound to the production `submit_inner` /
+//! `manifest_inner` / `status_inner` handlers and the credential-delivery push.
+//!
+//! Round-trip exercised:
+//!   1. applicant `submit` over DIDComm                  → real `submit_inner`, pending receipt
+//!   2. applicant `manifest` over DIDComm               → real `manifest_inner`, DCQL criteria
+//!   3. manifest DCQL → `vp_token` via `vta_sdk::vp`     → the OpenVTC **D4** capability
+//!   4. applicant `status` over DIDComm                 → real `status_inner`, still pending
+//!   5. admin `approve` over REST                        → real ceremony issues the VMC + role VEC
+//!   6. VMC delivered to the applicant **over DIDComm**  → `credential-exchange/issue` lands
+//!
+//! This is the template a downstream consumer (OpenVTC) copies to test its join
+//! + activation path against a real VTC.
+
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::auth::session::now_epoch;
+use vtc_service::schemas::accepts::{AcceptsCriterion, store_accepts};
+use vtc_service::test_support::MockVtcDidcomm;
+
+use vta_sdk::protocols::credential_exchange::{ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody};
+use vta_sdk::protocols::join_requests::{
+    JOIN_REQUEST_MANIFEST_TYPE, JOIN_REQUEST_STATUS_TYPE, JOIN_REQUEST_SUBMIT_TYPE,
+    JoinRequestManifestResponseBody, JoinRequestStatusBody, JoinRequestStatusResponseBody,
+    JoinRequestSubmitBody, JoinRequestSubmitReceiptBody,
+};
+use vta_sdk::vp::{HeldCredential, build_vp_token, select_credentials};
+
+const ADMIN_DID: &str = "did:key:z6MkJoinAdmin";
+const APPROVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0";
+
+/// Seed the join ceremony the same way `server::run` does at boot: default
+/// policies (so `join.rego` evaluates instead of failing closed), both status
+/// lists (so the approve handler can allocate a VMC revocation slot), an admin
+/// ACL entry, and one DCQL Accepts criterion (so the manifest advertises a
+/// `presentation_definition`). Returns an admin bearer token.
+async fn seed_join_ceremony(mock: &MockVtcDidcomm) -> String {
+    let state = &mock.vtc.state;
+
+    vtc_service::policy::default::install_defaults(&state.policies_ks, &state.active_policies_ks)
+        .await
+        .expect("install default policies");
+
+    for purpose in [
+        affinidi_status_list::StatusPurpose::Revocation,
+        affinidi_status_list::StatusPurpose::Suspension,
+    ] {
+        vtc_service::status_list::ensure_initial(
+            &state.status_lists_ks,
+            purpose,
+            format!("https://vtc.test/v1/status-lists/{purpose}"),
+        )
+        .await
+        .expect("ensure status list");
+    }
+
+    store_acl_entry(
+        &state.acl_ks,
+        &VtcAclEntry {
+            did: ADMIN_DID.into(),
+            role: VtcRole::Admin,
+            label: Some("join test admin".into()),
+            allowed_contexts: vec![],
+            created_at: now_epoch(),
+            created_by: "did:key:vtc-install".into(),
+            expires_at: None,
+        },
+    )
+    .await
+    .expect("store admin ACL");
+
+    // A DCQL Accepts criterion with no `meta.vct_values` — so it needs no
+    // schema-store registration — that the manifest surfaces as a
+    // `presentation_definition` for the applicant to satisfy.
+    store_accepts(
+        &state.schemas_ks,
+        &AcceptsCriterion {
+            id: "membership".into(),
+            query: json!({
+                "credentials": [{
+                    "id": "membership",
+                    "format": "ldp_vc",
+                    "claims": [ { "path": ["givenName"] } ]
+                }]
+            }),
+            description: Some("Join evidence".into()),
+            created_at: chrono::Utc::now(),
+            created_by_did: ADMIN_DID.into(),
+        },
+    )
+    .await
+    .expect("store Accepts criterion");
+
+    mock.vtc.token(ADMIN_DID, "admin", vec![]).await
+}
+
+/// `POST` a Trust-Task against the VTC's REST router (the admin surface).
+async fn rest_post(
+    mock: &MockVtcDidcomm,
+    uri: &str,
+    trust_task: &str,
+    token: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    let res = mock
+        .vtc
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .header("Trust-Task", trust_task)
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+#[tokio::test]
+async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_delivery() {
+    let mock = MockVtcDidcomm::start().await;
+    let admin_token = seed_join_ceremony(&mock).await;
+    let vtc_did = mock.vtc_did().to_string();
+    let applicant_did = mock.client.did().to_string();
+
+    // 1. Submit a join request over DIDComm — the authcrypt sender is the
+    //    applicant DID, so no holder-binding signature is needed. Hits the real
+    //    `submit_inner`; the default policy defers to a pending decision.
+    let submit = JoinRequestSubmitBody {
+        vp: json!({ "type": "VerifiablePresentation", "holder": applicant_did }),
+        registry_consent: false,
+        extensions: json!({}),
+    };
+    let receipt: JoinRequestSubmitReceiptBody = serde_json::from_value(
+        mock.client
+            .request(
+                &vtc_did,
+                JOIN_REQUEST_SUBMIT_TYPE,
+                serde_json::to_value(submit).unwrap(),
+            )
+            .await,
+    )
+    .expect("submit receipt");
+    assert_eq!(
+        receipt.status, "pending",
+        "default policy defers to pending"
+    );
+    let request_id = receipt.request_id;
+
+    // 2. Discover the community's join evidence over DIDComm (real
+    //    `manifest_inner`) — the seeded DCQL Accepts criterion.
+    let manifest: JoinRequestManifestResponseBody = serde_json::from_value(
+        mock.client
+            .request(&vtc_did, JOIN_REQUEST_MANIFEST_TYPE, json!({}))
+            .await,
+    )
+    .expect("manifest response");
+    assert_eq!(manifest.community_did, vtc_did);
+    let criterion = manifest
+        .criteria
+        .iter()
+        .find(|c| c.id == "membership")
+        .expect("manifest advertises the membership criterion");
+
+    // 3. OpenVTC D4: select a held credential against the manifest's DCQL and
+    //    assemble a holder-bound `vp_token` with the SDK helper — the exact
+    //    client-side construction the VTC verifies server-side.
+    let subject = json!({ "givenName": "Ada", "memberSince": "2024-01-01" });
+    let held = HeldCredential {
+        id: "vmc-held".into(),
+        format: "ldp_vc".into(),
+        claims: subject.clone(),
+        vct: None,
+        doctype: None,
+        supports_holder_binding: true,
+        vc: json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "credentialSubject": subject,
+        }),
+    };
+    let candidates = select_credentials(&criterion.presentation_definition, &[held])
+        .expect("held credential satisfies the manifest DCQL");
+    let vp_token = build_vp_token(
+        &candidates,
+        mock.client.holder_secret(),
+        "join-nonce",
+        &vtc_did,
+    )
+    .await
+    .expect("assemble vp_token");
+    assert!(
+        vp_token.get("membership").is_some(),
+        "vp_token is keyed by the credential-query id: {vp_token}"
+    );
+
+    // 4. Poll status over DIDComm (real `status_inner`) — still pending pre-approval.
+    let status: JoinRequestStatusResponseBody = serde_json::from_value(
+        mock.client
+            .request(
+                &vtc_did,
+                JOIN_REQUEST_STATUS_TYPE,
+                serde_json::to_value(JoinRequestStatusBody { request_id }).unwrap(),
+            )
+            .await,
+    )
+    .expect("status response");
+    assert_eq!(status.status, "pending");
+
+    // 5. Admin approves over REST — the real ceremony admits the applicant,
+    //    issues the VMC + role VEC, and pushes them to the applicant's wallet
+    //    over DIDComm (`deliver_membership_credentials`).
+    let (code, body) = rest_post(
+        &mock,
+        &format!("/v1/join-requests/{request_id}/approve"),
+        APPROVE_TASK,
+        &admin_token,
+        json!({}),
+    )
+    .await;
+    assert_eq!(code, StatusCode::OK, "approve failed: {body}");
+    assert_eq!(body["status"], "approved");
+
+    // 6. The membership credential lands at the applicant over DIDComm — the
+    //    full push the activation path (T6) needs.
+    let (typ, issue_body) = mock
+        .client
+        .next_pushed(Duration::from_secs(20))
+        .await
+        .expect("VMC delivered over DIDComm");
+    assert_eq!(typ, CREDENTIAL_ISSUE_TYPE);
+    let issue: IssueBody = serde_json::from_value(issue_body).expect("issue body");
+    let credential = issue
+        .credential_response
+        .expect("credential_response present")
+        .credential
+        .expect("credential present");
+    let types = credential["type"].as_array().expect("VC type array");
+    assert!(
+        types.iter().any(|t| t == "MembershipCredential"),
+        "delivered credential is a MembershipCredential: {credential}"
+    );
+    assert_eq!(
+        credential["credentialSubject"]["id"], applicant_did,
+        "VMC subject is the applicant"
+    );
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
Closes #436.

> **Stacked on #441** (`feat/437-dcql-vp-helper`). Base will retarget to `main` once #441 merges. Review only this branch's top commit.

## Summary

`MockVtc` was REST-only (`atm: None`), but OpenVTC joins a community over DIDComm via a mediator — so there was no way to drive OpenVTC's real join path against a real VTC. The T9 join e2e had to hand-roll the VTC side as a bare test-mediator profile fed canned `status-response` messages, never touching the actual `vtc-service` join logic.

## What this adds

`MockVtcDidcomm` (behind a new test-only `didcomm-harness` feature):

- Spins up an embedded `affinidi-messaging-test-mediator` carrying both a `did:peer` applicant and the VTC, and a VTC DIDComm responder whose dispatch loop calls the **real** `submit_inner` / `manifest_inner` / `status_inner` handlers (not canned replies), mirroring the proven e2e ATM-responder pattern.
- Wires the VTC's transport `did:peer` as the configured `vtc_did` plus the ATM + mediator into `AppState` (new additive `TestVtcBuilder::with_atm` / `messaging_mediator`), so `credential-exchange/issue` delivery (`push_to_holder`) forwards an issued VMC back to the applicant over the shared mediator.
- Ships a connected `TestJoinClient` (authcrypt request → threaded reply, plus an inbox for unsolicited pushes) so a downstream consumer drives the whole flow without touching the messaging internals.

## Worked example — `tests/join_didcomm.rs`

The template OpenVTC copies. Round-trips end to end over DIDComm against the real VTC:

`submit → pending receipt → manifest (DCQL) → build a holder vp_token from that DCQL via vta_sdk::vp (the OpenVTC D4 capability) → status → admin approve over REST → the MembershipCredential lands at the applicant over DIDComm.`

Seeded the same way `server::run` boots (default policies + status lists + admin ACL + one DCQL Accepts criterion).

## Compatibility

The builder additions are additive (optional fields default to `None`); the existing REST `TestVtc`/`MockVtc` surface and all current tests are unchanged (44 existing join tests + `test_support_smoke` still green). The `didcomm-harness` feature + `affinidi-messaging-test-mediator` dep are test-only — never in a production build. Release bump: vtc-service 0.9.2 → 0.9.3.