### PR TITLE
fix(vtc): audit credential issuance on policy auto-admit (P2.1)

### DIFF
--- a/vtc-service/src/routes/join_requests/audit.rs
+++ b/vtc-service/src/routes/join_requests/audit.rs
@@ -1,0 +1,97 @@
+//! Shared audit emission for the two member-admission paths.
+//!
+//! Admitting a member mints a VMC + role VEC and consumes a status-list slot.
+//! Both the manual-approve path ([`super::decide::approve`]) and the policy
+//! auto-admit path ([`super::submit::realize_join_verdict`]) run the *same*
+//! admit effect, so both must record the *same* audit envelopes for it:
+//! `MemberAdded` + `VmcIssued` + `VecIssued`.
+//!
+//! Previously only the manual path emitted these — an auto-admitted member's
+//! credential issuance left no audit trail. Centralising the emission here
+//! closes that gap and keeps the two paths from drifting again. The lifecycle
+//! event that *brackets* the admit (`JoinRequestApproved` on the manual path,
+//! `JoinRequestSubmitted` on auto-admit) differs per path and stays with each
+//! caller.
+
+use affinidi_vc::VerifiableCredential;
+use vti_common::audit::{AuditEvent, AuditWriter, CredentialIssuedData, MemberAddedData};
+use vti_common::error::AppError;
+
+use crate::ceremony::execute::{AdmitOutcome, top_level_id};
+use crate::credentials::vec::VEC_TYPE;
+use crate::credentials::vmc::VMC_TYPE;
+
+/// Emit the `MemberAdded` + `VmcIssued` + `VecIssued` envelopes for a completed
+/// admit effect. `actor_did` is whoever drove the admission (the approving
+/// admin on the manual path; the applicant themselves on policy auto-admit,
+/// which has no human actor), `subject_did` is the new member, and `role` is
+/// the role actually granted (manual approve always grants member; auto-admit
+/// uses the policy verdict's role).
+pub(crate) async fn emit_admit_audit(
+    audit_writer: &AuditWriter,
+    actor_did: &str,
+    subject_did: &str,
+    creds: &AdmitOutcome,
+    role: &str,
+    via_join_request_id: Option<String>,
+) -> Result<(), AppError> {
+    audit_writer
+        .write(
+            actor_did,
+            Some(subject_did),
+            AuditEvent::MemberAdded(MemberAddedData {
+                role: role.to_string(),
+                via_join_request_id,
+            }),
+        )
+        .await?;
+    audit_writer
+        .write(
+            actor_did,
+            Some(subject_did),
+            AuditEvent::VmcIssued(credential_issued_data(
+                &creds.vmc,
+                Some(creds.status_list_index),
+            )?),
+        )
+        .await?;
+    audit_writer
+        .write(
+            actor_did,
+            Some(subject_did),
+            AuditEvent::VecIssued(credential_issued_data(&creds.role_vec, None)?),
+        )
+        .await?;
+    Ok(())
+}
+
+/// Build a [`CredentialIssuedData`] payload from a signed VC.
+pub(crate) fn credential_issued_data(
+    vc: &VerifiableCredential,
+    status_list_index: Option<u32>,
+) -> Result<CredentialIssuedData, AppError> {
+    let id = top_level_id(vc).ok_or_else(|| {
+        AppError::Internal("credential is missing top-level `id` — issuance dropped it".into())
+    })?;
+    let credential_type = vc
+        .types
+        .iter()
+        .find(|t| *t == VMC_TYPE || *t == VEC_TYPE)
+        .cloned()
+        .ok_or_else(|| AppError::Internal("credential carries neither VMC nor VEC type".into()))?;
+    let valid_from = vc
+        .valid_from
+        .clone()
+        .ok_or_else(|| AppError::Internal("credential missing validFrom".into()))?;
+    let valid_until = vc
+        .valid_until
+        .clone()
+        .ok_or_else(|| AppError::Internal("credential missing validUntil".into()))?;
+    Ok(CredentialIssuedData {
+        credential_id: id,
+        credential_type,
+        valid_from,
+        valid_until,
+        status_list_index,
+    })
+}

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -7,7 +7,6 @@
 //! already validated at submit time so the only failure modes
 //! here are auth + duplicate-membership.
 
-use affinidi_vc::VerifiableCredential;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -16,17 +15,13 @@ use serde_json::Value as JsonValue;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use vti_common::audit::{
-    AuditEvent, CredentialIssuedData, JoinRequestData, JoinRequestRejectedData, MemberAddedData,
-};
+use vti_common::audit::{AuditEvent, JoinRequestData, JoinRequestRejectedData};
 use vti_common::error::AppError;
 
 use crate::acl::VtcRole;
 use crate::auth::AdminAuth;
-use crate::ceremony::execute::{self, top_level_id};
+use crate::ceremony::execute;
 use crate::ceremony::{EffectOutcome, EffectPlan};
-use crate::credentials::vec::VEC_TYPE;
-use crate::credentials::vmc::VMC_TYPE;
 use crate::join::{JoinStatus, get_join_request, store_join_request};
 use crate::server::AppState;
 
@@ -124,8 +119,6 @@ pub async fn approve(
         );
     }
 
-    let (vmc, role_vec, status_list_index) = (creds.vmc, creds.role_vec, creds.status_list_index);
-
     req.status = JoinStatus::Approved;
     store_join_request(&state.join_requests_ks, &req).await?;
 
@@ -139,36 +132,24 @@ pub async fn approve(
             }),
         )
         .await?;
-    audit_writer
-        .write(
-            &admin.0.did,
-            Some(&req.applicant_did),
-            AuditEvent::MemberAdded(MemberAddedData {
-                role: VtcRole::Member.to_string(),
-                via_join_request_id: Some(id.to_string()),
-            }),
-        )
-        .await?;
-    audit_writer
-        .write(
-            &admin.0.did,
-            Some(&req.applicant_did),
-            AuditEvent::VmcIssued(credential_issued_data(&vmc, Some(status_list_index))?),
-        )
-        .await?;
-    audit_writer
-        .write(
-            &admin.0.did,
-            Some(&req.applicant_did),
-            AuditEvent::VecIssued(credential_issued_data(&role_vec, None)?),
-        )
-        .await?;
+    // The MemberAdded + VmcIssued + VecIssued envelopes for the admit effect are
+    // shared with the auto-admit path (see `super::audit`) so the two cannot
+    // record divergent trails for the same effect.
+    super::audit::emit_admit_audit(
+        audit_writer,
+        &admin.0.did,
+        &req.applicant_did,
+        &creds,
+        &VtcRole::Member.to_string(),
+        Some(id.to_string()),
+    )
+    .await?;
 
     info!(
         request_id = %id,
         applicant = %req.applicant_did,
         admin = %admin.0.did,
-        status_list_index,
+        status_list_index = creds.status_list_index,
         "join request approved"
     );
 
@@ -178,46 +159,15 @@ pub async fn approve(
             request_id: id,
             status: req.status.to_string(),
             vmc: Some(
-                serde_json::to_value(&vmc)
+                serde_json::to_value(&creds.vmc)
                     .map_err(|e| AppError::Internal(format!("serialise VMC for response: {e}")))?,
             ),
             role_vec: Some(
-                serde_json::to_value(&role_vec)
+                serde_json::to_value(&creds.role_vec)
                     .map_err(|e| AppError::Internal(format!("serialise VEC for response: {e}")))?,
             ),
         }),
     ))
-}
-
-/// Build a [`CredentialIssuedData`] payload from a signed VC.
-fn credential_issued_data(
-    vc: &VerifiableCredential,
-    status_list_index: Option<u32>,
-) -> Result<CredentialIssuedData, AppError> {
-    let id = top_level_id(vc).ok_or_else(|| {
-        AppError::Internal("credential is missing top-level `id` — issuance dropped it".into())
-    })?;
-    let credential_type = vc
-        .types
-        .iter()
-        .find(|t| *t == VMC_TYPE || *t == VEC_TYPE)
-        .cloned()
-        .ok_or_else(|| AppError::Internal("credential carries neither VMC nor VEC type".into()))?;
-    let valid_from = vc
-        .valid_from
-        .clone()
-        .ok_or_else(|| AppError::Internal("credential missing validFrom".into()))?;
-    let valid_until = vc
-        .valid_until
-        .clone()
-        .ok_or_else(|| AppError::Internal("credential missing validUntil".into()))?;
-    Ok(CredentialIssuedData {
-        credential_id: id,
-        credential_type,
-        valid_from,
-        valid_until,
-        status_list_index,
-    })
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/routes/join_requests/mod.rs
+++ b/vtc-service/src/routes/join_requests/mod.rs
@@ -7,6 +7,7 @@
 //! Phase 2's policy surface).
 
 pub mod accept;
+pub(crate) mod audit;
 pub mod decide;
 pub mod manifest;
 pub mod present;

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -342,7 +342,7 @@ pub(crate) async fn realize_join_verdict(
             let role = allow.role.clone().unwrap_or_else(|| "member".to_string());
             let plan = EffectPlan::Admit {
                 subject: applicant_did.to_string(),
-                role,
+                role: role.clone(),
                 obligations: allow.obligations.clone(),
             };
             if let EffectOutcome::Admitted(creds) =
@@ -368,6 +368,21 @@ pub(crate) async fn realize_join_verdict(
                         "membership-credential delivery failed on auto-admit; credentials issued",
                     );
                 }
+                // Record the admit effect's audit envelopes (MemberAdded +
+                // VmcIssued + VecIssued) — the same set the manual-approve path
+                // emits. Policy auto-admit has no human approver, so the
+                // applicant (whose submission triggered the admission) is the
+                // actor. Closes the gap where auto-admitted credentials were
+                // issued with no audit trail.
+                super::audit::emit_admit_audit(
+                    audit_writer,
+                    applicant_did,
+                    applicant_did,
+                    &creds,
+                    &role,
+                    Some(request.id.to_string()),
+                )
+                .await?;
                 admit = Some(creds);
             }
             request.status = JoinStatus::Approved;

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -17,6 +17,7 @@ use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use tower::ServiceExt;
 use uuid::Uuid;
+use vti_common::audit::{AuditEnvelope, AuditEvent, CredentialIssuedData, MemberAddedData};
 use vti_common::auth::session::{Session, SessionState, store_session};
 use vti_common::store::KeyspaceHandle;
 
@@ -862,6 +863,124 @@ async fn rest_submit_under_allow_policy_auto_admits() {
             .is_some(),
         "auto-admitted applicant has a Member row"
     );
+}
+
+/// The three audit envelopes an admit effect must emit, collected from the
+/// audit keyspace.
+#[derive(Default)]
+struct AdmitAudit {
+    member_added: Vec<MemberAddedData>,
+    vmc_issued: Vec<CredentialIssuedData>,
+    vec_issued: Vec<CredentialIssuedData>,
+}
+
+async fn collect_admit_audit(audit_ks: &KeyspaceHandle) -> AdmitAudit {
+    let pairs = audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let mut out = AdmitAudit::default();
+    for (_k, raw) in pairs {
+        let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+        match env.event {
+            AuditEvent::MemberAdded(d) => out.member_added.push(d),
+            AuditEvent::VmcIssued(d) => out.vmc_issued.push(d),
+            AuditEvent::VecIssued(d) => out.vec_issued.push(d),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Regression for the auto-admit audit gap: policy auto-admit runs the same
+/// Admit effect as a manual approve (mints a VMC + role VEC, burns a status
+/// slot), so it must emit the same `MemberAdded` + `VmcIssued` + `VecIssued`
+/// envelopes. Before the shared `audit::emit_admit_audit` helper, the
+/// auto-admit path emitted none of them — credentials were issued with no
+/// audit trail.
+#[tokio::test]
+async fn auto_admit_emits_membership_issuance_audit() {
+    let fix = build_fixture().await;
+    activate_join_policy(
+        &fix,
+        "package vtc.join\nimport rego.v1\n\n\
+         default decision := {\"effect\": \"allow\", \"with\": {\"role\": \"member\"}}\n",
+    )
+    .await;
+
+    let (sk, applicant_did) = applicant_pair();
+    let vp = json!({ "type": "VerifiablePresentation", "holder": applicant_did });
+    let submit_body = signed_submit_body(&sk, &applicant_did, &vp);
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(submit_body),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "got {body}");
+    assert_eq!(body["status"], "approved");
+
+    let audit = collect_admit_audit(&fix.state.audit_ks).await;
+    assert_eq!(
+        audit.member_added.len(),
+        1,
+        "auto-admit must emit exactly one MemberAdded"
+    );
+    assert_eq!(audit.member_added[0].role, "member");
+    assert!(
+        audit.member_added[0].via_join_request_id.is_some(),
+        "MemberAdded must link the originating join request"
+    );
+    assert_eq!(audit.vmc_issued.len(), 1, "auto-admit must emit VmcIssued");
+    assert!(
+        audit.vmc_issued[0].status_list_index.is_some(),
+        "the VMC carries its allocated status-list slot"
+    );
+    assert_eq!(audit.vec_issued.len(), 1, "auto-admit must emit VecIssued");
+    assert!(
+        audit.vec_issued[0].status_list_index.is_none(),
+        "the role VEC has no status-list slot"
+    );
+}
+
+/// The manual-approve path emits the same admit-effect audit set, now via the
+/// shared helper — pins parity with the auto-admit path so the two cannot drift
+/// again.
+#[tokio::test]
+async fn manual_approve_emits_membership_issuance_audit() {
+    let fix = build_fixture().await;
+    let (sk, applicant_did) = applicant_pair();
+    let submit_body = signed_submit_body(&sk, &applicant_did, &json!({}));
+    let (_, body) = send(
+        &fix.router,
+        "POST",
+        "/v1/join-requests",
+        SUBMIT_TASK,
+        None,
+        Some(submit_body),
+    )
+    .await;
+    let id = body["requestId"].as_str().unwrap();
+
+    let (status, body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/approve"),
+        APPROVE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+
+    let audit = collect_admit_audit(&fix.state.audit_ks).await;
+    assert_eq!(audit.member_added.len(), 1, "approve emits one MemberAdded");
+    assert_eq!(audit.member_added[0].role, "member");
+    assert!(audit.member_added[0].via_join_request_id.is_some());
+    assert_eq!(audit.vmc_issued.len(), 1, "approve emits VmcIssued");
+    assert!(audit.vmc_issued[0].status_list_index.is_some());
+    assert_eq!(audit.vec_issued.len(), 1, "approve emits VecIssued");
+    assert!(audit.vec_issued[0].status_list_index.is_none());
 }
 
 /// With the default `policies.open` join policy the submit


### PR DESCRIPTION
## Problem

A join policy that **auto-admits** runs the same Admit effect as a manual approve — it mints a VMC + role VEC and burns a status-list slot — but the two paths recorded **different audit trails**:

| | lifecycle event | `MemberAdded` | `VmcIssued` | `VecIssued` |
|---|---|---|---|---|
| Manual approve (`decide::approve`) | `JoinRequestApproved` | ✅ | ✅ | ✅ |
| Auto-admit (`submit::realize_join_verdict`) | `JoinRequestSubmitted` | ❌ | ❌ | ❌ |

So an **auto-admitted member's credential issuance left no audit trail** (both the REST and DIDComm submit paths flow through `realize_join_verdict`). Surfaced during the Phase 2 review.

## Fix

Extract the shared admit-effect audit emission into `join_requests::audit::emit_admit_audit` (carrying `credential_issued_data`, hoisted out of `decide.rs`) and call it from **both** paths, so they emit the same `MemberAdded` + `VmcIssued` + `VecIssued` envelopes and cannot drift again. The lifecycle event that brackets the admit still differs per path and stays with each caller.

Auto-admit has no human approver, so the **applicant** (whose submission triggered the admission) is the audit actor, and the **role** comes from the policy verdict rather than the hardcoded `member` of manual approve.

## Tests

- `auto_admit_emits_membership_issuance_audit` — the regression: asserts all three envelopes now fire on auto-admit, with the VMC carrying a status-list slot and the role VEC carrying none.
- `manual_approve_emits_membership_issuance_audit` — pins parity through the shared helper.

`cargo test -p vtc-service --test join_requests` → 46 passed. `join_didcomm` green. fmt + clippy clean.

Part of the vtc-architecture Phase 2 work (fast-tracked ahead of the P2.1 structural move as a standalone correctness fix).