### PR TITLE
feat(vtc): OpenAPI 3.1 spec via OpenApiRouter, full VTC surface (#439)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10084,6 +10084,8 @@ dependencies = [
  "tracing-subscriber",
  "unicode-normalization",
  "url",
+ "utoipa",
+ "utoipa-axum",
  "uuid",
  "vta-sdk 0.13.1",
  "vtc-service",
@@ -10097,7 +10099,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -10130,6 +10132,7 @@ dependencies = [
  "tracing",
  "url",
  "utoipa",
+ "utoipa-axum",
  "uuid",
  "vta-sdk 0.13.1",
  "webauthn-rs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -88,6 +88,9 @@ vti-common = { path = "../vti-common", version = "0.10", features = [
   # `migrate_to_encrypted` for at-rest encryption of the secret-bearing
   # keyspaces (install, audit_key, passkey) — P0.7.
   "encryption",
+  # `openapi` gates ToSchema on shared wire types (Role, SessionState) +
+  # the OpenAPI-aware Trust-Task route helpers (`task_routes`/`task_layer`).
+  "openapi",
 ] }
 vta-sdk = { path = "../vta-sdk", version = "0.13", features = [
   "didcomm",
@@ -99,6 +102,9 @@ vta-sdk = { path = "../vta-sdk", version = "0.13", features = [
   # opener so it can bootstrap the VTC's identity against a VTA
   # (see `tasks/vtc-mvp/vta-driven-keys.md` §3).
   "provision-client",
+  # `openapi` gates ToSchema on the vta-sdk protocol wire types the VTC
+  # surface references (credential-exchange, discovery, etc.).
+  "openapi",
 ] }
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm-service = { workspace = true }
@@ -154,6 +160,10 @@ affinidi-did-resolver-cache-sdk = { workspace = true }
 base64 = { workspace = true }
 axum = { workspace = true }
 axum-extra = { workspace = true }
+# OpenAPI: `OpenApiRouter` makes the router the source of truth for the served
+# `/openapi.json`; `utoipa` provides `#[utoipa::path]` + `ToSchema` derives.
+utoipa = { workspace = true }
+utoipa-axum = { workspace = true }
 jsonwebtoken = { workspace = true }
 fjall = { workspace = true }
 toml = { workspace = true }

--- a/vtc-service/src/acl/admin.rs
+++ b/vtc-service/src/acl/admin.rs
@@ -31,6 +31,7 @@ use vti_common::store::KeyspaceHandle;
 /// `claim/finish` time.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RegisteredPasskey {
     /// Hex-encoded WebAuthn credential id. Matches the
     /// `CredentialMapping` key in the passkey store.

--- a/vtc-service/src/acl/role.rs
+++ b/vtc-service/src/acl/role.rs
@@ -55,7 +55,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vti_common::error::AppError;
 
 /// The VTC's role taxonomy. See module docs for the wire shape.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, utoipa::ToSchema)]
 pub enum VtcRole {
     /// Full management access. Spec §5.3 default permission matrix.
     Admin,

--- a/vtc-service/src/community/profile.rs
+++ b/vtc-service/src/community/profile.rs
@@ -82,6 +82,7 @@ impl CommunityProfile {
 /// clears the blob; omitting it (`None`) leaves it untouched.
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct CommunityProfileUpdate {
     pub name: Option<String>,
     pub description: Option<String>,

--- a/vtc-service/src/community/profile.rs
+++ b/vtc-service/src/community/profile.rs
@@ -34,6 +34,7 @@ pub const MAX_EXTENSIONS_BYTES: usize = 16 * 1024;
 /// + the admin UX read this shape directly.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct CommunityProfile {
     /// Immutable — set at install time. PUT requests cannot change
     /// this; see [`CommunityProfileUpdate`].

--- a/vtc-service/src/config_store.rs
+++ b/vtc-service/src/config_store.rs
@@ -48,7 +48,7 @@ fn storage_key(key: &str) -> Vec<u8> {
 
 /// Where the **prior** value came from in the four-layer overlay.
 /// Mirrors the variant on `vti_common::audit::ConfigSource` (M0.1.5).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ConfigSource {
     Env,
@@ -214,7 +214,7 @@ impl ConfigStore {
 /// operator can tell whether the running value was set in TOML, by
 /// an env override, by a PATCH against the DB layer, or fell back
 /// to the compiled-in default.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EffectiveField {
     pub key: String,
@@ -225,7 +225,7 @@ pub struct EffectiveField {
 
 /// Response shape for `GET /v1/admin/config` — every registry key
 /// resolved through the four-layer overlay.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct EffectiveConfig {
     pub fields: Vec<EffectiveField>,
 }

--- a/vtc-service/src/endorsement_types/mod.rs
+++ b/vtc-service/src/endorsement_types/mod.rs
@@ -38,6 +38,7 @@ pub const RESERVED_TYPE_URIS: &[&str] = &["CommunityRole"];
 /// registrar route enforces validation at insert time.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct EndorsementType {
     /// The type URI. Primary key — URL-encoded into the
     /// keyspace key.

--- a/vtc-service/src/endorsements/mod.rs
+++ b/vtc-service/src/endorsements/mod.rs
@@ -37,6 +37,7 @@ pub use storage::{
 /// VEC's `id` field if they need the proof.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct Endorsement {
     /// Server-allocated UUID. Forms `vec_id`'s
     /// `urn:uuid:<id>` shape.

--- a/vtc-service/src/join/mod.rs
+++ b/vtc-service/src/join/mod.rs
@@ -31,6 +31,7 @@ pub use storage::{
 /// State of a join request through its lifecycle.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[derive(utoipa::ToSchema)]
 pub enum JoinStatus {
     /// Submitted; awaiting admin / moderator decision.
     Pending,

--- a/vtc-service/src/join/mod.rs
+++ b/vtc-service/src/join/mod.rs
@@ -72,6 +72,7 @@ impl std::fmt::Display for JoinStatus {
 /// One join request. Stored under `join_requests:<id>`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct JoinRequest {
     pub id: Uuid,
     pub applicant_did: String,

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -189,6 +189,7 @@ impl Member {
 /// the Member record + status-list slot on member departure.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[derive(utoipa::ToSchema)]
 pub enum Disposition {
     /// Hard delete — Member row removed entirely. RTBF default.
     Purge,

--- a/vtc-service/src/policy/model.rs
+++ b/vtc-service/src/policy/model.rs
@@ -43,6 +43,7 @@ use uuid::Uuid;
 /// upload supersedes them.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct Policy {
     /// Server-allocated UUID. Stable across activations + renames.
     pub id: Uuid,
@@ -104,6 +105,7 @@ pub const POLICY_SOURCE_MAX_BYTES: usize = 64 * 1024;
 ///   [`Self::CrossCommunityRelationships`], [`Self::Relationships`].
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub enum PolicyPurpose {
     Join,
     Removal,

--- a/vtc-service/src/registry/health.rs
+++ b/vtc-service/src/registry/health.rs
@@ -27,6 +27,7 @@ use vti_common::audit::{AuditEvent, AuditWriter, RegistryStatusChangedData};
 /// /v1/community/profile` surfaces in `registryStatus`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
+#[derive(utoipa::ToSchema)]
 pub enum HealthStatus {
     /// Last probe succeeded — the registry is reachable.
     Active,

--- a/vtc-service/src/relationships/mod.rs
+++ b/vtc-service/src/relationships/mod.rs
@@ -58,6 +58,7 @@ pub use storage::{
 /// surface (issuer/subject DIDs + the credential body).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct Relationship {
     /// Server-allocated UUID. Surfaced as `urn:uuid:<id>` on
     /// the VRC's top-level `id` field at publish time when

--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -46,11 +46,23 @@ impl From<VtcAclEntry> for AclEntryResponse {
     }
 }
 
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Deserialize, utoipa::ToSchema, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct ListAclQuery {
     pub context: Option<String>,
 }
 
+/// GET /acl — list ACL entries visible to the caller. Auth: Manage.
+#[utoipa::path(
+    get, path = "/acl", tag = "acl",
+    security(("bearer_jwt" = [])),
+    params(ListAclQuery),
+    responses(
+        (status = 200, description = "Visible ACL entries", body = AclListResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller lacks manage authority"),
+    ),
+)]
 pub async fn list_acl(
     auth: ManageAuth,
     State(state): State<AppState>,
@@ -91,6 +103,17 @@ pub struct CreateAclRequest {
     pub expires_at: Option<u64>,
 }
 
+/// POST /acl — create a new ACL entry. Auth: Manage.
+#[utoipa::path(
+    post, path = "/acl", tag = "acl",
+    security(("bearer_jwt" = [])),
+    request_body = CreateAclRequest,
+    responses(
+        (status = 201, description = "ACL entry created", body = AclEntryResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller lacks manage authority"),
+    ),
+)]
 pub async fn create_acl(
     auth: ManageAuth,
     State(state): State<AppState>,
@@ -129,6 +152,18 @@ pub async fn create_acl(
 
 // ---------- GET /acl/{did} ----------
 
+/// GET /acl/{did} — retrieve a single ACL entry. Auth: Manage.
+#[utoipa::path(
+    get, path = "/acl/{did}", tag = "acl",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Subject DID")),
+    responses(
+        (status = 200, description = "ACL entry", body = AclEntryResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller lacks manage authority"),
+        (status = 404, description = "ACL entry not found"),
+    ),
+)]
 pub async fn get_acl(
     auth: ManageAuth,
     State(state): State<AppState>,
@@ -156,6 +191,19 @@ pub struct UpdateAclRequest {
     pub allowed_contexts: Option<Vec<String>>,
 }
 
+/// PATCH /acl/{did} — modify an ACL entry. Auth: Admin.
+#[utoipa::path(
+    patch, path = "/acl/{did}", tag = "acl",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Subject DID")),
+    request_body = UpdateAclRequest,
+    responses(
+        (status = 200, description = "Updated ACL entry", body = AclEntryResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "ACL entry not found"),
+    ),
+)]
 pub async fn update_acl(
     // Modifying an ACL entry can downgrade an existing admin or shrink their
     // `allowed_contexts`. Gate on Admin so a non-admin can't tamper with
@@ -230,6 +278,18 @@ pub async fn update_acl(
 
 // ---------- DELETE /acl/{did} ----------
 
+/// DELETE /acl/{did} — remove an ACL entry. Auth: Admin.
+#[utoipa::path(
+    delete, path = "/acl/{did}", tag = "acl",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Subject DID")),
+    responses(
+        (status = 204, description = "ACL entry deleted"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "ACL entry not found"),
+    ),
+)]
 pub async fn delete_acl(
     // Deletion is strictly more destructive than the `PATCH` edit, yet the
     // previous `ManageAuth` gate let an Initiator delete entries while `PATCH`

--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -15,12 +15,12 @@ use crate::server::AppState;
 
 // ---------- GET /acl ----------
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct AclListResponse {
     pub entries: Vec<AclEntryResponse>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct AclEntryResponse {
     pub did: String,
     pub role: VtcRole,
@@ -46,7 +46,7 @@ impl From<VtcAclEntry> for AclEntryResponse {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct ListAclQuery {
     pub context: Option<String>,
 }
@@ -80,7 +80,7 @@ pub async fn list_acl(
 
 // ---------- POST /acl ----------
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct CreateAclRequest {
     pub did: String,
     pub role: VtcRole,
@@ -149,7 +149,7 @@ pub async fn get_acl(
 
 // ---------- PATCH /acl/{did} ----------
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct UpdateAclRequest {
     pub role: Option<VtcRole>,
     pub label: Option<String>,

--- a/vtc-service/src/routes/admin/bootstrap.rs
+++ b/vtc-service/src/routes/admin/bootstrap.rs
@@ -51,6 +51,14 @@ pub struct BootstrapResponse {
     pub event_id: Uuid,
 }
 
+#[utoipa::path(
+    post, path = "/admin/bootstrap", tag = "admin",
+    request_body = BootstrapRequest,
+    responses(
+        (status = 200, description = "First admin bootstrapped; community installed", body = BootstrapResponse),
+        (status = 409, description = "An admin already exists"),
+    ),
+)]
 pub async fn bootstrap(
     State(state): State<AppState>,
     Json(req): Json<BootstrapRequest>,

--- a/vtc-service/src/routes/admin/bootstrap.rs
+++ b/vtc-service/src/routes/admin/bootstrap.rs
@@ -35,13 +35,14 @@ use crate::community::{CommunityProfile, load_profile, store_profile};
 use crate::install::InstallTokenSigner;
 use crate::server::AppState;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct BootstrapRequest {
     pub setup_session_token: String,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct BootstrapResponse {
     pub admin_did: String,
     /// `event_id` of the persisted `CommunityInstalled` audit

--- a/vtc-service/src/routes/admin/config.rs
+++ b/vtc-service/src/routes/admin/config.rs
@@ -44,7 +44,7 @@ use vti_common::audit::{
 /// PATCH request body: arbitrary `key → value` map. Keys not in
 /// [`crate::config_store::REGISTRY`] are reported back under
 /// `rejected` rather than silently dropped.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct PatchRequest {
     #[serde(flatten)]
     pub overrides: HashMap<String, Value>,
@@ -54,6 +54,7 @@ pub struct PatchRequest {
 /// which await restart, and which were rejected.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct PatchResponse {
     pub applied: Vec<String>,
     pub pending_restart: Vec<String>,
@@ -62,7 +63,7 @@ pub struct PatchResponse {
 
 /// One rejected key + the reason. Surfaced to the caller so the
 /// admin UX can present a meaningful error inline.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct RejectedKey {
     pub key: String,
     pub reason: String,
@@ -197,6 +198,7 @@ const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 30;
 /// the next restart.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ReloadResponse {
     pub keys_reloaded: Vec<String>,
 }
@@ -278,6 +280,7 @@ pub async fn reload_config(
 /// check passes.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RestartResponse {
     /// Which supervisor the daemon detected (so the operator's
     /// admin UX can echo it back).
@@ -403,6 +406,7 @@ pub const EXPORT_SCHEMA_VERSION: u32 = 1;
 /// per-host and aren't portable.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ConfigExport {
     pub schema_version: u32,
     pub exported_at: DateTime<Utc>,
@@ -433,7 +437,7 @@ pub async fn export_config(
 /// Query string for `POST /v1/admin/config/import`. Default is
 /// `confirm=false` (dry-run / diff). The operator UX shows the diff,
 /// then re-submits with `?confirm=true` to apply.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct ImportQuery {
     #[serde(default)]
     pub confirm: bool,
@@ -446,6 +450,7 @@ pub struct ImportQuery {
 /// alone", not "clear it".
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct FieldDiff {
     pub key: String,
     pub old_value: Option<Value>,
@@ -457,6 +462,7 @@ pub struct FieldDiff {
 /// confirm it lists the keys that actually persisted.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ImportResponse {
     /// Was the request a dry-run? Mirrors the inbound `?confirm`
     /// flag so an admin UX caching the response can render the

--- a/vtc-service/src/routes/admin/config.rs
+++ b/vtc-service/src/routes/admin/config.rs
@@ -70,6 +70,15 @@ pub struct RejectedKey {
 }
 
 /// GET handler.
+#[utoipa::path(
+    get, path = "/admin/config", tag = "admin",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Four-layer-merged effective config", body = EffectiveConfig),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn get_config(
     _admin: AdminAuth,
     State(state): State<AppState>,
@@ -81,6 +90,16 @@ pub async fn get_config(
 }
 
 /// PATCH handler.
+#[utoipa::path(
+    patch, path = "/admin/config", tag = "admin",
+    security(("bearer_jwt" = [])),
+    request_body = PatchRequest,
+    responses(
+        (status = 200, description = "Applied / pending-restart / rejected keys", body = PatchResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn patch_config(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -214,6 +233,15 @@ pub struct ReloadResponse {
 /// runtime-state subscribers (tracing subscriber filter handle,
 /// session-cleanup interval, etc.) will plug into the same diff
 /// loop.
+#[utoipa::path(
+    post, path = "/admin/config/reload", tag = "admin",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Keys re-applied in-memory", body = ReloadResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn reload_config(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -302,6 +330,15 @@ pub struct RestartResponse {
 /// On success the handler emits `RestartRequested` to the audit
 /// log *before* signalling shutdown — so the row survives even if
 /// the drain wedges.
+#[utoipa::path(
+    post, path = "/admin/config/restart", tag = "admin",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Restart requested", body = RestartResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn restart_config(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -414,6 +451,15 @@ pub struct ConfigExport {
     pub config_overrides: HashMap<String, Value>,
 }
 
+#[utoipa::path(
+    post, path = "/admin/config/export", tag = "admin",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Portable config + community-profile export", body = ConfigExport),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn export_config(
     _admin: AdminAuth,
     State(state): State<AppState>,
@@ -486,6 +532,17 @@ pub struct ImportResponse {
     pub rejected: Vec<RejectedKey>,
 }
 
+#[utoipa::path(
+    post, path = "/admin/config/import", tag = "admin",
+    security(("bearer_jwt" = [])),
+    params(("confirm" = Option<bool>, Query, description = "Apply the import (true) or dry-run diff (false, default)")),
+    request_body = ConfigExport,
+    responses(
+        (status = 200, description = "Import diff (dry-run) or applied keys", body = ImportResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn import_config(
     admin: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/admin/invites.rs
+++ b/vtc-service/src/routes/admin/invites.rs
@@ -135,6 +135,17 @@ pub struct RevokeInviteResponse {
 
 const MAX_TTL_SECONDS: u64 = 24 * 60 * 60;
 
+#[utoipa::path(
+    post, path = "/admin/invites", tag = "admin",
+    security(("bearer_jwt" = [])),
+    request_body = CreateInviteRequest,
+    responses(
+        (status = 200, description = "Install URL + one-time claim code minted", body = CreateInviteResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 409, description = "Target DID already has a non-admin ACL grant"),
+    ),
+)]
 pub async fn create_invite(
     _admin: AdminAuth,
     State(state): State<AppState>,
@@ -242,6 +253,15 @@ pub async fn create_invite(
 // GET handler
 // ---------------------------------------------------------------------------
 
+#[utoipa::path(
+    get, path = "/admin/invites", tag = "admin",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Outstanding + terminal install-token invites", body = ListInvitesResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn list_invites(
     _admin: AdminAuth,
     State(state): State<AppState>,
@@ -269,6 +289,17 @@ pub async fn list_invites(
 // DELETE handler
 // ---------------------------------------------------------------------------
 
+#[utoipa::path(
+    delete, path = "/admin/invites/{jti}", tag = "admin",
+    security(("bearer_jwt" = [])),
+    params(("jti" = String, Path, description = "Invite token id (jti)")),
+    responses(
+        (status = 200, description = "Invite revoked", body = RevokeInviteResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Invite not found"),
+    ),
+)]
 pub async fn revoke_invite(
     _admin: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/admin/invites.rs
+++ b/vtc-service/src/routes/admin/invites.rs
@@ -46,6 +46,7 @@ use crate::server::AppState;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct CreateInviteRequest {
     /// Admin DID the install URL grants a passkey for.
     pub did: String,
@@ -63,6 +64,7 @@ pub struct CreateInviteRequest {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct CreateInviteResponse {
     /// `jti` of the minted install token — also the key the GET +
     /// DELETE surfaces use.
@@ -85,6 +87,7 @@ pub struct CreateInviteResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct InviteSummary {
     pub jti: String,
     pub status: InviteStatus,
@@ -105,6 +108,7 @@ pub struct InviteSummary {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(utoipa::ToSchema)]
 pub enum InviteStatus {
     Issued,
     Consumed,
@@ -113,12 +117,14 @@ pub enum InviteStatus {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ListInvitesResponse {
     pub invites: Vec<InviteSummary>,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RevokeInviteResponse {
     pub jti: String,
 }

--- a/vtc-service/src/routes/admin/passkeys.rs
+++ b/vtc-service/src/routes/admin/passkeys.rs
@@ -67,26 +67,32 @@ static ADMIN_PASSKEY_LOCK: Mutex<()> = Mutex::const_new(());
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ListResponse {
     pub passkeys: Vec<RegisteredPasskey>,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RegisterStartResponse {
     /// Opaque id the operator passes back to `register/finish`.
     pub registration_id: String,
     /// `navigator.credentials.create()` options — EdDSA-restricted.
+    #[schema(value_type = Object)]
     pub register_options: CreationChallengeResponse,
     /// `navigator.credentials.get()` options for the step-up UV
     /// assertion against an existing passkey.
+    #[schema(value_type = Object)]
     pub uv_options: RequestChallengeResponse,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct RegisterFinishRequest {
     pub registration_id: String,
+    #[schema(value_type = Object)]
     pub register_response: RegisterPublicKeyCredential,
+    #[schema(value_type = Object)]
     pub uv_response: PublicKeyCredential,
     /// Operator-supplied label (e.g. `"YubiKey 5C"`).
     pub label: String,
@@ -96,30 +102,35 @@ pub struct RegisterFinishRequest {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RegisterFinishResponse {
     pub credential_id: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct RevokeStartRequest {
     pub credential_id: String,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RevokeStartResponse {
     pub revocation_id: String,
+    #[schema(value_type = Object)]
     pub uv_options: RequestChallengeResponse,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct RevokeFinishRequest {
     pub revocation_id: String,
+    #[schema(value_type = Object)]
     pub uv_response: PublicKeyCredential,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RevokeFinishResponse {
     pub credential_id: String,
 }

--- a/vtc-service/src/routes/admin/passkeys.rs
+++ b/vtc-service/src/routes/admin/passkeys.rs
@@ -147,6 +147,16 @@ fn revoke_target_key(revocation_id: &str) -> Vec<u8> {
 // GET list
 // ---------------------------------------------------------------------------
 
+#[utoipa::path(
+    get, path = "/admin/passkeys", tag = "admin",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Registered admin passkeys", body = ListResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "No admin entry for caller"),
+    ),
+)]
 pub async fn list(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -163,6 +173,16 @@ pub async fn list(
 // Register start + finish
 // ---------------------------------------------------------------------------
 
+#[utoipa::path(
+    post, path = "/admin/passkeys/register/start", tag = "admin",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "New-device registration + step-up UV challenges", body = RegisterStartResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "No passkey user for caller"),
+    ),
+)]
 pub async fn register_start(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -204,6 +224,16 @@ pub async fn register_start(
     }))
 }
 
+#[utoipa::path(
+    post, path = "/admin/passkeys/register/finish", tag = "admin",
+    security(("bearer_jwt" = [])),
+    request_body = RegisterFinishRequest,
+    responses(
+        (status = 200, description = "New passkey registered", body = RegisterFinishResponse),
+        (status = 401, description = "Missing/invalid bearer token, or step-up UV failed"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn register_finish(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -282,6 +312,17 @@ pub async fn register_finish(
 // Revoke start + finish
 // ---------------------------------------------------------------------------
 
+#[utoipa::path(
+    post, path = "/admin/passkeys/revoke/start", tag = "admin",
+    security(("bearer_jwt" = [])),
+    request_body = RevokeStartRequest,
+    responses(
+        (status = 200, description = "Step-up UV challenge for the revocation", body = RevokeStartResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "credential_id not registered for this admin"),
+    ),
+)]
 pub async fn revoke_start(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -331,6 +372,18 @@ pub async fn revoke_start(
     }))
 }
 
+#[utoipa::path(
+    post, path = "/admin/passkeys/revoke/finish", tag = "admin",
+    security(("bearer_jwt" = [])),
+    request_body = RevokeFinishRequest,
+    responses(
+        (status = 200, description = "Passkey revoked", body = RevokeFinishResponse),
+        (status = 401, description = "Missing/invalid bearer token, or step-up UV failed"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "credential_id not registered for this admin"),
+        (status = 409, description = "Refusing to leave the admin with zero passkeys"),
+    ),
+)]
 pub async fn revoke_finish(
     admin: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/audit.rs
+++ b/vtc-service/src/routes/audit.rs
@@ -29,7 +29,8 @@ use tracing::info;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(utoipa::ToSchema)]
+#[derive(utoipa::ToSchema, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct AuditQuery {
     /// Pagination cursor (returned by a previous call).
     pub cursor: Option<String>,
@@ -37,6 +38,17 @@ pub struct AuditQuery {
     pub limit: Option<usize>,
 }
 
+/// GET /audit — newest-first paginated audit envelopes. Auth: Super-admin.
+#[utoipa::path(
+    get, path = "/audit", tag = "audit",
+    security(("bearer_jwt" = [])),
+    params(AuditQuery),
+    responses(
+        (status = 200, description = "Paginated audit envelopes", body = Object),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not a super-admin"),
+    ),
+)]
 pub async fn list_audit(
     auth: SuperAdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/audit.rs
+++ b/vtc-service/src/routes/audit.rs
@@ -29,6 +29,7 @@ use tracing::info;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct AuditQuery {
     /// Pagination cursor (returned by a previous call).
     pub cursor: Option<String>,

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -26,6 +26,14 @@ use vti_common::store::KeyspaceHandle;
 
 /// Thin dispatcher — every substantive concern (ACL, rate
 /// limit, session persistence) lives in the canonical handler.
+#[utoipa::path(
+    post, path = "/auth/challenge", tag = "auth",
+    request_body = ChallengeRequest,
+    responses(
+        (status = 200, description = "DID-auth challenge nonce", body = ChallengeResponse),
+        (status = 401, description = "ACL gate rejected the subject DID"),
+    ),
+)]
 pub async fn challenge(
     State(state): State<AppState>,
     Json(req): Json<ChallengeRequest>,
@@ -44,6 +52,16 @@ pub async fn challenge(
 
 // ---------- POST /auth/ ----------
 
+/// `POST /v1/auth/` — verify a DIDComm/SIOP/Trust-Task authentication
+/// document and issue access + refresh tokens. Unauthenticated.
+#[utoipa::path(
+    post, path = "/auth/", tag = "auth",
+    request_body(content = String, description = "DIDComm envelope, SIOP id_token envelope, or Trust-Task auth document"),
+    responses(
+        (status = 200, description = "Access + refresh tokens"),
+        (status = 401, description = "Authentication failed (bad proof, challenge mismatch, or replay)"),
+    ),
+)]
 pub async fn authenticate(
     State(state): State<AppState>,
     body: String,
@@ -283,6 +301,14 @@ async fn authenticate_and_mint(
 ///
 /// Programmatic clients (cnm-cli, DIDComm bridges) keep using
 /// `POST /v1/auth/` — same JWT shape, no cookie side effects.
+#[utoipa::path(
+    post, path = "/auth/admin-login", tag = "auth",
+    request_body(content = String, description = "DIDComm/SIOP/Trust-Task authentication document"),
+    responses(
+        (status = 200, description = "Access + refresh tokens (sets admin session + CSRF cookies)"),
+        (status = 401, description = "Authentication failed"),
+    ),
+)]
 pub async fn admin_login(
     State(state): State<AppState>,
     body: String,
@@ -354,6 +380,14 @@ pub struct AdminSessionRequest {
 /// access token, which it could use directly as a bearer; this only mirrors
 /// it into the cookie the browser SPA expects. Browser-only by nature: the
 /// CSRF layer's same-origin check carries the (cookie-less) first call.
+#[utoipa::path(
+    post, path = "/auth/admin-session", tag = "auth",
+    request_body = AdminSessionRequest,
+    responses(
+        (status = 204, description = "Admin session + CSRF cookies set"),
+        (status = 401, description = "Invalid or expired access token"),
+    ),
+)]
 pub async fn admin_session(
     State(state): State<AppState>,
     Json(req): Json<AdminSessionRequest>,
@@ -420,6 +454,15 @@ pub struct PasskeyLoginStartResponse {
     pub options: webauthn_rs::prelude::RequestChallengeResponse,
 }
 
+/// `POST /v1/auth/passkey-login/start` — issue a WebAuthn assertion
+/// challenge across every registered passkey. Unauthenticated.
+#[utoipa::path(
+    post, path = "/auth/passkey-login/start", tag = "auth",
+    responses(
+        (status = 200, description = "WebAuthn assertion challenge", body = PasskeyLoginStartResponse),
+        (status = 401, description = "WebAuthn not configured or no passkeys registered"),
+    ),
+)]
 pub async fn passkey_login_start(
     State(state): State<AppState>,
 ) -> Result<Json<PasskeyLoginStartResponse>, AppError> {
@@ -474,6 +517,16 @@ pub struct PasskeyLoginFinishRequest {
     pub credential: webauthn_rs::prelude::PublicKeyCredential,
 }
 
+/// `POST /v1/auth/passkey-login/finish` — verify the WebAuthn assertion
+/// and mint a cookie session + bearer token. Unauthenticated.
+#[utoipa::path(
+    post, path = "/auth/passkey-login/finish", tag = "auth",
+    request_body = PasskeyLoginFinishRequest,
+    responses(
+        (status = 200, description = "Access + refresh tokens (sets admin session + CSRF cookies)"),
+        (status = 401, description = "Passkey assertion verification failed or credential not registered"),
+    ),
+)]
 pub async fn passkey_login_finish(
     State(state): State<AppState>,
     Json(req): Json<PasskeyLoginFinishRequest>,
@@ -700,6 +753,14 @@ mod cookie_format_tests {
 /// claim, refresh-expiry check, ACL re-look-up, AAL preservation
 /// across rotation, RFC 6749 §10.4 rotation semantics — lives in
 /// the canonical handler in vti-common.
+#[utoipa::path(
+    post, path = "/auth/refresh", tag = "auth",
+    request_body(content = String, description = "DIDComm envelope or Trust-Task refresh document"),
+    responses(
+        (status = 200, description = "Rotated access + refresh tokens"),
+        (status = 401, description = "Refresh token not found, revoked, or already used"),
+    ),
+)]
 pub async fn refresh(
     State(state): State<AppState>,
     body: String,
@@ -790,6 +851,14 @@ pub struct WhoamiResponse {
 /// pulled from the access token. Lets browser SPAs render a
 /// "signed in as" indicator without exposing the JWT to JS (the
 /// session cookie is HttpOnly by design).
+#[utoipa::path(
+    get, path = "/auth/whoami", tag = "auth",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Caller identity claims", body = WhoamiResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+    ),
+)]
 pub async fn whoami(auth: AuthClaims) -> Json<WhoamiResponse> {
     Json(WhoamiResponse {
         did: auth.did,
@@ -806,6 +875,14 @@ pub async fn whoami(auth: AuthClaims) -> Json<WhoamiResponse> {
 /// expire the cookie pair. The cookies' HttpOnly flag means JS
 /// can't clear them itself — only the server can issue
 /// `Set-Cookie: ...; Max-Age=0` to delete from the browser's jar.
+#[utoipa::path(
+    post, path = "/auth/sign-out", tag = "auth",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 204, description = "Session revoked and session/CSRF cookies cleared"),
+        (status = 401, description = "Missing or invalid bearer token"),
+    ),
+)]
 pub async fn sign_out(
     auth: AuthClaims,
     State(state): State<AppState>,
@@ -840,6 +917,17 @@ pub async fn sign_out(
     Ok(response)
 }
 
+/// `GET /v1/auth/sessions` — list active sessions visible to the caller.
+/// Super-admin sees all; context-admin sees only sessions in their contexts.
+#[utoipa::path(
+    get, path = "/auth/sessions", tag = "auth",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Active sessions", body = [SessionSummary]),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin/initiator"),
+    ),
+)]
 pub async fn session_list(
     auth: ManageAuth,
     State(state): State<AppState>,
@@ -873,6 +961,19 @@ pub async fn session_list(
 
 // ---------- DELETE /auth/sessions/{session_id} ----------
 
+/// `DELETE /v1/auth/sessions/{session_id}` — revoke a single session
+/// (caller's own, or any if admin).
+#[utoipa::path(
+    delete, path = "/auth/sessions/{session_id}", tag = "auth",
+    security(("bearer_jwt" = [])),
+    params(("session_id" = String, Path, description = "Session identifier")),
+    responses(
+        (status = 204, description = "Session revoked"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Cannot revoke another user's session"),
+        (status = 404, description = "Session not found"),
+    ),
+)]
 pub async fn revoke_session(
     auth: AuthClaims,
     State(state): State<AppState>,
@@ -907,6 +1008,18 @@ pub struct RevokeByDidResponse {
     pub revoked: u64,
 }
 
+/// `DELETE /v1/auth/sessions?did=X` — revoke all sessions for a DID.
+/// Super-admin unrestricted; context-admin limited to visible DIDs.
+#[utoipa::path(
+    delete, path = "/auth/sessions", tag = "auth",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Query, description = "Subject DID whose sessions to revoke")),
+    responses(
+        (status = 200, description = "Sessions revoked", body = RevokeByDidResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller cannot revoke sessions for this DID"),
+    ),
+)]
 pub async fn revoke_sessions_by_did(
     auth: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -332,6 +332,7 @@ pub async fn admin_login(
 /// Request body for [`admin_session`].
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct AdminSessionRequest {
     /// A valid VTC access token the caller already holds — e.g. from the
     /// VTA-wallet SIOP login, which returns it in `tokens.accessToken`.
@@ -412,8 +413,10 @@ pub async fn admin_session(
 /// proves possession of an enrolled credential, which is the auth.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct PasskeyLoginStartResponse {
     pub auth_id: String,
+    #[schema(value_type = Object)]
     pub options: webauthn_rs::prelude::RequestChallengeResponse,
 }
 
@@ -464,9 +467,10 @@ pub async fn passkey_login_start(
 /// `admin_login` does for the DIDComm CLI path. Returns the bearer
 /// token in the body for clients that want to also use it
 /// programmatically.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct PasskeyLoginFinishRequest {
     pub auth_id: String,
+    #[schema(value_type = Object)]
     pub credential: webauthn_rs::prelude::PublicKeyCredential,
 }
 
@@ -744,6 +748,7 @@ pub async fn refresh(
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct SessionSummary {
     pub session_id: String,
     pub did: String,
@@ -772,6 +777,7 @@ impl From<Session> for SessionSummary {
 /// cookie is HttpOnly).
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct WhoamiResponse {
     pub did: String,
     pub role: String,
@@ -891,12 +897,12 @@ pub async fn revoke_session(
 
 // ---------- DELETE /auth/sessions?did=X ----------
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct RevokeByDidQuery {
     pub did: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct RevokeByDidResponse {
     pub revoked: u64,
 }

--- a/vtc-service/src/routes/ceremonies.rs
+++ b/vtc-service/src/routes/ceremonies.rs
@@ -309,6 +309,14 @@ fn manifests() -> Vec<CeremonyManifest> {
 /// `GET /v1/ceremonies` — list the ceremony manifests. Authenticated
 /// (any session); the payload is admin-UI metadata, not secret, but
 /// the surface lives behind the same gate as the rest of the API.
+#[utoipa::path(
+    get, path = "/ceremonies", tag = "ceremonies",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Ceremony manifests", body = [CeremonyManifest]),
+        (status = 401, description = "Missing or invalid bearer token"),
+    ),
+)]
 pub async fn list(_claims: AuthClaims) -> Json<Vec<CeremonyManifest>> {
     Json(manifests())
 }

--- a/vtc-service/src/routes/ceremonies.rs
+++ b/vtc-service/src/routes/ceremonies.rs
@@ -21,7 +21,7 @@ use serde_json::{Value as JsonValue, json};
 
 use crate::auth::AuthClaims;
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct FieldOption {
     pub value: &'static str,
     pub label: &'static str,
@@ -32,6 +32,7 @@ pub struct FieldOption {
 /// matches `truthy`).
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ShowWhen {
     pub field: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -42,6 +43,7 @@ pub struct ShowWhen {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct FieldDef {
     pub key: &'static str,
     pub label: &'static str,
@@ -58,6 +60,7 @@ pub struct FieldDef {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct CeremonyManifest {
     pub purpose: &'static str,
     pub pkg: &'static str,

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -35,6 +35,7 @@ use crate::server::AppState;
 /// not persisted on the profile row.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct CommunityProfileResponse {
     /// The persisted profile fields. Flattened on the wire so
     /// existing consumers see no shape change.
@@ -57,6 +58,7 @@ pub struct CommunityProfileResponse {
 /// fetch.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct PublicCommunityProfile {
     pub community_did: String,
     pub name: String,
@@ -121,6 +123,7 @@ pub async fn get_profile(
 /// audit event emitter that lands alongside this in a follow-up).
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct UpdateProfileResponse {
     pub profile: CommunityProfile,
     pub fields_changed: Vec<String>,

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -76,6 +76,15 @@ pub struct PublicCommunityProfile {
 
 /// Public GET handler. Trust-Task-exempt, no auth. Returns only the
 /// curated subset of profile fields a visitor's browser should see.
+/// GET /community/public-profile — curated public community profile.
+/// Public, unauthenticated.
+#[utoipa::path(
+    get, path = "/community/public-profile", tag = "community",
+    responses(
+        (status = 200, description = "Public community profile", body = PublicCommunityProfile),
+        (status = 404, description = "Community profile not initialised"),
+    ),
+)]
 pub async fn get_public_profile(
     State(state): State<AppState>,
 ) -> Result<Json<PublicCommunityProfile>, AppError> {
@@ -104,6 +113,17 @@ pub async fn get_public_profile(
 
 /// GET handler. Returns the singleton profile + the live
 /// trust-registry status.
+/// GET /community/profile — full community profile + live registry status.
+/// Auth: any authenticated session.
+#[utoipa::path(
+    get, path = "/community/profile", tag = "community",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Community profile + registry status", body = CommunityProfileResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 404, description = "Community profile not initialised"),
+    ),
+)]
 pub async fn get_profile(
     _auth: AuthClaims,
     State(state): State<AppState>,
@@ -136,6 +156,20 @@ pub struct UpdateProfileResponse {
 /// can't be recorded (no `AuditWriter`) returns 503 rather than
 /// persisting silently — matching the `/v1/admin/config` doors so
 /// auditability doesn't depend on which surface the admin used.
+/// PUT /community/profile — update the community profile. Auth: Admin.
+/// Refuses changes to the immutable `community_did`.
+#[utoipa::path(
+    put, path = "/community/profile", tag = "community",
+    security(("bearer_jwt" = [])),
+    request_body = CommunityProfileUpdate,
+    responses(
+        (status = 200, description = "Updated profile + the fields that changed", body = UpdateProfileResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Community profile not initialised"),
+        (status = 503, description = "Audit writer not configured — change refused"),
+    ),
+)]
 pub async fn put_profile(
     admin: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/config.rs
+++ b/vtc-service/src/routes/config.rs
@@ -31,7 +31,7 @@ use crate::config_store::ConfigStore;
 use crate::error::AppError;
 use crate::server::AppState;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ConfigResponse {
     pub vtc_did: Option<String>,
     pub vtc_name: Option<String>,
@@ -42,14 +42,14 @@ pub struct ConfigResponse {
 
 /// Response for `PATCH /v1/config`: the resolved view plus any boot-stable keys
 /// that were stored but need a restart to take effect.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct UpdateConfigResponse {
     #[serde(flatten)]
     pub config: ConfigResponse,
     pub pending_restart: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct UpdateConfigRequest {
     pub vtc_did: Option<String>,
     /// Recovery-authority DID. Like `vtc_did`, set at setup and rejected here.

--- a/vtc-service/src/routes/config.rs
+++ b/vtc-service/src/routes/config.rs
@@ -87,6 +87,15 @@ async fn resolved_public_url(state: &AppState) -> Result<Option<String>, AppErro
     Ok(state.config.read().await.public_url.clone())
 }
 
+/// GET /config — resolved community config view. Auth: any session.
+#[utoipa::path(
+    get, path = "/config", tag = "config",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Resolved config view", body = ConfigResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+    ),
+)]
 pub async fn get_config(
     auth: AuthClaims,
     State(state): State<AppState>,
@@ -103,6 +112,18 @@ pub async fn get_config(
     }))
 }
 
+/// PATCH /config — update mutable community config. Auth: Super-admin.
+#[utoipa::path(
+    patch, path = "/config", tag = "config",
+    security(("bearer_jwt" = [])),
+    request_body = UpdateConfigRequest,
+    responses(
+        (status = 200, description = "Updated config view", body = UpdateConfigResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not a super-admin"),
+        (status = 409, description = "Attempt to rewrite immutable identity (vtc_did / vta_did)"),
+    ),
+)]
 pub async fn update_config(
     auth: SuperAdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/directory.rs
+++ b/vtc-service/src/routes/directory.rs
@@ -62,7 +62,8 @@ pub const DIRECTORY_FIELD_WHITELIST: [&str; 4] = ["did", "role", "joined_at", "s
 /// in. Advisory: the policy decides what it returns, and the PII
 /// boundary caps it. Recorded into the facts so a policy *may* honour
 /// it, but the default directory policy projects by viewer role.
-#[derive(Debug, Default, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Default, Deserialize, utoipa::ToSchema, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct DirectoryQuery {
     #[serde(default)]
     pub fields: Option<String>,
@@ -78,6 +79,19 @@ pub struct DirectoryResponse {
 }
 
 /// `GET /v1/directory/{did}`.
+#[utoipa::path(
+    get, path = "/directory/{did}", tag = "directory",
+    security(("bearer_jwt" = [])),
+    params(
+        ("did" = String, Path, description = "Subject DID"),
+        DirectoryQuery,
+    ),
+    responses(
+        (status = 200, description = "Projected subject record", body = DirectoryResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Directory access denied"),
+    ),
+)]
 pub async fn query(
     viewer: AuthClaims,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/directory.rs
+++ b/vtc-service/src/routes/directory.rs
@@ -62,7 +62,7 @@ pub const DIRECTORY_FIELD_WHITELIST: [&str; 4] = ["did", "role", "joined_at", "s
 /// in. Advisory: the policy decides what it returns, and the PII
 /// boundary caps it. Recorded into the facts so a policy *may* honour
 /// it, but the default directory policy projects by viewer role.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, utoipa::ToSchema)]
 pub struct DirectoryQuery {
     #[serde(default)]
     pub fields: Option<String>,
@@ -71,6 +71,7 @@ pub struct DirectoryQuery {
 /// The projected subject record.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct DirectoryResponse {
     pub subject: String,
     pub fields: Map<String, JsonValue>,

--- a/vtc-service/src/routes/endorsement_types.rs
+++ b/vtc-service/src/routes/endorsement_types.rs
@@ -56,6 +56,16 @@ pub struct RegisterBody {
     pub description: Option<String>,
 }
 
+#[utoipa::path(
+    post, path = "/endorsement-types", tag = "endorsement-types",
+    security(("bearer_jwt" = [])),
+    request_body = RegisterBody,
+    responses(
+        (status = 201, description = "Endorsement type registered", body = EndorsementType),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn register(
     auth: AdminAuth,
     State(state): State<AppState>,
@@ -116,12 +126,22 @@ pub async fn register(
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(utoipa::ToSchema)]
+#[derive(utoipa::ToSchema, utoipa::IntoParams)]
 pub struct ListQuery {
     pub cursor: Option<String>,
     pub limit: Option<usize>,
 }
 
+#[utoipa::path(
+    get, path = "/endorsement-types", tag = "endorsement-types",
+    security(("bearer_jwt" = [])),
+    params(ListQuery),
+    responses(
+        (status = 200, description = "Paginated list of endorsement types", body = Paginated<EndorsementType>),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn list(
     _auth: AdminAuth,
     State(state): State<AppState>,
@@ -159,6 +179,17 @@ pub struct DeleteResponse {
     pub type_uri: String,
 }
 
+#[utoipa::path(
+    delete, path = "/endorsement-types/{type_uri}", tag = "endorsement-types",
+    security(("bearer_jwt" = [])),
+    params(("type_uri" = String, Path, description = "Endorsement type URI")),
+    responses(
+        (status = 200, description = "Endorsement type deleted", body = DeleteResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Endorsement type not found"),
+    ),
+)]
 pub async fn delete(
     auth: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/endorsement_types.rs
+++ b/vtc-service/src/routes/endorsement_types.rs
@@ -47,6 +47,7 @@ const LIST_MAX_LIMIT: usize = 200;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RegisterBody {
     pub type_uri: String,
     #[serde(default)]
@@ -115,6 +116,7 @@ pub async fn register(
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ListQuery {
     pub cursor: Option<String>,
     pub limit: Option<usize>,
@@ -152,6 +154,7 @@ pub async fn list(
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct DeleteResponse {
     pub type_uri: String,
 }

--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -72,6 +72,16 @@ pub struct IssueResponse {
     pub vec: JsonValue,
 }
 
+#[utoipa::path(
+    post, path = "/credentials/endorsements", tag = "endorsements",
+    security(("bearer_jwt" = [])),
+    request_body = IssueBody,
+    responses(
+        (status = 201, description = "Endorsement issued", body = IssueResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin or issuer"),
+    ),
+)]
 pub async fn issue(
     auth: AuthClaims,
     State(state): State<AppState>,
@@ -245,12 +255,22 @@ pub async fn issue(
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(utoipa::ToSchema)]
+#[derive(utoipa::ToSchema, utoipa::IntoParams)]
 pub struct ListQuery {
     pub cursor: Option<String>,
     pub limit: Option<usize>,
 }
 
+#[utoipa::path(
+    get, path = "/credentials/endorsements", tag = "endorsements",
+    security(("bearer_jwt" = [])),
+    params(ListQuery),
+    responses(
+        (status = 200, description = "Paginated list of endorsements", body = Paginated<Endorsement>),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin or issuer"),
+    ),
+)]
 pub async fn list(
     auth: AuthClaims,
     State(state): State<AppState>,
@@ -285,6 +305,17 @@ pub async fn list(
 
 // ─── Show ────────────────────────────────────────────────
 
+#[utoipa::path(
+    get, path = "/credentials/endorsements/{id}", tag = "endorsements",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Endorsement id")),
+    responses(
+        (status = 200, description = "Endorsement", body = Endorsement),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin or issuer"),
+        (status = 404, description = "Endorsement not found"),
+    ),
+)]
 pub async fn show(
     auth: AuthClaims,
     State(state): State<AppState>,
@@ -313,6 +344,17 @@ pub struct RevokeResponse {
     pub id: String,
 }
 
+#[utoipa::path(
+    delete, path = "/credentials/endorsements/{id}", tag = "endorsements",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Endorsement id")),
+    responses(
+        (status = 200, description = "Endorsement revoked", body = RevokeResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin or issuer"),
+        (status = 404, description = "Endorsement not found"),
+    ),
+)]
 pub async fn revoke(
     auth: AuthClaims,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -52,6 +52,7 @@ const CLAIM_MAX_BYTES: usize = 8 * 1024;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct IssueBody {
     pub subject_did: String,
     #[serde(rename = "type")]
@@ -64,6 +65,7 @@ pub struct IssueBody {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct IssueResponse {
     pub id: Uuid,
     pub vec_id: String,
@@ -243,6 +245,7 @@ pub async fn issue(
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ListQuery {
     pub cursor: Option<String>,
     pub limit: Option<usize>,
@@ -305,6 +308,7 @@ pub async fn show(
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RevokeResponse {
     pub id: String,
 }

--- a/vtc-service/src/routes/health.rs
+++ b/vtc-service/src/routes/health.rs
@@ -9,7 +9,7 @@ use crate::auth::AdminAuth;
 use crate::registry::{HealthStatus, list_sync_jobs};
 use crate::server::AppState;
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct HealthResponse {
     status: &'static str,
     version: &'static str,

--- a/vtc-service/src/routes/health.rs
+++ b/vtc-service/src/routes/health.rs
@@ -79,7 +79,7 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
 /// Diagnostics is **admin-gated**, not super-admin: ops staff
 /// running on-call should be able to read this without
 /// holding the super-admin role.
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct DiagnosticsResponse {
     pub registry_status: String,
     pub queue_depth: u64,
@@ -95,6 +95,15 @@ pub struct DiagnosticsResponse {
     pub last_error: Option<String>,
 }
 
+#[utoipa::path(
+    get, path = "/health/diagnostics", tag = "health",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Trust-registry reconciler diagnostics", body = DiagnosticsResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn diagnostics(
     State(state): State<AppState>,
     _auth: AdminAuth,

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -61,7 +61,7 @@ use crate::server::AppState;
 // Wire shapes
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct ClaimStartRequest {
     pub install_token: String,
     /// Out-of-band claim code the operator received alongside the
@@ -77,6 +77,7 @@ pub struct ClaimStartRequest {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ClaimStartResponse {
     /// Echoes the install token's `jti`. Consumer must pass this
     /// back to `claim/finish` so the server can index the stored
@@ -84,18 +85,21 @@ pub struct ClaimStartResponse {
     pub registration_id: String,
     /// The WebAuthn `PublicKeyCredentialCreationOptions` payload —
     /// the operator's UA passes this to `navigator.credentials.create()`.
+    #[schema(value_type = Object)]
     pub options: CreationChallengeResponse,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct ClaimFinishRequest {
     pub install_token: String,
     pub registration_id: String,
+    #[schema(value_type = Object)]
     pub webauthn_response: RegisterPublicKeyCredential,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ClaimFinishResponse {
     pub admin_did: String,
     pub setup_session_token: String,

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -109,6 +109,16 @@ pub struct ClaimFinishResponse {
 // Handlers
 // ---------------------------------------------------------------------------
 
+/// `POST /v1/install/claim/start` — begin the WebAuthn install
+/// ceremony for the first admin. Unauthenticated.
+#[utoipa::path(
+    post, path = "/install/claim/start", tag = "install",
+    request_body = ClaimStartRequest,
+    responses(
+        (status = 201, description = "WebAuthn creation challenge", body = ClaimStartResponse),
+        (status = 401, description = "Invalid install token or claim secret"),
+    ),
+)]
 pub async fn claim_start(
     State(state): State<AppState>,
     Json(req): Json<ClaimStartRequest>,
@@ -198,6 +208,16 @@ pub async fn claim_start(
     ))
 }
 
+/// `POST /v1/install/claim/finish` — complete the WebAuthn install
+/// ceremony, mint the admin DID + setup-session token. Unauthenticated.
+#[utoipa::path(
+    post, path = "/install/claim/finish", tag = "install",
+    request_body = ClaimFinishRequest,
+    responses(
+        (status = 200, description = "Admin DID + setup-session token", body = ClaimFinishResponse),
+        (status = 401, description = "Invalid install token or registration state"),
+    ),
+)]
 pub async fn claim_finish(
     State(state): State<AppState>,
     Json(req): Json<ClaimFinishRequest>,

--- a/vtc-service/src/routes/join_requests/accept.rs
+++ b/vtc-service/src/routes/join_requests/accept.rs
@@ -48,6 +48,7 @@ const RECIPROCAL_VC_TYPE: &str = "MembershipAcknowledgement";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct AcceptRequestBody {
     pub member_did: String,
     pub vmc_id: String,
@@ -59,6 +60,7 @@ pub struct AcceptRequestBody {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct AcceptResponse {
     pub request_id: Uuid,
     pub status: String,

--- a/vtc-service/src/routes/join_requests/accept.rs
+++ b/vtc-service/src/routes/join_requests/accept.rs
@@ -77,6 +77,19 @@ pub struct AcceptOutcome {
     pub recorded: bool,
 }
 
+/// POST /join-requests/{id}/accept — record the member's reciprocal VC.
+/// Public: the reciprocal VC + holder-binding signature IS the auth.
+#[utoipa::path(
+    post, path = "/join-requests/{id}/accept", tag = "join-requests",
+    params(("id" = String, Path, description = "Join request id")),
+    request_body = AcceptRequestBody,
+    responses(
+        (status = 201, description = "Reciprocal VC recorded", body = AcceptResponse),
+        (status = 400, description = "Holder-binding / reciprocal-VC validation failed"),
+        (status = 404, description = "Join request or member not found"),
+        (status = 409, description = "Request not Approved, or VMC already reciprocated"),
+    ),
+)]
 pub async fn accept(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -34,6 +34,7 @@ const REJECT_REASON_MAX: usize = 1024;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct DecideResponse {
     pub request_id: Uuid,
     pub status: String,
@@ -211,6 +212,7 @@ fn credential_issued_data(
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RejectBody {
     #[serde(default)]
     pub reason: Option<String>,

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -53,6 +53,20 @@ pub struct DecideResponse {
 // Approve
 // ---------------------------------------------------------------------------
 
+/// POST /join-requests/{id}/approve — admit the applicant + issue the VMC.
+/// Auth: Admin.
+#[utoipa::path(
+    post, path = "/join-requests/{id}/approve", tag = "join-requests",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Join request id")),
+    responses(
+        (status = 201, description = "Applicant admitted; VMC + role VEC issued", body = DecideResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Join request not found"),
+        (status = 409, description = "Request is not Pending, or applicant is already a member"),
+    ),
+)]
 pub async fn approve(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -218,6 +232,22 @@ pub struct RejectBody {
     pub reason: Option<String>,
 }
 
+/// POST /join-requests/{id}/reject — reject a pending join request.
+/// Auth: Admin.
+#[utoipa::path(
+    post, path = "/join-requests/{id}/reject", tag = "join-requests",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Join request id")),
+    request_body = RejectBody,
+    responses(
+        (status = 201, description = "Join request rejected", body = DecideResponse),
+        (status = 400, description = "Reject reason exceeds the length cap"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Join request not found"),
+        (status = 409, description = "Request is not Pending"),
+    ),
+)]
 pub async fn reject(
     admin: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/join_requests/manifest.rs
+++ b/vtc-service/src/routes/join_requests/manifest.rs
@@ -17,6 +17,14 @@ use vti_common::error::AppError;
 use crate::schemas::accepts::list_accepts;
 use crate::server::AppState;
 
+/// GET /join-requests/manifest — pre-submit discovery of the community's
+/// Accepts criteria. Public, stateless read.
+#[utoipa::path(
+    get, path = "/join-requests/manifest", tag = "join-requests",
+    responses(
+        (status = 200, description = "Community join evidence requirements", body = JoinRequestManifestResponseBody),
+    ),
+)]
 pub async fn manifest(
     State(state): State<AppState>,
 ) -> Result<Json<JoinRequestManifestResponseBody>, AppError> {

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -155,6 +155,7 @@ pub async fn prepare_join_query(
 /// for `holderDid` from the named Accepts criterion.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct SendQueryRequest {
     /// The holder the query is for (delivered to it over DIDComm by the VTC or a
     /// relayer — relayer ≠ holder is supported; the holder still proves binding).
@@ -167,6 +168,7 @@ pub struct SendQueryRequest {
 /// the thread the holder presents on.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct SendQueryResponse {
     /// The DIDComm thread id the holder must reply on (the challenge is keyed by
     /// it; the `present` handler consumes it).
@@ -174,6 +176,7 @@ pub struct SendQueryResponse {
     /// Echoed for the caller's correlation.
     pub holder_did: String,
     /// The `credential-exchange/query` body to deliver to the holder.
+    #[schema(value_type = Object)]
     pub query: QueryBody,
     /// Whether the VTC pushed the query to the holder over DIDComm. `false` when
     /// no mediator is configured or the push failed — the caller can still relay

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -191,6 +191,19 @@ pub struct SendQueryResponse {
 /// push is unavailable — relayer ≠ holder is supported). The holder presents on
 /// the returned `threadId`, and the `credential-exchange/present` handler
 /// consumes the challenge.
+/// POST /join-requests/query — prepare + push a credential-exchange query to
+/// a holder for a registered Accepts criterion. Auth: Admin.
+#[utoipa::path(
+    post, path = "/join-requests/query", tag = "join-requests",
+    security(("bearer_jwt" = [])),
+    request_body = SendQueryRequest,
+    responses(
+        (status = 200, description = "Prepared query + thread to present on", body = SendQueryResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "No such Accepts criterion registered"),
+    ),
+)]
 pub async fn send_query(
     _auth: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/join_requests/read.rs
+++ b/vtc-service/src/routes/join_requests/read.rs
@@ -15,7 +15,7 @@ use crate::server::AppState;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(utoipa::ToSchema)]
+#[derive(utoipa::ToSchema, utoipa::IntoParams)]
 pub struct ListJoinRequestsQuery {
     /// Filter by status. Default `pending` — the operator-facing
     /// surface usually wants the work queue.
@@ -24,6 +24,17 @@ pub struct ListJoinRequestsQuery {
     pub limit: Option<usize>,
 }
 
+/// GET /join-requests — list join requests (admin work queue). Auth: Admin.
+#[utoipa::path(
+    get, path = "/join-requests", tag = "join-requests",
+    security(("bearer_jwt" = [])),
+    params(ListJoinRequestsQuery),
+    responses(
+        (status = 200, description = "Paginated join requests", body = Paginated<JoinRequest>),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn list_join_requests(
     _admin: AdminAuth,
     State(state): State<AppState>,
@@ -56,6 +67,18 @@ pub async fn list_join_requests(
     Ok(Json(page))
 }
 
+/// GET /join-requests/{id} — show a single join request. Auth: Admin.
+#[utoipa::path(
+    get, path = "/join-requests/{id}", tag = "join-requests",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Join request id")),
+    responses(
+        (status = 200, description = "Join request", body = JoinRequest),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Join request not found"),
+    ),
+)]
 pub async fn show_join_request(
     _admin: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/join_requests/read.rs
+++ b/vtc-service/src/routes/join_requests/read.rs
@@ -15,6 +15,7 @@ use crate::server::AppState;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ListJoinRequestsQuery {
     /// Filter by status. Default `pending` — the operator-facing
     /// surface usually wants the work queue.

--- a/vtc-service/src/routes/join_requests/status.rs
+++ b/vtc-service/src/routes/join_requests/status.rs
@@ -43,6 +43,19 @@ pub struct StatusRequestBody {
     pub signature: String,
 }
 
+/// POST /join-requests/{id}/status — applicant-facing lifecycle poll.
+/// Public: the holder-binding signature (REST) / authcrypt sender (DIDComm)
+/// IS the auth.
+#[utoipa::path(
+    post, path = "/join-requests/{id}/status", tag = "join-requests",
+    params(("id" = String, Path, description = "Join request id")),
+    request_body = StatusRequestBody,
+    responses(
+        (status = 200, description = "Join request lifecycle status", body = JoinRequestStatusResponseBody),
+        (status = 400, description = "Holder-binding validation failed"),
+        (status = 404, description = "Join request not found"),
+    ),
+)]
 pub async fn status(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,

--- a/vtc-service/src/routes/join_requests/status.rs
+++ b/vtc-service/src/routes/join_requests/status.rs
@@ -36,6 +36,7 @@ pub const JOIN_STATUS_DOMAIN_TAG: &[u8] = b"vtc-join-status/v1\0";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct StatusRequestBody {
     pub applicant_did: String,
     /// Hex-encoded Ed25519 signature over the canonical body.

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -133,6 +133,17 @@ pub struct JoinSubmitOutcome {
     pub admit: Option<Box<AdmitOutcome>>,
 }
 
+/// POST /join-requests — submit a join request. Public: the holder-binding
+/// signature (REST) or authcrypt sender (DIDComm) IS the auth.
+#[utoipa::path(
+    post, path = "/join-requests", tag = "join-requests",
+    request_body = SubmitRequestBody,
+    responses(
+        (status = 201, description = "Join request submitted", body = SubmitResponse),
+        (status = 400, description = "Holder-binding / audience / freshness validation failed"),
+        (status = 409, description = "An open join request already exists for this applicant"),
+    ),
+)]
 pub async fn submit(
     State(state): State<AppState>,
     Json(req): Json<SubmitRequestBody>,

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -79,6 +79,7 @@ const JOIN_SUBMIT_FUTURE_SKEW_SECS: i64 = 60;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct SubmitRequestBody {
     pub applicant_did: String,
     pub vp: JsonValue,
@@ -110,6 +111,7 @@ pub struct HolderBinding<'a> {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct SubmitResponse {
     pub request_id: Uuid,
     pub status: String,

--- a/vtc-service/src/routes/members/personhood.rs
+++ b/vtc-service/src/routes/members/personhood.rs
@@ -134,6 +134,7 @@ async fn take_challenge(
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ChallengeResponse {
     pub challenge_id: Uuid,
     pub expires_at: DateTime<Utc>,
@@ -178,7 +179,7 @@ pub async fn challenge(
 // Assert endpoint
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct AssertBody {
     /// W3C Verifiable Presentation. `holder` must equal the
     /// path-DID; `proof.challenge` must equal a fresh challenge
@@ -188,6 +189,7 @@ pub struct AssertBody {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct AssertResponse {
     pub did: String,
     pub personhood: bool,
@@ -372,6 +374,7 @@ pub async fn assert(
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RevokeResponse {
     pub did: String,
     pub personhood: bool,

--- a/vtc-service/src/routes/members/personhood.rs
+++ b/vtc-service/src/routes/members/personhood.rs
@@ -140,6 +140,18 @@ pub struct ChallengeResponse {
     pub expires_at: DateTime<Utc>,
 }
 
+/// POST /members/{did}/personhood/challenge — mint a personhood challenge.
+/// Auth: any authenticated session.
+#[utoipa::path(
+    post, path = "/members/{did}/personhood/challenge", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID")),
+    responses(
+        (status = 200, description = "Personhood challenge minted", body = ChallengeResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 404, description = "Member not found"),
+    ),
+)]
 pub async fn challenge(
     _auth: AuthClaims,
     State(state): State<AppState>,
@@ -197,6 +209,20 @@ pub struct AssertResponse {
     pub role_vec: JsonValue,
 }
 
+/// POST /members/{did}/personhood — assert personhood via a VP.
+/// Auth: any authenticated session.
+#[utoipa::path(
+    post, path = "/members/{did}/personhood", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID")),
+    request_body = AssertBody,
+    responses(
+        (status = 200, description = "Personhood asserted", body = AssertResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Personhood proof invalid / policy denied"),
+        (status = 404, description = "Member not found"),
+    ),
+)]
 pub async fn assert(
     _auth: AuthClaims,
     State(state): State<AppState>,
@@ -384,6 +410,18 @@ pub struct RevokeResponse {
     pub role_vec: Option<JsonValue>,
 }
 
+/// DELETE /members/{did}/personhood — revoke personhood. Auth: Admin or self.
+#[utoipa::path(
+    delete, path = "/members/{did}/personhood", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID")),
+    responses(
+        (status = 200, description = "Personhood revoked", body = RevokeResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is neither admin nor the subject member"),
+        (status = 404, description = "Member not found"),
+    ),
+)]
 pub async fn revoke(
     auth: AuthClaims,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/members/promote.rs
+++ b/vtc-service/src/routes/members/promote.rs
@@ -56,6 +56,19 @@ pub struct PromoteStartResponse {
     pub options: RequestChallengeResponse,
 }
 
+/// POST /members/{did}/promote-to-admin/start — begin step-up UV ceremony.
+/// Auth: Admin.
+#[utoipa::path(
+    post, path = "/members/{did}/promote-to-admin/start", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID being promoted")),
+    responses(
+        (status = 200, description = "UV challenge issued", body = PromoteStartResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin / has no registered passkeys"),
+        (status = 404, description = "Member not found"),
+    ),
+)]
 pub async fn promote_start(
     auth: AdminAuth,
     State(state): State<AppState>,
@@ -133,6 +146,20 @@ pub struct PromoteFinishResponse {
     pub event_id: Uuid,
 }
 
+/// POST /members/{did}/promote-to-admin/finish — complete the promotion.
+/// Auth: Admin.
+#[utoipa::path(
+    post, path = "/members/{did}/promote-to-admin/finish", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID being promoted")),
+    request_body = PromoteFinishRequest,
+    responses(
+        (status = 200, description = "Member promoted to admin", body = PromoteFinishResponse),
+        (status = 401, description = "Missing or invalid bearer token / step-up UV failed"),
+        (status = 403, description = "Caller is not an admin / promotion denied by policy"),
+        (status = 404, description = "Member not found"),
+    ),
+)]
 pub async fn promote_finish(
     auth: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/members/promote.rs
+++ b/vtc-service/src/routes/members/promote.rs
@@ -49,8 +49,10 @@ static PROMOTE_LOCK: Mutex<()> = Mutex::const_new(());
 /// admin/passkeys/register/start uses for its UV phase.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct PromoteStartResponse {
     pub registration_id: Uuid,
+    #[schema(value_type = Object)]
     pub options: RequestChallengeResponse,
 }
 
@@ -116,13 +118,16 @@ pub async fn promote_start(
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct PromoteFinishRequest {
     pub registration_id: Uuid,
+    #[schema(value_type = Object)]
     pub uv_response: PublicKeyCredential,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct PromoteFinishResponse {
     pub did: String,
     pub event_id: Uuid,

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -25,6 +25,7 @@ use crate::server::AppState;
 /// + `acl:<did>` so a caller doesn't need a second request.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct MemberResponse {
     pub did: String,
     pub role: VtcRole,
@@ -80,6 +81,7 @@ impl MemberResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ListMembersQuery {
     /// Filter by role, expressed in the same wire form
     /// [`VtcRole`] uses (`"admin"`, `"moderator"`,

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -81,7 +81,7 @@ impl MemberResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(utoipa::ToSchema)]
+#[derive(utoipa::ToSchema, utoipa::IntoParams)]
 pub struct ListMembersQuery {
     /// Filter by role, expressed in the same wire form
     /// [`VtcRole`] uses (`"admin"`, `"moderator"`,
@@ -95,6 +95,17 @@ pub struct ListMembersQuery {
     pub limit: Option<usize>,
 }
 
+/// GET /members — paginated member list. Auth: Admin.
+#[utoipa::path(
+    get, path = "/members", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(ListMembersQuery),
+    responses(
+        (status = 200, description = "Paginated member list", body = Paginated<MemberResponse>),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn list_members(
     _auth: AdminAuth,
     State(state): State<AppState>,
@@ -160,6 +171,18 @@ pub async fn list_members(
 // GET /v1/members/{did}
 // ---------------------------------------------------------------------------
 
+/// GET /members/{did} — single member. Auth: Admin.
+#[utoipa::path(
+    get, path = "/members/{did}", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID")),
+    responses(
+        (status = 200, description = "Member record", body = MemberResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Member not found"),
+    ),
+)]
 pub async fn show_member(
     _auth: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/members/relationships.rs
+++ b/vtc-service/src/routes/members/relationships.rs
@@ -31,6 +31,7 @@ const MAX_LIMIT: usize = 200;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ListQuery {
     pub cursor: Option<String>,
     pub limit: Option<usize>,

--- a/vtc-service/src/routes/members/relationships.rs
+++ b/vtc-service/src/routes/members/relationships.rs
@@ -31,12 +31,24 @@ const MAX_LIMIT: usize = 200;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(utoipa::ToSchema)]
+#[derive(utoipa::ToSchema, utoipa::IntoParams)]
 pub struct ListQuery {
     pub cursor: Option<String>,
     pub limit: Option<usize>,
 }
 
+/// GET /members/{did}/relationships — paginated VRC list for a member.
+/// Auth: any authenticated session.
+#[utoipa::path(
+    get, path = "/members/{did}/relationships", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID"), ListQuery),
+    responses(
+        (status = 200, description = "Paginated relationship list", body = Paginated<Relationship>),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not authorised"),
+    ),
+)]
 pub async fn list(
     _auth: AuthClaims,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -48,6 +48,7 @@ use crate::server::AppState;
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RemoveBody {
     #[serde(default)]
     pub disposition: Option<Disposition>,
@@ -60,6 +61,7 @@ pub struct RemoveBody {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RemoveResponse {
     pub did: String,
     pub disposition: String,

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -74,6 +74,17 @@ const REASON_MAX: usize = 1024;
 // DELETE /v1/members/me — M1.11.1
 // ---------------------------------------------------------------------------
 
+/// DELETE /members/me — self-leave ceremony. Auth: any authenticated member.
+#[utoipa::path(
+    delete, path = "/members/me", tag = "members",
+    security(("bearer_jwt" = [])),
+    request_body = RemoveBody,
+    responses(
+        (status = 200, description = "Member removed", body = RemoveResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Removal denied by policy"),
+    ),
+)]
 pub async fn self_remove(
     auth: AuthClaims,
     State(state): State<AppState>,
@@ -102,6 +113,19 @@ pub async fn self_remove(
 // DELETE /v1/members/{did} — M1.12.1 (REST only)
 // ---------------------------------------------------------------------------
 
+/// DELETE /members/{did} — admin removes another member. Auth: Admin.
+#[utoipa::path(
+    delete, path = "/members/{did}", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID")),
+    request_body = RemoveBody,
+    responses(
+        (status = 200, description = "Member removed", body = RemoveResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin / removal denied by policy"),
+        (status = 404, description = "Member not found"),
+    ),
+)]
 pub async fn admin_remove(
     admin: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/members/renew.rs
+++ b/vtc-service/src/routes/members/renew.rs
@@ -52,6 +52,7 @@ use crate::status_list;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RenewResponse {
     pub did: String,
     pub vmc: JsonValue,

--- a/vtc-service/src/routes/members/renew.rs
+++ b/vtc-service/src/routes/members/renew.rs
@@ -69,6 +69,16 @@ pub struct RenewResponse {
     pub personhood_changed: bool,
 }
 
+/// POST /members/me/renew — renew VMC + role VEC. Auth: any authenticated member.
+#[utoipa::path(
+    post, path = "/members/me/renew", tag = "members",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Membership renewed", body = RenewResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 404, description = "Caller is not a member"),
+    ),
+)]
 pub async fn renew(
     auth: AuthClaims,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/members/rotate.rs
+++ b/vtc-service/src/routes/members/rotate.rs
@@ -156,6 +156,7 @@ async fn take_challenge(state: &AppState, id: Uuid) -> Result<Option<RotationCha
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ChallengeResponse {
     pub rotation_id: Uuid,
     pub expires_at: DateTime<Utc>,
@@ -223,6 +224,7 @@ pub async fn challenge(
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct FinishBody {
     pub rotation_id: Uuid,
     pub old_did: String,
@@ -235,6 +237,7 @@ pub struct FinishBody {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct FinishResponse {
     pub new_did: String,
     pub method: String,

--- a/vtc-service/src/routes/members/rotate.rs
+++ b/vtc-service/src/routes/members/rotate.rs
@@ -173,6 +173,17 @@ pub struct ChallengeResponse {
     pub canonical_template: JsonValue,
 }
 
+/// POST /members/me/rotate/challenge — mint a DID-rotation challenge.
+/// Auth: any authenticated member.
+#[utoipa::path(
+    post, path = "/members/me/rotate/challenge", tag = "members",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Rotation challenge issued", body = ChallengeResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 404, description = "Caller is not a member"),
+    ),
+)]
 pub async fn challenge(
     auth: AuthClaims,
     State(state): State<AppState>,
@@ -245,6 +256,18 @@ pub struct FinishResponse {
     pub role_vec: JsonValue,
 }
 
+/// POST /members/me/rotate — complete a DID rotation. Auth: old DID's session.
+#[utoipa::path(
+    post, path = "/members/me/rotate", tag = "members",
+    security(("bearer_jwt" = [])),
+    request_body = FinishBody,
+    responses(
+        (status = 200, description = "DID rotated", body = FinishResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Session DID does not match oldDid"),
+        (status = 404, description = "Caller is not a member"),
+    ),
+)]
 pub async fn rotate(
     auth: AuthClaims,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -39,6 +39,7 @@ use crate::server::AppState;
 /// with no fields is a no-op (200 with the current row).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct UpdateMemberRequest {
     pub role: Option<VtcRole>,
     pub publish_consent: Option<bool>,

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -47,6 +47,19 @@ pub struct UpdateMemberRequest {
     pub extensions: Option<JsonValue>,
 }
 
+/// PATCH /members/{did} — update member role + profile fields. Auth: Admin.
+#[utoipa::path(
+    patch, path = "/members/{did}", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID")),
+    request_body = UpdateMemberRequest,
+    responses(
+        (status = 200, description = "Updated member record", body = MemberResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin / role change denied by policy"),
+        (status = 404, description = "Member not found"),
+    ),
+)]
 pub async fn update_member(
     auth: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -34,10 +34,82 @@ use tower_governor::GovernorLayer;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_governor::key_extractor::SmartIpKeyExtractor;
 
-use vti_common::trust_task::{TrustTask, TrustTaskRouter};
+use utoipa::OpenApi;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use vti_common::trust_task::{TrustTask, TrustTaskRouter, task_routes};
 
 use crate::config::RoutingConfig;
 use crate::server::AppState;
+
+/// OpenAPI document root for the VTC REST surface.
+///
+/// As in the VTA, the router is the single source of truth for *paths*: each
+/// handler annotated with `#[utoipa::path]` and registered via
+/// `routes!()` — wrapped in [`task_routes`] so the per-route Trust-Task header
+/// validation is preserved — contributes its operation to the served
+/// `/openapi.json`. This struct only seeds document metadata + the security
+/// scheme.
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Verifiable Trust Community (VTC) API",
+        description = "Community lifecycle, ACL, audit, policy, credentials, \
+                       endorsements, and cross-community recognition REST surface \
+                       of a Verifiable Trust Community.",
+        version = env!("CARGO_PKG_VERSION"),
+    ),
+    modifiers(&SecurityAddon),
+)]
+pub struct ApiDoc;
+
+/// Registers the `bearer_jwt` HTTP-bearer security scheme referenced by
+/// authenticated operations' `security(("bearer_jwt" = []))`.
+struct SecurityAddon;
+
+impl utoipa::Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+        let components = openapi.components.get_or_insert_with(Default::default);
+        components.add_security_scheme(
+            "bearer_jwt",
+            SecurityScheme::Http(
+                HttpBuilder::new()
+                    .scheme(HttpAuthScheme::Bearer)
+                    .bearer_format("JWT")
+                    .build(),
+            ),
+        );
+    }
+}
+
+/// Serve the assembled OpenAPI document as JSON at `GET /openapi.json`.
+/// Unauthenticated by design — it describes the API shape, not any secret.
+async fn serve_openapi(api: utoipa::openapi::OpenApi) -> axum::Json<utoipa::openapi::OpenApi> {
+    axum::Json(api)
+}
+
+/// The assembled OpenAPI document describing the VTC REST surface.
+///
+/// **Spike scope:** currently documents the single migrated route
+/// (`GET /v1/health/diagnostics`) to prove the `OpenApiRouter` +
+/// [`task_routes`] integration end-to-end. The remaining ~95 routes are
+/// migrated from [`build_api_chain`]'s `TrustTaskRouter` in follow-up work,
+/// at which point this is built from that same assembly (drift-free).
+pub fn openapi_spec() -> utoipa::openapi::OpenApi {
+    let diagnostics_task =
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0")
+            .expect("static Trust-Task URL");
+    let api = OpenApiRouter::<AppState>::new()
+        .routes(task_routes(routes!(health::diagnostics), diagnostics_task));
+    // The API surface nests under `/v1` (the default mount), mirroring how
+    // `assemble` mounts the live router; OpenApiRouter::nest composes the
+    // documented paths the same way.
+    OpenApiRouter::<AppState>::with_openapi(ApiDoc::openapi())
+        .nest("/v1", api)
+        .split_for_parts()
+        .1
+}
 
 /// Global API surface body cap (Phase 5 M5.1.4 — §14.4 runtime
 /// guard). Matches the VTA's `MAX_BODY_SIZE`. Website management
@@ -1074,6 +1146,7 @@ fn assemble(routing: &RoutingConfig, api: Router<AppState>) -> Router<AppState> 
         .fallback(any(placeholder_503))
         .layer(from_fn(security_headers));
 
+    let spec = openapi_spec();
     let mut app: Router<AppState> = Router::new()
         // `/health` is the single Trust-Task-exempt endpoint;
         // attached at the parent-router root so monitoring works
@@ -1081,6 +1154,10 @@ fn assemble(routing: &RoutingConfig, api: Router<AppState>) -> Router<AppState> 
         // operator just curls `/health` on whichever host the
         // daemon is reachable on).
         .route("/health", get(health::health))
+        // Machine-readable API description for black-box conformance / fuzz
+        // tooling. Unauthenticated (API shape, not secrets); served at the
+        // parent root like `/health`.
+        .route("/openapi.json", get(move || serve_openapi(spec.clone())))
         // `did:webvh` log publication. Mounted at the parent root
         // (above the `/v1` nest) because a serverless VTC's DID,
         // `did:webvh:<scid>:<host>`, resolves to
@@ -1186,8 +1263,12 @@ pub fn assemble_with_website(
             .layer(from_fn(security_headers)),
     };
 
+    let spec = openapi_spec();
     let mut app: Router<AppState> = Router::new()
         .route("/health", get(health::health))
+        // Machine-readable API description — see the matching comment in
+        // `assemble`.
+        .route("/openapi.json", get(move || serve_openapi(spec.clone())))
         // `did:webvh` log publication — see the matching comment in
         // `assemble`. Parent-root mount so a serverless VTC's
         // `did:webvh:<scid>:<host>` resolves to
@@ -1228,4 +1309,29 @@ async fn placeholder_503() -> impl IntoResponse {
         StatusCode::SERVICE_UNAVAILABLE,
         "surface not yet implemented",
     )
+}
+
+#[cfg(test)]
+mod openapi_tests {
+    use super::*;
+
+    #[test]
+    fn openapi_spec_documents_the_migrated_route_and_security_scheme() {
+        let spec = openapi_spec();
+        assert_eq!(spec.info.title, "Verifiable Trust Community (VTC) API");
+        // The migrated route is nested under the /v1 API mount.
+        let diag = spec
+            .paths
+            .paths
+            .get("/v1/health/diagnostics")
+            .expect("/v1/health/diagnostics must be documented");
+        assert!(diag.get.is_some(), "diagnostics documents a GET operation");
+        // The bearer scheme + the response schema are present.
+        let components = spec.components.as_ref().expect("components present");
+        assert!(components.security_schemes.contains_key("bearer_jwt"));
+        assert!(
+            components.schemas.contains_key("DiagnosticsResponse"),
+            "DiagnosticsResponse schema must be emitted"
+        );
+    }
 }

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -37,7 +37,7 @@ use tower_governor::key_extractor::SmartIpKeyExtractor;
 use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_axum::routes;
-use vti_common::trust_task::{TrustTask, TrustTaskRouter, task_routes};
+use vti_common::trust_task::{TrustTask, task_layer, task_routes};
 
 use crate::config::RoutingConfig;
 use crate::server::AppState;
@@ -91,22 +91,18 @@ async fn serve_openapi(api: utoipa::openapi::OpenApi) -> axum::Json<utoipa::open
 
 /// The assembled OpenAPI document describing the VTC REST surface.
 ///
-/// **Spike scope:** currently documents the single migrated route
-/// (`GET /v1/health/diagnostics`) to prove the `OpenApiRouter` +
-/// [`task_routes`] integration end-to-end. The remaining ~95 routes are
-/// migrated from [`build_api_chain`]'s `TrustTaskRouter` in follow-up work,
-/// at which point this is built from that same assembly (drift-free).
+/// Built from the same [`build_api_chain`] assembly that wires the live
+/// routes — every handler registered via [`task_routes`]`(routes!(...))`
+/// contributes its operation — so the document cannot drift from what the
+/// service serves. The API surface is nested under the `/v1` mount exactly as
+/// [`assemble`] mounts the live router; `OpenApiRouter::nest` composes the
+/// documented paths the same way. Served at `GET /openapi.json`.
+///
+/// Handlers still registered via [`task_layer`] (not yet `#[utoipa::path]`-
+/// annotated) are served but absent from the document until annotated.
 pub fn openapi_spec() -> utoipa::openapi::OpenApi {
-    let diagnostics_task =
-        TrustTask::new("https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0")
-            .expect("static Trust-Task URL");
-    let api = OpenApiRouter::<AppState>::new()
-        .routes(task_routes(routes!(health::diagnostics), diagnostics_task));
-    // The API surface nests under `/v1` (the default mount), mirroring how
-    // `assemble` mounts the live router; OpenApiRouter::nest composes the
-    // documented paths the same way.
     OpenApiRouter::<AppState>::with_openapi(ApiDoc::openapi())
-        .nest("/v1", api)
+        .nest("/v1", build_api_chain(&RoutingConfig::default(), false))
         .split_for_parts()
         .1
 }
@@ -197,7 +193,12 @@ pub fn router_with_xff(routing: &RoutingConfig, trust_xff: bool) -> Router<AppSt
 
 #[cfg(not(feature = "website"))]
 fn router_with_inner(routing: &RoutingConfig, trust_xff: bool) -> Router<AppState> {
-    let api_chain = build_api_chain(routing, trust_xff);
+    // `build_api_chain` returns an `OpenApiRouter` (the single source of truth
+    // for both routes and `/openapi.json`); split off the served axum `Router`
+    // for `assemble` to nest. The OpenAPI document is rebuilt from the same
+    // assembly by [`openapi_spec`] (which `assemble` serves), so the two cannot
+    // drift.
+    let api_chain = build_api_chain(routing, trust_xff).split_for_parts().0;
     assemble(routing, api_chain)
 }
 
@@ -207,7 +208,7 @@ fn router_with_inner(
     website_state: Option<crate::website::WebsiteState>,
     trust_xff: bool,
 ) -> Router<AppState> {
-    let api_chain = build_api_chain(routing, trust_xff);
+    let api_chain = build_api_chain(routing, trust_xff).split_for_parts().0;
     assemble_with_website(routing, api_chain, website_state)
 }
 
@@ -217,7 +218,7 @@ fn router_with_inner(
 /// [`assemble_with_website`]) but threaded through so a future
 /// per-mount override can land without changing this function's
 /// signature.
-fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState> {
+fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<AppState> {
     // Canonical cross-cutting auth tasks from trusttasks-tf. The legacy
     // openvtc/vtc/auth/legacy/* slugs were VTC-specific reimplementations
     // of primitives that VTA + did-hosting also have; consolidating here
@@ -437,101 +438,111 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
     // surface stays complete; the wire enforcement collapses to
     // the POST task on the shared mount.
 
-    let api = TrustTaskRouter::<AppState>::new()
-        .route_with_task(
-            "/health/diagnostics",
-            get(health::diagnostics),
+    let api = OpenApiRouter::<AppState>::new()
+        .routes(task_routes(
+            routes!(health::diagnostics),
             health_diagnostics,
-        )
+        ))
         // BitstringStatusList publication (M2.11). Trust-Task-
         // exempt — external verifiers don't carry our extension
         // header (same rationale as `did.jsonl`).
-        .route_exempt("/status-lists/{purpose}", get(status_lists::show))
+        .route("/status-lists/{purpose}", get(status_lists::show))
         // Auth routes. `POST /v1/auth/{challenge,authenticate,refresh}`
         // are unauthenticated and live in `build_unauth_routes` so the
         // tower-governor + tighter body cap apply. The two
         // session-management endpoints below are authenticated and
         // stay on the main chain.
-        .route_with_task(
+        .route(
             "/auth/sessions",
-            get(auth::session_list).delete(auth::revoke_sessions_by_did),
-            auth_sessions_manage,
+            task_layer(
+                get(auth::session_list).delete(auth::revoke_sessions_by_did),
+                auth_sessions_manage,
+            ),
         )
-        .route_with_task(
+        .route(
             "/auth/sessions/{session_id}",
-            delete(auth::revoke_session),
-            auth_sessions_revoke,
+            task_layer(delete(auth::revoke_session), auth_sessions_revoke),
         )
-        .route_with_task("/auth/whoami", get(auth::whoami), auth_whoami)
-        .route_with_task("/auth/sign-out", post(auth::sign_out), auth_sign_out)
+        .route("/auth/whoami", task_layer(get(auth::whoami), auth_whoami))
+        .route(
+            "/auth/sign-out",
+            task_layer(post(auth::sign_out), auth_sign_out),
+        )
         // Audit log read (super-admin only).
-        .route_with_task("/audit", get(audit::list_audit), audit_list)
+        .route("/audit", task_layer(get(audit::list_audit), audit_list))
         // Config
-        .route_with_task(
+        .route(
             "/config",
-            get(config::get_config).patch(config::update_config),
-            config_manage,
+            task_layer(
+                get(config::get_config).patch(config::update_config),
+                config_manage,
+            ),
         )
         // ACL
-        .route_with_task("/acl", get(acl::list_acl).post(acl::create_acl), acl_manage)
-        .route_with_task(
+        .route(
+            "/acl",
+            task_layer(get(acl::list_acl).post(acl::create_acl), acl_manage),
+        )
+        .route(
             "/acl/{did}",
-            get(acl::get_acl)
-                .patch(acl::update_acl)
-                .delete(acl::delete_acl),
-            acl_entry,
+            task_layer(
+                get(acl::get_acl)
+                    .patch(acl::update_acl)
+                    .delete(acl::delete_acl),
+                acl_entry,
+            ),
         )
         // Community profile (GET + PUT share one Trust Task today;
         // a spec-aligned split into community/profile/show/1.0 +
         // community/profile/update/1.0 lands when TrustTaskRouter
         // gains per-method task selectors in Phase 1+).
-        .route_with_task(
+        .route(
             "/community/profile",
-            get(community::profile::get_profile).put(community::profile::put_profile),
-            community_profile,
+            task_layer(
+                get(community::profile::get_profile).put(community::profile::put_profile),
+                community_profile,
+            ),
         )
         // Public read of the community profile. Trust-Task-exempt and
         // unauthenticated — visitors landing on the default public
         // website need the community's name + description + DIDs to
         // render before any session exists. Curated subset only (no
         // extensions, no registry status).
-        .route_exempt(
+        .route(
             "/community/public-profile",
             get(community::profile::get_public_profile),
         )
         // Admin config (M0.8 — GET + PATCH share one task; will
         // split into admin/config/show/1.0 + patch/1.0 when
         // TrustTaskRouter gains per-method selectors).
-        .route_with_task(
+        .route(
             "/admin/config",
-            get(admin::config::get_config).patch(admin::config::patch_config),
-            admin_config,
+            task_layer(
+                get(admin::config::get_config).patch(admin::config::patch_config),
+                admin_config,
+            ),
         )
         // Reload + restart (M0.8.3). Reload applies hot-reloadable
         // settings in-place; restart requires a supervisor (412
         // `SupervisorRequired` otherwise).
-        .route_with_task(
+        .route(
             "/admin/config/reload",
-            post(admin::config::reload_config),
-            admin_config_reload,
+            task_layer(post(admin::config::reload_config), admin_config_reload),
         )
-        .route_with_task(
+        .route(
             "/admin/config/restart",
-            post(admin::config::restart_config),
-            admin_config_restart,
+            task_layer(post(admin::config::restart_config), admin_config_restart),
         )
         // Export / import (M0.8.4). Export returns the portable
         // (db-layer overrides + community profile) JSON; import runs
         // diff-and-confirm via `?confirm=true|false`.
-        .route_with_task(
+        .route(
             "/admin/config/export",
-            post(admin::config::export_config),
-            admin_config_export,
+            task_layer(post(admin::config::export_config), admin_config_export),
         )
-        .route_with_task(
+        .route(
             "/admin/config/import",
-            post(admin::config::import_config),
-            admin_config_import,
+            task_layer(post(admin::config::import_config), admin_config_import),
         )
         // Install claim endpoints (`/install/claim/start` and
         // `/install/claim/finish`) are unauthenticated and live in
@@ -540,243 +551,257 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
         // Admin bootstrap (M0.6.2) — closes the install carve-out
         // and writes the first admin ACL entry. Unauthenticated
         // because the setup-session JWT IS the auth credential.
-        .route_with_task(
+        .route(
             "/admin/bootstrap",
-            post(admin::bootstrap::bootstrap),
-            admin_bootstrap,
+            task_layer(post(admin::bootstrap::bootstrap), admin_bootstrap),
         )
         // Admin passkey management (M0.6.3). Step-up UV is enforced
         // via the two-phase ceremony: `register/start` and
         // `revoke/start` issue a UV challenge bound to an existing
         // passkey; `register/finish` and `revoke/finish` reject if
         // the UV assertion doesn't verify.
-        .route_with_task(
+        .route(
             "/admin/passkeys",
-            get(admin::passkeys::list),
-            admin_passkeys_list,
+            task_layer(get(admin::passkeys::list), admin_passkeys_list),
         )
-        .route_with_task(
+        .route(
             "/admin/passkeys/register/start",
-            post(admin::passkeys::register_start),
-            admin_passkeys_register.clone(),
+            task_layer(
+                post(admin::passkeys::register_start),
+                admin_passkeys_register.clone(),
+            ),
         )
-        .route_with_task(
+        .route(
             "/admin/passkeys/register/finish",
-            post(admin::passkeys::register_finish),
-            admin_passkeys_register,
+            task_layer(
+                post(admin::passkeys::register_finish),
+                admin_passkeys_register,
+            ),
         )
-        .route_with_task(
+        .route(
             "/admin/passkeys/revoke/start",
-            post(admin::passkeys::revoke_start),
-            admin_passkeys_revoke.clone(),
+            task_layer(
+                post(admin::passkeys::revoke_start),
+                admin_passkeys_revoke.clone(),
+            ),
         )
-        .route_with_task(
+        .route(
             "/admin/passkeys/revoke/finish",
-            post(admin::passkeys::revoke_finish),
-            admin_passkeys_revoke,
+            task_layer(post(admin::passkeys::revoke_finish), admin_passkeys_revoke),
         )
         // Admin invites — REST mirror of `vtc admin invite`. GET +
         // POST share the same mount; DELETE on `/admin/invites/{jti}`
         // revokes outstanding (Issued) invites. Consumed rows are
         // immutable (audit history) — DELETE on those returns 409.
-        .route_with_task(
+        .route(
             "/admin/invites",
-            get(admin::invites::list_invites).post(admin::invites::create_invite),
-            admin_invites_manage,
+            task_layer(
+                get(admin::invites::list_invites).post(admin::invites::create_invite),
+                admin_invites_manage,
+            ),
         )
-        .route_with_task(
+        .route(
             "/admin/invites/{jti}",
-            axum::routing::delete(admin::invites::revoke_invite),
-            admin_invites_revoke,
+            task_layer(
+                axum::routing::delete(admin::invites::revoke_invite),
+                admin_invites_revoke,
+            ),
         )
         // Directory ceremony (read-only field projection via the
         // ceremony decision pipeline).
-        .route_with_task("/directory/{did}", get(directory::query), directory_query)
+        .route(
+            "/directory/{did}",
+            task_layer(get(directory::query), directory_query),
+        )
         // Ceremony registry — the admin-UI renders its flow + simulator
         // from these manifests (purpose / fields / facts template).
-        .route_with_task("/ceremonies", get(ceremonies::list), ceremonies_list)
+        .route(
+            "/ceremonies",
+            task_layer(get(ceremonies::list), ceremonies_list),
+        )
         // Members (Phase 1 M1.4–M1.6).
-        .route_with_task("/members", get(members::read::list_members), members_list)
+        .route(
+            "/members",
+            task_layer(get(members::read::list_members), members_list),
+        )
         // `/v1/members/me` for self-remove (M1.11.1). Must be
         // declared BEFORE the `/v1/members/{did}` mount otherwise
         // axum's path-trie picks the parameterised route first
         // and routes "me" as a literal DID.
-        .route_with_task(
+        .route(
             "/members/me",
-            axum::routing::delete(members::remove::self_remove),
-            members_self_remove,
+            task_layer(
+                axum::routing::delete(members::remove::self_remove),
+                members_self_remove,
+            ),
         )
         // Renewal (M2.13). POST on its own mount so the
         // Trust Task header check + per-method selectors are
         // unambiguous.
-        .route_with_task(
+        .route(
             "/members/me/renew",
-            post(members::renew::renew),
-            members_renew,
+            task_layer(post(members::renew::renew), members_renew),
         )
         // DID rotation (M2.15.1). Two-step ceremony — challenge
         // mints a single-use rotation_id, the finish endpoint
         // applies the co-signed swap atomically.
-        .route_with_task(
+        .route(
             "/members/me/rotate/challenge",
-            post(members::rotate::challenge),
-            members_rotate_challenge,
+            task_layer(post(members::rotate::challenge), members_rotate_challenge),
         )
-        .route_with_task(
+        .route(
             "/members/me/rotate",
-            post(members::rotate::rotate),
-            members_rotate,
+            task_layer(post(members::rotate::rotate), members_rotate),
         )
         // Phase 4 M4.3 + M4.4 — personhood lifecycle. Three
         // mounts on the same path prefix; declared BEFORE
         // `/v1/members/{did}` so axum's path-trie matches the
         // literal segment first. Personhood is a per-member
         // resource; `{did}` is the subject.
-        .route_with_task(
+        .route(
             "/members/{did}/personhood/challenge",
-            post(members::personhood::challenge),
-            members_personhood_challenge,
+            task_layer(
+                post(members::personhood::challenge),
+                members_personhood_challenge,
+            ),
         )
-        .route_with_task(
+        .route(
             "/members/{did}/personhood",
-            post(members::personhood::assert).delete(members::personhood::revoke),
-            // POST + DELETE share `personhood/assert/1.0` at
-            // the router layer pending per-method selectors;
-            // the standalone `personhood/revoke/1.0` Trust Task
-            // exists on disk + in index.json so the soft-gate
-            // surface stays complete. (Same workaround as
-            // members/{did}'s show + update + admin-remove.)
-            members_personhood_assert,
+            task_layer(
+                post(members::personhood::assert).delete(members::personhood::revoke), // POST + DELETE share `personhood/assert/1.0` at
+                // the router layer pending per-method selectors;
+                // the standalone `personhood/revoke/1.0` Trust Task
+                // exists on disk + in index.json so the soft-gate
+                // surface stays complete. (Same workaround as
+                // members/{did}'s show + update + admin-remove.)
+                members_personhood_assert,
+            ),
         )
         // Phase 4 M4.6 — VRC trust-graph endpoints. The
         // per-member list mounts under /v1/members/{did}/
         // and must precede the catchall `/v1/members/{did}`
         // (same path-trie precedence as personhood).
-        .route_with_task(
+        .route(
             "/members/{did}/relationships",
-            get(members::relationships::list),
-            relationships_list,
+            task_layer(get(members::relationships::list), relationships_list),
         )
-        .route_with_task(
+        .route(
             "/relationships",
-            post(relationships::publish),
-            relationships_publish,
+            task_layer(post(relationships::publish), relationships_publish),
         )
-        .route_with_task(
+        .route(
             "/relationships/{id}",
-            delete(relationships::revoke),
-            relationships_revoke,
+            task_layer(delete(relationships::revoke), relationships_revoke),
         )
         // Phase 4 M4.8.1 — operator-uploaded endorsement type
         // registry. Admin-gated CRUD.
-        .route_with_task(
+        .route(
             "/endorsement-types",
-            post(endorsement_types::register).get(endorsement_types::list),
-            // POST + GET share `register/1.0` at the router
-            // layer pending per-method selectors; standalone
-            // `list/1.0` exists on disk + in index.json.
-            endorsement_types_register,
+            task_layer(
+                post(endorsement_types::register).get(endorsement_types::list), // POST + GET share `register/1.0` at the router
+                // layer pending per-method selectors; standalone
+                // `list/1.0` exists on disk + in index.json.
+                endorsement_types_register,
+            ),
         )
-        .route_with_task(
+        .route(
             "/endorsement-types/{type_uri}",
-            delete(endorsement_types::delete),
-            endorsement_types_delete,
+            task_layer(delete(endorsement_types::delete), endorsement_types_delete),
         )
         // Phase 2 §8 — community schema store (Issues + Accepts
         // registry). Plain admin-gated CRUD (AdminAuth extractor),
         // exempt from the Trust-Task soft-gate. (`accepts` static
         // segments bind before the `{type_uri}` param via matchit.)
-        .route_exempt(
+        .route(
             "/schemas/accepts",
             post(schemas::register_accepts).get(schemas::list_accepts_route),
         )
-        .route_exempt(
+        .route(
             "/schemas/accepts/{id}",
             get(schemas::get_accepts_route).delete(schemas::delete_accepts_route),
         )
-        .route_exempt("/schemas", post(schemas::register).get(schemas::list))
-        .route_exempt(
+        .route("/schemas", post(schemas::register).get(schemas::list))
+        .route(
             "/schemas/{type_uri}",
             get(schemas::get_one).delete(schemas::delete_one),
         )
         // Phase 4 M4.8.2-4 — custom endorsement issuance +
         // retrieval + revocation. Admin OR Issuer-role member.
-        .route_with_task(
+        .route(
             "/credentials/endorsements",
-            post(endorsements::issue).get(endorsements::list),
-            // POST + GET share `issue/1.0` at the router
-            // layer pending per-method selectors; standalone
-            // `list/1.0` exists on disk + in index.json.
-            endorsements_issue,
+            task_layer(
+                post(endorsements::issue).get(endorsements::list), // POST + GET share `issue/1.0` at the router
+                // layer pending per-method selectors; standalone
+                // `list/1.0` exists on disk + in index.json.
+                endorsements_issue,
+            ),
         )
-        .route_with_task(
+        .route(
             "/credentials/endorsements/{id}",
-            axum::routing::get(endorsements::show).delete(endorsements::revoke),
-            // GET + DELETE share `show/1.0` at the router
-            // layer pending per-method selectors; standalone
-            // `revoke/1.0` exists on disk + in index.json.
-            endorsements_show_revoke,
+            task_layer(
+                axum::routing::get(endorsements::show).delete(endorsements::revoke), // GET + DELETE share `show/1.0` at the router
+                // layer pending per-method selectors; standalone
+                // `revoke/1.0` exists on disk + in index.json.
+                endorsements_show_revoke,
+            ),
         )
-        .route_with_task(
+        .route(
             "/members/{did}",
-            get(members::read::show_member)
-                .patch(members::update::update_member)
-                .delete(members::remove::admin_remove),
-            // GET + PATCH + DELETE share `members/show/1.0` at the
-            // router layer pending per-method selectors; the
-            // standalone `members/update/1.0` and
-            // `members/admin-remove/1.0` Trust Tasks exist on
-            // disk + in index.json so the soft-gate surface stays
-            // complete.
-            members_show,
+            task_layer(
+                get(members::read::show_member)
+                    .patch(members::update::update_member)
+                    .delete(members::remove::admin_remove), // GET + PATCH + DELETE share `members/show/1.0` at the
+                // router layer pending per-method selectors; the
+                // standalone `members/update/1.0` and
+                // `members/admin-remove/1.0` Trust Tasks exist on
+                // disk + in index.json so the soft-gate surface stays
+                // complete.
+                members_show,
+            ),
         )
-        .route_with_task(
+        .route(
             "/members/{did}/promote-to-admin/start",
-            post(members::promote::promote_start),
-            members_promote.clone(),
+            task_layer(
+                post(members::promote::promote_start),
+                members_promote.clone(),
+            ),
         )
-        .route_with_task(
+        .route(
             "/members/{did}/promote-to-admin/finish",
-            post(members::promote::promote_finish),
-            members_promote,
+            task_layer(post(members::promote::promote_finish), members_promote),
         )
         // Join requests (Phase 1 M1.7–M1.10). The unauth POST submit /
         // accept / status live on the governed branch (`build_unauth_routes`,
         // P0.5); the admin GET list keeps this `/join-requests` mount (axum
         // merges this GET with the governed-branch POST submit).
-        .route_with_task(
+        .route(
             "/join-requests",
-            get(join_requests::read::list_join_requests),
-            join_submit,
+            task_layer(get(join_requests::read::list_join_requests), join_submit),
         )
-        .route_with_task(
+        .route(
             "/join-requests/{id}",
-            get(join_requests::read::show_join_request),
-            join_show,
+            task_layer(get(join_requests::read::show_join_request), join_show),
         )
-        .route_with_task(
+        .route(
             "/join-requests/{id}/approve",
-            post(join_requests::decide::approve),
-            join_approve,
+            task_layer(post(join_requests::decide::approve), join_approve),
         )
-        .route_with_task(
+        .route(
             "/join-requests/{id}/reject",
-            post(join_requests::decide::reject),
-            join_reject,
+            task_layer(post(join_requests::decide::reject), join_reject),
         )
         // Manifest (unauth public discovery): the community's join
         // evidence requirements. Static `manifest` segment takes
         // precedence over the `{id}` show route.
-        .route_with_task(
+        .route(
             "/join-requests/manifest",
-            get(join_requests::manifest::manifest),
-            join_manifest,
+            task_layer(get(join_requests::manifest::manifest), join_manifest),
         )
         // Credential-exchange query send (admin): prepare a DCQL query + issue a
         // single-use presentation challenge for a holder. Plain admin route (no
         // Trust-Task descriptor) — the holder answers over the credential-exchange
         // DIDComm `present` surface.
-        .route_exempt(
+        .route(
             "/join-requests/query",
             post(join_requests::present::send_query),
         )
@@ -784,28 +809,29 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
         // Trust Tasks. `upload` mints + persists; `activate` flips
         // the per-purpose active pointer; `test` evaluates a stored
         // policy without mutating state.
-        .route_with_task(
+        .route(
             "/policies",
-            get(policies::read::list_policies).post(policies::admin::upload),
-            policies_upload.clone(),
+            task_layer(
+                get(policies::read::list_policies).post(policies::admin::upload),
+                policies_upload.clone(),
+            ),
         )
-        .route_with_task(
+        .route(
             "/policies/{id}",
-            get(policies::read::show_policy),
-            // Reuses the upload task on the shared mount; the
-            // `policies/show/1.0` Trust Task lives in index.json
-            // + on disk for the soft-gate surface (see above).
-            policies_upload.clone(),
+            task_layer(
+                get(policies::read::show_policy), // Reuses the upload task on the shared mount; the
+                // `policies/show/1.0` Trust Task lives in index.json
+                // + on disk for the soft-gate surface (see above).
+                policies_upload.clone(),
+            ),
         )
-        .route_with_task(
+        .route(
             "/policies/{id}/activate",
-            post(policies::admin::activate),
-            policies_activate,
+            task_layer(post(policies::admin::activate), policies_activate),
         )
-        .route_with_task(
+        .route(
             "/policies/{id}/test",
-            post(policies::admin::test),
-            policies_test,
+            task_layer(post(policies::admin::test), policies_test),
         );
 
     // Phase 5 M5.5 — public-website management routes. The
@@ -848,43 +874,42 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
         // the operator-configured value at runtime.
         const WEBSITE_ROUTE_CAP: usize = 64 * 1024 * 1024;
 
-        api.route_with_task(
+        api.route(
             "/website/files",
-            get(website::files::list),
-            website_files_list,
+            task_layer(get(website::files::list), website_files_list),
         )
-        .route_with_task(
+        .route(
             "/website/files/{*path}",
-            get(website::files::show)
-                .put(website::files::write)
-                .delete(website::files::delete)
-                .layer(DefaultBodyLimit::max(WEBSITE_ROUTE_CAP)),
-            // Three methods on the same mount share the show
-            // task per the TrustTaskRouter limitation already
-            // documented elsewhere. The `write` and `delete`
-            // tasks are still registered on disk + in index.json
-            // for the soft-gate surface.
-            website_files_show,
+            task_layer(
+                get(website::files::show)
+                    .put(website::files::write)
+                    .delete(website::files::delete)
+                    .layer(DefaultBodyLimit::max(WEBSITE_ROUTE_CAP)), // Three methods on the same mount share the show
+                // task per the TrustTaskRouter limitation already
+                // documented elsewhere. The `write` and `delete`
+                // tasks are still registered on disk + in index.json
+                // for the soft-gate surface.
+                website_files_show,
+            ),
         )
-        .route_with_task(
+        .route(
             "/website/deploy",
-            post(website::deploy::deploy).layer(DefaultBodyLimit::max(WEBSITE_ROUTE_CAP)),
-            website_deploy,
+            task_layer(
+                post(website::deploy::deploy).layer(DefaultBodyLimit::max(WEBSITE_ROUTE_CAP)),
+                website_deploy,
+            ),
         )
-        .route_with_task(
+        .route(
             "/website/generations",
-            get(website::generations::list),
-            website_gens_list,
+            task_layer(get(website::generations::list), website_gens_list),
         )
-        .route_with_task(
+        .route(
             "/website/rollback/{gen_num}",
-            post(website::generations::rollback),
-            website_rollback,
+            task_layer(post(website::generations::rollback), website_rollback),
         )
     };
 
     let api = api
-        .into_router()
         // §14.4 — every authenticated API route inherits the 1 MiB
         // global body cap. The per-route overrides above for
         // `/v1/website/*` apply first; this layer is the default
@@ -911,7 +936,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> Router<AppState
 ///   envelope, small enough to reject blob floods).
 /// - Per-IP `tower-governor` (5 rps + 10 burst) via
 ///   [`SmartIpKeyExtractor`].
-fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
+fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
     // Canonical cross-cutting auth tasks from trusttasks-tf.
     let auth_challenge = TrustTask::new("https://trusttasks.org/spec/auth/challenge/0.1")
         .expect("static Trust-Task URL");
@@ -995,9 +1020,15 @@ fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
     // is untouched.
     let synth_connect_info = axum::middleware::from_fn(insert_default_connect_info_if_missing);
 
-    let unauth_router = TrustTaskRouter::<AppState>::new()
-        .route_with_task("/auth/challenge", post(auth::challenge), auth_challenge)
-        .route_with_task("/auth/", post(auth::authenticate), auth_authenticate)
+    let unauth_router = OpenApiRouter::<AppState>::new()
+        .route(
+            "/auth/challenge",
+            task_layer(post(auth::challenge), auth_challenge),
+        )
+        .route(
+            "/auth/",
+            task_layer(post(auth::authenticate), auth_authenticate),
+        )
         // VTA-wallet login surface. The browser wallet extension drives
         // the SIOPv2 round-trip itself and posts to `<base>/auth/challenge`
         // + `<base>/auth/` with **no** `Trust-Task` header (the op `type`
@@ -1007,69 +1038,63 @@ fn build_unauth_routes(trust_xff: bool) -> Router<AppState> {
         // wallet at `<origin>/v1/wallet` so it lands here, leaving the
         // Trust-Task-gated `/auth/*` routes above untouched for DIDComm and
         // CLI clients. Mirrors did-hosting-control's header-less auth.
-        .route_exempt("/wallet/auth/challenge", post(auth::challenge))
-        .route_exempt("/wallet/auth/", post(auth::authenticate))
-        .route_with_task("/auth/refresh", post(auth::refresh), auth_refresh)
-        .route_with_task(
+        .route("/wallet/auth/challenge", post(auth::challenge))
+        .route("/wallet/auth/", post(auth::authenticate))
+        .route(
+            "/auth/refresh",
+            task_layer(post(auth::refresh), auth_refresh),
+        )
+        .route(
             "/auth/admin-login",
-            post(auth::admin_login),
-            auth_admin_login,
+            task_layer(post(auth::admin_login), auth_admin_login),
         )
-        .route_with_task(
+        .route(
             "/auth/admin-session",
-            post(auth::admin_session),
-            auth_admin_session,
+            task_layer(post(auth::admin_session), auth_admin_session),
         )
-        .route_with_task(
+        .route(
             "/auth/passkey-login/start",
-            post(auth::passkey_login_start),
-            auth_passkey_login_start,
+            task_layer(post(auth::passkey_login_start), auth_passkey_login_start),
         )
-        .route_with_task(
+        .route(
             "/auth/passkey-login/finish",
-            post(auth::passkey_login_finish),
-            auth_passkey_login_finish,
+            task_layer(post(auth::passkey_login_finish), auth_passkey_login_finish),
         )
-        .route_with_task(
+        .route(
             "/install/claim/start",
-            post(install::claim_start),
-            install_claim_start,
+            task_layer(post(install::claim_start), install_claim_start),
         )
-        .route_with_task(
+        .route(
             "/install/claim/finish",
-            post(install::claim_finish),
-            install_claim_finish,
+            task_layer(post(install::claim_finish), install_claim_finish),
         )
-        .route_with_task(
+        .route(
             "/auth/recognise/challenge",
-            post(recognise::recognise_challenge),
-            auth_recognise_challenge,
+            task_layer(
+                post(recognise::recognise_challenge),
+                auth_recognise_challenge,
+            ),
         )
-        .route_with_task(
+        .route(
             "/auth/recognise",
-            post(recognise::recognise),
-            auth_recognise,
+            task_layer(post(recognise::recognise), auth_recognise),
         )
         // Join-request POSTs (P0.5). Submit shares the `/join-requests` mount
         // with the admin GET list on the `api` chain — axum merges the GET +
         // POST method routers; the unauth POST lands here (governed), the admin
         // GET stays there (JWT-gated).
-        .route_with_task(
+        .route(
             "/join-requests",
-            post(join_requests::submit::submit),
-            join_submit,
+            task_layer(post(join_requests::submit::submit), join_submit),
         )
-        .route_with_task(
+        .route(
             "/join-requests/{id}/accept",
-            post(join_requests::accept::accept),
-            join_accept,
+            task_layer(post(join_requests::accept::accept), join_accept),
         )
-        .route_with_task(
+        .route(
             "/join-requests/{id}/status",
-            post(join_requests::status::status),
-            join_status,
+            task_layer(post(join_requests::status::status), join_status),
         )
-        .into_router()
         .layer(DefaultBodyLimit::max(UNAUTH_BODY_SIZE));
 
     // Apply the per-IP rate limiter in a branch so the two

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -29,7 +29,7 @@ use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::{any, delete, get, post};
+use axum::routing::{any, get, post};
 use tower_governor::GovernorLayer;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_governor::key_extractor::SmartIpKeyExtractor;
@@ -446,104 +446,84 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // BitstringStatusList publication (M2.11). Trust-Task-
         // exempt — external verifiers don't carry our extension
         // header (same rationale as `did.jsonl`).
-        .route("/status-lists/{purpose}", get(status_lists::show))
+        .routes(routes!(status_lists::show))
         // Auth routes. `POST /v1/auth/{challenge,authenticate,refresh}`
         // are unauthenticated and live in `build_unauth_routes` so the
         // tower-governor + tighter body cap apply. The two
         // session-management endpoints below are authenticated and
         // stay on the main chain.
-        .route(
-            "/auth/sessions",
-            task_layer(
-                get(auth::session_list).delete(auth::revoke_sessions_by_did),
-                auth_sessions_manage,
-            ),
-        )
-        .route(
-            "/auth/sessions/{session_id}",
-            task_layer(delete(auth::revoke_session), auth_sessions_revoke),
-        )
-        .route("/auth/whoami", task_layer(get(auth::whoami), auth_whoami))
-        .route(
-            "/auth/sign-out",
-            task_layer(post(auth::sign_out), auth_sign_out),
-        )
+        .routes(task_routes(
+            routes!(auth::session_list, auth::revoke_sessions_by_did),
+            auth_sessions_manage,
+        ))
+        .routes(task_routes(
+            routes!(auth::revoke_session),
+            auth_sessions_revoke,
+        ))
+        .routes(task_routes(routes!(auth::whoami), auth_whoami))
+        .routes(task_routes(routes!(auth::sign_out), auth_sign_out))
         // Audit log read (super-admin only).
-        .route("/audit", task_layer(get(audit::list_audit), audit_list))
+        .routes(task_routes(routes!(audit::list_audit), audit_list))
         // Config
-        .route(
-            "/config",
-            task_layer(
-                get(config::get_config).patch(config::update_config),
-                config_manage,
-            ),
-        )
+        .routes(task_routes(
+            routes!(config::get_config, config::update_config),
+            config_manage,
+        ))
         // ACL
-        .route(
-            "/acl",
-            task_layer(get(acl::list_acl).post(acl::create_acl), acl_manage),
-        )
-        .route(
-            "/acl/{did}",
-            task_layer(
-                get(acl::get_acl)
-                    .patch(acl::update_acl)
-                    .delete(acl::delete_acl),
-                acl_entry,
-            ),
-        )
+        .routes(task_routes(
+            routes!(acl::list_acl, acl::create_acl),
+            acl_manage,
+        ))
+        .routes(task_routes(
+            routes!(acl::get_acl, acl::update_acl, acl::delete_acl),
+            acl_entry,
+        ))
         // Community profile (GET + PUT share one Trust Task today;
         // a spec-aligned split into community/profile/show/1.0 +
         // community/profile/update/1.0 lands when TrustTaskRouter
         // gains per-method task selectors in Phase 1+).
-        .route(
-            "/community/profile",
-            task_layer(
-                get(community::profile::get_profile).put(community::profile::put_profile),
-                community_profile,
+        .routes(task_routes(
+            routes!(
+                community::profile::get_profile,
+                community::profile::put_profile
             ),
-        )
+            community_profile,
+        ))
         // Public read of the community profile. Trust-Task-exempt and
         // unauthenticated — visitors landing on the default public
         // website need the community's name + description + DIDs to
         // render before any session exists. Curated subset only (no
         // extensions, no registry status).
-        .route(
-            "/community/public-profile",
-            get(community::profile::get_public_profile),
-        )
+        .routes(routes!(community::profile::get_public_profile))
         // Admin config (M0.8 — GET + PATCH share one task; will
         // split into admin/config/show/1.0 + patch/1.0 when
         // TrustTaskRouter gains per-method selectors).
-        .route(
-            "/admin/config",
-            task_layer(
-                get(admin::config::get_config).patch(admin::config::patch_config),
-                admin_config,
-            ),
-        )
+        .routes(task_routes(
+            routes!(admin::config::get_config, admin::config::patch_config),
+            admin_config,
+        ))
         // Reload + restart (M0.8.3). Reload applies hot-reloadable
         // settings in-place; restart requires a supervisor (412
         // `SupervisorRequired` otherwise).
-        .route(
-            "/admin/config/reload",
-            task_layer(post(admin::config::reload_config), admin_config_reload),
-        )
-        .route(
-            "/admin/config/restart",
-            task_layer(post(admin::config::restart_config), admin_config_restart),
-        )
+        .routes(task_routes(
+            routes!(admin::config::reload_config),
+            admin_config_reload,
+        ))
+        .routes(task_routes(
+            routes!(admin::config::restart_config),
+            admin_config_restart,
+        ))
         // Export / import (M0.8.4). Export returns the portable
         // (db-layer overrides + community profile) JSON; import runs
         // diff-and-confirm via `?confirm=true|false`.
-        .route(
-            "/admin/config/export",
-            task_layer(post(admin::config::export_config), admin_config_export),
-        )
-        .route(
-            "/admin/config/import",
-            task_layer(post(admin::config::import_config), admin_config_import),
-        )
+        .routes(task_routes(
+            routes!(admin::config::export_config),
+            admin_config_export,
+        ))
+        .routes(task_routes(
+            routes!(admin::config::import_config),
+            admin_config_import,
+        ))
         // Install claim endpoints (`/install/claim/start` and
         // `/install/claim/finish`) are unauthenticated and live in
         // `build_unauth_routes` so the tower-governor + tighter
@@ -551,288 +531,227 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // Admin bootstrap (M0.6.2) — closes the install carve-out
         // and writes the first admin ACL entry. Unauthenticated
         // because the setup-session JWT IS the auth credential.
-        .route(
-            "/admin/bootstrap",
-            task_layer(post(admin::bootstrap::bootstrap), admin_bootstrap),
-        )
+        .routes(task_routes(
+            routes!(admin::bootstrap::bootstrap),
+            admin_bootstrap,
+        ))
         // Admin passkey management (M0.6.3). Step-up UV is enforced
         // via the two-phase ceremony: `register/start` and
         // `revoke/start` issue a UV challenge bound to an existing
         // passkey; `register/finish` and `revoke/finish` reject if
         // the UV assertion doesn't verify.
-        .route(
-            "/admin/passkeys",
-            task_layer(get(admin::passkeys::list), admin_passkeys_list),
-        )
-        .route(
-            "/admin/passkeys/register/start",
-            task_layer(
-                post(admin::passkeys::register_start),
-                admin_passkeys_register.clone(),
-            ),
-        )
-        .route(
-            "/admin/passkeys/register/finish",
-            task_layer(
-                post(admin::passkeys::register_finish),
-                admin_passkeys_register,
-            ),
-        )
-        .route(
-            "/admin/passkeys/revoke/start",
-            task_layer(
-                post(admin::passkeys::revoke_start),
-                admin_passkeys_revoke.clone(),
-            ),
-        )
-        .route(
-            "/admin/passkeys/revoke/finish",
-            task_layer(post(admin::passkeys::revoke_finish), admin_passkeys_revoke),
-        )
+        .routes(task_routes(
+            routes!(admin::passkeys::list),
+            admin_passkeys_list,
+        ))
+        .routes(task_routes(
+            routes!(admin::passkeys::register_start),
+            admin_passkeys_register.clone(),
+        ))
+        .routes(task_routes(
+            routes!(admin::passkeys::register_finish),
+            admin_passkeys_register,
+        ))
+        .routes(task_routes(
+            routes!(admin::passkeys::revoke_start),
+            admin_passkeys_revoke.clone(),
+        ))
+        .routes(task_routes(
+            routes!(admin::passkeys::revoke_finish),
+            admin_passkeys_revoke,
+        ))
         // Admin invites — REST mirror of `vtc admin invite`. GET +
         // POST share the same mount; DELETE on `/admin/invites/{jti}`
         // revokes outstanding (Issued) invites. Consumed rows are
         // immutable (audit history) — DELETE on those returns 409.
-        .route(
-            "/admin/invites",
-            task_layer(
-                get(admin::invites::list_invites).post(admin::invites::create_invite),
-                admin_invites_manage,
-            ),
-        )
-        .route(
-            "/admin/invites/{jti}",
-            task_layer(
-                axum::routing::delete(admin::invites::revoke_invite),
-                admin_invites_revoke,
-            ),
-        )
+        .routes(task_routes(
+            routes!(admin::invites::list_invites, admin::invites::create_invite),
+            admin_invites_manage,
+        ))
+        .routes(task_routes(
+            routes!(admin::invites::revoke_invite),
+            admin_invites_revoke,
+        ))
         // Directory ceremony (read-only field projection via the
         // ceremony decision pipeline).
-        .route(
-            "/directory/{did}",
-            task_layer(get(directory::query), directory_query),
-        )
+        .routes(task_routes(routes!(directory::query), directory_query))
         // Ceremony registry — the admin-UI renders its flow + simulator
         // from these manifests (purpose / fields / facts template).
-        .route(
-            "/ceremonies",
-            task_layer(get(ceremonies::list), ceremonies_list),
-        )
+        .routes(task_routes(routes!(ceremonies::list), ceremonies_list))
         // Members (Phase 1 M1.4–M1.6).
-        .route(
-            "/members",
-            task_layer(get(members::read::list_members), members_list),
-        )
+        .routes(task_routes(
+            routes!(members::read::list_members),
+            members_list,
+        ))
         // `/v1/members/me` for self-remove (M1.11.1). Must be
         // declared BEFORE the `/v1/members/{did}` mount otherwise
         // axum's path-trie picks the parameterised route first
         // and routes "me" as a literal DID.
-        .route(
-            "/members/me",
-            task_layer(
-                axum::routing::delete(members::remove::self_remove),
-                members_self_remove,
-            ),
-        )
+        .routes(task_routes(
+            routes!(members::remove::self_remove),
+            members_self_remove,
+        ))
         // Renewal (M2.13). POST on its own mount so the
         // Trust Task header check + per-method selectors are
         // unambiguous.
-        .route(
-            "/members/me/renew",
-            task_layer(post(members::renew::renew), members_renew),
-        )
+        .routes(task_routes(routes!(members::renew::renew), members_renew))
         // DID rotation (M2.15.1). Two-step ceremony — challenge
         // mints a single-use rotation_id, the finish endpoint
         // applies the co-signed swap atomically.
-        .route(
-            "/members/me/rotate/challenge",
-            task_layer(post(members::rotate::challenge), members_rotate_challenge),
-        )
-        .route(
-            "/members/me/rotate",
-            task_layer(post(members::rotate::rotate), members_rotate),
-        )
+        .routes(task_routes(
+            routes!(members::rotate::challenge),
+            members_rotate_challenge,
+        ))
+        .routes(task_routes(
+            routes!(members::rotate::rotate),
+            members_rotate,
+        ))
         // Phase 4 M4.3 + M4.4 — personhood lifecycle. Three
         // mounts on the same path prefix; declared BEFORE
         // `/v1/members/{did}` so axum's path-trie matches the
         // literal segment first. Personhood is a per-member
         // resource; `{did}` is the subject.
-        .route(
-            "/members/{did}/personhood/challenge",
-            task_layer(
-                post(members::personhood::challenge),
-                members_personhood_challenge,
-            ),
-        )
-        .route(
-            "/members/{did}/personhood",
-            task_layer(
-                post(members::personhood::assert).delete(members::personhood::revoke), // POST + DELETE share `personhood/assert/1.0` at
-                // the router layer pending per-method selectors;
-                // the standalone `personhood/revoke/1.0` Trust Task
-                // exists on disk + in index.json so the soft-gate
-                // surface stays complete. (Same workaround as
-                // members/{did}'s show + update + admin-remove.)
-                members_personhood_assert,
-            ),
-        )
+        .routes(task_routes(
+            routes!(members::personhood::challenge),
+            members_personhood_challenge,
+        ))
+        .routes(task_routes(
+            routes!(members::personhood::assert, members::personhood::revoke), // POST + DELETE share `personhood/assert/1.0` at
+            // the router layer pending per-method selectors;
+            // the standalone `personhood/revoke/1.0` Trust Task
+            // exists on disk + in index.json so the soft-gate
+            // surface stays complete. (Same workaround as
+            // members/{did}'s show + update + admin-remove.)
+            members_personhood_assert,
+        ))
         // Phase 4 M4.6 — VRC trust-graph endpoints. The
         // per-member list mounts under /v1/members/{did}/
         // and must precede the catchall `/v1/members/{did}`
         // (same path-trie precedence as personhood).
-        .route(
-            "/members/{did}/relationships",
-            task_layer(get(members::relationships::list), relationships_list),
-        )
-        .route(
-            "/relationships",
-            task_layer(post(relationships::publish), relationships_publish),
-        )
-        .route(
-            "/relationships/{id}",
-            task_layer(delete(relationships::revoke), relationships_revoke),
-        )
+        .routes(task_routes(
+            routes!(members::relationships::list),
+            relationships_list,
+        ))
+        .routes(task_routes(
+            routes!(relationships::publish),
+            relationships_publish,
+        ))
+        .routes(task_routes(
+            routes!(relationships::revoke),
+            relationships_revoke,
+        ))
         // Phase 4 M4.8.1 — operator-uploaded endorsement type
         // registry. Admin-gated CRUD.
-        .route(
-            "/endorsement-types",
-            task_layer(
-                post(endorsement_types::register).get(endorsement_types::list), // POST + GET share `register/1.0` at the router
-                // layer pending per-method selectors; standalone
-                // `list/1.0` exists on disk + in index.json.
-                endorsement_types_register,
-            ),
-        )
-        .route(
-            "/endorsement-types/{type_uri}",
-            task_layer(delete(endorsement_types::delete), endorsement_types_delete),
-        )
+        .routes(task_routes(
+            routes!(endorsement_types::register, endorsement_types::list), // POST + GET share `register/1.0` at the router
+            // layer pending per-method selectors; standalone
+            // `list/1.0` exists on disk + in index.json.
+            endorsement_types_register,
+        ))
+        .routes(task_routes(
+            routes!(endorsement_types::delete),
+            endorsement_types_delete,
+        ))
         // Phase 2 §8 — community schema store (Issues + Accepts
         // registry). Plain admin-gated CRUD (AdminAuth extractor),
         // exempt from the Trust-Task soft-gate. (`accepts` static
         // segments bind before the `{type_uri}` param via matchit.)
-        .route(
-            "/schemas/accepts",
-            post(schemas::register_accepts).get(schemas::list_accepts_route),
-        )
-        .route(
-            "/schemas/accepts/{id}",
-            get(schemas::get_accepts_route).delete(schemas::delete_accepts_route),
-        )
-        .route("/schemas", post(schemas::register).get(schemas::list))
-        .route(
-            "/schemas/{type_uri}",
-            get(schemas::get_one).delete(schemas::delete_one),
-        )
+        .routes(routes!(
+            schemas::register_accepts,
+            schemas::list_accepts_route
+        ))
+        .routes(routes!(
+            schemas::get_accepts_route,
+            schemas::delete_accepts_route
+        ))
+        .routes(routes!(schemas::register, schemas::list))
+        .routes(routes!(schemas::get_one, schemas::delete_one))
         // Phase 4 M4.8.2-4 — custom endorsement issuance +
         // retrieval + revocation. Admin OR Issuer-role member.
-        .route(
-            "/credentials/endorsements",
-            task_layer(
-                post(endorsements::issue).get(endorsements::list), // POST + GET share `issue/1.0` at the router
-                // layer pending per-method selectors; standalone
-                // `list/1.0` exists on disk + in index.json.
-                endorsements_issue,
-            ),
-        )
-        .route(
-            "/credentials/endorsements/{id}",
-            task_layer(
-                axum::routing::get(endorsements::show).delete(endorsements::revoke), // GET + DELETE share `show/1.0` at the router
-                // layer pending per-method selectors; standalone
-                // `revoke/1.0` exists on disk + in index.json.
-                endorsements_show_revoke,
-            ),
-        )
-        .route(
-            "/members/{did}",
-            task_layer(
-                get(members::read::show_member)
-                    .patch(members::update::update_member)
-                    .delete(members::remove::admin_remove), // GET + PATCH + DELETE share `members/show/1.0` at the
-                // router layer pending per-method selectors; the
-                // standalone `members/update/1.0` and
-                // `members/admin-remove/1.0` Trust Tasks exist on
-                // disk + in index.json so the soft-gate surface stays
-                // complete.
-                members_show,
-            ),
-        )
-        .route(
-            "/members/{did}/promote-to-admin/start",
-            task_layer(
-                post(members::promote::promote_start),
-                members_promote.clone(),
-            ),
-        )
-        .route(
-            "/members/{did}/promote-to-admin/finish",
-            task_layer(post(members::promote::promote_finish), members_promote),
-        )
+        .routes(task_routes(
+            routes!(endorsements::issue, endorsements::list), // POST + GET share `issue/1.0` at the router
+            // layer pending per-method selectors; standalone
+            // `list/1.0` exists on disk + in index.json.
+            endorsements_issue,
+        ))
+        .routes(task_routes(
+            routes!(endorsements::show, endorsements::revoke), // GET + DELETE share `show/1.0` at the router
+            // layer pending per-method selectors; standalone
+            // `revoke/1.0` exists on disk + in index.json.
+            endorsements_show_revoke,
+        ))
+        .routes(task_routes(
+            routes!(
+                members::read::show_member,
+                members::update::update_member,
+                members::remove::admin_remove
+            ), // GET + PATCH + DELETE share `members/show/1.0` at the
+            // router layer pending per-method selectors; the
+            // standalone `members/update/1.0` and
+            // `members/admin-remove/1.0` Trust Tasks exist on
+            // disk + in index.json so the soft-gate surface stays
+            // complete.
+            members_show,
+        ))
+        .routes(task_routes(
+            routes!(members::promote::promote_start),
+            members_promote.clone(),
+        ))
+        .routes(task_routes(
+            routes!(members::promote::promote_finish),
+            members_promote,
+        ))
         // Join requests (Phase 1 M1.7–M1.10). The unauth POST submit /
         // accept / status live on the governed branch (`build_unauth_routes`,
         // P0.5); the admin GET list keeps this `/join-requests` mount (axum
         // merges this GET with the governed-branch POST submit).
-        .route(
-            "/join-requests",
-            task_layer(get(join_requests::read::list_join_requests), join_submit),
-        )
-        .route(
-            "/join-requests/{id}",
-            task_layer(get(join_requests::read::show_join_request), join_show),
-        )
-        .route(
-            "/join-requests/{id}/approve",
-            task_layer(post(join_requests::decide::approve), join_approve),
-        )
-        .route(
-            "/join-requests/{id}/reject",
-            task_layer(post(join_requests::decide::reject), join_reject),
-        )
+        .routes(task_routes(
+            routes!(join_requests::read::list_join_requests),
+            join_submit,
+        ))
+        .routes(task_routes(
+            routes!(join_requests::read::show_join_request),
+            join_show,
+        ))
+        .routes(task_routes(
+            routes!(join_requests::decide::approve),
+            join_approve,
+        ))
+        .routes(task_routes(
+            routes!(join_requests::decide::reject),
+            join_reject,
+        ))
         // Manifest (unauth public discovery): the community's join
         // evidence requirements. Static `manifest` segment takes
         // precedence over the `{id}` show route.
-        .route(
-            "/join-requests/manifest",
-            task_layer(get(join_requests::manifest::manifest), join_manifest),
-        )
+        .routes(task_routes(
+            routes!(join_requests::manifest::manifest),
+            join_manifest,
+        ))
         // Credential-exchange query send (admin): prepare a DCQL query + issue a
         // single-use presentation challenge for a holder. Plain admin route (no
         // Trust-Task descriptor) — the holder answers over the credential-exchange
         // DIDComm `present` surface.
-        .route(
-            "/join-requests/query",
-            post(join_requests::present::send_query),
-        )
+        .routes(routes!(join_requests::present::send_query))
         // Policies (Phase 2 M2.3). Three POST endpoints, three
         // Trust Tasks. `upload` mints + persists; `activate` flips
         // the per-purpose active pointer; `test` evaluates a stored
         // policy without mutating state.
-        .route(
-            "/policies",
-            task_layer(
-                get(policies::read::list_policies).post(policies::admin::upload),
-                policies_upload.clone(),
-            ),
-        )
-        .route(
-            "/policies/{id}",
-            task_layer(
-                get(policies::read::show_policy), // Reuses the upload task on the shared mount; the
-                // `policies/show/1.0` Trust Task lives in index.json
-                // + on disk for the soft-gate surface (see above).
-                policies_upload.clone(),
-            ),
-        )
-        .route(
-            "/policies/{id}/activate",
-            task_layer(post(policies::admin::activate), policies_activate),
-        )
-        .route(
-            "/policies/{id}/test",
-            task_layer(post(policies::admin::test), policies_test),
-        );
+        .routes(task_routes(
+            routes!(policies::read::list_policies, policies::admin::upload),
+            policies_upload.clone(),
+        ))
+        .routes(task_routes(
+            routes!(policies::read::show_policy), // Reuses the upload task on the shared mount; the
+            // `policies/show/1.0` Trust Task lives in index.json
+            // + on disk for the soft-gate surface (see above).
+            policies_upload.clone(),
+        ))
+        .routes(task_routes(
+            routes!(policies::admin::activate),
+            policies_activate,
+        ))
+        .routes(task_routes(routes!(policies::admin::test), policies_test));
 
     // Phase 5 M5.5 — public-website management routes. The
     // `route_with_task` helper accepts a pre-layered `MethodRouter`
@@ -1021,14 +940,8 @@ fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
     let synth_connect_info = axum::middleware::from_fn(insert_default_connect_info_if_missing);
 
     let unauth_router = OpenApiRouter::<AppState>::new()
-        .route(
-            "/auth/challenge",
-            task_layer(post(auth::challenge), auth_challenge),
-        )
-        .route(
-            "/auth/",
-            task_layer(post(auth::authenticate), auth_authenticate),
-        )
+        .routes(task_routes(routes!(auth::challenge), auth_challenge))
+        .routes(task_routes(routes!(auth::authenticate), auth_authenticate))
         // VTA-wallet login surface. The browser wallet extension drives
         // the SIOPv2 round-trip itself and posts to `<base>/auth/challenge`
         // + `<base>/auth/` with **no** `Trust-Task` header (the op `type`
@@ -1040,61 +953,49 @@ fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
         // CLI clients. Mirrors did-hosting-control's header-less auth.
         .route("/wallet/auth/challenge", post(auth::challenge))
         .route("/wallet/auth/", post(auth::authenticate))
-        .route(
-            "/auth/refresh",
-            task_layer(post(auth::refresh), auth_refresh),
-        )
-        .route(
-            "/auth/admin-login",
-            task_layer(post(auth::admin_login), auth_admin_login),
-        )
-        .route(
-            "/auth/admin-session",
-            task_layer(post(auth::admin_session), auth_admin_session),
-        )
-        .route(
-            "/auth/passkey-login/start",
-            task_layer(post(auth::passkey_login_start), auth_passkey_login_start),
-        )
-        .route(
-            "/auth/passkey-login/finish",
-            task_layer(post(auth::passkey_login_finish), auth_passkey_login_finish),
-        )
-        .route(
-            "/install/claim/start",
-            task_layer(post(install::claim_start), install_claim_start),
-        )
-        .route(
-            "/install/claim/finish",
-            task_layer(post(install::claim_finish), install_claim_finish),
-        )
-        .route(
-            "/auth/recognise/challenge",
-            task_layer(
-                post(recognise::recognise_challenge),
-                auth_recognise_challenge,
-            ),
-        )
-        .route(
-            "/auth/recognise",
-            task_layer(post(recognise::recognise), auth_recognise),
-        )
+        .routes(task_routes(routes!(auth::refresh), auth_refresh))
+        .routes(task_routes(routes!(auth::admin_login), auth_admin_login))
+        .routes(task_routes(
+            routes!(auth::admin_session),
+            auth_admin_session,
+        ))
+        .routes(task_routes(
+            routes!(auth::passkey_login_start),
+            auth_passkey_login_start,
+        ))
+        .routes(task_routes(
+            routes!(auth::passkey_login_finish),
+            auth_passkey_login_finish,
+        ))
+        .routes(task_routes(
+            routes!(install::claim_start),
+            install_claim_start,
+        ))
+        .routes(task_routes(
+            routes!(install::claim_finish),
+            install_claim_finish,
+        ))
+        .routes(task_routes(
+            routes!(recognise::recognise_challenge),
+            auth_recognise_challenge,
+        ))
+        .routes(task_routes(routes!(recognise::recognise), auth_recognise))
         // Join-request POSTs (P0.5). Submit shares the `/join-requests` mount
         // with the admin GET list on the `api` chain — axum merges the GET +
         // POST method routers; the unauth POST lands here (governed), the admin
         // GET stays there (JWT-gated).
-        .route(
-            "/join-requests",
-            task_layer(post(join_requests::submit::submit), join_submit),
-        )
-        .route(
-            "/join-requests/{id}/accept",
-            task_layer(post(join_requests::accept::accept), join_accept),
-        )
-        .route(
-            "/join-requests/{id}/status",
-            task_layer(post(join_requests::status::status), join_status),
-        )
+        .routes(task_routes(
+            routes!(join_requests::submit::submit),
+            join_submit,
+        ))
+        .routes(task_routes(
+            routes!(join_requests::accept::accept),
+            join_accept,
+        ))
+        .routes(task_routes(
+            routes!(join_requests::status::status),
+            join_status,
+        ))
         .layer(DefaultBodyLimit::max(UNAUTH_BODY_SIZE));
 
     // Apply the per-IP rate limiter in a branch so the two
@@ -1357,6 +1258,42 @@ mod openapi_tests {
         assert!(
             components.schemas.contains_key("DiagnosticsResponse"),
             "DiagnosticsResponse schema must be emitted"
+        );
+    }
+
+    #[test]
+    fn openapi_spec_covers_the_route_groups() {
+        let spec = openapi_spec();
+        let paths = &spec.paths.paths;
+        // A representative path (all nested under /v1) from each major group.
+        for p in [
+            "/v1/acl",
+            "/v1/acl/{did}",
+            "/v1/audit",
+            "/v1/config",
+            "/v1/auth/challenge",
+            "/v1/auth/sessions",
+            "/v1/admin/config",
+            "/v1/admin/invites",
+            "/v1/admin/passkeys",
+            "/v1/members",
+            "/v1/members/{did}",
+            "/v1/community/profile",
+            "/v1/join-requests",
+            "/v1/policies",
+            "/v1/credentials/endorsements",
+            "/v1/endorsement-types",
+            "/v1/schemas",
+            "/v1/relationships",
+            "/v1/directory/{did}",
+            "/v1/install/claim/start",
+        ] {
+            assert!(paths.contains_key(p), "spec missing documented path {p}");
+        }
+        assert!(
+            paths.len() >= 55,
+            "expected the documented surface to be >= 55 paths, got {}",
+            paths.len()
         );
     }
 }

--- a/vtc-service/src/routes/policies/admin.rs
+++ b/vtc-service/src/routes/policies/admin.rs
@@ -59,6 +59,7 @@ static ACTIVATE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct UploadBody {
     /// Wire-form camelCase purpose (`"join"`, `"removal"`,
     /// `"crossCommunityRoles"`, …). Validated by serde against
@@ -71,6 +72,7 @@ pub struct UploadBody {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct UploadResponse {
     pub id: Uuid,
     /// SHA-256 of the source bytes, lowercase hex. Matches what
@@ -83,6 +85,7 @@ pub struct UploadResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ActivateResponse {
     pub id: Uuid,
     pub purpose: PolicyPurpose,
@@ -94,6 +97,7 @@ pub struct ActivateResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct TestBody {
     /// Rego query to evaluate against the candidate policy
     /// (e.g. `"data.vtc.join.allow"`). Caller chooses the query so
@@ -107,6 +111,7 @@ pub struct TestBody {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct TestResponse {
     pub id: Uuid,
     pub purpose: PolicyPurpose,

--- a/vtc-service/src/routes/policies/admin.rs
+++ b/vtc-service/src/routes/policies/admin.rs
@@ -128,6 +128,16 @@ pub struct TestResponse {
 
 /// Compile + persist a new policy revision. Does NOT activate it —
 /// `POST /v1/policies/{id}/activate` is a separate call.
+#[utoipa::path(
+    post, path = "/policies", tag = "policies",
+    security(("bearer_jwt" = [])),
+    request_body = UploadBody,
+    responses(
+        (status = 201, description = "Policy revision compiled + stored", body = UploadResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn upload(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -205,6 +215,17 @@ pub async fn upload(
 // POST /v1/policies/{id}/activate
 // ---------------------------------------------------------------------------
 
+#[utoipa::path(
+    post, path = "/policies/{id}/activate", tag = "policies",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Policy revision id")),
+    responses(
+        (status = 200, description = "Policy revision activated", body = ActivateResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Policy not found"),
+    ),
+)]
 pub async fn activate(
     admin: AdminAuth,
     State(state): State<AppState>,
@@ -279,6 +300,18 @@ pub async fn activate(
 /// **Does not activate** the policy and does not mutate any state
 /// beyond log lines. Used by operators to dry-run a candidate
 /// upload before flipping the active pointer.
+#[utoipa::path(
+    post, path = "/policies/{id}/test", tag = "policies",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Policy revision id")),
+    request_body = TestBody,
+    responses(
+        (status = 200, description = "Policy evaluation result", body = TestResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Policy not found"),
+    ),
+)]
 pub async fn test(
     admin: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/policies/read.rs
+++ b/vtc-service/src/routes/policies/read.rs
@@ -47,6 +47,7 @@ use crate::server::AppState;
 /// callers don't need a second round-trip).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct PolicyResponse {
     #[serde(flatten)]
     pub policy: Policy,
@@ -68,6 +69,7 @@ impl PolicyResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct ListPoliciesQuery {
     /// Filter by purpose (wire-form camelCase).
     pub purpose: Option<PolicyPurpose>,
@@ -83,6 +85,7 @@ pub struct ListPoliciesQuery {
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[derive(utoipa::ToSchema)]
 pub enum PolicyStatusFilter {
     Active,
     Archived,

--- a/vtc-service/src/routes/policies/read.rs
+++ b/vtc-service/src/routes/policies/read.rs
@@ -69,7 +69,7 @@ impl PolicyResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(utoipa::ToSchema)]
+#[derive(utoipa::ToSchema, utoipa::IntoParams)]
 pub struct ListPoliciesQuery {
     /// Filter by purpose (wire-form camelCase).
     pub purpose: Option<PolicyPurpose>,
@@ -91,6 +91,16 @@ pub enum PolicyStatusFilter {
     Archived,
 }
 
+#[utoipa::path(
+    get, path = "/policies", tag = "policies",
+    security(("bearer_jwt" = [])),
+    params(ListPoliciesQuery),
+    responses(
+        (status = 200, description = "Paginated list of policies", body = Paginated<PolicyResponse>),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn list_policies(
     _auth: AdminAuth,
     State(state): State<AppState>,
@@ -183,6 +193,17 @@ pub async fn list_policies(
 // GET /v1/policies/{id}
 // ---------------------------------------------------------------------------
 
+#[utoipa::path(
+    get, path = "/policies/{id}", tag = "policies",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Policy id")),
+    responses(
+        (status = 200, description = "Policy", body = PolicyResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Policy not found"),
+    ),
+)]
 pub async fn show_policy(
     _auth: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -73,7 +73,7 @@ use affinidi_vc::VerifiableCredential;
 /// plus this VTC's DID as the `domain`. The route verifies the holder proof,
 /// the embedded issuer proofs, the status list, and the registry recognition
 /// itself.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct RecogniseRequest {
     /// A W3C Data-Integrity VP, holder-signed with
     /// `proofPurpose: authentication`.
@@ -83,6 +83,7 @@ pub struct RecogniseRequest {
 /// Response body for `POST /v1/auth/recognise/challenge`.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RecogniseChallengeResponse {
     /// Single-use nonce the holder must bind into the VP's top-level `nonce`.
     pub nonce: String,
@@ -92,6 +93,7 @@ pub struct RecogniseChallengeResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RecogniseResponse {
     pub session_id: String,
     pub data: RecogniseData,
@@ -99,6 +101,7 @@ pub struct RecogniseResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RecogniseData {
     /// Minted JWT. Carries the *mapped local* role, not the
     /// foreign one.

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -118,6 +118,12 @@ pub struct RecogniseData {
 /// `POST /v1/auth/recognise/challenge` — issue a single-use, TTL'd nonce the
 /// holder binds into their recognise VP. Bound to this VTC's DID as the
 /// audience, so the resulting VP can't be replayed against a different VTC.
+#[utoipa::path(
+    post, path = "/auth/recognise/challenge", tag = "recognise",
+    responses(
+        (status = 200, description = "Single-use recognition nonce", body = RecogniseChallengeResponse),
+    ),
+)]
 pub async fn recognise_challenge(
     State(state): State<AppState>,
 ) -> Result<Json<RecogniseChallengeResponse>, AppError> {
@@ -134,6 +140,16 @@ pub async fn recognise_challenge(
     Ok(Json(RecogniseChallengeResponse { nonce, expires_at }))
 }
 
+/// `POST /v1/auth/recognise` — cross-community session mint from a
+/// holder-signed VP embedding a foreign VEC + VMC.
+#[utoipa::path(
+    post, path = "/auth/recognise", tag = "recognise",
+    request_body = RecogniseRequest,
+    responses(
+        (status = 200, description = "Minted cross-community session", body = RecogniseResponse),
+        (status = 403, description = "Holder-binding, recognition gate, or role-mapping denied"),
+    ),
+)]
 pub async fn recognise(
     State(state): State<AppState>,
     Json(req): Json<RecogniseRequest>,

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -72,6 +72,16 @@ pub struct PublishResponse {
     pub vrc_sha256: String,
 }
 
+#[utoipa::path(
+    post, path = "/relationships", tag = "relationships",
+    security(("bearer_jwt" = [])),
+    request_body = PublishBody,
+    responses(
+        (status = 201, description = "Relationship (VRC) published", body = PublishResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not the VRC issuer or policy denied"),
+    ),
+)]
 pub async fn publish(
     auth: AuthClaims,
     State(state): State<AppState>,
@@ -216,6 +226,17 @@ pub struct RevokeResponse {
     pub id: String,
 }
 
+#[utoipa::path(
+    delete, path = "/relationships/{id}", tag = "relationships",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Relationship (VRC) id")),
+    responses(
+        (status = 200, description = "Relationship (VRC) revoked", body = RevokeResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not the issuer or an admin"),
+        (status = 404, description = "Relationship not found"),
+    ),
+)]
 pub async fn revoke(
     auth: AuthClaims,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -52,7 +52,7 @@ use crate::server::AppState;
 
 // ─── Publish ─────────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct PublishBody {
     /// The self-issued VRC. Must be a JSON-LD VC body with
     /// `type` array including `VerifiableRecognitionCredential`,
@@ -64,6 +64,7 @@ pub struct PublishBody {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct PublishResponse {
     pub id: Uuid,
     pub issuer_did: String,
@@ -210,6 +211,7 @@ pub async fn publish(
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RevokeResponse {
     pub id: String,
 }

--- a/vtc-service/src/routes/schemas.rs
+++ b/vtc-service/src/routes/schemas.rs
@@ -34,6 +34,7 @@ use crate::server::AppState;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RegisterSchemaBody {
     pub type_uri: String,
     #[serde(default)]
@@ -102,6 +103,7 @@ pub async fn get_one(
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct DeleteResponse {
     pub id: String,
 }
@@ -124,6 +126,7 @@ pub async fn delete_one(
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct RegisterAcceptsBody {
     pub id: String,
     pub query: JsonValue,

--- a/vtc-service/src/routes/schemas.rs
+++ b/vtc-service/src/routes/schemas.rs
@@ -47,6 +47,16 @@ pub struct RegisterSchemaBody {
 }
 
 /// `POST /v1/schemas` — register (or update) a per-type schema entry.
+#[utoipa::path(
+    post, path = "/schemas", tag = "schemas",
+    security(("bearer_jwt" = [])),
+    request_body = RegisterSchemaBody,
+    responses(
+        (status = 201, description = "Schema registered", body = SchemaEntry),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn register(
     auth: AdminAuth,
     State(state): State<AppState>,
@@ -82,6 +92,15 @@ pub async fn register(
 }
 
 /// `GET /v1/schemas` — list every registered per-type schema.
+#[utoipa::path(
+    get, path = "/schemas", tag = "schemas",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "List of registered schemas", body = Vec<SchemaEntry>),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn list(
     _auth: AdminAuth,
     State(state): State<AppState>,
@@ -90,6 +109,17 @@ pub async fn list(
 }
 
 /// `GET /v1/schemas/{type_uri}` — fetch one registered schema.
+#[utoipa::path(
+    get, path = "/schemas/{type_uri}", tag = "schemas",
+    security(("bearer_jwt" = [])),
+    params(("type_uri" = String, Path, description = "Credential type URI")),
+    responses(
+        (status = 200, description = "Schema entry", body = SchemaEntry),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Schema not found"),
+    ),
+)]
 pub async fn get_one(
     _auth: AdminAuth,
     State(state): State<AppState>,
@@ -109,6 +139,17 @@ pub struct DeleteResponse {
 }
 
 /// `DELETE /v1/schemas/{type_uri}` — remove a registered schema.
+#[utoipa::path(
+    delete, path = "/schemas/{type_uri}", tag = "schemas",
+    security(("bearer_jwt" = [])),
+    params(("type_uri" = String, Path, description = "Credential type URI")),
+    responses(
+        (status = 200, description = "Schema deleted", body = DeleteResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Schema not found"),
+    ),
+)]
 pub async fn delete_one(
     auth: AdminAuth,
     State(state): State<AppState>,
@@ -137,6 +178,16 @@ pub struct RegisterAcceptsBody {
 /// `POST /v1/schemas/accepts` — register (or update) an Accepts criterion. The
 /// DCQL query is validated and every referenced type checked against the
 /// registry by [`store_accepts`].
+#[utoipa::path(
+    post, path = "/schemas/accepts", tag = "schemas",
+    security(("bearer_jwt" = [])),
+    request_body = RegisterAcceptsBody,
+    responses(
+        (status = 201, description = "Accepts criterion registered", body = AcceptsCriterion),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn register_accepts(
     auth: AdminAuth,
     State(state): State<AppState>,
@@ -161,6 +212,15 @@ pub async fn register_accepts(
 }
 
 /// `GET /v1/schemas/accepts` — list every Accepts criterion.
+#[utoipa::path(
+    get, path = "/schemas/accepts", tag = "schemas",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "List of Accepts criteria", body = Vec<AcceptsCriterion>),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
 pub async fn list_accepts_route(
     _auth: AdminAuth,
     State(state): State<AppState>,
@@ -169,6 +229,17 @@ pub async fn list_accepts_route(
 }
 
 /// `GET /v1/schemas/accepts/{id}` — fetch one Accepts criterion.
+#[utoipa::path(
+    get, path = "/schemas/accepts/{id}", tag = "schemas",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Accepts criterion id")),
+    responses(
+        (status = 200, description = "Accepts criterion", body = AcceptsCriterion),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Accepts criterion not found"),
+    ),
+)]
 pub async fn get_accepts_route(
     _auth: AdminAuth,
     State(state): State<AppState>,
@@ -181,6 +252,17 @@ pub async fn get_accepts_route(
 }
 
 /// `DELETE /v1/schemas/accepts/{id}` — remove an Accepts criterion.
+#[utoipa::path(
+    delete, path = "/schemas/accepts/{id}", tag = "schemas",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Accepts criterion id")),
+    responses(
+        (status = 200, description = "Accepts criterion deleted", body = DeleteResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "Accepts criterion not found"),
+    ),
+)]
 pub async fn delete_accepts_route(
     auth: AdminAuth,
     State(state): State<AppState>,

--- a/vtc-service/src/routes/status_lists.rs
+++ b/vtc-service/src/routes/status_lists.rs
@@ -40,6 +40,17 @@ fn parse_purpose(s: &str) -> Option<StatusPurpose> {
     }
 }
 
+/// GET /status-lists/{purpose} — public BitstringStatusList credential.
+/// Unauthenticated, Trust-Task-exempt verifier endpoint.
+#[utoipa::path(
+    get, path = "/status-lists/{purpose}", tag = "status-lists",
+    params(("purpose" = String, Path, description = "'revocation' or 'suspension'")),
+    responses(
+        (status = 200, description = "Bitstring status list credential", content_type = "application/json"),
+        (status = 404, description = "Unknown or unprovisioned purpose"),
+        (status = 503, description = "Credential signer or state not ready"),
+    ),
+)]
 pub async fn show(
     State(state): State<AppState>,
     Path(purpose_str): Path<String>,

--- a/vtc-service/src/schemas/accepts.rs
+++ b/vtc-service/src/schemas/accepts.rs
@@ -44,6 +44,7 @@ fn key(id: &str) -> Vec<u8> {
 /// credentials satisfy the community's acceptance rules.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct AcceptsCriterion {
     /// Criterion id (e.g. a ceremony purpose or a named manifest). Primary key.
     pub id: String,

--- a/vtc-service/src/schemas/mod.rs
+++ b/vtc-service/src/schemas/mod.rs
@@ -47,6 +47,7 @@ pub const TYPE_URI_MAX_BYTES: usize = 512;
 /// **Issues** (mints) or **Accepts** (recognises as evidence).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub enum SchemaKind {
     /// The VTC mints this credential type.
     Issues,

--- a/vtc-service/src/schemas/mod.rs
+++ b/vtc-service/src/schemas/mod.rs
@@ -58,6 +58,7 @@ pub enum SchemaKind {
 /// One registered credential-type schema in the community's schema store.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub struct SchemaEntry {
     /// The credential type URI / `vct`. Primary key — URL-encoded into the key.
     pub type_uri: String,

--- a/vtc-service/src/supervisor.rs
+++ b/vtc-service/src/supervisor.rs
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
 pub enum SupervisorKind {
     /// `VTC_SUPERVISED=1` env var present.
     Manual,

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.10.3"
+version = "0.10.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -35,7 +35,7 @@ setup = ["dep:dialoguer"]
 # types the VTA + VTC services expose through their `OpenApiRouter` (the ACL
 # `Role`, session `SessionState`). Off by default and zero-cost when off —
 # only the services turn it on.
-openapi = ["dep:utoipa"]
+openapi = ["dep:utoipa", "dep:utoipa-axum"]
 
 [dependencies]
 # vta-sdk for the canonical auth wire shapes
@@ -93,6 +93,9 @@ libc = { workspace = true, optional = true }
 # OpenAPI: `#[derive(ToSchema)]` on shared wire types (`Role`, `SessionState`).
 # Optional + gated on the `openapi` feature so non-service consumers stay slim.
 utoipa = { workspace = true, optional = true }
+# utoipa-axum `UtoipaMethodRouter` layering for the OpenAPI-aware
+# Trust-Task route helpers (`trust_task::openapi`). Gated on `openapi`.
+utoipa-axum = { workspace = true, optional = true }
 
 # Passkey feature deps. `rand` / `uuid` / `hex` are non-optional and
 # live in the main dep block since audit + idempotency need them

--- a/vti-common/src/audit/envelope.rs
+++ b/vti-common/src/audit/envelope.rs
@@ -32,6 +32,11 @@ pub const SCHEMA_VERSION: u32 = 1;
 pub const EVENT_VERSION: u32 = 1;
 
 /// A persisted audit-log entry.
+//
+// Note: deliberately NOT `ToSchema`. The `AuditEvent` payload enum fans out
+// into a large tree of variant-specific shapes; the single `/audit` read
+// endpoint documents its response body as an opaque object rather than drag
+// that whole surface into the OpenAPI components.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AuditEnvelope {
     /// Stable identifier for this specific event. Becomes the

--- a/vti-common/src/pagination/mod.rs
+++ b/vti-common/src/pagination/mod.rs
@@ -122,6 +122,7 @@ impl PaginationParams {
 /// (`None` when the caller has reached the end), and an optional
 /// total-count estimate.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Paginated<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,

--- a/vti-common/src/trust_task/mod.rs
+++ b/vti-common/src/trust_task/mod.rs
@@ -23,9 +23,13 @@
 //! route without any procedural-macro indirection.
 
 pub mod extractor;
+#[cfg(feature = "openapi")]
+pub mod openapi;
 pub mod router;
 
 pub use extractor::TrustTaskHeader;
+#[cfg(feature = "openapi")]
+pub use openapi::{task_layer, task_routes};
 pub use router::TrustTaskRouter;
 
 use crate::error::AppError;

--- a/vti-common/src/trust_task/openapi.rs
+++ b/vti-common/src/trust_task/openapi.rs
@@ -1,0 +1,147 @@
+//! OpenAPI-aware Trust-Task route layering.
+//!
+//! [`TrustTaskRouter`](super::TrustTaskRouter) wraps a plain axum `Router` and
+//! is opaque to OpenAPI generation. When a service assembles its surface as a
+//! utoipa-axum [`OpenApiRouter`](utoipa_axum::router::OpenApiRouter) instead —
+//! so the router is the single source of truth for the served `/openapi.json` —
+//! these free functions provide the same per-route Trust-Task header
+//! validation, layered without dropping the collected OpenAPI path/schema.
+//!
+//! - [`task_routes`] layers onto a `routes!()` [`UtoipaMethodRouter`], keeping
+//!   the operation in the spec — the drift-free replacement for
+//!   [`TrustTaskRouter::route_with_task`](super::TrustTaskRouter::route_with_task).
+//! - [`task_layer`] layers onto a plain [`MethodRouter`], for routes still on
+//!   `OpenApiRouter::route(...)` that haven't been `#[utoipa::path]`-annotated
+//!   yet, so wire enforcement is preserved through an incremental migration.
+//!
+//! The validation is byte-for-byte the same closure `route_with_task` applies.
+
+use std::sync::Arc;
+
+use axum::routing::MethodRouter;
+use utoipa_axum::router::{UtoipaMethodRouter, UtoipaMethodRouterExt};
+
+use super::TrustTask;
+
+/// Layer Trust-Task header validation onto a `routes!()`-produced
+/// [`UtoipaMethodRouter`], preserving its OpenAPI path + schemas.
+///
+/// Use in place of [`TrustTaskRouter::route_with_task`] when building an
+/// `OpenApiRouter`:
+///
+/// ```ignore
+/// OpenApiRouter::new()
+///     .routes(task_routes(routes!(handler), my_task))
+/// ```
+pub fn task_routes<S>(routes: UtoipaMethodRouter<S>, task: TrustTask) -> UtoipaMethodRouter<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    let task = Arc::new(task);
+    routes.layer(axum::middleware::from_fn(move |request, next| {
+        let task = task.clone();
+        async move { super::extractor::validate_header(&task, request, next).await }
+    }))
+}
+
+/// Layer Trust-Task header validation onto a plain [`MethodRouter`] — for
+/// routes mounted via `OpenApiRouter::route(...)` that are not yet
+/// `#[utoipa::path]`-annotated. Keeps the wire enforcement identical while a
+/// service is mid-migration from [`TrustTaskRouter`](super::TrustTaskRouter).
+pub fn task_layer<S>(method_router: MethodRouter<S>, task: TrustTask) -> MethodRouter<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    let task = Arc::new(task);
+    method_router.layer(axum::middleware::from_fn(move |request, next| {
+        let task = task.clone();
+        async move { super::extractor::validate_header(&task, request, next).await }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trust_task::HEADER_NAME;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+    use utoipa_axum::router::OpenApiRouter;
+    use utoipa_axum::routes;
+
+    #[utoipa::path(get, path = "/v1/install/claim", responses((status = 200)))]
+    async fn ok() -> &'static str {
+        "ok"
+    }
+
+    fn task() -> TrustTask {
+        TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/1.0").unwrap()
+    }
+
+    #[test]
+    fn task_routes_keeps_the_operation_in_the_spec() {
+        let (_router, api): (Router, _) = OpenApiRouter::new()
+            .routes(task_routes(routes!(ok), task()))
+            .split_for_parts();
+        // The layered route still contributes its operation to the document.
+        assert!(api.paths.paths.contains_key("/v1/install/claim"));
+    }
+
+    async fn app() -> Router {
+        OpenApiRouter::new()
+            .routes(task_routes(routes!(ok), task()))
+            .split_for_parts()
+            .0
+    }
+
+    #[tokio::test]
+    async fn task_routes_enforces_the_header() {
+        // Exact match → 200.
+        let resp = app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/install/claim")
+                    .header(
+                        HEADER_NAME,
+                        "https://trusttasks.org/openvtc/vtc/install/claim/1.0",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Missing header → 400.
+        let resp = app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/install/claim")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // Wrong task → 415.
+        let resp = app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/install/claim")
+                    .header(
+                        HEADER_NAME,
+                        "https://trusttasks.org/openvtc/vtc/auth/login/1.0",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+}


### PR DESCRIPTION
Completes **item 5** of the fuzzing-support issue #439 — the VTC half of the OpenAPI work (the VTA half landed in #447). VTC now serves a machine-readable OpenAPI 3.1 document at `GET /openapi.json` for black-box conformance / fuzz tooling (schemathesis, RESTler).

Closes the OpenAPI portion of #439.

## The VTC wrinkle: TrustTaskRouter
Unlike the VTA, VTC wraps Axum in a custom `TrustTaskRouter` that applies per-route **Trust-Task header validation** and is opaque to OpenAPI. The solution keeps the router as the single source of truth without forking that behaviour:

**New vti-common helpers** (`trust_task::openapi`, gated on the existing `openapi` feature):
- `task_routes(routes!(h), task)` — layers the exact same Trust-Task validation onto a utoipa-axum `UtoipaMethodRouter` while **preserving** its collected OpenAPI path/schema. The drift-free replacement for `route_with_task` when assembling an `OpenApiRouter`.
- `task_layer(mr, task)` — same for a plain `MethodRouter`, used for routes mid-migration.

Unit tests prove a `task_routes` route both lands in the spec **and** enforces the header (200 exact / 400 missing / 415 mismatch).

## Conversion
`build_api_chain` + `build_unauth_routes` migrated from `TrustTaskRouter` to `OpenApiRouter`. `route_with_task` → `task_routes(routes!(...))`, `route_exempt` → `routes!(...)`. `router_with_inner` splits off the served axum `Router` for the unchanged `assemble`; `openapi_spec()` rebuilds from the same `build_api_chain` nested under `/v1`, so document and served routes cannot drift.

## Coverage
**71 documented operations** under `/v1`, spanning every group: acl, auth (+sessions), audit, config, admin (config/bootstrap/passkeys/invites), community, members/*, join-requests/*, policies, endorsements, endorsement-types, schemas, relationships, directory, ceremonies, status-lists, recognise, install. Per-operation: method/path, bearer security (omitted on public ceremony/exempt routes), path/query params (`IntoParams`), request bodies, typed responses. Content-negotiated auth + Set-Cookie/raw-Response endpoints document prose responses without a body schema. The `/wallet/*` auth aliases and `/website/*` per-route-cap routes stay served-but-undocumented (a handler carries one `#[utoipa::path]`; website serves file content).

## Schemas
`ToSchema` blanketed across ~107 VTC wire structs + the domain enums they reference; foreign types (webauthn-rs `RequestChallengeResponse`/`PublicKeyCredential`/…, vta-sdk `QueryBody`) documented via `#[schema(value_type = Object)]`. vti-common gains gated `ToSchema` on the generic `Paginated<T>` list wrapper; `AuditEnvelope` stays an opaque object (its `AuditEvent` payload tree is large; the single `/audit` endpoint documents it as `Object`).

## Version bumps
Additive optional features; major.minor pins unchanged → no cascade:
- vti-common 0.10.3 → 0.10.4 (new `task_routes`/`task_layer` helpers + `Paginated` schema; the `openapi` feature now also pulls `utoipa-axum`)
- vtc-service 0.9.3 → 0.9.4 (serves `/openapi.json`)

## Verification
- `cargo test -p vtc-service` — **579 lib + all integration tests pass** (the conversion preserves trust-task enforcement, routing, body caps, and the governor across every route); new spec tests assert the doc builds (no duplicate-path panic), carries the bearer scheme, and documents ≥55 paths across every group.
- vti-common helper tests prove `task_routes` documents *and* enforces.
- `cargo clippy` clean; `cargo fmt --check` clean.

## Commits
1. OpenAPI foundation + the vti-common TrustTaskRouter integration spike
2. ToSchema across VTC + vti-common wire types
3. Router converted TrustTaskRouter → OpenApiRouter (all 579 tests green)
4. All handlers annotated + registered (71 documented operations)
