### PR TITLE
fix(vtc): validate + cache per-site CSP override (P3.4)

### DIFF
--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -166,12 +166,13 @@ the #457 posture backstop provides its regression guard.)
     `Path=/admin` cookie-isolation claim) — PR: #466
 - `[ ]` **P3.2** (M) CSRF bearer exemption + tighten exempt list; wire CSRF into
   the test harness — PR: ____
-- `[~]` **P3.3** (M) Website `PUT` through the full safety chain; validate before
+- `[x]` **P3.3** (M) Website `PUT` through the full safety chain; validate before
   `create_dir_all` — `canonical_within_root_for_create` (shared
   `validate_path_components`; rejects `..`/hidden/blocklist/control/NFC + symlinked
-  ancestor; no FS mutation before the check) — PR: #467 (in review)
-- `[ ]` **P3.4** (S) Validate/clamp per-site CSP override; cache (stop per-request
-  read) — PR: ____
+  ancestor; no FS mutation before the check) — PR: #467
+- `[~]` **P3.4** (S) Validate/clamp per-site CSP override; cache (stop per-request
+  read) — `validate_csp_override` refuses weakening script-src/object-src/base-uri;
+  `CspOverrideCache` (content-cache TTL) — PR: #469 (in review)
 - `[ ]` **P3.5** (S) `no-cache` on admin index/SPA-fallback; cache/gate
   `plugins.json` scan; implement `If-None-Match`→304 — PR: ____
 - `[ ]` **P3.6** (S) Typed errors at registry (503/502) + DIDComm (problem-reports)

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -1496,6 +1496,7 @@ async fn build_website_state(
         executable_blocklist: cfg.website.executable_blocklist.clone(),
         cache_control: cfg.website.cache_control.clone(),
         csp_override_file: cfg.website.csp_override_file.clone(),
+        csp_cache: crate::website::CspOverrideCache::new(cfg.website.live_cache_ttl_seconds),
     })
 }
 

--- a/vtc-service/src/website/mod.rs
+++ b/vtc-service/src/website/mod.rs
@@ -39,6 +39,6 @@ pub mod serve;
 pub mod storage;
 
 #[cfg(feature = "website")]
-pub use serve::{WebsiteState, serve};
+pub use serve::{CspOverrideCache, WebsiteState, serve};
 #[cfg(feature = "website")]
 pub use storage::WebsiteRoot;

--- a/vtc-service/src/website/serve.rs
+++ b/vtc-service/src/website/serve.rs
@@ -16,20 +16,27 @@
 //!   [`crate::routing::security_headers`] middleware attached to
 //!   the website sub-router.
 //! - Default CSP — also from `security_headers` middleware.
-//!   Per-site override via `<root>/.vtc-website.toml` is **read
-//!   here** (so it can override what the middleware would
-//!   default) and overwrites the `Content-Security-Policy` header
-//!   the middleware later attaches.
+//!   Per-site override via `<root>/.vtc-website.toml` is resolved
+//!   here (so it can override what the middleware would default)
+//!   and overwrites the `Content-Security-Policy` header the
+//!   middleware later attaches. The override is **validated** —
+//!   one that weakens `script-src` / `object-src` / `base-uri`
+//!   below the daemon default is refused (default applies instead)
+//!   — and **cached** with the content-cache TTL so it isn't
+//!   stat'd/parsed on every request.
 //!
 //! `If-None-Match` is honoured: matching ETag → 304 without body.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::{Request, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
+use tokio::sync::RwLock;
 
 use crate::error::AppError;
 use crate::website::cache::WebsiteCache;
@@ -45,17 +52,63 @@ pub struct WebsiteState {
     pub executable_blocklist: Vec<String>,
     pub cache_control: String,
     pub csp_override_file: String,
+    /// TTL cache for the parsed + validated per-site CSP override, so
+    /// the override file isn't stat'd/parsed on every request.
+    pub csp_cache: CspOverrideCache,
 }
 
-/// Optional per-site override TOML — read once per request from
+/// Optional per-site override TOML — read from
 /// `<root>/.vtc-website.toml` (or whatever
-/// `website.csp_override_file` points at).
+/// `website.csp_override_file` points at) and cached with the
+/// content-cache TTL.
 #[derive(Debug, Deserialize, Default)]
 pub struct WebsiteOverride {
-    /// CSP value to emit instead of the daemon default. Operator-
-    /// supplied verbatim; the daemon does not validate the
-    /// directive grammar.
+    /// CSP value to emit instead of the daemon default. Validated
+    /// before use — an override that weakens `script-src`,
+    /// `object-src`, or `base-uri` below the daemon default is
+    /// refused and the default CSP applies instead.
     pub csp: Option<String>,
+}
+
+/// A parsed-and-validated CSP override cached with a TTL, mirroring
+/// [`WebsiteCache`]'s `Instant + ttl` scheme. The cached value is the
+/// effective override (`Some` accepted CSP, or `None` for "no file /
+/// invalid / refused" — meaning the daemon default applies).
+#[derive(Debug, Clone)]
+pub struct CspOverrideCache {
+    inner: Arc<RwLock<Option<CachedCsp>>>,
+    ttl: Duration,
+}
+
+#[derive(Debug, Clone)]
+struct CachedCsp {
+    value: Option<String>,
+    fetched_at: Instant,
+}
+
+impl CspOverrideCache {
+    pub fn new(ttl_secs: u64) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(None)),
+            ttl: Duration::from_secs(ttl_secs),
+        }
+    }
+
+    /// The effective CSP override for this site, reading + validating
+    /// from disk only on a cache miss / expiry.
+    async fn get(&self, serve_root: &Path, override_file: &str) -> Option<String> {
+        if let Some(entry) = self.inner.read().await.as_ref()
+            && entry.fetched_at.elapsed() < self.ttl
+        {
+            return entry.value.clone();
+        }
+        let value = read_csp_override(serve_root, override_file).await;
+        *self.inner.write().await = Some(CachedCsp {
+            value: value.clone(),
+            fetched_at: Instant::now(),
+        });
+        value
+    }
 }
 
 /// Axum handler. Mounted at the website sub-router as a catch-all
@@ -128,7 +181,10 @@ async fn serve_inner(state: &WebsiteState, uri: &Uri) -> Result<Response, AppErr
         .first_or_octet_stream()
         .to_string();
 
-    let csp_override = read_csp_override(&serve_root, &state.csp_override_file).await;
+    let csp_override = state
+        .csp_cache
+        .get(&serve_root, &state.csp_override_file)
+        .await;
 
     let mut builder = Response::builder()
         .status(StatusCode::OK)
@@ -151,7 +207,101 @@ async fn read_csp_override(serve_root: &Path, override_file: &str) -> Option<Str
     let path: PathBuf = serve_root.join(override_file);
     let bytes = tokio::fs::read(&path).await.ok()?;
     let parsed: WebsiteOverride = toml::from_slice(&bytes).ok()?;
-    parsed.csp
+    let csp = parsed.csp?;
+    match validate_csp_override(&csp) {
+        Some(valid) => Some(valid),
+        None => {
+            tracing::warn!(
+                file = %path.display(),
+                "per-site CSP override weakens script-src/object-src/base-uri below the \
+                 daemon default; ignoring it and serving the default CSP",
+            );
+            None
+        }
+    }
+}
+
+/// Refuse a per-site CSP override that would weaken any of the
+/// security-critical directives — `script-src`, `object-src`,
+/// `base-uri` — below the daemon default. An operator (or anyone with
+/// website write access) must not be able to neutralise the default
+/// by, e.g., adding `script-src 'unsafe-inline'`. Other directives
+/// (img-src, connect-src, style-src, …) may be freely customised.
+///
+/// Returns the trimmed override on success, or `None` if it's refused
+/// (caller falls back to the daemon default).
+fn validate_csp_override(csp: &str) -> Option<String> {
+    let directives = parse_csp(csp);
+
+    // The effective source list for a directive is its own value, or
+    // the `default-src` fallback, or — if neither is present — no
+    // restriction at all (which is strictly weaker than the default).
+    let effective = |name: &str| -> Option<Vec<String>> {
+        directives
+            .get(name)
+            .or_else(|| directives.get("default-src"))
+            .cloned()
+    };
+
+    // script-src: strictest. Reject wildcards, unsafe-*, bare schemes,
+    // or an entirely unrestricted script source.
+    match effective("script-src") {
+        Some(sources) if !sources_are_loose(&sources, true) => {}
+        _ => return None,
+    }
+
+    // object-src + base-uri: reject wildcards / unsafe-inline. A
+    // missing object-src falls back to default-src (checked); a
+    // missing base-uri has no default-src fallback in the spec, so
+    // absence is fine (browsers default base-uri to the document URL,
+    // not a weaker policy than ours).
+    if let Some(sources) = effective("object-src")
+        && sources_are_loose(&sources, false)
+    {
+        return None;
+    }
+    if let Some(sources) = directives.get("base-uri")
+        && sources_are_loose(sources, false)
+    {
+        return None;
+    }
+
+    Some(csp.trim().to_string())
+}
+
+/// Parse a CSP string into `directive -> [source]`. Lower-cases the
+/// directive name (case-insensitive per spec) but preserves source
+/// token case (`'nonce-…'` etc. are case-sensitive).
+fn parse_csp(csp: &str) -> std::collections::HashMap<String, Vec<String>> {
+    let mut out = std::collections::HashMap::new();
+    for segment in csp.split(';') {
+        let mut tokens = segment.split_whitespace();
+        if let Some(name) = tokens.next() {
+            let sources: Vec<String> = tokens.map(str::to_string).collect();
+            out.insert(name.to_ascii_lowercase(), sources);
+        }
+    }
+    out
+}
+
+/// Whether a directive's source list is "loose" — contains a wildcard,
+/// an `'unsafe-*'` keyword, or (when `strict_schemes`) a bare scheme
+/// that would broaden script execution. An empty list is treated as
+/// loose only via the caller's effective-source logic, not here.
+fn sources_are_loose(sources: &[String], strict_schemes: bool) -> bool {
+    for src in sources {
+        if src.contains('*') {
+            return true;
+        }
+        let lower = src.to_ascii_lowercase();
+        if lower == "'unsafe-inline'" || lower == "'unsafe-eval'" || lower == "'unsafe-hashes'" {
+            return true;
+        }
+        if strict_schemes && matches!(lower.as_str(), "data:" | "blob:" | "http:" | "https:") {
+            return true;
+        }
+    }
+    false
 }
 
 #[cfg(test)]
@@ -170,6 +320,7 @@ mod tests {
             executable_blocklist: block(),
             cache_control: "public, max-age=300".into(),
             csp_override_file: ".vtc-website.toml".into(),
+            csp_cache: CspOverrideCache::new(60),
         }
     }
 
@@ -268,12 +419,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn per_site_csp_override_wins() {
+    async fn safe_per_site_csp_override_wins() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("index.html"), "<title>home</title>").unwrap();
+        // A safe override: keeps script-src strict, just widens img-src
+        // to a CDN. Must be applied verbatim.
         std::fs::write(
             dir.path().join(".vtc-website.toml"),
-            r#"csp = "default-src https:; script-src 'self' 'unsafe-inline'""#,
+            r#"csp = "default-src 'self'; script-src 'self'; img-src 'self' https://cdn.example.com""#,
         )
         .unwrap();
         // Note: .vtc-website.toml itself is hidden (starts with .)
@@ -288,6 +441,95 @@ mod tests {
             .get(header::CONTENT_SECURITY_POLICY)
             .and_then(|h| h.to_str().ok())
             .unwrap_or("");
-        assert!(csp.contains("'unsafe-inline'"), "got CSP: {csp}");
+        assert!(csp.contains("https://cdn.example.com"), "got CSP: {csp}");
+    }
+
+    #[tokio::test]
+    async fn loose_per_site_csp_override_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<title>home</title>").unwrap();
+        // Weakens script-src with 'unsafe-inline' — must be refused, so
+        // serve_inner emits no CSP header at all (the security-headers
+        // middleware then attaches the daemon default).
+        std::fs::write(
+            dir.path().join(".vtc-website.toml"),
+            r#"csp = "default-src 'self'; script-src 'self' 'unsafe-inline'""#,
+        )
+        .unwrap();
+        let state = make_state(dir.path()).await;
+
+        let uri: Uri = "/".parse().unwrap();
+        let resp = serve_inner(&state, &uri).await.expect("ok");
+        assert!(
+            resp.headers()
+                .get(header::CONTENT_SECURITY_POLICY)
+                .is_none(),
+            "loose override must not be emitted; got {:?}",
+            resp.headers().get(header::CONTENT_SECURITY_POLICY),
+        );
+    }
+
+    #[test]
+    fn validate_csp_accepts_strict_and_custom_directives() {
+        assert!(validate_csp_override("default-src 'self'; script-src 'self'").is_some());
+        // Custom non-critical directives are fine.
+        assert!(
+            validate_csp_override(
+                "default-src 'self'; script-src 'self'; connect-src 'self' https://api.example.com"
+            )
+            .is_some()
+        );
+        // default-src strict, script-src inherits it.
+        assert!(validate_csp_override("default-src 'self'").is_some());
+        // Empty script-src (blocks all scripts) is strict, not loose.
+        assert!(validate_csp_override("default-src 'self'; script-src").is_some());
+    }
+
+    #[test]
+    fn validate_csp_refuses_weakened_critical_directives() {
+        // script-src loosened directly.
+        assert!(
+            validate_csp_override("default-src 'self'; script-src 'self' 'unsafe-inline'")
+                .is_none()
+        );
+        assert!(validate_csp_override("default-src 'self'; script-src 'unsafe-eval'").is_none());
+        assert!(validate_csp_override("default-src 'self'; script-src *").is_none());
+        assert!(
+            validate_csp_override("default-src 'self'; script-src https://*.evil.com").is_none()
+        );
+        // script-src via a loose default-src fallback.
+        assert!(validate_csp_override("default-src * 'unsafe-inline'").is_none());
+        assert!(validate_csp_override("default-src https:").is_none());
+        // No script-src and no default-src → unrestricted scripts.
+        assert!(validate_csp_override("img-src 'self'").is_none());
+        // object-src / base-uri wildcards.
+        assert!(validate_csp_override("default-src 'self'; object-src *").is_none());
+        assert!(validate_csp_override("default-src 'self'; base-uri *").is_none());
+    }
+
+    #[tokio::test]
+    async fn csp_override_cache_is_not_read_every_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let override_path = dir.path().join(".vtc-website.toml");
+        std::fs::write(
+            &override_path,
+            r#"csp = "default-src 'self'; script-src 'self'; img-src 'self' https://a.example.com""#,
+        )
+        .unwrap();
+
+        // Large TTL → the first read is cached and reused.
+        let cache = CspOverrideCache::new(3600);
+        let first = cache.get(dir.path(), ".vtc-website.toml").await.unwrap();
+        assert!(first.contains("a.example.com"));
+
+        // Change the file on disk; within TTL the cached value stands,
+        // proving we don't stat/parse on every request.
+        std::fs::write(
+            &override_path,
+            r#"csp = "default-src 'self'; script-src 'self'; img-src 'self' https://b.example.com""#,
+        )
+        .unwrap();
+        let second = cache.get(dir.path(), ".vtc-website.toml").await.unwrap();
+        assert_eq!(first, second, "override must be cached within the TTL");
     }
 }


### PR DESCRIPTION
Phase 3 website-cluster hygiene (unblocked by P3.1).

## Problem

`read_csp_override` (`website/serve.rs`) read `<root>/.vtc-website.toml` **on every request** and emitted its `csp` **verbatim with no validation**. So an operator — or anyone with website write access (e.g. via the file `PUT` surface) — could set `script-src 'unsafe-inline'` and neutralise the daemon-default CSP. Plus a per-request disk stat + TOML parse on the hot path.

## Change (`website/serve.rs`)

- **`validate_csp_override`** refuses an override that weakens any security-critical directive (`script-src`, `object-src`, `base-uri`) below the default:
  - wildcards (`*`, `https://*.x`), `'unsafe-inline'` / `'unsafe-eval'` / `'unsafe-hashes'`, bare schemes (`data:`/`http:`/`https:`/`blob:`) in `script-src`, or an entirely unrestricted script source (no `script-src` **and** no `default-src`).
  - the effective source list honours the `default-src` fallback, so a loose `default-src` is caught too.
  - other directives (`img-src`, `connect-src`, `style-src`, …) stay freely customisable. A refused override is logged and dropped → the security-headers middleware applies the daemon default.
- **`CspOverrideCache`** caches the parsed+validated result with the content-cache TTL (`live_cache_ttl_seconds`), mirroring `WebsiteCache`'s `Instant + ttl` scheme — no more per-request read.

P3.1 already isolates a filesystem website onto its own host, so a relaxed website CSP can't reach the admin origin even when accepted.

## Accept criteria (covered by tests)

- An override that loosens `script-src` is refused (default CSP served); the override isn't parsed on every request.

## Tests

`validate_csp_override` accept/refuse matrix (strict + custom-directive accepts; unsafe-inline/eval, wildcard, loose default-src fallback, missing script-src, object-src/base-uri wildcards all refused); `safe_per_site_csp_override_wins` + `loose_per_site_csp_override_is_refused` through `serve_inner`; and a cache test proving the override isn't re-read within the TTL. The old `per_site_csp_override_wins` (which asserted an `unsafe-inline` override was applied) is rewritten to a safe override.

`cargo test -p vtc-service --lib website` (42) green; clippy/fmt clean.