### PR TITLE
refactor(vtc): one facts-assembly path for all ceremony purposes (P2.2)

### DIFF
--- a/vtc-service/src/ceremony/assemble.rs
+++ b/vtc-service/src/ceremony/assemble.rs
@@ -1,0 +1,94 @@
+//! One facts-assembly path for every ceremony purpose.
+//!
+//! The four route handlers (join submit, leave, role-change, directory) each
+//! built a [`Facts`] by hand, repeating the community-profile load, the cached
+//! member count, the authenticated [`Actor`], and the [`MemberState`] shaping
+//! (status from the tombstone, `joined_at`-or-now). This collapses that skeleton
+//! into [`assemble_facts`] + two small helpers; the callers keep only what
+//! genuinely differs per purpose — the evidence, and how the subject's role is
+//! sourced.
+
+use chrono::Utc;
+
+use vti_common::error::AppError;
+
+use crate::acl::get_acl_entry;
+use crate::community::load_profile;
+use crate::members::Member;
+use crate::server::AppState;
+
+use super::facts::{
+    Actor, Context, Evidence, Facts, MemberState, Purpose, State as FactsState, Subject,
+};
+
+/// The per-purpose inputs to [`assemble_facts`]. Everything else — the clock,
+/// the `"rest"` channel, the community profile, the cached member count, and
+/// `authenticated: true` — is uniform across ceremonies.
+pub struct FactsInputs {
+    pub purpose: Purpose,
+    pub actor_did: String,
+    /// The actor's community role. `None` for a join (the applicant isn't a
+    /// member yet); an ACL lookup ([`load_actor_role`]) for the rest.
+    pub actor_role: Option<String>,
+    pub subject_did: String,
+    pub subject_member: Option<MemberState>,
+    pub evidence: Evidence,
+}
+
+/// Build a [`Facts`] from the uniform community context plus the per-purpose
+/// [`FactsInputs`].
+pub async fn assemble_facts(state: &AppState, inputs: FactsInputs) -> Result<Facts, AppError> {
+    let community_did = load_profile(&state.community_ks)
+        .await?
+        .map(|p| p.community_did)
+        .unwrap_or_default();
+    Ok(Facts {
+        purpose: inputs.purpose,
+        now: Utc::now(),
+        actor: Actor {
+            did: inputs.actor_did,
+            role: inputs.actor_role,
+            authenticated: true,
+        },
+        subject: Subject {
+            did: inputs.subject_did,
+        },
+        context: Context {
+            community_did,
+            channel: "rest".to_string(),
+            member_count: state.member_count(),
+        },
+        evidence: inputs.evidence,
+        state: FactsState {
+            subject_member: inputs.subject_member,
+        },
+    })
+}
+
+/// The actor's community role from the ACL (`None` when no ACL row exists).
+pub async fn load_actor_role(state: &AppState, did: &str) -> Result<Option<String>, AppError> {
+    Ok(get_acl_entry(&state.acl_ks, did)
+        .await?
+        .map(|e| e.role.to_string()))
+}
+
+/// Shape a subject's [`MemberState`] from its role + optional member row:
+/// `status` from the row's tombstone (`removed`/`active`), `joined_at` from the
+/// row (or now when the row is absent).
+pub fn member_state(role: String, member: Option<&Member>) -> MemberState {
+    MemberState {
+        role,
+        status: member
+            .map(|m| {
+                if m.removed_at.is_some() {
+                    "removed"
+                } else {
+                    "active"
+                }
+            })
+            .unwrap_or("active")
+            .to_string(),
+        joined_at: member.map(|m| m.joined_at).unwrap_or_else(Utc::now),
+        personhood: None,
+    }
+}

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -56,6 +56,7 @@
 //! until ceremonies are ported over (build-vs-reuse map, pipeline
 //! §10).
 
+pub mod assemble;
 pub mod effects;
 pub mod evaluate;
 pub mod execute;
@@ -64,6 +65,7 @@ pub mod invariant;
 pub mod verdict;
 pub mod verify;
 
+pub use assemble::{FactsInputs, assemble_facts, load_actor_role, member_state};
 pub use effects::{EffectPlan, plan};
 pub use evaluate::evaluate;
 pub use execute::{AdmitOutcome, DepartOutcome, EffectOutcome, RemintOutcome, apply};

--- a/vtc-service/src/routes/directory.rs
+++ b/vtc-service/src/routes/directory.rs
@@ -31,7 +31,6 @@
 
 use axum::Json;
 use axum::extract::{Path, Query, State};
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as JsonValue, json};
 
@@ -40,10 +39,9 @@ use vti_common::error::AppError;
 use crate::acl::get_acl_entry;
 use crate::auth::AuthClaims;
 use crate::ceremony::{
-    self, Actor, Context, Evidence, Facts, MemberState, Purpose, State as FactsState, Subject,
-    Verdict, VerifiedFacts, effects::EffectPlan,
+    self, Evidence, Facts, Purpose, Verdict, VerifiedFacts, effects::EffectPlan,
 };
-use crate::community::load_profile;
+use crate::ceremony::{FactsInputs, assemble_facts, load_actor_role, member_state};
 use crate::members::get_member;
 use crate::policy::load_active_compiled;
 use crate::policy::model::PolicyPurpose;
@@ -152,42 +150,19 @@ async fn assemble_directory_facts(
     subject_did: &str,
     fields_hint: Option<String>,
 ) -> Result<Facts, AppError> {
-    // Actor's community role comes from the ACL, not the JWT.
-    let actor_role = get_acl_entry(&state.acl_ks, &viewer.did)
-        .await?
-        .map(|e| e.role.to_string());
-
-    // Subject's member facts: role from the ACL, status from the
-    // member row's tombstone, joined_at from the member row.
+    // Subject's member facts: role from the ACL, status + joined_at from the
+    // member row (directory sources the subject's role from the ACL rather than
+    // a caller-supplied current role, so it builds the MemberState explicitly).
     let subject_member = match get_member(&state.members_ks, subject_did).await? {
         Some(m) => {
             let role = get_acl_entry(&state.acl_ks, subject_did)
                 .await?
                 .map(|e| e.role.to_string())
                 .unwrap_or_else(|| "member".to_string());
-            let status = if m.removed_at.is_some() {
-                "removed"
-            } else {
-                "active"
-            };
-            Some(MemberState {
-                role,
-                status: status.to_string(),
-                joined_at: m.joined_at,
-                personhood: None,
-            })
+            Some(member_state(role, Some(&m)))
         }
         None => None,
     };
-
-    // community_did is informational for directory (the policy doesn't
-    // branch on it); empty when no profile is set yet.
-    let community_did = load_profile(&state.community_ks)
-        .await?
-        .map(|p| p.community_did)
-        .unwrap_or_default();
-
-    let member_count = state.member_count();
 
     let request = fields_hint.map(|raw| {
         let fields: Vec<String> = raw
@@ -198,27 +173,20 @@ async fn assemble_directory_facts(
         json!({ "fields_requested": fields })
     });
 
-    Ok(Facts {
-        purpose: Purpose::Directory,
-        now: Utc::now(),
-        actor: Actor {
-            did: viewer.did.clone(),
-            role: actor_role,
-            authenticated: true,
+    assemble_facts(
+        state,
+        FactsInputs {
+            purpose: Purpose::Directory,
+            actor_did: viewer.did.clone(),
+            actor_role: load_actor_role(state, &viewer.did).await?,
+            subject_did: subject_did.to_string(),
+            subject_member,
+            evidence: Evidence {
+                invitation: None,
+                presentation: None,
+                request,
+            },
         },
-        subject: Subject {
-            did: subject_did.to_string(),
-        },
-        context: Context {
-            community_did,
-            channel: "rest".to_string(),
-            member_count,
-        },
-        evidence: Evidence {
-            invitation: None,
-            presentation: None,
-            request,
-        },
-        state: FactsState { subject_member },
-    })
+    )
+    .await
 }

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -48,7 +48,6 @@
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::{info, warn};
@@ -59,10 +58,10 @@ use vti_common::error::AppError;
 
 use crate::ceremony::execute::{self, AdmitOutcome};
 use crate::ceremony::{
-    Actor, Context, Credential, CredentialStatus, EffectOutcome, EffectPlan, Evidence, Facts,
-    Presentation, Purpose, State as FactsState, Subject, Verdict, VerifiedFacts,
+    Credential, CredentialStatus, EffectOutcome, EffectPlan, Evidence, Facts, Presentation,
+    Purpose, Verdict, VerifiedFacts,
 };
-use crate::community::load_profile;
+use crate::ceremony::{FactsInputs, assemble_facts};
 use crate::join::{JoinRequest, JoinStatus, JoinTransport, list_join_requests, store_join_request};
 use crate::policy::{PolicyPurpose, extract::extract_vp_claims, load_active_compiled};
 use crate::server::AppState;
@@ -445,40 +444,25 @@ async fn assemble_join_facts(
     applicant_did: &str,
     presentation: Presentation,
 ) -> Result<Facts, AppError> {
-    let community_did = load_profile(&state.community_ks)
-        .await?
-        .map(|p| p.community_did)
-        .unwrap_or_default();
-    let member_count = state.member_count();
-
-    Ok(Facts {
-        purpose: Purpose::Join,
-        now: Utc::now(),
-        // The applicant proved holder-binding (route-layer for the VP path,
-        // cryptographic kb-jwt for the credential-exchange path); they are not
-        // (yet) a member, so they carry no community role.
-        actor: Actor {
-            did: applicant_did.to_string(),
-            role: None,
-            authenticated: true,
-        },
-        subject: Subject {
-            did: applicant_did.to_string(),
-        },
-        context: Context {
-            community_did,
-            channel: "rest".to_string(),
-            member_count,
-        },
-        evidence: Evidence {
-            invitation: None,
-            presentation: Some(presentation),
-            request: None,
-        },
-        state: FactsState {
+    // The applicant proved holder-binding (route-layer for the VP path,
+    // cryptographic kb-jwt for the credential-exchange path) but is not (yet) a
+    // member, so they carry no community role and no subject member-state.
+    assemble_facts(
+        state,
+        FactsInputs {
+            purpose: Purpose::Join,
+            actor_did: applicant_did.to_string(),
+            actor_role: None,
+            subject_did: applicant_did.to_string(),
             subject_member: None,
+            evidence: Evidence {
+                invitation: None,
+                presentation: Some(presentation),
+                request: None,
+            },
         },
-    })
+    )
+    .await
 }
 
 /// Project the VP into the [`Presentation`] the policy reads.

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -26,7 +26,6 @@ use affinidi_status_list::StatusPurpose;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::info;
@@ -38,10 +37,9 @@ use crate::acl::get_acl_entry;
 use crate::auth::{AdminAuth, AuthClaims};
 use crate::ceremony::execute;
 use crate::ceremony::{
-    Actor, Context, EffectOutcome, EffectPlan, Evidence, Facts, MemberState, Purpose,
-    State as FactsState, Subject, Verdict, VerifiedFacts,
+    EffectOutcome, EffectPlan, Evidence, Facts, Purpose, Verdict, VerifiedFacts,
 };
-use crate::community::load_profile;
+use crate::ceremony::{FactsInputs, assemble_facts, load_actor_role, member_state};
 use crate::members::{Disposition, get_member};
 use crate::policy::{PolicyPurpose, load_active_compiled};
 use crate::server::AppState;
@@ -320,32 +318,6 @@ async fn assemble_leave_facts(
     disposition: Option<Disposition>,
     reason: &str,
 ) -> Result<Facts, AppError> {
-    let actor_role = get_acl_entry(&state.acl_ks, actor_did)
-        .await?
-        .map(|e| e.role.to_string());
-
-    let subject_member_state = Some(MemberState {
-        role: subject_role.to_string(),
-        status: subject_member
-            .map(|m| {
-                if m.removed_at.is_some() {
-                    "removed"
-                } else {
-                    "active"
-                }
-            })
-            .unwrap_or("active")
-            .to_string(),
-        joined_at: subject_member.map(|m| m.joined_at).unwrap_or_else(Utc::now),
-        personhood: None,
-    });
-
-    let community_did = load_profile(&state.community_ks)
-        .await?
-        .map(|p| p.community_did)
-        .unwrap_or_default();
-    let member_count = state.member_count();
-
     // Ceremony request params: the operator's requested disposition +
     // the admin-supplied reason. Absent when neither is set.
     let request = if disposition.is_some() || !reason.is_empty() {
@@ -361,31 +333,22 @@ async fn assemble_leave_facts(
         None
     };
 
-    Ok(Facts {
-        purpose: Purpose::Leave,
-        now: Utc::now(),
-        actor: Actor {
-            did: actor_did.to_string(),
-            role: actor_role,
-            authenticated: true,
+    assemble_facts(
+        state,
+        FactsInputs {
+            purpose: Purpose::Leave,
+            actor_did: actor_did.to_string(),
+            actor_role: load_actor_role(state, actor_did).await?,
+            subject_did: subject_did.to_string(),
+            subject_member: Some(member_state(subject_role.to_string(), subject_member)),
+            evidence: Evidence {
+                invitation: None,
+                presentation: None,
+                request,
+            },
         },
-        subject: Subject {
-            did: subject_did.to_string(),
-        },
-        context: Context {
-            community_did,
-            channel: "rest".to_string(),
-            member_count,
-        },
-        evidence: Evidence {
-            invitation: None,
-            presentation: None,
-            request,
-        },
-        state: FactsState {
-            subject_member: subject_member_state,
-        },
-    })
+    )
+    .await
 }
 
 /// Parse a disposition wire string into a concrete `Disposition`.

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -14,7 +14,6 @@
 
 use axum::Json;
 use axum::extract::{Path, State};
-use chrono::Utc;
 use serde::Deserialize;
 use serde_json::{Value as JsonValue, json};
 use tracing::warn;
@@ -25,10 +24,9 @@ use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry};
 use crate::auth::AdminAuth;
 use crate::ceremony::execute;
 use crate::ceremony::{
-    Actor, Context, EffectOutcome, EffectPlan, Evidence, Facts, MemberState, Purpose,
-    State as FactsState, Subject, Verdict, VerifiedFacts,
+    EffectOutcome, EffectPlan, Evidence, Facts, Purpose, Verdict, VerifiedFacts,
 };
-use crate::community::load_profile;
+use crate::ceremony::{FactsInputs, assemble_facts, load_actor_role, member_state};
 use crate::error::AppError;
 use crate::members::{Disposition, Member, get_member, store_member};
 use crate::policy::{PolicyPurpose, load_active_compiled};
@@ -281,57 +279,29 @@ async fn assemble_role_change_facts(
     target_role: &str,
     step_up: bool,
 ) -> Result<Facts, AppError> {
-    let actor_role = get_acl_entry(&state.acl_ks, actor_did)
-        .await?
-        .map(|e| e.role.to_string());
     let subject_member = get_member(&state.members_ks, subject_did).await?;
 
-    let community_did = load_profile(&state.community_ks)
-        .await?
-        .map(|p| p.community_did)
-        .unwrap_or_default();
-    let member_count = state.member_count();
-
-    Ok(Facts {
-        purpose: Purpose::RoleChange,
-        now: Utc::now(),
-        actor: Actor {
-            did: actor_did.to_string(),
-            role: actor_role,
-            authenticated: true,
+    assemble_facts(
+        state,
+        FactsInputs {
+            purpose: Purpose::RoleChange,
+            actor_did: actor_did.to_string(),
+            actor_role: load_actor_role(state, actor_did).await?,
+            subject_did: subject_did.to_string(),
+            // The subject's role on the facts is their *current* role (the
+            // transition target lives in the evidence, below).
+            subject_member: Some(member_state(
+                current_role.to_string(),
+                subject_member.as_ref(),
+            )),
+            evidence: Evidence {
+                invitation: None,
+                presentation: None,
+                request: Some(json!({ "target_role": target_role, "step_up": step_up })),
+            },
         },
-        subject: Subject {
-            did: subject_did.to_string(),
-        },
-        context: Context {
-            community_did,
-            channel: "rest".to_string(),
-            member_count,
-        },
-        evidence: Evidence {
-            invitation: None,
-            presentation: None,
-            request: Some(json!({ "target_role": target_role, "step_up": step_up })),
-        },
-        state: FactsState {
-            subject_member: Some(MemberState {
-                role: current_role.to_string(),
-                status: subject_member
-                    .as_ref()
-                    .map(|m| {
-                        if m.removed_at.is_some() {
-                            "removed"
-                        } else {
-                            "active"
-                        }
-                    })
-                    .unwrap_or("active")
-                    .to_string(),
-                joined_at: subject_member.map(|m| m.joined_at).unwrap_or_else(Utc::now),
-                personhood: None,
-            }),
-        },
-    })
+    )
+    .await
 }
 
 // Re-export `from_pair` under a route-only alias so this module
@@ -366,6 +336,7 @@ mod p0_14_role_change_policy_tests {
     //! pipeline directly — the full UV ceremony is covered separately.
     use super::*;
     use affinidi_status_list::StatusPurpose;
+    use chrono::Utc;
 
     use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry, store_acl_entry};
     use crate::members::{Member, store_member};


### PR DESCRIPTION
The facts-builder-unification half of P2.2 (the cached-member-count half shipped in #453).

## Problem

The four ceremony facts builders — `assemble_join_facts`, `assemble_leave_facts`, `assemble_role_change_facts`, `assemble_directory_facts` — each hand-built a `Facts`, repeating:
- the community-profile load + cached `member_count`,
- the authenticated `Actor` / `Subject` / `Context` wiring (`"rest"` channel),
- the `MemberState` shaping (status from the row's `removed_at` tombstone, `joined_at`-or-now).

## Change

Collapse the skeleton into a new `ceremony::assemble` module:
- **`assemble_facts(state, FactsInputs)`** — builds the uniform community context + actor + subject + cached count; callers pass only the per-purpose bits (purpose, actor role, subject member-state, evidence).
- **`load_actor_role(state, did)`** — the shared `get_acl_entry(..).role` lookup.
- **`member_state(role, member)`** — the shared `MemberState` shaping.

Each route builder is now a thin `FactsInputs` construction; the repeated profile-load + `Context`/`Actor`/`Subject` wiring + `MemberState` construction is gone. `facts.rs` stays pure data — the assembly (which needs `AppState` + storage) lives beside `execute.rs`.

## Verification (behaviour-preserving — the assembled `Facts` is identical)

- `join_requests` 46, `removal` 15, `members_crud` 13, `directory` 4, `ceremony_execute` 9, full lib **582** — all green.
- fmt + clippy clean.

Route files shrank ~40% each; the shared module nets the dedup.