### PR TITLE
test(vtc): fuzz-friendly try_request on TestJoinClient (#464)

### DIFF
--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -537,7 +537,7 @@ impl Drop for MockVtc {
 }
 
 #[cfg(feature = "didcomm-harness")]
-pub use didcomm_harness::{MockVtcDidcomm, TestJoinClient};
+pub use didcomm_harness::{MockVtcDidcomm, ProblemReport, ReplyOutcome, TestJoinClient};
 
 /// In-process DIDComm join-requests harness (#436).
 ///
@@ -552,6 +552,7 @@ pub use didcomm_harness::{MockVtcDidcomm, TestJoinClient};
 mod didcomm_harness {
     use std::collections::VecDeque;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
     use affinidi_messaging_test_mediator::{TestMediator, TestMediatorHandle};
@@ -567,6 +568,7 @@ mod didcomm_harness {
     use serde_json::{Value, json};
     use tokio::sync::{Mutex, oneshot};
     use uuid::Uuid;
+    use vta_sdk::protocols::extract_problem_report;
     use vta_sdk::protocols::join_requests::{
         JOIN_REQUEST_MANIFEST_RESPONSE_TYPE, JOIN_REQUEST_MANIFEST_TYPE,
         JOIN_REQUEST_STATUS_RESPONSE_TYPE, JOIN_REQUEST_STATUS_TYPE,
@@ -616,6 +618,40 @@ mod didcomm_harness {
         body: Value,
     }
 
+    /// `true` if a DIDComm message type names the report-problem protocol.
+    fn is_problem_report(typ: &str) -> bool {
+        typ.contains("problem-report")
+    }
+
+    /// A DIDComm problem-report the VTC threaded back as a rejection, with its
+    /// `code`/`comment` already parsed via
+    /// [`vta_sdk::protocols::extract_problem_report`] plus the raw body for
+    /// finer assertions.
+    #[derive(Debug, Clone)]
+    pub struct ProblemReport {
+        /// The problem-report `code` (e.g. `e.p.msg.bad-request`).
+        pub code: String,
+        /// The human-readable `comment`.
+        pub comment: String,
+        /// The raw problem-report body.
+        pub body: Value,
+    }
+
+    /// The classified outcome of a [`TestJoinClient::try_request`] round trip —
+    /// the three buckets a negative/fuzz campaign tells apart.
+    #[derive(Debug, Clone)]
+    pub enum ReplyOutcome {
+        /// A threaded reply that is *not* a problem-report — the request was
+        /// accepted; carries the reply body.
+        Reply(Value),
+        /// A threaded DIDComm problem-report — the VTC rejected the request
+        /// cleanly (the expected, healthy behaviour for malformed input).
+        Problem(ProblemReport),
+        /// No threaded reply (nor problem-report) arrived within the timeout —
+        /// the signal a fuzzer treats as a potential hang/crash.
+        Timeout,
+    }
+
     /// A DIDComm join applicant connected to the harness mediator.
     ///
     /// Sends authcrypt requests to the VTC and awaits the threaded reply;
@@ -630,6 +666,13 @@ mod didcomm_harness {
         /// `vta_sdk::vp` — its `id` is a `did:key`.
         holder_secret: Secret,
         inbox: Mutex<VecDeque<Received>>,
+        /// When set (the default), [`recv_matching`](Self::recv_matching) panics
+        /// on any inbound problem-report — the right ergonomics for a happy-path
+        /// test, where an unexpected rejection should abort loudly. A
+        /// negative/fuzz campaign clears it for the duration of a
+        /// [`try_request`](Self::try_request) call so a clean rejection is
+        /// *returned* (classified) instead of aborting the run.
+        panic_on_problem_report: AtomicBool,
     }
 
     impl TestJoinClient {
@@ -655,6 +698,7 @@ mod didcomm_harness {
                 mediator_did,
                 holder_secret,
                 inbox: Mutex::new(VecDeque::new()),
+                panic_on_problem_report: AtomicBool::new(true),
             }
         }
 
@@ -672,21 +716,71 @@ mod didcomm_harness {
 
         /// Send `body` as a `typ` DIDComm message to `vtc_did` (authcrypt,
         /// forwarded via the mediator) and return the threaded reply body.
-        /// Panics on timeout — this is a test harness.
+        /// Panics on timeout *or* a problem-report — this is the happy-path
+        /// helper. Use [`try_request`](Self::try_request) for a negative/fuzz
+        /// campaign that needs to keep going past a (correct) rejection.
         pub async fn request(&self, vtc_did: &str, typ: &str, body: Value) -> Value {
+            match self
+                .try_request(vtc_did, typ, body, Duration::from_secs(15))
+                .await
+            {
+                ReplyOutcome::Reply(body) => body,
+                ReplyOutcome::Problem(p) => {
+                    panic!("applicant received problem-report: {}", p.body)
+                }
+                ReplyOutcome::Timeout => panic!("no reply to `{typ}` within timeout"),
+            }
+        }
+
+        /// Like [`request`](Self::request) but **non-panicking**: send `body` as
+        /// a `typ` message and *classify* the threaded outcome into the three
+        /// buckets a negative/fuzz campaign cares about — a clean accept
+        /// ([`ReplyOutcome::Reply`]), a clean DIDComm rejection
+        /// ([`ReplyOutcome::Problem`]), or no threaded reply within `timeout`
+        /// ([`ReplyOutcome::Timeout`], the signal for a hang/crash). This lets a
+        /// fuzzer run thousands of mutations per boot without aborting on the
+        /// first (correct) problem-report.
+        ///
+        /// Both a normal reply and a problem-report are threaded to this
+        /// request's id (the messaging framework's problem-report carries
+        /// `thid = <request id>`), so the same thread-correlation predicate
+        /// catches either; the reply `typ` is what distinguishes them.
+        pub async fn try_request(
+            &self,
+            vtc_did: &str,
+            typ: &str,
+            body: Value,
+            timeout: Duration,
+        ) -> ReplyOutcome {
             let req_id = Uuid::new_v4().to_string();
             let msg = Message::build(req_id.clone(), typ.to_string(), body)
                 .from(self.did.clone())
                 .to(vtc_did.to_string())
                 .finalize();
             self.send(&msg, vtc_did).await;
-            self.recv_matching(
-                |r| r.thid.as_deref() == Some(req_id.as_str()),
-                Duration::from_secs(15),
-            )
-            .await
-            .unwrap_or_else(|| panic!("no reply to `{typ}` within timeout"))
-            .body
+
+            // Suppress recv_matching's happy-path panic for this round trip so a
+            // problem-report is buffered/matched like any reply and classified
+            // below, then restore the prior setting for any later happy-path call
+            // on this client.
+            let prev = self.panic_on_problem_report.swap(false, Ordering::SeqCst);
+            let received = self
+                .recv_matching(|r| r.thid.as_deref() == Some(req_id.as_str()), timeout)
+                .await;
+            self.panic_on_problem_report.store(prev, Ordering::SeqCst);
+
+            match received {
+                Some(r) if is_problem_report(&r.typ) => {
+                    let (code, comment) = extract_problem_report(&r.body);
+                    ReplyOutcome::Problem(ProblemReport {
+                        code,
+                        comment,
+                        body: r.body,
+                    })
+                }
+                Some(r) => ReplyOutcome::Reply(r.body),
+                None => ReplyOutcome::Timeout,
+            }
         }
 
         /// Await the next unsolicited inbound message (no thread correlation),
@@ -737,8 +831,12 @@ mod didcomm_harness {
                     .live_stream_next(&self.profile, Some(POLL), true)
                     .await;
                 if let Ok(Some((msg, _meta))) = next {
-                    if msg.typ.contains("problem-report") {
-                        // Surface the problem rather than silently buffering it.
+                    if is_problem_report(&msg.typ)
+                        && self.panic_on_problem_report.load(Ordering::SeqCst)
+                    {
+                        // Happy-path ergonomics: surface the problem loudly rather
+                        // than silently buffering it. `try_request` clears the flag
+                        // so a negative/fuzz campaign classifies it instead.
                         panic!("applicant received problem-report: {}", msg.body);
                     }
                     let r = Received {

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -28,7 +28,7 @@ use tower::ServiceExt;
 use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
 use vtc_service::auth::session::now_epoch;
 use vtc_service::schemas::accepts::{AcceptsCriterion, store_accepts};
-use vtc_service::test_support::MockVtcDidcomm;
+use vtc_service::test_support::{MockVtcDidcomm, ReplyOutcome};
 
 use vta_sdk::protocols::credential_exchange::{ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody};
 use vta_sdk::protocols::join_requests::{
@@ -268,6 +268,66 @@ async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_deliver
         credential["credentialSubject"]["id"], applicant_did,
         "VMC subject is the applicant"
     );
+
+    mock.shutdown().await;
+}
+
+/// The negative-path counterpart that unblocks a cross-service fuzz campaign
+/// (#464): `try_request` must *classify* a rejection rather than abort. A
+/// malformed submit (missing the required `vp`) makes the real `submit_inner`
+/// reject; the VTC threads back a DIDComm problem-report, and the harness keeps
+/// going — exactly what a sustained negative campaign needs (reply = accepted,
+/// problem-report = clean reject, timeout = hang/crash).
+#[tokio::test]
+async fn didcomm_try_request_classifies_reject_and_keeps_going() {
+    let mock = MockVtcDidcomm::start().await;
+    let _admin_token = seed_join_ceremony(&mock).await;
+    let vtc_did = mock.vtc_did().to_string();
+
+    // A malformed submit body (no `vp`) fails to deserialize in the handler →
+    // the VTC replies with a problem-report instead of a receipt. The old
+    // `request` helper would panic here; `try_request` returns it classified.
+    let outcome = mock
+        .client
+        .try_request(
+            &vtc_did,
+            JOIN_REQUEST_SUBMIT_TYPE,
+            json!({ "registry_consent": false }),
+            Duration::from_secs(15),
+        )
+        .await;
+    match outcome {
+        ReplyOutcome::Problem(p) => {
+            assert!(!p.code.is_empty(), "problem-report carries a code: {:?}", p);
+        }
+        other => panic!("expected a clean problem-report rejection, got {other:?}"),
+    }
+
+    // The campaign keeps running on the same boot: a well-formed submit right
+    // after the rejection still round-trips to an accepted receipt.
+    let applicant_did = mock.client.did().to_string();
+    let good = JoinRequestSubmitBody {
+        vp: json!({ "type": "VerifiablePresentation", "holder": applicant_did }),
+        registry_consent: false,
+        extensions: json!({}),
+    };
+    let outcome = mock
+        .client
+        .try_request(
+            &vtc_did,
+            JOIN_REQUEST_SUBMIT_TYPE,
+            serde_json::to_value(good).unwrap(),
+            Duration::from_secs(15),
+        )
+        .await;
+    match outcome {
+        ReplyOutcome::Reply(body) => {
+            let receipt: JoinRequestSubmitReceiptBody =
+                serde_json::from_value(body).expect("submit receipt");
+            assert_eq!(receipt.status, "pending");
+        }
+        other => panic!("expected an accepted receipt after the reject, got {other:?}"),
+    }
 
     mock.shutdown().await;
 }


### PR DESCRIPTION
Closes part 1 of #464.

## Problem

`TestJoinClient::recv_matching` (`vtc-service/src/test_support.rs`) panicked on **any** inbound DIDComm problem-report. That is the right ergonomics for a happy-path test, but it aborts a cross-service negative/fuzz campaign on the first (correct) rejection — there is no way to tell a clean reject from a hang/crash and keep going. The panic also lived in the shared `recv_matching` primitive, so `request`, `next_pushed`, and the receipt path all aborted, not just `request`.

## Change

Add a non-panicking `try_request` that classifies the threaded outcome into the three buckets a fuzz campaign needs:

```rust
pub enum ReplyOutcome {
    Reply(Value),           // threaded non-problem-report reply  → accepted
    Problem(ProblemReport), // threaded DIDComm problem-report     → clean reject
    Timeout,                // no threaded reply within the window → hang/crash signal
}
pub struct ProblemReport { pub code: String, pub comment: String, pub body: Value }
```

- **`Timeout` is a returned variant, not a panic**, so the campaign keeps running and treats a missing reply as the bug signal. (A bare `Result<Value, ProblemReport>` — the original ask — can't express this third state, hence the enum.)
- **`code`/`comment` parsed via the existing `vta_sdk::protocols::extract_problem_report`** — no new problem-report type.
- **Correlation is sound**: the messaging framework threads the problem-report to the request id (`get_thread_id(msg) = thid ?? id`; `build_problem_report` sets `.thid(ctx.thread_id)`), so the same thread predicate catches a receipt or a problem-report; the `typ` distinguishes them.
- **Happy-path ergonomics preserved**: `recv_matching` still panics on a stray problem-report by default (gated on a per-client flag), and `request()` is re-expressed on top of `try_request`, panicking on `Problem`/`Timeout` exactly as before. `try_request` clears the flag only for its own round trip, so existing happy-path tests and the credential-push `next_pushed` path are unchanged.

## Test

New negative-path integration test in `tests/join_didcomm.rs`: a malformed submit (missing `vp`) → asserted `ReplyOutcome::Problem`, then a well-formed submit still round-trips on the **same boot** — i.e. the harness keeps going past a rejection. Both the new test and the existing happy-path round-trip pass.

```
test didcomm_try_request_classifies_reject_and_keeps_going ... ok
test didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_delivery ... ok
```

## Note on part 2 (handler entry points)

No change needed — `submit_inner`/`manifest_inner`/`status_inner` are already `pub` and reachable, and `TestVtc` already exposes a seeded `pub state: AppState`, so the in-process handler-level campaign can run today. Details in the issue thread.