### PR TITLE
feat(vtc): force host separation for a filesystem website + honest docs (P3.1, part 2)

### DIFF
--- a/docs/03-vtc/website-and-admin.md
+++ b/docs/03-vtc/website-and-admin.md
@@ -232,8 +232,15 @@ Three concurrent auth paths:
 - **Bearer JWT** — `Authorization: Bearer <jwt>`. Used by
   `cnm-cli`, DIDComm bridges, programmatic clients.
 - **Cookie session** — `Cookie: vtc_admin_session=<jwt>`. Used by
-  the admin SPA. Path-scoped to `/admin` so the public website
-  origin can't read it. HttpOnly + Secure + SameSite=Strict.
+  the admin SPA. Scoped `Path=/` (the API lives at `/v1`, not under
+  `/admin`, so the SPA→API call needs the cookie there — an earlier
+  `Path=/admin` design was reverted). HttpOnly keeps JS from reading
+  it on any path; Secure + SameSite=Strict prevent cross-site sends.
+  **Path mode does not isolate a deployed website on `/` from this
+  cookie** — same-origin website JS can still `fetch('/v1/...',
+  {credentials})` and ride it. The posture that *does* isolate is a
+  dedicated website host (see [Routing modes](#routing-modes)); a
+  filesystem website now requires one.
 - **CSRF double-submit** — `csrf=<random>` cookie (JS-readable) +
   `X-CSRF-Token` header. Required on every mutating call from the
   cookie session. Bearer-only callers don't carry CSRF.
@@ -276,9 +283,30 @@ graph TB
 
 Subdomain mode is enabled by setting per-surface `host = "..."` in
 the routing config. A tower middleware (`routing::host_dispatch`)
-short-circuits 404 when an unrecognised `Host` header arrives in
-strict mode (default). Set `routing.subdomain_mode_strict = false`
-to allow path-mode fallback for unknown hosts — debug aid only.
+enforces two things in strict mode (default):
+
+1. **Host membership** — an unrecognised `Host` header 404s
+   (`HostNotRecognised`). Set `routing.subdomain_mode_strict = false`
+   to fall back to path matching for unknown hosts — debug aid only,
+   and it disables (2).
+2. **Surface isolation** — a recognised host serves **only** the
+   surface bound to it. The request path is routed to its owning
+   surface (`/v1…`→api, `/admin…`→admin, else website) and 404s
+   (`SurfaceNotOnHost`) unless that surface is the one on this host.
+   So `admin.example.com/v1/acl` and `api.example.com/admin` both
+   404 — the API and SPA are reachable only on their own hosts.
+   (Parent-root infra routes — `/health`, `/openapi.json`,
+   `/.well-known/did.jsonl` — answer on every recognised host.)
+
+This is what actually isolates a deployed website origin from the
+admin session: on its own host the website has no `/v1`/`/admin`
+route to hit, and the admin cookie (host-only, `SameSite=Strict`) is
+never sent there. **Because path mode can't provide this, a
+filesystem website (`website.root_dir`) requires its own
+`routing.website.host`, distinct from the api/admin host — the
+daemon refuses to start otherwise.** The admin SPA and API may (and
+should) share a host. The in-tree default landing page (no
+`root_dir`) is trusted and may stay co-resident.
 
 **WebAuthn `RP ID`** must be set correctly per mode:
 
@@ -330,19 +358,30 @@ rp_id = "example.com"                      # WebAuthn RP ID
 [routing]
 subdomain_mode_strict = true
 
+# Host mode with an isolated filesystem website. The API + admin SPA
+# share one host (the Path=/ admin cookie needs them co-resident); the
+# website gets its own host so deployed content can't ride that cookie.
+# Required whenever website.root_dir is set.
 [routing.api]
 mount = "/v1"
-# host = "api.example.com"                 # uncomment for subdomain mode
+host = "app.example.com"
 
 [routing.admin_ui]
 mount = "/admin"
+host = "app.example.com"                    # same host as the API
 
 [routing.website]
 mount = "/"
+host = "www.example.com"                     # dedicated host (distinct)
 
 [cors]
 allowed_origins = []                       # add SPA origin for external mode
 ```
+
+In pure **path mode** (omit every `host`), all three surfaces share
+one origin. That's fine for the trusted built-in landing page, but
+`website.root_dir` is then refused at startup — point the website at
+its own host as above, or drop `root_dir` to serve the default page.
 
 ## See also
 

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -674,8 +674,15 @@ Route priority (highest first): `/health`, `/v1/*`,
 `/v1/website/*` (management API), `/admin/*`, `/*` (public site).
 
 **Subdomain mode**: per-surface `host` set; tower middleware routes
-by `Host`. Hosts not matching any surface return 404. Subdomain mode
-implies the operator handles per-surface TLS certs and DNS.
+by `Host`. Hosts not matching any surface return 404
+(`HostNotRecognised`). In strict mode it also enforces **surface
+isolation**: a recognised host serves only the surface bound to it —
+the path is routed to its owning surface (`/v1…`→api, `/admin…`→admin,
+else website) and 404s (`SurfaceNotOnHost`) unless that surface is on
+this host. So `admin.example.com/v1/*` and `api.example.com/admin`
+both 404; parent-root infra routes (`/health`, `/openapi.json`,
+`/.well-known/did.jsonl`) answer on every recognised host. Subdomain
+mode implies the operator handles per-surface TLS certs and DNS.
 
 The strictness of unknown-Host dispatch is configured by
 `routing.subdomain_mode_strict: bool` (default `true`). When `false`,
@@ -692,12 +699,22 @@ features and put a reverse proxy / CDN in front.
 
 `cors.allowed_origins` is a configured allowlist. Wildcards refused.
 
-**Isolation invariant.** When the public website (§12.1) and the
-admin UX (§12.2) are served on the same domain, they **must** be on
-different cookie scopes. Path-mode default achieves this by setting
-the admin session cookie with `Path=/admin; SameSite=Strict;
-Secure; HttpOnly`; the public website's origin gains no
-implicit access to admin session cookies.
+**Isolation invariant.** The admin session cookie is `Path=/`
+(`vtc_admin_session`, `SameSite=Strict; Secure; HttpOnly`) — the API
+lives at `/v1`, not under `/admin`, so the SPA→API call needs the
+cookie at root; an earlier `Path=/admin` design was reverted. The
+admin SPA and API therefore share one origin. `HttpOnly` + `SameSite`
++ CSRF keep that origin safe from *cross-site* attackers, but they do
+**not** isolate *same-origin* deployed website content: a filesystem
+website served on `/` runs same-origin with the admin SPA and can
+ride the cookie to call authenticated `/v1` endpoints. So the
+isolation invariant is enforced by **host separation**, not cookie
+path: when `website.root_dir` is configured, `routing.website.host`
+must be set and distinct from the api/admin host (which may be
+shared), and the §9.2 surface-isolation gate keeps `/v1`/`/admin` off
+the website host. The daemon refuses to start otherwise. The in-tree
+default landing page (no `root_dir`) is trusted code we ship and may
+stay co-resident.
 
 Admin UX in `embedded` mode: same-origin or near-origin; no CORS
 allowance for the admin UX itself.

--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -1,0 +1,212 @@
+# Todo: VTC Architecture Simplification & Hardening
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done · `[!]` blocked
+
+Plan with full problem statements, file references, acceptance criteria,
+and the invariants do-not-break list: `tasks/vtc-architecture-plan.md`.
+Record the PR number next to each task as it merges.
+
+Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note first.
+
+Note: VTC never targets TEE — no enclave/KMS/attestation work here (unlike VTA),
+but encryption-at-rest for private-key keyspaces still applies (P0.7).
+
+---
+
+## Phase 0 — Security & correctness fixes (parallelizable, land any time)
+
+- `[x]` **P0.1** (M) Status-list concurrency lock — revocation flips + slot
+  allocations lost under concurrent RMW; wrap flip+`mark_revoked` together — PR: #355
+  (also landed the `TestVtc`/`MockVtc` harness + 26-fixture migration, #348)
+- `[x]` **P0.2** (L) Cross-community `recognise`: require holder proof + nonce +
+  audience, bind VMC subject == VEC subject, fix unverified-actor audit — PR: #351
+  (part 1: VMC↔VEC subject bind) + #354 (part 2: holder proof-of-possession)
+- `[x]` **P0.3** (M) DIDComm handlers: authenticate sender via `encrypted_from_kid`,
+  require authcrypt/non-anon (MessagePolicy); fix self-remove first — PR: #350
+- `[x]` **P0.4** (M) Foreign-fetch client: `redirect(none)` + timeout + body-size
+  cap; re-guard redirects; one shared client — PR: #357
+- `[x]` **P0.5** (M) Move `join-requests` submit/accept/status onto the governed
+  64 KB unauth branch (split the shared mount) — PR: #359
+- `[x]` **P0.6** (S) Spawn `RetentionSweeper`; extend to `credx-pending:` /
+  `present-challenge:` / `Failed` sync jobs; fix model.rs comment — PR: #361
+- `[x]` **P0.7** (M) Encryption-at-rest (`with_encryption`) for `install`,
+  `audit_key`, `passkey`; HKDF storage key (`vtc-storage-key/v1`) from the
+  bundle Ed25519 seed. Back-compat via a one-shot idempotent/crash-safe
+  `KeyspaceHandle::migrate_to_encrypted` (NOT a try-decrypt-else-plain
+  fallback — that would reintroduce the cut-and-paste downgrade hole in the
+  VTA-shared encryption module) — PR: #364
+- `[x]` **P0.8** (S) Secret-store factory: hard-fail on set-but-uncompiled backend;
+  `deny_unknown_fields` on `SecretsConfig` — PR: #381
+- `[x]` **P0.9** (S) Configured-but-broken identity → hard-fail boot (not
+  warn-and-serve-dead); pre-setup still degraded — PR: #382
+- `[x]` **P0.10** (M) `spawn_blocking` for Argon2id (claim verify/hash);
+  `TimeoutLayer` (30s); multi-thread REST runtime — PR: #391
+- `[x]` **P0.11** (S) `relationships_by_did` colon-prefix collision — post-filter
+  hydrated rows by issuer/subject — PR: #384
+- `[x]` **P0.12** (M) Submit path: don't surface unverified VC claims under
+  `verified:true` — null claims + `unknown` status on the raw-VP path — PR: #389
+- `[x]` **P0.13** (S) Join-submit signature freshness/nonce/audience binding +
+  per-applicant open-request dedup/cap — PR: #393
+- `[x]` **P0.14** (M) Promote-to-admin through the role-change ceremony (honor
+  `role_change.rego` + host invariants) — PR: #387
+- `[x]` **P0.15** (S) `admit` serializing lock — duplicate-credential TOCTOU
+  (match `depart`/`remint`) — PR: #385
+- `[x]` **P0.16** (M) `check_acl` reads `VtcAclEntry` + maps `VtcRole→Role` —
+  non-admin DID no longer 500s `/auth/challenge` with serde leak. Shared
+  `crate::acl::resolve_auth_role` helper also fixes the identical bug in the
+  passkey-login finish path — PR: #367
+- `[x]` **P0.17** (S) 0600 perms on `config.toml`, plaintext secret file — PR: #370
+- `[x]` **P0.18** (M) Rego eval timeout/instruction budget + input-size cap;
+  fail-closed on bound exceeded — PR: #372
+- `[x]` **P0.19** (S) `vtc status` trust-ping: use `decode_secret_store_value`
+  (JSON bundle), drop the 64-byte assumption — PR: #374
+- `[x]` **P0.20** (S) ACL/session scoping: gate `delete_acl` on AdminAuth + check
+  target role; scope `revoke_sessions_by_did`/`session_list`; revoke sessions on
+  downgrade — PR: #376
+- `[x]` **P0.21** (S) Install `claim/start`: verify claim secret BEFORE taking the
+  300s ceremony lock (anti-grief) — PR: #378
+
+**Checkpoint 0:** `[x]` all P0 merged — every P0.1–P0.21 is on `main`
+(P0.8 #381, P0.9 #382, P0.10 #391, P0.11 #384, P0.12 #389, P0.13 #393,
+P0.14 #387, P0.15 #385); CI green; `[x]` docs updated —
+`docs/03-vtc/trust-registry.md` (the renamed cross-community.md) recognise
+holder-binding + vtc-mvp.md §8.4/§9.7/§13/§14.5 (P0.2/P0.3/P0.7) — PR: #379.
+**Phase 0 complete.**
+
+## Phase 1 — Kill the divergence engines
+
+- `[x]` **P1.1** (L) One config-mutation surface (config_store canonical);
+  `public_url`→registry requires_restart; profile owns name/desc; drop
+  `vtc_did`/`vta_did` from update body; atomic save — **done** (#396, #405, #408).
+  - `[x]` **part 1** (legacy `/v1/config`): `vtc_did`/`vta_did`→409; profile
+    owns name/desc (GET reads from it); `public_url` persisted env-safe +
+    atomic (tempfile-rename) with `pending_restart` — PR: #396
+  - `[x]` **part 2a** (the latent gap): boot now folds the `config_store`
+    db-overlay onto `AppConfig` (`apply_overrides`, `env > db > toml > default`)
+    before anything derives from it — so a PATCH of a `requires_restart` key
+    (`server.host`/`server.port`) is finally applied after restart — PR: #405
+  - `[x]` **part 2b**: `public_url` migrated off `config.toml` onto the
+    `config_store` overlay (REGISTRY `requires_restart` key; legacy `/v1/config` +
+    admin PATCH both write `config_store`; GET reads effective; `persist_public_url`
+    removed) — PR: #408
+- `[x]` **P1.2** (M) Audit `PATCH /admin/config` + `PUT /profile`; replace
+  `did:key:vtc-admin` sentinel with the real admin DID. `patch_config` emits
+  `ConfigChanged` (redact_if for sensitive keys), `put_profile` emits
+  `CommunityProfileUpdated`, all four sentinels (reload/restart/import×2) swapped
+  for `admin.0.did`; audit is fail-closed (503 when a change can't be recorded) —
+  PR: #400
+- `[x]` **P1.3** (S) RTBF/registry audit emits awaited (not detached); re-emit on
+  failure. `emit_override` awaited + fallible; `tick` emits overrides before
+  advancing the cursor so a failed write re-walks/re-emits (at-least-once);
+  `emit_outcome` stays detached (operational) — PR: #401
+- `[x]` **P1.4** (M) Shared `mint_session_tokens` (passkey login gets AAL2 short
+  TTL + audit); one `verify_domain_signed` helper (4 sites). Part 1: minter in
+  vti-common, canonical + passkey paths delegate. Part 2: `did:key` holder-sig
+  verifier dedup (submit/accept/status/rotate), byte-identical signed bytes —
+  PR: #402
+- `[x]` **P1.5** (S) Policy upload validates package matches purpose / yields a
+  decision. `PolicyPurpose::expected_package()` (4 ceremony purposes) +
+  `validate_purpose_package()` probing `data.<pkg>.{decision,allow}`; wired into
+  upload + activate; fixtures migrated off `vtc.test` — PR: #404
+
+**Checkpoint 1:** `[x]` **Phase 1 complete.** P1.1 (#396/#405/#408), P1.2 (#400),
+P1.3 (#401), P1.4 (#402), P1.5 (#404) all merged or in review. e2e green on each
+PR; admin-UI config/profile round-trips unchanged; recognise smoke unchanged.
+**Next: Phase 2** (collapse adapter shells + move logic out of routes; deps
+P1.1 + P1.4, both now done).
+
+## Phase 2 — Collapse adapter shells & move logic out of routes (deps: P1.1, P1.4)
+
+- `[x]` **P2.1** (L) Move join/leave/role-change orchestration out of routes into
+  `ceremony::orchestrate` (role-change + leave) and `join::orchestrate` (join);
+  shared auto-admit-vs-approve audit helper — deps: P1.4 — PR: #452 (audit-gap
+  bug fix + shared `emit_admit_audit`), #459 (role-change), #460 (leave),
+  #462 (join)
+- `[x]` **P2.2** (M) One `assemble_facts` builder (`ceremony::assemble`); cached
+  member counter (no full-keyspace scan per request) — PR: #453 (cached counter),
+  #458 (facts-builder unification)
+- `[x]` **P2.3** (L) Split `exchange.rs` (2,585) → `exchange/{issue,verify,pending,
+  jwt}.rs` — PR: #454
+- `[x]` **P2.4** (M) One DID-VM→DI-proof verifier (was 5 hand-rolled copies, not 3);
+  delegate to the DI library's `proof.verify(resolver)` with one shared
+  `DidVmResolver` + `check_issuer_binding`; deleted the bespoke
+  `ForeignIssuerKeyResolver` trait — deps: P2.3 — PR: #455 (shared resolver +
+  exchange + relationships), #456 (recognition)
+- `[x]` **P2.5** (S) `store::keyspaces` registry (names + `ALL`); `open_keyspaces`
+  iterates `ALL` (was 8/21); `persist()` on invite + emergency CLI paths;
+  `ALL.len()==21` + no-dup tests — PR: #409
+- `[x]` **P2.6** (L) `route_posture` backstop (spec-driven; every unauth route must
+  be classified governed/public — backstops P0.5) + collapsed the Trust-Task
+  router boilerplate via `tt()`/`ttl()` (−121 LOC). The full per-feature
+  builder split is deferred (the posture backstop already provides the
+  regression guard) — PR: #457 (posture backstop), #461 (boilerplate collapse)
+- `[x]` **P2.7** (M) `RegistryRecord::for_job(&SyncJob) -> Option<RegistryRecord>`
+  dedups the `run_call`/`update_mirror` record-shape (incl. the historical→active_to
+  branch); `None` = DeleteMember's remove path — PR: #412
+- `[x]` **P2.8** (S) Collapse DTG builders onto one `dtg::into_typed(doc, kind)`
+  JSON→VC helper (vmc/vec/custom_endorsement; invitation returns Value, untouched)
+  — PR: #411
+
+**Checkpoint 2:** `[x]` adapter LOC reduced; posture + orchestration tests pin
+behavior. `[x]` module docs refreshed for the Phase 2 module moves
+(`vtc-service/CLAUDE.md` source layout + `ceremony/mod.rs` + join-submit adapter
+doc) — PR: #463. (Note: per-feature router builder split deferred — see P2.6;
+the #457 posture backstop provides its regression guard.)
+**Phase 2 complete.**
+
+## Phase 3 — Strategic convergence + hygiene (ongoing)
+
+- `[~]` **P3.1** (L) Real host-based surface isolation (or force host-separation
+  when a website is configured + honest docs)
+  - `[~]` **part 1** per-surface host gate in `host_dispatch::enforce` (recognised
+    host serves only its bound surface; cross-surface → 404 `SurfaceNotOnHost`;
+    infra routes bypass) — PR: #465 (in review)
+  - `[ ]` **part 2** force host separation when a filesystem website
+    (`website.root_dir`) is configured + honest docs (correct the stale
+    `Path=/admin` cookie-isolation claim) — PR: ____
+- `[ ]` **P3.2** (M) CSRF bearer exemption + tighten exempt list; wire CSRF into
+  the test harness — PR: ____
+- `[ ]` **P3.3** (M) Website `PUT` through the full safety chain; validate before
+  `create_dir_all` — PR: ____
+- `[ ]` **P3.4** (S) Validate/clamp per-site CSP override; cache (stop per-request
+  read) — PR: ____
+- `[ ]` **P3.5** (S) `no-cache` on admin index/SPA-fallback; cache/gate
+  `plugins.json` scan; implement `If-None-Match`→304 — PR: ____
+- `[ ]` **P3.6** (S) Typed errors at registry (503/502) + DIDComm (problem-reports)
+  boundaries — PR: ____
+- `[ ]` **P3.7** (S) Minimal unauth `/health`; gate DID/mediator detail; `nosniff`
+  on `did.jsonl` — PR: ____
+- `[ ]` **P3.8** (M) Syncer: seek tail walk from cursor (range API); event_id-keyed
+  idempotent enqueue — PR: ____
+- `[ ]` **P3.9** (XL) Backup/restore for all keyspaces (Argon2id+AES-GCM, vtc_did
+  compat check) — design note first — deps: P2.5 — PR: ____
+- `[ ]` **P3.10** (L) `vtc setup --from <toml>` (WizardPlan + apply engine); fix
+  CLAUDE.md — PR: ____
+- `[ ]` **P3.11** (S) Emergency bootstrap: marker-before-wipe, clear sessions,
+  `persist()` — PR: ____
+- `[ ]` **P3.12** (S) Install `claim/finish` idempotent delivery against a
+  `Consumed` row — PR: ____
+- `[ ]` **P3.13** (M, several small PRs) Hygiene: stale webauthn doc; dead `b64:`
+  path; redact `Debug` on secret types + gate wizard key print; `vtcDid`/`vtcUrl`
+  field rename; public-profile field caps; path-param DID validation; reject
+  `http://` registry; supervisor restart-on-panic — PR(s): ____
+
+---
+
+## Cross-cutting themes (where the same root cause spans subsystems)
+
+- **Foreign/untrusted-fetch hardening** (P0.4) and **bearer recognise** (P0.2)
+  are the two halves of the cross-community trust boundary — land together if
+  possible; both touch `recognition/verify.rs` + `recognise.rs`.
+- **Unbounded-growth / missing sweeper** shows up four times (join requests,
+  credx-pending, present-challenge, failed sync jobs) — P0.6 fixes all in one
+  sweeper pass.
+- **Config triplication** (P1.1) is the root cause behind the unaudited mutation
+  (P1.2), the `vtc_did`-brick (P0.9 boot side), and the stale derived-state
+  divergence — P1.1 is the keystone; sequence it first in Phase 1.
+- **Logic-in-routes** (P2.1) is why several P0 fixes (auto-admit audit, dedup,
+  freshness) land in 2–3 places — doing P2.1 after the P0s makes future fixes
+  single-site.
+- **Status-list RMW race** (P0.1) and **`admit` TOCTOU** (P0.15) are the same
+  missing-lock class as the VTA review's counter races — one `with_locked` helper
+  pattern covers both.

--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -161,9 +161,9 @@ the #457 posture backstop provides its regression guard.)
   - `[~]` **part 1** per-surface host gate in `host_dispatch::enforce` (recognised
     host serves only its bound surface; cross-surface → 404 `SurfaceNotOnHost`;
     infra routes bypass) — PR: #465 (in review)
-  - `[ ]` **part 2** force host separation when a filesystem website
+  - `[~]` **part 2** force host separation when a filesystem website
     (`website.root_dir`) is configured + honest docs (correct the stale
-    `Path=/admin` cookie-isolation claim) — PR: ____
+    `Path=/admin` cookie-isolation claim) — PR: #466 (in review, stacked on #465)
 - `[ ]` **P3.2** (M) CSRF bearer exemption + tighten exempt list; wire CSRF into
   the test harness — PR: ____
 - `[ ]` **P3.3** (M) Website `PUT` through the full safety chain; validate before

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -576,6 +576,57 @@ fn validate_routing(routing: &RoutingConfig) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Force host separation for an operator-deployed filesystem website.
+///
+/// The trust boundary is **deployed website content (untrusted) vs the
+/// admin SPA + API (trusted)** — not admin-vs-API. The admin session
+/// cookie is `Path=/` (the API lives at `/v1`, not under `/admin`, so
+/// the SPA→API call needs it; an earlier `Path=/admin` design was
+/// reverted), so in a shared origin operator-deployed website JS (or
+/// stored XSS in marketing content) runs same-origin with the admin
+/// SPA and can ride the cookie to call authenticated `/v1` endpoints.
+/// The only posture that actually isolates that content is to put the
+/// website on its **own host** (host-only cookies + `SameSite=Strict`
+/// then keep the admin cookie off the website origin, and the P3.1
+/// per-surface gate keeps `/v1` / `/admin` off the website host).
+///
+/// So when a *filesystem* website is configured (`website.root_dir`
+/// set), require `routing.website.host` to be set and distinct from
+/// the api and admin_ui hosts. The in-tree default landing page
+/// (`root_dir` unset) is code we ship and trust, so it may stay
+/// co-resident — this check does not fire for it.
+fn validate_website_isolation(
+    routing: &RoutingConfig,
+    website_on_filesystem: bool,
+) -> Result<(), AppError> {
+    if !website_on_filesystem {
+        return Ok(());
+    }
+
+    let website_host = routing.website.host.as_deref().map(str::to_ascii_lowercase);
+    let Some(website_host) = website_host else {
+        return Err(AppError::Config(
+            "a filesystem website (website.root_dir) would share an origin with the \
+             admin/API surface, letting deployed website content ride the admin session \
+             cookie; set routing.website.host to a dedicated host, or remove \
+             website.root_dir to serve the trusted built-in landing page"
+                .into(),
+        ));
+    };
+
+    for (name, surface) in [("api", &routing.api), ("admin_ui", &routing.admin_ui)] {
+        if surface.host.as_deref().map(str::to_ascii_lowercase) == Some(website_host.clone()) {
+            return Err(AppError::Config(format!(
+                "routing.website.host = '{website_host}' collides with routing.{name}.host; \
+                 a filesystem website must be on a host distinct from the admin/API surface \
+                 so deployed content can't ride the admin session cookie"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 /// Refuse a CORS allowlist that includes `*` or empty / whitespace
 /// entries. Spec §9.3: "wildcards refused". An empty
 /// `allowed_origins` is valid — that's "no cross-origin requests
@@ -767,6 +818,7 @@ impl AppConfig {
     /// touching the filesystem.
     pub fn validate_routing_and_cors(&self) -> Result<(), AppError> {
         validate_routing(&self.routing)?;
+        validate_website_isolation(&self.routing, self.website.root_dir.is_some())?;
         validate_cors(&self.cors)?;
         Ok(())
     }

--- a/vtc-service/src/routing/host_dispatch.rs
+++ b/vtc-service/src/routing/host_dispatch.rs
@@ -1,4 +1,5 @@
-//! Subdomain-mode `Host` header check (Phase 5 M5.1.2).
+//! Subdomain-mode `Host` header check + per-surface isolation
+//! (Phase 5 M5.1.2, hardened in P3.1).
 //!
 //! Tower middleware that inspects the request `Host` header against
 //! the per-surface map declared in [`crate::config::RoutingConfig`].
@@ -7,26 +8,33 @@
 //! - When **every** surface has `host = None` (pure path mode), the
 //!   middleware is a no-op — the parent router does prefix matching
 //!   alone.
-//! - When **any** surface has a host set, the middleware:
+//! - When **any** surface has a host set ("host mode"), the
+//!   middleware:
 //!   1. Reads `Host` from the request (HTTP/2 `:authority` is
 //!      normalised onto the `Host` header by axum before the layer
 //!      runs).
-//!   2. Matches against the set of configured surface hosts
-//!      (case-insensitive, port-aware).
-//!   3. On match: pass through. The parent router then routes by
-//!      path within whichever surface matches.
-//!   4. On miss + `subdomain_mode_strict = true` (default): returns
-//!      404 `HostNotRecognised`.
-//!   5. On miss + `subdomain_mode_strict = false`: pass through —
-//!      the parent router falls back to path matching against all
-//!      configured mounts. Debug aid only; not recommended for
-//!      production.
+//!   2. Rejects a Host that matches no configured surface
+//!      (case-insensitive) with 404 `HostNotRecognised` when
+//!      `subdomain_mode_strict = true` (default). With strict off
+//!      (debug aid), an unrecognised host falls through to plain
+//!      path matching and surface isolation is **not** enforced.
+//!   3. For a recognised host in strict mode, enforces **surface
+//!      isolation**: the request path is routed to the surface whose
+//!      mount it falls under (longest-prefix match — `/v1…`→api,
+//!      `/admin…`→admin, else website), and the request passes only
+//!      if *that* surface is the one bound to the request's host. So
+//!      `admin.example.com/v1/acl` (api surface, bound to a different
+//!      host) returns 404 `SurfaceNotOnHost` rather than serving the
+//!      API. This is what actually isolates an operator-deployed
+//!      website origin from the admin/API surface — the earlier
+//!      version only checked allowlist membership and routed every
+//!      path on every recognised host.
 //!
-//! Per-host/per-path enforcement (e.g. `admin.example.com` 404s
-//! `/v1/...` paths) is **not** in this middleware. The path-mode
-//! prefix matching inside axum's `Router::nest` already does that —
-//! a path that doesn't match the surface's nest boundary returns
-//! 404 via the regular handler chain.
+//! Parent-root infrastructure routes (`/health`, `/openapi.json`,
+//! `/.well-known/did.jsonl`) are mounted outside any surface and must
+//! answer on every recognised host (the did:webvh log has to resolve
+//! on the website host; liveness has to answer on the api host), so
+//! they bypass the surface gate.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -39,28 +47,77 @@ use serde_json::json;
 
 use crate::config::RoutingConfig;
 
-/// Compiled host map. Cheap to clone, shared across requests via
-/// `Arc`. Built once at router-assembly time so the per-request
-/// path is a single `HashSet::contains` call.
+/// Parent-root routes mounted outside any surface mount. They must
+/// answer on every recognised host, so the surface gate skips them.
+const INFRA_PATHS: &[&str] = &["/health", "/openapi.json", "/.well-known/did.jsonl"];
+
+/// One routable surface: the mount prefix it attaches under and the
+/// host it is bound to (`None` in path mode). `priority` breaks ties
+/// when two surfaces share a mount length (e.g. admin at `/` next to
+/// the website catch-all) — lower wins, matching the parent router's
+/// api → admin → website nest precedence.
+#[derive(Debug, Clone)]
+struct Surface {
+    mount: String,
+    host: Option<String>,
+    priority: u8,
+}
+
+impl Surface {
+    /// Length of this surface's mount match against `path`, or `None`
+    /// if it doesn't claim the path. The `/` catch-all matches every
+    /// path but at the lowest specificity (length 1), so a concrete
+    /// `/v1` / `/admin` mount always wins the longest-prefix race.
+    fn match_len(&self, path: &str) -> Option<usize> {
+        if self.mount == "/" {
+            return Some(1);
+        }
+        // `/v1` matches `/v1` and `/v1/...`, but not `/v1abc`.
+        if path == self.mount || path.starts_with(&format!("{}/", self.mount)) {
+            Some(self.mount.len())
+        } else {
+            None
+        }
+    }
+}
+
+/// Compiled host/surface map. Cheap to clone, shared across requests
+/// via `Arc`. Built once at router-assembly time.
 #[derive(Debug, Clone)]
 pub struct HostMap {
     /// Lower-cased configured hosts. Empty when every surface uses
     /// path mode — the layer short-circuits.
     hosts: Arc<HashSet<String>>,
+    /// Per-surface mount + bound host, used for surface isolation.
+    /// Hosts are stored lower-cased.
+    surfaces: Arc<Vec<Surface>>,
     strict: bool,
 }
 
 impl HostMap {
-    /// Compile the surface host set from [`RoutingConfig`].
+    /// Compile the surface map from [`RoutingConfig`].
     pub fn from_routing(routing: &RoutingConfig) -> Self {
         let mut hosts = HashSet::new();
-        for surface in [&routing.api, &routing.admin_ui, &routing.website] {
-            if let Some(h) = surface.host.as_deref() {
-                hosts.insert(h.to_ascii_lowercase());
+        let mut surfaces = Vec::with_capacity(3);
+        // Priority order mirrors the parent router's nest precedence:
+        // api, then admin_ui, then the website catch-all.
+        for (priority, surface) in [&routing.api, &routing.admin_ui, &routing.website]
+            .into_iter()
+            .enumerate()
+        {
+            let host = surface.host.as_deref().map(str::to_ascii_lowercase);
+            if let Some(h) = host.as_deref() {
+                hosts.insert(h.to_string());
             }
+            surfaces.push(Surface {
+                mount: surface.mount.clone(),
+                host,
+                priority: priority as u8,
+            });
         }
         Self {
             hosts: Arc::new(hosts),
+            surfaces: Arc::new(surfaces),
             strict: routing.subdomain_mode_strict,
         }
     }
@@ -71,14 +128,56 @@ impl HostMap {
         self.hosts.is_empty()
     }
 
-    /// True when the configured Host map recognises this header
-    /// value (case-insensitive). Returns `true` unconditionally in
-    /// path mode so callers can use it as a single decision point.
+    /// True when the configured Host map recognises this header value
+    /// (case-insensitive) as belonging to *some* surface. Returns
+    /// `true` unconditionally in path mode so callers can use it as a
+    /// single decision point.
     fn matches(&self, host_header: &str) -> bool {
         if self.is_path_mode() {
             return true;
         }
         self.hosts.contains(&host_header.to_ascii_lowercase())
+    }
+
+    /// The surface that owns `path` (longest mount prefix; ties broken
+    /// toward the surface bound to `req_host`, else by `priority`).
+    /// `req_host` is already lower-cased.
+    fn target_surface(&self, path: &str, req_host: &str) -> Option<&Surface> {
+        let best = self
+            .surfaces
+            .iter()
+            .filter_map(|s| s.match_len(path).map(|len| (s, len)))
+            .max_by(|(a, alen), (b, blen)| {
+                // Longer mount wins; on a tie prefer the surface bound
+                // to the request host, then lower priority.
+                alen.cmp(blen)
+                    .then_with(|| {
+                        let a_owns = a.host.as_deref() == Some(req_host);
+                        let b_owns = b.host.as_deref() == Some(req_host);
+                        a_owns.cmp(&b_owns)
+                    })
+                    .then_with(|| b.priority.cmp(&a.priority))
+            });
+        best.map(|(s, _)| s)
+    }
+
+    /// Surface-isolation decision for a recognised host in strict
+    /// mode. `req_host` is already lower-cased. Returns `true` when
+    /// the path's owning surface is bound to this host (or to no host,
+    /// i.e. a path-mode surface in a mixed config, which can't be
+    /// isolated).
+    fn surface_allowed(&self, path: &str, req_host: &str) -> bool {
+        if INFRA_PATHS.contains(&path) {
+            return true;
+        }
+        match self.target_surface(path, req_host) {
+            Some(s) => match s.host.as_deref() {
+                Some(h) => h == req_host,
+                None => true,
+            },
+            // No surface claims the path — let the router 404 it.
+            None => true,
+        }
     }
 }
 
@@ -99,18 +198,46 @@ pub async fn enforce(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
-    let allowed = match host.as_deref() {
+    // Host-membership gate (unchanged): an unrecognised host is a 404
+    // in strict mode, or falls through in the debug-only lax mode.
+    let recognised = match host.as_deref() {
         Some(h) => map.matches(h),
         // Missing Host header — HTTP/1.1 requires it. Treat as
         // unrecognised in strict mode.
         None => false,
     };
-
-    if allowed || !map.strict {
+    if !recognised {
+        if map.strict {
+            return not_recognised(host);
+        }
         return next.run(request).await;
     }
 
-    // 404 with the same JSON shape as `AppError::IntoResponse`.
+    // Lax mode is a debug aid only — no surface isolation, just plain
+    // path matching once the host is recognised.
+    if !map.strict {
+        return next.run(request).await;
+    }
+
+    // Surface-isolation gate: the path must belong to the surface
+    // bound to this host.
+    let req_host = host.as_deref().unwrap_or_default().to_ascii_lowercase();
+    let path = request.uri().path();
+    if map.surface_allowed(path, &req_host) {
+        return next.run(request).await;
+    }
+
+    let body = json!({
+        "error": "SurfaceNotOnHost",
+        "host": host,
+        "path": request.uri().path(),
+    });
+    (StatusCode::NOT_FOUND, axum::Json(body)).into_response()
+}
+
+/// 404 with the same JSON shape as `AppError::IntoResponse` for a
+/// host that matches no configured surface.
+fn not_recognised(host: Option<String>) -> Response {
     let body = json!({
         "error": "HostNotRecognised",
         "host": host,
@@ -164,5 +291,68 @@ mod tests {
         assert!(map.matches("api.example.com"));
         assert!(map.matches("ADMIN.example.com")); // case-insensitive
         assert!(!map.matches("other.example.com"));
+    }
+
+    #[test]
+    fn surface_isolation_routes_path_to_its_own_host() {
+        let map = HostMap::from_routing(&cfg(
+            Some("api.example.com"),
+            Some("admin.example.com"),
+            Some("example.com"),
+        ));
+
+        // Each surface answers on its own host.
+        assert!(map.surface_allowed("/v1/acl", "api.example.com"));
+        assert!(map.surface_allowed("/admin/users", "admin.example.com"));
+        assert!(map.surface_allowed("/index.html", "example.com"));
+
+        // Cross-surface requests are rejected: the API surface is not
+        // served on the admin or website host, and vice-versa.
+        assert!(!map.surface_allowed("/v1/acl", "admin.example.com"));
+        assert!(!map.surface_allowed("/v1/acl", "example.com"));
+        assert!(!map.surface_allowed("/admin/users", "api.example.com"));
+        // The website catch-all is not served on the api/admin hosts.
+        assert!(!map.surface_allowed("/index.html", "api.example.com"));
+    }
+
+    #[test]
+    fn infra_paths_answer_on_every_recognised_host() {
+        let map = HostMap::from_routing(&cfg(
+            Some("api.example.com"),
+            Some("admin.example.com"),
+            Some("example.com"),
+        ));
+        for host in ["api.example.com", "admin.example.com", "example.com"] {
+            assert!(map.surface_allowed("/health", host), "host {host}");
+            assert!(map.surface_allowed("/.well-known/did.jsonl", host));
+            assert!(map.surface_allowed("/openapi.json", host));
+        }
+    }
+
+    #[test]
+    fn admin_at_root_in_host_mode_resolves_by_request_host() {
+        // admin_ui mounted at `/` next to the website catch-all (also
+        // `/`) — equal mount length. The tie breaks toward the surface
+        // bound to the request host, so each host serves its own.
+        let routing = RoutingConfig {
+            api: MountConfig {
+                mount: "/v1".into(),
+                host: Some("api.example.com".into()),
+            },
+            admin_ui: MountConfig {
+                mount: "/".into(),
+                host: Some("admin.example.com".into()),
+            },
+            website: MountConfig {
+                mount: "/".into(),
+                host: Some("example.com".into()),
+            },
+            subdomain_mode_strict: true,
+        };
+        let map = HostMap::from_routing(&routing);
+        assert!(map.surface_allowed("/dashboard", "admin.example.com"));
+        assert!(map.surface_allowed("/dashboard", "example.com"));
+        // API still isolated to its own host.
+        assert!(!map.surface_allowed("/v1/acl", "example.com"));
     }
 }

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -15,7 +15,7 @@ use http_body_util::BodyExt;
 use tower::ServiceExt;
 use vti_common::config::StoreConfig;
 
-use vtc_service::config::{AppConfig, CorsConfig, MountConfig, RoutingConfig};
+use vtc_service::config::{AppConfig, CorsConfig, MountConfig, RoutingConfig, WebsiteConfig};
 use vtc_service::routes;
 use vtc_service::test_support::TestVtc;
 
@@ -49,10 +49,89 @@ fn cfg_with(routing: RoutingConfig, cors: CorsConfig) -> AppConfig {
     }
 }
 
+/// Like [`cfg_with`] but lets a test set a filesystem website
+/// (`website.root_dir`) to exercise the host-separation guard.
+fn cfg_with_website(routing: RoutingConfig, website: WebsiteConfig) -> AppConfig {
+    AppConfig {
+        website,
+        ..cfg_with(routing, CorsConfig::default())
+    }
+}
+
+/// A three-host routing config where the website sits on its own host
+/// and the admin/API surface shares a host — the only posture that
+/// isolates a filesystem website.
+fn three_host_routing(website_host: Option<&str>) -> RoutingConfig {
+    RoutingConfig {
+        api: MountConfig {
+            mount: "/v1".into(),
+            host: Some("app.example.com".into()),
+        },
+        admin_ui: MountConfig {
+            mount: "/admin".into(),
+            host: Some("app.example.com".into()),
+        },
+        website: MountConfig {
+            mount: "/".into(),
+            host: website_host.map(String::from),
+        },
+        subdomain_mode_strict: true,
+    }
+}
+
 #[test]
 fn defaults_validate_clean() {
     let cfg = cfg_with(RoutingConfig::default(), CorsConfig::default());
     cfg.validate_routing_and_cors().expect("defaults are valid");
+}
+
+#[test]
+fn rejects_filesystem_website_sharing_admin_origin() {
+    // A filesystem website with no dedicated host shares the origin
+    // with the admin SPA + API, letting deployed content ride the
+    // admin session cookie. P3.1 refuses this posture.
+    let website = WebsiteConfig {
+        root_dir: Some(std::path::PathBuf::from("/srv/site")),
+        ..Default::default()
+    };
+    let err = cfg_with_website(RoutingConfig::default(), website)
+        .validate_routing_and_cors()
+        .expect_err("filesystem website on the shared origin must be rejected");
+    assert!(format!("{err}").contains("website.root_dir"), "got {err}");
+}
+
+#[test]
+fn rejects_filesystem_website_host_colliding_with_api() {
+    // website.host set, but equal to the api/admin host → still shares
+    // an origin. Rejected.
+    let website = WebsiteConfig {
+        root_dir: Some(std::path::PathBuf::from("/srv/site")),
+        ..Default::default()
+    };
+    let err = cfg_with_website(three_host_routing(Some("app.example.com")), website)
+        .validate_routing_and_cors()
+        .expect_err("colliding website host must be rejected");
+    assert!(format!("{err}").contains("collides"), "got {err}");
+}
+
+#[test]
+fn allows_filesystem_website_on_dedicated_host() {
+    let website = WebsiteConfig {
+        root_dir: Some(std::path::PathBuf::from("/srv/site")),
+        ..Default::default()
+    };
+    cfg_with_website(three_host_routing(Some("www.example.com")), website)
+        .validate_routing_and_cors()
+        .expect("a filesystem website on its own host is allowed");
+}
+
+#[test]
+fn allows_default_landing_page_on_shared_origin() {
+    // The in-tree default site (root_dir unset) is trusted code we
+    // ship, so the host-separation guard does not fire for it.
+    cfg_with(RoutingConfig::default(), CorsConfig::default())
+        .validate_routing_and_cors()
+        .expect("default landing page may stay co-resident");
 }
 
 #[test]

--- a/vtc-service/tests/routing_modes.rs
+++ b/vtc-service/tests/routing_modes.rs
@@ -183,14 +183,27 @@ async fn subdomain_mode_strict_404s_unknown_host() {
     }
 
     let map = HostMap::from_routing(&routing);
+    // Mount the three surface paths so the gate has something to route
+    // to once it passes.
     let app = Router::new()
+        .route("/v1/{*rest}", axum::routing::get(ok))
+        .route("/admin/{*rest}", axum::routing::get(ok))
         .route("/", axum::routing::get(ok))
         .layer(axum::middleware::from_fn_with_state(map, enforce));
 
-    // Known host → 200.
+    // Known host serving its own surface → 200.
+    let req = Request::builder()
+        .uri("/v1/acl")
+        .header("Host", "api.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Website host serving the website root → 200.
     let req = Request::builder()
         .uri("/")
-        .header("Host", "api.example.com")
+        .header("Host", "example.com")
         .body(Body::empty())
         .unwrap();
     let (status, _) = request(&app, req).await;
@@ -198,7 +211,7 @@ async fn subdomain_mode_strict_404s_unknown_host() {
 
     // Unknown host → 404 HostNotRecognised.
     let req = Request::builder()
-        .uri("/")
+        .uri("/v1/acl")
         .header("Host", "evil.example.com")
         .body(Body::empty())
         .unwrap();
@@ -206,6 +219,84 @@ async fn subdomain_mode_strict_404s_unknown_host() {
     assert_eq!(status, StatusCode::NOT_FOUND);
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(v["error"], "HostNotRecognised");
+}
+
+#[tokio::test]
+async fn subdomain_mode_isolates_surfaces_across_hosts() {
+    // Real surface isolation (P3.1): a recognised host serves only the
+    // surface bound to it. The API surface is not reachable on the
+    // admin or website host, and vice-versa — even though all three
+    // hosts are recognised.
+    let routing = RoutingConfig {
+        api: MountConfig {
+            mount: "/v1".into(),
+            host: Some("api.example.com".into()),
+        },
+        admin_ui: MountConfig {
+            mount: "/admin".into(),
+            host: Some("admin.example.com".into()),
+        },
+        website: MountConfig {
+            mount: "/".into(),
+            host: Some("example.com".into()),
+        },
+        subdomain_mode_strict: true,
+    };
+
+    async fn ok() -> &'static str {
+        "ok"
+    }
+
+    let map = HostMap::from_routing(&routing);
+    let app = Router::new()
+        .route("/health", axum::routing::get(ok))
+        .route("/v1/{*rest}", axum::routing::get(ok))
+        .route("/admin/{*rest}", axum::routing::get(ok))
+        .route("/", axum::routing::get(ok))
+        .route("/{*rest}", axum::routing::get(ok))
+        .layer(axum::middleware::from_fn_with_state(map, enforce));
+
+    // The API surface on the admin host → 404 SurfaceNotOnHost.
+    let req = Request::builder()
+        .uri("/v1/acl")
+        .header("Host", "admin.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = request(&app, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["error"], "SurfaceNotOnHost");
+
+    // The admin surface on the api host → 404.
+    let req = Request::builder()
+        .uri("/admin/users")
+        .header("Host", "api.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&app, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // Website content is not served on the api host → 404. This is the
+    // core isolation guarantee: deployed website JS can't ride the
+    // admin/API origin.
+    let req = Request::builder()
+        .uri("/marketing.js")
+        .header("Host", "api.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = request(&app, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // Infra routes answer on every recognised host.
+    for host in ["api.example.com", "admin.example.com", "example.com"] {
+        let req = Request::builder()
+            .uri("/health")
+            .header("Host", host)
+            .body(Body::empty())
+            .unwrap();
+        let (status, _) = request(&app, req).await;
+        assert_eq!(status, StatusCode::OK, "host {host}");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Part 2 of **P3.1**. Stacked on #465 (base = `p3.1-host-isolation`) — review/merge that first.

## Problem

A filesystem website (`website.root_dir`) served on `/` shares an origin with the admin SPA + API. The admin session cookie is `Path=/` (the API lives at `/v1`, not under `/admin` — an earlier `Path=/admin` design was reverted because it broke the SPA→API call), so same-origin deployed website JS (or stored XSS in marketing content) can `fetch('/v1/...', {credentials})` and ride the cookie; CSRF's `Sec-Fetch-Site: same-origin` check even passes it. Host separation is the only posture that isolates this — and part 1 (#465) makes host mode actually enforce per-surface routing, so it's now meaningful to require.

The docs/spec also still claimed a `Path=/admin` cookie isolation the code abandoned.

## Change

- **`validate_website_isolation`** (`config.rs`): when `website.root_dir` is set, require `routing.website.host` to be set **and** distinct from the api and admin_ui hosts (which may be shared). Reject at config load with an actionable message otherwise. The in-tree default landing page (`root_dir` unset) is trusted code we ship and may stay co-resident — the guard doesn't fire for it.
- **Honest docs** — `docs/03-vtc/website-and-admin.md` + `docs/05-design-notes/vtc-mvp.md` §9.2/§9.3:
  - Correct the cookie description (`Path=/`, not `Path=/admin`), and state plainly that path mode does **not** isolate deployed website content.
  - Document the surface-isolation gate (part 1) and the forced-posture requirement.
  - Replace the config example with a real isolated 3-host setup (API + admin SPA share a host; website on its own).

## Tests

`tests/routing_cors.rs`: filesystem website with no `website.host` → rejected; website host colliding with api/admin → rejected; website on a dedicated host → accepted; default landing page on a shared origin → still allowed.

`cargo test -p vtc-service` (routing_cors + routing_modes + cookie_session) green; clippy/fmt clean.