### PR TITLE
refactor(vtc): recognition verifies via shared resolver; delete bespoke trait (P2.4 part 2)

### DIFF
--- a/vtc-service/src/credentials/exchange/verify.rs
+++ b/vtc-service/src/credentials/exchange/verify.rs
@@ -218,7 +218,7 @@ pub async fn verify_presentation(
     } = parse_sd_jwt_presentation(compact)?;
 
     let hasher = Sha256Hasher;
-    let resolver = DidVmResolver::new(did_resolver);
+    let resolver = DidVmResolver::new(did_resolver.cloned());
     let issuer_verifier = EdDsaJwtVerifier {
         key: resolver.resolve_verifying_key(&issuer_vm).await?,
     };
@@ -397,7 +397,7 @@ async fn verify_di_vp(
 ) -> Result<Vec<VerifiedPresentation>, AppError> {
     use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
 
-    let resolver = DidVmResolver::new(did_resolver);
+    let resolver = DidVmResolver::new(did_resolver.cloned());
 
     // 1. Holder proof over the VP (minus its proof).
     let proof_val = vp
@@ -646,7 +646,9 @@ async fn verify_bbs_presentation(
         .and_then(Value::as_str)
         .ok_or_else(|| AppError::Validation("bbs-2023 proof has no `verificationMethod`".into()))?;
     check_issuer_binding(vm, issuer_did)?;
-    let g2 = DidVmResolver::new(did_resolver).resolve_bbs_g2(vm).await?;
+    let g2 = DidVmResolver::new(did_resolver.cloned())
+        .resolve_bbs_g2(vm)
+        .await?;
     let pk = PublicKey::from_bytes(&g2)
         .map_err(|e| AppError::Validation(format!("bbs-2023 issuer key is invalid: {e}")))?;
 

--- a/vtc-service/src/credentials/vm_resolver.rs
+++ b/vtc-service/src/credentials/vm_resolver.rs
@@ -16,19 +16,23 @@
 //! [`VerificationMethod::get_public_key_bytes`] extractor, which handles
 //! Multikey + `Ed25519VerificationKey2020` + `publicKeyJwk` uniformly.
 
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use ed25519_dalek::VerifyingKey;
 use vti_common::error::AppError;
 
 /// A [`VerificationMethodResolver`](affinidi_data_integrity::VerificationMethodResolver)
-/// over the VTC's optional [`DIDCacheClient`](affinidi_did_resolver_cache_sdk::DIDCacheClient).
-pub(crate) struct DidVmResolver<'a> {
-    resolver: Option<&'a affinidi_did_resolver_cache_sdk::DIDCacheClient>,
+/// over the VTC's optional [`DIDCacheClient`].
+///
+/// Owns its [`DIDCacheClient`] (which is cheap to clone — Arc-backed) rather
+/// than borrowing it, so the same resolver can be used both inline (`&resolver`)
+/// and behind an `Arc<dyn VerificationMethodResolver>` (the status-list fetcher
+/// holds one for the credential-signature check).
+pub(crate) struct DidVmResolver {
+    resolver: Option<DIDCacheClient>,
 }
 
-impl<'a> DidVmResolver<'a> {
-    pub(crate) fn new(
-        resolver: Option<&'a affinidi_did_resolver_cache_sdk::DIDCacheClient>,
-    ) -> Self {
+impl DidVmResolver {
+    pub(crate) fn new(resolver: Option<DIDCacheClient>) -> Self {
         Self { resolver }
     }
 
@@ -44,7 +48,7 @@ impl<'a> DidVmResolver<'a> {
                     AppError::Validation(format!("`{base_did}` is not a resolvable did:key: {e}"))
                 });
         }
-        let resolver = self.resolver.ok_or_else(|| {
+        let resolver = self.resolver.as_ref().ok_or_else(|| {
             AppError::Validation(format!(
                 "resolving `{base_did}` needs a DID resolver, but none is configured — configure \
                  the DID cache to verify did:webvh / did:web issuers + holders"
@@ -102,7 +106,7 @@ impl<'a> DidVmResolver<'a> {
                 AppError::Validation(format!("`{base_did}` is not a BBS did:key: {e}"))
             });
         }
-        let resolver = self.resolver.ok_or_else(|| {
+        let resolver = self.resolver.as_ref().ok_or_else(|| {
             AppError::Validation(format!(
                 "resolving `{base_did}` needs a DID resolver to verify did:webvh / did:web \
                  BBS issuers"
@@ -152,7 +156,7 @@ impl<'a> DidVmResolver<'a> {
 }
 
 #[async_trait::async_trait]
-impl affinidi_data_integrity::VerificationMethodResolver for DidVmResolver<'_> {
+impl affinidi_data_integrity::VerificationMethodResolver for DidVmResolver {
     async fn resolve_vm(
         &self,
         vm: &str,

--- a/vtc-service/src/recognition/mod.rs
+++ b/vtc-service/src/recognition/mod.rs
@@ -19,9 +19,11 @@
 //!
 //! 1. **Proof verification.** Both VEC + VMC carry
 //!    `DataIntegrityProof::eddsa-jcs-2022` signatures over the
-//!    foreign issuer's `#key-0`. Resolves via the workspace's
-//!    [`ForeignIssuerKeyResolver`] trait — production wires
-//!    `DIDCacheClient`, tests inject a stub.
+//!    foreign issuer's `#key-0`. Verified through the DI
+//!    library's `proof.verify` with the shared
+//!    `credentials::vm_resolver::DidVmResolver`
+//!    (`VerificationMethodResolver`) — production wires
+//!    `DIDCacheClient`, tests inject a stub resolver.
 //! 2. **StatusList revocation.** Fetches the credential's
 //!    `credentialStatus.statusListCredential` URL, decodes the
 //!    bitstring, and checks `statusListIndex`. A set bit
@@ -53,6 +55,6 @@ pub mod challenge;
 pub mod verify;
 
 pub use verify::{
-    DidResolverKeyResolver, ForeignIssuerKeyResolver, HttpStatusListFetcher, RecognitionError,
-    StatusListFetcher, VerifiedForeignCredential, verify_foreign_vec,
+    HttpStatusListFetcher, RecognitionError, StatusListFetcher, VerifiedForeignCredential,
+    verify_foreign_vec,
 };

--- a/vtc-service/src/recognition/verify.rs
+++ b/vtc-service/src/recognition/verify.rs
@@ -17,24 +17,28 @@
 //! pair — the route layer (`POST /v1/auth/recognise`) clamps
 //! the session TTL to that earliest expiry.
 //!
-//! ## Why traits for key resolution + status fetch
+//! ## Injectable resolver + status fetch
 //!
 //! Both surfaces are heavy: DID resolution can hit external
-//! HTTPS, status-list fetching is unconditionally HTTP. Hiding
-//! them behind small traits keeps `verify_foreign_vec` unit-
-//! testable without a live DID resolver or status-list host,
-//! and isolates the M3.9 logic from upstream API churn.
+//! HTTPS, status-list fetching is unconditionally HTTP. Key
+//! resolution goes through the DI library's
+//! `VerificationMethodResolver` (the shared
+//! [`crate::credentials::vm_resolver::DidVmResolver`]); status
+//! fetching is behind the small [`StatusListFetcher`] trait.
+//! Both are injected, so `verify_foreign_vec` is unit-testable
+//! without a live DID resolver or status-list host.
 
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
-use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
+use affinidi_data_integrity::{DataIntegrityProof, VerificationMethodResolver, VerifyOptions};
 use affinidi_vc::VerifiableCredential;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 
+use crate::credentials::vm_resolver::check_issuer_binding;
 use crate::registry::{RegistryError, TrustRegistryClient};
 
 /// Failure modes the verifier surfaces. Mapped to HTTP 403
@@ -95,24 +99,6 @@ impl RecognitionError {
     }
 }
 
-/// Resolves a foreign issuer's `#key-0` public bytes from
-/// their DID. The verifier consults this once per credential
-/// (VEC + VMC — usually the same issuer, so production wires
-/// a per-mint memoising layer in the route handler if needed).
-#[async_trait]
-pub trait ForeignIssuerKeyResolver: Send + Sync {
-    /// Resolve the issuer's `#key-0` Ed25519 public key bytes.
-    /// `verification_method` is the proof's
-    /// `verificationMethod` URI — typically `{issuer_did}#key-0`,
-    /// but the resolver decides which key to return based on
-    /// the URI fragment.
-    async fn resolve_key(
-        &self,
-        issuer_did: &str,
-        verification_method: &str,
-    ) -> Result<Vec<u8>, RecognitionError>;
-}
-
 /// Fetches + decodes a status-list credential. Production
 /// wires [`HttpStatusListFetcher`] (reqwest + JSON parse +
 /// bitstring decode); tests inject a stub returning a known
@@ -163,7 +149,7 @@ pub struct VerifiedForeignCredential {
 pub async fn verify_foreign_vec(
     vec: &VerifiableCredential,
     vmc: &VerifiableCredential,
-    key_resolver: &dyn ForeignIssuerKeyResolver,
+    resolver: &dyn VerificationMethodResolver,
     status_fetcher: &dyn StatusListFetcher,
     registry: Arc<dyn TrustRegistryClient>,
     now: DateTime<Utc>,
@@ -195,8 +181,8 @@ pub async fn verify_foreign_vec(
 
     // Step 1: proof verification. Cheap; runs first so a
     // malformed pair short-circuits before any network call.
-    verify_proof(vec, &issuer, key_resolver, "VEC").await?;
-    verify_proof(vmc, &issuer, key_resolver, "VMC").await?;
+    verify_proof(vec, &issuer, resolver, "VEC").await?;
+    verify_proof(vmc, &issuer, resolver, "VMC").await?;
 
     // Step 4 (early): validity windows. Cheap RFC3339 parse +
     // comparison. Bumped before the network calls so an
@@ -269,7 +255,7 @@ pub async fn verify_foreign_vec(
 async fn verify_proof(
     vc: &VerifiableCredential,
     issuer_did: &str,
-    key_resolver: &dyn ForeignIssuerKeyResolver,
+    resolver: &dyn VerificationMethodResolver,
     label: &str,
 ) -> Result<(), RecognitionError> {
     let proof_value = vc
@@ -285,16 +271,18 @@ async fn verify_proof(
         .ok_or_else(|| {
             RecognitionError::ProofInvalid(format!("{label} proof missing verificationMethod"))
         })?;
-
-    let pubkey = key_resolver
-        .resolve_key(issuer_did, verification_method)
-        .await?;
+    // The signing key must sit under the foreign issuer (a key controlled by
+    // some other DID must not sign this credential). The library `verify` then
+    // resolves it + checks the signature.
+    check_issuer_binding(verification_method, issuer_did)
+        .map_err(|e| RecognitionError::ProofInvalid(format!("{label}: {e}")))?;
 
     let mut vc_without_proof = vc.clone();
     vc_without_proof.proof = None;
 
     proof
-        .verify_with_public_key(&vc_without_proof, &pubkey, VerifyOptions::new())
+        .verify(&vc_without_proof, resolver, VerifyOptions::new())
+        .await
         .map_err(|e| RecognitionError::ProofInvalid(format!("{label}: {e}")))?;
     Ok(())
 }
@@ -408,60 +396,6 @@ fn extract_role_claim(vec: &VerifiableCredential) -> Result<(String, String), Re
 // Production trait impls
 // ---------------------------------------------------------------------------
 
-/// `ForeignIssuerKeyResolver` backed by the workspace's
-/// [`affinidi_did_resolver_cache_sdk::DIDCacheClient`]. Walks
-/// the resolved DID Document's `verificationMethod` array for
-/// an entry matching the proof's verificationMethod URI and
-/// extracts the Ed25519 public bytes from
-/// `publicKeyMultibase`.
-///
-/// Production deployments inject this; tests stub
-/// [`ForeignIssuerKeyResolver`] directly.
-pub struct DidResolverKeyResolver {
-    resolver: affinidi_did_resolver_cache_sdk::DIDCacheClient,
-}
-
-impl DidResolverKeyResolver {
-    pub fn new(resolver: affinidi_did_resolver_cache_sdk::DIDCacheClient) -> Self {
-        Self { resolver }
-    }
-}
-
-#[async_trait]
-impl ForeignIssuerKeyResolver for DidResolverKeyResolver {
-    async fn resolve_key(
-        &self,
-        issuer_did: &str,
-        verification_method: &str,
-    ) -> Result<Vec<u8>, RecognitionError> {
-        let resolved = self
-            .resolver
-            .resolve(issuer_did)
-            .await
-            .map_err(|e| RecognitionError::IssuerKeyUnresolved(format!("{issuer_did}: {e}")))?;
-        // Match the verificationMethod URI exactly. The
-        // foreign issuer's proof references something like
-        // `did:webvh:peer.example#key-0`; the resolved doc's
-        // `verification_method` array carries entries with the
-        // same `id` field.
-        let vm = resolved
-            .doc
-            .verification_method
-            .iter()
-            .find(|m| m.id.as_str() == verification_method)
-            .ok_or_else(|| {
-                RecognitionError::IssuerKeyUnresolved(format!(
-                    "verificationMethod {verification_method} not present on {issuer_did}"
-                ))
-            })?;
-        // Use the upstream's built-in extractor — handles
-        // Multikey + Ed25519VerificationKey2020 + publicKeyJwk
-        // shapes uniformly.
-        vm.get_public_key_bytes()
-            .map_err(|e| RecognitionError::IssuerKeyUnresolved(format!("extract pubkey: {e}")))
-    }
-}
-
 /// HTTP `StatusListFetcher` — fetches a BitstringStatusList
 /// credential by URL, parses out the encoded list, and tests
 /// the bit at `index`. Used by production deployments; tests
@@ -478,7 +412,7 @@ pub struct HttpStatusListFetcher {
     client: reqwest::Client,
     /// Resolves the list credential's issuer key for the signature check. `None`
     /// → no verification (fetch + decode only).
-    key_resolver: Option<Arc<dyn ForeignIssuerKeyResolver>>,
+    key_resolver: Option<Arc<dyn VerificationMethodResolver>>,
 }
 
 impl HttpStatusListFetcher {
@@ -495,7 +429,7 @@ impl HttpStatusListFetcher {
     /// A fetcher that verifies each fetched list credential's `eddsa-jcs-2022`
     /// issuer signature via `key_resolver` before trusting it. Uses the shared
     /// hardened client ([`foreign_fetch_client`]).
-    pub fn with_issuer_verification(key_resolver: Arc<dyn ForeignIssuerKeyResolver>) -> Self {
+    pub fn with_issuer_verification(key_resolver: Arc<dyn VerificationMethodResolver>) -> Self {
         Self {
             client: foreign_fetch_client(),
             key_resolver: Some(key_resolver),
@@ -586,7 +520,7 @@ async fn read_body_capped(
 async fn verify_status_list_signature(
     list_credential: &JsonValue,
     expected_issuer: Option<&str>,
-    key_resolver: &dyn ForeignIssuerKeyResolver,
+    resolver: &dyn VerificationMethodResolver,
     url: &str,
 ) -> Result<(), RecognitionError> {
     let list_issuer = list_credential
@@ -624,13 +558,8 @@ async fn verify_status_list_signature(
             ))
         })?;
     // The signing key must belong to the list's own issuer.
-    if vm.split('#').next().unwrap_or_default() != list_issuer {
-        return Err(RecognitionError::StatusListFailed(format!(
-            "status list {url} proof verificationMethod {vm} is not under its issuer {list_issuer}"
-        )));
-    }
-
-    let pubkey = key_resolver.resolve_key(&list_issuer, vm).await?;
+    check_issuer_binding(vm, &list_issuer)
+        .map_err(|e| RecognitionError::StatusListFailed(format!("status list {url} {e}")))?;
 
     // JCS is presence-sensitive: strip `proof` exactly as signing did.
     let mut signing_doc = list_credential.clone();
@@ -638,7 +567,8 @@ async fn verify_status_list_signature(
         obj.remove("proof");
     }
     proof
-        .verify_with_public_key(&signing_doc, &pubkey, VerifyOptions::new())
+        .verify(&signing_doc, resolver, VerifyOptions::new())
+        .await
         .map_err(|e| {
             RecognitionError::StatusListFailed(format!(
                 "status list {url} issuer signature did not verify: {e}"
@@ -872,8 +802,9 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Mutex;
 
-    /// In-memory key resolver. Tests seed the bytes they
-    /// expect the verifier to use.
+    /// In-memory `VerificationMethodResolver`. Tests seed the key bytes they
+    /// expect the verifier to use, keyed by issuer DID; `resolve_vm` looks them
+    /// up by the base DID of the verificationMethod URI.
     struct StubKeyResolver {
         keys: HashMap<String, Vec<u8>>,
     }
@@ -891,16 +822,22 @@ mod tests {
     }
 
     #[async_trait]
-    impl ForeignIssuerKeyResolver for StubKeyResolver {
-        async fn resolve_key(
+    impl VerificationMethodResolver for StubKeyResolver {
+        async fn resolve_vm(
             &self,
-            issuer_did: &str,
-            _verification_method: &str,
-        ) -> Result<Vec<u8>, RecognitionError> {
-            self.keys
-                .get(issuer_did)
-                .cloned()
-                .ok_or_else(|| RecognitionError::IssuerKeyUnresolved(issuer_did.into()))
+            vm: &str,
+        ) -> Result<affinidi_data_integrity::ResolvedKey, affinidi_data_integrity::DataIntegrityError>
+        {
+            let base = vm.split('#').next().unwrap_or(vm);
+            let bytes = self.keys.get(base).cloned().ok_or_else(|| {
+                affinidi_data_integrity::DataIntegrityError::Resolver(format!(
+                    "no test key for {base}"
+                ))
+            })?;
+            Ok(affinidi_data_integrity::ResolvedKey::new(
+                affinidi_secrets_resolver::secrets::KeyType::Ed25519,
+                bytes,
+            ))
         }
     }
 

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -39,10 +39,11 @@ use vti_common::error::AppError;
 use crate::ceremony::{Credential, CredentialStatus, Presentation};
 use crate::credentials::present_challenge::{self, DEFAULT_CHALLENGE_TTL};
 use crate::credentials::{VerifiedPresentation, VerifiedPresentationSet, verify_vp_token};
+use affinidi_data_integrity::VerificationMethodResolver;
+
+use crate::credentials::vm_resolver::DidVmResolver;
 use crate::join::JoinTransport;
-use crate::recognition::{
-    DidResolverKeyResolver, ForeignIssuerKeyResolver, HttpStatusListFetcher, StatusListFetcher,
-};
+use crate::recognition::{HttpStatusListFetcher, StatusListFetcher};
 use crate::registry::TrustRegistryClient;
 use crate::schemas::accepts::get_accepts;
 use crate::server::AppState;
@@ -284,8 +285,8 @@ async fn presentation_from_verified_set(
     // hide a revocation. Built once for the whole set.
     let status_fetcher = match state.did_resolver.clone() {
         Some(resolver) => {
-            let key_resolver: Arc<dyn ForeignIssuerKeyResolver> =
-                Arc::new(DidResolverKeyResolver::new(resolver));
+            let key_resolver: Arc<dyn VerificationMethodResolver> =
+                Arc::new(DidVmResolver::new(Some(resolver)));
             HttpStatusListFetcher::with_issuer_verification(key_resolver)
         }
         None => HttpStatusListFetcher::new(),

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -60,9 +60,12 @@ use crate::policy::{
     PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy, get_active_policy_id,
     get_policy,
 };
+use affinidi_data_integrity::VerificationMethodResolver;
+
+use crate::credentials::vm_resolver::DidVmResolver;
 use crate::recognition::{
-    DidResolverKeyResolver, ForeignIssuerKeyResolver, HttpStatusListFetcher, RecognitionError,
-    VerifiedForeignCredential, challenge, verify_foreign_vec,
+    HttpStatusListFetcher, RecognitionError, VerifiedForeignCredential, challenge,
+    verify_foreign_vec,
 };
 use crate::server::AppState;
 use affinidi_vc::VerifiableCredential;
@@ -235,8 +238,8 @@ pub async fn recognise(
     let registry = state.registry_client.as_ref().cloned().ok_or_else(|| {
         AppError::Validation("trust-registry client not configured on this VTC".into())
     })?;
-    let key_resolver: Arc<dyn ForeignIssuerKeyResolver> =
-        Arc::new(DidResolverKeyResolver::new(resolver));
+    let key_resolver: Arc<dyn VerificationMethodResolver> =
+        Arc::new(DidVmResolver::new(Some(resolver)));
     // Verify the foreign status list's own issuer signature (bound to the
     // VEC/VMC issuer) before trusting it — the same key resolver the proof check
     // uses.

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -335,7 +335,7 @@ async fn verify_vc_proof(
         obj.remove("proof");
     }
 
-    let vm_resolver = DidVmResolver::new(Some(resolver));
+    let vm_resolver = DidVmResolver::new(Some(resolver.clone()));
     proof
         .verify(&vrc_without_proof, &vm_resolver, VerifyOptions::new())
         .await


### PR DESCRIPTION
Second of two PRs unifying the DID-VM → DI-proof-verify copies (P2.4). Builds on #455 (the shared `credentials::vm_resolver`). This is the riskier half — it deletes recognition's bespoke trait and reworks its test stubs.

## What

Cross-community recognition hand-rolled key resolution in **two** places — `verify_proof` (VEC/VMC) and `verify_status_list_signature` — behind its own `ForeignIssuerKeyResolver` trait. Both now verify through the DI library's `proof.verify(doc, resolver, opts)` with the shared `DidVmResolver` + `check_issuer_binding`, the same path exchange + relationships already use (after #455).

- **Delete `ForeignIssuerKeyResolver` + `DidResolverKeyResolver`** — the 4th and 5th copies of the resolve-and-verify pattern are gone.
- `verify_foreign_vec`, `verify_status_list_signature`, and `HttpStatusListFetcher` now take/hold the standard `affinidi_data_integrity::VerificationMethodResolver`.
- **`DidVmResolver` now *owns* `Option<DIDCacheClient>`** (Arc-backed, cheap to clone) instead of borrowing — so one resolver works both inline (`&resolver`) and behind the fetcher's `Arc<dyn VerificationMethodResolver>`, resolving the ownership friction. Exchange + relationships construct it with `.cloned()`/`.clone()`.
- The recognition test `StubKeyResolver` now stubs the standard `VerificationMethodResolver` (returns a `ResolvedKey`). The test VCs carry **real** `eddsa-jcs-2022` proofs, so `proof.verify` does the identical crypto check the old `verify_with_public_key` did.
- Production wiring (`recognise.rs`, `present.rs`) builds `DidVmResolver::new(Some(resolver))`.

## Verification (behaviour-preserving)

- recognition unit tests **31**, `recognise` **15**, `relationships` **10**, `join_didcomm`, full lib **580** — all green.
- fmt + clippy clean. Net **−51 lines**.
- No wire/public-API change. The now-unused `RecognitionError::IssuerKeyUnresolved` variant is kept for its stable audit reason-code (SIEM filters).

## Result

After this lands, **all five** DID-VM→DI-proof-verify sites (exchange DI VP, exchange bbs-2023, relationships VRC, recognition VEC/VMC, recognition status-list) go through one `VerificationMethodResolver` (`DidVmResolver`) + one `check_issuer_binding`. P2.4 complete.