### PR TITLE
fix(vtc): website single-file PUT through the full safety chain (P3.3)

### DIFF
--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -156,18 +156,20 @@ the #457 posture backstop provides its regression guard.)
 
 ## Phase 3 — Strategic convergence + hygiene (ongoing)
 
-- `[~]` **P3.1** (L) Real host-based surface isolation (or force host-separation
-  when a website is configured + honest docs)
-  - `[~]` **part 1** per-surface host gate in `host_dispatch::enforce` (recognised
+- `[x]` **P3.1** (L) Real host-based surface isolation (or force host-separation
+  when a website is configured + honest docs) — **done** (#465, #466)
+  - `[x]` **part 1** per-surface host gate in `host_dispatch::enforce` (recognised
     host serves only its bound surface; cross-surface → 404 `SurfaceNotOnHost`;
-    infra routes bypass) — PR: #465 (in review)
-  - `[~]` **part 2** force host separation when a filesystem website
+    infra routes bypass) — PR: #465
+  - `[x]` **part 2** force host separation when a filesystem website
     (`website.root_dir`) is configured + honest docs (correct the stale
-    `Path=/admin` cookie-isolation claim) — PR: #466 (in review, stacked on #465)
+    `Path=/admin` cookie-isolation claim) — PR: #466
 - `[ ]` **P3.2** (M) CSRF bearer exemption + tighten exempt list; wire CSRF into
   the test harness — PR: ____
-- `[ ]` **P3.3** (M) Website `PUT` through the full safety chain; validate before
-  `create_dir_all` — PR: ____
+- `[~]` **P3.3** (M) Website `PUT` through the full safety chain; validate before
+  `create_dir_all` — `canonical_within_root_for_create` (shared
+  `validate_path_components`; rejects `..`/hidden/blocklist/control/NFC + symlinked
+  ancestor; no FS mutation before the check) — PR: #467 (in review)
 - `[ ]` **P3.4** (S) Validate/clamp per-site CSP override; cache (stop per-request
   read) — PR: ____
 - `[ ]` **P3.5** (S) `no-cache` on admin index/SPA-fallback; cache/gate

--- a/vtc-service/src/routes/website/files.rs
+++ b/vtc-service/src/routes/website/files.rs
@@ -21,7 +21,7 @@ use vti_common::auth::AdminAuth;
 
 use crate::error::AppError;
 use crate::server::AppState;
-use crate::website::paths::{PathError, canonical_within_root};
+use crate::website::paths::{PathError, canonical_within_root, canonical_within_root_for_create};
 
 use super::{WebsiteWriteResponse, require_website_config};
 
@@ -213,28 +213,23 @@ pub async fn write(
         ));
     }
 
-    let parent_for_path = root_dir.join(parent_dirs(&path));
-    if !parent_for_path.exists() {
-        std::fs::create_dir_all(&parent_for_path)
-            .map_err(|e| AppError::Internal(format!("mkdir -p {parent_for_path:?}: {e}")))?;
-    }
-
+    // Path safety FIRST — the target may not exist yet, so run the
+    // full safety chain (control/NFC, hidden, blocklist, contained-
+    // within-root) via the create-aware validator *before* touching
+    // the filesystem. Rejecting first, creating second, is what stops
+    // a PUT like `.../../foo/x` from `mkdir`-ing outside the root
+    // before the escape check, and stops `.htaccess` / `evil.php` /
+    // `.git/config` writes that `deploy` + `serve` already refuse.
     let req_path = format!("/{}", path.trim_start_matches('/'));
-    // Path safety: target file might not exist yet, so we use a
-    // shadow check against the parent + file name rather than
-    // calling `canonical_within_root` (which requires the file to
-    // exist). The parent must exist within root, and the file
-    // name must pass the same rules.
-    let _ = blocklist; // applied by listing; PUT validates via canonicalisation below
-    let target = root_dir.join(req_path.trim_start_matches('/'));
-    let canon_parent = std::fs::canonicalize(&parent_for_path)
-        .map_err(|e| AppError::Validation(format!("parent path not resolvable: {e}")))?;
-    let canon_root = std::fs::canonicalize(&root_dir)
-        .map_err(|e| AppError::Internal(format!("canonicalize root: {e}")))?;
-    if !canon_parent.starts_with(&canon_root) {
-        return Err(AppError::Validation(
-            "write target escapes website.root_dir".into(),
-        ));
+    let target = canonical_within_root_for_create(&root_dir, &req_path, &blocklist)
+        .map_err(|e| write_path_error(&path, e))?;
+
+    // Only now, after validation passed, create the parent dirs.
+    if let Some(parent) = target.parent()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| AppError::Internal(format!("mkdir -p {parent:?}: {e}")))?;
     }
 
     // Optional If-Match optimistic concurrency.
@@ -323,10 +318,17 @@ pub async fn delete(
     Ok(StatusCode::OK)
 }
 
-fn parent_dirs(path: &str) -> &str {
-    path.rsplit_once('/')
-        .map(|(parent, _)| parent)
-        .unwrap_or("")
+/// Map a [`PathError`] from the create-path validator to the HTTP
+/// response for `PUT`. Mirrors [`resolve_or_400`]: a blocklisted
+/// extension is a 403, a hidden target a 404, everything else a 400.
+fn write_path_error(path: &str, err: PathError) -> AppError {
+    match err {
+        PathError::BlockedExtension(ext) => {
+            AppError::Forbidden(format!("extension {ext} is blocklisted"))
+        }
+        PathError::Hidden => AppError::NotFound(format!("no such file: {path}")),
+        _ => AppError::Validation(format!("path rejected by website path-safety: {path}")),
+    }
 }
 
 fn rand_suffix() -> String {

--- a/vtc-service/src/website/paths.rs
+++ b/vtc-service/src/website/paths.rs
@@ -53,6 +53,42 @@ pub fn canonical_within_root(
     request_path: &str,
     executable_blocklist: &[String],
 ) -> Result<PathBuf, PathError> {
+    // Steps 1–4 are the pure-string component checks (control chars,
+    // NFC, hidden, blocklist) shared with the create path.
+    let trimmed = validate_path_components(request_path, executable_blocklist)?;
+
+    // 5 — canonicalise against root_dir.
+    let candidate = root_dir.join(&trimmed);
+    let canonical = std::fs::canonicalize(&candidate).map_err(|_| PathError::NotFound)?;
+    let root_canonical = std::fs::canonicalize(root_dir).map_err(|_| PathError::NotFound)?;
+
+    if !canonical.starts_with(&root_canonical) {
+        return Err(PathError::Escape);
+    }
+
+    // 6 — exec bit on regular files (Unix only).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = canonical.metadata()
+            && meta.is_file()
+            && meta.permissions().mode() & 0o111 != 0
+        {
+            return Err(PathError::ExecBit);
+        }
+    }
+
+    Ok(canonical)
+}
+
+/// Steps 1–4 of the safety chain: the pure-string checks that don't
+/// touch the filesystem and so apply equally to a path whose target
+/// doesn't exist yet (a `PUT` creating a file). Returns the trimmed,
+/// NFC-normalised relative path (no leading `/`) on success.
+fn validate_path_components(
+    request_path: &str,
+    executable_blocklist: &[String],
+) -> Result<String, PathError> {
     // 1 — NUL / control char check. Decoded URL paths shouldn't
     //     carry control bytes; surface explicitly so the audit
     //     log records the rejection reason.
@@ -76,8 +112,9 @@ pub fn canonical_within_root(
 
     // 3 — hidden-file check. Any component starting with `.` is
     //     refused. `.` and `..` are path-traversal markers, not
-    //     hidden files; canonicalisation below will surface a
-    //     traversal as `Escape` / `NotFound` instead.
+    //     hidden files; canonicalisation surfaces a traversal as
+    //     `Escape` / `NotFound` instead (the create path rejects
+    //     `..` outright — see [`canonical_within_root_for_create`]).
     let trimmed = nfc.trim_start_matches('/');
     for segment in trimmed.split('/') {
         if segment == "." || segment == ".." || segment.is_empty() {
@@ -100,28 +137,69 @@ pub fn canonical_within_root(
         }
     }
 
-    // 5 — canonicalise against root_dir.
-    let candidate = root_dir.join(trimmed);
-    let canonical = std::fs::canonicalize(&candidate).map_err(|_| PathError::NotFound)?;
-    let root_canonical = std::fs::canonicalize(root_dir).map_err(|_| PathError::NotFound)?;
+    Ok(trimmed.to_string())
+}
 
-    if !canonical.starts_with(&root_canonical) {
-        return Err(PathError::Escape);
+/// Validate a `PUT` target path against the **full** safety chain
+/// *before* any filesystem mutation, returning the (non-canonical,
+/// possibly not-yet-existing) target path inside `root_dir`.
+///
+/// [`canonical_within_root`] requires the target to exist (it
+/// `canonicalize`s it), so it can't gate a create. This applies the
+/// same component checks (control / NFC / hidden / blocklist), then
+/// proves containment without the target existing:
+///
+/// - `.` / `..` segments are rejected outright (`Escape`) — a create
+///   never legitimately traverses.
+/// - the **nearest existing ancestor** of the target is canonicalised
+///   and must stay within the canonical root, so a symlinked ancestor
+///   pointing outside the root is caught before we write or `mkdir`.
+///
+/// The caller creates the parent and writes only after this returns
+/// `Ok`.
+pub fn canonical_within_root_for_create(
+    root_dir: &Path,
+    request_path: &str,
+    executable_blocklist: &[String],
+) -> Result<PathBuf, PathError> {
+    let trimmed = validate_path_components(request_path, executable_blocklist)?;
+
+    // Reject traversal + a directory-valued target (empty final
+    // segment). The create path must name a concrete file.
+    if trimmed.is_empty() || trimmed.ends_with('/') {
+        return Err(PathError::NotFound);
     }
-
-    // 6 — exec bit on regular files (Unix only).
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if let Ok(meta) = canonical.metadata()
-            && meta.is_file()
-            && meta.permissions().mode() & 0o111 != 0
-        {
-            return Err(PathError::ExecBit);
+    for segment in trimmed.split('/') {
+        if segment == "." || segment == ".." {
+            return Err(PathError::Escape);
         }
     }
 
-    Ok(canonical)
+    let target = root_dir.join(&trimmed);
+    let root_canonical = std::fs::canonicalize(root_dir).map_err(|_| PathError::NotFound)?;
+
+    // Walk up from the target to the first ancestor that exists on
+    // disk and canonicalise it — that resolves any symlinks in the
+    // existing prefix. With no `..` in the path, an ancestor that
+    // canonicalises within root guarantees the target does too.
+    let mut existing = target.as_path();
+    let canonical_ancestor = loop {
+        match std::fs::canonicalize(existing) {
+            Ok(c) => break c,
+            Err(_) => match existing.parent() {
+                Some(p) => existing = p,
+                // Should be unreachable — root_dir always exists and
+                // is an ancestor — but fail closed.
+                None => return Err(PathError::Escape),
+            },
+        }
+    };
+
+    if !canonical_ancestor.starts_with(&root_canonical) {
+        return Err(PathError::Escape);
+    }
+
+    Ok(target)
 }
 
 #[cfg(test)]
@@ -217,5 +295,104 @@ mod tests {
 
         let err = canonical_within_root(&root, "/script.bin", &block()).expect_err("must reject");
         assert_eq!(err, PathError::ExecBit);
+    }
+
+    // ── canonical_within_root_for_create (PUT path) ──────────────
+
+    #[test]
+    fn create_allows_new_file_in_existing_dir() {
+        let (_d, root) = setup_root();
+        let target = canonical_within_root_for_create(&root, "/assets/new.css", &block()).unwrap();
+        assert!(target.ends_with("assets/new.css"));
+        // Validation must not create anything.
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn create_allows_new_nested_dir() {
+        let (_d, root) = setup_root();
+        // The parent dir doesn't exist yet — the create validator must
+        // still accept it (the caller mkdirs after).
+        let target =
+            canonical_within_root_for_create(&root, "/blog/2026/post.html", &block()).unwrap();
+        assert!(target.ends_with("blog/2026/post.html"));
+        assert!(!root.join("blog").exists(), "validation must not mkdir");
+    }
+
+    #[test]
+    fn create_rejects_blocklisted_extension() {
+        let (_d, root) = setup_root();
+        let err = canonical_within_root_for_create(&root, "/evil.php", &block())
+            .expect_err("must reject");
+        assert_eq!(err, PathError::BlockedExtension(".php".into()));
+    }
+
+    #[test]
+    fn create_rejects_hidden_target() {
+        let (_d, root) = setup_root();
+        // `.htaccess`, `.git/config`, etc. — caught by the hidden check.
+        for p in ["/.htaccess", "/.git/config", "/assets/.secret"] {
+            let err = canonical_within_root_for_create(&root, p, &block()).unwrap_err();
+            assert_eq!(err, PathError::Hidden, "path {p}");
+        }
+    }
+
+    #[test]
+    fn create_rejects_control_and_non_nfc() {
+        let (_d, root) = setup_root();
+        assert_eq!(
+            canonical_within_root_for_create(&root, "/x\0.html", &block()).unwrap_err(),
+            PathError::ControlChars,
+        );
+        assert_eq!(
+            canonical_within_root_for_create(&root, "/cafe\u{0301}.html", &block()).unwrap_err(),
+            PathError::NonNfc,
+        );
+    }
+
+    #[test]
+    fn create_rejects_dotdot_and_creates_nothing() {
+        let (_d, root) = setup_root();
+        let err = canonical_within_root_for_create(&root, "/../escape/x.html", &block())
+            .expect_err("must reject");
+        assert_eq!(err, PathError::Escape);
+        // The pre-validation `create_dir_all` bug created directories
+        // outside the root before rejecting; the validator must touch
+        // nothing.
+        assert!(!root.parent().unwrap().join("escape").exists());
+    }
+
+    #[test]
+    fn create_rejects_empty_and_dir_target() {
+        let (_d, root) = setup_root();
+        assert_eq!(
+            canonical_within_root_for_create(&root, "/", &block()).unwrap_err(),
+            PathError::NotFound,
+        );
+        assert_eq!(
+            canonical_within_root_for_create(&root, "/assets/", &block()).unwrap_err(),
+            PathError::NotFound,
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_rejects_symlinked_ancestor_escape() {
+        use std::os::unix::fs::symlink;
+
+        let (_d, root) = setup_root();
+        // An attacker-controlled symlink inside root pointing outside
+        // it: PUT through it must be rejected by the nearest-existing-
+        // ancestor canonicalisation, even though the target file
+        // doesn't exist yet.
+        let outside = _d.path().parent().unwrap().join("vtc-escape-target");
+        std::fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, root.join("link")).unwrap();
+
+        let err = canonical_within_root_for_create(&root, "/link/pwned.html", &block())
+            .expect_err("symlinked ancestor must be rejected");
+        assert_eq!(err, PathError::Escape);
+        assert!(!outside.join("pwned.html").exists());
+        let _ = std::fs::remove_dir_all(&outside);
     }
 }


### PR DESCRIPTION
Phase 3 hygiene/security — depends on nothing, lands any time.

## Problem

`PUT /v1/website/files/{*path}` (`routes/website/files.rs::write`) didn't use the `canonical_within_root` safety chain that `deploy` and `serve` go through. It ran a hand-rolled shadow check that:

- **explicitly dropped the executable blocklist** (`let _ = blocklist;`) and skipped the **hidden / control-char / NFC** checks — so an admin could `PUT /.htaccess`, `/evil.php`, `/.git/config` that `deploy` and `serve` both reject;
- ran **`create_dir_all` *before* the escape check** — so `PUT .../../foo/bar/x` created directories **outside** the root before the request was rejected (a pre-validation filesystem-mutation primitive, admin-gated).

## Why a new validator

`canonical_within_root` can't gate a create: it `canonicalize`s the target, which doesn't exist yet (that's exactly why `write` hand-rolled its own check).

## Change (`website/paths.rs`)

- Extract the pure-string component checks (control/NFC, hidden, blocklist) into `validate_path_components`, shared by both validators (no behaviour change to `canonical_within_root`).
- Add **`canonical_within_root_for_create`**: runs those checks, rejects `.`/`..` traversal and directory-valued/empty targets outright, then proves containment **without the target existing** by canonicalizing the **nearest existing ancestor** (so a symlinked ancestor pointing outside root is caught) — all before any filesystem mutation.
- `files.rs::write` now validates via it **first**, and only `create_dir_all`s the parent **after** the check passes. `PathError` → 403 (blocklist) / 404 (hidden) / 400 (everything else), mirroring the read path.

## Accept criteria (covered by tests)

- `PUT .../evil.php` → 403; `PUT .../.htaccess` / `.git/config` → 404 (hidden); `PUT .../../escape` → 400 and **creates no directory**.

## Tests

7 new unit tests on the create validator: new file in an existing/nested dir (creates nothing on validation), blocklist, hidden (`.htaccess`/`.git/config`/nested), control+NFC, `..` rejected with no dir created, empty/dir target, and a **symlinked-ancestor escape** (unix). Existing `canonical_within_root` tests unchanged and green.

`cargo test -p vtc-service --lib website` (38) green; clippy/fmt clean.