### PR TITLE
docs(vtc): refresh module docs for the Phase 2 module moves

### DIFF
--- a/vtc-service/CLAUDE.md
+++ b/vtc-service/CLAUDE.md
@@ -32,12 +32,19 @@ src/
 ├── acl/                ACL storage + role types (VtcRole)
 ├── audit/              (re-exports from vti-common::audit)
 ├── auth/               session, AuthClaims/AdminAuth/SuperAdminAuth extractors
+├── ceremony/           Decision pipeline (facts → verify → decide → effect/audit);
+│                       `assemble` (one Facts builder for every purpose) +
+│                       `orchestrate` (role-change + leave spines, out of routes)
 ├── community/          CommunityProfile storage
-├── credentials/        LocalSigner, VMC + role VEC + status-list builders
+├── credentials/        LocalSigner + VMC/VEC/status-list builders; `exchange/`
+│                       (OID4VCI issuer + OID4VP/SD-JWT/DI/bbs verifier, split into
+│                       issue/verify/pending/jwt) + `vm_resolver` (the single shared
+│                       DID-VM → key resolver + `check_issuer_binding`)
 ├── endorsement_types/  Operator-registered endorsement-type registry
 ├── endorsements/       Custom VEC + status-list flip
 ├── install/            Install-token state machine + claim secret
-├── join/               Join-request lifecycle
+├── join/               Join-request lifecycle + `orchestrate` (submit spine:
+│                       holder-binding → decide → auto-admit → admit audit)
 ├── members/            Member storage + lifecycle helpers
 ├── policy/             regorus engine, default policy bundle, evaluators
 ├── recognition/        Foreign-VEC verification (Phase 3 cross-community)

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -36,25 +36,25 @@
 //!   (read-only) is fully realized; the write plans (admit / depart /
 //!   re-mint) are typed intents the executor applies.
 //! - [`execute`] — the async effect executor ([`execute::apply`]):
-//!   applies a plan against `AppState`. The **Admit** (join) write
-//!   path is wired and is the op the manual approve route now goes
-//!   through; **Depart** / **Remint** await their ceremonies.
-//!
-//! Still to land on top of this spine (pipeline §11): the Depart /
-//! Remint executor arms (with their leave / role-change ceremonies)
-//! and the remaining state-dependent invariant — no-last-admin (see
-//! [`invariant`]).
+//!   applies a plan against `AppState`. All three write arms —
+//!   **Admit** (join), **Depart** (leave), **Remint** (role change) —
+//!   are wired, with the no-last-admin invariant host-enforced here.
+//! - [`assemble`] — the one `Facts` builder every purpose's
+//!   orchestration uses (community context + cached member count +
+//!   actor/subject), replacing the four hand-rolled per-route copies.
+//! - [`orchestrate`] — the per-ceremony `decide → effect → audit`
+//!   spines that drive the pipeline, lifted out of the route layer:
+//!   `role_change_via_pipeline` and `remove_inner` (leave) live here;
+//!   the join spine is the sibling [`crate::join::orchestrate`].
 //!
 //! ## Relationship to the existing `policy` + `join` modules
 //!
-//! This is the greenfield pipeline; [`crate::policy`] (the regorus
-//! engine plus persistence) is **reused** underneath it — `Verdict`
-//! parses the decision object [`crate::policy::engine::evaluate`]
-//! returns.
-//! The MVP's bespoke [`crate::join`] flow and its `vp_claims`
-//! projection are what this pipeline supersedes; they remain in place
-//! until ceremonies are ported over (build-vs-reuse map, pipeline
-//! §10).
+//! This pipeline is **reused** by every community ceremony; [`crate::policy`]
+//! (the regorus engine plus persistence) sits underneath it — `Verdict`
+//! parses the decision object [`crate::policy::engine::evaluate`] returns.
+//! The join lifecycle ([`crate::join`]) persists the `JoinRequest` rows and
+//! hosts the join-submit orchestration ([`crate::join::orchestrate`]), which
+//! drives this same pipeline.
 
 pub mod assemble;
 pub mod effects;

--- a/vtc-service/src/routes/join_requests/submit.rs
+++ b/vtc-service/src/routes/join_requests/submit.rs
@@ -1,5 +1,7 @@
-//! `POST /v1/join-requests` — REST submit (M1.8.1) + a shared
-//! inner `submit_inner` the DIDComm handler (M1.8.2) calls into.
+//! `POST /v1/join-requests` — the REST submit adapter (M1.8.1): wire
+//! body/response types + auth extraction. The shared orchestration spine
+//! ([`crate::join::submit_inner`], also driven by the DIDComm handler and the
+//! credential-exchange present path) lives in [`crate::join::orchestrate`].
 //!
 //! ## Holder binding
 //!
@@ -71,9 +73,10 @@ pub struct SubmitRequestBody {
     /// `vtc_did`. Bound into the holder signature so a body captured for one
     /// community can't be replayed against another (P0.13).
     pub audience: String,
-    /// Unix-seconds the applicant signed at. Must be within
-    /// [`JOIN_SUBMIT_FRESHNESS_SECS`] of now (small future skew allowed). Bound
-    /// into the signature so a stale captured body is rejected (P0.13).
+    /// Unix-seconds the applicant signed at. Must be within the join-submit
+    /// freshness window of now (small future skew allowed; enforced in
+    /// `crate::join::submit_inner`). Bound into the signature so a stale
+    /// captured body is rejected (P0.13).
     pub created: i64,
     /// Hex-encoded Ed25519 signature over the canonical payload (which now
     /// includes `audience` + `created`).


### PR DESCRIPTION
Cleanup follow-up to the Phase 2 refactors — the prose hadn't caught up with the module moves.

- **`vtc-service/CLAUDE.md`** source layout: adds the missing **`ceremony/`** entry (decision pipeline + `assemble` + `orchestrate`); notes `credentials/exchange/` (split issuer/verifier) + `credentials/vm_resolver` (shared DID-VM resolver); notes `join/orchestrate` (submit spine).
- **`ceremony/mod.rs`** doc: Admit/Depart/Remint executor arms + the leave/role-change ceremonies have all landed (were described as "await" / "still to land"); documents `assemble` + `orchestrate` and points at the sibling `join::orchestrate`.
- **`routes/join_requests/submit.rs`** doc: now the thin REST adapter; orchestration lives in `crate::join::orchestrate`. Also fixes a stale `[JOIN_SUBMIT_FRESHNESS_SECS]` rustdoc broken-link (the const moved with the spine).

Docs only — no behaviour change; builds clean.

The other deferred Phase-2 follow-up (per-feature router-builder split) is **not** included — it's a structural refactor, not cleanup, and the #457 posture backstop already provides its regression guard.