### PR TITLE
perf(vtc): cache member count, drop O(members) scan from ceremony facts (P2.2)

### DIFF
--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -218,6 +218,10 @@ async fn admit(
     member.current_role_vec_id = top_level_id(&role_vec);
     store_member(&state.members_ks, &member).await?;
 
+    // A new member row exists; keep the cached count in step (still under
+    // LAST_ADMIN_LOCK, so it's serialised with the duplicate-admit guard).
+    state.member_count_inc();
+
     Ok(AdmitOutcome {
         vmc,
         role_vec,
@@ -432,8 +436,15 @@ async fn depart(
     delete_acl_entry(&state.acl_ks, subject_did).await?;
 
     match (disposition, member) {
-        (Disposition::Purge, _) => {
+        (Disposition::Purge, existed) => {
             delete_member(&state.members_ks, subject_did).await?;
+            // Only a purge removes the row; tombstone/historical keep it, so
+            // they leave `list_members().len()` (and the cache) unchanged. Guard
+            // on prior existence so a purge of an already-absent member doesn't
+            // under-count.
+            if existed.is_some() {
+                state.member_count_dec();
+            }
         }
         (Disposition::Tombstone, Some(mut m)) => {
             m.tombstone();

--- a/vtc-service/src/routes/directory.rs
+++ b/vtc-service/src/routes/directory.rs
@@ -44,7 +44,7 @@ use crate::ceremony::{
     Verdict, VerifiedFacts, effects::EffectPlan,
 };
 use crate::community::load_profile;
-use crate::members::{get_member, list_members};
+use crate::members::get_member;
 use crate::policy::load_active_compiled;
 use crate::policy::model::PolicyPurpose;
 use crate::server::AppState;
@@ -187,7 +187,7 @@ async fn assemble_directory_facts(
         .map(|p| p.community_did)
         .unwrap_or_default();
 
-    let member_count = list_members(&state.members_ks).await?.len() as u64;
+    let member_count = state.member_count();
 
     let request = fields_hint.map(|raw| {
         let fields: Vec<String> = raw

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -64,7 +64,6 @@ use crate::ceremony::{
 };
 use crate::community::load_profile;
 use crate::join::{JoinRequest, JoinStatus, JoinTransport, list_join_requests, store_join_request};
-use crate::members::list_members;
 use crate::policy::{PolicyPurpose, extract::extract_vp_claims, load_active_compiled};
 use crate::server::AppState;
 
@@ -435,7 +434,7 @@ async fn assemble_join_facts(
         .await?
         .map(|p| p.community_did)
         .unwrap_or_default();
-    let member_count = list_members(&state.members_ks).await?.len() as u64;
+    let member_count = state.member_count();
 
     Ok(Facts {
         purpose: Purpose::Join,

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -42,7 +42,7 @@ use crate::ceremony::{
     State as FactsState, Subject, Verdict, VerifiedFacts,
 };
 use crate::community::load_profile;
-use crate::members::{Disposition, get_member, list_members};
+use crate::members::{Disposition, get_member};
 use crate::policy::{PolicyPurpose, load_active_compiled};
 use crate::server::AppState;
 
@@ -344,7 +344,7 @@ async fn assemble_leave_facts(
         .await?
         .map(|p| p.community_did)
         .unwrap_or_default();
-    let member_count = list_members(&state.members_ks).await?.len() as u64;
+    let member_count = state.member_count();
 
     // Ceremony request params: the operator's requested disposition +
     // the admin-supplied reason. Absent when neither is set.

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -30,7 +30,7 @@ use crate::ceremony::{
 };
 use crate::community::load_profile;
 use crate::error::AppError;
-use crate::members::{Disposition, Member, get_member, list_members, store_member};
+use crate::members::{Disposition, Member, get_member, store_member};
 use crate::policy::{PolicyPurpose, load_active_compiled};
 use crate::routes::members::read::MemberResponse;
 use crate::server::AppState;
@@ -290,7 +290,7 @@ async fn assemble_role_change_facts(
         .await?
         .map(|p| p.community_did)
         .unwrap_or_default();
-    let member_count = list_members(&state.members_ks).await?.len() as u64;
+    let member_count = state.member_count();
 
     Ok(Facts {
         purpose: Purpose::RoleChange,

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -1,5 +1,6 @@
 use crate::store::keyspaces;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
@@ -56,6 +57,16 @@ pub struct AppState {
     pub passkey_ks: KeyspaceHandle,
     pub install_ks: KeyspaceHandle,
     pub members_ks: KeyspaceHandle,
+    /// Cached count of member rows in [`Self::members_ks`] — kept equal to
+    /// `members::list_members(..).len()` so ceremony facts assembly (the
+    /// unauthenticated join-submit path included) reads it in O(1) instead of
+    /// walking the whole keyspace per request. Seeded once at boot, then
+    /// adjusted by the single member-mutation seam (`ceremony::execute`):
+    /// +1 on admit, −1 on a purge-departure. Tombstone/historical departures
+    /// and role-change re-mints keep the row, so they don't move it. Access via
+    /// [`Self::member_count`] / [`Self::member_count_inc`] /
+    /// [`Self::member_count_dec`].
+    pub member_count_cache: Arc<AtomicU64>,
     pub join_requests_ks: KeyspaceHandle,
     /// Uploaded Rego policies (M2.2). Holds every revision; the
     /// active pointer for each purpose lives in
@@ -148,6 +159,32 @@ pub struct AppState {
     /// `Some(Manual)` / `None` without racing other tests on the
     /// shared `std::env`.
     pub supervisor: Option<SupervisorKind>,
+}
+
+impl AppState {
+    /// Current cached member-row count (equal to
+    /// `members::list_members(..).len()`). O(1) — see
+    /// [`Self::member_count_cache`].
+    pub fn member_count(&self) -> u64 {
+        self.member_count_cache.load(Ordering::SeqCst)
+    }
+
+    /// Record a newly-admitted member. Call once per admit, under the same
+    /// guard that commits the member row.
+    pub fn member_count_inc(&self) {
+        self.member_count_cache.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Record a purged member. Saturating at zero so an unexpected
+    /// double-decrement can never wrap the count around to `u64::MAX` and
+    /// poison every size-gated policy.
+    pub fn member_count_dec(&self) {
+        let _ = self
+            .member_count_cache
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+                Some(n.saturating_sub(1))
+            });
+    }
 }
 
 impl AuthState for AppState {
@@ -428,6 +465,12 @@ pub async fn run(
     let storage_auth_config = config.auth.clone();
     let has_auth = jwt_keys.is_some();
 
+    // Seed the cached member counter with a single keyspace walk at boot; the
+    // ceremony executor keeps it in step with the row count thereafter.
+    let member_count_cache = Arc::new(AtomicU64::new(
+        crate::members::list_members(&members_ks).await?.len() as u64,
+    ));
+
     // Build AppState for the REST thread
     let state = AppState {
         sessions_ks,
@@ -437,6 +480,7 @@ pub async fn run(
         passkey_ks,
         install_ks,
         members_ks,
+        member_count_cache,
         join_requests_ks,
         policies_ks,
         active_policies_ks,

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -307,6 +307,13 @@ impl TestVtcBuilder {
 
         let install_store = InstallTokenStore::new(install_ks.clone());
 
+        let member_count_cache = Arc::new(std::sync::atomic::AtomicU64::new(
+            crate::members::list_members(&members_ks)
+                .await
+                .expect("seed member count")
+                .len() as u64,
+        ));
+
         let state = AppState {
             sessions_ks,
             acl_ks,
@@ -315,6 +322,7 @@ impl TestVtcBuilder {
             passkey_ks,
             install_ks,
             members_ks,
+            member_count_cache,
             join_requests_ks,
             policies_ks,
             active_policies_ks,

--- a/vtc-service/tests/ceremony_execute.rs
+++ b/vtc-service/tests/ceremony_execute.rs
@@ -19,7 +19,7 @@ use affinidi_status_list::StatusPurpose;
 use vtc_service::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
 use vtc_service::ceremony::EffectPlan;
 use vtc_service::ceremony::execute::{self, EffectOutcome};
-use vtc_service::members::{Disposition, get_member};
+use vtc_service::members::{Disposition, get_member, list_members};
 use vtc_service::server::AppState;
 use vtc_service::test_support::TestVtc;
 
@@ -388,4 +388,93 @@ async fn remint_refuses_demoting_the_last_admin() {
             .role,
         VtcRole::Admin
     );
+}
+
+/// The cached `member_count` must equal `list_members().len()` after every
+/// mutation the executor performs: +1 on admit, unchanged on a role-change
+/// re-mint and on a tombstone departure (the row is kept), −1 only on a purge.
+/// A drift here silently corrupts every size-gated policy decision, so assert
+/// the invariant after each step.
+#[tokio::test]
+async fn member_count_cache_tracks_list_members_len() {
+    let (state, _dir) = build_state().await;
+
+    async fn assert_consistent(state: &AppState) -> u64 {
+        let listed = list_members(&state.members_ks).await.unwrap().len() as u64;
+        assert_eq!(
+            state.member_count(),
+            listed,
+            "cached member_count drifted from list_members().len()"
+        );
+        listed
+    }
+
+    let admit = |did: &str, role: &str| EffectPlan::Admit {
+        subject: did.into(),
+        role: role.into(),
+        obligations: vec![],
+    };
+
+    assert_eq!(assert_consistent(&state).await, 0, "fresh community");
+
+    execute::apply(&state, admit("did:key:zA", "member"), ACTOR_DID)
+        .await
+        .expect("admit A");
+    assert_eq!(assert_consistent(&state).await, 1, "admit increments");
+
+    execute::apply(&state, admit("did:key:zB", "member"), ACTOR_DID)
+        .await
+        .expect("admit B");
+    assert_eq!(
+        assert_consistent(&state).await,
+        2,
+        "second admit increments"
+    );
+
+    // Role-change re-mint updates the existing row in place — no count change.
+    execute::apply(
+        &state,
+        EffectPlan::Remint {
+            subject: "did:key:zB".into(),
+            role: "moderator".into(),
+        },
+        ACTOR_DID,
+    )
+    .await
+    .expect("remint B");
+    assert_eq!(
+        assert_consistent(&state).await,
+        2,
+        "remint is count-neutral"
+    );
+
+    // Tombstone departure keeps the (now-removed-state) row, so the count holds.
+    execute::apply(
+        &state,
+        EffectPlan::Depart {
+            subject: "did:key:zA".into(),
+            disposition: Some("tombstone".into()),
+        },
+        ACTOR_DID,
+    )
+    .await
+    .expect("tombstone A");
+    assert_eq!(
+        assert_consistent(&state).await,
+        2,
+        "tombstone keeps the row, count unchanged"
+    );
+
+    // Purge removes the row — the one departure that decrements.
+    execute::apply(
+        &state,
+        EffectPlan::Depart {
+            subject: "did:key:zB".into(),
+            disposition: Some("purge".into()),
+        },
+        ACTOR_DID,
+    )
+    .await
+    .expect("purge B");
+    assert_eq!(assert_consistent(&state).await, 1, "purge decrements");
 }

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -293,6 +293,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         passkey_ks: passkey_ks.clone(),
         install_ks,
         members_ks: members_ks.clone(),
+        member_count_cache: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -72,6 +72,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         passkey_ks,
         install_ks: install_ks.clone(),
         members_ks: members_ks.clone(),
+        member_count_cache: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         join_requests_ks: join_requests_ks.clone(),
         policies_ks: policies_ks.clone(),
         active_policies_ks: active_policies_ks.clone(),


### PR DESCRIPTION
## Problem

The four ceremony facts builders (join, leave, role-change, directory) each computed `member_count` via `list_members(..).len()` — a **full `members:` keyspace walk + deserialize, per request**. On the **unauthenticated** join-submit path that's an `O(members)` scan an anonymous caller can drive (a cheap DoS amplifier); the authenticated paths pay it too. Surfaced during the Phase 2 review.

## Fix

Cache the count on `AppState` (`member_count_cache: Arc<AtomicU64>`), seeded by a single walk at boot, and keep it in step at the **one** member-mutation seam (`ceremony::execute` — confirmed the only `store_member`/`delete_member` caller):

| effect | row change | counter |
|---|---|---|
| admit | new row | **+1** |
| purge departure | row deleted | **−1** |
| tombstone / historical departure | row kept (status flipped) | 0 |
| role-change re-mint | row updated in place | 0 |

So the cache exactly tracks `list_members().len()`. The four builders now read `state.member_count()` in O(1).

### Correctness guards
- Adjustments run under the same `LAST_ADMIN_LOCK` that serialises the duplicate-admit check, so they're consistent with the row writes.
- The decrement **saturates at zero** — an unexpected double-purge can't wrap the count to `u64::MAX` and poison every size-gated policy decision.
- Purge decrements only when the member row actually existed.

## Test

`member_count_cache_tracks_list_members_len` (in `ceremony_execute`) drives admit → admit → re-mint → tombstone-depart → purge-depart and asserts `state.member_count() == list_members().len()` **after every step** — the drift guard. `join_requests` / `removal` / `members_crud` / `ceremony_execute` suites stay green; fmt + clippy clean.

Part of vtc-architecture Phase 2 (the cached-counter half of P2.2, fast-tracked as a standalone perf/DoS fix; the facts-builder unification follows in the P2.2 refactor).