### PR TITLE
refactor(vtc): shared DID-VM resolver + issuer-binding helper (P2.4 part 1)

### DIFF
--- a/vtc-service/src/credentials/exchange/verify.rs
+++ b/vtc-service/src/credentials/exchange/verify.rs
@@ -14,6 +14,8 @@ use ed25519_dalek::{Signature, VerifyingKey};
 use serde_json::Value;
 use vti_common::error::AppError;
 
+use crate::credentials::vm_resolver::{DidVmResolver, check_issuer_binding};
+
 // ── Verifier side: verify a presented vp_token (Phase 3, task 3.4) ──
 //
 // The VTC verifier emits a `credential-exchange/query` and receives a
@@ -91,180 +93,6 @@ fn extract_credential_status(source: &Value) -> Option<Value> {
         .get("credentialStatus")
         .or_else(|| source.get("status"))
         .cloned()
-}
-
-/// A [`VerificationMethodResolver`] over the VTC's optional [`DIDCacheClient`].
-///
-/// `did:key` verification methods resolve locally (no I/O); `did:webvh` /
-/// `did:web` resolve through the cache (which must then be configured). Returns
-/// Ed25519 keys only — the credential-exchange formats verified here are all
-/// EdDSA. The DID-document JSON navigation mirrors
-/// `recognition::verify::DidResolverKeyResolver`.
-pub(crate) struct DidVmResolver<'a> {
-    resolver: Option<&'a affinidi_did_resolver_cache_sdk::DIDCacheClient>,
-}
-
-impl<'a> DidVmResolver<'a> {
-    pub(crate) fn new(
-        resolver: Option<&'a affinidi_did_resolver_cache_sdk::DIDCacheClient>,
-    ) -> Self {
-        Self { resolver }
-    }
-
-    /// Resolve a verification-method URI (or a bare `did:key`) to its Ed25519
-    /// public-key bytes. `did:key` is local; other methods use the cache.
-    pub(crate) async fn resolve_ed25519(&self, vm: &str) -> Result<Vec<u8>, AppError> {
-        let base_did = vm.split('#').next().unwrap_or(vm);
-        if base_did.starts_with("did:key:") {
-            return affinidi_crypto::did_key::did_key_to_ed25519_pub(base_did)
-                .map(|k| k.to_vec())
-                .map_err(|e| {
-                    AppError::Validation(format!("`{base_did}` is not a resolvable did:key: {e}"))
-                });
-        }
-        let resolver = self.resolver.ok_or_else(|| {
-            AppError::Validation(format!(
-                "resolving `{base_did}` needs a DID resolver, but none is configured — configure \
-                 the DID cache to verify did:webvh / did:web issuers + holders"
-            ))
-        })?;
-        let resolved = resolver
-            .resolve(base_did)
-            .await
-            .map_err(|e| AppError::Validation(format!("DID `{base_did}` did not resolve: {e}")))?;
-        let doc: Value = serde_json::to_value(&resolved.doc)
-            .map_err(|e| AppError::Internal(format!("DID document serialise failed: {e}")))?;
-        let vms = doc
-            .get("verificationMethod")
-            .and_then(Value::as_array)
-            .ok_or_else(|| {
-                AppError::Validation(format!("DID `{base_did}` has no verificationMethod array"))
-            })?;
-        let relative = vm
-            .split_once('#')
-            .map(|(_, f)| format!("#{f}"))
-            .unwrap_or_default();
-        let entry = vms
-            .iter()
-            .find(|e| {
-                let id = e.get("id").and_then(Value::as_str).unwrap_or("");
-                id == vm || id == relative
-            })
-            .ok_or_else(|| {
-                AppError::Validation(format!(
-                    "verificationMethod `{vm}` not found in DID `{base_did}`"
-                ))
-            })?;
-        let multibase = entry
-            .get("publicKeyMultibase")
-            .and_then(Value::as_str)
-            .ok_or_else(|| {
-                AppError::Validation(format!(
-                    "verificationMethod `{vm}` has no publicKeyMultibase (Multikey-encoded \
-                     Ed25519 only)"
-                ))
-            })?;
-        // A `z`-prefixed Ed25519 Multikey is exactly the `did:key` suffix.
-        affinidi_crypto::did_key::did_key_to_ed25519_pub(&format!("did:key:{multibase}"))
-            .map(|k| k.to_vec())
-            .map_err(|e| {
-                AppError::Validation(format!(
-                    "verificationMethod `{vm}` is not an Ed25519 Multikey: {e}"
-                ))
-            })
-    }
-
-    /// As [`Self::resolve_ed25519`] but returns a [`VerifyingKey`] for the
-    /// SD-JWT issuer-signature path.
-    pub(crate) async fn resolve_verifying_key(&self, vm: &str) -> Result<VerifyingKey, AppError> {
-        let bytes = self.resolve_ed25519(vm).await?;
-        let arr: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
-            AppError::Validation(format!("verificationMethod `{vm}` key is not 32 bytes"))
-        })?;
-        VerifyingKey::from_bytes(&arr).map_err(|e| {
-            AppError::Validation(format!(
-                "verificationMethod `{vm}` is not a valid Ed25519 key: {e}"
-            ))
-        })
-    }
-
-    /// Resolve a verification-method URI (or a bare `did:key`) to its 96-byte
-    /// compressed BLS12-381 G2 public key — a BBS+ issuer key. Mirrors
-    /// [`Self::resolve_ed25519`] (a `z`-prefixed Multikey is exactly the
-    /// `did:key` suffix), decoding via the `0xeb` multicodec.
-    #[cfg(feature = "bbs")]
-    pub(crate) async fn resolve_bbs_g2(&self, vm: &str) -> Result<[u8; 96], AppError> {
-        let base_did = vm.split('#').next().unwrap_or(vm);
-        if base_did.starts_with("did:key:") {
-            return affinidi_crypto::bls12381::did_key_to_g2_pub(base_did).map_err(|e| {
-                AppError::Validation(format!("`{base_did}` is not a BBS did:key: {e}"))
-            });
-        }
-        let resolver = self.resolver.ok_or_else(|| {
-            AppError::Validation(format!(
-                "resolving `{base_did}` needs a DID resolver to verify did:webvh / did:web \
-                 BBS issuers"
-            ))
-        })?;
-        let resolved = resolver
-            .resolve(base_did)
-            .await
-            .map_err(|e| AppError::Validation(format!("DID `{base_did}` did not resolve: {e}")))?;
-        let doc: Value = serde_json::to_value(&resolved.doc)
-            .map_err(|e| AppError::Internal(format!("DID document serialise failed: {e}")))?;
-        let vms = doc
-            .get("verificationMethod")
-            .and_then(Value::as_array)
-            .ok_or_else(|| {
-                AppError::Validation(format!("DID `{base_did}` has no verificationMethod array"))
-            })?;
-        let relative = vm
-            .split_once('#')
-            .map(|(_, f)| format!("#{f}"))
-            .unwrap_or_default();
-        let entry = vms
-            .iter()
-            .find(|e| {
-                let id = e.get("id").and_then(Value::as_str).unwrap_or("");
-                id == vm || id == relative
-            })
-            .ok_or_else(|| {
-                AppError::Validation(format!(
-                    "verificationMethod `{vm}` not found in DID `{base_did}`"
-                ))
-            })?;
-        let multibase = entry
-            .get("publicKeyMultibase")
-            .and_then(Value::as_str)
-            .ok_or_else(|| {
-                AppError::Validation(format!(
-                    "verificationMethod `{vm}` has no publicKeyMultibase (BLS12-381 G2 Multikey)"
-                ))
-            })?;
-        affinidi_crypto::bls12381::did_key_to_g2_pub(&format!("did:key:{multibase}")).map_err(|e| {
-            AppError::Validation(format!(
-                "verificationMethod `{vm}` is not a BLS12-381 G2 Multikey: {e}"
-            ))
-        })
-    }
-}
-
-#[async_trait::async_trait]
-impl affinidi_data_integrity::VerificationMethodResolver for DidVmResolver<'_> {
-    async fn resolve_vm(
-        &self,
-        vm: &str,
-    ) -> Result<affinidi_data_integrity::ResolvedKey, affinidi_data_integrity::DataIntegrityError>
-    {
-        let bytes = self
-            .resolve_ed25519(vm)
-            .await
-            .map_err(|e| affinidi_data_integrity::DataIntegrityError::Resolver(e.to_string()))?;
-        Ok(affinidi_data_integrity::ResolvedKey::new(
-            affinidi_secrets_resolver::secrets::KeyType::Ed25519,
-            bytes,
-        ))
-    }
 }
 
 /// The structural, IO-free projection of an SD-JWT-VC presentation that
@@ -639,18 +467,7 @@ async fn verify_di_vp(
                 AppError::Validation(format!("DI VC proof is not a Data-Integrity proof: {e}"))
             })?;
         // Bind the signing key to the VC issuer.
-        if vc_proof
-            .verification_method
-            .split('#')
-            .next()
-            .unwrap_or_default()
-            != issuer_did
-        {
-            return Err(AppError::Validation(format!(
-                "DI VC proof verificationMethod `{}` is not under the issuer `{issuer_did}`",
-                vc_proof.verification_method
-            )));
-        }
+        check_issuer_binding(&vc_proof.verification_method, &issuer_did)?;
         let mut vc_unsigned = vc.clone();
         if let Some(obj) = vc_unsigned.as_object_mut() {
             obj.remove("proof");
@@ -828,11 +645,7 @@ async fn verify_bbs_presentation(
         .and_then(|p| p.get("verificationMethod"))
         .and_then(Value::as_str)
         .ok_or_else(|| AppError::Validation("bbs-2023 proof has no `verificationMethod`".into()))?;
-    if vm.split('#').next().unwrap_or_default() != issuer_did {
-        return Err(AppError::Validation(format!(
-            "bbs-2023 proof verificationMethod `{vm}` is not under the issuer `{issuer_did}`"
-        )));
-    }
+    check_issuer_binding(vm, issuer_did)?;
     let g2 = DidVmResolver::new(did_resolver).resolve_bbs_g2(vm).await?;
     let pk = PublicKey::from_bytes(&g2)
         .map_err(|e| AppError::Validation(format!("bbs-2023 issuer key is invalid: {e}")))?;

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -52,6 +52,7 @@ pub mod invitation;
 pub mod present_challenge;
 pub mod signer;
 pub mod vec;
+pub mod vm_resolver;
 pub mod vmc;
 
 pub use custom_endorsement::{CustomEndorsementParams, build_custom_endorsement};

--- a/vtc-service/src/credentials/vm_resolver.rs
+++ b/vtc-service/src/credentials/vm_resolver.rs
@@ -1,0 +1,184 @@
+//! The single DID verification-method → public-key resolver for the VTC, plus
+//! the issuer-binding check every Data-Integrity / SD-JWT verify shares.
+//!
+//! Three call sites used to hand-roll "resolve a DID doc → find the VM → pull
+//! the key → verify": the credential-exchange verifier, cross-community
+//! recognition, and VRC relationships. The exchange path already did it the
+//! right way — it delegates resolution to the `affinidi-data-integrity`
+//! library's [`DataIntegrityProof::verify`](affinidi_data_integrity::DataIntegrityProof::verify),
+//! handing it a [`VerificationMethodResolver`](affinidi_data_integrity::VerificationMethodResolver).
+//! This module hoists that one resolver so recognition + relationships verify
+//! through the same library path instead of re-implementing key resolution.
+//!
+//! Resolution: `did:key` verification methods resolve locally (no I/O); other
+//! methods (`did:webvh` / `did:web`) resolve through the DID cache (which must
+//! then be configured). Ed25519 keys are pulled with the upstream
+//! [`VerificationMethod::get_public_key_bytes`] extractor, which handles
+//! Multikey + `Ed25519VerificationKey2020` + `publicKeyJwk` uniformly.
+
+use ed25519_dalek::VerifyingKey;
+use vti_common::error::AppError;
+
+/// A [`VerificationMethodResolver`](affinidi_data_integrity::VerificationMethodResolver)
+/// over the VTC's optional [`DIDCacheClient`](affinidi_did_resolver_cache_sdk::DIDCacheClient).
+pub(crate) struct DidVmResolver<'a> {
+    resolver: Option<&'a affinidi_did_resolver_cache_sdk::DIDCacheClient>,
+}
+
+impl<'a> DidVmResolver<'a> {
+    pub(crate) fn new(
+        resolver: Option<&'a affinidi_did_resolver_cache_sdk::DIDCacheClient>,
+    ) -> Self {
+        Self { resolver }
+    }
+
+    /// Resolve a verification-method URI (or a bare `did:key`) to its Ed25519
+    /// public-key bytes. `did:key` is local; other methods use the cache and the
+    /// upstream key extractor (Multikey / `Ed25519VerificationKey2020` / JWK).
+    pub(crate) async fn resolve_ed25519(&self, vm: &str) -> Result<Vec<u8>, AppError> {
+        let base_did = vm.split('#').next().unwrap_or(vm);
+        if base_did.starts_with("did:key:") {
+            return affinidi_crypto::did_key::did_key_to_ed25519_pub(base_did)
+                .map(|k| k.to_vec())
+                .map_err(|e| {
+                    AppError::Validation(format!("`{base_did}` is not a resolvable did:key: {e}"))
+                });
+        }
+        let resolver = self.resolver.ok_or_else(|| {
+            AppError::Validation(format!(
+                "resolving `{base_did}` needs a DID resolver, but none is configured — configure \
+                 the DID cache to verify did:webvh / did:web issuers + holders"
+            ))
+        })?;
+        let resolved = resolver
+            .resolve(base_did)
+            .await
+            .map_err(|e| AppError::Validation(format!("DID `{base_did}` did not resolve: {e}")))?;
+        let relative = vm
+            .split_once('#')
+            .map(|(_, f)| format!("#{f}"))
+            .unwrap_or_default();
+        let entry = resolved
+            .doc
+            .verification_method
+            .iter()
+            .find(|m| m.id.as_str() == vm || m.id.as_str() == relative)
+            .ok_or_else(|| {
+                AppError::Validation(format!(
+                    "verificationMethod `{vm}` not found in DID `{base_did}`"
+                ))
+            })?;
+        entry.get_public_key_bytes().map_err(|e| {
+            AppError::Validation(format!(
+                "verificationMethod `{vm}` public key could not be extracted: {e}"
+            ))
+        })
+    }
+
+    /// As [`Self::resolve_ed25519`] but returns a [`VerifyingKey`] for the
+    /// SD-JWT issuer-signature path.
+    pub(crate) async fn resolve_verifying_key(&self, vm: &str) -> Result<VerifyingKey, AppError> {
+        let bytes = self.resolve_ed25519(vm).await?;
+        let arr: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+            AppError::Validation(format!("verificationMethod `{vm}` key is not 32 bytes"))
+        })?;
+        VerifyingKey::from_bytes(&arr).map_err(|e| {
+            AppError::Validation(format!(
+                "verificationMethod `{vm}` is not a valid Ed25519 key: {e}"
+            ))
+        })
+    }
+
+    /// Resolve a verification-method URI (or a bare `did:key`) to its 96-byte
+    /// compressed BLS12-381 G2 public key — a BBS+ issuer key. The upstream
+    /// Ed25519 extractor doesn't cover G2, so this keeps the explicit Multikey
+    /// (`0xeb` multicodec) decode.
+    #[cfg(feature = "bbs")]
+    pub(crate) async fn resolve_bbs_g2(&self, vm: &str) -> Result<[u8; 96], AppError> {
+        use serde_json::Value;
+        let base_did = vm.split('#').next().unwrap_or(vm);
+        if base_did.starts_with("did:key:") {
+            return affinidi_crypto::bls12381::did_key_to_g2_pub(base_did).map_err(|e| {
+                AppError::Validation(format!("`{base_did}` is not a BBS did:key: {e}"))
+            });
+        }
+        let resolver = self.resolver.ok_or_else(|| {
+            AppError::Validation(format!(
+                "resolving `{base_did}` needs a DID resolver to verify did:webvh / did:web \
+                 BBS issuers"
+            ))
+        })?;
+        let resolved = resolver
+            .resolve(base_did)
+            .await
+            .map_err(|e| AppError::Validation(format!("DID `{base_did}` did not resolve: {e}")))?;
+        let doc: Value = serde_json::to_value(&resolved.doc)
+            .map_err(|e| AppError::Internal(format!("DID document serialise failed: {e}")))?;
+        let vms = doc
+            .get("verificationMethod")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                AppError::Validation(format!("DID `{base_did}` has no verificationMethod array"))
+            })?;
+        let relative = vm
+            .split_once('#')
+            .map(|(_, f)| format!("#{f}"))
+            .unwrap_or_default();
+        let entry = vms
+            .iter()
+            .find(|e| {
+                let id = e.get("id").and_then(Value::as_str).unwrap_or("");
+                id == vm || id == relative
+            })
+            .ok_or_else(|| {
+                AppError::Validation(format!(
+                    "verificationMethod `{vm}` not found in DID `{base_did}`"
+                ))
+            })?;
+        let multibase = entry
+            .get("publicKeyMultibase")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                AppError::Validation(format!(
+                    "verificationMethod `{vm}` has no publicKeyMultibase (BLS12-381 G2 Multikey)"
+                ))
+            })?;
+        affinidi_crypto::bls12381::did_key_to_g2_pub(&format!("did:key:{multibase}")).map_err(|e| {
+            AppError::Validation(format!(
+                "verificationMethod `{vm}` is not a BLS12-381 G2 Multikey: {e}"
+            ))
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl affinidi_data_integrity::VerificationMethodResolver for DidVmResolver<'_> {
+    async fn resolve_vm(
+        &self,
+        vm: &str,
+    ) -> Result<affinidi_data_integrity::ResolvedKey, affinidi_data_integrity::DataIntegrityError>
+    {
+        let bytes = self
+            .resolve_ed25519(vm)
+            .await
+            .map_err(|e| affinidi_data_integrity::DataIntegrityError::Resolver(e.to_string()))?;
+        Ok(affinidi_data_integrity::ResolvedKey::new(
+            affinidi_secrets_resolver::secrets::KeyType::Ed25519,
+            bytes,
+        ))
+    }
+}
+
+/// A credential proof's `verificationMethod` must sit under the credential's
+/// declared `issuer` — a key controlled by some *other* DID must not sign a
+/// credential claiming this issuer. Shared by every issuer-bound DI verify
+/// (credential-exchange DI VPs, recognition foreign VECs, VRC relationships).
+pub(crate) fn check_issuer_binding(vm: &str, issuer_did: &str) -> Result<(), AppError> {
+    let base = vm.split('#').next().unwrap_or(vm);
+    if base != issuer_did {
+        return Err(AppError::Validation(format!(
+            "proof verificationMethod `{vm}` is not under the issuer `{issuer_did}`"
+        )));
+    }
+    Ok(())
+}

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -26,6 +26,8 @@
 
 use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+
+use crate::credentials::vm_resolver::{DidVmResolver, check_issuer_binding};
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -307,9 +309,10 @@ fn extract_subject_id(vrc: &JsonValue) -> Result<String, AppError> {
         })
 }
 
-/// Verify a VC's data-integrity proof against the issuer's
-/// resolved `#key-0`. Mirrors the personhood + recognition
-/// verifiers; same upstream `get_public_key_bytes()` helper.
+/// Verify a VRC's data-integrity proof: bind the proof's `verificationMethod`
+/// to the issuer, then let the DI library resolve the key (via the shared
+/// [`DidVmResolver`]) and check the signature — the same path the
+/// credential-exchange + recognition verifiers take.
 async fn verify_vc_proof(
     vrc: &JsonValue,
     issuer_did: &str,
@@ -321,32 +324,21 @@ async fn verify_vc_proof(
     let proof: DataIntegrityProof =
         serde_json::from_value(proof_value.clone()).map_err(|e| format!("parse proof: {e}"))?;
 
+    let verification_method = proof_value
+        .get("verificationMethod")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "proof missing verificationMethod".to_string())?;
+    check_issuer_binding(verification_method, issuer_did).map_err(|e| e.to_string())?;
+
     let mut vrc_without_proof = vrc.clone();
     if let Some(obj) = vrc_without_proof.as_object_mut() {
         obj.remove("proof");
     }
 
-    let verification_method = proof_value
-        .get("verificationMethod")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| "proof missing verificationMethod".to_string())?;
-
-    let resolved = resolver
-        .resolve(issuer_did)
-        .await
-        .map_err(|e| format!("resolve {issuer_did}: {e}"))?;
-    let vm = resolved
-        .doc
-        .verification_method
-        .iter()
-        .find(|m| m.id.as_str() == verification_method)
-        .ok_or_else(|| format!("verificationMethod {verification_method} not on {issuer_did}"))?;
-    let pubkey = vm
-        .get_public_key_bytes()
-        .map_err(|e| format!("extract pubkey: {e}"))?;
-
+    let vm_resolver = DidVmResolver::new(Some(resolver));
     proof
-        .verify_with_public_key(&vrc_without_proof, &pubkey, VerifyOptions::new())
+        .verify(&vrc_without_proof, &vm_resolver, VerifyOptions::new())
+        .await
         .map_err(|e| format!("verify: {e}"))?;
     Ok(())
 }


### PR DESCRIPTION
First of two PRs unifying the three hand-rolled DID-verificationMethod → key → DI-proof-verify copies (P2.4). This one lands the shared resolver and converts the two low-churn consumers; **part 2** handles recognition (which carries the bespoke-trait deletion + test-stub rework).

## Insight

The affinidi DI library already exposes `DataIntegrityProof::verify(doc, resolver, opts)` — it resolves the verificationMethod *internally* via a `VerificationMethodResolver`. **Exchange already used this correctly.** Recognition and relationships instead hand-rolled `resolve issuer doc → find VM → get_public_key_bytes → verify_with_public_key`. So the dedup is "make everyone verify through the library path with one shared resolver", not "merge three resolvers."

## This PR

- **New `credentials::vm_resolver`**: `DidVmResolver` (the single `VerificationMethodResolver`, moved out of `exchange/verify.rs`) + `check_issuer_binding(vm, issuer)` — the binding check the three paths each inlined.
- **Strict superset on key extraction**: the shared resolver now uses upstream `VerificationMethod::get_public_key_bytes()` (Multikey + Ed25519VerificationKey2020 + JWK) instead of exchange's old `publicKeyMultibase`-only decode — so converting recognition/relationships onto it drops no key shape. `did:key` fast path + BBS-G2 path unchanged.
- **`exchange/verify.rs`**: imports the shared resolver; uses `check_issuer_binding` for its DI + bbs-2023 binding checks (the SD-JWT JWS-`kid` binding, a different mechanism, stays inline).
- **`routes/relationships.rs::verify_vc_proof`**: drops hand-rolled resolution → `check_issuer_binding` + `proof.verify(&vrc, &DidVmResolver::new(Some(resolver)), opts)`.

## Verification

- `cargo test -p vtc-service --lib` → **580 passed** (exchange suite 32, unchanged).
- `relationships` integration → **10 passed** (the rewrite is behaviour-equivalent).
- fmt + clippy clean.

No wire/public-API change. No out-of-crate change.

## Part 2 (separate PR)

`recognition/verify.rs`: rewrite `verify_proof` to `proof.verify(resolver)` + `check_issuer_binding`; delete `ForeignIssuerKeyResolver` + `DidResolverKeyResolver`; convert the `StubKeyResolver` tests to stub the standard `VerificationMethodResolver`; rewire the 2 production sites (`recognise.rs`, `present.rs`).