### PR TITLE
feat(vtc): real per-surface host isolation (P3.1, part 1)

### DIFF
--- a/vtc-service/src/routing/host_dispatch.rs
+++ b/vtc-service/src/routing/host_dispatch.rs
@@ -1,4 +1,5 @@
-//! Subdomain-mode `Host` header check (Phase 5 M5.1.2).
+//! Subdomain-mode `Host` header check + per-surface isolation
+//! (Phase 5 M5.1.2, hardened in P3.1).
 //!
 //! Tower middleware that inspects the request `Host` header against
 //! the per-surface map declared in [`crate::config::RoutingConfig`].
@@ -7,26 +8,33 @@
 //! - When **every** surface has `host = None` (pure path mode), the
 //!   middleware is a no-op — the parent router does prefix matching
 //!   alone.
-//! - When **any** surface has a host set, the middleware:
+//! - When **any** surface has a host set ("host mode"), the
+//!   middleware:
 //!   1. Reads `Host` from the request (HTTP/2 `:authority` is
 //!      normalised onto the `Host` header by axum before the layer
 //!      runs).
-//!   2. Matches against the set of configured surface hosts
-//!      (case-insensitive, port-aware).
-//!   3. On match: pass through. The parent router then routes by
-//!      path within whichever surface matches.
-//!   4. On miss + `subdomain_mode_strict = true` (default): returns
-//!      404 `HostNotRecognised`.
-//!   5. On miss + `subdomain_mode_strict = false`: pass through —
-//!      the parent router falls back to path matching against all
-//!      configured mounts. Debug aid only; not recommended for
-//!      production.
+//!   2. Rejects a Host that matches no configured surface
+//!      (case-insensitive) with 404 `HostNotRecognised` when
+//!      `subdomain_mode_strict = true` (default). With strict off
+//!      (debug aid), an unrecognised host falls through to plain
+//!      path matching and surface isolation is **not** enforced.
+//!   3. For a recognised host in strict mode, enforces **surface
+//!      isolation**: the request path is routed to the surface whose
+//!      mount it falls under (longest-prefix match — `/v1…`→api,
+//!      `/admin…`→admin, else website), and the request passes only
+//!      if *that* surface is the one bound to the request's host. So
+//!      `admin.example.com/v1/acl` (api surface, bound to a different
+//!      host) returns 404 `SurfaceNotOnHost` rather than serving the
+//!      API. This is what actually isolates an operator-deployed
+//!      website origin from the admin/API surface — the earlier
+//!      version only checked allowlist membership and routed every
+//!      path on every recognised host.
 //!
-//! Per-host/per-path enforcement (e.g. `admin.example.com` 404s
-//! `/v1/...` paths) is **not** in this middleware. The path-mode
-//! prefix matching inside axum's `Router::nest` already does that —
-//! a path that doesn't match the surface's nest boundary returns
-//! 404 via the regular handler chain.
+//! Parent-root infrastructure routes (`/health`, `/openapi.json`,
+//! `/.well-known/did.jsonl`) are mounted outside any surface and must
+//! answer on every recognised host (the did:webvh log has to resolve
+//! on the website host; liveness has to answer on the api host), so
+//! they bypass the surface gate.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -39,28 +47,77 @@ use serde_json::json;
 
 use crate::config::RoutingConfig;
 
-/// Compiled host map. Cheap to clone, shared across requests via
-/// `Arc`. Built once at router-assembly time so the per-request
-/// path is a single `HashSet::contains` call.
+/// Parent-root routes mounted outside any surface mount. They must
+/// answer on every recognised host, so the surface gate skips them.
+const INFRA_PATHS: &[&str] = &["/health", "/openapi.json", "/.well-known/did.jsonl"];
+
+/// One routable surface: the mount prefix it attaches under and the
+/// host it is bound to (`None` in path mode). `priority` breaks ties
+/// when two surfaces share a mount length (e.g. admin at `/` next to
+/// the website catch-all) — lower wins, matching the parent router's
+/// api → admin → website nest precedence.
+#[derive(Debug, Clone)]
+struct Surface {
+    mount: String,
+    host: Option<String>,
+    priority: u8,
+}
+
+impl Surface {
+    /// Length of this surface's mount match against `path`, or `None`
+    /// if it doesn't claim the path. The `/` catch-all matches every
+    /// path but at the lowest specificity (length 1), so a concrete
+    /// `/v1` / `/admin` mount always wins the longest-prefix race.
+    fn match_len(&self, path: &str) -> Option<usize> {
+        if self.mount == "/" {
+            return Some(1);
+        }
+        // `/v1` matches `/v1` and `/v1/...`, but not `/v1abc`.
+        if path == self.mount || path.starts_with(&format!("{}/", self.mount)) {
+            Some(self.mount.len())
+        } else {
+            None
+        }
+    }
+}
+
+/// Compiled host/surface map. Cheap to clone, shared across requests
+/// via `Arc`. Built once at router-assembly time.
 #[derive(Debug, Clone)]
 pub struct HostMap {
     /// Lower-cased configured hosts. Empty when every surface uses
     /// path mode — the layer short-circuits.
     hosts: Arc<HashSet<String>>,
+    /// Per-surface mount + bound host, used for surface isolation.
+    /// Hosts are stored lower-cased.
+    surfaces: Arc<Vec<Surface>>,
     strict: bool,
 }
 
 impl HostMap {
-    /// Compile the surface host set from [`RoutingConfig`].
+    /// Compile the surface map from [`RoutingConfig`].
     pub fn from_routing(routing: &RoutingConfig) -> Self {
         let mut hosts = HashSet::new();
-        for surface in [&routing.api, &routing.admin_ui, &routing.website] {
-            if let Some(h) = surface.host.as_deref() {
-                hosts.insert(h.to_ascii_lowercase());
+        let mut surfaces = Vec::with_capacity(3);
+        // Priority order mirrors the parent router's nest precedence:
+        // api, then admin_ui, then the website catch-all.
+        for (priority, surface) in [&routing.api, &routing.admin_ui, &routing.website]
+            .into_iter()
+            .enumerate()
+        {
+            let host = surface.host.as_deref().map(str::to_ascii_lowercase);
+            if let Some(h) = host.as_deref() {
+                hosts.insert(h.to_string());
             }
+            surfaces.push(Surface {
+                mount: surface.mount.clone(),
+                host,
+                priority: priority as u8,
+            });
         }
         Self {
             hosts: Arc::new(hosts),
+            surfaces: Arc::new(surfaces),
             strict: routing.subdomain_mode_strict,
         }
     }
@@ -71,14 +128,56 @@ impl HostMap {
         self.hosts.is_empty()
     }
 
-    /// True when the configured Host map recognises this header
-    /// value (case-insensitive). Returns `true` unconditionally in
-    /// path mode so callers can use it as a single decision point.
+    /// True when the configured Host map recognises this header value
+    /// (case-insensitive) as belonging to *some* surface. Returns
+    /// `true` unconditionally in path mode so callers can use it as a
+    /// single decision point.
     fn matches(&self, host_header: &str) -> bool {
         if self.is_path_mode() {
             return true;
         }
         self.hosts.contains(&host_header.to_ascii_lowercase())
+    }
+
+    /// The surface that owns `path` (longest mount prefix; ties broken
+    /// toward the surface bound to `req_host`, else by `priority`).
+    /// `req_host` is already lower-cased.
+    fn target_surface(&self, path: &str, req_host: &str) -> Option<&Surface> {
+        let best = self
+            .surfaces
+            .iter()
+            .filter_map(|s| s.match_len(path).map(|len| (s, len)))
+            .max_by(|(a, alen), (b, blen)| {
+                // Longer mount wins; on a tie prefer the surface bound
+                // to the request host, then lower priority.
+                alen.cmp(blen)
+                    .then_with(|| {
+                        let a_owns = a.host.as_deref() == Some(req_host);
+                        let b_owns = b.host.as_deref() == Some(req_host);
+                        a_owns.cmp(&b_owns)
+                    })
+                    .then_with(|| b.priority.cmp(&a.priority))
+            });
+        best.map(|(s, _)| s)
+    }
+
+    /// Surface-isolation decision for a recognised host in strict
+    /// mode. `req_host` is already lower-cased. Returns `true` when
+    /// the path's owning surface is bound to this host (or to no host,
+    /// i.e. a path-mode surface in a mixed config, which can't be
+    /// isolated).
+    fn surface_allowed(&self, path: &str, req_host: &str) -> bool {
+        if INFRA_PATHS.contains(&path) {
+            return true;
+        }
+        match self.target_surface(path, req_host) {
+            Some(s) => match s.host.as_deref() {
+                Some(h) => h == req_host,
+                None => true,
+            },
+            // No surface claims the path — let the router 404 it.
+            None => true,
+        }
     }
 }
 
@@ -99,18 +198,46 @@ pub async fn enforce(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
-    let allowed = match host.as_deref() {
+    // Host-membership gate (unchanged): an unrecognised host is a 404
+    // in strict mode, or falls through in the debug-only lax mode.
+    let recognised = match host.as_deref() {
         Some(h) => map.matches(h),
         // Missing Host header — HTTP/1.1 requires it. Treat as
         // unrecognised in strict mode.
         None => false,
     };
-
-    if allowed || !map.strict {
+    if !recognised {
+        if map.strict {
+            return not_recognised(host);
+        }
         return next.run(request).await;
     }
 
-    // 404 with the same JSON shape as `AppError::IntoResponse`.
+    // Lax mode is a debug aid only — no surface isolation, just plain
+    // path matching once the host is recognised.
+    if !map.strict {
+        return next.run(request).await;
+    }
+
+    // Surface-isolation gate: the path must belong to the surface
+    // bound to this host.
+    let req_host = host.as_deref().unwrap_or_default().to_ascii_lowercase();
+    let path = request.uri().path();
+    if map.surface_allowed(path, &req_host) {
+        return next.run(request).await;
+    }
+
+    let body = json!({
+        "error": "SurfaceNotOnHost",
+        "host": host,
+        "path": request.uri().path(),
+    });
+    (StatusCode::NOT_FOUND, axum::Json(body)).into_response()
+}
+
+/// 404 with the same JSON shape as `AppError::IntoResponse` for a
+/// host that matches no configured surface.
+fn not_recognised(host: Option<String>) -> Response {
     let body = json!({
         "error": "HostNotRecognised",
         "host": host,
@@ -164,5 +291,68 @@ mod tests {
         assert!(map.matches("api.example.com"));
         assert!(map.matches("ADMIN.example.com")); // case-insensitive
         assert!(!map.matches("other.example.com"));
+    }
+
+    #[test]
+    fn surface_isolation_routes_path_to_its_own_host() {
+        let map = HostMap::from_routing(&cfg(
+            Some("api.example.com"),
+            Some("admin.example.com"),
+            Some("example.com"),
+        ));
+
+        // Each surface answers on its own host.
+        assert!(map.surface_allowed("/v1/acl", "api.example.com"));
+        assert!(map.surface_allowed("/admin/users", "admin.example.com"));
+        assert!(map.surface_allowed("/index.html", "example.com"));
+
+        // Cross-surface requests are rejected: the API surface is not
+        // served on the admin or website host, and vice-versa.
+        assert!(!map.surface_allowed("/v1/acl", "admin.example.com"));
+        assert!(!map.surface_allowed("/v1/acl", "example.com"));
+        assert!(!map.surface_allowed("/admin/users", "api.example.com"));
+        // The website catch-all is not served on the api/admin hosts.
+        assert!(!map.surface_allowed("/index.html", "api.example.com"));
+    }
+
+    #[test]
+    fn infra_paths_answer_on_every_recognised_host() {
+        let map = HostMap::from_routing(&cfg(
+            Some("api.example.com"),
+            Some("admin.example.com"),
+            Some("example.com"),
+        ));
+        for host in ["api.example.com", "admin.example.com", "example.com"] {
+            assert!(map.surface_allowed("/health", host), "host {host}");
+            assert!(map.surface_allowed("/.well-known/did.jsonl", host));
+            assert!(map.surface_allowed("/openapi.json", host));
+        }
+    }
+
+    #[test]
+    fn admin_at_root_in_host_mode_resolves_by_request_host() {
+        // admin_ui mounted at `/` next to the website catch-all (also
+        // `/`) — equal mount length. The tie breaks toward the surface
+        // bound to the request host, so each host serves its own.
+        let routing = RoutingConfig {
+            api: MountConfig {
+                mount: "/v1".into(),
+                host: Some("api.example.com".into()),
+            },
+            admin_ui: MountConfig {
+                mount: "/".into(),
+                host: Some("admin.example.com".into()),
+            },
+            website: MountConfig {
+                mount: "/".into(),
+                host: Some("example.com".into()),
+            },
+            subdomain_mode_strict: true,
+        };
+        let map = HostMap::from_routing(&routing);
+        assert!(map.surface_allowed("/dashboard", "admin.example.com"));
+        assert!(map.surface_allowed("/dashboard", "example.com"));
+        // API still isolated to its own host.
+        assert!(!map.surface_allowed("/v1/acl", "example.com"));
     }
 }

--- a/vtc-service/tests/routing_modes.rs
+++ b/vtc-service/tests/routing_modes.rs
@@ -183,14 +183,27 @@ async fn subdomain_mode_strict_404s_unknown_host() {
     }
 
     let map = HostMap::from_routing(&routing);
+    // Mount the three surface paths so the gate has something to route
+    // to once it passes.
     let app = Router::new()
+        .route("/v1/{*rest}", axum::routing::get(ok))
+        .route("/admin/{*rest}", axum::routing::get(ok))
         .route("/", axum::routing::get(ok))
         .layer(axum::middleware::from_fn_with_state(map, enforce));
 
-    // Known host → 200.
+    // Known host serving its own surface → 200.
+    let req = Request::builder()
+        .uri("/v1/acl")
+        .header("Host", "api.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Website host serving the website root → 200.
     let req = Request::builder()
         .uri("/")
-        .header("Host", "api.example.com")
+        .header("Host", "example.com")
         .body(Body::empty())
         .unwrap();
     let (status, _) = request(&app, req).await;
@@ -198,7 +211,7 @@ async fn subdomain_mode_strict_404s_unknown_host() {
 
     // Unknown host → 404 HostNotRecognised.
     let req = Request::builder()
-        .uri("/")
+        .uri("/v1/acl")
         .header("Host", "evil.example.com")
         .body(Body::empty())
         .unwrap();
@@ -206,6 +219,84 @@ async fn subdomain_mode_strict_404s_unknown_host() {
     assert_eq!(status, StatusCode::NOT_FOUND);
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(v["error"], "HostNotRecognised");
+}
+
+#[tokio::test]
+async fn subdomain_mode_isolates_surfaces_across_hosts() {
+    // Real surface isolation (P3.1): a recognised host serves only the
+    // surface bound to it. The API surface is not reachable on the
+    // admin or website host, and vice-versa — even though all three
+    // hosts are recognised.
+    let routing = RoutingConfig {
+        api: MountConfig {
+            mount: "/v1".into(),
+            host: Some("api.example.com".into()),
+        },
+        admin_ui: MountConfig {
+            mount: "/admin".into(),
+            host: Some("admin.example.com".into()),
+        },
+        website: MountConfig {
+            mount: "/".into(),
+            host: Some("example.com".into()),
+        },
+        subdomain_mode_strict: true,
+    };
+
+    async fn ok() -> &'static str {
+        "ok"
+    }
+
+    let map = HostMap::from_routing(&routing);
+    let app = Router::new()
+        .route("/health", axum::routing::get(ok))
+        .route("/v1/{*rest}", axum::routing::get(ok))
+        .route("/admin/{*rest}", axum::routing::get(ok))
+        .route("/", axum::routing::get(ok))
+        .route("/{*rest}", axum::routing::get(ok))
+        .layer(axum::middleware::from_fn_with_state(map, enforce));
+
+    // The API surface on the admin host → 404 SurfaceNotOnHost.
+    let req = Request::builder()
+        .uri("/v1/acl")
+        .header("Host", "admin.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = request(&app, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["error"], "SurfaceNotOnHost");
+
+    // The admin surface on the api host → 404.
+    let req = Request::builder()
+        .uri("/admin/users")
+        .header("Host", "api.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&app, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // Website content is not served on the api host → 404. This is the
+    // core isolation guarantee: deployed website JS can't ride the
+    // admin/API origin.
+    let req = Request::builder()
+        .uri("/marketing.js")
+        .header("Host", "api.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&app, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // Infra routes answer on every recognised host.
+    for host in ["api.example.com", "admin.example.com", "example.com"] {
+        let req = Request::builder()
+            .uri("/health")
+            .header("Host", host)
+            .body(Body::empty())
+            .unwrap();
+        let (status, _) = request(&app, req).await;
+        assert_eq!(status, StatusCode::OK, "host {host}");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
First task of **Phase 3** (strategic convergence + hygiene). Unblocks P3.3/P3.4/P3.5.

## Problem

VTC serves three HTTP surfaces — API (`/v1`), admin SPA (`/admin`), and the operator-deployable public website (`/`). In "host mode" they were **not** actually isolated: `host_dispatch::enforce` only checked Host-header **allowlist membership**, then the single combined router routed every path on every recognised host. So `admin.example.com/v1/acl` still served the API and `api.example.com/admin` still served the SPA. There was no deployment posture that isolated deployed website content from the admin/API surface.

## Change

Turn `host_dispatch::enforce` from an allowlist gate into a **per-surface host gate** (reusing the existing layer wiring in `server.rs`, no router restructuring):

- For a recognised host in **strict** mode, the request path is routed to the surface whose mount it falls under (longest-prefix match — `/v1…`→api, `/admin…`→admin, else website; ties broken toward the host-bound surface, then api→admin→website priority). The request passes only if *that* surface is the one bound to the request's host; otherwise → `404 SurfaceNotOnHost`.
- Parent-root infra routes (`/health`, `/openapi.json`, `/.well-known/did.jsonl`) bypass the gate so they answer on every recognised host (did:webvh log has to resolve on the website host; liveness on the api host).
- **Unchanged:** path-mode no-op, unrecognised-host `404 HostNotRecognised`, and the lax (non-strict) debug-aid fall-through (no surface isolation).

The observable result matches per-host sub-routers — a 404 for any path not belonging to the request's host — without the axum vhost-router surgery.

## Tests

- New unit tests in `host_dispatch.rs`: surface isolation across hosts, infra-path bypass, and the admin-at-`/` host-mode tie-break.
- `tests/routing_modes.rs`: updated `subdomain_mode_strict_404s_unknown_host` to use surface-appropriate paths, plus a new `subdomain_mode_isolates_surfaces_across_hosts` asserting `admin.<>/v1/acl`→404, `api.<>/admin`→404, website JS not served on the api origin, and `/health` on every host.

`cargo test -p vtc-service` (host_dispatch + routing_modes) green; clippy/fmt clean.

## Follow-up (part 2)

Force host separation when a *filesystem* website (`website.root_dir`) is configured, and correct the docs/spec that still claim a `Path=/admin` cookie isolation the code abandoned (`routes/auth.rs` uses `Path=/`).