### PR TITLE
fix(vtc): cache-control + unauth-scan hygiene on the admin/website edge (P3.5)

### DIFF
--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -170,11 +170,13 @@ the #457 posture backstop provides its regression guard.)
   `create_dir_all` — `canonical_within_root_for_create` (shared
   `validate_path_components`; rejects `..`/hidden/blocklist/control/NFC + symlinked
   ancestor; no FS mutation before the check) — PR: #467
-- `[~]` **P3.4** (S) Validate/clamp per-site CSP override; cache (stop per-request
+- `[x]` **P3.4** (S) Validate/clamp per-site CSP override; cache (stop per-request
   read) — `validate_csp_override` refuses weakening script-src/object-src/base-uri;
-  `CspOverrideCache` (content-cache TTL) — PR: #469 (in review)
-- `[ ]` **P3.5** (S) `no-cache` on admin index/SPA-fallback; cache/gate
-  `plugins.json` scan; implement `If-None-Match`→304 — PR: ____
+  `CspOverrideCache` (content-cache TTL) — PR: #469
+- `[~]` **P3.5** (S) `no-cache` on admin index/SPA-fallback; cache/gate
+  `plugins.json` scan; implement `If-None-Match`→304 — `cache_control_for`
+  (shell no-cache, hashed assets keep TTL); `scan_plugin_dir_cached` (30s TTL);
+  `etag_matches`→304 in website serve — PR: #470 (in review)
 - `[ ]` **P3.6** (S) Typed errors at registry (503/502) + DIDComm (problem-reports)
   boundaries — PR: ____
 - `[ ]` **P3.7** (S) Minimal unauth `/health`; gate DID/mediator detail; `nosniff`

--- a/vtc-service/src/admin_ui.rs
+++ b/vtc-service/src/admin_ui.rs
@@ -79,6 +79,21 @@ pub fn lookup(rel_path: &str) -> Option<&'static [u8]> {
     ADMIN_UI_DIR.get_file(trimmed).map(|f| f.contents())
 }
 
+/// Cache-control for an admin-UX response. The SPA shell
+/// (`index.html`, served for `/admin`, `/admin/`, and every
+/// history-mode fallback) must be revalidated each load —
+/// otherwise after an upgrade a browser serves a stale shell
+/// pointing at asset hashes the new binary dropped, breaking the
+/// SPA for the TTL window. Only the content-hashed `/assets/*`
+/// bundles (immutable by construction) keep the long TTL.
+fn cache_control_for(rel: &str, served_shell: bool) -> &'static str {
+    if !served_shell && rel.starts_with("/assets/") {
+        "public, max-age=300"
+    } else {
+        "no-cache"
+    }
+}
+
 /// Axum handler for `GET /admin/*`. Walks the request path
 /// through the embedded directory; falls back to `index.html`
 /// for client-side routing (SPA history mode).
@@ -96,24 +111,27 @@ pub async fn serve(req: Request<Body>) -> Response {
     // must reflect the *served* bytes (`text/html`), not the
     // *requested* path — otherwise the browser sees
     // `application/octet-stream` and tries to download the page.
-    let (bytes, mime) = match lookup(rel) {
+    let (bytes, mime, served_shell) = match lookup(rel) {
         Some(b) => (
             b,
             mime_guess::from_path(rel)
                 .first_or_octet_stream()
                 .to_string(),
+            rel == "/index.html",
         ),
         None => match lookup("/index.html") {
-            Some(b) => (b, "text/html; charset=utf-8".to_string()),
+            // History-mode fallback — we served the SPA shell.
+            Some(b) => (b, "text/html; charset=utf-8".to_string(), true),
             None => {
                 return (StatusCode::NOT_FOUND, "admin UX not embedded").into_response();
             }
         },
     };
+
     Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, mime)
-        .header(header::CACHE_CONTROL, "public, max-age=300")
+        .header(header::CACHE_CONTROL, cache_control_for(rel, served_shell))
         .body(Body::from(bytes))
         .unwrap_or_else(|_| (StatusCode::INTERNAL_SERVER_ERROR, "response build").into_response())
 }
@@ -132,6 +150,23 @@ mod tests {
             ADMIN_UI_DIR.get_file("index.html").is_some(),
             "index.html missing from embedded admin-ui — did the source dir get deleted?"
         );
+    }
+
+    #[test]
+    fn cache_control_no_cache_for_shell_long_ttl_for_assets() {
+        // SPA shell (index + every history-mode fallback) → no-cache.
+        assert_eq!(cache_control_for("/index.html", true), "no-cache");
+        assert_eq!(cache_control_for("/install", true), "no-cache"); // fallback
+        // A non-asset root file is also revalidated.
+        assert_eq!(cache_control_for("/favicon.ico", false), "no-cache");
+        // Content-hashed bundles keep the long TTL.
+        assert_eq!(
+            cache_control_for("/assets/index-a1b2c3.js", false),
+            "public, max-age=300"
+        );
+        // An /assets/* path that fell back to the shell is still
+        // no-cache (we served index.html, not the bundle).
+        assert_eq!(cache_control_for("/assets/missing.js", true), "no-cache");
     }
 
     #[test]

--- a/vtc-service/src/routes/admin_ui.rs
+++ b/vtc-service/src/routes/admin_ui.rs
@@ -13,6 +13,8 @@
 #![cfg(feature = "admin-ui")]
 
 use std::path::{Path as StdPath, PathBuf};
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
 use axum::Json;
 use axum::body::Body;
@@ -20,6 +22,7 @@ use axum::extract::{Path, Request, State};
 use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 use tracing::warn;
 
 use crate::admin_ui::AdminUiInfo;
@@ -65,7 +68,7 @@ pub async fn serve_spa(req: Request<Body>) -> Response {
 /// `icon` + `scopes`. The plugin's entry JS calls
 /// `window.VtcPluginApi.registerPlugin({...})` to wire its UI into
 /// the shell's router and nav.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PluginManifestEntry {
     pub id: String,
@@ -86,6 +89,22 @@ pub struct PluginsManifestResponse {
     pub plugins: Vec<PluginManifestEntry>,
 }
 
+/// Short-TTL cache of plugin-directory scans, keyed by the configured
+/// `plugin_dir` so a runtime config change rescans rather than serving
+/// a stale set. Keeps the **unauth** `/admin/plugins.json` route from
+/// doing a `readdir` + read-every-manifest on every request (a disk-
+/// amplification lever). The map holds one entry per distinct
+/// `plugin_dir` ever configured (≈1 for a running daemon).
+struct PluginScanEntry {
+    scanned_at: Instant,
+    plugins: Vec<PluginManifestEntry>,
+}
+
+static PLUGIN_SCAN_CACHE: LazyLock<RwLock<std::collections::HashMap<PathBuf, PluginScanEntry>>> =
+    LazyLock::new(|| RwLock::new(std::collections::HashMap::new()));
+
+const PLUGIN_SCAN_TTL: Duration = Duration::from_secs(30);
+
 /// `GET /admin/plugins.json` — third-party plugin manifest.
 ///
 /// Scans `admin_ui.plugin_dir` (if configured) for subdirectories;
@@ -94,7 +113,7 @@ pub struct PluginsManifestResponse {
 /// response. IDs that fail the regex, manifests that fail to parse,
 /// or paths that escape the plugin root are dropped silently (with
 /// a `warn!`) so one malformed plugin can't take down the manifest
-/// surface.
+/// surface. The scan result is cached for [`PLUGIN_SCAN_TTL`].
 ///
 /// Unauth on purpose: knowing which plugins are installed is not
 /// sensitive, and the shell fetches the manifest before login.
@@ -105,8 +124,26 @@ pub async fn plugins_manifest(State(state): State<AppState>) -> Json<PluginsMani
     };
 
     Json(PluginsManifestResponse {
-        plugins: scan_plugin_dir(&plugin_dir),
+        plugins: scan_plugin_dir_cached(&plugin_dir).await,
     })
+}
+
+/// [`scan_plugin_dir`] behind the [`PLUGIN_SCAN_CACHE`] TTL.
+async fn scan_plugin_dir_cached(plugin_dir: &StdPath) -> Vec<PluginManifestEntry> {
+    if let Some(entry) = PLUGIN_SCAN_CACHE.read().await.get(plugin_dir)
+        && entry.scanned_at.elapsed() < PLUGIN_SCAN_TTL
+    {
+        return entry.plugins.clone();
+    }
+    let plugins = scan_plugin_dir(plugin_dir);
+    PLUGIN_SCAN_CACHE.write().await.insert(
+        plugin_dir.to_path_buf(),
+        PluginScanEntry {
+            scanned_at: Instant::now(),
+            plugins: plugins.clone(),
+        },
+    );
+    plugins
 }
 
 fn scan_plugin_dir(plugin_dir: &StdPath) -> Vec<PluginManifestEntry> {
@@ -266,4 +303,52 @@ pub async fn plugin_asset(
         .header(header::CACHE_CONTROL, "public, max-age=300")
         .body(Body::from(bytes))
         .unwrap_or_else(|_| (StatusCode::INTERNAL_SERVER_ERROR, "response build").into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_plugin(dir: &StdPath, id: &str, entry: &str) {
+        let pdir = dir.join(id);
+        std::fs::create_dir_all(&pdir).unwrap();
+        std::fs::write(
+            pdir.join("manifest.json"),
+            format!(r#"{{"label":"{id}","path":"/{id}","entry":"{entry}"}}"#),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn scan_skips_invalid_ids_and_traversal_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        write_plugin(dir.path(), "good", "index.js");
+        write_plugin(dir.path(), "Bad_Id", "index.js"); // invalid id
+        write_plugin(dir.path(), "escape", "../../etc/passwd"); // traversal
+
+        let plugins = scan_plugin_dir(dir.path());
+        assert_eq!(plugins.len(), 1, "only the valid plugin survives");
+        assert_eq!(plugins[0].id, "good");
+        assert_eq!(plugins[0].entry, "/admin/plugins/good/index.js");
+    }
+
+    #[tokio::test]
+    async fn cached_scan_is_not_reread_within_ttl() {
+        let dir = tempfile::tempdir().unwrap();
+        write_plugin(dir.path(), "alpha", "index.js");
+
+        // First call populates the cache.
+        let first = scan_plugin_dir_cached(dir.path()).await;
+        assert_eq!(first.len(), 1);
+
+        // Add a second plugin; within the TTL the cached (single)
+        // result still stands, proving we don't readdir every request.
+        write_plugin(dir.path(), "beta", "index.js");
+        let second = scan_plugin_dir_cached(dir.path()).await;
+        assert_eq!(second.len(), 1, "scan must be cached within the TTL");
+
+        // A direct (uncached) scan sees both — confirms the cache, not
+        // the scanner, is what hid the new plugin.
+        assert_eq!(scan_plugin_dir(dir.path()).len(), 2);
+    }
 }

--- a/vtc-service/src/website/serve.rs
+++ b/vtc-service/src/website/serve.rs
@@ -115,13 +115,22 @@ impl CspOverrideCache {
 /// fallback (`/{*path}` semantics) so any unmatched request lands
 /// here.
 pub async fn serve(State(state): State<WebsiteState>, req: Request<Body>) -> Response {
-    match serve_inner(&state, req.uri()).await {
+    let if_none_match = req
+        .headers()
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    match serve_inner(&state, req.uri(), if_none_match.as_deref()).await {
         Ok(resp) => resp,
         Err(err) => err.into_response(),
     }
 }
 
-async fn serve_inner(state: &WebsiteState, uri: &Uri) -> Result<Response, AppError> {
+async fn serve_inner(
+    state: &WebsiteState,
+    uri: &Uri,
+    if_none_match: Option<&str>,
+) -> Result<Response, AppError> {
     let raw_path = uri.path();
     // Default-document rule: a directory request maps to
     // `index.html`. The path-safety chain runs against the
@@ -177,6 +186,20 @@ async fn serve_inner(state: &WebsiteState, uri: &Uri) -> Result<Response, AppErr
 
     let etag = format!("\"{}\"", cached.digest_hex);
 
+    // Conditional GET: a matching `If-None-Match` short-circuits to
+    // 304 with no body (but still carries ETag + Cache-Control so the
+    // client can keep revalidating).
+    if let Some(inm) = if_none_match
+        && etag_matches(inm, &etag)
+    {
+        return Response::builder()
+            .status(StatusCode::NOT_MODIFIED)
+            .header(header::ETAG, etag)
+            .header(header::CACHE_CONTROL, state.cache_control.clone())
+            .body(Body::empty())
+            .map_err(|e| AppError::Internal(format!("response build: {e}")));
+    }
+
     let mime = mime_guess::from_path(&resolved)
         .first_or_octet_stream()
         .to_string();
@@ -201,6 +224,17 @@ async fn serve_inner(state: &WebsiteState, uri: &Uri) -> Result<Response, AppErr
     builder
         .body(Body::from((*cached.body).clone()))
         .map_err(|e| AppError::Internal(format!("response build: {e}")))
+}
+
+/// Whether an `If-None-Match` header value matches `etag`. Handles a
+/// comma-separated list, the `*` any-match, and the `W/` weak prefix
+/// (our ETags are content digests, so weak/strong compare equal here).
+fn etag_matches(if_none_match: &str, etag: &str) -> bool {
+    if_none_match.split(',').any(|tok| {
+        let tok = tok.trim();
+        let tok = tok.strip_prefix("W/").unwrap_or(tok);
+        tok == "*" || tok == etag
+    })
 }
 
 async fn read_csp_override(serve_root: &Path, override_file: &str) -> Option<String> {
@@ -331,7 +365,7 @@ mod tests {
         let state = make_state(dir.path()).await;
 
         let uri: Uri = "/hello.html".parse().unwrap();
-        let resp = serve_inner(&state, &uri).await.expect("ok");
+        let resp = serve_inner(&state, &uri, None).await.expect("ok");
         assert_eq!(resp.status(), StatusCode::OK);
         assert!(resp.headers().get(header::ETAG).is_some());
         assert_eq!(
@@ -345,13 +379,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn matching_if_none_match_returns_304() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.html"), "<p>hi</p>").unwrap();
+        let state = make_state(dir.path()).await;
+        let uri: Uri = "/hello.html".parse().unwrap();
+
+        // First request to learn the ETag.
+        let resp = serve_inner(&state, &uri, None).await.expect("ok");
+        let etag = resp
+            .headers()
+            .get(header::ETAG)
+            .and_then(|h| h.to_str().ok())
+            .unwrap()
+            .to_string();
+
+        // Conditional GET with the matching ETag → 304, empty body,
+        // ETag still present.
+        let resp = serve_inner(&state, &uri, Some(&etag)).await.expect("ok");
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(
+            resp.headers()
+                .get(header::ETAG)
+                .and_then(|h| h.to_str().ok()),
+            Some(etag.as_str()),
+        );
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(bytes.is_empty(), "304 must carry no body");
+
+        // A stale/non-matching ETag → full 200.
+        let resp = serve_inner(&state, &uri, Some("\"deadbeef\""))
+            .await
+            .expect("ok");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // `*` always matches (RFC 9110).
+        let resp = serve_inner(&state, &uri, Some("*")).await.expect("ok");
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[test]
+    fn etag_matches_handles_lists_weak_and_star() {
+        assert!(etag_matches("\"abc\"", "\"abc\""));
+        assert!(etag_matches("\"x\", \"abc\", \"y\"", "\"abc\""));
+        assert!(etag_matches("W/\"abc\"", "\"abc\""));
+        assert!(etag_matches("*", "\"abc\""));
+        assert!(!etag_matches("\"abc\"", "\"def\""));
+        assert!(!etag_matches("", "\"abc\""));
+    }
+
+    #[tokio::test]
     async fn serves_index_for_root_request() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("index.html"), "<title>home</title>").unwrap();
         let state = make_state(dir.path()).await;
 
         let uri: Uri = "/".parse().unwrap();
-        let resp = serve_inner(&state, &uri).await.expect("ok");
+        let resp = serve_inner(&state, &uri, None).await.expect("ok");
         assert_eq!(resp.status(), StatusCode::OK);
         assert!(
             resp.headers()
@@ -371,7 +455,9 @@ mod tests {
         let state = make_state(dir.path()).await;
 
         let uri: Uri = "/.secrets".parse().unwrap();
-        let err = serve_inner(&state, &uri).await.expect_err("must reject");
+        let err = serve_inner(&state, &uri, None)
+            .await
+            .expect_err("must reject");
         assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
     }
 
@@ -382,7 +468,9 @@ mod tests {
         let state = make_state(dir.path()).await;
 
         let uri: Uri = "/evil.cgi".parse().unwrap();
-        let err = serve_inner(&state, &uri).await.expect_err("must reject");
+        let err = serve_inner(&state, &uri, None)
+            .await
+            .expect_err("must reject");
         assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
     }
 
@@ -397,7 +485,9 @@ mod tests {
         // host platform's behaviour around non-existent paths can
         // pick either branch — accept both as "not served".
         let uri: Uri = "/../../etc/passwd".parse().unwrap();
-        let err = serve_inner(&state, &uri).await.expect_err("must reject");
+        let err = serve_inner(&state, &uri, None)
+            .await
+            .expect_err("must reject");
         assert!(
             matches!(err, AppError::NotFound(_) | AppError::Validation(_)),
             "got {err:?}"
@@ -414,7 +504,9 @@ mod tests {
         // the default-document rule only fires on trailing slash.
         // Must 404 — we don't auto-list directories.
         let uri: Uri = "/assets".parse().unwrap();
-        let err = serve_inner(&state, &uri).await.expect_err("must reject");
+        let err = serve_inner(&state, &uri, None)
+            .await
+            .expect_err("must reject");
         assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
     }
 
@@ -435,7 +527,7 @@ mod tests {
         let state = make_state(dir.path()).await;
 
         let uri: Uri = "/".parse().unwrap();
-        let resp = serve_inner(&state, &uri).await.expect("ok");
+        let resp = serve_inner(&state, &uri, None).await.expect("ok");
         let csp = resp
             .headers()
             .get(header::CONTENT_SECURITY_POLICY)
@@ -459,7 +551,7 @@ mod tests {
         let state = make_state(dir.path()).await;
 
         let uri: Uri = "/".parse().unwrap();
-        let resp = serve_inner(&state, &uri).await.expect("ok");
+        let resp = serve_inner(&state, &uri, None).await.expect("ok");
         assert!(
             resp.headers()
                 .get(header::CONTENT_SECURITY_POLICY)


### PR DESCRIPTION
Phase 3 website-cluster hygiene (three small edge-cache fixes).

## 1. Admin SPA shell was cached like a hashed asset

`admin_ui::serve` emitted `public, max-age=300` for **every** admin path — including `index.html` and every history-mode fallback. After an upgrade a browser served a stale shell pointing at asset hashes the new binary dropped → broken SPA for up to the TTL window. `cache_control_for(rel, served_shell)` now serves the shell `no-cache` and keeps the long TTL only for content-hashed `/assets/*`.

## 2. Unauth `/admin/plugins.json` re-scanned the plugin dir every request

`plugins_manifest` did a `readdir` + read-every-`manifest.json` on every **unauthenticated** request — a disk-amplification lever. `scan_plugin_dir_cached` wraps the scan in a 30s TTL cache keyed by `plugin_dir` (per-dir map, so a runtime config change rescans). Kept unauth — the shell fetches it before login, per the existing contract — rather than gating behind auth.

## 3. Website `serve` claimed `If-None-Match`→304 but never did it

The module doc promised conditional-GET support that wasn't implemented. `serve` now reads `If-None-Match` and short-circuits to **304** (ETag + Cache-Control, empty body) on a match. `etag_matches` handles comma-separated lists, the `W/` weak prefix, and `*`.

## Accept criteria (covered by tests)

- `/admin/` (+ fallbacks) carry `no-cache`; `/admin/assets/<hash>.js` keeps the long TTL.
- Repeated `plugins.json` doesn't re-`readdir` within the TTL.
- A conditional GET with a matching ETag → 304.

## Tests

`cache_control_for` shell-vs-asset matrix; `scan_skips_invalid_ids_and_traversal_entries` + `cached_scan_is_not_reread_within_ttl`; website `matching_if_none_match_returns_304` (match/non-match/`*`) + `etag_matches` unit cases.

`cargo test -p vtc-service --lib` (602) green; clippy/fmt clean.